### PR TITLE
feat(adj-formula-stdlib): fractional excretion of sodium — StatPearls FeNa formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_sodium_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_sodium_e2e.rs
@@ -1,0 +1,215 @@
+//! End-to-end tests for the `clinical/fractional-excretion-of-sodium.adj` library — the fractional
+//! excretion of sodium (FeNa = 100 × urinary sodium × serum creatinine / (serum sodium × urinary
+//! creatinine)) and its four exact rearrangements — driven through the built CLI binary against the
+//! SHIPPED stdlib. The same invariant as every other formula library: a consumer states NO arithmetic;
+//! it imports the grounded library, binds the four laboratory values with `observe`, and the engine
+//! applies the cited formula on the CPU, computing the EXACT value (over exact rationals) and rendering
+//! the citation and trust tier in the `derived` section (the auditable answer). The five formulas
+//! INVERT around the worked case urinary sodium = 20, serum creatinine = 4, serum sodium = 125,
+//! urinary creatinine = 80: 100 × 20 × 4 / (125 × 80) = 0.8 (FeNa), and each inverse back-solves its
+//! own input — 0.8 × 125 × 80 / (100 × 4) = 20 (urine Na), 0.8 × 125 × 80 / (100 × 20) = 4 (serum Cr),
+//! 100 × 20 × 4 / (0.8 × 80) = 125 (serum Na), 100 × 20 × 4 / (0.8 × 125) = 80 (urine Cr). The five
+//! asserted values (0.8, 20, 4, 125, 80) are distinct, none a colon-anchored prefix of another.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped fractional-excretion-of-sodium library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_fena_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-sodium.adj")
+        .canonicalize()
+        .expect("shipped fractional-excretion-of-sodium.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fena_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_fena_lib()).unwrap();
+    std::fs::write(dir.join("fractional-excretion-of-sodium.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// fractional_excretion_sodium — the index: 100 × uNa × sCr / (sNa × uCr).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_fena_library_and_computes_it_with_citation() {
+    let dir = scratch("fena");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-sodium.adj\"\n\
+         observe urinary_sodium(20)\n\
+         observe serum_creatinine(4)\n\
+         observe serum_sodium(125)\n\
+         observe urinary_creatinine(80)\n\
+         ? fractional_excretion_sodium(urinary_sodium, serum_creatinine, serum_sodium, urinary_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 100 × 20 × 4 / (125 × 80) = 0.8,
+    // computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"fractional_excretion_sodium\"") && s.contains("\"value\":0.8"),
+        "fractional_excretion_sodium(20, 4, 125, 80) = 0.8: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urinary_sodium — the same equation solved for the urinary sodium: FeNa × sNa × uCr / (100 × sCr).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urinary_sodium_from_fena_with_citation() {
+    let dir = scratch("una");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-sodium.adj\"\n\
+         observe fractional_excretion_sodium(0.8)\n\
+         observe serum_creatinine(4)\n\
+         observe serum_sodium(125)\n\
+         observe urinary_creatinine(80)\n\
+         ? urinary_sodium(fractional_excretion_sodium, serum_creatinine, serum_sodium, urinary_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 0.8 × 125 × 80 / (100 × 4) = 20, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urinary_sodium\"") && s.contains("\"value\":20"),
+        "urinary_sodium(0.8, 4, 125, 80) = 20: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urinary_sodium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_creatinine — the same equation solved for the serum creatinine: FeNa × sNa × uCr / (100 × uNa).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_creatinine_from_fena_with_citation() {
+    let dir = scratch("scr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-sodium.adj\"\n\
+         observe fractional_excretion_sodium(0.8)\n\
+         observe urinary_sodium(20)\n\
+         observe serum_sodium(125)\n\
+         observe urinary_creatinine(80)\n\
+         ? serum_creatinine(fractional_excretion_sodium, urinary_sodium, serum_sodium, urinary_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 0.8 × 125 × 80 / (100 × 20) = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_creatinine\"") && s.contains("\"value\":4"),
+        "serum_creatinine(0.8, 20, 125, 80) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_creatinine carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_sodium — the same equation solved for the serum sodium: 100 × uNa × sCr / (FeNa × uCr).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_sodium_from_fena_with_citation() {
+    let dir = scratch("sna");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-sodium.adj\"\n\
+         observe fractional_excretion_sodium(0.8)\n\
+         observe urinary_sodium(20)\n\
+         observe serum_creatinine(4)\n\
+         observe urinary_creatinine(80)\n\
+         ? serum_sodium(fractional_excretion_sodium, urinary_sodium, serum_creatinine, urinary_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 100 × 20 × 4 / (0.8 × 80) = 125, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_sodium\"") && s.contains("\"value\":125"),
+        "serum_sodium(0.8, 20, 4, 80) = 125: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_sodium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urinary_creatinine — the same equation solved for the urinary creatinine: 100 × uNa × sCr / (FeNa ×
+// sNa), the fifth reading of the one index.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urinary_creatinine_from_fena_with_citation() {
+    let dir = scratch("ucr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-sodium.adj\"\n\
+         observe fractional_excretion_sodium(0.8)\n\
+         observe urinary_sodium(20)\n\
+         observe serum_creatinine(4)\n\
+         observe serum_sodium(125)\n\
+         ? urinary_creatinine(fractional_excretion_sodium, urinary_sodium, serum_creatinine, serum_sodium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 100 × 20 × 4 / (0.8 × 125) = 80, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urinary_creatinine\"") && s.contains("\"value\":80"),
+        "urinary_creatinine(0.8, 20, 4, 125) = 80: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urinary_creatinine carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-sodium.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-sodium.adj
@@ -1,0 +1,121 @@
+% ============================================================================
+% fractional-excretion-of-sodium.adj — the fractional excretion of sodium
+% (FeNa = 100 × urinary sodium × serum creatinine / (serum sodium × urinary creatinine)) in the ADJ
+% standard library.
+% ============================================================================
+% The fractional-excretion-of-sodium entry of the *clinical* track — the share of the sodium filtered by
+% the glomerulus that is finally EXCRETED in the urine, expressed as a percentage. It is the classic
+% bedside discriminator between the two big causes of acute kidney injury: an AVID, sodium-reabsorbing
+% pre-renal kidney spills little of its filtered sodium (a low FeNa), whereas an injured tubule
+% (acute tubular necrosis) cannot reclaim it (a high FeNa). Because the true filtered load is not
+% measured directly, FeNa is computed from a paired SPOT urine and serum by normalising the sodium
+% clearance to the creatinine clearance: THE FRACTIONAL EXCRETION OF SODIUM IS ONE HUNDRED TIMES THE
+% URINARY SODIUM TIMES THE SERUM CREATININE, DIVIDED BY THE SERUM SODIUM TIMES THE URINARY CREATININE —
+% i.e. 100 × (urinary sodium × serum creatinine) / (serum sodium × urinary creatinine). It ships as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its four exact rearrangements
+% (each of the four measured quantities solved for from the other three and the index). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds the four laboratory
+% values from its own byte-provenance decomposition, and asks the engine to APPLY the cited formula on
+% the CPU. Zero math is performed by the model; the engine computes each value EXACTLY (over exact
+% rationals), carrying the formula's citation.
+%
+%     import "fractional-excretion-of-sodium.adj"
+%     observe urinary_sodium(20)        % "…urine sodium 20 mmol/L…"    (span cited by the model)
+%     observe serum_creatinine(4)        % "…creatinine 4 mg/dL…"        (span cited by the model)
+%     observe serum_sodium(125)          % "…sodium 125 mmol/L…"         (span cited by the model)
+%     observe urinary_creatinine(80)     % "…urine creatinine 80 mg/dL…" (span cited by the model)
+%     ? fractional_excretion_sodium(urinary_sodium, serum_creatinine, serum_sodium, urinary_creatinine)
+%                                         % engine → 0.8 (percent), the fractional excretion of sodium
+%
+% The 100 is the EXACT percent-scaling of the cited formula (not a measurement); the formulas are
+% otherwise exact expressions over the four parameters, so every value the engine returns is exact. They
+% COMPOSE and invert cleanly around the worked case urinary sodium = 20, serum creatinine = 4, serum
+% sodium = 125, urinary creatinine = 80 (FeNa = 100 × 20 × 4 / (125 × 80) = 8000 / 10000 = 0.8): the
+% `fractional_excretion_sodium` a consumer computes is exactly the value each of the four inverse
+% formulas back-solves to recover its own measured input (20, 4, 125, 80).
+%
+%   fractional_excretion_sodium(urinary_sodium, serum_creatinine, serum_sodium, urinary_creatinine)
+%       = 100 * urinary_sodium * serum_creatinine / (serum_sodium * urinary_creatinine)               % (FeNa, percent)
+%   urinary_sodium(fractional_excretion_sodium, serum_creatinine, serum_sodium, urinary_creatinine)
+%       = fractional_excretion_sodium * serum_sodium * urinary_creatinine / (100 * serum_creatinine)  % (solved for urine Na)
+%   serum_creatinine(fractional_excretion_sodium, urinary_sodium, serum_sodium, urinary_creatinine)
+%       = fractional_excretion_sodium * serum_sodium * urinary_creatinine / (100 * urinary_sodium)    % (solved for serum Cr)
+%   serum_sodium(fractional_excretion_sodium, urinary_sodium, serum_creatinine, urinary_creatinine)
+%       = 100 * urinary_sodium * serum_creatinine / (fractional_excretion_sodium * urinary_creatinine)% (solved for serum Na)
+%   urinary_creatinine(fractional_excretion_sodium, urinary_sodium, serum_creatinine, serum_sodium)
+%       = 100 * urinary_sodium * serum_creatinine / (fractional_excretion_sodium * serum_sodium)      % (solved for urine Cr)
+%
+% NOTE ON UNITS AND MODELLING: the two sodiums must be in the SAME concentration unit (e.g. mmol/L) and
+% the two creatinines in the SAME concentration unit (e.g. mg/dL); because sodium appears as a ratio and
+% creatinine appears as a ratio, those two units CANCEL and FeNa is a pure percentage independent of
+% which consistent units are chosen — exactly why the index is written as this dimensionless product of
+% two ratios. This is the index EXACTLY as the cited article writes it — 100 × (urinary sodium × serum
+% creatinine)/(serum sodium × urinary creatinine). A value under 1% points to a pre-renal cause and a
+% value over 2% to an intrinsic (tubular) cause, per the cited page; this library only COMPUTES the
+% index — it does not itself make that call.
+%
+% All five formulas are defended by the SAME clause — the quoted FeNa equation — because that one
+% statement (FeNa IS 100 times urinary-sodium times serum-creatinine over serum-sodium times
+% urinary-creatinine) sanctions the relation read every way. The quote is transcribed verbatim from the
+% StatPearls "Renal Function Tests" article on the NCBI Bookshelf (a current, non-archived article), so
+% each `formula` carries the provenance envelope every shipped grounded clause carries; the linter
+% rejects an unsourced one. (See feedback_nothing_human_authored — the formula, including its 100
+% constant, is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each of the five quantities appears BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the intended
+% unit.
+% ----------------------------------------------------------------------------
+dictionary fractional_excretion_sodium_vocab {
+    define urinary_sodium               : finding  surface "urinary sodium", "urine sodium", "urine Na", "UNa"          % concentration (e.g. mmol/L)
+    define serum_creatinine             : finding  surface "serum creatinine", "plasma creatinine", "SCr", "PCr"        % concentration (e.g. mg/dL)
+    define serum_sodium                 : finding  surface "serum sodium", "plasma sodium", "SNa", "PNa"                % concentration (e.g. mmol/L)
+    define urinary_creatinine           : finding  surface "urinary creatinine", "urine creatinine", "UCr"             % concentration (e.g. mg/dL)
+    define fractional_excretion_sodium  : finding  surface "fractional excretion of sodium", "FENa", "FeNa"            % percent
+}
+
+% ----------------------------------------------------------------------------
+% The fractional excretion of sodium, all five ways. Each is a named, importable, reusable formula over
+% its formal parameters, bound at apply time, and each carries the FeNa equation from the StatPearls
+% "Renal Function Tests" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each
+% is an exact expression in the four measured quantities and the cited 100 constant, so the engine
+% returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook fractional_excretion_sodium_laws {
+    use fractional_excretion_sodium_vocab
+
+    % Fractional excretion of sodium — one hundred times urinary-sodium times serum-creatinine, over
+    % serum-sodium times urinary-creatinine.
+    formula fractional_excretion_sodium(urinary_sodium, serum_creatinine, serum_sodium, urinary_creatinine) = 100 * urinary_sodium * serum_creatinine / (serum_sodium * urinary_creatinine)
+        source "FeNa = 100 × (urinary sodium × serum creatinine)/(serum sodium × urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507821/"
+        trust authoritative
+
+    % Urinary sodium — the same equation solved for the urinary sodium. Defended by the SAME sentence.
+    formula urinary_sodium(fractional_excretion_sodium, serum_creatinine, serum_sodium, urinary_creatinine) = fractional_excretion_sodium * serum_sodium * urinary_creatinine / (100 * serum_creatinine)
+        source "FeNa = 100 × (urinary sodium × serum creatinine)/(serum sodium × urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507821/"
+        trust authoritative
+
+    % Serum creatinine — the same equation solved for the serum creatinine. The SAME sentence.
+    formula serum_creatinine(fractional_excretion_sodium, urinary_sodium, serum_sodium, urinary_creatinine) = fractional_excretion_sodium * serum_sodium * urinary_creatinine / (100 * urinary_sodium)
+        source "FeNa = 100 × (urinary sodium × serum creatinine)/(serum sodium × urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507821/"
+        trust authoritative
+
+    % Serum sodium — the same equation solved for the serum sodium. The SAME sentence, read again.
+    formula serum_sodium(fractional_excretion_sodium, urinary_sodium, serum_creatinine, urinary_creatinine) = 100 * urinary_sodium * serum_creatinine / (fractional_excretion_sodium * urinary_creatinine)
+        source "FeNa = 100 × (urinary sodium × serum creatinine)/(serum sodium × urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507821/"
+        trust authoritative
+
+    % Urinary creatinine — the same equation solved for the urinary creatinine. The SAME sentence, the
+    % fifth reading of the one index.
+    formula urinary_creatinine(fractional_excretion_sodium, urinary_sodium, serum_creatinine, serum_sodium) = 100 * urinary_sodium * serum_creatinine / (fractional_excretion_sodium * serum_sodium)
+        source "FeNa = 100 × (urinary sodium × serum creatinine)/(serum sodium × urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507821/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-sodium.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-sodium.query.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% fractional-excretion-of-sodium.query.adj — worked applications of the fractional excretion of sodium.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an acute-kidney-injury vignette into a paired
+% spot urine and serum: it `import`s the grounded formulabook, `observe`s the four laboratory values,
+% and asks the engine to APPLY the cited index. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on
+% the CPU, with zero model calls.
+%
+% Worked case (urinary sodium = 20, serum creatinine = 4, serum sodium = 125, urinary creatinine = 80):
+% FeNa = 100 × 20 × 4 / (125 × 80) = 8000 / 10000 = 0.8 (percent). Each query fixes the index and three
+% of the four measured quantities and asks the engine to recover the fourth; every answer is exact and
+% the five COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli fractional-excretion-of-sodium.query.adj
+% ============================================================================
+
+import "fractional-excretion-of-sodium.adj"
+
+% --- Index: the FeNa the four laboratory values imply (expect 0.8). ---------------------------------
+observe urinary_sodium(20)
+observe serum_creatinine(4)
+observe serum_sodium(125)
+observe urinary_creatinine(80)
+? fractional_excretion_sodium(urinary_sodium, serum_creatinine, serum_sodium, urinary_creatinine)   % expect 0.8
+
+% --- Inverse: the urinary sodium a FeNa of 0.8 implies at the other three values (expect 20). -------
+observe fractional_excretion_sodium(0.8)
+? urinary_sodium(fractional_excretion_sodium, serum_creatinine, serum_sodium, urinary_creatinine)   % expect 20


### PR DESCRIPTION
## What

Adds the **fractional excretion of sodium (FeNa)** entry of the `adj-formula-stdlib` *clinical* track — the share of filtered sodium that is finally excreted in the urine, the classic bedside discriminator between **pre-renal** acute kidney injury (a sodium-avid kidney → low FeNa) and **acute tubular necrosis** (an injured tubule that cannot reclaim sodium → high FeNa), computed from a paired spot urine and serum.

Ships as an importable, byte-provenanced, parameterized `formula` together with its **four exact algebraic rearrangements** — each of the four measured laboratory quantities solved for from the other three and the index. A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the four values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the article citation and trust tier in the auditable `derived` section. Zero model calls at answer time.

## Grounding (nothing human-authored)

All five formulas are defended by the **same clause** — the FeNa equation transcribed **verbatim** from the StatPearls **"Renal Function Tests"** article on the NCBI Bookshelf ([NBK507821](https://www.ncbi.nlm.nih.gov/books/NBK507821/), a current, non-archived page), under the heading *"Acute Versus Chronic Renal Impairment"*:

> FeNa = 100 × (urinary sodium × serum creatinine)/(serum sodium × urinary creatinine).

because that one statement sanctions the relation read every way. The `100` is the exact percent-scaling of the cited formula; the sodium and creatinine units cancel, so FeNa is a dimensionless percentage.

## Worked case (the five compose and invert)

urinary sodium = 20, serum creatinine = 4, serum sodium = 125, urinary creatinine = 80:

- FeNa = 100 × 20 × 4 / (125 × 80) = 8000/10000 = **0.8**
- and each inverse back-solves its own input → **20**, **4**, **125**, **80**.

The five asserted values are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-sodium.adj`
- `code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-sodium.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_sodium_e2e.rs` — 5 tests, all pass

## Verification

- Render-probe against the built CLI: forward `0.8` + all four inverses (`20`, `4`, `125`, `80`) render exactly with `"trust":"authoritative"` and the NCBI citation.
- `cargo test -p adj-lang-cli --test formula_fractional_excretion_of_sodium_e2e` → 5 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes.
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)