### PR TITLE
feat(adj-formula-stdlib): sodium deficit — StatPearls hyponatremia sodium-replacement formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_sodium_deficit_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_sodium_deficit_e2e.rs
@@ -1,0 +1,177 @@
+//! End-to-end tests for the `clinical/sodium-deficit.adj` library — the hyponatraemia sodium deficit
+//! (deficit = total body water × (desired sodium − current sodium)) and its three exact rearrangements
+//! — driven through the built CLI binary against the SHIPPED stdlib. The same invariant as every other
+//! formula library: a consumer states NO arithmetic; it imports the grounded library, binds the total
+//! body water and the desired and current sodium with `observe`, and the engine applies the cited
+//! formula on the CPU, computing the EXACT value (over exact rationals) and rendering the citation and
+//! trust tier in the `derived` section (the auditable answer). The four formulas INVERT around the
+//! worked case total body water = 42, desired sodium = 140, current sodium = 120:
+//! 42 × (140 − 120) = 840 (deficit), 840 / (140 − 120) = 42 (TBW), 840/42 + 120 = 140 (desired),
+//! 140 − 840/42 = 120 (current). The four asserted values (840, 42, 140, 120) are distinct, none a
+//! colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped sodium-deficit library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_sodium_deficit_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/sodium-deficit.adj")
+        .canonicalize()
+        .expect("shipped sodium-deficit.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_nadeficit_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_sodium_deficit_lib()).unwrap();
+    std::fs::write(dir.join("sodium-deficit.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// sodium_deficit — the deficit: total body water × (desired − current sodium).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_sodium_deficit_library_and_computes_it_with_citation() {
+    let dir = scratch("deficit");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"sodium-deficit.adj\"\n\
+         observe total_body_water(42)\n\
+         observe desired_sodium(140)\n\
+         observe current_sodium(120)\n\
+         ? sodium_deficit(total_body_water, desired_sodium, current_sodium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 42 × (140 − 120) = 42 × 20 =
+    // 840, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"sodium_deficit\"") && s.contains("\"value\":840"),
+        "sodium_deficit(42, 140, 120) = 840: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// total_body_water — the same equation solved for the TBW: deficit / (desired − current sodium).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_total_body_water_from_sodium_deficit_with_citation() {
+    let dir = scratch("tbw");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"sodium-deficit.adj\"\n\
+         observe sodium_deficit(840)\n\
+         observe desired_sodium(140)\n\
+         observe current_sodium(120)\n\
+         ? total_body_water(sodium_deficit, desired_sodium, current_sodium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 840 / (140 − 120) = 840 / 20 = 42, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"total_body_water\"") && s.contains("\"value\":42"),
+        "total_body_water(840, 140, 120) = 42: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "total_body_water carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// desired_sodium — the same equation solved for the desired sodium: deficit / TBW + current sodium.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_desired_sodium_from_sodium_deficit_with_citation() {
+    let dir = scratch("desired");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"sodium-deficit.adj\"\n\
+         observe sodium_deficit(840)\n\
+         observe total_body_water(42)\n\
+         observe current_sodium(120)\n\
+         ? desired_sodium(sodium_deficit, total_body_water, current_sodium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 840 / 42 + 120 = 20 + 120 = 140, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"desired_sodium\"") && s.contains("\"value\":140"),
+        "desired_sodium(840, 42, 120) = 140: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "desired_sodium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// current_sodium — the same equation solved for the current sodium: desired sodium − deficit / TBW, the
+// fourth reading of the one deficit.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_current_sodium_from_sodium_deficit_with_citation() {
+    let dir = scratch("current");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"sodium-deficit.adj\"\n\
+         observe sodium_deficit(840)\n\
+         observe total_body_water(42)\n\
+         observe desired_sodium(140)\n\
+         ? current_sodium(sodium_deficit, total_body_water, desired_sodium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 140 − 840 / 42 = 140 − 20 = 120, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"current_sodium\"") && s.contains("\"value\":120"),
+        "current_sodium(840, 42, 140) = 120: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "current_sodium carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/sodium-deficit.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/sodium-deficit.adj
@@ -1,0 +1,105 @@
+% ============================================================================
+% sodium-deficit.adj — the sodium deficit in hyponatraemia
+% (sodium deficit = total body water × (desired sodium − current sodium)) in the ADJ standard library.
+% ============================================================================
+% The sodium-deficit entry of the *clinical* track — the total amount of sodium that must be replaced to
+% raise a hyponatraemic patient's serum sodium to a chosen target, the quantity that sets the rate of a
+% hypertonic (3%) saline infusion. Sodium is distributed through the whole body water, so the millimoles
+% needed to move the concentration is the total body water times the concentration change desired. THE
+% SODIUM DEFICIT IS THE TOTAL BODY WATER TIMES THE DIFFERENCE BETWEEN THE DESIRED AND THE CURRENT SODIUM
+% — i.e. total body water × (desired sodium − current sodium). It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its three exact rearrangements (each of the
+% other three quantities solved for from the deficit and the remaining two). As with every compute
+% library, a consumer states NO arithmetic: it `import`s this file, binds the total body water and the
+% desired and current sodium from its own byte-provenance decomposition, and asks the engine to APPLY
+% the cited formula on the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "sodium-deficit.adj"
+%     observe total_body_water(42)    % "…70 kg man, TBW 0.6 × 70 = 42 L…"   (span cited by the model)
+%     observe desired_sodium(140)      % "…target sodium 140 mmol/L…"          (span cited by the model)
+%     observe current_sodium(120)      % "…sodium 120 mmol/L…"                 (span cited by the model)
+%     ? sodium_deficit(total_body_water, desired_sodium, current_sodium)
+%                                       % engine → 840 (mmol), the sodium deficit
+%
+% There is no reference constant to taint — the deficit is a pure product of the total body water and a
+% difference — so every value the engine returns is exact when the inputs are exact. They COMPOSE and
+% invert cleanly around the worked case total body water = 42 L, desired sodium = 140 mmol/L, current
+% sodium = 120 mmol/L (sodium deficit = 42 × (140 − 120) = 42 × 20 = 840 mmol): the `sodium_deficit` a
+% consumer computes is exactly the value each of the three inverse formulas back-solves to recover its
+% own measured input (42, 140, 120).
+%
+%   sodium_deficit(total_body_water, desired_sodium, current_sodium)
+%       = total_body_water * (desired_sodium - current_sodium)                       % (deficit, mmol)
+%   total_body_water(sodium_deficit, desired_sodium, current_sodium)
+%       = sodium_deficit / (desired_sodium - current_sodium)                         % (solved for TBW)
+%   desired_sodium(sodium_deficit, total_body_water, current_sodium)
+%       = sodium_deficit / total_body_water + current_sodium                         % (solved for desired sodium)
+%   current_sodium(sodium_deficit, total_body_water, desired_sodium)
+%       = desired_sodium - sodium_deficit / total_body_water                         % (solved for current sodium)
+%
+% NOTE ON UNITS AND MODELLING: total body water in litres, sodium concentrations in mmol/L (mEq/L),
+% deficit in millimoles. The cited page writes the total body water as "weight (kg) × 0.6 for men and
+% children or 0.5 for women and older adults"; this library takes the total body water as its bound
+% input (a consumer computes it from weight and sex and binds it), and grounds the deficit relation
+% itself — total body water × (desired sodium − current sodium) — exactly as the page prints it. The
+% deficit only says how much sodium is missing; the correction RATE must be slow (the same page warns
+% against overcorrection, which risks osmotic demyelination).
+%
+% All four formulas are defended by the SAME clause — the quoted sodium-deficit equation — because that
+% one statement (the deficit IS the total body water times desired-minus-current sodium) sanctions the
+% relation read every way. The quote is transcribed verbatim from the StatPearls "Hyponatremia" article
+% on the NCBI Bookshelf (a current, non-archived article), so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each of the four quantities appears BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the intended
+% unit.
+% ----------------------------------------------------------------------------
+dictionary sodium_deficit_vocab {
+    define total_body_water   : finding  surface "total body water", "TBW"                                        % litres
+    define desired_sodium     : finding  surface "desired sodium", "target sodium", "goal sodium"                 % mmol/L
+    define current_sodium     : finding  surface "current sodium", "serum sodium", "measured sodium", "sodium"    % mmol/L
+    define sodium_deficit     : finding  surface "sodium deficit", "sodium requirement"                           % millimoles
+}
+
+% ----------------------------------------------------------------------------
+% The sodium deficit, all four ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the deficit equation from the StatPearls
+% "Hyponatremia" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact expression in the measured quantities (the deficit carries NO constant), so the engine returns
+% each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook sodium_deficit_laws {
+    use sodium_deficit_vocab
+
+    % Sodium deficit — the total body water times desired-minus-current sodium.
+    formula sodium_deficit(total_body_water, desired_sodium, current_sodium) = total_body_water * (desired_sodium - current_sodium)
+        source "Sodium Deficit (mEq/L) = Total Body Water × (Desired Sodium Level − Current Sodium Level)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470386/"
+        trust authoritative
+
+    % Total body water — the same equation solved for the total body water. Defended by the SAME sentence.
+    formula total_body_water(sodium_deficit, desired_sodium, current_sodium) = sodium_deficit / (desired_sodium - current_sodium)
+        source "Sodium Deficit (mEq/L) = Total Body Water × (Desired Sodium Level − Current Sodium Level)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470386/"
+        trust authoritative
+
+    % Desired sodium — the same equation solved for the desired sodium. The SAME sentence.
+    formula desired_sodium(sodium_deficit, total_body_water, current_sodium) = sodium_deficit / total_body_water + current_sodium
+        source "Sodium Deficit (mEq/L) = Total Body Water × (Desired Sodium Level − Current Sodium Level)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470386/"
+        trust authoritative
+
+    % Current sodium — the same equation solved for the current sodium. The SAME sentence, the fourth
+    % reading of the one deficit.
+    formula current_sodium(sodium_deficit, total_body_water, desired_sodium) = desired_sodium - sodium_deficit / total_body_water
+        source "Sodium Deficit (mEq/L) = Total Body Water × (Desired Sodium Level − Current Sodium Level)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470386/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/sodium-deficit.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/sodium-deficit.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% sodium-deficit.query.adj — worked applications of the sodium deficit.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a hyponatraemia vignette into a total body water,
+% a target sodium and the current sodium: it `import`s the grounded formulabook, `observe`s the three
+% values, and asks the engine to APPLY the cited deficit formula. No arithmetic is stated by the
+% consumer; the engine computes each value EXACTLY (over exact rationals) and carries the article's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (total body water = 42 L, i.e. a 70 kg man at 0.6 × weight; desired sodium = 140 mmol/L;
+% current sodium = 120 mmol/L): sodium deficit = 42 × (140 − 120) = 42 × 20 = 840 mmol. Each query fixes
+% three of the four quantities and asks the engine to recover the fourth; every answer is exact and the
+% four COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli sodium-deficit.query.adj
+% ============================================================================
+
+import "sodium-deficit.adj"
+
+% --- Deficit: the sodium deficit the TBW and the sodium gap imply (expect 840). ---------------------
+observe total_body_water(42)
+observe desired_sodium(140)
+observe current_sodium(120)
+? sodium_deficit(total_body_water, desired_sodium, current_sodium)   % expect 840
+
+% --- Inverse: the total body water a deficit of 840 implies at the same sodium gap (expect 42). -----
+observe sodium_deficit(840)
+? total_body_water(sodium_deficit, desired_sodium, current_sodium)   % expect 42


