### PR TITLE
feat(twig-aot): Twig strings under the collector — stop the calloc leak (0.48.0)

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — `twig-aot`
 
+## 0.48.0 - 2026-07-29 — Twig strings under the collector (stop the calloc leak)
+
+Brings the Twig native-AOT **string** heap type under gc-core, so string-heavy programs no
+longer grow without bound. Part of "every Twig heap feature has a native GC in the AOT path"
+(cons cells already were; strings were the one leaking type).
+
+- **`__twig_alloc_bytes` (runtime/twig_runtime.c)** — the allocator behind every runtime string
+  (`str_const`, `str_concat`, `str_slice`, `input_str`) — now allocates through gc-core
+  (`__gc_register_kind` + `__gc_alloc_kind`) instead of `calloc` + intentional leak. A string is
+  a `[int64 len][bytes]` opaque blob with no interior GC references, so it is registered under a
+  **no-reference "blob" kind** (empty field map): the collector scans none of its bytes (precise
+  — no look-alike-pointer false pinning) and treats it as a movable leaf. Safe under compaction
+  by pin-when-unsure (a string reached only via a raw handle in a non-reference slot is pinned;
+  one reached via a tagged heap-ref slot is moved + fixed up). Kind registered lazily on first
+  use, mirroring `__dyn_cons`.
+- **New smoke test** `end_to_end_gc_manages_runtime_strings` (macOS/aarch64): a compiled native
+  program builds three string blocks (`live_bytes == 34`, proving they are gc-core allocations —
+  a `calloc` block would report `0`), then a precise collect **reclaims the two now-dead literals**
+  (34 → 13, freeing 21 B) while keeping the live concatenation — a Twig string is reclaimed when
+  it dies, not leaked.
+- `e4d_str_helpers` (which compiles `twig_runtime.c` standalone to test string *logic*) gains
+  trivial `calloc`-backed `__gc_*` stubs so it still links without the collector archive.
+- No behaviour change for existing string semantics; `twig-aot` 0.47.0 → 0.48.0.
+
 ## 0.47.0 - 2026-07-27 — end-to-end native incremental collection (AOT00-T4 §6) — precision ladder COMPLETE
 
 - New macOS smoke test `end_to_end_gc_incremental_keeps_live_ref`: a compiled native program

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.28.0 (E4d-4 fix): strip_dead_aot_string_allocs now keeps EVERY buffer bound to a live string alias — a branch-selected (multi-block) str var aliases several buffers, and the old alias-keyed map dropped all but the last, so a not-last branch read a freed/empty buffer at run time. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 

