### PR TITLE
feat(adj-formula-stdlib): ideal body weight — Devine formulabook composing with adjusted-body-weight (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_ideal_body_weight_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_ideal_body_weight_e2e.rs
@@ -1,0 +1,137 @@
+//! End-to-end tests for the `clinical/ideal-body-weight.adj` library — the Devine ideal body weight
+//! (IBW = base + 2.3 × (height in inches − 60), base 50 male / 45.5 female) and the male inverse —
+//! driven through the built CLI binary against the SHIPPED stdlib. The same invariant as every other
+//! formula library: a consumer states NO arithmetic; it imports the grounded library, binds the height
+//! with `observe`, and the engine applies the cited formula on the CPU, computing the EXACT value (over
+//! exact rationals — 2.3 = 23/10, 45.5 = 91/2) and rendering the citation and trust tier in the
+//! `derived` section (the auditable answer). The formulas COMPOSE and invert around the worked case
+//! height = 70 inches: 50 + 2.3 × (70 − 60) = 73 (male IBW), 45.5 + 23 = 68.5 (female IBW),
+//! (73 − 50)/2.3 + 60 = 70 (height back from the male IBW). The three asserted values (73, 68.5, 70)
+//! are distinct, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped ideal-body-weight library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_ibw_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/ideal-body-weight.adj")
+        .canonicalize()
+        .expect("shipped ideal-body-weight.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ibw_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_ibw_lib()).unwrap();
+    std::fs::write(dir.join("ideal-body-weight.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// ideal_body_weight_male — 50 + 2.3 × (height − 60).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_ibw_library_and_computes_male_with_citation() {
+    let dir = scratch("male");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ideal-body-weight.adj\"\n\
+         observe height(70)\n\
+         ? ideal_body_weight_male(height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 50 + 2.3 × (70 − 60) = 73,
+    // computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"ideal_body_weight_male\"") && s.contains("\"value\":73"),
+        "ideal_body_weight_male(70) = 73: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ideal_body_weight_female — 45.5 + 2.3 × (height − 60).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_female_ideal_body_weight_with_citation() {
+    let dir = scratch("female");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ideal-body-weight.adj\"\n\
+         observe height(70)\n\
+         ? ideal_body_weight_female(height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 45.5 + 2.3 × (70 − 60) = 45.5 + 23 = 68.5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"ideal_body_weight_female\"") && s.contains("\"value\":68.5"),
+        "ideal_body_weight_female(70) = 68.5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "ideal_body_weight_female carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// height — the male equation solved for the height: (male IBW − 50) / 2.3 + 60.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_height_from_male_ideal_body_weight_with_citation() {
+    let dir = scratch("height");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ideal-body-weight.adj\"\n\
+         observe ideal_body_weight_male(73)\n\
+         ? height(ideal_body_weight_male)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (73 − 50) / 2.3 + 60 = 10 + 60 = 70, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"height\"") && s.contains("\"value\":70"),
+        "height(73) = 70: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "height carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/ideal-body-weight.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/ideal-body-weight.adj
@@ -1,0 +1,91 @@
+% ============================================================================
+% ideal-body-weight.adj — the ideal body weight (Devine formula)
+% (IBW = base + 2.3 × (height in inches − 60), base 50 male / 45.5 female) in the ADJ standard library.
+% ============================================================================
+% The ideal-body-weight entry of the *clinical* track — the reference weight for a given height, the
+% starting point for weight-based drug dosing, ventilator tidal-volume setting, and nutrition. The
+% Devine formula takes a base weight at 5 feet (60 inches) and adds a fixed 2.3 kg for every inch of
+% height above 60. THE IDEAL BODY WEIGHT IS THE BASE (50 kg FOR MALES, 45.5 kg FOR FEMALES) PLUS 2.3
+% TIMES THE NUMBER OF INCHES THE HEIGHT EXCEEDS 60 — i.e. base + 2.3 × (height in inches − 60). It ships
+% as an importable, byte-provenanced, PARAMETERIZED `formula` for each sex, plus the height a male ideal
+% weight implies. As with every compute library, a consumer states NO arithmetic: it `import`s this
+% file, binds the height (and sex) from its own byte-provenance decomposition, and asks the engine to
+% APPLY the cited formula on the CPU. Zero math is performed by the model; the engine computes each
+% value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "ideal-body-weight.adj"
+%     observe height(70)   % "…height 70 inches…"   (span cited by the model)
+%     ? ideal_body_weight_male(height)     % engine → 73    (kg), the male ideal body weight
+%     ? ideal_body_weight_female(height)   % engine → 68.5  (kg), the female ideal body weight
+%
+% This library is the natural COMPANION of adjusted-body-weight (write-once-use-many): a consumer
+% computes the ideal body weight HERE from height and sex, then feeds it as the `ideal_body_weight`
+% input of the adjusted-body-weight formula to obtain the obese-dosing weight. The SAME cited source
+% states both equations, so the two libraries share one provenance origin.
+%
+% The 50 / 45.5 bases, the 2.3 per-inch factor and the 60-inch reference are the EXACT defined constants
+% of the cited formula (not measurements); the formulas are otherwise exact expressions over the height,
+% so every value the engine returns is exact — 2.3 is exactly 23/10 and 45.5 is exactly 91/2. They
+% COMPOSE and invert cleanly around the worked case height = 70 inches (male IBW = 50 + 2.3 × (70 − 60) =
+% 50 + 2.3 × 10 = 50 + 23 = 73 kg; female IBW = 45.5 + 23 = 68.5 kg): the height the `height` formula
+% back-solves from a male ideal weight of 73 is exactly the 70 the forward formula started from.
+%
+%   ideal_body_weight_male(height) = 50 + 2.3 * (height - 60)                     % (male IBW, kg)
+%   ideal_body_weight_female(height) = 45.5 + 2.3 * (height - 60)                 % (female IBW, kg)
+%   height(ideal_body_weight_male) = (ideal_body_weight_male - 50) / 2.3 + 60     % (solved for height from the male IBW)
+%
+% NOTE ON UNITS AND MODELLING: height in inches, ideal body weight in kilograms. The formula applies for
+% heights at or above 60 inches (5 feet); the base weight IS the ideal weight at exactly 60 inches. The
+% female inverse is the exact mirror of the male inverse — (female IBW − 45.5) / 2.3 + 60 — and is
+% omitted here only to keep one canonical `height` result; a consumer needing it rearranges the female
+% forward the same way. This library computes the reference weight; it does not itself choose a dose.
+%
+% All three formulas are defended by the SAME clause — the quoted Devine equation, stating both sex
+% bases — because that one statement (IBW IS 50-or-45.5 plus 2.3 per inch over 60) sanctions the
+% relation read every way. The quote is transcribed verbatim from the same peer-reviewed obese-dosing
+% study on PubMed Central (NCBI) that grounds the adjusted-body-weight library, a primary, re-fetchable
+% source, so each `formula` carries the provenance envelope every shipped grounded clause carries; the
+% linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula, including its
+% 50 / 45.5 / 2.3 / 60 constants, is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `height` is the shared input; `ideal_body_weight_male` and `ideal_body_weight_female` are
+% the two sex-specific results, and the male result is also the input of the height inverse. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary ideal_body_weight_vocab {
+    define height                     : finding  surface "height", "height in inches", "stature"                          % inches
+    define ideal_body_weight_male     : finding  surface "ideal body weight male", "male ideal body weight", "IBW male"   % kilograms
+    define ideal_body_weight_female   : finding  surface "ideal body weight female", "female ideal body weight", "IBW female"  % kilograms
+}
+
+% ----------------------------------------------------------------------------
+% The Devine ideal body weight, both sexes plus the male inverse. Each is a named, importable, reusable
+% formula over its formal parameters, bound at apply time, and each carries the Devine equation from the
+% cited obese-dosing study on PubMed Central (a quote is required on a shipped formula). Each is an
+% exact expression in the height and the cited 50 / 45.5 / 2.3 / 60 constants, so the engine returns
+% each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook ideal_body_weight_laws {
+    use ideal_body_weight_vocab
+
+    % Male ideal body weight — 50 kg plus 2.3 kg per inch of height over 60.
+    formula ideal_body_weight_male(height) = 50 + 2.3 * (height - 60)
+        source "45.5 + (height in inches >60 × 2.3) for females and 50 + (height in inches >60 × 2.3) for males"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC6354309/"
+        trust authoritative
+
+    % Female ideal body weight — 45.5 kg plus 2.3 kg per inch of height over 60. Same clause, female base.
+    formula ideal_body_weight_female(height) = 45.5 + 2.3 * (height - 60)
+        source "45.5 + (height in inches >60 × 2.3) for females and 50 + (height in inches >60 × 2.3) for males"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC6354309/"
+        trust authoritative
+
+    % Height — the male equation solved for the height. The SAME clause, read backwards.
+    formula height(ideal_body_weight_male) = (ideal_body_weight_male - 50) / 2.3 + 60
+        source "45.5 + (height in inches >60 × 2.3) for females and 50 + (height in inches >60 × 2.3) for males"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC6354309/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/ideal-body-weight.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/ideal-body-weight.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% ideal-body-weight.query.adj — worked applications of the Devine ideal body weight.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a dosing vignette into a height (and a sex): it
+% `import`s the grounded formulabook, `observe`s the height, and asks the engine to APPLY the cited
+% Devine formula. No arithmetic is stated by the consumer; the engine computes each value EXACTLY (over
+% exact rationals) and carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (height = 70 inches): male IBW = 50 + 2.3 × (70 − 60) = 50 + 23 = 73 kg; female IBW =
+% 45.5 + 23 = 68.5 kg. The male inverse recovers the height exactly: (73 − 50) / 2.3 + 60 = 10 + 60 = 70.
+% The ideal body weight computed here is exactly what a consumer feeds to the adjusted-body-weight
+% library as its `ideal_body_weight` input (write-once-use-many).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ideal-body-weight.query.adj
+% ============================================================================
+
+import "ideal-body-weight.adj"
+
+% --- Forward: the male and female ideal body weights a height of 70 inches implies (expect 73, 68.5). -
+observe height(70)
+? ideal_body_weight_male(height)     % expect 73
+? ideal_body_weight_female(height)   % expect 68.5
+
+% --- Inverse: the height a male ideal body weight of 73 implies (expect 70). ------------------------
+observe ideal_body_weight_male(73)
+? height(ideal_body_weight_male)     % expect 70


### PR DESCRIPTION
## What

Adds the **ideal body weight (Devine)** entry of the `adj-formula-stdlib` *clinical* track — the reference weight for a given height, the starting point for weight-based drug dosing, ventilator tidal-volume setting, and nutrition. The formula takes a base weight at 5 feet (60 inches) and adds a fixed **2.3 kg per inch above 60**.

Ships as an importable, byte-provenanced, parameterized `formula` for **each sex** plus the height a male ideal weight implies. A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the height with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Write-once-use-many (composes with adjusted-body-weight)

This library is the natural **companion of `adjusted-body-weight`**: a consumer computes the ideal body weight *here* from height and sex, then feeds it as the `ideal_body_weight` input of the adjusted-body-weight formula to get the obese-dosing weight. Both equations are stated by the **same cited source**, so the two libraries share one provenance origin — a live demonstration of grounded libraries composing.

## Grounding (nothing human-authored)

All three formulas are defended by the **same clause** — the Devine equation transcribed **verbatim** from the same peer-reviewed obese-dosing study on PubMed Central ([PMC6354309](https://pmc.ncbi.nlm.nih.gov/articles/PMC6354309/), Methods) that grounds `adjusted-body-weight`:

> 45.5 + (height in inches >60 × 2.3) for females and 50 + (height in inches >60 × 2.3) for males

The `50 / 45.5` bases, the `2.3` per-inch factor and the `60`-inch reference are the exact constants (`2.3 = 23/10`, `45.5 = 91/2`), so every value stays in the exact rationals.

## Worked case (compose and invert)

height = 70 inches:

- male IBW = 50 + 2.3 × (70 − 60) = 50 + 23 = **73** kg
- female IBW = 45.5 + 23 = **68.5** kg
- male inverse back-solves the height: (73 − 50)/2.3 + 60 = **70**.

The three asserted values (73, 68.5, 70) are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/ideal-body-weight.adj`
- `code/specs/data/adj-formula-stdlib/clinical/ideal-body-weight.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_ideal_body_weight_e2e.rs` — 3 tests, all pass

## Verification

- Render-probe against the built CLI: male `73` + female `68.5` + height inverse `70` render exactly with `"trust":"authoritative"` and the NCBI citation.
- `cargo test -p adj-lang-cli --test formula_ideal_body_weight_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes (the source string's Unicode `×` is clean).
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)