### PR TITLE
feat(adj-formula-stdlib): transtubular potassium gradient — TTKG constant-free formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_transtubular_potassium_gradient_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_transtubular_potassium_gradient_e2e.rs
@@ -1,0 +1,215 @@
+//! End-to-end tests for the `clinical/transtubular-potassium-gradient.adj` library — the transtubular
+//! potassium gradient (TTKG = (urine K / serum K) / (urine osmolality / serum osmolality)) and its four
+//! exact rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the four laboratory values with `observe`, and the engine applies the cited formula
+//! on the CPU, computing the EXACT value (over exact rationals — the gradient carries no constant) and
+//! rendering the citation and trust tier in the `derived` section (the auditable answer). The five
+//! formulas INVERT around the worked case urine K = 63, serum K = 7, urine osmolality = 610, serum
+//! osmolality = 305: (63/7)/(610/305) = 9/2 = 4.5 (TTKG), and each inverse back-solves its own input —
+//! 4.5 × 7 × 610 / 305 = 63 (urine K), 63 × 305 / (4.5 × 610) = 7 (serum K),
+//! 63 × 305 / (4.5 × 7) = 610 (urine osm), 4.5 × 7 × 610 / 63 = 305 (serum osm). The five asserted
+//! values (4.5, 63, 7, 610, 305) are distinct, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped transtubular-potassium-gradient library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_ttkg_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/transtubular-potassium-gradient.adj")
+        .canonicalize()
+        .expect("shipped transtubular-potassium-gradient.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ttkg_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_ttkg_lib()).unwrap();
+    std::fs::write(dir.join("transtubular-potassium-gradient.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// transtubular_potassium_gradient — the gradient: (uK/sK) / (uOsm/sOsm).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_ttkg_library_and_computes_it_with_citation() {
+    let dir = scratch("ttkg");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"transtubular-potassium-gradient.adj\"\n\
+         observe urine_potassium(63)\n\
+         observe serum_potassium(7)\n\
+         observe urine_osmolality(610)\n\
+         observe serum_osmolality(305)\n\
+         ? transtubular_potassium_gradient(urine_potassium, serum_potassium, urine_osmolality, serum_osmolality)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: (63/7)/(610/305) = 9/2 = 4.5,
+    // computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"transtubular_potassium_gradient\"") && s.contains("\"value\":4.5"),
+        "transtubular_potassium_gradient(63, 7, 610, 305) = 4.5: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_potassium — the same equation solved for the urine potassium: TTKG × sK × uOsm / sOsm.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_potassium_from_ttkg_with_citation() {
+    let dir = scratch("uk");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"transtubular-potassium-gradient.adj\"\n\
+         observe transtubular_potassium_gradient(4.5)\n\
+         observe serum_potassium(7)\n\
+         observe urine_osmolality(610)\n\
+         observe serum_osmolality(305)\n\
+         ? urine_potassium(transtubular_potassium_gradient, serum_potassium, urine_osmolality, serum_osmolality)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4.5 × 7 × 610 / 305 = 63, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_potassium\"") && s.contains("\"value\":63"),
+        "urine_potassium(4.5, 7, 610, 305) = 63: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_potassium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_potassium — the same equation solved for the serum potassium: uK × sOsm / (TTKG × uOsm).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_potassium_from_ttkg_with_citation() {
+    let dir = scratch("sk");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"transtubular-potassium-gradient.adj\"\n\
+         observe transtubular_potassium_gradient(4.5)\n\
+         observe urine_potassium(63)\n\
+         observe urine_osmolality(610)\n\
+         observe serum_osmolality(305)\n\
+         ? serum_potassium(transtubular_potassium_gradient, urine_potassium, urine_osmolality, serum_osmolality)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 63 × 305 / (4.5 × 610) = 7, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_potassium\"") && s.contains("\"value\":7"),
+        "serum_potassium(4.5, 63, 610, 305) = 7: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_potassium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_osmolality — the same equation solved for the urine osmolality: uK × sOsm / (TTKG × sK).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_osmolality_from_ttkg_with_citation() {
+    let dir = scratch("uosm");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"transtubular-potassium-gradient.adj\"\n\
+         observe transtubular_potassium_gradient(4.5)\n\
+         observe urine_potassium(63)\n\
+         observe serum_potassium(7)\n\
+         observe serum_osmolality(305)\n\
+         ? urine_osmolality(transtubular_potassium_gradient, urine_potassium, serum_potassium, serum_osmolality)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 63 × 305 / (4.5 × 7) = 610, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_osmolality\"") && s.contains("\"value\":610"),
+        "urine_osmolality(4.5, 63, 7, 305) = 610: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_osmolality carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_osmolality — the same equation solved for the serum osmolality: TTKG × sK × uOsm / uK, the
+// fifth reading of the one gradient.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_osmolality_from_ttkg_with_citation() {
+    let dir = scratch("sosm");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"transtubular-potassium-gradient.adj\"\n\
+         observe transtubular_potassium_gradient(4.5)\n\
+         observe urine_potassium(63)\n\
+         observe serum_potassium(7)\n\
+         observe urine_osmolality(610)\n\
+         ? serum_osmolality(transtubular_potassium_gradient, urine_potassium, serum_potassium, urine_osmolality)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4.5 × 7 × 610 / 63 = 305, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_osmolality\"") && s.contains("\"value\":305"),
+        "serum_osmolality(4.5, 63, 7, 610) = 305: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_osmolality carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/transtubular-potassium-gradient.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/transtubular-potassium-gradient.adj
@@ -1,0 +1,118 @@
+% ============================================================================
+% transtubular-potassium-gradient.adj — the transtubular potassium gradient
+% (TTKG = (urine K / serum K) / (urine osmolality / serum osmolality)) in the ADJ standard library.
+% ============================================================================
+% The transtubular-potassium-gradient entry of the *clinical* track — a bedside index of ALDOSTERONE
+% ACTION at the cortical collecting duct, used to work up a potassium disorder. It estimates the
+% potassium concentration at the end of the cortical collecting duct (relative to plasma) by correcting
+% the urine-to-plasma potassium ratio for the water that has since been reabsorbed — which the
+% urine-to-plasma OSMOLALITY ratio measures. A low TTKG in the face of HYPERkalaemia points to too
+% little aldosterone effect (hypoaldosteronism); a low TTKG in HYPOkalaemia points to appropriate renal
+% potassium conservation. THE TRANSTUBULAR POTASSIUM GRADIENT IS THE URINE POTASSIUM OVER THE SERUM
+% POTASSIUM, ALL DIVIDED BY THE URINE OSMOLALITY OVER THE SERUM OSMOLALITY — i.e.
+% (urine K / serum K) / (urine osmolality / serum osmolality). It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its four exact rearrangements (each of the
+% four measured quantities solved for from the other three and the gradient). As with every compute
+% library, a consumer states NO arithmetic: it `import`s this file, binds the four laboratory values
+% from its own byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU.
+% Zero math is performed by the model; the engine computes each value EXACTLY (over exact rationals),
+% carrying the formula's citation.
+%
+%     import "transtubular-potassium-gradient.adj"
+%     observe urine_potassium(63)      % "…urine K 63 mmol/L…"       (span cited by the model)
+%     observe serum_potassium(7)        % "…serum K 7 mmol/L…"        (span cited by the model)
+%     observe urine_osmolality(610)     % "…urine osm 610 mOsm/kg…"   (span cited by the model)
+%     observe serum_osmolality(305)     % "…serum osm 305 mOsm/kg…"   (span cited by the model)
+%     ? transtubular_potassium_gradient(urine_potassium, serum_potassium, urine_osmolality, serum_osmolality)
+%                                        % engine → 4.5, the transtubular potassium gradient
+%
+% The gradient is a pure ratio of ratios — there is NO constant to taint it — so it is exact whenever
+% the four inputs are exact, and every value the engine returns is exact. The formulas COMPOSE and
+% invert cleanly around the worked case urine K = 63, serum K = 7, urine osmolality = 610, serum
+% osmolality = 305 (TTKG = (63 / 7) / (610 / 305) = 9 / 2 = 4.5): the
+% `transtubular_potassium_gradient` a consumer computes is exactly the value each of the four inverse
+% formulas back-solves to recover its own measured input (63, 7, 610, 305).
+%
+%   transtubular_potassium_gradient(urine_potassium, serum_potassium, urine_osmolality, serum_osmolality)
+%       = (urine_potassium / serum_potassium) / (urine_osmolality / serum_osmolality)                              % (TTKG)
+%   urine_potassium(transtubular_potassium_gradient, serum_potassium, urine_osmolality, serum_osmolality)
+%       = transtubular_potassium_gradient * serum_potassium * urine_osmolality / serum_osmolality                  % (solved for urine K)
+%   serum_potassium(transtubular_potassium_gradient, urine_potassium, urine_osmolality, serum_osmolality)
+%       = urine_potassium * serum_osmolality / (transtubular_potassium_gradient * urine_osmolality)                % (solved for serum K)
+%   urine_osmolality(transtubular_potassium_gradient, urine_potassium, serum_potassium, serum_osmolality)
+%       = urine_potassium * serum_osmolality / (transtubular_potassium_gradient * serum_potassium)                 % (solved for urine osm)
+%   serum_osmolality(transtubular_potassium_gradient, urine_potassium, serum_potassium, urine_osmolality)
+%       = transtubular_potassium_gradient * serum_potassium * urine_osmolality / urine_potassium                   % (solved for serum osm)
+%
+% NOTE ON UNITS AND MODELLING: the two potassiums must be in the SAME concentration unit (e.g. mmol/L)
+% and the two osmolalities in the SAME unit (e.g. mOsm/kg); because potassium appears as a ratio and
+% osmolality appears as a ratio, those units CANCEL and the TTKG is a pure dimensionless number — which
+% is exactly why it is written as this ratio of two ratios. The index is only valid when the urine
+% osmolality EXCEEDS the serum osmolality and the urine sodium is adequate (the cited page states these
+% limits); this library COMPUTES the gradient — it does not itself check those preconditions or make the
+% aldosterone call.
+%
+% All five formulas are defended by the SAME clause — the quoted TTKG equation — because that one
+% statement (the TTKG IS urine-K-over-serum-K divided by urine-osm-over-serum-osm) sanctions the
+% relation read every way. The quote is transcribed verbatim from a peer-reviewed
+% potassium-metabolism review on PubMed Central (NCBI), a primary, re-fetchable source, so each
+% `formula` carries the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the formula is a verbatim span of the cited
+% page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each of the five quantities appears BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the intended
+% unit.
+% ----------------------------------------------------------------------------
+dictionary transtubular_potassium_gradient_vocab {
+    define urine_potassium                  : finding  surface "urine potassium", "urinary potassium", "urine K", "UK"        % concentration (e.g. mmol/L)
+    define serum_potassium                  : finding  surface "serum potassium", "plasma potassium", "serum K", "SK"         % concentration (e.g. mmol/L)
+    define urine_osmolality                 : finding  surface "urine osmolality", "urinary osmolality", "urine osm"          % mOsm/kg
+    define serum_osmolality                 : finding  surface "serum osmolality", "plasma osmolality", "serum osm"           % mOsm/kg
+    define transtubular_potassium_gradient  : finding  surface "transtubular potassium gradient", "TTKG", "transtubular K gradient"  % dimensionless
+}
+
+% ----------------------------------------------------------------------------
+% The transtubular potassium gradient, all five ways. Each is a named, importable, reusable formula over
+% its formal parameters, bound at apply time, and each carries the TTKG equation from the cited
+% potassium-metabolism review on PubMed Central (a quote is required on a shipped formula). Each is an
+% exact expression in the four measured quantities (the gradient carries NO constant), so the engine
+% returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook transtubular_potassium_gradient_laws {
+    use transtubular_potassium_gradient_vocab
+
+    % Transtubular potassium gradient — urine-K-over-serum-K, all divided by urine-osm-over-serum-osm.
+    formula transtubular_potassium_gradient(urine_potassium, serum_potassium, urine_osmolality, serum_osmolality) = (urine_potassium / serum_potassium) / (urine_osmolality / serum_osmolality)
+        source "TTKG is calculated as (urine K concentration/serum K concentration)/(urine osmolality/plasma osmolality)"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC8224083/"
+        trust authoritative
+
+    % Urine potassium — the same equation solved for the urine potassium. Defended by the SAME sentence.
+    formula urine_potassium(transtubular_potassium_gradient, serum_potassium, urine_osmolality, serum_osmolality) = transtubular_potassium_gradient * serum_potassium * urine_osmolality / serum_osmolality
+        source "TTKG is calculated as (urine K concentration/serum K concentration)/(urine osmolality/plasma osmolality)"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC8224083/"
+        trust authoritative
+
+    % Serum potassium — the same equation solved for the serum potassium. The SAME sentence.
+    formula serum_potassium(transtubular_potassium_gradient, urine_potassium, urine_osmolality, serum_osmolality) = urine_potassium * serum_osmolality / (transtubular_potassium_gradient * urine_osmolality)
+        source "TTKG is calculated as (urine K concentration/serum K concentration)/(urine osmolality/plasma osmolality)"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC8224083/"
+        trust authoritative
+
+    % Urine osmolality — the same equation solved for the urine osmolality. The SAME sentence, again.
+    formula urine_osmolality(transtubular_potassium_gradient, urine_potassium, serum_potassium, serum_osmolality) = urine_potassium * serum_osmolality / (transtubular_potassium_gradient * serum_potassium)
+        source "TTKG is calculated as (urine K concentration/serum K concentration)/(urine osmolality/plasma osmolality)"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC8224083/"
+        trust authoritative
+
+    % Serum osmolality — the same equation solved for the serum osmolality. The SAME sentence, the fifth
+    % reading of the one gradient.
+    formula serum_osmolality(transtubular_potassium_gradient, urine_potassium, serum_potassium, urine_osmolality) = transtubular_potassium_gradient * serum_potassium * urine_osmolality / urine_potassium
+        source "TTKG is calculated as (urine K concentration/serum K concentration)/(urine osmolality/plasma osmolality)"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC8224083/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/transtubular-potassium-gradient.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/transtubular-potassium-gradient.query.adj
@@ -1,0 +1,31 @@
+% ============================================================================
+% transtubular-potassium-gradient.query.adj — worked applications of the transtubular potassium gradient.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a potassium-disorder vignette into a paired urine
+% and serum potassium and osmolality: it `import`s the grounded formulabook, `observe`s the four
+% laboratory values, and asks the engine to APPLY the cited gradient. No arithmetic is stated by the
+% consumer; the engine computes each value EXACTLY (over exact rationals) and carries the article's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (urine K = 63, serum K = 7, urine osmolality = 610, serum osmolality = 305): TTKG =
+% (63 / 7) / (610 / 305) = 9 / 2 = 4.5 — a TTKG under 6 in the face of a serum potassium of 7
+% (hyperkalaemia) points toward hypoaldosteronism. Each query fixes the gradient and three of the four
+% measured quantities and asks the engine to recover the fourth; every answer is exact and the five
+% COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli transtubular-potassium-gradient.query.adj
+% ============================================================================
+
+import "transtubular-potassium-gradient.adj"
+
+% --- Gradient: the TTKG the four laboratory values imply (expect 4.5). ------------------------------
+observe urine_potassium(63)
+observe serum_potassium(7)
+observe urine_osmolality(610)
+observe serum_osmolality(305)
+? transtubular_potassium_gradient(urine_potassium, serum_potassium, urine_osmolality, serum_osmolality)   % expect 4.5
+
+% --- Inverse: the urine potassium a TTKG of 4.5 implies at the other three values (expect 63). ------
+observe transtubular_potassium_gradient(4.5)
+? urine_potassium(transtubular_potassium_gradient, serum_potassium, urine_osmolality, serum_osmolality)   % expect 63


### PR DESCRIPTION
## What

Adds the **transtubular potassium gradient (TTKG)** entry of the `adj-formula-stdlib` *clinical* track — a bedside index of **aldosterone action** at the cortical collecting duct, used to work up a potassium disorder. It corrects the urine-to-plasma potassium ratio for the water since reabsorbed (measured by the urine-to-plasma osmolality ratio); a low TTKG despite hyperkalaemia points to hypoaldosteronism.

Ships as an importable, byte-provenanced, parameterized `formula` together with its **four exact algebraic rearrangements** — each of the four measured laboratory quantities solved for from the other three and the gradient. A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the four values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Grounding (nothing human-authored)

All five formulas are defended by the **same clause** — the TTKG equation transcribed **verbatim** from a peer-reviewed potassium-metabolism review on PubMed Central ([PMC8224083](https://pmc.ncbi.nlm.nih.gov/articles/PMC8224083/), §12.2):

> TTKG is calculated as (urine K concentration/serum K concentration)/(urine osmolality/plasma osmolality)

The gradient is a **pure ratio of two ratios — no constant** to taint it — so it is exact whenever the four inputs are exact. This is the library's first ratio-of-ratios shape as a full **5-formula** clinical inverter (a nested `(a/b)/(c/d)` forward + four flattened cross-multiplied inverses).

## Worked case (the five compose and invert)

urine K = 63, serum K = 7, urine osmolality = 610, serum osmolality = 305:

- TTKG = (63/7)/(610/305) = 9/2 = **4.5** — a TTKG under 6 with a serum K of 7 (hyperkalaemia) points toward hypoaldosteronism.
- and each inverse back-solves its own input → **63**, **7**, **610**, **305**.

The five asserted values are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/transtubular-potassium-gradient.adj`
- `code/specs/data/adj-formula-stdlib/clinical/transtubular-potassium-gradient.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_transtubular_potassium_gradient_e2e.rs` — 5 tests, all pass

## Verification

- Render-probe against the built CLI: forward `4.5` + all four inverses (`63`, `7`, `610`, `305`) render exactly with `"trust":"authoritative"` and the NCBI citation. (Validates the nested ratio-of-ratios forward and the four flattened inversions.)
- `cargo test -p adj-lang-cli --test formula_transtubular_potassium_gradient_e2e` → 5 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes.
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)