--- a/code/packages/rust/twig-aot/runtime/twig_runtime.c
+++ b/code/packages/rust/twig-aot/runtime/twig_runtime.c
@@ -63,6 +63,19 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Precise-GC kind registration + allocation (gc-core-capi), used by
+ * `__twig_alloc_bytes` so runtime string blocks are managed by the collector
+ * (traced + reclaimed) instead of leaking via `calloc`. A Twig string is a
+ * `[int64 len][bytes]` opaque BLOB with no interior GC references, so it is
+ * registered under a HeapKind with an EMPTY field map — the collector then
+ * scans none of its bytes (precise: no look-alike-pointer false pinning) and
+ * treats it as a movable leaf. `__gc_register_kind(NULL, 0)` returns a 1-based
+ * kind id for that no-ref layout; `__gc_alloc_kind(n, kind)` returns `n`
+ * zeroed, 16-aligned bytes tagged with it. Both are exported by gc-core-capi
+ * and linked into the AOT image via `libgc_core_capi.a`. */
+extern int64_t __gc_register_kind(const int64_t *field_offsets, int64_t count);
+extern int64_t __gc_alloc_kind(int64_t n, uint16_t kind);
+
 /* __twig_print_i64 — print a signed 64-bit integer followed by a newline.
  *
  * Calling convention:
@@ -182,29 +195,41 @@ int64_t __twig_str_eq(int64_t a, int64_t b) {
     return memcmp((const char *)a + 8, (const char *)b + 8, (size_t)len_a) == 0 ? 1 : 0;
 }
 
-/* __twig_alloc_bytes — allocate `n` zero-initialised bytes on the heap
- * (LANG76).
+/* __twig_alloc_bytes — allocate `n` zero-initialised bytes for a runtime
+ * string block, MANAGED BY THE COLLECTOR (LANG76; gc-core convergence).
  *
- * Returns a 64-bit pointer.  The pointer is valid until process exit;
- * V1 has no `__twig_free` and intentionally leaks — fine for AOT'd
- * command-line scripts.
+ * Returns a 64-bit pointer to `n` zeroed, 16-aligned bytes.  Unlike the
+ * original `calloc` version (which leaked every string until process exit),
+ * the block is now a gc-core allocation: it is TRACED and RECLAIMED when it
+ * becomes unreachable, so string-heavy programs no longer grow without bound.
  *
- * `calloc(1, n)` is used (rather than `malloc(n) + memset`) so the
- * compiler/libc can take the zero-initialised-page fast path when one
- * is available.  Negative or zero `n` returns NULL — programs that
- * dereference the result without a null check will crash, which is
- * acceptable per the V1 "no bounds checking, no null checking"
- * contract.
+ * A string is a `[int64 len][bytes]` opaque blob — it holds NO interior GC
+ * references — so it is allocated under a registered no-ref HeapKind (an empty
+ * field map).  The collector therefore scans none of its bytes: a byte pattern
+ * that merely looks like a pointer can never falsely pin another object
+ * (precise tracing), and the block is a movable leaf.  Movability is safe under
+ * the compacting collector by pin-when-unsure: a string reached only via a raw
+ * `int64` handle in a non-reference slot is reached conservatively and is
+ * PINNED (never moved, so the raw handle never dangles); a string reached via a
+ * tagged heap-reference slot is moved and its slot fixed up.  Either way no
+ * handle is left dangling.
  *
- * The returned `void*` is treated as `int64_t` by the frontend (the
- * AAPCS64 / System V / MS x64 ABIs all return pointers in `x0` / `rax`
- * regardless of pointer-vs-integer typing, so no type coercion is
- * needed at the call site).
+ * The kind is registered lazily on first use.  The runtime is single-threaded,
+ * so the `static` init needs no synchronisation.  Negative or zero `n` returns
+ * NULL (V1 "no null checking" contract, unchanged); OOM returns NULL.
+ *
+ * The returned pointer is treated as `int64_t` by the frontend (the AAPCS64 /
+ * System V / MS x64 ABIs all return pointers in `x0` / `rax` regardless of
+ * pointer-vs-integer typing, so no coercion is needed at the call site).
  */
 int64_t __twig_alloc_bytes(int64_t n) {
     if (n <= 0) return 0;
-    void *p = calloc(1, (size_t)n);
-    return (int64_t)(intptr_t)p;
+    static int64_t blob_kind = 0; /* 0 = not yet registered */
+    if (blob_kind == 0) {
+        /* An empty field map: the string's bytes are never traced as pointers. */
+        blob_kind = __gc_register_kind(NULL, 0); /* 1-based id */
+    }
+    return __gc_alloc_kind(n, (uint16_t)blob_kind);
 }
 
 /* __twig_input_str — read one line from stdin as an E4-dyn runtime string

--- a/code/packages/rust/twig-aot/tests/e4d_str_helpers.rs
+++ b/code/packages/rust/twig-aot/tests/e4d_str_helpers.rs
@@ -64,6 +64,19 @@ int64_t __twig_str_index(int64_t, int64_t);
 int64_t __twig_str_cmp(int64_t, int64_t);
 int64_t __twig_str_eq(int64_t, int64_t);
 
+/* `__twig_alloc_bytes` now allocates string blocks through gc-core
+ * (`__gc_register_kind` + `__gc_alloc_kind`).  This unit test compiles
+ * `twig_runtime.c` standalone to exercise string *logic*, not the collector, so
+ * we back those two symbols with a trivial `calloc` stub — the `[len][bytes]`
+ * behaviour is identical.  (End-to-end GC reclamation is proven by the
+ * `*_smoke.rs` tests, which link the real `libgc_core_capi.a`.) */
+int64_t __gc_register_kind(const int64_t *offsets, int64_t count) {
+    (void)offsets; (void)count; return 1;
+}
+int64_t __gc_alloc_kind(int64_t n, uint16_t kind) {
+    (void)kind; return (int64_t)(intptr_t)calloc(1, (size_t)n);
+}
+
 /* Build a [i64 len][bytes] heap block, the E5/E4-dyn string layout. */
 static int64_t mk(const char *s, int64_t n) {
     char *p = (char *)malloc(8 + (size_t)n);

--- a/code/packages/rust/twig-aot/tests/macos_arm64_smoke.rs
+++ b/code/packages/rust/twig-aot/tests/macos_arm64_smoke.rs
@@ -444,6 +444,99 @@ fn end_to_end_gc_stress_live_bytes_differential() {
     );
 }
 
