### PR TITLE
feat(mini-sqlite): ORDER BY <n> over an aggregate sorts by the materialized column (closes the last oracle-ledger entry)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.70 — `ORDER BY <n>` over an aggregate sorts by the materialized value (ledger now empty)
+
+`SELECT k, sum(v) FROM g GROUP BY k ORDER BY 2` now sorts by the aggregated
+`sum(v)` column, matching SQLite. Previously a positional key pointing at an
+aggregate output could not be honored — the sort path re-evaluates its key per
+row, and an aggregate has no per-row value — so it was a documented differential
+divergence. The planner now records the target output index on the sort key and
+codegen binds it to the already-materialized column by name (see sql-planner
+0.2.34, sql-optimizer 0.1.7, sql-codegen 0.6.14, sql-vm 0.4.40).
+
+This was the **last** entry in the differential-oracle ledger: every seed case
+now matches bundled real SQLite exactly, so `LEDGER` is empty (zero known
+divergences). The oracle also gains a `DESC` variant of the aggregate-ordinal
+case with distinct sums, pinning the sort order. Verified against bundled real
+SQLite.
+
 ## 0.5.69 — `replace()` with an empty search returns the subject unchanged
 
 `replace('abc', '', 'X')` now returns `'abc'`, matching SQLite — an empty search

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.69"
+version = "0.5.70"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -2268,10 +2268,12 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT a FROM u ORDER BY 5",
     },
