### PR TITLE
feat(adj-formula-stdlib): fractional excretion of potassium — FEK = [(urine K/serum K)/(urine Cr/serum Cr)]x100 library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_potassium_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_potassium_e2e.rs
@@ -1,0 +1,147 @@
+//! End-to-end tests for the `clinical/fractional-excretion-of-potassium.adj` library — the fractional
+//! excretion of potassium (FEK = [(urine K / serum K) / (urine Cr / serum Cr)] × 100) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same invariant as
+//! every other formula library: a consumer states NO arithmetic; it imports the grounded library, binds
+//! the four laboratory values with `observe`, and the engine applies the cited formula on the CPU,
+//! computing the EXACT value (over exact rationals) and rendering the citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case urine K = 60,
+//! serum K = 5, urine Cr = 120, serum Cr = 1: (60 / 5) / (120 / 1) × 100 = 10 (FEK),
+//! 10 × 5 × (120 / 1) / 100 = 60 (urine K), 60 / (120 / 1) / 10 × 100 = 5 (serum K). The three asserted
+//! values (10, 60, 5) are distinct, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped fractional-excretion-of-potassium library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_fek_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-potassium.adj")
+        .canonicalize()
+        .expect("shipped fractional-excretion-of-potassium.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fek_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_fek_lib()).unwrap();
+    std::fs::write(dir.join("fractional-excretion-of-potassium.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// fek — the fraction: [(urine K / serum K) / (urine Cr / serum Cr)] × 100.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_fek_library_and_computes_it_with_citation() {
+    let dir = scratch("fek");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-potassium.adj\"\n\
+         observe urine_k(60)\n\
+         observe serum_k(5)\n\
+         observe urine_creatinine(120)\n\
+         observe serum_creatinine(1)\n\
+         ? fek(urine_k, serum_k, urine_creatinine, serum_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: (60 / 5) / (120 / 1) × 100 =
+    // 12 / 120 × 100 = 10, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"fek\"") && s.contains("\"value\":10"),
+        "fek(60, 5, 120, 1) = 10: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_k — the same equation solved for the urine potassium: FEK × serum K × (urine Cr / serum Cr) / 100.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_k_from_fek_with_citation() {
+    let dir = scratch("uk");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-potassium.adj\"\n\
+         observe fek(10)\n\
+         observe serum_k(5)\n\
+         observe urine_creatinine(120)\n\
+         observe serum_creatinine(1)\n\
+         ? urine_k(fek, serum_k, urine_creatinine, serum_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 × 5 × (120 / 1) / 100 = 10 × 5 × 120 / 100 = 6000 / 100 = 60, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_k\"") && s.contains("\"value\":60"),
+        "urine_k(10, 5, 120, 1) = 60: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_k carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_k — the same equation solved for the serum potassium: urine K / (urine Cr / serum Cr) / FEK × 100,
+// the third reading of the one ratio.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_k_from_fek_with_citation() {
+    let dir = scratch("sk");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-potassium.adj\"\n\
+         observe fek(10)\n\
+         observe urine_k(60)\n\
+         observe urine_creatinine(120)\n\
+         observe serum_creatinine(1)\n\
+         ? serum_k(fek, urine_k, urine_creatinine, serum_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 60 / (120 / 1) / 10 × 100 = 60 / 120 / 10 × 100 = 0.5 / 10 × 100 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_k\"") && s.contains("\"value\":5"),
+        "serum_k(10, 60, 120, 1) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_k carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-potassium.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-potassium.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% fractional-excretion-of-potassium.adj — the fractional excretion of potassium
+% (FEK = [(urine K / serum K) / (urine Cr / serum Cr)] × 100) in the ADJ standard library.
+% ============================================================================
+% The fractional-excretion-of-potassium entry of the *clinical* track — the fraction of the potassium
+% filtered by the glomerulus that ends up excreted in the urine, read off a single paired spot urine and
+% serum sample. Creatinine (freely filtered and essentially not reabsorbed) stands in for the glomerular
+% filtration, so the urine-to-serum creatinine ratio corrects the urine-to-serum potassium ratio for how
+% concentrated the urine is. FEK is the potassium companion of the fractional excretion of sodium
+% (fractional-excretion-of-sodium.adj): in a hypokalaemic patient a LOW FEK says the kidney is
+% appropriately conserving potassium (the loss is extrarenal, e.g. gastrointestinal), whereas a HIGH FEK
+% says the kidney is wasting potassium (a renal cause). THE FRACTIONAL EXCRETION OF POTASSIUM IS THE
+% URINE-TO-SERUM POTASSIUM RATIO DIVIDED BY THE URINE-TO-SERUM CREATININE RATIO, TIMES 100 — i.e.
+% [(urine K / serum K) / (urine Cr / serum Cr)] × 100. It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with two exact rearrangements (the urine potassium a given FEK implies,
+% and the serum potassium a given FEK implies). As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the four laboratory values from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "fractional-excretion-of-potassium.adj"
+%     observe urine_k(60)            % "…urine K 60…"           (span cited by the model)
+%     observe serum_k(5)             % "…serum K 5…"            (span cited by the model)
+%     observe urine_creatinine(120)  % "…urine creatinine 120…" (span cited by the model)
+%     observe serum_creatinine(1)    % "…serum creatinine 1…"   (span cited by the model)
+%     ? fek(urine_k, serum_k, urine_creatinine, serum_creatinine)   % engine → 10 (%)
+%
+% This is the potassium analogue of the fractional excretion of sodium: same ratio-of-ratios structure,
+% different measured analyte (potassium), answering a different clinical question (renal vs extrarenal
+% hypokalaemia rather than pre-renal vs intrinsic acute kidney injury). The × 100 turns the dimensionless
+% ratio into a percentage; the formula is otherwise an exact expression over the four measured values, so
+% every value the engine returns is exact. The three formulas COMPOSE and invert cleanly around the worked
+% case urine K = 60, serum K = 5, urine Cr = 120, serum Cr = 1 (FEK = (60/5)/(120/1) × 100 = 12/120 × 100 =
+% 10%): the `fek` a consumer computes is exactly the value each inverse formula back-solves to recover its
+% own measured input (60, 5).
+%
+%   fek(urine_k, serum_k, urine_creatinine, serum_creatinine) = (urine_k / serum_k) / (urine_creatinine / serum_creatinine) * 100
+%   urine_k(fek, serum_k, urine_creatinine, serum_creatinine) = fek * serum_k * (urine_creatinine / serum_creatinine) / 100
+%   serum_k(fek, urine_k, urine_creatinine, serum_creatinine) = urine_k / (urine_creatinine / serum_creatinine) / fek * 100
+%
+% NOTE ON UNITS AND MODELLING: the potassium concentrations are in milliequivalents per litre (mEq/L) and
+% the creatinines in milligrams per decilitre (mg/dL), but because FEK is a ratio of ratios every unit
+% cancels, so only the numeric magnitudes matter as long as the two potassiums share a unit and the two
+% creatinines share a unit. FEK is a plain percentage number (e.g. 10 for 10%, NOT 0.10). This library
+% only COMPUTES the percentage; the interpretation (a low value pointing to appropriate renal conservation,
+% a high value to renal wasting) is stated by the cited source but is applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted FEK equation — because that one equation
+% ([(urine K / serum K) / (urine Cr / serum Cr)] × 100) sanctions the relation read every way. The quote
+% is transcribed verbatim from the article "Fractional excretion of potassium in the course of acute kidney
+% injury in critically ill patients" on PubMed Central (a current, freely available NCBI-hosted article),
+% so each `formula` carries the provenance envelope every shipped grounded clause carries; the linter
+% rejects an unsourced one. (See feedback_nothing_human_authored — the formula is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `urine_k`, `serum_k`, `urine_creatinine`, `serum_creatinine` and `fek` each appear BOTH as a
+% derived result and as an input (of the other formulas), so each is a single dictionary term used in both
+% roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary fractional_excretion_of_potassium_vocab {
+    define urine_k           : finding  surface "urine potassium", "urine K", "urinary potassium", "KU"        % mEq/L
+    define serum_k           : finding  surface "serum potassium", "serum K", "plasma potassium", "K+"         % mEq/L
+    define urine_creatinine  : finding  surface "urine creatinine", "urinary creatinine", "CrU"                % mg/dL
+    define serum_creatinine  : finding  surface "serum creatinine", "plasma creatinine", "SCr"                 % mg/dL
+    define fek               : finding  surface "fractional excretion of potassium", "FEK", "FE potassium"     % percent
+}
+
+% ----------------------------------------------------------------------------
+% The fractional excretion of potassium, three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the FEK equation from the cited article on
+% PubMed Central (a quote is required on a shipped formula). Each is an exact expression in the measured
+% laboratory values, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook fractional_excretion_of_potassium_laws {
+    use fractional_excretion_of_potassium_vocab
+
+    % FEK — the urine-to-serum potassium ratio over the urine-to-serum creatinine ratio, times 100.
+    formula fek(urine_k, serum_k, urine_creatinine, serum_creatinine) = (urine_k / serum_k) / (urine_creatinine / serum_creatinine) * 100
+        source "FEK (%)=[(KU (mEq/L)/K+ (mEq/L))/(CrU (mg/dL)/SCr (mg/dL))]x100"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC4103940/"
+        trust authoritative
+
+    % Urine potassium — the same equation solved for the urine potassium. Defended by the SAME equation.
+    formula urine_k(fek, serum_k, urine_creatinine, serum_creatinine) = fek * serum_k * (urine_creatinine / serum_creatinine) / 100
+        source "FEK (%)=[(KU (mEq/L)/K+ (mEq/L))/(CrU (mg/dL)/SCr (mg/dL))]x100"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC4103940/"
+        trust authoritative
+
+    % Serum potassium — the same equation solved for the serum potassium, the third reading of the one ratio.
+    formula serum_k(fek, urine_k, urine_creatinine, serum_creatinine) = urine_k / (urine_creatinine / serum_creatinine) / fek * 100
+        source "FEK (%)=[(KU (mEq/L)/K+ (mEq/L))/(CrU (mg/dL)/SCr (mg/dL))]x100"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC4103940/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-potassium.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-potassium.query.adj
@@ -1,0 +1,31 @@
+% ============================================================================
+% fractional-excretion-of-potassium.query.adj — worked applications of the FEK.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a hypokalaemia workup into a paired urine and serum
+% potassium and creatinine: it `import`s the grounded formulabook, `observe`s the four values, and asks the
+% engine to APPLY the cited FEK formula. No arithmetic is stated by the consumer; the engine computes each
+% value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with
+% zero model calls.
+%
+% Worked case (urine K = 60 mEq/L, serum K = 5 mEq/L, urine Cr = 120 mg/dL, serum Cr = 1 mg/dL):
+% FEK = (60 / 5) / (120 / 1) × 100 = 12 / 120 × 100 = 10% — an elevated value pointing to renal potassium
+% wasting rather than an extrarenal loss. Each query fixes all but one quantity and asks the engine to
+% recover the missing one; every answer is exact and the inversions COMPOSE (each recovers exactly the
+% worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli fractional-excretion-of-potassium.query.adj
+% ============================================================================
+
+import "fractional-excretion-of-potassium.adj"
+
+% --- FEK: the fractional excretion of potassium the four labs imply (expect 10). --------------------
+observe urine_k(60)
+observe serum_k(5)
+observe urine_creatinine(120)
+observe serum_creatinine(1)
+? fek(urine_k, serum_k, urine_creatinine, serum_creatinine)   % expect 10
+
+% --- Inverse: the urine potassium an FEK of 10 implies at the same serum K and creatinines (expect 60). -
+observe fek(10)
+? urine_k(fek, serum_k, urine_creatinine, serum_creatinine)   % expect 60


### PR DESCRIPTION
## Fractional excretion of potassium (FEK) — clinical formulabook

Ships the **fractional excretion of potassium** — the fraction of filtered potassium excreted in the urine, read off a paired spot urine/serum sample — with **two exact rearrangements** (urine and serum potassium, each recovered from a given FEK and the other labs). Distinguishes **renal vs extrarenal hypokalaemia** (low FEK = appropriate renal conservation; high FEK = renal wasting).

**Companion to the shipped fractional-excretion-of-sodium library:** same ratio-of-ratios structure, different measured analyte, different clinical question.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from the PubMed Central article *Fractional excretion of potassium in the course of acute kidney injury in critically ill patients* ([PMC4103940](https://pmc.ncbi.nlm.nih.gov/articles/PMC4103940/)):

> FEK (%)=[(KU (mEq/L)/K+ (mEq/L))/(CrU (mg/dL)/SCr (mg/dL))]x100

carrying `source` / `locator` / `trust authoritative`. A ratio of ratios with a single integer constant (×100) — the engine computes every value **exactly over rationals**.

### Contents
- `fractional-excretion-of-potassium.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `fractional-excretion-of-potassium.query.adj` — worked case.
- `formula_fractional_excretion_of_potassium_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
urine K 60, serum K 5 mEq/L, urine Cr 120, serum Cr 1 mg/dL → FEK = (60/5)/(120/1) × 100 = 12/120 × 100 = **10%**. The three formulas compose and invert cleanly; asserted values {10, 60, 5} are collision-safe.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)