+/// **Twig strings are now managed by the collector** (gc-core convergence): a runtime string
+/// block, previously `calloc`'d and leaked, is allocated through `__gc_alloc_kind` (a
+/// no-reference "blob" kind) by `__twig_alloc_bytes`. A leaking `calloc` block was invisible to
+/// the collector and never freed; a gc-core block is **counted in `live_bytes`** and reclaimed
+/// when unreachable.
+///
+/// ```text
+///   main() -> i64:
+///       a = str_const "AB"
+///       b = str_const "CDE"
+///       c = str_concat(a, b)     ; a FRESH gc-managed [len][bytes] block
+///       [gc_collect_precise]     ; optional
+///       lb = gc_live_bytes()
+///       ret lb
+/// ```
+///
+/// Every runtime string block goes through `__twig_alloc_bytes` → gc-core: the two literals
+/// ("AB" = 8+2 = 10 B, "CDE" = 8+3 = 11 B) and the concatenation ("ABCDE" = 8+5 = 13 B), so
+/// `live_bytes == 34`.
+///
+/// - **No collect:** `live_bytes == 34` — all three string blocks are counted by the collector,
+///   proving strings go through gc-core at all (leaking `calloc` blocks would report `0`).
+/// - **Precise collect:** `live_bytes == 13` — the two literals `a`/`b`, **dead** after the
+///   concatenation, are reclaimed (34 → 13, freeing "AB" + "CDE" = 21 B), while the still-live
+///   concatenation `c` is kept (its `str` handle is a reference the precise walk roots). So a
+///   Twig string is genuinely **reclaimed when it dies**, not leaked — the headline of the
+///   gc-core convergence, proven end-to-end through the native path.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn end_to_end_gc_manages_runtime_strings() {
+    use interpreter_ir::instr::{IIRInstr, Operand};
+
+    fn build(collect: Option<&str>) -> IIRModule {
+        let mut body = vec![
+            IIRInstr::new("str_const", Some("a".into()), vec![Operand::Str("AB".into())], "str"),
+            IIRInstr::new("str_const", Some("b".into()), vec![Operand::Str("CDE".into())], "str"),
+            // A fresh runtime string → __twig_str_concat → __twig_alloc_bytes → __gc_alloc_kind.
+            IIRInstr::new(
+                "call_builtin",
+                Some("c".into()),
+                vec![Operand::Var("str_concat".into()), Operand::Var("a".into()), Operand::Var("b".into())],
+                "str",
+            ),
+        ];
+        if let Some(collect) = collect {
+            body.push(IIRInstr::new(
+                "call_builtin",
+                Some("freed".into()),
+                vec![Operand::Var(collect.into())],
+                "i64",
+            ));
+        }
+        body.push(IIRInstr::new(
+            "call_builtin",
+            Some("lb".into()),
+            vec![Operand::Var("gc_live_bytes".into())],
+            "i64",
+        ));
+        body.push(IIRInstr::new("ret", None, vec![Operand::Var("lb".into())], "i64"));
+
+        let mut m = IIRModule::new("gc_strings", "twig");
+        m.add_or_replace(IIRFunction::new("main", vec![], "i64", body));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |tag: &str, collect: Option<&str>| -> i32 {
+        let m = build(collect);
+        let exe = dir.path().join(tag);
+        twig_aot::compile_module_to_macos_executable(&m, &exe)
+            .unwrap_or_else(|e| panic!("{tag} compiles+links: {e}"));
+        let out = Command::new(&exe).output().unwrap_or_else(|e| panic!("{tag} runs: {e}"));
+        out.status.code().unwrap_or_else(|| panic!("{tag} exited by signal: {out:?}"))
+    };
+
+    let tracked = run("gc_str_tracked", None);
+    let after_precise = run("gc_str_kept", Some("gc_collect_precise"));
+
+    assert_eq!(
+        tracked, 34,
+        "every runtime string block must be a gc-core allocation counted in live_bytes: \
+         \"AB\"(10) + \"CDE\"(11) + \"ABCDE\"(13) = 34; leaking calloc blocks would report 0 \
+         (invisible to the collector). got {tracked}",
+    );
+    assert_eq!(
+        after_precise, 13,
+        "a precise collect must reclaim the two literals dead after the concat (freeing 21 B) and \
+         keep the live concatenation \"ABCDE\"(13); a Twig string is reclaimed when it dies, not \
+         leaked. got live_bytes={after_precise}",
+    );
+}
+
 /// AOT00-T1 — the **complete** precise-roots correctness statement: precise roots must
 /// *keep* a genuine heap reference AND *reclaim* a non-reference look-alike, in one run.
 ///