-    // Positional reference to an AGGREGATE output column. SQLite sorts by the
-    // computed aggregate (`SUM(v)`); mini-sqlite cannot re-evaluate an aggregate
-    // in the per-row sort path, so it leaves the rows in group order. Documented
-    // in LEDGER until the sort can bind to an already-materialized output column.
+    // Positional `ORDER BY <n>` over an AGGREGATE output column: SQLite sorts by
+    // the computed aggregate (`SUM(v)`). The planner binds such a key to the
+    // output column BY INDEX and codegen resolves it to the materialized column's
+    // emitted name, so the sort reads the already-computed value rather than
+    // re-evaluating the aggregate per row. Here group 'a' sums to 4 and 'b' to 2,
+    // so `ORDER BY 2` yields (b,2) then (a,4). Two variants — bare and DESC.
     Case {
         id: "order_by_ordinal_over_aggregate",
         setup: &[
@@ -2279,6 +2281,14 @@ const CASES: &[Case] = &[
             "INSERT INTO g VALUES ('a',1),('b',2),('a',3)",
         ],
         query: "SELECT k, sum(v) FROM g GROUP BY k ORDER BY 2",
+    },
+    Case {
+        id: "order_by_ordinal_over_aggregate_desc",
+        setup: &[
+            "CREATE TABLE g (k TEXT, v INTEGER)",
+            "INSERT INTO g VALUES ('a',1),('b',2),('a',3),('c',10)",
+        ],
+        query: "SELECT k, sum(v) AS s FROM g GROUP BY k ORDER BY 2 DESC",
     },
     // `TOTAL(x)` is SQLite's NULL-free companion to SUM: always REAL, and 0.0
     // (not NULL) for an empty or all-NULL group. Here the mixed int/real values
@@ -2357,19 +2367,13 @@ const CASES: &[Case] = &[
 ///
 /// A newly discovered divergence is added back here with a reason rather than
 /// silently skipped, so the list stays an honest measure.
-const LEDGER: &[(&str, &str)] = &[
-    // Positional `ORDER BY <n>` that points at an AGGREGATE output column.
-    // Non-aggregate positional keys are fully supported (see the
-    // `order_by_ordinal_*` gated cases); the aggregate case remains open because
-    // the sort path re-evaluates its key per row, and an aggregate has no per-row
-    // value. Closing it means teaching the sort to bind a positional key to an
-    // already-materialized output column by index instead of substituting its
-    // expression. Until then this is a documented divergence, not a silent skip.
-    (
-        "order_by_ordinal_over_aggregate",
-        "positional ORDER BY over an aggregate output column not yet re-bound to the materialized column",
-    ),
-];
+// The ledger is EMPTY — every seed case above matches real SQLite exactly. It
+// opened at ten reproduced divergences and was driven to zero one oracle-gated
+// increment at a time; the final entry (`order_by_ordinal_over_aggregate`) closed
+// when the sort learned to bind a positional key to the materialized output
+// column by index. Keep it empty: any new divergence is a regression to fix, not
+// a line to add here.
+const LEDGER: &[(&str, &str)] = &[];
 
 #[test]
 fn mini_sqlite_matches_real_sqlite() {

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.6.14] - Unreleased
+
+### Added
+
+- **Positional `ORDER BY <n>` over an aggregate resolves to the output column.**
+  `CompiledSortKey` gains `output_index: Option<usize>`. When a sort key carries
+  one (set by the planner for an aggregate ordinal), the compiler resolves it to
+  the emitted name of the Project's column at that index via `output_column_name`
+  — running BEFORE the hidden-sort analysis so the key is treated as an existing
+  output column, not spuriously re-materialized. The VM then sorts by name as it
+  always has; `output_index` is `None` by the time bytecode runs.
+
 ## [0.6.13] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.13"
+version = "0.6.14"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -219,6 +219,12 @@ pub struct CompiledSortKey {
     /// comparison. `None` = default byte order (BINARY). `Some("NOCASE")` =
     /// ASCII case-insensitive; `Some("RTRIM")` = ignore trailing spaces.
     pub collation: Option<String>,
+    /// Set when a positional `ORDER BY <n>` binds to output column `n-1` by INDEX
+    /// (a `ORDER BY <n>` over an aggregate, whose emitted value must be sorted
+    /// directly). During compilation this index is resolved to `column` (the
+    /// output column's emitted name) once the Project's columns are known; the VM
+    /// only ever reads `column`, so this is `None` by the time it runs.
+    pub output_index: Option<usize>,
 }
 
 /// The complete bytecode instruction set for the Mini-SQLite VM.
@@ -770,6 +776,27 @@ impl Compiler {
         // appending a `TruncateOutputColumns(n)` post-op after `SortResult` to
         // strip them.  This keeps `SortResult` as a simple name-based lookup.
         let (inner, mut post_ops) = peel_post_ops_through_project(plan);
+
+        // Resolve any positional `ORDER BY <n>` key that binds to an output column
+        // BY INDEX — a `ORDER BY <n>` over an AGGREGATE, which must sort the
+        // already-materialized value. The planner records the output index but
+        // cannot name the column (the emitted name is computed here); so bind the
+        // key to `output_column_name(columns[i])`. This runs BEFORE the hidden-sort
+        // analysis below so the resolved key is recognized as an OUTPUT column
+        // (not spuriously treated as a hidden sort column and re-evaluated).
+        if let OptimizedPlan::Project { columns, .. } = inner.as_ref() {
+            for op in &mut post_ops {
+                if let Instruction::SortResult(keys) = op {
+                    for key in keys.iter_mut() {
+                        if let Some(i) = key.output_index {
+                            if let Some(col) = columns.get(i) {
+                                key.column = output_column_name(col);
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         // Extract the sort keys (if any) so we can pass hidden sort columns
         // to compile_project.
@@ -2301,6 +2328,7 @@ fn peel_post_ops(plan: &OptimizedPlan) -> (&OptimizedPlan, Vec<Instruction>) {
                         ascending: k.ascending,
                         nulls_first: k.nulls_first,
                         collation: k.collation.clone(),
+                        output_index: k.output_index,
                     })
                     .collect();
                 post_ops.push(Instruction::SortResult(compiled_keys));
@@ -2971,6 +2999,7 @@ mod tests {
                 ascending: true,
                 nulls_first: None,
                 collation: None,
+                output_index: None,
             }],
         });
         let v = instrs(&plan);
@@ -2991,6 +3020,7 @@ mod tests {
                 ascending: true,
                 nulls_first: None,
                 collation: None,
+                output_index: None,
             }],
         });
         let v = instrs(&plan);
@@ -3012,6 +3042,7 @@ mod tests {
                 ascending: false,
                 nulls_first: None,
                 collation: None,
+                output_index: None,
             }],
         });
         let v = instrs(&plan);
@@ -3034,12 +3065,14 @@ mod tests {
                     ascending: true,
                     nulls_first: None,
                     collation: None,
+                    output_index: None,
                 },
                 SortKey {
                     expr: col("b"),
                     ascending: false,
                     nulls_first: None,
                     collation: None,
+                    output_index: None,
                 },
             ],
         });
@@ -3817,6 +3850,7 @@ mod tests {
                 ascending: true,
                 nulls_first: None,
                 collation: None,
+                output_index: None,
             }],
         });
         let v = instrs(&plan);