### PR DESCRIPTION
## What

Adds the **sodium deficit** entry of the `adj-formula-stdlib` *clinical* track — the total sodium that must be replaced to raise a hyponatraemic patient's serum sodium to a chosen target, the quantity that sets a hypertonic (3%) saline infusion rate. Sodium distributes through the whole body water, so the millimoles needed is the total body water times the desired concentration change.

Ships as an importable, byte-provenanced, parameterized `formula` together with its **three exact algebraic rearrangements** (each of the other three quantities solved for from the deficit and the remaining two). A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Grounding (nothing human-authored)

All four formulas are defended by the **same clause** — the deficit equation transcribed **verbatim** from the StatPearls **"Hyponatremia"** article on the NCBI Bookshelf ([NBK470386](https://www.ncbi.nlm.nih.gov/books/NBK470386/), a current, non-archived page):

> Sodium Deficit (mEq/L) = Total Body Water × (Desired Sodium Level − Current Sodium Level)

There is **no reference constant** to taint — the deficit is a pure product of the total body water and a difference — so every value stays in the exact rationals. This is a **new structural shape** for the library (a value times a two-term difference), and it **pairs with `free-water-deficit`** — the two sides of dysnatraemia correction.

## Worked case (the four compose and invert)

total body water = 42 L (a 70 kg man at 0.6 × weight), desired sodium = 140, current sodium = 120:

- deficit = 42 × (140 − 120) = 42 × 20 = **840** mmol
- and each inverse back-solves its own input → **42**, **140**, **120**.

The four asserted values (840, 42, 140, 120) are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/sodium-deficit.adj`
- `code/specs/data/adj-formula-stdlib/clinical/sodium-deficit.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_sodium_deficit_e2e.rs` — 4 tests, all pass

## Verification

- Render-probe against the built CLI: forward `840` + all three inverses (`42`, `140`, `120`) render exactly with `"trust":"authoritative"` and the NCBI citation.
- `cargo test -p adj-lang-cli --test formula_sodium_deficit_e2e` → 4 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes (the source string's Unicode ×/− are intact).
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)