### PR DESCRIPTION
## Twig strings are now GC-managed (no more leak)

First step of *"every Twig heap feature has a native GC in the AOT path."* Cons cells were already GC-managed and movable; **strings** were the one heap type still allocated outside the collector — `__twig_alloc_bytes` used `calloc` and intentionally leaked, so any string-heavy program grew without bound.

### Change
- **`__twig_alloc_bytes`** (`runtime/twig_runtime.c`) — the allocator behind every runtime string (`str_const`, `str_concat`, `str_slice`, `input_str`) — now allocates through gc-core (`__gc_register_kind` + `__gc_alloc_kind`) instead of `calloc`. A string is a `[int64 len][bytes]` **opaque blob with no interior GC references**, so it registers a **no-reference "blob" kind** (empty field map): the collector scans none of its bytes (precise — no look-alike-pointer false pinning) and treats it as a movable leaf. Safe under compaction by pin-when-unsure (a string reached only via a raw handle in a non-reference slot is pinned; one reached via a tagged heap-ref slot is moved + fixed up). The kind is registered lazily on first use, mirroring `__dyn_cons`.

### Verification
- **New native smoke test** `end_to_end_gc_manages_runtime_strings` (macOS/aarch64): a compiled program builds three string blocks (`live_bytes == 34` — proving they are gc-core allocations; a `calloc` block would report `0`), then a precise collect **reclaims the two now-dead literals** (34 → 13, freeing 21 B) while keeping the live concatenation. A Twig string is reclaimed when it dies, not leaked — proven end-to-end through the native path.
- `e4d_str_helpers` (compiles `twig_runtime.c` standalone to test string *logic*) gains trivial `calloc`-backed `__gc_*` stubs so it still links without the collector archive (test-scoped; `build.rs` compiles only the runtime `.c`, never test files, so the stub can't shadow the real symbols).
- 57 lib + 4 str + 12 smoke pass (the pre-existing local-only `end_to_end_typed_twig_returns_42` `__gc_register_stackmap` link artifact is unaffected — fails identically on clean main). clippy clean; **security review PASSED**.

Next in this arc: precise/movable records (`alloc` kind-0 → kinded), symbols (interned-immortal decision), and — per the expanded scope — **native closure codegen** so closures run natively and then join the GC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)