### PR TITLE
feat(adj-formula-stdlib): fractional-excretion-of-urea — FEUrea = ([Uurea/Surea]/[Ucr/Scr]) × 100 renal library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_urea_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_urea_e2e.rs
@@ -1,0 +1,152 @@
+//! End-to-end tests for the `clinical/fractional-excretion-of-urea.adj` library — the fractional excretion
+//! of urea (FEUrea = [urine urea / serum urea] / [urine creatinine / serum creatinine] × 100) and its two
+//! exact rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same invariant
+//! as every other formula library: a consumer states NO arithmetic; it imports the grounded library, binds
+//! the four measured concentrations with `observe`, and the engine applies the cited formula on the CPU,
+//! computing the EXACT value (over exact rationals) and rendering the citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case Uurea = 300,
+//! Surea = 30, Ucr = 100, Scr = 2: 300 × 2 × 100 / (30 × 100) = 20 (FEUrea),
+//! 20 × 30 × 100 / (2 × 100) = 300 (Uurea), 300 × 2 × 100 / (20 × 100) = 30 (Surea).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation tree carries the constant 100 and intermediates (600, 3000, 60000), and 30
+//! is a leading-digit prefix of 300, so a bare numeric substring could spuriously match. The name-anchored
+//! adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped fractional-excretion-of-urea library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_feurea_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-urea.adj")
+        .canonicalize()
+        .expect("shipped fractional-excretion-of-urea.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_feurea_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_feurea_lib()).unwrap();
+    std::fs::write(dir.join("fractional-excretion-of-urea.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// fractional_excretion_of_urea — the percentage: Uurea × Scr × 100 / (Surea × Ucr).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_feurea_library_and_computes_it_with_citation() {
+    let dir = scratch("feurea");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-urea.adj\"\n\
+         observe urine_urea(300)\n\
+         observe serum_urea(30)\n\
+         observe urine_creatinine(100)\n\
+         observe serum_creatinine(2)\n\
+         ? fractional_excretion_of_urea(urine_urea, serum_creatinine, serum_urea, urine_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 300 × 2 × 100 / (30 × 100) = 20,
+    // computed EXACTLY over rationals. Match the adjacent name/value pair so the 100 constant and the
+    // 600/3000/60000 intermediates cannot spuriously satisfy a bare "value":20.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"fractional_excretion_of_urea\",\"value\":20"),
+        "fractional_excretion_of_urea(300, 2, 30, 100) = 20: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_urea — the same equation solved for the urine urea: FEUrea × Surea × Ucr / (Scr × 100).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_urea_from_feurea_with_citation() {
+    let dir = scratch("uu");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-urea.adj\"\n\
+         observe fractional_excretion_of_urea(20)\n\
+         observe serum_urea(30)\n\
+         observe urine_creatinine(100)\n\
+         observe serum_creatinine(2)\n\
+         ? urine_urea(fractional_excretion_of_urea, serum_urea, urine_creatinine, serum_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 20 × 30 × 100 / (2 × 100) = 60000 / 200 = 300, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_urea\",\"value\":300"),
+        "urine_urea(20, 30, 100, 2) = 300: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_urea carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_urea — the same equation solved for the serum urea: Uurea × Scr × 100 / (FEUrea × Ucr), the third
+// reading of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_urea_from_feurea_with_citation() {
+    let dir = scratch("su");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-urea.adj\"\n\
+         observe fractional_excretion_of_urea(20)\n\
+         observe urine_urea(300)\n\
+         observe serum_creatinine(2)\n\
+         observe urine_creatinine(100)\n\
+         ? serum_urea(fractional_excretion_of_urea, urine_urea, serum_creatinine, urine_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 300 × 2 × 100 / (20 × 100) = 60000 / 2000 = 30, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_urea\",\"value\":30"),
+        "serum_urea(20, 300, 2, 100) = 30: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_urea carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-urea.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-urea.adj
@@ -1,0 +1,104 @@
+% ============================================================================
+% fractional-excretion-of-urea.adj — the fractional excretion of urea
+% (FEUrea = [urine urea / serum urea] / [urine creatinine / serum creatinine] × 100) in the ADJ stdlib.
+% ============================================================================
+% The fractional-excretion-of-urea entry of the *clinical* track — the percentage of the urea filtered by
+% the glomerulus that is finally excreted in the urine, used to tell PRERENAL acute kidney injury (avid
+% tubular reabsorption, low FEUrea) from INTRINSIC/acute tubular injury (impaired reabsorption, high
+% FEUrea). It is the urea analogue of the fractional excretion of sodium, and its particular value is that
+% urea handling is driven by passive forces rather than by the transporters that diuretics act on, so FEUrea
+% stays informative in a patient who has already received a loop diuretic — exactly the situation where the
+% fractional excretion of sodium becomes unreliable. Like every fractional-excretion index it is a
+% clearance RATIO scaled to a percentage: the urine-to-serum urea ratio divided by the urine-to-serum
+% creatinine ratio (creatinine standing in for the filtered volume), times 100. THE FRACTIONAL EXCRETION OF
+% UREA IS THE URINE/SERUM UREA RATIO OVER THE URINE/SERUM CREATININE RATIO, TIMES 100 — i.e.
+% FEUrea = ([Uurea/Surea] / [Ucr/Scr]) × 100. It ships as an importable, byte-provenanced, PARAMETERIZED
+% `formula`, together with two exact rearrangements (the urine urea and the serum urea a given FEUrea
+% implies). As with every compute library, a consumer states NO arithmetic: it `import`s this file, binds the
+% four measured concentrations from its own byte-provenance decomposition, and asks the engine to APPLY the
+% cited formula on the CPU. Zero math is performed by the model; the engine computes each value EXACTLY (over
+% exact rationals), carrying the formula's citation.
+%
+%     import "fractional-excretion-of-urea.adj"
+%     observe urine_urea(300)        % "…urine urea 300…"   (span cited by the model)
+%     observe serum_urea(30)          % "…serum urea 30…"    (span cited by the model)
+%     observe urine_creatinine(100)   % "…urine Cr 100…"     (span cited by the model)
+%     observe serum_creatinine(2)     % "…serum Cr 2…"       (span cited by the model)
+%     ? fractional_excretion_of_urea(urine_urea, serum_creatinine, serum_urea, urine_creatinine)   % engine → 20
+%
+% Structurally this is a RATIO OF TWO RATIOS, SCALED BY 100 — the same clearance-fraction shape as the
+% fractional excretions of sodium, potassium, and phosphate — which is why this library reuses that proven
+% shape rather than inventing a new one; the novelty here is the ANALYTE (urea) and its diuretic-robust
+% clinical role, not the arithmetic. Written as a single fraction it is (Uurea × Scr × 100) / (Surea × Ucr).
+% The ONLY constant is the exact integer 100 (the percentage scale named in the cited equation); the four
+% concentrations are all formal parameters bound at apply time, so every value the engine returns is exact.
+% The three formulas COMPOSE and invert cleanly around the worked case urine urea = 300, serum urea = 30,
+% urine creatinine = 100, serum creatinine = 2 (FEUrea = 300 × 2 × 100 / (30 × 100) = 60000 / 3000 = 20 %):
+% the `fractional_excretion_of_urea` a consumer computes is exactly the value each inverse formula
+% back-solves to recover its own measured input (300, 30).
+%
+%   fractional_excretion_of_urea(urine_urea, serum_creatinine, serum_urea, urine_creatinine) = urine_urea * serum_creatinine * 100 / (serum_urea * urine_creatinine)   % (%)
+%   urine_urea(fractional_excretion_of_urea, serum_urea, urine_creatinine, serum_creatinine) = fractional_excretion_of_urea * serum_urea * urine_creatinine / (serum_creatinine * 100)  % (solved for urine urea)
+%   serum_urea(fractional_excretion_of_urea, urine_urea, serum_creatinine, urine_creatinine) = urine_urea * serum_creatinine * 100 / (fractional_excretion_of_urea * urine_creatinine)  % (solved for serum urea)
+%
+% NOTE ON UNITS AND MODELLING: urea and creatinine each appear as a URINE and a SERUM concentration, and
+% because the formula is a ratio of ratios the answer is unit-independent as long as each analyte uses the
+% SAME unit in numerator and denominator (urine urea and serum urea in the same unit; urine and serum
+% creatinine in the same unit). The result is a percentage. A FEUrea below roughly 35 % suggests a prerenal
+% state and above ~50 % suggests intrinsic injury; interpreting the number is the clinician's task, stated by
+% the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted FEUrea equation — because that one equation
+% ([Uurea/Surea]/[Ucr/Scr] × 100) sanctions the relation read every way. The quote is transcribed verbatim
+% from the PubMed Central article "Diagnostic performance of fractional excretion of urea in the evaluation
+% of critically ill patients with acute kidney injury: a multicenter cohort study", where the definition is
+% printed as "The FeUrea percentage was calculated as ([urinary urea/serum urea]/[urinary creatinine/serum
+% creatinine]) ×100" — a fully-bracketed, operand-complete formula. (That correctly-bracketed form was
+% chosen over an unbracketed "FEUN = … " restatement elsewhere whose strict operator precedence would place
+% urine creatinine in the numerator, i.e. would encode the wrong relation — grounding it would ground a
+% mistake.) Each `formula` therefore carries the provenance envelope every shipped grounded clause carries;
+% the linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula is a verbatim span
+% of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `urine_urea`, `serum_urea`, `urine_creatinine`, `serum_creatinine` and
+% `fractional_excretion_of_urea` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the everyday
+% names a decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary fractional_excretion_of_urea_vocab {
+    define urine_urea                    : finding  surface "urine urea", "urinary urea", "Uurea", "urine urea nitrogen" % conc
+    define serum_urea                    : finding  surface "serum urea", "plasma urea", "Surea", "serum urea nitrogen"  % conc
+    define urine_creatinine              : finding  surface "urine creatinine", "urinary creatinine", "UCr"              % conc
+    define serum_creatinine              : finding  surface "serum creatinine", "plasma creatinine", "SCr"               % conc
+    define fractional_excretion_of_urea  : finding  surface "fractional excretion of urea", "FEUrea", "FeUrea", "FEUN"   % %
+}
+
+% ----------------------------------------------------------------------------
+% The fractional excretion of urea, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the FEUrea equation from the PMC article (a quote is
+% required on a shipped formula). Each is an exact expression in the measured values and the exact integer
+% 100, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook fractional_excretion_of_urea_laws {
+    use fractional_excretion_of_urea_vocab
+
+    % FEUrea — the urine/serum urea ratio over the urine/serum creatinine ratio, as a percentage.
+    formula fractional_excretion_of_urea(urine_urea, serum_creatinine, serum_urea, urine_creatinine) = urine_urea * serum_creatinine * 100 / (serum_urea * urine_creatinine)
+        source "([urinary urea/serum urea]/[urinary creatinine/serum creatinine]) ×100"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC3387621/"
+        trust authoritative
+
+    % Urine urea — the same equation solved for the urine urea. Defended by the SAME equation.
+    formula urine_urea(fractional_excretion_of_urea, serum_urea, urine_creatinine, serum_creatinine) = fractional_excretion_of_urea * serum_urea * urine_creatinine / (serum_creatinine * 100)
+        source "([urinary urea/serum urea]/[urinary creatinine/serum creatinine]) ×100"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC3387621/"
+        trust authoritative
+
+    % Serum urea — the same equation solved for the serum urea, the third reading of the one law.
+    formula serum_urea(fractional_excretion_of_urea, urine_urea, serum_creatinine, urine_creatinine) = urine_urea * serum_creatinine * 100 / (fractional_excretion_of_urea * urine_creatinine)
+        source "([urinary urea/serum urea]/[urinary creatinine/serum creatinine]) ×100"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC3387621/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-urea.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-urea.query.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% fractional-excretion-of-urea.query.adj — worked applications of the fractional excretion of urea.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an AKI work-up into a urine urea, a serum urea, a
+% urine creatinine, and a serum creatinine: it `import`s the grounded formulabook, `observe`s the four
+% values, and asks the engine to APPLY the cited FEUrea formula. No arithmetic is stated by the consumer;
+% the engine computes each value EXACTLY (over exact rationals) and carries the article's citation as its
+% proof, on the CPU, with zero model calls.
+%
+% Worked case (urine urea = 300, serum urea = 30, urine creatinine = 100, serum creatinine = 2):
+% FEUrea = 300 × 2 × 100 / (30 × 100) = 60000 / 3000 = 20 %. Each query fixes the other inputs and asks the
+% engine to recover another quantity; every answer is exact and the inversions COMPOSE (each recovers
+% exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli fractional-excretion-of-urea.query.adj
+% ============================================================================
+
+import "fractional-excretion-of-urea.adj"
+
+% --- FEUrea: the percentage the four concentrations imply (expect 20). -------------------------------
+observe urine_urea(300)
+observe serum_urea(30)
+observe urine_creatinine(100)
+observe serum_creatinine(2)
+? fractional_excretion_of_urea(urine_urea, serum_creatinine, serum_urea, urine_creatinine)   % expect 20
+
+% --- Inverse: the urine urea a FEUrea of 20 implies at the same other values (expect 300). -----------
+observe fractional_excretion_of_urea(20)
+? urine_urea(fractional_excretion_of_urea, serum_urea, urine_creatinine, serum_creatinine)   % expect 300


### PR DESCRIPTION
## Summary

Adds the **fractional excretion of urea (FEUrea)** to the clinical formulabook track of `adj-formula-stdlib`:

> FEUrea = **([urine urea / serum urea] / [urine creatinine / serum creatinine]) × 100**

with two exact algebraic rearrangements (solve for urine urea; solve for serum urea). All three formulas carry the SAME verbatim equation, transcribed from the PMC article **"Diagnostic performance of fractional excretion of urea in the evaluation of critically ill patients with acute kidney injury: a multicenter cohort study"** ([PMC3387621](https://pmc.ncbi.nlm.nih.gov/articles/PMC3387621/)):

> `([urinary urea/serum urea]/[urinary creatinine/serum creatinine]) ×100`

## Why this formula

FEUrea distinguishes **prerenal** AKI (low) from **intrinsic/ATN** (high), and — because urea handling is passive rather than transporter-driven — it stays informative when loop diuretics have made the fractional excretion of sodium unreliable. That diuretic-robust role is its distinct clinical value. Arithmetically it is the **same ratio-of-two-ratios × 100 shape** as the shipped FE-sodium/potassium/phosphate libraries, deliberately reused rather than reinvented — the novelty here is the **analyte** (urea), not the shape. As a single fraction: `(Uurea × Scr × 100) / (Surea × Ucr)`. The only constant is the exact integer 100; the four concentrations are formal parameters bound at apply time, so every value the engine returns is exact (over exact rationals).

## Provenance note (why this source, not another)

The correctly-**bracketed** PMC3387621 form was chosen over an equals-sign restatement on another PMC page — `FEUN=urinary urea×serum creatinine×100/serum urea×urinary creatinine` — whose **unbracketed** notation, read under strict operator precedence, places urine creatinine in the **numerator**, i.e. encodes the *wrong* relation. Grounding the exact bytes of that form would ground a mistake; the bracketed ratio-of-ratios is the faithful, correct span.

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the four concentrations, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case Uurea = 300, Surea = 30, Ucr = 100, Scr = 2 (300 × 2 × 100 / (30 × 100) = **20 %**): each inverse back-solves exactly to recover its own measured input.

## Files
- `clinical/fractional-excretion-of-urea.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/fractional-excretion-of-urea.query.adj` — worked case (FEUrea 20; inverse urine urea 300)
- `adj-lang-cli/tests/formula_fractional_excretion_of_urea_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the derivation carries the `100` constant and the `600`/`3000`/`60000` intermediates, and `30` is a prefix of `300`, so the name-anchored adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)