### PR TITLE
feat(adj-formula-stdlib): delta ratio — StatPearls delta-delta mixed-acidosis formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_delta_ratio_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_delta_ratio_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/delta-ratio.adj` library — the delta ratio (delta-delta / delta
+//! gap ratio, (anion gap − 12) / (24 − bicarbonate)) and its two exact rearrangements — driven through
+//! the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula library:
+//! a consumer states NO arithmetic; it imports the grounded library, binds the anion gap and
+//! bicarbonate with `observe`, and the engine applies the cited formula on the CPU, computing the EXACT
+//! value (over exact rationals — 18/10 = 9/5) and rendering the citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case anion
+//! gap = 30, bicarbonate = 14: (30 − 12)/(24 − 14) = 18/10 = 1.8 (delta ratio),
+//! 1.8 × (24 − 14) + 12 = 30 (anion gap), 24 − (30 − 12)/1.8 = 14 (bicarbonate). The three asserted
+//! values (1.8, 30, 14) are distinct, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped delta-ratio library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_delta_ratio_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/delta-ratio.adj")
+        .canonicalize()
+        .expect("shipped delta-ratio.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_deltaratio_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_delta_ratio_lib()).unwrap();
+    std::fs::write(dir.join("delta-ratio.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// delta_ratio — the ratio: (anion gap − 12) / (24 − bicarbonate).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_delta_ratio_library_and_computes_it_with_citation() {
+    let dir = scratch("ratio");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"delta-ratio.adj\"\n\
+         observe anion_gap(30)\n\
+         observe bicarbonate(14)\n\
+         ? delta_ratio(anion_gap, bicarbonate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: (30 − 12)/(24 − 14) = 18/10 =
+    // 1.8, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"delta_ratio\"") && s.contains("\"value\":1.8"),
+        "delta_ratio(30, 14) = 1.8: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// anion_gap — the same equation solved for the anion gap: delta_ratio × (24 − bicarbonate) + 12.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_anion_gap_from_delta_ratio_with_citation() {
+    let dir = scratch("ag");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"delta-ratio.adj\"\n\
+         observe delta_ratio(1.8)\n\
+         observe bicarbonate(14)\n\
+         ? anion_gap(delta_ratio, bicarbonate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 1.8 × (24 − 14) + 12 = 18 + 12 = 30, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"anion_gap\"") && s.contains("\"value\":30"),
+        "anion_gap(1.8, 14) = 30: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "anion_gap carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// bicarbonate — the same equation solved for the bicarbonate: 24 − (anion gap − 12) / delta_ratio, the
+// third reading of the one ratio.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_bicarbonate_from_delta_ratio_with_citation() {
+    let dir = scratch("hco3");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"delta-ratio.adj\"\n\
+         observe delta_ratio(1.8)\n\
+         observe anion_gap(30)\n\
+         ? bicarbonate(delta_ratio, anion_gap)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 24 − (30 − 12) / 1.8 = 24 − 10 = 14, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"bicarbonate\"") && s.contains("\"value\":14"),
+        "bicarbonate(1.8, 30) = 14: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "bicarbonate carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/delta-ratio.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/delta-ratio.adj
@@ -1,0 +1,91 @@
+% ============================================================================
+% delta-ratio.adj — the delta ratio (delta-delta / delta gap ratio)
+% (delta ratio = (anion gap − 12) / (24 − bicarbonate)) in the ADJ standard library.
+% ============================================================================
+% The delta-ratio entry of the *clinical* track — the bedside test for a MIXED metabolic acid-base
+% disorder hiding behind a high-anion-gap metabolic acidosis. In a pure anion-gap acidosis every
+% milliequivalent added to the anion gap should have consumed one milliequivalent of bicarbonate, so the
+% RISE in the anion gap (above the normal 12) should equal the FALL in bicarbonate (below the normal
+% 24) — a ratio near 1. A ratio well BELOW 1 means bicarbonate fell more than the gap rose (a
+% co-existing normal-gap acidosis); a ratio well ABOVE 1 (roughly >2) means bicarbonate fell less than
+% expected (a co-existing metabolic alkalosis). THE DELTA RATIO IS THE ANION GAP MINUS 12, DIVIDED BY 24
+% MINUS THE BICARBONATE — i.e. (anion gap − 12) / (24 − bicarbonate). It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the anion gap a
+% ratio implies at a given bicarbonate, and the bicarbonate a ratio implies at a given anion gap). As
+% with every compute library, a consumer states NO arithmetic: it `import`s this file, binds the anion
+% gap and bicarbonate from its own byte-provenance decomposition, and asks the engine to APPLY the cited
+% formula on the CPU. Zero math is performed by the model; the engine computes each value EXACTLY (over
+% exact rationals), carrying the formula's citation.
+%
+%     import "delta-ratio.adj"
+%     observe anion_gap(30)     % "…anion gap 30…"        (span cited by the model)
+%     observe bicarbonate(14)    % "…bicarbonate 14…"      (span cited by the model)
+%     ? delta_ratio(anion_gap, bicarbonate)   % engine → 1.8, the delta ratio
+%
+% The 12 (upper-limit-of-normal anion gap) and 24 (normal bicarbonate) are the EXACT reference constants
+% of the cited formula (not measurements); the formulas are otherwise exact expressions over the
+% parameters, so every value the engine returns is exact. They COMPOSE and invert cleanly around the
+% worked case anion gap = 30, bicarbonate = 14 (delta ratio = (30 − 12) / (24 − 14) = 18 / 10 = 1.8, a
+% ratio between 1 and 2, i.e. a pure high-anion-gap acidosis): the `delta_ratio` a consumer computes is
+% exactly the value each inverse formula back-solves to recover its own measured input (30, 14).
+%
+%   delta_ratio(anion_gap, bicarbonate) = (anion_gap - 12) / (24 - bicarbonate)          % (delta ratio)
+%   anion_gap(delta_ratio, bicarbonate) = delta_ratio * (24 - bicarbonate) + 12          % (solved for anion gap)
+%   bicarbonate(delta_ratio, anion_gap) = 24 - (anion_gap - 12) / delta_ratio            % (solved for bicarbonate)
+%
+% NOTE ON UNITS AND MODELLING: anion gap and bicarbonate in the same unit (mEq/L or mmol/L); the ratio
+% is dimensionless. The 12 and 24 are this page's stated normal references (some sources use an anion-gap
+% normal of 10-12); the single equation grounded here is the one transcribed VERBATIM from the cited
+% page. Interpretation bands (< 1 concurrent normal-gap acidosis, 1-2 pure anion-gap acidosis, > 2
+% concurrent metabolic alkalosis) are stated by the same page but are separate from this ratio
+% computation. This library only COMPUTES the ratio; it does not itself name the mixed disorder.
+%
+% All three formulas are defended by the SAME clause — the quoted delta-ratio equation — because that
+% one statement (the delta ratio IS anion-gap-minus-12 over 24-minus-bicarbonate) sanctions the relation
+% read every way. The quote is transcribed verbatim from the StatPearls "Anion Gap and Non-Anion Gap
+% Metabolic Acidosis" article on the NCBI Bookshelf (a current, non-archived article), so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an unsourced
+% one. (See feedback_nothing_human_authored — the formula, including its 12 and 24 constants, is a
+% verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `anion_gap`, `bicarbonate` and `delta_ratio` each appear BOTH as a derived result and as
+% an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary delta_ratio_vocab {
+    define anion_gap     : finding  surface "anion gap", "corrected anion gap", "AG"           % mEq/L
+    define bicarbonate   : finding  surface "bicarbonate", "HCO3", "serum bicarbonate", "measured HCO3"  % mEq/L
+    define delta_ratio   : finding  surface "delta ratio", "delta-delta", "delta gap ratio"    % dimensionless
+}
+
+% ----------------------------------------------------------------------------
+% The delta ratio, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the delta-ratio equation from the StatPearls "Anion
+% Gap and Non-Anion Gap Metabolic Acidosis" article on the NCBI Bookshelf (a quote is required on a
+% shipped formula). Each is an exact expression in the measured quantities and the cited 12 / 24
+% constants, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook delta_ratio_laws {
+    use delta_ratio_vocab
+
+    % Delta ratio — the anion gap minus 12, over 24 minus the bicarbonate.
+    formula delta_ratio(anion_gap, bicarbonate) = (anion_gap - 12) / (24 - bicarbonate)
+        source "Δanion gap / ΔHCO3 = (corrected anion gap − 12) / (24 − measured HCO3)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448090/"
+        trust authoritative
+
+    % Anion gap — the same equation solved for the anion gap. Defended by the SAME sentence.
+    formula anion_gap(delta_ratio, bicarbonate) = delta_ratio * (24 - bicarbonate) + 12
+        source "Δanion gap / ΔHCO3 = (corrected anion gap − 12) / (24 − measured HCO3)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448090/"
+        trust authoritative
+
+    % Bicarbonate — the same equation solved for the bicarbonate. The SAME sentence, read the third way.
+    formula bicarbonate(delta_ratio, anion_gap) = 24 - (anion_gap - 12) / delta_ratio
+        source "Δanion gap / ΔHCO3 = (corrected anion gap − 12) / (24 − measured HCO3)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448090/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/delta-ratio.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/delta-ratio.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% delta-ratio.query.adj — worked applications of the delta ratio.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a metabolic-acidosis vignette into an anion gap
+% and a bicarbonate: it `import`s the grounded formulabook, `observe`s the two values, and asks the
+% engine to APPLY the cited delta-ratio formula. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on
+% the CPU, with zero model calls.
+%
+% Worked case (anion gap = 30, bicarbonate = 14): delta ratio = (30 − 12) / (24 − 14) = 18 / 10 = 1.8 —
+% a ratio between 1 and 2, consistent with a pure high-anion-gap metabolic acidosis (no hidden second
+% disorder). Each query fixes two of the three quantities and asks the engine to recover the third;
+% every answer is exact and the three COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli delta-ratio.query.adj
+% ============================================================================
+
+import "delta-ratio.adj"
+
+% --- Ratio: the delta ratio the anion gap and bicarbonate imply (expect 1.8). ----------------------
+observe anion_gap(30)
+observe bicarbonate(14)
+? delta_ratio(anion_gap, bicarbonate)   % expect 1.8
+
+% --- Inverse: the anion gap a delta ratio of 1.8 implies at bicarbonate 14 (expect 30). ------------
+observe delta_ratio(1.8)
+? anion_gap(delta_ratio, bicarbonate)   % expect 30


### PR DESCRIPTION
## What

Adds the **delta ratio (delta-delta / delta gap ratio)** entry of the `adj-formula-stdlib` *clinical* track — the bedside test for a **mixed** metabolic acid-base disorder hiding behind a high-anion-gap metabolic acidosis. In a pure anion-gap acidosis the rise in the anion gap above the normal 12 should equal the fall in bicarbonate below the normal 24 (ratio near 1); a ratio well below 1 unmasks a co-existing normal-gap acidosis, and above ~2 a co-existing metabolic alkalosis.

Ships as an importable, byte-provenanced, parameterized `formula` together with its **two exact algebraic rearrangements** (the anion gap a ratio implies at a given bicarbonate, and the bicarbonate a ratio implies at a given anion gap). A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Grounding (nothing human-authored)

All three formulas are defended by the **same clause** — the delta-ratio equation transcribed **verbatim** from the StatPearls **"Anion Gap and Non-Anion Gap Metabolic Acidosis"** article on the NCBI Bookshelf ([NBK448090](https://www.ncbi.nlm.nih.gov/books/NBK448090/), a current, non-archived page — the same page that grounds `winters-formula`):

> Δanion gap / ΔHCO3 = (corrected anion gap − 12) / (24 − measured HCO3)

The `12` (upper-normal anion gap) and `24` (normal bicarbonate) are the exact reference constants. This is a **new structural shape** for the library — a **ratio of two differences**.

## Worked case (the three compose and invert)

anion gap = 30, bicarbonate = 14:

- delta ratio = (30 − 12)/(24 − 14) = 18/10 = **1.8** (a ratio between 1 and 2 → a pure high-anion-gap acidosis, no hidden second disorder)
- and each inverse back-solves its own input → **30**, **14**.

The three asserted values (1.8, 30, 14) are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/delta-ratio.adj`
- `code/specs/data/adj-formula-stdlib/clinical/delta-ratio.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_delta_ratio_e2e.rs` — 3 tests, all pass

## Verification

- Render-probe against the built CLI: forward `1.8` + both inverses (`30`, `14`) render exactly with `"trust":"authoritative"` and the NCBI citation. (Validates the ratio-of-two-differences forward and both inversions.)
- `cargo test -p adj-lang-cli --test formula_delta_ratio_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes (the source string's Unicode Δ/− are intact).
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)