--- a/code/packages/rust/sql-optimizer/CHANGELOG.md
+++ b/code/packages/rust/sql-optimizer/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this crate will be documented here.
 
+## [0.1.7] - Unreleased
+
+### Changed
+
+- Constant folding (`fold_plan`) now threads the `SortKey::output_index` field
+  (added in sql-planner 0.2.34) through the `Sort` node it rebuilds, so a
+  positional `ORDER BY <n>` over an aggregate keeps its output-index binding
+  across optimization for codegen to resolve.
+
 ## [0.1.6] - Unreleased
 
 ### Changed

--- a/code/packages/rust/sql-optimizer/Cargo.toml
+++ b/code/packages/rust/sql-optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-optimizer"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Logical query plan optimizer for the Mini-SQLite SQL pipeline (Level 1)"
 authors = ["Adhithya Rajasekaran <adhithyan15@gmail.com>"]

--- a/code/packages/rust/sql-optimizer/src/lib.rs
+++ b/code/packages/rust/sql-optimizer/src/lib.rs
@@ -538,6 +538,9 @@ fn fold_plan(plan: OptimizedPlan) -> OptimizedPlan {
                     ascending: k.ascending,
                     nulls_first: k.nulls_first,
                     collation: k.collation,
+                    // Preserve the positional-aggregate output-index binding across
+                    // constant folding (codegen resolves it to a column name).
+                    output_index: k.output_index,
                 })
                 .collect(),
         },
@@ -1825,6 +1828,7 @@ mod tests {
                 ascending: true,
                 nulls_first: None,
                 collation: None,
+                output_index: None,
             }],
         }
     }
@@ -2462,6 +2466,7 @@ mod tests {
                 ascending: true,
                 nulls_first: None,
                 collation: None,
+                output_index: None,
             }],
         };
         let opt = optimize_with_passes(plan, &[&DeadCodeEliminationPass]);
@@ -2641,6 +2646,7 @@ mod tests {
                     ascending: true,
                     nulls_first: None,
                     collation: None,
+                    output_index: None,
                 }],
             }),
             count: Some(10),

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.34] - Unreleased
+
+### Added
+
+- **Positional `ORDER BY <n>` over an aggregate binds by output index.** A key
+  like `ORDER BY 2` in `SELECT k, sum(v) … GROUP BY k ORDER BY 2` previously fell
+  through unchanged (it could not re-substitute the aggregate — an aggregate has
+  no per-row value for the sort path). `SortKey` now carries an
+  `output_index: Option<usize>`, and `resolve_positional_key` returns a new
+  three-way `PositionalKey` (`NotPositional` / `Expr` / `Index`): an aggregate
+  ordinal resolves to `Index(n-1)`, recording the target output column so codegen
+  can sort the already-materialized value by its emitted name. Non-aggregate
+  positional keys and `SELECT *` are unchanged (`output_index` is `None`).
+
 ## [0.2.33] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.33"
+version = "0.2.34"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -451,6 +451,14 @@ pub struct SortKey {
     /// case-insensitively; `Some("RTRIM")` ignores trailing spaces. Non-text
     /// values are unaffected by collation. Stored uppercased.
     pub collation: Option<String>,
+    /// A positional `ORDER BY <n>` that points at an AGGREGATE output column
+    /// (e.g. `SELECT k, sum(v) … ORDER BY 2`) binds to output column `n-1` by
+    /// INDEX rather than by re-substituting the aggregate expression: the sort
+    /// must read the already-materialized value, which an aggregate has no
+    /// per-row form for. Codegen resolves this index to that column's emitted
+    /// name (the planner cannot — the name is computed in codegen). `None` for
+    /// every ordinary key, whose `expr` drives the sort as before.
+    pub output_index: Option<usize>,
 }
 
 /// An aggregate item inside an `Aggregate` plan node.
