### PR TITLE
feat(adj-formula-stdlib): static-compliance — respiratory-system static compliance (Cstat = V / (Pplat − PEEP)) library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_static_compliance_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_static_compliance_e2e.rs
@@ -1,0 +1,148 @@
+//! End-to-end tests for the `clinical/static-compliance.adj` library — static respiratory-system
+//! compliance (Cstat = tidal volume / (plateau pressure − PEEP)) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula
+//! library: a consumer states NO arithmetic; it imports the grounded library, binds the tidal volume, the
+//! plateau pressure, and the PEEP with `observe`, and the engine applies the cited formula on the CPU,
+//! computing the EXACT value (over exact rationals) and rendering the citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case V = 500,
+//! Pplat = 20, PEEP = 10: 500 / (20 − 10) = 50 (Cstat), 50 × (20 − 10) = 500 (V), 500 / 50 + 10 = 20 (Pplat).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the compliance result 50 is a leading-digit prefix of the tidal-volume 500, and the
+//! derivation tree also carries the driving-pressure intermediate 10, so a bare `"value":50` substring could
+//! spuriously match `"value":500`. The adjacent, name-anchored form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped static-compliance library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_cstat_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/static-compliance.adj")
+        .canonicalize()
+        .expect("shipped static-compliance.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_cstat_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_cstat_lib()).unwrap();
+    std::fs::write(dir.join("static-compliance.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// static_compliance — the compliance: tidal volume / (plateau − PEEP).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_static_compliance_library_and_computes_it_with_citation() {
+    let dir = scratch("cstat");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"static-compliance.adj\"\n\
+         observe tidal_volume(500)\n\
+         observe plateau_pressure(20)\n\
+         observe peep(10)\n\
+         ? static_compliance(tidal_volume, plateau_pressure, peep)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 500 / (20 − 10) = 50, computed EXACTLY
+    // over rationals. Match the adjacent name/value pair so the tidal-volume 500 and the 10 intermediate in
+    // the derivation cannot spuriously satisfy a bare "value":50.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"static_compliance\",\"value\":50"),
+        "static_compliance(500, 20, 10) = 50: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tidal_volume — the same equation solved for the volume: Cstat × (plateau − PEEP).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_tidal_volume_from_compliance_with_citation() {
+    let dir = scratch("vt");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"static-compliance.adj\"\n\
+         observe static_compliance(50)\n\
+         observe plateau_pressure(20)\n\
+         observe peep(10)\n\
+         ? tidal_volume(static_compliance, plateau_pressure, peep)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 50 × (20 − 10) = 50 × 10 = 500, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"tidal_volume\",\"value\":500"),
+        "tidal_volume(50, 20, 10) = 500: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "tidal_volume carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// plateau_pressure — the same equation solved for the plateau pressure: V / Cstat + PEEP, the third reading
+// of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_plateau_pressure_from_compliance_with_citation() {
+    let dir = scratch("pplat");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"static-compliance.adj\"\n\
+         observe static_compliance(50)\n\
+         observe tidal_volume(500)\n\
+         observe peep(10)\n\
+         ? plateau_pressure(static_compliance, tidal_volume, peep)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 500 / 50 + 10 = 10 + 10 = 20, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"plateau_pressure\",\"value\":20"),
+        "plateau_pressure(50, 500, 10) = 20: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "plateau_pressure carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/static-compliance.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/static-compliance.adj
@@ -1,0 +1,96 @@
+% ============================================================================
+% static-compliance.adj — static respiratory-system compliance
+% (Cstat = tidal volume / (plateau pressure − PEEP)) in the ADJ standard library.
+% ============================================================================
+% The static-compliance entry of the *clinical* track — the distensibility of the respiratory system
+% measured on a mechanical ventilator during an inspiratory hold, when there is no gas flow. With flow
+% stopped, the pressure the ventilator reads is the PLATEAU pressure, which reflects only the elastic recoil
+% of the lungs and chest wall (the resistive, flow-dependent component has dropped out). Static compliance is
+% the volume delivered per unit of that elastic distending pressure: the tidal volume divided by the
+% difference between the plateau pressure and the end-expiratory pressure (PEEP). A stiff (low-compliance)
+% lung — ARDS, pulmonary oedema, fibrosis — needs a large driving pressure for a small breath, so its
+% compliance is low; a floppy (high-compliance) lung — emphysema — moves a large breath for little pressure.
+% THE STATIC COMPLIANCE IS THE TIDAL VOLUME DIVIDED BY THE DRIVING PRESSURE (PLATEAU MINUS PEEP) — i.e.
+% Cstat = V / (Pplat − PEEP). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together
+% with two exact rearrangements (the tidal volume a given compliance and driving pressure imply, and the
+% plateau pressure a given tidal volume and compliance imply). As with every compute library, a consumer
+% states NO arithmetic: it `import`s this file, binds the tidal volume, plateau pressure, and PEEP from its
+% own byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "static-compliance.adj"
+%     observe tidal_volume(500)       % "…Vt 500 mL…"          (span cited by the model)
+%     observe plateau_pressure(20)     % "…plateau 20 cmH2O…"   (span cited by the model)
+%     observe peep(10)                 % "…PEEP 10 cmH2O…"      (span cited by the model)
+%     ? static_compliance(tidal_volume, plateau_pressure, peep)   % engine → 50 (mL/cmH2O)
+%
+% Structurally this is a QUOTIENT WHOSE DENOMINATOR IS A DIFFERENCE — the tidal volume over the driving
+% pressure — a shape distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant,
+% chained-division, constant-scaled-difference, product-times-constant, three-way-product-over-divisor, and
+% product-of-a-ratio-and-a-value forms of the other clinical libraries. There is NO embedded constant: the
+% tidal volume, plateau pressure, and PEEP are all formal parameters bound at apply time, so every value the
+% engine returns is exact. The three formulas COMPOSE and invert cleanly around the worked case tidal
+% volume = 500 mL, plateau pressure = 20 cmH2O, PEEP = 10 cmH2O (Cstat = 500 / (20 − 10) = 500 / 10 = 50
+% mL/cmH2O): the `static_compliance` a consumer computes is exactly the value each inverse formula
+% back-solves to recover its own measured input (500, 20).
+%
+%   static_compliance(tidal_volume, plateau_pressure, peep) = tidal_volume / (plateau_pressure - peep)   % (mL/cmH2O)
+%   tidal_volume(static_compliance, plateau_pressure, peep) = static_compliance * (plateau_pressure - peep) % (solved for volume)
+%   plateau_pressure(static_compliance, tidal_volume, peep) = tidal_volume / static_compliance + peep       % (solved for plateau pressure)
+%
+% NOTE ON UNITS AND MODELLING: the tidal volume is in millilitres (mL), the plateau and end-expiratory
+% pressures in centimetres of water (cmH2O), and the resulting compliance in mL/cmH2O. The plateau pressure
+% must be measured during an inspiratory pause (no flow); using the peak inspiratory pressure instead would
+% mix in airway resistance and understate the compliance. This library only COMPUTES the static compliance;
+% obtaining a true plateau pressure and interpreting the number against the clinical picture is the
+% bedside clinician's task, stated by the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted compliance equation — because that one
+% equation (V / (Pplat − PEEP)) sanctions the relation read every way. The quote is transcribed verbatim
+% from the StatPearls "Pulmonary Compliance" article on the NCBI Bookshelf, so each `formula` carries the
+% provenance envelope every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `tidal_volume`, `plateau_pressure`, `peep` and `static_compliance` each appear BOTH as a
+% derived result and as an input (of the other formulas), so each is a single dictionary term used in both
+% roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing
+% comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary static_compliance_vocab {
+    define tidal_volume       : finding  surface "tidal volume", "V", "VT", "Vt"                         % mL
+    define plateau_pressure   : finding  surface "plateau pressure", "Pplat", "plateau", "P plateau"     % cmH2O
+    define peep               : finding  surface "PEEP", "end-expiratory pressure", "end expiratory pressure" % cmH2O
+    define static_compliance  : finding  surface "static compliance", "Cstat", "compliance", "Cstatic"    % mL/cmH2O
+}
+
+% ----------------------------------------------------------------------------
+% The static compliance, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the compliance equation from the StatPearls "Pulmonary
+% Compliance" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% expression in the measured values, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook static_compliance_laws {
+    use static_compliance_vocab
+
+    % Static compliance — tidal volume over the driving pressure (plateau minus PEEP).
+    formula static_compliance(tidal_volume, plateau_pressure, peep) = tidal_volume / (plateau_pressure - peep)
+        source "Cstat = V/(Pplat – PEEP)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK538324/"
+        trust authoritative
+
+    % Tidal volume — the same equation solved for the volume. Defended by the SAME equation.
+    formula tidal_volume(static_compliance, plateau_pressure, peep) = static_compliance * (plateau_pressure - peep)
+        source "Cstat = V/(Pplat – PEEP)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK538324/"
+        trust authoritative
+
+    % Plateau pressure — the same equation solved for the plateau pressure, the third reading of the one law.
+    formula plateau_pressure(static_compliance, tidal_volume, peep) = tidal_volume / static_compliance + peep
+        source "Cstat = V/(Pplat – PEEP)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK538324/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/static-compliance.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/static-compliance.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% static-compliance.query.adj — worked applications of static respiratory-system compliance.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a ventilator problem into a tidal volume, a plateau
+% pressure, and a PEEP: it `import`s the grounded formulabook, `observe`s the three values, and asks the
+% engine to APPLY the cited compliance formula. No arithmetic is stated by the consumer; the engine computes
+% each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with
+% zero model calls.
+%
+% Worked case (tidal volume = 500 mL, plateau pressure = 20 cmH2O, PEEP = 10 cmH2O): static compliance =
+% 500 / (20 − 10) = 500 / 10 = 50 mL/cmH2O. Each query fixes two of the three inputs and asks the engine to
+% recover another quantity; every answer is exact and the inversions COMPOSE (each recovers exactly the
+% worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli static-compliance.query.adj
+% ============================================================================
+
+import "static-compliance.adj"
+
+% --- Static compliance: the mL/cmH2O the volume and driving pressure imply (expect 50). --------------
+observe tidal_volume(500)
+observe plateau_pressure(20)
+observe peep(10)
+? static_compliance(tidal_volume, plateau_pressure, peep)   % expect 50
+
+% --- Inverse: the tidal volume a 50 mL/cmH2O compliance delivers at the same pressures (expect 500). --
+observe static_compliance(50)
+? tidal_volume(static_compliance, plateau_pressure, peep)   % expect 500


### PR DESCRIPTION
## Summary

Adds the **static respiratory-system compliance** entry to the clinical formulabook track of `adj-formula-stdlib`:

> Cstat = **tidal volume / (plateau pressure − PEEP)**

with two exact algebraic rearrangements (solve for tidal volume; solve for plateau pressure). All three formulas carry the SAME verbatim equation, transcribed from the StatPearls **"Pulmonary Compliance"** article on the NCBI Bookshelf ([NBK538324](https://www.ncbi.nlm.nih.gov/books/NBK538324/)):

> `Cstat = V/(Pplat – PEEP)`

The en-dash (U+2013) between `Pplat` and `PEEP` is transcribed **byte-faithfully** from the page — verified via hexdump as `e2 80 93` in all three source strings; the file's only other non-ASCII characters are typographic marks in comments (—, …, →, −).

## Why this shape

Structurally this is a **quotient whose denominator is a difference** (tidal volume over the driving pressure) — a shape distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant, chained-division, constant-scaled-difference, product-times-constant, three-way-product-over-divisor, and product-of-a-ratio-and-a-value forms of the other clinical libraries. There is **no embedded constant**: tidal volume, plateau pressure, and PEEP are all formal parameters bound at apply time, so every value the engine returns is exact (over exact rationals). It also opens a **new clinical domain** for the track — respiratory mechanics / ventilator management.

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the three quantities, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case V = 500 mL, Pplat = 20 cmH2O, PEEP = 10 cmH2O (500 / (20 − 10) = **50** mL/cmH2O): each inverse back-solves exactly to recover its own measured input.

## Files
- `clinical/static-compliance.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/static-compliance.query.adj` — worked case (compliance 50; inverse volume 500)
- `adj-lang-cli/tests/formula_static_compliance_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the compliance result `50` is a leading-digit prefix of the tidal-volume `500`, so the name-anchored adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)