### PR TITLE
feat(adj-formula-stdlib): fractional excretion of phosphate — FEPO4 = (UPO4 x PCr x 100)/(PPO4 x UCr) library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_phosphate_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_phosphate_e2e.rs
@@ -1,0 +1,148 @@
+//! End-to-end tests for the `clinical/fractional-excretion-of-phosphate.adj` library — the fractional
+//! excretion of phosphate (FEPO4 = (urine PO4 × serum Cr × 100) / (serum PO4 × urine Cr)) and its two
+//! exact rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the four laboratory values with `observe`, and the engine applies the cited formula on
+//! the CPU, computing the EXACT value (over exact rationals) and rendering the citation and trust tier in
+//! the `derived` section (the auditable answer). The three formulas INVERT around the worked case urine
+//! PO4 = 30, serum PO4 = 4, urine Cr = 50, serum Cr = 1: (30 × 1 × 100) / (4 × 50) = 15 (FEPO4),
+//! 15 × 4 × 50 / (100 × 1) = 30 (urine PO4), 30 × 1 × 100 / (15 × 50) = 4 (serum PO4). The three asserted
+//! values (15, 30, 4) are distinct, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped fractional-excretion-of-phosphate library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_fep_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-phosphate.adj")
+        .canonicalize()
+        .expect("shipped fractional-excretion-of-phosphate.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fep_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_fep_lib()).unwrap();
+    std::fs::write(dir.join("fractional-excretion-of-phosphate.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// fep — the fraction: (urine PO4 × serum Cr × 100) / (serum PO4 × urine Cr).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_fep_library_and_computes_it_with_citation() {
+    let dir = scratch("fep");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-phosphate.adj\"\n\
+         observe urine_phosphate(30)\n\
+         observe serum_phosphate(4)\n\
+         observe urine_creatinine(50)\n\
+         observe serum_creatinine(1)\n\
+         ? fep(urine_phosphate, serum_phosphate, urine_creatinine, serum_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: (30 × 1 × 100) / (4 × 50) =
+    // 3000 / 200 = 15, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"fep\"") && s.contains("\"value\":15"),
+        "fep(30, 4, 50, 1) = 15: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_phosphate — the same equation solved for the urine phosphate:
+// FEPO4 × serum PO4 × urine Cr / (100 × serum Cr).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_phosphate_from_fep_with_citation() {
+    let dir = scratch("upo4");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-phosphate.adj\"\n\
+         observe fep(15)\n\
+         observe serum_phosphate(4)\n\
+         observe urine_creatinine(50)\n\
+         observe serum_creatinine(1)\n\
+         ? urine_phosphate(fep, serum_phosphate, urine_creatinine, serum_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 15 × 4 × 50 / (100 × 1) = 3000 / 100 = 30, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_phosphate\"") && s.contains("\"value\":30"),
+        "urine_phosphate(15, 4, 50, 1) = 30: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_phosphate carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_phosphate — the same equation solved for the serum phosphate:
+// urine PO4 × serum Cr × 100 / (FEPO4 × urine Cr), the third reading of the one ratio.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_phosphate_from_fep_with_citation() {
+    let dir = scratch("ppo4");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-phosphate.adj\"\n\
+         observe fep(15)\n\
+         observe urine_phosphate(30)\n\
+         observe urine_creatinine(50)\n\
+         observe serum_creatinine(1)\n\
+         ? serum_phosphate(fep, urine_phosphate, urine_creatinine, serum_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 30 × 1 × 100 / (15 × 50) = 3000 / 750 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_phosphate\"") && s.contains("\"value\":4"),
+        "serum_phosphate(15, 30, 50, 1) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_phosphate carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-phosphate.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-phosphate.adj
@@ -1,0 +1,99 @@
+% ============================================================================
+% fractional-excretion-of-phosphate.adj — the fractional excretion of phosphate
+% (FEPO4 = (urine PO4 × serum Cr × 100) / (serum PO4 × urine Cr)) in the ADJ standard library.
+% ============================================================================
+% The fractional-excretion-of-phosphate entry of the *clinical* track — the fraction of the phosphate
+% filtered by the glomerulus that ends up excreted in the urine, read off a single paired spot urine and
+% serum sample. As with the sodium and potassium fractional excretions, creatinine (freely filtered and
+% essentially not reabsorbed) stands in for the glomerular filtration, so the urine-to-serum creatinine
+% ratio corrects the urine-to-serum phosphate ratio for how concentrated the urine is. FEPO4 completes the
+% renal-tubular-handling trio alongside fractional-excretion-of-sodium.adj and
+% fractional-excretion-of-potassium.adj: in a hypophosphataemic patient a HIGH FEPO4 says the kidney is
+% inappropriately WASTING phosphate (a renal phosphate leak — e.g. an FGF23-driven process such as tumour
+% induced osteomalacia or X-linked hypophosphataemia, or a proximal tubulopathy), whereas a LOW FEPO4 says
+% the kidney is appropriately conserving phosphate (the deficit is from redistribution or gastrointestinal
+% loss). THE FRACTIONAL EXCRETION OF PHOSPHATE IS THE URINE PHOSPHATE TIMES THE SERUM CREATININE TIMES 100,
+% DIVIDED BY THE SERUM PHOSPHATE TIMES THE URINE CREATININE — i.e. (urine PO4 × serum Cr × 100) /
+% (serum PO4 × urine Cr). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together
+% with two exact rearrangements (the urine phosphate a given FEPO4 implies, and the serum phosphate a given
+% FEPO4 implies). As with every compute library, a consumer states NO arithmetic: it `import`s this file,
+% binds the four laboratory values from its own byte-provenance decomposition, and asks the engine to
+% APPLY the cited formula on the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "fractional-excretion-of-phosphate.adj"
+%     observe urine_phosphate(30)     % "…urine phosphate 30…"    (span cited by the model)
+%     observe serum_phosphate(4)      % "…serum phosphate 4…"     (span cited by the model)
+%     observe urine_creatinine(50)    % "…urine creatinine 50…"   (span cited by the model)
+%     observe serum_creatinine(1)     % "…serum creatinine 1…"    (span cited by the model)
+%     ? fep(urine_phosphate, serum_phosphate, urine_creatinine, serum_creatinine)   % engine → 15 (%)
+%
+% This is the phosphate member of the fractional-excretion family: the same creatinine-corrected structure
+% as the sodium and potassium versions, a different measured analyte (phosphate), and a different clinical
+% question (renal phosphate wasting rather than pre-renal AKI or hypokalaemia). The × 100 turns the
+% dimensionless ratio into a percentage; the formula is otherwise an exact expression over the four
+% measured values, so every value the engine returns is exact. The three formulas COMPOSE and invert
+% cleanly around the worked case urine PO4 = 30, serum PO4 = 4, urine Cr = 50, serum Cr = 1
+% (FEPO4 = (30 × 1 × 100) / (4 × 50) = 3000 / 200 = 15%): the `fep` a consumer computes is exactly the
+% value each inverse formula back-solves to recover its own measured input (30, 4).
+%
+%   fep(urine_phosphate, serum_phosphate, urine_creatinine, serum_creatinine) = urine_phosphate * serum_creatinine * 100 / (serum_phosphate * urine_creatinine)
+%   urine_phosphate(fep, serum_phosphate, urine_creatinine, serum_creatinine) = fep * serum_phosphate * urine_creatinine / (100 * serum_creatinine)
+%   serum_phosphate(fep, urine_phosphate, urine_creatinine, serum_creatinine) = urine_phosphate * serum_creatinine * 100 / (fep * urine_creatinine)
+%
+% NOTE ON UNITS AND MODELLING: the phosphate concentrations share a unit (e.g. mg/dL) and the creatinines
+% share a unit (e.g. mg/dL); because FEPO4 is a ratio the units cancel, so only the numeric magnitudes
+% matter as long as the two phosphates share a unit and the two creatinines share a unit. FEPO4 is a plain
+% percentage number (e.g. 15 for 15%, NOT 0.15). This library only COMPUTES the percentage; the
+% interpretation (a high value pointing to renal phosphate wasting, a low value to appropriate conservation)
+% is stated by the cited source but is applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted FEPO4 equation — because that one
+% equation ((urine PO4 × serum Cr × 100) / (serum PO4 × urine Cr)) sanctions the relation read every way.
+% The quote is transcribed verbatim from the StatPearls "Hypophosphatemia" article on the NCBI Bookshelf
+% (a current, non-archived article), so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored — the
+% formula is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `urine_phosphate`, `serum_phosphate`, `urine_creatinine`, `serum_creatinine` and `fep` each
+% appear BOTH as a derived result and as an input (of the other formulas), so each is a single dictionary
+% term used in both roles. The `surface` lists are the everyday names a decomposer maps onto the canonical
+% term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary fractional_excretion_of_phosphate_vocab {
+    define urine_phosphate   : finding  surface "urine phosphate", "urine PO4", "urinary phosphate", "UPO4"     % mg/dL
+    define serum_phosphate   : finding  surface "serum phosphate", "plasma phosphate", "PPO4"                   % mg/dL
+    define urine_creatinine  : finding  surface "urine creatinine", "urinary creatinine", "UCr"                 % mg/dL
+    define serum_creatinine  : finding  surface "serum creatinine", "plasma creatinine", "PCr"                  % mg/dL
+    define fep               : finding  surface "fractional excretion of phosphate", "FEPO4", "FE phosphate"    % percent
+}
+
+% ----------------------------------------------------------------------------
+% The fractional excretion of phosphate, three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the FEPO4 equation from the StatPearls
+% "Hypophosphatemia" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact expression in the measured laboratory values, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook fractional_excretion_of_phosphate_laws {
+    use fractional_excretion_of_phosphate_vocab
+
+    % FEPO4 — urine phosphate times serum creatinine times 100, over serum phosphate times urine creatinine.
+    formula fep(urine_phosphate, serum_phosphate, urine_creatinine, serum_creatinine) = urine_phosphate * serum_creatinine * 100 / (serum_phosphate * urine_creatinine)
+        source "FEPO4 = (UPO4 x PCr x 100) / (PPO4 x UCr)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK493172/"
+        trust authoritative
+
+    % Urine phosphate — the same equation solved for the urine phosphate. Defended by the SAME equation.
+    formula urine_phosphate(fep, serum_phosphate, urine_creatinine, serum_creatinine) = fep * serum_phosphate * urine_creatinine / (100 * serum_creatinine)
+        source "FEPO4 = (UPO4 x PCr x 100) / (PPO4 x UCr)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK493172/"
+        trust authoritative
+
+    % Serum phosphate — the same equation solved for the serum phosphate, the third reading of the one ratio.
+    formula serum_phosphate(fep, urine_phosphate, urine_creatinine, serum_creatinine) = urine_phosphate * serum_creatinine * 100 / (fep * urine_creatinine)
+        source "FEPO4 = (UPO4 x PCr x 100) / (PPO4 x UCr)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK493172/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-phosphate.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-phosphate.query.adj
@@ -1,0 +1,31 @@
+% ============================================================================
+% fractional-excretion-of-phosphate.query.adj — worked applications of the FEPO4.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a hypophosphataemia workup into a paired urine and
+% serum phosphate and creatinine: it `import`s the grounded formulabook, `observe`s the four values, and
+% asks the engine to APPLY the cited FEPO4 formula. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on
+% the CPU, with zero model calls.
+%
+% Worked case (urine PO4 = 30 mg/dL, serum PO4 = 4 mg/dL, urine Cr = 50 mg/dL, serum Cr = 1 mg/dL):
+% FEPO4 = (30 × 1 × 100) / (4 × 50) = 3000 / 200 = 15% — an elevated value pointing to renal phosphate
+% wasting rather than a redistributive or gastrointestinal cause. Each query fixes all but one quantity and
+% asks the engine to recover the missing one; every answer is exact and the inversions COMPOSE (each
+% recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli fractional-excretion-of-phosphate.query.adj
+% ============================================================================
+
+import "fractional-excretion-of-phosphate.adj"
+
+% --- FEPO4: the fractional excretion of phosphate the four labs imply (expect 15). ------------------
+observe urine_phosphate(30)
+observe serum_phosphate(4)
+observe urine_creatinine(50)
+observe serum_creatinine(1)
+? fep(urine_phosphate, serum_phosphate, urine_creatinine, serum_creatinine)   % expect 15
+
+% --- Inverse: the urine phosphate an FEPO4 of 15 implies at the same serum PO4 and creatinines (expect 30). -
+observe fep(15)
+? urine_phosphate(fep, serum_phosphate, urine_creatinine, serum_creatinine)   % expect 30


### PR DESCRIPTION
## Fractional excretion of phosphate (FEPO₄) — clinical formulabook

Ships the **fractional excretion of phosphate** — the fraction of filtered phosphate excreted in the urine, read off a paired spot urine/serum sample — with **two exact rearrangements** (urine and serum phosphate, each recovered from a given FEPO₄ and the other labs). Distinguishes **renal phosphate wasting** (high FEPO₄ — FGF23-driven tumour-induced osteomalacia, X-linked hypophosphataemia, proximal tubulopathy) from appropriate conservation (low FEPO₄).

**Completes the renal-tubular-handling trio** with the shipped fractional-excretion-of-**sodium** and **-potassium** libraries: same creatinine-corrected structure, different analyte, different clinical question.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from the StatPearls *Hypophosphatemia* article (NCBI Bookshelf [NBK493172](https://www.ncbi.nlm.nih.gov/books/NBK493172/)):

> FEPO4 = (UPO4 x PCr x 100) / (PPO4 x UCr)

carrying `source` / `locator` / `trust authoritative`. A single integer constant (×100) — the engine computes every value **exactly over rationals**, all outputs clean integers.

### Contents
- `fractional-excretion-of-phosphate.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `fractional-excretion-of-phosphate.query.adj` — worked case.
- `formula_fractional_excretion_of_phosphate_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
urine PO₄ 30, serum PO₄ 4, urine Cr 50, serum Cr 1 mg/dL → FEPO₄ = (30 × 1 × 100)/(4 × 50) = 3000/200 = **15%**. The three formulas compose and invert cleanly; asserted values {15, 30, 4} are collision-safe.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)