### PR TITLE
feat(adj-formula-stdlib): fractional shortening — StatPearls FS = (LVIDd − LVIDs) / LVIDd × 100 echo library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_fractional_shortening_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_fractional_shortening_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end tests for the `clinical/fractional-shortening.adj` library — left ventricular fractional
+//! shortening (FS = (LVIDd − LVIDs) / LVIDd × 100) and its two exact rearrangements — driven through the
+//! built CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a
+//! consumer states NO arithmetic; it imports the grounded library, binds the two diameters with `observe`,
+//! and the engine applies the cited formula on the CPU, computing the EXACT value (over exact rationals)
+//! and rendering the citation and trust tier in the `derived` section (the auditable answer). The three
+//! formulas INVERT around the worked case LVIDd = 50, LVIDs = 32: (50 − 32) / 50 × 100 = 36 (FS),
+//! 50 − 50 × 36 / 100 = 32 (LVIDs), 100 × 32 / (100 − 36) = 50 (LVIDd). The three asserted values (36, 32,
+//! 50) are distinct, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped fractional-shortening library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_fractional_shortening_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/fractional-shortening.adj")
+        .canonicalize()
+        .expect("shipped fractional-shortening.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fs_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_fractional_shortening_lib()).unwrap();
+    std::fs::write(dir.join("fractional-shortening.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// fractional_shortening — the percentage: (LVIDd − LVIDs) / LVIDd × 100.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_fractional_shortening_library_and_computes_it_with_citation() {
+    let dir = scratch("fs");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-shortening.adj\"\n\
+         observe lvidd(50)\n\
+         observe lvids(32)\n\
+         ? fractional_shortening(lvidd, lvids)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: (50 − 32) / 50 × 100 = 36, computed
+    // EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"fractional_shortening\"") && s.contains("\"value\":36"),
+        "fractional_shortening(50, 32) = 36: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// lvids — the same equation solved for the end-systolic diameter: LVIDd − LVIDd × FS / 100.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_lvids_from_fractional_shortening_with_citation() {
+    let dir = scratch("lvids");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-shortening.adj\"\n\
+         observe lvidd(50)\n\
+         observe fractional_shortening(36)\n\
+         ? lvids(lvidd, fractional_shortening)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 50 − 50 × 36 / 100 = 50 − 18 = 32, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"lvids\"") && s.contains("\"value\":32"),
+        "lvids(50, 36) = 32: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "lvids carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// lvidd — the same equation solved for the end-diastolic diameter: 100 × LVIDs / (100 − FS), the third
+// reading of the one ratio.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_lvidd_from_fractional_shortening_with_citation() {
+    let dir = scratch("lvidd");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-shortening.adj\"\n\
+         observe lvids(32)\n\
+         observe fractional_shortening(36)\n\
+         ? lvidd(lvids, fractional_shortening)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 100 × 32 / (100 − 36) = 3200 / 64 = 50, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"lvidd\"") && s.contains("\"value\":50"),
+        "lvidd(32, 36) = 50: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "lvidd carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-shortening.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-shortening.adj
@@ -1,0 +1,89 @@
+% ============================================================================
+% fractional-shortening.adj — left ventricular fractional shortening
+% (FS = (LVIDd − LVIDs) / LVIDd × 100) in the ADJ standard library.
+% ============================================================================
+% The fractional-shortening entry of the *clinical* track — an M-mode echocardiographic measure of left
+% ventricular systolic function. It is the fractional (percentage) reduction in the left ventricular
+% internal diameter between diastole and systole: the diameter shrinks from its end-diastolic value
+% (LVIDd) to its end-systolic value (LVIDs) as the ventricle contracts, and FS reports that shrinkage as a
+% percentage of the diastolic diameter. It is not a direct measure of the ejection fraction but correlates
+% with it and gives a quick bedside estimate of systolic function (a normal FS is roughly 25–45%).
+% FRACTIONAL SHORTENING IS THE END-DIASTOLIC DIAMETER MINUS THE END-SYSTOLIC DIAMETER, DIVIDED BY THE
+% END-DIASTOLIC DIAMETER, TIMES 100 — i.e. (LVIDd − LVIDs) / LVIDd × 100. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the end-systolic
+% diameter a given FS implies at a known diastolic diameter, and the diastolic diameter a given FS implies
+% at a known systolic diameter). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the two measured diameters from its own byte-provenance decomposition, and
+% asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "fractional-shortening.adj"
+%     observe lvidd(50)   % "…LVIDd 50 mm…"   (span cited by the model)
+%     observe lvids(32)   % "…LVIDs 32 mm…"   (span cited by the model)
+%     ? fractional_shortening(lvidd, lvids)   % engine → 36 (%)
+%
+% This is the M-mode LINEAR-DIAMETER fractional shortening, a distinct entity from the VOLUMETRIC ejection
+% fraction (ejection-fraction.adj): fractional shortening contracts two one-dimensional diameters, while
+% the ejection fraction contracts two three-dimensional volumes. The × 100 turns the dimensionless ratio
+% into a percentage; the formula is otherwise an exact expression over the two diameters, so every value
+% the engine returns is exact. The three formulas COMPOSE and invert cleanly around the worked case
+% LVIDd = 50 mm, LVIDs = 32 mm (FS = (50 − 32) / 50 × 100 = 36%): the `fractional_shortening` a consumer
+% computes is exactly the value each inverse formula back-solves to recover its own measured input (32, 50).
+%
+%   fractional_shortening(lvidd, lvids) = (lvidd - lvids) / lvidd * 100    % (percentage)
+%   lvids(lvidd, fractional_shortening) = lvidd - lvidd * fractional_shortening / 100   % (solved for end-systolic diameter)
+%   lvidd(lvids, fractional_shortening) = 100 * lvids / (100 - fractional_shortening)   % (solved for end-diastolic diameter)
+%
+% NOTE ON UNITS AND MODELLING: the two diameters are in the same length unit (millimetres, as measured on
+% M-mode), FS is a plain percentage number (e.g. 36 for 36%, NOT 0.36). Because FS is a ratio of two
+% lengths the diameter unit cancels, so only the numeric magnitudes matter as long as both diameters share
+% a unit. This library only COMPUTES the percentage; the interpretation (normal ≈ 25–45%, reduced values
+% indicating impaired systolic function) is stated by the same page but is applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted fractional-shortening statement — because
+% that one equation ((LVIDd − LVIDs) / LVIDd × 100) sanctions the relation read every way. The quote is
+% transcribed verbatim from the StatPearls "Left Ventricular Ejection Fraction" article on the NCBI
+% Bookshelf (a current, non-archived article), so each `formula` carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored
+% — the formula is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `lvidd`, `lvids` and `fractional_shortening` each appear BOTH as a derived result and as an
+% input (of the other formulas), so each is a single dictionary term used in both roles. The `surface`
+% lists are the everyday names a decomposer maps onto the canonical term; the trailing comment records the
+% intended unit.
+% ----------------------------------------------------------------------------
+dictionary fractional_shortening_vocab {
+    define lvidd                 : finding  surface "LVIDd", "LVEDD", "end-diastolic diameter", "left ventricular internal diameter in diastole"   % mm
+    define lvids                 : finding  surface "LVIDs", "LVESD", "end-systolic diameter", "left ventricular internal diameter in systole"      % mm
+    define fractional_shortening : finding  surface "fractional shortening", "FS", "LV fractional shortening"   % percent
+}
+
+% ----------------------------------------------------------------------------
+% Fractional shortening, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the fractional-shortening equation from the StatPearls
+% "Left Ventricular Ejection Fraction" article on the NCBI Bookshelf (a quote is required on a shipped
+% formula). Each is an exact expression in the measured diameters, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook fractional_shortening_laws {
+    use fractional_shortening_vocab
+
+    % Fractional shortening — end-diastolic minus end-systolic diameter, over the end-diastolic diameter, times 100.
+    formula fractional_shortening(lvidd, lvids) = (lvidd - lvids) / lvidd * 100
+        source "FS (%) = (LVIDd − LVIDs) / LVIDd × 100"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459131/"
+        trust authoritative
+
+    % End-systolic diameter — the same equation solved for LVIDs. Defended by the SAME equation.
+    formula lvids(lvidd, fractional_shortening) = lvidd - lvidd * fractional_shortening / 100
+        source "FS (%) = (LVIDd − LVIDs) / LVIDd × 100"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459131/"
+        trust authoritative
+
+    % End-diastolic diameter — the same equation solved for LVIDd, the third reading of the one ratio.
+    formula lvidd(lvids, fractional_shortening) = 100 * lvids / (100 - fractional_shortening)
+        source "FS (%) = (LVIDd − LVIDs) / LVIDd × 100"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459131/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-shortening.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-shortening.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% fractional-shortening.query.adj — worked applications of LV fractional shortening.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an echocardiography report into an end-diastolic
+% and an end-systolic left ventricular internal diameter: it `import`s the grounded formulabook,
+% `observe`s the two values, and asks the engine to APPLY the cited fractional-shortening formula. No
+% arithmetic is stated by the consumer; the engine computes each value EXACTLY (over exact rationals) and
+% carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (LVIDd = 50 mm, LVIDs = 32 mm): fractional shortening = (50 − 32) / 50 × 100 = 18 / 50 × 100
+% = 36% — a normal value (normal FS is roughly 25–45%). Each query fixes two of the three quantities and
+% asks the engine to recover the third; every answer is exact and the three COMPOSE (each inversion
+% recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli fractional-shortening.query.adj
+% ============================================================================
+
+import "fractional-shortening.adj"
+
+% --- FS: the fractional shortening the two diameters imply (expect 36). -----------------------------
+observe lvidd(50)
+observe lvids(32)
+? fractional_shortening(lvidd, lvids)   % expect 36
+
+% --- Inverse: the end-systolic diameter an FS of 36 implies at LVIDd 50 (expect 32). ----------------
+observe fractional_shortening(36)
+? lvids(lvidd, fractional_shortening)   % expect 32


### PR DESCRIPTION
## LV fractional shortening — clinical formulabook

Ships **left ventricular fractional shortening** — an M-mode echocardiographic measure of systolic function: the percentage reduction in the LV internal diameter between diastole and systole (normal ≈ 25–45%). Includes the forward formula plus **two exact rearrangements** (end-systolic and end-diastolic diameter, each recovered from a given FS and the other diameter).

Distinct from the already-shipped **volumetric** ejection-fraction library: fractional shortening contracts two *one-dimensional* M-mode diameters, while the ejection fraction contracts two *three-dimensional* volumes.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from the StatPearls *Left Ventricular Ejection Fraction* article (NCBI Bookshelf [NBK459131](https://www.ncbi.nlm.nih.gov/books/NBK459131/), current / non-archived):

> FS (%) = (LVIDd − LVIDs) / LVIDd × 100

carrying `source` / `locator` / `trust authoritative`. Exact expression over the two diameters — the engine computes every value **exactly over rationals**.

### Contents
- `fractional-shortening.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `fractional-shortening.query.adj` — worked case.
- `formula_fractional_shortening_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
LVIDd 50 mm, LVIDs 32 mm → FS = (50 − 32) / 50 × 100 = **36%** (normal). The three formulas compose and invert cleanly; asserted values {36, 32, 50} are collision-safe.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)