### PR TITLE
feat(adj-formula-stdlib): reticulocyte-production-index — StatPearls anaemia-adjusted reticulocyte index formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_reticulocyte_production_index_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_reticulocyte_production_index_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/reticulocyte-production-index.adj` library — the reticulocyte
+//! production index (RPI = reticulocyte% × hematocrit / 45) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula
+//! library: a consumer states NO arithmetic; it imports the grounded library, binds the reticulocyte
+//! percentage and hematocrit with `observe`, and the engine applies the cited formula on the CPU,
+//! computing the EXACT value (over exact rationals) and rendering the citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case
+//! reticulocyte% = 6, hematocrit = 15: 6 × 15 / 45 = 2 (RPI), 2 × 45 / 15 = 6 (reticulocyte%),
+//! 2 × 45 / 6 = 15 (hematocrit). The three asserted values (2, 6, 15) are distinct, none a
+//! colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped reticulocyte-production-index library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_rpi_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/reticulocyte-production-index.adj")
+        .canonicalize()
+        .expect("shipped reticulocyte-production-index.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rpi_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_rpi_lib()).unwrap();
+    std::fs::write(dir.join("reticulocyte-production-index.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// reticulocyte_production_index — the index: reticulocyte% × hematocrit / 45.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_rpi_library_and_computes_it_with_citation() {
+    let dir = scratch("rpi");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"reticulocyte-production-index.adj\"\n\
+         observe reticulocyte_percent(6)\n\
+         observe hematocrit(15)\n\
+         ? reticulocyte_production_index(reticulocyte_percent, hematocrit)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 6 × 15 / 45 = 2, computed
+    // EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"reticulocyte_production_index\"") && s.contains("\"value\":2"),
+        "reticulocyte_production_index(6, 15) = 2: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// reticulocyte_percent — the same equation solved for the reticulocyte percentage: RPI × 45 / hematocrit.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_reticulocyte_percent_from_rpi_with_citation() {
+    let dir = scratch("retic");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"reticulocyte-production-index.adj\"\n\
+         observe reticulocyte_production_index(2)\n\
+         observe hematocrit(15)\n\
+         ? reticulocyte_percent(reticulocyte_production_index, hematocrit)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 × 45 / 15 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"reticulocyte_percent\"") && s.contains("\"value\":6"),
+        "reticulocyte_percent(2, 15) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "reticulocyte_percent carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// hematocrit — the same equation solved for the hematocrit: RPI × 45 / reticulocyte%, the third reading
+// of the one index.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_hematocrit_from_rpi_and_reticulocyte_percent_with_citation() {
+    let dir = scratch("hct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"reticulocyte-production-index.adj\"\n\
+         observe reticulocyte_production_index(2)\n\
+         observe reticulocyte_percent(6)\n\
+         ? hematocrit(reticulocyte_production_index, reticulocyte_percent)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 × 45 / 6 = 15, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"hematocrit\"") && s.contains("\"value\":15"),
+        "hematocrit(2, 6) = 15: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "hematocrit carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/reticulocyte-production-index.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/reticulocyte-production-index.adj
@@ -1,0 +1,92 @@
+% ============================================================================
+% reticulocyte-production-index.adj — the reticulocyte production index
+% (RPI = reticulocyte% × hematocrit / 45) in the ADJ standard library.
+% ============================================================================
+% The reticulocyte-production-index entry of the *clinical* track — the anaemia-adjusted reticulocyte
+% measure. A raw reticulocyte PERCENTAGE overstates marrow output in anaemia, because the percentage is
+% taken against a reduced red-cell mass; scaling by the ratio of the patient's hematocrit to a normal
+% hematocrit of 45 corrects the percentage to what it would be at a normal red-cell mass. THE
+% RETICULOCYTE PRODUCTION INDEX IS THE RETICULOCYTE PERCENTAGE TIMES THE PATIENT'S HEMATOCRIT DIVIDED BY
+% THE NORMAL HEMATOCRIT OF 45 — i.e. reticulocyte% × hematocrit / 45. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the
+% reticulocyte percentage an index implies at a given hematocrit, and the hematocrit an index/percentage
+% pair implies). As with every compute library, a consumer states NO arithmetic: it `import`s this file,
+% binds the reticulocyte percentage and hematocrit from its own byte-provenance decomposition, and asks
+% the engine to APPLY the cited formula on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "reticulocyte-production-index.adj"
+%     observe reticulocyte_percent(6)   % "…reticulocytes 6%…"       (span cited by the model)
+%     observe hematocrit(15)             % "…hematocrit 15%…"         (span cited by the model)
+%     ? reticulocyte_production_index(reticulocyte_percent, hematocrit)
+%                                         % engine → 2, the reticulocyte production index
+%
+% The 45 normal-hematocrit reference is the EXACT constant of the cited formula (not a measurement);
+% the formulas are otherwise exact expressions over the parameters, so every value the engine returns is
+% exact. They COMPOSE and invert cleanly around the worked case reticulocyte% = 6, hematocrit = 15 (RPI
+% = 6 × 15 / 45 = 90 / 45 = 2): the `reticulocyte_production_index` a consumer computes is exactly the
+% value the `reticulocyte_percent` formula back-solves to recover 6, and exactly the value the
+% `hematocrit` formula back-solves to recover 15.
+%
+%   reticulocyte_production_index(reticulocyte_percent, hematocrit) = reticulocyte_percent * hematocrit / 45   % (index)
+%   reticulocyte_percent(reticulocyte_production_index, hematocrit) = reticulocyte_production_index * 45 / hematocrit  % (solved for retic%)
+%   hematocrit(reticulocyte_production_index, reticulocyte_percent) = reticulocyte_production_index * 45 / reticulocyte_percent  % (solved for hematocrit)
+%
+% NOTE ON UNITS AND MODELLING: reticulocyte percentage and hematocrit both as percentages, reference
+% hematocrit 45. This is the index EXACTLY as the cited article writes it — reticulocyte% × Hct / 45; a
+% fuller reticulocyte production index sometimes also divides by a maturation factor, but the cited
+% page's stated equation is the single expression grounded here, and that is what this library computes.
+% The index only ADJUSTS the interpretation of the reticulocyte percentage for the degree of anaemia; it
+% does not itself diagnose the anaemia.
+%
+% All three formulas are defended by the SAME clause — the quoted index equation — because that one
+% statement (the RPI IS the reticulocyte percentage times the hematocrit over 45) sanctions the relation
+% read every way. The quote is transcribed verbatim from the StatPearls "Histology, Reticulocytes"
+% article on the NCBI Bookshelf (a current, non-archived article), so each `formula` carries the
+% provenance envelope every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula, including its 45 constant, is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `reticulocyte_percent`, `hematocrit` and `reticulocyte_production_index` each appear BOTH
+% as a derived result and as an input (of the other formulas), so each is a single dictionary term used
+% in both roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term;
+% the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary reticulocyte_production_index_vocab {
+    define reticulocyte_percent           : finding  surface "reticulocyte percent", "reticulocyte percentage", "reticulocytes", "retic count"  % percent
+    define hematocrit                     : finding  surface "hematocrit", "haematocrit", "Hct"                                                  % percent
+    define reticulocyte_production_index   : finding  surface "reticulocyte production index", "RPI", "corrected reticulocyte count"             % index (dimensionless)
+}
+
+% ----------------------------------------------------------------------------
+% The reticulocyte production index, all three ways. Each is a named, importable, reusable formula over
+% its formal parameters, bound at apply time, and each carries the index equation from the StatPearls
+% "Histology, Reticulocytes" article on the NCBI Bookshelf (a quote is required on a shipped formula).
+% Each is an exact expression in the measured quantities and the cited 45 constant, so the engine
+% returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook reticulocyte_production_index_laws {
+    use reticulocyte_production_index_vocab
+
+    % Reticulocyte production index — the reticulocyte percentage times the hematocrit over the 45
+    % normal-hematocrit reference.
+    formula reticulocyte_production_index(reticulocyte_percent, hematocrit) = reticulocyte_percent * hematocrit / 45
+        source "Reticulocyte production index (RPI) = [%reticulocyte count x Patient Hct]/45(normal Hct)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542172/"
+        trust authoritative
+
+    % Reticulocyte percentage — the same equation solved for the reticulocyte percentage. Defended by
+    % the SAME sentence.
+    formula reticulocyte_percent(reticulocyte_production_index, hematocrit) = reticulocyte_production_index * 45 / hematocrit
+        source "Reticulocyte production index (RPI) = [%reticulocyte count x Patient Hct]/45(normal Hct)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542172/"
+        trust authoritative
+
+    % Hematocrit — the same equation solved for the hematocrit. The SAME sentence, read the third way.
+    formula hematocrit(reticulocyte_production_index, reticulocyte_percent) = reticulocyte_production_index * 45 / reticulocyte_percent
+        source "Reticulocyte production index (RPI) = [%reticulocyte count x Patient Hct]/45(normal Hct)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542172/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/reticulocyte-production-index.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/reticulocyte-production-index.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% reticulocyte-production-index.query.adj — worked applications of the reticulocyte production index.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an anaemia vignette into a reticulocyte
+% percentage and a hematocrit: it `import`s the grounded formulabook, `observe`s the two values, and
+% asks the engine to APPLY the cited index. No arithmetic is stated by the consumer; the engine computes
+% each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU,
+% with zero model calls.
+%
+% Worked case (reticulocyte% = 6, hematocrit = 15): RPI = 6 × 15 / 45 = 2. Each query fixes two of the
+% three quantities and asks the engine to recover the third; every answer is exact and the three
+% COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli reticulocyte-production-index.query.adj
+% ============================================================================
+
+import "reticulocyte-production-index.adj"
+
+% --- Index: the RPI the reticulocyte percentage and hematocrit imply (expect 2). --------------------
+observe reticulocyte_percent(6)
+observe hematocrit(15)
+? reticulocyte_production_index(reticulocyte_percent, hematocrit)   % expect 2
+
+% --- Inverse: the reticulocyte percentage an RPI of 2 implies at hematocrit 15 (expect 6). ----------
+observe reticulocyte_production_index(2)
+? reticulocyte_percent(reticulocyte_production_index, hematocrit)   % expect 6


### PR DESCRIPTION
## What

Adds the **reticulocyte production index** (the anaemia-adjusted reticulocyte measure) to the ADJ formula standard library (clinical track), as a byte-provenanced, importable `formulabook` together with its two exact rearrangements:

```
reticulocyte_production_index(reticulocyte_percent, hematocrit) = reticulocyte_percent * hematocrit / 45
reticulocyte_percent(reticulocyte_production_index, hematocrit) = reticulocyte_production_index * 45 / hematocrit
hematocrit(reticulocyte_production_index, reticulocyte_percent) = reticulocyte_production_index * 45 / reticulocyte_percent
```

All three formulas are defended by the **same verbatim clause** from the current (non-archived) StatPearls *Histology, Reticulocytes* article on the NCBI Bookshelf ([NBK542172](https://www.ncbi.nlm.nih.gov/books/NBK542172/)):

> Reticulocyte production index (RPI) = [%reticulocyte count x Patient Hct]/45(normal Hct)

The `45` normal-hematocrit reference is the exact constant of the cited formula. A raw reticulocyte percentage overstates marrow output in anaemia (it's measured against a reduced red-cell mass); scaling by `Hct/45` corrects it to a normal red-cell mass. The engine computes every value **exactly over rationals**. As with every compute library, a consumer states **no arithmetic** — it imports the library, `observe`s the reticulocyte percentage and hematocrit, and the engine applies the cited formula on the CPU. New hematology formula, distinct from the shipped mentzer-index.

## Files

- `code/specs/data/adj-formula-stdlib/clinical/reticulocyte-production-index.adj` — dictionary + 3-formula formulabook (each carrying source/locator/trust).
- `code/specs/data/adj-formula-stdlib/clinical/reticulocyte-production-index.query.adj` — worked forward + inverse applications.
- `code/packages/rust/adj-lang-cli/tests/formula_reticulocyte_production_index_e2e.rs` — dedicated e2e test.

## Worked case & inversion (asserted by the e2e test)

- forward: reticulocyte_percent=6, hematocrit=15 → `RPI = 6 × 15 / 45 = 2`
- inverse: RPI=2, hematocrit=15 → `reticulocyte_percent = 6`
- inverse: RPI=2, reticulocyte_percent=6 → `hematocrit = 15`

Each answer carries the NBK542172 citation and `trust:authoritative`.

## Checks

- `cargo test -p adj-lang-cli --test formula_reticulocyte_production_index_e2e` — 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probe against the built CLI confirms `RPI=2` / `reticulocyte_percent=6`, both with the NBK542172 locator + authoritative trust.
- NUL-scan clean on all three new files.
- `/security-review` — SECURITY REVIEW PASSED.

Data + test only; no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)