### PR TITLE
feat(adj-formula-stdlib): corrected phenytoin — StatPearls Sheiner-Tozer albumin-correction formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_corrected_phenytoin_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_corrected_phenytoin_e2e.rs
@@ -1,0 +1,143 @@
+//! End-to-end tests for the `clinical/corrected-phenytoin.adj` library — the albumin-corrected
+//! (Sheiner–Tozer) phenytoin concentration (corrected = obtained / (0.275 × albumin + 0.1)) and its
+//! two exact rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the obtained level and albumin with `observe`, and the engine applies the cited
+//! formula on the CPU, computing the EXACT value (over exact rationals — 0.275 = 11/40, 0.1 = 1/10) and
+//! rendering the citation and trust tier in the `derived` section (the auditable answer). The three
+//! formulas INVERT around the worked case obtained = 6.5, albumin = 2: 6.5 / (0.275 × 2 + 0.1) =
+//! 6.5 / 0.65 = 10 (corrected), 10 × 0.65 = 6.5 (obtained), (6.5/10 − 0.1)/0.275 = 2 (albumin). The
+//! three asserted values (10, 6.5, 2) are distinct, none a colon-anchored prefix of another rendered
+//! value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped corrected-phenytoin library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_phenytoin_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/corrected-phenytoin.adj")
+        .canonicalize()
+        .expect("shipped corrected-phenytoin.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_phenytoin_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_phenytoin_lib()).unwrap();
+    std::fs::write(dir.join("corrected-phenytoin.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// corrected_phenytoin — the correction: obtained / (0.275 × albumin + 0.1).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_phenytoin_library_and_computes_it_with_citation() {
+    let dir = scratch("corr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-phenytoin.adj\"\n\
+         observe obtained_phenytoin(6.5)\n\
+         observe albumin(2)\n\
+         ? corrected_phenytoin(obtained_phenytoin, albumin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 6.5 / (0.275 × 2 + 0.1) =
+    // 6.5 / 0.65 = 10, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"corrected_phenytoin\"") && s.contains("\"value\":10"),
+        "corrected_phenytoin(6.5, 2) = 10: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// obtained_phenytoin — the same equation solved for the obtained level: corrected × (0.275 × albumin +
+// 0.1).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_obtained_phenytoin_from_corrected_with_citation() {
+    let dir = scratch("obt");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-phenytoin.adj\"\n\
+         observe corrected_phenytoin(10)\n\
+         observe albumin(2)\n\
+         ? obtained_phenytoin(corrected_phenytoin, albumin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 × (0.275 × 2 + 0.1) = 10 × 0.65 = 6.5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"obtained_phenytoin\"") && s.contains("\"value\":6.5"),
+        "obtained_phenytoin(10, 2) = 6.5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "obtained_phenytoin carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// albumin — the same equation solved for the albumin: (obtained / corrected − 0.1) / 0.275, the third
+// reading of the one correction.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_albumin_from_phenytoin_pair_with_citation() {
+    let dir = scratch("alb");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-phenytoin.adj\"\n\
+         observe obtained_phenytoin(6.5)\n\
+         observe corrected_phenytoin(10)\n\
+         ? albumin(corrected_phenytoin, obtained_phenytoin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (6.5 / 10 − 0.1) / 0.275 = (0.65 − 0.1) / 0.275 = 0.55 / 0.275 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"albumin\"") && s.contains("\"value\":2"),
+        "albumin(10, 6.5) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "albumin carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/corrected-phenytoin.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/corrected-phenytoin.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% corrected-phenytoin.adj — the albumin-corrected (Sheiner–Tozer / Winter–Tozer) phenytoin
+% concentration (corrected = obtained / (0.275 × albumin + 0.1)) in the ADJ standard library.
+% ============================================================================
+% The corrected-phenytoin entry of the *clinical* track — the albumin-adjusted estimate of the total
+% phenytoin concentration. Phenytoin is ~90% bound to albumin and only the UNBOUND fraction is
+% pharmacologically active, so in HYPOALBUMINAEMIA a measured TOTAL level understates the active drug:
+% the same total corresponds to a higher free concentration. The Sheiner–Tozer correction scales the
+% obtained total up to the total that WOULD have been measured at a normal albumin. THE CORRECTED
+% PHENYTOIN IS THE OBTAINED PHENYTOIN LEVEL DIVIDED BY 0.275 TIMES THE ALBUMIN PLUS 0.1 — i.e. obtained
+% / (0.275 × albumin + 0.1), using the page's standard adjustment 0.275 (albumin in g/dL, phenytoin in
+% µg/mL). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its two
+% exact rearrangements (the obtained level a corrected value implies at a given albumin, and the albumin
+% an obtained/corrected pair implies). As with every compute library, a consumer states NO arithmetic:
+% it `import`s this file, binds the obtained level and albumin from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by
+% the model; the engine computes each value EXACTLY (over exact rationals), carrying the formula's
+% citation.
+%
+%     import "corrected-phenytoin.adj"
+%     observe obtained_phenytoin(6.5)   % "…phenytoin level 6.5 µg/mL…"   (span cited by the model)
+%     observe albumin(2)                 % "…albumin 2 g/dL…"              (span cited by the model)
+%     ? corrected_phenytoin(obtained_phenytoin, albumin)
+%                                         % engine → 10 (µg/mL), the albumin-corrected phenytoin
+%
+% The 0.275, 0.1 are the EXACT defined constants of the cited formula's standard adjustment (not
+% measurements); the formulas are otherwise exact expressions over the parameters, so every value the
+% engine returns is exact — 0.275 is exactly 11/40 and 0.1 is exactly 1/10, so the products and sums
+% stay in the exact rationals. They COMPOSE and invert cleanly around the worked case obtained = 6.5,
+% albumin = 2 (corrected = 6.5 / (0.275 × 2 + 0.1) = 6.5 / (0.55 + 0.1) = 6.5 / 0.65 = 10): the
+% `corrected_phenytoin` a consumer computes is exactly the value each inverse formula back-solves to
+% recover its own measured input (6.5, 2).
+%
+%   corrected_phenytoin(obtained_phenytoin, albumin) = obtained_phenytoin / (0.275 * albumin + 0.1)          % (corrected, µg/mL)
+%   obtained_phenytoin(corrected_phenytoin, albumin) = corrected_phenytoin * (0.275 * albumin + 0.1)          % (solved for obtained)
+%   albumin(corrected_phenytoin, obtained_phenytoin) = (obtained_phenytoin / corrected_phenytoin - 0.1) / 0.275 % (solved for albumin)
+%
+% NOTE ON UNITS AND MODELLING: albumin in g/dL, phenytoin in µg/mL. The cited page writes the general
+% form with a symbolic "adjustment" and states its STANDARD value is 0.275; it also gives a variant
+% adjustment of 0.2 when the creatinine clearance is < 20 mL/min (renal impairment reduces binding
+% further). This library grounds the STANDARD 0.275 form; a renal-impairment library would ground the
+% 0.2 variant identically. The correction only reinterprets the measured total for the degree of
+% hypoalbuminaemia — it does not itself decide dosing.
+%
+% All three formulas are defended by the SAME clause — the quoted correction equation — because that one
+% statement (corrected phenytoin IS the obtained level over 0.275 times albumin plus 0.1) sanctions the
+% relation read every way. The quote is transcribed verbatim from the StatPearls "Antiepileptic Drug
+% Monitoring" article on the NCBI Bookshelf (a current, non-archived article), so each `formula` carries
+% the provenance envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the formula, including its 0.275 and 0.1 constants, is a
+% verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `obtained_phenytoin`, `albumin` and `corrected_phenytoin` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary term used in both
+% roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary corrected_phenytoin_vocab {
+    define obtained_phenytoin   : finding  surface "obtained phenytoin", "measured phenytoin", "total phenytoin", "phenytoin level"  % µg/mL
+    define albumin              : finding  surface "albumin", "serum albumin"                                                        % g/dL
+    define corrected_phenytoin  : finding  surface "corrected phenytoin", "adjusted phenytoin", "albumin-corrected phenytoin"        % µg/mL
+}
+
+% ----------------------------------------------------------------------------
+% The albumin-corrected phenytoin, all three ways. Each is a named, importable, reusable formula over
+% its formal parameters, bound at apply time, and each carries the correction equation from the
+% StatPearls "Antiepileptic Drug Monitoring" article on the NCBI Bookshelf (a quote is required on a
+% shipped formula). Each is an exact expression in the measured quantities and the cited 0.275 / 0.1
+% constants, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook corrected_phenytoin_laws {
+    use corrected_phenytoin_vocab
+
+    % Corrected phenytoin — the obtained level over 0.275 times albumin plus 0.1.
+    formula corrected_phenytoin(obtained_phenytoin, albumin) = obtained_phenytoin / (0.275 * albumin + 0.1)
+        source "Corrected phenytoin = obtained phenytoin level/([adjustment x albumin] + 0.1)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482298/"
+        trust authoritative
+
+    % Obtained phenytoin — the same equation solved for the obtained level. Defended by the SAME sentence.
+    formula obtained_phenytoin(corrected_phenytoin, albumin) = corrected_phenytoin * (0.275 * albumin + 0.1)
+        source "Corrected phenytoin = obtained phenytoin level/([adjustment x albumin] + 0.1)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482298/"
+        trust authoritative
+
+    % Albumin — the same equation solved for the albumin. The SAME sentence, read the third way.
+    formula albumin(corrected_phenytoin, obtained_phenytoin) = (obtained_phenytoin / corrected_phenytoin - 0.1) / 0.275
+        source "Corrected phenytoin = obtained phenytoin level/([adjustment x albumin] + 0.1)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482298/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/corrected-phenytoin.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/corrected-phenytoin.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% corrected-phenytoin.query.adj — worked applications of the albumin-corrected phenytoin.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a therapeutic-drug-monitoring vignette into an
+% obtained phenytoin level and an albumin: it `import`s the grounded formulabook, `observe`s the two
+% values, and asks the engine to APPLY the cited Sheiner–Tozer correction. No arithmetic is stated by
+% the consumer; the engine computes each value EXACTLY (over exact rationals) and carries the article's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (obtained = 6.5 µg/mL, albumin = 2 g/dL): corrected = 6.5 / (0.275 × 2 + 0.1) =
+% 6.5 / 0.65 = 10 µg/mL — a subtherapeutic-looking total that, corrected for the low albumin, sits at
+% the bottom of the therapeutic range. Each query fixes two of the three quantities and asks the engine
+% to recover the third; every answer is exact and the three COMPOSE (each inversion recovers exactly the
+% worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli corrected-phenytoin.query.adj
+% ============================================================================
+
+import "corrected-phenytoin.adj"
+
+% --- Corrected: the albumin-corrected level the obtained value and albumin imply (expect 10). --------
+observe obtained_phenytoin(6.5)
+observe albumin(2)
+? corrected_phenytoin(obtained_phenytoin, albumin)   % expect 10
+
+% --- Inverse: the obtained level a corrected 10 implies at albumin 2 (expect 6.5). ------------------
+observe corrected_phenytoin(10)
+? obtained_phenytoin(corrected_phenytoin, albumin)   % expect 6.5


### PR DESCRIPTION
## What

Adds the **albumin-corrected (Sheiner–Tozer) phenytoin** entry of the `adj-formula-stdlib` *clinical* track. Phenytoin is ~90% albumin-bound and only the free fraction is active, so in **hypoalbuminaemia** a measured total understates the active drug; the correction scales the obtained total up to the total that would have been measured at a normal albumin.

Ships as an importable, byte-provenanced, parameterized `formula` together with its **two exact algebraic rearrangements** (the obtained level a corrected value implies at a given albumin, and the albumin an obtained/corrected pair implies). A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Grounding (nothing human-authored)

All three formulas are defended by the **same clause** — the correction equation transcribed **verbatim** from the StatPearls **"Antiepileptic Drug Monitoring"** article on the NCBI Bookshelf ([NBK482298](https://www.ncbi.nlm.nih.gov/books/NBK482298/), a current, non-archived page), under "Clinical Significance":

> Corrected phenytoin = obtained phenytoin level/([adjustment x albumin] + 0.1)

with the page's stated **standard adjustment 0.275** (it also gives 0.2 when creatinine clearance < 20 mL/min; this library grounds the standard 0.275 form). `0.275 = 11/40` and `0.1 = 1/10` are exact, so every value stays in the exact rationals. This is a **new structural shape** for the library — a single value divided by an *affine function* of one variable.

## Worked case (the three compose and invert)

obtained = 6.5 µg/mL, albumin = 2 g/dL:

- corrected = 6.5 / (0.275 × 2 + 0.1) = 6.5 / 0.65 = **10** µg/mL — a subtherapeutic-looking total that, corrected for the low albumin, sits at the bottom of the therapeutic range.
- and each inverse back-solves its own input → **6.5**, **2**.

The three asserted values are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/corrected-phenytoin.adj`
- `code/specs/data/adj-formula-stdlib/clinical/corrected-phenytoin.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_corrected_phenytoin_e2e.rs` — 3 tests, all pass

## Verification

- Render-probe against the built CLI: forward `10` + both inverses (`6.5`, `2`) render exactly with `"trust":"authoritative"` and the NCBI citation. (Validates the affine-denominator division and the nested-ratio albumin inversion.)
- `cargo test -p adj-lang-cli --test formula_corrected_phenytoin_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes.
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)