@@ -1155,21 +1163,23 @@ fn plan_order_by(
 /// | `1+0`         | constant `1` (no reorder)   |
 /// | `name`        | column/alias `name`         |
 ///
-/// Returns:
-/// - `Ok(Some(expr))` — the key was a positional reference; `expr` is the
-///   substituted n-th output expression.
-/// - `Ok(None)` — the key is not positional (leave it as written). Also the
-///   escape hatch for `SELECT *`, whose column count/identity isn't known at
-///   plan time; we leave such a key unchanged rather than guess.
+/// Returns a [`PositionalKey`]:
+/// - `Expr(e)` — a positional reference; `e` is the substituted n-th output
+///   expression (routed through the ordinary per-row sort path).
+/// - `Index(i)` — a positional reference whose target output column is (or
+///   contains) an AGGREGATE; the sort must bind to the MATERIALIZED value at
+///   output index `i`, not re-evaluate the aggregate per row.
+/// - `NotPositional` — the key is not positional (leave it as written), also the
+///   escape hatch for `SELECT *`, whose column identity isn't known at plan time.
 /// - `Err(..)` — a positional reference out of range, matching SQLite's
 ///   "ORDER BY term out of range" (only diagnosed for a fully-explicit list).
 fn resolve_positional_key(
     expr: &SqlExpr,
     outputs: &[OutputColumn],
-) -> Result<Option<SqlExpr>, PlanError> {
+) -> Result<PositionalKey, PlanError> {
     // Only a bare integer literal is a positional reference.
     let SqlExpr::Literal(SqlValue::Int(n)) = expr else {
-        return Ok(None);
+        return Ok(PositionalKey::NotPositional);
     };
     let n = *n;
 
@@ -1180,7 +1190,7 @@ fn resolve_positional_key(
         matches!(&c.expr, SqlExpr::Column { name, .. } if name == "*")
     });
     if has_star {
-        return Ok(None);
+        return Ok(PositionalKey::NotPositional);
     }
 
     // Fully explicit list: range-check exactly like SQLite (1..=ncols). Compare
@@ -1196,22 +1206,34 @@ fn resolve_positional_key(
 
     // Safe: `1 <= n <= outputs.len()`, so `n - 1` is a valid 0-based index that
     // fits `usize` on every platform.
-    let target = &outputs[(n - 1) as usize].expr;
+    let idx = (n - 1) as usize;
+    let target = &outputs[idx].expr;
 
     // If the target is (or contains) an aggregate, we cannot substitute its
     // expression: aggregates are computed once per group, not re-evaluated per
     // row in the sort path, so routing `SUM(v)` back through the sort would
-    // ignore it. Sorting by a positional aggregate is left unchanged here (a
-    // known-divergence ledger entry) rather than silently mis-sorting. The
-    // non-aggregate case — the overwhelming majority — resolves below.
+    // ignore it. Instead bind by INDEX — codegen sorts the already-materialized
+    // output column at this position (see `SortKey::output_index`).
     if expr_contains_aggregate(target) {
-        return Ok(None);
+        return Ok(PositionalKey::Index(idx));
     }
 
     // Substitute the n-th output expression. Routing the real expression through
     // the ordinary sort path means positional keys inherit all the existing
     // machinery (hidden sort-key columns, collation, NULL placement) for free.
-    Ok(Some(target.clone()))
+    Ok(PositionalKey::Expr(target.clone()))
+}
+
+/// The three outcomes of resolving a positional `ORDER BY <n>` key — see
+/// [`resolve_positional_key`].
+enum PositionalKey {
+    /// Not a positional reference (or an unresolvable `SELECT *`): leave as-is.
+    NotPositional,
+    /// A positional non-aggregate reference; sort by the substituted expression.
+    Expr(SqlExpr),
+    /// A positional reference to an aggregate output column; sort by the
+    /// materialized value at this 0-based output index.
+    Index(usize),
 }
 
 /// Does this expression tree contain an aggregate function anywhere?
@@ -1639,9 +1661,15 @@ fn plan_order_item(
     // real output expression BEFORE collation inheritance below, so a positional
     // key over a `COLLATE NOCASE` column still picks up that collation. Non-
     // positional keys (and `SELECT *`) pass through unchanged.
-    let expr = match resolve_positional_key(&raw_expr, output_columns)? {
-        Some(resolved) => resolved,
-        None => raw_expr,
+    let (expr, output_index) = match resolve_positional_key(&raw_expr, output_columns)? {
+        PositionalKey::Expr(resolved) => (resolved, None),
+        // A positional aggregate key: sort by the materialized output column at
+        // this index. The `expr` is kept as the aggregate for reference (codegen
+        // uses `output_index`, not the expr, to name the sort column); it also
+        // makes the collation-inheritance below a no-op (an aggregate is not a
+        // base-table column, so it inherits nothing).
+        PositionalKey::Index(i) => (output_columns[i].expr.clone(), Some(i)),
+        PositionalKey::NotPositional => (raw_expr, None),
     };
 
     // ASC is the default; DESC reverses.
@@ -1748,6 +1776,7 @@ fn plan_order_item(
         ascending,
         nulls_first,
         collation,
+        output_index,
     })
 }
 

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.40] - Unreleased
+
+### Changed
+
+- `CompiledSortKey` (re-exported from sql-codegen) gains an `output_index` field
+  used only during compilation to bind a positional `ORDER BY <n>` over an
+  aggregate to its output column. The VM is unaffected — `SortResult` still sorts
+  purely by the resolved `column` name; only test constructions of the struct
+  were updated to supply the new field.
+
 ## [0.4.39] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.39"
