### PR TITLE
feat(adj-formula-stdlib): thermal-conductivity — NIST SP 811 B.9 thermal-conductivity→W/(m·K) factor (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1712,6 +1712,51 @@ fn shipped_specific_energy_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// Shipped thermal-conductivity table — the EXACT NIST SP 811 B.9 factor resolves, and a wrong-dimension
+// unit (a mass unit) abstains. Guards the SLICE of a NEW dimension (thermal conductivity, the watt per
+// metre kelvin) and the honest cross-dimension abstention: `pound` is a mass unit, so a
+// thermal-conductivity lookup for it must abstain, catching the thermal-conductivity/mass confusion
+// directly, not mere absence of a value. (Thermal conductivity is power per length per temperature —
+// distinct from plain power, W, and from specific heat capacity, J/(kg·K).)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_thermal_conductivity_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_thermalconductivity");
+    let src = stdlib().join("reference/thermal-conductivity-conversions.adj");
+    std::fs::copy(&src, dir.join("thermal-conductivity-conversions.adj"))
+        .expect("copy shipped thermal-conductivity-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"thermal-conductivity-conversions.adj\"\n\
+         ? thermal_conductivity_to_watt_per_metre_kelvin(calorie_th_per_centimetre_second_celsius, $v)\n\
+         ? thermal_conductivity_to_watt_per_metre_kelvin(pound, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table (boldface =
+    // exact; the thermochemical calorie is exactly 4.184 J and cm→m is an exact ×10², so
+    // calth/(cm·s·°C) = 418.4 W/(m·K), exactly).
+    assert!(
+        out.contains("\"v\":\"418.4\""),
+        "calorieth per centimetre second degree Celsius = 4.184 E+02 W/(m*K): {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `pound` is a MASS unit (it converts to the kilogram, a DIFFERENT quantity), so this
+    // thermal-conductivity table has no row for it — the engine abstains rather than mis-converting a
+    // mass unit as if it were a thermal-conductivity unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/thermal-conductivity-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/thermal-conductivity-conversions.adj
@@ -1,0 +1,64 @@
+% ============================================================================
+% thermal-conductivity-conversions — thermal-conductivity unit → watt-per-metre-kelvin factors
+% (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the NIST-cited conversion tables (length, mass, area, volume, energy, force,
+% power, pressure, the electric-EMU family, the two viscosities, wave number, linear mass density,
+% temperature interval, mass density, moment of force, specific heat capacity, density of heat, specific
+% energy, and the rest): a native tabular relation ingested VERBATIM from a published NIST conversion
+% table. Each row states the factor converting a common non-SI unit of THERMAL CONDUCTIVITY (a
+% material's intrinsic ability to conduct heat — the heat FLUX per unit temperature GRADIENT) to the SI
+% coherent derived unit, the watt per metre kelvin, W/(m·K):
+%
+%     ? thermal_conductivity_to_watt_per_metre_kelvin(calorie_th_per_centimetre_second_celsius, $v)   % 418.4
+%
+% This opens a NEW dimension — THERMAL CONDUCTIVITY (power / (length × temperature), W/(m·K)) —
+% alongside the already-tabulated length/mass/area/volume/time/speed/energy/pressure/force/power/
+% acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/magnetic-flux/illuminance/
+% luminance/radioactivity/absorbed-dose/dose-equivalent/exposure/wave-number/linear-mass-density/
+% temperature-interval/mass-density/moment-of-force/specific-heat-capacity/density-of-heat/
+% specific-energy tables and the electric charge/potential/resistance/capacitance/inductance/
+% conductance/current tables. Thermal conductivity is power per (length × temperature) — distinct from
+% plain POWER, the watt, and from SPECIFIC HEAT CAPACITY, J/(kg·K): do NOT confuse them. A value given
+% in cal/(cm·s·°C) must be put into SI first, then reasoned over (write-once-use-many). Why a `table`
+% and not hand-written `relate` clauses: this is exactly the shape reference data comes in — a published
+% table, not prose. The citable artifact IS the NIST conversion-factors table at the `locator` below;
+% each factor here is a CELL of NIST Special Publication 811, Appendix B.9, defended by one provenance
+% envelope. Each `row` lowers to a ground relation
+% `thermal_conductivity_to_watt_per_metre_kelvin(unit, v)`, so the exact lookup above is the ordinary
+% SLD binding query — the engine returns the factor WITH this table's citation as its proof, on the CPU,
+% with zero model calls.
+%
+% HONESTY NOTE (like every other NIST table, only the EXACT defined factors get rows): NIST SP 811 B.9
+% prints the thermal-conductivity factor below in BOLDFACE, its convention for factors that are EXACT by
+% definition, transcribed here as the plain decimal number of watts per metre kelvin it names:
+%
+%     calorieth per centimeter second degree Celsius [calth/(cm·s·°C)]   4.184 E+02  →  418.4
+%
+% It is EXACT and terminates; nothing here is a rounded measurement. It is exact because the
+% thermochemical calorie is DEFINED as exactly 4.184 J, the centimetre→metre scaling is an exact ×10²,
+% and a Celsius-degree interval EQUALS a kelvin interval: calth/(cm·s·°C) = 4.184 J / (10⁻² m · s · K) =
+% 4.184 / 10⁻² = 4.184 × 10² = 418.4 W/(m·K), exactly. (NIST SP 811 B.9 also lists British-thermal-unit
+% thermal-conductivity units — e.g. Btu·in/(h·ft²·°F) — but their W/(m·K) factors are NON-terminating,
+% carrying the inch/foot's 2.54-based length and the °F 5/9 interval through, so, per the exact-only
+% rule, they get no row here; only the thermochemical-calorie unit is exact.) This table is SPECIFIC to
+% thermal conductivity: a unit of a DIFFERENT quantity — e.g. the "pound", which NIST SP 811 B.9 lists
+% separately as a MASS unit converting to the kilogram, NOT to W/(m·K) — therefore gets no row here, and
+% a `? thermal_conductivity_to_watt_per_metre_kelvin(pound, $v)` ABSTAINS rather than mis-converting a
+% mass unit as if it were a thermal-conductivity unit. The only claim this table makes is "this is the
+% exact factor NIST SP 811 B.9 prints for the calorieth per centimetre second degree Celsius's
+% conversion to the watt per metre kelvin" — which is exactly what a byte-check against the cited table
+% verifies. `trust authoritative` — a primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — the factor is a verbatim cell of the cited table, nothing asserted
+% from memory.)
+% ============================================================================
+
+table thermal_conductivity_to_watt_per_metre_kelvin {
+    columns unit, watt_per_metre_kelvin
+
+    row (calorie_th_per_centimetre_second_celsius, 418.4)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/thermal-conductivity-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/thermal-conductivity-conversions.query.adj
@@ -1,0 +1,25 @@
+% ============================================================================
+% thermal-conductivity-conversions.query.adj — worked lookups over the NIST thermal-conductivity →
+% watt-per-metre-kelvin table.
+% ============================================================================
+% The shape a consumer produces to convert a thermal conductivity given in a non-SI unit into SI: it
+% `import`s the grounded table and asks the engine to bind the factor. No arithmetic and no factor is
+% stated by the consumer; the engine returns the cell WITH the table's NIST citation as its proof, on
+% the CPU.
+%
+%   ? thermal_conductivity_to_watt_per_metre_kelvin(calorie_th_per_centimetre_second_celsius, $v)   % 418.4
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The "pound" is a MASS unit (it converts to the kilogram), NOT
+% a thermal-conductivity unit — so it is caught rather than silently mis-converted:
+%
+%   ? thermal_conductivity_to_watt_per_metre_kelvin(pound, $v)   % abstains (pound is mass → kilogram)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli thermal-conductivity-conversions.query.adj
+% ============================================================================
+
+import "thermal-conductivity-conversions.adj"
+
+? thermal_conductivity_to_watt_per_metre_kelvin(calorie_th_per_centimetre_second_celsius, $v)   % expect 418.4  (exact NIST SP 811 B.9 factor)
+? thermal_conductivity_to_watt_per_metre_kelvin(pound, $v)                                      % expect abstain (mass unit, wrong dimension)


### PR DESCRIPTION
## What

Adds a new NIST-cited RS-5 reference conversion `table` opening a **new dimension** — **thermal conductivity** (power per length per temperature, the watt per metre kelvin `W/(m·K)`) — alongside the length/mass/energy/power/pressure/force/moment-of-force/viscosity/electric/specific-heat-capacity/density-of-heat/specific-energy/… tables already shipped.

One **exact** (NIST-boldface) factor, transcribed verbatim from [SP 811 Appendix B.9](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9):

| from | to | factor |
|---|---|---|
| calorie_th per centimeter second degree Celsius [cal_th/(cm·s·°C)] | W/(m·K) | **418.4** |

It is exact and terminates: the thermochemical calorie is exactly `4.184 J`, cm→m is an exact `×10²`, and a Celsius interval equals a kelvin interval, so `cal_th/(cm·s·°C) = 4.184 / 1e-2 = 418.4` W/(m·K), exactly. NIST also lists British-thermal-unit thermal-conductivity units, but their W/(m·K) factors are **non-terminating** (2.54-based inch/foot + 5/9 °F interval), so only the thermochemical-calorie unit is exact and gets a row.

## Files

- `code/specs/data/adj-formula-stdlib/reference/thermal-conductivity-conversions.adj` — the table (1 row + one provenance envelope).
- `code/specs/data/adj-formula-stdlib/reference/thermal-conductivity-conversions.query.adj` — worked lookup + a wrong-dimension abstain probe.
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — appends `shipped_thermal_conductivity_conversions_table_resolves_and_abstains` to the shared RS-5 anchor.

## Behaviour (asserted by the e2e test)

- `? …(calorie_th_per_centimetre_second_celsius, $v)` → `418.4`, carrying the B.9 locator + `trust:authoritative`
- `? …(pound, $v)` → **abstains** (`pound` is a MASS unit → kilogram; the table refuses to mis-convert across dimensions rather than fabricating a factor)

## Checks

- `cargo test -p adj-lang-cli --test rs5_table_e2e thermal_conductivity` — 1 passed (43 total in the anchor).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probe against the built CLI confirms `418.4` resolves and `pound` abstains, with the NIST locator.
- NUL-scan clean on all three files.
- `/security-review` — SECURITY REVIEW PASSED.

Data + test only; no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)