### PR TITLE
Add runnable Venture macOS host

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -170,6 +170,7 @@ members = [
     "html-to-layout",
     "html-to-paint",
     "venture-browser-core",
+    "venture-browser-macos",
     "html-renderer",
     "intel4004-gatelevel",
     "mos6502-gatelevel",

--- a/code/packages/rust/venture-browser-macos/BUILD
+++ b/code/packages/rust/venture-browser-macos/BUILD
@@ -1,0 +1,2 @@
+cargo test --manifest-path Cargo.toml
+cargo build --manifest-path Cargo.toml

--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add a runnable macOS Venture host using AppKit, CoreText, and Metal.
+- Add a native acceptance test carrying canned HTML through CoreText glyph
+  bindings into non-empty Metal-rendered pixels.

--- a/code/packages/rust/venture-browser-macos/Cargo.toml
+++ b/code/packages/rust/venture-browser-macos/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "venture-browser-macos"
+version = "0.1.0"
+edition = "2021"
+description = "Runnable AppKit, CoreText, and Metal host for the Venture browser."
+
+[dependencies]
+html-to-layout = { path = "../html-to-layout" }
+html-to-paint = { path = "../html-to-paint" }
+layout-text-measure-native = { path = "../layout-text-measure-native" }
+paint-metal = { path = "../paint-metal" }
+text-native = { path = "../text-native" }
+venture-browser-core = { path = "../venture-browser-core" }
+window-appkit = { path = "../window-appkit" }
+window-core = { path = "../window-core" }
+
+[target.'cfg(target_vendor = "apple")'.dependencies]
+objc-bridge = { path = "../objc-bridge" }

--- a/code/packages/rust/venture-browser-macos/README.md
+++ b/code/packages/rust/venture-browser-macos/README.md
@@ -1,0 +1,30 @@
+# venture-browser-macos
+
+The first runnable native host for Venture, the educational Mosaic-era
+browser. It composes:
+
+- `venture-browser-core` for transactional navigation and page loading;
+- CoreText for native measurement and shaping;
+- AppKit for the native window and `CAMetalLayer`;
+- `paint-metal` for presenting the viewport scene.
+
+Run the first CERN web page:
+
+```bash
+cargo run -p venture-browser-macos
+```
+
+Or provide another HTTP URL:
+
+```bash
+cargo run -p venture-browser-macos -- http://example.com/
+```
+
+Exercise the real AppKit + Metal presentation path and close automatically:
+
+```bash
+cargo run -p venture-browser-macos -- --smoke-seconds 1 http://info.cern.ch/
+```
+
+This first host slice loads and presents one page. Native controls, input-event
+translation, scrolling, and link activation are the next integration layer.

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -12,9 +12,12 @@ use std::fmt;
 use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 use venture_browser_core::{
     BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
-    BrowserSession, HttpBrowserFetcher,
+    BrowserSession,
 };
 use window_core::WindowError;
+
+#[cfg(target_vendor = "apple")]
+use venture_browser_core::HttpBrowserFetcher;
 
 pub const VERSION: &str = "0.1.0";
 pub const DEFAULT_START_URL: &str = "http://info.cern.ch/";
@@ -179,6 +182,8 @@ pub fn run_for_smoke(_start_url: &str, _seconds: f64) -> Result<(), MacBrowserEr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_vendor = "apple")]
     use venture_browser_core::BrowserFetchResponse;
 
     #[test]

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -1,0 +1,237 @@
+//! Runnable macOS host for the Venture browser.
+//!
+//! The host deliberately stays thin: shared crates own navigation, fetching,
+//! HTML parsing, layout, paint composition, scrolling, and hit-testing. This
+//! crate selects native CoreText services, creates an AppKit Metal window, and
+//! presents the loaded viewport.
+
+use html_to_layout::mosaic_html_theme;
+use html_to_paint::HtmlPaintViewport;
+use layout_text_measure_native::NativeMeasurer;
+use std::fmt;
+use text_native::{NativeMetrics, NativeResolver, NativeShaper};
+use venture_browser_core::{
+    BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
+    BrowserSession, HttpBrowserFetcher,
+};
+use window_core::WindowError;
+
+pub const VERSION: &str = "0.1.0";
+pub const DEFAULT_START_URL: &str = "http://info.cern.ch/";
+pub const DEFAULT_WINDOW_WIDTH: f64 = 1024.0;
+pub const DEFAULT_WINDOW_HEIGHT: f64 = 720.0;
+
+#[derive(Debug)]
+pub enum MacBrowserError {
+    UnsupportedPlatform,
+    Load(BrowserLoadError),
+    Window(WindowError),
+    MissingMetalLayer,
+    Paint(String),
+    MissingViewport,
+}
+
+impl fmt::Display for MacBrowserError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedPlatform => {
+                write!(
+                    formatter,
+                    "the Venture macOS host requires an Apple platform"
+                )
+            }
+            Self::Load(error) => write!(formatter, "page load failed: {error}"),
+            Self::Window(error) => write!(formatter, "window setup failed: {error}"),
+            Self::MissingMetalLayer => {
+                write!(
+                    formatter,
+                    "AppKit did not attach the requested CAMetalLayer"
+                )
+            }
+            Self::Paint(message) => write!(formatter, "Metal presentation failed: {message}"),
+            Self::MissingViewport => write!(formatter, "page load completed without a viewport"),
+        }
+    }
+}
+
+impl std::error::Error for MacBrowserError {}
+
+impl From<BrowserLoadError> for MacBrowserError {
+    fn from(error: BrowserLoadError) -> Self {
+        Self::Load(error)
+    }
+}
+
+impl From<WindowError> for MacBrowserError {
+    fn from(error: WindowError) -> Self {
+        Self::Window(error)
+    }
+}
+
+pub fn window_title(page_title: Option<&str>, final_url: &str) -> String {
+    match page_title.map(str::trim).filter(|title| !title.is_empty()) {
+        Some(page_title) => format!("{page_title} — Venture — {final_url}"),
+        None => format!("Venture — {final_url}"),
+    }
+}
+
+/// Load the first page with native text measurement and shaping.
+///
+/// Keeping the fetcher injectable makes the same acceptance path deterministic
+/// in tests while the executable uses `HttpBrowserFetcher`.
+pub fn load_initial_session<F>(
+    start_url: &str,
+    width: f64,
+    height: f64,
+    fetcher: &F,
+) -> Result<BrowserSession, BrowserLoadError>
+where
+    F: BrowserResourceFetcher,
+{
+    let theme = mosaic_html_theme();
+    let measurer = NativeMeasurer::new();
+    let shaper = NativeShaper::new();
+    let metrics = NativeMetrics::new();
+    let resolver = NativeResolver::new();
+    let pipeline = BrowserPagePipeline::new(
+        &theme,
+        HtmlPaintViewport::new(width, height, 1.0),
+        &measurer,
+        &shaper,
+        &metrics,
+        &resolver,
+    );
+    let mut session = BrowserSession::new(start_url, height);
+    session.execute(
+        BrowserNavigation::Navigate(start_url.to_string()),
+        &pipeline,
+        fetcher,
+    )?;
+    Ok(session)
+}
+
+#[cfg(target_vendor = "apple")]
+pub fn run(start_url: &str) -> Result<(), MacBrowserError> {
+    run_with_termination(start_url, None)
+}
+
+/// Launch the native browser host and terminate it after a short interval.
+///
+/// This exercises the real AppKit + `CAMetalLayer` presentation path in
+/// automated smoke runs while normal `run` remains interactive until close.
+#[cfg(target_vendor = "apple")]
+pub fn run_for_smoke(start_url: &str, seconds: f64) -> Result<(), MacBrowserError> {
+    run_with_termination(start_url, Some(seconds.max(0.0)))
+}
+
+#[cfg(target_vendor = "apple")]
+fn run_with_termination(
+    start_url: &str,
+    terminate_after: Option<f64>,
+) -> Result<(), MacBrowserError> {
+    use window_appkit::AppKitBackend;
+    use window_core::{LogicalSize, SurfacePreference, WindowBuilder};
+
+    let session = load_initial_session(
+        start_url,
+        DEFAULT_WINDOW_WIDTH,
+        DEFAULT_WINDOW_HEIGHT,
+        &HttpBrowserFetcher::default(),
+    )?;
+    let viewport = session.viewport().ok_or(MacBrowserError::MissingViewport)?;
+    let scene = viewport.viewport_scene();
+    let page = viewport.page();
+    let title = window_title(page.document.title.as_deref(), &page.final_url);
+
+    let mut backend = AppKitBackend::new();
+    let window = WindowBuilder::new()
+        .title(title)
+        .initial_size(LogicalSize::new(
+            DEFAULT_WINDOW_WIDTH,
+            DEFAULT_WINDOW_HEIGHT,
+        ))
+        .preferred_surface(SurfacePreference::Metal)
+        .build_with(&mut backend)?;
+    let layer = window
+        .appkit_target()
+        .metal_layer
+        .ok_or(MacBrowserError::MissingMetalLayer)?;
+    paint_metal::render_to_metal_layer(&scene, layer as objc_bridge::Id)
+        .map_err(|error| MacBrowserError::Paint(error.to_string()))?;
+
+    if let Some(seconds) = terminate_after {
+        backend.terminate_after(seconds)?;
+    }
+    backend.run()?;
+    Ok(())
+}
+
+#[cfg(not(target_vendor = "apple"))]
+pub fn run(_start_url: &str) -> Result<(), MacBrowserError> {
+    Err(MacBrowserError::UnsupportedPlatform)
+}
+
+#[cfg(not(target_vendor = "apple"))]
+pub fn run_for_smoke(_start_url: &str, _seconds: f64) -> Result<(), MacBrowserError> {
+    Err(MacBrowserError::UnsupportedPlatform)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use venture_browser_core::BrowserFetchResponse;
+
+    #[test]
+    fn window_title_includes_page_and_final_url() {
+        assert_eq!(
+            window_title(Some("World Wide Web"), "http://info.cern.ch/"),
+            "World Wide Web — Venture — http://info.cern.ch/"
+        );
+        assert_eq!(
+            window_title(Some("  "), "http://info.cern.ch/"),
+            "Venture — http://info.cern.ch/"
+        );
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[test]
+    fn canned_html_reaches_coretext_and_metal_pixels() {
+        let fetcher = |url: &str| {
+            Ok(BrowserFetchResponse::new(
+                url,
+                200,
+                Some("text/html; charset=utf-8".into()),
+                b"<title>Venture</title><h1>World Wide Web</h1>\
+                  <p><a href='next.html'>What's out there?</a></p>"
+                    .to_vec(),
+            ))
+        };
+        let session = load_initial_session("http://example.test/", 320.0, 180.0, &fetcher)
+            .expect("native browser pipeline should load canned HTML");
+        let scene = session
+            .viewport()
+            .expect("loaded session should have a viewport")
+            .viewport_scene();
+
+        assert!(
+            format!("{:?}", scene.instructions).contains("coretext:"),
+            "native glyph runs should preserve CoreText font bindings"
+        );
+        let pixels = paint_metal::render(&scene);
+        assert_eq!(pixels.width, 320);
+        assert_eq!(pixels.height, 180);
+        assert!(pixels
+            .data
+            .chunks_exact(4)
+            .any(|pixel| pixel != [192, 192, 192, 255]));
+    }
+
+    #[cfg(not(target_vendor = "apple"))]
+    #[test]
+    fn runtime_rejects_non_apple_hosts() {
+        assert!(matches!(
+            run(DEFAULT_START_URL),
+            Err(MacBrowserError::UnsupportedPlatform)
+        ));
+    }
+}

--- a/code/packages/rust/venture-browser-macos/src/main.rs
+++ b/code/packages/rust/venture-browser-macos/src/main.rs
@@ -1,0 +1,26 @@
+use venture_browser_macos::{run, run_for_smoke, DEFAULT_START_URL};
+
+fn main() {
+    let mut arguments = std::env::args().skip(1);
+    let first = arguments.next();
+    let (smoke_seconds, start_url) = if first.as_deref() == Some("--smoke-seconds") {
+        let seconds = arguments
+            .next()
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or(1.0);
+        let url = arguments
+            .next()
+            .unwrap_or_else(|| DEFAULT_START_URL.to_string());
+        (Some(seconds), url)
+    } else {
+        (None, first.unwrap_or_else(|| DEFAULT_START_URL.to_string()))
+    };
+    let result = match smoke_seconds {
+        Some(seconds) => run_for_smoke(&start_url, seconds),
+        None => run(&start_url),
+    };
+    if let Err(error) = result {
+        eprintln!("venture-browser-macos: {error}");
+        std::process::exit(1);
+    }
+}

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -70,8 +70,11 @@ scroll-aware link hit-testing, and viewport scene translation.
 scroll coherently when the page changes. `BrowserSession` now dispatches native
 navigation commands and content-link activation through transactional page
 loads, preserving the prior history and viewport on failure. The remaining
-browser gate is the concrete platform shell that binds the session to native
-window events, controls, scrollbars, and the selected production paint backend.
+browser gate is now being closed on macOS first: `venture-browser-macos` loads
+an HTTP page with native CoreText services, creates an AppKit `CAMetalLayer`,
+and presents the viewport through `paint-metal`. Native event translation,
+controls, scrolling, and repeated navigation remain before the shell is
+interactive.
 
 ## Where It Fits
 
@@ -267,13 +270,14 @@ the browser.
 
 ### Platform Abstraction
 
-The browser itself has a thin platform layer. Only Windows is implemented for
-v0.1; macOS and Linux are future work.
+The browser itself has a thin platform layer. The first runnable host targets
+macOS so it can be exercised on current development hardware; Windows remains
+the intended v0.1 parity target after the interaction model is proven.
 
 | Platform | Window              | Rendering                                     | Text Measurement           |
 |----------|---------------------|-----------------------------------------------|----------------------------|
-| Windows  | Win32 CreateWindowExW | paint-vm-direct2d (P2D06) or paint-vm-gdi (P2D07) | text-measure-directwrite  |
-| macOS    | Cocoa NSWindow (future) | paint-vm-metal (exists, partial)            | text-measure-coretext (future) |
+| Windows  | Win32 CreateWindowExW (next host) | paint-vm-direct2d (P2D06) or paint-vm-gdi (P2D07) | text-native DirectWrite |
+| macOS    | Cocoa NSWindow (initial host) | paint-metal + CAMetalLayer              | text-native CoreText |
 | Linux    | GTK/X11 (future)    | paint-vm-cairo (P2D08, future)                | text-measure-pango (future) |
 
 ### Win32 Window Structure


### PR DESCRIPTION
## What changed

- add `venture-browser-macos`, the first runnable native Venture host
- load an HTTP page through `BrowserSession` with native CoreText measurement and shaping
- create an AppKit window backed by `CAMetalLayer` and present the viewport through `paint-metal`
- add a timed native smoke mode and an Apple-only acceptance test
- update BR01 to record the macOS-first host sequence and the remaining interaction work

This deliberately lands the smallest real platform acceptance slice. It proves HTTP → HTML/layout/paint → CoreText → AppKit/Metal on current development hardware. Native event translation, browser controls, scrolling, link activation, and repeated navigation remain follow-up slices; Windows follows once that interaction model is proven.

## Validation

- `cargo fmt --manifest-path venture-browser-macos/Cargo.toml -- --check`
- `cargo clippy -q -p venture-browser-macos --all-targets -- -D warnings`
- `cargo test -q -p venture-browser-macos -p venture-browser-core -p window-appkit -p paint-metal -p html-to-paint` (46 tests)
- `cargo metadata --no-deps --format-version 1`
- `cargo build -q -p venture-browser-macos`
- `cargo run -q -p venture-browser-macos -- --smoke-seconds 1 http://info.cern.ch/` (real AppKit/Metal launch, exit 0)
- live upstream HTML conformance audit: tree 1,934 upstream / 2,637 local / 0 missing; tokenizer 6,806 upstream / 7,015 local raw / 0 missing; 7,242 normalized / 0 skipped
- `git diff --check`