### PR TITLE
feat(adj-formula-stdlib): Parkland formula — StatPearls burn-resuscitation fluid formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_parkland_formula_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_parkland_formula_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/parkland-formula.adj` library — the Parkland burn resuscitation
+//! formula (total 24-hour fluid = 4 × weight × %TBSA) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula
+//! library: a consumer states NO arithmetic; it imports the grounded library, binds the weight and
+//! burned surface area with `observe`, and the engine applies the cited formula on the CPU, computing
+//! the EXACT value (over exact rationals) and rendering the citation and trust tier in the `derived`
+//! section (the auditable answer). The three formulas INVERT around the worked case weight = 80,
+//! TBSA = 30: 4 × 80 × 30 = 9600 (total fluid), 9600 / (4 × 30) = 80 (weight),
+//! 9600 / (4 × 80) = 30 (%TBSA). The three asserted values (9600, 80, 30) are distinct, none a
+//! colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped parkland-formula library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_parkland_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/parkland-formula.adj")
+        .canonicalize()
+        .expect("shipped parkland-formula.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_parkland_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_parkland_lib()).unwrap();
+    std::fs::write(dir.join("parkland-formula.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// total_fluid — the resuscitation volume: 4 × weight × %TBSA.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_parkland_library_and_computes_fluid_with_citation() {
+    let dir = scratch("fluid");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"parkland-formula.adj\"\n\
+         observe weight(80)\n\
+         observe tbsa(30)\n\
+         ? total_fluid(weight, tbsa)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 4 × 80 × 30 = 9600, computed
+    // EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"total_fluid\"") && s.contains("\"value\":9600"),
+        "total_fluid(80, 30) = 9600: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// weight — the same equation solved for the weight: total_fluid / (4 × %TBSA).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_weight_from_parkland_fluid_with_citation() {
+    let dir = scratch("weight");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"parkland-formula.adj\"\n\
+         observe total_fluid(9600)\n\
+         observe tbsa(30)\n\
+         ? weight(total_fluid, tbsa)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 9600 / (4 × 30) = 9600 / 120 = 80, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"weight\"") && s.contains("\"value\":80"),
+        "weight(9600, 30) = 80: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "weight carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tbsa — the same equation solved for the burn size: total_fluid / (4 × weight), the third reading of
+// the one formula.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_tbsa_from_parkland_fluid_with_citation() {
+    let dir = scratch("tbsa");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"parkland-formula.adj\"\n\
+         observe total_fluid(9600)\n\
+         observe weight(80)\n\
+         ? tbsa(total_fluid, weight)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 9600 / (4 × 80) = 9600 / 320 = 30, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"tbsa\"") && s.contains("\"value\":30"),
+        "tbsa(9600, 80) = 30: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "tbsa carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/parkland-formula.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/parkland-formula.adj
@@ -1,0 +1,91 @@
+% ============================================================================
+% parkland-formula.adj — the Parkland burn resuscitation formula
+% (total 24-hour fluid = 4 × weight × %TBSA burned) in the ADJ standard library.
+% ============================================================================
+% The parkland-formula entry of the *clinical* track — the most-used estimate of the crystalloid volume
+% a burn patient needs in the first 24 hours. A large burn leaks plasma into the tissues; the Parkland
+% formula sizes the replacement to the patient's mass and the fraction of the body surface burned, then
+% gives half in the first 8 hours and the rest over the next 16. THE TOTAL 24-HOUR FLUID IS 4 mL TIMES
+% THE BODY WEIGHT IN KILOGRAMS TIMES THE PERCENTAGE OF TOTAL BODY SURFACE AREA BURNED — i.e.
+% 4 × weight × %TBSA. It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together
+% with its two exact rearrangements (the weight a total volume implies at a given burn size, and the
+% burn size a total volume implies at a given weight). As with every compute library, a consumer states
+% NO arithmetic: it `import`s this file, binds the weight and the burned surface area from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "parkland-formula.adj"
+%     observe weight(80)   % "…80 kg…"          (span cited by the model)
+%     observe tbsa(30)      % "…30% TBSA burn…"  (span cited by the model)
+%     ? total_fluid(weight, tbsa)   % engine → 9600 (mL), the 24-hour Parkland volume
+%
+% The 4 mL/kg/%TBSA factor is the EXACT constant of the cited (adult) formula (not a measurement); the
+% formulas are otherwise exact expressions over the parameters, so every value the engine returns is
+% exact. They COMPOSE and invert cleanly around the worked case weight = 80 kg, TBSA = 30% (total fluid =
+% 4 × 80 × 30 = 9600 mL, of which half — 4800 mL — is given in the first 8 hours): the `total_fluid` a
+% consumer computes is exactly the value each inverse formula back-solves to recover its own measured
+% input (80, 30).
+%
+%   total_fluid(weight, tbsa) = 4 * weight * tbsa       % (24-hour fluid, mL)
+%   weight(total_fluid, tbsa) = total_fluid / (4 * tbsa) % (solved for weight)
+%   tbsa(total_fluid, weight) = total_fluid / (4 * weight)% (solved for %TBSA)
+%
+% NOTE ON UNITS AND MODELLING: weight in kilograms, TBSA as a plain percentage number (e.g. 30 for a 30%
+% burn, NOT 0.30), total fluid in millilitres over the first 24 hours. The cited page gives the ADULT
+% factor of 4 mL/kg/%TBSA; a paediatric variant uses 3 mL/kg/%TBSA and would be a sibling library
+% grounded the same way. The formula sizes the total 24-hour crystalloid; the "half in the first 8
+% hours" split and the choice of lactated Ringer's are stated by the same page but are separate from
+% this total-volume computation. This library only COMPUTES the volume; it does not itself titrate to
+% urine output (which ultimately guides real resuscitation).
+%
+% All three formulas are defended by the SAME clause — the quoted Parkland statement — because that one
+% sentence (the Parkland formula uses 4 mL per kg per %TBSA) sanctions the relation read every way. The
+% quote is transcribed verbatim from the StatPearls "Parkland Formula" article on the NCBI Bookshelf (a
+% current, non-archived article), so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored —
+% the formula, including its 4 mL/kg/%TBSA constant, is a verbatim span of the cited page, not asserted
+% from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `weight`, `tbsa` and `total_fluid` each appear BOTH as a derived result and as an input
+% (of the other formulas), so each is a single dictionary term used in both roles. The `surface` lists
+% are the everyday names a decomposer maps onto the canonical term; the trailing comment records the
+% intended unit.
+% ----------------------------------------------------------------------------
+dictionary parkland_formula_vocab {
+    define weight        : finding  surface "weight", "body weight", "total body weight"                          % kilograms
+    define tbsa          : finding  surface "TBSA", "total body surface area", "percent TBSA", "burn surface area"  % percent
+    define total_fluid   : finding  surface "total fluid", "resuscitation fluid", "24-hour fluid", "parkland fluid"  % millilitres (first 24 h)
+}
+
+% ----------------------------------------------------------------------------
+% The Parkland formula, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the Parkland statement from the StatPearls "Parkland
+% Formula" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% expression in the measured quantities and the cited 4 mL/kg/%TBSA constant, so the engine returns each
+% value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook parkland_formula_laws {
+    use parkland_formula_vocab
+
+    % Total 24-hour fluid — 4 mL times the weight times the percentage of TBSA burned.
+    formula total_fluid(weight, tbsa) = 4 * weight * tbsa
+        source "The Parkland formula uses 4 mL per patient weight in kilograms per percentage of TBSA burned"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537190/"
+        trust authoritative
+
+    % Weight — the same equation solved for the weight. Defended by the SAME sentence.
+    formula weight(total_fluid, tbsa) = total_fluid / (4 * tbsa)
+        source "The Parkland formula uses 4 mL per patient weight in kilograms per percentage of TBSA burned"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537190/"
+        trust authoritative
+
+    % Percentage of TBSA burned — the same equation solved for the burn size. The SAME sentence, read
+    % the third way.
+    formula tbsa(total_fluid, weight) = total_fluid / (4 * weight)
+        source "The Parkland formula uses 4 mL per patient weight in kilograms per percentage of TBSA burned"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537190/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/parkland-formula.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/parkland-formula.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% parkland-formula.query.adj — worked applications of the Parkland burn formula.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a burn vignette into a body weight and a burned
+% surface area: it `import`s the grounded formulabook, `observe`s the two values, and asks the engine to
+% APPLY the cited Parkland formula. No arithmetic is stated by the consumer; the engine computes each
+% value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with
+% zero model calls.
+%
+% Worked case (weight = 80 kg, TBSA = 30%): total 24-hour fluid = 4 × 80 × 30 = 9600 mL — half (4800 mL)
+% over the first 8 hours, the remaining 4800 mL over the next 16. Each query fixes two of the three
+% quantities and asks the engine to recover the third; every answer is exact and the three COMPOSE (each
+% inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli parkland-formula.query.adj
+% ============================================================================
+
+import "parkland-formula.adj"
+
+% --- Fluid: the 24-hour resuscitation volume the weight and burn size imply (expect 9600). ----------
+observe weight(80)
+observe tbsa(30)
+? total_fluid(weight, tbsa)   % expect 9600
+
+% --- Inverse: the weight a total volume of 9600 implies at a 30% burn (expect 80). ------------------
+observe total_fluid(9600)
+? weight(total_fluid, tbsa)   % expect 80


### PR DESCRIPTION
## What

Adds the **Parkland burn resuscitation formula** entry of the `adj-formula-stdlib` *clinical* track — the most-used estimate of the crystalloid volume a burn patient needs in the first 24 hours. A large burn leaks plasma into the tissues; Parkland sizes the replacement to the patient's mass and the fraction of body surface burned (half in the first 8 hours, the rest over the next 16).

Ships as an importable, byte-provenanced, parameterized `formula` together with its **two exact algebraic rearrangements** (the weight a total volume implies at a given burn size, and the burn size a total volume implies at a given weight). A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Grounding (nothing human-authored)

All three formulas are defended by the **same clause** — the Parkland statement transcribed **verbatim** from the StatPearls **"Parkland Formula"** article on the NCBI Bookshelf ([NBK537190](https://www.ncbi.nlm.nih.gov/books/NBK537190/), a current, non-archived page):

> The Parkland formula uses 4 mL per patient weight in kilograms per percentage of TBSA burned

The `4 mL/kg/%TBSA` factor is the exact adult constant. This is a **new structural shape** for the library — a three-factor product (`constant × weight × %TBSA`).

## Worked case (the three compose and invert)

weight = 80 kg, TBSA = 30%:

- total fluid = 4 × 80 × 30 = **9600** mL (half = 4800 mL over the first 8 hours)
- and each inverse back-solves its own input → **80**, **30**.

The three asserted values (9600, 80, 30) are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/parkland-formula.adj`
- `code/specs/data/adj-formula-stdlib/clinical/parkland-formula.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_parkland_formula_e2e.rs` — 3 tests, all pass

## Verification

- Render-probe against the built CLI: forward `9600` + both inverses (`80`, `30`) render exactly with `"trust":"authoritative"` and the NCBI citation.
- `cargo test -p adj-lang-cli --test formula_parkland_formula_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes.
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)