### PR TITLE
feat(adj-formula-stdlib): absolute neutrophil count — StatPearls ANC = WBC x (PMNs + bands)/100 library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_absolute_neutrophil_count_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_absolute_neutrophil_count_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end tests for the `clinical/absolute-neutrophil-count.adj` library — the absolute neutrophil
+//! count (ANC = WBC × (percent PMNs + percent bands) / 100) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula
+//! library: a consumer states NO arithmetic; it imports the grounded library, binds the count and the two
+//! percentages with `observe`, and the engine applies the cited formula on the CPU, computing the EXACT
+//! value (over exact rationals) and rendering the citation and trust tier in the `derived` section (the
+//! auditable answer). The three formulas INVERT around the worked case WBC = 5000, PMNs = 40, bands = 10:
+//! 5000 × (40 + 10) / 100 = 2500 (ANC), 2500 × 100 / (40 + 10) = 5000 (WBC), 2500 × 100 / 5000 − 10 = 40
+//! (PMNs). The three asserted values (2500, 5000, 40) are distinct, none a colon-anchored prefix of
+//! another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped absolute-neutrophil-count library, resolved from this crate's manifest dir
+/// so the test is location-independent.
+fn shipped_anc_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/absolute-neutrophil-count.adj")
+        .canonicalize()
+        .expect("shipped absolute-neutrophil-count.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_anc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_anc_lib()).unwrap();
+    std::fs::write(dir.join("absolute-neutrophil-count.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// anc — the count: WBC × (percent PMNs + percent bands) / 100.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_anc_library_and_computes_it_with_citation() {
+    let dir = scratch("anc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"absolute-neutrophil-count.adj\"\n\
+         observe wbc(5000)\n\
+         observe pmns(40)\n\
+         observe bands(10)\n\
+         ? anc(wbc, pmns, bands)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 5000 × (40 + 10) / 100 =
+    // 5000 × 50 / 100 = 2500, computed EXACTLY over rationals, not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"anc\"") && s.contains("\"value\":2500"),
+        "anc(5000, 40, 10) = 2500: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// wbc — the same equation solved for the white count: ANC × 100 / (percent PMNs + percent bands).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_wbc_from_anc_with_citation() {
+    let dir = scratch("wbc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"absolute-neutrophil-count.adj\"\n\
+         observe anc(2500)\n\
+         observe pmns(40)\n\
+         observe bands(10)\n\
+         ? wbc(anc, pmns, bands)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2500 × 100 / (40 + 10) = 250000 / 50 = 5000, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"wbc\"") && s.contains("\"value\":5000"),
+        "wbc(2500, 40, 10) = 5000: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "wbc carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// pmns — the same equation solved for the segmented-neutrophil percentage:
+// ANC × 100 / WBC − percent bands, the third reading of the one count.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_pmns_from_anc_with_citation() {
+    let dir = scratch("pmns");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"absolute-neutrophil-count.adj\"\n\
+         observe anc(2500)\n\
+         observe wbc(5000)\n\
+         observe bands(10)\n\
+         ? pmns(anc, wbc, bands)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2500 × 100 / 5000 − 10 = 250000 / 5000 − 10 = 50 − 10 = 40, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"pmns\"") && s.contains("\"value\":40"),
+        "pmns(2500, 5000, 10) = 40: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "pmns carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/absolute-neutrophil-count.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/absolute-neutrophil-count.adj
@@ -1,0 +1,91 @@
+% ============================================================================
+% absolute-neutrophil-count.adj — the absolute neutrophil count
+% (ANC = WBC × (percent PMNs + percent bands) / 100) in the ADJ standard library.
+% ============================================================================
+% The absolute-neutrophil-count entry of the *clinical* track — the number of infection-fighting
+% neutrophils circulating per microlitre of blood, recovered from a complete blood count with differential.
+% The automated count reports a total white cell count and a DIFFERENTIAL in percentages; the neutrophil
+% line is split into mature segmented cells (the polymorphonuclear cells, PMNs or "segs") and immature band
+% forms, so the ANC is the total white count scaled by the COMBINED neutrophil fraction. It is the number
+% that stratifies infection risk: an ANC below 1500 is neutropenia and below 500 is severe neutropenia
+% (the threshold at which febrile neutropenia becomes an emergency). THE ABSOLUTE NEUTROPHIL COUNT IS THE
+% WHITE BLOOD CELL COUNT TIMES THE SUM OF THE SEGMENTED-NEUTROPHIL AND BAND PERCENTAGES, DIVIDED BY 100 —
+% i.e. WBC × (percent PMNs + percent bands) / 100. It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with two exact rearrangements (the white count a given ANC implies, and
+% the segmented-neutrophil percentage a given ANC implies). As with every compute library, a consumer
+% states NO arithmetic: it `import`s this file, binds the count and the two percentages from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "absolute-neutrophil-count.adj"
+%     observe wbc(5000)   % "…WBC 5000…"        (span cited by the model)
+%     observe pmns(40)     % "…40% segs…"        (span cited by the model)
+%     observe bands(10)    % "…10% bands…"       (span cited by the model)
+%     ? anc(wbc, pmns, bands)   % engine → 2500 (cells/microL)
+%
+% Structurally this is a total scaled by a SUM of two percentages over 100 — distinct from the ratio and
+% ratio-of-ratios shapes of the other haematology and renal libraries. The two neutrophil percentages are
+% added FIRST, then the product with the white count is taken and divided by 100; the only constant is the
+% 100 that converts the summed percentage to a fraction, so every value the engine returns is exact. The
+% three formulas COMPOSE and invert cleanly around the worked case WBC = 5000, PMNs = 40%, bands = 10%
+% (ANC = 5000 × (40 + 10) / 100 = 5000 × 50 / 100 = 2500 cells/microL — a normal count): the `anc` a
+% consumer computes is exactly the value each inverse formula back-solves to recover its own measured input
+% (5000, 40).
+%
+%   anc(wbc, pmns, bands) = wbc * (pmns + bands) / 100      % (cells/microL)
+%   wbc(anc, pmns, bands) = anc * 100 / (pmns + bands)      % (solved for the white count)
+%   pmns(anc, wbc, bands) = anc * 100 / wbc - bands         % (solved for the segmented-neutrophil percentage)
+%
+% NOTE ON UNITS AND MODELLING: the white blood cell count and the ANC are in cells per microlitre
+% (cells/microL), and the two neutrophil figures are plain percentage numbers (e.g. 40 for 40%, NOT 0.40).
+% This library only COMPUTES the count; the interpretation (normal, neutropenic below 1500, severely
+% neutropenic below 500) is stated by the cited source but is applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted ANC equation — because that one equation
+% (WBC × (percent PMNs + percent bands) / 100) sanctions the relation read every way. The quote is
+% transcribed verbatim from the StatPearls "Febrile Neutropenia" article on the NCBI Bookshelf (a current,
+% non-archived article), so each `formula` carries the provenance envelope every shipped grounded clause
+% carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula is a
+% verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `wbc`, `pmns`, `bands` and `anc` each appear BOTH as a derived result and as an input (of the
+% other formulas), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary absolute_neutrophil_count_vocab {
+    define wbc    : finding  surface "WBC", "white blood cell count", "total WBC", "white count"           % cells/microL
+    define pmns   : finding  surface "PMNs", "segmented neutrophils", "segs", "polymorphonuclear cells"    % percent
+    define bands  : finding  surface "bands", "band neutrophils", "band forms"                             % percent
+    define anc    : finding  surface "ANC", "absolute neutrophil count"                                    % cells/microL
+}
+
+% ----------------------------------------------------------------------------
+% The absolute neutrophil count, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the ANC equation from the StatPearls "Febrile
+% Neutropenia" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% expression in the measured count and percentages, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook absolute_neutrophil_count_laws {
+    use absolute_neutrophil_count_vocab
+
+    % ANC — the white count times the summed neutrophil percentages, over 100.
+    formula anc(wbc, pmns, bands) = wbc * (pmns + bands) / 100
+        source "ANC = WBC (cells/microL) x percent (PMNs + bands) / 100"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541102/"
+        trust authoritative
+
+    % White count — the same equation solved for the WBC. Defended by the SAME equation.
+    formula wbc(anc, pmns, bands) = anc * 100 / (pmns + bands)
+        source "ANC = WBC (cells/microL) x percent (PMNs + bands) / 100"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541102/"
+        trust authoritative
+
+    % Segmented-neutrophil percentage — the same equation solved for PMNs, the third reading of the one count.
+    formula pmns(anc, wbc, bands) = anc * 100 / wbc - bands
+        source "ANC = WBC (cells/microL) x percent (PMNs + bands) / 100"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541102/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/absolute-neutrophil-count.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/absolute-neutrophil-count.query.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% absolute-neutrophil-count.query.adj — worked applications of the ANC.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a complete-blood-count-with-differential into a
+% white cell count and the segmented and band neutrophil percentages: it `import`s the grounded
+% formulabook, `observe`s the three values, and asks the engine to APPLY the cited ANC formula. No
+% arithmetic is stated by the consumer; the engine computes each value EXACTLY (over exact rationals) and
+% carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (WBC = 5000 cells/microL, segmented neutrophils = 40%, bands = 10%):
+% ANC = 5000 × (40 + 10) / 100 = 5000 × 50 / 100 = 2500 cells/microL — a normal count (neutropenia is
+% below 1500, severe below 500). Each query fixes two of the three quantities and asks the engine to
+% recover the third; every answer is exact and the inversions COMPOSE (each recovers exactly the worked
+% value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli absolute-neutrophil-count.query.adj
+% ============================================================================
+
+import "absolute-neutrophil-count.adj"
+
+% --- ANC: the absolute neutrophil count the white count and percentages imply (expect 2500). --------
+observe wbc(5000)
+observe pmns(40)
+observe bands(10)
+? anc(wbc, pmns, bands)   % expect 2500
+
+% --- Inverse: the white count an ANC of 2500 implies at the same percentages (expect 5000). ---------
+observe anc(2500)
+? wbc(anc, pmns, bands)   % expect 5000


### PR DESCRIPTION
## Absolute neutrophil count (ANC) — clinical formulabook

Ships the **absolute neutrophil count** — the number of neutrophils per microlitre from a CBC differential, the value that stratifies infection risk (neutropenia < 1500, severe < 500 — the febrile-neutropenia emergency threshold) — with **two exact rearrangements** (white count, and segmented-neutrophil percentage, each recovered from a given ANC and the rest).

**Structurally distinct** from the recently-shipped fractional-excretion family: a total scaled by a *sum* of two percentages over 100 — `a × (b + c) / 100`, not a ratio of ratios.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from the StatPearls *Febrile Neutropenia* article (NCBI Bookshelf [NBK541102](https://www.ncbi.nlm.nih.gov/books/NBK541102/)):

> ANC = WBC (cells/microL) x percent (PMNs + bands) / 100

carrying `source` / `locator` / `trust authoritative`. A single integer constant (100) — the engine computes every value **exactly over rationals**, all outputs clean integers.

### Contents
- `absolute-neutrophil-count.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `absolute-neutrophil-count.query.adj` — worked case.
- `formula_absolute_neutrophil_count_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
WBC 5000 cells/microL, segs 40%, bands 10% → ANC = 5000 × (40 + 10)/100 = 5000 × 50/100 = **2500 cells/microL** (a normal count). The three formulas compose and invert cleanly; asserted values {2500, 5000, 40} are collision-safe.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)