### PR TITLE
feat(adj-formula-stdlib): oxygen delivery — DO2 = CO × CaO2 × 10 critical-care library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_oxygen_delivery_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_oxygen_delivery_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end tests for the `clinical/oxygen-delivery.adj` library — global oxygen delivery
+//! (DO2 = cardiac output × arterial oxygen content × 10) and its two exact rearrangements — driven through
+//! the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a
+//! consumer states NO arithmetic; it imports the grounded library, binds the cardiac output and the
+//! arterial oxygen content with `observe`, and the engine applies the cited formula on the CPU, computing
+//! the EXACT value (over exact rationals) and rendering the citation and trust tier in the `derived`
+//! section (the auditable answer). The three formulas INVERT around the worked case CO = 5, CaO2 = 20:
+//! 5 × 20 × 10 = 1000 (DO2), 1000 / (20 × 10) = 5 (CO), 1000 / (5 × 10) = 20 (CaO2).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation tree contains the 10 constant and the intermediate 200, so a bare
+//! `"value":20` could spuriously match the leading digits of `200`. The adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped oxygen-delivery library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_do2_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/oxygen-delivery.adj")
+        .canonicalize()
+        .expect("shipped oxygen-delivery.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_do2_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_do2_lib()).unwrap();
+    std::fs::write(dir.join("oxygen-delivery.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// do2 — the delivery: cardiac output × arterial oxygen content × 10.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_oxygen_delivery_library_and_computes_it_with_citation() {
+    let dir = scratch("do2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"oxygen-delivery.adj\"\n\
+         observe cardiac_output(5)\n\
+         observe arterial_oxygen_content(20)\n\
+         ? do2(cardiac_output, arterial_oxygen_content)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 5 × 20 × 10 = 1000, computed EXACTLY
+    // over rationals. Match the adjacent name/value pair so the 10 constant and the 200 intermediate in the
+    // derivation cannot spuriously satisfy a bare "value":1000.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"do2\",\"value\":1000"),
+        "do2(5, 20) = 1000: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// cardiac_output — the same equation solved for the cardiac output: DO2 / (CaO2 × 10).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_cardiac_output_from_do2_with_citation() {
+    let dir = scratch("co");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"oxygen-delivery.adj\"\n\
+         observe do2(1000)\n\
+         observe arterial_oxygen_content(20)\n\
+         ? cardiac_output(do2, arterial_oxygen_content)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 1000 / (20 × 10) = 1000 / 200 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"cardiac_output\",\"value\":5"),
+        "cardiac_output(1000, 20) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "cardiac_output carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// arterial_oxygen_content — the same equation solved for the content: DO2 / (CO × 10), the third reading
+// of the one delivery.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_arterial_oxygen_content_from_do2_with_citation() {
+    let dir = scratch("cao2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"oxygen-delivery.adj\"\n\
+         observe do2(1000)\n\
+         observe cardiac_output(5)\n\
+         ? arterial_oxygen_content(do2, cardiac_output)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 1000 / (5 × 10) = 1000 / 50 = 20, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"arterial_oxygen_content\",\"value\":20"),
+        "arterial_oxygen_content(1000, 5) = 20: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "arterial_oxygen_content carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/oxygen-delivery.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/oxygen-delivery.adj
@@ -1,0 +1,94 @@
+% ============================================================================
+% oxygen-delivery.adj — global oxygen delivery
+% (DO2 = cardiac output × arterial oxygen content × 10) in the ADJ standard library.
+% ============================================================================
+% The oxygen-delivery entry of the *clinical* track — the amount of oxygen the circulation carries to the
+% tissues each minute, the central quantity of goal-directed resuscitation in critically ill and high-risk
+% surgical patients. It is the product of how much blood the heart pumps per minute (the cardiac output)
+% and how much oxygen each unit of that blood carries (the arterial oxygen content), with a factor of 10
+% that reconciles the units (arterial oxygen content is quoted per 100 mL of blood, cardiac output per
+% litre). Because it couples circulation and oxygenation in one number, DO2 is the therapeutic target that
+% falls in shock and that resuscitation aims to restore. THE OXYGEN DELIVERY IS THE CARDIAC OUTPUT TIMES
+% THE ARTERIAL OXYGEN CONTENT TIMES 10 — i.e. DO2 = CO × CaO2 × 10. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the cardiac output
+% a given DO2 implies at a known oxygen content, and the arterial oxygen content a given DO2 implies at a
+% known cardiac output). As with every compute library, a consumer states NO arithmetic: it `import`s this
+% file, binds the cardiac output and the arterial oxygen content from its own byte-provenance decomposition,
+% and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "oxygen-delivery.adj"
+%     observe cardiac_output(5)             % "…CO 5 L/min…"       (span cited by the model)
+%     observe arterial_oxygen_content(20)   % "…CaO2 20 mL/dL…"    (span cited by the model)
+%     ? do2(cardiac_output, arterial_oxygen_content)   % engine → 1000 (mL/min)
+%
+% Structurally this is a PRODUCT OF TWO MEASURED QUANTITIES SCALED BY A CONSTANT — the cardiac output times
+% the arterial oxygen content times the fixed unit factor of 10 — a shape distinct from the ratio,
+% ratio-of-ratios, percentage-sum, product-over-constant, chained-division, and constant-scaled-difference
+% forms of the other clinical libraries. The arterial oxygen content is taken here as a single measured
+% input (a consumer that needs to compute it in turn from haemoglobin, saturation, and PaO2 would use a
+% separate content formula); the 10 is the EXACT unit-reconciling constant of the cited formula, so every
+% value the engine returns is exact. The three formulas COMPOSE and invert cleanly around the worked case
+% cardiac output = 5 L/min, arterial oxygen content = 20 mL/dL (DO2 = 5 × 20 × 10 = 1000 mL/min, a normal
+% value): the `do2` a consumer computes is exactly the value each inverse formula back-solves to recover
+% its own measured input (5, 20).
+%
+%   do2(cardiac_output, arterial_oxygen_content) = cardiac_output * arterial_oxygen_content * 10   % (mL/min)
+%   cardiac_output(do2, arterial_oxygen_content) = do2 / (arterial_oxygen_content * 10)             % (solved for CO)
+%   arterial_oxygen_content(do2, cardiac_output) = do2 / (cardiac_output * 10)                      % (solved for CaO2)
+%
+% NOTE ON UNITS AND MODELLING: the cardiac output is in litres per minute (L/min), the arterial oxygen
+% content in millilitres of O2 per decilitre of blood (mL/dL), and the resulting oxygen delivery in
+% millilitres of O2 per minute (mL/min); the factor of 10 converts the per-decilitre content to a
+% per-litre basis so the product matches the cardiac output's per-litre volume. DO2 is a rate of oxygen
+% delivery. This library only COMPUTES the delivery; the interpretation (a target that falls in shock and
+% guides resuscitation) is stated by the cited source but is applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted oxygen-delivery equation — because that
+% one equation (CO × CaO2 × 10) sanctions the relation read every way. The quote is transcribed verbatim
+% from the article "Non-invasive monitoring of oxygen delivery in acutely ill patients: new frontiers" on
+% PubMed Central (a current, freely available NCBI-hosted article), so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula, including its 10 constant, is a verbatim span of the cited
+% page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `cardiac_output`, `arterial_oxygen_content` and `do2` each appear BOTH as a derived result
+% and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary oxygen_delivery_vocab {
+    define cardiac_output           : finding  surface "cardiac output", "CO"                                    % L/min
+    define arterial_oxygen_content  : finding  surface "arterial oxygen content", "CaO2", "arterial O2 content"  % mL/dL
+    define do2                      : finding  surface "oxygen delivery", "DO2", "global oxygen delivery"        % mL/min
+}
+
+% ----------------------------------------------------------------------------
+% Oxygen delivery, three ways. Each is a named, importable, reusable formula over its formal parameters,
+% bound at apply time, and each carries the oxygen-delivery equation from the cited PubMed Central article
+% (a quote is required on a shipped formula). Each is an exact expression in the measured values and the
+% cited 10 constant, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook oxygen_delivery_laws {
+    use oxygen_delivery_vocab
+
+    % Oxygen delivery — the cardiac output times the arterial oxygen content times 10.
+    formula do2(cardiac_output, arterial_oxygen_content) = cardiac_output * arterial_oxygen_content * 10
+        source "DO2 = CO × CaO2 × 10"
+        locator "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4573965/"
+        trust authoritative
+
+    % Cardiac output — the same equation solved for the CO. Defended by the SAME equation.
+    formula cardiac_output(do2, arterial_oxygen_content) = do2 / (arterial_oxygen_content * 10)
+        source "DO2 = CO × CaO2 × 10"
+        locator "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4573965/"
+        trust authoritative
+
+    % Arterial oxygen content — the same equation solved for the CaO2, the third reading of the one delivery.
+    formula arterial_oxygen_content(do2, cardiac_output) = do2 / (cardiac_output * 10)
+        source "DO2 = CO × CaO2 × 10"
+        locator "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4573965/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/oxygen-delivery.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/oxygen-delivery.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% oxygen-delivery.query.adj — worked applications of global oxygen delivery.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a haemodynamic assessment into a cardiac output and
+% an arterial oxygen content: it `import`s the grounded formulabook, `observe`s the two values, and asks the
+% engine to APPLY the cited oxygen-delivery formula. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the
+% CPU, with zero model calls.
+%
+% Worked case (cardiac output = 5 L/min, arterial oxygen content = 20 mL/dL):
+% oxygen delivery = 5 × 20 × 10 = 1000 mL/min — a normal global oxygen delivery. Each query fixes two of
+% the three quantities and asks the engine to recover the third; every answer is exact and the inversions
+% COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli oxygen-delivery.query.adj
+% ============================================================================
+
+import "oxygen-delivery.adj"
+
+% --- DO2: the oxygen delivery the cardiac output and content imply (expect 1000). -------------------
+observe cardiac_output(5)
+observe arterial_oxygen_content(20)
+? do2(cardiac_output, arterial_oxygen_content)   % expect 1000
+
+% --- Inverse: the cardiac output a DO2 of 1000 implies at the same content (expect 5). --------------
+observe do2(1000)
+? cardiac_output(do2, arterial_oxygen_content)   % expect 5


### PR DESCRIPTION
## Global oxygen delivery (DO₂) — clinical formulabook

Ships **global oxygen delivery (DO₂)** — the oxygen the circulation carries to the tissues per minute, the central target of goal-directed resuscitation in critically ill and high-risk surgical patients — with **two exact rearrangements** (cardiac output, and arterial oxygen content, each recovered from a given DO₂ and the other).

Opens the **critical-care / haemodynamics** domain and a **new arithmetic shape** — a product of two measured quantities scaled by a constant (`a × b × 10`), distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant, chained-division, and constant-scaled-difference forms already shipped.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from *Non-invasive monitoring of oxygen delivery in acutely ill patients: new frontiers* on PubMed Central ([PMC4573965](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4573965/)):

> DO2 = CO × CaO2 × 10

carrying `source` / `locator` / `trust authoritative`. The single integer constant (10) keeps outputs clean integers; the engine computes every value **exactly over rationals**. (Arterial oxygen content is taken as a single measured input here — a consumer needing to compute it in turn would use a separate content formula.)

### Contents
- `oxygen-delivery.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `oxygen-delivery.query.adj` — worked case.
- `formula_oxygen_delivery_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
cardiac output 5 L/min, arterial oxygen content 20 mL/dL → DO₂ = 5 × 20 × 10 = **1000 mL/min** (normal). The three formulas compose and invert cleanly. Because the derivation tree holds the 10 constant and the 200 intermediate, the e2e tests assert the **adjacent** `"name":…,"value":…` pair.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)