### PR TITLE
feat(adj-formula-stdlib): modified Brooke formula — StatPearls burn-resuscitation sibling of Parkland (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_modified_brooke_formula_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_modified_brooke_formula_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/modified-brooke-formula.adj` library — the modified Brooke burn
+//! resuscitation formula (total 24-hour fluid = 2 × weight × %TBSA) and its two exact rearrangements —
+//! driven through the built CLI binary against the SHIPPED stdlib. The same invariant as every other
+//! formula library: a consumer states NO arithmetic; it imports the grounded library, binds the weight
+//! and burned surface area with `observe`, and the engine applies the cited formula on the CPU,
+//! computing the EXACT value (over exact rationals) and rendering the citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case
+//! weight = 80, TBSA = 30: 2 × 80 × 30 = 4800 (total fluid, exactly half the Parkland volume),
+//! 4800 / (2 × 30) = 80 (weight), 4800 / (2 × 80) = 30 (%TBSA). The three asserted values (4800, 80,
+//! 30) are distinct, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped modified-brooke-formula library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_brooke_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/modified-brooke-formula.adj")
+        .canonicalize()
+        .expect("shipped modified-brooke-formula.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_brooke_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_brooke_lib()).unwrap();
+    std::fs::write(dir.join("modified-brooke-formula.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// total_fluid — the resuscitation volume: 2 × weight × %TBSA.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_modified_brooke_library_and_computes_fluid_with_citation() {
+    let dir = scratch("fluid");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"modified-brooke-formula.adj\"\n\
+         observe weight(80)\n\
+         observe tbsa(30)\n\
+         ? total_fluid(weight, tbsa)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 2 × 80 × 30 = 4800, computed
+    // EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"total_fluid\"") && s.contains("\"value\":4800"),
+        "total_fluid(80, 30) = 4800: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// weight — the same equation solved for the weight: total_fluid / (2 × %TBSA).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_weight_from_modified_brooke_fluid_with_citation() {
+    let dir = scratch("weight");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"modified-brooke-formula.adj\"\n\
+         observe total_fluid(4800)\n\
+         observe tbsa(30)\n\
+         ? weight(total_fluid, tbsa)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4800 / (2 × 30) = 4800 / 60 = 80, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"weight\"") && s.contains("\"value\":80"),
+        "weight(4800, 30) = 80: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "weight carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tbsa — the same equation solved for the burn size: total_fluid / (2 × weight), the third reading of
+// the one formula.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_tbsa_from_modified_brooke_fluid_with_citation() {
+    let dir = scratch("tbsa");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"modified-brooke-formula.adj\"\n\
+         observe total_fluid(4800)\n\
+         observe weight(80)\n\
+         ? tbsa(total_fluid, weight)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4800 / (2 × 80) = 4800 / 160 = 30, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"tbsa\"") && s.contains("\"value\":30"),
+        "tbsa(4800, 80) = 30: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "tbsa carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/modified-brooke-formula.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/modified-brooke-formula.adj
@@ -1,0 +1,92 @@
+% ============================================================================
+% modified-brooke-formula.adj — the modified Brooke burn resuscitation formula
+% (total 24-hour fluid = 2 × weight × %TBSA burned) in the ADJ standard library.
+% ============================================================================
+% The modified-Brooke-formula entry of the *clinical* track — the SIBLING of the Parkland formula and
+% the other standard estimate of the crystalloid volume a burn patient needs in the first 24 hours. It
+% is structurally identical to Parkland but uses a HALF-size 2 mL/kg/%TBSA factor instead of 4, on the
+% view that the larger Parkland volume tends to over-resuscitate; both then give half in the first 8
+% hours and titrate to urine output. THE TOTAL 24-HOUR FLUID IS 2 mL TIMES THE BODY WEIGHT IN KILOGRAMS
+% TIMES THE PERCENTAGE OF TOTAL BODY SURFACE AREA BURNED — i.e. 2 × weight × %TBSA. It ships as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the
+% weight a total volume implies at a given burn size, and the burn size a total volume implies at a
+% given weight). As with every compute library, a consumer states NO arithmetic: it `import`s this file,
+% binds the weight and the burned surface area from its own byte-provenance decomposition, and asks the
+% engine to APPLY the cited formula on the CPU. Zero math is performed by the model; the engine computes
+% each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "modified-brooke-formula.adj"
+%     observe weight(80)   % "…80 kg…"          (span cited by the model)
+%     observe tbsa(30)      % "…30% TBSA burn…"  (span cited by the model)
+%     ? total_fluid(weight, tbsa)   % engine → 4800 (mL), the 24-hour modified-Brooke volume
+%
+% This library and the parkland-formula library are the two standard burn-resuscitation estimates,
+% differing ONLY in the constant (2 vs 4 mL/kg/%TBSA): on the same worked patient modified Brooke gives
+% exactly HALF the Parkland volume. The 2 mL/kg/%TBSA factor is the EXACT constant of the cited (adult)
+% formula (not a measurement); the formulas are otherwise exact expressions over the parameters, so
+% every value the engine returns is exact. They COMPOSE and invert cleanly around the worked case
+% weight = 80 kg, TBSA = 30% (total fluid = 2 × 80 × 30 = 4800 mL, of which half — 2400 mL — is given in
+% the first 8 hours): the `total_fluid` a consumer computes is exactly the value each inverse formula
+% back-solves to recover its own measured input (80, 30).
+%
+%   total_fluid(weight, tbsa) = 2 * weight * tbsa       % (24-hour fluid, mL)
+%   weight(total_fluid, tbsa) = total_fluid / (2 * tbsa) % (solved for weight)
+%   tbsa(total_fluid, weight) = total_fluid / (2 * weight)% (solved for %TBSA)
+%
+% NOTE ON UNITS AND MODELLING: weight in kilograms, TBSA as a plain percentage number (e.g. 30 for a 30%
+% burn, NOT 0.30), total fluid in millilitres over the first 24 hours. The cited page gives the ADULT
+% factor of 2 mL/kg/%TBSA; the formula sizes the total 24-hour crystalloid, and the "half in the first 8
+% hours" split is stated by the same page but is separate from this total-volume computation. This
+% library only COMPUTES the volume; it does not itself titrate to urine output (which ultimately guides
+% real resuscitation).
+%
+% All three formulas are defended by the SAME clause — the quoted modified-Brooke statement — because
+% that one sentence (the modified Brooke formula recommends 2 mL/kg/%TBSA) sanctions the relation read
+% every way. The quote is transcribed verbatim from the StatPearls "Burn Fluid Resuscitation" article on
+% the NCBI Bookshelf (a current, non-archived article), so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula, including its 2 mL/kg/%TBSA constant, is a verbatim
+% span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `weight`, `tbsa` and `total_fluid` each appear BOTH as a derived result and as an input
+% (of the other formulas), so each is a single dictionary term used in both roles. The `surface` lists
+% are the everyday names a decomposer maps onto the canonical term; the trailing comment records the
+% intended unit.
+% ----------------------------------------------------------------------------
+dictionary modified_brooke_formula_vocab {
+    define weight        : finding  surface "weight", "body weight", "total body weight"                          % kilograms
+    define tbsa          : finding  surface "TBSA", "total body surface area", "percent TBSA", "burn surface area"  % percent
+    define total_fluid   : finding  surface "total fluid", "resuscitation fluid", "24-hour fluid", "modified brooke fluid"  % millilitres (first 24 h)
+}
+
+% ----------------------------------------------------------------------------
+% The modified Brooke formula, all three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the modified-Brooke statement from the
+% StatPearls "Burn Fluid Resuscitation" article on the NCBI Bookshelf (a quote is required on a shipped
+% formula). Each is an exact expression in the measured quantities and the cited 2 mL/kg/%TBSA constant,
+% so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook modified_brooke_formula_laws {
+    use modified_brooke_formula_vocab
+
+    % Total 24-hour fluid — 2 mL times the weight times the percentage of TBSA burned.
+    formula total_fluid(weight, tbsa) = 2 * weight * tbsa
+        source "The modified Brooke formula, similar to the Parkland formula, recommends 2 mL/kg/%TBSA for adults"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534227/"
+        trust authoritative
+
+    % Weight — the same equation solved for the weight. Defended by the SAME sentence.
+    formula weight(total_fluid, tbsa) = total_fluid / (2 * tbsa)
+        source "The modified Brooke formula, similar to the Parkland formula, recommends 2 mL/kg/%TBSA for adults"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534227/"
+        trust authoritative
+
+    % Percentage of TBSA burned — the same equation solved for the burn size. The SAME sentence, read
+    % the third way.
+    formula tbsa(total_fluid, weight) = total_fluid / (2 * weight)
+        source "The modified Brooke formula, similar to the Parkland formula, recommends 2 mL/kg/%TBSA for adults"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534227/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/modified-brooke-formula.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/modified-brooke-formula.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% modified-brooke-formula.query.adj — worked applications of the modified Brooke burn formula.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a burn vignette into a body weight and a burned
+% surface area: it `import`s the grounded formulabook, `observe`s the two values, and asks the engine to
+% APPLY the cited modified-Brooke formula. No arithmetic is stated by the consumer; the engine computes
+% each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU,
+% with zero model calls.
+%
+% Worked case (weight = 80 kg, TBSA = 30%): total 24-hour fluid = 2 × 80 × 30 = 4800 mL — half (2400 mL)
+% over the first 8 hours, the remaining 2400 mL over the next 16, and exactly HALF the Parkland volume
+% (9600 mL) for the same patient. Each query fixes two of the three quantities and asks the engine to
+% recover the third; every answer is exact and the three COMPOSE (each inversion recovers exactly the
+% worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli modified-brooke-formula.query.adj
+% ============================================================================
+
+import "modified-brooke-formula.adj"
+
+% --- Fluid: the 24-hour resuscitation volume the weight and burn size imply (expect 4800). ----------
+observe weight(80)
+observe tbsa(30)
+? total_fluid(weight, tbsa)   % expect 4800
+
+% --- Inverse: the weight a total volume of 4800 implies at a 30% burn (expect 80). ------------------
+observe total_fluid(4800)
+? weight(total_fluid, tbsa)   % expect 80


### PR DESCRIPTION
## What

Adds the **modified Brooke formula** entry of the `adj-formula-stdlib` *clinical* track — the **sibling of the Parkland formula** and the other standard estimate of the crystalloid volume a burn patient needs in the first 24 hours. It is structurally identical to Parkland but uses a **half-size 2 mL/kg/%TBSA** factor instead of 4 (on the view that Parkland tends to over-resuscitate); both give half in the first 8 hours and titrate to urine output.

Ships as an importable, byte-provenanced, parameterized `formula` together with its **two exact algebraic rearrangements**. A consumer states **no arithmetic**: it `import`s the grounded formulabook, binds the values with `observe`, and the engine applies the cited formula on the CPU, computing each value **exactly over rationals** and carrying the citation and trust tier in the auditable `derived` section.

## Grounding (nothing human-authored)

All three formulas are defended by the **same clause** — transcribed **verbatim** from the StatPearls **"Burn Fluid Resuscitation"** article on the NCBI Bookshelf ([NBK534227](https://www.ncbi.nlm.nih.gov/books/NBK534227/), "Technique or Treatment"):

> The modified Brooke formula, similar to the Parkland formula, recommends 2 mL/kg/%TBSA for adults

The `2 mL/kg/%TBSA` factor is the exact adult constant. This library and the shipped **`parkland-formula`** library are the two standard burn-resuscitation estimates, differing **only in the constant (2 vs 4)** — on the same patient modified Brooke gives exactly **half** the Parkland volume, a clean sibling pairing.

## Worked case (the three compose and invert)

weight = 80 kg, TBSA = 30%:

- total fluid = 2 × 80 × 30 = **4800** mL (half of Parkland's 9600 mL)
- and each inverse back-solves its own input → **80**, **30**.

The three asserted values (4800, 80, 30) are distinct, none a colon-anchored prefix of another rendered value.

## Files (data + one dedicated e2e test — no engine change, **no version bump**)

- `code/specs/data/adj-formula-stdlib/clinical/modified-brooke-formula.adj`
- `code/specs/data/adj-formula-stdlib/clinical/modified-brooke-formula.query.adj`
- `code/packages/rust/adj-lang-cli/tests/formula_modified_brooke_formula_e2e.rs` — 3 tests, all pass

## Verification

- Render-probe against the built CLI: forward `4800` + both inverses (`80`, `30`) render exactly with `"trust":"authoritative"` and the NCBI citation.
- `cargo test -p adj-lang-cli --test formula_modified_brooke_formula_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- NUL-scan of all three new files → 0 bytes.
- `/security-review` → SECURITY REVIEW PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)