### PR TITLE
content: 15 concepts + Latin catch-up (9) + 3 small gap-fills, chain-wide

### DIFF
--- a/code/learning/human-languages/arabic/lessons/AR-C07-asif.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C07-asif.md
@@ -1,0 +1,64 @@
+---
+id: AR-C07-asif
+chapter: 7
+type: word
+headword: آسف / آسفة
+gloss: sorry (āsif masc. / āsifa fem. — a GENDERED adjective, from asifa "to grieve, regret")
+concept_tag: COURTESY-SORRY
+prerequisites: [AR-C06-min-fadlik]
+sounds: [alef-madda, gendered-ending, arabic-rtl]
+roots: [asifa-arabic]
+etymology_hook: "آسف āsif/āsifa 'sorry' is a GENDERED adjective — unlike English sorry, the speaker's own gender changes the word"
+est_minutes: 4
+reviews_of: [AR-C06-min-fadlik]
+---
+
+# آسف / آسفة (āsif / āsifa) — sorry
+
+## Warm-up
+
+[PAUSE 2s] You already know **من فضلك**, "please." Arabic's word for "sorry"
+teaches a new lesson entirely: it isn't a fixed word at all — **it changes
+with the speaker.**
+
+## The word, taken apart
+
+**آسف** (*āsif*, said by a man) and **آسفة** (*āsifa*, said by a woman) both
+mean "**sorry**." They come from the verb **أَسِفَ** (*asifa*), "to grieve, to
+be filled with regret" — so saying *āsif* is describing yourself as
+*grieved / regretful*, the way you'd say "I am tired" or "I am happy."
+
+That's the key: **آسف is an adjective**, and Arabic adjectives **agree with the
+gender of the person they describe**. A man says **آسف**; a woman says
+**آسفة** — the extra **ة** (*tāʾ marbūṭa*) is the everyday feminine ending you'll
+meet across Arabic adjectives. English "sorry" never changes no matter who
+says it; Arabic "sorry" always tells you the speaker's gender in the same
+breath.
+
+## Be honest about the other word: معذرة
+
+For a quick, **ungendered** "excuse me / pardon" — squeezing past someone,
+interrupting, a light apology — Arabic reaches for **معذرة** (*maʿdhira*),
+from the root **ع-ذ-ر** ("to excuse"), the same root as **عذر** (*ʿudhr*,
+"an excuse") and the verb **يعتذر** (*yaʿtadhiru*, "to apologize"). Unlike
+*āsif/āsifa*, **معذرة doesn't change with gender** — it's a noun, not an
+adjective, so anyone says the same word.
+
+Use **آسف/آسفة** when you mean a real, felt "I'm sorry" (and remember to match
+your own gender); reach for **معذرة** for the light, everyday "pardon me."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: a man says — "āsif"]
+- [YOU SAY: a woman says — "āsifa"]
+- [YOU SAY: the ungendered one — "maʿdhira" = excuse me / pardon]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What's unusual about **آسف / آسفة** compared to English "sorry"?
+(**It's a gendered adjective** — *āsif* for a man, *āsifa* for a woman — where
+English never changes.) What root gives *āsif*, and what does it mean? (**أسف
+asafa**, "to grieve, regret.") What's the ungendered word for a quick "excuse
+me," and what root is it from? (**معذرة maʿdhira**, from **ع-ذ-ر** "to
+excuse.")

--- a/code/learning/human-languages/arabic/lessons/AR-C08-al-ahad-al-khamis.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C08-al-ahad-al-khamis.md
@@ -1,0 +1,57 @@
+---
+id: AR-C08-al-ahad-al-khamis
+chapter: 8
+type: word
+headword: الأحد الإثنين الثلاثاء الأربعاء الخميس
+gloss: Sunday–Thursday — Arabic counts its weekdays instead of naming them for planets
+concept_tag: AR-DAYS-WEEKDAYS
+prerequisites: [AR-C07-asif]
+sounds: [arabic-rtl, hamza-variants, definite-article-al]
+roots: [ahad-wahid, ithnayn, thalatha, arbaa, khamsa]
+etymology_hook: "Arabic weekdays are literally ordinal numbers — al-aḥad 'the first,' al-ithnayn 'the second' — a genuinely different system from Rome's planet-week"
+est_minutes: 5
+reviews_of: [AR-C07-asif]
+---
+
+# الأحد to الخميس (al-aḥad to al-khamīs) — Sunday to Thursday, by the numbers
+
+## Warm-up
+
+[PAUSE 2s] Every language so far in this course names its weekdays for
+planet-gods. Arabic does something completely different: it just **counts**
+them.
+
+## The pattern: definite article + ordinal number
+
+Five of Arabic's seven days are simply **"the [number]th"** — the definite
+article **ال** (*al-*) plus an ordinal built on the number word:
+
+| Arabic | literally | from the number | day |
+|---|---|---|---|
+| **الأحد** (*al-aḥad*) | "the **first**" | *wāḥid*, "one" | Sunday |
+| **الإثنين** (*al-ithnayn*) | "the **second**" (lit. "the two") | *ithnān*, "two" | Monday |
+| **الثلاثاء** (*ath-thulāthāʾ*) | "the **third**" | *thalātha*, "three" | Tuesday |
+| **الأربعاء** (*al-arbiʿāʾ*) | "the **fourth**" | *arbaʿa*, "four" | Wednesday |
+| **الخميس** (*al-khamīs*) | "the **fifth**" | *khamsa*, "five" | Thursday |
+
+No moon, no war-god, no planets at all — just **day one, day two, day
+three…** This also tells you something about the week itself: counting
+starts from **Sunday**, so Sunday is "day one" — the Arabic week, like the
+Jewish and much of the Christian calendar tradition, begins where the
+European Monday-first convention doesn't.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "al-aḥad" — the first, Sunday]
+- [YOU SAY: count up — "al-ithnayn, ath-thulāthāʾ, al-arbiʿāʾ, al-khamīs" —
+  second through fifth]
+- [YOU SAY: contrast — no planet-gods here, just numbers]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Arabic name Sunday through Thursday? (**As ordinal
+numbers** — "the first" through "the fifth," not planet-gods.) Which number
+is Sunday, and what does that tell you about the week? (**"The first"** —
+the Arabic week counts starting from **Sunday**.) What Arabic prefix turns a
+number into "the [x]th day"? (**ال** *al-*, the definite article.)

--- a/code/learning/human-languages/arabic/lessons/AR-C08-al-jumua-as-sabt.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C08-al-jumua-as-sabt.md
@@ -1,0 +1,57 @@
+---
+id: AR-C08-al-jumua-as-sabt
+chapter: 8
+type: word
+headword: الجمعة السبت
+gloss: Friday and Saturday — the two days that break the counting pattern
+concept_tag: AR-DAYS-WEEKEND
+prerequisites: [AR-C08-al-ahad-al-khamis]
+sounds: [arabic-rtl, ayn-sound, teh-marbuta]
+roots: [jamaa-gather, sabt-semitic]
+etymology_hook: "as-sabt is a Semitic COUSIN of Hebrew shabbat (same family, shared root) — unlike Latin's Sabbatum, which BORROWED the word across a language-family line"
+est_minutes: 5
+reviews_of: [AR-C08-al-ahad-al-khamis]
+---
+
+# الجمعة and السبت (al-jumʿa, as-sabt) — Friday and Saturday
+
+## Warm-up
+
+[PAUSE 2s] Five days counted off — and then two days important enough to get
+**real names** instead of numbers.
+
+## The two named days
+
+- **الجمعة** (*al-jumʿa*) = "**the gathering**," from **جمع** (*jamaʿa*), "to
+  gather, collect." This is the day of the congregational Friday prayer
+  (*ṣalāt al-jumʿa*) — the most religiously significant day of the Islamic
+  week, and important enough to earn its own name rather than a number.
+- **السبت** (*as-sabt*) = "**the Sabbath**."
+
+## Be honest about how السبت differs from Latin's Sabbatum
+
+You may remember Latin borrowed the word **Sabbatum** from Hebrew to replace
+its own pagan *diēs Saturnī* — a loanword crossing from a Semitic language
+into an Italic one. Arabic's **سبت** (*sabt*) is a different kind of
+relationship entirely: Arabic **is itself a Semitic language**, in the same
+family as Hebrew. So **as-sabt and Hebrew shabbāt aren't borrower-and-lender —
+they're cousins**, both descending from the same ancient Semitic root
+**س-ب-ت** meaning "to rest, to cease." Where Latin **borrowed** a foreign
+word, Arabic simply **inherited** a family word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "al-jumʿa" — the gathering, Friday]
+- [YOU SAY: "as-sabt" — the Sabbath, Saturday]
+- [YOU SAY: the contrast — Latin borrowed "Sabbatum"; Arabic's "sabt" is a
+  blood relative of Hebrew "shabbāt"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does **الجمعة** break the counting pattern? (**It's named for
+the congregational Friday prayer** — "the gathering" — not counted as a
+number.) How is Arabic's **السبت** different from Latin's borrowed
+**Sabbatum**? (**Arabic and Hebrew are both Semitic languages** — *as-sabt*
+and *shabbāt* are **cousins** from a shared root, not a loanword crossing
+between unrelated language families.)

--- a/code/learning/human-languages/arabic/lessons/AR-C09-ahmar-azraq.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C09-ahmar-azraq.md
@@ -1,0 +1,50 @@
+---
+id: AR-C09-ahmar-azraq
+chapter: 9
+type: word
+headword: أحمر أزرق
+gloss: red and blue — the same gendered color template as black and white
+concept_tag: AR-COLOUR-RED-BLUE
+prerequisites: [AR-C09-aswad-abyad]
+sounds: [hamza-variants, feminine-alif-hamza-ending]
+roots: [hamar-red, zaraq-blue]
+etymology_hook: "أحمر ahmar / حمراء hamraa' (red) and أزرق azraq / زرقاء zarqaa' (blue) confirm the pattern — Arabic's CLASSIC colors all follow the same masc. أ... / fem. ...اء template"
+est_minutes: 4
+reviews_of: [AR-C09-aswad-abyad]
+---
+
+# أحمر / أزرق (ahmar / azraq) — red and blue, the same template again
+
+## Warm-up
+
+[PAUSE 2s] Two more colors — and the exact same shape you just learned.
+
+## The pattern holds
+
+- **أحمر** (*aḥmar*, masculine) / **حمراء** (*ḥamrāʾ*, feminine) — "**red**"
+- **أزرق** (*azraq*, masculine) / **زرقاء** (*zarqāʾ*, feminine) — "**blue**"
+
+Same recipe every time: masculine opens with **أ**, feminine drops that
+opening and closes with **‑اء** instead. Once you've internalized this
+template from black and white, the whole family of **classic, old** Arabic
+colors slots into it (yellow **أصفر/صفراء**, green **أخضر/خضراء**, too) — one
+pattern, several colors. (Newer colors like brown, gray, purple, orange, and
+pink use a **different** pattern entirely, borrowed from nouns — so "every
+color" would overstate it; this template belongs specifically to Arabic's
+oldest, core color set.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: masculine — "aḥmar, azraq" — red, blue]
+- [YOU SAY: feminine — "ḥamrāʾ, zarqāʾ" — red, blue]
+- [YOU SAY: all four masculine forms in a row — "aswad, abyad, aḥmar, azraq"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What's the masculine/feminine pair for red? (**أحمر aḥmar /
+حمراء ḥamrāʾ**.) For blue? (**أزرق azraq / زرقاء zarqāʾ**.) Does every
+Arabic color use this same template? (**No** — Arabic's classic, oldest
+colors (black, white, red, blue, yellow, green) share **one** template, masc.
+أ‑‑‑ / fem. ‑‑‑اء; newer colors like brown or purple use a different,
+noun-based pattern instead.)

--- a/code/learning/human-languages/arabic/lessons/AR-C09-aswad-abyad.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C09-aswad-abyad.md
@@ -1,0 +1,49 @@
+---
+id: AR-C09-aswad-abyad
+chapter: 9
+type: word
+headword: أسود أبيض
+gloss: black and white — color adjectives that change shape with gender, more than "sorry" did
+concept_tag: AR-COLOUR-BLACK-WHITE
+prerequisites: [AR-C08-al-jumua-as-sabt]
+sounds: [hamza-variants, feminine-alif-hamza-ending, arabic-rtl]
+roots: [sawad-black, bayad-white]
+etymology_hook: "أسود aswad / سوداء sawdaa' (black) and أبيض abyad / بيضاء baydaa' (white) share ONE grammatical template — masc. أ...   fem. ...اء — that Arabic reserves for colors and physical traits"
+est_minutes: 5
+reviews_of: [AR-C08-al-jumua-as-sabt, AR-C07-asif]
+---
+
+# أسود / أبيض (aswad / abyad) — black and white, a whole new gender pattern
+
+## Warm-up
+
+[PAUSE 2s] You've already met a gendered adjective — **آسف/آسفة** ("sorry"),
+which just added a feminine ending. Color words go further: they reshape the
+**whole word**, front and back, for gender.
+
+## The pattern: masculine أ‑‑‑ / feminine ‑‑‑اء
+
+- **أسود** (*aswad*, masculine) / **سوداء** (*sawdāʾ*, feminine) — "**black**"
+- **أبيض** (*abyad*, masculine) / **بيضاء** (*bayḍāʾ*, feminine) — "**white**"
+
+Notice the shape: the masculine form **starts** with **أ** (a hamza-alif), and
+the feminine form **drops** that opening letter but **adds** **‑اء** (*-āʾ*)
+at the end instead. This isn't the simple "add one letter" pattern *āsif/
+āsifa* used — it's a **dedicated template** Arabic reserves specifically for
+**colors and physical characteristics** (this same shape appears again for
+red and blue in the next lesson).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: masculine — "aswad, abyad" — black, white]
+- [YOU SAY: feminine — "sawdāʾ, bayḍāʾ" — black, white]
+- [YOU SAY: notice the shape — أ‑‑‑ drops, ‑‑‑اء appears]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What's the masculine/feminine pair for black? (**أسود aswad /
+سوداء sawdāʾ**.) For white? (**أبيض abyad / بيضاء bayḍāʾ**.) How is this
+gender-shape different from *āsif/āsifa*? (**It reshapes the whole word** —
+losing the opening أ and gaining a closing ‑اء — a template reserved for
+colors and physical traits, not just adding a simple ending.)

--- a/code/learning/human-languages/arabic/lessons/AR-C10-ab-umm.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C10-ab-umm.md
@@ -1,0 +1,56 @@
+---
+id: AR-C10-ab-umm
+chapter: 10
+type: word
+headword: أب أم
+gloss: father and mother — ancient Semitic roots, cousins of Hebrew's own family words
+concept_tag: AR-FAMILY-PARENTS
+prerequisites: [AR-C09-ahmar-azraq]
+sounds: [hamza-variants, arabic-rtl]
+roots: [semitic-ab, semitic-umm]
+etymology_hook: "أب ab 'father' and أم umm 'mother' are ancient Semitic roots, cousins of Hebrew av and em — the same roots behind Aramaic abba ('Abba, Father') and the honorific naming pattern Umm [child]"
+est_minutes: 5
+reviews_of: [AR-C09-ahmar-azraq]
+---
+
+# أب, أم (ab, umm) — father and mother
+
+## Warm-up
+
+[PAUSE 2s] Two short, ancient words — each just two or three letters — sitting
+at the root of Semitic family vocabulary across several languages, not just
+Arabic.
+
+## Taken apart
+
+- **أب** (*ab*) = "**father**." A short, ancient Semitic root, cousin of
+  Hebrew **אב** (*av*) and Aramaic **אבא** (*abba*) — the very word behind
+  "**Abba, Father**" in the New Testament.
+- **أم** (*umm*) = "**mother**." Equally ancient, cousin of Hebrew **אם**
+  (*em*).
+
+These aren't borrowings between Arabic and Hebrew — both descend from the
+same ancient Semitic family vocabulary, the way *pater* and English *father*
+are cousins through PIE rather than one copying the other.
+
+## A living naming pattern
+
+**أم** stays productive in everyday Arabic naming: **أم** + a child's name
+forms a **kunya**, an honorific "**mother of ___**" (and **أبو**, *abū*,
+does the same for fathers — "**father of ___**"). Someone might be known
+publicly as *Umm Khālid*, "mother of Khālid," rather than by their own given
+name — a naming custom still very much alive today.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ab" — father — then "umm," mother]
+- [YOU SAY: the Hebrew cousins — "ab/av, umm/em"]
+- [YOU SAY: the naming pattern — "Umm + [child's name]" = mother of ___]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are Arabic's words for father and mother? (**أب ab, أم
+umm**.) What are their Hebrew cousins? (**av, em** — not borrowings, both
+from the same ancient Semitic root.) What naming pattern does **umm** still
+form today? (**Umm + [child's name]**, "mother of ___," a living honorific.)

--- a/code/learning/human-languages/arabic/lessons/AR-C10-akh-ukht.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C10-akh-ukht.md
@@ -1,0 +1,47 @@
+---
+id: AR-C10-akh-ukht
+chapter: 10
+type: word
+headword: أخ أخت
+gloss: brother and sister — one shared Semitic root, gendered by a single added letter
+concept_tag: AR-FAMILY-SIBLINGS
+prerequisites: [AR-C10-ab-umm]
+sounds: [hamza-variants, feminine-ta-marbuta]
+roots: [semitic-akh]
+etymology_hook: "أخ akh 'brother' and أخت ukht 'sister' share one root, cousin of Hebrew ach/achot — sister is simply brother plus the feminine -t ending"
+est_minutes: 4
+reviews_of: [AR-C10-ab-umm]
+---
+
+# أخ, أخت (akh, ukht) — brother and sister
+
+## Warm-up
+
+[PAUSE 2s] Unlike the color words you just learned (a whole reshaped
+template for masculine/feminine), siblings here use the **simplest**
+possible gender marker.
+
+## Taken apart
+
+- **أخ** (*akh*) = "**brother**" — another short, ancient Semitic root,
+  cousin of Hebrew **אח** (*ach*).
+- **أخت** (*ukht*) = "**sister**" — the **same root**, plus a plain feminine
+  **‑ت** (*‑t*) ending, cousin of Hebrew **אחות** (*achot*).
+
+So *ukht* isn't a separate word — it's *akh* wearing the ordinary feminine
+ending, the simple pattern you already know from **آسف/آسفة** (*āsif/āsifa*,
+"sorry"), not the elaborate colors template.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "akh" — brother — then "ukht," sister]
+- [YOU SAY: the shared root plus a simple ending — akh + ‑t]
+- [YOU SAY: the Hebrew cousins — "akh/ach, ukht/achot"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are Arabic's words for brother and sister? (**أخ akh, أخت
+ukht**.) How is *ukht* built from *akh*? (**The same root, plus a plain
+feminine ‑ت ending** — the simple pattern, not the colors' elaborate
+template.) What are their Hebrew cousins? (**ach, achot**.)

--- a/code/learning/human-languages/arabic/lessons/AR-C11-ras.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C11-ras.md
@@ -1,0 +1,51 @@
+---
+id: AR-C11-ras
+chapter: 11
+type: word
+headword: رأس
+gloss: the head — a Semitic root cognate with Hebrew rosh, and the source of "president" in Arabic itself
+concept_tag: AR-BODY-HEAD
+prerequisites: [AR-C10-akh-ukht]
+sounds: [hamza-medial, arabic-rtl]
+roots: [semitic-ras]
+etymology_hook: "رأس ra's 'head' is cognate with Hebrew rosh (Rosh Hashanah, 'head of the year') — and gives Arabic ra'iis 'president,' literally 'head [of state],' the same move English makes with capital/captain from Latin caput"
+est_minutes: 4
+reviews_of: [AR-C10-akh-ukht]
+---
+
+# رأس (raʾs) — the head
+
+## Warm-up
+
+[PAUSE 2s] One more ancient Semitic root — and a word still hard at work in
+modern political vocabulary, the same way Latin's *caput* is in English.
+
+## The word
+
+**رأس** (*raʾs*) = "**head**" — an ancient Semitic root, cousin of Hebrew
+**ראש** (*rosh*), the very word inside **Rosh Hashanah**, "head of the
+year."
+
+## From "head" to "president"
+
+Arabic builds **رئيس** (*raʾīs*), "**president, chief, head [of an
+organization]**," directly on this same root — literally "the one who is
+the head." That's exactly the move English makes with Latin *caput*:
+**captain** ("head" of a unit), **capital** ("head" city). Different
+language families, the same very human idea — the person or place "at the
+head" is the one in charge.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "raʾs" — head]
+- [YOU SAY: "raʾīs" — president, literally "the head [one]"]
+- [YOU SAY: the Hebrew cousin — "raʾs / rosh"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **رأس** mean, and what's its Hebrew cousin? (**"Head"**
+— cousin of **rosh**, as in Rosh Hashanah.) What word is built on it for
+"president," and what does it literally mean? (**رئيس** *raʾīs*, "the head
+[one]" — the same "head = leader" idea as English *captain/capital* from
+Latin *caput*.)

--- a/code/learning/human-languages/arabic/lessons/AR-C11-yad.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C11-yad.md
@@ -1,0 +1,42 @@
+---
+id: AR-C11-yad
+chapter: 11
+type: word
+headword: يد
+gloss: the hand — an ancient Semitic root, nearly unchanged since its Hebrew cousin
+concept_tag: AR-BODY-HAND
+prerequisites: [AR-C11-ras]
+sounds: [arabic-rtl, short-word]
+roots: [semitic-yad]
+etymology_hook: "يد yad 'hand' is one of Arabic's oldest, shortest words — and it's nearly IDENTICAL to its Hebrew cousin יד yad, not just related but almost unchanged across the whole Semitic family"
+est_minutes: 4
+reviews_of: [AR-C11-ras]
+---
+
+# يد (yad) — the hand
+
+## Warm-up
+
+[PAUSE 2s] Some words wear their age lightly — worn down, reshaped,
+disguised. This one hasn't changed much at all.
+
+## The word
+
+**يد** (*yad*) = "**hand**" — a short, ancient Semitic root. Its Hebrew
+cousin is spelled and pronounced almost **identically**: **יד** (*yad*).
+Where *raʾs/rosh* show a family resemblance, *yad/yad* is closer to
+twins — one of the more strikingly unchanged shared words across the whole
+Semitic family.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "yad" — hand]
+- [YOU SAY: the Hebrew twin — "yad" — almost the same word]
+- [YOU SAY: contrast — "raʾs/rosh" changed more than "yad/yad" did]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **يد** mean? (**"Hand."**) How does it compare to its
+Hebrew cousin? (**Nearly identical** — both *yad* — one of the more
+strikingly unchanged shared words across the Semitic family.)

--- a/code/learning/human-languages/arabic/lessons/AR-C12-al-fusul.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C12-al-fusul.md
@@ -1,0 +1,67 @@
+---
+id: AR-C12-al-fusul
+chapter: 12
+type: word
+headword: ربيع صيف خريف شتاء
+gloss: the four seasons — Modern Standard Arabic's set, though the classical calendar didn't always carve up the year this way
+concept_tag: AR-SEASONS
+prerequisites: [AR-C11-yad]
+sounds: [ayn-sound, hamza-final, arabic-rtl]
+roots: [rabii-spring, sayf-summer, khariif-autumn, shitaa-winter]
+etymology_hook: "ربيع rabii' 'spring' is also the name of two Islamic calendar months (Rabi' al-Awwal, Rabi' al-Thani) — the season-word and the month-names share one root, a reminder that the lunar Islamic calendar and the solar seasons are two separate systems"
+est_minutes: 5
+reviews_of: [AR-C11-yad]
+---
+
+# ربيع, صيف, خريف, شتاء — the four seasons
+
+## Warm-up
+
+[PAUSE 2s] Four words for the turning year — and a genuine reminder that the
+tidy four-season picture is a **temperate-climate** habit of mind, not a
+universal one.
+
+## The four seasons
+
+| Arabic | meaning |
+|---|---|
+| **ربيع** (*rabīʿ*) | **spring** |
+| **صيف** (*ṣayf*) | **summer** |
+| **خريف** (*kharīf*) | **autumn** |
+| **شتاء** (*shitāʾ*) | **winter** |
+
+## Be honest about the calendar underneath
+
+**ربيع** (*rabīʿ*) does double duty: it also names **two months** of the
+Islamic calendar, **Rabīʿ al-Awwal** and **Rabīʿ al-Thānī** ("first/second
+Rabīʿ"). That's worth pausing on, because the **Islamic calendar is
+lunar** — its months drift across all four solar seasons over roughly a
+33-year cycle, unmoored from any actual spring. So a month named "Rabīʿ"
+won't reliably fall in spring at all; the name is a fossil from an earlier
+calendar, kept even as the lunar calendar carried the months loose from the
+seasons they were once named for.
+
+More broadly: the tidy four-season year assumes a temperate climate with
+four clearly distinct weather patterns. Much of the Arabic-speaking world
+spans very different climates — desert, Mediterranean, tropical — where a
+strict four-way split maps onto lived experience less cleanly than it does
+further north. The four words above are the standard Modern Standard Arabic
+vocabulary, useful and real, but not necessarily the only or most natural
+way every Arabic-speaking region actually experiences the year.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rabīʿ, ṣayf, kharīf, shitāʾ" — spring, summer, autumn, winter]
+- [YOU SAY: the calendar twist — "rabīʿ" also names two Islamic months]
+- [YOU SAY: the honest note — lunar months drift free of the solar seasons]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ربيع** do besides name a season? (**Names two Islamic
+calendar months**, Rabīʿ al-Awwal/al-Thānī.) Why don't those months
+reliably fall in spring? (**The Islamic calendar is lunar** — its months
+drift across all four seasons over a ~33-year cycle.) Is the four-season
+frame equally natural everywhere Arabic is spoken? (**Not necessarily** —
+it fits temperate climates better than the desert/tropical/Mediterranean
+climates found across much of the Arabic-speaking world.)

--- a/code/learning/human-languages/arabic/lessons/AR-C13-maa-khubz.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C13-maa-khubz.md
@@ -1,0 +1,54 @@
+---
+id: AR-C13-maa-khubz
+chapter: 13
+type: word
+headword: ماء خبز
+gloss: water and bread — one of Arabic's most irregular common words, and one built on a clean, ordinary Semitic root
+concept_tag: AR-FOOD-BASIC
+prerequisites: [AR-C12-al-fusul]
+sounds: [hamza-final, arabic-rtl]
+roots: [semitic-maa-irregular, khabaza-bake]
+etymology_hook: "ماء maa' 'water' is one of Arabic's few genuinely IRREGULAR nouns (its plural miyaah and construct forms don't follow the ordinary pattern) — خبز khubz 'bread' is built on the plain, regular root kh-b-z, 'to bake'"
+est_minutes: 4
+reviews_of: [AR-C12-al-fusul]
+---
+
+# ماء, خبز (māʾ, khubz) — water and bread
+
+## Warm-up
+
+[PAUSE 2s] Two everyday words — and a study in contrasts: one of them is
+one of Arabic's genuinely **oddest** common nouns, and the other is about
+as **regular** as a word gets.
+
+## ماء — an old, irregular word
+
+**ماء** (*māʾ*) = "**water**." This word is short but **irregular**: its
+plural (**مياه**, *miyāh*) and the forms it takes when attached to another
+noun don't follow Arabic's ordinary noun patterns the way most words do.
+Words this basic — for water, fire, blood, mouth — are often among the
+oldest in any language family, and old words wear their irregularities
+proudly; they were already worn smooth by daily use long before the
+grammar of the rest of the language settled into its regular patterns.
+
+## خبز — clean, regular, and freshly made
+
+**خبز** (*khubz*) = "**bread**" — built cleanly on the root **خ-ب-ز**
+(*kh-b-z*), "**to bake**." Where *māʾ* is a fossil, *khubz* is
+transparent: the noun for the baked thing, straight from the verb for
+baking it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "māʾ" — water — then "miyāh," its irregular plural]
+- [YOU SAY: "khubz" — bread — from kh-b-z, "to bake"]
+- [YOU SAY: the contrast — one word is a worn-smooth fossil, the other
+  freshly transparent]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What's unusual about **ماء**? (**It's genuinely irregular** —
+its plural *miyāh* and attached forms don't follow the ordinary pattern,
+typical of very old, basic words.) What root is **خبز** built on, and what
+does that root mean? (**خ-ب-ز**, "**to bake**.")

--- a/code/learning/human-languages/arabic/lessons/AR-C14-ashhur.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C14-ashhur.md
@@ -1,0 +1,91 @@
+---
+id: AR-C14-ashhur
+chapter: 14
+type: word
+headword: يناير فبراير مارس أبريل مايو يونيو يوليو أغسطس سبتمبر أكتوبر نوفمبر ديسمبر
+gloss: the Gregorian months — Latin names borrowed almost intact, running ALONGSIDE the Islamic calendar's own, entirely different lunar months
+concept_tag: AR-MONTHS
+prerequisites: [AR-C13-maa-khubz]
+sounds: [arabic-rtl, long-vowels]
+roots: [latin-months-borrowed]
+etymology_hook: "yanaayir, maaris, uktuubar... are simply Latin month-names in Arabic dress, borrowed for everyday/civil use — while the Islamic Hijri calendar keeps its OWN, entirely different 12 lunar months (Muharram, Rabi' al-Awwal...) for religious life, both running side by side"
+est_minutes: 6
+reviews_of: [AR-C13-maa-khubz]
+---
+
+# يناير to ديسمبر — Latin names, borrowed whole, running beside a second calendar
+
+## Warm-up
+
+[PAUSE 2s] Here's a genuinely different kind of honesty this lesson needs:
+Arabic doesn't have **one** answer to "what are the months called" — it has
+**two full calendars**, used for different purposes, side by side.
+
+## The Gregorian months — Latin, barely disguised
+
+For the everyday, civil, solar calendar, Modern Standard Arabic simply
+**borrows** the familiar Latin-derived month names you already know from
+Spanish/French/English:
+
+| Arabic | ≈ |
+|---|---|
+| **يناير** (*yanāyir*) | January |
+| **فبراير** (*fabrāyir*) | February |
+| **مارس** (*māris*) | March |
+| **أبريل** (*abrīl*) | April |
+| **مايو** (*māyū*) | May |
+| **يونيو** (*yūniyū*) | June |
+| **يوليو** (*yūliyū*) | July |
+| **أغسطس** (*aghusṭus*) | August |
+| **سبتمبر** (*sibtambir*) | September |
+| **أكتوبر** (*uktūbar*) | October |
+| **نوفمبر** (*nūfambir*) | November |
+| **ديسمبر** (*dīsambir*) | December |
+
+You can hear the Latin (and French) originals right through the Arabic
+sounds — this is a straightforward, recent borrowing for civil/business
+use, not an ancient Arabic-invented system.
+
+**One more honest wrinkle:** these Latin-derived names are the everyday
+convention in Egypt, the Gulf, and much pan-Arab media — but the Levant and
+Iraq (Syria, Lebanon, Jordan, Palestine, Iraq) traditionally use a **third**,
+completely different set for these same twelve solar months, of **Syriac**
+origin: **كانون الثاني** (*Kānūn al-Thānī*, January), **شباط** (*Shubāṭ*,
+February), **آذار** (*Ādhār*, March), and so on. So depending on the
+country, an Arabic speaker's civil-calendar month name might come from
+Latin *or* from Syriac — a third naming system, not just two.
+
+## Be honest: a second, completely different calendar runs alongside it
+
+For **religious life** — Ramadan, Hajj, and the Islamic calendar generally
+— Arabic uses an entirely **separate** set of month names, from the
+**lunar Hijri calendar**: **محرم** (*Muḥarram*), **صفر** (*Ṣafar*), **ربيع
+الأول/الثاني** (*Rabīʿ al-Awwal/al-Thānī* — the very "Rabīʿ" from the
+seasons lesson), and eight more, none of which correspond to a fixed solar
+month. Because the Hijri calendar has **no leap-month correction**, these
+twelve lunar months drift steadily across all four solar seasons over a
+roughly 33-year cycle — so Ramadan, for instance, doesn't fall in the same
+season every year.
+
+Two calendars, two jobs: the borrowed Latin names for the ordinary business
+week, the older lunar names for religious observance.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "yanāyir, fabrāyir, māris" — January, February, March — hear the
+  Latin]
+- [YOU SAY: the second calendar — "Muḥarram, Ṣafar, Rabīʿ al-Awwal" —
+  entirely different names]
+- [YOU SAY: the honest point — two calendars, two purposes, both in
+  everyday use]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where do Arabic's civil month names (*yanāyir, māris...*) come
+from? (**Borrowed Latin/European names**, recent civil-calendar loans.)
+What runs alongside them for religious life? (**The Hijri lunar
+calendar**, with its own entirely different 12 month names — *Muḥarram,
+Ṣafar, Rabīʿ al-Awwal*...) Why do Hijri months drift across the seasons?
+(**No leap-month correction** — the lunar year is shorter than the solar
+year, so the calendar drifts over a ~33-year cycle.)

--- a/code/learning/human-languages/arabic/lessons/AR-C15-ad-duhr-muntasaf-al-layl.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C15-ad-duhr-muntasaf-al-layl.md
@@ -1,0 +1,58 @@
+---
+id: AR-C15-ad-duhr-muntasaf-al-layl
+chapter: 15
+type: phrase
+headword: الظهر منتصف الليل
+gloss: noon (also the name of the midday Islamic prayer) and midnight ("the half of the night")
+concept_tag: AR-TIME-NOON-MIDNIGHT
+prerequisites: [AR-C14-ashhur]
+sounds: [arabic-rtl, emphatic-zaa]
+roots: [zahara-appear, nisf-half]
+etymology_hook: "الظهر (adh-dhuhr) 'noon' is also the name of the midday prayer, salat al-zuhr — Arabic's word for noon is bound up with the daily prayer schedule, not a neutral clock-time word; منتصف الليل (muntasaf al-layl) 'the half of the night' is fully transparent, from nisf 'half'"
+est_minutes: 5
+reviews_of: [AR-C14-ashhur]
+---
+
+# الظهر, منتصف الليل — noon and midnight
+
+## Warm-up
+
+[PAUSE 2s] Noon in Arabic isn't just a clock-time word — it's tied
+directly into the rhythm of daily prayer.
+
+## الظهر — noon, and a prayer
+
+**الظهر** (*aẓ-ẓuhr* or *adh-dhuhr*) = "**noon**" — from the root
+**ظ-ه-ر** (*ẓ-h-r*), "**to appear, become visible**" (the sun standing at
+its highest, most visible point). Be honest about what makes this word
+different from Spanish's *mediodía*: **الظهر is also the name of the
+midday Islamic prayer**, *ṣalāt al-ẓuhr*. For a Muslim, "noon" and "time for
+the noon prayer" are the same word — this isn't a neutral clock-time term
+the way "noon" or *mediodía* are in cultures where the day isn't organized
+around five fixed prayer times.
+
+## منتصف الليل — a transparent "half of the night"
+
+**منتصف الليل** (*muntaṣaf al-layl*) = "**midnight**," literally "**the
+half of the night**." **منتصف** (*muntaṣaf*) comes from the root **ن-ص-ف**
+(*n-ṣ-f*), "**half**" (the same root as **نصف**, *niṣf*, "a half"), and
+**الليل** (*al-layl*) is simply "**the night**." This one is fully
+transparent — no erosion, no double meaning, just "the middle of the
+night," structurally exactly like Latin's *media nox*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "aẓ-ẓuhr" — noon, also the midday prayer]
+- [YOU SAY: "muntaṣaf al-layl" — literally "the half of the night"]
+- [YOU SAY: the honest point — Arabic noon carries a religious meaning that
+  mediodía doesn't]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **الظهر** name besides the time of day? (**The midday
+Islamic prayer**, *ṣalāt al-ẓuhr*.) What does **منتصف الليل** literally
+mean, and what root gives it "half"? ("**The half of the night**" —
+*muntaṣaf*, from **ن-ص-ف** *n-ṣ-f*, "half.") Is Arabic's word for noon a
+neutral clock-time word the way Spanish's *mediodía* is? (**No** — it's
+bound up with the daily prayer schedule.)

--- a/code/learning/human-languages/arabic/lessons/AR-C16-al-saa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C16-al-saa.md
@@ -1,0 +1,68 @@
+---
+id: AR-C16-al-saa
+chapter: 16
+type: word
+headword: الساعة
+gloss: hour / o'clock — and the same word Arabic uses for "clock" and "a while"
+concept_tag: AR-TIME-HOUR
+prerequisites: [AR-C15-ad-duhr-muntasaf-al-layl]
+sounds: [arabic-ain, teh-marbuta]
+roots: [aramaic-shaata-hour]
+etymology_hook: "ساعة (sāʿa, 'hour') is a loanword from Aramaic شָׁעְתָא/ܫܳܥܬܳܐ (šāʿəṯā) — the same Semitic root behind Hebrew's שָׁעָה (šāʿā), borrowed into Arabic long before Islam; ساعة does triple duty for 'hour,' 'clock,' and 'a while, a moment'"
+est_minutes: 5
+reviews_of: [AR-C15-ad-duhr-muntasaf-al-layl]
+---
+
+# الساعة — one word for "hour," "clock," and "a moment"
+
+## Warm-up
+
+[PAUSE 2s] Arabic's word for "hour" isn't native Arabic at all — it's a very old
+borrowing, and it still carries three meanings at once.
+
+## ساعة — borrowed from Aramaic, long ago
+
+**ساعة** (*sāʿa*) = "**hour**" — but also "**clock/watch**" (as an object) and
+"**a while, a moment**" (as in "wait a *sāʿa*"). According to the historical
+linguist Theodor Nöldeke, Arabic **ساعة** was borrowed from **Aramaic** **شָׁעְתָא**
+(*šāʿəṯā*) — the same Semitic root that gives Hebrew its word for hour, **שָׁעָה**
+(*šāʿā*). This borrowing happened long before Islam, deep in Arabic's pre-Islamic
+contact with Aramaic-speaking communities — so unlike some of the religiously-tied
+vocabulary you've seen (like *aẓ-ẓuhr*), *sāʿa* is simply an old, everyday loanword,
+carrying no special religious weight.
+
+## Grammar Lens: كم الساعة؟ — "how much is the hour?"
+
+Arabic asks the time with **كم الساعة؟** (*kam as-sāʿa?*), literally "**how much/
+how many is the hour**" — and answers with **الساعة** + an **ordinal** number
+("the second," "the third"...):
+
+> **الساعة الثانية.** — "It is two o'clock." (literally "the hour [is] the second")
+> **الساعة الثالثة.** — "It is three o'clock." (literally "the hour [is] the third")
+
+Be honest about the one exception: **one o'clock breaks this pattern**. You'd
+expect the ordinal *al-ūlā* ("the first"), but Arabic actually says **الساعة
+الواحدة** (*as-sāʿa al-wāḥida*) — using **al-wāḥida**, the plain **cardinal**
+"one," not the ordinal. So the rule is "ordinal numbers from two o'clock onward,
+except one o'clock, which uses the cardinal instead" — a genuine irregularity,
+not a typo. This is still a different grammatical shape than Spanish's *la
+una*/*las dos* or French's *une heure*/*deux heures*, both of which use plain
+cardinal numbers throughout, with no ordinal/cardinal split at all.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "sāʿa" — hour, clock, or a while, depending on context]
+- [YOU SAY: "kam as-sāʿa?" — what time is it?]
+- [YOU SAY: "as-sāʿa al-thāniya" — it is two o'clock, an ordinal number]
+- [YOU SAY: "as-sāʿa al-wāḥida" — it is one o'clock, the one exception, using the
+  cardinal "one" instead]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What language did Arabic borrow **ساعة** from, and what Hebrew word is
+its cousin? (**Aramaic** *šāʿəṯā*; cousin of Hebrew *šāʿā*.) What three things can
+**ساعة** mean? (**Hour, clock/watch, and a while/moment**.) Does Arabic use
+cardinal or ordinal numbers to tell the time — and is there an exception? (**Ordinal**
+from two o'clock onward — "the hour is the *second*" — but **one o'clock is the
+exception**, using the cardinal *al-wāḥida*, "one," instead of the ordinal.)

--- a/code/learning/human-languages/arabic/lessons/AR-C17-kam-umruka.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C17-kam-umruka.md
@@ -1,0 +1,62 @@
+---
+id: AR-C17-kam-umruka
+chapter: 17
+type: phrase
+headword: كم عمرك؟
+gloss: how old are you? — literally "how much [is] your lifetime?"; age as a NOUN you possess, not a verb you conjugate
+concept_tag: AR-AGE
+prerequisites: [AR-C16-al-saa]
+sounds: [arabic-ain, possessive-suffix-ka-ki]
+roots: [arabic-umr-life]
+etymology_hook: "كم عمرك؟ (kam ʿumruka?, 'how old are you?') is literally 'how much [is] your ʿumr' — ʿumr (life, lifetime, age) from root ع-م-ر, the same root behind the name ʿUmar; Arabic asks age with a NOUN + possessive suffix, no verb at all — a FOURTH shape, after Romance's 'have', Germanic's 'be', and Latin's 'born + accusative of duration'"
+est_minutes: 5
+reviews_of: [AR-C16-al-saa]
+---
+
+# كم عمرك؟ — asking age with a noun, not a verb
+
+## Warm-up
+
+[PAUSE 2s] You've seen Romance languages **have** their years, Germanic
+languages **be** their years, and Classical Latin itself use a third
+construction ("born" + accusative of duration). Arabic does something
+structurally different again: it doesn't use a verb for this at all.
+
+## عمر — life, lifetime, age
+
+**عمر** (*ʿumr*) = "**age, lifetime, life span**" — from the root **ع-م-ر**
+(*ʿ-m-r*), broadly tied to the idea of **living, dwelling, flourishing** (the
+same root behind the personal name **ʿUmar**, and words for "building,
+habitation"). Age in Arabic isn't something you *have* or *are* — it's
+expressed as a possessed **noun**: "**your** ʿumr," "**my** ʿumr."
+
+## Grammar Lens: كم عمرك؟ — no verb needed
+
+> **كم عمرك؟** — "How old are you?" (to a man) — literally "**how much [is]
+  your** *ʿumr*." (*kam ʿumruka?*)
+> **عمري عشرون سنة.** — "I am twenty years old." — literally "**my** *ʿumr*
+  [is] twenty years." (*ʿumrī ʿishrūna sana*.)
+
+Notice there's **no verb "to be" at all** in the present tense here — Arabic
+simply juxtaposes two nouns ("my age" / "twenty years"), exactly the way it
+forms ordinary present-tense sentences without *is/are*. So this is a genuinely
+**fourth shape** for the concept: not Romance's "I **have** twenty years," not
+Germanic's "I **am** twenty years [old]," not Latin's "**born** twenty years
+[so far]," but "**my age** [is] twenty years" — age as a possessed
+noun-quantity, stated without any verb at all.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ʿumr" — age, lifetime, life span]
+- [YOU SAY: "kam ʿumruka?" — how old are you? (to a man)]
+- [YOU SAY: "ʿumrī ʿishrūna sana" — my age is twenty years, no verb at all]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **عمر** literally mean, and what root is it from? ("**Age,
+lifetime**" — root **ع-م-ر**, tied to living/flourishing.) Does Arabic use a
+verb to state age, the way Romance ("have"), Germanic ("be"), or Latin
+("born" + duration) do? (**No** — it juxtaposes "my age" and the number, with no
+verb needed at all.) What does **كم عمرك؟** literally ask? ("**How much [is]
+your** *ʿumr*?")

--- a/code/learning/human-languages/arabic/lessons/AR-C18-al-taqs.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C18-al-taqs.md
@@ -1,0 +1,67 @@
+---
+id: AR-C18-al-taqs
+chapter: 18
+type: phrase
+headword: الطقس
+gloss: weather — the SAME root also gives "rite, religious ceremony"; hot/cold are verbless adjectives, but rain gets its own personal verb
+concept_tag: AR-WEATHER
+prerequisites: [AR-C17-kam-umruka]
+sounds: [arabic-emphatic-taa, arabic-feminine-dummy-pronoun]
+roots: [arabic-taqs-weather-rite]
+etymology_hook: "الطقس (aṭ-ṭaqs, 'weather') shares its root ط-ق-س with طقوس (ṭuqūs), 'rites, religious ceremonies' — weather and ritual sharing one root; الجو حار/بارد ('it's hot/cold') are verbless, like كم عمرك, but rain gets its OWN personal verb: إنها تمطر, 'she/it is raining'"
+est_minutes: 5
+reviews_of: [AR-C17-kam-umruka]
+---
+
+# الطقس — weather and ritual, one root
+
+## Warm-up
+
+[PAUSE 2s] Here's an unexpected pairing: Arabic's word for "weather" shares its
+root with the word for religious "rites."
+
+## طقس — weather, and its plural means "rites"
+
+**الطقس** (*aṭ-ṭaqs*) = "**the weather**" — from root **ط-ق-س** (*ṭ-q-s*). Its
+plural, **طقوس** (*ṭuqūs*), means "**rites, religious ceremonies, liturgy**" —
+the same root covering both "atmospheric conditions" and "prescribed ritual
+observances." (Casual speech often prefers **الجو** (*al-jaw*, "the
+atmosphere") instead, keeping *aṭ-ṭaqs* for more formal or written use.)
+
+## الجو حار / بارد — hot and cold, still verbless
+
+> **الجو حار.** — "It's hot." — literally "**the atmosphere [is] hot**."
+  (*al-jaw ḥārr.*)
+> **الجو بارد.** — "It's cold." — literally "**the atmosphere [is] cold**."
+  (*al-jaw bārid.*)
+
+Same pattern as **كم عمرك؟** from the AGE lesson: **no verb "to be"** at all —
+just two nouns/adjectives sitting side by side.
+
+## إنها تمطر — but rain gets its OWN personal verb
+
+> **إنها تمطر.** — "It's raining." — literally "**she is raining**." (*innahā
+  tumṭir* — from **مطر**, *maṭar*, "rain," the same root gives **تمطر**,
+  *tumṭir*, "is raining.")
+
+Unlike *hot* and *cold*, rain isn't a verbless adjective sentence — Arabic
+uses an actual **personal verb**, *tumṭir* ("is raining"), with a **feminine
+dummy pronoun**, **إنها** (*innahā*, "she/it"), standing in as the subject.
+So within Arabic's own weather vocabulary, hot/cold stay verbless while rain
+gets a real, conjugated verb — echoing the same "rain behaves differently
+from other weather" pattern you saw in Latin's dedicated *pluit*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "aṭ-ṭaqs" — weather, same root as "ṭuqūs," rites]
+- [YOU SAY: "al-jaw ḥārr. al-jaw bārid." — it's hot/cold, no verb]
+- [YOU SAY: "innahā tumṭir" — it's raining, with an actual verb]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the plural of **طقس** mean, and what's the connection to
+"weather"? (**طقوس**, "**rites, religious ceremonies**" — sharing the same
+root.) Do **الجو حار** and **الجو بارد** use a verb? (**No** — verbless, like
+*kam ʿumruka?*.) Does **إنها تمطر** use a verb? (**Yes** — *tumṭir*, "is
+raining," with a feminine dummy pronoun.)

--- a/code/learning/human-languages/arabic/lessons/AR-C19-wahid-khamsa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C19-wahid-khamsa.md
@@ -1,0 +1,67 @@
+---
+id: AR-C19-wahid-khamsa
+chapter: 19
+type: word
+headword: واحد اثنان ثلاثة أربعة خمسة
+gloss: one through five — the Arabic WORDS for numbers, genuinely different from "Arabic numerals" (the written digit shapes 0-9), which actually trace back to India
+concept_tag: AR-NUM-1-5
+prerequisites: [AR-C18-al-taqs]
+sounds: [arabic-hamza, arabic-teh-marbuta]
+roots: [arabic-semitic-numerals]
+etymology_hook: "واحد، اثنان، ثلاثة، أربعة، خمسة (wāḥid, ithnān, thalātha, arbaʿa, khamsa) are the Arabic WORDS for 1-5 — genuinely different from 'Arabic numerals' (the written digit shapes 0-9), which actually originated in India and reached Europe via Arabic mathematicians like al-Khwārizmī, not from these words at all"
+est_minutes: 5
+reviews_of: [AR-C18-al-taqs]
+---
+
+# واحد، اثنان، ثلاثة، أربعة، خمسة — one through five
+
+## Warm-up
+
+[PAUSE 2s] Before the numbers themselves — an honest correction to a very
+common mix-up: "Arabic numerals" (the digit shapes **0, 1, 2, 3**...) are
+**not** these words, and don't come from Arabic at all.
+
+## واحد, اثنان, ثلاثة, أربعة, خمسة — the words
+
+| Arabic | Transliteration | Meaning |
+|---|---|---|
+| **واحد** | *wāḥid* | one |
+| **اثنان** | *ithnān* | two |
+| **ثلاثة** | *thalātha* | three |
+| **أربعة** | *arbaʿa* | four |
+| **خمسة** | *khamsa* | five |
+
+These are ordinary Semitic-root Arabic words, built the same way Arabic
+builds any noun — nothing to do with the shapes of the digits you write.
+
+## Be honest: "Arabic numerals" are actually Indian
+
+Here's the correction: the **digit shapes** **0, 1, 2, 3, 4, 5, 6, 7, 8, 9**
+that English calls "Arabic numerals" didn't originate in Arabic at all — they
+were invented in **India**, appearing in Indian mathematical texts and
+inscriptions centuries before reaching the Arab world. The 9th-century
+Persian mathematician **al-Khwārizmī** (whose name gives English
+**algorithm**) wrote an influential treatise on calculating with these
+**Hindu numerals**, which carried the system into the Islamic world and then,
+via Latin translations, into Europe. So "Arabic numerals" is really a
+transmission credit, not an origin credit — the shapes are Indian; only their
+route to Europe ran through Arabic mathematics. The **words** you're learning
+here (*wāḥid, ithnān, thalātha*...) are a completely separate thing: genuine,
+native Arabic vocabulary, unrelated to that digit-shape history.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "wāḥid, ithnān, thalātha, arbaʿa, khamsa" — one through five]
+- [YOU SAY: the honest correction — "Arabic numerals" (the digit SHAPES) are
+  actually Indian in origin, not these Arabic WORDS]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the Arabic words for one through five? (**wāḥid, ithnān,
+thalātha, arbaʿa, khamsa**.) Where did the digit shapes 0-9 actually
+originate, and who's credited with carrying them to Europe? (**India** —
+carried into the Islamic world and then Europe largely through
+**al-Khwārizmī**'s writings.) Are "Arabic numerals" the same thing as these
+Arabic number words? (**No** — completely separate: one is a set of written
+digit shapes with Indian origins, the other is native Arabic vocabulary.)

--- a/code/learning/human-languages/arabic/lessons/AR-C20-ahada-ashar-ishrun.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C20-ahada-ashar-ishrun.md
@@ -1,0 +1,66 @@
+---
+id: AR-C20-ahada-ashar-ishrun
+chapter: 20
+type: word
+headword: أحد عشر — عشرون
+gloss: 11-15, plain "X-and-ten" compounds — then twenty, NOT "two-ten" but its OWN plural form of "ten"
+concept_tag: AR-NUM-11-20
+prerequisites: [AR-C19-wahid-khamsa]
+sounds: [arabic-ain-shiin, arabic-teh-marbuta]
+roots: [arabic-ashar-ten, arabic-ishrun-twenty]
+etymology_hook: "أحد عشر through خمسة عشر (11-15) are plain 'X and ten' compounds, X + عشر (ʿashar, 'ten') — but عشرون (ʿishrūn, 'twenty') is NOT 'two-ten'; it's its OWN distinct plural-like form built directly on the 'ten' root, the same root behind Hebrew's eser and English's own '-teen'"
+est_minutes: 6
+reviews_of: [AR-C19-wahid-khamsa]
+---
+
+# أحد عشر, عشرون — plain compounds, then a genuinely different twenty
+
+## Warm-up
+
+[PAUSE 2s] Eleven through fifteen build the same simple way every time. Then
+twenty breaks the pattern completely — it isn't built the way you'd expect at
+all.
+
+## أحد عشر – خمسة عشر — "X and ten"
+
+| Arabic | literally |
+|---|---|
+| **أحد عشر** | *aḥada ʿashar* — "one-ten" (11) |
+| **اثنا عشر** | *ithnā ʿashar* — "two-ten" (12) |
+| **ثلاثة عشر** | *thalāthata ʿashar* — "three-ten" (13) |
+| **أربعة عشر** | *arbaʿata ʿashar* — "four-ten" (14) |
+| **خمسة عشر** | *khamsata ʿashar* — "five-ten" (15) |
+
+Every one of these is the counting-word (from the AGE and NUM-1-5 lessons)
+plus **عشر** (*ʿashar*, "**ten**") — a straightforward additive compound, the
+same shape you've now seen in Spanish's *once*-*quince* and Latin's
+*ūndecim*-*quīndecim*.
+
+## عشرون — NOT "two-ten," a genuinely different word
+
+Here's the honest surprise: **twenty** is **not** built from "two" + "ten" the
+way 11-15 were built. **عشرون** (*ʿishrūn*, "twenty") is its **own**, distinct
+word — a special **plural-like form** built directly on the same "ten" root,
+**ع-ش-ر** (*ʿ-sh-r*), rather than a compound of *ithnān* ("two") and *ʿashar*
+("ten"). That root, *ʿashar*/*ʿishrūn*, is the same Semitic "ten" root behind
+Hebrew's **עֶשֶׂר** (*eser*, "ten") — and, coincidentally, resembles the
+Indo-European "ten" root that gives English its own **-teen** suffix, though
+the two roots are **not** related: Arabic and English inherited "ten" from
+two entirely separate language families, so this is a parallel, not a shared
+borrowing or common ancestor.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "aḥada ʿashar, ithnā ʿashar, thalāthata ʿashar" — 11, 12, 13, "X
+  and ten"]
+- [YOU SAY: "ʿishrūn" — twenty, its OWN word, not "two-ten"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How are 11-15 built in Arabic? (**X + ʿashar** — "one-ten,"
+"two-ten," and so on, a plain additive compound.) Is **عشرون** (twenty) built
+the same way, as "two-ten"? (**No** — it's a distinct, standalone plural-like
+form built on the same "ten" root, not a compound of "two" and "ten.") What
+root does **ʿashar**/**ʿishrūn** share with Hebrew? (**ע-ש-ר**/**ع-ش-ر**, the
+Semitic root for "ten," giving Hebrew's *eser*.)

--- a/code/learning/human-languages/arabic/lessons/AR-C21-kalb-qitt.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C21-kalb-qitt.md
@@ -1,0 +1,70 @@
+---
+id: AR-C21-kalb-qitt
+chapter: 21
+type: word
+headword: كلب, قط
+gloss: dog and cat — kalb is a solid, well-attested Semitic root (cousin of Hebrew's own dog-word), unlike the mystery words you've met in other languages; qitt most likely closes the loop, widely compared to the SAME ancient root behind Latin's cattus/gato/chat/Katze, though the exact relationship is still debated
+concept_tag: AR-ANIMALS
+prerequisites: [AR-C20-ahada-ashar-ishrun]
+sounds: [arabic-qaf, arabic-geminate-tt]
+roots: [semitic-kalb-dog, afroasiatic-qitt-cat]
+etymology_hook: "كلب (kalb, 'dog') is Proto-Semitic *kalb-, cousin of Hebrew's own כֶּלֶב (kelev) — a solid, well-attested root, no mystery here; قط (qiṭṭ, 'cat/tomcat') is widely compared to the same ancient Afro-Asiatic root behind Latin's cattus (and so Spanish's gato, French's chat, German's Katze) — some linguists argue for a shared ancestor, though the exact relationship and even the direction of borrowing are still genuinely debated"
+est_minutes: 6
+reviews_of: [AR-C20-ahada-ashar-ishrun]
+---
+
+# كلب, قط — a solid root, and the word that closes the loop
+
+## Warm-up
+
+[PAUSE 2s] You've met a genuine dog-word mystery in Spanish, and another one
+in German by way of English. Arabic's dog-word has no such mystery — and its
+cat-word turns out to be a long-lost cousin of nearly every European cat-word
+you've already learned.
+
+## كلب — a solid Semitic root, no mystery here
+
+**كلب** (*kalb*, "**dog**") traces to **Proto-Semitic** ***\*kalb-*** — the
+exact same root behind **Hebrew**'s own word for dog, **כֶּלֶב** (*kelev*)
+(the name **Caleb** is traditionally connected to this same root, though
+some scholars instead derive it from *kol-lev*, "whole-hearted"). Unlike
+Spanish's *perro* or
+the English word that replaced "hound," *kalb* is a solid, well-attested,
+unmysterious Semitic root, shared across the whole Semitic family (Aramaic,
+Akkadian, and more).
+
+## قط — most likely the word that closes the loop
+
+Here's how this whole arc most likely ties together: **قط** (*qiṭṭ*, "**cat,
+tomcat**") is not just a coincidence-sounding lookalike — it's widely
+**compared** to the exact same ancient **Afro-Asiatic** root behind Latin's
+**cattus** (alongside Nubian *kadis*, mentioned back in the Spanish and Latin
+lessons). Be honest about the uncertainty here, though: linguists don't fully
+agree on the relationship. Some argue *qiṭṭ* and *cattus* both descend from a
+**shared** ancestor; others have proposed that *kadis* (and even *qiṭṭ*
+itself) could be a **later** borrowing **from** Arabic rather than an
+independent cousin, reversing the direction. What's not in serious dispute is
+that Arabic's word for "cat" sits in the same tangled word-family as Spanish's
+*gato*, French's *chat*, Italian's *gatto*, and German's *Katze* — one root
+(or a tight cluster of related roots), spreading out in every direction from
+wherever cats were first domesticated, even if the exact family tree is still
+being worked out.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kalb" — dog, a solid Semitic root, cousin of Hebrew's kelev]
+- [YOU SAY: "qiṭṭ" — cat, most likely a distant cousin of Latin's cattus and
+  every European cat-word you've learned]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root does **كلب** trace to, and what's its Hebrew cousin?
+(**Proto-Semitic *\*kalb-***; cousin of Hebrew **כֶּלֶב**, *kelev*.) Is
+**قط**'s relationship to Latin's *cattus* fully settled? (**No** — widely
+compared, most likely from a shared Afro-Asiatic root, but linguists still
+debate the exact relationship and direction.) What does this most likely mean
+for Arabic's word for "cat" compared to Spanish's *gato*, French's *chat*,
+and German's *Katze*? (**They most likely belong to the same tangled ancient
+word family** — spreading in every direction from the region where cats were
+first domesticated.)

--- a/code/learning/human-languages/arabic/lessons/AR-C22-akhdar-asfar.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C22-akhdar-asfar.md
@@ -1,0 +1,59 @@
+---
+id: AR-C22-akhdar-asfar
+chapter: 22
+type: word
+headword: أخضر, أصفر
+gloss: green and yellow — akhdar's root also gives "vegetables" (echoing English's own "greens"), and asfar shares its root with sifr, "zero" — the very word behind English "zero" and "cipher"
+concept_tag: AR-COLOUR-GREEN-YELLOW
+prerequisites: [AR-C21-kalb-qitt]
+sounds: [arabic-dad, arabic-sad]
+roots: [semitic-khadara-green, semitic-safara-empty]
+etymology_hook: "أخضر (akhḍar, 'green') is from root خ-ض-ر (kh-ḍ-r, 'to be green') — the same root behind خضار (khuḍār, 'vegetables'), echoing English's own 'greens' for vegetables, and the name of the Quranic figure al-Khiḍr, 'the Green One'; أصفر (aṣfar, 'yellow') shares its root, ص-ف-ر (ṣ-f-r), with صفر (ṣifr, 'zero, empty') — the very word behind English 'zero' and 'cipher'"
+est_minutes: 6
+reviews_of: [AR-C21-kalb-qitt]
+---
+
+# أخضر, أصفر — "greens" you'd recognize, and a hidden zero
+
+## Warm-up
+
+[PAUSE 2s] Arabic's green word hides an English-style pun. Its yellow word
+hides something even better — the exact root behind the word "zero" itself.
+
+## أخضر — the same root as "vegetables," and a Quranic name
+
+**أخضر** (*akhḍar*, "**green**") comes from the root **خ-ض-ر** (*kh-ḍ-r*,
+"**to be green**"). That same root gives **خضار** (*khuḍār*,
+"**vegetables**") — echoing the exact same move English makes when it calls
+vegetables "**greens**." The same root also names the mysterious Quranic
+figure **الخِضْر** (*al-Khiḍr*), "**the Green One**" — traditionally said to
+be called this because the ground turned green wherever he sat or prayed.
+
+## أصفر — the same root as "zero" itself
+
+Here's the real surprise: **أصفر** (*aṣfar*, "**yellow**") shares its root,
+**ص-ف-ر** (*ṣ-f-r*), with **صفر** (*ṣifr*, "**zero, empty, void**") — the
+**exact** Arabic word that gave English both **zero** (via Italian
+*zefiro*/*zero*) and **cipher** (via Medieval Latin *cifra*). So the same
+three-letter Arabic root sits behind "yellow" and behind the number **zero**
+itself. The sources don't fully explain *why* "emptiness" and "yellow"
+share a root — but the shared root itself, connecting Arabic's yellow-word
+straight back to the origin of "zero," is genuine and well documented.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "akhḍar" — green, same root as "khuḍār," vegetables]
+- [YOU SAY: "aṣfar" — yellow, same root as "ṣifr," zero]
+- [YOU SAY: the connection — "aṣfar, ṣifr, zero, cipher" — one Arabic root,
+  reaching all the way into English math vocabulary]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root does **أخضر** share with "vegetables," and what English
+phrase does this echo? (**خ-ض-ر**, *kh-ḍ-r* — echoes English calling
+vegetables "**greens**.") What Quranic figure shares this root, and what does
+his name mean? (**الخِضْر**, *al-Khiḍr* — "**the Green One**.") What word
+does **أصفر** share its root with, and what two English words trace back to
+it? (**صفر**, *ṣifr*, "zero, empty" — the source of English **zero** and
+**cipher**.)

--- a/code/learning/human-languages/arabic/lessons/AR-C23-afwan.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C23-afwan.md
@@ -1,0 +1,63 @@
+---
+id: AR-C23-afwan
+chapter: 23
+type: word
+headword: عفوا
+gloss: "you're welcome" (also "excuse me/pardon/sorry," depending on context) — root ʿ-f-w, "to erase, to pardon"; grammatically the same construction as shukran itself
+concept_tag: AR-COURTESY-YOUREWELCOME
+prerequisites: [AR-C01-shukran]
+sounds: [ayn, tanwin-fath]
+roots: [ayn-f-w]
+etymology_hook: "عفوا (ʿafwan), root ʿ-f-w, 'to erase, obliterate' → 'to pardon, forgive' (forgiving as metaphorically erasing an offense) — the same root behind العفو (al-ʿAfuww, 'The Supreme Pardoner,' one of the 99 names of Allah); grammatically, ʿafwan carries the exact same indefinite-accusative ending (tanwīn fatḥ, the '-an' sound) as شكرا (shukran) itself — both are fixed, idiomatic accusative forms, not full sentences"
+est_minutes: 5
+reviews_of: [AR-C01-shukran]
+---
+
+# عفوا (ʿafwan) — "you're welcome," from a root meaning "to erase"
+
+## Warm-up
+
+[PAUSE 2s] Your very first Arabic lesson already used this word once, in
+passing, as the reply to *shukran*. Here it gets its own full treatment —
+starting with a root that literally means "to erase."
+
+## The word, taken apart
+
+**عفوا** (*ʿafwan*), root **ʿ-f-w** (**ع-ف-و**): the root's core sense is
+"**to erase, obliterate, remove**" — and "to pardon, forgive" grows
+directly out of that, since forgiving something is, metaphorically,
+**erasing** it. The same root gives **العفو** (*al-ʿAfuww*, "**the Supreme
+Pardoner**"), one of the **99 names of Allah** in Islamic tradition.
+
+## Be honest: ʿafwan does more than one job
+
+**ʿAfwan** answers *shukran* as "**you're welcome**" — but depending on
+tone and context, the exact same word also does duty as "**excuse me**,"
+"**pardon**," or "**sorry**." One root, one word, several closely related
+jobs — all growing from that same "erase/pardon" sense.
+
+## Grammar Lens: the same ending as shukran itself
+
+Look closely at the spelling: **عفوا** ends in the same **tanwīn fatḥ**
+("**-an**") you already met in **شكرا** (*shukran*) — the indefinite
+accusative ending. Neither word is a full sentence with its own verb; both
+are fixed, idiomatic accusative forms functioning as a complete
+conversational turn on their own. The grammar you learned once, for
+*shukran*, already explains *ʿafwan* too.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "عفوا" — *ʿafwan*, "you're welcome"]
+- [YOU SAY: the root ʿ-f-w — "to erase" → "to pardon"]
+- [YOU SAY: the shared ending — shukran and ʿafwan both end in the same
+  tanwīn fatḥ, "-an"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the root **ʿ-f-w** literally mean, before it comes to
+mean "pardon"? (**"To erase, obliterate."**) Besides "you're welcome," what
+other jobs can **ʿafwan** do? (**"Excuse me," "pardon," "sorry"** —
+context-dependent.) What grammatical ending does *ʿafwan* share with
+*shukran*? (The **tanwīn fatḥ**, "-an" — both are fixed indefinite-
+accusative forms, not full sentences.)

--- a/code/learning/human-languages/arabic/lessons/AR-C24-ila-al-ghad.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C24-ila-al-ghad.md
@@ -1,0 +1,60 @@
+---
+id: AR-C24-ila-al-ghad
+chapter: 24
+type: phrase
+headword: إلى الغد
+gloss: "see you tomorrow — literally 'until tomorrow', reusing the same ilā ('until') already met in see you later"
+romanization: ilā l-ghad
+concept_tag: AR-FAREWELL-TOMORROW
+prerequisites: [AR-C04-ila-liqaa]
+sounds: [ghayn, sun-letter-assimilation]
+roots: [gh-d-w]
+etymology_hook: "إلى الغد (ilā l-ghad), 'until tomorrow,' reuses إلى (ilā, 'until') from ilā l-liqāʾ; الغد (al-ghad, 'tomorrow') is root gh-d-w, whose core sense is 'to go out at dawn, early morning' — the same 'morning becomes tomorrow' shift already seen in Latin's māne→mañana/demain, an honest cross-language echo, not a coincidence unique to Romance"
+est_minutes: 5
+reviews_of: [AR-C04-ila-liqaa]
+---
+
+# إلى الغد (ilā l-ghad) — "see you tomorrow," the same ilā again
+
+## Warm-up
+
+[PAUSE 2s] You already have the pattern: **ilā** + a future point = "see
+you [then]." Here it is again, with "tomorrow" filling the slot.
+
+## The two pieces, one already familiar
+
+**إلى الغد** (*ilā l-ghad*) = "**until tomorrow**":
+
+- **إلى** (*ilā*) — "**until**," the exact same word from *ilā l-liqāʾ*
+  ("see you [later]").
+- **الغد** (*al-ghad*) — "**tomorrow**," root **gh-d-w** (غ-د-و).
+- Note **ل** is a sun letter, so *al-ghad* would assimilate — but **غ**
+  (*ghayn*) is a **moon letter**, so here the *l* stays put: *al-ghad*, not
+  doubled the way *al-liqāʾ* and *as-salāma* were.
+
+## The root: another "morning becomes tomorrow" story
+
+**Gh-d-w**'s core sense is "**to go out at dawn, early morning**" — and
+**"tomorrow"** grows directly out of that "early morning" sense. This is
+**not** a one-off coincidence: you've already seen this **exact** shift
+happen in Latin, where *māne* ("morning") became French's *demain* and
+Spanish's *mañana* ("tomorrow"). Two completely unrelated language
+families — Semitic and Indo-European — independently building "tomorrow"
+out of "morning."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ilā l-ghad" — "until tomorrow"]
+- [YOU SAY: the reused piece — ilā, already known from ilā l-liqāʾ]
+- [YOU SAY: the root echo — gh-d-w, "dawn/morning" → "tomorrow," the same
+  shift as Latin māne → mañana/demain]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What word does **ilā l-ghad** share with **ilā l-liqāʾ**?
+(**Ilā**, "until.") What does the root **gh-d-w** literally mean, before it
+comes to mean "tomorrow"? (**"To go out at dawn, early morning."**) Is this
+morning-to-tomorrow shift unique to Arabic? (**No** — Latin's *māne*
+("morning") independently became French's *demain* and Spanish's *mañana*,
+"tomorrow," the same way.)

--- a/code/learning/human-languages/french/lessons/FR-C09-mois.md
+++ b/code/learning/human-languages/french/lessons/FR-C09-mois.md
@@ -8,7 +8,7 @@ concept_tag: FR-MONTHS
 prerequisites: [FR-C06-nombres-6-10, FR-C07-jours-1]
 sounds: [nasal-an, silent-final]
 roots: [latin-months, roman-gods]
-etymology_hook: "the French months are Roman gods and emperors: janvier←Janus, mars←Mars (= mardi!), juillet←Julius Caesar; septembre–décembre still mean Latin 7–10"
+etymology_hook: "the French months are Roman gods and emperors: janvier←Janus, mars←Mars (= mardi!); septembre–décembre still mean Latin 7–10 — not because Julius/Augustus added months, but because January/February were added centuries earlier"
 est_minutes: 5
 reviews_of: [FR-C06-nombres-6-10, FR-C07-jours-1]
 ---
@@ -32,8 +32,8 @@ numbers 7–10 from the counting chapter.
 | **avril** | *Aprilis* | perhaps *aperire* "to **open**" (buds opening) |
 | **mai** | *Maius* | **Maia**, goddess of growth |
 | **juin** | *Junius* | **Juno**, queen of the gods |
-| **juillet** | *Julius* | **Julius Caesar** (he inserted this month) |
-| **août** | *Augustus* | the emperor **Augustus** (he inserted this one) |
+| **juillet** | *Julius* | originally *Quintilis*, "the 5th [month]" — **renamed** for **Julius Caesar** after his death |
+| **août** | *Augustus* | originally *Sextilis*, "the 6th [month]" — **renamed** for the emperor **Augustus** |
 | **septembre** | *september* | "**7th**" (*septem*) |
 | **octobre** | *october* | "**8th**" (*octo*) |
 | **novembre** | *november* | "**9th**" (*novem*) |
@@ -44,9 +44,14 @@ Two payoffs land at once:
 - **mars = Mars = mardi.** The month and the weekday honour the *same* war-god —
   *Martius* (his month) and *Martis diēs* (his day). Spot one, you know the other.
 - **The 7–10 months.** *Septembre* through *décembre* still carry *septem, octo,
-  novem, decem* — because the old Roman year began in **March**, so September really
-  was the 7th month. Then **Julius** and **Augustus** shoved two months in
-  (*juillet, août*), and the counting slid out of place — but the names stuck.
+  novem, decem* — because the old Roman year originally began in **March**,
+  with September genuinely the 7th month. Centuries before Caesar, two new
+  months (Januarius, Februarius) were added at the front to cover the
+  winter, pushing every later month's number out of step with its name.
+  **Julius** and **Augustus** had nothing to do with that shift: they simply
+  got two already-existing months — *Quintilis* and *Sextilis*, literally
+  "5th" and "6th" — **renamed** in their honour after the fact. The names
+  stuck; the months themselves were never new.
 
 ## Guided Practice
 
@@ -59,6 +64,9 @@ Two payoffs land at once:
 ## Wrap-up Recall
 
 [PAUSE 3s] Which god links *mars* and *mardi*? (**Mars**, the war-god — his month
-and his day.) Why is *décembre* Latin for "ten"? (The Roman year began in March.)
-Which two months are named for **people**, not gods? (*Juillet* — Julius Caesar;
-*août* — Augustus.) Next: the **seasons**.
+and his day.) Why is *décembre* Latin for "ten"? (**The Roman year began in
+March**, and adding January/February at the front later pushed every month's
+number out of step with its name.) Did Julius Caesar and Augustus **add** new
+months to the calendar? (**No** — *juillet* and *août* were already-existing
+months, *Quintilis* and *Sextilis* ("5th"/"6th"), simply **renamed** in their
+honour.) Next: the **seasons**.

--- a/code/learning/human-languages/french/lessons/FR-C20-je-suis-desole.md
+++ b/code/learning/human-languages/french/lessons/FR-C20-je-suis-desole.md
@@ -1,0 +1,71 @@
+---
+id: FR-C20-je-suis-desole
+chapter: 20
+type: phrase
+headword: je suis désolé(e)
+gloss: I'm sorry (literally "I am desolate")
+concept_tag: COURTESY-SORRY
+prerequisites: [FR-C19-sil-vous-plait]
+sounds: [nasal-vowel, silent-final-e, liaison]
+roots: [desolare-latin]
+etymology_hook: "désolé ← Latin dēsōlāre 'to make utterly alone' (dē- + sōlus 'alone') — cousin of English desolate, solo, sole, solitary"
+est_minutes: 4
+reviews_of: [FR-C19-sil-vous-plait]
+---
+
+# je suis désolé(e) — "I'm sorry" (literally "I am desolate")
+
+## Warm-up
+
+[PAUSE 2s] You already know **s'il vous plaît**, "please" — "if it pleases
+you." French's "sorry" is, secretly, a much bigger word than it sounds:
+**désolé** is the same word as English **desolate**.
+
+## The phrase, taken apart
+
+- **je suis** = "**I am**."
+- **désolé** (feminine **désolée**) = "**sorry**," but literally "**made utterly
+  alone / devastated.**" It comes from Latin **dēsōlāre**, "to make solitary" —
+  **dē-** ("thoroughly, completely") + **sōlus** ("alone"), the very root of
+  English **sole**, **solo**, **solitary**, and **desolate** itself.
+
+So **je suis désolé(e)** literally says "**I am desolate**" — French reaches for
+a word of real devastation to say a plain "sorry," the way English keeps
+"terribly sorry" as an option rather than a requirement.
+
+## Be honest about the other words: pardon and excusez-moi
+
+French keeps two more courtesy words for different jobs:
+
+- **pardon** — a quick, all-purpose "sorry / pardon me" (bumping someone,
+  a small slip). It comes from **pardonner**, Latin **per-** ("thoroughly") +
+  **dōnāre** ("to give") — "to give completely," i.e. to forgive. The neat part
+  isn't that French and Spanish coined this separately — it's that they
+  **didn't have to**: **perdōnāre** was already one word in Late Latin, so
+  French *pardonner* and Spanish *perdón/perdonar* are simply two children of
+  the *same* inherited word, not two languages independently landing on the
+  same idea.
+- **excusez-moi** — "**excuse me**," from **excuser** < Latin **ex-** ("out
+  of, free from") + **causa** ("cause, charge") — literally "to free from a
+  charge." Reach for this to get someone's **attention**, not to apologize for
+  a real fault.
+
+**Je suis désolé(e)** carries the most **regret**; **pardon** is the quick,
+light reflex; **excusez-moi** is for getting attention. Native speakers slide
+between all three by feel.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "désolé" — sorry / desolate — then "je suis désolé," I am sorry]
+- [YOU SAY: the quick one — "pardon"]
+- [YOU SAY: the attention one — "excusez-moi"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **désolé** literally mean, and what English word is it
+identical to? (**"Made utterly alone"** — the same word as English
+**desolate**.) What is **pardon** built from, and why does **Spanish perdón** look just like
+it? (**Per- "thoroughly" + dōnāre "to give"** — both simply inherited the
+*same* already-formed Latin word, **perdōnāre**.) What's **excusez-moi**
+for? (**Getting someone's attention**, not apologizing for a real fault.)

--- a/code/learning/human-languages/french/lessons/FR-C21-le-temps.md
+++ b/code/learning/human-languages/french/lessons/FR-C21-le-temps.md
@@ -1,0 +1,64 @@
+---
+id: FR-C21-le-temps
+chapter: 21
+type: phrase
+headword: le temps, il pleut
+gloss: weather — le temps means BOTH "time" and "weather," the SAME Latin tempus polysemy as Spanish's tiempo; il pleut keeps Latin's pl- UNCHANGED, unlike Spanish's llueve
+concept_tag: FR-WEATHER
+prerequisites: [FR-C14-age]
+sounds: [nasal-en, silent-final]
+roots: [tempus-latin, pluere-latin]
+etymology_hook: "le temps means BOTH 'time' and 'weather' — the exact same Latin tempus double sense as Spanish's tiempo (this widening happened within Latin itself, shared by both languages, not a Spanish-only development); il fait chaud/froid reuse faire ('to make'), just like Spanish's hacer; il pleut ('it's raining') KEEPS Latin pluere's pl- unchanged, unlike Spanish's llueve, which underwent the pl-→ll- shift"
+est_minutes: 5
+reviews_of: [FR-C14-age]
+---
+
+# le temps, il pleut — the same Latin word, a different fate for "rain"
+
+## Warm-up
+
+[PAUSE 2s] You've seen Spanish's *tiempo* mean both "time" and "weather" at
+once, from Latin *tempus*. French has the exact same word, the exact same
+double meaning — because this widening happened within Latin itself, before
+French and Spanish went their separate ways.
+
+## le temps — time AND weather, again
+
+**le temps** = both "**time**" and "**weather**" — from Latin **tempus**,
+same as Spanish's *tiempo* (English kept only the "time" half: **temporal,
+tempo**). So **quel temps fait-il ?** ("what's the weather like?") is
+literally "**what time does it make**?" — the identical construction you met
+in Spanish's *¿qué tiempo hace?*.
+
+## il fait chaud / il fait froid — reusing faire, like Spanish's hacer
+
+> **Il fait chaud.** — "It's hot." — literally "it **makes** hot."
+> **Il fait froid.** — "It's cold." — literally "it **makes** cold."
+
+Same *hacer*-style periphrasis as Spanish, just with French's own **faire**
+("to make/do").
+
+## il pleut — Latin's pl- kept intact, unlike Spanish's llueve
+
+> **Il pleut.** — "It's raining." — from **pleuvoir** ← Latin **pluere**, "to
+  rain" — the **same** Latin verb behind Spanish's *llueve*. But here's the
+  honest difference: Spanish underwent the **pl- → ll-** shift (*pluere* →
+  *llover*), while French kept the **pl-** cluster fully intact — *pleuvoir*
+  still visibly starts with *pl-*, just like the Latin original. So the same
+  Latin verb took two different sound-change paths in its two daughters: one
+  eroded the cluster, one preserved it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "le temps" — time, or weather, depending on context]
+- [YOU SAY: "il fait chaud. il fait froid." — it's hot/cold]
+- [YOU SAY: "il pleut" — it's raining, pl- kept intact from Latin]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two things does **le temps** mean, and where does this
+polysemy come from? (**"Time"** and **"weather"** — from Latin *tempus*,
+already double-sensed before French/Spanish split apart.) Does French's *il
+pleut* show the same *pl- → ll-* shift as Spanish's *llueve*? (**No** — French
+kept the *pl-* cluster intact; only Spanish underwent that shift.)

--- a/code/learning/human-languages/french/lessons/FR-C22-chien-chat.md
+++ b/code/learning/human-languages/french/lessons/FR-C22-chien-chat.md
@@ -1,0 +1,64 @@
+---
+id: FR-C22-chien-chat
+chapter: 22
+type: word
+headword: chien, chat
+gloss: dog and cat — chien is the REGULAR, expected descendant of canis (unlike Spanish's mysterious perro); chat continues cattus, the same Egypt-to-Rome story as Spanish's gato
+concept_tag: FR-ANIMALS
+prerequisites: [FR-C14-age]
+sounds: [ca-to-cha-shift, nasal-en]
+roots: [latin-canis-dog, latin-cattus-afroasiatic]
+etymology_hook: "chien is the fully REGULAR French descendant of Latin canis — the same ca- → cha- palatalization that also gives champ (← campus) and chanter (← cantāre) — unlike Spanish, which replaced canis-derived can with the still-unexplained perro; chat continues cattus, the same word (probably Afro-Asiatic, traveling with the cat out of Egypt) behind Spanish's gato and Italian's gatto"
+est_minutes: 6
+reviews_of: [FR-C14-age]
+---
+
+# chien, chat — the regular one, and the well-traveled one
+
+## Warm-up
+
+[PAUSE 2s] You've met Spanish's *perro*, a genuine unsolved mystery, and
+Latin's own *canis*/*fēlēs*→*cattus* history. French's two animal words tell
+a cleaner story: one is perfectly regular, the other is the same well-
+documented word you already know.
+
+## chien — the regular, expected descendant of canis
+
+**chien** ("**dog**") comes straight from Latin **canis** (accusative
+*canem*) — and unlike Spanish, French kept it. Two separate, regular changes
+are stacked here: the initial **c**→**ch** is the same **ca- → cha-**
+palatalization you can check against other Latin words — **campus** →
+**champ** ("field"), **cantāre** → **chanter** ("to sing"); the **a**→**ie**
+in the middle is a different, later shift specific to words like *canem*
+(known as Bartsch's Law — the outcome is completely regular and undisputed,
+even though the precise phonetic trigger is still debated). Put together,
+*chien* is a fully **regular** sound change, following French's own rules
+predictably — a genuinely different story from Spanish, where the expected
+descendant (*can*) got pushed aside by the still-unexplained *perro*.
+
+## chat — the same well-traveled word as gato
+
+**chat** ("**cat**") continues **cattus**, the same Late Latin word — most
+likely ultimately **Afro-Asiatic** (compare Nubian *kadis*) — that spread
+along Roman trade routes as domestic cats themselves spread out of **Egypt**.
+This is the identical word behind Spanish's *gato* and Italian's *gatto* —
+French, Spanish, and Italian all independently inherited the exact same Late
+Latin replacement for Classical *fēlēs*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "chien" — dog, the regular descendant of canis]
+- [YOU SAY: "champ, chanter" — the same ca- → cha- shift, in field and to
+  sing]
+- [YOU SAY: "chat" — cat, the same word as Spanish's gato, from Egypt via
+  Rome]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is *chien* a regular or irregular descendant of Latin *canis*?
+(**Regular** — the same *ca- → cha-* shift as *champ* and *chanter*.) Does
+French show the same *perro*-style mystery Spanish does for "dog"? (**No**
+— French kept the expected Latin word.) What word does *chat* continue, and
+where did that word most likely originate? (**Cattus**, most likely
+**Afro-Asiatic**, traveling with the cat out of **Egypt**.)

--- a/code/learning/human-languages/french/lessons/FR-C23-vert-jaune.md
+++ b/code/learning/human-languages/french/lessons/FR-C23-vert-jaune.md
@@ -3,12 +3,12 @@ id: FR-C23-vert-jaune
 chapter: 23
 type: word
 headword: vert, jaune
-gloss: green and yellow — vert is the standard, expected Latin viridis descendant shared by nearly every Romance language; jaune comes from a Latin word that literally meant "yellow-GREEN," and shares its ultimate PIE root with German's gelb
+gloss: green and yellow — vert is the standard, expected Latin viridis descendant shared by nearly every Romance language; jaune comes from a Latin word that literally meant "yellow-GREEN," and is usually said to share its ultimate PIE root with German's gelb, though that particular link is less secure than it first appears
 concept_tag: FR-COLOUR-GREEN-YELLOW
 prerequisites: [FR-C22-chien-chat]
 sounds: [nasal-en, diphthong-au]
 roots: [latin-viridis-vireo, latin-galbinus-shine]
-etymology_hook: "vert ← Latin viridis, the standard source of 'green' across nearly every Romance language (Spanish verde, Italian verde, Portuguese verde); jaune ← Latin galbinus, literally 'yellow-GREEN' — an extended form of galbus, from PIE *ghel-, 'to shine' — the SAME ultimate PIE root behind German's gelb, making jaune and gelb genuine deep cousins despite arriving by completely separate Romance/Germanic paths"
+etymology_hook: "vert ← Latin viridis, the standard source of 'green' across nearly every Romance language (Spanish verde, Italian verde, Portuguese verde); jaune ← Latin galbinus, literally 'yellow-GREEN' — an extended form of galbus, usually traced to PIE *ghel-, 'to shine,' the same root claimed for German's gelb — though modern Latin scholarship treats galbus's origin as genuinely unknown, so treat jaune/gelb as probable, not certain, cousins"
 est_minutes: 6
 reviews_of: [FR-C22-chien-chat]
 ---
@@ -34,26 +34,30 @@ surprise here — a clean, shared inheritance.
 "**yellow-green**" — an extended form of **galbus**, from **Proto-Indo-
 European** ***\*ghel-***, "**to shine**" (with derivatives covering green,
 yellow, and gold alike — the same root gives Greek *khlōros*, "greenish-
-yellow"). Here's the genuinely surprising part: this **exact same PIE
-root**, ***\*ghel-***, is also the source of **German**'s **gelb** and
-English's **yellow** — by a completely separate, Germanic path (Proto-
-Germanic ***\*gelwaz***). So *jaune* and *gelb* are true **cousins**, all the
-way back at the Proto-Indo-European level, despite one reaching French
-through Latin and the other reaching German directly through Germanic.
+yellow"). Here's the genuinely surprising part: this **same PIE root**,
+***\*ghel-***, is also usually cited as the source of **German**'s **gelb**
+and English's **yellow** — by a completely separate, Germanic path (Proto-
+Germanic ***\*gelwaz***). Honesty check, though: the *galbus*→*\*ghel-* link
+itself is **less secure** than it looks — some modern Latin scholarship
+treats *galbus*'s origin as unknown rather than confirming the connection.
+So *jaune* and *gelb* are **probably** cousins at the Proto-Indo-European
+level, despite one reaching French through Latin and the other reaching
+German directly through Germanic — just don't treat that link as airtight.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "vert" — green, the standard Romance word]
 - [YOU SAY: "jaune" — yellow, literally "yellow-green"]
-- [YOU SAY: the hidden cousin — "jaune, gelb" — same ancient PIE root, two
-  completely different paths]
+- [YOU SAY: the probable cousin — "jaune, gelb" — likely the same ancient
+  PIE root, two completely different paths, though the link isn't airtight]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Is **vert** a typical or unusual Romance word for "green"?
 (**Typical** — the standard source across nearly all Romance languages.)
 What did Latin **galbinus**, the source of *jaune*, literally mean?
-("**Yellow-green**.") What German word turns out to be *jaune*'s deep PIE
-cousin? (**Gelb** — both from PIE *\*ghel-*, "to shine," though by completely
-separate Romance and Germanic paths.)
+("**Yellow-green**.") What German word is usually called *jaune*'s deep PIE
+cousin, and how solid is that link? (**Gelb** — both usually traced to PIE
+*\*ghel-*, "to shine," though modern Latin scholarship treats *galbus*'s
+origin as genuinely unknown, so the connection is probable, not certain.)

--- a/code/learning/human-languages/french/lessons/FR-C23-vert-jaune.md
+++ b/code/learning/human-languages/french/lessons/FR-C23-vert-jaune.md
@@ -1,0 +1,59 @@
+---
+id: FR-C23-vert-jaune
+chapter: 23
+type: word
+headword: vert, jaune
+gloss: green and yellow — vert is the standard, expected Latin viridis descendant shared by nearly every Romance language; jaune comes from a Latin word that literally meant "yellow-GREEN," and shares its ultimate PIE root with German's gelb
+concept_tag: FR-COLOUR-GREEN-YELLOW
+prerequisites: [FR-C22-chien-chat]
+sounds: [nasal-en, diphthong-au]
+roots: [latin-viridis-vireo, latin-galbinus-shine]
+etymology_hook: "vert ← Latin viridis, the standard source of 'green' across nearly every Romance language (Spanish verde, Italian verde, Portuguese verde); jaune ← Latin galbinus, literally 'yellow-GREEN' — an extended form of galbus, from PIE *ghel-, 'to shine' — the SAME ultimate PIE root behind German's gelb, making jaune and gelb genuine deep cousins despite arriving by completely separate Romance/Germanic paths"
+est_minutes: 6
+reviews_of: [FR-C22-chien-chat]
+---
+
+# vert, jaune — the expected inheritance, and a hidden PIE-level cousin
+
+## Warm-up
+
+[PAUSE 2s] French's green word is exactly what you'd expect. Its yellow word
+hides something you won't expect at all — a secret cousin sitting inside
+German.
+
+## vert — the standard Romance inheritance
+
+**vert** ("**green**") ← Latin **viridis** — and this is genuinely the
+**standard** source of "green" across nearly every Romance language:
+Spanish *verde*, Italian *verde*, Portuguese *verde*, Catalan *verd*. No
+surprise here — a clean, shared inheritance.
+
+## jaune — literally "yellow-GREEN," and a secret cousin of German's gelb
+
+**jaune** ("**yellow**") ← Latin **galbinus**, which literally meant
+"**yellow-green**" — an extended form of **galbus**, from **Proto-Indo-
+European** ***\*ghel-***, "**to shine**" (with derivatives covering green,
+yellow, and gold alike — the same root gives Greek *khlōros*, "greenish-
+yellow"). Here's the genuinely surprising part: this **exact same PIE
+root**, ***\*ghel-***, is also the source of **German**'s **gelb** and
+English's **yellow** — by a completely separate, Germanic path (Proto-
+Germanic ***\*gelwaz***). So *jaune* and *gelb* are true **cousins**, all the
+way back at the Proto-Indo-European level, despite one reaching French
+through Latin and the other reaching German directly through Germanic.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vert" — green, the standard Romance word]
+- [YOU SAY: "jaune" — yellow, literally "yellow-green"]
+- [YOU SAY: the hidden cousin — "jaune, gelb" — same ancient PIE root, two
+  completely different paths]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **vert** a typical or unusual Romance word for "green"?
+(**Typical** — the standard source across nearly all Romance languages.)
+What did Latin **galbinus**, the source of *jaune*, literally mean?
+("**Yellow-green**.") What German word turns out to be *jaune*'s deep PIE
+cousin? (**Gelb** — both from PIE *\*ghel-*, "to shine," though by completely
+separate Romance and Germanic paths.)

--- a/code/learning/human-languages/german/lessons/GE-C04-bis-spater.md
+++ b/code/learning/human-languages/german/lessons/GE-C04-bis-spater.md
@@ -1,0 +1,71 @@
+---
+id: GE-C04-bis-spater
+chapter: 4
+type: phrase
+headword: bis später
+gloss: see you later (literally "until later")
+concept_tag: FAREWELL-LATER
+prerequisites: [GE-C04-bis-bald, GE-C04-bis-morgen]
+sounds: [a-umlaut-long]
+roots: [spat-german]
+etymology_hook: "bis ('until') + später (comparative of spät, 'late'); unlike bald (→ English bold) and Morgen (→ English morning/morrow), spät has no established English cognate (English 'late' is a false friend, actually related to German laß, 'idle, weary,' a completely different root) — it's already attested as Gothic spēdiza ('later') some 1,500-1,700 years ago, and beyond that, some German dictionaries (Pfeifer/DWDS) only speculate a distant, unconfirmed link to the root behind sparen ('to spare') and sputen ('to hurry')"
+est_minutes: 3
+reviews_of: [GE-C04-bis-bald, GE-C04-bis-morgen]
+---
+
+# bis später — "see you later," the one without an English cousin
+
+## Warm-up
+
+[PAUSE 2s] The last two "bis" farewells each had a satisfying English
+cousin — *bald*/bold, *Morgen*/morning. This one is honest about not
+having one.
+
+## Sounds you'll need
+
+- `a-umlaut-long` — **später** = *SHPĀ-ter*, with a long, umlauted *ä* (like
+  English "air" without the *r*-color). Whole phrase: *biss SHPĀ-ter*.
+
+## The phrase, taken apart
+
+> **bis später** = "until later" → "see you later."
+
+- **bis** = "until" (already met).
+- **später** = "later" — the **comparative** form of **spät**, "late."
+
+## Be honest: no tidy English cousin this time
+
+Unlike *bald* (→ English **bold**) and *Morgen* (→ English **morning**/
+**morrow**), **spät** has **no established English cousin**. (Careful:
+English "**late**" is a false friend here — same meaning, but actually
+related to German *laß*, "idle, weary," a completely different root.)
+Gothic, the earliest recorded Germanic language, already had **spēdiza**
+("later") and **spēdists** ("last, latest") some 1,500–1,700 years ago —
+and past that, the trail goes cold: some German dictionaries only
+speculate a distant, unconfirmed link to the root behind *sparen* ("to
+spare") and *sputen* ("to hurry"). Not every German word connects neatly
+to an English one; this is one of the honest, unresolved cases.
+
+## Grammar Lens: the "bis …" farewells, now complete
+
+German's full soft-goodbye set is now genuinely complete: **bis bald**
+(soon), **bis später** (later), **bis morgen** (tomorrow) — plus **auf
+Wiedersehen** (formal) and **tschüss** (casual).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bis später" — *biss SHPĀ-ter*]
+- [YOU SAY: später = comparative of spät, "late"]
+- [YOU SAY: the honest gap — spät has no established English cousin, unlike bald
+  or Morgen]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is **später**, grammatically? (The **comparative** of
+*spät*, "late.") Does *spät* have an established English cousin, the way
+*bald* and *Morgen* did? (**No** — attested as Gothic *spēdiza* some
+1,500–1,700 years ago, with only a speculative, unconfirmed link proposed
+beyond that; English "late" *looks* similar but is unrelated.) What are all
+three of German's "bis" farewells now? (**Bis bald, bis später, bis
+morgen** — soon, later, tomorrow.)

--- a/code/learning/human-languages/german/lessons/GE-C21-das-wetter.md
+++ b/code/learning/human-languages/german/lessons/GE-C21-das-wetter.md
@@ -1,0 +1,63 @@
+---
+id: GE-C21-das-wetter
+chapter: 21
+type: phrase
+headword: das Wetter, es regnet
+gloss: weather — a NATIVE Germanic word, unlike Romance's shared Latin tempus family; Wetter is the SAME word as English "weather," and regnet is the SAME word as English "rain"
+concept_tag: GE-WEATHER
+prerequisites: [GE-C14-alter]
+sounds: [w-as-v, umlaut-none]
+roots: [germanic-wetter-weather, germanic-regen-rain]
+etymology_hook: "das Wetter is a native Germanic word (Proto-Germanic *wedrą) — the SAME word as English 'weather' itself, not a Latin loan like every Romance language's tempus-based word; es regnet ('it's raining') is likewise native, from Proto-Germanic *regnōną — the SAME root as English 'rain'"
+est_minutes: 5
+reviews_of: [GE-C14-alter]
+---
+
+# das Wetter, es regnet — German's own native words, English's own cousins
+
+## Warm-up
+
+[PAUSE 2s] Every Romance language you've met so far shares the exact same
+Latin word for "weather" (*tempus*). German breaks completely from that
+family — with a word that's actually a much closer cousin of English.
+
+## das Wetter — native Germanic, the same word as English "weather"
+
+**das Wetter** = "**weather**" — from Proto-Germanic ***wedrą*** — the
+**exact same word** as English **weather** itself (both descend from the same
+Germanic ancestor, not one borrowed from the other). Unlike Spanish's
+*tiempo*, French's *temps*, or Latin's own *tempus*-family, German's weather
+word has **no connection to Latin at all** — it's a native Germanic
+inheritance, cousin to English rather than to Romance.
+
+## Es ist heiß / Es ist kalt — sein, matching German's own pattern
+
+> **Es ist heiß.** — "It's hot." — literally "it **is** hot."
+> **Es ist kalt.** — "It's cold." — literally "it **is** cold."
+
+German uses **sein** ("to be") here — matching the same "**be**" pattern you
+already met in German's own AGE lesson (*ich bin zwanzig*), not the Romance
+"make" periphrasis (*hacer*/*faire*).
+
+## es regnet — also native, the same root as English "rain"
+
+> **Es regnet.** — "It's raining." — from **regnen** ← Proto-Germanic
+  ***regnōną*** — the **same root** as English **rain**. Just like *Wetter*/
+  "weather," this is a genuine Germanic cousin-pair, not a shared Latin
+  borrowing the way Spanish's *llueve* and French's *pleut* are.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Wetter" — weather, the same word as English "weather"]
+- [YOU SAY: "Es ist heiß. Es ist kalt." — it's hot/cold]
+- [YOU SAY: "Es regnet" — it's raining, same root as English "rain"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **Wetter** come from Latin, like the Romance languages'
+weather words? (**No** — it's native Germanic, the same word as English
+"weather.") What verb does German use for "it's hot/cold" — *sein* ("be") or
+a *hacer*-style "make"? (***Sein***, "to be" — matching German's own AGE
+pattern.) What English word is **regnet** related to? (**Rain** — same
+Proto-Germanic root, *regnōną*.)

--- a/code/learning/human-languages/german/lessons/GE-C22-hund-katze.md
+++ b/code/learning/human-languages/german/lessons/GE-C22-hund-katze.md
@@ -1,0 +1,68 @@
+---
+id: GE-C22-hund-katze
+chapter: 22
+type: word
+headword: Hund, Katze
+gloss: dog and cat — Hund is native Germanic, cognate with English's OWN discarded word "hound"; Katze, surprisingly, is NOT native — it's the same borrowed Latin word behind French chat and Spanish gato (though not every European language shares it)
+concept_tag: GE-ANIMALS
+prerequisites: [GE-C14-alter]
+sounds: [u-umlaut-none, tz-affricate]
+roots: [germanic-hund-dog, latin-cattus-afroasiatic]
+etymology_hook: "Hund is native Germanic (Proto-Indo-European *kwon-), cognate with English's OWN 'hound' — the word English ITSELF replaced with the still-unexplained 'dog,' the same shape of mystery as Spanish's perro; Katze, surprisingly, is NOT native Germanic at all — like French/Spanish/Italian, German borrowed the same Late Latin cattus, so 'cat' words are remarkably widespread across Germanic AND Romance (though NOT every European language: Romanian and much of South Slavic use their own onomatopoeic cat-words instead), while 'dog' words go their own separate ways almost everywhere"
+est_minutes: 6
+reviews_of: [GE-C14-alter]
+---
+
+# Hund, Katze — one native word, one surprising loan
+
+## Warm-up
+
+[PAUSE 2s] Here's a real surprise to end this comparison on: German's word
+for "dog" is native and expected — but its word for "cat" secretly isn't
+native at all.
+
+## Hund — native Germanic, and English's own abandoned twin
+
+**Hund** ("**dog**") is native Germanic, from **Proto-Indo-European**
+***\*ḱwon-*** — and it has a direct cousin sitting inside English itself:
+**hound**. Old English **hund** was the ordinary, everyday word for "dog"
+for centuries — until, for reasons nobody fully understands, **dog**
+(Old English *docga*) pushed it out by the 16th century, leaving *hound* to
+narrow down to just hunting dogs. English's *dog* is, honestly, its **own**
+unexplained mystery word, with no confirmed cognates in any other
+language — the exact same *shape* of story as Spanish's *perro* displacing
+*can*, just in a completely different language family.
+
+## Katze — surprisingly NOT native
+
+Here's the twist: **Katze** ("**cat**") looks like it should be native
+Germanic too, sitting right next to native *Hund* — but it isn't. **Katze**
+descends from Proto-Germanic **\*kattuz**, which is itself a borrowing of the
+**same Late Latin cattus** you already met with French's *chat* and Spanish's
+*gato* — most likely ultimately **Afro-Asiatic**, traveling out of Egypt
+along Roman trade routes. Every Germanic language shows this **same**
+borrowing (Dutch *kat*, Swedish *katt*, Icelandic *köttur*) — so unlike "dog"
+words, which go their own separate ways in nearly every language, "cat"
+words are remarkably **widespread** across both Germanic and Romance,
+because the word traveled **with the animal itself**. Be honest that this
+isn't a universal rule, though: **Romanian** (*pisică*) and much of **South
+Slavic** (Serbian/Croatian *mačka*) built their own onomatopoeic cat-words
+instead, imitating the sound of a cat's call rather than inheriting *cattus*
+— so the spread is wide, but not without real exceptions.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Hund" — dog, native Germanic, cousin of English "hound"]
+- [YOU SAY: the parallel — English replaced "hound" with the still-mysterious
+  "dog," the same shape as Spanish's perro/can]
+- [YOU SAY: "Katze" — cat, surprisingly a Latin loanword, not native at all]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **Hund** native Germanic, and what's its English cousin? (**Yes**
+— cousin of English **hound**.) What word did English replace *hound* with,
+and is that word's origin known? (**Dog** — genuinely **unexplained**, no
+confirmed cognates anywhere.) Is **Katze** native Germanic? (**No** —
+surprisingly, it's the same borrowed Late Latin *cattus* behind French's
+*chat* and Spanish's *gato*.)

--- a/code/learning/human-languages/german/lessons/GE-C23-gruen-gelb.md
+++ b/code/learning/human-languages/german/lessons/GE-C23-gruen-gelb.md
@@ -1,0 +1,60 @@
+---
+id: GE-C23-gruen-gelb
+chapter: 23
+type: word
+headword: grün, gelb
+gloss: green and yellow — grün is native Germanic, the direct cousin of English's OWN "green" (a different root entirely from Latin's viridis); gelb is native too, but shares its ultimate PIE root with French's jaune, despite the two words arriving by completely separate paths
+concept_tag: GE-COLOUR-GREEN-YELLOW
+prerequisites: [GE-C22-hund-katze]
+sounds: [umlaut-u, consonant-b-final]
+roots: [germanic-groeniz-grow, pie-ghel-shine]
+etymology_hook: "grün is native Germanic, the direct cousin of English's own 'green' (Proto-Germanic *grōniz, PIE *ǵʰreh₁-, 'to grow, become green') — a COMPLETELY DIFFERENT root from Latin's viridis, even though both independently mean 'grow' → 'green'; gelb is native too (Proto-Germanic *gelwaz), but shares its ultimate PIE root, *ghel- ('to shine'), with French's jaune — true cousins across the Germanic/Romance split"
+est_minutes: 6
+reviews_of: [GE-C22-hund-katze]
+---
+
+# grün, gelb — English's own cousin, and a secret cousin of French
+
+## Warm-up
+
+[PAUSE 2s] German's green word is a direct cousin of English's own word.
+Its yellow word has a cousin too — but a much more surprising one, sitting
+inside French.
+
+## grün — English's own cousin, NOT Latin's
+
+**grün** ("**green**") is native Germanic, from Proto-Germanic
+***\*grōniz***, ultimately from **Proto-Indo-European** ***\*ǵʰreh₁-***,
+"**to grow, to become green**" — the **exact same root** as English's own
+**green**. Be careful, though: this is a **completely different** root from
+Latin's **viridis** (source of Spanish's *verde*, French's *vert*), which
+traces to its own, separate "to grow/flourish" root, ***\*weis-***. Two
+unrelated language families each independently built a "green" word out of
+a verb meaning "to grow" — a real coincidence of logic, not a shared word.
+
+## gelb — a hidden cousin of French's jaune
+
+**gelb** ("**yellow**") is native too, from Proto-Germanic ***\*gelwaz*** —
+and the same word as English's **yellow**. But here's the honest surprise:
+trace it back far enough, to **Proto-Indo-European** ***\*ghel-*** ("**to
+shine**," with derivatives covering yellow, green, and gold), and you land
+on the **exact same ancient root** behind Latin's **galbus/galbinus** — the
+source of **French**'s **jaune**. So *gelb* and *jaune* are genuine PIE-level
+cousins, despite belonging to completely different language families and
+reaching German and French by entirely separate paths.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "grün" — green, direct cousin of English's own "green"]
+- [YOU SAY: "gelb" — yellow, hidden cousin of French's jaune]
+- [YOU SAY: the contrast — grün's root is unrelated to Latin's viridis, but
+  gelb's root IS shared with French's jaune]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **grün** related to Latin's *viridis*? (**No** — a completely
+different root, though both independently mean "grow" → "green"; *grün*
+IS a direct cousin of English's own "green.") What French word is **gelb**'s
+hidden PIE cousin? (**Jaune** — both from PIE *\*ghel-*, "to shine," despite
+Germanic and Romance reaching it by separate paths.)

--- a/code/learning/human-languages/german/lessons/GE-C23-gruen-gelb.md
+++ b/code/learning/human-languages/german/lessons/GE-C23-gruen-gelb.md
@@ -3,12 +3,12 @@ id: GE-C23-gruen-gelb
 chapter: 23
 type: word
 headword: grün, gelb
-gloss: green and yellow — grün is native Germanic, the direct cousin of English's OWN "green" (a different root entirely from Latin's viridis); gelb is native too, but shares its ultimate PIE root with French's jaune, despite the two words arriving by completely separate paths
+gloss: green and yellow — grün is native Germanic, the direct cousin of English's OWN "green" (a different root entirely from Latin's viridis); gelb is native too, and is usually said to share its ultimate PIE root with French's jaune, though that particular link is less secure than it first appears
 concept_tag: GE-COLOUR-GREEN-YELLOW
 prerequisites: [GE-C22-hund-katze]
 sounds: [umlaut-u, consonant-b-final]
 roots: [germanic-groeniz-grow, pie-ghel-shine]
-etymology_hook: "grün is native Germanic, the direct cousin of English's own 'green' (Proto-Germanic *grōniz, PIE *ǵʰreh₁-, 'to grow, become green') — a COMPLETELY DIFFERENT root from Latin's viridis, even though both independently mean 'grow' → 'green'; gelb is native too (Proto-Germanic *gelwaz), but shares its ultimate PIE root, *ghel- ('to shine'), with French's jaune — true cousins across the Germanic/Romance split"
+etymology_hook: "grün is native Germanic, the direct cousin of English's own 'green' (Proto-Germanic *grōniz, PIE *ǵʰreh₁-, 'to grow, become green') — a COMPLETELY DIFFERENT root from Latin's viridis, even though both independently mean 'grow' → 'green'; gelb is native too (Proto-Germanic *gelwaz), usually traced to the same ultimate PIE root, *ghel- ('to shine'), as French's jaune — though modern Latin scholarship treats jaune's Latin ancestor galbus as genuinely unknown in origin, so treat gelb/jaune as probable, not certain, cousins"
 est_minutes: 6
 reviews_of: [GE-C22-hund-katze]
 ---
@@ -35,26 +35,32 @@ a verb meaning "to grow" — a real coincidence of logic, not a shared word.
 ## gelb — a hidden cousin of French's jaune
 
 **gelb** ("**yellow**") is native too, from Proto-Germanic ***\*gelwaz*** —
-and the same word as English's **yellow**. But here's the honest surprise:
-trace it back far enough, to **Proto-Indo-European** ***\*ghel-*** ("**to
-shine**," with derivatives covering yellow, green, and gold), and you land
-on the **exact same ancient root** behind Latin's **galbus/galbinus** — the
-source of **French**'s **jaune**. So *gelb* and *jaune* are genuine PIE-level
-cousins, despite belonging to completely different language families and
-reaching German and French by entirely separate paths.
+and the same word as English's **yellow**. Trace it back far enough, to
+**Proto-Indo-European** ***\*ghel-*** ("**to shine**," with derivatives
+covering yellow, green, and gold), and it is usually said to land on the
+**same ancient root** behind Latin's **galbus/galbinus** — the source of
+**French**'s **jaune**. Honesty check, though: that particular link is
+**less secure** than it looks — some modern Latin scholarship treats
+*galbus*'s origin as genuinely unknown rather than confirming the *\*ghel-*
+connection. So *gelb* and *jaune* are **probably** PIE-level cousins,
+despite belonging to completely different language families and reaching
+German and French by entirely separate paths — just don't treat the link
+as airtight.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "grün" — green, direct cousin of English's own "green"]
-- [YOU SAY: "gelb" — yellow, hidden cousin of French's jaune]
+- [YOU SAY: "gelb" — yellow, probable hidden cousin of French's jaune]
 - [YOU SAY: the contrast — grün's root is unrelated to Latin's viridis, but
-  gelb's root IS shared with French's jaune]
+  gelb's root is PROBABLY shared with French's jaune]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Is **grün** related to Latin's *viridis*? (**No** — a completely
 different root, though both independently mean "grow" → "green"; *grün*
 IS a direct cousin of English's own "green.") What French word is **gelb**'s
-hidden PIE cousin? (**Jaune** — both from PIE *\*ghel-*, "to shine," despite
-Germanic and Romance reaching it by separate paths.)
+probable PIE cousin, and how solid is that link? (**Jaune** — both usually
+traced to PIE *\*ghel-*, "to shine," though modern Latin scholarship treats
+*galbus*'s origin as genuinely unknown, so the connection is probable, not
+certain.)

--- a/code/learning/human-languages/hindi/lessons/HI-C09-maaf-kijiye.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C09-maaf-kijiye.md
@@ -1,0 +1,65 @@
+---
+id: HI-C09-maaf-kijiye
+chapter: 9
+type: phrase
+headword: माफ़ कीजिए
+gloss: please forgive me / sorry (māf kījiye — "please do forgiveness")
+concept_tag: COURTESY-SORRY
+prerequisites: [HI-C08-kripaya]
+sounds: [nukta-f, vocalic-i-long]
+roots: [afw-arabic-via-persian, kar-hindi]
+etymology_hook: "माफ़ कीजिए māf kījiye = borrowed Persian/Arabic māf 'forgiven' + Hindi kījiye 'please do' — the same light-verb pattern as kṛpayā's family"
+est_minutes: 4
+reviews_of: [HI-C08-kripaya]
+---
+
+# माफ़ कीजिए (māf kījiye) — please forgive me / sorry
+
+## Warm-up
+
+[PAUSE 2s] You already know the formal **कृपया** (*kṛpayā*), "please." Hindi's
+everyday "sorry" is built the same way you build a request: **name the
+kindness, ask for it to be done.**
+
+## The phrase, taken apart
+
+- **माफ़** (*māf*) = "**forgiven, pardoned**" — not a native Hindi word at all!
+  It's borrowed through **Persian** from **Arabic** **عفو** (*ʿafw*), "to
+  pardon, efface, wipe away [a wrong]." Look closely at the spelling: the dot
+  under फ (called a **nuqtā**) turns the plain *pha* sound into **fa** —
+  Hindi's way of writing sounds that arrived from Persian and Arabic.
+- **कीजिए** (*kījiye*) = the **respectful imperative** "**please do**," from
+  **करना** (*karnā*), "to do."
+
+So **माफ़ कीजिए** is literally "**please do forgiven[-ness]**" — *please make
+[this] forgiven.* It's the same light-verb move you've already met: naming a
+state (forgiveness, kindness, compassion) and asking someone to *do* it.
+
+## Be honest about register — and about English creeping in
+
+**माफ़ कीजिए** is warm and genuinely everyday — but Hindi keeps a **more
+formal, Sanskritic** cousin for writing and ceremony: **क्षमा करें** (*kṣamā
+karēṁ*), "please grant **kṣamā**" — from Sanskrit **क्षमा** (*kṣamā*),
+"patience, forbearance, forgiveness." Where *kṛpayā* was the bookish "please,"
+**kṣamā karēṁ** is the bookish "sorry."
+
+And here's the honest twist: in casual conversation, many Hindi speakers
+simply say the **English word "sorry"** outright — it has been fully adopted
+into everyday Hindi, the same way English "please" sometimes stands in for
+*kṛpayā*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "māf" — forgiven — then "kījiye," please do]
+- [YOU SAY: the whole phrase — "māf kījiye" = please forgive me]
+- [YOU SAY: the formal cousin — "kṣamā karēṁ"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **माफ़ कीजिए** literally mean? (**"Please do
+forgiven[-ness]"** — *māf* "forgiven" + *kījiye* "please do.") Where does
+*māf* come from? (**Borrowed via Persian from Arabic** *ʿafw*, "to pardon.")
+What's the more formal, Sanskritic cousin? (**क्षमा करें** *kṣamā karēṁ*, from
+*kṣamā* "patience/forgiveness.") What do many Hindi speakers just say instead,
+casually? (**The English word "sorry."**)

--- a/code/learning/human-languages/hindi/lessons/HI-C10-shanivaar-ravivaar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C10-shanivaar-ravivaar.md
@@ -1,0 +1,54 @@
+---
+id: HI-C10-shanivaar-ravivaar
+chapter: 10
+type: word
+headword: शनिवार रविवार
+gloss: Saturday and Sunday — completing Hindi's planet-week
+concept_tag: HI-DAYS-WEEKEND
+prerequisites: [HI-C10-somavaar-shukravaar]
+sounds: [devanagari-long-aa, sha-vs-sa]
+roots: [vara-sanskrit, navagraha]
+etymology_hook: "शनिवार śanivār (Saturn) and रविवार ravivār (Sun) complete Hindi's planet-week — UNLIKE Spanish/French, no religion ever swapped these two out"
+est_minutes: 4
+reviews_of: [HI-C10-somavaar-shukravaar]
+---
+
+# शनिवार and रविवार — Saturday and Sunday, no rewrite needed
+
+## Warm-up
+
+[PAUSE 2s] You've met five Hindi weekdays, each a deity's name plus **वार**
+(*vār*), "day." The last two complete the set — and here, unlike Spanish or
+French, **nothing ever got renamed**.
+
+## The last two days
+
+- **शनिवार** (*śanivār*) = "**Śani's day**" — **Saturn**.
+- **रविवार** (*ravivār*) = "**Ravi's day**" — the **Sun** (*Ravi*, one of the
+  Sun's many Sanskrit names).
+
+## Be honest about the contrast with Spanish and French
+
+Remember: Spanish's **sábado**/**domingo** and French's **samedi**/**dimanche**
+are **not** simple planet-names — Christianity renamed both (Saturn's day
+became the *Sabbath*; the Sun's day became "*the Lord's day*"). Hindi's
+weekend went through **no such rewrite**: **शनिवार** and **रविवार** are still,
+today, plainly "Saturn's day" and "Sun's day" — the full planet-week, all
+seven days, standing untouched by any later religious relabeling.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śanivār" — Saturn's day — then "ravivār," Sun's day]
+- [YOU SAY: the whole week — "somavār, maṅgalvār, budhvār, guruvār,
+  śukravār, śanivār, ravivār"]
+- [YOU SAY: the contrast — Spanish/French renamed their weekend; Hindi never
+  did]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do **शनिवार** and **रविवार** literally mean? (**"Saturn's
+day"** and **"Sun's day."**) How is Hindi's weekend different from Spanish's
+or French's? (**No religious rewrite ever happened** — Hindi kept the plain
+planet-names for all seven days, while Spanish/French swapped in *Sabbath* /
+*Lord's day* for the weekend.)

--- a/code/learning/human-languages/hindi/lessons/HI-C10-somavaar-shukravaar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C10-somavaar-shukravaar.md
@@ -1,0 +1,66 @@
+---
+id: HI-C10-somavaar-shukravaar
+chapter: 10
+type: word
+headword: सोमवार मंगलवार बुधवार गुरुवार शुक्रवार
+gloss: Monday–Friday — Hindi's own planet-week, independent of Rome's
+concept_tag: HI-DAYS-WEEKDAYS
+prerequisites: [HI-C06-numbers-1-5]
+sounds: [devanagari-conjunct-kra, anusvara]
+roots: [vara-sanskrit, navagraha]
+etymology_hook: "सोमवार somavār 'Moon's day' and its four siblings are India's OWN planet-week — the same seven-body idea as Rome's, likely both downstream of a shared Babylonian source, not one copying the other"
+est_minutes: 5
+reviews_of: [HI-C06-numbers-1-5]
+---
+
+# सोमवार to शुक्रवार — Hindi's own planet-week
+
+## Warm-up
+
+[PAUSE 2s] You've seen Spanish, Latin, and French name their weekdays for
+planet-gods. Here's the surprise: **Hindi does too** — with its own,
+independent set of gods.
+
+## The pattern: [deity] + वार, "day"
+
+Every Hindi weekday is a **deity's name** plus **वार** (*vār*), "**day**"
+(Sanskrit *vāra*):
+
+| Hindi | literally | deity/planet | day |
+|---|---|---|---|
+| **सोमवार** (*somavār*) | Soma's day | the **Moon** | Monday |
+| **मंगलवार** (*maṅgalvār*) | Mangala's day | **Mars** | Tuesday |
+| **बुधवार** (*budhvār*) | Budha's day | **Mercury** | Wednesday |
+| **गुरुवार** (*guruvār*) | Guru's day | **Jupiter** (*Bṛhaspati*, called "Guru," teacher of the gods) | Thursday |
+| **शुक्रवार** (*śukravār*) | Śukra's day | **Venus** | Friday |
+
+## Be honest about where this system came from
+
+This is **the same seven-body idea** as Rome's planetary week — Sun, Moon,
+Mercury, Venus, Mars, Jupiter, Saturn — and it is **not** an isolated Indian
+invention: historians trace it, ultimately, to a shared source in
+**Babylonian astronomy**, and most accounts hold that it reached both Rome
+and India through the **same Hellenistic-Greek channel** of transmission
+(India's own horoscopic-astrology texts, like the *Yavanajātaka*, are
+explicitly adapted from Greek originals). The exact path and timing into
+India are still debated among historians of astronomy, but the system isn't
+a case of Rome and India copying each other directly — both are more like
+**cousins**, downstream of one much older shared idea of the sky.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "somavār" — Soma/Moon's day — then "maṅgalvār," Mangala/Mars's
+  day]
+- [YOU SAY: the pattern — "[deity] + vār" = [deity]'s day]
+- [YOU SAY: "guruvār" — Thursday — Bṛhaspati, called "Guru"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does every Hindi weekday end in, and what does it mean?
+(**वार** *vār*, "day.") Which planet is **गुरुवार**, and what title does its
+deity carry? (**Jupiter** — the deity Bṛhaspati, called "**Guru**," teacher of
+the gods — an ancient title Bṛhaspati bears, not the source of the word
+itself.) Did Hindi borrow its planet-week from Rome? (**No** — both likely
+trace back through **Hellenistic Greece** to a shared **Babylonian**
+astronomical source, though the exact route into India is still debated.)

--- a/code/learning/human-languages/hindi/lessons/HI-C11-kaalaa-safed.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C11-kaalaa-safed.md
@@ -1,0 +1,59 @@
+---
+id: HI-C11-kaalaa-safed
+chapter: 11
+type: word
+headword: काला सफ़ेद
+gloss: black and white — one Sanskrit word tangled up with time and death, one a Persian loan
+concept_tag: HI-COLOUR-BLACK-WHITE
+prerequisites: [HI-C10-shanivaar-ravivaar]
+sounds: [devanagari-long-aa, nukta-f]
+roots: [kala-sanskrit, safed-persian]
+etymology_hook: "काला kālā 'black' is traditionally linked to काल kāla, Sanskrit for 'time' and 'death' — the same word underlies Kali and Yama's title Kaala, though whether the two senses truly share one root is still debated; सफ़ेद safed is a Persian loan"
+est_minutes: 5
+reviews_of: [HI-C10-shanivaar-ravivaar]
+---
+
+# काला, सफ़ेद (kālā, safed) — black and white
+
+## Warm-up
+
+[PAUSE 2s] Hindi's word for black hides something bigger inside it: the very
+same word Sanskrit uses for **time itself** — and for death.
+
+## काला — black, time, and death, tangled together
+
+**काला** (*kālā*) = "**black**," from Sanskrit **काल** (*kāla*), a word that
+covers both "**black/dark**" **and** "**time**." Sanskrit's own tradition
+ties the two together poetically — **time devours everything**, and that
+devouring is imagined as *dark* — and the same word names the fierce goddess
+**Kālī** ("the black/dark one") and stands as an epithet of **Yama**, the god
+of death. Be honest, though: whether "black" and "time" are truly **one and
+the same root**, or two separate ancient words that Sanskrit poetry and
+theology later **fused** into a single idea, is a real, still-debated
+question among linguists — the cultural connection is certain; the precise
+etymology underneath it is not.
+
+## सफ़ेद — a Persian loan
+
+**सफ़ेद** (*safed*) = "**white**" — borrowed from **Persian** (سفید *safēd*),
+the same kind of Persian-into-Hindi borrowing you've already met in **माफ़**
+(*māf*, "forgiven," from the "sorry" lesson). Notice the **नुक़्ता** (*nuqtā*,
+the dot under फ): it turns *pha* into **fa**, the tell-tale mark of a sound
+that arrived from Persian or Arabic.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kāla" — time/black/death, then "kālā" — black]
+- [YOU SAY: "safed" — white, a Persian loan]
+- [YOU SAY: the dot — नुक़्ता under फ turns pha into fa]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **काला**'s root **काल** (*kāla*) also mean, besides
+"black"? (**"Time"** — and by extension, **death**; the same word names the
+goddess **Kālī** and Yama's epithet **Kāla**.) Is it settled that "black" and
+"time" are the same root? (**No** — the cultural link is real and ancient,
+but linguists still debate whether it's one true root or two words later
+fused.) Where does **सफ़ेद** come from? (**Persian** *safēd* — the same kind
+of loan as *māf*, "sorry.")

--- a/code/learning/human-languages/hindi/lessons/HI-C11-laal-niila.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C11-laal-niila.md
@@ -1,0 +1,59 @@
+---
+id: HI-C11-laal-niila
+chapter: 11
+type: word
+headword: लाल नीला
+gloss: red and blue — a Persian gemstone-name, and the Sanskrit word behind the world's word for "indigo"
+concept_tag: HI-COLOUR-RED-BLUE
+prerequisites: [HI-C11-kaalaa-safed]
+sounds: [devanagari-long-aa, retroflex-la-vs-dental]
+roots: [laal-persian, nila-sanskrit]
+etymology_hook: "लाल laal 'red' comes from a Persian word for a RUBY; नीला niilaa 'blue' is Sanskrit for the indigo plant — and India's indigo trade is why English says 'indigo' at all"
+est_minutes: 5
+reviews_of: [HI-C11-kaalaa-safed]
+---
+
+# लाल, नीला (lāl, nīlā) — a gemstone's name, and India's dye
+
+## Warm-up
+
+[PAUSE 2s] One more color pair, and one more Persian loan — plus a Sanskrit
+word connected to why English itself says "**indigo**."
+
+## लाल — named for a gem, not a color
+
+**लाल** (*lāl*) = "**red**" — borrowed from Persian **لعل** (properly *laʿl*,
+with a middle *ʿayn* the Hindi/Persian pronunciation *lāl* smooths over), which
+originally named a specific **deep-red gemstone** (a ruby or spinel), and
+only later widened to mean the color itself. Hindi's everyday word for "red"
+started life as a jeweler's word.
+
+## नीला — Sanskrit's dark blue, and the world's word for indigo
+
+**नीला** (*nīlā*) = "**blue**," from Sanskrit **नील** (*nīla*), "dark blue" —
+also the name of the **indigo plant** and its dye. Here's the honest,
+careful version of a famous connection: English **"indigo"** does **not**
+come from *nīla* by sound change. It comes from **Greek** *indikón*, simply
+meaning "**the Indian [thing]**" — because Greek and Roman traders imported
+the blue dye **from India**. So *nīlā* and "indigo" aren't the same word
+evolving — they're two **separate** words for the same dye, one Indian
+(*nīla*, describing the color) and one foreign (*indikón*, describing the
+dye's *origin*). The connection is real, but it's a connection of **history
+and trade**, not of sound.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "lāl" — red, originally a gemstone's name]
+- [YOU SAY: "nīlā" — blue, from Sanskrit nīla]
+- [YOU SAY: the honest distinction — nīla and "indigo" are two different
+  words linked by trade, not by sound]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did **लाल** originally name, before it meant "red"? (**A deep
+red gemstone**, borrowed from Persian.) Does English "**indigo**" come
+directly from Sanskrit **नील** *nīla*? (**No** — indigo is from Greek
+*indikón*, "the Indian [thing]," describing where the dye came from; *nīla*
+and "indigo" are two separate words connected by history, not by sound
+change.)

--- a/code/learning/human-languages/hindi/lessons/HI-C12-bhaai-bahin.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C12-bhaai-bahin.md
@@ -1,0 +1,66 @@
+---
+id: HI-C12-bhaai-bahin
+chapter: 12
+type: word
+headword: भाई बहन
+gloss: brother (a PIE cousin of English "brother") and sister (a DIFFERENT Sanskrit word entirely, not the PIE cousin of "sister")
+concept_tag: HI-FAMILY-SIBLINGS
+prerequisites: [HI-C12-pitaa-maataa]
+sounds: [devanagari-long-ii, aspirated-bha]
+roots: [pie-bhrater, bhaga-sanskrit]
+etymology_hook: "भाई bhāī IS the PIE cousin of English 'brother' — but बहन bahin is NOT the cousin of 'sister'; Sanskrit's PIE-cognate word for sister (svasṛ) faded, replaced by bhaginī, 'the one who shares,' the ancestor of bahin"
+est_minutes: 5
+reviews_of: [HI-C12-pitaa-maataa]
+---
+
+# भाई, बहन (bhāī, bahin) — one cousin word, one different word entirely
+
+## Warm-up
+
+[PAUSE 2s] You've met *frāter* and *soror* as PIE cousins of "brother" and
+"sister." Hindi's pair has a genuine surprise hiding in it: only **one** of
+these two continues that ancient family.
+
+## भाई — the expected cousin
+
+**भाई** (*bhāī*) = "**brother**" — from Sanskrit **भ्रातृ** (*bhrātṛ*), which
+**does** continue the same PIE root, ***bʰréh₂tēr***, as Latin *frāter* and
+English *brother*. This one is exactly what you'd expect: one more cousin in
+the same old family.
+
+## बहन — NOT the expected cousin
+
+Sanskrit did have a direct PIE-cognate word for "sister" too: **स्वसृ**
+(*svasṛ*), the very cousin of Latin *soror* and English *sister*. But that
+word **faded from use**. In its place, Sanskrit built a **different** word,
+**भगिनी** (*bhaginī*) — and *that* word, not *svasṛ*, is the confirmed
+ancestor of Hindi's everyday **बहन** (*bahin*). (Where *bhaginī* itself comes
+from is the less certain part: it's often explained as **भग** (*bhaga*, "a
+share, good fortune") plus a feminine suffix, "the one who shares" — but
+Sanskritists don't all agree on this, and some suspect it's a reshaping of
+an older form avoiding an unrelated, indelicate sense of *bhaga*. That
+deeper question is worth a linguist's extra check; the *bahin ≠ svasṛ*
+finding itself is solid.)
+
+So Hindi's brother/sister pair is **lopsided** in its ancestry: *bhāī*
+genuinely continues the ancient PIE word; *bahin* comes from an entirely
+different Sanskrit formation that **replaced** the PIE-cognate word before
+Hindi ever inherited it. (Sanskrit-to-Hindi sound history has plenty of non-obvious
+turns.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bhāī" — brother — the true PIE cousin of "brother"]
+- [YOU SAY: "bahin" — sister — from bhaginī, "the one who shares," NOT from
+  the PIE word for sister]
+- [YOU SAY: the asymmetry — one cousin, one completely different word]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **भाई** continue the same ancient root as English
+"brother"? (**Yes** — Sanskrit *bhrātṛ* < PIE *bʰréh₂tēr*, same as Latin
+*frāter*.) Does **बहन** continue the same ancient root as English "sister"?
+(**No** — Sanskrit's PIE-cognate word, *svasṛ*, faded; *bahin* comes from
+**भगिनी** *bhaginī*, an unrelated Sanskrit formation — often glossed "the one
+who shares," though *bhaginī*'s own deeper origin is itself debated.)

--- a/code/learning/human-languages/hindi/lessons/HI-C12-pitaa-maataa.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C12-pitaa-maataa.md
@@ -1,0 +1,62 @@
+---
+id: HI-C12-pitaa-maataa
+chapter: 12
+type: word
+headword: पिता माता
+gloss: father and mother — Sanskrit cousins of Latin pater/mater and English father/mother
+concept_tag: HI-FAMILY-PARENTS
+prerequisites: [HI-C11-laal-niila]
+sounds: [devanagari-long-aa, retroflex-vs-dental-ta]
+roots: [pie-pater, pie-mater]
+etymology_hook: "पिता pitā and माता mātā are Sanskrit cousins of Latin pater/mater and English father/mother; बाप bāp and माँ māṁ are ALSO Sanskrit-descended, just via a different root (vaptṛ) and a Prakrit doublet, not uncertain outliers"
+est_minutes: 5
+reviews_of: [HI-C11-laal-niila]
+---
+
+# पिता, माता (pitā, mātā) — father and mother, cousins across a huge family
+
+## Warm-up
+
+[PAUSE 2s] You've already met Latin **pater/māter** and their English
+cousins **father/mother** — all descending from one ancient shared word.
+Hindi keeps a cousin of its own, in the very same family.
+
+## Taken apart
+
+- **पिता** (*pitā*) = "**father**" — Sanskrit **पितृ** (*pitṛ*), from the
+  **same PIE root**, ***ph₂tḗr***, as Latin *pater* and English *father*.
+- **माता** (*mātā*) = "**mother**" — Sanskrit **मातृ** (*mātṛ*), from
+  ***méh₂tēr***, the same root as Latin *māter* and English *mother*.
+
+So *pitā* and *father* are, at the deepest level, the **same ancient word**
+— reaching you here through Sanskrit rather than through Latin or Germanic,
+one more branch of the same very old family tree.
+
+## Be honest about register — the everyday words
+
+**पिता/माता** are correct, respectable Hindi — but the words you'll hear
+**most often in daily life** are different: **बाप** (*bāp*, "father," an
+everyday/colloquial word) and **माँ** (*māṁ*, "mother," universally the
+warm, everyday word — closer to English "mom" than "mother"). These aren't
+uncertain outliers, either — they're **also** Sanskrit-descended, just by a
+different path than *pitā/mātā*: **बाप** traces through Prakrit to Sanskrit
+**वप्तृ** (*vaptṛ*, "father," a different Sanskrit root from *pitṛ*), while
+**माँ** is a genuine **doublet** of *mātā* — both come from the very same
+Sanskrit *mātṛ*, just worn down along a more colloquial Prakrit line.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pitā, mātā" — the Sanskrit-descended, formal pair]
+- [YOU SAY: "bāp, māṁ" — the everyday, spoken pair]
+- [YOU SAY: the deep cousin — "pitā and father are the same ancient PIE
+  word"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are पिता and माता cousins of, in Latin and English? (**Pater/
+father** and **māter/mother** — all from the same PIE roots.) What are the
+everyday, spoken words instead? (**बाप bāp** and **माँ māṁ**.) Are *bāp* and
+*māṁ* also Sanskrit-descended? (**Yes** — *bāp* traces to Sanskrit *vaptṛ*, a
+different root from *pitṛ*; *māṁ* is a genuine **doublet** of *mātā*, both
+from *mātṛ*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C13-haath.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C13-haath.md
@@ -1,0 +1,57 @@
+---
+id: HI-C13-haath
+chapter: 13
+type: word
+headword: हाथ
+gloss: the hand — from Sanskrit hasta, with a real (if non-obvious) sound-change story
+concept_tag: HI-BODY-HAND
+prerequisites: [HI-C13-sir]
+sounds: [devanagari-long-aa, aspirated-tha]
+roots: [hasta-sanskrit]
+etymology_hook: "हाथ hāth comes from Sanskrit हस्त hasta — the -st- cluster simplified through Prakrit into a geminate (doubled) aspirated consonant, which later simplified again, lengthening the vowel before it to make up for the lost sound"
+est_minutes: 4
+reviews_of: [HI-C13-sir]
+---
+
+# हाथ (hāth) — the hand
+
+## Warm-up
+
+[PAUSE 2s] This word looks nothing like its Sanskrit ancestor at first
+glance — but the change between them follows a real, traceable pattern, not
+a random drift.
+
+## The word
+
+**हाथ** (*hāth*) = "**hand**" — from Sanskrit **हस्त** (*hasta*), "hand."
+
+## The honest sound-change story
+
+Getting from *hasta* to *hāth* isn't one clean step — it passed through
+**Prakrit** (the everyday spoken languages that stood between Sanskrit and
+modern Hindi) along the way: Sanskrit's **‑st‑** consonant cluster
+regularly simplified in Prakrit into a **geminate** (doubled), **aspirated**
+consonant (giving an intermediate form like *hattha*). Later, as that doubled
+consonant simplified further down to modern Hindi's single **‑th‑**, the
+**vowel just before it lengthened** — *a* becoming **ā** — as if to make up
+for the sound that was lost. That's the general shape of the change: **‑ st‑
+→ (Prakrit geminate aspirate) → single aspirate + a longer vowel** — a
+recognized pattern in how Sanskrit consonant clusters evolved into modern
+Hindi, not a one-off coincidence for this word alone.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hāth" — hand]
+- [YOU SAY: the Sanskrit source — "hasta"]
+- [YOU SAY: the shape of the change — "‑st‑ cluster → simplified consonant +
+  longer vowel"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **हाथ** mean, and what Sanskrit word is it from?
+(**"Hand"** — from **हस्त** *hasta*.) What's the general shape of the sound
+change between them? (**Sanskrit's ‑st‑ cluster simplified** through Prakrit
+into a **geminate** aspirated consonant (*hattha*), which later simplified
+to a single consonant — and the vowel before it **lengthened** to
+compensate.)

--- a/code/learning/human-languages/hindi/lessons/HI-C13-sir.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C13-sir.md
@@ -1,0 +1,46 @@
+---
+id: HI-C13-sir
+chapter: 13
+type: word
+headword: सिर
+gloss: the head — from Sanskrit śiras, worn down through a thousand years of everyday speech
+concept_tag: HI-BODY-HEAD
+prerequisites: [HI-C12-bhaai-bahin]
+sounds: [devanagari-short-i, retroflex-vs-dental]
+roots: [shiras-sanskrit]
+etymology_hook: "सिर sir comes from Sanskrit शिरस् śiras, 'head' — worn down over centuries of everyday use, the same word behind the Sanskrit medical/anatomical term shirsha-related vocabulary still used today"
+est_minutes: 4
+reviews_of: [HI-C12-bhaai-bahin]
+---
+
+# सिर (sir) — the head
+
+## Warm-up
+
+[PAUSE 2s] A short, everyday word — and, once you look, a worn-down piece
+of a much older Sanskrit word you may recognize from yoga or anatomy.
+
+## The word
+
+**सिर** (*sir*) = "**head**" — from Sanskrit **शिरस्** (*śiras*), "head."
+Centuries of everyday use wore the word down from the fuller, formal
+Sanskrit shape to the short, simple *sir* you use every day.
+
+Sanskrit's *śiras* root is still alive in more formal/technical registers
+too — related *śīrṣa*-based vocabulary shows up in yoga and Ayurvedic
+anatomical terms (as in poses and positions named for the head), even while
+everyday Hindi kept the shorter, worn-down *sir*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "sir" — head]
+- [YOU SAY: the fuller Sanskrit source — "śiras"]
+- [YOU SAY: worn down over time — "śiras → sir"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **सिर** mean, and what Sanskrit word is it worn down
+from? (**"Head"** — from **शिरस्** *śiras*.) Where else does this root show
+up, in a more formal register? (**Yoga/anatomical terms** built on the
+related *śīrṣa* root.)

--- a/code/learning/human-languages/hindi/lessons/HI-C14-ritu.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C14-ritu.md
@@ -1,0 +1,71 @@
+---
+id: HI-C14-ritu
+chapter: 14
+type: word
+headword: वसंत ग्रीष्म वर्षा शरद् हेमंत शिशिर
+gloss: SIX traditional seasons, not four — India's own ऋतु system, which the Western four-season frame doesn't map onto cleanly
+concept_tag: HI-SEASONS
+prerequisites: [HI-C13-haath]
+sounds: [devanagari-conjunct-shma, anusvara]
+roots: [ritu-sanskrit-six-season-system]
+etymology_hook: "Hindi's traditional calendar recognizes SIX ऋतु (ṛtu) 'seasons', not four — vasant, grishma, varsha (monsoon), sharad, hemant, shishir — a genuinely different structure, not just extra vocabulary"
+est_minutes: 6
+reviews_of: [HI-C13-haath]
+---
+
+# वसंत, ग्रीष्म, वर्षा, शरद्, हेमंत, शिशिर — six seasons, not four
+
+## Warm-up
+
+[PAUSE 2s] Every European language in this course splits the year into
+**four** seasons. Hindi's own tradition doesn't — it recognizes **six**, and
+this isn't extra vocabulary bolted onto a four-season frame. It's a
+genuinely different way of dividing the year.
+
+## The six ऋतु (ṛtu, "seasons")
+
+| Hindi | rough Western match |
+|---|---|
+| **वसंत** (*vasant*) | spring |
+| **ग्रीष्म** (*grīṣma*) | summer |
+| **वर्षा** (*varṣā*) | **monsoon/rains** — no Western equivalent |
+| **शरद्** (*śarad*) | autumn |
+| **हेमंत** (*hemant*) | pre-winter/late autumn |
+| **शिशिर** (*śiśir*) | deep winter |
+
+This six-season calendar, **ऋतु** (*ṛtu*), is rooted in classical Sanskrit
+tradition and Indian astronomy/astrology, and it maps onto the actual
+climate of much of the Indian subcontinent far better than a four-season
+frame does: the **monsoon** (*varṣā*) is a real, distinct, and hugely
+important season there — not a subdivision of "summer" or "autumn," but its
+own season with no clean Western counterpart. And the cold season splits
+into **two** stages, *hemant* (the onset) and *śiśir* (deep winter), rather
+than being lumped into one "winter."
+
+## Be honest: don't force the four-season frame onto this
+
+It would be a mistake to just match these six words one-to-one against
+Spanish's four or French's four the way earlier lessons matched *tala* to
+*talai*. The **structure itself is different** — six real seasons, not four
+plus two extras. Everyday spoken Hindi *does* also use looser, more casual
+four-part talk about seasons (borrowing straightforwardly from the idea of
+"summer," "winter," etc.), but the traditional, classical ऋतु system is
+genuinely six-fold, and it's worth learning as its own thing rather than
+squeezed into someone else's frame.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: all six — "vasant, grīṣma, varṣā, śarad, hemant, śiśir"]
+- [YOU SAY: the one with no Western match — "varṣā," the monsoon]
+- [YOU SAY: the honest point — six seasons is a different STRUCTURE, not
+  extra vocabulary]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How many seasons does Hindi's traditional ऋतु calendar
+recognize? (**Six**, not four.) Which season has no clean Western
+equivalent, and why? (**वर्षा** *varṣā*, the **monsoon** — a real, distinct
+season central to the subcontinent's climate.) Is this just extra
+vocabulary added to a four-season frame? (**No** — it's a genuinely
+different structural division of the year.)

--- a/code/learning/human-languages/hindi/lessons/HI-C15-paani-roti.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C15-paani-roti.md
@@ -1,0 +1,62 @@
+---
+id: HI-C15-paani-roti
+chapter: 15
+type: word
+headword: पानी रोटी
+gloss: water (literally "the drinkable one," not the ancient Sanskrit word for water) and bread/flatbread
+concept_tag: HI-FOOD-BASIC
+prerequisites: [HI-C14-ritu]
+sounds: [devanagari-long-ii, retroflex-tta]
+roots: [paaniiya-sanskrit-drink, roti-uncertain]
+etymology_hook: "पानी paanii doesn't come from Sanskrit's ancient water-words (ap, jala) — it's from पानीय paaniiya, 'the drinkable thing,' from पा paa 'to drink' — water named for what you DO with it, not what it IS"
+est_minutes: 5
+reviews_of: [HI-C14-ritu]
+---
+
+# पानी, रोटी (pānī, roṭī) — water (the "drinkable thing") and bread
+
+## Warm-up
+
+[PAUSE 2s] Hindi's everyday word for water isn't the ancient Sanskrit word
+you might expect — it names water by what you **do** with it, not by what
+it **is**.
+
+## पानी — "the drinkable thing"
+
+**पानी** (*pānī*) = "**water**." Sanskrit actually has older, more
+"basic" words for water — **आप्** (*āp*) and **जल** (*jala*) among them
+— but Hindi's everyday word descends from neither. It comes from
+Sanskrit **पानीय** (*pānīya*), built on the verb **पा** (*pā*), "**to
+drink**," plus a suffix meaning roughly "**fit for**." So *pānīya*, and
+Hindi's *pānī* after it, literally means "**the drinkable thing**" —
+water defined by its use, not named as a substance in its own right.
+
+## रोटी — bread, honestly uncertain in origin
+
+**रोटी** (*roṭī*) = "**bread, flatbread**" — the everyday word for the
+flatbreads (roti, chapati-style breads) central to North Indian meals.
+Be honest: unlike *pānī*, *roṭī*'s deeper history is **not cleanly
+traced** back through Sanskrit the way many everyday Hindi words are.
+It comes through Prakrit **रोट्ट** (*roṭṭa*, "a kind of bread") from
+Sanskrit **रोटिका** (*roṭikā*); beyond that, one proposal (Turner's
+Indo-Aryan dictionary) tentatively links it to a root meaning "**to
+strike / to press or crush**" — perhaps evoking the pounding and
+flattening of dough — but this is genuinely uncertain, one guess among
+scholars rather than a settled chain. Worth knowing honestly rather than
+forcing a confident derivation that isn't there.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pānī" — water, "the drinkable thing"]
+- [YOU SAY: the root — "pā," to drink, + "-nīya," fit for]
+- [YOU SAY: "roṭī" — bread, flatbread]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **पानी** come from Sanskrit's ancient water-words, *āp* or
+*jala*? (**No** — from **पानीय** *pānīya*, "the drinkable thing," from
+**पा** *pā*, "to drink.") Is **रोटी**'s etymology as clearly traced as
+*pānī*'s? (**No** — it traces to Prakrit *roṭṭa* < Sanskrit *roṭikā*, but
+beyond that the deeper root is genuinely uncertain — one proposal links it
+to "striking/pressing" dough, not a settled chain.)

--- a/code/learning/human-languages/hindi/lessons/HI-C16-mahine.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C16-mahine.md
@@ -1,0 +1,66 @@
+---
+id: HI-C16-mahine
+chapter: 16
+type: word
+headword: जनवरी फ़रवरी मार्च अप्रैल मई जून जुलाई अगस्त सितंबर अक्टूबर नवंबर दिसंबर
+gloss: the Gregorian months — borrowed English/international names, running ALONGSIDE the traditional Vikram Samvat calendar's own six-ritu-linked months
+concept_tag: HI-MONTHS
+prerequisites: [HI-C15-paani-roti]
+sounds: [nukta-f, devanagari-long-ii]
+roots: [gregorian-months-borrowed, vikrama-samvat-sanskrit]
+etymology_hook: "janvarii, maarch, agast... are borrowed English/international month-names for everyday civil use — Hindu tradition keeps a SEPARATE calendar, Vikram Samvat, whose months (Chaitra, Vaishaakh...) map onto the SIX ritu from the seasons lesson, not four Western seasons"
+est_minutes: 6
+reviews_of: [HI-C15-paani-roti]
+---
+
+# जनवरी to दिसंबर — borrowed names, and a second calendar underneath
+
+## Warm-up
+
+[PAUSE 2s] Like Arabic, Hindi doesn't have just **one** set of months —
+everyday civil life and traditional/religious life run on **two different
+calendars**.
+
+## The Gregorian months — recent, borrowed
+
+For dates, school, business, and government, Hindi uses month names
+borrowed straightforwardly from **English**:
+
+**जनवरी, फ़रवरी, मार्च, अप्रैल, मई, जून, जुलाई, अगस्त, सितंबर, अक्टूबर,
+नवंबर, दिसंबर** (*janvarī, farvarī, mārc, aprail, maī, jūn, julāī, agast,
+sitambar, aktūbar, navambar, disambar*) — you can hear "January," "March,"
+"August" right through the Hindi pronunciation. This is a modern civil
+borrowing, not an ancient Sanskrit system.
+
+## Be honest: the traditional calendar is a genuinely different structure
+
+Hindu tradition keeps its **own**, much older lunisolar calendar — **विक्रम
+संवत्** (*Vikram Samvat*) — with twelve **different** month names:
+**चैत्र, वैशाख, ज्येष्ठ, आषाढ़, श्रावण, भाद्रपद, आश्विन, कार्तिक,
+मार्गशीर्ष, पौष, माघ, फाल्गुन** (*Chaitra, Vaiśākh, Jyeṣṭha, Āṣāḍh,
+Śrāvaṇ, Bhādrapad, Āśvin, Kārtik, Mārgaśīrṣ, Pauṣ, Māgh, Phālgun*).
+
+This isn't just a second set of labels for the same twelve solar months —
+these months are tied to the **six-ṛtu** seasonal calendar from the
+seasons lesson (in the traditional/classical scheme, each pair of Vikram
+Samvat months corresponds to one of the six *ṛtu*), and major festivals (Holi, Diwali, and many others) are
+dated by **this** calendar, not the Gregorian one — which is why their
+Gregorian-calendar date shifts from year to year.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "janvarī, mārc, agast" — hear the borrowed English names]
+- [YOU SAY: the traditional calendar — "Chaitra, Vaiśākh, Jyeṣṭha"]
+- [YOU SAY: the honest point — festivals shift on the Gregorian calendar
+  because they're dated by Vikram Samvat instead]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where do Hindi's everyday civil month names come from?
+(**Borrowed from English** — *janvarī, mārc, agast*...) What traditional
+calendar runs alongside it, and what is it tied to? (**Vikram Samvat** —
+tied to the **six ṛtu** seasons, not the four-season Western frame.) Why do
+festivals like Holi and Diwali fall on different Gregorian dates each
+year? (**They're dated by Vikram Samvat**, a different calendar system
+entirely.)

--- a/code/learning/human-languages/hindi/lessons/HI-C17-dopahar-aadhi-raat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C17-dopahar-aadhi-raat.md
@@ -1,0 +1,58 @@
+---
+id: HI-C17-dopahar-aadhi-raat
+chapter: 17
+type: phrase
+headword: दोपहर आधी रात
+gloss: noon (literally "two pahars," a traditional ~3-hour time unit) and midnight ("half night," fully transparent)
+concept_tag: HI-TIME-NOON-MIDNIGHT
+prerequisites: [HI-C16-mahine]
+sounds: [devanagari-vowel-sign-o, devanagari-long-ii]
+roots: [do-two, pahar-traditional-watch, aadhi-half, raat-night]
+etymology_hook: "दोपहर (dopahar) 'noon' is literally 'two pahars' — pahar being a traditional ~3-hour time-unit, with noon falling at the end of the second pahar after sunrise; आधी रात (aadhi raat) 'half night' is fully transparent, just like Latin's media nox"
+est_minutes: 5
+reviews_of: [HI-C16-mahine]
+---
+
+# दोपहर, आधी रात — noon by an old clock, midnight fully transparent
+
+## Warm-up
+
+[PAUSE 2s] Hindi's word for noon hides a whole traditional timekeeping
+system inside it — one very different from hours and minutes.
+
+## दोपहर — "two pahars"
+
+**दोपहर** (*dopahar*) = "**noon, midday**" — literally "**two** (*do*) +
+**pahar**." A **पहर** (*pahar*, from Sanskrit *prahara*) is a traditional
+Indian unit of time, roughly **three hours** long, with the day
+traditionally divided into eight *pahars* (four for daytime, four for
+night), counted from sunrise. Noon falls right around the end of the
+**second** daytime *pahar* after sunrise — so *do-pahar*, "two pahars [in],"
+became the everyday word for midday. (This traditional pahar-based account
+is the standard one, though — as with any folk-timekeeping etymology this
+old — treat the exact number of pahars as the general shape of the story
+rather than a precisely dated fact.)
+
+## आधी रात — fully transparent "half night"
+
+**आधी रात** (*ādhī rāt*) = "**midnight**," literally "**half night**" —
+**आधी** (*ādhī*, the feminine form of **आधा**, *ādhā*, "half") + **रात**
+(*rāt*, "night"). No erosion, no double meaning — structurally identical to
+Latin's *media nox* and Spanish's *medianoche*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pahar" — a traditional ~3-hour watch — then "do-pahar," two
+  pahars, noon]
+- [YOU SAY: "ādhī rāt" — half night, midnight]
+- [YOU SAY: the contrast — dopahar counts an old time-unit; ādhī rāt is
+  plainly "half" + "night"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **दोपहर** literally mean, and what's a *pahar*? ("**Two
+pahars**" — a *pahar* being a traditional ~3-hour time-unit, with noon
+falling around the end of the second one after sunrise.) What does **आधी
+रात** literally mean? ("**Half night**" — *ādhī* "half" + *rāt* "night,"
+fully transparent, just like Latin's *media nox*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C18-ghanta.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C18-ghanta.md
@@ -1,0 +1,59 @@
+---
+id: HI-C18-ghanta
+chapter: 18
+type: word
+headword: घंटा
+gloss: hour — literally "bell," from the historical practice of striking a bell to mark the hour
+concept_tag: HI-TIME-HOUR
+prerequisites: [HI-C17-dopahar-aadhi-raat]
+sounds: [devanagari-anusvara, devanagari-conjunct-none]
+roots: [sanskrit-ghanta-bell]
+etymology_hook: "घंटा (ghanṭā, 'hour') comes from Sanskrit घण्टा (ghaṇṭā), 'bell, gong' — the SAME word Hindi still uses for an actual bell, because clocks and towns once marked the hour by striking one; telling time uses बजना (bajnā), 'to strike/toll,' the same imagery"
+est_minutes: 5
+reviews_of: [HI-C17-dopahar-aadhi-raat]
+---
+
+# घंटा — "hour," literally "bell"
+
+## Warm-up
+
+[PAUSE 2s] Here's a word that wears its history on its sleeve: Hindi's word for
+"hour" is the exact same word as "bell."
+
+## घंटा — bell AND hour, one word
+
+**घंटा** (*ghanṭā*) = "**hour**" — and it means "**bell, gong**" just as commonly.
+It comes from Sanskrit **घण्टा** (*ghaṇṭā*), "bell, gong." The
+connection isn't a coincidence: temples, towns, and later clock towers historically
+marked the passing of time by **striking a bell** — the hour was announced by
+sound, not read off a face — so the word for the bell itself came to mean the unit
+of time it announced. Compare this to English **o'clock**, itself a worn-down "**of
+the clock**," or French's **il est … heures**: different languages, but time-telling
+vocabulary keeps circling back to the *instrument* used to mark it.
+
+## Grammar Lens: बजना — "to strike, to toll"
+
+Hindi tells the time with the verb **बजना** (*bajnā*), "**to strike, to toll**" —
+the same imagery as a bell striking the hour:
+
+> **एक बज रहा है।** — "It is one o'clock." (literally "**one is striking**")
+> **दो बज रहे हैं।** — "It is two o'clock." (literally "**two are striking**")
+
+Just like Spanish switches from singular *es* to plural *son* after "one," Hindi
+switches **बज रहा है** (singular) to **बज रहे हैं** (plural) once the count passes
+one — matching the number, not just tacking on "o'clock."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ghanṭā" — hour, also "bell"]
+- [YOU SAY: "ek baj raha hai" — it is one o'clock, "one is striking"]
+- [YOU SAY: "do baj rahe hain" — it is two o'clock, "two are striking"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **घंटा** literally mean besides "hour"? (**"Bell, gong"** —
+from Sanskrit *ghaṇṭā*.) Why did "bell" come to mean "hour"? (Because clocks/towns
+historically **struck a bell** to announce the hour.) What verb does Hindi use to
+tell the time, and what does it literally mean? (**बजना**, *bajnā* — "to strike, to
+toll," as in *ek baj raha hai*, "one is striking.")

--- a/code/learning/human-languages/hindi/lessons/HI-C19-umr.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C19-umr.md
@@ -1,0 +1,66 @@
+---
+id: HI-C19-umr
+chapter: 19
+type: phrase
+headword: उम्र
+gloss: age — the SAME word as Arabic's ʿumr, borrowed via Persian; telling age uses a "belonging to N years" construction, a fifth shape distinct from Romance/Germanic/Latin/Arabic
+concept_tag: HI-AGE
+prerequisites: [HI-C18-ghanta]
+sounds: [devanagari-conjunct-mra, devanagari-independent-vowel]
+roots: [arabic-umr-life, sanskrit-aayu-lifespan]
+etymology_hook: "उम्र (umr, 'age') is the SAME Arabic ʿumr you just met, borrowed into Hindi/Urdu via Persian — everyday Hindi uses this Perso-Arabic loan, while more formal/shuddh Hindi uses the native Sanskrit आयु (āyu) instead; telling age uses 'kitne saal ke ho,' literally 'of how many years are you,' a genitive-possessive shape distinct from Romance's 'have,' Germanic's 'be,' Latin's 'born + duration,' or Arabic's no-verb noun sentence"
+est_minutes: 6
+reviews_of: [HI-C18-ghanta]
+---
+
+# उम्र — the same word as Arabic, and a fifth grammatical shape
+
+## Warm-up
+
+[PAUSE 2s] You just met Arabic's *ʿumr*. Hindi's everyday word for "age" is the
+**exact same word** — and its age-telling grammar is a fifth distinct pattern
+you haven't seen yet.
+
+## उम्र — a Perso-Arabic loan, and a native alternative
+
+**उम्र** (*umr*) = "**age**" — this is **Arabic's ʿumr**, borrowed into Hindi
+through Persian, and it's the everyday, colloquial word most Hindi speakers use.
+Hindi also has a fully **native Sanskrit** alternative, **आयु** (*āyu*,
+"age, lifespan"), which feels more formal or literary — a register split you've
+now seen several times (compare Kannada's Sanskrit-tatsama *madhyāhna* vs.
+Tamil's native words for the same concepts, just flipped here: the **borrowed**
+word is the everyday one, the **native** word is the formal one).
+
+## Grammar Lens: "kitne sāl ke ho?" — a fifth shape
+
+> **तुम कितने साल के हो?** — "How old are you?" (informal) — literally "**you,
+  of how many years, are**?" (*tum kitne sāl ke ho?*)
+> **मैं बीस साल का हूँ।** — "I am twenty years old." — literally "**I [am one]
+  belonging to twenty years**." (*maiṅ bīs sāl kā hūṅ.*)
+
+Look closely at **के** / **का** (*ke*/*kā*) here — this is Hindi's **genitive
+postposition**, "of, belonging to," the same word that marks possession
+elsewhere in Hindi (*merā ghar*, "my house" uses the same family of markers).
+So the construction is genuinely a **fifth** shape for this concept: not
+Romance's "I **have** years," not Germanic's simple "I **am** [a number],"
+not Latin's "**born** + N years [of duration]," not Arabic's verbless "my age
+[is] a number" — but "I am [one] **belonging to** that many years," using a
+possessive/genitive marker plus **होना** (*honā*, "to be").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "umr" — age, same word as Arabic's ʿumr]
+- [YOU SAY: "tum kitne sāl ke ho?" — how old are you?]
+- [YOU SAY: "maiṅ bīs sāl kā hūṅ" — I am twenty years old, literally
+  "belonging to twenty years"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What language does Hindi's **उम्र** come from, and what's the native
+Sanskrit alternative? (**Arabic** *ʿumr*, via Persian; native alternative is
+**आयु**, *āyu*.) What does **के**/**का** mark in "*bīs sāl kā hūṅ*"? (A
+**genitive/possessive** relationship — "belonging to.") Is Hindi's age
+construction the same as Romance's "have," Germanic's "be," Latin's "born +
+duration," or Arabic's verbless noun sentence? (**No** — it's a **fifth**
+shape: "belonging to N years" + *honā*, "to be.")

--- a/code/learning/human-languages/hindi/lessons/HI-C20-mausam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C20-mausam.md
@@ -1,0 +1,79 @@
+---
+id: HI-C20-mausam
+chapter: 20
+type: phrase
+headword: मौसम
+gloss: weather — the SAME root as English "monsoon"; rain has TWO words that sound alike but are NOT related, a real false-friend trap
+concept_tag: HI-WEATHER
+prerequisites: [HI-C19-umr]
+sounds: [devanagari-vowel-sign-au, devanagari-conjunct-rsha]
+roots: [arabic-mawsim-season, sanskrit-varsha-rain, persian-baarish-rain]
+etymology_hook: "मौसम (mausam, 'weather') is ANOTHER Arabic loan via Persian (mawsim, 'season'), like umr — and the SAME root as English 'monsoon' (via Portuguese/Dutch traders, 1580s, not the later British Raj); be careful, though: बारिश (baarish, 'rain,' from Persian bāriš) and वर्षा (varṣā, native Sanskrit 'rain,' PIE cousin of Greek hérsē 'dew') sound alike but are flagged by dictionaries as PROBABLY unrelated — a likely false-friend trap, not a confirmed doublet"
+est_minutes: 6
+reviews_of: [HI-C19-umr]
+---
+
+# मौसम — another Perso-Arabic loan, and a false-friend trap
+
+## Warm-up
+
+[PAUSE 2s] You've already seen Hindi borrow *umr* from Arabic. Here's another
+one — and this time, English borrowed the SAME root too.
+
+## मौसम — the same root as "monsoon"
+
+**मौसम** (*mausam*) = "**weather**" — borrowed from Classical **Persian**
+**موسم** (*mawsim*), itself from **Arabic** **مَوْسِم** (*mawsim*, "season,
+time of year, occasion"; likely originally used by Arab sailors for seasonal
+winds). This is the **exact same root** that gave English **monsoon** —
+carried into English in the **1580s**, well before the British Raj, via
+**Portuguese and Dutch** traders in the Indian Ocean spice trade (Portuguese
+*monção*, Dutch *monssoen*, both from this same Arabic *mawsim*). So
+"monsoon" and Hindi's everyday word for "weather" are, quite directly, the
+same word.
+
+## गर्मी है, ठंड है — heat and cold, native words
+
+> **गर्मी है।** — "It's hot." — literally "**there is heat**." (*garmī hai.*)
+> **ठंड है।** — "It's cold." — literally "**there is cold**." (*ṭhanḍ hai.*)
+
+Both use ordinary Hindi nouns (**गर्मी**, "heat"; **ठंड**, "cold") plus
+**है** (*hai*, "is/there is") — simpler in shape than Arabic's fully verbless
+pattern, since Hindi still needs *hai* here.
+
+## बारिश vs. वर्षा — a genuine false-friend trap
+
+Hindi has **two** words for "rain" that sound similar enough to assume
+they're related — **don't** make that assumption:
+
+- **बारिश** (*baarish*) — from **Persian** **بارش** (*bāriš*) — the everyday,
+  colloquial word: **बारिश हो रही है** ("it's raining," literally "rain is
+  happening").
+- **वर्षा** (*varṣā*) — fully **native Sanskrit**, from **वर्ष** (*varṣá*,
+  "rain"), tracing to **Proto-Indo-European** ***h₁wers-*** ("to rain") —
+  cousin of Greek **hérsē** ("dew") and Old Irish **frass** ("rain-shower").
+  This is the more formal/literary word.
+
+Despite the similar sound, dictionaries flag *baarish* and *varṣā* as
+**probably not related** — one's a Persian loan, the other a native Sanskrit
+inheritance from deep in the Indo-European family. A likely false-friend
+trap, not a confirmed doublet.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mausam" — weather, same root as English "monsoon"]
+- [YOU SAY: "garmī hai. ṭhanḍ hai." — it's hot / it's cold]
+- [YOU SAY: "baarish hai" (everyday) vs. "varṣā" (formal) — probably NOT
+  related despite sounding alike]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What English word shares मौसम's exact root, and how did it reach
+English? (**Monsoon** — from Arabic *mawsim* via Persian, carried into
+English in the 1580s by Portuguese/Dutch traders, well before the British
+Raj.) Are **बारिश** and **वर्षा** related words? (**Probably not** — despite
+sounding similar, *baarish* is a Persian loan and *varṣā* is native Sanskrit;
+dictionaries flag them as likely unrelated.) What PIE root does **वर्षा**
+trace to, and what's its Greek cousin? (***h₁wers-***, "to rain" — cousin of
+Greek *hérsē*, "dew.")

--- a/code/learning/human-languages/hindi/lessons/HI-C21-numbers-6-10.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C21-numbers-6-10.md
@@ -1,0 +1,94 @@
+---
+id: HI-C21-numbers-6-10
+chapter: 21
+type: word
+headword: छह सात आठ नौ दस
+gloss: six to ten — the SAME cluster-simplifies/vowel-lengthens erosion as three and four, twice more
+concept_tag: HI-NUMBERS-6-10
+prerequisites: [HI-C06-numbers-1-5]
+sounds: [matra-au, retroflex-tha]
+roots: [sanskrit-sas, sanskrit-sapta, sanskrit-ashta, sanskrit-nava, sanskrit-dasa]
+etymology_hook: "sapta → satta → सात sāt and aṣṭa → aṭṭha → आठ āṭh repeat EXACTLY the trīṇi→tiṇṇi→tīn mechanism from lesson 6 — a consonant cluster simplifies to a geminate, then the geminate simplifies again and the vowel lengthens to pay for it; nau (nine) shows a different fate entirely, an intervocalic -v- dissolving into a diphthong"
+est_minutes: 5
+reviews_of: [HI-C06-numbers-1-5]
+---
+
+# छह, सात, आठ, नौ, दस — six to ten, the same erosion twice more
+
+## Warm-up
+
+[PAUSE 2s] You already watched *trīṇi* wear down to *tīn* in two careful
+steps. Two more numbers here do exactly the same thing.
+
+## The five
+
+| | Hindi | said |
+|---|---|---|
+| 6 | **छह** | *chhah* |
+| 7 | **सात** | *sāt* |
+| 8 | **आठ** | *āṭh* |
+| 9 | **नौ** | *nau* |
+| 10 | **दस** | *das* |
+
+## sapta → satta → sāt, aṣṭa → aṭṭha → āṭh — the same mechanism again
+
+Put seven and eight beside their Sanskrit ancestors:
+
+| Sanskrit | → Prakrit → | Hindi |
+|---|---|---|
+| *saptá* | *satta* | **sāt** |
+| *aṣṭá* | *aṭṭha* | **āṭh** |
+
+This is the **identical two-step process** you already watched turn *trīṇi*
+into *tīn*:
+
+1. The consonant cluster (*-pt-*, *-ṣṭ-*) **simplifies into a doubled
+   consonant** (*-tt-*, *-ṭṭh-*) — the same weight, packed into one place.
+2. The doubled consonant **simplifies again**, and the **vowel lengthens** to
+   pay for what was lost — *satta* → *sāt*, *aṭṭha* → *āṭh*.
+
+Same trade, same reason, two more numbers. This is exactly what the anchor
+lesson meant by "not decay in any bad sense" — it's the standard Prakrit
+weight-conservation move, and by now you've seen it three times.
+
+## ṣaṣ → chhah — a different consonant story
+
+**छह** (*chhah*) continues Sanskrit **ṣaṣ** ("six") — here the retroflex
+sibilant **ṣ** shifted forward into Hindi's **छ** (*ch*), a separate sound
+change from the cluster-simplification story above, but still the same
+overall picture: two thousand years of ordinary use reshaping a Sanskrit
+word into its modern Hindi descendant.
+
+## nava → nau — the consonant that dissolved
+
+**नौ** (*nau*) continues Sanskrit **nava** ("nine") differently again: the
+**v** between the two vowels didn't survive at all — it weakened and
+disappeared, and the two vowels either side of it **contracted into one
+diphthong**, *-ava-* → *-au-*. Compare this to *pāṁch*'s nasal-migration
+story from lesson 6: different mechanism, same underlying truth — consonants
+between vowels are exactly where Prakrit did its heaviest wearing-down.
+
+## दस — the simple one
+
+**दस** (*das*) continues Sanskrit **daśa** ("ten") the plainest way of all —
+just the final vowel dropping, no cluster to simplify, no consonant to lose.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "chhah, sāt, āṭh, nau, das"]
+- [YOU SAY: the repeated mechanism — "saptá … satta … **sāt**" and "aṣṭá …
+  aṭṭha … **āṭh**"]
+- [YOU SAY: the different one — "nava … **nau**," a **v** dissolving between
+  vowels]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count six to ten in Hindi. (*Chhah, sāt, āṭh, nau, das*.) What
+mechanism do *sāt* and *āṭh* share with lesson 6's *tīn*? (**Cluster
+simplifies to a geminate, then the geminate simplifies again and the vowel
+lengthens** — the same weight-conservation move, three numbers running.) What
+happened to the **v** in *nava* on its way to *nau*? (It **dissolved between
+the vowels**, which then contracted into one diphthong.) Which of these five
+numbers changed the least from Sanskrit? (**दस**, *das* — just the final
+vowel dropped.)

--- a/code/learning/human-languages/hindi/lessons/HI-C22-gyarah-bees.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C22-gyarah-bees.md
@@ -1,0 +1,89 @@
+---
+id: HI-C22-gyarah-bees
+chapter: 22
+type: word
+headword: ग्यारह — बीस
+gloss: 11-20 — genuinely irregular, must be memorized individually; but उन्नीस (19) most likely preserves Sanskrit's OWN subtractive naming, the same logic as Latin's ūndēvīgintī
+concept_tag: HI-NUMBERS-11-20
+prerequisites: [HI-C21-numbers-6-10]
+sounds: [conjunct-gya, vowel-sign-ii]
+roots: [sanskrit-ekadasha-vimshati, sanskrit-una-subtractive]
+etymology_hook: "ग्यारह-अठारह (11-18) are each opaque, individually-eroded Sanskrit descendants that must be memorized, unlike Spanish's transparent teens — but उन्नीस (unnīs, 19) most likely continues Sanskrit's OWN subtractive ūnaviṃśati ('one less than twenty,' the later, eka-less form of the fuller Vedic ekonaviṃśati), the SAME logic as Latin's ūndēvīgintī from the Latin numbers lesson — two unrelated language families independently naming 19 as 'twenty minus one'"
+est_minutes: 6
+reviews_of: [HI-C21-numbers-6-10]
+---
+
+# ग्यारह, बीस — genuinely irregular, and one honest exception
+
+## Warm-up
+
+[PAUSE 2s] Be honest about this one: Hindi's teens don't follow a clean,
+predictable pattern the way Spanish's or Latin's do. But hiding inside that
+irregularity is a real echo of something you just saw in Latin.
+
+## The ten
+
+| | Hindi | said |
+|---|---|---|
+| 11 | **ग्यारह** | *gyārah* |
+| 12 | **बारह** | *bārah* |
+| 13 | **तेरह** | *terah* |
+| 14 | **चौदह** | *chaudah* |
+| 15 | **पंद्रह** | *pandrah* |
+| 16 | **सोलह** | *solah* |
+| 17 | **सत्रह** | *satrah* |
+| 18 | **अठारह** | *aṭhārah* |
+| 19 | **उन्नीस** | *unnīs* |
+| 20 | **बीस** | *bīs* |
+
+## Be honest: these are genuinely irregular, not a clean pattern
+
+Unlike Spanish's transparent *dieciséis*-*diecinueve* or even the fused-but-
+regular *once*-*quince*, Hindi's 11-18 each descend from their own Sanskrit
+number-word (*ekādaśa, dvādaśa, trayodaśa*...) through centuries of
+individually unpredictable erosion. Most end in **-rah**, a worn-down echo of
+Sanskrit's "-daśa" ("ten"), but the erosion of each number's front half isn't
+predictable from the number itself — these genuinely have to be memorized one
+by one, the way English speakers just memorize "eleven" and "twelve" rather
+than deriving them.
+
+## उन्नीस — the one that most likely isn't just erosion
+
+Here's the honest exception: **उन्नीस** (*unnīs*, 19) most likely isn't simply
+a worn-down "nine-ten" — it likely continues Sanskrit's **own** special,
+**subtractive** name for 19: **ऊनविंशति** (*ūnaviṃśati*), literally "**one
+less than twenty**" (from *ūna*, "less, deficient," + *viṃśati*, "twenty" —
+a later, shortened form of the fuller Vedic *ekonaviṃśati*, "one-less-twenty,"
+with the *eka*, "one," eventually dropped). Sanskrit used this same *ūna-*/
+*ekona-* ("one-less-than") subtractive pattern for every number ending in 9
+up through 99 — 29, 49, 99, all named as "one less than" the next round
+number.
+
+This is a genuine, striking parallel to something you already met: **Latin's
+own ūndēvīgintī** ("one from twenty") for 19, from the numbers-11-20 lesson.
+Two completely unrelated language families — Indo-Aryan and Italic, both
+descended from Proto-Indo-European but separated for thousands of years —
+independently landed on the exact same subtractive logic for naming
+nineteen.
+
+## बीस
+
+**बीस** (*bīs*, "twenty") continues Sanskrit **विंशति** (*viṃśati*, "twenty").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "gyārah, bārah, terah" — 11, 12, 13, each individually memorized]
+- [YOU SAY: "unnīs" — 19, most likely "one less than twenty" (ūnaviṃśati),
+  echoing Latin's ūndēvīgintī]
+- [YOU SAY: "bīs" — twenty]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Do Hindi's numbers 11-18 follow a predictable pattern the way
+Spanish's teens do? (**No** — each is individually eroded from its own
+Sanskrit ancestor and must be memorized.) What does **उन्नीस** most likely
+preserve from Sanskrit, and what does it mean? (Sanskrit's **subtractive**
+*ūnaviṃśati*, "**one less than twenty**.") What Latin number from an
+earlier lesson uses the exact same subtractive logic? (**ūndēvīgintī**,
+"one from twenty" — two unrelated language families, the same idea.)

--- a/code/learning/human-languages/hindi/lessons/HI-C23-kutta-billi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C23-kutta-billi.md
@@ -1,0 +1,77 @@
+---
+id: HI-C23-kutta-billi
+chapter: 23
+type: word
+headword: कुत्ता, बिल्ली
+gloss: dog and cat — kutta is a THIRD instance of a genuinely-uncertain-origin word displacing the PIE-inherited word for dog (echoing perro/can and dog/hound); billi most likely traces to Sanskrit's own loan from DRAVIDIAN — a probable fourth, separate "cat word" family in this course
+concept_tag: HI-ANIMALS
+prerequisites: [HI-C22-gyarah-bees]
+sounds: [conjunct-tta, conjunct-lli]
+roots: [uncertain-kutta, dravidian-bidala-cat]
+etymology_hook: "कुत्ता (kuttā, 'dog') is of genuinely UNCERTAIN origin — either onomatopoeic or non-Indo-Aryan, linguists disagree — and it displaced Sanskrit's own PIE-inherited word for dog, श्वान (śvān, cognate with Latin canis, English hound/German Hund), the SAME shape of mystery-word-displaces-inherited-word as Spanish's perro and English's dog; बिल्ली (billī, 'cat') most likely traces to Sanskrit बिडाल (biḍāla), itself most likely (though not universally agreed) a loan from Dravidian — a probable fourth, separate cat-word family, distinct from the Afro-Asiatic cattus/qitt story"
+est_minutes: 6
+reviews_of: [HI-C22-gyarah-bees]
+---
+
+# कुत्ता, बिल्ली — a third mystery dog-word, and a fourth cat-word family
+
+## Warm-up
+
+[PAUSE 2s] You've now met a mystery dog-word in Spanish, and another one in
+English/German. Hindi genuinely gives you a **third** — and its cat-word
+opens up a completely separate story, tracing all the way back to the
+Dravidian languages you already know from elsewhere in this course.
+
+## कुत्ता — a third mystery, displacing Sanskrit's own PIE word
+
+Sanskrit's actual, **inherited** word for dog was **श्वान** (*śvān*) — the
+**exact same PIE root**, ***\*ḱwon-***, behind Latin's *canis*, English's
+*hound*, and German's *Hund*. It's the **only** word for dog found in the
+Rigveda. But everyday Hindi doesn't use *śvān* at all — the ordinary word is
+**कुत्ता** (*kuttā*), which traces through Prakrit to a Sanskrit form,
+**कुर्कुर** (*kurkura*). Its ultimate origin is honestly **unresolved** —
+serious proposals split between an **onomatopoeic** origin (imitating a
+dog's bark) and a **non-Indo-Aryan substrate** word borrowed from an
+unrelated language family, with no consensus on which is right. Either way,
+*kuttā* quietly pushed *śvān* into rare, formal, literary use — the **exact
+same shape of story** as
+Spanish's *perro* displacing *can*, and English's *dog* displacing *hound*.
+Three unrelated language families, three mystery words, all crowding out the
+same inherited PIE word for "dog."
+
+## बिल्ली — most likely Sanskrit's own loan from Dravidian
+
+**बिल्ली** (*billī*, "**cat**") traces through Sauraseni Prakrit to Sanskrit
+**बिडालिका** (*biḍālikā*), a diminutive of **बिडाल** (*biḍāla*, "cat"). Be
+honest that *biḍāla*'s own origin isn't fully settled: most linguists
+consider it most likely a loanword **into** Sanskrit **from Dravidian**, but
+this isn't universal — some (notably Mayrhofer) are skeptical of the
+Dravidian comparison, and at least one serious alternative derives it from
+an unattested native Sanskrit compound instead, ***vidāla**, "that which
+tears apart [small birds]." If the Dravidian derivation holds, this opens up
+a probable **fourth** cat-word story in this course: unlike Arabic's *qiṭṭ*,
+Latin's *cattus*, Spanish's *gato*, French's *chat*, and German's *Katze* —
+all most likely cousins of the same Afro-Asiatic root — Hindi's *billī*
+would come from a **completely separate** word family, one that started in
+the Dravidian languages themselves before Sanskrit borrowed it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kuttā" — dog, genuinely uncertain origin, displacing
+  Sanskrit's own śvān]
+- [YOU SAY: "śvān" — the PIE-inherited word, now rare and formal]
+- [YOU SAY: "billī" — cat, most likely from Sanskrit's own Dravidian
+  loanword]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What was Sanskrit's actual inherited word for "dog," and what
+family does it belong to? (**श्वान**, *śvān* — same PIE root as Latin
+*canis*, English *hound*, German *Hund*.) Does everyday Hindi use *śvān*?
+(**No** — *kuttā* displaced it, echoing Spanish's *perro* and English's
+*dog*.) Is *kuttā*'s own origin settled? (**No** — genuinely disputed
+between an onomatopoeic origin and a non-Indo-Aryan substrate word.) Where
+does **बिल्ली** most likely come from? (**Dravidian** — via Sanskrit
+*biḍāla*, though this isn't universally agreed — a probable cat-word family
+distinct from Arabic's *qiṭṭ* or Latin's *cattus*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C24-hara-pila.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C24-hara-pila.md
@@ -1,0 +1,73 @@
+---
+id: HI-C24-hara-pila
+chapter: 24
+type: word
+headword: हरा, पीला
+gloss: green and yellow — harā traces to Sanskrit's own descendant of the same ancient root behind French's jaune and German's gelb, so Hindi's word for GREEN turns out to be a deep cousin of other languages' words for YELLOW; pīlā comes from a Sanskrit word that also literally means "drunk," though nobody is fully sure why
+concept_tag: HI-COLOUR-GREEN-YELLOW
+prerequisites: [HI-C23-kutta-billi]
+sounds: [retroflex-l, vowel-length-aa]
+roots: [pie-ghelh3-shine, sanskrit-pita-drunk]
+etymology_hook: "हरा (harā, 'green') ← Sanskrit हरित (harita, 'green, yellowish, tawny'), from Proto-Indo-European *ǵʰelh₃-, 'to shine' — the SAME confirmed ancient root behind German's gelb, meaning Hindi's word for GREEN is a genuine cousin of German's word for YELLOW (French's jaune is usually traced to this same family too, via Latin galbinus, though that particular link is less secure than the others); पीला (pīlā, 'yellow') ← Prakrit पीअल (pīala) ← Sanskrit पीतल (pītala), from पीत (pīta) — which also literally means 'drunk, quaffed' — though the exact semantic chain connecting 'drink' to 'yellow' is explicitly flagged by sources as uncertain"
+est_minutes: 6
+reviews_of: [HI-C23-kutta-billi]
+---
+
+# हरा, पीला — a cousin hiding in plain sight, and a word that also means "drunk"
+
+## Warm-up
+
+[PAUSE 2s] Hindi's green word turns out to share deep roots with words other
+languages use for yellow. Hindi's yellow word hides something even stranger —
+it comes from a word that also means "drunk."
+
+## हरा — a hidden cousin of jaune and gelb
+
+**हरा** (**harā**, "**green**") comes from **Sanskrit** **हरित** (**harita**,
+"**green, yellowish, tawny**") — a well-documented descendant of
+**Proto-Indo-European** ***\*ǵʰelh₃-***, "**to shine**." That confirmed root
+is also behind **German**'s **gelb** (via Proto-Germanic *\*gelwaz*) and
+English's own "yellow" and "gold" — making Hindi's word for **GREEN** a
+genuine cousin of German's word for **YELLOW**. **French**'s **jaune** is
+usually traced to this same family too, via Latin *galbinus* — though,
+honestly, that particular link is **less secure** than the others: some
+modern Latin scholarship treats *galbus*'s origin as unknown rather than
+confirming the *\*ǵʰelh₃-* connection. So here's the honest surprise: Hindi's
+word for GREEN and German's word for YELLOW are, at the deepest level,
+**cousins** — not a contradiction, since this root originally covered a
+blurry "shining, yellow-to-green" zone before languages carved out different
+pieces of it. Sanskrit *harita* itself kept some of that blur, historically
+covering shades from green through yellowish and tawny, before Hindi's
+*harā* settled specifically on "green."
+
+## पीला — literally "drunk"
+
+**पीला** (**pīlā**, "**yellow**") traces through **Prakrit** **पीअल**
+(**pīala**) back to **Sanskrit** **पीतल** (**pītala**), built on **पीत**
+(**pīta**) — which means "**yellow**," but **also, literally, "drunk,
+quaffed,"** from a root meaning "to drink." Why would "yellow" and "drunk"
+share a word? Here's the honest answer: the connecting chain is **not
+settled**. One proposed path runs "to drink" → "to become full, swell" →
+"the color of fat" → "yellow" — but sources explicitly flag this specific
+semantic mechanism as **uncertain**, not established fact. What **is** solid
+is the plain sound history: *pīta* → *pītala* → *pīala* → *pīlā*, an entirely
+ordinary chain of yellow-word ancestors ending in Hindi's *pīlā* today.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "हरा" — green, a hidden PIE cousin of German's gelb]
+- [YOU SAY: "पीला" — yellow, literally built on a word meaning "drunk"]
+- [YOU SAY: the contrast — harā's root is SHARED with German's yellow word;
+  pīlā's root carries an unsolved semantic mystery]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What ancient Proto-Indo-European root connects **harā** to
+German's *gelb*? (***\*ǵʰelh₃-***, "to shine" — Hindi's GREEN word is a
+genuine cousin of German's YELLOW word; French's *jaune* is usually placed
+in this family too, though that link is less secure.) What does
+**पीत** (*pīta*), the root behind **pīlā**, also literally mean? ("**Drunk,
+quaffed**.") Is the "drink → yellow" semantic connection settled fact?
+(**No** — sources explicitly flag it as uncertain; only the sound-history
+chain *pīta* → *pītala* → *pīala* → *pīlā* is solid.)

--- a/code/learning/human-languages/kannada/lessons/KA-C09-kshamisi.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C09-kshamisi.md
@@ -1,0 +1,73 @@
+---
+id: KA-C09-kshamisi
+chapter: 9
+type: word
+headword: ಕ್ಷಮಿಸಿ
+gloss: forgive me / sorry (kṣamisi — imperative of kṣamisu, "to forgive," from Sanskrit kṣamā)
+concept_tag: COURTESY-SORRY
+prerequisites: [KA-C08-dayavittu]
+sounds: [kannada-conjunct-kssa, kannada-vowel-sign-i]
+roots: [kshama-sanskrit]
+etymology_hook: "ಕ್ಷಮಿಸಿ kṣamisi ← Sanskrit kṣamā 'patience/forgiveness' + Kannada verb-making -isu — the same trick Kannada uses to borrow Sanskrit nouns as verbs"
+est_minutes: 5
+reviews_of: [KA-C08-dayavittu]
+---
+
+# ಕ್ಷಮಿಸಿ (kṣamisi) — forgive me / sorry
+
+## Warm-up
+
+[PAUSE 2s] You already know **ದಯವಿಟ್ಟು**, "please." Kannada's "sorry" reuses
+a trick you'll see everywhere in this language: taking a Sanskrit noun and
+turning it into a working Kannada verb.
+
+## The word, taken apart
+
+- **ಕ್ಷಮಾ** (*kṣamā*) = "**patience, forbearance, forgiveness**" — a Sanskrit
+  noun, unchanged.
+- **‑ಇಸು** (*‑isu*) = a **verb-making suffix**: bolt it onto a Sanskrit noun
+  and you get a brand-new Kannada verb. *kṣamā* + *‑isu* → **ಕ್ಷಮಿಸು**
+  (*kṣamisu*), "**to forgive**." (The same move builds ಪ್ರಾರಂಭಿಸು
+  *prārambhisu*, "to begin," from Sanskrit *prārambha*.)
+- **‑ಿ** (*‑i*) = the plain **imperative** ending — the very one you met on
+  *kuḷitukoḷḷi* ("please sit") in the please lesson.
+
+So **ಕ್ಷಮಿಸಿ** is simply "**forgive!**" — *kṣamisu* wearing its imperative
+ending.
+
+## The Dravidian family, side by side
+
+Three of the four Dravidian cousins build "sorry" from the very same Sanskrit
+noun, each with its own verb-making suffix and its own imperative shape:
+
+- Kannada **ಕ್ಷಮಿಸಿ** *kṣami**si*** — Sanskrit *kṣamā* + **‑isu** (verb) + **‑i**
+  (imperative)
+- Telugu **క్షమించండి** *kṣamin̄**caṇḍi*** — Sanskrit *kṣamā* + **‑in̄cu**
+  (verb) + **‑aṇḍi** (imperative)
+- Malayalam **ക്ഷമിക്കണം** *kṣami**kkaṇaṁ*** — Sanskrit *kṣama* + **‑ikkuka**
+  (verb) + **‑aṇaṁ** (necessitative)
+- Tamil **மன்னிக்கவும்** *maṉṉi**kkavum*** — its **own** native root *maṉṉi*,
+  not Sanskrit at all
+
+## Be honest about how it's used
+
+**ಕ್ಷಮಿಸಿ** is a genuine, everyday way to say "sorry" — not overly formal —
+but in casual conversation you'll also hear the softer **ಕ್ಷಮಿಸಿ ಬಿಡಿ**
+(*kṣamisi biḍi*, roughly "just forgive [it]") or simply the borrowed English
+"**sorry**," which is extremely common in spoken Kannada.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kṣamā" — the Sanskrit noun, patience/forgiveness]
+- [YOU SAY: the verb — "kṣamisu," to forgive — then "kṣamisi," forgive!]
+- [YOU SAY: contrast — Tamil's maṉṉikkavum uses its own root instead]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is **ಕ್ಷಮಿಸಿ** built from? (**Sanskrit kṣamā** "forgiveness"
++ the verb-making suffix **‑isu** + the imperative **‑i**.) Which cousin
+languages do the same trick, and which one doesn't? (**Telugu and Malayalam**
+also verb-ify *kṣamā*; **Tamil** uses its own native root *maṉṉi* instead.)
+What do people often say casually instead? (**Kṣamisi biḍi**, or simply
+borrowed English "**sorry**.")

--- a/code/learning/human-languages/kannada/lessons/KA-C10-vaara.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C10-vaara.md
@@ -1,0 +1,58 @@
+---
+id: KA-C10-vaara
+chapter: 10
+type: word
+headword: ಸೋಮವಾರ ಮಂಗಳವಾರ ಬುಧವಾರ ಗುರುವಾರ ಶುಕ್ರವಾರ ಶನಿವಾರ ಭಾನುವಾರ
+gloss: the seven weekdays — fully Sanskritic, like Hindi, but Sunday uses a DIFFERENT sun-name
+concept_tag: KA-DAYS-WEEK
+prerequisites: [KA-C09-kshamisi]
+sounds: [kannada-anusvara, kannada-conjunct-kra]
+roots: [sanskrit-planet-words]
+etymology_hook: "Kannada's week is fully Sanskritic like Hindi's — Somavāra, Maṅgaḷavāra… — but Sunday is Bhānuvāra ('day of light'), a different Sanskrit sun-name than Hindi's Ravivāra"
+est_minutes: 5
+reviews_of: [KA-C09-kshamisi]
+---
+
+# ಸೋಮವಾರ to ಭಾನುವಾರ — Kannada's fully Sanskritic week
+
+## Warm-up
+
+[PAUSE 2s] Unlike Tamil and Malayalam, Kannada's week is built entirely from
+Sanskrit — the same recipe as Hindi's. But even here, one day picks a
+**different** Sanskrit word than Hindi does.
+
+## The pattern: [deity] + ವಾರ, "day"
+
+| Kannada | deity/planet | day |
+|---|---|---|
+| **ಸೋಮವಾರ** (*Somavāra*) | **Moon** (Soma) | Monday |
+| **ಮಂಗಳವಾರ** (*Maṅgaḷavāra*) | **Mars** (Maṅgala) | Tuesday |
+| **ಬುಧವಾರ** (*Budhavāra*) | **Mercury** (Budha) | Wednesday |
+| **ಗುರುವಾರ** (*Guruvāra*) | **Jupiter** (Guru/Bṛhaspati) | Thursday |
+| **ಶುಕ್ರವಾರ** (*Śukravāra*) | **Venus** (Śukra) | Friday |
+| **ಶನಿವಾರ** (*Śanivāra*) | **Saturn** (Śani) | Saturday |
+| **ಭಾನುವಾರ** (*Bhānuvāra*) | the **Sun** (Bhānu, "light, splendor") | Sunday |
+
+Five of these are identical in shape to Hindi's — same deity, same **‑vāra/
+‑vār** ending. **Sunday** is the interesting exception: where Hindi says
+**रविवार** (*Ravivār*, from *Ravi*, "sun"), Kannada says **ಭಾನುವಾರ**
+(*Bhānuvāra*), built on a **different** Sanskrit word for the sun — **Bhānu**,
+"light, splendor," rather than *Ravi*. Sanskrit has **many** names for the
+sun, and different languages downstream picked different ones for their
+week.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Somavāra, Maṅgaḷavāra, Budhavāra, Guruvāra, Śukravāra,
+  Śanivāra" — Monday through Saturday]
+- [YOU SAY: the different one — "Bhānuvāra," Sunday]
+- [YOU SAY: the contrast — Hindi says Ravivāra (Ravi), Kannada says Bhānuvāra
+  (Bhānu) — two different Sanskrit sun-names]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What ending does every Kannada weekday share, and where's it
+from? (**‑ವಾರ** *-vāra*, Sanskrit "day.") Which day differs from Hindi's
+version, and how? (**Sunday** — Kannada's *Bhānuvāra* ("light") uses a
+different Sanskrit sun-name than Hindi's *Ravivār* ("Ravi").)

--- a/code/learning/human-languages/kannada/lessons/KA-C11-bannagalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C11-bannagalu.md
@@ -1,0 +1,51 @@
+---
+id: KA-C11-bannagalu
+chapter: 11
+type: word
+headword: ಕಪ್ಪು ಬಿಳಿ ಕೆಂಪು ನೀಲಿ
+gloss: black, white, red, blue — Kannada's own basic colors, and the same shared Sanskrit blue
+concept_tag: KA-COLOUR-BASIC
+prerequisites: [KA-C10-vaara]
+sounds: [kannada-anusvara, kannada-virama-geminate]
+roots: [dravidian-native-colors, sanskrit-nila]
+etymology_hook: "ಕಪ್ಪು/ಬಿಳಿ/ಕೆಂಪು (black/white/red) are native Dravidian, unlike Kannada's fully-Sanskritic day-names — but ನೀಲಿ (blue) is Sanskrit, same root as Tamil/Hindi/Malayalam"
+est_minutes: 5
+reviews_of: [KA-C10-vaara]
+---
+
+# ಕಪ್ಪು, ಬಿಳಿ, ಕೆಂಪು, ನೀಲಿ — native colors, after a fully Sanskrit week
+
+## Warm-up
+
+[PAUSE 2s] Kannada's week ran entirely on Sanskrit deity-names. Its colors
+tell a different story — here, native Dravidian vocabulary is back in
+charge, except for one familiar exception.
+
+## Three native colors
+
+- **ಕಪ್ಪು** (*kappu*) = "**black**" — native Dravidian.
+- **ಬಿಳಿ** (*biḷi*) = "**white**" — native Dravidian.
+- **ಕೆಂಪು** (*kempu*) = "**red**" — native Dravidian.
+
+## The familiar borrowed blue
+
+**ನೀಲಿ** (*nīli*) = "**blue**" — from the **same Sanskrit** ನೀಲ (*nīla*)
+that Tamil, Malayalam, and Hindi all reach for. Even Kannada, whose week
+went fully Sanskritic, still keeps its everyday black/white/red **native** —
+it's specifically **blue** that pulls in the Sanskrit word, across all four
+Dravidian languages and Hindi alike.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kappu, biḷi, kempu" — black, white, red]
+- [YOU SAY: "nīli" — blue, the shared Sanskrit word]
+- [YOU SAY: the contrast — Kannada's week is Sanskritic, but its colors
+  (except blue) are native]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are Kannada's black/white/red native or Sanskrit? (**Native
+Dravidian** — kappu, biḷi, kempu.) Which color is the shared Sanskrit loan
+across Kannada, Tamil, Malayalam, and Hindi? (**Blue** — ನೀಲಿ *nīli* / நீலம்
+*nīlam* / നീല *nīla* / नीला *nīlā*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C12-kutumba.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C12-kutumba.md
@@ -1,0 +1,55 @@
+---
+id: KA-C12-kutumba
+chapter: 12
+type: word
+headword: ಅಪ್ಪ ಅಮ್ಮ ಅಣ್ಣ ತಮ್ಮ ಅಕ್ಕ ತಂಗಿ
+gloss: father, mother, and four age-graded sibling words — nearly identical to Tamil's own set
+concept_tag: KA-FAMILY-BASIC
+prerequisites: [KA-C11-bannagalu]
+sounds: [kannada-retroflex-nna, kannada-anusvara]
+roots: [dravidian-appa-amma, dravidian-age-graded-siblings]
+etymology_hook: "ಅಪ್ಪ appa/ಅಮ್ಮ amma and the four sibling words (ಅಣ್ಣ/ತಮ್ಮ, ಅಕ್ಕ/ತಂಗಿ) match Tamil's set almost word-for-word — Kannada splits siblings by age too"
+est_minutes: 5
+reviews_of: [KA-C11-bannagalu]
+---
+
+# ಅಪ್ಪ, ಅಮ್ಮ, and four sibling words — the same system as Tamil
+
+## Warm-up
+
+[PAUSE 2s] Kannada asks the same question Tamil does about any sibling:
+**older, or younger?** — and the words for answering it are almost
+identical.
+
+## Parents — native, and matching Tamil
+
+- **ಅಪ್ಪ** (*appa*) = "**father**" — matches Tamil *appā* closely.
+- **ಅಮ್ಮ** (*amma*) = "**mother**" — matches Tamil *ammā* closely.
+
+## Four sibling words, age before gender
+
+| Kannada | meaning | compare Tamil |
+|---|---|---|
+| **ಅಣ್ಣ** (*aṇṇa*) | **older** brother | *aṇṇaṉ* — near match |
+| **ತಮ್ಮ** (*tamma*) | **younger** brother | *tambi* — near match |
+| **ಅಕ್ಕ** (*akka*) | **older** sister | *akkā* — near match |
+| **ತಂಗಿ** (*tangi*) | **younger** sister | *tangai* — near match |
+
+Just like Tamil, Kannada has **no single word** that simply means "brother"
+or "sister" — you name the sibling's **relative age** every time, not just
+their gender. This age-first system runs across the whole Dravidian family,
+not just one language.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "appa, amma" — father, mother]
+- [YOU SAY: "aṇṇa, tamma" — older/younger brother]
+- [YOU SAY: "akka, tangi" — older/younger sister]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How many Kannada sibling words are there, and what do they split
+on? (**Four** — ಅಣ್ಣ/ತಮ್ಮ, ಅಕ್ಕ/ತಂಗಿ — split by **relative age**, not just
+gender.) How closely do Kannada's words match Tamil's? (**Very closely** —
+nearly the same forms across the whole set.)

--- a/code/learning/human-languages/kannada/lessons/KA-C13-dehada-bhagagalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C13-dehada-bhagagalu.md
@@ -1,0 +1,41 @@
+---
+id: KA-C13-dehada-bhagagalu
+chapter: 13
+type: word
+headword: ತಲೆ ಕೈ
+gloss: head and hand — native Dravidian, matching Tamil/Malayalam closely
+concept_tag: KA-BODY-BASIC
+prerequisites: [KA-C12-kutumba]
+sounds: [kannada-vowel-sign-ai]
+roots: [dravidian-tale-kai]
+etymology_hook: "ತಲೆ tale (head) and ಕೈ kai (hand) are native Dravidian, matching Tamil talai/kai and Malayalam thala/kai closely — a shared core across three of the four languages"
+est_minutes: 4
+reviews_of: [KA-C12-kutumba]
+---
+
+# ತಲೆ, ಕೈ — head and hand, the shared Dravidian core
+
+## Warm-up
+
+[PAUSE 2s] Three languages, nearly one word each — Kannada's basic body
+parts line up with Tamil and Malayalam almost perfectly.
+
+## The words
+
+- **ತಲೆ** (*tale*) = "**head**" — native Dravidian, matching Tamil *talai*
+  and Malayalam *thala*.
+- **ಕೈ** (*kai*) = "**hand**" — native Dravidian, matching Tamil and
+  Malayalam's *kai* almost exactly.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tale" — head]
+- [YOU SAY: "kai" — hand]
+- [YOU SAY: the match — nearly identical across Tamil, Malayalam, Kannada]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are Kannada's words for head and hand? (**ತಲೆ tale, ಕೈ
+kai**.) How closely do they match Tamil and Malayalam? (**Very closely** —
+all three share essentially the same native Dravidian words.)

--- a/code/learning/human-languages/kannada/lessons/KA-C14-kaalagalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C14-kaalagalu.md
@@ -1,0 +1,59 @@
+---
+id: KA-C14-kaalagalu
+chapter: 14
+type: word
+headword: ವಸಂತ ಋತು ಬೇಸಿಗೆ ಮಳೆಗಾಲ ಚಳಿಗಾಲ
+gloss: spring, summer, monsoon, winter — native heat/rain/cold words, one shared Sanskrit "spring"
+concept_tag: KA-SEASONS
+prerequisites: [KA-C13-dehada-bhagagalu]
+sounds: [kannada-vocalic-r, kannada-anusvara]
+roots: [dravidian-besige-male-chali, sanskrit-vasanta]
+etymology_hook: "ಬೇಸಿಗೆ besige (summer) and ಮಳೆ male (rain) are native Dravidian; ವಸಂತ ಋತು vasanta rutu (spring) uses the same Sanskrit vasanta AND the Sanskrit word rutu itself, 'season' — a double Sanskrit loan where Tamil/Malayalam just say kaalam"
+est_minutes: 5
+reviews_of: [KA-C13-dehada-bhagagalu]
+---
+
+# ವಸಂತ ಋತು, ಬೇಸಿಗೆ, ಮಳೆಗಾಲ, ಚಳಿಗಾಲ — native words, plus a double Sanskrit loan
+
+## Warm-up
+
+[PAUSE 2s] Kannada's summer, rain, and cold words are native, just like
+Tamil's — but its word for "spring" borrows **twice** from Sanskrit, not
+once.
+
+## The words
+
+| Kannada | meaning | source |
+|---|---|---|
+| **ವಸಂತ ಋತು** (*vasanta ṛtu*) | "spring" | **both** *vasanta* AND **ಋತು** *ṛtu* ("season") are Sanskrit |
+| **ಬೇಸಿಗೆ** (*bēsige*) | "summer" | native Dravidian |
+| **ಮಳೆಗಾಲ** (*maḷegāla*) | "rainy season" | **ಮಳೆ** *maḷe*, native Dravidian ("rain") + **ಕಾಲ** *kāla* ("time," itself a Sanskrit loan) |
+| **ಚಳಿಗಾಲ** (*caḷigāla*) | "winter/cold season" | **ಚಳಿ** *caḷi*, native Dravidian ("cold") + *kāla* |
+
+## Be honest about the double loan — and the real season
+
+Where Tamil and Malayalam just say *kaalam* ("time/season," itself
+ultimately Sanskrit-derived too, but assimilated long ago as ordinary
+vocabulary), Kannada's word for spring, **ವಸಂತ ಋತು**, keeps **both** halves
+visibly Sanskrit — *vasanta* the season-name, *ṛtu* the very word for
+"season." Summer, rain, and cold, by contrast, are built on native
+Dravidian roots (*bēsige*, *maḷe*, *caḷi*).
+
+And as with Tamil and Malayalam: it's **ಮಳೆಗಾಲ** (*maḷegāla*, the rains)
+that shapes Karnataka's agricultural year the most, not a clean four-way
+Western split.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bēsige" — summer, native]
+- [YOU SAY: "maḷegāla" — the rains]
+- [YOU SAY: "caḷigāla" — the cold season, native]
+- [YOU SAY: the double loan — "vasanta ṛtu" — both halves Sanskrit]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What's unusual about ವಸಂತ ಋತು compared to Tamil/Malayalam's
+spring-word? (**Both halves are Sanskrit** — *vasanta* and *ṛtu*, "season"
+itself — where Tamil/Malayalam just add the long-assimilated *kaalam*.) Which season
+actually shapes Karnataka's year most? (**ಮಳೆಗಾಲ**, the rains.)

--- a/code/learning/human-languages/kannada/lessons/KA-C15-niiru-akki.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C15-niiru-akki.md
@@ -1,0 +1,46 @@
+---
+id: KA-C15-niiru-akki
+chapter: 15
+type: word
+headword: ನೀರು ಅಕ್ಕಿ ಅನ್ನ
+gloss: water (matching Tamil's neer, unlike Malayalam), and rice raw/cooked
+concept_tag: KA-FOOD-BASIC
+prerequisites: [KA-C14-kaalagalu]
+sounds: [kannada-vowel-sign-ii, kannada-geminate-kka]
+roots: [niiru-water-dravidian, akki-rice-dravidian]
+etymology_hook: "ನೀರು niiru (water) matches Tamil's nir/thanneer closely — unlike Malayalam's genuinely different vellam; ಅಕ್ಕಿ akki (rice) and ಅನ್ನ anna (cooked rice) complete the same raw/cooked distinction found across the family"
+est_minutes: 5
+reviews_of: [KA-C14-kaalagalu]
+---
+
+# ನೀರು, ಅಕ್ಕಿ, ಅನ್ನ — water matching Tamil, and rice, raw and cooked
+
+## Warm-up
+
+[PAUSE 2s] Kannada's water-word sides with Tamil, not with Malayalam's
+surprising break from the pack.
+
+## ನೀರು — matching Tamil
+
+**ನೀರು** (*nīru*) = "**water**" — matching Tamil's **நீர்** (*nīr*, the
+root inside *taṇṇīr*) closely. Kannada didn't make Malayalam's switch to
+the *veḷ-* "bright/white" root.
+
+## ಅಕ್ಕಿ, ಅನ್ನ — rice, raw and cooked
+
+- **ಅಕ್ಕಿ** (*akki*) = "**rice**" (raw grain).
+- **ಅನ್ನ** (*anna*) = "**cooked rice**" (the meal) — likely Sanskrit-
+  influenced, the same general idea as Tamil's *sātam*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nīru" — water, matching Tamil]
+- [YOU SAY: "akki" — raw rice]
+- [YOU SAY: "anna" — cooked rice]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does Kannada's water-word match Tamil's or Malayalam's? (**Tamil's**
+— *nīru*/*nīr*, not Malayalam's *veḷḷam*.) What's the raw/cooked rice pair?
+(**ಅಕ್ಕಿ** *akki* raw, **ಅನ್ನ** *anna* cooked.)

--- a/code/learning/human-languages/kannada/lessons/KA-C16-tingalugalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C16-tingalugalu.md
@@ -1,0 +1,55 @@
+---
+id: KA-C16-tingalugalu
+chapter: 16
+type: word
+headword: ಚೈತ್ರ ವೈಶಾಖ ಜ್ಯೇಷ್ಠ ಆಷಾಢ ಶ್ರಾವಣ ಭಾದ್ರಪದ ಆಶ್ವಯುಜ ಕಾರ್ತೀಕ ಮಾರ್ಗಶಿರ ಪುಷ್ಯ ಮಾಘ ಫಾಲ್ಗುಣ
+gloss: the twelve lunisolar months — NOT Kannada's own calendar like Tamil/Malayalam's, but the same pan-Indian Sanskritic system Hindi's Vikram Samvat uses
+concept_tag: KA-MONTHS
+prerequisites: [KA-C15-niiru-akki]
+sounds: [kannada-conjunct-shtha, kannada-anusvara]
+roots: [sanskrit-lunisolar-chaitra-system]
+etymology_hook: "Unlike Tamil and Malayalam, which built their OWN solar calendars, Kannada uses the same pan-Indian Sanskritic lunisolar calendar as Hindi's Vikram Samvat — Ugadi falls on Chaitra Shukla Pratipada, the SAME calendar Telugu uses too"
+est_minutes: 5
+reviews_of: [KA-C15-niiru-akki]
+---
+
+# ಚೈತ್ರ to ಫಾಲ್ಗುಣ — the calendar Kannada shares with Hindi, not with Tamil
+
+## Warm-up
+
+[PAUSE 2s] Tamil and Malayalam each built their own solar calendar. Kannada
+takes a different path entirely — the same path as Hindi.
+
+## The twelve months
+
+**ಚೈತ್ರ, ವೈಶಾಖ, ಜ್ಯೇಷ್ಠ, ಆಷಾಢ, ಶ್ರಾವಣ, ಭಾದ್ರಪದ, ಆಶ್ವಯುಜ, ಕಾರ್ತೀಕ,
+ಮಾರ್ಗಶಿರ, ಪುಷ್ಯ, ಮಾಘ, ಫಾಲ್ಗುಣ** (*Caitra, Vaiśākha, Jyēṣṭha, Āṣāḍha,
+Śrāvaṇa, Bhādrapada, Āśvayuja, Kārtīka, Mārgaśira, Puṣya, Māgha,
+Phālguṇa*).
+
+## Be honest: this is Hindi's calendar too, not a Dravidian one
+
+This is the **same pan-Indian Sanskritic lunisolar calendar** you already
+met as Hindi's **Vikram Samvat** — the same twelve month names, tied to the
+same **six-ṛtu** seasonal cycle. Karnataka's own New Year, **Ugadi**, falls
+on *Chaitra Śukla Pratipada* — the first day of the bright fortnight of
+Chaitra — exactly the reasoning behind Hindu New Year celebrations across
+much of India. Unlike Tamil's or Malayalam's genuinely home-grown solar
+calendars, Kannada didn't build its own separate system here — it shares
+this one with Hindi, Telugu, and much of the rest of the subcontinent.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "Caitra, Vaiśākha, Jyēṣṭha, Āṣāḍha, Śrāvaṇa,
+  Bhādrapada, Āśvayuja, Kārtīka, Mārgaśira, Puṣya, Māgha, Phālguṇa"]
+- [YOU SAY: "Ugadi — Chaitra Śukla Pratipada"]
+- [YOU SAY: the honest point — shared with Hindi, unlike Tamil/Malayalam's
+  own calendars]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does Kannada use its own solar calendar, like Tamil and
+Malayalam? (**No** — it uses the **same pan-Indian lunisolar calendar** as
+Hindi's Vikram Samvat.) What is Kannada's New Year called, and when does it
+fall? (**Ugadi**, on *Chaitra Śukla Pratipada*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C17-madhyaahna-madhyaraatri.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C17-madhyaahna-madhyaraatri.md
@@ -1,0 +1,66 @@
+---
+id: KA-C17-madhyaahna-madhyaraatri
+chapter: 17
+type: word
+headword: ಮಧ್ಯಾಹ್ನ ಮಧ್ಯರಾತ್ರಿ
+gloss: noon and midnight — both direct Sanskrit tatsama compounds built on the SAME "middle" root, madhya
+concept_tag: KA-TIME-NOON-MIDNIGHT
+prerequisites: [KA-C16-tingalugalu]
+sounds: [kannada-conjunct-dhya, kannada-vowel-sign-aa]
+roots: [sanskrit-madhya-middle]
+etymology_hook: "ಮಧ್ಯಾಹ್ನ (madhyāhna, noon) and ಮಧ್ಯರಾತ್ರಿ (madhyarātri, midnight) are both direct Sanskrit tatsama compounds on madhya, 'middle' — Kannada's everyday words for these times are the SAME Sanskrit-formal register that Hindi keeps as a bookish alternate to its own colloquial dopahar / aadhi raat"
+est_minutes: 5
+reviews_of: [KA-C16-tingalugalu]
+---
+
+# ಮಧ್ಯಾಹ್ನ, ಮಧ್ಯರಾತ್ರಿ — one Sanskrit root, two everyday Kannada words
+
+## Warm-up
+
+[PAUSE 2s] You've just seen Hindi's *dopahar* (an old timekeeping unit) and
+*aadhi raat* (plain "half night"). Kannada takes a completely different
+path — straight to Sanskrit, and straight down the middle.
+
+## ಮಧ್ಯಾಹ್ನ — "middle of the day"
+
+**ಮಧ್ಯಾಹ್ನ** (*madhyāhna*) = "**noon, midday**" — a Sanskrit *tatsama*
+(borrowed whole, unchanged) compound: **ಮಧ್ಯ** (*madhya*, "**middle**") +
+**ಅಹ್ನ** (*ahna*, "**day**"). This is the everyday, ordinary Kannada word for
+noon — not a formal or bookish alternative the way it can feel in some of
+its sister languages.
+
+## ಮಧ್ಯರಾತ್ರಿ — "middle of the night"
+
+**ಮಧ್ಯರಾತ್ರಿ** (*madhyarātri*) = "**midnight**" — the exact same **ಮಧ್ಯ**
+(*madhya*, "middle") root, this time compounded with **ರಾತ್ರಿ** (*rātri*,
+"**night**"). Same logic, same "middle" word, just paired with "night"
+instead of "day."
+
+## Be honest: this is Sanskrit's "middle," used as Kannada's default
+
+Both words are unmistakably **Sanskrit tatsama** compounds — Kannada
+borrowed them whole rather than building native Dravidian equivalents.
+That's worth contrasting directly with Hindi, a language actually
+*descended* from Sanskrit: Hindi has these exact same words too
+(*madhyāhna*, *madhyarātri*), but treats them as the more **formal,
+literary** register — its everyday words are the homegrown *dopahar*
+("two pahars") and *aadhi raat* ("half night") instead. Kannada, by
+contrast, took the Sanskrit-formal compound and made it the **plain,
+everyday** word — there's no separate native-Dravidian doublet in common
+use here the way there is for some other concepts.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "madhyāhna" — noon, "middle of the day"]
+- [YOU SAY: "madhyarātri" — midnight, "middle of the night"]
+- [YOU SAY: the shared piece — "madhya," middle, in both words]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Sanskrit root do **ಮಧ್ಯಾಹ್ನ** and **ಮಧ್ಯರಾತ್ರಿ** share, and
+what does it mean? (**ಮಧ್ಯ**, *madhya*, "middle.") Are these native Dravidian
+words or Sanskrit borrowings? (**Sanskrit tatsama** borrowings, taken
+whole.) Does Hindi treat its version of these words as everyday or formal?
+(**Formal/literary** — Hindi's everyday words are *dopahar* and *aadhi
+raat* instead.)

--- a/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
@@ -1,0 +1,62 @@
+---
+id: KA-C18-gante
+chapter: 18
+type: word
+headword: ಗಂಟೆ
+gloss: hour — the SAME Sanskrit "bell" word behind Hindi's ghantā, borrowed via Prakrit
+concept_tag: KA-TIME-HOUR
+prerequisites: [KA-C17-madhyaahna-madhyaraatri]
+sounds: [kannada-anusvara, kannada-vowel-sign-e]
+roots: [sanskrit-ghanta-bell]
+etymology_hook: "ಗಂಟೆ (gaṇṭe, 'hour') is related to Sanskrit घण्टा (ghaṇṭā, 'bell') — the SAME word and the SAME bell-strikes-the-hour logic as Hindi's ghanṭā, unlike Tamil's most-likely-native maṇi"
+est_minutes: 5
+reviews_of: [KA-C17-madhyaahna-madhyaraatri]
+---
+
+# ಗಂಟೆ — the same "bell" word as Hindi, borrowed through Prakrit
+
+## Warm-up
+
+[PAUSE 2s] You've already met Hindi's *ghanṭā* — "hour," literally "bell." Kannada
+has the exact same word, arriving by the exact same logic.
+
+## ಗಂಟೆ — bell AND hour, again
+
+**ಗಂಟೆ** (*gaṇṭe*) = "**hour**" — and, just like Hindi, it means "**bell, gong**"
+just as commonly. It's related to the same Sanskrit **घण्टा** (*ghaṇṭā*, "bell").
+The semantic shift is identical to Hindi's: temples, towns, and clock towers
+announced the hour by striking a bell, so the bell-word became the hour-word.
+
+## Be honest: this is Kannada matching Hindi, not matching Tamil
+
+This is a genuinely different picture from what you'll see in Tamil. Kannada's
+*gaṇṭe*, like Hindi's *ghanṭā*, is a **Sanskrit-derived** "bell → hour" word.
+Tamil, by contrast, most likely uses a **native Dravidian** word for exactly the
+same "bell → hour" idea — a different root entirely, arrived at independently
+(though even specialists don't call this fully settled). So the *pattern*
+(bell-word becomes hour-word) repeats across languages, but the *word itself*
+splits along the same Sanskrit/native line you've seen before in this course
+(compare *madhyāhna* vs. Tamil's *naḷ*-based words for noon).
+
+## Grammar Lens: telling the time
+
+> **ಒಂದು ಗಂಟೆ.** — "One o'clock." (*ondu gaṇṭe*, "one hour/bell")
+> **ಎರಡು ಗಂಟೆ.** — "Two o'clock." (*eraḍu gaṇṭe*, "two hour/bell")
+
+Kannada simply pairs the cardinal number with *gaṇṭe* — no ordinal/cardinal split
+like Arabic's, no singular/plural verb switch like Hindi's *bajnā*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "gaṇṭe" — hour, also "bell"]
+- [YOU SAY: "ondu gaṇṭe" — one o'clock]
+- [YOU SAY: "eraḍu gaṇṭe" — two o'clock]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ಗಂಟೆ** mean besides "hour," and what Sanskrit word is it
+related to? (**"Bell, gong"** — related to Sanskrit *ghaṇṭā*.) Is this the same
+root Hindi uses for "hour"? (**Yes** — Hindi's *ghanṭā* is the same Sanskrit word.)
+Does Tamil use this same Sanskrit root for "hour"? (**Most likely not** — it uses
+a native Dravidian word instead, arrived at independently.)

--- a/code/learning/human-languages/kannada/lessons/KA-C19-vayassu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C19-vayassu.md
@@ -1,0 +1,58 @@
+---
+id: KA-C19-vayassu
+chapter: 19
+type: phrase
+headword: ನಿನ್ನ ವಯಸ್ಸು ಎಷ್ಟು?
+gloss: how old are you? — literally "your age how-much?"; ವಯಸ್ಸು is a Sanskrit loan, distant cousin of Latin's own vīs
+concept_tag: KA-AGE
+prerequisites: [KA-C18-gante]
+sounds: [kannada-anusvara, kannada-conjunct-ssu]
+roots: [sanskrit-vayas-vigor-age]
+etymology_hook: "ವಯಸ್ಸು (vayassu, 'age') is from Sanskrit वयस् (vayas, 'age, youth, vigor'), from PIE *wéyh₁os — the SAME PIE root as Latin's vīs ('force'), the very word you met in Latin's age lesson's own vocabulary family; Kannada asks age with a simple possessive, 'your age how-much,' no verb at all"
+est_minutes: 5
+reviews_of: [KA-C18-gante]
+---
+
+# ನಿನ್ನ ವಯಸ್ಸು ಎಷ್ಟು? — "your age, how much?"
+
+## Warm-up
+
+[PAUSE 2s] Here's a genuinely nice callback: the Sanskrit word behind Kannada's
+"age" is a distant cousin of a Latin word you already know.
+
+## ವಯಸ್ಸು — a Sanskrit word, and a PIE cousin of Latin vīs
+
+**ವಯಸ್ಸು** (*vayassu*) = "**age**" — from Sanskrit **वयस्** (*vayas*, "age,
+youth, vigor, strength"), which traces back to **Proto-Indo-European**
+***wéyh₁os**. That PIE root is the **same** one behind Latin **vīs**, "force,
+strength, vigor" — so Sanskrit's word for "age" and Latin's word for "force" are
+genuine, distant cousins, both carrying the older sense of "vigor, life-force"
+before splitting toward different specific meanings.
+
+## Grammar Lens: a simple possessive, no verb
+
+> **ನಿನ್ನ ವಯಸ್ಸು ಎಷ್ಟು?** — "How old are you?" — literally "**your age
+  how-much**?" (*ninna vayassu eṣṭu?*)
+> **ನನ್ನ ವಯಸ್ಸು ಇಪ್ಪತ್ತು.** — "I am twenty years old." — literally "**my age**
+  [is] **twenty**." (*nanna vayassu ippattu.*)
+
+Just like Arabic's *ʿumr*, this is a **verbless** construction in the present
+tense — Kannada simply states "your age" and "how much," with no "is" needed.
+But notice the shape is simpler than Arabic's: no possessive suffix fused onto
+the noun, just the ordinary possessive word **ನಿನ್ನ** (*ninna*, "your") sitting
+in front of **ವಯಸ್ಸು**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vayassu" — age]
+- [YOU SAY: "ninna vayassu eṣṭu?" — how old are you?]
+- [YOU SAY: "nanna vayassu ippattu" — I am twenty, "my age [is] twenty"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Sanskrit word is **ವಯಸ್ಸು** from, and what Latin word is its PIE
+cousin? (**वयस्**, *vayas*, "age/vigor" — cousin of Latin **vīs**, "force," both
+from PIE *wéyh₁os.) Does Kannada use a verb to state age? (**No** — "your age
+how-much," no verb needed.) How do you say "I am twenty"? (*Nanna vayassu
+ippattu* — "my age [is] twenty.")

--- a/code/learning/human-languages/kannada/lessons/KA-C20-hannondu-ippattu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C20-hannondu-ippattu.md
@@ -1,0 +1,70 @@
+---
+id: KA-C20-hannondu-ippattu
+chapter: 20
+type: word
+headword: ಹನ್ನೊಂದು — ಇಪ್ಪತ್ತು
+gloss: 11-20 — additive "ten-echo" compounds for the teens, then ಇಪ್ಪತ್ತು (20), compositionally "two-tens" from OLD Dravidian roots — though the pieces have shifted enough that it no longer looks like the MODERN words eraḍu/hattu on the surface
+concept_tag: KA-NUM-11-20
+prerequisites: [KA-C19-vayassu]
+sounds: [kannada-anusvara-o, kannada-geminate-pp]
+roots: [dravidian-hattu-ten, dravidian-ir-two-bound]
+etymology_hook: "ಹನ್ನೊಂದು-ಹತ್ತೊಂಬತ್ತು (11-19) are compounds echoing ಹತ್ತು (hattu, 'ten') + a digit — ಇಪ್ಪತ್ತು (ippattu, 'twenty') traces to Proto-Dravidian *ir- ('two') + *paHtu ('ten'), a real compositional origin, but Kannada's own sound changes (gemination, and a p→h shift that only fires word-initially) mean neither modern eraḍu nor modern hattu is directly visible inside it today — unlike Sanskrit/Latin/Arabic, which have no compositional origin for 'twenty' AT ALL"
+est_minutes: 6
+reviews_of: [KA-C19-vayassu]
+---
+
+# ಹನ್ನೊಂದು, ಇಪ್ಪತ್ತು — a real "two-tens" compound, just not one you can see today
+
+## Warm-up
+
+[PAUSE 2s] You've now seen four different language families each build
+"twenty" as its own special, opaque word — Sanskrit's *vimshati*, Latin's
+*viginti*, Arabic's *ʿishrūn*. Kannada's twenty genuinely started life as
+"two tens" too — but be careful: the modern surface no longer shows it
+plainly.
+
+## ಹನ್ನೊಂದು–ಹತ್ತೊಂಬತ್ತು — "ten" + digit
+
+Kannada's teens are built on **ಹತ್ತು** (*hattu*, "**ten**") plus each digit —
+**ಹನ್ನೊಂದು** (*hannondu*, 11), **ಹನ್ನೆರಡು** (*hanneraḍu*, 12), and onward
+through **ಹತ್ತೊಂಬತ್ತು** (*hattombattu*, 19). Each teen is a compound
+built the same way English builds "four-**teen**" — just placed the same
+digit-plus-ten pattern in front instead of behind.
+
+## ಇಪ್ಪತ್ತು — "two-tens" underneath, but not on the surface anymore
+
+**ಇಪ್ಪತ್ತು** (*ippattu*, "**twenty**") traces back to Proto-Dravidian
+**\*ir-** ("**two**") + **\*paHtu** ("**ten**") — a genuine compositional
+origin, "two-tens." But be honest about what's actually visible today: the
+**\*ir-** piece is an old *bound* root, not the same as modern Kannada's
+everyday word for "two," **ಎರಡು** (*eraḍu*) — a separate, longer descendant of
+the same ancient family. And the "ten" piece surfaces here as **-pp-**
+(geminated after the *r*), not as modern **ಹತ್ತು** (*hattu*)'s **h-** — because
+Kannada's historical *p → h* shift only fired at the **start** of a word, and
+this "ten" sits in the **middle** of the compound, so it never lenited. So
+*ippattu* really did start as "two-tens" — you just can't spot modern *eraḍu*
+or modern *hattu* inside it anymore the way you might expect. Compare this to
+Sanskrit's **विंशति** (*vimshati*), Latin's **vīgintī**, and Arabic's
+**عشرون** (*ʿishrūn*): those have **no** compositional "two-ten" origin at
+all, not even a buried one — a genuinely different kind of history from
+Kannada's.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hannondu, hanneraḍu" — 11, 12]
+- [YOU SAY: "hattu" — ten (today's word), "eraḍu" — two (today's word)]
+- [YOU SAY: "ippattu" — twenty, "two-tens" underneath, from the OLD *ir-/
+  *paHtu roots, not directly from hattu/eraḍu]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How are Kannada's teens built? (**ಹತ್ತು** (ten) + a digit,
+compounded.) Does **ಇಪ್ಪತ್ತು** (twenty) have a compositional "two-tens"
+origin? (**Yes** — Proto-Dravidian *\*ir-* "two" + *\*paHtu* "ten.") Can you
+still spot modern *eraḍu* or modern *hattu* inside it today? (**No** — the
+old bound "two" root and the un-lenited middle-of-word "ten" root look
+different from their modern standalone descendants.) Do Sanskrit's
+*vimshati* or Latin's *vīgintī* have any compositional origin like this at
+all? (**No** — neither has a buried "two-ten" history the way Kannada's
+does.)

--- a/code/learning/human-languages/kannada/lessons/KA-C20-havamana.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C20-havamana.md
@@ -1,0 +1,57 @@
+---
+id: KA-C20-havamana
+chapter: 20
+type: phrase
+headword: ಹವಾಮಾನ
+gloss: weather — a Persian+Sanskrit HYBRID compound: hava ("air," from Persian/Arabic) + maana ("measure," Sanskrit)
+concept_tag: KA-WEATHER
+prerequisites: [KA-C18-gante]
+sounds: [kannada-vowel-sign-aa, kannada-compound-word]
+roots: [persian-hava-air, sanskrit-maana-measure]
+etymology_hook: "ಹವಾಮಾನ (havāmāna, 'weather') is a genuine hybrid compound: ಹವಾ (hava, 'air') is itself a Persian/Arabic loan (havā ← Arabic hawāʾ, the SAME root behind Hindi's hawa), fused with ಮಾನ (māna, 'measure,' native Sanskrit) — literally 'air-measure'"
+est_minutes: 5
+reviews_of: [KA-C18-gante]
+---
+
+# ಹವಾಮಾನ — a genuine two-language hybrid word
+
+## Warm-up
+
+[PAUSE 2s] Kannada's word for "weather" isn't purely Sanskrit or purely
+native — it's a compound with a piece from each of two different borrowed
+sources.
+
+## ಹವಾಮಾನ — "air-measure," a hybrid compound
+
+**ಹವಾಮಾನ** (*havāmāna*) = "**weather**" — built from two pieces:
+
+- **ಹವಾ** (*hava*, "**air**") — itself a loanword, from **Persian** **هوا**
+  (*havā*), which traces back to **Arabic** **هَوَاء** (*hawāʾ*, "air"). This
+  is the exact same root behind Hindi's own **हवा** (*havā*, "air, wind").
+- **ಮಾನ** (*māna*, "**measure**") — from **Sanskrit** **मान** (*māna*),
+  "measure, standard" (the same word behind *pramāṇa*, "proof, measure of
+  truth").
+
+So *havāmāna* literally means "**air-measure**" — and it's genuinely a
+two-source hybrid, not a single borrowed compound: one piece Perso-Arabic, one
+piece Sanskrit, fused into one Kannada word.
+
+## ಮಳೆ ಬರುತ್ತಿದೆ — "rain is coming"
+
+> **ಮಳೆ ಬರುತ್ತಿದೆ.** — "It's raining." — literally "**rain is coming**."
+  (*maḷe baruttide.*)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "havāmāna" — weather, literally "air-measure"]
+- [YOU SAY: "hava" — air, a Persian/Arabic loan]
+- [YOU SAY: "maḷe baruttide" — it's raining, "rain is coming"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the two pieces of **ಹವಾಮಾನ**, and where does each come
+from? (**ಹವಾ**, "air," a **Persian/Arabic** loan; **ಮಾನ**, "measure," native
+**Sanskrit**.) What does *havāmāna* literally mean? ("**Air-measure**.") What
+other Indian language shares the exact same word for "air"? (**Hindi** —
+*havā*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C21-naayi-bekku.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C21-naayi-bekku.md
@@ -1,0 +1,54 @@
+---
+id: KA-C21-naayi-bekku
+chapter: 21
+type: word
+headword: ನಾಯಿ, ಬೆಕ್ಕು
+gloss: dog and cat — naayi is a solid, ancient native Dravidian root, no mystery at all; bekku is a DIFFERENT ancient Dravidian "wildcat" root, distinct from Tamil's everyday word for cat
+concept_tag: KA-ANIMALS
+prerequisites: [KA-C20-hannondu-ippattu]
+sounds: [kannada-vowel-sign-e, kannada-geminate-kk]
+roots: [dravidian-naay-dog, dravidian-veruku-wildcat]
+etymology_hook: "ನಾಯಿ (nāyi, 'dog') is a solid, native Proto-Dravidian root — no mystery, unlike every dog-word you've met elsewhere in this arc; ಬೆಕ್ಕು (bekku, 'cat') is cognate with a DIFFERENT ancient Dravidian root, the same one behind Tamil/Malayalam's word for wildcat/civet cat — Kannada's everyday cat-word and Tamil's everyday cat-word (pūnai) come from two genuinely separate Dravidian roots"
+est_minutes: 6
+reviews_of: [KA-C20-hannondu-ippattu]
+---
+
+# ನಾಯಿ, ಬೆಕ್ಕು — solid ground, and a genuine split
+
+## Warm-up
+
+[PAUSE 2s] After a whole arc of mystery dog-words — Spanish's *perro*,
+English's *dog*, Hindi's *kuttā* — here's the opposite: a dog-word with
+absolutely no mystery attached.
+
+## ನಾಯಿ — solid ground at last
+
+**ನಾಯಿ** (*nāyi*, "**dog**") is a genuine, native **Proto-Dravidian** root —
+no debate, no substrate mystery, nothing like the *perro*/*dog*/*kuttā*
+pattern you've now seen across three unrelated language families. It's the
+same root shared right across the Dravidian family.
+
+## ಬೆಕ್ಕು — a genuinely different root than Tamil's
+
+**ಬೆಕ್ಕು** (*bekku*, "**cat**") is where things get honestly more
+complicated. It's cognate with a **different** ancient Dravidian root — the
+same one behind Tamil and Malayalam's word for "**wildcat**" or "**civet
+cat**" — not the same root as Tamil's **everyday** word for cat. So unlike
+"dog," where Dravidian largely agrees on one shared root, "cat" genuinely
+**splits**: different Dravidian languages settled on different ancient roots
+for their everyday word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāyi" — dog, solid native Dravidian, no mystery]
+- [YOU SAY: "bekku" — cat, a different Dravidian root than Tamil's everyday
+  word]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **ನಾಯಿ** a mystery word, like Spanish's *perro* or Hindi's
+*kuttā*? (**No** — a solid, native Proto-Dravidian root.) Does **ಬೆಕ್ಕು**
+come from the same root as Tamil's everyday cat-word? (**No** — a genuinely
+different ancient Dravidian root, related instead to the word for
+"wildcat.")

--- a/code/learning/human-languages/kannada/lessons/KA-C22-hasiru-haladi.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C22-hasiru-haladi.md
@@ -1,0 +1,71 @@
+---
+id: KA-C22-hasiru-haladi
+chapter: 22
+type: word
+headword: ಹಸಿರು, ಹಳದಿ
+gloss: green and yellow — hasiru is genuine pan-Dravidian, sharing its Proto-Dravidian root with Tamil's paccai and Telugu's pacca; haladi is a Sanskrit/Hindi loan built on the word for turmeric, and traces back to the SAME ancient PIE root already behind Hindi's harā (green) and German's gelb (yellow)
+concept_tag: KA-COLOUR-GREEN-YELLOW
+prerequisites: [KA-C11-bannagalu, KA-C21-naayi-bekku]
+sounds: [kannada-retroflex-lla, kannada-virama-geminate]
+roots: [proto-dravidian-pac-green, sanskrit-haridra-turmeric]
+etymology_hook: "ಹಸಿರು (hasiru, 'green') ← Old Kannada ಪಸಿರ್ (pasir) ← Proto-Dravidian *pac-, 'green' — the SAME root as Tamil's பச்சை (paccai) and Telugu's పచ్చ (pacca); ಹಳದಿ (haḷadi, 'yellow') appears to be a Sanskrit/Hindi loan built on हरिद्रा (haridrā, 'turmeric'), which traces to हरि (hari, 'yellow, tawny') from Proto-Indo-European *ǵʰelh₃- — the same ancient root already behind Hindi's harā (green) and German's gelb (yellow); note that Hindi itself keeps 'turmeric' (haldi) and 'yellow' (pīlā) as two separate, unrelated words, unlike Kannada/Bengali/Odia which reuse the turmeric-word for the color"
+est_minutes: 6
+reviews_of: [KA-C21-naayi-bekku]
+---
+
+# ಹಸಿರು, ಹಳದಿ — a real Dravidian family, and a borrowed cousin of gelb
+
+## Warm-up
+
+[PAUSE 2s] Kannada's green word belongs to a real Dravidian family you'll
+meet again soon. Its yellow word isn't native at all — and it turns out to
+be hiding the very same ancient root this whole arc keeps circling back to.
+
+## ಹಸಿರು — a genuine pan-Dravidian word
+
+**ಹಸಿರು** (**hasiru**, "**green**") comes from **Old Kannada** **ಪಸಿರ್**
+(**pasir**), from **Proto-Dravidian** ***\*pac-***, "**green**" — the
+**exact same root** behind **Tamil**'s **பச்சை** (*paccai*) and **Telugu**'s
+**పచ్చ** (*pacca*). Kannada even keeps a doublet of its own, **ಪಚ್ಚೆ**
+(*pacce*), sitting right alongside *hasiru*. So unlike Kannada's **blue**
+(ನೀಲಿ, borrowed from Sanskrit), green here is the real, deep, native
+Dravidian word — and this particular root will keep resurfacing as Telugu,
+Malayalam, and Tamil's own green words come up later in this same arc.
+
+## ಹಳದಿ — a turmeric-word loan, and a secret cousin of gelb
+
+**ಹಳದಿ** (**haḷadi**, "**yellow**") is **not** Kannada's native turmeric
+word — that's **ಅರಿಶಿನ** (*ariśina*). Instead, *haḷadi* appears to be shaped
+by Sanskrit/Hindi **हरिद्रा/हल्दी** (**haridrā**/*haldi*, "**turmeric**"),
+the same word that gives "turmeric" across a huge swath of Indo-Aryan
+languages (Hindi/Urdu/Punjabi *haldi*, Bengali *holud*, Odia *haladi*) —
+and in some of these, like Bengali and Odia, that turmeric-word doubles as
+the everyday word for the color **yellow** itself, exactly as *haḷadi* does
+in Kannada (Hindi keeps the two separate: *haldi* stays "turmeric," while
+"yellow" is the unrelated word *pīlā*). Here's the part that closes a loop
+running through this whole arc: **haridrā** itself
+traces back to **हरि** (**hari**, "**yellow, tawny**"), from **Proto-Indo-
+European** ***\*ǵʰelh₃-*** — the **same ancient root** already behind
+Hindi's own **हरा** (*harā*, "green") and German's **gelb** ("yellow"). So
+Kannada picked up its yellow word from a completely different language
+family, Indo-Aryan rather than Dravidian — and that borrowed word still
+lands on the exact same PIE root this arc has been tracing all along.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ಹಸಿರು" — green, a real Dravidian cousin of Tamil paccai and
+  Telugu pacca]
+- [YOU SAY: "ಹಳದಿ" — yellow, borrowed, and secretly a cousin of gelb]
+- [YOU SAY: the contrast — hasiru is native Dravidian; haladi is a Sanskrit/
+  Hindi loan built on the turmeric word]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Proto-Dravidian root gives **ಹಸಿರು** (*hasiru*), and which
+two other Dravidian languages share it? (***\*pac-***, "green" — shared with
+**Tamil**'s *paccai* and **Telugu**'s *pacca*.) Is **ಹಳದಿ** (*haḷadi*)
+Kannada's native word for turmeric? (**No** — that's *ariśina*; *haḷadi* is
+a Sanskrit/Hindi loan.) What ancient PIE root connects **haḷadi**, through
+Sanskrit **hari**, to Hindi's **harā** and German's **gelb**?
+(***\*ǵʰelh₃-***, "to shine.")

--- a/code/learning/human-languages/latin/lessons/LA-C04-ignosce-mihi.md
+++ b/code/learning/human-languages/latin/lessons/LA-C04-ignosce-mihi.md
@@ -1,0 +1,68 @@
+---
+id: LA-C04-ignosce-mihi
+chapter: 4
+type: phrase
+headword: ignōsce mihi
+gloss: forgive me / I'm sorry (imperative of ignōscere, "to not-know, overlook, pardon")
+concept_tag: COURTESY-SORRY
+prerequisites: [LA-C03-quaeso]
+sounds: [gn-cluster, macron-long-vowel]
+roots: [gnoscere-latin]
+etymology_hook: "ignōsce ← in-/ig- 'not' + (g)nōscere 'to know' — 'don't hold it against me,' cousin of English know, recognize, cognition"
+est_minutes: 4
+reviews_of: [LA-C03-quaeso]
+---
+
+# ignōsce mihi — "forgive me" / I'm sorry
+
+## Warm-up
+
+[PAUSE 2s] You've met **quaesō**, the worn-down "I ask" Romans used for
+*please*. Their word for *sorry* is built the very same way — a small verb
+carrying the whole apology.
+
+## The phrase, taken apart
+
+- **ignōsce** — the imperative "**forgive!**," from **ignōscere**, itself
+  **in-** (here appearing as **ig-**, "not") + **(g)nōscere**, "**to know.**"
+  Literally, *ignōscere* means "**to not-know**" — i.e. to overlook, to treat
+  as unseen. Asking forgiveness in Latin is asking someone *not to hold
+  something against you*, as if they hadn't noticed it.
+- **mihi** — "**to me**," the dative pronoun.
+
+So **ignōsce mihi** is "**forgive [it] to me**" — *don't hold this against
+me.*
+
+That root **(g)nōscere**, "to know," reaches deep into English: **know**
+itself traces to the very same ancient root, alongside **recognize**
+("know again"), **cognition**, and **notice**. Latin's word for "sorry" and
+English's word for "know" are, at bottom, blood relatives.
+
+## Latin's other way to say it: paenitet mē
+
+Latin also had an **impersonal** construction for plain regret — no imperative,
+no "you" at all: **paenitet mē**, literally "**it grieves me**" (*mē* here is
+accusative, "me," the one afflicted by the regret) — *"I regret [it]."* It
+comes from the verb **paenitēre**, "to cause regret,"
+the direct ancestor of English **penitent**, **penitence**, and **repent**.
+
+Where **ignōsce mihi** asks someone to **forgive** you, **paenitet mē** simply
+names your own **regret** — closer to "I'm sorry [that happened]" than to
+"please forgive me." The same regret/forgiveness split you'll meet again and
+again across languages.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ignōsce" — forgive — then "mihi," to me]
+- [YOU SAY: the whole phrase — "ignōsce mihi" = forgive me]
+- [YOU SAY: the other one — "paenitet mē" = I regret it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ignōsce mihi** literally mean, piece by piece?
+(**"Forgive to me"** — *ignōscere* "to not-know/overlook" + *mihi* "to me.")
+What English words share the *(g)nōscere* root? (**Know, recognize,
+cognition, notice**.) What's Latin's other way to express regret, and how is
+it different? (**Paenitet mē**, "it grieves me" — names the regret,
+rather than asking to be forgiven.)

--- a/code/learning/human-languages/latin/lessons/LA-C05-dies-lunae-veneris.md
+++ b/code/learning/human-languages/latin/lessons/LA-C05-dies-lunae-veneris.md
@@ -1,0 +1,66 @@
+---
+id: LA-C05-dies-lunae-veneris
+chapter: 5
+type: phrase
+headword: diēs Lūnae, Mārtis, Mercuriī, Iovis, Veneris
+gloss: the weekdays (Monday–Friday) — the full, un-worn-down planet-god phrases
+concept_tag: LA-DAYS-WEEKDAYS
+prerequisites: [LA-C02-numbers-6-10]
+sounds: [macron-long-vowel, ae-diphthong]
+roots: [dies-latin, planet-gods]
+etymology_hook: "Latin's own week names are the FULL 'diēs [planet]' phrase that Spanish and French later wore down to lunes/lundi, martes/mardi…"
+est_minutes: 5
+reviews_of: [LA-C02-numbers-6-10]
+---
+
+# diēs Lūnae to diēs Veneris — the week, before it wore down
+
+## Warm-up
+
+[PAUSE 2s] Spanish says *lunes*; French says *lundi*. Both are worn-down
+descendants of something Latin still says in **full**: **diēs Lūnae**, "the
+**day of the Moon**." This lesson gives you the un-eroded originals.
+
+## The five weekdays, spelled out in full
+
+Each weekday is simply **diēs** ("day") plus a **planet-god's name in the
+genitive** ("of ___"):
+
+| Latin | literally | planet-god | worn down to (Spanish / French) |
+|---|---|---|---|
+| **diēs Lūnae** | day of the **Moon** | Luna | lunes / lundi |
+| **diēs Mārtis** | day of **Mars** | Mars | martes / mardi |
+| **diēs Mercuriī** | day of **Mercury** | Mercury | miércoles / mercredi |
+| **diēs Iovis** | day of **Jupiter** | Jupiter (*Iuppiter*) | jueves / jeudi |
+| **diēs Veneris** | day of **Venus** | Venus | viernes / vendredi |
+
+Later languages kept only fragments of this phrase — a bare **‑s**, a bare
+**‑di** — but you're now looking at the whole thing, still standing.
+
+## Be honest about where this system came from
+
+Rome didn't always keep a seven-day planetary week. For much of the
+Republic, Romans ran an **eight-day market cycle** (letters *A* through *H*,
+not planets at all). The **planetary week** — the Sun, Moon, and five visible
+planets, each ruling a day, in a fixed order — spread into Rome later, from
+Hellenistic astrology, and only gradually displaced the older market cycle.
+So *diēs Lūnae* and its siblings are themselves a Roman **adoption**, not an
+ancient Roman invention — a system Rome picked up and then passed on, worn
+down, to Spanish and French centuries later.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "diēs Lūnae" — day of the Moon — then "diēs Mārtis," day of Mars]
+- [YOU SAY: all five in a row — "diēs Lūnae, Mārtis, Mercuriī, Iovis, Veneris"]
+- [YOU SAY: the wear-down — "diēs Mārtis" became Spanish "martes," French
+  "mardi"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **diēs Mārtis** literally mean, and what does it become
+in Spanish and French? (**"Day of Mars"** — *martes* / *mardi*.) Did Rome
+always use a seven-day planetary week? (**No** — for much of the Republic it
+ran an eight-day market cycle; the planetary week arrived later, from
+Hellenistic astrology.) What holds every Latin weekday name together?
+(**diēs** "day" + the planet-god's name in the **genitive**, "of ___.")

--- a/code/learning/human-languages/latin/lessons/LA-C05-saturni-solis.md
+++ b/code/learning/human-languages/latin/lessons/LA-C05-saturni-solis.md
@@ -1,0 +1,67 @@
+---
+id: LA-C05-saturni-solis
+chapter: 5
+type: phrase
+headword: diēs Saturnī, diēs Sōlis
+gloss: Saturday and Sunday — Rome's own pagan names, and how Christianity later renamed them
+concept_tag: LA-DAYS-WEEKEND
+prerequisites: [LA-C05-dies-lunae-veneris]
+sounds: [macron-long-vowel]
+roots: [saturnus-latin, sol-latin, sabbatum-latin, dominus-latin]
+etymology_hook: "Latin ORIGINALLY said diēs Saturnī and diēs Sōlis — English Saturday/Sunday kept these pagan names directly, while Spanish/French later swapped in the Christian Sabbatum/Dominica"
+est_minutes: 5
+reviews_of: [LA-C05-dies-lunae-veneris]
+---
+
+# diēs Saturnī, diēs Sōlis — Saturday and Sunday, before the renaming
+
+## Warm-up
+
+[PAUSE 2s] The Roman planetary week had **seven** days, not five. The last
+two — Saturn's and the Sun's — tell a story neither Spanish nor French kept:
+a **religious renaming** that some languages accepted, and others didn't.
+
+## The two original names
+
+- **diēs Saturnī** — "**day of Saturn**." This one survives almost
+  untouched in English: **Saturday** (Old English *Sæternesdæg*) is a **direct
+  borrowing** of the Latin god's own name — the one weekday English kept a
+  **Roman** god outright, rather than swapping in a Germanic equivalent,
+  because there was no obvious Germanic god to stand in for stern old Saturn.
+- **diēs Sōlis** — "**day of the Sun**." Also a direct hit in English:
+  **Sunday** (*Sunnandæg*), a plain translation — the Sun didn't need a
+  separate Germanic identity to be swapped in.
+
+## Then Christianity renamed both — and Spanish/French followed
+
+As Christianity spread through the Empire, Latin usage **replaced** both
+pagan names:
+
+- **diēs Saturnī** → **Sabbatum**, borrowing the Jewish **Sabbath** (Hebrew
+  *shabbāt*, "to rest").
+- **diēs Sōlis** → **diēs Dominica**, "the **Lord's** day" (*Dominus*, "lord").
+
+**Spanish** (*sábado*, *domingo*) and **French** (*samedi*, *dimanche*)
+inherited these newer, **Christianized** names. **English never made the
+swap** — so, unexpectedly, **English's Saturday and Sunday are the older,
+more pagan forms**, while Spanish and French's weekend names are the
+**newer**, religiously rewritten ones. The direction of "old vs. new" flips
+depending which language you're standing in.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "diēs Saturnī" — day of Saturn — then "diēs Sōlis," day of the Sun]
+- [YOU SAY: English kept these directly — "Saturday, Sunday"]
+- [YOU SAY: Spanish/French renamed them — "sábado/samedi (Sabbath), domingo/
+  dimanche (the Lord's day)"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did Rome originally call Saturday and Sunday? (**Diēs
+Saturnī** "day of Saturn," **diēs Sōlis** "day of the Sun.") Which modern
+language kept these pagan names **directly**, and which two languages
+**renamed** them? (**English** kept them (*Saturday, Sunday*); **Spanish and
+French** replaced them with the Christian *Sabbatum* / *diēs Dominica*.)
+So which is actually "older" — English's weekend names, or Spanish's?
+(**English's** — Spanish's are the later, Christianized rewrite.)

--- a/code/learning/human-languages/latin/lessons/LA-C06-niger-albus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C06-niger-albus.md
@@ -1,0 +1,68 @@
+---
+id: LA-C06-niger-albus
+chapter: 6
+type: word
+headword: niger, albus
+gloss: black and white — the source words for Spanish/French/Italian, each with a shine-vs-matte twin
+concept_tag: LA-COLOUR-BLACK-WHITE
+prerequisites: [LA-C05-saturni-solis]
+sounds: [macron-long-vowel]
+roots: [niger-latin, albus-latin, ater-latin, candidus-latin]
+etymology_hook: "niger and albus each had a brightness-twin — ater 'dull black' vs niger 'gleaming black', albus 'dull white' vs candidus 'shining white' — a distinction Romance mostly dropped"
+est_minutes: 5
+reviews_of: [LA-C05-saturni-solis, LA-C05-dies-lunae-veneris]
+---
+
+# niger, albus — Latin's black and white, each with a shine-twin
+
+## Warm-up
+
+[PAUSE 2s] You've seen **niger** already, hiding inside French *noir* and
+Spanish *negro*. Here's what those daughter languages left behind: Latin
+didn't have just one word for black, or just one for white — it had **two of
+each**, split by **brightness**, not just hue.
+
+## Two blacks, two whites
+
+- **niger** = "black" with a **gleam** — a shiny, lustrous black. This is the
+  one that survives into Romance (*noir, negro, nero*).
+- **āter** = "black" that's **dull, matte, lightless** — the flatter, duller
+  black. (English keeps a fossil of it in **atrocious** and **atrocity** —
+  something so dark/dreadful it's "black" in the *āter* sense.)
+- **albus** = "white" that's **plain, dull, matte** — this is the one that
+  mostly faded from Romance's everyday vocabulary (surviving in Spanish
+  *alba*/French *aube*, "dawn," rather than as the everyday color word).
+- **candidus** = "white" with a **shine, a gleam, a glow** — bright white.
+  English keeps this one working hard: **candid** (originally "shining
+  bright," then "morally bright/honest"), **candidate** (Romans running for
+  office wore a bleached, gleaming-white toga, the *toga candida*), and
+  **candle**.
+
+## Be honest about what happened to the distinction
+
+Romance languages mostly **dropped** this shine-vs-matte split and kept only
+one word per color (*niger* survived for black; *albus* and *candidus* both
+survive, but neither became the plain everyday "white" in most daughter
+languages — Spanish and French instead borrowed a **Germanic** word, *blanco/
+blanc*, for their everyday white, as you may already have seen). So Latin's
+four color-words shrank to cover just two basic ideas — brightness stopped
+being how Latin-descended languages sort black and white.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "niger" — gleaming black — then "āter," dull black]
+- [YOU SAY: "albus" — dull white — then "candidus," shining white]
+- [YOU SAY: the English fossils — "atrocious" (āter), "candid, candidate"
+  (candidus)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What distinguished Latin's two black words, and its two white
+words? (**Brightness** — *niger* "gleaming black" vs. *āter* "dull black";
+*candidus* "shining white" vs. *albus* "dull white.") Which two English words
+come from *candidus*, and why does *candidate* mean what it does? (**Candid**
+and **candidate** — Roman office-seekers wore a bleached-white *toga
+candida*.) Did Romance keep this four-way split? (**No** — it settled on one
+plain word per color, and Spanish/French even borrowed a **Germanic** word
+for everyday white.)

--- a/code/learning/human-languages/latin/lessons/LA-C06-ruber-caeruleus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C06-ruber-caeruleus.md
@@ -1,0 +1,69 @@
+---
+id: LA-C06-ruber-caeruleus
+chapter: 6
+type: word
+headword: ruber, caeruleus
+gloss: red (rock-solid) and blue (surprisingly shaky) — Latin's clearest color word, and one of its weakest
+concept_tag: LA-COLOUR-RED-BLUE
+prerequisites: [LA-C06-niger-albus]
+sounds: [ae-diphthong, macron-long-vowel]
+roots: [pie-rewdh, caeruleus-latin]
+etymology_hook: "ruber is a rock-solid PIE-rooted red, ancestor of BOTH Spanish rojo (via russus) and French rouge (via rubeus) — but Latin's closest word for 'blue', caeruleus, was never a clean single color the way ruber was"
+est_minutes: 5
+reviews_of: [LA-C06-niger-albus]
+---
+
+# ruber, caeruleus — a rock-solid red, and a shaky blue
+
+## Warm-up
+
+[PAUSE 2s] One of these two words is about as old and stable a color-word as
+language gets. The other is a genuine puzzle — because Latin, like a
+surprising number of ancient languages, never quite settled on a clean word
+for "blue."
+
+## ruber — ancient, and the parent of two Romance reds
+
+**ruber** ("red") descends from PIE ***h₁rewdʰ-***, a root so old it also
+gives English **red**, **rust**, **ruddy**, and German **rot**. Latin's own
+family used **two** everyday variants of this root — **rubeus** and
+**russus** — and Romance split them between languages: French **rouge**
+comes from *rubeus*; Spanish **rojo** comes from *russus*. Different Latin
+words, same ancient root, same color.
+
+## caeruleus — Latin's shakiest color word
+
+You might expect a clean Latin ancestor for "blue" the way *ruber* is for
+red. There isn't really one. **Caeruleus** is the closest word Latin had —
+and it's a much fuzzier idea than *ruber*: it covers the color of the **sky**
+and the **sea** (*caeruleum mare*, "the blue/dark sea"), but it can also
+shade toward **dark green** or simply "**dark**," depending on context. It
+isn't a fixed, single hue-word the way *ruber* clearly is.
+
+This isn't just a Latin quirk. Classicists and linguists have long noted that
+**many ancient languages lacked a clean, stable basic word for blue** —
+Ancient Greek is the most famous case (Homer's "**wine-dark sea**," never a
+simple "blue sea"). Across many language families, "blue" tends to be one of
+the **last** basic color words to settle into place, historically — sometimes
+splitting off late from words that also covered green, dark, or grey. Latin's
+*caeruleus* looks like part of that same broader pattern, though the exact
+reasons are still debated among linguists rather than fully settled.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ruber" — red — the ancient, PIE-rooted color word]
+- [YOU SAY: its two children — "rubeus → French rouge," "russus → Spanish
+  rojo"]
+- [YOU SAY: "caeruleus" — sea/sky-colored — Latin's shakiest, least fixed
+  color word]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What PIE root gives **ruber**, and what English words share it?
+(***h₁rewdʰ-*** — **red, rust, ruddy**.) Which two Latin red-words split
+between French and Spanish, and which went where? (**Rubeus → French
+rouge**; **russus → Spanish rojo**.) Why is **caeruleus** a shakier word than
+*ruber*? (**It covers sea/sky and can shade toward dark or green** — it was
+never a single fixed "blue," a pattern linguists have noticed across many
+ancient languages, most famously Greek's "wine-dark sea.")

--- a/code/learning/human-languages/latin/lessons/LA-C07-frater-soror.md
+++ b/code/learning/human-languages/latin/lessons/LA-C07-frater-soror.md
@@ -1,0 +1,69 @@
+---
+id: LA-C07-frater-soror
+chapter: 7
+type: word
+headword: frater, soror
+gloss: brother and sister — the words Vulgar Latin later abandoned in favor of germanus
+concept_tag: LA-FAMILY-SIBLINGS
+prerequisites: [LA-C07-pater-mater]
+sounds: [macron-long-vowel]
+roots: [pie-bhrater, pie-swesor]
+etymology_hook: "frater and English brother are cousins via PIE *bhreh2ter (Grimm's Law bh→b); soror and English sister are cousins via PIE *swesor, NOT soror turning into sister — Latin simplified sw- to s-, Germanic kept it"
+est_minutes: 5
+reviews_of: [LA-C07-pater-mater]
+---
+
+# frater, soror — Latin's original siblings, before Spanish moved on
+
+## Warm-up
+
+[PAUSE 2s] Two more ancient words — and a preview of a twist: these are the
+very words that later got **pushed aside** in everyday Latin, on the road to
+Spanish.
+
+## Taken apart
+
+- **frāter** ("brother") ← PIE ***bʰréh₂tēr***.
+- **soror** ("sister") ← PIE ***swésōr***.
+
+## Cousins with English, not ancestors of it
+
+Same rule as *pater/māter*: **frāter is not the source of English
+"brother"** — they're **cousins**, both from *bʰréh₂tēr*, with Grimm's Law
+shifting the Germanic branch's **bʰ → b** while Latin developed its own **f**
+(from an earlier *bʰ → f* shift already inside Latin itself).
+
+**Soror** is the more surprising one. English **sister** looks nothing like
+*soror* — and that's because Latin **dropped** the *w* from the PIE cluster
+*sw-* (giving plain *s-*), while the Germanic branch **kept** the *w* far
+longer (Old English had *sweostor*). So *soror* and *sister* are, once
+again, **cousins from the same PIE word**, *swésōr* — neither one turned
+into the other; each branch just handled that opening *sw-* differently.
+
+## Be honest about what happened next: germanus took over
+
+Here's the twist: classical Latin could say **frāter germānus**, "a brother
+**of the same blood**," to mark a *full* sibling. Over time, in everyday
+(Vulgar) Latin, that **adjective** *germānus* took over the whole job, and
+**frāter itself faded out of common use** — which is exactly why Spanish
+says **hermano**, not a descendant of *frāter* at all. (French *frère* took
+the opposite path and kept *frāter* as its everyday word — different Latin
+regions, different survivors.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "frāter, soror" — brother, sister]
+- [YOU SAY: the cousin relationship — "frāter/brother and soror/sister are
+  BOTH parallel descendants, not one from the other"]
+- [YOU SAY: the twist — "frāter germānus" → just "germānus" → Spanish
+  "hermano"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is English "sister" descended from Latin *soror*? (**No** — both
+are cousins from PIE *swésōr*; Latin dropped the *w*, Germanic kept it
+longer.) What Latin phrase eventually replaced *frāter* in everyday speech,
+and where does it show up today? (***Frāter germānus*** → just *germānus* →
+Spanish **hermano**.) Did every Romance language make that same swap? (**No**
+— French kept *frāter* as *frère*; Spanish moved on to *germānus*.)

--- a/code/learning/human-languages/latin/lessons/LA-C07-pater-mater.md
+++ b/code/learning/human-languages/latin/lessons/LA-C07-pater-mater.md
@@ -1,0 +1,62 @@
+---
+id: LA-C07-pater-mater
+chapter: 7
+type: word
+headword: pater, mater
+gloss: father and mother — the PIE ancestor Latin and English both inherited, in parallel
+concept_tag: LA-FAMILY-PARENTS
+prerequisites: [LA-C06-ruber-caeruleus]
+sounds: [macron-long-vowel]
+roots: [pie-pater, pie-mater]
+etymology_hook: "pater and English father are COUSINS, not parent-and-child — both descend independently from PIE *ph2ter, with Latin keeping the p and Germanic shifting it to f via Grimm's Law"
+est_minutes: 5
+reviews_of: [LA-C06-ruber-caeruleus, LA-C06-niger-albus]
+---
+
+# pater, mater — the oldest words, kept close to the source
+
+## Warm-up
+
+[PAUSE 2s] "Father" and "mother" are among the **oldest reconstructible
+words in human language**. Latin kept them almost exactly as they were;
+English took the very same ancestor down a different road.
+
+## Taken apart
+
+- **pater** ("father") ← PIE ***ph₂tḗr***.
+- **māter** ("mother") ← PIE ***méh₂tēr***.
+
+## Cousins, not parent and child
+
+Here's the point worth getting exactly right: **pater and English father are
+not one derived from the other.** Both descend **independently, in
+parallel**, from the same PIE word. Latin simply kept the ancestral **p**
+and **t** close to unchanged; the Germanic branch that produced English took
+a separate route through **Grimm's Law**, which shifted that same inherited
+**p → f** and **t → th**:
+
+| PIE ancestor | Latin | Germanic → English |
+|---|---|---|
+| *ph₂tḗr* | **pater** | **f**a**th**er |
+| *méh₂tēr* | **māter** | **m**o**th**er |
+
+So *pater* and *father* are **siblings**, sharing one parent-word thousands
+of years back — not a case of English borrowing or descending from Latin.
+*Pater* also gives Latin (and later English, through Latin) the whole
+"of-a-parent" family: **paternus** ("fatherly," → English *paternal*) and
+**māternus** (→ *maternal*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pater, māter" — father, mother]
+- [YOU SAY: the relationship — "cousins, not ancestor and descendant"]
+- [YOU SAY: "pater → paternus → paternal; māter → māternus → maternal"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does English *father* come **from** Latin *pater*? (**No** — both
+descend **independently** from the same PIE word, *ph₂tḗr*.) What sound-law
+explains the difference between them? (**Grimm's Law** — the Germanic branch
+shifted the inherited p → f, t → th; Latin kept them.) What Latin adjectives
+give English *paternal* and *maternal*? (**Paternus, māternus**.)

--- a/code/learning/human-languages/latin/lessons/LA-C08-caput.md
+++ b/code/learning/human-languages/latin/lessons/LA-C08-caput.md
@@ -1,0 +1,68 @@
+---
+id: LA-C08-caput
+chapter: 8
+type: word
+headword: caput
+gloss: the head — the word French abandoned, but Spanish and English kept working hard
+concept_tag: LA-BODY-HEAD
+prerequisites: [LA-C07-frater-soror]
+sounds: [macron-long-vowel]
+roots: [pie-kaput]
+etymology_hook: "caput 'head' gives English captain/capital/decapitate/capitulate and Spanish cabeza (via capitia) — but French quietly REPLACED it with testa, 'pot,' Roman soldiers' slang for the skull"
+est_minutes: 5
+reviews_of: [LA-C07-frater-soror, LA-C07-pater-mater]
+---
+
+# caput — the head, still working two thousand years later
+
+## Warm-up
+
+[PAUSE 2s] Few Latin words stayed as busy in English as this one. And yet —
+one of Latin's own descendants **abandoned** it for the actual body part.
+
+## The word
+
+**caput, capitis** — "**head**." A perfectly ordinary noun, and one of
+Latin's most productive exports:
+
+| English | literally |
+|---|---|
+| **cap**tain | the "head" of a ship or unit |
+| **cap**ital | the "head" city, or the "head" sum of money |
+| de**cap**itate | to remove the head |
+| **cap**itulate | to arrange terms under "little-head" headings — hence, to yield |
+
+Spanish kept *caput* as its everyday word too: **cabeza** descends from it
+(by way of Vulgar Latin *capitia*).
+
+## Be honest about what happened in French
+
+French had *caput* available — and **dropped it** for the body part
+entirely. Instead French says **tête**, from Latin **testa**, "an
+earthenware pot, a shell." Roman soldiers joked about the skull the way
+English speakers say "noggin" (a small mug), and in Gaul, that joke
+eventually **replaced** *caput* as the everyday word. *Caput* didn't
+disappear from French, though — it survives there too, just not for the
+actual head: **chef** ("chief"), **chapitre**, **capital**, **capitaine**.
+
+So three languages took three different paths with the very same word:
+**Spanish** kept *caput* as the plain, everyday "head"; **French** demoted
+it to "chief/chapter/capital" and reached for a pot-joke instead; **English**
+never used it for the body part at all, only for these borrowed "head of
+something" senses.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "caput, capitis" — head]
+- [YOU SAY: the English family — "captain, capital, decapitate, capitulate"]
+- [YOU SAY: the twist — French swapped *caput* out for *testa*, "pot"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **caput** mean, and what English words come from it?
+(**"Head"** — *captain, capital, decapitate, capitulate*.) Did every Romance
+language keep it as the everyday word for "head"? (**No** — Spanish did
+(*cabeza*); French replaced it with **testa**, "pot," soldiers' slang for
+the skull.) Where does *caput* survive in French, if not as "head"? (**Chef,
+chapitre, capital, capitaine**.)

--- a/code/learning/human-languages/latin/lessons/LA-C08-manus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C08-manus.md
@@ -1,0 +1,66 @@
+---
+id: LA-C08-manus
+chapter: 8
+type: word
+headword: manus
+gloss: the hand — a rare feminine noun in an overwhelmingly masculine group of Latin words
+concept_tag: LA-BODY-HAND
+prerequisites: [LA-C08-caput]
+sounds: [macron-long-vowel]
+roots: [pie-man]
+etymology_hook: "manus is feminine despite belonging to the 4th declension, a group of -us nouns that runs mostly MASCULINE (fructus, exercitus, senatus) — manus is one of only a handful of exceptions, and Spanish's mano inherited that oddity intact"
+est_minutes: 5
+reviews_of: [LA-C08-caput]
+---
+
+# manus — the hand, and a famous grammatical exception
+
+## Warm-up
+
+[PAUSE 2s] Here's a word that's productive in English *and* grammatically
+odd in Latin itself — an oddity that then rode straight through into
+Spanish.
+
+## The word
+
+**manus, manūs** — "**hand**." It belongs to Latin's **4th declension** — a
+group of nouns ending in *-us* that runs **overwhelmingly masculine**:
+*frūctus* ("fruit"), *exercitus* ("army"), *senātus* ("senate"), *portus*
+("port") are all masculine. **Manus is one of only a handful of exceptions**
+in that declension — feminine, alongside *anus* ("old woman") and *domus*
+("house," though *domus* is even messier: it mixes 4th- and 2nd-declension
+endings throughout its own paradigm) — for reasons tied to each noun's own
+ancient history, not a rule you could predict from the *-us* ending alone.
+
+That oddity didn't stay buried in Latin grammar books: Spanish's word for
+hand, **mano**, inherited *manus*'s feminine gender directly — which is
+exactly why *mano* is famously feminine despite ending in **-o**, the
+ending that signals *masculine* in nearly every other Spanish noun. One
+small Latin exception, carried whole into a completely different pattern in
+a daughter language, centuries later.
+
+## manus — one of the most productive roots in English
+
+| English | literally |
+|---|---|
+| **manual** | done by hand |
+| **manufacture** | made by hand (*manus* + *facere*, "to make") |
+| **manuscript** | written by hand (*manus* + *scrībere*) |
+| **maintain** | hold in the hand (*manū tenēre*) |
+| **manage** | to handle |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "manus, manūs" — hand]
+- [YOU SAY: the exception — "feminine, unlike frūctus, exercitus, senātus"]
+- [YOU SAY: the English family — "manual, manufacture, maintain, manage"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What gender is **manus**, and is that typical for its
+declension? (**Feminine** — unusual, since the 4th declension runs mostly
+**masculine**; *manus* is one of a few exceptions, alongside *domus* and
+*anus*.) What Spanish word inherited this exact oddity? (**Mano** — feminine
+despite ending in *-o*.) Give an English word from *manus*. (**Manual,
+manufacture, manuscript, maintain, manage**.)

--- a/code/learning/human-languages/latin/lessons/LA-C09-anni-tempora.md
+++ b/code/learning/human-languages/latin/lessons/LA-C09-anni-tempora.md
@@ -1,0 +1,83 @@
+---
+id: LA-C09-anni-tempora
+chapter: 9
+type: word
+headword: vēr, aestās, autumnus, hiems
+gloss: the four seasons — and why Romance languages often skipped the plain noun for an adjective phrase instead
+concept_tag: LA-SEASONS
+prerequisites: [LA-C08-manus, LA-C08-caput]
+sounds: [macron-long-vowel, ae-diphthong]
+roots: [ver-latin, aestas-latin, autumnus-latin, hiems-latin]
+etymology_hook: "vēr, aestās, autumnus, hiems are Latin's own four season-nouns — but Spanish/French didn't always keep the plain nouns; for spring and winter, they built new words from ADJECTIVE phrases instead (prīma vēra 'first spring,' hībernum tempus 'wintry time')"
+est_minutes: 5
+reviews_of: [LA-C08-manus, LA-C08-caput]
+---
+
+# vēr, aestās, autumnus, hiems — Latin's own four seasons
+
+## Warm-up
+
+[PAUSE 2s] Four Latin nouns, one for each season — and a genuine surprise
+about which ones actually survived into Spanish and French as ordinary
+words.
+
+## The four seasons, plain and simple
+
+| Latin | meaning |
+|---|---|
+| **vēr, vēris** | **spring** |
+| **aestās, aestātis** | **summer** (also just "heat") |
+| **autumnus, autumnī** | **autumn** |
+| **hiems, hiemis** | **winter** |
+
+## Be honest about which ones actually survived as-is
+
+**autumnus** survived plainly: it's the direct ancestor of Spanish *otoño*,
+French *automne*, and English *autumn* itself — no detours.
+
+But **vēr** and **hiems**, the plain nouns for spring and winter, mostly
+**didn't** make it into everyday Romance vocabulary. Instead, Spanish and
+French built brand-new words out of **adjective phrases** describing those
+seasons:
+
+- Not *vēr* alone, but a Vulgar Latin phrase/reanalysis, **prīma vēra**
+  (roughly "**first spring**") → Spanish *primavera*, French (originally)
+  *primevère* — later displaced there by *printemps* ("first-time," from
+  *prīmum tempus*, the very same "adjective + tempus" recipe as winter's
+  word below; *primevère* narrowed to just mean "**primrose**" today) —
+  and Italian *primavera*, still the everyday word there.
+- Not *hiems* alone, but **hībernum (tempus)**, "**the wintry [time]**" →
+  Spanish *invierno*, French *hiver* — the same root as English
+  **hibernate**.
+
+**Aestās** ("summer/heat") did survive directly into French *été* — but
+Spanish took yet another path: it built **vērānum (tempus)** ("of spring")
+from *vēr* itself, and that word's *meaning* later drifted forward to name
+**summer** instead of spring, giving Spanish *verano* — leaving *primavera*
+to do spring's job.
+
+So the picture is mixed, not a clean split: **autumnus** cruised straight
+through into Spanish, French, *and* English unchanged; **aestās** cruised
+through into French (*été*) but got replaced in Spanish; **vēr** and
+**hiems**, the plain nouns for spring and winter, essentially left **no**
+everyday trace in either language — both were replaced by phrase-built
+words instead (or, in *verano*'s case, by a related word whose meaning
+simply moved).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vēr, aestās, autumnus, hiems" — the four seasons]
+- [YOU SAY: the one that survived plainly — "autumnus → otoño, automne,
+  autumn"]
+- [YOU SAY: the two built from phrases — "prīma vēra → primavera," "hībernum
+  → invierno, hiver"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are Latin's four season-nouns? (**Vēr, aestās, autumnus,
+hiems**.) Which one survived plainly into Spanish, French, and English?
+(**Autumnus** → *otoño, automne, autumn*.) What did Spanish and French build
+instead of the plain words *vēr* and *hiems*? (**Adjective phrases** — *prīma
+vēra* "first spring" → *primavera/primevère*; *hībernum* "wintry" →
+*invierno/hiver*.)

--- a/code/learning/human-languages/latin/lessons/LA-C10-aqua-vinum.md
+++ b/code/learning/human-languages/latin/lessons/LA-C10-aqua-vinum.md
@@ -1,0 +1,67 @@
+---
+id: LA-C10-aqua-vinum
+chapter: 10
+type: word
+headword: aqua, vīnum
+gloss: water and wine — one word French wore down to almost nothing, one that barely changed anywhere
+concept_tag: LA-FOOD-DRINKS
+prerequisites: [LA-C09-anni-tempora]
+sounds: [macron-long-vowel, qu-as-kw]
+roots: [aqua-latin, vinum-latin]
+etymology_hook: "aqua survived nearly whole into Spanish agua and Italian acqua — but French wore it all the way down to a bare 'eau'; vīnum, by contrast, barely changed ANYWHERE, surviving into every Romance daughter and into Germanic English as 'wine'"
+est_minutes: 5
+reviews_of: [LA-C09-anni-tempora, LA-C08-manus]
+---
+
+# aqua, vīnum — one word worn thin, one word untouched
+
+## Warm-up
+
+[PAUSE 2s] Two everyday Latin nouns — and two wildly different fates. One
+of Rome's daughters wore this word down to almost nothing. The other word
+barely moved at all, anywhere.
+
+## aqua — mostly kept, one daughter wore it down to a whisper
+
+**aqua, aquae** — "**water**." Spanish and Italian kept it close to whole:
+**agua**, **acqua**. French, though, eroded it further than almost any
+other Latin word in this course: *aqua → ewe → eaue → **eau*** — three
+written letters, *e-a-u*, spelling one bare vowel sound, "oh." Compare
+*caput*, which French similarly abandoned as an everyday word (for *testa*)
+— *aqua* wasn't replaced, but it was worn down almost to nothing while
+staying in place.
+
+English kept the **whole, undamaged** word as a learned borrowing:
+**aquatic, aquarium, aqueduct, aqualung** all sound exactly like their
+Latin ancestor.
+
+## vīnum — survived, everywhere, almost untouched
+
+**vīnum, vīnī** — "**wine**." Unlike *aqua* and *caput*, this word simply
+**didn't erode much in any direction**: Spanish *vino*, French *vin*,
+Italian *vino* — all close to the original. Germanic borrowed it directly
+and early, giving English **wine** itself. Centuries later, English
+picked up more of the family — this time secondhand, through **French**:
+**vine** (< OF *vigne* < *vīnea*, "vineyard"), **vinegar** (< OF *vinaigre*,
+*vin* + *aigre*, ultimately *acer* "sour"), **vintage** (< OF *vendage* <
+*vīndēmia*, *vīnum* + *dēmere* "to harvest"). **Vineyard** isn't a
+borrowing at all — English built it at home, compounding the already-
+borrowed "wine" with native "yard." Few Latin words traveled this far, by
+this many different roads, and stayed this recognizable.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "aqua" — water — then the daughters: "agua, acqua, eau"]
+- [YOU SAY: "vīnum" — wine — then: "vino, vin, vino, wine"]
+- [YOU SAY: the contrast — aqua wore thin in French; vīnum stayed solid
+  everywhere]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which Latin word for a drink got worn down almost to nothing,
+and in which language? (**Aqua**, in **French** — down to a bare "eau.")
+Which word barely changed **anywhere**, surviving into every Romance
+daughter and into English too? (**Vīnum** — wine, vino, vin, vino.) Where
+did the *whole*, undamaged form of *aqua* survive in English? (**Aquatic,
+aquarium, aqueduct** — learned borrowings, not everyday words.)

--- a/code/learning/human-languages/latin/lessons/LA-C10-panis.md
+++ b/code/learning/human-languages/latin/lessons/LA-C10-panis.md
@@ -1,0 +1,62 @@
+---
+id: LA-C10-panis
+chapter: 10
+type: word
+headword: pānis
+gloss: bread — the source of "companion," and of the friendship-word every Romance daughter still shares with it
+concept_tag: LA-FOOD-BREAD
+prerequisites: [LA-C10-aqua-vinum]
+sounds: [macron-long-vowel]
+roots: [panis-latin]
+etymology_hook: "pānis 'bread' gives Spanish pan, French pain, Italian pane directly — AND builds companion/company (com- + panis, 'sharing bread') and Spanish's compañero, which keeps both halves of the word-family Spanish English split apart"
+est_minutes: 4
+reviews_of: [LA-C10-aqua-vinum]
+---
+
+# pānis — bread, and the friend who shares it
+
+## Warm-up
+
+[PAUSE 2s] One Latin word for bread, surviving whole across every Romance
+daughter — and hiding, inside a compound, one of the loveliest word-stories
+in English.
+
+## The word, kept plain
+
+**pānis, pānis** — "**bread**." Spanish **pan**, French **pain**, Italian
+**pane** all continue it directly — bread mattered enough to keep its own
+name everywhere.
+
+## com- + pānis — "sharing bread"
+
+Add the prefix **com-** ("with, together") and you get **compānio/
+compānia** — a Vulgar Latin coinage, not a Classical-era word — literally
+"**one you share bread with**," the direct ancestor of English
+**companion** and **company**. A *company* was, at first, nothing more
+than a group who ate together.
+
+## Be honest about what happened next
+
+English only kept the **friendship** half of this word — *companion* has
+nothing to do with actual bread anymore to an English speaker. **Spanish**,
+though, still keeps **both halves** traceably related: **pan** (the bread
+itself) and **compañero** (the friend, "one who shares *pan*") sit right
+next to each other in the same language, both transparently built from the
+same root. Latin's *pānis* split into two separate lives in English, but
+stayed one visible family in Spanish.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pānis" — bread — then "pan, pain, pane"]
+- [YOU SAY: "com- + pānis" — "with bread" — companion, company]
+- [YOU SAY: the contrast — English kept only the friend; Spanish kept both
+  the bread and the friend]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **pānis** give Spanish, French, and Italian directly?
+(**Pan, pain, pane** — bread.) What English words come from *com- + pānis*,
+and what do they literally mean? (**Companion, company** — "one you **share
+bread with**.") Does English still connect "companion" to actual bread?
+(**No** — only Spanish keeps both *pan* and *compañero* traceably related.)

--- a/code/learning/human-languages/latin/lessons/LA-C11-menses.md
+++ b/code/learning/human-languages/latin/lessons/LA-C11-menses.md
@@ -1,0 +1,75 @@
+---
+id: LA-C11-menses
+chapter: 11
+type: word
+headword: Iānuārius, Februārius, Mārtius, Aprīlis, Māius, Iūnius, Quīntīlis, Sextīlis, September, Octōber, November, December
+gloss: the twelve months — and the two ORIGINAL names, Quintilis and Sextilis, before Rome renamed them
+concept_tag: LA-MONTHS
+prerequisites: [LA-C10-panis, LA-C10-aqua-vinum]
+sounds: [macron-long-vowel, qu-as-kw]
+roots: [ianus-latin, mars-latin, numbering-months]
+etymology_hook: "Quintilis and Sextilis, 'the 5th and 6th months,' were later RENAMED Iulius and Augustus in honor of Caesar and the emperor — Rome didn't add two new months, it just relabeled two old ones"
+est_minutes: 6
+reviews_of: [LA-C10-panis, LA-C10-aqua-vinum]
+---
+
+# Iānuārius to December — the twelve months, before and after the rename
+
+## Warm-up
+
+[PAUSE 2s] You'll meet these twelve names again, worn down, in Spanish and
+French. Latin lets you see something they can't show you directly: **two
+of these months used to have completely different names.**
+
+## The twelve, taken apart
+
+| Latin | who / what |
+|---|---|
+| **Iānuārius** | **Janus**, the two-faced god of doors and beginnings |
+| **Februārius** | *Februa*, the Roman **purification** festival |
+| **Mārtius** | **Mars**, the war-god |
+| **Aprīlis** | perhaps **aperīre**, "to open" (buds opening) |
+| **Māius** | **Maia**, goddess of growth |
+| **Iūnius** | **Juno**, queen of the gods |
+| **Quīntīlis** | literally "**the fifth**" (*quīntus*) — **later renamed Iūlius** |
+| **Sextīlis** | literally "**the sixth**" (*sextus*) — **later renamed Augustus** |
+| **September** | "**the seventh**" (*septem*) |
+| **Octōber** | "**the eighth**" (*octō*) |
+| **November** | "**the ninth**" (*novem*) |
+| **December** | "**the tenth**" (*decem*) |
+
+## Be honest about the renaming — a popular myth, corrected
+
+You'll often hear that **Julius Caesar and Augustus "added" two months** to
+the calendar, which is why September through December no longer match
+their numbers. That's **not what happened**. Rome's year, centuries
+earlier, had already been expanded from ten months to twelve by adding
+**Iānuārius** and **Februārius** at the front — that's the real reason
+*September* ("seventh") ended up as the **ninth** month.
+
+*Quīntīlis* ("the fifth") and *Sextīlis* ("the sixth") already existed as
+ordinary, plainly-numbered months, right alongside *September* through
+*December*. Long after Julius Caesar's death, the Senate simply **renamed**
+*Quīntīlis* to **Iūlius** in his honor; decades later, Augustus received
+the same honor, and *Sextīlis* became **Augustus**. No months were
+created — two old, numbered ones just got new names, and Latin's fifth and
+sixth months quietly disappeared from view, hiding inside *julio/juillet*
+and *agosto/août* in every daughter language.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "Iānuārius, Februārius, Mārtius, Aprīlis, Māius,
+  Iūnius, Quīntīlis, Sextīlis, September, Octōber, November, December"]
+- [YOU SAY: the originals — "Quīntīlis, the fifth" / "Sextīlis, the sixth"]
+- [YOU SAY: the correction — "renamed, not inserted"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What were *Iūlius* and *Augustus* called **before** they were
+renamed, and what did those names mean? (**Quīntīlis** "the fifth" and
+**Sextīlis** "the sixth.") Did Julius Caesar and Augustus add new months to
+the calendar? (**No** — they got two already-existing months **renamed**
+after them.) What actually caused *September–December* to fall out of step
+with their numbers? (**Adding Iānuārius and Februārius** to the front of
+the year, centuries earlier.)

--- a/code/learning/human-languages/latin/lessons/LA-C12-medius-dies-nox.md
+++ b/code/learning/human-languages/latin/lessons/LA-C12-medius-dies-nox.md
@@ -1,0 +1,67 @@
+---
+id: LA-C12-medius-dies-nox
+chapter: 12
+type: phrase
+headword: medius diēs, media nox
+gloss: noon and midnight — the source phrase daughters kept whole, wore down unevenly, or eroded almost entirely
+concept_tag: LA-TIME-NOON-MIDNIGHT
+prerequisites: [LA-C11-menses]
+sounds: [macron-long-vowel]
+roots: [medius-latin, dies-latin, nox-latin]
+etymology_hook: "medius diēs 'mid-day' and media nox 'mid-night' survived at wildly different rates: Spanish kept both halves fully alive, French kept nox/nuit but wore diēs/-di to a fossil, and English's OWN word for noon isn't even this phrase — it's nōna hōra, 'the ninth hour,' which drifted from 3pm to midday"
+est_minutes: 5
+reviews_of: [LA-C11-menses]
+---
+
+# medius diēs, media nox — the source phrase, worn down at different rates
+
+## Warm-up
+
+[PAUSE 2s] Here's the same Latin phrase, followed into three languages —
+and each one treated it completely differently.
+
+## The two phrases
+
+- **medius diēs** — literally "**the middle day**," meaning "**midday,
+  noon**" (*medius*, "middle" + *diēs*, "day").
+- **media nox** — literally "**the middle night**," meaning "**midnight**"
+  (*media*, the feminine of *medius* + *nox, noctis*, "night").
+
+## Be honest: three languages, three different erosion stories
+
+- **Spanish** kept **both halves of both phrases** as fully ordinary,
+  living words: *medio/media* ("middle") and *día/noche* ("day/night") —
+  giving *mediodía* and *medianoche*, entirely transparent.
+- **French** eroded the **same phrase unevenly**. *Nox* survived as the
+  everyday word *nuit* ("night") — still fully transparent inside
+  *minuit*. But *diēs* did **not** survive as French's everyday word for
+  "day" (that's *jour* instead) — so inside *midi*, the *-di* fragment is a
+  fossil, recognizable only from weekday names like *lundi, mardi*, not
+  from any living, standalone word for "day."
+- **English** didn't inherit this phrase for "noon" **at all**. Instead,
+  English's *noon* comes from an entirely different Latin phrase: **nōna
+  hōra**, "the **ninth hour**" — originally meaning roughly 3 p.m. (counting
+  from a sunrise start), it drifted steadily earlier over the centuries
+  until it settled on **midday**.
+
+One Latin phrase, three completely different fates: fully kept, half-worn,
+and simply replaced by another Latin phrase altogether.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "medius diēs" — mid-day, then "media nox" — mid-night]
+- [YOU SAY: the three fates — "Spanish kept both halves, French kept only
+  night, English used a different phrase entirely"]
+- [YOU SAY: "nōna hōra" — the ninth hour — English's real ancestor for
+  "noon"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do **medius diēs** and **media nox** literally mean? ("The
+middle day" = noon; "the middle night" = midnight.) Which language kept
+both halves of both phrases fully transparent? (**Spanish** — *mediodía,
+medianoche*.) Which language kept "night" but not "day"? (**French** —
+*nuit* stayed alive, *-di* became a fossil.) Does English's *noon* come
+from this same phrase? (**No** — from *nōna hōra*, "the ninth hour," which
+drifted from afternoon to midday.)

--- a/code/learning/human-languages/latin/lessons/LA-C13-hora.md
+++ b/code/learning/human-languages/latin/lessons/LA-C13-hora.md
@@ -1,0 +1,67 @@
+---
+id: LA-C13-hora
+chapter: 13
+type: word
+headword: hōra
+gloss: hour — the source word itself, and the Roman hour was NOT a fixed length
+concept_tag: LA-TIME-HOUR
+prerequisites: [LA-C12-medius-dies-nox]
+sounds: [macron-long-vowel, h-aspirate]
+roots: [hora-greek]
+etymology_hook: "hōra, borrowed from Greek hṓrā ('a season, a time of day'), is the source of Spanish hora, French heure, German's later-borrowed Uhr, and English hour — but the Roman hōra itself wasn't a fixed 60 minutes: it was 1/12 of THAT DAY'S sunrise-to-sunset span, so it stretched and shrank with the seasons"
+est_minutes: 6
+reviews_of: [LA-C12-medius-dies-nox]
+---
+
+# hōra — the source word, and an hour that wasn't always 60 minutes
+
+## Warm-up
+
+[PAUSE 2s] You already met **nōna hōra**, "the ninth hour," in an earlier lesson —
+now meet the word itself, and an honest surprise about what a Roman "hour"
+actually was.
+
+## hōra ← Greek hṓrā
+
+**hōra** = "**hour**" — borrowed from **Greek** **hṓrā**, "a season, the right
+time, a time of day" (the Greek goddesses of the seasons, the *Hōrai*, share this
+root). Latin narrowed the broader Greek sense down to today's specific meaning:
+one twelfth of the day.
+
+## Be honest: a Roman hōra was NOT a fixed length
+
+Here's the part that trips people up: the Romans divided **daylight** — sunrise to
+sunset — into **12 equal hōrae**, and **night** into another 12. But since daylight
+itself is longer in summer and shorter in winter, **each hōra stretched or shrank
+with the seasons**: a summer daytime hōra in Rome could run close to 75 modern
+minutes, a winter one closer to 45. Only at the two equinoxes did an hōra land
+close to today's fixed 60 minutes. This is exactly why **nōna hōra** ("the ninth
+hour," counted from sunrise) landed around 3 p.m. at the equinox but could shift
+earlier or later depending on the season — and why it drifted, over centuries, into
+the fixed clock-time we call "noon."
+
+## The one Latin word, four different fates
+
+| language | word | what happened |
+|---|---|---|
+| **Spanish** | *hora* | inherited almost unchanged |
+| **French** | *heure* | inherited, worn down further |
+| **German** | *Uhr* | **not** inherited — borrowed centuries later, separately |
+| **English** | *hour* | inherited via French |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hōra" — the source word, Greek *hṓrā* underneath]
+- [YOU SAY: the honest surprise — a Roman hōra stretched and shrank with the
+  seasons, it wasn't a fixed 60 minutes]
+- [YOU SAY: "hōra / hora / heure / hour" — one root, four different fates]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Greek word is *hōra* from, and what did it originally mean? (*hṓrā*
+— "a season, the right time.") Was a Roman hōra always 60 minutes long? (**No** —
+it was 1/12 of that day's actual daylight or nighttime span, so it stretched in
+summer and shrank in winter.) Which of Spanish, French, and German did **not**
+directly inherit this word from Latin? (**German** — it borrowed *Uhr* separately,
+much later.)

--- a/code/learning/human-languages/latin/lessons/LA-C14-annos-natus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C14-annos-natus.md
@@ -1,0 +1,71 @@
+---
+id: LA-C14-annos-natus
+chapter: 14
+type: phrase
+headword: vīgintī annōs nātus sum
+gloss: "I am twenty years old" — literally "I am, having been born, twenty years [so far]"; NEITHER Romance's "have" NOR Germanic's "be my years" — Latin used a THIRD construction, later abandoned
+concept_tag: LA-AGE
+prerequisites: [LA-C13-hora]
+sounds: [macron-long-vowel, accusative-duration]
+roots: [nascor-natus-born, annus-latin]
+etymology_hook: "vīgintī annōs nātus sum, 'I am twenty years [having been] born' — Classical Latin's age construction used nātus ('born') + the ACCUSATIVE of duration, not habēre ('have'); the Romance 'I HAVE my years' pattern (Spanish tengo, French j'ai) is a LATER Vulgar Latin innovation, not inherited from Classical Latin itself"
+est_minutes: 6
+reviews_of: [LA-C13-hora]
+---
+
+# vīgintī annōs nātus sum — a THIRD way to say your age
+
+## Warm-up
+
+[PAUSE 2s] You already know that Spanish and French say "I HAVE my years," and
+German/English say "I AM my years." Here's the honest surprise: Latin itself did
+**neither**.
+
+## vīgintī annōs nātus sum — "twenty years born"
+
+**vīgintī annōs nātus sum** = "**I am twenty years old**" — literally "**I am,
+having been born, twenty years**" (a man speaking; a woman says **nāta**). Taken
+apart:
+
+- **nātus/nāta** — "**born**," the perfect passive participle of **nāscor**, "to
+  be born" (the same root behind English **nature, native, nation, innate**).
+- **annōs** — "**years**," in the **accusative case**, marking **duration** — "for
+  twenty years [of life so far]." This is the same accusative-of-duration you'd
+  use for "I studied **for three years**" (*trēs annōs*).
+- **sum** — "I am."
+
+So the whole phrase reads: "I am — having been born [and living] twenty years [so
+far]." Cicero uses exactly this pattern in *Cato Maior de Senectute* (§14), in
+Cato's own voice: **quīnque et sexāgintā annōs nātus**, "having been born
+sixty-**five** years," i.e., "at sixty-five years old" — the same section also
+gives Ennius's age as **annōs septuāgintā nātus**, "seventy."
+
+## Be honest: this is neither the Romance nor the Germanic pattern
+
+You've already met the clean Romance/Germanic split for this concept — Romance
+languages **have** their years (*tengo*, *j'ai*, *ho*), Germanic languages **are**
+their years (*ich bin*, *I am*). Here's the twist: **Latin itself used neither
+construction.** Classical Latin's *nātus* + accusative-of-duration pattern is a
+**third**, distinct grammatical shape — not "having" years, not simply "being" a
+number, but "being **born-for-that-long**." The Romance "have your years" pattern
+(*habēre* + years) that Spanish, French, and Italian all inherited is a
+**Vulgar Latin innovation** that arose **after** Classical Latin, replacing the
+older *nātus* construction — so Spanish's *tengo veinte años* is NOT a direct
+continuation of how Cicero would have said it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vīgintī annōs nātus sum" — I am twenty years old, literally "born
+  twenty years"]
+- [YOU SAY: "nātus" — born, same root as English "native, nature, nation"]
+- [YOU SAY: the honest surprise — this is a THIRD pattern, neither "have" nor
+  simple "be"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **vīgintī annōs nātus sum** literally mean? ("I am, having
+been **born**, twenty years" — using the perfect participle *nātus* + the
+accusative of duration.) Does this match Romance's "have your years" pattern? (**No**
+— that's a **later Vulgar Latin innovation**, not what Classical Latin did.) What
+English words share the root of *nātus*? (**Native, nature, nation, innate**.)

--- a/code/learning/human-languages/latin/lessons/LA-C15-tempestas-pluit.md
+++ b/code/learning/human-languages/latin/lessons/LA-C15-tempestas-pluit.md
@@ -1,0 +1,79 @@
+---
+id: LA-C15-tempestas-pluit
+chapter: 15
+type: phrase
+headword: tempestās, pluit
+gloss: "storm/weather" and "it rains" — tempestās is a DERIVATIVE of tempus that specialized for weather in Classical Latin, while tempus itself meant only "time"; later, WITHIN LATIN ITSELF (before Spanish/French/Italian split apart), tempus re-widened to also mean "weather," while tempestās narrowed further to just "storm" and survives in Spanish as its own separate word, tempestad
+concept_tag: LA-WEATHER
+prerequisites: [LA-C14-annos-natus]
+sounds: [macron-long-vowel, impersonal-verb-3rd-singular]
+roots: [tempus-latin, tempestas-latin, calor-latin, sol-latin, pluere-latin]
+etymology_hook: "tempestās ('weather, storm') is a DERIVATIVE noun built on tempus ('time') that specialized in Classical Latin to mean weather/storm specifically — but Latin ITSELF later re-widened tempus to also mean 'weather' (shared by French temps, Italian tempo too, not a Spanish-only innovation), while tempestās narrowed to just 'storm' and survives in Spanish as its own word, tempestad; pluit ('it rains'), calor, and sol are the direct sources of Spanish's llueve/calor/sol"
+est_minutes: 6
+reviews_of: [LA-C14-annos-natus]
+---
+
+# tempestās, pluit — one Latin word widened, its own derivative narrowed
+
+## Warm-up
+
+[PAUSE 2s] You've seen Spanish's *tiempo* mean both "time" and "weather" at
+once. Here's the honest history: Classical Latin actually kept these apart —
+but it wasn't Spanish that changed that. It happened inside Latin itself.
+
+## tempestās — a derivative of tempus, specialized for weather, then narrowed further
+
+**tempestās** = "**weather, storm**" — grammatically a **derivative noun**
+built on **tempus** ("time"), and by Classical Latin it had already
+**specialized**: *tempus* stayed strictly "time," while *tempestās* carried the
+weather/storm sense on its own. (English kept this split too: *tempestās*
+gives **tempest**, "a violent storm," while *tempus* gives **temporal,
+tempo**.)
+
+Be careful with what happened next, though: Spanish's single *tiempo* is
+**not** these two words merging back together. Later — still **within
+Latin's own history**, before Spanish, French, or Italian existed as separate
+languages — **tempus itself re-widened** to also cover "weather" (that's why
+French *temps* and Italian *tempo* carry the exact same double sense; this
+happened at the shared Latin stage, not as a Spanish-only development).
+Meanwhile *tempestās* kept going too, narrowing further to mean specifically
+"**storm**" — and it's still alive in Spanish today as its own separate word,
+**tempestad** ("storm, tempest"), sitting right alongside *tiempo*. So it's
+one word (*tempus*) widening back out, not two words fusing into one.
+
+## pluit — Latin's own impersonal "it rains"
+
+Latin states weather with **dedicated impersonal verbs**, no subject at all:
+**pluit** ("**it rains**"), **ningit** ("it snows"), **tonat** ("it thunders").
+**pluit** is the direct ancestor of Spanish's **llueve** — the same **pl- →
+ll-** shift you've now met repeatedly (*clāmāre → llamar*, *clāvem → llave*,
+*flamma → llama*, *plovere → llover*). Latin's impersonal-verb pattern for
+weather is actually closer to English's own "it **rains**" than to Spanish's
+*hacer*-based "**hace** calor" — Spanish only kept the dedicated-verb pattern
+for rain, and invented the *hacer* periphrasis fresh for heat, cold, and sun.
+
+## calor and sol — carried straight through, unchanged
+
+**calor** ("heat") and **sol** ("sun") are the exact same words in Latin and
+Spanish — no sound change at all, just carried straight through.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tempestās" — weather/storm, a derivative of tempus, "time,"
+  narrowed today to Spanish's "tempestad"]
+- [YOU SAY: "pluit" — it rains, ancestor of Spanish's llueve]
+- [YOU SAY: "calor," "sol" — unchanged in both languages]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Were *tempus* and *tempestās* the same word in Classical Latin?
+(**No** — *tempestās* is a derivative that specialized for weather/storm,
+while *tempus* stayed strictly "time.") Did Spanish merge these two words back
+together? (**No** — *tempus* itself re-widened to cover "weather" already
+within Latin's own history, shared by French/Italian too; *tempestās* kept
+narrowing and survives separately as Spanish *tempestad*.) How does Latin
+state "it rains," and what does it become in Spanish? (**pluit** → *llueve*,
+via the same *pl- → ll-* shift as *llamar*.) Does Latin's weather grammar look
+more like Spanish's *hacer* pattern or English's dedicated verbs? (**English's**
+— Latin uses dedicated impersonal verbs like *pluit*, *ningit*, *tonat*.)

--- a/code/learning/human-languages/latin/lessons/LA-C16-undecim-viginti.md
+++ b/code/learning/human-languages/latin/lessons/LA-C16-undecim-viginti.md
@@ -1,0 +1,79 @@
+---
+id: LA-C16-undecim-viginti
+chapter: 16
+type: word
+headword: ūndecim — vīgintī
+gloss: 11-20, the source numbers themselves — including Latin's own genuine oddity, SUBTRACTIVE 18 and 19, which Spanish quietly regularized away
+concept_tag: LA-NUM-11-20
+prerequisites: [LA-C15-tempestas-pluit]
+sounds: [macron-long-vowel, prefix-un-duo]
+roots: [latin-decim-ten, latin-viginti-twenty]
+etymology_hook: "ūndecim through quīndecim (11-15) are simple 'X-ten' compounds, the direct source of Spanish's fused once-quince; but 18 and 19 are the genuinely odd ones — duodēvīgintī ('two FROM twenty') and ūndēvīgintī ('one FROM twenty'), SUBTRACTIVE counting that Spanish did NOT inherit, replacing it with plain addition instead"
+est_minutes: 6
+reviews_of: [LA-C15-tempestas-pluit]
+---
+
+# ūndecim, vīgintī — the source numbers, including a genuine oddity
+
+## Warm-up
+
+[PAUSE 2s] You've seen Spanish's *once* through *quince* as fused, worn-down
+compounds. Here are the whole, un-fused Latin originals — plus a real quirk
+in Latin's own counting system that Spanish quietly dropped.
+
+## ūndecim–quīndecim — plain "X-ten" compounds
+
+| Latin | literally |
+|---|---|
+| **ūndecim** | *ūnus* + *decim*, "one-ten" |
+| **duodecim** | *duo* + *decim*, "two-ten" |
+| **tredecim** | *trēs* + *decim*, "three-ten" |
+| **quattuordecim** | *quattuor* + *decim*, "four-ten" |
+| **quīndecim** | *quīnque* + *decim*, "five-ten" |
+
+Straightforward additive compounds — number, then *decim* ("ten," from
+**decem**). These are the direct, whole ancestors of Spanish's *once,
+doce, trece, catorce, quince* — fused down over the centuries into single
+words.
+
+## sēdecim, septendecim — still additive
+
+**sēdecim** (16, "six-ten") and **septendecim** (17, "seven-ten") keep the
+same additive pattern.
+
+## Be honest: 18 and 19 are genuinely SUBTRACTIVE
+
+Here's the real oddity. Latin didn't say "eight-ten" or "nine-ten" for 18 and
+19 — it counted **backward from twenty** instead:
+
+> **duodēvīgintī** — "**two FROM twenty**" (18)
+> **ūndēvīgintī** — "**one FROM twenty**" (19)
+
+This is genuinely **subtractive** counting, not additive — the same logic
+behind how Latin also names the day before the Kalends. It's a real
+irregularity sitting right in the middle of an otherwise perfectly additive
+system. **Spanish did not inherit this quirk**: *dieciocho* and *diecinueve*
+are built fresh on the simple "ten-and-X" template, quietly regularizing away
+something genuinely odd in Latin's own counting.
+
+## vīgintī
+
+**vīgintī** ("twenty") — the direct, unchanged source of Spanish's *veinte*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ūndecim, duodecim, tredecim, quattuordecim, quīndecim" — the
+  plain "X-ten" compounds]
+- [YOU SAY: "duodēvīgintī, ūndēvīgintī" — 18 and 19, counted BACKWARD from
+  twenty]
+- [YOU SAY: "vīgintī" — twenty]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What pattern do *ūndecim* through *quīndecim* follow? (**Additive**
+— number + *decim*, "ten.") What's genuinely odd about Latin's 18 and 19?
+(They're **subtractive** — *duodēvīgintī*/*ūndēvīgintī*, literally "two/one
+FROM twenty," not "eight/nine-ten.") Did Spanish keep this subtractive
+pattern? (**No** — *dieciocho*/*diecinueve* are built fresh on plain
+addition, regularizing away Latin's own quirk.)

--- a/code/learning/human-languages/latin/lessons/LA-C17-canis-feles-cattus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C17-canis-feles-cattus.md
@@ -1,0 +1,77 @@
+---
+id: LA-C17-canis-feles-cattus
+chapter: 17
+type: word
+headword: canis, fēlēs, cattus
+gloss: dog and (two words for) cat — canis is the "expected" ancestor Spanish's perro mysteriously replaced; fēlēs was Classical Latin's OWN word for cat, later pushed out by the newcomer cattus
+concept_tag: LA-ANIMALS
+prerequisites: [LA-C16-undecim-viginti]
+sounds: [macron-long-vowel, consonant-cluster-tt]
+roots: [latin-canis-dog, latin-feles-cat, latin-cattus-afroasiatic]
+etymology_hook: "canis ('dog') is the source of English canine, French chien, Italian cane — and the word Spanish's perro mysteriously displaced, surviving there only as archaic can; fēlēs was Classical Latin's OWN word for 'cat' (source of the scientific Felis), later pushed out within Latin itself by the newcomer cattus, probably an Afro-Asiatic loanword that traveled with the cat itself out of Egypt"
+est_minutes: 6
+reviews_of: [LA-C16-undecim-viginti]
+---
+
+# canis, fēlēs, cattus — the expected word, and the word that pushed it out
+
+## Warm-up
+
+[PAUSE 2s] You just met Spanish's *perro* — a genuine etymological mystery
+that quietly displaced the word Latin actually gave it. Here's that word,
+and a second, parallel story about "cat."
+
+## canis — the word Spanish was "supposed" to keep
+
+**canis** ("**dog**") is the direct source of English **canine**, French
+**chien**, Italian **cane** — and it's also the Latin word Spanish
+**inherited** first, as **can**. But Spanish's everyday word for dog today is
+*perro* instead, a word with **no confirmed etymology at all** — *can*
+survives only in archaic or literary use, quietly pushed aside by a
+newcomer nobody can fully explain.
+
+## fēlēs and cattus — a similar displacement, this time INSIDE Latin
+
+Here's a genuine parallel, but this one happened **within Latin itself**,
+before any Romance language existed:
+
+- **fēlēs** was Classical Latin's own, original word for "**cat**" — used by
+  Cicero, Pliny, and others, and still preserved today in the scientific
+  name for the domestic cat, ***Felis catus***.
+- **cattus** (also *catta*) is a **later** word that entered Latin as
+  domestic cats themselves spread along Roman trade routes, out of their
+  point of domestication in **Egypt** (c. 2000 BCE). *Cattus* is most likely
+  ultimately an **Afro-Asiatic** word (compare Nubian *kadis*, "cat") — the
+  word traveled **with the animal**.
+
+By around 700 CE, *cattus* had pushed *fēlēs* out of everyday use almost
+everywhere — it's *cattus*, not *fēlēs*, that gives Spanish *gato*, Italian
+*gatto*, French *chat*, and more.
+
+## Be honest: two displacements, two very different kinds of certainty
+
+Both "dog" and "cat" show a Latin-inherited word getting pushed aside by a
+newcomer — but the two stories aren't equally well understood. *Cattus*
+replacing *fēlēs* is a well-documented, well-sourced piece of history, with a
+real trade-route explanation. *Perro* replacing *canis*-derived *can* is
+genuinely **unexplained** — a real gap in the historical record, not just a
+simplification for beginners.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "canis" — dog, source of English "canine"]
+- [YOU SAY: "fēlēs" — Classical Latin's own word for cat]
+- [YOU SAY: "cattus" — the newcomer that replaced it, probably from Egypt via
+  Africa]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What English word is a direct cousin of **canis**? (**Canine**.)
+Which Latin word for "cat" is older — *fēlēs* or *cattus*? (**Fēlēs** —
+Classical Latin's own word, later displaced.) Where does *cattus* most
+likely come from? (An **Afro-Asiatic** word, probably from **Egypt**, that
+traveled with the cat itself.) Is Spanish's *perro*-for-*can* displacement
+just as well understood as Latin's *cattus*-for-*fēlēs* displacement?
+(**No** — *cattus* has a real, sourced history; *perro* remains a genuine,
+unsolved mystery.)

--- a/code/learning/human-languages/latin/lessons/LA-C18-viridis-flavus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C18-viridis-flavus.md
@@ -1,0 +1,72 @@
+---
+id: LA-C18-viridis-flavus
+chapter: 18
+type: word
+headword: viridis, flāvus
+gloss: green and yellow — viridis is the direct, kept source of Spanish's verde; flāvus is Latin's own real word for yellow, and almost NO Romance language kept it as their everyday color word — most (French, Italian, Romanian) converged on a DIFFERENT shared Latin word instead
+concept_tag: LA-COLOUR-GREEN-YELLOW
+prerequisites: [LA-C17-canis-feles-cattus]
+sounds: [macron-long-vowel, consonant-v]
+roots: [latin-virere-flourish, pie-bhleh3w-shine]
+etymology_hook: "viridis ('green'), from virēre, 'to flourish,' is the direct source of Spanish's verde; flāvus ('yellow, golden, blond'), from PIE *bhleh₃w-, is Latin's OWN real word for yellow — but Spanish/Portuguese reinvented amarillo/amarelo from 'bitter,' while French's jaune, Italian's giallo, and Romanian's galben ALL independently converge on a different shared Latin word instead, galbinus, 'light GREEN,' not yellow at all; flavus survives mainly in Roman names like Flavius"
+est_minutes: 6
+reviews_of: [LA-C17-canis-feles-cattus]
+---
+
+# viridis, flāvus — the kept word, and the word Romance abandoned twice over
+
+## Warm-up
+
+[PAUSE 2s] One of Latin's color words survived cleanly into Spanish. The
+other one is a genuine oddity: Latin had a perfectly good word for yellow —
+and virtually **no** Romance language kept it, though most of them agreed on
+a surprising replacement together.
+
+## viridis — the direct, kept source of Spanish's verde
+
+**viridis** ("**green**") comes from **virēre**, "**to flourish, to be
+green, to be vigorous**" — and this is the **direct** source of Spanish's
+*verde*, worn down by entirely ordinary sound change (syncope of the
+medial vowel: *viridis* → *virdis* → *verde*). A clean, uneventful
+inheritance.
+
+## flāvus — Latin's OWN word for yellow, almost universally abandoned
+
+**flāvus** ("**yellow, golden, blond**," often specifically of hair) is a
+genuine, well-attested Classical Latin color word, from **Proto-Indo-European**
+***\*bhleh₃w-*** ("shining, light-colored") — though *lūteus* was Latin's
+more neutral, plain "yellow" word in everyday prose. Here's the honest
+oddity: almost **no** Romance language kept *flāvus* as its everyday word
+for "yellow." Spanish and Portuguese independently reinvented
+*amarillo*/*amarelo* from *amarus*, "bitter." But here's the genuinely
+surprising twist: **French**'s *jaune*, **Italian**'s *giallo*, and
+**Romanian**'s *galben* all converge on a **different shared Latin word**
+instead — **galbinus**, which meant "**light green**," not yellow at all.
+So this isn't every daughter language scattering off in its own direction —
+it's closer to **two** major replacement stories: Ibero-Romance's shared
+"bitter" reinvention, and a much wider swath of Romance sharing *galbinus*
+instead. *Flāvus* itself didn't vanish completely — it survives today
+mainly in **Roman personal names**, like **Flāvius** and **Flāvia**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "viridis" — green, direct source of verde]
+- [YOU SAY: "flāvus" — yellow, Latin's own word, almost universally
+  abandoned]
+- [YOU SAY: "galbinus" — "light green," yet somehow the shared source of
+  French's jaune, Italian's giallo, AND Romanian's galben]
+- [YOU SAY: "Flāvius" — a Roman name preserving flāvus, where the color
+  word itself didn't survive]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb gives **viridis**, and what Spanish word does it
+directly become? (**Virēre**, "to flourish" → **verde**.) Did most Romance
+languages keep **flāvus** as their word for yellow? (**No.**) What are the
+**two** main replacement stories, and which languages fall into each?
+(**Ibero-Romance** — Spanish/Portuguese — independently reinvented
+*amarillo*/*amarelo* from "bitter"; **French, Italian, and Romanian** all
+instead converge on the *same* Latin word, *galbinus*, "light green," not
+yellow at all.) Where does *flāvus* mainly survive today? (**Roman personal
+names**, like *Flāvius* and *Flāvia*.)

--- a/code/learning/human-languages/latin/lessons/LA-C19-quid-agis.md
+++ b/code/learning/human-languages/latin/lessons/LA-C19-quid-agis.md
@@ -1,0 +1,67 @@
+---
+id: LA-C19-quid-agis
+chapter: 19
+type: phrase
+headword: quid agis? / ut valēs?
+gloss: how are you? — both genuinely attested in Plautus and Terence's comedies; the reply, valeō ("I fare well"), is the very same verb already hiding inside valē, the "goodbye" you learned in Chapter 1
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [LA-C01-vale, LA-C01-ita-non]
+sounds: [macron-long-vowel, qu-kw-sound]
+roots: [valere-latin, agere-latin]
+etymology_hook: "quid agis?, literally 'what are you doing?', and ut valēs?, literally 'how do you fare?', are both genuinely attested in Plautus and Terence's comedies — colloquial, everyday Latin, not literary invention; the reply valeō ('I fare well'), sometimes intensified as Plautus's valeō rēctē or valeō et salvōs sum rēctē, is the exact same verb, valēre, already hiding inside valē, the farewell from Chapter 1 (itself literally an imperative, 'be well!')"
+est_minutes: 6
+reviews_of: [LA-C01-vale]
+---
+
+# quid agis?, ut valēs? — "how are you?", two genuinely Roman ways
+
+## Warm-up
+
+[PAUSE 2s] You already know **valē** — "goodbye," Chapter 1. What you didn't
+know yet: that same verb comes back here, as the honest Roman answer to
+"how are you?"
+
+## Two real, attested questions — not modern invention
+
+Latin has **no single fixed idiom** for "how are you?" the way Spanish has
+*¿cómo estás?* — but it has **two** genuinely attested colloquial questions,
+both found repeatedly in **Plautus** and **Terence**'s comedies (the closest
+thing Latin has to recorded everyday speech):
+
+- **Quid agis?** — literally "**what are you doing**?", used idiomatically
+  the way English uses "what's up?" or "how's it going?"
+- **Ut valēs?** — literally "**how do you fare**?", built on **valēre**,
+  "to be strong, to be well" — the **same verb** as *valē*.
+
+A third phrase, **quōmodo tē habēs?** ("how do you hold yourself?"), shows
+up constantly in **modern** spoken-Latin teaching materials, and it's
+grammatically perfectly sound — but it is **not** actually found in any
+surviving classical text. Be careful with this one: it's a reasonable
+modern construction, not a Roman one.
+
+## valeō — the honest answer, and the same word as "goodbye"
+
+The genuinely attested reply draws on the very same verb as the question:
+**valeō**, "**I fare well, I am strong**" — Plautus's characters intensify it
+several different ways (*valeō rēctē*, "I'm well, rightly so"; *valeō et
+salvōs sum rēctē*, "I'm well and safe and rightly so"). This is the **exact
+same verb**, *valēre*, that gives you *valē* — so "goodbye" was, this whole
+time, literally an imperative: "**be well!**" Asking *ut valēs?* and
+answering *valeō* is just that same verb moving between question,
+statement, and farewell.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "quid agis?" — literally "what are you doing?"]
+- [YOU SAY: "ut valēs?" — literally "how do you fare?"]
+- [YOU SAY: "valeō" — "I fare well" — the reply, and the same verb as valē]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **quid agis?** literally mean? ("**What are you
+doing?**") What verb connects **ut valēs?**, **valeō**, and the *valē* you
+already knew from Chapter 1? (***Valēre***, "to be strong/well" — *valē* is
+literally an imperative, "be well!") Is **quōmodo tē habēs?** genuinely
+attested in classical Latin? (**No** — grammatically sound, but a modern
+pedagogical construction, not found in surviving Roman texts.)

--- a/code/learning/human-languages/latin/lessons/LA-C20-quid-tibi-nomen.md
+++ b/code/learning/human-languages/latin/lessons/LA-C20-quid-tibi-nomen.md
@@ -1,0 +1,68 @@
+---
+id: LA-C20-quid-tibi-nomen
+chapter: 20
+type: phrase
+headword: quid tibi nōmen est? / mihi nōmen est...
+gloss: what's your name? / my name is... — a genuinely classical construction (the "dative of possession"), attested across authors from Plautus to Livy, though Cicero notably preferred keeping the name itself in the nominative rather than pulling it into the dative to match
+concept_tag: INTRO-WHATS-YOUR-NAME
+prerequisites: [LA-C01-salve, LA-C19-quid-agis]
+sounds: [macron-long-vowel, qu-kw-sound]
+roots: [nomen-latin, dative-possession]
+etymology_hook: "quid tibi nōmen est?, literally 'what is the name TO YOU?', and its reply mihi nōmen est [X], 'the name TO ME is [X]', use Latin's 'dative of possession' — the name belongs to a person by being dative TO them, not by a possessive verb like English 'have' or German's heißen; the dative possessor itself (tibi/mihi/puerō) is attested from Plautus down through Livy and Sallust, but authors differ on the NAME's own case — Cicero preferred keeping it nominative (puerō nōmen est Mārcus, 'to-the-boy the name is Marcus'), while Livy/Sallust more often pulled it into the dative to match (puerō nōmen est Mārcō)"
+est_minutes: 6
+reviews_of: [LA-C19-quid-agis]
+---
+
+# quid tibi nōmen est?, mihi nōmen est... — "what's your name?", the dative way
+
+## Warm-up
+
+[PAUSE 2s] English says you **have** a name. German says you're **called**
+something. Latin does neither — it says the name **belongs to you**, using
+nothing but a case ending.
+
+## quid tibi nōmen est? — literally "what is the name TO YOU?"
+
+**Quid tibi nōmen est?** ("**what's your name?**") is, word for word,
+"**what** [is] **the-name** [to] **you**?" — no verb for "have," no verb for
+"be called." The name simply **exists**, and **tibi** ("to you," dative
+case) says who it belongs to.
+
+## mihi nōmen est... — the same construction, in reply
+
+The reply follows the identical pattern: **mihi nōmen est** [name] —
+"[the-name] [is] to-me [name]." This is Latin's genuine **"dative of
+possession"**: instead of a possessive verb, the possessor simply sits in
+the dative case, and the thing possessed — here, **nōmen**, "name" — stays
+in the nominative, as the sentence's real subject.
+
+## A real classical construction, with real stylistic variation
+
+This isn't a modern teaching simplification — it's a genuinely attested
+pattern, found from **Plautus**'s comedies through **Livy** and **Sallust**
+— the dative possessor itself (*puerō*, "to the boy") is the constant part.
+But be honest about a real point of variation **within** the construction:
+authors differ on what case the **name itself** takes. **Cicero** preferred
+keeping the name in the **nominative** — *puerō nōmen est Mārcus*,
+"to-the-boy the name is Marcus" — while **Livy** and **Sallust** more often
+pulled the name into the **dative** too, to match the possessor: *puerō
+nōmen est Mārcō*. Same underlying construction, genuinely different habits
+about the name's own case — not one single rigid rule.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "quid tibi nōmen est?" — literally "what's the name to you?"]
+- [YOU SAY: "mihi nōmen est..." — "the name is to me..."]
+- [YOU SAY: the case doing the work — dative *tibi*/*mihi*, not a verb]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What case does the possessor sit in, in **mihi nōmen est**?
+(**Dative** — *mihi*, "to me.") Does Latin use a verb like "have" or "be
+called" for this? (**No** — the name simply exists; possession is shown by
+the dative case alone.) What genuinely varied between authors — the
+possessor's case, or the name's own case? (**The name's own case**: Cicero
+kept it nominative, *puerō nōmen est Mārcus*; Livy/Sallust more often
+pulled it into the dative too, *puerō nōmen est Mārcō* — the dative
+possessor itself was constant throughout.)

--- a/code/learning/human-languages/latin/lessons/LA-C21-volup-est-convenisse.md
+++ b/code/learning/human-languages/latin/lessons/LA-C21-volup-est-convenisse.md
@@ -1,0 +1,79 @@
+---
+id: LA-C21-volup-est-convenisse
+chapter: 21
+type: phrase
+headword: volup est convēnisse
+gloss: "nice to meet you" — Latin genuinely has NO fixed idiom for this the way modern languages do, but Plautus gives us a real, attested phrase that does the job, "it's a pleasure to have met you"
+concept_tag: INTRO-NICE-TO-MEET-YOU
+prerequisites: [LA-C20-quid-tibi-nomen]
+sounds: [macron-long-vowel, perfect-infinitive]
+roots: [volup-latin, convenire-latin]
+etymology_hook: "Latin has no single fixed 'nice to meet you' idiom the way Spanish/French/German do; but Plautus's Miles Gloriosus gives a genuinely attested real-world phrase for the same job — 'Tē ... volup est convēnisse', literally '[to have met] you is a pleasure', built on volup ('pleasant, pleasing') + the perfect infinitive convēnisse ('to have come together, met')"
+est_minutes: 6
+reviews_of: [LA-C20-quid-tibi-nomen]
+---
+
+# volup est convēnisse — the phrase Latin uses instead of a fixed idiom
+
+## Warm-up
+
+[PAUSE 2s] Every modern language in this course has one fixed phrase for
+"nice to meet you." Latin, honestly, does **not** — but it has something
+better: a real line from a Roman comedy that does the job.
+
+## No fixed idiom — an honest gap, not an oversight
+
+Unlike Spanish's *encantado* or German's *freut mich*, Classical Latin has
+**no single, fixed idiom** that means exactly "nice to meet you." This
+isn't a curriculum gap to patch over — it's a real, honest feature of the
+language: Romans simply expressed the sentiment differently depending on
+context, rather than reaching for one fixed formula.
+
+## volup est convēnisse — a genuinely attested phrase for the job
+
+**Plautus**'s comedy *Miles Gloriosus* (Act 2, Scene 3) gives us a real
+line that does exactly this work: **"Tē, [name], volup est convēnisse"** —
+literally "**you, [name], [it] is-a-pleasure to-have-met**," or naturally,
+"**it's a pleasure to have met you, [name].**" Break it down:
+
+- **volup** — an old, indeclinable word for "**pleasant, pleasing**"
+  (functioning here the way *iuvat*, "it pleases," would)
+- **est** — "[it] **is**"
+- **convēnisse** — the **perfect infinitive** of *convenīre*, "to come
+  together, to meet" — "**to have met**"
+
+Put together: "**to have met [you] is a pleasure.**" This is a genuine,
+attested line — not a modern reconstruction. One honest caveat: in the
+play, Sceledrus and Palaestrio are fellow slaves who already know each
+other; the line greets a **chance encounter**, not a first-time
+introduction to a stranger. It's repurposed here for the same
+conversational slot "nice to meet you" fills, not a perfect match in
+context.
+
+## Be careful: one popular alternative is NOT classical
+
+You may see **"mihi pergrātum est tē convenīre"** ("it is very pleasing to
+me to meet you") in modern spoken-Latin guides. It's grammatically fine —
+but it does **not** appear in any surviving classical text. Like *quōmodo
+tē habēs?* from the last lesson, this is a reasonable modern construction,
+not a genuinely Roman one. Stick with *volup est convēnisse* if you want
+the real thing.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "volup est convēnisse" — "it's a pleasure to have met you"]
+- [YOU SAY: the pieces — volup (pleasant) + est (is) + convēnisse
+  (to have met)]
+- [YOU SAY: the honest fact — Latin has no fixed idiom here, unlike every
+  modern language in this course]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does Classical Latin have one single fixed idiom for "nice to
+meet you"? (**No** — a genuine, honest gap, unlike Spanish/French/German.)
+What real, attested phrase does the same job, and where does it come from?
+(**"Volup est convēnisse"**, literally "to have met [you] is a pleasure" —
+**Plautus**, *Miles Gloriosus*.) Is "mihi pergrātum est tē convenīre"
+genuinely classical? (**No** — grammatically sound, but a modern
+spoken-Latin construction with no attestation in surviving texts.)

--- a/code/learning/human-languages/latin/lessons/LA-C22-tu-vos.md
+++ b/code/learning/human-languages/latin/lessons/LA-C22-tu-vos.md
@@ -1,0 +1,69 @@
+---
+id: LA-C22-tu-vos
+chapter: 22
+type: word
+headword: tū / vōs
+gloss: you (singular) / you (plural) — a PURELY grammatical number distinction in Classical Latin, with no politeness dimension at all; the polite-vous pattern (a Late Latin innovation) is vōs's own direct descendant, unlike German's Sie, which solved the same politeness problem independently via a completely different pronoun (3rd-person plural, not 2nd)
+concept_tag: PRONOUN-YOU
+prerequisites: [LA-C20-quid-tibi-nomen]
+sounds: [long-vowel-u, macron-long-vowel]
+roots: [tu-pie, vos-pie]
+etymology_hook: "tū ('you,' singular) and vōs ('you,' plural) are a PURELY grammatical number distinction in Classical Latin — genuinely NO politeness dimension existed yet; the later habit of using plural vōs to address one person politely only developed in LATE Latin, after the classical period, and is the direct ancestor of French's polite vous — a genuinely separate solution from German's Sie, which independently repurposes an entirely different pronoun (3rd-person plural 'they'), not a descendant of vōs at all"
+est_minutes: 5
+reviews_of: [LA-C20-quid-tibi-nomen]
+---
+
+# tū, vōs — "you," before politeness got involved
+
+## Warm-up
+
+[PAUSE 2s] German's lesson on "you" was about **formality** — *du* versus
+*Sie*. Latin's version of this same lesson is about something completely
+different: plain **number**. Formality hadn't been invented yet.
+
+## tū — you, one person
+
+**Tū** = "**you**," addressing **one** person. That's the whole rule — no
+formal/informal split, just singular number. You've already used its dative
+form, *tibi*, in *quid tibi nōmen est?*
+
+## vōs — you, more than one person
+
+**Vōs** = "**you**," addressing **more than one** person — plain plural,
+nothing more.
+
+## The honest historical twist: no politeness distinction yet
+
+Here's the real teaching point: in **Classical Latin**, this is a **purely
+grammatical number** distinction. There is **no** formal/informal
+dimension at all — using *vōs* to politely address a single powerful person
+had **not yet started**. That habit — plural pronoun used respectfully for
+one person — only developed later, in **Late Latin**, well after the
+classical period. It's the **direct ancestor** of French's polite *vous*.
+Careful, though: it is **not** the ancestor of German's *Sie* from the last
+lesson — *Sie* solves the same politeness problem in a completely
+**different** way, by repurposing an unrelated pronoun (3rd-person plural
+"they"), not by descending from *vōs* at all. Classical Romans simply
+didn't have this option yet: one person was always *tū*, no matter how
+important they were — though Romans still had **other** ways to show
+deference, like respectful titles (*domine*, "sir/lord"), just not through
+the pronoun itself.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tū" — you, singular, one person]
+- [YOU SAY: "vōs" — you, plural, more than one person]
+- [YOU SAY: the honest twist — Classical Latin's tū/vōs is PURE number, no
+  politeness at all, unlike German's du/Sie]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What's the difference between **tū** and **vōs** in Classical
+Latin — number, or politeness? (**Pure number** — *tū* is singular, *vōs*
+is plural; no formality dimension existed yet.) When did using *vōs* to
+politely address one person begin? (**Late Latin**, after the classical
+period — the direct ancestor of French's polite *vous*.) Is German's
+**Sie** descended from *vōs* the same way? (**No** — *Sie* solves the same
+problem independently, by repurposing 3rd-person plural "they," not by
+inheriting from *vōs* at all.)

--- a/code/learning/human-languages/latin/lessons/LA-C23-nihil-est.md
+++ b/code/learning/human-languages/latin/lessons/LA-C23-nihil-est.md
@@ -1,0 +1,68 @@
+---
+id: LA-C23-nihil-est
+chapter: 23
+type: phrase
+headword: nihil est
+gloss: "you're welcome" — another honest gap: Classical Latin has no single fixed reply to thanks, and nihil est ("it's nothing") is a modern conversational-Latin convention built from genuinely real words, not a specific classical citation for this exact job
+concept_tag: COURTESY-YOUREWELCOME
+prerequisites: [LA-C01-gratias]
+sounds: [h-aspirated, nihil-two-syllables]
+roots: [nihil-latin, est-latin]
+etymology_hook: "Classical Latin has no single fixed reply to grātiās agō the way modern languages do; nihil est ('it's nothing,' from nihil, 'nothing,' ← ne + hīlum, 'not [even] a tiny bit') is the phrase modern conversational-Latin communities reach for — the words themselves are genuinely classical, but no surviving text shows this exact phrase used specifically as a reply to thanks, so treat it as a well-grounded modern convention, not an ancient one"
+est_minutes: 5
+reviews_of: [LA-C01-gratias]
+---
+
+# nihil est — "you're welcome," another honest gap
+
+## Warm-up
+
+[PAUSE 2s] You already learned that Latin has no fixed "nice to meet you."
+Here's the same honest gap again: no fixed reply to "thank you" either.
+
+## nihil est — "it's nothing"
+
+**Nihil est** = literally "[it] **is nothing**" — **nihil** ("nothing")
++ **est** ("is"). This is the phrase modern conversational-Latin
+communities commonly reach for as "you're welcome," parallel to English
+"it's nothing" or Spanish *de nada*.
+
+## nihil — a real word, worn down from "not one tiny bit"
+
+**Nihil** itself is genuinely classical and richly attested, from an older
+***nihilum***, itself built from **ne-** ("not") + **hīlum** ("a tiny
+thing, a trifle" — said to have originally meant "the eye of a bean," though
+its own ultimate origin is uncertain). So "nothing" in Latin literally
+started life as "not [even] a tiny bit" — the
+same shape of story as French's *pas* ("not," originally "a step") or
+Spanish's *nada* (from *nāta*, "a thing born").
+
+## Be honest: the words are real, the specific reply is a modern habit
+
+Here's the careful part: **nihil** and **est** are both thoroughly
+classical, and *nihil est* itself appears in real Latin texts — but always
+meaning things like "there's nothing to it" (*"nihil est, nūgae"*, "nothing,
+trifles," Plautus's *Bacchidēs*) or "that's nothing" (*"istuc quidem
+[edepol] nihil est"*, Plautus's *Mīles Glōriōsus*), **never** specifically
+attested as a reply **to thanks**. No surviving Roman text shows someone
+answering *grātiās agō* with *nihil est*. Treat it the way you already
+treated *quōmodo tē habēs?*: real Latin words, put to a genuinely useful
+modern job, but not a citation from a Roman play.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nihil est" — "it's nothing," Latin's answer to "thank you"]
+- [YOU SAY: nihil's own history — ne- + hīlum, "not a tiny bit"]
+- [YOU SAY: the honest caveat — real words, modern job, not an ancient
+  citation]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **nihil est** literally mean, and what job does it do
+here? ("**[It] is nothing**" — the reply to *grātiās agō*, "thank you.")
+What does **nihil** itself literally break down into? (**ne-** "not" +
+**hīlum** "a tiny thing" — "not a tiny bit.") Is *nihil est* specifically
+attested in a classical text as a reply to thanks? (**No** — a modern
+conversational-Latin convention built from real words, not an ancient
+citation.)

--- a/code/learning/human-languages/latin/lessons/LA-C24-propediem-te-videbo.md
+++ b/code/learning/human-languages/latin/lessons/LA-C24-propediem-te-videbo.md
@@ -1,0 +1,64 @@
+---
+id: LA-C24-propediem-te-videbo
+chapter: 24
+type: phrase
+headword: propediem tē vidēbō
+gloss: "see you later/soon" — a genuine change of pace from the last few lessons: this one IS solidly attested, twice, in Cicero's own letters
+concept_tag: FAREWELL-LATER
+prerequisites: [LA-C05-dies-lunae-veneris, LA-C01-vale, LA-C01-gratias]
+sounds: [macron-long-vowel, future-tense-bo]
+roots: [prope-latin, dies-latin, videre-latin]
+etymology_hook: "propediem tē vidēbō, 'I shall see you soon,' is genuinely attested TWICE in Cicero's own letters (Ad Familiārēs 2.12, to Caelius: 'Sed, ut spērō, propediem tē vidēbō'; and Ad Familiārēs 15.6, to Cato, in reversed order: 'Ego, ut spērō, tē propediem vidēbō'); propediem itself breaks down as prope ('near') + diem (accusative of diēs, 'day' — the same diēs from your days-of-week lessons), literally 'near the day' = 'very soon'"
+est_minutes: 6
+reviews_of: [LA-C01-vale]
+---
+
+# propediem tē vidēbō — a real change of pace: solidly attested, twice
+
+## Warm-up
+
+[PAUSE 2s] The last few lessons were honest about real gaps — no fixed
+"how are you," no fixed "nice to meet you," no fixed "you're welcome." This
+one is different: a genuine, repeated Ciceronian phrase.
+
+## propediem tē vidēbō — "I shall see you soon"
+
+**Propediem tē vidēbō** — "**I shall see you soon**" — is genuinely
+attested, not once but **twice**, in **Cicero**'s own letters:
+
+- **Ad Familiārēs 2.12** (to Caelius): *"Sed, ut spērō, propediem tē
+  vidēbō"* — "**But, as I hope, I shall see you soon.**"
+- **Ad Familiārēs 15.6** (to Cato): *"Ego, ut spērō, tē propediem vidēbō"* — the same
+  phrase, word order reshuffled, "**I, as I hope, shall see you soon.**"
+
+## propediem — "near the day," built from a word you already know
+
+**Propediem** breaks down as **prope** ("**near**") + **diem** (accusative
+of **diēs**, "**day**") — literally "**near the day**," meaning "very soon,
+shortly." That's the **same diēs** from your days-of-week lessons
+(*diēs Lūnae*, *diēs Veneris*) — a familiar root showing up in a brand-new
+job.
+
+## vidēbō — the verb ending doing the work, again
+
+**Vidēbō** is the **future tense** of **vidēre**, "to see" — and just like
+*agō* back in "thank you," the **-bō** ending already carries "**I will**,"
+so no separate pronoun for "I" is needed. *Tē* ("you") is simply the direct
+object: "[I] will-see you."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "propediem tē vidēbō" — "I shall see you soon"]
+- [YOU SAY: propediem's own pieces — prope (near) + diem (the day)]
+- [YOU SAY: the honest contrast — unlike the last few lessons, this phrase
+  IS solidly attested, twice, in Cicero]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where is **propediem tē vidēbō** genuinely attested, and how many
+times? (**Twice**, in **Cicero**'s letters — *Ad Familiārēs* 2.12 and 15.6.)
+What does **propediem** literally break down into? (**Prope** "near" +
+**diem** "the day" — the same *diēs* from the days-of-week lessons.) Does
+*vidēbō* need a separate word for "I"? (**No** — the *-bō* future ending
+already carries it, the same way *agō*'s *-ō* did.)

--- a/code/learning/human-languages/latin/lessons/LA-C25-cras-te-videbo.md
+++ b/code/learning/human-languages/latin/lessons/LA-C25-cras-te-videbo.md
@@ -1,0 +1,72 @@
+---
+id: LA-C25-cras-te-videbo
+chapter: 25
+type: phrase
+headword: crās tē vidēbō
+gloss: "see you tomorrow" — built from two genuinely classical pieces (crās, "tomorrow," and vidēbō, already met last lesson) using the exact same pattern as the attested propediem tē vidēbō, though this specific combination isn't itself pulled from one surviving letter
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [LA-C24-propediem-te-videbo]
+sounds: [macron-long-vowel, future-tense-bo]
+roots: [cras-latin, videre-latin]
+etymology_hook: "crās tē vidēbō, 'I'll see you tomorrow,' combines crās ('tomorrow,' Proto-Italic *krās, deeper origin genuinely uncertain/debated) with vidēbō (future of vidēre, already met in propediem tē vidēbō) — same grammatical pattern as that attested phrase, though THIS exact combination isn't itself quoted in a surviving letter; honest cross-language twist: crās was abandoned by most major Romance languages (French demain, Italian domani, Catalan demà all rebuilt 'tomorrow' from dē māne, 'in the morning' instead) — Sardinian and Sicilian are the main holdouts that kept crās itself"
+est_minutes: 6
+reviews_of: [LA-C24-propediem-te-videbo]
+---
+
+# crās tē vidēbō — the same pattern, honestly not the same citation
+
+## Warm-up
+
+[PAUSE 2s] Last lesson's phrase was a direct quote from Cicero. This one
+uses the exact same grammatical machinery — but be honest: it isn't itself
+pulled from a surviving letter.
+
+## crās tē vidēbō — built from known-good pieces
+
+**Crās tē vidēbō** — "**I'll see you tomorrow**" — swaps **crās**
+("**tomorrow**") in for *propediem* ("soon") from the last lesson, keeping
+the same **vidēbō** ("I will see") you already learned. Both pieces are
+genuinely classical: *crās* is a real, common Latin adverb, and *vidēbō* is
+the same attested future-tense verb as before. But be careful: unlike
+*propediem tē vidēbō*, this **specific combination** isn't itself quoted in
+any surviving Roman letter — it's a well-formed construction built by
+analogy, not a direct citation.
+
+## crās — ancient, but its own deepest root is uncertain
+
+**Crās** traces back to **Proto-Italic** ***\*krās*** — but past that point,
+its ultimate origin is genuinely **uncertain**, with scholars proposing
+several different, competing Proto-Indo-European sources. Some things in
+etymology just don't resolve cleanly, even for a word this ordinary.
+
+## An honest twist: nearly every Romance language abandoned crās
+
+Here's the real teaching point: **crās** didn't survive as the everyday
+word for "tomorrow" in most of its major daughter languages. **French**'s
+*demain*, **Italian**'s *domani*, and **Catalan**'s *demà* all rebuilt
+"tomorrow" from **dē māne** ("**in the morning**") instead — the same
+morning-based logic reappearing three separate times. **Sardinian** and
+**Sicilian** are the main holdouts that kept *crās* itself as an everyday
+word. Spanish, too, moved away from it, building its own *mañana* on
+**māne** ("morning") rather than keeping *crās*. A genuinely ordinary Latin
+word, abandoned by most of the family — echoing, if less completely, the
+same shape of story as *flāvus* from the colors lesson (which survives
+nowhere as an everyday word, only in names like *Flāvius*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "crās tē vidēbō" — "I'll see you tomorrow"]
+- [YOU SAY: the honest caveat — same pattern as propediem tē vidēbō, but not
+  itself a direct quotation]
+- [YOU SAY: the Romance twist — nearly everyone replaced crās with a
+  morning-based word instead]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **crās tē vidēbō** itself quoted in a surviving Cicero
+letter, the way *propediem tē vidēbō* was? (**No** — same grammatical
+pattern, built from two genuinely classical pieces, but not itself a direct
+citation.) Which Romance language kept **crās** as its everyday word for
+"tomorrow"? (**Sardinian and Sicilian** — most of the rest rebuilt it from *dē māne*,
+"in the morning," instead.)

--- a/code/learning/human-languages/latin/lessons/LA-C26-quomodo.md
+++ b/code/learning/human-languages/latin/lessons/LA-C26-quomodo.md
@@ -1,0 +1,71 @@
+---
+id: LA-C26-quomodo
+chapter: 26
+type: word
+headword: quōmodo
+gloss: "how, in what way" — the genuine classical word behind Italian come, Spanish cómo, and French comment, which went one step further and double-marked "manner"
+concept_tag: QUESTION-HOW
+prerequisites: [LA-C19-quid-agis]
+sounds: [macron-long-vowel, qu-kw-sound]
+roots: [quo-latin, modus-latin, mens-latin]
+etymology_hook: "quōmodo, 'how, in what way,' is a genuine classical word — a univerbation of quō (ablative of quis/quid, 'what') + modō (ablative of modus, 'manner, measure'), literally 'by what manner,' attested in Cicero and Seneca; it's the direct source of Italian come and Spanish cómo, but French's comment went one step further, with comme (← quōmodo) picking up its own French -ment suffix (← mēns, 'mind,' the same suffix in rapidement) — one well-attested account has it double-marking 'manner' rather than carrying it once, though the exact historical mechanism has more than one proposal"
+est_minutes: 6
+reviews_of: [LA-C19-quid-agis]
+---
+
+# quōmodo — the real word behind "how," in three Romance languages at once
+
+## Warm-up
+
+[PAUSE 2s] You've already met *quōmodo* once, as part of a phrase that
+turned out **not** to be classically attested. This lesson is honest about
+the flip side: the **word itself** is completely genuine.
+
+## quōmodo — genuinely classical, "by what manner"
+
+**Quōmodo** ("**how, in what way**") is a real, common Classical Latin
+word — a fusion of **quō** (ablative of *quis/quid*, "what") + **modō**
+(ablative of *modus*, "manner, measure"), literally "**by what manner**."
+It's attested in both **Cicero** (*Dē Inventiōne*) and **Seneca**
+(*Epistulae Mōrālēs*) — genuinely classical, unlike the specific
+*quōmodo tē habēs?* greeting from Chapter 19, which was a modern
+construction. The **word** is real; it was only that one **exact phrase**
+that wasn't.
+
+## The direct Romance descendants: Italian come, Spanish cómo
+
+**Quōmodo** is the **direct source** of Italian's **come** and Spanish's
+**cómo** — both simply continue *quōmodo*, worn down by ordinary sound
+change.
+
+## French's comment — the same word, doubled
+
+Here's the honest surprise: French's **comment** is **not** a simple
+continuation of *quōmodo* the way Italian and Spanish's words are. French's
+**comme** ("how, as, like") continues *quōmodo* just like Italian's *come*
+does — but then **comment** picks up French's own **-ment** adverb ending
+on top of that, from **mente** (ablative of *mēns*, "mind") — the **same**
+*-ment* that turns any adjective into an adverb (*rapide* → *rapidement*,
+"quickly"). One well-attested account of this history holds that *comment*
+therefore marks "manner" **twice** — once via *quōmodo*'s own *modō*, once
+via *-ment*'s *mente* — where Italian and Spanish mark it only once,
+though the exact historical steps have more than one scholarly account.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "quōmodo" — "how," genuinely classical]
+- [YOU SAY: quō (what) + modō (manner) — "by what manner"]
+- [YOU SAY: the honest surprise — French's comment double-marks "manner";
+  Italian/Spanish's come/cómo mark it once]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **quōmodo** itself genuinely classical, even though the
+specific phrase *quōmodo tē habēs?* wasn't? (**Yes** — the word is real,
+attested in Cicero and Seneca; only that one specific greeting was modern.)
+What are quōmodo's two Latin pieces, and what do they mean? (**Quō**
+"what" + **modō** "manner" — "by what manner.") Is French's **comment** a
+simple continuation of *quōmodo*, the way Italian's *come* is? (**No** — it
+adds a second "manner" marker, *mente*, doubling up where Italian/Spanish
+only carry the sense once.)

--- a/code/learning/human-languages/latin/lessons/LA-C27-bene.md
+++ b/code/learning/human-languages/latin/lessons/LA-C27-bene.md
@@ -1,0 +1,74 @@
+---
+id: LA-C27-bene
+chapter: 27
+type: word
+headword: bene
+gloss: "well" — a morphologically simple inheritance: French bien and Spanish bien are just bene plus one regular sound change (the same short-e-diphthongizes-to-ie shift as mel→miel), with no extra grafted-on suffix, unlike quōmodo's more roundabout Romance history
+concept_tag: WORD-WELL
+prerequisites: [LA-C19-quid-agis]
+sounds: [macron-none-short-e]
+roots: [bene-latin, bonus-latin]
+etymology_hook: "bene ('well') is a genuinely classical adverb, related to bonus ('good') — both from the same Old Latin ancestor duenos/duonus (found in the famous Duenos inscription, one of the oldest surviving Latin texts), ultimately from a Proto-Indo-European root with several competing proposals; French bien and Spanish bien both continue bene through one single, regular sound change (short stressed e diphthongizing to 'ie,' the same shift behind mel→miel, terra→tierra) and nothing more — no extra suffix grafted on, unlike quōmodo's more roundabout Romance history; bene is genuinely attested used alone, repeated, as a toast in Plautus's Stichus 709: 'bene vōs, bene nōs, bene tē, bene mē, bene nostram etiam Stephanium'"
+est_minutes: 5
+reviews_of: [LA-C19-quid-agis]
+---
+
+# bene — a morphologically simple inheritance
+
+## Warm-up
+
+[PAUSE 2s] Last lesson's "how" took a roundabout path into Romance,
+picking up an extra piece along the way. This one is refreshingly simple:
+one Latin word, one regular sound change, nothing grafted on.
+
+## bene — "well," related to bonus
+
+**Bene** ("**well**") is a genuine Classical Latin adverb, closely related
+to **bonus** ("**good**") — both descend from the same **Old Latin**
+ancestor, **duenos/duonus** (found in the famous **Duenos inscription**,
+one of the oldest surviving Latin texts). Past that point, the ultimate
+Proto-Indo-European root is debated, with more than one proposal on the
+table.
+
+## A morphologically simple inheritance into Romance
+
+Here's the refreshing part: French's **bien** and Spanish's **bien** both
+continue **bene** through **one single, regular sound change** — short
+stressed *e* diphthongizing to "**ie**," the exact same shift behind
+*mel* → *miel* and *terra* → *tierra*/*terre* — and **nothing else**. No
+extra suffix gets grafted on, unlike *quōmodo*'s roundabout, multi-step
+journey into *come*/*cómo*/*comment*. When two Romance languages agree this
+closely, picking up only one shared, ordinary sound change between them,
+you're looking almost straight at the Latin parent itself.
+
+## Genuinely attested, alone — as a toast
+
+**Bene** is attested being used **alone**, repeated, in Plautus's
+**Stichus**, line 709 — though be honest about the context: it's a
+**drinking toast**, not literally an answer to "how are you." The
+characters raise their cups and say: **"bene vōs, bene nōs, bene tē, bene
+mē, bene nostram etiam Stephanium"** — "**well to you, well to us, well to
+you, well to me, well to our Stephanium too**." A real, attested use of
+*bene* standing alone — just repurposed here for the same conversational
+slot "well" fills, the way *volup est convēnisse* was for "nice to meet
+you."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bene" — "well," related to bonus]
+- [YOU SAY: the morphologically simple inheritance — French/Spanish bien
+  is bene plus one regular sound change, nothing grafted on]
+- [YOU SAY: the honest context — bene vōs, bene nōs... is a drinking toast
+  in Plautus, not literally "how are you"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word is French and Spanish's **bien**, continued
+through one regular sound change? (**Bene**, "well.") Is *quōmodo*'s path
+into Romance as morphologically simple as *bene*'s? (**No** — *quōmodo*
+picked up an extra grafted-on suffix along the way; *bene* → *bien* picked
+up only one ordinary sound change and nothing more.) Where is *bene*
+genuinely attested standing alone, and in what context? (**Plautus's
+Stichus, around line 708-709** — a drinking toast, not an answer to "how
+are you.")

--- a/code/learning/human-languages/latin/lessons/LA-C28-dies.md
+++ b/code/learning/human-languages/latin/lessons/LA-C28-dies.md
@@ -1,0 +1,61 @@
+---
+id: LA-C28-dies
+chapter: 28
+type: word
+headword: diēs
+gloss: "day" — the word you've already been using all along, inside diēs Lūnae and medius diēs, now on its own
+concept_tag: TIME-DAY
+prerequisites: [LA-C05-dies-lunae-veneris, LA-C12-medius-dies-nox]
+sounds: [macron-long-vowel, diphthong-ie]
+roots: [dies-latin]
+etymology_hook: "diēs ('day') is the same word already hiding inside diēs Lūnae ('Monday') and medius diēs ('noon') — its derivative diurnum ('daytime, daily') gives English diurnal and, via French jour/journée/jornel, journal and journey; a SIBLING derivative, diārium ('daily allowance'), gives English diary directly, a separate path from diurnum; a genuine PIE root (*dyēws-, 'to shine, sky') also connects diēs to deus ('god') and Jupiter"
+est_minutes: 5
+reviews_of: [LA-C05-dies-lunae-veneris, LA-C12-medius-dies-nox]
+---
+
+# diēs — the word you already know, now standing alone
+
+## Warm-up
+
+[PAUSE 2s] You've used this word twice already without a lesson of its own —
+inside *diēs Lūnae* and *medius diēs*. Time to meet it directly.
+
+## diēs — "day"
+
+**Diēs** — "**day**" — is a genuinely common, everyday Classical Latin word,
+not a rare or bookish one. You've already met it embedded in:
+
+- **diēs Lūnae** ("Monday," literally "day of the Moon" — Chapter 5)
+- **medius diēs** ("noon," literally "mid-day" — Chapter 12)
+
+Now it's the headword itself.
+
+## A rich family of English cousins
+
+Diēs has its own derivative, **diurnum** ("daytime, daily"), which gives
+English **diurnal** directly — and, through French's *jour*, *journée*,
+and *jornel* (all descendants of *diurnum* in their own right), **journal**
+and **journey** as well (a "journey" was originally "a **day's** travel").
+**Diary** takes a **separate** path: it comes from a **sibling**
+derivative of *diēs*, **diārium** ("daily allowance"), not from *diurnum*
+itself — two related but distinct branches off the same root. Further out,
+a genuine **Proto-Indo-European** root, ***\*dyēws-*** ("to shine, sky"),
+connects *diēs* to Latin's own **deus** ("god") and to **Iuppiter**
+(Jupiter, literally "sky-father") — the same root that shines through the
+sky-god imagery of gods across the Indo-European world.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "diēs" — "day"]
+- [YOU SAY: where you've already met it — diēs Lūnae, medius diēs]
+- [YOU SAY: the English cousins — diurnal, diary, journal, journey]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where have you already met **diēs** twice before this lesson?
+(**Diēs Lūnae**, "Monday"; **medius diēs**, "noon.") What English word
+comes from diēs's derivative *diurnum* directly? (**Diurnal**.) What two
+words come through French descendants of *diurnum* — *jour*, *journée*,
+*jornel*? (**Journal, journey**.) Does **diary** also come from *diurnum*?
+(**No** — a separate sibling derivative, *diārium*, "daily allowance.")

--- a/code/learning/human-languages/latin/lessons/LA-C29-nox.md
+++ b/code/learning/human-languages/latin/lessons/LA-C29-nox.md
@@ -1,0 +1,63 @@
+---
+id: LA-C29-nox
+chapter: 29
+type: word
+headword: nox
+gloss: "night" — the word already hiding inside media nox ('midnight'), one of the most rock-solid PIE roots in the whole Indo-European family
+concept_tag: TIME-NIGHT
+prerequisites: [LA-C12-medius-dies-nox, LA-C28-dies]
+sounds: [macron-none-short-vowel, x-ks-sound]
+roots: [nox-latin]
+etymology_hook: "nox ('night'), genitive noctis, is cognate with English 'night' itself, German Nacht, Greek nyx, Sanskrit nakta — all from Proto-Indo-European *nókʷts, one of the most solid, uncontroversial PIE reconstructions there is; its own derivative nocturnus ('of the night') was coined directly on the analogy of diēs's own diurnum, reusing its exact -urnus suffix, and gives English nocturnal/nocturne; aequus ('equal') + nox/noct- gives equinox, 'equal night'"
+est_minutes: 5
+reviews_of: [LA-C12-medius-dies-nox, LA-C28-dies]
+---
+
+# nox — English's own word, wearing a Roman toga
+
+## Warm-up
+
+[PAUSE 2s] Last lesson gave *diēs* its own moment. Here's its partner from
+*media nox* — and this time, the English cousin isn't hiding behind
+centuries of sound change. It's staring you in the face.
+
+## nox — "night"
+
+**Nox** (genitive **noctis**) — "**night**" — is the word you've already
+met inside **media nox** ("midnight," Chapter 12).
+
+## One of the strongest PIE roots there is
+
+Trace *nox* back far enough and you land on **Proto-Indo-European**
+***\*nókʷts*** — and this is about as solid a reconstruction as historical
+linguistics gets. The cognates read almost like the same word spelled
+differently across a dozen languages: English's own **night**, German
+**Nacht**, Greek **nyx**, Sanskrit **nakta**, Old Norse **nátt**, Gothic
+**nahts**. *Nox* and "night" aren't just related — they're about as close
+to being the same word as two languages 6,000 years apart can get.
+
+## The same suffix as diurnum, and a name for equal nights
+
+Nox's own derivative, **nocturnus** ("of the night"), wasn't built from
+scratch — it was coined **directly on the analogy** of *diēs*'s own
+**diurnum**, reusing its exact *-urnus* suffix on purpose: the same
+suffix-machine, deliberately applied to a second time-word. *Nocturnus*
+gives English **nocturnal** and **nocturne** directly. And **aequus**
+("equal") + nox's stem *noct-* gives **equinox** — literally "**equal
+night**," the day when day and night balance.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nox" — "night," genitive *noctis*]
+- [YOU SAY: the tight cousin — nox/night, nearly the same word]
+- [YOU SAY: nocturnus's shared suffix with diurnum — the same -urnus
+  pattern, two different times of day]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where have you already met **nox** before this lesson? (**Media
+nox**, "midnight.") What English word is *nox* almost identical to, both
+descending from PIE *\*nókʷts*? (**Night**.) What suffix does *nocturnus*
+share with *diēs*'s *diurnum*? (***-urnus***.) What does *aequus* + *nox*
+give in English? (**Equinox**, "equal night.")

--- a/code/learning/human-languages/malayalam/lessons/ML-C09-kshamikkanam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C09-kshamikkanam.md
@@ -1,0 +1,70 @@
+---
+id: ML-C09-kshamikkanam
+chapter: 9
+type: word
+headword: ക്ഷമിക്കണം
+gloss: (you) should forgive / sorry (kṣamikkaṇaṁ — from kṣamikkuka "to forgive," Sanskrit kṣama + necessitative -aṇaṁ)
+concept_tag: COURTESY-SORRY
+prerequisites: [ML-C08-dayavayi]
+sounds: [malayalam-conjunct-kssa, malayalam-geminate-kka]
+roots: [kshama-sanskrit]
+etymology_hook: "ക്ഷമിക്കണം kṣamikkaṇaṁ ← Sanskrit kṣama 'forgiveness' + Malayalam verb-making -ikkuka + the SAME necessitative -aṇaṁ noted in ദയവായി's lesson"
+est_minutes: 5
+reviews_of: [ML-C08-dayavayi]
+---
+
+# ക്ഷമിക്കണം (kṣamikkaṇaṁ) — (you) should forgive / sorry
+
+## Warm-up
+
+[PAUSE 2s] You already know **ദയവായി** and the necessitative **‑ണം** ending
+mentioned there. Malayalam's "sorry" is that very ending, now carrying a
+forgiveness-verb.
+
+## The word, taken apart
+
+- **ക്ഷമ** (*kṣama*) = "**forgiveness, patience**" — the Sanskrit noun.
+- **‑ഇക്കുക** (*‑ikkuka*) = a **verb-making suffix**: *kṣama* + *‑ikkuka* →
+  **ക്ഷമിക്കുക** (*kṣamikkuka*), "**to forgive**."
+- **‑ണം** (*‑aṇaṁ*) = the **necessitative** ending, "**must / should**" —
+  literally *kṣamikkaṇaṁ* says "**[you] must forgive**," used as a softened,
+  polite request exactly the way English can soften a request into "you
+  should really forgive me" without meaning it as an order.
+
+So **ക്ഷമിക്കണം** leans on obligation to be polite — a very different move
+from a plain imperative.
+
+## The Dravidian family, side by side
+
+- Malayalam **ക്ഷമിക്കണം** *kṣami**kkaṇaṁ*** — Sanskrit *kṣama* +
+  **‑ikkuka** (verb) + **‑aṇaṁ** (necessitative: "must/should")
+- Kannada **ಕ್ಷಮಿಸಿ** *kṣami**si*** — Sanskrit *kṣamā* + **‑isu** (verb) +
+  **‑i** (imperative)
+- Telugu **క్షమించండి** *kṣamin̄**caṇḍi*** — Sanskrit *kṣamā* + **‑in̄cu**
+  (verb) + **‑aṇḍi** (imperative)
+- Tamil **மன்னிக்கவும்** *maṉṉi**kkavum*** — its **own** native root *maṉṉi*,
+  not Sanskrit at all
+
+## Be honest about how it's used
+
+**ക്ഷമിക്കണം** is a genuine, common way to ask forgiveness — but Malayalam
+speakers reach just as often for the plain imperative **ക്ഷമിക്കൂ**
+(*kṣamikkū*, using the **‑ൂ** ending from the please lesson) or simply the
+borrowed English **"sorry."**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kṣama" — the Sanskrit noun, forgiveness]
+- [YOU SAY: the verb — "kṣamikkuka," to forgive — then "kṣamikkaṇaṁ," you
+  should forgive]
+- [YOU SAY: the plainer version — "kṣamikkū," using the ‑ū ending you know]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ക്ഷമിക്കണം** literally say, and why is that polite?
+(**"[You] must forgive"** — the necessitative **‑aṇaṁ** softens an obligation
+into a request, same as *ദയവായി*'s note on ‑aṇaṁ.) Which cousins also
+verb-ify *kṣama*? (**Kannada and Telugu**; **Tamil** uses its own root
+*maṉṉi*.) What's a plainer alternative? (**Kṣamikkū**, using the ‑ū ending, or
+borrowed English "sorry.")

--- a/code/learning/human-languages/malayalam/lessons/ML-C10-azhcha.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C10-azhcha.md
@@ -1,0 +1,66 @@
+---
+id: ML-C10-azhcha
+chapter: 10
+type: word
+headword: തിങ്കൾ ചൊവ്വ ബുധൻ വ്യാഴം വെള്ളി ശനി ഞായർ
+gloss: the seven weekdays — Malayalam shares Tamil's native planet-words, being its closest cousin
+concept_tag: ML-DAYS-WEEK
+prerequisites: [ML-C09-kshamikkanam]
+sounds: [malayalam-zha, malayalam-nya]
+roots: [dravidian-native-planet-words, sanskrit-planet-words]
+etymology_hook: "Malayalam's week-word ആഴ്ച āzhcha and several planet-names (thiṅkaḷ, veḷḷi, ñāyar) are near-identical to Tamil's — the two split apart only centuries ago"
+est_minutes: 6
+reviews_of: [ML-C09-kshamikkanam]
+---
+
+# തിങ്കൾ to ഞായർ — the week Malayalam shares with Tamil
+
+## Warm-up
+
+[PAUSE 2s] Malayalam and Tamil are close cousins — they were once, long ago,
+the same language — and nowhere does that show more clearly than in the
+words for the days of the week.
+
+## The pattern: [planet] + ആഴ്ച, "day/week"
+
+| Malayalam | planet-word | meaning | compare Tamil |
+|---|---|---|---|
+| **തിങ്കളാഴ്ച** | *thiṅkaḷ* | "**Moon**" | *thiṅgaḷ* — nearly identical |
+| **ചൊവ്വാഴ്ച** | *covva* | traditionally "**the red one**" | *cevvāy* — the same word, worn differently |
+| **ബുധനാഴ്ച** | *budhan* | **Mercury** | Sanskrit **Budha**, same as Tamil *pudhaṉ* |
+| **വ്യാഴാഴ്ച** | *vyāzham* | **Jupiter** | matches Tamil's *viyāzhaṉ* closely |
+| **വെള്ളിയാഴ്ച** | *veḷḷi* | traditionally "**silver**" | *veḷḷi* — the **same word** |
+| **ശനിയാഴ്ച** | *śani* | **Saturn** | Sanskrit **Śani**, same as Tamil *saṉi* |
+| **ഞായറാഴ്ച** | *ñāyar* | "**Sun**" | *ñāyiṟu* — the same root |
+
+## Be honest about the family resemblance
+
+This is the closest family match you'll see across this whole course:
+**thiṅkaḷ/thiṅgaḷ**, **veḷḷi/veḷḷi**, and **ñāyar/ñāyiṟu** are essentially
+**the same words**, because Malayalam only became a distinct language from
+Tamil within roughly the last thousand years or so. Where Tamil says
+**கிழமை** (*kizhamai*) for "day," Malayalam says **ஆழ்ச** (*āzhcha*) — a
+different word for the same idea (the two aren't confirmed cognates; treat
+this as two languages solving the same naming problem separately, not
+necessarily one shared root). Like Tamil,
+Malayalam mixes **native** planet-words (Moon, Mars, Venus, Sun) with
+**Sanskrit** ones (Mercury, Jupiter, Saturn) — the same split, inherited from
+the same shared ancestor language.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "thiṅkaḷ" — moon — then "āzhcha," day/week]
+- [YOU SAY: the shared words — "veḷḷi" (Venus), same in both Malayalam and
+  Tamil]
+- [YOU SAY: the Sanskrit ones — "budhan, vyāzham, śani" — Mercury, Jupiter,
+  Saturn]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why do Malayalam and Tamil's day-names look so alike? (**They were
+the same language until roughly a thousand years ago.**) Which planet-names
+does Malayalam share almost word-for-word with Tamil? (**thiṅkaḷ/Moon,
+veḷḷi/Venus, ñāyar/Sun** — and *covva*/Mars, a worn variant of *cevvāy*.)
+Which three come from Sanskrit in both languages? (**Mercury (Budha), Jupiter
+(vyāzham/viyāzhaṉ), Saturn (Śani).**)

--- a/code/learning/human-languages/malayalam/lessons/ML-C11-nirangal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C11-nirangal.md
@@ -1,0 +1,55 @@
+---
+id: ML-C11-nirangal
+chapter: 11
+type: word
+headword: കറുപ്പ് വെള്ള ചുവപ്പ് നീല
+gloss: black, white, red, blue — Malayalam shares Tamil's native colors, and its Sanskrit blue too
+concept_tag: ML-COLOUR-BASIC
+prerequisites: [ML-C10-azhcha]
+sounds: [malayalam-virama-final, malayalam-cha]
+roots: [dravidian-native-colors, sanskrit-nila]
+etymology_hook: "കറുപ്പ്/വെള്ള/ചുവപ്പ് (black/white/red) closely match Tamil's karuppu/vellai/sivappu; നീല (blue) is the same Sanskrit loan as Tamil's nilam"
+est_minutes: 5
+reviews_of: [ML-C10-azhcha]
+---
+
+# കറുപ്പ്, വെള്ള, ചുവപ്പ്, നീല — the same split as Tamil
+
+## Warm-up
+
+[PAUSE 2s] You've seen Malayalam and Tamil share day-names almost
+word-for-word. Their colors follow the exact same family pattern.
+
+## Three native colors, matching Tamil closely
+
+- **കറുപ്പ്** (*karuppŭ*) = "**black**" — matches Tamil *karuppu* almost
+  exactly.
+- **വെള്ള** (*veḷḷa*) = "**white**" — the same **veḷ-** "bright/silvery"
+  root as Tamil *veḷḷai*.
+- **ചുവപ്പ്** (*cuvappŭ*) = "**red**" — a related word from the same
+  Dravidian root family as Tamil *sivappu*, though the two differ in both
+  their opening consonant's sound and their vowel — a looser cousin than
+  *karuppŭ*/*karuppu* or *veḷḷa*/*veḷḷai*, which match almost exactly.
+
+## The same borrowed blue
+
+**നീല** (*nīla*) = "**blue**" — the same **Sanskrit** loan Tamil uses
+(*nīlam*), and the same one Hindi uses (*nīlā*). Blue is where Malayalam,
+Tamil, and Hindi all converge on one shared Sanskrit word, even though
+Malayalam and Tamil otherwise built their own native words for black, white,
+and red.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "karuppŭ, veḷḷa, cuvappŭ" — black, white, red]
+- [YOU SAY: "nīla" — blue, shared with Tamil and Hindi]
+- [YOU SAY: the family match — "karuppŭ/karuppu, veḷḷa/veḷḷai,
+  cuvappŭ/sivappu"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which three Malayalam colors closely match Tamil's own words?
+(**Karuppŭ, veḷḷa, cuvappŭ** — black, white, red.) Which color is a shared
+Sanskrit loan across Malayalam, Tamil, and Hindi? (**Blue** — நீല *nīla* /
+நீலம் *nīlam* / नीला *nīlā*.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C12-kudumbam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C12-kudumbam.md
@@ -1,0 +1,62 @@
+---
+id: ML-C12-kudumbam
+chapter: 12
+type: word
+headword: അച്ഛൻ അമ്മ ചേട്ടൻ അനിയൻ ചേച്ചി അനിയത്തി
+gloss: father, mother, and four age-graded sibling words — Malayalam's own distinct set, still following the shared Dravidian age-first pattern
+concept_tag: ML-FAMILY-BASIC
+prerequisites: [ML-C11-nirangal]
+sounds: [malayalam-chillu-n, malayalam-geminate-tta]
+roots: [dravidian-age-graded-siblings]
+etymology_hook: "അച്ഛൻ achan/അമ്മ amma and ചേട്ടൻ/അനിയൻ/ചേച്ചി/അനിയത്തി look less like Tamil's set than Kannada/Telugu's do — but the age-before-gender sibling system still holds"
+est_minutes: 5
+reviews_of: [ML-C11-nirangal]
+---
+
+# അച്ഛൻ, അമ്മ, and four sibling words — Malayalam's own set
+
+## Warm-up
+
+[PAUSE 2s] Malayalam and Tamil share a great deal of their vocabulary — but
+family words are where Malayalam goes its own way further than you might
+expect, while still keeping the family's signature age-first sibling
+system.
+
+## Parents
+
+- **അച്ഛൻ** (*acchan*) = "**father**" — a different form from Tamil's
+  *appā*; **this word's own deeper origin is less settled** than the simple
+  *appā/amma* pattern, and worth a linguist's extra look.
+- **അമ്മ** (*amma*) = "**mother**" — matches the family's shared *amma*
+  pattern closely.
+
+## Four sibling words, age before gender — again
+
+| Malayalam | meaning |
+|---|---|
+| **ചേട്ടൻ** (*cēṭṭan*) | **older** brother |
+| **അനിയൻ** (*aniyan*) | **younger** brother |
+| **ചേച്ചി** (*cēcci*) | **older** sister |
+| **അനിയത്തി** (*aniyatti*) | **younger** sister |
+
+Notice these don't closely match Tamil/Kannada/Telugu's *aṇṇaṉ/anna*,
+*tambi/tammuḍu*, *akkā/akka*, or *tangai/celli* — Malayalam built its own
+set of sibling words. But the **structure** is identical: **four** words,
+not two, split by whether the sibling is **older or younger than you** —
+the same signature pattern you've now seen across all four Dravidian
+languages, even where the specific words diverge.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "acchan, amma" — father, mother]
+- [YOU SAY: "cēṭṭan, aniyan" — older/younger brother]
+- [YOU SAY: "cēcci, aniyatti" — older/younger sister]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Do Malayalam's sibling words closely match Tamil's? (**No** —
+Malayalam built its own distinct set (cēṭṭan/aniyan/cēcci/aniyatti), unlike
+how closely Kannada and Telugu track Tamil.) Does Malayalam still split
+siblings by age? (**Yes** — four words, older vs. younger, the same
+structural pattern across the whole Dravidian family.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C13-shareera-bhaagangal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C13-shareera-bhaagangal.md
@@ -1,0 +1,44 @@
+---
+id: ML-C13-shareera-bhaagangal
+chapter: 13
+type: word
+headword: തല കൈ
+gloss: head and hand — matching Tamil's native pair almost exactly
+concept_tag: ML-BODY-BASIC
+prerequisites: [ML-C12-kudumbam]
+sounds: [malayalam-vowel-sign-ai]
+roots: [dravidian-tala-kai]
+etymology_hook: "തല thala (head) and കൈ kai (hand) are native Dravidian, matching Tamil's talai/kai closely — unlike the family words, Malayalam stays close to Tamil here"
+est_minutes: 4
+reviews_of: [ML-C12-kudumbam]
+---
+
+# തല, കൈ — head and hand, matching Tamil closely
+
+## Warm-up
+
+[PAUSE 2s] Malayalam's family words (*achan*, *cēṭṭan*...) went their own
+way from Tamil's. Body parts snap right back to the close match you saw in
+colors and days.
+
+## The words
+
+- **തല** (*thala*) = "**head**" — matches Tamil *talai* closely.
+- **കൈ** (*kai*) = "**hand**" — matches Tamil *kai* almost exactly.
+
+Both native Dravidian, both close cousins of Tamil's own words — a reminder
+that Malayalam and Tamil's vocabulary agreement varies concept by concept,
+not uniformly.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "thala" — head]
+- [YOU SAY: "kai" — hand]
+- [YOU SAY: the match — nearly identical to Tamil's talai/kai]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are Malayalam's words for head and hand, and how closely do
+they match Tamil? (**തല thala, കൈ kai** — very closely, both native
+Dravidian.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C14-kaalangal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C14-kaalangal.md
@@ -1,0 +1,60 @@
+---
+id: ML-C14-kaalangal
+chapter: 14
+type: word
+headword: വസന്തകാലം വേനൽക്കാലം മഴക്കാലം ശൈത്യകാലം
+gloss: spring, summer, monsoon, winter — matching Tamil's pattern of native heat/rain/cold words plus a Sanskrit "spring"
+concept_tag: ML-SEASONS
+prerequisites: [ML-C13-shareera-bhaagangal]
+sounds: [malayalam-chillu-l, malayalam-anusvara]
+roots: [dravidian-venal-mazha, sanskrit-vasantha]
+etymology_hook: "വേനൽ venal (summer heat) and മഴ mazha (rain) are native Dravidian, matching Tamil's kodai/mazhai closely — വസന്തം vasantham (spring) is the same Sanskrit loan Tamil uses too"
+est_minutes: 5
+reviews_of: [ML-C13-shareera-bhaagangal]
+---
+
+# വസന്തകാലം, വേനൽ, മഴ, ശൈത്യം — the same pattern as Tamil
+
+## Warm-up
+
+[PAUSE 2s] Malayalam's season words follow the very same recipe as Tamil's
+— native words for what a season *feels like*, plus one shared Sanskrit
+loan for spring.
+
+## The four words
+
+| Malayalam | meaning | source |
+|---|---|---|
+| **വസന്തകാലം** (*vasanthakaalam*) | "spring" | *vasantham* — the same **Sanskrit** loan as Tamil |
+| **വേനൽക്കാലം** (*venalkkaalam*) | "summer" | **വേനൽ** *venal*, native Dravidian, matching Tamil *kodai*'s role |
+| **മഴക്കാലം** (*mazhakkaalam*) | "rainy season" | **മഴ** *mazha*, native Dravidian, matching Tamil *mazhai* closely |
+| **ശൈത്യകാലം** (*śaithyakaalam*) | "winter/cold season" | *śaithya* — this one leans more **Sanskrit-flavored** than Tamil's native *kulir* |
+
+Every one shares the ending **‑കാലം** (*‑kaalam*, "time/season") — itself
+ultimately from Sanskrit **काल** (*kāla*), but assimilated so long ago that
+it functions as ordinary vocabulary, quite unlike a fresher loan like
+*vasantham*.
+
+## Be honest about the real season here too
+
+As with Tamil, Kerala's actual climate is shaped far more by
+**മഴക്കാലം** (*mazhakkaalam*, "the rains" — including Kerala's famous
+southwest monsoon) than by a clean four-way Western split. The rains
+aren't a footnote to "summer" or "autumn" — they're their own major season,
+central to daily and agricultural life.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "venal" — summer heat — then "kaalam," season]
+- [YOU SAY: "mazhakkaalam" — the rains, the real central season]
+- [YOU SAY: "śaithyakaalam" — the cold season]
+- [YOU SAY: the shared loanword — "vasanthakaalam," spring, same as Tamil]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which Malayalam season-words match Tamil's closely, and which is
+shared with Tamil as a Sanskrit loan? (**Venal/mazha** match Tamil's
+*kodai/mazhai*; **vasanthakaalam** is the same Sanskrit loan as Tamil's
+*vasantha kaalam*.) What's the real central season in Kerala's climate?
+(**Mazhakkaalam**, the rains/monsoon.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C15-vellam-ari.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C15-vellam-ari.md
@@ -1,0 +1,62 @@
+---
+id: ML-C15-vellam-ari
+chapter: 15
+type: word
+headword: വെള്ളം അരി ചോറ്
+gloss: water (a genuinely DIFFERENT word than Tamil's), and rice raw/cooked, closely matching Tamil
+concept_tag: ML-FOOD-BASIC
+prerequisites: [ML-C14-kaalangal]
+sounds: [malayalam-geminate-lla, malayalam-vowel-sign-oo]
+roots: [vellam-flood-white, ari-rice-dravidian]
+etymology_hook: "വെള്ളം vellam (water) does NOT match Tamil's neer/thanneer — it shares the veL- 'bright/white' root already met in Malayalam's word for silver/Venus, originally meaning 'flood'; അരി ari (rice) DOES match Tamil's arisi closely"
+est_minutes: 5
+reviews_of: [ML-C14-kaalangal]
+---
+
+# വെള്ളം, അരി, ചോറ് — a different water-word, the same rice-words
+
+## Warm-up
+
+[PAUSE 2s] For once, Malayalam's everyday word for something basic
+genuinely **doesn't** match Tamil's — even though water is about as basic
+as vocabulary gets.
+
+## വെള്ളം — not the everyday nīr-word
+
+**വെള്ളം** (*veḷḷam*) = "**water**" — and notably, this is **not** built on
+*nīr* the way Tamil's *taṇṇīr* is. Instead, *veḷḷam* shares the **വെള്‍**
+(*veḷ-*, "**bright, white**") root you already met in *veḷḷi*, "silver/
+Venus," from the colors and days lessons — *veḷḷam* originally meant
+something closer to "**flood, deluge**" before becoming Malayalam's plain,
+everyday word for water. (*Nīr* itself hasn't vanished from Malayalam —
+it survives inside compounds like **ഇളനീർ** *iḷanīr*, "tender coconut
+water," and **കണ്ണീർ** *kaṇṇīr*, "tears" — it's just not the standalone
+everyday word anymore.)
+
+## അரி, ചോറ് — rice, matching Tamil closely
+
+Rice, though, tells the familiar story:
+
+- **അരി** (*ari*) = "**rice**" (raw grain) — closely matching Tamil
+  *arisi*.
+- **ചോറ്** (*cōṟu*) = "**cooked rice**" (the meal) — and here Malayalam
+  actually **does** have a Tamil cognate: Tamil keeps its own native
+  **சோறு** (also *cōṟu*), used alongside the Sanskrit-influenced *sātam*
+  as an everyday near-synonym. Malayalam simply made *cōṟu* its main
+  word, where Tamil more often reaches for *sātam*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "veḷḷam" — water, NOT matching Tamil's neer]
+- [YOU SAY: "ari" — raw rice, matching Tamil closely]
+- [YOU SAY: "cōṟu" — cooked rice, Malayalam's own word]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does Malayalam's everyday water-word match Tamil's? (**No** —
+*veḷḷam* shares the *veḷ-* "bright/white" root instead, originally meaning
+"flood"; though *nīr* itself survives in compounds like *iḷanīr* and
+*kaṇṇīr*.)
+Does its raw-rice word match Tamil's? (**Yes** — *ari* closely matches
+*arisi*.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C16-kollavarsham-maasangal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C16-kollavarsham-maasangal.md
@@ -1,0 +1,65 @@
+---
+id: ML-C16-kollavarsham-maasangal
+chapter: 16
+type: word
+headword: ചിങ്ങം കന്നി തുലാം വൃശ്ചികം ധനു മകരം കുംഭം മീനം മേടം ഇടവം മിഥുനം കർക്കടകം
+gloss: the twelve months of the Malayalam (Kollam Era) solar calendar — also solar, like Tamil's, but named for ZODIAC SIGNS rather than nakshatras
+concept_tag: ML-MONTHS
+prerequisites: [ML-C15-vellam-ari]
+sounds: [malayalam-anusvara, malayalam-chillu-rr]
+roots: [malayalam-solar-calendar-zodiac, kollam-era]
+etymology_hook: "Malayalam's Kollam Era calendar is ALSO solar, like Tamil's — but its months are named for the ZODIAC SIGN the sun occupies (Chingam = Leo, Kanni = Virgo...), not nakshatras — a genuinely different naming logic from its closest cousin"
+est_minutes: 6
+reviews_of: [ML-C15-vellam-ari]
+---
+
+# ചിങ്ങം to കർക്കടകം — Kerala's own solar calendar, named by the zodiac
+
+## Warm-up
+
+[PAUSE 2s] Malayalam, like Tamil, has its **own** solar calendar — but even
+here, the two closest cousins name their months by two **different**
+logics.
+
+## The twelve Malayalam months
+
+**ചിങ്ങം, കന്നി, തുലാം, വൃശ്ചികം, ധനു, മകരം, കുംഭം, മീനം, മേടം, ഇടവം,
+മിഥുനം, കർക്കടകം** (*Chiṅṅam, Kanni, Tulām, Vr̥ścikam, Dhanu, Makaram,
+Kumbham, Mīnam, Mēḍam, Iḍavam, Mithunam, Karkiḍakam*).
+
+This is the **Kollam Era** calendar (also called the Malayalam calendar),
+Kerala's own solar civil calendar — genuinely separate from the Gregorian,
+the pan-Indian Hindu lunisolar calendar, **and** Tamil's solar calendar.
+
+## Be honest: same solar structure, different naming logic
+
+Both Tamil's and Malayalam's calendars are **solar**, and both are
+independent of the Hindu lunisolar system — but they name their months
+differently. Tamil ties each month to a **nakshatra** (a lunar-mansion star
+cluster). Malayalam instead names each month directly for the **zodiac
+sign** (rāśi) the sun is passing through: **ചിങ്ങം** (*Chiṅṅam*) = Leo,
+**കന്നി** (*Kanni*) = Virgo, **തുലാം** (*Tulām*) = Libra, and so on straight
+through the zodiac. Same underlying idea — track the sun's yearly path
+against the stars — but two Dravidian languages chose two different sets
+of star-markers to name it by.
+
+**ചിങ്ങം 1** (the 1st of Chiṅṅam) marks the **Malayalam New Year** and the
+start of the **Onam** festival season — Kerala's own solar calendar,
+running its own independent year.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "Chiṅṅam, Kanni, Tulām, Vr̥ścikam, Dhanu, Makaram,
+  Kumbham, Mīnam, Mēḍam, Iḍavam, Mithunam, Karkiḍakam"]
+- [YOU SAY: "Chiṅṅam = Leo" — a zodiac sign, not a nakshatra]
+- [YOU SAY: the contrast — Tamil uses nakshatras, Malayalam uses zodiac
+  signs]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is Malayalam's calendar solar or lunisolar? (**Solar** — like
+Tamil's, and separate from the Hindu lunisolar system.) How does it differ
+from Tamil's in naming logic? (**Zodiac signs** — Chiṅṅam=Leo, Kanni=Virgo
+— rather than Tamil's nakshatra-based names.) What does Chiṅṅam 1 mark?
+(**Malayalam New Year**, the start of the Onam season.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C17-ucha-paathira.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C17-ucha-paathira.md
@@ -1,0 +1,79 @@
+---
+id: ML-C17-ucha-paathira
+chapter: 17
+type: word
+headword: ഉച്ച പാതിരാ
+gloss: noon (most likely a DIFFERENT Sanskrit root than Kannada/Telugu's madhya — height, not middle) and midnight ("half-night," from paathi, "half")
+concept_tag: ML-TIME-NOON-MIDNIGHT
+prerequisites: [ML-C16-kollavarsham-maasangal]
+sounds: [malayalam-virama-cha, malayalam-vowel-sign-aa]
+roots: [sanskrit-ucca-high, dravidian-paathi-half]
+etymology_hook: "ഉച്ച (ucha, noon) most likely shares its root with Tamil உச்சி and Kannada ಉಚ್ಚಿ (ucci, 'peak, crown, zenith') — and per Wiktionary, THAT family is itself a Sanskrit borrowing, from ucca, 'high,' not a native Dravidian word; so Malayalam's noon may be just as Sanskrit-derived as Kannada's madhyāhna, only from a DIFFERENT Sanskrit root (height, not middle)"
+est_minutes: 5
+reviews_of: [ML-C16-kollavarsham-maasangal]
+---
+
+# ഉച്ച, പാതിരാ — a different Sanskrit metaphor, not a Sanskrit-free one
+
+## Warm-up
+
+[PAUSE 2s] Kannada and Telugu both reached for Sanskrit's *madhya*,
+"middle," to name noon. Malayalam looks different at first glance — but be
+careful before you call it "native."
+
+## ഉച്ച — not "the middle," but "the peak" (and likely still Sanskrit)
+
+**ഉച്ച** (*ucha*) = "**noon, midday**" — and unlike Kannada's *madhyāhna* or
+Telugu's *madhyāhnam*, this is **not** a *madhya* ("middle") compound at
+all. It most likely shares its root with Tamil **உச்சி** (*ucci*, "**crown
+of the head, peak, summit, zenith**") and Kannada's own **ಉಚ್ಚಿ** (*ucci*).
+Here's the honest twist: per Wiktionary, that whole *ucci* family across
+Tamil and Kannada is itself documented as a **Sanskrit borrowing**, from
+**उच्च** (*ucca*, "**high**"). Malayalam's own *ucha* has no fully
+documented etymology yet, so treat the connection as likely rather than
+settled — but if it holds, this isn't a case of Malayalam **avoiding**
+Sanskrit at all. It's Malayalam reaching for a **different** Sanskrit root
+than its neighbors: *ucca* ("high") instead of *madhya* ("middle"). Noon
+becomes "**the sun at its peak**" rather than "the middle of the day" — the
+same zenith-based idea you already saw in Arabic's *aẓ-ẓuhr* (from a root
+meaning "to appear, become visible/apex"), just arrived at from Sanskrit
+rather than Arabic.
+
+## പാതിരാ — "half," a different word than Telugu's ardha
+
+**പാതിരാ** (*paathira*) = "**midnight**" — built on **പാതി** (*paathi*,
+"**half**," an everyday Malayalam word — think "half price," *paathi
+vila*) fused with a shortened form of night. This lands on the same
+"half-night" shape as Telugu's *ardharātri* and Hindi's *ādhī rāt* — but
+*paathi* is a genuinely **different word** from Sanskrit's *ardha* (the
+root behind Telugu's *ardharātri* and, further back, Hindi's *ādhī*
+itself). Two languages, same "half-night" logic, two unrelated words for
+"half."
+
+## Be honest: not "Sanskrit vs. native" — more likely "which Sanskrit root"
+
+Don't walk away thinking Malayalam dodged Sanskrit here while Kannada and
+Telugu didn't. The more likely picture: **ഉച്ച** may be just as
+Sanskrit-rooted as *madhyāhna* — it's simply a *different* Sanskrit root
+(*ucca*, "high," rather than *madhya*, "middle"). What's genuinely
+different is the **metaphor**, not necessarily the **language of origin**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ucha" — noon, "the peak" — compare Tamil's "ucci"]
+- [YOU SAY: "paathira" — midnight, from "paathi," half]
+- [YOU SAY: the honest contrast — Kannada/Telugu's noon word means
+  "middle"; Malayalam's most likely means "peak" — both probably still
+  Sanskrit, just different Sanskrit roots]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **ഉച്ച** a Sanskrit "middle" word like Kannada's *madhyāhna*?
+(**No** — it most likely comes from a *different* Sanskrit root, *ucca*,
+"high/peak," not *madhya*, "middle.") Does that make ഉച്ച a native Dravidian
+word? (**Not necessarily** — its likely relatives, Tamil *ucci* and Kannada
+*ucci*, are themselves documented Sanskrit borrowings.) What does
+**പാതിരാ** literally build on, and how does that differ from Telugu's
+midnight word? (**പാതി**, *paathi*, "half" — a different word entirely from
+Sanskrit's *ardha*, behind Telugu's *ardharātri*.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C18-mani.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C18-mani.md
@@ -1,0 +1,71 @@
+---
+id: ML-C18-mani
+chapter: 18
+type: word
+headword: മണി
+gloss: hour — Malayalam's OWN dictionary tradition treats bell/hour/gem as ONE Sanskrit word, unlike Tamil's closely related mani, which its own dictionaries split into two unrelated homophones
+concept_tag: ML-TIME-HOUR
+prerequisites: [ML-C17-ucha-paathira]
+sounds: [malayalam-retroflex-nna, malayalam-vowel-sign-i]
+roots: [sanskrit-mani-gem-bell]
+etymology_hook: "മണി (mani, 'hour, bell, gem') — Malayalam's Wiktionary entry treats ALL these senses as ONE word borrowed from Sanskrit मणि (maṇi, 'gem'); this is genuinely different from how Tamil's OWN dictionaries treat its cognate மணி, which splits into two separate, unrelated words (a native 'bell/hour' word and a separate Sanskrit 'gem' loan) — two closest-cousin languages, two different scholarly pictures of the very same word"
+est_minutes: 6
+reviews_of: [ML-C17-ucha-paathira]
+---
+
+# മണി — one word in Malayalam's dictionaries, two in Tamil's
+
+## Warm-up
+
+[PAUSE 2s] Kannada and Telugu both borrowed Sanskrit's "bell" word for "hour."
+Malayalam's story is genuinely murkier — and it's about to disagree with its
+closest cousin, Tamil, on how this exact word is even structured.
+
+## മണി — bell, hour, AND gem, all under one Sanskrit roof
+
+**മണി** (*mani*) = "**hour, o'clock**" — and it also means "**bell, gong**" and
+"**gem, jewel, pearl**." Here's the honest, slightly untidy part: Malayalam's own
+dictionary tradition treats **all three of these senses as ONE word**, borrowed
+from Sanskrit **मणि** (*maṇi*, "gem, jewel, pearl") — the same Sanskrit word
+behind names like *Manipravalam* and the mantra syllable in "*om mani padme
+hum*." Under this account, "bell/hour" isn't a separate native word at all — it's
+just another meaning that grew out of the same borrowed "gem" word (a
+bell-shaped gem or ornament, perhaps, extending to the bell itself, and then to
+the hour it announces).
+
+## Be honest: Tamil's OWN dictionaries tell a different story about the SAME word
+
+Here's what makes this genuinely interesting rather than settled: Tamil's closely
+related cognate **மணி** is analyzed very differently by Tamil's own reference
+dictionaries — as **two separate, unrelated words** that happen to be spelled and
+pronounced identically: a **native Dravidian** "bell, gong" word (which extends to
+"hour"), and a completely separate Sanskrit loan meaning "gem." The broader
+comparative Dravidian dictionary (DEDR) does list Malayalam among the languages
+sharing that native "bell" word too — but even DEDR flags a possible Sanskrit
+connection for the whole word-family as unresolved. So: two closest-cousin
+languages, and even the specialists don't fully agree on whether this is one
+Sanskrit word wearing three meanings, or a native word and a Sanskrit word that
+just happen to sound alike.
+
+## Grammar Lens: telling the time
+
+> **ഒരു മണി.** — "One o'clock." (*oru mani*, "one hour/bell")
+> **രണ്ട് മണി.** — "Two o'clock." (*raṇṭŭ mani*, "two hour/bell")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mani" — hour, also "bell," also "gem" — genuinely debated whether
+  that's one word or two]
+- [YOU SAY: "oru mani" — one o'clock]
+- [YOU SAY: the honest point — Malayalam's own dictionaries call it one Sanskrit
+  word; Tamil's call the bell/hour sense a separate, native word]
+
+## Wrap-up Recall
+
+[PAUSE 3s] According to Malayalam's own dictionary tradition, are "hour," "bell,"
+and "gem" one word or two? (**One** — all traced to Sanskrit *maṇi*, "gem.") How
+does Tamil's own dictionary tradition treat its cognate word differently? (As
+**two separate, unrelated homophones** — a native "bell/hour" word and a distinct
+Sanskrit "gem" loan.) Is this fully settled? (**No** — even the comparative
+Dravidian dictionary flags the Sanskrit connection as an open question.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C19-vayassu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C19-vayassu.md
@@ -1,0 +1,60 @@
+---
+id: ML-C19-vayassu
+chapter: 19
+type: phrase
+headword: നിങ്ങൾക്ക് എത്ര വയസ്സുണ്ട്?
+gloss: how old are you? — literally "to you how much age exists?"; the SAME Sanskrit vayas word, but Malayalam adds a dative-subject + existential verb, a genuinely different shape than Kannada/Telugu's plain possessive
+concept_tag: ML-AGE
+prerequisites: [ML-C18-mani]
+sounds: [malayalam-chillu-l, malayalam-existential-undu]
+roots: [sanskrit-vayas-vigor-age]
+etymology_hook: "വയസ്സ് (vayass, 'age') is the same Sanskrit वयस् as Kannada/Telugu's word — but Malayalam asks it differently: 'നിങ്ങൾക്ക് എത്ര വയസ്സുണ്ട്?' (ningalkku ethra vayassundu?, 'to you how much age exists?'), a DATIVE-SUBJECT + existential-verb (undu, 'exists') construction, a genuinely different grammatical shape than Kannada/Telugu's plain verbless possessive"
+est_minutes: 6
+reviews_of: [ML-C18-mani]
+---
+
+# നിങ്ങൾക്ക് എത്ര വയസ്സുണ്ട്? — "to you, how much age exists?"
+
+## Warm-up
+
+[PAUSE 2s] Same Sanskrit word as Kannada and Telugu — but Malayalam builds a
+genuinely different sentence around it.
+
+## വയസ്സ് — the same Sanskrit "vigor/age" word, again
+
+**വയസ്സ്** (*vayass*) = "**age**" — the same Sanskrit **वयस्** (*vayas*, "age,
+vigor," PIE cousin of Latin **vīs**) behind Kannada's *vayassu* and Telugu's
+*vayasu*.
+
+## Grammar Lens: dative subject + "exists"
+
+> **നിങ്ങൾക്ക് എത്ര വയസ്സുണ്ട്?** — "How old are you?" (formal/plural) —
+  literally "**to you, how much age exists**?" (*ningaḷkku ethra vayassuṇṭŭ?*
+  — from *ningaḷkku*, "to you" [dative] + *ethra vayassu*, "how much age" +
+  *uṇṭŭ*, "exists.")
+> **എനിക്ക് ഇരുപത് വയസ്സുണ്ട്.** — "I am twenty years old." — literally "**to
+  me twenty age exists**." (*enikku irupatu vayassuṇṭŭ.*)
+
+This is a real grammatical departure from Kannada and Telugu's plain "your age
+how-much?" Malayalam puts the **person in the dative case** ("to you," not
+"your") and adds **ഉണ്ട്** (*uṇṭŭ*, "exists, there is") — the same existential
+verb Malayalam uses for ordinary possession and existence sentences generally.
+So the literal shape is "**to me, twenty years' worth of age exists**" — a
+dative-subject-plus-existential-verb construction, genuinely different from
+its two Dravidian cousins even though the age-word itself is identical.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vayassu" — age]
+- [YOU SAY: "ningaḷkku ethra vayassuṇṭŭ?" — how old are you?]
+- [YOU SAY: "enikku irupatu vayassuṇṭŭ" — I am twenty, "to me twenty age
+  exists"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is Malayalam's **വയസ്സ്** the same Sanskrit word as Kannada's and
+Telugu's? (**Yes**.) Does Malayalam ask age the same simple way Kannada and
+Telugu do? (**No** — it uses a **dative** subject, "to you," plus the
+existential verb **ഉണ്ട്**, "exists.") What does *enikku irupatu vayassuṇṭŭ*
+literally mean? ("**To me twenty age exists**.")

--- a/code/learning/human-languages/malayalam/lessons/ML-C20-kalavastha.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C20-kalavastha.md
@@ -1,0 +1,59 @@
+---
+id: ML-C20-kalavastha
+chapter: 20
+type: phrase
+headword: കാലാവസ്ഥ
+gloss: weather — a Sanskrit compound literally meaning "state of TIME": kaala ("time") + avastha ("state, condition") — a real echo of Spanish's tiempo meaning both "time" AND "weather"
+concept_tag: ML-WEATHER
+prerequisites: [ML-C18-mani]
+sounds: [malayalam-vowel-sign-aa, malayalam-conjunct-stha]
+roots: [sanskrit-kaala-time, sanskrit-avastha-state]
+etymology_hook: "കാലാവസ്ഥ (kālāvastha, 'weather') is a Sanskrit compound literally meaning 'state of TIME' — കാലം (kālam, 'time') + അവസ്ഥ (avastha, 'state, condition') — echoing Spanish's tiempo (which means BOTH 'time' and 'weather' in one word) but built as a compound rather than a single polysemous word"
+est_minutes: 6
+reviews_of: [ML-C18-mani]
+---
+
+# കാലാവസ്ഥ — "the state of time," an echo of Spanish's tiempo
+
+## Warm-up
+
+[PAUSE 2s] Remember Spanish's *tiempo*, one word for both "time" and
+"weather"? Malayalam reaches the same connection between time and weather —
+but builds it as a compound instead of reusing one word.
+
+## കാലാവസ്ഥ — kaalam + avastha
+
+**കാലാവസ്ഥ** (*kālāvastha*) = "**weather**" — built from:
+
+- **കാലം** (*kālam*, "**time**") — Sanskrit **काल** (*kāla*), "time," also the
+  name of the god **Kāla** (an epithet of Śiva/Yama as the personification of
+  time).
+- **അവസ്ഥ** (*avastha*, "**state, condition**") — Sanskrit **अवस्था**
+  (*avasthā*).
+
+So *kālāvastha* literally means "**the state of time**" — a genuinely
+different construction than Spanish's *tiempo*, but reaching for the exact
+same underlying idea: weather as bound up with time. Where Spanish just
+**reuses** its word for "time" to also mean "weather," Malayalam **compounds**
+"time" with "state" to build a brand-new word for the same concept.
+
+## മഴ പെയ്യുന്നു — "rain is falling"
+
+> **മഴ പെയ്യുന്നു.** — "It's raining." — literally "**rain is falling**."
+  (*mazha peyyunnu.*)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kālāvastha" — weather, "the state of time"]
+- [YOU SAY: "kālam" — time, "avastha" — state]
+- [YOU SAY: "mazha peyyunnu" — it's raining, "rain is falling"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the two Sanskrit pieces of **കാലാവസ്ഥ**, and what does the
+whole word literally mean? (**കാലം**, "time," + **അവസ്ഥ**, "state" — "**the
+state of time**.") What earlier lesson does this echo, and how is the
+construction different? (**Spanish's *tiempo*** — Spanish reuses ONE word for
+both senses; Malayalam **compounds** two separate words instead.) What word
+does Malayalam use for "rain"? (**മഴ**, *mazha*.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C20-pathinonnu-irupathu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C20-pathinonnu-irupathu.md
@@ -1,0 +1,52 @@
+---
+id: ML-C20-pathinonnu-irupathu
+chapter: 20
+type: word
+headword: പതിനൊന്ന് — ഇരുപത്
+gloss: 11-20 — additive "ten-echo" compounds for the teens, then irupathu (20), transparently "two-tens" — iru ("two") + pathu ("ten"), matching Tamil closely
+concept_tag: ML-NUM-11-20
+prerequisites: [ML-C19-vayassu]
+sounds: [malayalam-virama-final, malayalam-vowel-sign-i]
+roots: [dravidian-pathu-ten, dravidian-iru-two]
+etymology_hook: "പതിനൊന്ന്-പത്തൊമ്പത് (11-19) echo പത്ത് (pathu, 'ten') + a digit — ഇരുപത് (irupathu, 'twenty') is transparently 'two-tens', ഇരു (iru, an older word for 'two') + പത്ത് (pathu, 'ten') — matching Tamil's own irupathu almost exactly, both languages keeping this compound visibly transparent where Telugu's has worn down further"
+est_minutes: 6
+reviews_of: [ML-C19-vayassu]
+---
+
+# പതിനൊന്ന്, ഇരുപത് — transparent "two-tens," matching Tamil closely
+
+## Warm-up
+
+[PAUSE 2s] Malayalam keeps the same "two-tens" idea you've now seen across
+this whole family — and here it's still fully visible on the surface, almost
+identically to its closest cousin, Tamil.
+
+## പതിനൊന്ന്–പത്തൊമ്പത് — "ten" + digit
+
+Malayalam's teens echo **പത്ത്** (*pathu*, "**ten**") plus each digit —
+**പതിനൊന്ന്** (*pathinonnu*, 11), **പന്ത്രണ്ട്** (*panthraṇṭŭ*, 12), and
+onward through **പത്തൊമ്പത്** (*pathompathu*, 19) — the same
+digit-plus-ten-echo compounding as its Dravidian cousins.
+
+## ഇരുപത് — transparently "two-tens," like Tamil
+
+**ഇരുപത്** (*irupathu*, "**twenty**") = **ഇരു** (*iru*, an older word for
+"**two**") + **പത്ത്** (*pathu*, "**ten**") — still fully visible as
+"**two-tens**" today. This matches **Tamil's own** *irupathu* almost
+letter-for-letter, both languages having kept this compound transparent —
+unlike Telugu's *iravai*, which most likely continues the same underlying
+pattern but has worn down past the point of visibly splitting apart.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pathinonnu, panthraṇṭŭ" — 11, 12]
+- [YOU SAY: "iru" — an older word for two, "pathu" — ten]
+- [YOU SAY: "irupathu" — twenty, "two-tens," transparent]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How are Malayalam's teens built? (**പത്ത്** (ten) + a digit,
+compounded.) What two pieces build **ഇരുപത്** (twenty)? (**ഇരു** "two" +
+**പത്ത്** "ten" — "**two-tens**.") Which other Dravidian language keeps this
+exact same transparent compound for twenty? (**Tamil**.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C21-naaya-poocha.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C21-naaya-poocha.md
@@ -1,0 +1,51 @@
+---
+id: ML-C21-naaya-poocha
+chapter: 21
+type: word
+headword: നായ, പൂച്ച
+gloss: dog and cat — naaya continues the solid, ancient native Dravidian dog-root shared with Kannada and Tamil, no mystery; poocha matches Tamil's everyday cat-word closely, part of the pattern where Dravidian genuinely splits on "cat" more than "dog"
+concept_tag: ML-ANIMALS
+prerequisites: [ML-C20-pathinonnu-irupathu]
+sounds: [malayalam-vowel-sign-aa, malayalam-geminate-ch]
+roots: [dravidian-naay-dog, dravidian-punai-cat]
+etymology_hook: "നായ (nāya, 'dog') continues the same solid, native Proto-Dravidian root as Kannada's naayi and Tamil's naay — no mystery, unlike every other language in this arc's dog-word; പൂച്ച (pūcha, 'cat') closely matches Tamil's everyday word pūnai, part of a family distinct from Kannada's bekku and Telugu's pilli — Dravidian genuinely splits more on 'cat' than on 'dog'"
+est_minutes: 6
+reviews_of: [ML-C20-pathinonnu-irupathu]
+---
+
+# നായ, പൂച്ച — matching Tamil closely on both counts
+
+## Warm-up
+
+[PAUSE 2s] Malayalam keeps close company with its nearest cousin, Tamil,
+on both words this time — while still fitting into the honest, more
+fragmented Dravidian picture for "cat."
+
+## നായ — the same solid root as Kannada and Tamil
+
+**നായ** (*nāya*, "**dog**") continues the same solid, native
+**Proto-Dravidian** root as Kannada's **ನಾಯಿ** (*nāyi*) and Tamil's own word
+— no mystery here at all, unlike every dog-word you've met elsewhere in this
+entire arc.
+
+## പൂച്ച — matching Tamil, not Kannada or Telugu
+
+**പൂച്ച** (*pūcha*, "**cat**") closely matches Tamil's **everyday** word for
+cat — a different root from Kannada's **ಬೆಕ್ಕು** (*bekku*, related instead to
+the word for "wildcat") and Telugu's **పిల్లి** (*pilli*, a separate
+Proto-Dravidian root of its own, most likely the source behind Sanskrit's
+*biḍāla* and Hindi's *billī*). So "cat" genuinely splits three ways across
+just these four Dravidian languages, even though "dog" mostly agrees.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāya" — dog, same solid root as Kannada and Tamil]
+- [YOU SAY: "pūcha" — cat, matching Tamil's everyday word closely]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **നായ** share Kannada's *nāyi* root? (**Yes** — the same
+solid, native Proto-Dravidian root.) Does **പൂച്ച** match Kannada's *bekku*
+or Tamil's everyday cat-word? (**Tamil's** — Kannada's *bekku* and Telugu's
+*pilli* both come from different roots entirely.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C22-paccha-manja.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C22-paccha-manja.md
@@ -1,0 +1,62 @@
+---
+id: ML-C22-paccha-manja
+chapter: 22
+type: word
+headword: പച്ച, മഞ്ഞ
+gloss: green and yellow — paccha matches Tamil's paccai almost exactly (the same pan-Dravidian *pac- root already seen in Kannada and Telugu); manja is a completely separate native Dravidian root, a doublet of manjal ("turmeric"), matching Tamil's own mañcaḷ — a third, independent solution to this arc's recurring green/yellow puzzle
+concept_tag: ML-COLOUR-GREEN-YELLOW
+prerequisites: [ML-C11-nirangal, ML-C21-naaya-poocha]
+sounds: [malayalam-chillu-l, malayalam-virama-geminate]
+roots: [proto-dravidian-pac-green, dravidian-mancal-turmeric]
+etymology_hook: "പച്ച (paccha, 'green') ← Proto-Dravidian *pac-, matching Tamil's பச்சை (paccai) almost exactly; മഞ്ഞ (mañña, 'yellow') is a doublet of മഞ്ഞൾ (maññaḷ, 'turmeric'), from a SEPARATE native Dravidian root matching Tamil's மஞ்சள் (mañcaḷ) — unlike Telugu, where green and yellow are doublets of ONE root, Malayalam's green and yellow are two independent native Dravidian word-families that happen to sit side by side"
+est_minutes: 6
+reviews_of: [ML-C21-naaya-poocha]
+---
+
+# പച്ച, മഞ്ഞ — matching Tamil twice over, by two different routes
+
+## Warm-up
+
+[PAUSE 2s] Telugu's green and yellow turned out to be one word wearing two
+faces. Malayalam's green and yellow are a different story again — two
+completely separate native words, each one matching Tamil closely, just not
+matching *each other*.
+
+## പച്ച — the familiar pan-Dravidian green
+
+**പച്ച** (**paccha**, "**green**") comes from **Proto-Dravidian** ***\*pac-***
+— matching **Tamil**'s **பச்சை** (*paccai*) almost exactly, and the same
+root already seen in Kannada's *hasiru* and Telugu's *pacca*. No surprises
+here; this is the familiar family from the last two lessons.
+
+## മഞ്ഞ — a separate native root, matching Tamil's manjal-family
+
+**മഞ്ഞ** (**mañña**, "**yellow**") is a **doublet** of **മഞ്ഞൾ**
+(**maññaḷ**, "**turmeric**") — but this is a **completely different**
+Dravidian root from *pac-*, matching **Tamil**'s own turmeric/yellow pair,
+**மஞ்சள்** (*mañcaḷ*), closely. So here's the honest
+shape of this arc so far: Kannada split green and yellow into two unrelated
+families (native vs. Sanskrit loan); Telugu kept them as doublets of the
+**same** native root; and Malayalam keeps them as **two separate** native
+Dravidian roots, each one independently matching its Tamil counterpart. No
+single pattern holds across all three languages — the honest answer is that
+each solved "green vs. yellow" its own way.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "പച്ച" — green, matching Tamil paccai]
+- [YOU SAY: "മഞ്ഞ" — yellow, matching Tamil mañcaḷ, a separate root
+  entirely]
+- [YOU SAY: the contrast — paccha and mañña are NOT doublets of each other,
+  unlike Telugu's pacca/pasupu]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **മഞ്ഞ** (*mañña*, "yellow") share a root with **പച്ച**
+(*paccha*, "green")? (**No** — they are two separate native Dravidian
+roots.) What Tamil word does **മഞ്ഞ** closely match? (**மஞ்சள்**,
+*mañcaḷ*, "turmeric/yellow.") Across Kannada, Telugu, and Malayalam, is
+there one single pattern for how green and yellow relate? (**No** — Kannada
+split them into native vs. Sanskrit-loan; Telugu made them doublets of one
+root; Malayalam keeps them as two separate native roots.)

--- a/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
@@ -1,0 +1,75 @@
+---
+id: ES-C21-lunes-viernes
+chapter: 21
+type: word
+headword: lunes, martes, miércoles, jueves, viernes
+gloss: the weekdays (Monday–Friday) — worn-down planet-god names
+concept_tag: ES-DAYS-WEEKDAYS
+prerequisites: [ES-C08-numeros-6-10]
+sounds: [r-tap, diphthong-ie]
+roots: [dies-latin, planet-gods]
+etymology_hook: "Spanish weekdays mostly just DROPPED diēs 'day' — martes 'Mars's [day]' keeps its trailing -s from Martis itself, not from diēs — where French still spells 'day' out loud as -di"
+est_minutes: 5
+reviews_of: [ES-C08-numeros-6-10]
+---
+
+# lunes to viernes — the planets of the week, worn down
+
+## Warm-up
+
+[PAUSE 2s] The Romans mapped the seven-day week onto the seven visible
+"wandering stars" — the planet-gods. Spanish kept that map, but handled the
+word "day" differently from its Romance cousins: where French still spells
+out "**-di**" (day) on every weekday, Spanish mostly just **dropped it**.
+
+## The pattern: [planet's name], with "day" mostly gone
+
+Each weekday began life as **"[planet-god]'s **diēs** (day)."** In Vulgar
+Latin, *diēs* was simply **dropped as a separate word** in most of these —
+what survived is just the planet's own Latin genitive form. That's why
+**martes, jueves, viernes** already end in **‑s**: not because *diēs* wore
+down into one, but because **Martis, Iovis, Veneris** — the planets' own
+genitive forms — end in *‑s* in Latin already. **Lunes** has no such *‑s* to
+inherit (*lūnae* doesn't end in one), so it likely picked up the ending by
+**analogy** with its four siblings:
+
+| Spanish | ← Latin | planet-god | English echo |
+|---|---|---|---|
+| **lunes** | *lūnae diēs* | the **Moon** (*luna*) | *Mon*day = Moon-day |
+| **martes** | *Martis diēs* | **Mars** | *Tues*day (Tiw, the Germanic war-god = Mars) |
+| **miércoles** | *Mercuriī diēs* | **Mercury** | *Wednes*day (Woden = Mercury) |
+| **jueves** | *Jovis diēs* | **Jupiter** (*Jove*) | *Thurs*day (**Thor** = Jupiter) |
+| **viernes** | *Veneris diēs* | **Venus** | *Fri*day (Frigg/Freya = Venus) |
+
+Compare **French**, which keeps *diēs* as its own visible syllable on every
+day — **lundi**, **mardi**, **jeudi** — while Spanish dropped it from four of
+its five weekdays. **miércoles** is the odd one out: some historians of the
+language think its extra "**‑coles**" is a genuine surviving trace of *diēs*
+itself (fused in and reshaped) — though the exact sound changes are debated,
+unlike the plainer, better-understood story for its four siblings.
+
+And once again: **martes and Tuesday are the same day** — both "the war-god's
+day" — Latin naming **Mars**, the Germanic tribes naming **their** war-god
+**Tiw** instead (*interpretatio germanica*, the same swap French's *mardi*
+shows).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "lunes, martes, miércoles, jueves, viernes" — the work week]
+- [YOU SAY: each as "[planet]'s day, worn down" — "lunes = Moon, jueves =
+  Jupiter"]
+- [YOU SAY: the bridge — "martes / Tuesday, both the war-god's day (Mars /
+  Tiw)"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did every Spanish weekday begin life as? (**"[Planet-god]'s
+diēs (day)"** — the same Latin phrase French keeps more visibly with *-di*.)
+Why do **martes, jueves, viernes** end in *-s*, and where does **lunes** get
+its *-s* from? (**From the planet's own Latin genitive** — Martis/Iovis/
+Veneris already end in *-s*; *lunes* likely picked it up **by analogy**, since
+*lūnae* has no *-s* of its own.) What's debated about **miércoles**? (**Whether
+its "‑coles" is a genuine surviving trace of diēs** — unlike the plainer,
+better-understood story for its four siblings.) Why do *martes* and *Tuesday* line up? (Same day — the war-god's —
+named *Mars* in Latin, *Tiw* in Germanic.)

--- a/code/learning/human-languages/spanish/lessons/ES-C21-sabado-domingo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C21-sabado-domingo.md
@@ -1,0 +1,59 @@
+---
+id: ES-C21-sabado-domingo
+chapter: 21
+type: word
+headword: sábado, domingo
+gloss: the weekend (Saturday, Sunday) — where religion overwrote astronomy
+concept_tag: ES-DAYS-WEEKEND
+prerequisites: [ES-C21-lunes-viernes]
+sounds: [r-tap, stress-accent]
+roots: [sabbatum-latin, dominica-latin]
+etymology_hook: "sábado ← Sabbatum (the Sabbath), domingo ← diēs Dominica ('the Lord's day') — the two days that broke the planet-god pattern"
+est_minutes: 4
+reviews_of: [ES-C21-lunes-viernes, ES-C08-numeros-6-10]
+---
+
+# sábado and domingo — the week's religious edge
+
+## Warm-up
+
+[PAUSE 2s] Five days named for planets — then two that broke the pattern
+entirely. The weekend is where **religion overwrote astronomy**, and Spanish
+keeps both rewrites in plain view.
+
+## The two days, taken apart
+
+| Spanish | ← Latin | meaning | note |
+|---|---|---|---|
+| **sábado** | *sabbatum* | "**Sabbath**" | the planet-god (Saturn) is gone — replaced by the Hebrew *shabbāt*, "to rest" |
+| **domingo** | *diēs Dominica* | "the **Lord's** day" | *Dominica* ← *Dominus*, "lord/master" — Spanish kept this one much less worn-down than French's *dimanche* |
+
+Two different rewrites:
+
+- **sábado** would have been "Saturn's day" (as English **Satur**day still
+  is — the one weekday English kept a Roman god for). Instead, Latin
+  Christians borrowed the Jewish **Sabbath** (*Sabbatum* ← Hebrew *shabbāt*),
+  and it became *sábado*. So English **Saturday** and Spanish **sábado** are
+  the **same day, two different names** — the planet vs. the Sabbath.
+- **domingo** drops Sun-worship entirely: where English keeps **Sun**day,
+  Spanish made it *diēs Dominica*, "the Lord's day" (*Dominus* → English
+  **dominion**, **dominate**, **dame**). Spanish kept **domingo** recognizably
+  close to *Dominica* — compare French's more worn-down **dimanche**, where
+  the *di-* (day) fossil jumped to the front of the word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full week — "lunes, martes, miércoles, jueves, viernes,
+  sábado, domingo"]
+- [YOU SAY: "sábado = Sabbath, domingo = the Lord's day" — religion, not
+  planets]
+- [YOU SAY: the pair-ups — "sábado / Saturday (Sabbath vs. Saturn)", "domingo
+  / Sunday (Lord vs. Sun)"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give all seven Spanish days. (*Lunes … domingo*.) Where does
+**sábado** come from, and its English contrast? (The **Sabbath**, *Sabbatum*;
+English kept *Saturday* = Saturn's day.) What does **domingo** mean
+literally? ("The **Lord's** day," *diēs Dominica*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C22-negro-blanco.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-negro-blanco.md
@@ -1,0 +1,77 @@
+---
+id: ES-C22-negro-blanco
+chapter: 22
+type: word
+headword: negro, blanco
+gloss: black and white — one inherited from Latin, one a Germanic loan traditionally linked to the Visigothic era
+concept_tag: ES-COLOUR-BLACK-WHITE
+prerequisites: [ES-C21-sabado-domingo]
+sounds: [r-tap, nasal-n]
+roots: [latin-niger, germanic-blank]
+etymology_hook: "negro ← Latin niger, but blanco is NOT from Latin albus — it's Germanic *blank 'shining', traditionally linked to Visigothic-era contact, the same word French borrowed (more firmly attested) via the Franks"
+est_minutes: 5
+reviews_of: [ES-C21-sabado-domingo, ES-C21-lunes-viernes]
+---
+
+# negro, blanco — one inherited, one borrowed
+
+## Warm-up
+
+[PAUSE 2s] Two colors, two very different histories. One is straight-line
+Latin. The other arrived with **Germanic settlers** — and Spanish isn't even
+alone in borrowing it that way.
+
+## negro — the expected one
+
+**negro** ("black") ← Latin **niger**. Nothing surprising here: the same
+Latin root that gives English **denigrate** ("to blacken someone's name")
+and the Romance family's other words for black (French *noir*, Italian
+*nero*).
+
+## blanco — the imported one
+
+You'd expect Latin **albus** ("white"). Spanish doesn't use it. Instead it
+says **blanco**, from **Germanic *blank*** — "**shining, gleaming**" — a loan
+traditionally attributed to contact with the **Visigoths**, the Germanic
+people who ruled Spain for centuries after Rome's collapse (though, unlike
+French's case below, no surviving Gothic text actually preserves this exact
+word, so the precise route in is a plausible traditional account rather than
+a directly documented one). French, meanwhile, took the very **same**
+Germanic word (*blanc*) — this time **well-attested** as a borrowing from a
+**different** Germanic people, the **Franks**. Either way, two Romance
+sister languages ended up with the same borrowed word for white.
+
+Why would a "shining" word beat Latin's own "white"? Color words often lose
+out to something more **vivid** — *blank* didn't just mean pale, it meant
+**bright, gleaming** — a flashier idea than plain *albus*.
+
+## Where albus went
+
+Latin's own white didn't vanish — it just stopped being the everyday color
+word:
+
+| word | meaning | the white inside |
+|---|---|---|
+| **alba** | dawn | the sky going *white* |
+| *albo* (rare, poetic) | white, pale | a fossil use, mostly literary now |
+| *álbum* (Eng. *album*) | album | a *blank white* tablet |
+| *albino* (Eng./Sp.) | albino | white-skinned |
+
+So Latin's white is still around — tucked into *alba* and *álbum*, just not
+where a learner would first look.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "negro, blanco"]
+- [YOU SAY: the pairing — "negro from Latin, blanco from the Visigoths"]
+- [YOU SAY: "el alba" — dawn — and hear the old Latin white inside it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which of the two is inherited from Latin? (**Negro** ← *niger*.)
+Where does **blanco** come from? (**Germanic *blank***, "shining" — brought
+by the **Visigoths**.) Which other language borrowed the very same Germanic
+word, from a different tribe? (**French** *blanc*, via the **Franks**.) Where
+did Latin's *albus* end up? (**Alba**, "dawn" — no longer the everyday color
+word.)

--- a/code/learning/human-languages/spanish/lessons/ES-C22-rojo-azul.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-rojo-azul.md
@@ -1,0 +1,64 @@
+---
+id: ES-C22-rojo-azul
+chapter: 22
+type: word
+headword: rojo, azul
+gloss: red and blue — an ancient inherited root (via a different Latin word than French's), and an Arabic loan
+concept_tag: ES-COLOUR-RED-BLUE
+prerequisites: [ES-C22-negro-blanco]
+sounds: [r-tap, palatal-j]
+roots: [pie-rewdh-russus, arabic-lazaward]
+etymology_hook: "rojo ← Latin russus, a cousin (not a copy) of French's rouge (← rubeus) — both ultimately from PIE *h₁rewdʰ-; azul ← Arabic lāzaward, and unlike French, this IS Spanish's everyday word for blue"
+est_minutes: 5
+reviews_of: [ES-C22-negro-blanco]
+---
+
+# rojo, azul — an old word (taken a different path) and a borrowed one
+
+## Warm-up
+
+[PAUSE 2s] Last lesson: one inherited color, one borrowed. This lesson
+repeats the shape — but **red** takes a subtly different road than you might
+expect from French, and **blue** flips which word is "the everyday one."
+
+## rojo — old, but not the SAME old word as French
+
+**rojo** ("red") ← Latin **russus** — a more everyday, expressive Latin
+color-word for red. That's a **different specific Latin word** from the one
+behind French *rouge* (← **rubeus**). Both **russus** and **rubeus**,
+though, descend from the very same ancient root: PIE ***h₁rewdʰ-*** — the
+root behind English **red**, **rust**, **ruddy**, and Latin *ruber* itself.
+So *rojo* and *rouge* (and English *red*) are all **cousins** — just via two
+different branches of the same very old family, not one borrowed from the
+other.
+
+## azul — borrowed, and here it's the MAIN word
+
+**azul** ("blue") ← Arabic **لازورد** (*lāzaward*), "**lapis lazuli**" — the
+same ultimate source as the English word **azure**. Spanish picked this up
+during centuries of Arabic-speaking rule in Iberia (al-Andalus).
+
+Here's the honest contrast worth knowing: in **French**, *azur* exists too —
+but only as a **secondary, poetic** word (the sky's blue, the *Côte d'Azur*),
+while the **everyday** French blue is the Germanic loan *bleu*. In
+**Spanish**, it's the reverse: **azul is the plain, everyday word for blue**
+— there's no separate Germanic blue-word competing with it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rojo, azul"]
+- [YOU SAY: the cousins — "rojo · rouge · red," three descendants of one PIE
+  root]
+- [YOU SAY: the contrast — "azul is Spanish's everyday blue; French's azur is
+  only poetic"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **rojo** the same Latin word as French's *rouge*? (**No** —
+*rojo* ← *russus*, *rouge* ← *rubeus* — different Latin words, but true
+**cousins** via the shared PIE root *h₁rewdʰ-*.) Where does **azul** come
+from? (**Arabic** *lāzaward*, "lapis lazuli" — the same root as English
+*azure*.) How does azul's role in Spanish differ from azur's role in French?
+(**Azul is Spanish's everyday blue**; French's *azur* is only a secondary,
+poetic word, with *bleu* as the everyday one.)

--- a/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hermana.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hermana.md
@@ -1,0 +1,79 @@
+---
+id: ES-C23-hermano-hermana
+chapter: 23
+type: word
+headword: el hermano, la hermana
+gloss: brother and sister — NOT from frater/soror, but from an adjective meaning "of the same seed"
+concept_tag: ES-FAMILY-SIBLINGS
+prerequisites: [ES-C23-padre-madre]
+sounds: [silent-h, r-tap]
+roots: [germanus-latin, germen-latin]
+etymology_hook: "hermano is NOT Spanish for frater — it's from germanus, 'of the same stock/seed' (→ English germ, germinate, germane); its initial g simply dropped in an unstressed syllable, and the h you see today was added later, purely in spelling"
+est_minutes: 5
+reviews_of: [ES-C23-padre-madre]
+---
+
+# el hermano, la hermana — brother and sister, from a different word entirely
+
+## Warm-up
+
+[PAUSE 2s] You might expect Spanish "brother" to come from Latin **frāter**,
+the way French's *frère* does. It doesn't. Spanish's siblings took a
+completely different word — one about **seeds**.
+
+## Not frāter — germanus
+
+Classical Latin could say **frāter germānus**, literally "a brother **of the
+same stock/blood**" — distinguishing a *full* brother from a half-brother or
+a "brother" in a looser sense. Over time, in everyday Latin, the
+**adjective** *germānus* took over the whole job and the noun *frāter*
+quietly dropped out. That adjective is where Spanish's words come from:
+
+- **el hermano** ("brother") ← Latin **germānus**.
+- **la hermana** ("sister") ← Latin **germāna**.
+
+## Where germanus itself comes from
+
+**Germānus** traces back to **germen**, "**sprout, bud, seed**" — the same
+root that gives English **germ**, **germinate**, and **germane** (originally
+"closely related," from the same "seed," before it loosened to just
+"relevant"). So calling someone your *hermano* is, at the etymological root,
+calling them "**sprung from the same seed**."
+
+## Be honest about that silent h — it's a different story than hijo/hacer
+
+You may already know that Spanish sometimes turns a Latin initial **f** into
+a silent **h** — *filius* → **hijo** ("son"), *facere* → **hacer** ("to
+do"). **Hermano is NOT that.** Its story is different, and worth getting
+right:
+
+*Germānus* is stressed on its **third** syllable (*ger‑MĀ‑nus*), which
+leaves the opening **ger‑** unstressed. Latin's **g** before a front vowel
+(*e*, here) had already softened toward a *y*-like sound in everyday speech
+— and in this **unstressed** position, that soft opening simply **fell away
+entirely**, giving Old Spanish ***ermano*** (no *h* at all — this is the
+form actually recorded centuries ago). The **h** you see in today's
+*hermano* was added **later, in spelling only**, to visually mark the word's
+old connection to Latin *g‑* — unlike *hijo* and *hacer*, where the *h* really
+was **pronounced** for a long stretch of Spanish's history before falling
+silent. Same letter today, two completely different backstories.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hermano, hermana" — brother, sister]
+- [YOU SAY: the root — "germen, seed" → "germanus, of the same seed" →
+  "hermano"]
+- [YOU SAY: the honest distinction — hijo/hacer's h was once truly spoken;
+  hermano's h never was]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does Spanish "hermano" come from Latin *frāter*? (**No** — from
+**germānus**, "of the same stock/seed," which replaced *frāter* over time.)
+What English words share *germānus*'s root, and what does that root mean?
+(**Germ, germinate, germane** — from *germen*, "seed/sprout.") Is *hermano*'s
+*h* the same kind of sound-change as *hijo*'s or *hacer*'s? (**No** —
+*hijo/hacer*'s *h* was once genuinely pronounced; *germānus*'s opening sound
+simply **dropped** in an unstressed syllable, and *hermano*'s *h* is a later,
+purely written addition that was never spoken.)

--- a/code/learning/human-languages/spanish/lessons/ES-C23-padre-madre.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C23-padre-madre.md
@@ -1,0 +1,65 @@
+---
+id: ES-C23-padre-madre
+chapter: 23
+type: word
+headword: el padre, la madre
+gloss: father and mother — among the oldest reconstructible words in the whole family
+concept_tag: ES-FAMILY-PARENTS
+prerequisites: [ES-C22-rojo-azul]
+sounds: [r-tap, d-soft]
+roots: [pater-latin, mater-latin]
+etymology_hook: "padre ← pater, madre ← mater — the same PIE *ph2ter/*meh2ter that gave English father/mother via Grimm's law (p→f, t→th)"
+est_minutes: 5
+reviews_of: [ES-C22-rojo-azul, ES-C22-negro-blanco]
+---
+
+# el padre, la madre — among the oldest words there are
+
+## Warm-up
+
+[PAUSE 2s] "Father" and "mother" are some of the **oldest reconstructible
+words in human language** — older than Latin, older than Rome. Spanish kept
+them close to the Latin original, and they are secretly the *same words* as
+English **father** and **mother**.
+
+## Taken apart
+
+- **el padre** ("father") ← Latin **pater** ← PIE ***ph₂tḗr***.
+- **la madre** ("mother") ← Latin **māter** ← PIE ***méh₂tēr***.
+
+## The English connection — one sound-law
+
+*Padre* and English *father* both descend independently from the **same**
+PIE word — they're siblings, not parent and child. Latin (and Spanish after
+it) kept the original *p* and *t* largely intact; the Germanic branch that
+gave English took a separate road through **Grimm's Law**, which shifted the
+**inherited p → f** and **t → th**:
+
+| PIE ancestor | Latin → Spanish | Germanic → English |
+|---|---|---|
+| *ph₂tḗr* | *pater* → **padre** | **f**a**th**er |
+| *méh₂tēr* | *māter* → **madre** | **m**o**th**er |
+
+So *padre* and *father* aren't lookalikes borrowed late, and neither one
+comes *from* the other — they're the **same inherited PIE word**, one branch
+keeping the *p*, the other shifting it to *f*. The Latin root also gives
+Spanish and English their "of a parent" adjectives: **paternal, paternidad,
+patrón** and **maternal, maternidad**. (A further Latin-only offshoot,
+*māter* → *māteria*, "the stuff a tree-mother produces," gives Spanish
+*materia* and, separately, *matriz* — "womb" — via Latin *mātrix*.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "el padre, la madre"]
+- [YOU SAY: the sound-law — "padre keeps p; father shifts to f — same word"]
+- [YOU SAY: "padre → paternal; madre → maternal"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "father" and "mother" with their articles. (**el padre, la
+madre**.) Does *padre* turn into English *father* directly? (**No** — both
+descend independently from the same PIE word; the Germanic branch shifted
+p → f and t → th via **Grimm's Law**, while Latin/Spanish kept the original
+sounds.) Name an English cousin of each. (*padre* → paternal; *madre* →
+maternal.)

--- a/code/learning/human-languages/spanish/lessons/ES-C24-cabeza.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C24-cabeza.md
@@ -1,0 +1,65 @@
+---
+id: ES-C24-cabeza
+chapter: 24
+type: word
+headword: la cabeza
+gloss: the head — Spanish KEPT Latin's real word, unlike French, which replaced it with slang for "pot"
+concept_tag: ES-BODY-HEAD
+prerequisites: [ES-C23-hermano-hermana]
+sounds: [z-as-th-or-s, feminine-a-ending]
+roots: [latin-caput]
+etymology_hook: "cabeza IS Latin caput (via capitia) — English captain/capital/decapitate too — where French tête abandoned caput entirely for testa, slang for 'pot'"
+est_minutes: 4
+reviews_of: [ES-C23-hermano-hermana, ES-C23-padre-madre]
+---
+
+# la cabeza — "the head"
+
+## Warm-up
+
+[PAUSE 2s] Spanish's word for "head" is the boring, expected one — and
+that's exactly what makes it interesting, once you see what French did
+instead.
+
+## The word
+
+> **la cabeza** — the head. Feminine, so **la**.
+
+## caput — the word Spanish kept
+
+Latin's word for "head" was **caput**. Spanish's *cabeza* comes straight
+from it (by way of Vulgar Latin *capitia*), and *caput* shows up all over
+English too:
+
+| English | literally |
+|---|---|
+| **cap**tain | the "head" of a ship/unit |
+| **cap**ital | the "head" city, or "head" sum of money |
+| de**cap**itate | to remove the head |
+| **cap**itulate | to arrange under "headings" — hence, to yield |
+
+## Be honest about French's very different choice
+
+French had the exact same Latin word available — and **dropped it**. French
+*tête* ("head") comes instead from **testa**, Latin for an **earthenware
+pot**: Roman soldiers joked about the skull the way English speakers say
+"noggin" (a small mug), and in Gaul that joke eventually **replaced** the
+real word entirely. Spanish never made that swap — *cabeza* is *caput*,
+plain and simple, still standing after two thousand years.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "la cabeza" — the head]
+- [YOU SAY: "me duele la cabeza" — "my head hurts"]
+- [YOU SAY: the English family — "captain, capital, decapitate"]
+- [YOU SAY: the contrast — Spanish kept caput; French swapped it for a pot
+  joke]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "the head." (*La cabeza* — feminine.) What Latin word is it
+from? (**Caput**.) Give an English word from the same root. (**Captain,
+capital, decapitate**...) What did French do instead? (**Replaced caput
+with *testa*, "pot"** — soldiers' slang for the skull that took over
+completely.)

--- a/code/learning/human-languages/spanish/lessons/ES-C24-mano.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C24-mano.md
@@ -1,0 +1,70 @@
+---
+id: ES-C24-mano
+chapter: 24
+type: word
+headword: la mano
+gloss: the hand — feminine despite ending in -o, Spanish's most famous gender exception
+concept_tag: ES-BODY-HAND
+prerequisites: [ES-C24-cabeza, ES-C23-hermano-hermana]
+sounds: [feminine-o-exception]
+roots: [latin-manus]
+etymology_hook: "mano is feminine despite ending in -o (manus was 4th-declension feminine in Latin) — Spanish's most famous exception to the -o=masculine/-a=feminine rule; the same manus behind manual, manufacture, maintain"
+est_minutes: 4
+reviews_of: [ES-C24-cabeza]
+---
+
+# la mano — "the hand"
+
+## Warm-up
+
+[PAUSE 2s] You've been trusting "-o words are masculine, -a words are
+feminine" since Chapter 1. Here's the word that breaks it — and everyone
+learning Spanish has to memorize this one by name.
+
+## The word — and the exception
+
+> **la mano** — the hand. **Feminine**, despite ending in **-o**.
+
+Almost every Spanish noun ending in *-o* is masculine (*el libro, el
+gato*...). *Mano* is the single most common exception, and it's actually
+**doubly** irregular. Latin **manus** ("hand") belonged to the **4th
+declension** — a group of *-us* nouns that were mostly **masculine**
+(*frūctus* "fruit," *exercitus* "army," *senātus* "senate"). *Manus* was one
+of a small handful of exceptions that were **feminine** instead (alongside
+*domus* "house" and *anus* "old woman"). So *mano* broke the rule **twice
+over**: an exception within Latin's own mostly-masculine 4th declension, and
+then an exception again against Spanish's usual *-o* = masculine pattern.
+
+## manus — one of the most productive roots in English
+
+**Mano** comes from Latin **manus**, "hand" — and that root is buried inside
+an enormous number of English words:
+
+| English | literally |
+|---|---|
+| **manual** | done by hand |
+| **manufacture** | made by hand (*manus* + *facere*, "to make") |
+| **manuscript** | written by hand (*manus* + *scrībere*) |
+| **maintain** | hold in the hand (*manū tenēre*) |
+| **manage** | to handle |
+
+**Manufacture** is worth pausing on: it literally means "made by hand" — and
+today it names precisely the opposite.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "la mano" — feminine, despite the -o]
+- [YOU SAY: "me duele la mano" — "my hand hurts"]
+- [YOU SAY: the family — "manual, manufacture, maintain — all a hand"]
+- [YOU SAY: the irony — "manufacture = made by hand"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "the hand," and name its gender. (*La mano* — **feminine**,
+despite ending in *-o*.) Why is *mano* feminine when most *-o* words aren't?
+(**It's doubly irregular** — Latin's 4th declension, where *manus* belongs,
+was mostly **masculine**; *manus* was one of a few feminine exceptions
+there, and then an exception again against Spanish's usual -o=masculine
+rule.) Give an English word built on *manus*. (**Manual, manufacture,
+manuscript, maintain, manage**.)

--- a/code/learning/human-languages/spanish/lessons/ES-C25-las-estaciones.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C25-las-estaciones.md
@@ -1,0 +1,73 @@
+---
+id: ES-C25-las-estaciones
+chapter: 25
+type: word
+headword: la primavera, el verano, el otoño, el invierno
+gloss: the four seasons — three straightforward, and one whose MEANING quietly shifted from "spring" to "summer"
+concept_tag: ES-SEASONS
+prerequisites: [ES-C24-mano, ES-C24-cabeza]
+sounds: [r-tap, diphthong-ie]
+roots: [latin-prima-vera, latin-autumnus, latin-hibernum, latin-veranum]
+etymology_hook: "primavera = prima vera 'first spring' (Italian keeps the same word); otoño ← autumnus; invierno ← hibernum ('wintry') — but verano did NOT come from aestas like French été; it's veranum, 'of spring,' whose MEANING drifted to summer once primavera took over spring's job"
+est_minutes: 5
+reviews_of: [ES-C24-mano, ES-C24-cabeza]
+---
+
+# la primavera, el verano, el otoño, el invierno — three plain, one surprising
+
+## Warm-up
+
+[PAUSE 2s] Three of Spanish's four seasons are exactly what you'd expect
+from Latin. The fourth hides a genuine surprise: its **meaning itself**
+drifted from one season to another.
+
+## The three straightforward ones
+
+- **la primavera** ("spring") ← Latin ***prīma vēra***, literally "**first
+  spring**" (*vēr*, "spring," + *prīma*, "first"). Italian still says the
+  identical phrase, *primavera*, unchanged. (Old French once said
+  *primevère* too, before switching to *printemps*.)
+- **el otoño** ("autumn") ← Latin ***autumnus*** — the same root behind
+  French *automne* and English *autumn* itself.
+- **el invierno** ("winter") ← Latin ***hībernum*** (*tempus*), "the
+  **wintry** [season]" — the same root as French *hiver* and English
+  **hibernate**, "to spend the winter."
+
+## The surprising one: verano
+
+You might expect *verano* ("summer") to come from Latin **aestas**, "heat" —
+the way French *été* does. It doesn't. The standard account (per Spanish
+etymological dictionaries) traces **verano** to Latin ***vērānum*** (*tempus*),
+"**of spring**" — built on the very same *vēr*, "spring," behind
+*primavera*.
+
+So how did a word meaning "spring-ish" end up naming **summer**? The honest
+answer is a **shift in meaning over time**, not a sound change — though the
+exact story is murkier than a tidy one-line explanation. The traditional,
+simplified account says that as *primavera* ("first spring") rose to become
+the standard word for spring, *verano*'s meaning drifted forward into the
+season right after, summer; the fuller picture likely also involves
+Vulgar Latin agricultural usage (a "vernal" grazing or working period that
+stretched from late spring into early summer), so the drift may not be
+purely a case of one word simply vacating a job for the other. Either way,
+two Spanish words both rooted in *vēr*, "spring," ended up naming two
+different seasons.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "primavera, verano, otoño, invierno" — the four seasons]
+- [YOU SAY: "primavera = prima vera, first spring"]
+- [YOU SAY: the surprise — "verano ALSO comes from vēr, 'spring' — but its
+  meaning moved to summer"]
+- [YOU SAY: "invierno ~ hibernate"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **primavera** literally mean? (**"First spring"** —
+*prīma vēra*.) Does **verano** come from Latin *aestas*, like French *été*?
+(**No** — from *vērānum*, "of spring," the same *vēr* root as *primavera*;
+its meaning **shifted** toward summer over time — traditionally linked to
+*primavera* taking over the job of naming spring, though the fuller history
+is murkier than that alone.) What English word is **invierno** the cousin
+of? (**Hibernate**.)

--- a/code/learning/human-languages/spanish/lessons/ES-C26-agua-vino.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C26-agua-vino.md
@@ -47,9 +47,12 @@ noun's actual gender.
 ## el vino (wine) — Latin vīnum, kept whole
 
 **vino** ("wine") ← Latin **vīnum** — held its shape, the way French *vin*
-did too. English shares the very same root: **wine** itself is *vīnum*
-borrowed into old Germanic, plus **vine, vinegar, vintage, vineyard,
-vinyl**.
+did too. English shares the very same root, by more than one road: **wine**
+itself is *vīnum* borrowed directly into old Germanic; **vine** and
+**vinegar** arrived centuries later, secondhand, via **French** (*vin +
+aigre*, "sour wine," for vinegar); and **vineyard** isn't a borrowing at
+all — English built it at home, from the already-borrowed "wine" plus
+native "yard."
 
 ## Guided Practice
 

--- a/code/learning/human-languages/spanish/lessons/ES-C26-agua-vino.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C26-agua-vino.md
@@ -1,0 +1,71 @@
+---
+id: ES-C26-agua-vino
+chapter: 26
+type: word
+headword: el agua, el vino
+gloss: water and wine — agua kept its Latin shape almost whole, unlike French's worn-down eau
+concept_tag: ES-FOOD-DRINKS
+prerequisites: [ES-C25-las-estaciones]
+sounds: [stressed-a-el-not-la, nasal-none]
+roots: [aqua-latin, vinum-latin]
+etymology_hook: "agua ← Latin aqua, barely changed at all — where French wore aqua all the way down to just 'eau' (a bare 'oh'); agua also takes EL despite being feminine, a purely phonological rule (avoiding la agua), not a gender change like mano's"
+est_minutes: 5
+reviews_of: [ES-C25-las-estaciones]
+---
+
+# el agua, el vino — water and wine
+
+## Warm-up
+
+[PAUSE 2s] Two drinks, two very different journeys from Latin. One barely
+changed at all. And the "masculine-looking" article on a feminine word
+isn't a mistake — it's a real, well-documented rule.
+
+## el agua (water) — Latin aqua, barely touched
+
+**agua** ("water") ← Latin **aqua** — almost unchanged. Compare French,
+where the very same word was worn all the way down to a bare **"eau,"**
+just the sound "oh." Spanish kept nearly the whole thing.
+
+English kept the **original**, whole Latin word too, just as a learned
+borrowing rather than an everyday one: **aquatic, aquarium, aqueduct,
+aqualung** all come straight from *aqua*.
+
+## Be honest about el agua's gender
+
+Notice: **el agua**, not *la agua* — but *agua* is genuinely **feminine**
+(you'll see it in *el agua fría*, "the cold water," where *fría* keeps its
+feminine ending). This isn't an exception to gender; it's a **pronunciation
+rule**: Spanish swaps *la* for *el* right before any **singular** feminine
+noun that **starts with a stressed *a*-sound** (to avoid running two
+identical vowel sounds together, *la agua*) — the plural goes right back to
+*las*: *las aguas*, never *los aguas*. You'll meet the singular swap again
+with words like *el águila* ("the eagle," still feminine) and *el hacha*
+("the axe," still feminine). It's only the article that changes, never the
+noun's actual gender.
+
+## el vino (wine) — Latin vīnum, kept whole
+
+**vino** ("wine") ← Latin **vīnum** — held its shape, the way French *vin*
+did too. English shares the very same root: **wine** itself is *vīnum*
+borrowed into old Germanic, plus **vine, vinegar, vintage, vineyard,
+vinyl**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "el agua" — water, feminine, but takes el]
+- [YOU SAY: "el vino" — wine]
+- [YOU SAY: the contrast — "agua barely changed from aqua; French's eau wore
+  all the way down"]
+- [YOU SAY: "el águila, el hacha" — the same el-before-stressed-a pattern]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **agua** masculine or feminine, and why does it take *el*?
+(**Feminine** — *el* replaces *la* only because *agua* starts with a
+**stressed a**, a pronunciation rule, not a gender change.) How does
+*agua*'s erosion from Latin *aqua* compare to French's *eau*? (**Much
+less** — Spanish kept nearly the whole word; French wore it down to a bare
+"oh.") Give an English cousin of *vino*. (**Wine, vine, vinegar,
+vintage**.)

--- a/code/learning/human-languages/spanish/lessons/ES-C26-pan.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C26-pan.md
@@ -1,0 +1,58 @@
+---
+id: ES-C26-pan
+chapter: 26
+type: word
+headword: el pan
+gloss: bread — and the compañero who shares it with you
+concept_tag: ES-FOOD-BREAD
+prerequisites: [ES-C26-agua-vino]
+sounds: [nasal-none, short-vowel]
+roots: [panis-latin]
+etymology_hook: "pan ← Latin panis 'bread' → compañero ('one you share bread with', com- + panis) — the very same word-story as English companion, and Spanish keeps BOTH the bread and the friendship"
+est_minutes: 4
+reviews_of: [ES-C26-agua-vino]
+---
+
+# el pan — bread, and the friend who shares it
+
+## Warm-up
+
+[PAUSE 2s] Spanish's word for bread hides the same lovely word-story you'd
+find in English's "companion" — except Spanish kept **both halves**, the
+bread and the friendship.
+
+## The word
+
+**el pan** ("bread") ← Latin **pānis**. Masculine: *el pan*.
+
+## The "bread" family — bread AND friendship, both in Spanish
+
+The Latin root **pān-** ("bread") gives Spanish its own word for a close
+friend:
+
+- **compañero / compañera** ("companion, friend, partner") ← *com-* ("with")
+  + *pānis* — literally "**one you share bread with**." Spanish built this
+  word from the very same recipe as English **companion** and **company**
+  (which come from the identical Latin pieces) — but where English only
+  kept the *friendship* sense, Spanish still visibly uses the **same root**
+  for the actual **bread** (*pan*) too.
+- **panadería** ("bakery") and **panadero** ("baker") — both transparently
+  built on *pan*.
+
+So *pan* and *compañero* are the same word-family doing double duty in
+Spanish: name the food, and name the friend you'd share it with.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "el pan" — bread]
+- [YOU SAY: "compañero" — literally, one you share bread with]
+- [YOU SAY: "panadería, panadero" — bakery, baker]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "bread" with its article. (**El pan**.) What does
+*compañero* literally mean, and what's it built from? ("**One you share
+bread with**" — *com-* + *pānis*.) Does English keep this same double
+meaning? (**No** — English's *companion* only kept the friendship sense;
+Spanish still uses the same root for the actual bread, *pan*, too.)

--- a/code/learning/human-languages/spanish/lessons/ES-C27-los-meses.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C27-los-meses.md
@@ -1,0 +1,75 @@
+---
+id: ES-C27-los-meses
+chapter: 27
+type: word
+headword: los meses
+gloss: the months — Roman gods and emperors, marching almost unchanged from Latin
+concept_tag: ES-MONTHS
+prerequisites: [ES-C21-lunes-viernes, ES-C08-numeros-6-10]
+sounds: [r-tap, diphthong-ie]
+roots: [latin-months, roman-gods]
+etymology_hook: "marzo ← Martius ← Mars, the SAME war-god behind martes; septiembre–diciembre still mean Latin 7–10 because the year once started in March — Julius and Augustus didn't ADD months, they just got two already-existing ones (Quintilis, Sextilis) RENAMED after them"
+est_minutes: 5
+reviews_of: [ES-C21-lunes-viernes, ES-C08-numeros-6-10]
+---
+
+# los meses — the calendar's gods and Caesars
+
+## Warm-up
+
+[PAUSE 2s] Spanish's twelve months are a **procession of Roman gods and
+emperors**, barely changed from Latin. Two things you already know pay off
+immediately: *marzo* is the war-god you met in *martes*, and
+*septiembre–diciembre* are the Latin numbers 7–10 from the counting
+chapters.
+
+## The months, taken apart
+
+| Spanish | ← Latin | who / what |
+|---|---|---|
+| **enero** | *Iānuārius* | **Janus**, the two-faced god of doors & beginnings |
+| **febrero** | *Februārius* | *Februa*, the Roman **purification** festival |
+| **marzo** | *Martius* | **Mars**, the war-god — *the same Mars as* **martes** (Tuesday)! |
+| **abril** | *Aprīlis* | perhaps *aperīre*, "to **open**" (buds opening) |
+| **mayo** | *Māius* | **Maia**, goddess of growth |
+| **junio** | *Iūnius* | **Juno**, queen of the gods |
+| **julio** | *Iūlius* | originally *Quīntīlis*, "the 5th [month]" — **renamed** for **Julius Caesar** after his death |
+| **agosto** | *Augustus* | originally *Sextīlis*, "the 6th [month]" — **renamed** for the emperor **Augustus** |
+| **septiembre** | *september* | "**7th**" (*septem*) |
+| **octubre** | *octōber* | "**8th**" (*octō*) |
+| **noviembre** | *november* | "**9th**" (*novem*) |
+| **diciembre** | *december* | "**10th**" (*decem*) |
+
+Two payoffs land at once:
+
+- **marzo = Mars = martes.** The month and the weekday honor the *same*
+  war-god — *Martius* (his month) and *Martis diēs* (his day). Spot one,
+  you know the other.
+- **The 7–10 months.** *Septiembre* through *diciembre* still carry
+  *septem, octō, novem, decem* — because the old Roman year originally
+  began in **March**, with September genuinely the 7th month. Centuries
+  before Caesar, two new months (Januarius, Februarius) were added at the
+  front to cover the winter, which pushed every later month's number out
+  of step with its name — September became the *9th* month while still
+  being *named* "7th." **Julius** and **Augustus** had nothing to do with
+  that shift: they simply got two already-existing months — *Quintilis*
+  and *Sextilis*, literally "5th" and "6th" — **renamed** in their honor
+  after the fact. The names stuck; the months themselves were never new.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "enero, febrero, marzo, abril, mayo, junio, julio,
+  agosto, septiembre, octubre, noviembre, diciembre"]
+- [YOU SAY: the tie-back — "marzo / martes — both Mars, the war-god"]
+- [YOU SAY: "septiembre = 7, diciembre = 10" — the old March-start year]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which god links *marzo* and *martes*? (**Mars**, the war-god —
+his month and his day.) Why is *diciembre* Latin for "ten"? (**The Roman
+year began in March**, and adding January/February at the front later
+pushed every month's number out of step with its name.) Did Julius Caesar
+and Augustus **add** new months to the calendar? (**No** — *julio* and
+*agosto* were already-existing months, *Quintilis* and *Sextilis*
+("5th"/"6th"), simply **renamed** in their honor.)

--- a/code/learning/human-languages/spanish/lessons/ES-C28-mediodia-medianoche.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C28-mediodia-medianoche.md
@@ -1,0 +1,69 @@
+---
+id: ES-C28-mediodia-medianoche
+chapter: 28
+type: word
+headword: mediodía, medianoche
+gloss: noon and midnight — both halves still fully alive as ordinary Spanish words, unlike French's worn-down midi/minuit
+concept_tag: ES-TIME-NOON-MIDNIGHT
+prerequisites: [ES-C27-los-meses]
+sounds: [diphthong-ia, nasal-none]
+roots: [medius-dies-latin, media-nox-latin]
+etymology_hook: "mediodía ← medius diēs, medianoche ← media nox — Spanish kept día/noche fully alive as ordinary words; French's -di (in midi) wore down to an opaque fragment, though its -nuit (in minuit) stayed just as recognizable as Spanish's noche"
+est_minutes: 4
+reviews_of: [ES-C27-los-meses]
+---
+
+# mediodía, medianoche — noon and midnight, spelled out in full
+
+## Warm-up
+
+[PAUSE 2s] Two hours that don't get a number — they get a name. And
+Spanish keeps that name far more transparent than its French cousin does.
+
+## The two words, taken apart
+
+| Spanish | ← Latin | literally |
+|---|---|---|
+| **mediodía** | *medius diēs* | "**mid**-**day**" (*medio* "middle" + *día* "day") |
+| **medianoche** | *media nox* | "**mid**-**night**" (*media* "middle" + *noche* "night") |
+
+Both halves are **fully alive, ordinary Spanish words on their own**:
+**medio/media** ("middle" — cousin of English *medium, mid, middle*) and
+**día/noche** ("day/night," words you already know). Compare French, which
+took the same Latin phrase down a bumpier road: *minuit*'s second half,
+**-nuit**, is still the plain, everyday French word for "night" — just as
+recognizable as Spanish's *noche*. But *midi*'s second half, **-di**, wore
+down into an opaque fragment: the ordinary French word for "day" is *jour*,
+not *di* — that piece survives only as a fossil, tucked inside weekday
+names like *lundi* and *mardi*. So the erosion split unevenly: French kept
+"night" transparent and lost "day," while Spanish kept both.
+
+They don't need *horas* the way a normal Spanish time (*son las tres*)
+never does either — they simply stand in for the hour on their own:
+
+> **Es mediodía.** — "It is noon." **Es medianoche.** — "It is midnight."
+
+(Fun aside: English **noon** comes from Latin *nōna hōra*, "the **ninth**
+hour" — originally mid-afternoon, it drifted earlier over the centuries to
+mean midday. Spanish kept the tidier, transparent "mid-day" instead.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mediodía" (noon), "medianoche" (midnight)]
+- [YOU SAY: break them — "medio + día", "media + noche" — both halves
+  still ordinary words]
+- [YOU SAY: "Es mediodía. Es medianoche." — they stand in for the hour]
+- [YOU SAY: the contrast — French kept "night" (nuit) but wore "day" down
+  to a fossil (-di)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *mediodía* and *medianoche* literally mean, and from
+what Latin? ("Mid-day" ← *medius diēs*; "mid-night" ← *media nox*.) Are
+both halves still recognizable, ordinary Spanish words? (**Yes** — *medio/
+media* "middle," *día/noche* "day/night.") Did French erode its phrase
+evenly? (**No** — French's *-nuit* stayed just as transparent as Spanish's
+*noche*, but its *-di* wore down to an opaque fossil, since the everyday
+French word for "day" is actually *jour*.) How do you say "it is noon"?
+(*Es mediodía*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C29-la-hora.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C29-la-hora.md
@@ -1,0 +1,73 @@
+---
+id: ES-C29-la-hora
+chapter: 29
+type: word
+headword: la hora
+gloss: hour / o'clock — telling the time, and a word Spanish inherited almost unchanged from Latin
+concept_tag: ES-TIME-HOUR
+prerequisites: [ES-C28-mediodia-medianoche]
+sounds: [silent-h, article-la-las]
+roots: [hora-latin, hora-greek]
+etymology_hook: "hora ← Latin hōra ← Greek hṓrā, 'a season, a time of day' — Spanish inherited it almost unchanged, with a silent h that's a fossil of an already-weak Latin h (NOT the same story as hijo/hacer's silent h, which comes from Spanish's own later f- → h- sound change); the same Latin source as French heure, German's separately-borrowed Uhr, and English hour"
+est_minutes: 5
+reviews_of: [ES-C28-mediodia-medianoche]
+---
+
+# la hora — Spanish's barely-changed Latin hour
+
+## Warm-up
+
+[PAUSE 2s] You've now seen this Latin word take three different paths: French wore
+it down to *heure*, German borrowed it centuries later as *Uhr*. Spanish's path is
+the simplest of all — it barely changed.
+
+## The word, taken apart
+
+**hora** ← Latin **hōra** ← Greek **hṓrā**, "a season, a time of day" (the Greek
+goddesses of the seasons were the *Hōrai*). Spanish kept the word almost exactly as
+Latin had it — just a silent **h** in spelling, a fossil of a Latin *h* that was
+already weak and barely pronounced by the time Spanish inherited the word (the same
+non-story as French *heure* or English *hour*'s silent *h*). Be careful not to
+confuse this with *hijo* and *hacer*'s silent *h* — those come from a completely
+different, later Spanish sound change (Latin **f-** → Old Spanish aspirated *h-* →
+eventual silence), not from an already-weak Latin *h* the way *hora*'s is. Two
+different roads to the same "silent letter" result. Compare its cousins: French
+wore *hōra* down further to *heure*; German didn't inherit the word at all, but
+borrowed it later as *Uhr*; English took the same Latin *hōra* and made *hour*.
+
+| language | word | what happened |
+|---|---|---|
+| **Spanish** | **hora** | inherited almost unchanged, just a silent *h* |
+| French | *heure* | inherited, but worn down further |
+| German | *Uhr* | not inherited — borrowed later, separately |
+| English | *hour* | inherited via French, silent *h* |
+
+## Grammar Lens: "Son las…" — telling the time
+
+Spanish uses **ser** ("to be") plus the **feminine plural article** (agreeing with
+the unspoken *horas*) to tell time — and famously switches number for "one":
+
+> **Es la una.** — "It is one o'clock." (singular — *la una*, "the one")
+> **Son las dos.** — "It is two o'clock." (plural — *las dos*, "the two")
+> **Son las diez.** — "It is ten o'clock."
+
+Literally "**it is the one**" / "**they are the two/ten**" — the hour count itself
+is implied by the article and number, without needing to say *hora(s)* at all in
+everyday speech (unlike French's *il est deux heures*, which spells out "hours"
+every time).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hora" — silent h, a fossil of an already-weak Latin h]
+- [YOU SAY: "Es la una. Son las dos. Son las diez."]
+- [YOU SAY: "hora / heure / hour" — one Latin root, three different fates]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin (and Greek) word is *hora* from? (*hōra* ← Greek *hṓrā*.) How
+did Spanish's path differ from French's and German's? (**Spanish** inherited it
+almost unchanged; **French** wore it down further to *heure*; **German** didn't
+inherit it at all and borrowed *Uhr* separately, much later.) How do you say "it is
+one o'clock" vs. "it is two o'clock"? (*Es la una* — singular; *Son las dos* —
+plural.)

--- a/code/learning/human-languages/spanish/lessons/ES-C30-el-tiempo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C30-el-tiempo.md
@@ -1,0 +1,69 @@
+---
+id: ES-C30-el-tiempo
+chapter: 30
+type: phrase
+headword: el tiempo, llueve
+gloss: weather — el tiempo means BOTH "time" and "weather"; hace calor/frío/sol reuse hacer, but llueve is its OWN dedicated verb, and a callback to the cl-/pl- → ll- sound change
+concept_tag: ES-WEATHER
+prerequisites: [ES-C12-hacer, ES-C03-llamar]
+sounds: [ll-digraph, diphthong-ue]
+roots: [tempus-latin, calor-latin, frigidus-latin, sol-latin, pluere-latin]
+etymology_hook: "el tiempo means BOTH 'time' and 'weather' — from Latin tempus, which already covered both senses; hace calor/frío/sol reuse hacer ('it makes'), but llueve ('it's raining') is its own dedicated verb, llover ← Latin pluere, the SAME cl-/fl-/pl- → ll- sound change you met in llamar/llave/llama"
+est_minutes: 5
+reviews_of: [ES-C12-hacer, ES-C03-llamar]
+---
+
+# el tiempo — weather, and a word that means two things at once
+
+## Warm-up
+
+[PAUSE 2s] Ask a Spanish speaker "¿qué tiempo hace?" and you're literally
+asking "what time does it make?" — because *tiempo* doesn't distinguish
+"time" from "weather" the way English does.
+
+## el tiempo — one word, two meanings
+
+**el tiempo** = both "**time**" and "**weather**" — from Latin **tempus**,
+which already covered this same double sense (English kept only the "time"
+half: **temporal, contemporary, tempo**). So **¿qué tiempo hace?** ("what's
+the weather like?") is literally "**what time does it make**?" — context alone
+tells a Spanish speaker which sense is meant.
+
+## calor, frío, sol — three Latin words for the weather itself
+
+- **calor** ← Latin **calor**, "heat, warmth" → English **calorie, caloric**.
+- **frío** ← Latin **frigidus**, "cold" (with the middle syncopated away over
+  time) → English **frigid, refrigerate**.
+- **sol** ← Latin **sol**, "sun," unchanged → English **solar, solstice,
+  parasol**.
+
+You've already met **hace calor** and **hace frío** ("it's hot/cold," literally
+"it **makes** heat/cold") back when you learned *hacer* — the same **hacer**
+("to make") that reports weather this way also covers "sunny": **hace sol**
+("it's sunny," literally "it makes sun").
+
+## llueve — a dedicated verb, not hacer
+
+**Rain** breaks the *hacer* pattern entirely: **llueve** ("it's raining") comes
+from its own verb, **llover** ← Latin **pluere**, "to rain." Recognize that
+**pl- → ll-** shift? It's the **same** regular sound change you met with
+*llamar* (← *clamāre*), *llave* (← *clāvem*), and *llama* (← *flamma*) — Latin
+*cl-*, *fl-*, and *pl-* clusters all regularly became Spanish *ll-*. So while
+*calor/frío/sol* just need **hacer** in front of them, *rain* gets its own
+dedicated, impersonal verb — much like English's own dedicated "it **rains**"
+versus "it **is** hot."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "el tiempo" — time, or weather, depending on context]
+- [YOU SAY: "hace calor. hace frío. hace sol." — it's hot/cold/sunny]
+- [YOU SAY: "llueve" — it's raining, its own verb, not hacer]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two things does **el tiempo** mean, and what Latin word covers
+both? (**"Time"** and **"weather"** — Latin **tempus**.) Which weather word
+does NOT use *hacer*? (**Llueve** — "it's raining," its own verb *llover*.)
+What Latin cluster did *llover*'s *ll-* come from, and what other word taught
+you this same sound change? (**pl-**, the same shift as *llamar* ← *clamāre*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C31-numeros-11-20.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C31-numeros-11-20.md
@@ -1,0 +1,82 @@
+---
+id: ES-C31-numeros-11-20
+chapter: 31
+type: word
+headword: once — veinte
+gloss: 11-20 — five fused Latin irregulars (once-quince), then Spanish REGULARIZES away from Latin's own quirky teens
+concept_tag: ES-NUM-11-20
+prerequisites: [ES-C08-numeros-6-10]
+sounds: [diphthong-ie, silent-none]
+roots: [latin-undecim-quindecim, latin-viginti]
+etymology_hook: "once-quince (11-15) are Latin's ūndecim-quīndecim, fused down almost past recognition; dieciséis-diecinueve (16-19) are perfectly transparent 'diez y seis' compounds — but Latin's OWN 18 and 19 were subtractive oddities, duodēvīgintī ('two from twenty') and ūndēvīgintī ('one from twenty'); Spanish didn't inherit that quirk, it replaced it with plain addition"
+est_minutes: 6
+reviews_of: [ES-C08-numeros-6-10]
+---
+
+# once, veinte — five fused Latins, then Spanish fixes Latin's own quirk
+
+## Warm-up
+
+[PAUSE 2s] Eleven through twenty splits into two very different stories: five
+numbers worn down almost past recognition, and five that Spanish built fresh
+— fixing a genuine oddity in Latin's own counting system along the way.
+
+## once–quince — five fused Latin compounds
+
+| Spanish | ← Latin |
+|---|---|
+| **once** | *undecim* ("one-ten") |
+| **doce** | *duodecim* ("two-ten") |
+| **trece** | *tredecim* ("three-ten") |
+| **catorce** | *quattuordecim* ("four-ten") |
+| **quince** | *quindecim* ("five-ten") |
+
+Each of these was originally a compound — number + *-decim* ("ten," the same
+root as *diez*) — but centuries of everyday use fused them into single,
+opaque words. You can still faintly hear *-ce* as the worn-down echo of
+*-decim* in all five.
+
+## dieciséis–diecinueve — transparent, built fresh
+
+| Spanish | literally |
+|---|---|
+| **dieciséis** | *diez y seis*, "ten and six" |
+| **diecisiete** | *diez y siete*, "ten and seven" |
+| **dieciocho** | *diez y ocho*, "ten and eight" |
+| **diecinueve** | *diez y nueve*, "ten and nine" |
+
+No fusion here — these are fully transparent "ten-and-X" compounds, and you
+can hear *diez* plainly in every one.
+
+## Be honest: Spanish fixed a real quirk in Latin's own teens
+
+Here's the genuinely interesting part. You might expect *dieciocho* and
+*diecinueve* to simply continue whatever Latin did for 18 and 19 — but Latin's
+own words for those two numbers were **subtractive**, not additive:
+**duodēvīgintī** ("**two from twenty**") for 18, and **ūndēvīgintī** ("**one
+from twenty**") for 19. Spanish didn't inherit that pattern at all — it built
+*dieciocho* and *diecinueve* fresh, on the same simple "ten-and-X" template as
+16 and 17, quietly **regularizing away** a genuine irregularity that existed
+in Latin itself.
+
+## veinte
+
+**veinte** ("twenty") ← Latin **vīgintī** — worn down by ordinary sound
+change, but never fused from two separate words the way *once*-*quince* were.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "once, doce, trece, catorce, quince" — the five fused Latins]
+- [YOU SAY: "dieciséis, diecisiete, dieciocho, diecinueve" — transparent
+  "ten-and-X"]
+- [YOU SAY: "veinte" — twenty]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are *once* through *quince*, structurally? (**Fused Latin
+compounds** — number + *-decim*, "ten," worn down to *-ce*.) Are *dieciséis*
+through *diecinueve* fused or transparent? (**Transparent** — plain "ten and
+X.") Did Spanish inherit Latin's own words for 18 and 19? (**No** — Latin's
+*duodēvīgintī*/*ūndēvīgintī* were **subtractive** ["two/one FROM twenty"];
+Spanish replaced that with straightforward addition instead.)

--- a/code/learning/human-languages/spanish/lessons/ES-C32-perro-gato.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C32-perro-gato.md
@@ -1,0 +1,70 @@
+---
+id: ES-C32-perro-gato
+chapter: 32
+type: word
+headword: perro, gato
+gloss: dog and cat — gato has a real, sourced etymology all the way back to Egypt; perro is a genuine, unsolved etymological mystery that replaced Latin's own word for "dog"
+concept_tag: ES-ANIMALS
+prerequisites: [ES-C08-numeros-6-10]
+sounds: [rolled-rr, silent-none]
+roots: [latin-cattus-afroasiatic, unknown-perro]
+etymology_hook: "gato ← Latin cattus, itself probably from an Afro-Asiatic word (compare Nubian kadis) that traveled along Roman trade routes as domestic cats spread out of Egypt — a real, sourced etymology; perro, by honest contrast, is a genuine UNSOLVED mystery with no confirmed origin at all, and it quietly REPLACED Latin's own word for dog, canis (which survives as archaic Spanish can)"
+est_minutes: 6
+reviews_of: [ES-C08-numeros-6-10]
+---
+
+# perro, gato — one sourced etymology, one genuine mystery
+
+## Warm-up
+
+[PAUSE 2s] Two everyday animal words, two completely different kinds of
+history: one traces all the way back to ancient Egypt. The other is a real,
+unsolved puzzle that linguists still argue about.
+
+## gato — a word that traveled with the cat itself
+
+**gato** ("**cat**") ← Latin **cattus** — but *cattus* itself wasn't the
+original Latin word for cat at all. Classical Latin's word was **fēlēs**
+(still surviving in the scientific name *Felis catus*). *Cattus* only
+entered Latin later, as domestic cats spread out along **Roman trade
+routes** from their point of domestication — **Egypt**, around 2000 BCE.
+*Cattus* is most likely ultimately an **Afro-Asiatic** word (compare Nubian
+**kadis**, "cat") — so the word, like the animal, **traveled** into Europe
+from Africa, eventually pushing out *fēlēs* almost everywhere (the same
+*cattus* gives Italian *gatto*, French *chat*, even Old Irish *cat* and Welsh
+*cath*).
+
+## perro — a genuine, unsolved mystery
+
+**perro** ("**dog**") is honestly different: nobody knows for certain where
+it comes from. The word Spanish "should" have inherited from Latin is
+**canis** — the same root as English **canine**, French **chien**, Italian
+**cane** — and that word did survive into Spanish, as the now-archaic **can**.
+But at some point, **perro** pushed *can* almost entirely out of everyday use,
+and *perro* itself has **no agreed etymology**. Serious proposals include: an
+onomatopoeic imitation of a dog's growl or a shepherd's calling-sound (*"perr
+perr"*); a pre-Roman, pre-Latin word from the Iberian substrate (the *-rro*
+ending is itself a marker of likely pre-Latin origin in Spanish); and even a
+possible link to Persian *persus*, a hunting-dog breed that became popular in
+the late Roman Empire. None of these is confirmed — *perro* remains one of
+Spanish's genuinely open etymological puzzles.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "gato" — cat, traced all the way back to Egypt via Latin
+  cattus]
+- [YOU SAY: "perro" — dog, a real unsolved mystery]
+- [YOU SAY: "can" — the archaic Spanish word perro replaced, from Latin
+  canis]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What was Classical Latin's actual word for "cat," and where did
+*cattus* most likely come from instead? (**Fēlēs**; *cattus* is probably
+**Afro-Asiatic**, traveling with the domesticated cat out of **Egypt**.) Does
+*perro* have a confirmed etymology? (**No** — it's a genuine, unsolved
+mystery, with competing onomatopoeic, pre-Latin substrate, and Persian
+theories.) What archaic Spanish word did *perro* replace, and what's its
+Latin source? (**can**, from Latin **canis** — the same root as English
+*canine*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C33-verde-amarillo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C33-verde-amarillo.md
@@ -1,0 +1,60 @@
+---
+id: ES-C33-verde-amarillo
+chapter: 33
+type: word
+headword: verde, amarillo
+gloss: green and yellow — a straightforward Latin inheritance, and a genuinely surprising one that doesn't come from any Latin "yellow" word at all
+concept_tag: ES-COLOUR-GREEN-YELLOW
+prerequisites: [ES-C22-rojo-azul]
+sounds: [rolled-none, double-l-y]
+roots: [latin-viridis-vireo, latin-amarus-bitter]
+etymology_hook: "verde ← Latin viridis, 'green,' from virere, 'to be green/vigorous' (cousin of English verdant, verdure — NOT of English green itself, a separate Germanic root); amarillo is the real surprise — it does NOT come from any Latin word for yellow at all, but from amarellus, 'a little bitter,' a diminutive of amarus, 'bitter' — the same root as Spanish's own amargo, 'bitter'"
+est_minutes: 6
+reviews_of: [ES-C22-rojo-azul]
+---
+
+# verde, amarillo — the expected inheritance, and a real surprise
+
+## Warm-up
+
+[PAUSE 2s] One of these colors is exactly what you'd expect from Latin.
+The other one will genuinely surprise you — it has nothing to do with any
+Latin word for "yellow" at all.
+
+## verde — straightforward, from "to flourish"
+
+**verde** ("**green**") ← Latin **viridis** (worn down via **virdis**), from
+the verb **virēre**, "**to be green, to flourish, to be vigorous**." This is
+a cousin of English **verdant** and **verdure** — though **not** of English
+**green** itself, which comes from a completely separate Germanic root. A
+clean, expected Latin inheritance.
+
+## amarillo — genuinely NOT from a "yellow" word at all
+
+Here's the honest surprise: **amarillo** ("**yellow**") does **not** trace
+to any of Latin's actual words for yellow (*flāvus*, *gilvus*, *lūteus*).
+Instead, it comes from Late Latin **amarellus**, "**a little bitter**" — a
+diminutive of **amarus**, "**bitter**." The connection runs through an old
+association between the color yellow and **bitterness** — bile, jaundice,
+and many bitter-tasting plants all share a yellowish cast. Over centuries,
+"a little bitter" softened into simply "yellowish," and by Spanish's Golden
+Age the word had shed its bitter meaning entirely, leaving just the color.
+*Amarillo* is a genuine cousin of Spanish's own **amargo** ("bitter") —
+both descend from the same *amarus*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "verde" — green, from "to flourish"]
+- [YOU SAY: "amarillo" — yellow, literally "a little bitter"]
+- [YOU SAY: the cousins — "amarillo, amargo" — yellow and bitter, same
+  Latin root]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb gives **verde**, and what does it mean? (**Virēre**,
+"to be green/flourish" — cousin of English *verdant*, *verdure*, not of
+English *green* itself.) Does **amarillo** come from a Latin "yellow" word?
+(**No** — from *amarellus*, "a little bitter," a diminutive of *amarus*,
+"bitter.") What everyday Spanish word is **amarillo**'s cousin? (**Amargo**,
+"bitter.")

--- a/code/learning/human-languages/tamil/lessons/TA-C09-mannikkavum.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C09-mannikkavum.md
@@ -1,0 +1,85 @@
+---
+id: TA-C09-mannikkavum
+chapter: 9
+type: phrase
+headword: மன்னிக்கவும்
+gloss: please forgive (maṉṉikkavum — a formal/written polite request, from மன்னி maṉṉi "to forgive")
+concept_tag: COURTESY-SORRY
+prerequisites: [TA-C08-tayavuseytu]
+sounds: [tamil-double-nnna, pulli-virama]
+roots: [manni-tamil]
+etymology_hook: "மன்னிக்கவும் maṉṉikkavum is built on மன்னி maṉṉi 'to forgive' — Tamil's OWN native word, unlike its Dravidian cousins' Sanskrit kṣamā"
+est_minutes: 5
+reviews_of: [TA-C08-tayavuseytu]
+---
+
+# மன்னிக்கவும் (maṉṉikkavum) — please forgive
+
+## Warm-up
+
+[PAUSE 2s] You already know **தயவுசெய்து**, "please." Tamil's "sorry" gives
+you something its Dravidian cousins don't: a forgiveness-word that's Tamil
+through and through, not borrowed from Sanskrit.
+
+## The word, taken apart
+
+**மன்னிக்கவும்** is built from three pieces:
+
+- **மன்னி** (*maṉṉi*) = "**to forgive, excuse, pardon**" — and unlike the
+  words you'll meet in Kannada, Telugu, and Malayalam, this is Tamil's **own**
+  native verb, not borrowed from Sanskrit **kṣamā**.
+- **‑க்க** (*‑kka*) = an infinitive-forming ending.
+- **‑உம்** (*‑um*) = a formal, written-register particle used to make a
+  soft, general request or permission — the same particle you'd see on a
+  sign asking visitors to *வரவும்* ("please come" / "you may come").
+
+So **மன்னிக்கவும்** reads as something like "**may [one] forgive**" —
+a polite, slightly formal way of asking for forgiveness, more at home in
+writing or a considered apology than tossed off in passing.
+
+## The Dravidian family, side by side — and Tamil's own path
+
+Where Kannada, Telugu, and Malayalam all reach for the Sanskrit noun **kṣamā**
+("patience, forgiveness") and turn it into a verb, **Tamil uses its own root**:
+
+- Tamil **மன்னிக்கவும்** *maṉṉi**kkavum*** — from Tamil **மன்னி** *maṉṉi*
+- Kannada **ಕ್ಷಮಿಸಿ** *kṣami**si*** — from Sanskrit **kṣamā**
+- Telugu **క్షమించండి** *kṣamin̄**caṇḍi*** — from Sanskrit **kṣamā**
+- Malayalam **ക്ഷമിക്കണം** *kṣami**kkaṇam*** — from Sanskrit **kṣamā**
+
+Where "please" showed the whole family sharing one Sanskrit-derived idea
+(*daya*), "sorry" shows the opposite: Tamil kept its own word while its
+cousins borrowed the same Sanskrit one.
+
+## Be honest about register
+
+**மன்னிக்கவும்** leans formal — the kind of "please forgive" you'd read on a
+notice or offer in a considered apology. Everyday spoken Tamil often reaches
+for something shorter and more local depending on region, or simply borrows
+the English word "sorry." (This is one for a Tamil speaker to sharpen further
+— regional colloquial Tamil varies more than a single lesson can capture.)
+
+## Sound & structure point
+
+Notice **ன்னி**: the alveolar **ன** (*ṉ* — a third "n," distinct from dental
+ந and retroflex ண) is silenced by the **புள்ளி** (*puḷḷi*, virama dot) and
+then **doubled** before the vowel — the same gemination-by-repetition device
+you saw building numbers, here holding the *ṉ* consonant twice across the
+syllable boundary.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "maṉṉi" — forgive — the Tamil root, not from Sanskrit]
+- [YOU SAY: the whole word — "maṉṉikkavum" = please forgive]
+- [YOU SAY: contrast — Kannada, Telugu, Malayalam all use kṣamā instead]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **மன்னிக்கவும்** mean, and what is it built from?
+(**"Please forgive"** — *maṉṉi* "to forgive" + *‑kkavum*, a formal request
+ending.) What's different about Tamil's forgiveness-word compared to Kannada,
+Telugu, and Malayalam? (**It's Tamil's own native root** — the other three
+borrow Sanskrit *kṣamā* instead.) Is மன்னிக்கவும் the everyday spoken word?
+(**Not necessarily** — it leans formal/written; everyday speech varies by
+region or may just borrow English "sorry.")

--- a/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
@@ -1,0 +1,71 @@
+---
+id: TA-C10-vaara-kizhamai
+chapter: 10
+type: word
+headword: திங்கள் செவ்வாய் புதன் வியாழன் வெள்ளி சனி ஞாயிறு
+gloss: the seven weekdays — a mix of Tamil's OWN planet-words and Sanskrit borrowings
+concept_tag: TA-DAYS-WEEK
+prerequisites: [TA-C09-mannikkavum]
+sounds: [tamil-alveolar-rra, pulli-virama, tamil-nya]
+roots: [dravidian-native-planet-words, sanskrit-planet-words]
+etymology_hook: "Tamil names its week with கிழமை kizhamai 'day' — a native Dravidian word, not Sanskrit vāra — and four of its seven planet-names (moon, Mars, Venus, sun) are Tamil's own, not borrowed"
+est_minutes: 6
+reviews_of: [TA-C09-mannikkavum]
+---
+
+# திங்கள் to ஞாயிறு — the week, home-grown and borrowed together
+
+## Warm-up
+
+[PAUSE 2s] You've seen Hindi's week built entirely from Sanskrit deity-names
+plus **वार** (*vār*). Tamil's week tells a richer story: it uses its **own**
+word for "day," and **some** of its planet-names are Tamil's own too — while
+others are borrowed, just like Hindi's.
+
+## The pattern: [planet] + கிழமை, "day"
+
+Every Tamil weekday ends in **கிழமை** (*kizhamai*), "**day**" — a native
+Dravidian word, not the Sanskrit **வாரம்** (*vāram*) that Hindi, Kannada, and
+Telugu build on (though Tamil also keeps a more formal, Sanskritic
+*-vāram* set alongside this everyday one):
+
+| Tamil | planet-word | meaning of the planet-word | source |
+|---|---|---|---|
+| **திங்கள்கிழமை** | *thiṅgaḷ* | "**Moon**" | Tamil's **own** word for moon |
+| **செவ்வாய்க்கிழமை** | *cevvāy* | traditionally read as "**the red one**" | likely Tamil's **own** descriptive name for Mars |
+| **புதன்கிழமை** | *pudhaṉ* | **Mercury** | borrowed from Sanskrit **Budha** |
+| **வியாழக்கிழமை** | *viyāzhaṉ* | **Jupiter** | likely from Sanskrit, via a name for **Bṛhaspati** |
+| **வெள்ளிக்கிழமை** | *veḷḷi* | traditionally read as "**silver**" | likely Tamil's **own** descriptive name for Venus |
+| **சனிக்கிழமை** | *saṉi* | **Saturn** | borrowed from Sanskrit **Śani** |
+| **ஞாயிற்றுக்கிழமை** | *ñāyiṟu* | "**Sun**" | Tamil's **own** word for sun |
+
+## Be honest about the mix
+
+Notice the pattern: **Moon, Mars, Venus, and Sun** all carry Tamil's own
+descriptive or native words, while **Mercury, Jupiter, and Saturn** carry
+Sanskrit ones. This isn't Tamil "failing" to have its own full week — it's a
+genuine **blend**, native Dravidian vocabulary standing right alongside
+Sanskrit loans, in the same list. (Note for the Tamil-speaking reviewer: this
+lesson spells Monday **திங்கள்கிழமை**, the common form — the more
+traditional sandhi-shifted spelling **திங்கட்கிழமை** may be preferred and
+should be swapped in on review if so. The *cevvāy* "red one" and *viyāzhaṉ*
+Jupiter-name derivations in particular are worth treating as the traditional,
+commonly-given account rather than settled certainty — exact planet-name
+histories this old are not always fully nailed down.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "thiṅgaḷ" — moon, Tamil's own word — then "kizhamai," day]
+- [YOU SAY: the borrowed ones — "pudhaṉ, viyāzhaṉ, saṉi" — Mercury, Jupiter,
+  Saturn from Sanskrit]
+- [YOU SAY: the native ones — "thiṅgaḷ, cevvāy, veḷḷi, ñāyiṟu" — moon, Mars,
+  Venus, sun]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does every Tamil weekday end in, and where does that word
+come from? (**கிழமை** *kizhamai*, "day" — Tamil's **own** word, not Sanskrit
+*vāra*.) Which four planet-names are Tamil's own, and which three are
+Sanskrit borrowings? (**Moon, Mars, Venus, Sun are native**; **Mercury,
+Jupiter, Saturn are Sanskrit** — *Budha, Bṛhaspati, Śani*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C11-nirangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C11-nirangal.md
@@ -1,0 +1,73 @@
+---
+id: TA-C11-nirangal
+chapter: 11
+type: word
+headword: கருப்பு வெள்ளை சிவப்பு நீலம்
+gloss: black, white, red, blue — three native Tamil colors, and one Sanskrit loan
+concept_tag: TA-COLOUR-BASIC
+prerequisites: [TA-C10-vaara-kizhamai]
+sounds: [tamil-double-lla, pulli-virama]
+roots: [dravidian-native-colors, sanskrit-nila]
+etymology_hook: "கருப்பு, வெள்ளை, சிவப்பு (black/white/red) are Tamil's OWN native words; நீலம் (blue) is a Sanskrit loan — the same 'blue arrives late' pattern Latin's caeruleus showed"
+est_minutes: 5
+reviews_of: [TA-C10-vaara-kizhamai]
+---
+
+# கருப்பு, வெள்ளை, சிவப்பு, நீலம் — three of Tamil's own, one borrowed
+
+## Warm-up
+
+[PAUSE 2s] You've already seen Tamil mix native and Sanskrit words in its
+day-names. Colors tell a **cleaner** version of the same story: three colors
+are Tamil's own, and the fourth is the one color that keeps showing up
+borrowed, in language after language.
+
+## Three native colors
+
+- **கருப்பு** (*karuppu*) = "**black**" — native Tamil/Dravidian.
+- **வெள்ளை** (*veḷḷai*) = "**white**" — native Tamil/Dravidian, and built on
+  the very same **வெள்** (*veḷ-*, "bright, silvery") root you already met in
+  **வெள்ளி** (*veḷḷi*), "Venus/silver," from the days-of-the-week lesson.
+- **சிவப்பு** (*sivappu*) = "**red**" — native Tamil/Dravidian.
+
+## One borrowed color
+
+**நீலம்** (*nīlam*) = "**blue**" — from **Sanskrit** நீல (*nīla*), "dark
+blue," the very same root behind Hindi's **नीला** (*nīlā*). This *nīla* is
+also the name of the indigo plant and its dye — part of why blue dye is so
+historically linked to India — but be careful: the English word **indigo**
+itself is a *separate*, Greek-derived word (describing where the dye was
+imported *from*, not descended from *nīla* by sound change; see the Hindi
+color lesson for that careful distinction).
+
+## Be honest about why blue is the odd one out
+
+This isn't random. You may remember from Latin's color lesson that **"blue"**
+is, across many of the world's languages, one of the **last** basic colors
+to settle into its own fixed word — often arriving late, or borrowed,
+compared to black, white, and red. Tamil's colors look like exactly this
+pattern in miniature: three old, native words, and one — blue — reaching
+outside the language for a Sanskrit loan.
+
+(Note for the Tamil-speaking reviewer: please confirm *karuppu, veḷḷai,
+sivappu, nīlam* are the forms you'd teach first — regional/colloquial Tamil
+may prefer different everyday variants, and this lesson would benefit from
+your check the way the day-names lesson did.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the three native ones — "karuppu, veḷḷai, sivappu" — black,
+  white, red]
+- [YOU SAY: the borrowed one — "nīlam" — blue, from Sanskrit]
+- [YOU SAY: the echo — "veḷḷai" and "veḷḷi" share the same veḷ- root]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which three Tamil colors are native, and which one is borrowed?
+(**Karuppu, veḷḷai, sivappu** (black/white/red) are native; **nīlam** (blue)
+is a **Sanskrit** loan.) What root does *veḷḷai* share with a word you
+already know? (**Veḷ-** "bright/silvery" — the same root as *veḷḷi*,
+"Venus/silver.") Why might blue be the one borrowed color? (**Blue is
+often one of the last basic colors** to settle into a fixed word across many
+languages — the same pattern Latin's *caeruleus* showed.)

--- a/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
@@ -1,0 +1,72 @@
+---
+id: TA-C12-kudumbam
+chapter: 12
+type: word
+headword: அப்பா அம்மா அண்ணன் தம்பி அக்கா தங்கை
+gloss: father, mother, and FOUR sibling words — Tamil splits "brother"/"sister" by age, where Spanish/French use just one word each
+concept_tag: TA-FAMILY-BASIC
+prerequisites: [TA-C11-nirangal]
+sounds: [tamil-double-nna-retroflex, pulli-virama]
+roots: [dravidian-appa-amma, dravidian-age-graded-siblings]
+etymology_hook: "அப்பா appā/அம்மா ammā (native, baby-talk-type words found worldwide) are just the start — Tamil has FOUR sibling words, split by the sibling's AGE relative to you, not just their gender"
+est_minutes: 6
+reviews_of: [TA-C11-nirangal]
+---
+
+# அப்பா, அம்மா, and four ways to say "brother/sister"
+
+## Warm-up
+
+[PAUSE 2s] You've learned Spanish's *hermano/hermana* and French's
+*frère/sœur* — one word each for "brother" and "sister." Tamil asks a
+question those languages never do: **is this sibling older or younger than
+you?**
+
+## Parents — simple and native
+
+- **அப்பா** (*appā*) = "**father**"
+- **அம்மா** (*ammā*) = "**mother**"
+
+Both are native Dravidian words, of the same simple, worldwide "baby-talk"
+shape (a repeated consonant plus a vowel) found across unrelated language
+families everywhere — not borrowed from Sanskrit, not a coincidence with any
+one language in particular, just how small children's mouths tend to form
+their first words for parents.
+
+## Siblings — split by age, not just gender
+
+Here's the real lesson: Tamil doesn't have one word for "brother" and one
+for "sister." It has **four**:
+
+| Tamil | meaning |
+|---|---|
+| **அண்ணன்** (*aṇṇaṉ*) | **older** brother |
+| **தம்பி** (*tambi*) | **younger** brother |
+| **அக்கா** (*akkā*) | **older** sister |
+| **தங்கை** (*tangai*) | **younger** sister |
+
+There is no single Tamil word that just means "brother" the way Spanish
+*hermano* does — you're expected to know, and say, **whether they're older
+or younger than you** every time you refer to a sibling. This isn't a small
+detail: it reflects how central **relative age and seniority** are in South
+Asian family structure and address — the same instinct that makes "older
+sibling" versus "younger sibling" a live, spoken distinction, not just
+something you *could* mention if you wanted to.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "appā, ammā" — father, mother]
+- [YOU SAY: the four siblings — "aṇṇaṉ, tambi" (older/younger brother),
+  "akkā, tangai" (older/younger sister)]
+- [YOU SAY: the key question — "older, or younger?" — before you can even
+  say "brother" or "sister" in Tamil]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How many Tamil words mean "brother" or "sister," and why?
+(**Four** — அண்ணன்/தம்பி for older/younger brother, அக்கா/தங்கை for
+older/younger sister — Tamil requires knowing the sibling's **age relative
+to you**.) Are அப்பா and அம்மா borrowed from Sanskrit? (**No** — native
+Dravidian baby-talk-type words, of a shape found across unrelated languages
+worldwide.)

--- a/code/learning/human-languages/tamil/lessons/TA-C13-udal-uruppugal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C13-udal-uruppugal.md
@@ -1,0 +1,44 @@
+---
+id: TA-C13-udal-uruppugal
+chapter: 13
+type: word
+headword: தலை கை
+gloss: head and hand — both native Dravidian words, unlike Hindi's Sanskrit-descended pair
+concept_tag: TA-BODY-BASIC
+prerequisites: [TA-C12-kudumbam]
+sounds: [tamil-vowel-sign-ai]
+roots: [dravidian-talai-kai]
+etymology_hook: "தலை talai (head) and கை kai (hand) are Tamil's OWN native words — unlike Hindi's sir/hāth, which both descend from Sanskrit"
+est_minutes: 4
+reviews_of: [TA-C12-kudumbam]
+---
+
+# தலை, கை — head and hand, both Tamil's own
+
+## Warm-up
+
+[PAUSE 2s] You've seen Hindi's *sir* and *hāth* trace all the way back to
+Sanskrit. Tamil's words for the same two body parts tell a simpler story:
+**both are native.**
+
+## The words
+
+- **தலை** (*talai*) = "**head**" — native Dravidian.
+- **கை** (*kai*) = "**hand**" — native Dravidian.
+
+Neither is borrowed from Sanskrit, unlike Hindi's *sir* (< Sanskrit *śiras*)
+or *hāth* (< Sanskrit *hasta*). Tamil simply kept its own words for two of
+the most basic parts of the body.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "talai" — head]
+- [YOU SAY: "kai" — hand]
+- [YOU SAY: the contrast — Hindi borrowed these from Sanskrit; Tamil didn't]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are Tamil's words for head and hand? (**தலை** *talai*,
+**கை** *kai*.) Are either of these Sanskrit loans? (**No** — both native
+Dravidian, unlike Hindi's Sanskrit-descended *sir* and *hāth*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C14-kaalangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C14-kaalangal.md
@@ -1,0 +1,72 @@
+---
+id: TA-C14-kaalangal
+chapter: 14
+type: word
+headword: வசந்த காலம் கோடைக் காலம் மழைக் காலம் குளிர் காலம்
+gloss: spring, summer, monsoon, winter — and the honest note that the REAL locally central season is the rains, not a Western four-way split
+concept_tag: TA-SEASONS
+prerequisites: [TA-C13-udal-uruppugal]
+sounds: [tamil-vowel-sign-ai, tamil-retroflex-lla]
+roots: [dravidian-kodai-mazhai-kulir, sanskrit-vasantha]
+etymology_hook: "கோடை kodai (summer heat) and குளிர் kulir (cold) are native Tamil words; வசந்தம் vasantham (spring) is a Sanskrit loan — but the season that actually shapes life in Tamil Nadu is மழைக்காலம், the RAINS, not any of the four Western ones"
+est_minutes: 6
+reviews_of: [TA-C13-udal-uruppugal]
+---
+
+# வசந்த காலம், கோடை, மழை, குளிர் — the four words, and the real season underneath
+
+## Warm-up
+
+[PAUSE 2s] Tamil has words that line up with Spanish's four seasons — but,
+just like the Hindi lesson on ऋतु, forcing them into a clean four-way split
+hides what actually matters on the ground.
+
+## The four words
+
+| Tamil | meaning | source |
+|---|---|---|
+| **வசந்த காலம்** (*vasantha kaalam*) | "spring" | *vasantham* is a **Sanskrit** loan |
+| **கோடைக் காலம்** (*kodai kaalam*) | "summer" | **கோடை** *kodai* is **native** Tamil for "heat" |
+| **மழைக் காலம்** (*mazhai kaalam*) | "rainy season" | **மழை** *mazhai*, native Tamil for "rain" |
+| **குளிர் காலம்** (*kulir kaalam*) | "winter/cold season" | **குளிர்** *kulir*, native Tamil for "cold" |
+
+Every one of these is built the same way: a word for the **feel** of the
+season (heat, rain, cold — or the borrowed *vasantham*) plus **காலம்**
+(*kaalam*), "**time/season**." Be honest about *kaalam* itself, too: it's
+ultimately from Sanskrit **काल** (*kāla*, "time") — but it was assimilated
+into Tamil so long ago and so thoroughly that it functions as completely
+ordinary vocabulary today, quite unlike a fresh, still-foreign-feeling loan
+like *vasantham*.
+
+## Be honest: the rains are the real season here
+
+Just as Hindi's traditional calendar makes the monsoon (*varṣā*) its own
+central season rather than a footnote, Tamil Nadu's actual climate is
+shaped far more by **மழைக்காலம்** (*mazhai kaalam*, "the rains") than by any
+crisp four-way Western split. There's no dramatic autumn leaf-fall in a
+tropical climate, and "spring" as a distinct, keenly-felt season is a much
+weaker idea here than in temperate Europe. The four words above are real
+and used — but the rains, not a European four-season year, are what
+actually organizes agricultural and everyday life across much of Tamil
+Nadu.
+
+(Note for the Tamil-speaking reviewer: please check whether these are the
+words and register you'd teach first, and whether there's more to say about
+how Tamil Nadu's own seasonal year is actually divided in practice.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kodai" — heat/summer, native — then "kaalam," time/season]
+- [YOU SAY: "mazhai kaalam" — the rains, the real central season]
+- [YOU SAY: "kulir kaalam" — the cold season]
+- [YOU SAY: the one loanword — "vasantha kaalam," spring, from Sanskrit]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which of the four season-words is a Sanskrit loan, and which are
+native Tamil? (**வசந்தம்** *vasantham* is Sanskrit; **கோடை, மழை, குளிர்**
+are all native.) What season actually shapes life in Tamil Nadu the most,
+and why doesn't the four-season frame capture that? (**மழைக்காலம்**, the
+**rains** — Tamil Nadu's tropical climate doesn't have a sharp four-way
+split the way temperate Europe does.)

--- a/code/learning/human-languages/tamil/lessons/TA-C15-thanneer-arisi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C15-thanneer-arisi.md
@@ -1,0 +1,70 @@
+---
+id: TA-C15-thanneer-arisi
+chapter: 15
+type: word
+headword: தண்ணீர் அரிசி சாதம்
+gloss: water, and rice — the actual staple food here, not bread — with a widely-cited (if not fully certain) link from arisi to the English word "rice" itself
+concept_tag: TA-FOOD-BASIC
+prerequisites: [TA-C14-kaalangal]
+sounds: [tamil-retroflex-nna-double, tamil-vowel-sign-ii]
+roots: [thann-cool-nir-water, arisi-rice-dravidian]
+etymology_hook: "அரிசி arisi (uncooked rice) may be the ULTIMATE source of the English word 'rice' itself, via Greek oryza — a widely cited hypothesis, though etymologists don't all agree on the exact chain"
+est_minutes: 6
+reviews_of: [TA-C14-kaalangal]
+---
+
+# தண்ணீர், அரிசி, சாதம் — water, and rice, the real staple
+
+## Warm-up
+
+[PAUSE 2s] Every language so far in this arc taught "bread" as the staple
+food. Here, that would be **dishonest** — bread isn't the everyday
+staple in Tamil food culture. **Rice** is, and it comes with one of the
+most famous (if contested) etymological journeys of any food-word.
+
+## தண்ணீர் — water, literally "cool water"
+
+**தண்ணீர்** (*taṇṇīr*) = "**water**" — built from **தண்** (*taṇ*, "**cool**")
++ **நீர்** (*nīr*, "**water**"). Everyday Tamil doesn't just say "water" —
+it says, quite literally, "**cool water**."
+
+## அரிசி and சாதம் — rice, raw and cooked
+
+Tamil, like most of South India, distinguishes the **uncooked grain** from
+the **cooked dish** with two separate words, not one:
+
+- **அரிசி** (*arisi*) = "**rice**" (the raw, husked grain) — native
+  Dravidian.
+- **சாதம்** (*sātam*) = "**cooked rice**" (the meal itself, what's actually
+  eaten) — likely Sanskrit-influenced. Tamil also keeps a native word for
+  the same idea, **சோறு** (*cōṟu*) — the two sit side by side as everyday
+  near-synonyms.
+
+## Be honest about a famous (contested) word-journey
+
+Here's the exciting part, held with appropriate care: many etymologists
+connect **அரிசி** (*arisi*) to the **English word "rice" itself** — the
+proposed chain runs Dravidian *arisi* → **Greek** *óryza* → Latin *oryza* →
+Old French *ris* → English **rice**. If true, English speakers have been
+saying a Dravidian word for centuries without knowing it. But be
+honest: standard etymological dictionaries mark Greek *óryza*'s origin as
+**genuinely uncertain** — a Dravidian source is one widely cited hypothesis
+among others (an Indo-Aryan *vrīhi*-related source is also proposed), not a
+settled, universally agreed fact.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "taṇ" — cool — then "nīr," water — then "taṇṇīr," cool water]
+- [YOU SAY: "arisi" — raw rice — then "sātam," cooked rice]
+- [YOU SAY: the famous (contested) link — "arisi" → possibly English "rice"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **தண்ணீர்** literally mean? (**"Cool water"** — *taṇ*
+"cool" + *nīr* "water.") What two words does Tamil use for rice, and why
+two? (**அரிசி** *arisi*, raw grain; **சாதம்** *sātam*, cooked rice — the
+raw grain and the cooked meal get separate words.) Is it certain that
+English "rice" comes from Tamil *arisi*? (**Not certain** — it's a widely
+cited hypothesis via Greek *óryza*, but that Greek word's origin is
+genuinely disputed among etymologists.)

--- a/code/learning/human-languages/tamil/lessons/TA-C16-thamizh-maadangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C16-thamizh-maadangal.md
@@ -1,0 +1,67 @@
+---
+id: TA-C16-thamizh-maadangal
+chapter: 16
+type: word
+headword: சித்திரை வைகாசி ஆனி ஆடி ஆவணி புரட்டாசி ஐப்பசி கார்த்திகை மார்கழி தை மாசி பங்குனி
+gloss: the twelve months of the Tamil solar calendar — Tamil's OWN calendar, distinct from both the Gregorian and Hindu lunisolar systems
+concept_tag: TA-MONTHS
+prerequisites: [TA-C15-thanneer-arisi]
+sounds: [tamil-vowel-sign-ai, tamil-retroflex-lla]
+roots: [tamil-solar-calendar-nakshatra]
+etymology_hook: "The Tamil solar calendar's twelve months are named for nakshatras (lunar-mansion star groups) the MOON sits near on the full-moon day within that month — a THIRD calendar system, alongside the Gregorian and the pan-Indian Hindu lunisolar calendar, still governing Tamil New Year and Pongal today"
+est_minutes: 6
+reviews_of: [TA-C15-thanneer-arisi]
+---
+
+# சித்திரை to பங்குனி — Tamil's own solar calendar
+
+## Warm-up
+
+[PAUSE 2s] By now you've seen Arabic and Hindi each juggle two calendars.
+Tamil adds a **third distinct system** to the mix — one still actively
+used for Tamil New Year and Pongal, not a historical curiosity.
+
+## The twelve Tamil months
+
+**சித்திரை, வைகாசி, ஆனி, ஆடி, ஆவணி, புரட்டாசி, ஐப்பசி, கார்த்திகை,
+மார்கழி, தை, மாசி, பங்குனி** (*Chithirai, Vaikāsi, Āṉi, Āḍi, Āvaṇi,
+Puraṭṭāsi, Aippasi, Kārthigai, Mārgazhi, Thai, Māsi, Panguṉi*).
+
+This is the **Tamil solar calendar** — a real, independent civil calendar,
+distinct from both the Gregorian calendar and the Hindu lunisolar (Vikram
+Samvat–style) calendar. Its months are traditionally tied to **nakshatras**
+(the 27 lunar-mansion star groups): each month is named for the nakshatra
+the **moon** sits near on the **full-moon (pournami) day** that falls
+within that month — the moon's position, not the sun's, and tied to that
+month's full moon specifically, not simply the month's start.
+
+## Be honest: this is a THIRD calendar, not a variant of the others
+
+You've now met three genuinely separate calendar traditions across this
+course: the Gregorian solar calendar (borrowed names, everyday civil use
+in most of the world), the pan-Indian Hindu lunisolar calendar (Chaitra,
+Vaishākh... tied to the six *ṛtu*), and now Tamil's **own** solar
+calendar, following neither. **சித்திரை 1** (the 1st of Chithirai) is
+**Tamil New Year**; **தை 1** (the 1st of Thai) is **Pongal**, one of
+Tamil Nadu's most important harvest festivals. These dates are fixed by
+the Tamil solar calendar, and only shift slightly against the Gregorian
+calendar (rather than drifting widely, the way lunar/lunisolar festival
+dates do) because it's solar too — just a different solar calendar,
+starting its year at a different point and naming its months differently.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "Chithirai, Vaikāsi, Āṉi, Āḍi, Āvaṇi, Puraṭṭāsi,
+  Aippasi, Kārthigai, Mārgazhi, Thai, Māsi, Panguṉi"]
+- [YOU SAY: "Chithirai 1" — Tamil New Year]
+- [YOU SAY: "Thai 1" — Pongal]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What kind of calendar is the Tamil month system — solar,
+lunar, or lunisolar? (**Solar** — a genuinely separate calendar from both
+Gregorian and Hindu lunisolar.) What are the twelve months traditionally
+named for? (**Nakshatras**, lunar-mansion star groups.) What two important
+occasions are dated by this calendar? (**Tamil New Year** (Chithirai 1) and
+**Pongal** (Thai 1).)

--- a/code/learning/human-languages/tamil/lessons/TA-C17-nanpakal-nalliravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C17-nanpakal-nalliravu.md
@@ -1,0 +1,78 @@
+---
+id: TA-C17-nanpakal-nalliravu
+chapter: 17
+type: word
+headword: நண்பகல் நள்ளிரவு
+gloss: noon and midnight — NO Sanskrit here at all (unlike Kannada/Telugu); both trace to the same old "middle" root, நள் (naḷ), but Tamil ALSO keeps fully transparent synonyms built on நடு, the everyday word for "middle"
+concept_tag: TA-TIME-NOON-MIDNIGHT
+prerequisites: [TA-C16-thamizh-maadangal]
+sounds: [tamil-retroflex-lla, tamil-vowel-sign-u]
+roots: [tamil-nal-middle-proto-dravidian, tamil-naTu-middle]
+etymology_hook: "நண்பகல் (naṇpakal, noon) and நள்ளிரவு (naḷḷiravu, midnight) both trace to நள் (naḷ, 'middle'), a documented Proto-Dravidian root that survives today mainly in literary compounds like நள்ளிருள் ('thick darkness') — but Tamil ALSO keeps fully transparent synonyms, நடுப்பகல்/நடு இரவு, built directly on நடு (naṭu), the everyday colloquial word for 'middle'"
+est_minutes: 6
+reviews_of: [TA-C16-thamizh-maadangal]
+---
+
+# நண்பகல், நள்ளிரவு — one old "middle" root, two survival stories
+
+## Warm-up
+
+[PAUSE 2s] You've just watched Kannada and Telugu each reach for Sanskrit's
+*madhya* to name noon. Tamil doesn't reach for Sanskrit at all here — it
+reaches into its own, much older layer of vocabulary instead.
+
+## நள் — an old, documented Dravidian word for "middle"
+
+Both of today's words trace back to the same root: **நள்** (*naḷ*), a
+**Proto-Dravidian** word for "**middle, centre**" — a genuine synonym of
+the everyday **நடு** (*naṭu*, "middle") you already know, just from an
+older layer of the vocabulary. நள் didn't disappear from Tamil; it survives
+today mainly in **literary/poetic** compounds — **நள்ளிருள்** (*naḷḷiruḷ*,
+"thick darkness") and **நள்ளென் கங்குல்** (*naḷḷeṉ kaṅkul*, "deep
+night") — rather than in everyday colloquial speech.
+
+## நண்பகல் and நள்ளிரவு — the same root, two different surfaces
+
+**நள்ளிரவு** (*naḷḷiravu*) = "**midnight**" = **நள்** (*naḷ*, "middle") +
+**இரவு** (*iravu*, "**night**," a word every Tamil speaker still uses on
+its own) — நள் shows up here exactly as you'd expect. **நண்பகல்**
+(*naṇpakal*) = "**noon, midday**" traces to the **same** நள் root, fused
+with **பகல்** (*pakal*, "**daytime**") — but here it surfaces as
+**நண்-** rather than நள்-, a sandhi-driven surface change before the
+following ப. Same root, two different faces, depending on what it's fused
+to.
+
+## The genuinely interesting part: Tamil ALSO kept the transparent version
+
+Here's what makes Tamil's case different from the Latin *medius diēs*
+story you saw earlier — where **different daughter languages** (Spanish,
+French, English) each inherited **one** fate for the phrase. Tamil kept
+**both fates in the very same language**, as living synonyms:
+
+- **நடுப்பகல்** (*naṭuppakal*) — dictionary-listed as a synonym of
+  *naṇpakal* — built directly on **நடு** (*naṭu*, "**middle**"), a word
+  every Tamil speaker still uses today (as in *naḍuvē*, "in the middle").
+- **நடு இரவு** (*naṭu iravu*) — the fully transparent synonym of
+  *naḷḷiravu*, again built directly on *naṭu*.
+
+So Tamil didn't have to choose between "erode it" and "keep it
+transparent" the way Latin's daughters did — it simply kept **both**,
+side by side, as everyday synonyms.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "naḷ" — an old word for "middle" — then "naḷḷiravu," midnight]
+- [YOU SAY: "naṇpakal" — noon, the same naḷ root, resurfacing as naṇ-]
+- [YOU SAY: the everyday synonyms — "naṭuppakal," "naṭu iravu," built on
+  naṭu, the "middle" word you already know]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What old Proto-Dravidian root do நண்பகல் and நள்ளிரவு both trace
+back to, and what does it mean? (**நள்** *naḷ*, "middle" — surviving mainly
+in literary compounds like *naḷḷiruḷ*, "thick darkness.") What fully
+transparent, everyday synonyms does Tamil ALSO keep for the same meanings?
+(**நடுப்பகல்** and **நடு இரவு**, built on the everyday word **நடு**,
+"middle.") Does Tamil reach for a Sanskrit word here, the way Kannada and
+Telugu do? (**No** — every piece here is native Tamil.)

--- a/code/learning/human-languages/tamil/lessons/TA-C18-mani.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C18-mani.md
@@ -1,0 +1,74 @@
+---
+id: TA-C18-mani
+chapter: 18
+type: word
+headword: மணி
+gloss: hour — Tamil's OWN dictionaries treat this as a native Dravidian "bell" word, most likely NOT Kannada/Telugu/Hindi's Sanskrit ghaṇṭā, and a probable homophone trap with an unrelated Sanskrit "gem" word spelled the same way
+concept_tag: TA-TIME-HOUR
+prerequisites: [TA-C17-nanpakal-nalliravu]
+sounds: [tamil-retroflex-nna, tamil-vowel-sign-i]
+roots: [tamil-mani-bell]
+etymology_hook: "மணி (maṇi, 'hour') — Tamil's own dictionaries (Wiktionary) split this into a native Dravidian 'bell, gong' word (→'hour', via the same bell-strikes-the-hour logic as Sanskrit's ghaṇṭā) and a wholly separate Sanskrit loan meaning 'gem' — though even the comparative Dravidian dictionary (DEDR) flags a possible Sanskrit connection for the whole family as unresolved, so treat 'native' as the best current account, not a closed case"
+est_minutes: 6
+reviews_of: [TA-C17-nanpakal-nalliravu]
+---
+
+# மணி — Tamil's native "bell," and a real homophone trap
+
+## Warm-up
+
+[PAUSE 2s] You've just watched Kannada and Telugu both borrow Sanskrit's "bell"
+word for "hour," matching Hindi exactly. Tamil goes its own way again here — with
+a genuinely tricky twist along the way.
+
+## மணி — native "bell," independently landing on "hour"
+
+**மணி** (*maṇi*) = "**hour, o'clock**" — and it also means "**bell, gong**," the
+same double duty you've now seen several times. Wiktionary's Tamil entry gives
+this *maṇi* its **own etymology**, separate from a Sanskrit-loan entry of the
+same spelling — most likely a **native Dravidian** word, not the Sanskrit
+**घण्टा** (*ghaṇṭā*) behind Kannada's *gaṇṭe*, Telugu's *ganṭa*, and Hindi's
+*ghanṭā*. On this account, Tamil underwent the **same** "a bell announces the
+hour, so the bell-word becomes the hour-word" shift on its own, from a different
+starting point — though even the comparative Dravidian dictionary (DEDR) flags a
+possible Sanskrit connection for this whole word-family as unresolved, so hold
+"native" as the best current account rather than a settled fact.
+
+## Be careful: a likely second, separate மணி means "gem"
+
+Here's the honest trap. Tamil's dictionaries ALSO list a **second, separate**
+entry spelled and pronounced exactly the same — **மணி**, borrowed from
+**Sanskrit** **मणि** (*maṇi*, "**gem, jewel, precious stone**"), the same
+Sanskrit word behind Tamil personal names like *Maṇi*. This gem-word and the
+bell/hour-word are treated as **homophones**: identical in sound and spelling,
+but listed as separate, unrelated entries — one most likely inherited Dravidian
+vocabulary, the other a clear Sanskrit loan. Only context tells them apart
+(*maṇi* the hour vs. *maṇi* a jewel in someone's name or a piece of jewelry).
+Worth noting: Malayalam, Tamil's closest cousin, handles this exact word very
+differently — its own dictionaries treat bell/hour and gem as **one single**
+Sanskrit-derived word, not two separate homophones. Even between two closely
+related languages, this hasn't settled into one agreed story.
+
+## Grammar Lens: telling the time
+
+> **ஒரு மணி.** — "One o'clock." (*oru maṇi*, "one hour/bell")
+> **இரண்டு மணி.** — "Two o'clock." (*iraṇṭu maṇi*, "two hour/bell")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "maṇi" — hour, also "bell" — native, NOT from Sanskrit ghaṇṭā]
+- [YOU SAY: "oru maṇi" — one o'clock]
+- [YOU SAY: the homophone trap — a completely separate maṇi, from Sanskrit, means
+  "gem"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is Tamil's **மணி** ("hour") from the same Sanskrit root as
+Kannada/Telugu/Hindi's hour-words? (**Most likely no** — it's treated as a native
+Dravidian "bell" word that independently reached "hour" the same way, though even
+DEDR flags this as not fully settled.) What's the homophone trap here? (A likely
+**separate**, Sanskrit-borrowed மணி means "**gem, jewel**" — identical in sound
+and spelling, listed as an unrelated entry.) Does Malayalam treat its cognate the
+same way? (**No** — Malayalam's own dictionaries treat bell/hour and gem as
+**one single** Sanskrit word, not two separate homophones.)

--- a/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
@@ -1,0 +1,72 @@
+---
+id: TA-C19-vayathu
+chapter: 19
+type: phrase
+headword: உனக்கு எத்தனை வயது ஆகிறது?
+gloss: how old are you? — literally "to you how many years is becoming?"; the SAME Sanskrit vayas word as Kannada/Telugu/Malayalam; Tamil actually spans BOTH grammatical shapes seen so far, from a plain possessive in casual speech to this more formal dative+verb construction
+concept_tag: TA-AGE
+prerequisites: [TA-C18-mani]
+sounds: [tamil-dative-ukku, tamil-verb-aakiradhu]
+roots: [sanskrit-vayas-vigor-age]
+etymology_hook: "வயது (vayathu, 'age') is the same Sanskrit वयस् (vayas, 'vigor, age,' PIE cousin of Latin vīs) as its Kannada/Telugu/Malayalam cousins — Tamil actually has BOTH shapes seen so far: a plain possessive in casual speech ('un vayasu enna?', matching Kannada/Telugu), and this more formal dative-subject + ஆகிறது (aakirathu, 'is becoming') construction, matching Malayalam's shape"
+est_minutes: 6
+reviews_of: [TA-C18-mani]
+---
+
+# உனக்கு எத்தனை வயது ஆகிறது? — Tamil actually has BOTH shapes
+
+## Warm-up
+
+[PAUSE 2s] Same Sanskrit word one more time — but be careful here: Tamil isn't
+locked into just one of the two grammatical shapes you've now seen. It has
+both, in different registers.
+
+## வயது — the same Sanskrit "vigor/age" word, a fourth time
+
+**வயது** (*vayathu*) = "**age**" — the same Sanskrit **वयस्** (*vayas*, "age,
+vigor," PIE cousin of Latin **vīs**) you've now met four times across Kannada,
+Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact
+Sanskrit word for "age" — none of them built a native alternative for this
+particular concept, unlike some others you've seen in this course.
+
+## Grammar Lens: casual possessive AND formal dative + "become"
+
+Be honest here: Tamil doesn't pick just one shape. **Casual, spoken** Tamil
+uses the exact same **plain possessive** shape as Kannada and Telugu:
+
+> **உன் வயசு என்ன?** — "How old are you?" (casual) — literally "**your age
+  what**?" (*un vayasu enna?*) — no dative, no verb, just like Kannada's
+  *ninna vayassu eṣṭu?*
+
+**Formal, written** Tamil instead uses a **dative-subject + verb** shape,
+matching Malayalam's:
+
+> **உனக்கு எத்தனை வயது ஆகிறது?** — "How old are you?" (formal) — literally
+  "**to you how many years is becoming**?" (*unakku ettanai vayathu
+  aakirathu?* — from *unakku*, "to you" [dative] + *ettanai vayathu*, "how
+  many years" + *aakirathu*, "is becoming," from *aaha*, "to become.")
+> **எனக்கு இருபது வயது ஆகிறது.** — "I am twenty years old." — literally "**to
+  me twenty years is becoming**." (*enakku irupathu vayathu aakirathu.*)
+
+Where Malayalam reaches for **ഉണ്ട്** (*uṇṭŭ*, "exists") in this formal shape,
+Tamil reaches for its own verb, **ஆகிறது** (*aakirathu*, "is becoming, is
+happening," from **ஆகு** *aaku*, "to become"). So don't treat this as "Tamil's
+one grammar" — it's the more **formal** register, existing alongside a
+perfectly ordinary casual register that looks just like Kannada's and Telugu's.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vayathu" — age]
+- [YOU SAY: "un vayasu enna?" — how old are you? (casual, like Kannada/Telugu)]
+- [YOU SAY: "unakku ettanai vayathu aakirathu?" — how old are you? (formal,
+  like Malayalam)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is Tamil's **வயது** the same Sanskrit word borrowed by all four
+Dravidian languages here? (**Yes** — none built a native alternative for this
+concept.) Does Tamil use only ONE grammatical shape for asking age? (**No** —
+casual Tamil uses Kannada/Telugu's **plain possessive** shape; formal Tamil
+uses Malayalam's **dative + verb** shape.) What verb does formal Tamil use
+instead of Malayalam's "exists"? (**ஆகிறது**, *aakirathu*, "is becoming.")

--- a/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
@@ -1,0 +1,68 @@
+---
+id: TA-C20-pathinondru-irupathu
+chapter: 20
+type: word
+headword: பதினொன்று — இருபது
+gloss: 11-20 — additive "ten-echo" compounds for the teens, then இருபது (20), transparently "two-tens" — closing out the arc: all four Dravidian languages build twenty compositionally, unlike Sanskrit, Latin, or Arabic's opaque special words
+concept_tag: TA-NUM-11-20
+prerequisites: [TA-C19-vayathu]
+sounds: [tamil-vowel-sign-o, tamil-rra-letter]
+roots: [dravidian-pathu-ten, dravidian-iru-two]
+etymology_hook: "பதினொன்று-பத்தொன்பது (11-19) echo பத்து (pathu, 'ten') + a digit — இருபது (irupathu, 'twenty') is transparently 'two-tens', இரு (iru, an older word for 'two') + பத்து (pathu, 'ten'), matching Malayalam's own irupathu almost exactly — closing the arc: all four Dravidian languages build twenty compositionally, where Sanskrit/Latin/Arabic each have their own opaque, non-compositional special word"
+est_minutes: 6
+reviews_of: [TA-C19-vayathu]
+---
+
+# பதினொன்று, இருபது — Dravidian's shared, transparent twenty
+
+## Warm-up
+
+[PAUSE 2s] Here's how this arc closes: four completely different
+approaches to "twenty" across Sanskrit, Latin, Arabic — and then all four
+Dravidian languages quietly agreeing on the exact same compositional idea.
+
+## பதினொன்று–பத்தொன்பது — "ten" + digit
+
+Tamil's teens echo **பத்து** (*pathu*, "**ten**") plus each digit —
+**பதினொன்று** (*patiṉoṉḏṟu*, 11), **பன்னிரண்டு** (*paṉṉiraṇḍu*, 12), and
+onward through **பத்தொன்பது** (*pattoṉbatu*, 19) — the same digit-plus-
+ten-echo compounding you've now seen across Kannada, Telugu, and Malayalam.
+
+## இருபது — transparently "two-tens"
+
+**இருபது** (*irupathu*, "**twenty**") = **இரு** (*iru*, an older word for
+"**two**," alongside the everyday **இரண்டு** *iraṇḍu*) + **பத்து** (*pathu*,
+"**ten**") — fully transparent as "**two-tens**," matching **Malayalam's**
+own *irupathu* almost letter-for-letter.
+
+## Be honest: one shared Dravidian idea, four different other-family answers
+
+This closes the numbers arc with a genuinely clean pattern. Every Dravidian
+language in this course builds "twenty" the **same** compositional way —
+some (Tamil, Malayalam) keeping it fully transparent on the surface today,
+some (Kannada) with the same compositional origin but no longer visibly
+matching the modern standalone words for "two" and "ten," some (Telugu) worn
+down further but most likely from the same root. Compare that to the other
+three families you've met:
+Sanskrit's **विंशति** (*vimshati*), Latin's **vīgintī**, and Arabic's
+**عشرون** (*ʿishrūn*) are each their **own** special, non-compositional word
+for twenty — none built transparently from "two" and "ten" the way every
+single Dravidian language in this course does.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "patiṉoṉḏṟu, paṉṉiraṇḍu" — 11, 12]
+- [YOU SAY: "iru" — an older word for two, "pathu" — ten]
+- [YOU SAY: "irupathu" — twenty, "two-tens," transparent]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two pieces build **இருபது** (twenty)? (**இரு** "two" +
+**பத்து** "ten" — "**two-tens**.") Do all four Dravidian languages in this
+course build "twenty" the same compositional way? (**Yes** — Tamil and
+Malayalam keep it fully transparent today; Kannada shares the same
+compositional origin but its modern "two"/"ten" words no longer visibly
+match; Telugu's is worn down further but most likely the same root.) Do
+Sanskrit, Latin, or Arabic build their word for twenty this way? (**No** —
+each has its own special, non-compositional standalone word instead.)

--- a/code/learning/human-languages/tamil/lessons/TA-C20-vaanilai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-vaanilai.md
@@ -1,0 +1,64 @@
+---
+id: TA-C20-vaanilai
+chapter: 20
+type: word
+headword: வானிலை
+gloss: weather — most likely a NATIVE Dravidian compound, unlike Kannada/Telugu/Malayalam's Sanskrit compounds: vaanam ("sky") + nilai ("state, standing")
+concept_tag: TA-WEATHER
+prerequisites: [TA-C18-mani]
+sounds: [tamil-vowel-sign-ai, tamil-compound-word]
+roots: [dravidian-vaanam-sky, dravidian-nilai-state]
+etymology_hook: "வானிலை (vāṉilai, 'weather') most likely breaks from Kannada/Telugu/Malayalam's Sanskrit compounds entirely — வானம் (vāṉam, 'sky,' likely native Dravidian, with confirmed cognates in Kannada ಬಾನು/bānu and Telugu వాన/vāna, distinct from the Sanskrit sky word ākāśa) + நிலை (nilai, 'state, standing,' from நில் nil, 'to stand,' a core native Dravidian verb) — literally 'the state/standing of the sky'"
+est_minutes: 6
+reviews_of: [TA-C18-mani]
+---
+
+# வானிலை — "the standing of the sky," most likely all native
+
+## Warm-up
+
+[PAUSE 2s] You've now seen a Persian+Sanskrit hybrid (Kannada), a pure
+Sanskrit compound (Telugu), and a Sanskrit compound echoing "time" (Malayalam).
+Tamil most likely breaks the pattern one more time — with a word built
+entirely from native pieces.
+
+## வானிலை — vaanam + nilai
+
+**வானிலை** (*vāṉilai*) = "**weather**" — built from:
+
+- **வானம்** (*vāṉam*, "**sky**") — most likely a **native Dravidian** word,
+  with confirmed cognates in **Kannada** **ಬಾನು** (*bānu*, "sky") and
+  **Telugu** **వాన** (*vāna*, "rain," from the same sky/rain-cloud root) —
+  distinct from the Sanskrit sky word *ākāśa* that those same two languages
+  use elsewhere.
+- **நிலை** (*nilai*, "**state, standing, condition**") — from **நில்** (*nil*,
+  "**to stand**"), one of Tamil's most basic native verb roots.
+
+So *vāṉilai* literally means "**the standing of the sky**" or "**the sky's
+state**" — and unlike its three Dravidian cousins, neither piece here is a
+Sanskrit or Persian/Arabic loan. (Treat "native" as the best current account
+rather than a fully settled fact, the same hedge you've seen elsewhere in this
+course — but both pieces are independently well-attested as old, native
+Dravidian vocabulary.)
+
+## மழை பெய்கிறது — "rain is falling"
+
+> **மழை பெய்கிறது.** — "It's raining." — literally "**rain is falling**."
+  (*mazhai peykiRathu* — from **பெய்** *pey*, "to fall/pour," specifically used
+  for rain.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vāṉilai" — weather, "the standing of the sky"]
+- [YOU SAY: "vāṉam" — sky, "nilai" — state, from "nil," to stand]
+- [YOU SAY: "mazhai peykiRathu" — it's raining, "rain is falling"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the two pieces of **வானிலை**, and what does the whole word
+literally mean? (**வானம்**, "sky," + **நிலை**, "state/standing" — "**the
+standing of the sky**.") Is either piece a Sanskrit or Persian/Arabic loan,
+unlike Kannada, Telugu, or Malayalam's weather words? (**Most likely not** —
+both pieces are native Dravidian.) What Tamil word does Malayalam's *mazha*
+match for "rain"? (**மழை**, *mazhai*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C21-naay-poonai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C21-naay-poonai.md
@@ -1,0 +1,67 @@
+---
+id: TA-C21-naay-poonai
+chapter: 21
+type: word
+headword: நாய், பூனை
+gloss: dog and cat — நாய் is THE solid, ancient, undisputed Dravidian root behind Kannada/Malayalam's dog-words too, the honest opposite of every mystery dog-word in this arc; பூனை is Tamil's everyday cat-word, one of (at least) three genuinely separate Dravidian cat-word families
+concept_tag: TA-ANIMALS
+prerequisites: [TA-C20-pathinondru-irupathu]
+sounds: [tamil-vowel-sign-ai, tamil-final-y]
+roots: [dravidian-naay-dog, dravidian-punai-cat]
+etymology_hook: "நாய் (nāy, 'dog') is a solid, undisputed native Proto-Dravidian root — the SAME root behind Kannada's naayi and Malayalam's naaya — closing this whole arc's dog-word theme on solid ground, the honest opposite of Spanish's perro, English's dog, and Hindi's kuttā, all genuine unsolved mysteries; பூனை (pūnai, 'cat') is Tamil's everyday word, matching Malayalam closely but genuinely different from Kannada's bekku and Telugu's pilli — Tamil itself even keeps rarer alternate cat-words (பில்லி, வெருகு) echoing those other roots"
+est_minutes: 6
+reviews_of: [TA-C20-pathinondru-irupathu]
+---
+
+# நாய், பூனை — solid ground to close the arc, and an honest three-way split
+
+## Warm-up
+
+[PAUSE 2s] This whole ANIMALS arc kept finding mystery dog-words — Spanish's
+*perro*, English's *dog*, Hindi's *kuttā*, each one an unsolved puzzle
+displacing an older, expected word. Tamil's dog-word closes the arc on the
+complete opposite footing: total, undisputed solid ground.
+
+## நாய் — no mystery, anywhere
+
+**நாய்** (*nāy*, "**dog**") is a solid, native **Proto-Dravidian** root —
+the exact same one behind Kannada's **ನಾಯಿ** (*nāyi*) and Malayalam's
+**നായ** (*nāya*). There is no debate about its origin, no substrate mystery,
+nothing like the *perro*/*dog*/*kuttā* pattern that ran through Spanish,
+English, and Hindi. Three unrelated language families each lost their
+expected word for "dog" to an unexplained newcomer — and right here, in the
+Dravidian family, the expected word simply **survived**, plainly and
+solidly, across (at least) three of its languages.
+
+## பூனை — Tamil's word, and an honest three-way Dravidian split
+
+**பூனை** (*pūnai*, "**cat**") is Tamil's own everyday word, matching
+Malayalam's **പൂച്ച** (*pūcha*) closely — but be honest that "cat"
+splits Dravidian in a way "dog" doesn't. Kannada's everyday word,
+**ಬೆಕ್ಕು** (*bekku*), comes from a **different** ancient root (related to
+the word for "wildcat"); Telugu's, **పిల్లి** (*pilli*), comes from yet
+**another** separate Proto-Dravidian root, most likely the very source
+behind Sanskrit's *biḍāla* and Hindi's *billī*. Tamil itself even keeps
+**rarer, alternate** cat-words — **பில்லி** and **வெருகு** — cognate with
+Telugu's and Kannada's everyday choices respectively, showing that all
+three roots were once available across the family; each language just
+settled on a different one as its everyday word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāy" — dog, solid native Dravidian, no mystery anywhere]
+- [YOU SAY: "pūnai" — cat, Tamil's everyday word, matching Malayalam]
+- [YOU SAY: the honest split — Kannada's bekku and Telugu's pilli come from
+  two other, separate ancient roots]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **நாய்** a mystery word, like Spanish's *perro*, English's
+*dog*, or Hindi's *kuttā*? (**No** — a solid, undisputed native Dravidian
+root, shared with Kannada and Malayalam.) Does **பூனை** share a root with
+Kannada's *bekku* or Telugu's *pilli*? (**No** — all three are genuinely
+separate ancient Dravidian roots; Tamil even keeps rarer alternate
+cat-words, *pilli* and *veruku*, echoing both of them.) Which Dravidian
+cat-word is most likely the source of Sanskrit's *biḍāla* and Hindi's
+*billī*? (**Telugu's pilli**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C22-paccai-manjal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C22-paccai-manjal.md
@@ -1,0 +1,72 @@
+---
+id: TA-C22-paccai-manjal
+chapter: 22
+type: word
+headword: பச்சை, மஞ்சள்
+gloss: green and yellow — paccai is the pan-Dravidian *pac- word already met in Kannada, Telugu, and Malayalam; manjal ("yellow, turmeric") is a separate native Dravidian root, matching Malayalam's mañña/maññaḷ closely — and Tamil dictionaries also record a rarer, less-commonly-used pacuppu ("greenish yellow"), a genuine doublet of paccai itself, echoing Telugu's pattern in miniature
+concept_tag: TA-COLOUR-GREEN-YELLOW
+prerequisites: [TA-C11-nirangal, TA-C21-naay-poonai]
+sounds: [tamil-double-lla, pulli-virama]
+roots: [proto-dravidian-pac-green, dravidian-mancal-turmeric]
+etymology_hook: "பச்சை (paccai, 'green') ← Proto-Dravidian *pac-, the same root as Kannada's hasiru, Telugu's pacca, and Malayalam's paccha; மஞ்சள் (mañcaḷ, 'yellow, turmeric') is a SEPARATE native Dravidian root, matching Malayalam's മഞ്ഞ/മഞ്ഞൾ (mañña/maññaḷ) closely — modern comparative Dravidian linguistics treats it as inherited (cognates in Kannada, Kodava, Tulu), though one older Tamil dictionary source floats a Sanskrit derivation via मञ्जिष्ठा (mañjiṣṭha, a red-dye plant name) that the semantic mismatch makes unlikely; the Tamil Lexicon additionally records பசுப்பு (pacuppu, 'greenish yellow'), a genuine doublet of paccai from the *pac- root — a rarer word, but one that means Tamil quietly holds BOTH of this arc's Dravidian patterns (Telugu's one-root-doublet AND Malayalam's two-separate-roots) inside itself"
+est_minutes: 6
+reviews_of: [TA-C21-naay-poonai]
+---
+
+# பச்சை, மஞ்சள் — closing the Dravidian arc, holding both patterns at once
+
+## Warm-up
+
+[PAUSE 2s] You've now seen three different Dravidian answers to "how do
+green and yellow relate": Kannada split them apart, Telugu fused them into
+one root, Malayalam kept them as two separate native words. Tamil, it turns
+out, quietly contains a trace of **both** of the last two patterns.
+
+## பச்சை — the familiar pan-Dravidian green
+
+**பச்சை** (**paccai**, "**green**") ← **Proto-Dravidian** ***\*pac-*** — the
+same root you've now met four times: Kannada's *hasiru*, Telugu's *pacca*,
+Malayalam's *paccha*, and now Tamil's own *paccai*.
+
+## மஞ்சள் — Tamil's real, everyday yellow, a separate native root
+
+**மஞ்சள்** (**mañcaḷ**, "**yellow, turmeric**") is Tamil's actual, everyday
+word for yellow — and it comes from a **completely separate** native
+Dravidian root, matching Malayalam's **മഞ്ഞ/മഞ്ഞൾ** (*mañña*/*maññaḷ*)
+closely. Like Malayalam's pair, this root has no Sanskrit involvement — it
+sits alongside *paccai*, not descended from it.
+
+## பசுப்பு — a rarer doublet, echoing Telugu in miniature
+
+The **Tamil Lexicon** also records **பசுப்பு** (**pacuppu**, "**greenish
+yellow**") — a genuine **doublet** of *paccai* itself, from the same
+***\*pac-*** root, matching Telugu's *pasupu* closely. Unlike Telugu, though,
+this doublet is **not** Tamil's everyday word for yellow — that job belongs
+to *mañcaḷ*; *pacuppu* survives mainly as a dictionary-recorded shade word.
+So Tamil, uniquely in this arc, holds a trace of **both** patterns at once:
+a *pac-* doublet sitting quietly in the dictionary (Telugu's pattern), next
+to a separate, dominant root doing the everyday work (Malayalam's pattern).
+
+(Note for the Tamil-speaking reviewer: *pacuppu*'s everyday currency is the
+part I'm least certain of — please confirm whether it's a word you'd
+recognize as "greenish yellow," or whether it reads as archaic/purely
+literary in the Tamil you'd teach first.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "பச்சை" — green, the pan-Dravidian *pac- word]
+- [YOU SAY: "மஞ்சள்" — yellow, Tamil's real everyday word, a separate root]
+- [YOU SAY: "பசுப்பு" — a rarer doublet of paccai, echoing Telugu's pattern]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is Tamil's everyday word for yellow, and is it related to
+**paccai**? (**மஞ்சள்**, *mañcaḷ* — **no**, a completely separate native
+root, matching Malayalam's *mañña/maññaḷ*.) What rarer Tamil word IS a
+doublet of *paccai*, from the same *pac-* root? (**பசுப்பு**, *pacuppu*,
+"greenish yellow" — echoing Telugu's *pacca/pasupu* pattern.) Does any one
+pattern hold across all the Dravidian languages in this arc? (**No** —
+Kannada splits native/loan, Telugu fuses one root, Malayalam keeps two
+separate roots, and Tamil turns out to hold traces of both Telugu's and
+Malayalam's patterns at once.)

--- a/code/learning/human-languages/telugu/lessons/TE-C09-kshaminchandi.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C09-kshaminchandi.md
@@ -1,0 +1,68 @@
+---
+id: TE-C09-kshaminchandi
+chapter: 9
+type: word
+headword: క్షమించండి
+gloss: please forgive / sorry (kṣamin̄caṇḍi — from kṣamin̄cu "to forgive," Sanskrit kṣamā + respectful -aṇḍi)
+concept_tag: COURTESY-SORRY
+prerequisites: [TE-C08-dayachesi]
+sounds: [telugu-conjunct-kssa, telugu-anusvara]
+roots: [kshama-sanskrit]
+etymology_hook: "క్షమించండి kṣamin̄caṇḍi ← Sanskrit kṣamā 'forgiveness' + Telugu verb-making -in̄cu + the SAME respectful -aṇḍi ending from దయచేసి...ండి"
+est_minutes: 5
+reviews_of: [TE-C08-dayachesi]
+---
+
+# క్షమించండి (kṣamin̄caṇḍi) — please forgive / sorry
+
+## Warm-up
+
+[PAUSE 2s] You already know **దయచేసి** and its respectful **‑ండి** ending
+(*kūrcōṇḍi*, "please sit"). Telugu's "sorry" hands you that very ending
+again, riding a brand-new verb.
+
+## The word, taken apart
+
+- **క్షమా** (*kṣamā*) = "**forgiveness, patience**" — the Sanskrit noun,
+  borrowed whole.
+- **‑ఇంచు** (*‑in̄cu*) = a **verb-making suffix**: *kṣamā* + *‑in̄cu* →
+  **క్షమించు** (*kṣamin̄cu*), "**to forgive**." (The same pattern gives
+  ప్రారంభించు *prārambhin̄cu*, "to begin," from Sanskrit *prārambha*.)
+- **‑ండి** (*‑aṇḍi*) = the **respectful imperative** ending — exactly the one
+  you already met on *kūrcōṇḍi* "please sit" and *ceppaṇḍi* "please tell me."
+
+So **క్షమించండి** is "**please forgive**" — the same polite mold you already
+know, filled with a new verb.
+
+## The Dravidian family, side by side
+
+- Telugu **క్షమించండి** *kṣamin̄**caṇḍi*** — Sanskrit *kṣamā* + **‑in̄cu**
+  (verb) + **‑aṇḍi** (imperative)
+- Kannada **ಕ್ಷಮಿಸಿ** *kṣami**si*** — Sanskrit *kṣamā* + **‑isu** (verb) +
+  **‑i** (imperative)
+- Malayalam **ക്ഷമിക്കണം** *kṣami**kkaṇaṁ*** — Sanskrit *kṣama* + **‑ikkuka**
+  (verb) + **‑aṇaṁ** (necessitative)
+- Tamil **மன்னிக்கவும்** *maṉṉi**kkavum*** — its **own** native root *maṉṉi*,
+  not Sanskrit at all
+
+## Be honest about how it's used
+
+**క్షమించండి** is a real, everyday "sorry / please forgive me" — not
+stiffly formal — though in quick, casual exchanges Telugu speakers just as
+often reach for the borrowed English **"sorry."**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kṣamā" — the Sanskrit noun, forgiveness]
+- [YOU SAY: the verb — "kṣamin̄cu," to forgive — then "kṣamin̄caṇḍi," please
+  forgive]
+- [YOU SAY: the ending you already know — "‑aṇḍi," same as kūrcōṇḍi]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is **క్షమించండి** built from? (**Sanskrit kṣamā** +
+the verb-making suffix **‑in̄cu** + the respectful ending **‑aṇḍi**, which you
+already met on *kūrcōṇḍi*.) Which cousins also verb-ify *kṣamā*, and which
+doesn't? (**Kannada and Malayalam** do too; **Tamil** uses its own root
+*maṉṉi*.) What's the casual alternative? (**Borrowed English "sorry."**)

--- a/code/learning/human-languages/telugu/lessons/TE-C10-vaaram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C10-vaaram.md
@@ -1,0 +1,58 @@
+---
+id: TE-C10-vaaram
+chapter: 10
+type: word
+headword: సోమవారం మంగళవారం బుధవారం గురువారం శుక్రవారం శనివారం ఆదివారం
+gloss: the seven weekdays — Sanskritic like Hindi, but Sunday means "the FIRST day," not "Sun's day"
+concept_tag: TE-DAYS-WEEK
+prerequisites: [TE-C09-kshaminchandi]
+sounds: [telugu-anusvara, telugu-conjunct-kra]
+roots: [sanskrit-planet-words]
+etymology_hook: "Telugu's week is Sanskritic like Hindi's, but Sunday is Ādivāram — 'the FIRST day' (Sanskrit ādi 'beginning'), not a sun-name at all"
+est_minutes: 5
+reviews_of: [TE-C09-kshaminchandi]
+---
+
+# సోమవారం to ఆదివారం — Telugu's week, with a twist on Sunday
+
+## Warm-up
+
+[PAUSE 2s] Like Kannada, Telugu's week runs on Sanskrit deity-names — but its
+Sunday breaks the "planet" pattern entirely, in a way even Kannada's doesn't.
+
+## The pattern: [deity] + వారం, "day"
+
+| Telugu | deity/planet | day |
+|---|---|---|
+| **సోమవారం** (*Somavāram*) | **Moon** (Soma) | Monday |
+| **మంగళవారం** (*Maṅgaḷavāram*) | **Mars** (Maṅgala) | Tuesday |
+| **బుధవారం** (*Budhavāram*) | **Mercury** (Budha) | Wednesday |
+| **గురువారం** (*Guruvāram*) | **Jupiter** (Guru/Bṛhaspati) | Thursday |
+| **శుక్రవారం** (*Śukravāram*) | **Venus** (Śukra) | Friday |
+| **శనివారం** (*Śanivāram*) | **Saturn** (Śani) | Saturday |
+| **ఆదివారం** (*Ādivāram*) | — not a planet at all | Sunday |
+
+## Be honest: Sunday isn't a planet-name here
+
+Five days match the familiar planet-deity pattern — but **ఆదివారం**
+(*Ādivāram*) doesn't name the Sun at all. **ఆది** (*ādi*) is Sanskrit for
+"**the beginning, the first**." So Telugu's Sunday literally means
+"**the first day**" — a **positional** name, like Arabic's numbered weekdays,
+sitting right next to six planet-names that don't work that way. Even within
+one single week, a language can mix completely different naming strategies.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Somavāram, Maṅgaḷavāram, Budhavāram, Guruvāram, Śukravāram,
+  Śanivāram" — Monday through Saturday]
+- [YOU SAY: the odd one — "Ādivāram" — not a planet, "the first day"]
+- [YOU SAY: the parallel — like Arabic's numbered days, one Telugu day is
+  positional too]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ఆదివారం** literally mean, and is it a planet-name?
+(**"The first day"** — **ādi** "beginning" — **not** a planet-name, unlike
+the other six.) What ending do the other six Telugu weekdays share? (**‑వారం**
+*-vāram*, Sanskrit "day," each paired with a planet-deity.)

--- a/code/learning/human-languages/telugu/lessons/TE-C11-rangulu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C11-rangulu.md
@@ -1,0 +1,51 @@
+---
+id: TE-C11-rangulu
+chapter: 11
+type: word
+headword: నలుపు తెలుపు ఎరుపు నీలం
+gloss: black, white, red, blue — Telugu's own basic colors, completing the whole family's shared blue
+concept_tag: TE-COLOUR-BASIC
+prerequisites: [TE-C10-vaaram]
+sounds: [telugu-anusvara, telugu-short-vowels]
+roots: [dravidian-native-colors, sanskrit-nila]
+etymology_hook: "నలుపు/తెలుపు/ఎరుపు (black/white/red) are native Dravidian, matching a pattern across all four languages — నీలం (blue) closes the set as the one shared Sanskrit loan, everywhere"
+est_minutes: 5
+reviews_of: [TE-C10-vaaram]
+---
+
+# నలుపు, తెలుపు, ఎరుపు, నీలం — the pattern completes itself
+
+## Warm-up
+
+[PAUSE 2s] By now the shape should feel familiar: native colors for black,
+white, and red — and one shared Sanskrit word for blue. Telugu confirms it a
+fourth time.
+
+## Three native colors
+
+- **నలుపు** (*nalupu*) = "**black**" — native Dravidian.
+- **తెలుపు** (*telupu*) = "**white**" — native Dravidian.
+- **ఎరుపు** (*erupu*) = "**red**" — native Dravidian.
+
+## The same shared blue, one more time
+
+**నీలం** (*nīlam*) = "**blue**" — the identical Sanskrit **నీల** (*nīla*)
+loan you've now seen in Tamil (*nīlam*), Malayalam (*nīla*), Kannada
+(*nīli*), and Hindi (*nīlā*). Four Dravidian languages plus Hindi, all
+independently keeping their own native black/white/red, and all reaching for
+the **exact same** borrowed word the moment it comes to blue.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nalupu, telupu, erupu" — black, white, red]
+- [YOU SAY: "nīlam" — blue, the word every language in this course now
+  shares]
+- [YOU SAY: the whole pattern, one more time — native, native, native,
+  **borrowed**]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What's the pattern across Tamil, Malayalam, Kannada, and Telugu's
+basic colors? (**Black, white, and red are native Dravidian words in every
+one of them; blue is a shared Sanskrit loan (nīla) in every one of them.**)

--- a/code/learning/human-languages/telugu/lessons/TE-C12-kutumbam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C12-kutumbam.md
@@ -1,0 +1,58 @@
+---
+id: TE-C12-kutumbam
+chapter: 12
+type: word
+headword: నాన్న అమ్మ అన్న తమ్ముడు అక్క చెల్లి
+gloss: father, mother, and four age-graded sibling words — Telugu's own father-word and "younger sister" word, but the same age-first system
+concept_tag: TE-FAMILY-BASIC
+prerequisites: [TE-C11-rangulu]
+sounds: [telugu-retroflex-dda, telugu-geminate-nna]
+roots: [dravidian-appa-amma, dravidian-age-graded-siblings]
+etymology_hook: "నాన్న naanna (father) and చెల్లి chelli (younger sister) are Telugu's OWN forms, unlike Tamil/Kannada's appa/tangi — but the age-before-gender sibling system is the same across the family"
+est_minutes: 5
+reviews_of: [TE-C11-rangulu]
+---
+
+# నాన్న, అమ్మ, and four sibling words — Telugu's own twist
+
+## Warm-up
+
+[PAUSE 2s] Telugu shares the Dravidian family's age-first sibling system —
+but its words for "father" and "younger sister" go their own way.
+
+## Parents — one matches, one is Telugu's own
+
+- **నాన్న** (*nānna*) = "**father**" — **Telugu's own word**, unlike Tamil/
+  Kannada's *appā/appa*.
+- **అమ్మ** (*amma*) = "**mother**" — matches Tamil/Kannada's *ammā/amma*
+  closely.
+
+## Four sibling words, mostly shared — with one exception
+
+| Telugu | meaning | compare Tamil/Kannada |
+|---|---|---|
+| **అన్న** (*anna*) | **older** brother | *aṇṇaṉ/aṇṇa* — near match |
+| **తమ్ముడు** (*tammuḍu*) | **younger** brother | *tambi/tamma* — near match |
+| **అక్క** (*akka*) | **older** sister | *akkā/akka* — near match |
+| **చెల్లి** (*celli*) | **younger** sister | *tangai/tangi* — **Telugu's own word here** |
+
+So the *system* — four words, split by relative age rather than just
+gender — is shared across Tamil, Kannada, and Telugu. But the exact words
+aren't identical everywhere: Telugu keeps its own **నాన్న** for father and
+**చెల్లి** for "younger sister," even while three of the six words line up
+closely with its cousins.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nānna, amma" — father, mother]
+- [YOU SAY: "anna, tammuḍu" — older/younger brother]
+- [YOU SAY: "akka, celli" — older/younger sister — celli is Telugu's own]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which two Telugu family words are its own, rather than matching
+Tamil/Kannada? (**నాన్న** *nānna*, "father," and **చెల్లి** *celli*,
+"younger sister.") Does Telugu still split siblings by age the same way?
+(**Yes** — the four-way age-before-gender system is shared across the whole
+Dravidian family, even where the exact words differ.)

--- a/code/learning/human-languages/telugu/lessons/TE-C13-sharira-bhagalu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C13-sharira-bhagalu.md
@@ -1,0 +1,52 @@
+---
+id: TE-C13-sharira-bhagalu
+chapter: 13
+type: word
+headword: తల చెయ్యి
+gloss: head (matching its cousins) and hand (the SAME Dravidian root as the others, transformed almost past recognition)
+concept_tag: TE-BODY-BASIC
+prerequisites: [TE-C12-kutumbam]
+sounds: [telugu-geminate-yya]
+roots: [dravidian-tala-kay]
+etymology_hook: "చెయ్యి ceyyi (hand) LOOKS unrelated to Tamil/Kannada/Malayalam's kai — but it's the same Proto-Dravidian root *kay-, reshaped by Telugu's own regular k-to-c sound change"
+est_minutes: 4
+reviews_of: [TE-C12-kutumbam]
+---
+
+# తల, చెయ్యి — head shared outright, hand shared in disguise
+
+## Warm-up
+
+[PAUSE 2s] Head matches its cousins plainly. Hand looks, at first glance,
+like Telugu went its own way — but look closer, and it's the same word
+after all, just heavily reshaped.
+
+## The words
+
+- **తల** (*tala*) = "**head**" — native Dravidian, matching Tamil *talai*,
+  Malayalam *thala*, and Kannada *tale* closely and plainly.
+- **చెయ్యి** (*ceyyi*) = "**hand**" — also native Dravidian, and **the very
+  same root** as Tamil/Malayalam/Kannada's *kai*: Proto-Dravidian ***kay-***.
+  Telugu's own regular sound change turned that ancient **k-** into **c-**,
+  and reshaped the rest of the word alongside it — so *ceyyi* only *looks*
+  unrelated to *kai*. It's a cognate in disguise, not a different word.
+
+So all four Dravidian languages actually **agree** on both "head" and
+"hand" at the root level — Telugu's hand-word has simply drifted further
+in sound than its cousins have, thanks to a sound change that reshaped many
+Telugu words the same way.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tala" — head, matching its cousins plainly]
+- [YOU SAY: "ceyyi" — hand, the SAME root as kai, reshaped by sound change]
+- [YOU SAY: the lesson — looks different, is actually the same word]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does Telugu's word for "head" match its cousins? (**Yes** —
+*tala*, like Tamil/Malayalam/Kannada.) Is its word for "hand," *ceyyi*, truly
+a different word from *kai*? (**No** — it's the **same Proto-Dravidian root**
+*kay-*, reshaped by Telugu's own regular k→c sound change — a cognate in
+disguise, not an unrelated word.)

--- a/code/learning/human-languages/telugu/lessons/TE-C14-rutuvulu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C14-rutuvulu.md
@@ -1,0 +1,57 @@
+---
+id: TE-C14-rutuvulu
+chapter: 14
+type: word
+headword: వసంత ఋతువు వేసవి వానాకాలం శీతాకాలం
+gloss: spring, summer, monsoon, winter — completing the Dravidian pattern of native heat/rain words plus Sanskrit spring
+concept_tag: TE-SEASONS
+prerequisites: [TE-C13-sharira-bhagalu]
+sounds: [telugu-vocalic-r, telugu-anusvara]
+roots: [dravidian-vesavi-vaana, sanskrit-vasanta-rutu]
+etymology_hook: "వేసవి vesavi (summer) is native Dravidian, cousin of Kannada's besige — వసంత ఋతువు vasanta rutuvu (spring) borrows both vasanta AND rutu from Sanskrit, like Kannada, not just Tamil/Malayalam's single vasantham loan"
+est_minutes: 5
+reviews_of: [TE-C13-sharira-bhagalu]
+---
+
+# వసంత ఋతువు, వేసవి, వానాకాలం, శీతాకాలం — the pattern completes itself
+
+## Warm-up
+
+[PAUSE 2s] Telugu closes out the Dravidian season words the same way
+Kannada did: native words for summer/rain/cold, and a spring-word borrowed
+twice over from Sanskrit.
+
+## The words
+
+| Telugu | meaning | source |
+|---|---|---|
+| **వసంత ఋతువు** (*vasanta ṛtuvu*) | "spring" | both *vasanta* and **ఋతువు** *ṛtuvu* ("season") are Sanskrit, like Kannada's pair |
+| **వేసవి** (*vēsavi*) | "summer" | native Dravidian — cousin of Kannada's *bēsige* |
+| **వానాకాలం** (*vānākālam*) | "rainy season" | **వాన** *vāna* ("rain," native) + *kālam* ("time," itself Sanskrit-derived but long assimilated) |
+| **శీతాకాలం** (*śītākālam*) | "winter/cold season" | *śīta* ("cold") leans Sanskrit-flavored here, unlike Tamil/Kannada's fully native cold-words |
+
+## Be honest about the pattern, one more time
+
+Telugu's *vēsavi* and Kannada's *bēsige* are close enough in shape to be
+genuine cousins — the same native Dravidian summer-word wearing two
+languages' sound changes. And once again, it's **వానాకాలం** (*vānākālam*,
+the rains) that actually organizes Andhra/Telangana's agricultural year,
+not a clean four-way Western split — the same honest point every language
+in this arc has made.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vēsavi" — summer, cousin of Kannada's bēsige]
+- [YOU SAY: "vānākālam" — the rains, the real central season]
+- [YOU SAY: "śītākālam" — the cold season]
+- [YOU SAY: the double Sanskrit loan — "vasanta ṛtuvu," like Kannada]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What's the relationship between Telugu's *vēsavi* and Kannada's
+*bēsige*? (**Cousins** — the same native Dravidian summer-word.) Which
+Dravidian languages borrow BOTH halves of their spring-word from Sanskrit
+(the season-name AND the word for "season" itself)? (**Kannada and
+Telugu** — *vasanta ṛtu(vu)* — unlike Tamil/Malayalam's single *vasantham*
+loan plus the long-assimilated *kaalam*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C15-neellu-biyyam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C15-neellu-biyyam.md
@@ -1,0 +1,53 @@
+---
+id: TE-C15-neellu-biyyam
+chapter: 15
+type: word
+headword: నీళ్ళు బియ్యం అన్నం
+gloss: water (matching Tamil/Kannada's neer/niiru), and rice raw/cooked — completing the family's water and rice pattern
+concept_tag: TE-FOOD-BASIC
+prerequisites: [TE-C14-rutuvulu]
+sounds: [telugu-geminate-lla, telugu-anusvara]
+roots: [neellu-water-dravidian, biyyam-rice-dravidian]
+etymology_hook: "నీళ్ళు neellu (water) matches Tamil/Kannada's neer/niiru, completing the 3-against-1 pattern against Malayalam's vellam; బియ్యం biyyam (raw rice) is Telugu's own word, unlike Tamil/Kannada/Malayalam's shared ari/arisi/akki"
+est_minutes: 5
+reviews_of: [TE-C14-rutuvulu]
+---
+
+# నీళ్ళు, బియ్యం, అన్నం — water matching its cousins, rice going its own way
+
+## Warm-up
+
+[PAUSE 2s] Water closes out 3-against-1 against Malayalam. Rice, though,
+turns out to have its own twist here.
+
+## నీళ్ళు — matching the majority
+
+**నీళ్ళు** (*nīḷḷu*) = "**water**" — matching Tamil's *nīr* and Kannada's
+*nīru*. Malayalam's *veḷḷam* is the odd one out among all four Dravidian
+languages for water, not Telugu.
+
+## బియ్యం, అన్నం — rice, with a twist
+
+- **బియ్యం** (*biyyam*) = "**rice**" (raw grain) — **Telugu's own word**,
+  unlike the shared *ari/arisi/akki* found in Malayalam, Tamil, and
+  Kannada.
+- **అన్నం** (*annam*) = "**cooked rice**" (the meal) — matching Kannada's
+  *anna* closely, both likely Sanskrit-influenced.
+
+So the pattern flips between water and rice: for **water**, Telugu joins
+the majority (Tamil/Kannada) against Malayalam; for **raw rice**, Telugu is
+itself the odd one out against the other three.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nīḷḷu" — water, matching Tamil/Kannada]
+- [YOU SAY: "biyyam" — raw rice, Telugu's own word]
+- [YOU SAY: "annam" — cooked rice, matching Kannada's anna]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which language is the odd one out for water, and which for raw
+rice? (**Malayalam** is the odd one out for water (*veḷḷam*); **Telugu** is
+the odd one out for raw rice (*biyyam*, unlike the shared *ari/arisi/akki*
+elsewhere).)

--- a/code/learning/human-languages/telugu/lessons/TE-C16-nelalu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C16-nelalu.md
@@ -1,0 +1,57 @@
+---
+id: TE-C16-nelalu
+chapter: 16
+type: word
+headword: చైత్రం వైశాఖం జ్యేష్ఠం ఆషాఢం శ్రావణం భాద్రపదం ఆశ్వయుజం కార్తీకం మార్గశిరం పుష్యం మాఘం ఫాల్గుణం
+gloss: the twelve lunisolar months — matching Kannada and Hindi's shared pan-Indian calendar, completing the split with Tamil/Malayalam's own solar systems
+concept_tag: TE-MONTHS
+prerequisites: [TE-C15-neellu-biyyam]
+sounds: [telugu-conjunct-shtha, telugu-anusvara]
+roots: [sanskrit-lunisolar-chaitra-system]
+etymology_hook: "Telugu shares the same pan-Indian Sanskritic lunisolar calendar as Kannada and Hindi (Ugadi falls the SAME day, Chaitra Shudda Padyami) — completing a clean split: Tamil and Malayalam built their OWN solar calendars, Kannada and Telugu share the pan-Indian one"
+est_minutes: 5
+reviews_of: [TE-C15-neellu-biyyam]
+---
+
+# చైత్రం to ఫాల్గుణం — completing the split
+
+## Warm-up
+
+[PAUSE 2s] The pattern across all four Dravidian languages is now
+complete: Telugu, like Kannada, shares its calendar with Hindi rather than
+building its own.
+
+## The twelve months
+
+**చైత్రం, వైశాఖం, జ్యేష్ఠం, ఆషాఢం, శ్రావణం, భాద్రపదం, ఆశ్వయుజం, కార్తీకం,
+మార్గశిరం, పుష్యం, మాఘం, ఫాల్గుణం** (*Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ,
+Āṣāḍhaṁ, Śrāvaṇaṁ, Bhādrapadaṁ, Āśvayujaṁ, Kārtīkaṁ, Mārgaśiraṁ, Puṣyaṁ,
+Māghaṁ, Phālguṇaṁ*).
+
+## The whole Dravidian family, in one honest picture
+
+This closes out a genuine, clean split across the four Dravidian
+languages: **Tamil** and **Malayalam** each built their **own** solar
+calendar (nakshatra-named and zodiac-named, respectively) — while
+**Kannada** and **Telugu** instead share the **same pan-Indian Sanskritic
+lunisolar calendar** as Hindi's Vikram Samvat. Telugu's New Year, **Ugadi**,
+falls on the very same day as Kannada's — *Chaitra Śuddha Pādyami*, the
+first day of Chaitra's bright fortnight.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "Caitraṁ, Vaiśākhaṁ, Jyēṣṭhaṁ, Āṣāḍhaṁ, Śrāvaṇaṁ,
+  Bhādrapadaṁ, Āśvayujaṁ, Kārtīkaṁ, Mārgaśiraṁ, Puṣyaṁ, Māghaṁ,
+  Phālguṇaṁ"]
+- [YOU SAY: "Ugadi — Chaitra Śuddha Pādyami"]
+- [YOU SAY: the whole family split — Tamil/Malayalam their own; Kannada/
+  Telugu shared with Hindi]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does the four-language Dravidian calendar picture split?
+(**Tamil and Malayalam** each have their **own** solar calendar; **Kannada
+and Telugu** share the **same pan-Indian lunisolar calendar** as Hindi.)
+What is Telugu's New Year, and when does it fall? (**Ugadi**, on *Chaitra
+Śuddha Pādyami* — the same day as Kannada's Ugadi.)

--- a/code/learning/human-languages/telugu/lessons/TE-C17-madhyaahnam-ardharaatri.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C17-madhyaahnam-ardharaatri.md
@@ -1,0 +1,62 @@
+---
+id: TE-C17-madhyaahnam-ardharaatri
+chapter: 17
+type: word
+headword: మధ్యాహ్నం అర్ధరాత్రి
+gloss: noon (Sanskrit "middle of day," same as Kannada) and midnight (Sanskrit "HALF of night" — a different root than Kannada's midnight word)
+concept_tag: TE-TIME-NOON-MIDNIGHT
+prerequisites: [TE-C16-nelalu]
+sounds: [telugu-conjunct-rdha, telugu-anusvara]
+roots: [sanskrit-madhya-middle, sanskrit-ardha-half]
+etymology_hook: "Telugu's మధ్యాహ్నం (madhyāhnam, noon) matches Kannada's madhya ('middle') root exactly — but its midnight word, అర్ధరాత్రి (ardharātri), switches to a DIFFERENT Sanskrit root, ardha ('half'), echoing Hindi's colloquial 'half night' pattern instead of Kannada's 'middle night'"
+est_minutes: 5
+reviews_of: [TE-C16-nelalu]
+---
+
+# మధ్యాహ్నం, అర్ధరాత్రి — the same noon word, a different midnight word
+
+## Warm-up
+
+[PAUSE 2s] Telugu and Kannada share the exact same Sanskrit word for noon —
+but then quietly part ways on midnight.
+
+## మధ్యాహ్నం — matching Kannada exactly
+
+**మధ్యాహ్నం** (*madhyāhnam*) = "**noon, midday**" — the same Sanskrit
+*tatsama* compound as Kannada's *madhyāhna*: **మధ్య** (*madhya*, "**middle**")
++ **అహ్న** (*ahna*, "**day**"), plus Telugu's own **-ం** (*anusvāra*)
+ending. Same root, same meaning, same everyday register in both languages.
+
+## అర్ధరాత్రి — a DIFFERENT Sanskrit root: "half," not "middle"
+
+**అర్ధరాత్రి** (*ardharātri*) = "**midnight**" — but here Telugu reaches for
+a **different** Sanskrit root: **అర్ధ** (*ardha*, "**half**"), not *madhya*
+("middle"). Paired with **రాత్రి** (*rātri*, "**night**"), it literally
+means "**half-night**" — structurally the same shape as Hindi's colloquial
+*ādhī rāt* ("half night") and Latin's transparent *media nox* pattern, but
+built from Sanskrit's own dedicated "half" word rather than "middle."
+
+## Be honest: two different "middle-ish" ideas, side by side
+
+Don't assume *madhya* and *ardha* are the same word wearing different
+clothes — they're genuinely **separate Sanskrit roots** ("middle" vs.
+"half") that happen to land on the same meaning here, the way English
+"midday" and "half the day gone" would both point at noon without sharing
+a root. Telugu's noon word keeps Kannada's "middle" logic; its midnight
+word switches to "half" logic instead.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "madhyāhnam" — noon, same root as Kannada]
+- [YOU SAY: "ardharātri" — midnight, literally "half-night"]
+- [YOU SAY: the contrast — "madhya" (middle) for noon, "ardha" (half) for
+  midnight — two different Sanskrit roots]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does Telugu's noon word match Kannada's? (**Yes** — both
+*madhyāhna(m)*, from *madhya*, "middle.") Does Telugu's midnight word use
+the same root? (**No** — *ardharātri* uses **ardha**, "half," a different
+Sanskrit root.) What does *ardharātri* literally mean? ("**Half-night**" —
+the same shape as Hindi's *ādhī rāt*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C18-ganta.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C18-ganta.md
@@ -1,0 +1,67 @@
+---
+id: TE-C18-ganta
+chapter: 18
+type: word
+headword: గంట
+gloss: hour — matching Kannada and Hindi exactly, the same Sanskrit "bell" word
+concept_tag: TE-TIME-HOUR
+prerequisites: [TE-C17-madhyaahnam-ardharaatri]
+sounds: [telugu-anusvara, telugu-retroflex-tta]
+roots: [sanskrit-ghanta-bell]
+etymology_hook: "గంట (ganṭa, 'hour') is the same Sanskrit ghaṇṭā ('bell') word as Kannada's gaṇṭe and Hindi's ghanṭā — Telugu completes a clean 3-way match on this concept, contrasting with Tamil's most-likely-native maṇi (Malayalam's cognate mani, interestingly, traces to a DIFFERENT Sanskrit word, maṇi 'gem,' per its own dictionaries)"
+est_minutes: 5
+reviews_of: [TE-C17-madhyaahnam-ardharaatri]
+---
+
+# గంట — matching Kannada and Hindi's "bell" word exactly
+
+## Warm-up
+
+[PAUSE 2s] Telugu completes a clean three-way match: Hindi, Kannada, and now
+Telugu all use the same Sanskrit "bell" word for "hour."
+
+## గంట — bell AND hour, a third time
+
+**గంట** (*ganṭa*) = "**hour**" — and, exactly like Hindi's *ghanṭā* and Kannada's
+*gaṇṭe*, it means "**bell, clapper**" just as commonly, from the same Sanskrit
+**घण्टा** (*ghaṇṭā*). Same word, same bell-strikes-the-hour logic, three
+languages in a row.
+
+## Be honest: the split isn't a clean "Dravidian vs. Hindi" line
+
+So on this concept, the split isn't "Hindi vs. all four Dravidian languages" —
+**Hindi, Kannada, and Telugu** all share the Sanskrit *ghaṇṭā* ("bell") root.
+**Tamil** most likely goes its own way with a native Dravidian word instead
+(though even specialists don't call this fully settled). **Malayalam** is the
+genuinely surprising one: its cognate word, *mani*, is ALSO Sanskrit-derived per
+its own dictionaries — just from a **different** Sanskrit word, *maṇi* ("gem"),
+not *ghaṇṭā*. So three of these four languages likely trace their hour-word to
+Sanskrit, just not all to the *same* Sanskrit word — worth remembering that a
+Sanskrit/native split isn't fixed per language, and isn't always a clean binary
+either.
+
+## Grammar Lens: telling the time
+
+> **ఒక గంట.** — "One o'clock." (*oka ganṭa*, "one hour/bell")
+> **రెండు గంటలు.** — "Two o'clock." (*reṇḍu ganṭalu* — *ganṭa* takes its plural
+  form, *ganṭalu*, once the count passes one)
+
+Notice Telugu's *ganṭa* pluralizes to *ganṭalu* for "two o'clock" onward — a
+small grammatical wrinkle Kannada's *gaṇṭe* didn't show you.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ganṭa" — hour, also "bell"]
+- [YOU SAY: "oka ganṭa" — one o'clock]
+- [YOU SAY: "reṇḍu ganṭalu" — two o'clock, plural *ganṭalu*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Sanskrit word do **గంట**, Kannada's *gaṇṭe*, and Hindi's *ghanṭā*
+all share? (**घण्टा**, *ghaṇṭā*, "bell.") Which Dravidian language most likely does
+NOT use this Sanskrit word for "hour"? (**Tamil** — most likely a native Dravidian
+word instead.) Does Malayalam's cognate word skip Sanskrit entirely too? (**No** —
+it's Sanskrit-derived too, per its own dictionaries, just from a *different*
+Sanskrit word, *maṇi*, "gem.") What happens to *ganṭa* for "two o'clock"? (It
+**pluralizes** to *ganṭalu*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C19-vayasu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C19-vayasu.md
@@ -1,0 +1,55 @@
+---
+id: TE-C19-vayasu
+chapter: 19
+type: phrase
+headword: నీ వయసెంత?
+gloss: how old are you? — literally "your age how-much?", matching Kannada's simple verbless possessive exactly
+concept_tag: TE-AGE
+prerequisites: [TE-C18-ganta]
+sounds: [telugu-anusvara, telugu-vowel-sandhi]
+roots: [sanskrit-vayas-vigor-age]
+etymology_hook: "వయస్సు (vayasu, 'age') is the same Sanskrit वयस् (vayas, 'vigor, age') as Kannada's vayassu — PIE cousin of Latin vīs — and Telugu asks it the same simple, verbless way: 'నీ వయసెంత?' (nī vayasenta?, 'your age how-much?'), where వయస్సు+ఎంత fuse into vayas-enta by regular vowel sandhi"
+est_minutes: 5
+reviews_of: [TE-C18-ganta]
+---
+
+# నీ వయసెంత? — matching Kannada's simple possessive exactly
+
+## Warm-up
+
+[PAUSE 2s] Telugu matches Kannada closely here — same Sanskrit word, same
+verbless grammar, just fused together by ordinary Telugu vowel sandhi.
+
+## వయస్సు — the same Sanskrit "vigor/age" word
+
+**వయస్సు** (*vayasu*) = "**age**" — the exact same Sanskrit **वयस्** (*vayas*,
+"age, vigor, strength," PIE cousin of Latin **vīs**) you just met in Kannada.
+
+## Grammar Lens: fused by sandhi, still verbless
+
+> **నీ వయసెంత?** — "How old are you?" — literally "**your age how-much**?"
+  (*nī vayas-enta?* — from *nī vayasu* + *enta*, "how much," fused by regular
+  vowel sandhi into *vayasenta*.)
+> **నా వయస్సు ఇరవై.** — "I am twenty years old." — literally "**my age**
+  [is] **twenty**." (*nā vayasu iravai.*)
+
+Same shape as Kannada: a plain possessive ("your/my age") sitting next to the
+number, **no verb at all**. The only wrinkle is surface-level: everyday spoken
+Telugu often **fuses** *vayasu* + *enta* into one word, *vayasenta*, the same
+kind of vowel sandhi you'd see fusing any two Telugu words in fast speech — the
+underlying grammar is identical to Kannada's, just written closer together.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vayasu" — age]
+- [YOU SAY: "nī vayasenta?" — how old are you?]
+- [YOU SAY: "nā vayasu iravai" — I am twenty, "my age [is] twenty"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is Telugu's **వయస్సు** the same Sanskrit word as Kannada's
+*vayassu*? (**Yes** — both from *vayas*, PIE cousin of Latin *vīs*.) What
+happens to *vayasu* + *enta* in "*nī vayasenta*?"? (They **fuse** by ordinary
+vowel sandhi.) Does Telugu use a verb to state age, like Kannada? (**No** —
+same verbless possessive shape.)

--- a/code/learning/human-languages/telugu/lessons/TE-C20-padakondu-iravai.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C20-padakondu-iravai.md
@@ -1,0 +1,57 @@
+---
+id: TE-C20-padakondu-iravai
+chapter: 20
+type: word
+headword: పదకొండు — ఇరవై
+gloss: 11-20 — additive "ten-echo" compounds for the teens; ఇరవై (20) most likely continues the SAME pan-Dravidian "two-tens" pattern as Kannada's ippattu, though worn down further and less transparent on the surface today
+concept_tag: TE-NUM-11-20
+prerequisites: [TE-C19-vayasu]
+sounds: [telugu-vowel-sign-ai, telugu-geminate-none]
+roots: [dravidian-padi-ten, dravidian-rendu-two]
+etymology_hook: "పదకొండు-పందొమ్మిది (11-19) echo పది (padi, 'ten') + a digit — ఇరవై (iravai, 'twenty') most likely continues the same pan-Dravidian *iru-/*renḍu ('two') + *pad- ('ten') pattern as Kannada's transparent ippattu, but centuries of erosion have worn iravai down further, so it doesn't visibly split into 'two' + 'ten' on the surface the way Kannada's does today"
+est_minutes: 6
+reviews_of: [TE-C19-vayasu]
+---
+
+# పదకొండు, ఇరవై — the same pattern, worn down one step further
+
+## Warm-up
+
+[PAUSE 2s] You just watched Kannada's twenty split cleanly into "two" +
+"ten." Telugu most likely comes from the exact same pattern — but centuries
+of extra erosion have worn it past the point of being visible today.
+
+## పదకొండు–పందొమ్మిది — "ten" + digit
+
+Telugu's teens echo **పది** (*padi*, "**ten**") plus each digit — **పదకొండు**
+(*padakoṇḍu*, 11), **పన్నెండు** (*panneṇḍu*, 12), and onward through
+**పందొమ్మిది** (*paṅdommidi*, 19) — the same "digit + ten-echo" compounding
+you just saw in Kannada.
+
+## ఇరవై — most likely the same "two-tens," just worn further
+
+**ఇరవై** (*iravai*, "**twenty**") most likely continues the **same**
+pan-Dravidian pattern as Kannada's *ippattu* — an old **\*iru-**/**\*renḍu**
+("two") root fused with an old "ten" root — but here's the honest difference:
+centuries of sound change have worn *iravai* down far enough that it no
+longer visibly splits into "two" and "ten" on the surface, the way Kannada's
+*ippattu* still does today. Telugu's own word for "two," **రెండు** (*renḍu*),
+doesn't obviously show up inside *iravai* anymore — treat this as the most
+likely comparative-Dravidian account rather than a transparent, easily
+re-derivable compound.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "padakoṇḍu, panneṇḍu" — 11, 12]
+- [YOU SAY: "padi" — ten]
+- [YOU SAY: "iravai" — twenty, most likely the same "two-tens" idea as
+  Kannada, just worn down further]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How are Telugu's teens built? (**పది** (ten) + a digit,
+compounded.) Does **ఇరవై** visibly split into "two" + "ten" today, the way
+Kannada's *ippattu* does? (**No** — it most likely continues the same
+pan-Dravidian pattern, but erosion has worn away the visible split.) What's
+Telugu's word for "two"? (**రెండు**, *renḍu*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C20-vatavaranam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C20-vatavaranam.md
@@ -1,0 +1,56 @@
+---
+id: TE-C20-vatavaranam
+chapter: 20
+type: phrase
+headword: వాతావరణం
+gloss: weather/atmosphere — a PURE Sanskrit compound, unlike Kannada's Persian+Sanskrit hybrid: vata ("air/wind") + avarana ("covering")
+concept_tag: TE-WEATHER
+prerequisites: [TE-C18-ganta]
+sounds: [telugu-anusvara, telugu-compound-word]
+roots: [sanskrit-vata-wind, sanskrit-avarana-covering]
+etymology_hook: "వాతావరణం (vātāvaraṇam, 'weather, atmosphere') is a PURE Sanskrit compound — వాత (vāta, 'wind, air') + ఆవరణ (āvaraṇa, 'covering, layer') — literally 'the covering of air,' unlike Kannada's Persian+Sanskrit hybrid havāmāna for the same concept"
+est_minutes: 5
+reviews_of: [TE-C18-ganta]
+---
+
+# వాతావరణం — "the covering of air," pure Sanskrit this time
+
+## Warm-up
+
+[PAUSE 2s] Kannada's weather word mixed a Persian loan with a Sanskrit one.
+Telugu's is different again — a single, unmixed Sanskrit compound.
+
+## వాతావరణం — vāta + āvaraṇa
+
+**వాతావరణం** (*vātāvaraṇam*) = "**weather, atmosphere**" — built entirely
+from Sanskrit:
+
+- **వాత** (*vāta*, "**wind, air**") — the same Sanskrit root behind **వాయువు**
+  (*vāyuvu*, "wind," and the wind-god Vāyu).
+- **ఆవరణ** (*āvaraṇa*, "**covering, layer, enclosure**").
+
+So *vātāvaraṇam* literally means "**the covering of air**" — the layer of air
+surrounding everything, i.e., the atmosphere/weather. Unlike Kannada's
+*havāmāna* (Persian *hava* + Sanskrit *māna*), **both** pieces here are
+Sanskrit — no Perso-Arabic loan involved at all.
+
+## వర్షం పడుతోంది — "rain is falling"
+
+> **వర్షం పడుతోంది.** — "It's raining." — literally "**rain is falling**."
+  (*varṣaṁ paḍutōndi.*) — **వర్షం** (*varṣaṁ*, "rain") is the same Sanskrit
+  root, *varṣā*, you'll see again in the Dravidian arc.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vātāvaraṇam" — weather, "the covering of air"]
+- [YOU SAY: "vāta" — wind/air, "āvaraṇa" — covering]
+- [YOU SAY: "varṣaṁ paḍutōndi" — it's raining, "rain is falling"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the two Sanskrit pieces of **వాతావరణం**, and what does the
+whole word literally mean? (**వాత**, "air," + **ఆవరణ**, "covering" — "**the
+covering of air**.") Is either piece a Persian/Arabic loan, like part of
+Kannada's word? (**No** — both pieces are Sanskrit.) What word does Telugu use
+for "rain"? (**వర్షం**, *varṣaṁ*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C21-kukka-pilli.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C21-kukka-pilli.md
@@ -1,0 +1,58 @@
+---
+id: TE-C21-kukka-pilli
+chapter: 21
+type: word
+headword: కుక్క, పిల్లి
+gloss: dog and cat — kukka genuinely breaks from its Dravidian cousins' shared naayi root, debated as onomatopoeic or a Sanskrit loan; pilli most likely closes the ENTIRE arc's cat-story loop, the probable Dravidian source behind Sanskrit's biDaala and so Hindi's billi
+concept_tag: TE-ANIMALS
+prerequisites: [TE-C20-padakondu-iravai]
+sounds: [telugu-geminate-kk, telugu-geminate-ll]
+roots: [uncertain-kukka, dravidian-pillu-cat]
+etymology_hook: "కుక్క (kukka, 'dog') genuinely breaks from Kannada/Malayalam/Tamil's shared naayi root — debated between an onomatopoeic origin (imitating a bark) and a Sanskrit loan (कुक्कुर, kukkura); పిల్లి (pilli, 'cat') is Proto-Dravidian *pillV, and most likely closes this WHOLE arc's cat-word loop — the probable Dravidian source Sanskrit borrowed as बिडाल (biḍāla), giving Hindi's बिल्ली (billī)"
+est_minutes: 6
+reviews_of: [TE-C20-padakondu-iravai]
+---
+
+# కుక్క, పిల్లి — the odd one out, and the word that most likely closes the loop
+
+## Warm-up
+
+[PAUSE 2s] Kannada just gave you a rock-solid native dog-word. Telugu breaks
+from that pattern — but its cat-word may be the single most important word
+in this whole arc.
+
+## కుక్క — genuinely the odd one out
+
+**కుక్క** (*kukka*, "**dog**") does **not** clearly continue the same
+**నాయి**-family root shared by Kannada, Malayalam, and Tamil. Its origin is
+honestly debated: some linguists propose it's **onomatopoeic**, imitating
+the sound of a bark; others propose a borrowing from **Sanskrit**
+**कुक्कुर** (*kukkura*, itself a similarly-shaped word for dog). Neither is
+settled — but either way, Telugu's everyday dog-word genuinely doesn't
+match its closest cousins.
+
+## పిల్లి — most likely closing the whole arc's loop
+
+**పిల్లి** (*pilli*, "**cat**") is a real, documented **Proto-Dravidian**
+root, ***\*pillV*** — with cognates surviving as **rarer, alternate** words
+for cat in both Tamil and Kannada. Here's why this word matters for the
+**whole** arc: Sanskrit's word for cat, **बिडाल** (*biḍāla*) — the word
+behind Hindi's **बिल्ली** (*billī*), which you met as "most likely" borrowed
+from Dravidian, without a confirmed specific source — most likely traces
+back to **this exact root**. So Telugu's everyday word for "cat" is most
+likely the closest living relative of the very word Sanskrit borrowed,
+tying together Latin's *cattus*/Arabic's *qiṭṭ* story on one side and
+Hindi's *billī* story on the other, all within this single course.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kukka" — dog, genuinely different from its Dravidian cousins]
+- [YOU SAY: "pilli" — cat, most likely the source behind Hindi's billī]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **కుక్క** continue the same root as Kannada's *nāyi*? (**No**
+— genuinely different, debated between onomatopoeia and a Sanskrit loan.)
+What is **పిల్లి** most likely the source of? (**Sanskrit's बिडाल**,
+*biḍāla* — and so Hindi's **बिल्ली**, *billī*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C22-pacha-pasupu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C22-pacha-pasupu.md
@@ -1,0 +1,59 @@
+---
+id: TE-C22-pacha-pasupu
+chapter: 22
+type: word
+headword: పచ్చ, పసుపు
+gloss: green and yellow — a genuine Telugu doublet pair, both from the same Proto-Dravidian *pac- root, unlike Kannada, where the yellow word broke away as a Sanskrit loan
+concept_tag: TE-COLOUR-GREEN-YELLOW
+prerequisites: [TE-C11-rangulu, TE-C21-kukka-pilli]
+sounds: [telugu-short-vowels, telugu-virama-geminate]
+roots: [proto-dravidian-pac-green]
+etymology_hook: "పచ్చ (pacca, 'green') and పసుపు (pasupu, 'yellow, turmeric') are both descendants of the SAME Proto-Dravidian root, *pac- — true doublets of each other, not two separate word families; పచ్చ also shares that root with Tamil's பச்சை (paccai) and Kannada's ಹಸಿರು (hasiru), while Tamil's பசுப்பு (pacuppu) is a direct cognate of పసుపు itself"
+est_minutes: 6
+reviews_of: [TE-C21-kukka-pilli]
+---
+
+# పచ్చ, పసుపు — two colors, one Dravidian root
+
+## Warm-up
+
+[PAUSE 2s] In Kannada, green stayed native but yellow got borrowed from
+Sanskrit. Telugu tells a tighter story: its green word and its yellow word
+turn out to be **doublets of the same root**, wearing two different faces.
+
+## పచ్చ — the native Dravidian green, again
+
+**పచ్చ** (**pacca**, "**green**") comes from **Proto-Dravidian** ***\*pac-***
+— the same root already behind Tamil's **பச்சை** (*paccai*) and Kannada's
+**ಹಸಿರು** (*hasiru*, via Old Kannada *pasir*). No surprise here; this is the
+same pan-Dravidian green family from the last lesson.
+
+## పసుపు — a genuine doublet of pacca, not a separate word
+
+**పసుపు** (**pasupu**, "**yellow, turmeric**") is, remarkably, **also** a
+direct descendant of that **same** Proto-Dravidian ***\*pac-*** root — a
+true **doublet** of *pacca* itself, not a separate borrowing the way
+Kannada's *haḷadi* was. Tamil even keeps a matching cognate,
+**பசுப்பு** (*pacuppu*), sitting alongside its own *paccai*. So where
+Kannada split green and yellow into two unrelated families (native
+Dravidian vs. a Sanskrit turmeric-loan), Telugu kept **both** colors inside
+the same native word-family — *pacca* and *pasupu* are, at root, doublets
+of the same word, one settling on "green" and the other on "yellow,
+turmeric-colored."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "పచ్చ" — green, from Proto-Dravidian *pac-]
+- [YOU SAY: "పసుపు" — yellow/turmeric, a true doublet of pacca, same root]
+- [YOU SAY: the contrast with Kannada — Telugu kept both colors in one
+  native family; Kannada's yellow broke away as a Sanskrit loan]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are **పచ్చ** and **పసుపు** two unrelated words, or doublets of
+the same root? (**Doublets** — both from Proto-Dravidian *\*pac-*.) Does
+Telugu's yellow word follow the same pattern as Kannada's *haḷadi* (a
+Sanskrit loan)? (**No** — Telugu kept its yellow word native, unlike
+Kannada.) What Tamil word is *pasupu*'s direct cognate? (**பசுப்பு**,
+*pacuppu*.)

--- a/lessons.md
+++ b/lessons.md
@@ -1854,3 +1854,32 @@ shape of a neighboring entry, e.g. `COURTESY-PLEASE`) and validate it's still pa
 JSON, THEN write the lessons. Re-run both suites
 (`code/packages/typescript/human-language-data` + the app suite) after any new
 concept_tag lands — a green run before is not evidence the new tag is registered.
+
+## Accumulator-PR pattern: GitHub auto-deletes the head branch on merge — a push right after merge silently recreates an empty-history branch with no PR
+
+Running a "keep adding commits to one PR" loop (per explicit user instruction, see
+`feedback_consolidate_pr_when_reviewer_away.md`), a background push to
+`content/dravidian-please` succeeded with `git push` printing `[new branch]` instead
+of a normal fast-forward update — the tell that something was wrong. The repo has
+"automatically delete head branches" enabled, so the moment the user merged PR
+#9210, GitHub deleted `content/dravidian-please` on the remote. My next `git push`
+to that same branch name didn't fail or warn — it just recreated the ref from
+scratch, accepting local history that was still based on the *old* pre-merge
+`main`. The commit landed on a branch with no PR, silently orphaned, invisible
+until `gh pr list --head <branch>` came up empty.
+
+**The check that catches it:** after ANY push in an accumulator-PR loop, don't
+just verify `git rev-parse HEAD == origin/<branch>` (that was true here — the
+push "succeeded"). Also check `git push`'s own output for `[new branch]` on a
+branch you believe already has history/a PR, and independently confirm the PR
+still exists and is still open (`gh pr view <N> --json state,mergedAt`) *before*
+building the next slice, not just before pushing it. A merge can land at any
+point mid-loop, not only when you happen to check.
+
+**The fix, once caught:** `git fetch origin --quiet`, diff origin/main against
+the orphaned branch to see which commits are already merged (`git ls-tree
+origin/main -- <path>` per file, or compare `git log --oneline` lines) vs. still
+new, then `git switch -c <fresh-name> origin/main` and `git cherry-pick` only the
+truly-new commits onto a clean base — don't just re-push the stale branch. Delete
+the orphaned remote branch afterward (`git push origin --delete <name>`) so it
+doesn't linger with no PR pointing at it.


### PR DESCRIPTION
## What
This accumulator PR now completes **fifteen full concepts** across all 10 languages (Spanish, German, Latin, French, Arabic, Hindi, Tamil, Kannada, Telugu, Malayalam) — **COURTESY-SORRY** through **AGE**, **WEATHER**, **ANIMALS**, and **COLOUR-GREEN-YELLOW** — plus a full numbers-completeness push (1-5, 6-10, 11-20) — plus a **9-lesson Latin-only catch-up arc** closing a real early-curriculum gap that predates this session's concept-parity work.

### Latin conversational-basics catch-up — a real gap, not another 10-language concept arc
A fresh frontier survey (after COLOUR-GREEN-YELLOW closed) found something different from the usual "missing 8" pattern: **Latin's own curriculum** was missing a whole cluster of basic conversational concepts that every other language already had — Latin jumps straight from greetings/thanks/sorry/please into numbers/days/colors, skipping "how are you," "what's your name," "nice to meet you," and related basics entirely. Verified via grep this wasn't a tagging-convention artifact (Latin already covers yes/no under one combined tag, `RESPONSE-YESNO`) — these were genuinely absent. Built all nine, one per commit:
- **quid agis? / ut valēs?** ("how are you?") — both genuinely attested in Plautus and Terence's comedies. Contrasted honestly with *quōmodo tē habēs?*, ubiquitous in modern spoken-Latin pedagogy but **not** found in any surviving classical text. The attested reply, *valeō* ("I fare well"), turns out to be the same verb, *valēre*, already hiding inside *valē* ("goodbye," Chapter 1) — *valē* is literally an imperative, "be well!"
- **quid tibi nōmen est? / mihi nōmen est...** ("what's your name?") — Latin's genuine "dative of possession": the possessor sits in the dative case, not a possessive verb. Attested Plautus through Livy/Sallust, though Cicero preferred keeping the *name itself* nominative while Livy/Sallust more often pulled it into the dative too (*puerō nōmen est Mārcus* vs. *puerō nōmen est Mārcō*) — review caught my first draft mixing up exactly which element varied.
- **volup est convēnisse** ("nice to meet you") — Classical Latin genuinely has **no fixed idiom** for this at all (an honest gap, not an oversight), filled by a real Plautus line (*Miles Gloriosus* II.iii) that does the same conversational job.
- **tū / vōs** ("you," singular/plural) — a **purely grammatical number** distinction in Classical Latin, with **zero** politeness dimension; the polite-*vōs*-for-one habit only emerged in Late Latin (the direct ancestor of French's *vous*). Review caught a real overclaim: this is **not** also the root of German's *Sie*, which independently repurposes an unrelated pronoun (3rd-person plural) — a mistake that would have directly contradicted the project's own already-shipped German lesson.
- **nihil est** ("you're welcome") — another honest "no fixed idiom" gap; the words are genuinely classical (*nihil* ← *ne-* + *hīlum*, "not a tiny bit") and *nihil est* itself is attested in Plautus, just never specifically as a reply to thanks.
- **propediem tē vidēbō** ("see you later/soon") — a genuine change of pace: solidly attested **twice** in Cicero's own letters (*Ad Familiārēs* 2.12 and 15.6).
- **crās tē vidēbō** ("see you tomorrow") — built from two independently classical pieces using the same pattern as the Cicero-attested phrase above, but explicitly flagged as **not itself** a direct quotation. Honest cross-language twist: *crās* was abandoned as the everyday "tomorrow" word by French/Italian/Catalan (all rebuilt from *dē māne*, "in the morning") and by Spanish (→ *māne* → *mañana*) — Sardinian and Sicilian are the main holdouts that kept it.
- **quōmodo** ("how") — genuinely classical (Cicero, Seneca), direct source of Italian *come* and Spanish *cómo*; French's *comment* went one step further, adding its own *-ment* suffix on top.
- **bene** ("well") — related to *bonus*, continued into French/Spanish *bien* through one ordinary sound change and nothing more (contrasted with *quōmodo*'s extra grafted-on suffix). Attested standing alone as a repeated toast in Plautus's *Stichus*.

Every one of these nine went through the full linguistics-review checklist, and the reviewer caught a real, fixable issue in the large majority of them — the recurring theme this arc was distinguishing "the individual words are genuinely classical" from "this exact phrase/comparison is specifically attested," and getting each hedge calibrated to the right claim.

**Judgment call, flagged for transparency**: `INTRO-MY-NAME-IS` is not a separate file — the "mihi nōmen est" reply half is already fully taught inside the `quid tibi nōmen est?` lesson above, and a second near-duplicate file would just be padding, not new content.

### COLOUR-GREEN-YELLOW — now complete chain-wide, and a genuine three-way Dravidian split
Fresh frontier survey after ANIMALS found every language's COLOUR coverage stops at black/white and red/blue — nobody has green/yellow yet. Explicitly checked French/German needed this too before starting (not assumed).
- **Spanish**: *verde* ← Latin *viridis* (expected). *amarillo* — the real surprise — does NOT come from any Latin yellow-word at all; it traces to Late Latin *amarellus*, "a little bitter" (← *amarus*, "bitter") — a genuine cousin of Spanish's own *amargo*.
- **Latin**: *viridis* itself, plus *flāvus* — Latin's own real yellow word — which almost no Romance language kept. Review caught a real error: my first draft claimed every Romance language independently invented its own replacement, but Italian's *giallo* and Romanian's *galben* actually share French's *galbinus* ("light green") root — the real picture is two clusters (Ibero-Romance's "bitter" reinvention vs. the rest converging on *galbinus*), not universal chaos — rewritten.
- **French**: *vert* is the standard Romance inheritance. *jaune* ← *galbinus* ("yellow-green") is usually said to share its ultimate PIE root (*ghel-*, "to shine") with **German's own** *gelb* — though on a later pass this specific *galbus*→*ghel-* link turned out to be more contested than first presented (some modern Latin scholarship treats *galbus*'s origin as unknown); hedged to "probable, not certain" cousins, and the same hedge was retrofitted into the German lesson below for consistency.
- **German**: *grün* is native Germanic, a direct cognate of **English's own** "green" — but a genuinely different root from Latin's *viridis* (confirmed carefully in both directions, given this project's history of "unrelated" claims turning out wrong). *gelb* is native too, and probably (not certainly — see French, above) shares its PIE root with French's *jaune*.
- **Arabic**: *akhḍar* ("green") shares its root with *khuḍār* ("vegetables," echoing English's own "greens") and the Quranic *al-Khiḍr* epithet. *aṣfar* ("yellow") shares its root with *ṣifr* ("zero") — the actual historical source of English "zero" and "cipher."
- **Hindi**: *harā* ("green") ← Sanskrit *harita* ← PIE *ǵʰelh₃-*, the same confirmed root behind German's *gelb* — making Hindi's GREEN word a genuine cousin of German's YELLOW word. *pīlā* ("yellow") ← Sanskrit *pīta*, which also literally means "drunk" — the semantic link between the two senses is hedged as unsettled, per the source.
- **Kannada**: *hasiru* ("green") ← Proto-Dravidian *pac-*, the first appearance of the root that will recur through Telugu/Malayalam/Tamil below. *haḷadi* ("yellow") appears to be a Sanskrit/Hindi loan on *haridrā* ("turmeric," not Kannada's own native turmeric word *ariśina*) — which itself traces to Sanskrit *hari* ("yellow, tawny") from the same PIE *ǵʰelh₃-* already behind Hindi's *harā* and German's *gelb*. Review caught a real conflation (claiming *haridrā*/*haldi* means "yellow" uniformly across Hindi/Urdu/Punjabi/Bengali/Odia, when Hindi/Urdu/Punjabi *haldi* means only "turmeric" — their actual yellow-word is the unrelated *pīlā*) — reworded.
- **Telugu**: *pacca* ("green") and *pasupu* ("yellow, turmeric") are genuine **doublets of the same** Proto-Dravidian *pac-* root — confirmed directly via Telugu Wiktionary's own etymology and cross-checked against DEDR, which glosses Tamil's matching cognate *pacuppu* as "greenish yellow." Unlike Kannada, Telugu kept both colors inside one native family. Self-caught (before review ran) two mixed-script contamination bugs — a Telugu character had been typed into what should have been pure Kannada/Tamil citations — fixed via the reusable Unicode-block scanner.
- **Malayalam**: *paccha* ("green") matches Tamil's *paccai* via the same *pac-* root. *mañña* ("yellow") is a **completely separate** native Dravidian root (a doublet of *maññaḷ*, "turmeric," matching Tamil's *mañcaḷ*) — giving the arc its first genuine three-way Dravidian contrast: Kannada splits native/loan, Telugu fuses one root, Malayalam keeps two separate roots. Review caught a wrong romanization ("mañjaḷ" implied a nonexistent j-sound; corrected to "maññaḷ," a geminated ña) and a stray "four languages" miscount (only three Dravidian patterns are ever discussed).
- **Tamil (closes the arc chain-wide)**: *paccai* ("green") is the same familiar *pac-* root. *mañcaḷ* ("yellow, turmeric") is Tamil's real everyday word, matching Malayalam's *mañña/maññaḷ*, with no Sanskrit involvement (one older Tamil Lexicon note floats a Sanskrit *mañjiṣṭha* derivation, hedged as unlikely — semantic mismatch, *mañjiṣṭha* names a red-dye plant, not turmeric). The Tamil Lexicon separately records *pacuppu* ("greenish yellow") as a real, rarer *pac-* doublet of *paccai* — confirmed via direct Lexicon lookup — meaning Tamil quietly holds traces of **both** the Telugu pattern (doublet of one root) and the Malayalam pattern (two separate roots) at once, closing out the Dravidian sub-arc's three-way split. Self-caught and fixed, before review, a Sanskrit word typed in the wrong script (Tamil instead of Devanagari); review then caught one script-citation defect (a Malayalam word paired with a different word's romanization) — fixed to match the body text's correct dual-script citation.

### ANIMALS — a brand-new concept (learned from WEATHER's mistake: checking FR/GE too)
Fresh frontier survey after numbers closed out confirmed ANIMALS doesn't exist in **any** language yet — the second genuinely new concept category this session. Explicitly checked up front (unlike the WEATHER episode) that French and German needed this too, not just the usual "missing 8" — and built them right away rather than assuming.
- **Spanish**: *gato* ← Latin *cattus*, a real, well-sourced etymology — *cattus* wasn't even Classical Latin's own word (that was *fēlēs*, source of *Felis catus*); it entered later as domestic cats spread out of Egypt along Roman trade routes, most likely an Afro-Asiatic loanword (cf. Nubian *kadis*). *Perro*, by honest contrast, is a genuine **unsolved** mystery — it displaced Latin's own *canis* (surviving in Spanish only as archaic *can*), and nobody knows for sure where *perro* itself comes from.
- **Latin**: the source words themselves — *canis* (→ English *canine*), and the *fēlēs*→*cattus* displacement, which happened entirely **within Latin**. Review caught one macron slip (a Linnaean binomial written with a vowel-length mark that doesn't belong there) — fixed.
- **French**: *chien* is the fully **regular** French descendant of *canis* — a genuinely different story from Spanish's unexplained *perro*. *chat* continues the same *cattus* as Spanish's *gato*.
- **German**: *Hund* is native Germanic — and a direct cousin of **English's own** abandoned word "hound," which English itself replaced with the still-unexplained "dog," the same shape of mystery as Spanish's *perro* in a completely different language family. *Katze*, surprisingly, is **not** native Germanic — it's the same borrowed Late Latin *cattus*. Review caught a real overclaim ("cat words are uniform across Germanic, Romance, Celtic, and Slavic") — Romanian and much of South Slavic actually use their own onomatopoeic cat-words instead; softened to the accurate picture with exceptions named.
- **Arabic**: *kalb* ("dog") is a solid, well-attested Proto-Semitic root, cousin of Hebrew's *kelev* — no mystery here. *qiṭṭ* ("cat") is most likely a distant cousin of the same Afro-Asiatic root behind *cattus* — the arc's cat story most likely closes the loop.
- **Hindi**: *kuttā* ("dog") is a **third** instance of the exact perro/dog pattern — a genuinely uncertain-origin word displacing Sanskrit's own PIE-inherited *śvān* (cognate with *canis*/hound/Hund), across a third unrelated language family. *billī* ("cat") most likely traces to Sanskrit's own loanword from Dravidian — a probable fourth, separate cat-word family. Review caught the same overclaim shape twice here (asserting *qiṭṭ*/*cattus* as a settled cognate, and *biḍāla*'s Dravidian origin as definitive, when both are genuinely live scholarly disputes) — hedged throughout both files. Also self-caught, before review even ran: a mixed-script glyph bug in one Hindi header (Tamil characters had gotten mixed into what should be pure Devanagari) — found via direct codepoint inspection and fixed.
- **Dravidian — ANIMALS now complete chain-wide, and the whole session's cat-word story closes**: Kannada/Malayalam/Tamil all share the SAME solid, undisputed native "dog" root — the honest opposite of every other dog-word in this arc; Telugu's *kukka* genuinely breaks from it (onomatopoeia vs. Sanskrit loan, unresolved). "Cat" genuinely splits three ways across just these four languages — Tamil/Malayalam share one root, Kannada's *bekku* comes from a "wildcat" root, and Telugu's *pilli* is a third root that most likely turns out to be the closest living relative of the very word Sanskrit borrowed as *biḍāla*, closing the loop back to Hindi's *billī*. Self-caught (before review ran) a **third** instance of the mixed-script glyph bug this session — two Devanagari citations in the Telugu file had gotten corrupted with Telugu-script characters — fixed via codepoint inspection, then built and ran an automated mixed-script scanner across all four files to confirm no further contamination.

### NUMBERS — foundational gaps, not the usual FR/GE pattern
Fresh frontier survey after WEATHER turned up something more basic than another missing-concept arc: **Arabic had zero numbers content of any kind** (every other language had at least 1-5), and **Hindi was missing 6-10** (its own 1-5 lesson literally ended with "Next: six to ten," a promise never cashed in). Filled both, then moved on to **NUMBERS-11-20** (exists FR/GE/IT/PT, missing everywhere else now that 1-10 is solid chain-wide):
- **Arabic**: *wāḥid, ithnān, thalātha, arbaʿa, khamsa* (1-5) — plus an honest correction as the teaching hook: "Arabic numerals" (the digit shapes 0-9) aren't these words and don't come from Arabic at all — they originated in India and reached Europe largely through al-Khwārizmī's 9th-century treatise (whose name gives English "algorithm"). A transmission credit, not an origin credit.
- **Hindi**: *chhah, sāt, āṭh, nau, das* (6-10) — *sāt* and *āṭh* repeat, verbatim, the exact same Sanskrit-cluster-simplifies-then-vowel-lengthens mechanism the existing 1-5 lesson already taught for *tīn*/*chār* (saptá→satta→sāt, aṣṭá→aṭṭha→āṭh); *nau* shows a different fate (an intervocalic -v- dissolving between vowels).
- **Spanish/Latin 11-20**: *once-quince* (11-15) are Latin's *ūndecim-quīndecim* fused into single words; *dieciséis-diecinueve* (16-19) are transparent "ten-and-X" compounds. The honest hook: Latin's OWN 18 and 19 were genuinely **subtractive** — *duodēvīgintī* ("two FROM twenty") and *ūndēvīgintī* ("one FROM twenty") — a real oddity Spanish quietly regularized away, building *dieciocho*/*diecinueve* fresh on plain addition instead. Review caught a real Unicode corruption bug (a stray combining breve had garbled two Latin words, splitting one across a line break) — fixed.
- **Arabic/Hindi 11-20**: Arabic's *ʿishrūn* (20) genuinely is NOT "two-ten" — it's its own standalone plural-like form of the "ten" root, cognate with Hebrew's *eser*. Hindi's 11-18 are honestly irregular and must be memorized — but *unnīs* (19) most likely preserves Sanskrit's **own** subtractive numeral name, echoing Latin's *ūndēvīgintī*: two unrelated Indo-European branches independently landing on "twenty minus one" for nineteen. Review caught a real citation error — my first draft attributed *unnīs* to the wrong specific Sanskrit form (the older *ekonaviṃśati* rather than the actually-attested later *ūnaviṃśati*) — corrected throughout.
- **Dravidian 11-20 — NUMBERS-11-20 now complete chain-wide**: all four Dravidian languages build "twenty" the same underlying compositional way, "two-tens" — genuinely different from Sanskrit/Latin/Arabic, none of which have *any* compositional origin for their word for twenty. But the four sit at different points on a transparency gradient: Tamil/Malayalam keep it fully visible today (*iru* "two" + *pathu* "ten"); Kannada shares the same Proto-Dravidian origin but its own sound changes mean the modern words no longer show through; Telugu's is worn down further still. Review caught a real overclaim in the Kannada draft (asserting its twenty was built directly from the *modern* words for "two" and "ten," when actually neither survives visibly inside it) — rewritten to the accurate, more honest picture, with the Tamil closing lesson's cross-reference updated to match.

### AGE highlights — five genuinely different grammatical shapes for "how old are you"
- **Romance** (already shipped): "I **HAVE** twenty years." **Germanic** (already shipped): "I **AM** twenty years old."
- **Latin**: neither! *vīgintī annōs nātus sum* — "I am, **having been born**, twenty years" — Cicero's own construction (*Cato Maior de Senectute* §14). The Romance "have" pattern is a **later** Vulgar Latin innovation.
- **Arabic**: *kam ʿumruka?* — "how much [is] your **ʿumr**?" — a fully **verbless** noun sentence.
- **Hindi**: *umr* is literally **Arabic's ʿumr**, borrowed via Persian — told with a genitive-postposition + *honā*.
- **Dravidian**: all four share the exact same Sanskrit word for age (*vayas*, PIE cousin of **Latin's own *vīs***!) — but the grammar splits: Kannada/Telugu use a plain verbless possessive; Malayalam uses dative-subject + "exists"; Tamil genuinely spans **both** registers.

### WEATHER — a brand-new concept, now complete chain-wide
Fresh frontier survey confirmed the FR/GE/IT/PT "missing 8" gap pattern is now fully exhausted — WEATHER didn't exist in **any** language, so this is the session's second full concept arc beyond the original survey.
- **Spanish**: *el tiempo* means BOTH "time" and "weather" (Latin *tempus*). *llueve* is its own dedicated verb (*llover* ← *pluere*), the same *pl-→ll-* shift as *llamar*.
- **Latin**: *tempestās* is a derivative of *tempus* that specialized for weather in Classical Latin — review caught a real error: my first draft credited **Spanish** with "reunifying" two Latin words, but the widening of *tempus* to also mean "weather" happened **within Latin itself**, shared by French/Italian too; *tempestās* narrowed separately and survives in Spanish as *tempestad*.
- **Arabic**: *aṭ-ṭaqs* ("weather") shares its root with *ṭuqūs*, "religious rites." Hot/cold are verbless; rain gets its own conjugated verb.
- **Hindi**: *mausam* is another Perso-Arabic loan — the **same root as English "monsoon"** (review caught me misattributing its English entry to the British Raj; it actually arrived via Portuguese/Dutch traders in the 1580s). *Baarish* (Persian, everyday) and *varṣā* (Sanskrit, formal) sound alike but are flagged as probably unrelated — a genuine false-friend.
- **Dravidian — four genuinely different patterns, no forced uniformity**: Kannada's *havāmāna* is a Persian+Sanskrit hybrid ("air-measure"); Telugu's *vātāvaraṇam* is pure Sanskrit ("covering of air"); Malayalam's *kālāvastha* is pure Sanskrit too, but echoes Spanish's time/weather link ("state of time"); Tamil's *vāṉilai* most likely breaks from all three — fully native Dravidian ("standing of the sky"). Review caught an unverifiable DEDR citation in the Tamil file (swapped for confirmed Kannada/Telugu cognates) and a sounds-tag bug.
- **French/German — a real gap self-caught on the next frontier survey**: WEATHER was confirmed missing from ALL 10 languages when this arc started, but the session's habitual "FR/GE already has it" assumption (correct for nearly every earlier concept) caused French and German to get skipped by mistake for several ticks. Caught and fixed: French's *le temps* shares Spanish's exact time/weather polysemy (same shared-Latin-stage widening, not French-specific); *il pleut* ← *pluere* keeps the Latin *pl-* cluster fully intact, unlike Spanish's *llueve* — same verb, two different sound-change fates. German's *das Wetter* is a **native Germanic word**, the same word as English "weather" itself — zero connection to the Latin *tempus* family every Romance language shares; *es regnet* is native too, cognate with English "rain."

### Fresh frontier survey — three small, genuine gaps found and closed
After the Latin arc closed, a new concept_tag survey (checking near-universal tags present in 8-9 of 10 languages, and cross-checking against sibling lesson body text, not just tag strings) turned up three small, confirmed-genuine gaps — plus two false positives worth noting for future survey rounds: German's `WORD-WELL`/`COURTESY-PLEASE` "gaps" turned out to be satisfied in spirit (`gut` already covers good+well in one lesson since German doesn't lexically split them; `bitte` already covers please+you're-welcome in one lesson) — not rebuilt.
- **German FAREWELL-LATER** — *bis später* ("see you later"). Notable because the already-shipped sibling lessons (`bis-bald`, `bis-morgen`) both explicitly *promise* "bis später" as part of the complete farewell set in their own body text, but the file was never created — a real, well-documented oversight found by reading sibling content, not just tag-grepping. Honest note: *später*/*spät* has no established English cognate (unlike *bald*→bold, *Morgen*→morning/morrow in the siblings) — review caught my first draft overstating this as a flat "dead end," when German dictionaries actually propose a hedged, unconfirmed link to *sparen*/*sputen* (→ English spare/speed); softened, and flagged English "late" as an unrelated false friend.
- **Arabic COURTESY-YOUREWELCOME** — *عفوا* (*ʿafwan*), root *ʿ-f-w* ("to erase, obliterate" → "to pardon" — forgiving as metaphorically erasing an offense), the same root as *al-ʿAfuww*, "The Supreme Pardoner," one of the 99 names of Allah. Genuinely multi-purpose (also "excuse me"/"pardon"/"sorry"). Shares the same *tanwīn fatḥ* ("-an") ending as *shukrān* itself — both fixed accusative idioms, no verb.
- **Arabic FAREWELL-TOMORROW** — *إلى الغد* (*ilā l-ghad*, "until tomorrow"), reusing *ilā* ("until") from the already-shipped *ilā l-liqāʾ* sibling. *Al-ghad* ← root *gh-d-w* ("to go out at dawn") → "tomorrow" — the same morning-to-tomorrow drift already taught for Latin *māne* → French *demain*/Spanish *mañana*, now shown to be a genuine independent convergence across two unrelated language families (Semitic and Indo-European), not a Romance-only quirk.

## ⚠️ Please review: Tamil
Sixteen Tamil lessons need your eyes now — sorry, days, colors, family, body parts, seasons, food, months, noon/midnight, hour, age, weather, numbers 11-20, animals, and now green/yellow (**[TA-C22-paccai-manjal.md](code/learning/human-languages/tamil/lessons/TA-C22-paccai-manjal.md)**). This latest one carries its own explicit reviewer note asking you to confirm whether *pacuppu* ("greenish yellow") has any everyday currency for you, or reads as purely archaic/dictionary Tamil.

Every lesson went through linguistics-subagent review, with real catches throughout this session: overclaimed "settled/native/cognate" etymologies where real scholarly disagreement exists (seven times now), a misattributed Cicero quote, a misattributed English word-history claim, glyph/script bugs (six instances now, several self-caught before review even ran, via a reusable automated mixed-script scanner), a chapter-numbering collision caught mid-tick, clean grammatical/etymological splits that didn't hold once a specific language was checked more carefully (four times now), and a whole language-pair (French/German) silently skipped on a false assumption during WEATHER — a mistake explicitly avoided in every arc since.

## Note on workflow
Standing accumulator PR per your instruction. COLOUR-GREEN-YELLOW is complete chain-wide (all 10 languages), the Latin-only conversational-basics catch-up arc is closed (9/9 items), and the first post-arc frontier survey's three confirmed gaps are all closed too. Next: another fresh frontier survey across all 10 languages, explicitly re-checking French/German/Italian/Portuguese rather than assuming, watching for tagging-convention false positives (raw concept_tag gaps can be naming-convention artifacts, not real missing content — caught twice now: Latin's combined `RESPONSE-YESNO` tag, and German's `gut`/`bitte` dual-purpose words), and reading sibling lesson bodies (not just tags) for promised-but-missing content the way `bis später` was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


