### PR TITLE
feat(adj-formula-stdlib): heat-flux-density — NIST SP 811 B.9 heat-flux-density→W/m² factor (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1757,6 +1757,53 @@ fn shipped_thermal_conductivity_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// Shipped table — reference/heat-flux-density-conversions.adj resolves the exact NIST SP 811 B.9
+// density-of-heat-flow-rate factor and abstains on a wrong-dimension unit. Heat flux density is power
+// per area (W/m²): the exact boldface factor is calorieth per square centimetre second → 4.184 E+04 =
+// 41840 (the thermochemical calorie is exactly 4.184 J and cm²→m² is an exact ×10⁴). The `pound` is a
+// MASS unit (it converts to the kilogram, a DIFFERENT quantity), so the heat-flux-density lookup for it
+// must abstain, catching the heat-flux/mass confusion directly, not mere absence of a value. (Heat flux
+// density is power per area — distinct from DENSITY OF HEAT, J/m² (energy per area), from THERMAL
+// CONDUCTIVITY, W/(m·K), and from plain POWER, W.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_heat_flux_density_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_heatfluxdensity");
+    let src = stdlib().join("reference/heat-flux-density-conversions.adj");
+    std::fs::copy(&src, dir.join("heat-flux-density-conversions.adj"))
+        .expect("copy shipped heat-flux-density-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"heat-flux-density-conversions.adj\"\n\
+         ? heat_flux_density_to_watt_per_square_metre(calorie_th_per_square_centimetre_second, $v)\n\
+         ? heat_flux_density_to_watt_per_square_metre(pound, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table (boldface =
+    // exact; the thermochemical calorie is exactly 4.184 J and cm²→m² is an exact ×10⁴, so
+    // calth/(cm²·s) = 41840 W/m², exactly).
+    assert!(
+        out.contains("\"v\":\"41840\""),
+        "calorieth per square centimetre second = 4.184 E+04 W/m^2: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `pound` is a MASS unit (it converts to the kilogram, a DIFFERENT quantity), so this
+    // heat-flux-density table has no row for it — the engine abstains rather than mis-converting a mass
+    // unit as if it were a heat-flux-density unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/heat-flux-density-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/heat-flux-density-conversions.adj
@@ -1,0 +1,69 @@
+% ============================================================================
+% heat-flux-density-conversions — heat-flux-density unit → watt-per-square-metre factors
+% (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the NIST-cited conversion tables (length, mass, area, volume, energy, force,
+% power, pressure, the electric-EMU family, the two viscosities, wave number, linear mass density,
+% temperature interval, mass density, moment of force, specific heat capacity, density of heat, specific
+% energy, thermal conductivity, and the rest): a native tabular relation ingested VERBATIM from a
+% published NIST conversion table. Each row states the factor converting a common non-SI unit of HEAT
+% FLUX DENSITY — the RATE at which heat energy FLOWS through unit area, which NIST SP 811 B.9 names the
+% "density of heat flow rate" — to the SI coherent derived unit, the watt per square metre, W/m²:
+%
+%     ? heat_flux_density_to_watt_per_square_metre(calorie_th_per_square_centimetre_second, $v)   % 41840
+%
+% This opens a NEW dimension — HEAT FLUX DENSITY (power / area, W/m²) — alongside the already-tabulated
+% length/mass/area/volume/time/speed/energy/pressure/force/power/acceleration/dynamic-viscosity/
+% kinematic-viscosity/magnetic-flux-density/magnetic-flux/illuminance/luminance/radioactivity/
+% absorbed-dose/dose-equivalent/exposure/wave-number/linear-mass-density/temperature-interval/
+% mass-density/moment-of-force/specific-heat-capacity/density-of-heat/specific-energy/
+% thermal-conductivity tables and the electric charge/potential/resistance/capacitance/inductance/
+% conductance/current tables. Heat flux density is power PER AREA [power / area] — the heat energy
+% crossing a surface per unit time per unit area. Do NOT confuse it with its three heat-named
+% neighbours: it is distinct from DENSITY OF HEAT, J/m² (ENERGY per area, no time), from
+% THERMAL CONDUCTIVITY, W/(m·K) (flux per temperature GRADIENT), and from SPECIFIC HEAT CAPACITY,
+% J/(kg·K). A value given in cal/(cm²·s) must be put into SI first, then reasoned over
+% (write-once-use-many). Why a `table` and not hand-written `relate` clauses: this is exactly the shape
+% reference data comes in — a published table, not prose. The citable artifact IS the NIST
+% conversion-factors table at the `locator` below; each factor here is a CELL of NIST Special
+% Publication 811, Appendix B.9, defended by one provenance envelope. Each `row` lowers to a ground
+% relation `heat_flux_density_to_watt_per_square_metre(unit, v)`, so the exact lookup above is the
+% ordinary SLD binding query — the engine returns the factor WITH this table's citation as its proof, on
+% the CPU, with zero model calls.
+%
+% HONESTY NOTE (like every other NIST table, only the EXACT defined factors get rows): NIST SP 811 B.9
+% prints the density-of-heat-flow-rate factor below in BOLDFACE, its convention for factors that are
+% EXACT by definition, transcribed here as the plain decimal number of watts per square metre it names:
+%
+%     calorieth per square centimeter second [calth/(cm²·s)]   4.184 E+04  →  41840
+%
+% It is EXACT and terminates; nothing here is a rounded measurement. It is exact because the
+% thermochemical calorie is DEFINED as exactly 4.184 J and the square-centimetre→square-metre scaling is
+% an exact ×10⁴: calth/(cm²·s) = 4.184 J / (10⁻⁴ m² · s) = 4.184 / 10⁻⁴ = 4.184 × 10⁴ = 41840 W/m²,
+% exactly. (This is the same NUMBER the density-of-heat table carries for calth/cm², because both scale
+% the thermochemical calorie by the same ×10⁴ per-square-centimetre factor; they are nonetheless a
+% DIFFERENT quantity — a heat flux density is a power per area, W/m², whereas a density of heat is an
+% energy per area, J/m² — and get their own table.) NIST SP 811 B.9 also lists British-thermal-unit
+% heat-flux units — e.g. BtuIT/(ft²·h) — but their W/m² factors are NON-terminating, carrying the
+% foot's 2.54-based length and the hour's factor through, so, per the exact-only rule, they get no row
+% here; only the thermochemical-calorie unit is exact. This table is SPECIFIC to heat flux density: a
+% unit of a DIFFERENT quantity — e.g. the "pound", which NIST SP 811 B.9 lists separately as a MASS unit
+% converting to the kilogram, NOT to W/m² — therefore gets no row here, and a
+% `? heat_flux_density_to_watt_per_square_metre(pound, $v)` ABSTAINS rather than mis-converting a mass
+% unit as if it were a heat-flux-density unit. The only claim this table makes is "this is the exact
+% factor NIST SP 811 B.9 prints for the calorieth per square centimetre second's conversion to the watt
+% per square metre" — which is exactly what a byte-check against the cited table verifies.
+% `trust authoritative` — a primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — the factor is a verbatim cell of the cited table, nothing asserted
+% from memory.)
+% ============================================================================
+
+table heat_flux_density_to_watt_per_square_metre {
+    columns unit, watt_per_square_metre
+
+    row (calorie_th_per_square_centimetre_second, 41840)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/heat-flux-density-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/heat-flux-density-conversions.query.adj
@@ -1,0 +1,25 @@
+% ============================================================================
+% heat-flux-density-conversions.query.adj — worked lookups over the NIST heat-flux-density →
+% watt-per-square-metre table.
+% ============================================================================
+% The shape a consumer produces to convert a heat flux density given in a non-SI unit into SI: it
+% `import`s the grounded table and asks the engine to bind the factor. No arithmetic and no factor is
+% stated by the consumer; the engine returns the cell WITH the table's NIST citation as its proof, on
+% the CPU.
+%
+%   ? heat_flux_density_to_watt_per_square_metre(calorie_th_per_square_centimetre_second, $v)   % 41840
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The "pound" is a MASS unit (it converts to the kilogram), NOT
+% a heat-flux-density unit — so it is caught rather than silently mis-converted:
+%
+%   ? heat_flux_density_to_watt_per_square_metre(pound, $v)   % abstains (pound is mass → kilogram)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli heat-flux-density-conversions.query.adj
+% ============================================================================
+
+import "heat-flux-density-conversions.adj"
+
+? heat_flux_density_to_watt_per_square_metre(calorie_th_per_square_centimetre_second, $v)   % expect 41840 (exact NIST SP 811 B.9 factor)
+? heat_flux_density_to_watt_per_square_metre(pound, $v)                                     % expect abstain (mass unit, wrong dimension)


### PR DESCRIPTION
## What

Adds the **heat flux density** RS-5 conversion `table` (NIST's *"density of heat flow rate"* quantity) — a native tabular relation transcribing **verbatim** the one boldface (exact-by-definition) factor NIST Special Publication 811, Appendix B.9 prints for a heat-flux-density unit's conversion to the SI coherent derived unit, the **watt per square metre, W/m²**. This opens a **new dimension** — heat flux density is *power per area* (the rate heat energy flows through unit area) — alongside the length/mass/…/thermal-conductivity conversion tables.

```
? heat_flux_density_to_watt_per_square_metre(calorie_th_per_square_centimetre_second, $v)   % 41840
```

## The exact row (nothing human-authored)

> calorieth per square centimeter second [calth/(cm²·s)]   **4.184 E+04**  →  41840

The factor is **boldface/exact** and terminates: the thermochemical calorie is exactly 4.184 J and cm²→m² is an exact ×10⁴, so `calth/(cm²·s) = 4.184 × 10⁴ = 41840 W/m²`, exactly. NIST B.9's British-thermal-unit heat-flux units (`BtuIT/(ft²·h)`, etc.) are **non-boldface / non-terminating** and, per the exact-only rule, get no row. (41840 is the same *number* the density-of-heat table carries for `calth/cm²`, since both scale the thermochemical calorie by the same ×10⁴ per-square-centimetre factor — but it's a **different quantity**: power per area, W/m², vs energy per area, J/m² — so it gets its own table.)

Locator: [NIST SP 811 Appendix B.9](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9), byte-verified against the page.

## Dimension guard

`pound` is a **mass** unit (it converts to the kilogram, a different quantity), so `? heat_flux_density_to_watt_per_square_metre(pound, $v)` **abstains** (`"abstained":true`) rather than mis-converting across dimensions — never a cross-dimension fabricated factor.

## Files (data + shared-anchor test block — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/reference/heat-flux-density-conversions.adj`
- `code/specs/data/adj-formula-stdlib/reference/heat-flux-density-conversions.query.adj`
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — `shipped_heat_flux_density_conversions_table_resolves_and_abstains`, appended to the shared anchor just before the `// (c) Arity guard` comment (only one facts-\* PR open at a time on this shared anchor).

## Verification

- Render-probe against the built CLI: `"v":"41840"` resolves with the NIST locator; `pound` yields `"abstained":true`.
- `cargo test -p adj-lang-cli --test rs5_table_e2e heat_flux_density` → 1 passed (43 filtered).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three files → 0 bytes.
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)