### PR TITLE
feat(gc-core): kind_of object-class accessor + __gc_kind_of C ABI (AOT00-T6 PR-3)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this crate are documented here.
 
+## 0.21.0 - 2026-07-29 — C ABI `__gc_kind_of` — object-class accessor (AOT00-T6)
+
+- **`__gc_kind_of(ptr) -> kind_id`** (new `#[no_mangle]` export + `gc_core.h` decl) — the C-ABI
+  seam for `gc_core::FlatHeap::kind_of` (gc-core 0.24.0). Returns the kind id of the live heap
+  object at payload address `ptr`, or `0` for null / non-heap / stale addresses (validated before
+  any header read — no OOB). Lets a native runtime discriminate object classes that share the heap
+  tag — e.g. a closure kind from a cons kind for `procedure?` / `pair?` — from a tag-stripped
+  value. Foundation for the native-closures arc (AOT00-T6). Test
+  `c_abi_kind_of_discriminates_classes`.
+
 ## 0.20.0 - 2026-07-29 — twig-compat alias `__twig_gc_register_ref_array_kind` — PR-4 (AOT00-T5)
 
 - **`__twig_gc_register_ref_array_kind(fixed, fixed_count, tail_from)`** (new `twig_compat` alias

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -64,6 +64,13 @@ int64_t __gc_register_kind(const int64_t *field_offsets, int64_t count);
 int64_t __gc_register_ref_array_kind(const int64_t *fixed, int64_t fixed_count,
                                      int64_t tail_from);
 
+/* Return the kind id of the live heap object at payload address `ptr`, or 0 if `ptr`
+ * is not inside any live GC block (null / non-heap / stale). Lets a frontend tell one
+ * object class from another that shares the heap tag — e.g. a closure kind from a cons
+ * kind for procedure?/pair? — from a value it has already stripped of its low-bit tag.
+ * Read-only; `ptr` is validated before any header read (a bogus value yields 0). */
+int64_t __gc_kind_of(int64_t ptr);
+
 /* Mark from `count` root words at `roots`, then sweep. Returns objects freed.
  * A null `roots` or count <= 0 means "no roots". */
 int64_t __gc_collect_roots(const int64_t *roots, int64_t count);

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -193,6 +193,24 @@ pub unsafe extern "C" fn __gc_register_ref_array_kind(
     with_heap(|h| h.register_ref_array_kind(&offsets, tail) as i64)
 }
 
+/// Return the **kind id** of the live heap object at payload address `ptr`, or `0` if `ptr` is
+/// not inside any live GC block (null, a non-heap value, or a stale/foreign pointer). A frontend
+/// uses this to discriminate object *classes* that share the heap tag — e.g. telling a closure
+/// kind from a cons kind for `procedure?` / `pair?` — from a value it has already stripped of its
+/// low-bit tag. Read-only; performs no allocation or collection.
+///
+/// # Safety
+///
+/// `ptr` is validated against the live-block list before any header read, so a bogus or foreign
+/// value yields `0` rather than an out-of-bounds read. Standard C-ABI integer argument.
+#[no_mangle]
+pub unsafe extern "C" fn __gc_kind_of(ptr: i64) -> i64 {
+    if ptr <= 0 {
+        return 0;
+    }
+    with_heap(|h| h.kind_of(ptr as usize) as i64)
+}
+
 /// **Generational write barrier.** The native runtime calls this whenever it
 /// stores a heap reference `child` into a field of heap object `parent` (both
 /// payload addresses). If `parent` is **old**, it is recorded so a later
@@ -682,6 +700,34 @@ mod tests {
         let freed2 = unsafe { __gc_collect_roots(roots.as_ptr(), 2) };
         assert_eq!(freed2, 1, "clearing the tail slot reclaims the element");
         assert_eq!(__gc_live_bytes(), 40, "only the two arrays remain (16 + 24)");
+
+        __gc_reset();
+    }
+
+    /// `__gc_kind_of` reports an object's kind id through the C ABI, so a frontend can tell a
+    /// closure kind from a cons kind (e.g. for `procedure?` / `pair?`), and returns `0` for
+    /// kind-0 / null / non-heap addresses without an out-of-bounds read.
+    #[test]
+    fn c_abi_kind_of_discriminates_classes() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+
+        let cons_offsets = [0i64, 8];
+        let cons_kind = unsafe { __gc_register_kind(cons_offsets.as_ptr(), 2) };
+        // A closure kind: code_ptr @0 (non-ref), captured refs tail from offset 8.
+        let closure_kind = unsafe { __gc_register_ref_array_kind(std::ptr::null(), 0, 8) };
+        assert!(cons_kind >= 1 && closure_kind >= 1 && cons_kind != closure_kind);
+
+        let pair = __gc_alloc_kind(16, cons_kind as u16);
+        let closure = __gc_alloc_kind(24, closure_kind as u16);
+        let opaque = __gc_alloc(16); // kind 0
+        assert!(pair != 0 && closure != 0 && opaque != 0);
+
+        assert_eq!(unsafe { __gc_kind_of(pair) }, cons_kind, "pair → cons kind");
+        assert_eq!(unsafe { __gc_kind_of(closure) }, closure_kind, "closure → closure kind");
+        assert_eq!(unsafe { __gc_kind_of(opaque) }, 0, "kind-0 object → 0");
+        assert_eq!(unsafe { __gc_kind_of(0) }, 0, "null → 0");
+        assert_eq!(unsafe { __gc_kind_of(0x1234) }, 0, "non-heap address → 0 (no OOB read)");
 
         __gc_reset();
     }

