### PR TITLE
feat(adj-formula-stdlib): serum osmolality — StatPearls Dorwart-Chalmers calculated-osmolality formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_serum_osmolality_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_serum_osmolality_e2e.rs
@@ -1,0 +1,178 @@
+//! End-to-end tests for the `clinical/serum-osmolality.adj` library — the calculated (Dorwart and
+//! Chalmers) serum osmolality (1.86 × sodium + glucose/18 + BUN/2.8 + 9) and its three exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same invariant
+//! as every other formula library: a consumer states NO arithmetic; it imports the grounded library,
+//! binds sodium, glucose and BUN with `observe`, and the engine applies the cited formula on the CPU,
+//! computing the EXACT value (over exact rationals — 1.86 = 93/50, 2.8 = 14/5) and rendering the
+//! citation and trust tier in the `derived` section (the auditable answer). The four formulas INVERT
+//! around the worked case sodium = 145, glucose = 90, BUN = 28: 1.86 × 145 + 90/18 + 28/2.8 + 9 =
+//! 269.7 + 5 + 10 + 9 = 293.7 (osmolality), and each inverse back-solves its own input —
+//! (293.7 − 5 − 10 − 9)/1.86 = 145 (sodium), (293.7 − 269.7 − 10 − 9)×18 = 90 (glucose),
+//! (293.7 − 269.7 − 5 − 9)×2.8 = 28 (BUN). The four asserted values (293.7, 145, 90, 28) are distinct,
+//! none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped serum-osmolality library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_osm_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/serum-osmolality.adj")
+        .canonicalize()
+        .expect("shipped serum-osmolality.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_osm_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_osm_lib()).unwrap();
+    std::fs::write(dir.join("serum-osmolality.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// serum_osmolality — the estimate: 1.86 × sodium + glucose/18 + BUN/2.8 + 9.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_osmolality_library_and_computes_it_with_citation() {
+    let dir = scratch("osm");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"serum-osmolality.adj\"\n\
+         observe sodium(145)\n\
+         observe glucose(90)\n\
+         observe bun(28)\n\
+         ? serum_osmolality(sodium, glucose, bun)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result:
+    // 1.86 × 145 + 90/18 + 28/2.8 + 9 = 293.7, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"serum_osmolality\"") && s.contains("\"value\":293.7"),
+        "serum_osmolality(145, 90, 28) = 293.7: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// sodium — the same equation solved for the sodium: (osmolality − glucose/18 − BUN/2.8 − 9) / 1.86.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_sodium_from_osmolality_with_citation() {
+    let dir = scratch("na");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"serum-osmolality.adj\"\n\
+         observe serum_osmolality(293.7)\n\
+         observe glucose(90)\n\
+         observe bun(28)\n\
+         ? sodium(serum_osmolality, glucose, bun)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (293.7 − 5 − 10 − 9) / 1.86 = 145, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"sodium\"") && s.contains("\"value\":145"),
+        "sodium(293.7, 90, 28) = 145: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "sodium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// glucose — the same equation solved for the glucose: (osmolality − 1.86×sodium − BUN/2.8 − 9) × 18.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_glucose_from_osmolality_with_citation() {
+    let dir = scratch("glu");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"serum-osmolality.adj\"\n\
+         observe serum_osmolality(293.7)\n\
+         observe sodium(145)\n\
+         observe bun(28)\n\
+         ? glucose(serum_osmolality, sodium, bun)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (293.7 − 269.7 − 10 − 9) × 18 = 90, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"glucose\"") && s.contains("\"value\":90"),
+        "glucose(293.7, 145, 28) = 90: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "glucose carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// bun — the same equation solved for the BUN: (osmolality − 1.86×sodium − glucose/18 − 9) × 2.8, the
+// fourth reading of the one formula.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_bun_from_osmolality_with_citation() {
+    let dir = scratch("bun");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"serum-osmolality.adj\"\n\
+         observe serum_osmolality(293.7)\n\
+         observe sodium(145)\n\
+         observe glucose(90)\n\
+         ? bun(serum_osmolality, sodium, glucose)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (293.7 − 269.7 − 5 − 9) × 2.8 = 28, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"bun\"") && s.contains("\"value\":28"),
+        "bun(293.7, 145, 90) = 28: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "bun carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/serum-osmolality.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/serum-osmolality.adj
@@ -1,0 +1,107 @@
+% ============================================================================
+% serum-osmolality.adj — the calculated (estimated) serum osmolality
+% (Serum Osmolality = 1.86 × sodium + glucose/18 + BUN/2.8 + 9, the Dorwart and Chalmers formula) in
+% the ADJ standard library.
+% ============================================================================
+% The serum-osmolality entry of the *clinical* track — the ESTIMATE of the number of osmotically active
+% particles per kilogram of serum computed from the routine basic metabolic panel, without an osmometer.
+% Sodium (with its accompanying anions) is the dominant contributor, and glucose and urea add the rest;
+% dividing glucose and blood-urea-nitrogen (both in mg/dL) by their molar factors 18 and 2.8 converts
+% them to the same milliosmole scale. THE CALCULATED SERUM OSMOLALITY IS 1.86 TIMES THE SODIUM, PLUS THE
+% GLUCOSE OVER 18, PLUS THE BLOOD UREA NITROGEN OVER 2.8, PLUS 9 — i.e. 1.86 × sodium + glucose/18 +
+% BUN/2.8 + 9 (the Dorwart and Chalmers formula). It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its three exact rearrangements (each of the three measured
+% inputs solved for from the other two and the osmolality). This is the very quantity the separate
+% osmolar-gap library consumes as its `calculated_osmolality` input: compute it here, then the osmol gap
+% is the measured value minus this estimate (write-once-use-many). As with every compute library, a
+% consumer states NO arithmetic: it `import`s this file, binds sodium, glucose and BUN from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "serum-osmolality.adj"
+%     observe sodium(145)     % "…sodium 145 mmol/L…"    (span cited by the model)
+%     observe glucose(90)     % "…glucose 90 mg/dL…"     (span cited by the model)
+%     observe bun(28)         % "…BUN 28 mg/dL…"         (span cited by the model)
+%     ? serum_osmolality(sodium, glucose, bun)
+%                             % engine → 293.7 mOsm/kg, the calculated serum osmolality
+%
+% The 1.86, 18, 2.8 and 9 are the EXACT defined constants of the cited formula (not measurements); the
+% formulas are otherwise exact expressions over the three parameters, so every value the engine returns
+% is exact — 1.86 is exactly 93/50 and 2.8 is exactly 14/5, so the division and multiplication stay in
+% the exact rationals. They COMPOSE and invert cleanly around the worked case sodium = 145, glucose = 90,
+% BUN = 28 (osmolality = 1.86 × 145 + 90/18 + 28/2.8 + 9 = 269.7 + 5 + 10 + 9 = 293.7): the
+% `serum_osmolality` a consumer computes is exactly the value each of the three inverse formulas
+% back-solves to recover its own measured input (145, 90, 28).
+%
+%   serum_osmolality(sodium, glucose, bun) = 1.86 * sodium + glucose / 18 + bun / 2.8 + 9            % (osmolality, mOsm/kg)
+%   sodium(serum_osmolality, glucose, bun) = (serum_osmolality - glucose / 18 - bun / 2.8 - 9) / 1.86% (solved for sodium)
+%   glucose(serum_osmolality, sodium, bun) = (serum_osmolality - 1.86 * sodium - bun / 2.8 - 9) * 18 % (solved for glucose)
+%   bun(serum_osmolality, sodium, glucose) = (serum_osmolality - 1.86 * sodium - glucose / 18 - 9) * 2.8 % (solved for BUN)
+%
+% NOTE ON UNITS AND MODELLING: this is the Dorwart and Chalmers form the cited page prints — sodium in
+% mmol/L (mEq/L), glucose and BUN in mg/dL, the 18 and 2.8 being the mg/dL→mmol/L molar conversions for
+% glucose and urea-nitrogen. Several simpler variants exist (e.g. 2 × Na + glucose/18 + BUN/2.8, which
+% the page notes is "equally effective"), but the single equation grounded here is the one transcribed
+% VERBATIM from the cited page, and that is what this library computes. This is the CALCULATED estimate;
+% the osmolar GAP (measured minus calculated) — the quantity that flags unmeasured osmoles such as toxic
+% alcohols — is the separate osmolar-gap library, which takes this value as its calculated input. This
+% library only COMPUTES the estimate; it does not itself diagnose.
+%
+% All four formulas are defended by the SAME clause — the quoted Dorwart and Chalmers equation — because
+% that one statement (serum osmolality IS 1.86 times sodium plus glucose over 18 plus BUN over 2.8 plus
+% 9) sanctions the relation read every way. The quote is transcribed verbatim from the StatPearls
+% "Physiology, Plasma Osmolality and Oncotic Pressure" article on the NCBI Bookshelf (a current,
+% non-archived article), so each `formula` carries the provenance envelope every shipped grounded clause
+% carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula,
+% including its 1.86, 18, 2.8 and 9 constants, is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `sodium`, `glucose`, `bun` and `serum_osmolality` each appear BOTH as a derived result and
+% as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary serum_osmolality_vocab {
+    define sodium            : finding  surface "sodium", "serum sodium", "Na"                                        % mmol/L (mEq/L)
+    define glucose           : finding  surface "glucose", "serum glucose", "blood glucose"                           % mg/dL
+    define bun               : finding  surface "BUN", "blood urea nitrogen", "urea nitrogen"                         % mg/dL
+    define serum_osmolality  : finding  surface "serum osmolality", "calculated serum osmolality", "estimated osmolality"  % mOsm/kg
+}
+
+% ----------------------------------------------------------------------------
+% The calculated serum osmolality, all four ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the Dorwart and Chalmers equation from the
+% StatPearls "Physiology, Plasma Osmolality and Oncotic Pressure" article on the NCBI Bookshelf (a quote
+% is required on a shipped formula). Each is an exact expression in the measured quantities and the
+% cited 1.86 / 18 / 2.8 / 9 constants, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook serum_osmolality_laws {
+    use serum_osmolality_vocab
+
+    % Calculated serum osmolality — 1.86 times sodium, plus glucose over 18, plus BUN over 2.8, plus 9.
+    formula serum_osmolality(sodium, glucose, bun) = 1.86 * sodium + glucose / 18 + bun / 2.8 + 9
+        source "Serum Osmolality=1.86 (Na)+(Glucose)/18 +(BUN)/2.8+9"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544365/"
+        trust authoritative
+
+    % Sodium — the same equation solved for the sodium. Defended by the SAME sentence.
+    formula sodium(serum_osmolality, glucose, bun) = (serum_osmolality - glucose / 18 - bun / 2.8 - 9) / 1.86
+        source "Serum Osmolality=1.86 (Na)+(Glucose)/18 +(BUN)/2.8+9"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544365/"
+        trust authoritative
+
+    % Glucose — the same equation solved for the glucose. The SAME sentence.
+    formula glucose(serum_osmolality, sodium, bun) = (serum_osmolality - 1.86 * sodium - bun / 2.8 - 9) * 18
+        source "Serum Osmolality=1.86 (Na)+(Glucose)/18 +(BUN)/2.8+9"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544365/"
+        trust authoritative
+
+    % Blood urea nitrogen — the same equation solved for the BUN. The SAME sentence, the fourth reading.
+    formula bun(serum_osmolality, sodium, glucose) = (serum_osmolality - 1.86 * sodium - glucose / 18 - 9) * 2.8
+        source "Serum Osmolality=1.86 (Na)+(Glucose)/18 +(BUN)/2.8+9"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544365/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/serum-osmolality.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/serum-osmolality.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% serum-osmolality.query.adj — worked applications of the calculated serum osmolality.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a basic-metabolic-panel vignette into a sodium,
+% a glucose and a BUN: it `import`s the grounded formulabook, `observe`s the three values, and asks the
+% engine to APPLY the cited Dorwart and Chalmers formula. No arithmetic is stated by the consumer; the
+% engine computes each value EXACTLY (over exact rationals) and carries the article's citation as its
+% proof, on the CPU, with zero model calls.
+%
+% Worked case (sodium = 145, glucose = 90, BUN = 28): osmolality = 1.86 × 145 + 90/18 + 28/2.8 + 9 =
+% 269.7 + 5 + 10 + 9 = 293.7 mOsm/kg. Each query fixes the osmolality and two of the three measured
+% quantities and asks the engine to recover the third; every answer is exact and the four COMPOSE (each
+% inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli serum-osmolality.query.adj
+% ============================================================================
+
+import "serum-osmolality.adj"
+
+% --- Osmolality: the value sodium, glucose and BUN imply (expect 293.7). ----------------------------
+observe sodium(145)
+observe glucose(90)
+observe bun(28)
+? serum_osmolality(sodium, glucose, bun)   % expect 293.7
+
+% --- Inverse: the sodium an osmolality of 293.7 implies at glucose 90, BUN 28 (expect 145). ---------
+observe serum_osmolality(293.7)
+? sodium(serum_osmolality, glucose, bun)   % expect 145


### PR DESCRIPTION
## What

Adds the **calculated serum osmolality** entry of the `adj-formula-stdlib` *clinical* track — the estimate of osmotically active particles per kg of serum computed from the routine basic metabolic panel (no osmometer needed). This is the very quantity the separate **osmolar-gap** library consumes as its `calculated_osmolality` input: compute it here, subtract from the measured value there → the osmol gap (**write-once-use-many**).

Ships as an importable, byte-provenanced, parameterized `formula` together with its **three exact algebraic rearrangements** — each of the three measured inputs (sodium, glucose, BUN) solved for from the other two and the osmolality. A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Grounding (nothing human-authored)

All four formulas are defended by the **same clause** — the **Dorwart and Chalmers** equation transcribed **verbatim** from the StatPearls **"Physiology, Plasma Osmolality and Oncotic Pressure"** article on the NCBI Bookshelf ([NBK544365](https://www.ncbi.nlm.nih.gov/books/NBK544365/), a current, non-archived page):

> Serum Osmolality=1.86 (Na)+(Glucose)/18 +(BUN)/2.8+9

because that one statement sanctions the relation read every way. `1.86 = 93/50` and `2.8 = 14/5` are exact, so every value stays in the exact rationals. (The page notes the simpler `2×Na` variant is "equally effective", but the single equation grounded here is the one printed verbatim.)

## Worked case (the four compose and invert)

sodium = 145, glucose = 90, BUN = 28:

- osmolality = 1.86 × 145 + 90/18 + 28/2.8 + 9 = 269.7 + 5 + 10 + 9 = **293.7** mOsm/kg
- and each inverse back-solves its own input → **145**, **90**, **28**.

The four asserted values are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/serum-osmolality.adj`
- `code/specs/data/adj-formula-stdlib/clinical/serum-osmolality.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_serum_osmolality_e2e.rs` — 4 tests, all pass

## Verification

- Render-probe against the built CLI: forward `293.7` + all three inverses (`145`, `90`, `28`) render exactly with `"trust":"authoritative"` and the NCBI citation. (Validates the parenthesized-subtraction-over-constant inverse expressions parse and compute exactly.)
- `cargo test -p adj-lang-cli --test formula_serum_osmolality_e2e` → 4 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes.
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)