### PR TITLE
feat(adj-formula-stdlib): urine anion gap — StatPearls (urine Na + urine K − urine Cl) NH4+ estimate library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_urine_anion_gap_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_urine_anion_gap_e2e.rs
@@ -1,0 +1,176 @@
+//! End-to-end tests for the `clinical/urine-anion-gap.adj` library — the urine anion gap
+//! (urine Na + urine K − urine Cl) and its three exact rearrangements — driven through the built CLI
+//! binary against the SHIPPED stdlib. The same invariant as every other formula library: a consumer
+//! states NO arithmetic; it imports the grounded library, binds the three urine electrolytes with
+//! `observe`, and the engine applies the cited formula on the CPU, computing the EXACT value (over exact
+//! rationals) and rendering the citation and trust tier in the `derived` section (the auditable answer).
+//! The four formulas INVERT around the worked case urine Na = 40, urine K = 30, urine Cl = 60:
+//! 40 + 30 − 60 = 10 (gap), 10 + 60 − 30 = 40 (Na), 10 + 60 − 40 = 30 (K), 40 + 30 − 10 = 60 (Cl). The
+//! four asserted values (10, 40, 30, 60) are distinct, none a colon-anchored prefix of another rendered
+//! value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped urine-anion-gap library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_urine_anion_gap_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/urine-anion-gap.adj")
+        .canonicalize()
+        .expect("shipped urine-anion-gap.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_uag_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_urine_anion_gap_lib()).unwrap();
+    std::fs::write(dir.join("urine-anion-gap.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// urine_anion_gap — the gap: urine Na + urine K − urine Cl.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_urine_anion_gap_library_and_computes_it_with_citation() {
+    let dir = scratch("gap");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"urine-anion-gap.adj\"\n\
+         observe urine_sodium(40)\n\
+         observe urine_potassium(30)\n\
+         observe urine_chloride(60)\n\
+         ? urine_anion_gap(urine_sodium, urine_potassium, urine_chloride)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 40 + 30 − 60 = 10, computed EXACTLY
+    // over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"urine_anion_gap\"") && s.contains("\"value\":10"),
+        "urine_anion_gap(40, 30, 60) = 10: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_sodium — the same equation solved for the urine sodium: gap + urine Cl − urine K.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_sodium_from_gap_with_citation() {
+    let dir = scratch("na");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"urine-anion-gap.adj\"\n\
+         observe urine_anion_gap(10)\n\
+         observe urine_potassium(30)\n\
+         observe urine_chloride(60)\n\
+         ? urine_sodium(urine_anion_gap, urine_potassium, urine_chloride)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 + 60 − 30 = 40, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_sodium\"") && s.contains("\"value\":40"),
+        "urine_sodium(10, 30, 60) = 40: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_sodium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_potassium — the same equation solved for the urine potassium: gap + urine Cl − urine Na.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_potassium_from_gap_with_citation() {
+    let dir = scratch("k");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"urine-anion-gap.adj\"\n\
+         observe urine_anion_gap(10)\n\
+         observe urine_sodium(40)\n\
+         observe urine_chloride(60)\n\
+         ? urine_potassium(urine_anion_gap, urine_sodium, urine_chloride)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 + 60 − 40 = 30, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_potassium\"") && s.contains("\"value\":30"),
+        "urine_potassium(10, 40, 60) = 30: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_potassium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_chloride — the same equation solved for the urine chloride: urine Na + urine K − gap, the fourth
+// reading of the one gap.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_chloride_from_gap_with_citation() {
+    let dir = scratch("cl");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"urine-anion-gap.adj\"\n\
+         observe urine_sodium(40)\n\
+         observe urine_potassium(30)\n\
+         observe urine_anion_gap(10)\n\
+         ? urine_chloride(urine_sodium, urine_potassium, urine_anion_gap)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 40 + 30 − 10 = 60, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_chloride\"") && s.contains("\"value\":60"),
+        "urine_chloride(40, 30, 10) = 60: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_chloride carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/urine-anion-gap.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/urine-anion-gap.adj
@@ -1,0 +1,103 @@
+% ============================================================================
+% urine-anion-gap.adj — the URINE anion gap (urine Na + urine K − urine Cl) in
+% the ADJ standard library.
+% ============================================================================
+% The urine-anion-gap entry of the *clinical* track — the bedside estimate of urinary ammonium (NH4+)
+% excretion used to work up a NORMAL-anion-gap (hyperchloraemic) metabolic acidosis. Ammonium is not
+% measured directly on a routine urine electrolyte panel, so its excretion is inferred from the charge
+% balance of the ions that ARE measured: a strongly NEGATIVE urine anion gap says the kidney is excreting
+% plenty of NH4+ (an appropriate response — the acidosis is from a gastrointestinal bicarbonate loss such
+% as diarrhoea), whereas a POSITIVE urine anion gap says NH4+ excretion is impaired (a renal cause, such
+% as a distal renal tubular acidosis). THE URINE ANION GAP IS THE URINE SODIUM PLUS THE URINE POTASSIUM
+% MINUS THE URINE CHLORIDE — i.e. urine Na + urine K − urine Cl. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its three exact rearrangements (each of the
+% three measured urine electrolytes recovered from the gap and the other two). As with every compute
+% library, a consumer states NO arithmetic: it `import`s this file, binds the three urine electrolytes
+% from its own byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU.
+% Zero math is performed by the model; the engine computes each value EXACTLY (over exact rationals),
+% carrying the formula's citation.
+%
+%     import "urine-anion-gap.adj"
+%     observe urine_sodium(40)     % "…urine Na 40…"   (span cited by the model)
+%     observe urine_potassium(30)  % "…urine K 30…"    (span cited by the model)
+%     observe urine_chloride(60)   % "…urine Cl 60…"   (span cited by the model)
+%     ? urine_anion_gap(urine_sodium, urine_potassium, urine_chloride)   % engine → 10 (mEq/L)
+%
+% This is the URINE anion gap, a distinct entity from the serum anion gap (anion-gap.adj): the serum gap
+% subtracts BOTH chloride and bicarbonate from the measured cations to flag an unmeasured-anion acidosis,
+% while the urine gap subtracts chloride ALONE (in the acid-urine, pH < 6.5 case the cited page gives) to
+% estimate ammonium. The formula is an exact linear expression in the three measured electrolytes — no
+% constant at all — so every value the engine returns is exact. The four formulas COMPOSE and invert
+% cleanly around the worked case urine Na = 40, urine K = 30, urine Cl = 60 (urine anion gap =
+% 40 + 30 − 60 = 10 mEq/L, a POSITIVE gap pointing to impaired renal NH4+ excretion): the
+% `urine_anion_gap` a consumer computes is exactly the value each inverse formula back-solves to recover
+% its own measured input (40, 30, 60).
+%
+%   urine_anion_gap(urine_sodium, urine_potassium, urine_chloride) = urine_sodium + urine_potassium - urine_chloride
+%   urine_sodium(urine_anion_gap, urine_potassium, urine_chloride) = urine_anion_gap + urine_chloride - urine_potassium
+%   urine_potassium(urine_anion_gap, urine_sodium, urine_chloride) = urine_anion_gap + urine_chloride - urine_sodium
+%   urine_chloride(urine_sodium, urine_potassium, urine_anion_gap) = urine_sodium + urine_potassium - urine_anion_gap
+%
+% NOTE ON UNITS AND MODELLING: all four quantities are in milliequivalents per litre (mEq/L). The cited
+% page states the plain form (urine Na + urine K − urine Cl) for the usual acid-urine case (urine pH
+% < 6.5); when the urine pH is > 6.5 the same page adds a urine-bicarbonate correction, which is a
+% separate expression not modelled here. This library only COMPUTES the gap from the three electrolytes;
+% the interpretation (negative → GI/appropriate, positive → renal/impaired) is stated by the same page but
+% is applied by the reader.
+%
+% All four formulas are defended by the SAME clause — the quoted urine-anion-gap statement — because that
+% one sentence (urine anion gap = urine Na + urine K − urine Cl) sanctions the relation read every way.
+% The quote is transcribed verbatim from the StatPearls "Anion Gap and Non-Anion Gap Metabolic Acidosis"
+% article on the NCBI Bookshelf (a current, non-archived article — the same page that defends delta-ratio.adj),
+% so each `formula` carries the provenance envelope every shipped grounded clause carries; the linter
+% rejects an unsourced one. (See feedback_nothing_human_authored — the formula is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `urine_sodium`, `urine_potassium`, `urine_chloride` and `urine_anion_gap` each appear BOTH
+% as a derived result and as an input (of the other formulas), so each is a single dictionary term used in
+% both roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary urine_anion_gap_vocab {
+    define urine_sodium     : finding  surface "urine sodium", "urine Na", "urinary sodium"        % mEq/L
+    define urine_potassium  : finding  surface "urine potassium", "urine K", "urinary potassium"   % mEq/L
+    define urine_chloride   : finding  surface "urine chloride", "urine Cl", "urinary chloride"     % mEq/L
+    define urine_anion_gap  : finding  surface "urine anion gap", "urinary anion gap", "UAG"        % mEq/L
+}
+
+% ----------------------------------------------------------------------------
+% The urine anion gap, all four ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the urine-anion-gap statement from the StatPearls
+% "Anion Gap and Non-Anion Gap Metabolic Acidosis" article on the NCBI Bookshelf (a quote is required on a
+% shipped formula). Each is an exact linear expression in the measured electrolytes — no constant — so the
+% engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook urine_anion_gap_laws {
+    use urine_anion_gap_vocab
+
+    % The urine anion gap — urine sodium plus urine potassium minus urine chloride.
+    formula urine_anion_gap(urine_sodium, urine_potassium, urine_chloride) = urine_sodium + urine_potassium - urine_chloride
+        source "Urine anion gap = Urine Na + Urine K – Urine Cl, if urine pH is <6.5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448090/"
+        trust authoritative
+
+    % Urine sodium — the same equation solved for the urine sodium. Defended by the SAME sentence.
+    formula urine_sodium(urine_anion_gap, urine_potassium, urine_chloride) = urine_anion_gap + urine_chloride - urine_potassium
+        source "Urine anion gap = Urine Na + Urine K – Urine Cl, if urine pH is <6.5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448090/"
+        trust authoritative
+
+    % Urine potassium — the same equation solved for the urine potassium. The SAME sentence.
+    formula urine_potassium(urine_anion_gap, urine_sodium, urine_chloride) = urine_anion_gap + urine_chloride - urine_sodium
+        source "Urine anion gap = Urine Na + Urine K – Urine Cl, if urine pH is <6.5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448090/"
+        trust authoritative
+
+    % Urine chloride — the same equation solved for the urine chloride, the fourth reading of the one gap.
+    formula urine_chloride(urine_sodium, urine_potassium, urine_anion_gap) = urine_sodium + urine_potassium - urine_anion_gap
+        source "Urine anion gap = Urine Na + Urine K – Urine Cl, if urine pH is <6.5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448090/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/urine-anion-gap.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/urine-anion-gap.query.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% urine-anion-gap.query.adj — worked applications of the urine anion gap.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a hyperchloraemic-acidosis workup into a urine
+% sodium, a urine potassium and a urine chloride: it `import`s the grounded formulabook, `observe`s the
+% three values, and asks the engine to APPLY the cited urine-anion-gap formula. No arithmetic is stated by
+% the consumer; the engine computes each value EXACTLY (over exact rationals) and carries the article's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (urine Na = 40, urine K = 30, urine Cl = 60 mEq/L): urine anion gap = 40 + 30 − 60 = 10
+% mEq/L — a POSITIVE gap, pointing to impaired renal ammonium excretion (e.g. a distal renal tubular
+% acidosis) rather than a gastrointestinal bicarbonate loss. Each query fixes three of the four quantities
+% and asks the engine to recover the fourth; every answer is exact and the four COMPOSE (each inversion
+% recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli urine-anion-gap.query.adj
+% ============================================================================
+
+import "urine-anion-gap.adj"
+
+% --- Gap: the urine anion gap the three urine electrolytes imply (expect 10). -----------------------
+observe urine_sodium(40)
+observe urine_potassium(30)
+observe urine_chloride(60)
+? urine_anion_gap(urine_sodium, urine_potassium, urine_chloride)   % expect 10
+
+% --- Inverse: the urine chloride a gap of 10 implies at the same Na and K (expect 60). --------------
+observe urine_anion_gap(10)
+? urine_chloride(urine_sodium, urine_potassium, urine_anion_gap)   % expect 60


### PR DESCRIPTION
## Urine anion gap — clinical formulabook

Ships the **urine anion gap** clinical library — the bedside estimate of urinary ammonium (NH4+) excretion used to work up a **normal-anion-gap (hyperchloraemic) metabolic acidosis**: a negative gap points to an appropriate renal response (a GI bicarbonate loss such as diarrhoea), a positive gap to impaired renal NH4+ excretion (e.g. a distal renal tubular acidosis).

Distinct from the already-shipped **serum** anion-gap library: the urine gap subtracts chloride *alone* to estimate ammonium, whereas the serum gap subtracts both chloride and bicarbonate to flag an unmeasured-anion acidosis.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation from the StatPearls *Anion Gap and Non-Anion Gap Metabolic Acidosis* article (NCBI Bookshelf [NBK448090](https://www.ncbi.nlm.nih.gov/books/NBK448090/), current / non-archived — the same page that defends `delta-ratio.adj`):

> Urine anion gap = Urine Na + Urine K – Urine Cl, if urine pH is <6.5

carrying `source` / `locator` / `trust authoritative`. It is an exact linear expression — no constant — so the engine computes every value **exactly over rationals**.

### Contents
- `urine-anion-gap.adj` — dictionary + formulabook with the forward formula and **three exact rearrangements** (each urine electrolyte recovered from the gap and the other two).
- `urine-anion-gap.query.adj` — worked case.
- `formula_urine_anion_gap_e2e.rs` — **4 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
urine Na 40, urine K 30, urine Cl 60 mEq/L → urine anion gap = 40 + 30 − 60 = **10 mEq/L** (positive → impaired renal NH4+ excretion). The four formulas compose and invert cleanly; asserted values {10, 40, 30, 60} are collision-safe.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)