--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — gc-core
 
+## 0.24.0 — 2026-07-29 — `FlatHeap::kind_of` — object-class accessor (AOT00-T6)
+
+- **`FlatHeap::kind_of(addr) -> u16`** — the kind id of the live heap object containing payload
+  address `addr`, or `0` if `addr` is not inside any live block (null, non-heap, or stale
+  pointer). A frontend uses it to discriminate object *classes* that share the heap tag — e.g. a
+  closure kind (`register_ref_array_kind([], 8)`) from a cons kind — for `procedure?` / `pair?`
+  predicates. Safe: the address is validated against the live-block list before any header read,
+  so a bogus value yields `0` (no out-of-bounds read). O(n) in the live-object count; intended for
+  cold type predicates. Foundation for the native-closures arc (AOT00-T6). Test
+  `kind_of_reports_object_kind_and_zero_for_non_heap`.
+
 ## 0.23.2 — 2026-07-29 — robustness-at-scale tests (AOT00-T5, tests only)
 
 Test-only. Confirms the collector stays correct and O(n) as the heap grows to many thousands of

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.23.2"
+version = "0.24.0"
 edition = "2021"
 description = "LANG16 — adaptive GC adapter layer wiring garbage-collector into the LANG VM pipeline."
 license = "MIT"

--- a/code/packages/rust/gc-core/src/flat_heap.rs
+++ b/code/packages/rust/gc-core/src/flat_heap.rs
@@ -589,6 +589,26 @@ impl FlatHeap {
         self.field_maps.len()
     }
 
+    /// The **kind id** of the live heap object containing payload address `addr`, or `0` if
+    /// `addr` is not inside any live block this heap owns (including `0`/null and any non-heap
+    /// value). A frontend uses this to discriminate object *classes* that share the heap tag —
+    /// e.g. telling a closure kind from a cons kind for `procedure?` / `pair?` — from a value it
+    /// has already stripped of its tag.
+    ///
+    /// Safe: the address is *validated* against the live-block list ([`Self::find_header`])
+    /// before any header read, so a bogus or foreign pointer yields `0` rather than reading
+    /// out of bounds. O(n) in the live-object count (the block-list walk); intended for cold
+    /// type predicates, not per-element hot loops.
+    pub fn kind_of(&self, addr: usize) -> u16 {
+        let h = self.find_header(addr);
+        if h.is_null() {
+            0
+        } else {
+            // SAFETY: `find_header` returned a live block we own; its header is valid.
+            unsafe { (*h).kind }
+        }
+    }
+
     /// Whether the live set has reached the threshold — i.e. a collection is due.
     ///
     /// This is the *policy* half of paced collection: it answers "should I collect
