### PR TITLE
feat(adj-formula-stdlib): adjusted body weight — obese-dosing AdjBW formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_adjusted_body_weight_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_adjusted_body_weight_e2e.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for the `clinical/adjusted-body-weight.adj` library — the obese-dosing adjusted
+//! body weight (AdjBW = ideal body weight + 0.4 × (actual body weight − ideal body weight)) and its two
+//! exact rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the ideal and actual body weights with `observe`, and the engine applies the cited
+//! formula on the CPU, computing the EXACT value (over exact rationals — 0.4 = 2/5, 0.6 = 3/5) and
+//! rendering the citation and trust tier in the `derived` section (the auditable answer). The three
+//! formulas INVERT around the worked case ideal body weight = 70, actual body weight = 100:
+//! 70 + 0.4 × (100 − 70) = 70 + 12 = 82 (adjusted), (82 − 70)/0.4 + 70 = 100 (actual),
+//! (82 − 0.4 × 100)/0.6 = 70 (ideal). The three asserted values (82, 100, 70) are distinct, none a
+//! colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped adjusted-body-weight library, resolved from this crate's manifest dir
+/// so the test is location-independent.
+fn shipped_abw_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/adjusted-body-weight.adj")
+        .canonicalize()
+        .expect("shipped adjusted-body-weight.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_abw_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_abw_lib()).unwrap();
+    std::fs::write(dir.join("adjusted-body-weight.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// adjusted_body_weight — the adjustment: IBW + 0.4 × (actual − IBW).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_abw_library_and_computes_it_with_citation() {
+    let dir = scratch("abw");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"adjusted-body-weight.adj\"\n\
+         observe ideal_body_weight(70)\n\
+         observe actual_body_weight(100)\n\
+         ? adjusted_body_weight(ideal_body_weight, actual_body_weight)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 70 + 0.4 × (100 − 70) =
+    // 70 + 12 = 82, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"adjusted_body_weight\"") && s.contains("\"value\":82"),
+        "adjusted_body_weight(70, 100) = 82: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// actual_body_weight — the same equation solved for the actual body weight: (adjusted − IBW)/0.4 + IBW.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_actual_body_weight_from_adjusted_with_citation() {
+    let dir = scratch("actual");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"adjusted-body-weight.adj\"\n\
+         observe adjusted_body_weight(82)\n\
+         observe ideal_body_weight(70)\n\
+         ? actual_body_weight(adjusted_body_weight, ideal_body_weight)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (82 − 70) / 0.4 + 70 = 30 + 70 = 100, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"actual_body_weight\"") && s.contains("\"value\":100"),
+        "actual_body_weight(82, 70) = 100: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "actual_body_weight carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ideal_body_weight — the same equation solved for the ideal body weight: (adjusted − 0.4 × actual)/0.6,
+// the third reading of the one adjustment.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_ideal_body_weight_from_adjusted_with_citation() {
+    let dir = scratch("ideal");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"adjusted-body-weight.adj\"\n\
+         observe adjusted_body_weight(82)\n\
+         observe actual_body_weight(100)\n\
+         ? ideal_body_weight(adjusted_body_weight, actual_body_weight)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (82 − 0.4 × 100) / 0.6 = (82 − 40) / 0.6 = 42 / 0.6 = 70, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"ideal_body_weight\"") && s.contains("\"value\":70"),
+        "ideal_body_weight(82, 100) = 70: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "ideal_body_weight carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/adjusted-body-weight.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/adjusted-body-weight.adj
@@ -1,0 +1,99 @@
+% ============================================================================
+% adjusted-body-weight.adj — the adjusted body weight for drug dosing in obesity
+% (AdjBW = ideal body weight + 0.4 × (actual body weight − ideal body weight)) in the ADJ standard
+% library.
+% ============================================================================
+% The adjusted-body-weight entry of the *clinical* track — the dosing weight used for many drugs
+% (aminoglycosides, and others) in obese patients. Neither the actual body weight nor the ideal body
+% weight alone gives the right dose: adipose tissue is only PARTLY perfused and metabolically active, so
+% dosing on the full actual weight over-doses, while dosing on the ideal weight under-doses. The
+% adjusted body weight adds back a fixed FRACTION — a 0.4 (40%) correction factor — of the excess weight
+% above ideal. THE ADJUSTED BODY WEIGHT IS THE IDEAL BODY WEIGHT PLUS 0.4 TIMES THE ACTUAL BODY WEIGHT
+% MINUS THE IDEAL BODY WEIGHT — i.e. ideal body weight + 0.4 × (actual body weight − ideal body weight).
+% It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the actual body weight an adjusted value implies at a given ideal weight, and the
+% ideal body weight an adjusted/actual pair implies). As with every compute library, a consumer states
+% NO arithmetic: it `import`s this file, binds the ideal and actual body weights from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "adjusted-body-weight.adj"
+%     observe ideal_body_weight(70)    % "…IBW 70 kg…"        (span cited by the model)
+%     observe actual_body_weight(100)   % "…weight 100 kg…"    (span cited by the model)
+%     ? adjusted_body_weight(ideal_body_weight, actual_body_weight)
+%                                        % engine → 82 (kg), the adjusted (dosing) body weight
+%
+% The 0.4 correction factor is the EXACT constant of the cited formula (not a measurement); the formulas
+% are otherwise exact expressions over the parameters, so every value the engine returns is exact — 0.4
+% is exactly 2/5 and the complementary 0.6 (= 1 − 0.4) is exactly 3/5, so the products and the
+% back-solve stay in the exact rationals. They COMPOSE and invert cleanly around the worked case ideal
+% body weight = 70 kg, actual body weight = 100 kg (adjusted = 70 + 0.4 × (100 − 70) = 70 + 0.4 × 30 =
+% 70 + 12 = 82 kg): the `adjusted_body_weight` a consumer computes is exactly the value each inverse
+% formula back-solves to recover its own measured input (100, 70).
+%
+%   adjusted_body_weight(ideal_body_weight, actual_body_weight)
+%       = ideal_body_weight + 0.4 * (actual_body_weight - ideal_body_weight)                            % (adjusted, kg)
+%   actual_body_weight(adjusted_body_weight, ideal_body_weight)
+%       = (adjusted_body_weight - ideal_body_weight) / 0.4 + ideal_body_weight                          % (solved for actual)
+%   ideal_body_weight(adjusted_body_weight, actual_body_weight)
+%       = (adjusted_body_weight - 0.4 * actual_body_weight) / 0.6                                        % (solved for ideal)
+%
+% NOTE ON UNITS AND MODELLING: all three weights in the same mass unit (e.g. kilograms). The ideal body
+% weight is taken here as a bound INPUT — a consumer computes it from height and sex (e.g. by the Devine
+% formula the cited article also states) and binds it — and this library grounds the adjustment relation
+% itself, exactly as the page prints it. The 0.4 factor is the general dosing-weight correction; a few
+% drugs use a different factor, but the single equation grounded here is the one transcribed VERBATIM
+% from the cited page. The adjusted body weight only produces the dosing weight; it does not itself pick
+% the dose or the drug.
+%
+% All three formulas are defended by the SAME clause — the quoted adjusted-body-weight equation —
+% because that one statement (the adjusted body weight IS the ideal weight plus 0.4 of the actual minus
+% the ideal) sanctions the relation read every way. The quote is transcribed verbatim from the
+% peer-reviewed obese-dosing study on PubMed Central (NCBI), a primary, re-fetchable source, so each
+% `formula` carries the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the formula, including its 0.4 constant, is a
+% verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `ideal_body_weight`, `actual_body_weight` and `adjusted_body_weight` each appear BOTH as a
+% derived result and as an input (of the other formulas), so each is a single dictionary term used in
+% both roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary adjusted_body_weight_vocab {
+    define ideal_body_weight     : finding  surface "ideal body weight", "IBW"                                  % kilograms
+    define actual_body_weight    : finding  surface "actual body weight", "total body weight", "ABW", "weight"  % kilograms
+    define adjusted_body_weight  : finding  surface "adjusted body weight", "AdjBW", "AjBW", "dosing weight"     % kilograms
+}
+
+% ----------------------------------------------------------------------------
+% The adjusted body weight, all three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the adjustment equation from the cited
+% obese-dosing study on PubMed Central (a quote is required on a shipped formula). Each is an exact
+% expression in the measured quantities and the cited 0.4 constant, so the engine returns each value
+% EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook adjusted_body_weight_laws {
+    use adjusted_body_weight_vocab
+
+    % Adjusted body weight — the ideal weight plus 0.4 of the actual minus the ideal.
+    formula adjusted_body_weight(ideal_body_weight, actual_body_weight) = ideal_body_weight + 0.4 * (actual_body_weight - ideal_body_weight)
+        source "AdjBW [IBW + 0.4 (ABW - IBW)]"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC6354309/"
+        trust authoritative
+
+    % Actual body weight — the same equation solved for the actual body weight. Defended by the SAME sentence.
+    formula actual_body_weight(adjusted_body_weight, ideal_body_weight) = (adjusted_body_weight - ideal_body_weight) / 0.4 + ideal_body_weight
+        source "AdjBW [IBW + 0.4 (ABW - IBW)]"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC6354309/"
+        trust authoritative
+
+    % Ideal body weight — the same equation solved for the ideal body weight. The SAME sentence, read
+    % the third way.
+    formula ideal_body_weight(adjusted_body_weight, actual_body_weight) = (adjusted_body_weight - 0.4 * actual_body_weight) / 0.6
+        source "AdjBW [IBW + 0.4 (ABW - IBW)]"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC6354309/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/adjusted-body-weight.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/adjusted-body-weight.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% adjusted-body-weight.query.adj — worked applications of the adjusted body weight.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an obese-dosing vignette into an ideal body
+% weight and an actual body weight: it `import`s the grounded formulabook, `observe`s the two values,
+% and asks the engine to APPLY the cited adjustment. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on
+% the CPU, with zero model calls.
+%
+% Worked case (ideal body weight = 70 kg, actual body weight = 100 kg): adjusted = 70 + 0.4 × (100 − 70)
+% = 70 + 0.4 × 30 = 70 + 12 = 82 kg — the dosing weight sits between the ideal and the actual, closer to
+% ideal. Each query fixes two of the three quantities and asks the engine to recover the third; every
+% answer is exact and the three COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli adjusted-body-weight.query.adj
+% ============================================================================
+
+import "adjusted-body-weight.adj"
+
+% --- Adjusted: the dosing weight the ideal and actual weights imply (expect 82). --------------------
+observe ideal_body_weight(70)
+observe actual_body_weight(100)
+? adjusted_body_weight(ideal_body_weight, actual_body_weight)   % expect 82
+
+% --- Inverse: the actual body weight an adjusted 82 implies at ideal 70 (expect 100). --------------
+observe adjusted_body_weight(82)
+? actual_body_weight(adjusted_body_weight, ideal_body_weight)   % expect 100


### PR DESCRIPTION
## What

Adds the **adjusted body weight (AdjBW)** entry of the `adj-formula-stdlib` *clinical* track — the dosing weight used for many drugs (aminoglycosides and others) in obese patients. Dosing on the full actual weight over-doses (adipose tissue is only partly perfused) and dosing on ideal under-doses, so the adjusted weight adds back a fixed **0.4 (40%) correction fraction** of the excess weight above ideal.

Ships as an importable, byte-provenanced, parameterized `formula` together with its **two exact algebraic rearrangements** (the actual body weight an adjusted value implies at a given ideal weight, and the ideal body weight an adjusted/actual pair implies). A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Grounding (nothing human-authored)

All three formulas are defended by the **same clause** — the adjustment equation transcribed **verbatim** from a peer-reviewed obese-dosing study on PubMed Central ([PMC6354309](https://pmc.ncbi.nlm.nih.gov/articles/PMC6354309/), Methods section):

> AdjBW [IBW + 0.4 (ABW - IBW)]

The `0.4` correction factor is the exact constant (`0.4 = 2/5`, complementary `0.6 = 3/5`); the library takes the **ideal body weight as its bound input** (a consumer computes it from height and sex) and grounds the adjustment relation itself. This is a **new structural shape** for the library — a base plus a fraction of a difference.

## Worked case (the three compose and invert)

ideal body weight = 70 kg, actual body weight = 100 kg:

- adjusted = 70 + 0.4 × (100 − 70) = 70 + 12 = **82** kg (the dosing weight, between ideal and actual, closer to ideal)
- and each inverse back-solves its own input → **100**, **70**.

The three asserted values (82, 100, 70) are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/adjusted-body-weight.adj`
- `code/specs/data/adj-formula-stdlib/clinical/adjusted-body-weight.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_adjusted_body_weight_e2e.rs` — 3 tests, all pass

## Verification

- Render-probe against the built CLI: forward `82` + both inverses (`100`, `70`) render exactly with `"trust":"authoritative"` and the NCBI citation.
- `cargo test -p adj-lang-cli --test formula_adjusted_body_weight_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes.
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)