### PR TITLE
feat(adj-formula-stdlib): alveolar gas equation — StatPearls PAO2 = FiO2 (Patm − PH2O) − PaCO2/RQ library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_alveolar_gas_equation_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_alveolar_gas_equation_e2e.rs
@@ -1,0 +1,150 @@
+//! End-to-end tests for the `clinical/alveolar-gas-equation.adj` library — the alveolar gas equation
+//! (PAO2 = FiO2 × (Patm − PH2O) − PaCO2 / RQ) and its two exact rearrangements — driven through the built
+//! CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a consumer
+//! states NO arithmetic; it imports the grounded library, binds the inspired-gas and blood-gas quantities
+//! with `observe`, and the engine applies the cited formula on the CPU, computing the EXACT value (over
+//! exact rationals) and rendering the citation and trust tier in the `derived` section (the auditable
+//! answer). The three formulas INVERT around the worked case FiO2 = 1, Patm = 760, PH2O = 47, PaCO2 = 40,
+//! RQ = 0.8: 1 × (760 − 47) − 40 / 0.8 = 663 (alveolar PO2), (1 × (760 − 47) − 663) × 0.8 = 40 (PaCO2),
+//! (663 + 40 / 0.8) / 1 + 47 = 760 (Patm). The three asserted values (663, 40, 760) are distinct, none a
+//! colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped alveolar-gas-equation library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_alveolar_gas_equation_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/alveolar-gas-equation.adj")
+        .canonicalize()
+        .expect("shipped alveolar-gas-equation.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_alvgas_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_alveolar_gas_equation_lib()).unwrap();
+    std::fs::write(dir.join("alveolar-gas-equation.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// alveolar_po2 — the alveolar oxygen: FiO2 × (Patm − PH2O) − PaCO2 / RQ.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_alveolar_gas_equation_library_and_computes_pao2_with_citation() {
+    let dir = scratch("pao2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-gas-equation.adj\"\n\
+         observe fio2(1)\n\
+         observe patm(760)\n\
+         observe ph2o(47)\n\
+         observe paco2(40)\n\
+         observe rq(0.8)\n\
+         ? alveolar_po2(fio2, patm, ph2o, paco2, rq)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 1 × (760 − 47) − 40 / 0.8 =
+    // 713 − 50 = 663, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"alveolar_po2\"") && s.contains("\"value\":663"),
+        "alveolar_po2(1, 760, 47, 40, 0.8) = 663: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// paco2 — the same equation solved for the arterial CO2: (FiO2 × (Patm − PH2O) − PAO2) × RQ.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_paco2_from_alveolar_gas_equation_with_citation() {
+    let dir = scratch("paco2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-gas-equation.adj\"\n\
+         observe fio2(1)\n\
+         observe patm(760)\n\
+         observe ph2o(47)\n\
+         observe alveolar_po2(663)\n\
+         observe rq(0.8)\n\
+         ? paco2(fio2, patm, ph2o, alveolar_po2, rq)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (1 × (760 − 47) − 663) × 0.8 = (713 − 663) × 0.8 = 50 × 0.8 = 40, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"paco2\"") && s.contains("\"value\":40"),
+        "paco2(1, 760, 47, 663, 0.8) = 40: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "paco2 carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// patm — the same equation solved for the atmospheric pressure: (PAO2 + PaCO2 / RQ) / FiO2 + PH2O, the
+// third reading of the one equation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_patm_from_alveolar_gas_equation_with_citation() {
+    let dir = scratch("patm");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-gas-equation.adj\"\n\
+         observe fio2(1)\n\
+         observe ph2o(47)\n\
+         observe paco2(40)\n\
+         observe alveolar_po2(663)\n\
+         observe rq(0.8)\n\
+         ? patm(fio2, ph2o, paco2, alveolar_po2, rq)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (663 + 40 / 0.8) / 1 + 47 = (663 + 50) + 47 = 760, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"patm\"") && s.contains("\"value\":760"),
+        "patm(1, 47, 40, 663, 0.8) = 760: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "patm carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/alveolar-gas-equation.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/alveolar-gas-equation.adj
@@ -1,0 +1,98 @@
+% ============================================================================
+% alveolar-gas-equation.adj — the alveolar gas equation for the alveolar oxygen
+% partial pressure (PAO2 = [(Patm − PH2O) FiO2] − (PaCO2/RQ)) in the ADJ standard library.
+% ============================================================================
+% The alveolar-gas-equation entry of the *clinical* track — the equation that gives the partial pressure
+% of oxygen in the alveolus (PAO2) from the inspired gas and the arterial CO2. The inspired air is first
+% humidified (so the dry-gas pressure available is the atmospheric pressure minus the water vapour
+% pressure), the fraction of that which is oxygen is FiO2, and the alveolar CO2 displaces oxygen in
+% proportion to how much CO2 is produced per oxygen consumed (the respiratory quotient). The result is the
+% alveolar PO2 that the arterial PO2 is then compared against to form the alveolar–arterial (A-a) gradient
+% (see alveolar-arterial-gradient.adj, which takes THIS value as its input). THE ALVEOLAR OXYGEN PARTIAL
+% PRESSURE IS THE FRACTION OF INSPIRED OXYGEN TIMES THE DRY INSPIRED PRESSURE (ATMOSPHERIC MINUS WATER
+% VAPOUR), MINUS THE ARTERIAL CO2 DIVIDED BY THE RESPIRATORY QUOTIENT — i.e. FiO2 × (Patm − PH2O) −
+% PaCO2 / RQ. It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with two
+% exact rearrangements (the arterial CO2 a given alveolar PO2 implies, and the atmospheric pressure a
+% given alveolar PO2 implies). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the inspired-gas and blood-gas quantities from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "alveolar-gas-equation.adj"
+%     observe fio2(1)      % "…100% oxygen…"        (span cited by the model)
+%     observe patm(760)    % "…at sea level…"       (span cited by the model)
+%     observe ph2o(47)     % "…water vapour 47…"    (span cited by the model)
+%     observe paco2(40)    % "…PaCO2 40 mmHg…"      (span cited by the model)
+%     observe rq(0.8)      % "…respiratory quotient 0.8…"   (span cited by the model)
+%     ? alveolar_po2(fio2, patm, ph2o, paco2, rq)   % engine → 663 (mmHg)
+%
+% The equation carries NO embedded constant: every quantity — the inspired-oxygen fraction, the
+% atmospheric and water-vapour pressures, the arterial CO2, and the respiratory quotient — is a formal
+% parameter bound at apply time (the source quotes the equation with these as symbols; the usual values,
+% ~760 mmHg atmospheric at sea level, ~47 mmHg water vapour at body temperature, and a respiratory
+% quotient of about 0.8, are supplied by the consumer, not baked in). The formula is an exact expression
+% in those parameters, so every value the engine returns is exact. The three formulas COMPOSE and invert
+% cleanly around the worked case FiO2 = 1, Patm = 760, PH2O = 47, PaCO2 = 40, RQ = 0.8
+% (PAO2 = 1 × (760 − 47) − 40 / 0.8 = 713 − 50 = 663 mmHg): the `alveolar_po2` a consumer computes is
+% exactly the value each inverse formula back-solves to recover its own measured input (40, 760).
+%
+%   alveolar_po2(fio2, patm, ph2o, paco2, rq) = fio2 * (patm - ph2o) - paco2 / rq     % (alveolar PO2, mmHg)
+%   paco2(fio2, patm, ph2o, alveolar_po2, rq) = (fio2 * (patm - ph2o) - alveolar_po2) * rq   % (solved for arterial CO2)
+%   patm(fio2, ph2o, paco2, alveolar_po2, rq) = (alveolar_po2 + paco2 / rq) / fio2 + ph2o    % (solved for atmospheric pressure)
+%
+% NOTE ON UNITS AND MODELLING: the pressures (Patm, PH2O, PaCO2, PAO2) are all in millimetres of mercury
+% (mmHg), FiO2 is a fraction between 0 and 1 (e.g. 0.21 for room air, 1 for 100% oxygen), and RQ is a
+% dimensionless ratio (about 0.8). This library only COMPUTES the alveolar PO2; the downstream A-a
+% gradient (alveolar PO2 minus arterial PO2) and its interpretation are handled by the separate
+% alveolar-arterial-gradient.adj library, for which this formula supplies the alveolar term.
+%
+% All three formulas are defended by the SAME clause — the quoted alveolar-gas-equation statement —
+% because that one equation (FiO2 × (Patm − PH2O) − PaCO2 / RQ) sanctions the relation read every way. The
+% quote is transcribed verbatim from the StatPearls "Alveolar Gas Equation" article on the NCBI Bookshelf
+% (a current, non-archived article), so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored — the
+% formula is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `fio2`, `patm`, `ph2o`, `paco2`, `rq` and `alveolar_po2` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary term used in both roles.
+% The `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing
+% comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary alveolar_gas_equation_vocab {
+    define fio2         : finding  surface "FiO2", "fraction of inspired oxygen", "inspired oxygen fraction"   % fraction 0-1
+    define patm         : finding  surface "Patm", "atmospheric pressure", "barometric pressure"               % mmHg
+    define ph2o         : finding  surface "PH2O", "water vapour pressure", "partial pressure of water"        % mmHg
+    define paco2        : finding  surface "PaCO2", "arterial CO2", "arterial carbon dioxide"                  % mmHg
+    define rq           : finding  surface "RQ", "respiratory quotient", "respiratory exchange ratio"          % ratio
+    define alveolar_po2 : finding  surface "PAO2", "alveolar PO2", "alveolar oxygen partial pressure"          % mmHg
+}
+
+% ----------------------------------------------------------------------------
+% The alveolar gas equation, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the alveolar-gas-equation statement from the StatPearls
+% "Alveolar Gas Equation" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is
+% an exact expression in the parameters, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook alveolar_gas_equation_laws {
+    use alveolar_gas_equation_vocab
+
+    % Alveolar PO2 — inspired-oxygen fraction times the dry inspired pressure, minus arterial CO2 over RQ.
+    formula alveolar_po2(fio2, patm, ph2o, paco2, rq) = fio2 * (patm - ph2o) - paco2 / rq
+        source "PAO2 = [(Patm − PH2O) FiO2] − (PaCO2/RQ)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482268/"
+        trust authoritative
+
+    % Arterial CO2 — the same equation solved for PaCO2. Defended by the SAME equation.
+    formula paco2(fio2, patm, ph2o, alveolar_po2, rq) = (fio2 * (patm - ph2o) - alveolar_po2) * rq
+        source "PAO2 = [(Patm − PH2O) FiO2] − (PaCO2/RQ)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482268/"
+        trust authoritative
+
+    % Atmospheric pressure — the same equation solved for Patm, the third reading of the one equation.
+    formula patm(fio2, ph2o, paco2, alveolar_po2, rq) = (alveolar_po2 + paco2 / rq) / fio2 + ph2o
+        source "PAO2 = [(Patm − PH2O) FiO2] − (PaCO2/RQ)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482268/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/alveolar-gas-equation.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/alveolar-gas-equation.query.adj
@@ -1,0 +1,32 @@
+% ============================================================================
+% alveolar-gas-equation.query.adj — worked applications of the alveolar gas equation.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a blood-gas / oxygenation vignette into an inspired
+% oxygen fraction, the atmospheric and water-vapour pressures, the arterial CO2, and the respiratory
+% quotient: it `import`s the grounded formulabook, `observe`s the values, and asks the engine to APPLY the
+% cited alveolar gas equation. No arithmetic is stated by the consumer; the engine computes each value
+% EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with zero
+% model calls.
+%
+% Worked case (FiO2 = 1 i.e. 100% oxygen, Patm = 760 mmHg, PH2O = 47 mmHg, PaCO2 = 40 mmHg, RQ = 0.8):
+% alveolar PO2 = 1 × (760 − 47) − 40 / 0.8 = 713 − 50 = 663 mmHg. Each query fixes all but one quantity and
+% asks the engine to recover the missing one; every answer is exact and the inversions COMPOSE (each
+% recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli alveolar-gas-equation.query.adj
+% ============================================================================
+
+import "alveolar-gas-equation.adj"
+
+% --- Alveolar PO2: the alveolar oxygen the inspired gas and arterial CO2 imply (expect 663). --------
+observe fio2(1)
+observe patm(760)
+observe ph2o(47)
+observe paco2(40)
+observe rq(0.8)
+? alveolar_po2(fio2, patm, ph2o, paco2, rq)   % expect 663
+
+% --- Inverse: the arterial CO2 an alveolar PO2 of 663 implies at the same inspired gas (expect 40). -
+observe alveolar_po2(663)
+? paco2(fio2, patm, ph2o, alveolar_po2, rq)   % expect 40


### PR DESCRIPTION
## Alveolar gas equation — clinical formulabook

Ships the **alveolar gas equation** — the alveolar oxygen partial pressure (PAO₂) from the inspired gas and arterial CO₂ — with **two exact rearrangements** (arterial CO₂, and atmospheric pressure, each recovered from a given PAO₂ and the rest).

**Composes with the shipped A-a gradient library:** this computes the alveolar term that `alveolar-arterial-gradient.adj` consumes (A-a gradient = alveolar PO₂ − arterial PO₂).

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from the StatPearls *Alveolar Gas Equation* article (NCBI Bookshelf [NBK482268](https://www.ncbi.nlm.nih.gov/books/NBK482268/), current / non-archived):

> PAO2 = [(Patm − PH2O) FiO2] − (PaCO2/RQ)

carrying `source` / `locator` / `trust authoritative`. The equation carries **no embedded constant** — FiO₂, Patm, PH₂O, PaCO₂ and RQ are all formal parameters bound at apply time (the page states the equation symbolically; usual values are supplied by the consumer). Exact expression — the engine computes every value **exactly over rationals**.

### Contents
- `alveolar-gas-equation.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `alveolar-gas-equation.query.adj` — worked case.
- `formula_alveolar_gas_equation_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
FiO₂ 1 (100% O₂), Patm 760, PH₂O 47, PaCO₂ 40 mmHg, RQ 0.8 → PAO₂ = 1 × (760 − 47) − 40 / 0.8 = **663 mmHg**. The three formulas compose and invert cleanly; asserted values {663, 40, 760} are collision-safe.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)