### PR TITLE
feat(adj-formula-stdlib): Maddrey discriminant function — 4.6 x (PT − control PT) + bilirubin alcoholic-hepatitis severity library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_maddrey_discriminant_function_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_maddrey_discriminant_function_e2e.rs
@@ -1,0 +1,150 @@
+//! End-to-end tests for the `clinical/maddrey-discriminant-function.adj` library — the Maddrey
+//! discriminant function (DF = 4.6 × (patient PT − control PT) + total bilirubin) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same invariant as
+//! every other formula library: a consumer states NO arithmetic; it imports the grounded library, binds
+//! the two prothrombin times and the bilirubin with `observe`, and the engine applies the cited formula on
+//! the CPU, computing the EXACT value (over exact rationals) and rendering the citation and trust tier in
+//! the `derived` section (the auditable answer). The three formulas INVERT around the worked case PT = 25,
+//! control PT = 15, bilirubin = 8: 4.6 × (25 − 15) + 8 = 54 (DF), (54 − 8) / 4.6 + 15 = 25 (PT),
+//! 54 − 4.6 × (25 − 15) = 8 (bilirubin).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation tree contains the 4.6 constant (rendered `"value":4.6`) and the intermediate
+//! 46, so a bare `"value":<short>` could spuriously match a longer number's leading digits. The adjacent
+//! form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped maddrey-discriminant-function library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_mdf_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/maddrey-discriminant-function.adj")
+        .canonicalize()
+        .expect("shipped maddrey-discriminant-function.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_mdf_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_mdf_lib()).unwrap();
+    std::fs::write(dir.join("maddrey-discriminant-function.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// discriminant_function — the score: 4.6 × (patient PT − control PT) + total bilirubin.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_mdf_library_and_computes_it_with_citation() {
+    let dir = scratch("df");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"maddrey-discriminant-function.adj\"\n\
+         observe pt(25)\n\
+         observe control_pt(15)\n\
+         observe tbili(8)\n\
+         ? discriminant_function(pt, control_pt, tbili)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 4.6 × (25 − 15) + 8 = 46 + 8 = 54,
+    // computed EXACTLY over rationals. Match the adjacent name/value pair so the 4.6 constant and the 46
+    // intermediate in the derivation cannot spuriously satisfy a bare "value":54.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"discriminant_function\",\"value\":54"),
+        "discriminant_function(25, 15, 8) = 54: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// pt — the same equation solved for the patient prothrombin time:
+// (DF − total bilirubin) / 4.6 + control PT.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_pt_from_mdf_with_citation() {
+    let dir = scratch("pt");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"maddrey-discriminant-function.adj\"\n\
+         observe discriminant_function(54)\n\
+         observe control_pt(15)\n\
+         observe tbili(8)\n\
+         ? pt(discriminant_function, control_pt, tbili)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (54 − 8) / 4.6 + 15 = 46 / 4.6 + 15 = 10 + 15 = 25, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"pt\",\"value\":25"),
+        "pt(54, 15, 8) = 25: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "pt carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tbili — the same equation solved for the total bilirubin: DF − 4.6 × (patient PT − control PT), the
+// third reading of the one score.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_tbili_from_mdf_with_citation() {
+    let dir = scratch("tbili");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"maddrey-discriminant-function.adj\"\n\
+         observe discriminant_function(54)\n\
+         observe pt(25)\n\
+         observe control_pt(15)\n\
+         ? tbili(discriminant_function, pt, control_pt)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 54 − 4.6 × (25 − 15) = 54 − 46 = 8, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"tbili\",\"value\":8"),
+        "tbili(54, 25, 15) = 8: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "tbili carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/maddrey-discriminant-function.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/maddrey-discriminant-function.adj
@@ -1,0 +1,95 @@
+% ============================================================================
+% maddrey-discriminant-function.adj — the Maddrey discriminant function
+% (DF = 4.6 × (patient PT − control PT) + total bilirubin) in the ADJ standard library.
+% ============================================================================
+% The Maddrey-discriminant-function entry of the *clinical* track — the 1977 severity score for
+% ALCOHOL-ASSOCIATED HEPATITIS that decides whether a patient is sick enough to warrant corticosteroids.
+% It combines the two labs that track how badly the liver is failing acutely: the prothrombin time (how
+% far coagulation-factor synthesis has fallen, measured against the lab's control PT) and the total serum
+% bilirubin (how far excretion has fallen). A value of 32 or more marks severe disease with a roughly
+% 50% 28-day mortality — the threshold at which steroids are considered. THE DISCRIMINANT FUNCTION IS 4.6
+% TIMES THE PATIENT'S PROTHROMBIN TIME MINUS THE CONTROL PROTHROMBIN TIME, PLUS THE TOTAL BILIRUBIN —
+% i.e. 4.6 × (patient PT − control PT) + total bilirubin. It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its two exact rearrangements (the patient prothrombin time a given
+% DF implies, and the total bilirubin a given DF implies). As with every compute library, a consumer states
+% NO arithmetic: it `import`s this file, binds the two prothrombin times and the bilirubin from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "maddrey-discriminant-function.adj"
+%     observe pt(25)          % "…PT 25 s…"           (span cited by the model)
+%     observe control_pt(15)   % "…control PT 15 s…"   (span cited by the model)
+%     observe tbili(8)         % "…bilirubin 8…"       (span cited by the model)
+%     ? discriminant_function(pt, control_pt, tbili)   % engine → 54 (severe, ≥ 32)
+%
+% Structurally this is a CONSTANT-SCALED DIFFERENCE PLUS A TERM — the fixed 4.6 coefficient times the
+% prolongation of the prothrombin time (patient minus control), plus the bilirubin — a shape distinct from
+% the ratio, ratio-of-ratios, percentage-sum, product-over-constant, and chained-division forms of the
+% other clinical libraries. The 4.6 coefficient is the EXACT constant of the cited formula (not a
+% measurement); the formula is otherwise an exact expression over the three measured quantities, so every
+% value the engine returns is exact. The three formulas COMPOSE and invert cleanly around the worked case
+% patient PT = 25 s, control PT = 15 s, total bilirubin = 8 (DF = 4.6 × (25 − 15) + 8 = 46 + 8 = 54, well
+% above the 32 severe-disease threshold): the `discriminant_function` a consumer computes is exactly the
+% value each inverse formula back-solves to recover its own measured input (25, 8).
+%
+%   discriminant_function(pt, control_pt, tbili) = 4.6 * (pt - control_pt) + tbili   % (score)
+%   pt(discriminant_function, control_pt, tbili) = (discriminant_function - tbili) / 4.6 + control_pt   % (solved for patient PT)
+%   tbili(discriminant_function, pt, control_pt) = discriminant_function - 4.6 * (pt - control_pt)   % (solved for total bilirubin)
+%
+% NOTE ON UNITS AND MODELLING: the two prothrombin times are in seconds and the total bilirubin is in
+% mg/dL, as the cited (US-unit) form of the equation prints it (a μmol/L form divides the bilirubin by an
+% extra factor; this library grounds the mg/dL form exactly as printed). The discriminant function is a
+% plain dimensionless score. This library only COMPUTES the score; the interpretation (≥ 32 marking severe
+% disease and prompting consideration of corticosteroids) is stated by the cited source but is applied by
+% the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted discriminant-function equation — because
+% that one equation (4.6 × (patient PT − control PT) + total bilirubin) sanctions the relation read every
+% way. The quote is transcribed verbatim from the review article "Prognostic and diagnostic scoring models
+% in acute alcohol-associated hepatitis" on PubMed Central (a current, freely available NCBI-hosted
+% article), so each `formula` carries the provenance envelope every shipped grounded clause carries; the
+% linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula, including its 4.6
+% constant, is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `pt`, `control_pt`, `tbili` and `discriminant_function` each appear BOTH as a derived result
+% and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary maddrey_discriminant_function_vocab {
+    define pt                     : finding  surface "PT", "prothrombin time", "patient PT", "patient prothrombin time"  % seconds
+    define control_pt             : finding  surface "control PT", "control prothrombin time", "reference PT"            % seconds
+    define tbili                  : finding  surface "total bilirubin", "TBili", "serum bilirubin", "bilirubin"          % mg/dL
+    define discriminant_function  : finding  surface "discriminant function", "Maddrey discriminant function", "mDF", "MDF"  % score
+}
+
+% ----------------------------------------------------------------------------
+% The Maddrey discriminant function, three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the discriminant-function equation from the
+% cited PubMed Central review article (a quote is required on a shipped formula). Each is an exact
+% expression in the measured values and the cited 4.6 constant, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook maddrey_discriminant_function_laws {
+    use maddrey_discriminant_function_vocab
+
+    % Discriminant function — 4.6 times the prothrombin-time prolongation, plus the bilirubin.
+    formula discriminant_function(pt, control_pt, tbili) = 4.6 * (pt - control_pt) + tbili
+        source "Discriminant Function = 4.6 × (Pt's PT-control PT) + TBili"
+        locator "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10494564/"
+        trust authoritative
+
+    % Patient prothrombin time — the same equation solved for the patient PT. Defended by the SAME equation.
+    formula pt(discriminant_function, control_pt, tbili) = (discriminant_function - tbili) / 4.6 + control_pt
+        source "Discriminant Function = 4.6 × (Pt's PT-control PT) + TBili"
+        locator "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10494564/"
+        trust authoritative
+
+    % Total bilirubin — the same equation solved for the bilirubin, the third reading of the one score.
+    formula tbili(discriminant_function, pt, control_pt) = discriminant_function - 4.6 * (pt - control_pt)
+        source "Discriminant Function = 4.6 × (Pt's PT-control PT) + TBili"
+        locator "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10494564/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/maddrey-discriminant-function.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/maddrey-discriminant-function.query.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% maddrey-discriminant-function.query.adj — worked applications of the Maddrey DF.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an alcohol-associated-hepatitis assessment into a
+% patient prothrombin time, a control prothrombin time, and a total bilirubin: it `import`s the grounded
+% formulabook, `observe`s the three values, and asks the engine to APPLY the cited discriminant-function
+% formula. No arithmetic is stated by the consumer; the engine computes each value EXACTLY (over exact
+% rationals) and carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (patient PT = 25 s, control PT = 15 s, total bilirubin = 8 mg/dL):
+% discriminant function = 4.6 × (25 − 15) + 8 = 4.6 × 10 + 8 = 46 + 8 = 54 — well above 32, marking severe
+% disease and prompting consideration of corticosteroids. Each query fixes two of the three quantities and
+% asks the engine to recover the third; every answer is exact and the inversions COMPOSE (each recovers
+% exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli maddrey-discriminant-function.query.adj
+% ============================================================================
+
+import "maddrey-discriminant-function.adj"
+
+% --- DF: the discriminant function the PTs and bilirubin imply (expect 54). -------------------------
+observe pt(25)
+observe control_pt(15)
+observe tbili(8)
+? discriminant_function(pt, control_pt, tbili)   % expect 54
+
+% --- Inverse: the patient PT a DF of 54 implies at the same control PT and bilirubin (expect 25). ---
+observe discriminant_function(54)
+? pt(discriminant_function, control_pt, tbili)   % expect 25


### PR DESCRIPTION
## Maddrey discriminant function — clinical formulabook

Ships the **Maddrey discriminant function** — the 1977 severity score for **alcohol-associated hepatitis** (≥ 32 marks severe disease, ~50% 28-day mortality — the threshold for considering corticosteroids) — with **two exact rearrangements** (patient prothrombin time, and total bilirubin, each recovered from a given DF and the rest).

A **new arithmetic shape** for the library — a constant-scaled difference plus a term (`4.6 × (a − b) + c`), distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant, and chained-division forms already shipped.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from the review *Prognostic and diagnostic scoring models in acute alcohol-associated hepatitis* on PubMed Central ([PMC10494564](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10494564/)):

> Discriminant Function = 4.6 × (Pt's PT-control PT) + TBili

(the mg/dL form as printed) carrying `source` / `locator` / `trust authoritative`. The 4.6 coefficient is dyadic-safe for integer worked cases (4.6 × 10 = 46), so outputs render as clean integers; the engine computes every value **exactly over rationals**.

### Contents
- `maddrey-discriminant-function.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `maddrey-discriminant-function.query.adj` — worked case.
- `formula_maddrey_discriminant_function_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
patient PT 25 s, control PT 15 s, total bilirubin 8 mg/dL → DF = 4.6 × (25 − 15) + 8 = 46 + 8 = **54** (severe). The three formulas compose and invert cleanly. Because the derivation tree holds the 4.6 constant and the 46 intermediate, the e2e tests assert the **adjacent** `"name":…,"value":…` pair.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)