### PR TITLE
feat(adj-formula-stdlib): systemic-vascular-resistance — SVR = 80 × (MAP − MVP) / CO hemodynamic library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_systemic_vascular_resistance_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_systemic_vascular_resistance_e2e.rs
@@ -1,0 +1,149 @@
+//! End-to-end tests for the `clinical/systemic-vascular-resistance.adj` library — systemic vascular
+//! resistance (SVR = 80 × (mean arterial pressure − mean venous pressure) / cardiac output) and its two
+//! exact rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same invariant
+//! as every other formula library: a consumer states NO arithmetic; it imports the grounded library, binds
+//! the mean arterial pressure, the mean venous pressure, and the cardiac output with `observe`, and the
+//! engine applies the cited formula on the CPU, computing the EXACT value (over exact rationals) and
+//! rendering the citation and trust tier in the `derived` section (the auditable answer). The three formulas
+//! INVERT around the worked case MAP = 90, MVP = 10, CO = 5: 80 × (90 − 10) / 5 = 1280 (SVR),
+//! 80 × (90 − 10) / 1280 = 5 (CO), 1280 × 5 / 80 + 10 = 90 (MAP).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation tree carries the unit constant 80 and the intermediates 80 (= 90 − 10) and
+//! 6400 (= 80 × 80), so a bare numeric substring could spuriously match. The name-anchored adjacent form is
+//! collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped systemic-vascular-resistance library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_svr_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/systemic-vascular-resistance.adj")
+        .canonicalize()
+        .expect("shipped systemic-vascular-resistance.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_svr_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_svr_lib()).unwrap();
+    std::fs::write(dir.join("systemic-vascular-resistance.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// systemic_vascular_resistance — the resistance: 80 × (MAP − MVP) / CO.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_systemic_vascular_resistance_library_and_computes_it_with_citation() {
+    let dir = scratch("svr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"systemic-vascular-resistance.adj\"\n\
+         observe mean_arterial_pressure(90)\n\
+         observe mean_venous_pressure(10)\n\
+         observe cardiac_output(5)\n\
+         ? systemic_vascular_resistance(mean_arterial_pressure, mean_venous_pressure, cardiac_output)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 80 × (90 − 10) / 5 = 1280, computed
+    // EXACTLY over rationals. Match the adjacent name/value pair so the 80 constant and the 80/6400
+    // intermediates in the derivation cannot spuriously satisfy a bare "value":1280.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"systemic_vascular_resistance\",\"value\":1280"),
+        "systemic_vascular_resistance(90, 10, 5) = 1280: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// cardiac_output — the same equation solved for the flow: 80 × (MAP − MVP) / SVR.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_cardiac_output_from_svr_with_citation() {
+    let dir = scratch("co");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"systemic-vascular-resistance.adj\"\n\
+         observe systemic_vascular_resistance(1280)\n\
+         observe mean_arterial_pressure(90)\n\
+         observe mean_venous_pressure(10)\n\
+         ? cardiac_output(systemic_vascular_resistance, mean_arterial_pressure, mean_venous_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 80 × (90 − 10) / 1280 = 6400 / 1280 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"cardiac_output\",\"value\":5"),
+        "cardiac_output(1280, 90, 10) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "cardiac_output carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// mean_arterial_pressure — the same equation solved for MAP: SVR × CO / 80 + MVP, the third reading of the
+// one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_mean_arterial_pressure_from_svr_with_citation() {
+    let dir = scratch("map");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"systemic-vascular-resistance.adj\"\n\
+         observe systemic_vascular_resistance(1280)\n\
+         observe cardiac_output(5)\n\
+         observe mean_venous_pressure(10)\n\
+         ? mean_arterial_pressure(systemic_vascular_resistance, cardiac_output, mean_venous_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 1280 × 5 / 80 + 10 = 6400 / 80 + 10 = 80 + 10 = 90, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"mean_arterial_pressure\",\"value\":90"),
+        "mean_arterial_pressure(1280, 5, 10) = 90: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "mean_arterial_pressure carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/systemic-vascular-resistance.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/systemic-vascular-resistance.adj
@@ -1,0 +1,98 @@
+% ============================================================================
+% systemic-vascular-resistance.adj — systemic vascular resistance
+% (SVR = 80 × (mean arterial pressure − mean venous pressure) / cardiac output) in the ADJ standard library.
+% ============================================================================
+% The systemic-vascular-resistance entry of the *clinical* track — the total resistance the systemic
+% circulation offers to the blood the left heart ejects. It is the haemodynamic analogue of Ohm's law
+% (resistance = pressure drop / flow): the pressure DROP across the systemic circuit is the mean arterial
+% pressure minus the mean (central) venous pressure, the flow is the cardiac output, and the leading factor
+% of 80 converts the pressure-per-flow ratio from mmHg·min/L (Wood units) into the conventional CGS units of
+% dynes·s·cm⁻⁵. A vasoconstricted patient (hypovolaemic or cardiogenic shock) has a HIGH SVR; a vasodilated
+% patient (septic or neurogenic shock, or after a vasodilator) has a LOW SVR, which is why SVR is the number
+% that distinguishes the shock states at the bedside. THE SYSTEMIC VASCULAR RESISTANCE IS 80 TIMES THE
+% ARTERIOVENOUS PRESSURE DIFFERENCE DIVIDED BY THE CARDIAC OUTPUT — i.e. SVR = 80 × (MAP − MVP) / CO. It ships
+% as an importable, byte-provenanced, PARAMETERIZED `formula`, together with two exact rearrangements (the
+% cardiac output a given resistance and pressure gradient imply, and the mean arterial pressure a given
+% resistance and output imply). As with every compute library, a consumer states NO arithmetic: it `import`s
+% this file, binds the mean arterial pressure, mean venous pressure, and cardiac output from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "systemic-vascular-resistance.adj"
+%     observe mean_arterial_pressure(90)   % "…MAP 90 mmHg…"   (span cited by the model)
+%     observe mean_venous_pressure(10)      % "…CVP 10 mmHg…"   (span cited by the model)
+%     observe cardiac_output(5)             % "…CO 5 L/min…"    (span cited by the model)
+%     ? systemic_vascular_resistance(mean_arterial_pressure, mean_venous_pressure, cardiac_output)   % engine → 1280
+%
+% Structurally this is a CONSTANT TIMES A DIFFERENCE, OVER A DIVISOR — the arteriovenous pressure gap scaled
+% by the unit-conversion factor 80 and divided by the flow — a shape distinct from the ratio, ratio-of-ratios,
+% percentage-sum, product-over-constant, chained-division, constant-scaled-difference, product-times-constant,
+% three-way-product-over-divisor, product-of-a-ratio-and-a-value, and quotient-over-a-difference forms of the
+% other clinical libraries. The ONLY constant is the exact integer 80 (the mmHg·min/L → dyn·s·cm⁻⁵ unit
+% factor named in the cited equation); the three pressures and flow are all formal parameters bound at apply
+% time, so every value the engine returns is exact. The three formulas COMPOSE and invert cleanly around the
+% worked case mean arterial pressure = 90 mmHg, mean venous pressure = 10 mmHg, cardiac output = 5 L/min
+% (SVR = 80 × (90 − 10) / 5 = 80 × 80 / 5 = 1280 dyn·s·cm⁻⁵): the `systemic_vascular_resistance` a consumer
+% computes is exactly the value each inverse formula back-solves to recover its own measured input (5, 90).
+%
+%   systemic_vascular_resistance(mean_arterial_pressure, mean_venous_pressure, cardiac_output) = 80 * (mean_arterial_pressure - mean_venous_pressure) / cardiac_output   % (dyn·s·cm⁻⁵)
+%   cardiac_output(systemic_vascular_resistance, mean_arterial_pressure, mean_venous_pressure) = 80 * (mean_arterial_pressure - mean_venous_pressure) / systemic_vascular_resistance   % (solved for flow)
+%   mean_arterial_pressure(systemic_vascular_resistance, cardiac_output, mean_venous_pressure) = systemic_vascular_resistance * cardiac_output / 80 + mean_venous_pressure   % (solved for MAP)
+%
+% NOTE ON UNITS AND MODELLING: the pressures are in millimetres of mercury (mmHg), the cardiac output in
+% litres per minute (L/min), and — because of the leading factor of 80 — the resistance in dyn·s·cm⁻⁵
+% (normal ≈ 800–1200). Omitting the 80 leaves the resistance in Wood units (mmHg·min/L) instead; this library
+% grounds the equation exactly as the source prints it, WITH the 80. The mean venous pressure is often
+% approximated by the central venous pressure (and taken as 0 when unmeasured). This library only COMPUTES
+% the resistance; interpreting it against the shock state is the clinician's task, stated by the cited source
+% but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted SVR equation — because that one equation
+% (80 × (MAP − MVP) / CO) sanctions the relation read every way. The quote is transcribed verbatim from the
+% StatPearls "Hypotension" article on the NCBI Bookshelf (a current, non-archived article), so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `mean_arterial_pressure`, `mean_venous_pressure`, `cardiac_output` and
+% `systemic_vascular_resistance` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the everyday
+% names a decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary systemic_vascular_resistance_vocab {
+    define mean_arterial_pressure        : finding  surface "mean arterial pressure", "MAP"                           % mmHg
+    define mean_venous_pressure          : finding  surface "mean venous pressure", "MVP", "central venous pressure", "CVP" % mmHg
+    define cardiac_output                : finding  surface "cardiac output", "CO"                                    % L/min
+    define systemic_vascular_resistance  : finding  surface "systemic vascular resistance", "SVR"                     % dyn·s·cm⁻⁵
+}
+
+% ----------------------------------------------------------------------------
+% The systemic vascular resistance, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the SVR equation from the StatPearls "Hypotension" article
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact expression in the
+% measured values and the exact integer 80, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook systemic_vascular_resistance_laws {
+    use systemic_vascular_resistance_vocab
+
+    % SVR — the unit factor 80 times the arteriovenous pressure gap, over the cardiac output.
+    formula systemic_vascular_resistance(mean_arterial_pressure, mean_venous_pressure, cardiac_output) = 80 * (mean_arterial_pressure - mean_venous_pressure) / cardiac_output
+        source "Systemic vascular resistance = 80 × (Mean arterial pressure − Mean venous pressure) / Cardiac output"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499961/"
+        trust authoritative
+
+    % Cardiac output — the same equation solved for the flow. Defended by the SAME equation.
+    formula cardiac_output(systemic_vascular_resistance, mean_arterial_pressure, mean_venous_pressure) = 80 * (mean_arterial_pressure - mean_venous_pressure) / systemic_vascular_resistance
+        source "Systemic vascular resistance = 80 × (Mean arterial pressure − Mean venous pressure) / Cardiac output"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499961/"
+        trust authoritative
+
+    % Mean arterial pressure — the same equation solved for MAP, the third reading of the one law.
+    formula mean_arterial_pressure(systemic_vascular_resistance, cardiac_output, mean_venous_pressure) = systemic_vascular_resistance * cardiac_output / 80 + mean_venous_pressure
+        source "Systemic vascular resistance = 80 × (Mean arterial pressure − Mean venous pressure) / Cardiac output"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499961/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/systemic-vascular-resistance.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/systemic-vascular-resistance.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% systemic-vascular-resistance.query.adj — worked applications of systemic vascular resistance.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a haemodynamic problem into a mean arterial pressure,
+% a mean (central) venous pressure, and a cardiac output: it `import`s the grounded formulabook, `observe`s
+% the three values, and asks the engine to APPLY the cited SVR formula. No arithmetic is stated by the
+% consumer; the engine computes each value EXACTLY (over exact rationals) and carries the article's citation
+% as its proof, on the CPU, with zero model calls.
+%
+% Worked case (mean arterial pressure = 90 mmHg, mean venous pressure = 10 mmHg, cardiac output = 5 L/min):
+% SVR = 80 × (90 − 10) / 5 = 80 × 80 / 5 = 1280 dyn·s·cm⁻⁵. Each query fixes two of the three inputs and
+% asks the engine to recover another quantity; every answer is exact and the inversions COMPOSE (each
+% recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli systemic-vascular-resistance.query.adj
+% ============================================================================
+
+import "systemic-vascular-resistance.adj"
+
+% --- SVR: the resistance the pressures and flow imply (expect 1280). ---------------------------------
+observe mean_arterial_pressure(90)
+observe mean_venous_pressure(10)
+observe cardiac_output(5)
+? systemic_vascular_resistance(mean_arterial_pressure, mean_venous_pressure, cardiac_output)   % expect 1280
+
+% --- Inverse: the cardiac output an SVR of 1280 implies at the same pressures (expect 5). ------------
+observe systemic_vascular_resistance(1280)
+? cardiac_output(systemic_vascular_resistance, mean_arterial_pressure, mean_venous_pressure)   % expect 5


### PR DESCRIPTION
## Summary

Adds the **systemic vascular resistance** entry to the clinical formulabook track of `adj-formula-stdlib`:

> SVR = **80 × (mean arterial pressure − mean venous pressure) / cardiac output**

with two exact algebraic rearrangements (solve for cardiac output; solve for mean arterial pressure). All three formulas carry the SAME verbatim equation, transcribed from the StatPearls **"Hypotension"** article on the NCBI Bookshelf ([NBK499961](https://www.ncbi.nlm.nih.gov/books/NBK499961/), current/non-archived):

> `Systemic vascular resistance = 80 × (Mean arterial pressure − Mean venous pressure) / Cardiac output`

The `×` (U+00D7) and `−` (U+2212) are transcribed **byte-faithfully** from the page's math typography — verified via hexdump as `c3 97` and `e2 88 92` in all three source strings; those are the only non-ASCII characters in the source strings.

## Why this shape

Structurally this is a **constant times a difference, over a divisor** (the arteriovenous pressure gap scaled by the unit factor 80, divided by the flow) — a shape distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant, chained-division, constant-scaled-difference, product-times-constant, three-way-product-over-divisor, product-of-a-ratio-and-a-value, and quotient-over-a-difference forms of the other clinical libraries. The only constant is the **exact integer 80** (the mmHg·min/L → dyn·s·cm⁻⁵ unit factor named in the cited equation); the three pressures and the flow are all formal parameters bound at apply time, so every value the engine returns is exact (over exact rationals). It opens a **new clinical domain** for the track — haemodynamics / shock-state differentiation.

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the three quantities, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case MAP = 90 mmHg, MVP = 10 mmHg, CO = 5 L/min (80 × (90 − 10) / 5 = **1280** dyn·s·cm⁻⁵): each inverse back-solves exactly to recover its own measured input.

## Files
- `clinical/systemic-vascular-resistance.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/systemic-vascular-resistance.query.adj` — worked case (SVR 1280; inverse CO 5)
- `adj-lang-cli/tests/formula_systemic_vascular_resistance_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the derivation carries the unit constant `80` and the intermediates `80` (= 90 − 10) and `6400` (= 80 × 80), so the name-anchored adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)