### PR TITLE
feat(adj-formula-stdlib): iv-drip-rate — gravity IV infusion drip rate ([volume/time] × drop factor) library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_iv_drip_rate_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_iv_drip_rate_e2e.rs
@@ -1,0 +1,149 @@
+//! End-to-end tests for the `clinical/iv-drip-rate.adj` library — the gravity IV infusion drip rate
+//! (drops per minute = [total IV volume / time] × drop factor) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula
+//! library: a consumer states NO arithmetic; it imports the grounded library, binds the total volume, the
+//! time in minutes, and the giving-set drop factor with `observe`, and the engine applies the cited formula
+//! on the CPU, computing the EXACT value (over exact rationals) and rendering the citation and trust tier in
+//! the `derived` section (the auditable answer). The three formulas INVERT around the worked case
+//! volume = 1000, time = 100, drop factor = 15: 1000 / 100 × 15 = 150 (drops/min),
+//! 150 × 100 / 15 = 1000 (volume), 150 × 100 / 1000 = 15 (drop factor).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation tree contains the intermediate 10 (= 1000 / 100) and the drop-factor input
+//! 15, and `"value":15` is a leading-digit prefix of `"value":150`, so a bare substring could spuriously
+//! match. The adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped iv-drip-rate library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_drip_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/iv-drip-rate.adj")
+        .canonicalize()
+        .expect("shipped iv-drip-rate.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_drip_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_drip_lib()).unwrap();
+    std::fs::write(dir.join("iv-drip-rate.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// drops_per_minute — the drip rate: [total IV volume / time] × drop factor.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_iv_drip_rate_library_and_computes_it_with_citation() {
+    let dir = scratch("dpm");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"iv-drip-rate.adj\"\n\
+         observe total_iv_volume(1000)\n\
+         observe infusion_time(100)\n\
+         observe drop_factor(15)\n\
+         ? drops_per_minute(total_iv_volume, infusion_time, drop_factor)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 1000 / 100 × 15 = 150, computed
+    // EXACTLY over rationals. Match the adjacent name/value pair so the 10 intermediate and the 15 input in
+    // the derivation cannot spuriously satisfy a bare "value":150.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"drops_per_minute\",\"value\":150"),
+        "drops_per_minute(1000, 100, 15) = 150: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// total_iv_volume — the same equation solved for the volume: drops/min × time / drop factor.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_total_iv_volume_from_drip_rate_with_citation() {
+    let dir = scratch("vol");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"iv-drip-rate.adj\"\n\
+         observe drops_per_minute(150)\n\
+         observe infusion_time(100)\n\
+         observe drop_factor(15)\n\
+         ? total_iv_volume(drops_per_minute, infusion_time, drop_factor)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 150 × 100 / 15 = 15000 / 15 = 1000, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"total_iv_volume\",\"value\":1000"),
+        "total_iv_volume(150, 100, 15) = 1000: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "total_iv_volume carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// drop_factor — the same equation solved for the drop factor: drops/min × time / volume, the third
+// reading of the one rate.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_drop_factor_from_drip_rate_with_citation() {
+    let dir = scratch("df");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"iv-drip-rate.adj\"\n\
+         observe drops_per_minute(150)\n\
+         observe total_iv_volume(1000)\n\
+         observe infusion_time(100)\n\
+         ? drop_factor(drops_per_minute, total_iv_volume, infusion_time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 150 × 100 / 1000 = 15000 / 1000 = 15, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"drop_factor\",\"value\":15"),
+        "drop_factor(150, 1000, 100) = 15: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "drop_factor carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/iv-drip-rate.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/iv-drip-rate.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% iv-drip-rate.adj — the gravity IV infusion drip rate
+% (drops per minute = [total IV volume / time] × drop factor) in the ADJ standard library.
+% ============================================================================
+% The IV-drip-rate entry of the *clinical* track — the number of drops per minute a nurse counts to run a
+% gravity (roller-clamp) intravenous infusion at the ordered rate. A gravity set has no pump, so the flow
+% is regulated by eye: the ordered volume over the ordered time gives a millilitre-per-minute rate, and the
+% tubing's DROP FACTOR (how many drops the particular giving-set delivers per millilitre — commonly 10, 15,
+% or 20 for macrodrip sets, 60 for microdrip) converts that volume rate into a countable drops-per-minute
+% rate. THE DRIP RATE IS THE TOTAL IV VOLUME DIVIDED BY THE TIME IN MINUTES, TIMES THE DROP FACTOR — i.e.
+% drops per minute = [total IV volume / time] × drop factor. It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with two exact rearrangements (the total volume a given drip rate
+% delivers, and the drop factor a given drip rate implies). As with every compute library, a consumer
+% states NO arithmetic: it `import`s this file, binds the ordered volume, the time, and the set's drop
+% factor from its own byte-provenance decomposition, and asks the engine to APPLY the cited formula on the
+% CPU. Zero math is performed by the model; the engine computes each value EXACTLY (over exact rationals),
+% carrying the formula's citation.
+%
+%     import "iv-drip-rate.adj"
+%     observe total_iv_volume(1000)   % "…1000 mL…"        (span cited by the model)
+%     observe infusion_time(100)       % "…over 100 min…"   (span cited by the model)
+%     observe drop_factor(15)          % "…15 gtt/mL set…"  (span cited by the model)
+%     ? drops_per_minute(total_iv_volume, infusion_time, drop_factor)   % engine → 150 (gtt/min)
+%
+% Structurally this is a PRODUCT OF A RATIO AND A VALUE — the volume-per-time rate scaled by the drop
+% factor — a shape distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant,
+% chained-division, constant-scaled-difference, product-times-constant, and three-way-product-over-divisor
+% forms of the other clinical libraries. There is NO embedded constant: the volume, time, and drop factor
+% are all formal parameters bound at apply time (the drop factor is a property of the giving set, supplied
+% by the consumer, not baked in), so every value the engine returns is exact. The three formulas COMPOSE
+% and invert cleanly around the worked case total IV volume = 1000 mL, time = 100 min, drop factor = 15
+% gtt/mL (drops per minute = 1000 / 100 × 15 = 10 × 15 = 150 gtt/min): the `drops_per_minute` a consumer
+% computes is exactly the value each inverse formula back-solves to recover its own measured input
+% (1000, 15).
+%
+%   drops_per_minute(total_iv_volume, infusion_time, drop_factor) = total_iv_volume / infusion_time * drop_factor   % (gtt/min)
+%   total_iv_volume(drops_per_minute, infusion_time, drop_factor) = drops_per_minute * infusion_time / drop_factor    % (solved for volume)
+%   drop_factor(drops_per_minute, total_iv_volume, infusion_time) = drops_per_minute * infusion_time / total_iv_volume % (solved for drop factor)
+%
+% NOTE ON UNITS AND MODELLING: the total IV volume is in millilitres (mL), the time in MINUTES (an order
+% written "over 8 hours" must be converted to minutes before binding), the drop factor in drops per
+% millilitre (gtt/mL), and the resulting drip rate in drops per minute (gtt/min). This library only
+% COMPUTES the drip rate; the ordered volume and duration come from the prescription and the drop factor
+% from the giving set's packaging, and the nurse counts and adjusts the roller clamp to the computed rate.
+%
+% All three formulas are defended by the SAME clause — the quoted drip-rate equation — because that one
+% equation ([total IV volume / time] × drop factor) sanctions the relation read every way. The quote is
+% transcribed verbatim from the StatPearls "Pharmacy Calculations" article on the NCBI Bookshelf (a
+% current, non-archived article), so each `formula` carries the provenance envelope every shipped grounded
+% clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula
+% is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `total_iv_volume`, `infusion_time`, `drop_factor` and `drops_per_minute` each appear BOTH as
+% a derived result and as an input (of the other formulas), so each is a single dictionary term used in
+% both roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary iv_drip_rate_vocab {
+    define total_iv_volume   : finding  surface "total IV volume", "IV volume", "volume", "total volume"     % mL
+    define infusion_time     : finding  surface "time", "infusion time", "time in minutes"                   % minutes
+    define drop_factor       : finding  surface "drop factor", "drops per mL", "gtt factor", "set factor"    % gtt/mL
+    define drops_per_minute  : finding  surface "drops per minute", "drip rate", "gtt/min", "gtt per minute"  % gtt/min
+}
+
+% ----------------------------------------------------------------------------
+% The IV drip rate, three ways. Each is a named, importable, reusable formula over its formal parameters,
+% bound at apply time, and each carries the drip-rate equation from the StatPearls "Pharmacy Calculations"
+% article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact expression in
+% the measured values, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook iv_drip_rate_laws {
+    use iv_drip_rate_vocab
+
+    % Drip rate — the volume-over-time rate times the drop factor.
+    formula drops_per_minute(total_iv_volume, infusion_time, drop_factor) = total_iv_volume / infusion_time * drop_factor
+        source "[Total IV volume/Time (minute)] X Drop Factor = Drops per minute"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560924/"
+        trust authoritative
+
+    % Total IV volume — the same equation solved for the volume. Defended by the SAME equation.
+    formula total_iv_volume(drops_per_minute, infusion_time, drop_factor) = drops_per_minute * infusion_time / drop_factor
+        source "[Total IV volume/Time (minute)] X Drop Factor = Drops per minute"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560924/"
+        trust authoritative
+
+    % Drop factor — the same equation solved for the drop factor, the third reading of the one rate.
+    formula drop_factor(drops_per_minute, total_iv_volume, infusion_time) = drops_per_minute * infusion_time / total_iv_volume
+        source "[Total IV volume/Time (minute)] X Drop Factor = Drops per minute"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560924/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/iv-drip-rate.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/iv-drip-rate.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% iv-drip-rate.query.adj — worked applications of the gravity IV infusion drip rate.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an infusion order into a total volume, a time in
+% minutes, and the giving-set drop factor: it `import`s the grounded formulabook, `observe`s the three
+% values, and asks the engine to APPLY the cited drip-rate formula. No arithmetic is stated by the
+% consumer; the engine computes each value EXACTLY (over exact rationals) and carries the article's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (total IV volume = 1000 mL, time = 100 min, drop factor = 15 gtt/mL): drip rate =
+% 1000 / 100 × 15 = 10 × 15 = 150 gtt/min. Each query fixes two of the three inputs and asks the engine to
+% recover another quantity; every answer is exact and the inversions COMPOSE (each recovers exactly the
+% worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli iv-drip-rate.query.adj
+% ============================================================================
+
+import "iv-drip-rate.adj"
+
+% --- Drip rate: the drops/min the volume, time, and drop factor imply (expect 150). ------------------
+observe total_iv_volume(1000)
+observe infusion_time(100)
+observe drop_factor(15)
+? drops_per_minute(total_iv_volume, infusion_time, drop_factor)   % expect 150
+
+% --- Inverse: the total volume a 150 gtt/min rate delivers at the same time and drop factor (expect 1000). -
+observe drops_per_minute(150)
+? total_iv_volume(drops_per_minute, infusion_time, drop_factor)   % expect 1000


### PR DESCRIPTION
## Summary

Adds the **gravity IV infusion drip-rate** entry to the clinical formulabook track of `adj-formula-stdlib`:

> drops per minute = **[total IV volume / time (min)] × drop factor**

with two exact algebraic rearrangements (solve for total volume; solve for drop factor). All three formulas carry the SAME verbatim equation, transcribed from the StatPearls **"Pharmacy Calculations"** article on the NCBI Bookshelf ([NBK560924](https://www.ncbi.nlm.nih.gov/books/NBK560924/)):

> `[Total IV volume/Time (minute)] X Drop Factor = Drops per minute`

## Why this shape

Structurally this is a **product of a ratio and a value** (the volume-per-time rate scaled by the giving-set drop factor) — a shape distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant, chained-division, constant-scaled-difference, product-times-constant, and three-way-product-over-divisor forms of the other clinical libraries. There is **no embedded constant**: volume, time, and drop factor are all formal parameters bound at apply time, so every value the engine returns is exact (over exact rationals).

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the three quantities, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case volume = 1000 mL, time = 100 min, drop factor = 15 gtt/mL (1000 / 100 × 15 = **150** gtt/min): each inverse back-solves exactly to recover its own measured input.

## Files
- `clinical/iv-drip-rate.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/iv-drip-rate.query.adj` — worked case (drip rate 150; inverse volume 1000)
- `adj-lang-cli/tests/formula_iv_drip_rate_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the derivation carries the intermediate 10 and the drop-factor input 15, and `"value":15` is a leading-digit prefix of `"value":150`, so the adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)