### PR TITLE
feat(adj-formula-stdlib): APRI — AST-to-platelet ratio index ((AST/ULN/platelets) x 100) liver-fibrosis library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_apri_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_apri_e2e.rs
@@ -1,0 +1,148 @@
+//! End-to-end tests for the `clinical/apri.adj` library — the AST-to-platelet ratio index
+//! (APRI = AST / ULN / platelet count × 100) and its two exact rearrangements — driven through the built
+//! CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a consumer
+//! states NO arithmetic; it imports the grounded library, binds the AST, its upper limit of normal, and
+//! the platelet count with `observe`, and the engine applies the cited formula on the CPU, computing the
+//! EXACT value (over exact rationals) and rendering the citation and trust tier in the `derived` section
+//! (the auditable answer). The three formulas INVERT around the worked case AST = 80, ULN = 40, platelets
+//! = 100: 80 / 40 / 100 × 100 = 2 (APRI), 2 × 40 × 100 / 100 = 80 (AST), 80 / 40 × 100 / 2 = 100 (platelets).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation tree contains the 100 constant and the intermediates 200 and 8000, so a
+//! bare `"value":2` / `"value":80` / `"value":100` could spuriously match `200` / `8000` / the `100`
+//! literal. The adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped apri library, resolved from this crate's manifest dir so the test is
+/// location-independent.
+fn shipped_apri_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/apri.adj")
+        .canonicalize()
+        .expect("shipped apri.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_apri_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_apri_lib()).unwrap();
+    std::fs::write(dir.join("apri.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// apri — the index: AST / ULN / platelet count × 100.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_apri_library_and_computes_it_with_citation() {
+    let dir = scratch("index");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"apri.adj\"\n\
+         observe ast(80)\n\
+         observe ast_uln(40)\n\
+         observe platelet_count(100)\n\
+         ? apri(ast, ast_uln, platelet_count)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 80 / 40 / 100 × 100 = 2, computed
+    // EXACTLY over rationals. Match the adjacent name/value pair so the 100 literal and the 200/8000
+    // intermediates in the derivation cannot spuriously satisfy a bare "value":2.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"apri\",\"value\":2"),
+        "apri(80, 40, 100) = 2: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ast — the same equation solved for the AST: APRI × ULN × platelet count / 100.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_ast_from_apri_with_citation() {
+    let dir = scratch("ast");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"apri.adj\"\n\
+         observe apri(2)\n\
+         observe ast_uln(40)\n\
+         observe platelet_count(100)\n\
+         ? ast(apri, ast_uln, platelet_count)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 × 40 × 100 / 100 = 8000 / 100 = 80, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"ast\",\"value\":80"),
+        "ast(2, 40, 100) = 80: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "ast carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// platelet_count — the same equation solved for the platelet count: AST / ULN × 100 / APRI, the third
+// reading of the one index.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_platelet_count_from_apri_with_citation() {
+    let dir = scratch("plt");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"apri.adj\"\n\
+         observe apri(2)\n\
+         observe ast(80)\n\
+         observe ast_uln(40)\n\
+         ? platelet_count(apri, ast, ast_uln)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 80 / 40 × 100 / 2 = 2 × 100 / 2 = 200 / 2 = 100, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"platelet_count\",\"value\":100"),
+        "platelet_count(2, 80, 40) = 100: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "platelet_count carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/apri.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/apri.adj
@@ -1,0 +1,95 @@
+% ============================================================================
+% apri.adj — the AST-to-platelet ratio index
+% (APRI = (AST / upper-limit-of-normal AST / platelet count) × 100) in the ADJ standard library.
+% ============================================================================
+% The APRI entry of the *clinical* track — a simple, non-invasive index that estimates the degree of
+% liver FIBROSIS from two routine blood tests, so a clinician can gauge how scarred a liver is without a
+% biopsy. Two things move together as a liver scars: the aspartate transaminase (AST) leaks up as
+% hepatocytes are injured, and the platelet count falls as portal hypertension and reduced thrombopoietin
+% take hold. APRI captures both in one number by normalising the AST to its laboratory upper limit of
+% normal (so different assays are comparable) and dividing by the platelet count. It was validated first in
+% hepatitis C and is widely used in hepatitis B and C: APRI < 0.5 argues against significant fibrosis,
+% > 1.5 suggests probable cirrhosis. THE APRI IS THE AST DIVIDED BY ITS UPPER LIMIT OF NORMAL, DIVIDED BY
+% THE PLATELET COUNT, TIMES 100 — i.e. (AST / ULN / platelet count) × 100. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the AST a given
+% APRI implies, and the platelet count a given APRI implies). As with every compute library, a consumer
+% states NO arithmetic: it `import`s this file, binds the AST, its upper limit of normal, and the platelet
+% count from its own byte-provenance decomposition, and asks the engine to APPLY the cited formula on the
+% CPU. Zero math is performed by the model; the engine computes each value EXACTLY (over exact rationals),
+% carrying the formula's citation.
+%
+%     import "apri.adj"
+%     observe ast(80)             % "…AST 80…"          (span cited by the model)
+%     observe ast_uln(40)          % "…AST ULN 40…"      (span cited by the model)
+%     observe platelet_count(100)  % "…platelets 100…"   (span cited by the model)
+%     ? apri(ast, ast_uln, platelet_count)   % engine → 2
+%
+% Structurally this is a CHAINED DIVISION scaled by a constant — the AST divided by two successive
+% quantities (its upper limit of normal, then the platelet count), times 100 — a shape distinct from the
+% single-ratio, ratio-of-ratios, percentage-sum, and product-over-constant forms of the other clinical
+% libraries. The only constant is the 100 that scales the index; the formula is otherwise an exact
+% expression over the three measured quantities, so every value the engine returns is exact. The three
+% formulas COMPOSE and invert cleanly around the worked case AST = 80, ULN = 40, platelet count = 100
+% (×10⁹/L) (APRI = 80 / 40 / 100 × 100 = 2 / 100 × 100 = 2 — well above the 1.5 cirrhosis threshold): the
+% `apri` a consumer computes is exactly the value each inverse formula back-solves to recover its own
+% measured input (80, 100).
+%
+%   apri(ast, ast_uln, platelet_count) = ast / ast_uln / platelet_count * 100   % (index)
+%   ast(apri, ast_uln, platelet_count) = apri * ast_uln * platelet_count / 100   % (solved for AST)
+%   platelet_count(apri, ast, ast_uln) = ast / ast_uln * 100 / apri             % (solved for platelet count)
+%
+% NOTE ON UNITS AND MODELLING: the AST and its upper limit of normal share a unit (IU/L), so that ratio is
+% dimensionless, and the platelet count is in units of 10⁹/L as the cited page prints. Because APRI
+% normalises the AST to its OWN laboratory upper limit of normal, the index is comparable across assays.
+% APRI is a plain dimensionless index. This library only COMPUTES the index; the interpretation
+% (< 0.5 fibrosis-free, > 1.5 probable cirrhosis) is stated by the cited source but is applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted APRI equation — because that one equation
+% ((AST / upper-limit-of-normal AST / platelet count) × 100) sanctions the relation read every way. The
+% quote is transcribed verbatim from the article "Noninvasive assessment of liver fibrosis with the
+% aspartate transaminase to platelet ratio index (APRI)" on PubMed Central (a current, freely available
+% NCBI-hosted article), so each `formula` carries the provenance envelope every shipped grounded clause
+% carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula is a
+% verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `ast`, `ast_uln`, `platelet_count` and `apri` each appear BOTH as a derived result and as an
+% input (of the other formulas), so each is a single dictionary term used in both roles. The `surface`
+% lists are the everyday names a decomposer maps onto the canonical term; the trailing comment records the
+% intended unit.
+% ----------------------------------------------------------------------------
+dictionary apri_vocab {
+    define ast             : finding  surface "AST", "aspartate transaminase", "aspartate aminotransferase"   % IU/L
+    define ast_uln          : finding  surface "AST ULN", "upper limit of normal AST", "AST upper normal limit"  % IU/L
+    define platelet_count   : finding  surface "platelet count", "platelets", "PLT"                             % 10^9/L
+    define apri             : finding  surface "APRI", "AST to platelet ratio index", "AST-platelet ratio index"  % index
+}
+
+% ----------------------------------------------------------------------------
+% APRI, three ways. Each is a named, importable, reusable formula over its formal parameters, bound at apply
+% time, and each carries the APRI equation from the cited PubMed Central article (a quote is required on a
+% shipped formula). Each is an exact expression in the measured values and the cited 100 constant, so the
+% engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook apri_laws {
+    use apri_vocab
+
+    % APRI — the AST over its upper limit of normal, over the platelet count, times 100.
+    formula apri(ast, ast_uln, platelet_count) = ast / ast_uln / platelet_count * 100
+        source "APRI = (AST level/Upper normal limit for AST / Platelet count (10⁹/L)) × 100"
+        locator "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3206675/"
+        trust authoritative
+
+    % AST — the same equation solved for the AST. Defended by the SAME equation.
+    formula ast(apri, ast_uln, platelet_count) = apri * ast_uln * platelet_count / 100
+        source "APRI = (AST level/Upper normal limit for AST / Platelet count (10⁹/L)) × 100"
+        locator "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3206675/"
+        trust authoritative
+
+    % Platelet count — the same equation solved for the platelet count, the third reading of the one index.
+    formula platelet_count(apri, ast, ast_uln) = ast / ast_uln * 100 / apri
+        source "APRI = (AST level/Upper normal limit for AST / Platelet count (10⁹/L)) × 100"
+        locator "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3206675/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/apri.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/apri.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% apri.query.adj — worked applications of the AST-to-platelet ratio index.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a liver-fibrosis workup into an AST, its upper limit
+% of normal, and a platelet count: it `import`s the grounded formulabook, `observe`s the three values, and
+% asks the engine to APPLY the cited APRI formula. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the
+% CPU, with zero model calls.
+%
+% Worked case (AST = 80 IU/L, AST upper limit of normal = 40 IU/L, platelet count = 100 ×10⁹/L):
+% APRI = 80 / 40 / 100 × 100 = 2 / 100 × 100 = 2 — well above the 1.5 threshold for probable cirrhosis.
+% Each query fixes two of the three quantities and asks the engine to recover the third; every answer is
+% exact and the inversions COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli apri.query.adj
+% ============================================================================
+
+import "apri.adj"
+
+% --- APRI: the fibrosis index the AST, its ULN, and the platelets imply (expect 2). -----------------
+observe ast(80)
+observe ast_uln(40)
+observe platelet_count(100)
+? apri(ast, ast_uln, platelet_count)   % expect 2
+
+% --- Inverse: the AST an APRI of 2 implies at the same ULN and platelet count (expect 80). ----------
+observe apri(2)
+? ast(apri, ast_uln, platelet_count)   % expect 80


### PR DESCRIPTION
## APRI — clinical formulabook

Ships **APRI** (AST-to-platelet ratio index) — the simple non-invasive estimate of liver **fibrosis** from AST and platelet count (< 0.5 fibrosis-free, > 1.5 probable cirrhosis; validated in hepatitis B/C) — with **two exact rearrangements** (AST, and platelet count, each recovered from a given APRI and the rest).

Opens the **hepatology domain** and a **new arithmetic shape** — a chained division scaled by a constant (`AST ÷ ULN ÷ platelets × 100`), distinct from the single-ratio, ratio-of-ratios, percentage-sum, and product-over-constant forms already shipped.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from *Noninvasive assessment of liver fibrosis with the aspartate transaminase to platelet ratio index (APRI)* on PubMed Central ([PMC3206675](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3206675/)):

> APRI = (AST level/Upper normal limit for AST / Platelet count (10⁹/L)) × 100

(the canonical ULN-normalised form) carrying `source` / `locator` / `trust authoritative`. The single integer constant (100) keeps outputs clean integers; the engine computes every value **exactly over rationals**.

### Contents
- `apri.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `apri.query.adj` — worked case.
- `formula_apri_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
AST 80, AST ULN 40 IU/L, platelet count 100 ×10⁹/L → APRI = 80/40/100 × 100 = **2** (above the 1.5 cirrhosis threshold). The three formulas compose and invert cleanly. Because the derivation tree holds the 100 constant and the 200/8000 intermediates, the e2e tests assert the **adjacent** `"name":…,"value":…` pair rather than a bare `"value":2`.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)