+version = "0.4.40"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -4956,7 +4956,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None, collation: None }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None, collation: None, output_index: None }]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);
     }
@@ -4979,7 +4979,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: false, nulls_first: None, collation: None }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: false, nulls_first: None, collation: None, output_index: None }]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(3)], vec![int(2)], vec![int(1)]]);
     }
@@ -5010,8 +5010,8 @@ mod tests {
             Instruction::CloseScan(None),
             Instruction::Halt,
             Instruction::SortResult(vec![
-                CompiledSortKey { column: "a".to_string(), ascending: true, nulls_first: None, collation: None },
-                CompiledSortKey { column: "b".to_string(), ascending: true, nulls_first: None, collation: None },
+                CompiledSortKey { column: "a".to_string(), ascending: true, nulls_first: None, collation: None, output_index: None },
+                CompiledSortKey { column: "b".to_string(), ascending: true, nulls_first: None, collation: None, output_index: None },
             ]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows[0], vec![int(1), int(1)]);
@@ -5542,7 +5542,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None, collation: None }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None, collation: None, output_index: None }]),
             Instruction::LimitResult(Some(3), None),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);
@@ -5569,7 +5569,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None, collation: None }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None, collation: None, output_index: None }]),
             Instruction::DistinctResult(vec![]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);


### PR DESCRIPTION
## What & why

`SELECT k, sum(v) FROM g GROUP BY k ORDER BY 2` now sorts by the aggregated
`sum(v)` column, matching real SQLite. A positional `ORDER BY <n>` pointing at an
**aggregate** output column could not previously be honored — the sort path
re-evaluates its key per row, and an aggregate has no per-row value — so the key
fell through unchanged and was recorded as a documented differential-oracle
divergence.

**This was the FINAL entry in the differential-oracle ledger.** Every seed case
now matches bundled real SQLite exactly, so `LEDGER` is now empty — **zero known
divergences** against real SQLite.

## How

Codegen stays the naming authority; the planner records a binding *by index* and
codegen resolves that index to the emitted column name:

| Crate | Version | Change |
|-------|---------|--------|
| sql-planner | 0.2.34 | `SortKey.output_index: Option<usize>`; `resolve_positional_key` returns a three-way `PositionalKey` (`NotPositional`/`Expr`/`Index`) — an aggregate ordinal resolves to `Index(n-1)` instead of substituting the aggregate expression |
| sql-optimizer | 0.1.7 | constant folding threads `output_index` through the rebuilt `Sort` node |
| sql-codegen | 0.6.14 | `CompiledSortKey.output_index`; a resolution pass binds it to the Project column's `output_column_name`, running **before** hidden-sort analysis so the key is treated as an existing output column, not re-materialized |
| sql-vm | 0.4.40 | consumes the new field transparently (still sorts by resolved `column` name); only test constructions updated |

Ordinary positional keys and `SELECT *` are unchanged (`output_index` is `None`).

## Verification

- Differential oracle passes with an **empty ledger**; added a `DESC` variant of
  the aggregate-ordinal case (distinct sums) to pin sort order.
- Full `sql-planner` / `sql-optimizer` / `sql-codegen` / `sql-vm` / `mini-sqlite`
  suites green.
- Clippy clean on the diff (the one remaining `is_multiple_of` note is
  pre-existing blob-literal code on `main`, untouched here).
- Security-reviewed (cross-crate index binding): memory-safe & panic-free — the
  codegen resolution uses `.get()`, and the planner/Project shared-vector
  invariant (respected by every optimizer pass) keeps `output_index` always
  valid and pointing at the intended column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
