### PR TITLE
feat(spice): validate MOS channel modulation

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values with a
+  stable diagnostic before current evaluation.
 - Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values with a
   stable diagnostic before threshold preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `KP` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -582,6 +582,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET KP must be finite and positive")
         elif canonical == "VT0" and not math.isfinite(value):
             raise ValueError(f"{name}: MOSFET VT0 must be finite")
+        elif canonical == "LAMBDA" and not math.isfinite(value):
+            raise ValueError(f"{name}: MOSFET LAMBDA must be finite")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1068,6 +1068,16 @@ def test_mos_model_card_rejects_non_finite_threshold_voltage() -> None:
             normalize_model_card("Minvalid", "nmos", {"VTO": invalid_threshold})
 
 
+def test_mos_model_card_rejects_non_finite_channel_modulation() -> None:
+    for name, value in (("LAMBDA", -0.01), ("LAM", 0.0), ("LAMBDA", 0.01)):
+        valid = normalize_model_card("Mvalid", "nmos", {name: value})
+        assert valid.parameters["LAMBDA"] == pytest.approx(value)
+
+    for invalid_modulation in (-math.inf, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET LAMBDA must be finite"):
+            normalize_model_card("Minvalid", "nmos", {"LAM": invalid_modulation})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values with a
+  stable diagnostic before current evaluation.
 - Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values with a
   stable diagnostic before threshold preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `KP` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4385,6 +4385,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET VT0 must be finite".to_string(),
                 });
+            } else if canonical == "LAMBDA" && !raw_value.is_finite() {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET LAMBDA must be finite".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -879,6 +879,22 @@ fn mos_model_card_rejects_non_finite_threshold_voltage() {
 }
 
 #[test]
+fn mos_model_card_rejects_non_finite_channel_modulation() {
+    for (name, value) in [("LAMBDA", -0.01), ("LAM", 0.0), ("LAMBDA", 0.01)] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[(name, value)]).unwrap();
+        assert_close(*valid.parameters.get("LAMBDA").unwrap(), value);
+    }
+
+    for invalid_modulation in [f64::NEG_INFINITY, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("LAM", invalid_modulation)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET LAMBDA must be finite"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values with a
+  stable diagnostic before current evaluation.
 - Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values with a
   stable diagnostic before threshold preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `KP` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8444,6 +8444,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET KP must be finite and positive");
     } else if (canonical === "VT0" && !Number.isFinite(value)) {
       throw invalidElement(name, "MOSFET VT0 must be finite");
+    } else if (canonical === "LAMBDA" && !Number.isFinite(value)) {
+      throw invalidElement(name, "MOSFET LAMBDA must be finite");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -747,6 +747,27 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects non-finite MOS channel modulation", () => {
+    for (const [name, value] of [
+      ["LAMBDA", -0.01],
+      ["LAM", 0.0],
+      ["LAMBDA", 0.01],
+    ] as const) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { [name]: value });
+      expect(valid.parameters.LAMBDA).toBe(value);
+    }
+
+    for (const invalidModulation of [
+      Number.NEGATIVE_INFINITY,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { LAM: invalidModulation }),
+      ).toThrow("MOSFET LAMBDA must be finite");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS threshold-voltage validation.
+1. Cross-language Level-1 MOS channel-modulation validation.
    - Status: current PR completion candidate.
-   - Reject non-finite model-card `VT0` / `VTO` / `VTH` values before threshold
-     preprocessing and explicit-value precedence.
-   - Preserve arbitrary finite NMOS and PMOS threshold voltages across Rust,
-     Python, and TypeScript.
+   - Reject non-finite model-card `LAMBDA` / `LAM` values before current
+     evaluation.
+   - Preserve arbitrary finite channel-length modulation coefficients across
+     Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3678,6 +3678,13 @@ the Rust, Python, and TypeScript surfaces together.
      temperature scaling and current evaluation.
    - Positive explicit transconductance and its precedence over process-derived
      `KP` remain aligned across Rust, Python, and TypeScript.
+
+300. Cross-language Level-1 MOS threshold-voltage validation.
+   - Status: completed in PR 9206.
+   - Non-finite model-card `VT0` / `VTO` / `VTH` values are rejected before
+     threshold preprocessing and explicit-value precedence.
+   - Arbitrary finite NMOS and PMOS threshold voltages remain aligned across
+     Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-finite Level-1 MOS `LAMBDA` / `LAM` model-card values during normalization
- preserve arbitrary finite channel-length modulation coefficients across Rust, Python, and TypeScript
- add cross-language regression coverage, changelog entries, and roll the SPICE implementation plan forward from PR #9206

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python: `ruff check src tests` and `pytest` (682 passed, 88.95% coverage)
- TypeScript: `npm ci`, `npm test` (425 passed), and `npm run build`
- post-rebase focused Rust, Python, and TypeScript checks