@@ -2660,6 +2680,28 @@ mod tests {
         assert_eq!(heap.register_kind(&[0]), 1);
         assert_eq!(heap.register_kind(&[0, 8]), 2);
         assert_eq!(heap.registered_kinds(), 2);
+    }
+
+    /// `kind_of` reports the registered kind of a live object (for frontend class
+    /// discrimination, e.g. closure vs. cons), `0` for kind-0 / opaque objects, and `0` for any
+    /// address not inside a live block (null, an interior-of-nothing, a stale/foreign pointer).
+    #[test]
+    fn kind_of_reports_object_kind_and_zero_for_non_heap() {
+        let mut heap = FlatHeap::new();
+        let cons = heap.register_kind(&[0, 8]); // e.g. a pair
+        let clos = heap.register_ref_array_kind(&[], 8); // e.g. a closure: code_ptr @0, caps tail
+        let pair = heap.alloc(16, cons) as usize;
+        let closure = heap.alloc(24, clos) as usize;
+        let opaque = heap.alloc(16, 0) as usize; // kind 0
+
+        assert_eq!(heap.kind_of(pair), cons, "pair reports its cons kind");
+        assert_eq!(heap.kind_of(closure), clos, "closure reports its closure kind");
+        assert_ne!(heap.kind_of(pair), heap.kind_of(closure), "distinct classes distinguishable");
+        assert_eq!(heap.kind_of(opaque), 0, "a kind-0 object reports 0");
+        assert_eq!(heap.kind_of(0), 0, "null → 0");
+        assert_eq!(heap.kind_of(0xdead_beef), 0, "a non-heap address → 0 (no OOB read)");
+        // An interior address of a live block still resolves to that block's kind.
+        assert_eq!(heap.kind_of(pair + 8), cons, "interior address resolves to the block's kind");
     }
 
     /// The headline property: with a precise kind whose only ref field is at


### PR DESCRIPTION
## AOT00-T6 PR-3: object-class accessor (first native-closures rung)

Per the [AOT00-T6 native-closures spec](../blob/main/code/specs/AOT00-T6-native-closures.md) (#9221), this is the safe, self-contained first unit (spec §4.1): a way for a native frontend to discriminate object *classes* that share the heap tag — e.g. a closure kind from a cons kind for `procedure?` / `pair?` — from a tag-stripped value.

### Change
- **gc-core 0.24.0** — `FlatHeap::kind_of(addr) -> u16`: the kind id of the live heap object containing payload address `addr`, or `0` if `addr` is not inside any live block (null / non-heap / stale). **Safe** — the address is validated against the live-block list (`find_header`) before any header read, so a bogus value yields `0`, never an OOB read. O(n) in the live-object count; for cold type predicates.
- **gc-core-capi 0.21.0** — `__gc_kind_of(ptr) -> i64` (`#[no_mangle]` + `gc_core.h` decl): the C-ABI seam; returns `0` for `ptr <= 0` and non-heap addresses.

### Verification
- gc-core **104** tests + `cargo miri test kind_of` clean; gc-core-capi **36** tests + clippy clean.
- **Security review PASSED** — verified strictly safer than the existing `write_barrier` path (validates via `find_header` before any deref; no OOB, no aliasing/lock concern).
- Note: an intermittent **pre-existing** stack-scan flake (`incremental_collect_keeps_live_local_frees_dead`) is unrelated (passes 3/3 on re-run; those tests scan the real stack and are codegen-layout sensitive).

Next in the arc: the env-transform + `alloc_closure`/`call_closure` lowering land as one coupled native-closures PR (the transform can't be applied to a function that falls back to the interpreter — spec §4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)