### PR TITLE
feat(adj-formula-stdlib): HOMA-IR — Endotext (fasting insulin x fasting glucose / 22.5) insulin-resistance index library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_homa_ir_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_homa_ir_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end tests for the `clinical/homa-ir.adj` library — the homeostatic model assessment of insulin
+//! resistance (HOMA-IR = fasting insulin × fasting glucose / 22.5) and its two exact rearrangements —
+//! driven through the built CLI binary against the SHIPPED stdlib. The same invariant as every other
+//! formula library: a consumer states NO arithmetic; it imports the grounded library, binds the two
+//! fasting values with `observe`, and the engine applies the cited formula on the CPU, computing the EXACT
+//! value (over exact rationals) and rendering the citation and trust tier in the `derived` section (the
+//! auditable answer). The three formulas INVERT around the worked case insulin = 9, glucose = 5:
+//! 9 × 5 / 22.5 = 2 (HOMA-IR), 2 × 22.5 / 5 = 9 (insulin), 2 × 22.5 / 9 = 5 (glucose).
+//!
+//! Note the assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a
+//! bare `"value":N`: the 22.5 constant renders as `"value":22.5` in the derivation tree, so a bare
+//! `"value":2` would spuriously match the leading `2` of `22.5`. The adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped homa-ir library, resolved from this crate's manifest dir so the test is
+/// location-independent.
+fn shipped_homa_ir_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/homa-ir.adj")
+        .canonicalize()
+        .expect("shipped homa-ir.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_homair_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_homa_ir_lib()).unwrap();
+    std::fs::write(dir.join("homa-ir.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// homa_ir — the index: fasting insulin × fasting glucose / 22.5.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_homa_ir_library_and_computes_it_with_citation() {
+    let dir = scratch("index");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"homa-ir.adj\"\n\
+         observe fasting_insulin(9)\n\
+         observe fasting_glucose(5)\n\
+         ? homa_ir(fasting_insulin, fasting_glucose)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 9 × 5 / 22.5 = 45 / 22.5 = 2,
+    // computed EXACTLY over rationals, not as a rounded float. Match the adjacent name/value pair so the
+    // 22.5 literal in the derivation cannot spuriously satisfy a bare "value":2.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"homa_ir\",\"value\":2"),
+        "homa_ir(9, 5) = 2: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// fasting_insulin — the same equation solved for the insulin: HOMA-IR × 22.5 / glucose.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_fasting_insulin_from_homa_ir_with_citation() {
+    let dir = scratch("insulin");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"homa-ir.adj\"\n\
+         observe homa_ir(2)\n\
+         observe fasting_glucose(5)\n\
+         ? fasting_insulin(homa_ir, fasting_glucose)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 × 22.5 / 5 = 45 / 5 = 9, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"fasting_insulin\",\"value\":9"),
+        "fasting_insulin(2, 5) = 9: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "fasting_insulin carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// fasting_glucose — the same equation solved for the glucose: HOMA-IR × 22.5 / insulin, the third reading
+// of the one index.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_fasting_glucose_from_homa_ir_with_citation() {
+    let dir = scratch("glucose");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"homa-ir.adj\"\n\
+         observe homa_ir(2)\n\
+         observe fasting_insulin(9)\n\
+         ? fasting_glucose(homa_ir, fasting_insulin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 × 22.5 / 9 = 45 / 9 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"fasting_glucose\",\"value\":5"),
+        "fasting_glucose(2, 9) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "fasting_glucose carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/homa-ir.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/homa-ir.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% homa-ir.adj — the homeostatic model assessment of insulin resistance
+% (HOMA-IR = fasting insulin × fasting glucose / 22.5) in the ADJ standard library.
+% ============================================================================
+% The HOMA-IR entry of the *clinical* track — a fasting-sample estimate of insulin resistance. In a
+% steady fasting state the pancreas trims insulin secretion until glucose settles, so the PRODUCT of the
+% fasting glucose and the fasting insulin measures how hard the beta cells must work to hold that glucose:
+% the more insulin it takes to keep glucose in range, the more resistant the tissues. Dividing that product
+% by a normalising constant scales an ideal, fully-insulin-sensitive individual to a value of 1. HOMA-IR
+% is the workhorse index for insulin resistance in metabolic syndrome, type 2 diabetes risk, and polycystic
+% ovary syndrome. THE HOMA-IR IS THE FASTING INSULIN TIMES THE FASTING GLUCOSE, DIVIDED BY 22.5 — i.e.
+% fasting insulin × fasting glucose / 22.5 (with glucose in mmol/L). It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the fasting
+% insulin a given HOMA-IR implies at a known glucose, and the fasting glucose a given HOMA-IR implies at a
+% known insulin). As with every compute library, a consumer states NO arithmetic: it `import`s this file,
+% binds the two fasting values from its own byte-provenance decomposition, and asks the engine to APPLY the
+% cited formula on the CPU. Zero math is performed by the model; the engine computes each value EXACTLY
+% (over exact rationals), carrying the formula's citation.
+%
+%     import "homa-ir.adj"
+%     observe fasting_insulin(9)   % "…fasting insulin 9 μU/ml…"    (span cited by the model)
+%     observe fasting_glucose(5)    % "…fasting glucose 5 mmol/l…"   (span cited by the model)
+%     ? homa_ir(fasting_insulin, fasting_glucose)   % engine → 2
+%
+% Structurally this is a PRODUCT of two measured quantities over a single normalising constant — a shape
+% distinct from the ratio, ratio-of-ratios, and percentage-sum forms of the other clinical libraries. The
+% 22.5 normalising constant is the EXACT constant of the cited formula (the product of a normal fasting
+% insulin of 5 μU/ml and a normal fasting glucose of 4.5 mmol/l — not a measurement), so every value the
+% engine returns is exact. The three formulas COMPOSE and invert cleanly around the worked case fasting
+% insulin = 9 μU/ml, fasting glucose = 5 mmol/l (HOMA-IR = 9 × 5 / 22.5 = 45 / 22.5 = 2 — a value at the
+% upper limit of normal, insulin resistance being roughly HOMA-IR ≥ 2): the `homa_ir` a consumer computes
+% is exactly the value each inverse formula back-solves to recover its own measured input (9, 5).
+%
+%   homa_ir(fasting_insulin, fasting_glucose) = fasting_insulin * fasting_glucose / 22.5   % (index)
+%   fasting_insulin(homa_ir, fasting_glucose) = homa_ir * 22.5 / fasting_glucose            % (solved for insulin)
+%   fasting_glucose(homa_ir, fasting_insulin) = homa_ir * 22.5 / fasting_insulin            % (solved for glucose)
+%
+% NOTE ON UNITS AND MODELLING: this is the mmol/L form the cited page prints, so the fasting glucose is in
+% millimoles per litre (mmol/L) and the fasting insulin in microunits per millilitre (μU/ml), with 22.5 as
+% the divisor; the equivalent mg/dL form uses a divisor of 405 instead, but this library grounds the
+% mmol/L form exactly as printed. HOMA-IR is a plain dimensionless index (about 1 in a normal individual).
+% This library only COMPUTES the index; the interpretation (higher values indicating greater insulin
+% resistance) is stated by the cited source but is applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted HOMA-IR equation — because that one
+% equation (fasting insulin × fasting glucose / 22.5) sanctions the relation read every way. The quote is
+% transcribed verbatim from the Endotext "Assessing Insulin Sensitivity and Resistance in Humans" chapter
+% on the NCBI Bookshelf (a current, freely available NCBI-hosted reference), so each `formula` carries the
+% provenance envelope every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula, including its 22.5 constant, is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `fasting_insulin`, `fasting_glucose` and `homa_ir` each appear BOTH as a derived result and
+% as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary homa_ir_vocab {
+    define fasting_insulin  : finding  surface "fasting insulin", "insulin", "fasting plasma insulin"          % μU/ml
+    define fasting_glucose  : finding  surface "fasting glucose", "glucose", "fasting plasma glucose", "FPG"    % mmol/L
+    define homa_ir          : finding  surface "HOMA-IR", "HOMA", "insulin resistance index"                    % index
+}
+
+% ----------------------------------------------------------------------------
+% HOMA-IR, three ways. Each is a named, importable, reusable formula over its formal parameters, bound at
+% apply time, and each carries the HOMA-IR equation from the Endotext "Assessing Insulin Sensitivity and
+% Resistance in Humans" chapter on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact expression in the measured values and the cited 22.5 constant, so the engine returns each value
+% EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook homa_ir_laws {
+    use homa_ir_vocab
+
+    % HOMA-IR — the fasting insulin times the fasting glucose, over 22.5.
+    formula homa_ir(fasting_insulin, fasting_glucose) = fasting_insulin * fasting_glucose / 22.5
+        source "HOMA-IR = fasting insulin (μU/ml) × fasting glucose (mmol/l) / 22.5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK278954/"
+        trust authoritative
+
+    % Fasting insulin — the same equation solved for the insulin. Defended by the SAME equation.
+    formula fasting_insulin(homa_ir, fasting_glucose) = homa_ir * 22.5 / fasting_glucose
+        source "HOMA-IR = fasting insulin (μU/ml) × fasting glucose (mmol/l) / 22.5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK278954/"
+        trust authoritative
+
+    % Fasting glucose — the same equation solved for the glucose, the third reading of the one index.
+    formula fasting_glucose(homa_ir, fasting_insulin) = homa_ir * 22.5 / fasting_insulin
+        source "HOMA-IR = fasting insulin (μU/ml) × fasting glucose (mmol/l) / 22.5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK278954/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/homa-ir.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/homa-ir.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% homa-ir.query.adj — worked applications of the HOMA-IR insulin resistance index.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a metabolic workup into a fasting insulin and a
+% fasting glucose: it `import`s the grounded formulabook, `observe`s the two values, and asks the engine to
+% APPLY the cited HOMA-IR formula. No arithmetic is stated by the consumer; the engine computes each value
+% EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with zero
+% model calls.
+%
+% Worked case (fasting insulin = 9 μU/ml, fasting glucose = 5 mmol/l): HOMA-IR = 9 × 5 / 22.5 = 45 / 22.5 =
+% 2 — at the upper limit of normal (insulin resistance is roughly HOMA-IR ≥ 2). Each query fixes two of
+% the three quantities and asks the engine to recover the third; every answer is exact and the inversions
+% COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli homa-ir.query.adj
+% ============================================================================
+
+import "homa-ir.adj"
+
+% --- HOMA-IR: the index the fasting insulin and glucose imply (expect 2). ---------------------------
+observe fasting_insulin(9)
+observe fasting_glucose(5)
+? homa_ir(fasting_insulin, fasting_glucose)   % expect 2
+
+% --- Inverse: the fasting insulin a HOMA-IR of 2 implies at the same glucose (expect 9). ------------
+observe homa_ir(2)
+? fasting_insulin(homa_ir, fasting_glucose)   % expect 9


### PR DESCRIPTION
## HOMA-IR — clinical formulabook

Ships **HOMA-IR** (homeostatic model assessment of insulin resistance) — the fasting-sample index of insulin resistance used across metabolic syndrome, type 2 diabetes risk, and PCOS — with **two exact rearrangements** (fasting insulin, and fasting glucose, each recovered from a given HOMA-IR and the other).

Opens a **new clinical domain** (endocrine/metabolic) and a **new arithmetic shape** for the library — a product of two measured quantities over a single normalising constant, distinct from the ratio, ratio-of-ratios, and percentage-sum forms already shipped.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from the Endotext *Assessing Insulin Sensitivity and Resistance in Humans* chapter (NCBI Bookshelf [NBK278954](https://www.ncbi.nlm.nih.gov/books/NBK278954/)):

> HOMA-IR = fasting insulin (μU/ml) × fasting glucose (mmol/l) / 22.5

(the mmol/L form as printed) carrying `source` / `locator` / `trust authoritative`. The 22.5 normalising constant is dyadic-exact, so outputs render as clean integers; the engine computes every value **exactly over rationals**.

### Contents
- `homa-ir.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `homa-ir.query.adj` — worked case.
- `formula_homa_ir_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
fasting insulin 9 μU/ml, fasting glucose 5 mmol/l → HOMA-IR = 9 × 5 / 22.5 = 45 / 22.5 = **2**. The three formulas compose and invert cleanly. Because `22.5` renders as `"value":22.5` in the derivation tree, the e2e tests assert the **adjacent** `"name":…,"value":…` pair rather than a bare `"value":2` (which the 22.5 literal's leading digit would otherwise satisfy).

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)