### PR TITLE
feat(adj-formula-stdlib): free water deficit — StatPearls hypernatremia water-deficit formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_free_water_deficit_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_free_water_deficit_e2e.rs
@@ -1,0 +1,143 @@
+//! End-to-end tests for the `clinical/free-water-deficit.adj` library — the hypernatraemia free water
+//! deficit (deficit = total body water × (plasma sodium / 140 − 1)) and its two exact rearrangements —
+//! driven through the built CLI binary against the SHIPPED stdlib. The same invariant as every other
+//! formula library: a consumer states NO arithmetic; it imports the grounded library, binds the total
+//! body water and plasma sodium with `observe`, and the engine applies the cited formula on the CPU,
+//! computing the EXACT value (over exact rationals — 154/140 = 11/10) and rendering the citation and
+//! trust tier in the `derived` section (the auditable answer). The three formulas INVERT around the
+//! worked case total body water = 42, plasma sodium = 154: 42 × (154/140 − 1) = 42 × 0.1 = 4.2
+//! (deficit), 4.2 / 0.1 = 42 (total body water), 140 × (4.2/42 + 1) = 140 × 1.1 = 154 (plasma sodium).
+//! The three asserted values (4.2, 42, 154) are distinct, none a colon-anchored prefix of another
+//! rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped free-water-deficit library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_fwd_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/free-water-deficit.adj")
+        .canonicalize()
+        .expect("shipped free-water-deficit.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fwd_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_fwd_lib()).unwrap();
+    std::fs::write(dir.join("free-water-deficit.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// free_water_deficit — the deficit: total body water × (plasma sodium / 140 − 1).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_fwd_library_and_computes_it_with_citation() {
+    let dir = scratch("fwd");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"free-water-deficit.adj\"\n\
+         observe total_body_water(42)\n\
+         observe plasma_sodium(154)\n\
+         ? free_water_deficit(total_body_water, plasma_sodium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 42 × (154/140 − 1) =
+    // 42 × 0.1 = 4.2, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"free_water_deficit\"") && s.contains("\"value\":4.2"),
+        "free_water_deficit(42, 154) = 4.2: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// total_body_water — the same equation solved for the total body water: deficit / (plasma sodium / 140
+// − 1).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_total_body_water_from_deficit_with_citation() {
+    let dir = scratch("tbw");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"free-water-deficit.adj\"\n\
+         observe free_water_deficit(4.2)\n\
+         observe plasma_sodium(154)\n\
+         ? total_body_water(free_water_deficit, plasma_sodium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4.2 / (154/140 − 1) = 4.2 / 0.1 = 42, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"total_body_water\"") && s.contains("\"value\":42"),
+        "total_body_water(4.2, 154) = 42: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "total_body_water carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// plasma_sodium — the same equation solved for the plasma sodium: 140 × (deficit / total body water +
+// 1), the third reading of the one deficit.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_plasma_sodium_from_deficit_with_citation() {
+    let dir = scratch("na");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"free-water-deficit.adj\"\n\
+         observe free_water_deficit(4.2)\n\
+         observe total_body_water(42)\n\
+         ? plasma_sodium(free_water_deficit, total_body_water)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 140 × (4.2 / 42 + 1) = 140 × 1.1 = 154, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"plasma_sodium\"") && s.contains("\"value\":154"),
+        "plasma_sodium(4.2, 42) = 154: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "plasma_sodium carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/free-water-deficit.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/free-water-deficit.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% free-water-deficit.adj — the free water deficit in hypernatraemia
+% (deficit = total body water × (plasma sodium / 140 − 1)) in the ADJ standard library.
+% ============================================================================
+% The free-water-deficit entry of the *clinical* track — the volume of pure water a hypernatraemic
+% patient must retain (or be given) to bring the plasma sodium back to a normal 140 mmol/L. Sodium is
+% confined to the body water it is dissolved in, so the total sodium content stays fixed while water is
+% lost; the plasma sodium therefore rises in inverse proportion to the remaining water. Restoring it to
+% 140 means adding back exactly the water that the concentration ratio says is missing. THE FREE WATER
+% DEFICIT IS THE TOTAL BODY WATER TIMES THE QUANTITY PLASMA SODIUM OVER 140 MINUS 1 — i.e. total body
+% water × (plasma sodium / 140 − 1). It ships as an importable, byte-provenanced, PARAMETERIZED
+% `formula`, together with its two exact rearrangements (the total body water a deficit implies at a
+% given plasma sodium, and the plasma sodium a deficit/total-body-water pair implies). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds the total body water
+% and plasma sodium from its own byte-provenance decomposition, and asks the engine to APPLY the cited
+% formula on the CPU. Zero math is performed by the model; the engine computes each value EXACTLY (over
+% exact rationals), carrying the formula's citation.
+%
+%     import "free-water-deficit.adj"
+%     observe total_body_water(42)   % "…70 kg man, TBW 0.6 × 70 = 42 L…"   (span cited by the model)
+%     observe plasma_sodium(154)      % "…sodium 154 mmol/L…"                (span cited by the model)
+%     ? free_water_deficit(total_body_water, plasma_sodium)
+%                                      % engine → 4.2 (litres), the free water deficit
+%
+% The 140 normal-sodium reference is the EXACT constant of the cited formula (not a measurement); the
+% formulas are otherwise exact expressions over the parameters, so every value the engine returns is
+% exact. They COMPOSE and invert cleanly around the worked case total body water = 42 L, plasma sodium =
+% 154 mmol/L (deficit = 42 × (154 / 140 − 1) = 42 × (1.1 − 1) = 42 × 0.1 = 4.2 L): the
+% `free_water_deficit` a consumer computes is exactly the value each inverse formula back-solves to
+% recover its own measured input (42, 154).
+%
+%   free_water_deficit(total_body_water, plasma_sodium) = total_body_water * (plasma_sodium / 140 - 1)      % (deficit, litres)
+%   total_body_water(free_water_deficit, plasma_sodium) = free_water_deficit / (plasma_sodium / 140 - 1)      % (solved for TBW)
+%   plasma_sodium(free_water_deficit, total_body_water) = 140 * (free_water_deficit / total_body_water + 1)    % (solved for plasma sodium)
+%
+% NOTE ON UNITS AND MODELLING: total body water in litres, plasma sodium in mmol/L, deficit in litres.
+% The cited page writes the total body water inline as "0.6 in men and 0.5 in women × body weight (kg)";
+% this library takes the total body water as its bound input (a consumer computes it from weight and sex
+% and binds it), and grounds the deficit relation itself — total body water × (plasma sodium / 140 − 1)
+% — exactly as the page prints it. The page also gives a separate replacement-rate formula (4 mL ×
+% weight × desired change in sodium); that is a different quantity and is not this library. The deficit
+% only says how much water is missing; it does not itself prescribe the correction rate (which must be
+% slow to avoid cerebral oedema).
+%
+% All three formulas are defended by the SAME clause — the quoted free-water-deficit equation — because
+% that one statement (the deficit IS the total body water times plasma-sodium-over-140 minus 1)
+% sanctions the relation read every way. The quote is transcribed verbatim from the StatPearls
+% "Hypernatremia" article on the NCBI Bookshelf (a current, non-archived article), so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an unsourced
+% one. (See feedback_nothing_human_authored — the formula, including its 140 constant, is a verbatim
+% span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `total_body_water`, `plasma_sodium` and `free_water_deficit` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary term used in both
+% roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary free_water_deficit_vocab {
+    define total_body_water    : finding  surface "total body water", "TBW"                                    % litres
+    define plasma_sodium       : finding  surface "plasma sodium", "serum sodium", "sodium", "Na"              % mmol/L
+    define free_water_deficit  : finding  surface "free water deficit", "water deficit", "free-water deficit"  % litres
+}
+
+% ----------------------------------------------------------------------------
+% The free water deficit, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the deficit equation from the StatPearls
+% "Hypernatremia" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact expression in the measured quantities and the cited 140 constant, so the engine returns each
+% value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook free_water_deficit_laws {
+    use free_water_deficit_vocab
+
+    % Free water deficit — the total body water times plasma-sodium-over-140 minus 1.
+    formula free_water_deficit(total_body_water, plasma_sodium) = total_body_water * (plasma_sodium / 140 - 1)
+        source "Total Body Water[0.6 in men and 0.5 in women x body weight(kg)] x [(plasma sodium/140) -1]"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441960/"
+        trust authoritative
+
+    % Total body water — the same equation solved for the total body water. Defended by the SAME sentence.
+    formula total_body_water(free_water_deficit, plasma_sodium) = free_water_deficit / (plasma_sodium / 140 - 1)
+        source "Total Body Water[0.6 in men and 0.5 in women x body weight(kg)] x [(plasma sodium/140) -1]"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441960/"
+        trust authoritative
+
+    % Plasma sodium — the same equation solved for the plasma sodium. The SAME sentence, read the third way.
+    formula plasma_sodium(free_water_deficit, total_body_water) = 140 * (free_water_deficit / total_body_water + 1)
+        source "Total Body Water[0.6 in men and 0.5 in women x body weight(kg)] x [(plasma sodium/140) -1]"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441960/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/free-water-deficit.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/free-water-deficit.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% free-water-deficit.query.adj — worked applications of the free water deficit.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a hypernatraemia vignette into a total body
+% water and a plasma sodium: it `import`s the grounded formulabook, `observe`s the two values, and asks
+% the engine to APPLY the cited deficit formula. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on
+% the CPU, with zero model calls.
+%
+% Worked case (total body water = 42 L, i.e. a 70 kg man at 0.6 × weight; plasma sodium = 154 mmol/L):
+% deficit = 42 × (154 / 140 − 1) = 42 × (1.1 − 1) = 42 × 0.1 = 4.2 L. Each query fixes two of the three
+% quantities and asks the engine to recover the third; every answer is exact and the three COMPOSE (each
+% inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli free-water-deficit.query.adj
+% ============================================================================
+
+import "free-water-deficit.adj"
+
+% --- Deficit: the free water deficit the TBW and plasma sodium imply (expect 4.2). ------------------
+observe total_body_water(42)
+observe plasma_sodium(154)
+? free_water_deficit(total_body_water, plasma_sodium)   % expect 4.2
+
+% --- Inverse: the total body water a deficit of 4.2 implies at plasma sodium 154 (expect 42). -------
+observe free_water_deficit(4.2)
+? total_body_water(free_water_deficit, plasma_sodium)   % expect 42


### PR DESCRIPTION
## What

Adds the **free water deficit** entry of the `adj-formula-stdlib` *clinical* track — the volume of pure water a hypernatraemic patient must retain (or receive) to bring the plasma sodium back to a normal 140 mmol/L. Sodium is confined to the body water it is dissolved in, so as water is lost the plasma sodium rises in inverse proportion to the remaining water; restoring it to 140 means replacing exactly the water the concentration ratio says is missing.

Ships as an importable, byte-provenanced, parameterized `formula` together with its **two exact algebraic rearrangements** (the total body water a deficit implies at a given plasma sodium, and the plasma sodium a deficit/total-body-water pair implies). A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Grounding (nothing human-authored)

All three formulas are defended by the **same clause** — the free-water-deficit equation transcribed **verbatim** from the StatPearls **"Hypernatremia"** article on the NCBI Bookshelf ([NBK441960](https://www.ncbi.nlm.nih.gov/books/NBK441960/), a current, non-archived page), under "Treatment / Management":

> Total Body Water[0.6 in men and 0.5 in women x body weight(kg)] x [(plasma sodium/140) -1]

The `140` normal-sodium reference is the exact constant; the library takes the **total body water as its bound input** (a consumer computes it from weight and sex) and grounds the deficit relation itself. This is a **new structural shape** for the library — a value times a `(ratio − 1)`.

## Worked case (the three compose and invert)

total body water = 42 L (a 70 kg man at 0.6 × weight), plasma sodium = 154 mmol/L:

- deficit = 42 × (154/140 − 1) = 42 × 0.1 = **4.2** L
- and each inverse back-solves its own input → **42**, **154**.

The three asserted values (4.2, 42, 154) are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/free-water-deficit.adj`
- `code/specs/data/adj-formula-stdlib/clinical/free-water-deficit.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_free_water_deficit_e2e.rs` — 3 tests, all pass

## Verification

- Render-probe against the built CLI: forward `4.2` + both inverses (`42`, `154`) render exactly with `"trust":"authoritative"` and the NCBI citation. (Validates the `value × (ratio − 1)` forward and the `const × (ratio + 1)` inversion.)
- `cargo test -p adj-lang-cli --test formula_free_water_deficit_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes.
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)