### PR TITLE
feat(adj-formula-stdlib): oxygenation-index — OI = MAP × FiO2 × 100 / PaO2 respiratory-failure severity library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_oxygenation_index_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_oxygenation_index_e2e.rs
@@ -1,0 +1,149 @@
+//! End-to-end tests for the `clinical/oxygenation-index.adj` library — the oxygenation index
+//! (OI = mean airway pressure × FiO2 × 100 / PaO2) and its two exact rearrangements — driven through the
+//! built CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a
+//! consumer states NO arithmetic; it imports the grounded library, binds the mean airway pressure, the FiO2
+//! (as a fraction), and the PaO2 with `observe`, and the engine applies the cited formula on the CPU,
+//! computing the EXACT value (over exact rationals) and rendering the citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case MAP = 10,
+//! FiO2 = 0.5, PaO2 = 50: 10 × 0.5 × 100 / 50 = 10 (OI), 10 × 0.5 × 100 / 10 = 50 (PaO2),
+//! 10 × 50 / (0.5 × 100) = 10 (MAP).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation tree carries the constant 100 and the intermediate 500 (= 10 × 0.5 × 100),
+//! so bare substrings like `"value":10` (a prefix of `100`) or `"value":50` (a prefix of `500`) could
+//! spuriously match. The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped oxygenation-index library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_oi_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/oxygenation-index.adj")
+        .canonicalize()
+        .expect("shipped oxygenation-index.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_oi_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_oi_lib()).unwrap();
+    std::fs::write(dir.join("oxygenation-index.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// oxygen_index — the index: MAP × FiO2 × 100 / PaO2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_oxygenation_index_library_and_computes_it_with_citation() {
+    let dir = scratch("oi");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"oxygenation-index.adj\"\n\
+         observe mean_airway_pressure(10)\n\
+         observe fio2(0.5)\n\
+         observe pao2(50)\n\
+         ? oxygen_index(mean_airway_pressure, fio2, pao2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 10 × 0.5 × 100 / 50 = 10, computed
+    // EXACTLY over rationals. Match the adjacent name/value pair so the 100 constant and the 500 intermediate
+    // in the derivation cannot spuriously satisfy a bare "value":10.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"oxygen_index\",\"value\":10"),
+        "oxygen_index(10, 0.5, 50) = 10: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// pao2 — the same equation solved for the arterial oxygen tension: MAP × FiO2 × 100 / OI.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_pao2_from_oxygenation_index_with_citation() {
+    let dir = scratch("pao2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"oxygenation-index.adj\"\n\
+         observe oxygen_index(10)\n\
+         observe mean_airway_pressure(10)\n\
+         observe fio2(0.5)\n\
+         ? pao2(oxygen_index, mean_airway_pressure, fio2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 × 0.5 × 100 / 10 = 500 / 10 = 50, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"pao2\",\"value\":50"),
+        "pao2(10, 10, 0.5) = 50: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "pao2 carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// mean_airway_pressure — the same equation solved for the support pressure: OI × PaO2 / (FiO2 × 100), the
+// third reading of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_mean_airway_pressure_from_oxygenation_index_with_citation() {
+    let dir = scratch("map");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"oxygenation-index.adj\"\n\
+         observe oxygen_index(10)\n\
+         observe pao2(50)\n\
+         observe fio2(0.5)\n\
+         ? mean_airway_pressure(oxygen_index, pao2, fio2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 × 50 / (0.5 × 100) = 500 / 50 = 10, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"mean_airway_pressure\",\"value\":10"),
+        "mean_airway_pressure(10, 50, 0.5) = 10: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "mean_airway_pressure carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/oxygenation-index.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/oxygenation-index.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% oxygenation-index.adj — the oxygenation index
+% (OI = mean airway pressure × FiO2 × 100 / PaO2) in the ADJ standard library.
+% ============================================================================
+% The oxygenation-index entry of the *clinical* track — a severity index of hypoxaemic respiratory failure
+% used mainly in neonates and children on mechanical ventilation, and a classic trigger threshold for
+% extracorporeal membrane oxygenation (ECMO). Unlike the simple P/F ratio, the oxygenation index weighs the
+% oxygenation achieved against the ventilator SUPPORT needed to achieve it: a child kept at a given PaO2 only
+% by a high mean airway pressure and a high inspired-oxygen fraction is far sicker than one holding the same
+% PaO2 on minimal support, and the index rises accordingly. It is the mean airway pressure times the fraction
+% of inspired oxygen times 100, divided by the arterial oxygen tension — so a HIGHER index means WORSE
+% oxygenation (the opposite sense to the P/F ratio). Rough bands: ≤ 15 mild, 16–25 moderate, 26–40 severe,
+% and > 40 very severe (an ECMO consideration). THE OXYGENATION INDEX IS THE MEAN AIRWAY PRESSURE TIMES FiO2
+% TIMES 100, OVER THE PaO2 — i.e. OI = MAP × FiO2 × 100 / PaO2. It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with two exact rearrangements (the PaO2 a given index and support imply,
+% and the mean airway pressure a given index and PaO2 imply). As with every compute library, a consumer
+% states NO arithmetic: it `import`s this file, binds the mean airway pressure, FiO2, and PaO2 from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "oxygenation-index.adj"
+%     observe mean_airway_pressure(10)   % "…Paw 10 cmH2O…"   (span cited by the model)
+%     observe fio2(0.5)                   % "…FiO2 0.5…"       (span cited by the model)
+%     observe pao2(50)                    % "…PaO2 50 mmHg…"   (span cited by the model)
+%     ? oxygen_index(mean_airway_pressure, fio2, pao2)   % engine → 10
+%
+% Structurally this is a PRODUCT OF TWO VARIABLES AND A CONSTANT, OVER A DIVISOR — the support (mean airway
+% pressure times FiO2) scaled by 100 and divided by the achieved PaO2 — a shape distinct from the ratio,
+% ratio-of-ratios, percentage-sum, product-over-constant, chained-division, constant-scaled-difference,
+% product-times-constant, three-way-product-over-divisor, product-of-a-ratio-and-a-value,
+% quotient-over-a-difference, and constant-times-a-difference-over-a-divisor forms of the other clinical
+% libraries. The ONLY constant is the exact integer 100 (named in the cited equation); the mean airway
+% pressure, FiO2, and PaO2 are all formal parameters bound at apply time, so every value the engine returns
+% is exact. The three formulas COMPOSE and invert cleanly around the worked case mean airway pressure = 10
+% cmH2O, FiO2 = 0.5, PaO2 = 50 mmHg (OI = 10 × 0.5 × 100 / 50 = 500 / 50 = 10): the `oxygen_index` a consumer
+% computes is exactly the value each inverse formula back-solves to recover its own measured input (50, 10).
+%
+%   oxygen_index(mean_airway_pressure, fio2, pao2) = mean_airway_pressure * fio2 * 100 / pao2        % (dimensionless index)
+%   pao2(oxygen_index, mean_airway_pressure, fio2) = mean_airway_pressure * fio2 * 100 / oxygen_index % (solved for PaO2)
+%   mean_airway_pressure(oxygen_index, pao2, fio2) = oxygen_index * pao2 / (fio2 * 100)                % (solved for mean airway pressure)
+%
+% NOTE ON UNITS AND MODELLING: the mean airway pressure is in cmH2O, the PaO2 in mmHg, and — crucially — the
+% FiO2 is entered as a FRACTION between 0 and 1 (0.5 for 50%), not as a percentage; entering it as 50 would
+% inflate the index a hundredfold. The resulting index is dimensionless. This library only COMPUTES the
+% index; deciding what a given index means for escalation (including ECMO referral) is the clinician's task,
+% stated by the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted oxygenation-index equation — because that
+% one equation (MAP × FiO2 × 100 / PaO2) sanctions the relation read every way. The quote is transcribed
+% verbatim from the PubMed Central article "Correlation of Oxygen Index, Oxygen Saturation Index, and
+% PaO2/FiO2 Ratio in Invasive Mechanically Ventilated Adults", so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `mean_airway_pressure`, `fio2`, `pao2` and `oxygen_index` each appear BOTH as a derived result
+% and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary oxygenation_index_vocab {
+    define mean_airway_pressure  : finding  surface "mean airway pressure", "MAP", "Paw", "mean Paw"       % cmH2O
+    define fio2                  : finding  surface "FiO2", "fraction of inspired oxygen", "inspired oxygen fraction" % fraction 0-1
+    define pao2                  : finding  surface "PaO2", "arterial oxygen tension", "arterial pO2"       % mmHg
+    define oxygen_index          : finding  surface "oxygenation index", "oxygen index", "OI"               % dimensionless
+}
+
+% ----------------------------------------------------------------------------
+% The oxygenation index, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the oxygenation-index equation from the PMC article
+% (a quote is required on a shipped formula). Each is an exact expression in the measured values and the
+% exact integer 100, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook oxygenation_index_laws {
+    use oxygenation_index_vocab
+
+    % OI — the support (mean airway pressure times FiO2) scaled by 100, over the achieved PaO2.
+    formula oxygen_index(mean_airway_pressure, fio2, pao2) = mean_airway_pressure * fio2 * 100 / pao2
+        source "OI = MAP × FiO2 × 100 ÷ PaO2"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC7874290/"
+        trust authoritative
+
+    % PaO2 — the same equation solved for the arterial oxygen tension. Defended by the SAME equation.
+    formula pao2(oxygen_index, mean_airway_pressure, fio2) = mean_airway_pressure * fio2 * 100 / oxygen_index
+        source "OI = MAP × FiO2 × 100 ÷ PaO2"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC7874290/"
+        trust authoritative
+
+    % Mean airway pressure — the same equation solved for the support pressure, the third reading of the law.
+    formula mean_airway_pressure(oxygen_index, pao2, fio2) = oxygen_index * pao2 / (fio2 * 100)
+        source "OI = MAP × FiO2 × 100 ÷ PaO2"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC7874290/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/oxygenation-index.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/oxygenation-index.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% oxygenation-index.query.adj — worked applications of the oxygenation index.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a ventilator problem into a mean airway pressure, an
+% FiO2 (as a fraction), and a PaO2: it `import`s the grounded formulabook, `observe`s the three values, and
+% asks the engine to APPLY the cited oxygenation-index formula. No arithmetic is stated by the consumer; the
+% engine computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof,
+% on the CPU, with zero model calls.
+%
+% Worked case (mean airway pressure = 10 cmH2O, FiO2 = 0.5, PaO2 = 50 mmHg): OI = 10 × 0.5 × 100 / 50 =
+% 500 / 50 = 10. Each query fixes two of the three inputs and asks the engine to recover another quantity;
+% every answer is exact and the inversions COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli oxygenation-index.query.adj
+% ============================================================================
+
+import "oxygenation-index.adj"
+
+% --- OI: the index the support and PaO2 imply (expect 10). -------------------------------------------
+observe mean_airway_pressure(10)
+observe fio2(0.5)
+observe pao2(50)
+? oxygen_index(mean_airway_pressure, fio2, pao2)   % expect 10
+
+% --- Inverse: the PaO2 an index of 10 implies at the same support (expect 50). -----------------------
+observe oxygen_index(10)
+? pao2(oxygen_index, mean_airway_pressure, fio2)   % expect 50


### PR DESCRIPTION
## Summary

Adds the **oxygenation index** to the clinical formulabook track of `adj-formula-stdlib`:

> OI = **mean airway pressure × FiO₂ × 100 / PaO₂**

a ventilator severity index of hypoxaemic respiratory failure used mainly in neonates/children and a classic ECMO trigger threshold, with two exact algebraic rearrangements (solve for PaO₂; solve for mean airway pressure). All three formulas carry the SAME verbatim equation, transcribed from the PMC article **"Correlation of Oxygen Index, Oxygen Saturation Index, and PaO2/FiO2 Ratio in Invasive Mechanically Ventilated Adults"** ([PMC7874290](https://pmc.ncbi.nlm.nih.gov/articles/PMC7874290/)):

> `OI = MAP × FiO2 × 100 ÷ PaO2`

The `×` (U+00D7) and `÷` (U+00F7) are transcribed **byte-faithfully** — verified as the only non-ASCII characters in the source strings.

## Why this shape

Structurally this is a **product of two variables and a constant, over a divisor** (the support — mean airway pressure times FiO₂ — scaled by 100 and divided by the achieved PaO₂) — a shape distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant, chained-division, constant-scaled-difference, product-times-constant, three-way-product-over-divisor, product-of-a-ratio-and-a-value, quotient-over-a-difference, and constant-times-a-difference-over-a-divisor forms of the other clinical libraries. The only constant is the **exact integer 100** (named in the cited equation); the mean airway pressure, FiO₂, and PaO₂ are all formal parameters bound at apply time, so every value the engine returns is exact (over exact rationals). It opens a **new clinical domain** — neonatal/pediatric hypoxaemic respiratory failure / ECMO criteria.

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the three quantities, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case MAP = 10 cmH₂O, FiO₂ = 0.5, PaO₂ = 50 mmHg (10 × 0.5 × 100 / 50 = **10**): each inverse back-solves exactly to recover its own measured input.

> **Note:** FiO₂ is bound as a **fraction** (0.5), not a percentage — entering 50 would inflate the index a hundredfold.

## Files
- `clinical/oxygenation-index.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/oxygenation-index.query.adj` — worked case (OI 10; inverse PaO₂ 50)
- `adj-lang-cli/tests/formula_oxygenation_index_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the derivation carries the `100` constant and the `500` intermediate, and `10` is a prefix of `100` while `50` is a prefix of `500`, so the name-anchored adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)