### PR TITLE
feat(adj-formula-stdlib): maintenance dose — MD = SSC·CL·DI/B pharmacokinetic dosing library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_maintenance_dose_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_maintenance_dose_e2e.rs
@@ -1,0 +1,151 @@
+//! End-to-end tests for the `clinical/maintenance-dose.adj` library — the pharmacokinetic maintenance dose
+//! (MD = steady-state concentration × clearance × dosing interval / bioavailability) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same invariant as
+//! every other formula library: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! four pharmacokinetic quantities with `observe`, and the engine applies the cited formula on the CPU,
+//! computing the EXACT value (over exact rationals) and rendering the citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case SSC = 10,
+//! CL = 5, DI = 8, B = 1: 10 × 5 × 8 / 1 = 400 (MD), 400 × 1 / (5 × 8) = 10 (SSC), 400 × 1 / (10 × 8) = 5
+//! (CL).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation tree contains the intermediates 40 and 80 (and the B = 1 input), so a bare
+//! `"value":40`-style substring could spuriously match the leading digits of a longer number. The adjacent
+//! form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped maintenance-dose library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_md_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/maintenance-dose.adj")
+        .canonicalize()
+        .expect("shipped maintenance-dose.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_md_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_md_lib()).unwrap();
+    std::fs::write(dir.join("maintenance-dose.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// md — the dose: SSC × CL × DI / B.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_maintenance_dose_library_and_computes_it_with_citation() {
+    let dir = scratch("md");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"maintenance-dose.adj\"\n\
+         observe ssc(10)\n\
+         observe cl(5)\n\
+         observe di(8)\n\
+         observe b(1)\n\
+         ? md(ssc, cl, di, b)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 10 × 5 × 8 / 1 = 400, computed
+    // EXACTLY over rationals. Match the adjacent name/value pair so intermediates in the derivation cannot
+    // spuriously satisfy a bare "value":400.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"md\",\"value\":400"),
+        "md(10, 5, 8, 1) = 400: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ssc — the same equation solved for the steady-state concentration: MD × B / (CL × DI).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_ssc_from_maintenance_dose_with_citation() {
+    let dir = scratch("ssc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"maintenance-dose.adj\"\n\
+         observe md(400)\n\
+         observe cl(5)\n\
+         observe di(8)\n\
+         observe b(1)\n\
+         ? ssc(md, cl, di, b)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 400 × 1 / (5 × 8) = 400 / 40 = 10, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"ssc\",\"value\":10"),
+        "ssc(400, 5, 8, 1) = 10: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "ssc carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// cl — the same equation solved for the clearance: MD × B / (SSC × DI), the third reading of the one dose.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_cl_from_maintenance_dose_with_citation() {
+    let dir = scratch("cl");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"maintenance-dose.adj\"\n\
+         observe md(400)\n\
+         observe ssc(10)\n\
+         observe di(8)\n\
+         observe b(1)\n\
+         ? cl(md, ssc, di, b)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 400 × 1 / (10 × 8) = 400 / 80 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"cl\",\"value\":5"),
+        "cl(400, 10, 8, 1) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "cl carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/maintenance-dose.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/maintenance-dose.adj
@@ -1,0 +1,96 @@
+% ============================================================================
+% maintenance-dose.adj — the pharmacokinetic maintenance dose
+% (MD = steady-state concentration × clearance × dosing interval / bioavailability) in the ADJ standard library.
+% ============================================================================
+% The maintenance-dose entry of the *clinical* track — the amount of drug to give each dosing interval to
+% hold a chosen steady-state concentration. At steady state the amount delivered per interval must exactly
+% replace the amount the body clears over that interval, so the dose scales with how fast the drug is
+% cleared (the clearance), how long the interval is (a longer interval means more is cleared before the
+% next dose), and the target concentration, and is divided by the bioavailability because only that fraction
+% of an administered dose reaches the circulation (an oral drug with 50% bioavailability needs twice the IV
+% dose). It is the companion of the loading dose (loading-dose.adj, which fills the volume of distribution
+% once): the loading dose gets the concentration up, the maintenance dose keeps it there. THE MAINTENANCE
+% DOSE IS THE STEADY-STATE CONCENTRATION TIMES THE CLEARANCE TIMES THE DOSING INTERVAL, DIVIDED BY THE
+% BIOAVAILABILITY — i.e. MD = SSC × CL × DI / B. It ships as an importable, byte-provenanced, PARAMETERIZED
+% `formula`, together with two exact rearrangements (the steady-state concentration a given dose achieves,
+% and the clearance a given dose implies). As with every compute library, a consumer states NO arithmetic:
+% it `import`s this file, binds the target concentration, clearance, interval, and bioavailability from its
+% own byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "maintenance-dose.adj"
+%     observe ssc(10)   % "…target 10 mg/L…"     (span cited by the model)
+%     observe cl(5)      % "…clearance 5 L/h…"    (span cited by the model)
+%     observe di(8)      % "…every 8 hours…"      (span cited by the model)
+%     observe b(1)       % "…IV, F = 1…"          (span cited by the model)
+%     ? md(ssc, cl, di, b)   % engine → 400 (mg)
+%
+% Structurally this is a THREE-WAY PRODUCT OVER A SINGLE DIVISOR — the target concentration, clearance, and
+% interval multiplied, then divided by the bioavailability — a shape distinct from the ratio,
+% ratio-of-ratios, percentage-sum, product-over-constant, chained-division, constant-scaled-difference, and
+% product-times-constant forms of the other clinical libraries. There is NO embedded constant: all four
+% quantities are formal parameters bound at apply time (the cited equation is stated with these as symbols),
+% so every value the engine returns is exact. The three formulas COMPOSE and invert cleanly around the
+% worked case steady-state concentration = 10, clearance = 5, dosing interval = 8, bioavailability = 1
+% (MD = 10 × 5 × 8 / 1 = 400): the `md` a consumer computes is exactly the value each inverse formula
+% back-solves to recover its own measured input (10, 5).
+%
+%   md(ssc, cl, di, b) = ssc * cl * di / b        % (dose per interval)
+%   ssc(md, cl, di, b) = md * b / (cl * di)        % (solved for the steady-state concentration)
+%   cl(md, ssc, di, b) = md * b / (ssc * di)       % (solved for the clearance)
+%
+% NOTE ON UNITS AND MODELLING: the units must be internally consistent — with clearance in L/h, the dosing
+% interval in h, and the target concentration in mg/L, the dose comes out in mg; bioavailability is a
+% dimensionless fraction between 0 and 1 (1 for a fully-absorbed or intravenous drug). This library only
+% COMPUTES the dose; choosing the target concentration and confirming it against the therapeutic window is
+% the clinician's judgement, stated by the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted maintenance-dose equation — because that
+% one equation (SSC × CL × DI / B) sanctions the relation read every way. The quote is transcribed verbatim
+% from the StatPearls "Steady State Concentration" article on the NCBI Bookshelf (a current, non-archived
+% article), so each `formula` carries the provenance envelope every shipped grounded clause carries; the
+% linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula is a verbatim span of
+% the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `ssc`, `cl`, `di`, `b` and `md` each appear BOTH as a derived result and as an input (of the
+% other formulas), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary maintenance_dose_vocab {
+    define ssc  : finding  surface "steady-state concentration", "SSC", "Css", "target concentration"    % mg/L
+    define cl   : finding  surface "clearance", "CL", "drug clearance"                                    % L/h
+    define di   : finding  surface "dosing interval", "DI", "dose interval"                               % h
+    define b    : finding  surface "bioavailability", "B", "F"                                            % fraction 0-1
+    define md   : finding  surface "maintenance dose", "MD"                                               % mg
+}
+
+% ----------------------------------------------------------------------------
+% The maintenance dose, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the maintenance-dose equation from the StatPearls
+% "Steady State Concentration" article on the NCBI Bookshelf (a quote is required on a shipped formula).
+% Each is an exact expression in the parameters, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook maintenance_dose_laws {
+    use maintenance_dose_vocab
+
+    % Maintenance dose — target concentration times clearance times interval, over bioavailability.
+    formula md(ssc, cl, di, b) = ssc * cl * di / b
+        source "MD = SSC•CL•DI/B"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553132/"
+        trust authoritative
+
+    % Steady-state concentration — the same equation solved for SSC. Defended by the SAME equation.
+    formula ssc(md, cl, di, b) = md * b / (cl * di)
+        source "MD = SSC•CL•DI/B"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553132/"
+        trust authoritative
+
+    % Clearance — the same equation solved for the clearance, the third reading of the one dose.
+    formula cl(md, ssc, di, b) = md * b / (ssc * di)
+        source "MD = SSC•CL•DI/B"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553132/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/maintenance-dose.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/maintenance-dose.query.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% maintenance-dose.query.adj — worked applications of the pharmacokinetic maintenance dose.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a dosing problem into a target steady-state
+% concentration, a clearance, a dosing interval, and a bioavailability: it `import`s the grounded
+% formulabook, `observe`s the four values, and asks the engine to APPLY the cited maintenance-dose formula.
+% No arithmetic is stated by the consumer; the engine computes each value EXACTLY (over exact rationals) and
+% carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (target steady-state concentration = 10 mg/L, clearance = 5 L/h, dosing interval = 8 h,
+% bioavailability = 1 for an intravenous drug): maintenance dose = 10 × 5 × 8 / 1 = 400 mg every 8 hours.
+% Each query fixes three of the four inputs and asks the engine to recover another quantity; every answer
+% is exact and the inversions COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli maintenance-dose.query.adj
+% ============================================================================
+
+import "maintenance-dose.adj"
+
+% --- MD: the maintenance dose the target, clearance, interval, and F imply (expect 400). ------------
+observe ssc(10)
+observe cl(5)
+observe di(8)
+observe b(1)
+? md(ssc, cl, di, b)   % expect 400
+
+% --- Inverse: the steady-state concentration a 400 mg dose achieves at the same CL, DI, F (expect 10). -
+observe md(400)
+? ssc(md, cl, di, b)   % expect 10


### PR DESCRIPTION
## Pharmacokinetic maintenance dose — clinical formulabook

Ships the **maintenance dose** — the amount to give each dosing interval to hold a target steady-state concentration — with **two exact rearrangements** (steady-state concentration, and clearance, each recovered from a given dose and the rest).

**Companion of the shipped loading-dose library:** loading fills the volume of distribution once to reach the concentration; maintenance replaces per-interval clearance to keep it there.

A **new arithmetic shape** for the library — a three-way product over a single divisor (`(a·b·c)/d`), distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant, chained-division, constant-scaled-difference, and product-times-constant forms already shipped. **No embedded constant** — all four quantities are parameters.

### Grounding (byte-provenance)
Every formula quotes the **verbatim** equation, as typed text, from the StatPearls *Steady State Concentration* article (NCBI Bookshelf [NBK553132](https://www.ncbi.nlm.nih.gov/books/NBK553132/)):

> MD = SSC•CL•DI/B

carrying `source` / `locator` / `trust authoritative`. Exact expression — the engine computes every value **exactly over rationals**.

### Contents
- `maintenance-dose.adj` — dictionary + formulabook (forward + 2 exact inversions).
- `maintenance-dose.query.adj` — worked case.
- `formula_maintenance_dose_e2e.rs` — **3 e2e tests**, dedicated file (no shared-anchor conflict).

### Worked case
target SSC 10 mg/L, clearance 5 L/h, dosing interval 8 h, bioavailability 1 (IV) → MD = 10 × 5 × 8 / 1 = **400 mg**. The three formulas compose and invert cleanly. Because the derivation tree holds the 40/80 intermediates, the e2e tests assert the **adjacent** `"name":…,"value":…` pair.

Data + test only; **no version bump**. Clippy clean, security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)