### PR TITLE
feat(adj-formula-stdlib): physiologic-dead-space — Bohr equation VD = VT × (PaCO2 − PeCO2) / PaCO2 (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_physiologic_dead_space_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_physiologic_dead_space_e2e.rs
@@ -1,0 +1,147 @@
+//! End-to-end tests for the `clinical/physiologic-dead-space.adj` library — the Bohr physiologic dead space
+//! (VD = tidal volume × (PaCO2 − PeCO2) / PaCO2) and its two exact rearrangements — driven through the built
+//! CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a consumer
+//! states NO arithmetic; it imports the grounded library, binds the tidal volume, the arterial CO2, and the
+//! mixed-expired CO2 with `observe`, and the engine applies the cited formula on the CPU, computing the
+//! EXACT value (over exact rationals) and rendering the citation and trust tier in the `derived` section
+//! (the auditable answer). The three formulas INVERT around the worked case VT = 500, PaCO2 = 40, PeCO2 = 20:
+//! 500 × (40 − 20) / 40 = 250 (VD), 250 × 40 / (40 − 20) = 500 (VT), 40 − 250 × 40 / 500 = 20 (PeCO2).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation tree carries the intermediates 20 (= 40 − 20) and 10000 (= 500 × 20), so a
+//! bare numeric substring could spuriously match. The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped physiologic-dead-space library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_vd_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/physiologic-dead-space.adj")
+        .canonicalize()
+        .expect("shipped physiologic-dead-space.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_vd_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_vd_lib()).unwrap();
+    std::fs::write(dir.join("physiologic-dead-space.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// dead_space_volume — the dead space: VT × (PaCO2 − PeCO2) / PaCO2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_dead_space_library_and_computes_it_with_citation() {
+    let dir = scratch("vd");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"physiologic-dead-space.adj\"\n\
+         observe tidal_volume(500)\n\
+         observe paco2(40)\n\
+         observe peco2(20)\n\
+         ? dead_space_volume(tidal_volume, paco2, peco2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 500 × (40 − 20) / 40 = 250, computed
+    // EXACTLY over rationals. Match the adjacent name/value pair so the 20 and 10000 intermediates cannot
+    // spuriously satisfy a bare "value":250.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"dead_space_volume\",\"value\":250"),
+        "dead_space_volume(500, 40, 20) = 250: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tidal_volume — the same equation solved for the tidal volume: VD × PaCO2 / (PaCO2 − PeCO2).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_tidal_volume_from_dead_space_with_citation() {
+    let dir = scratch("vt");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"physiologic-dead-space.adj\"\n\
+         observe dead_space_volume(250)\n\
+         observe paco2(40)\n\
+         observe peco2(20)\n\
+         ? tidal_volume(dead_space_volume, paco2, peco2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 250 × 40 / (40 − 20) = 10000 / 20 = 500, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"tidal_volume\",\"value\":500"),
+        "tidal_volume(250, 40, 20) = 500: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "tidal_volume carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// peco2 — the same equation solved for the mixed-expired CO2: PaCO2 − VD × PaCO2 / VT, the third reading of
+// the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_peco2_from_dead_space_with_citation() {
+    let dir = scratch("peco2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"physiologic-dead-space.adj\"\n\
+         observe dead_space_volume(250)\n\
+         observe tidal_volume(500)\n\
+         observe paco2(40)\n\
+         ? peco2(dead_space_volume, tidal_volume, paco2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 40 − 250 × 40 / 500 = 40 − 10000 / 500 = 40 − 20 = 20, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"peco2\",\"value\":20"),
+        "peco2(250, 500, 40) = 20: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "peco2 carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/physiologic-dead-space.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/physiologic-dead-space.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% physiologic-dead-space.adj — the physiologic dead space (Bohr equation)
+% (VD = tidal volume × (PaCO2 − PeCO2) / PaCO2) in the ADJ standard library.
+% ============================================================================
+% The physiologic-dead-space entry of the *clinical* track — the portion of each breath that ventilates
+% airway and alveoli WITHOUT taking part in gas exchange, quantified by the Bohr equation. The logic is a
+% CO2 mass balance: all the CO2 in the mixed expired gas comes only from the alveoli that were perfused, so
+% the fraction of the tidal volume that was "wasted" (dead space) equals the shortfall between the arterial
+% CO2 tension (what perfused alveoli equilibrate to) and the mixed-expired CO2 tension (diluted by
+% dead-space gas that carries none), scaled by the tidal volume. A rising dead space — pulmonary embolism,
+% low cardiac output, over-distension — shows up as a falling mixed-expired (and end-tidal) CO2 despite an
+% unchanged arterial CO2, which is exactly what this equation captures. THE PHYSIOLOGIC DEAD SPACE IS THE
+% TIDAL VOLUME TIMES THE ARTERIAL-MINUS-EXPIRED CO2 GAP, DIVIDED BY THE ARTERIAL CO2 — i.e.
+% VD = VT × (PaCO2 − PeCO2) / PaCO2. It ships as an importable, byte-provenanced, PARAMETERIZED `formula`,
+% together with two exact rearrangements (the tidal volume a given dead space implies, and the mixed-expired
+% CO2 a given dead space implies). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the tidal volume, arterial CO2, and expired CO2 from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "physiologic-dead-space.adj"
+%     observe tidal_volume(500)   % "…VT 500 mL…"        (span cited by the model)
+%     observe paco2(40)            % "…PaCO2 40 mmHg…"    (span cited by the model)
+%     observe peco2(20)            % "…PeCO2 20 mmHg…"    (span cited by the model)
+%     ? dead_space_volume(tidal_volume, paco2, peco2)   % engine → 250 (mL)
+%
+% Structurally this is a PRODUCT OF A VALUE AND A DIFFERENCE, OVER A VALUE THAT ALSO APPEARS IN THE
+% DIFFERENCE — the tidal volume times the CO2 gap, divided by the arterial CO2 (which is also the difference's
+% minuend) — a shape distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant,
+% chained-division, constant-scaled-difference, product-times-constant, three-way-product-over-divisor,
+% product-of-a-ratio-and-a-value, quotient-over-a-difference, constant-times-a-difference-over-a-divisor, and
+% two-variables-and-a-constant-over-a-divisor forms of the other clinical libraries. There is NO embedded
+% constant: the tidal volume and the two CO2 tensions are all formal parameters bound at apply time, so
+% every value the engine returns is exact. The three formulas COMPOSE and invert cleanly around the worked
+% case tidal volume = 500 mL, arterial CO2 = 40 mmHg, expired CO2 = 20 mmHg
+% (VD = 500 × (40 − 20) / 40 = 500 × 20 / 40 = 250 mL): the `dead_space_volume` a consumer computes is
+% exactly the value each inverse formula back-solves to recover its own measured input (500, 20).
+%
+%   dead_space_volume(tidal_volume, paco2, peco2) = tidal_volume * (paco2 - peco2) / paco2        % (mL)
+%   tidal_volume(dead_space_volume, paco2, peco2) = dead_space_volume * paco2 / (paco2 - peco2)     % (solved for tidal volume)
+%   peco2(dead_space_volume, tidal_volume, paco2) = paco2 - dead_space_volume * paco2 / tidal_volume % (solved for expired CO2)
+%
+% NOTE ON UNITS AND MODELLING: the tidal volume is in millilitres (mL) and the dead space comes out in the
+% same unit; the two CO2 tensions must share a unit (mmHg here, but the ratio is unit-independent as long as
+% PaCO2 and PeCO2 match). PeCO2 is the MIXED-EXPIRED CO2 (from collected expirate), which is not the same as
+% the end-tidal CO2; substituting end-tidal for mixed-expired gives the Enghoff modification, a different
+% (larger) dead space. This library only COMPUTES the dead space; obtaining a true mixed-expired CO2 and
+% interpreting the number is the clinician's task, stated by the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted Bohr equation — because that one equation
+% (VT × (PaCO2 − PeCO2) / PaCO2) sanctions the relation read every way. The quote is transcribed verbatim
+% from the StatPearls "Physiology, Lung Dead Space" article on the NCBI Bookshelf (a current, non-archived
+% article), so each `formula` carries the provenance envelope every shipped grounded clause carries; the
+% linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula is a verbatim span of
+% the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `tidal_volume`, `paco2`, `peco2` and `dead_space_volume` each appear BOTH as a derived result
+% and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary physiologic_dead_space_vocab {
+    define tidal_volume       : finding  surface "tidal volume", "VT", "Vt"                                 % mL
+    define paco2              : finding  surface "PaCO2", "arterial CO2", "arterial carbon dioxide tension" % mmHg
+    define peco2              : finding  surface "PeCO2", "mixed expired CO2", "mixed-expired carbon dioxide" % mmHg
+    define dead_space_volume  : finding  surface "dead space volume", "physiologic dead space", "VD", "dead space" % mL
+}
+
+% ----------------------------------------------------------------------------
+% The physiologic dead space, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the Bohr equation from the StatPearls "Physiology, Lung
+% Dead Space" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% expression in the measured values, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook physiologic_dead_space_laws {
+    use physiologic_dead_space_vocab
+
+    % Dead space — tidal volume times the arterial-minus-expired CO2 gap, over the arterial CO2.
+    formula dead_space_volume(tidal_volume, paco2, peco2) = tidal_volume * (paco2 - peco2) / paco2
+        source "VD = VT × (PaCO2 − PeCO2) / PaCO2"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482501/"
+        trust authoritative
+
+    % Tidal volume — the same equation solved for the tidal volume. Defended by the SAME equation.
+    formula tidal_volume(dead_space_volume, paco2, peco2) = dead_space_volume * paco2 / (paco2 - peco2)
+        source "VD = VT × (PaCO2 − PeCO2) / PaCO2"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482501/"
+        trust authoritative
+
+    % Mixed-expired CO2 — the same equation solved for PeCO2, the third reading of the one law.
+    formula peco2(dead_space_volume, tidal_volume, paco2) = paco2 - dead_space_volume * paco2 / tidal_volume
+        source "VD = VT × (PaCO2 − PeCO2) / PaCO2"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482501/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/physiologic-dead-space.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/physiologic-dead-space.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% physiologic-dead-space.query.adj — worked applications of the Bohr physiologic dead space.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a ventilation problem into a tidal volume, an
+% arterial CO2, and a mixed-expired CO2: it `import`s the grounded formulabook, `observe`s the three values,
+% and asks the engine to APPLY the cited Bohr equation. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the
+% CPU, with zero model calls.
+%
+% Worked case (tidal volume = 500 mL, arterial CO2 = 40 mmHg, mixed-expired CO2 = 20 mmHg):
+% VD = 500 × (40 − 20) / 40 = 500 × 20 / 40 = 250 mL. Each query fixes two of the three inputs and asks the
+% engine to recover another quantity; every answer is exact and the inversions COMPOSE (each recovers
+% exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli physiologic-dead-space.query.adj
+% ============================================================================
+
+import "physiologic-dead-space.adj"
+
+% --- VD: the dead space the tidal volume and CO2 tensions imply (expect 250). ------------------------
+observe tidal_volume(500)
+observe paco2(40)
+observe peco2(20)
+? dead_space_volume(tidal_volume, paco2, peco2)   % expect 250
+
+% --- Inverse: the tidal volume a 250 mL dead space implies at the same CO2 tensions (expect 500). ----
+observe dead_space_volume(250)
+? tidal_volume(dead_space_volume, paco2, peco2)   % expect 500


### PR DESCRIPTION
## Summary

Adds the **physiologic (Bohr) dead space** to the clinical formulabook track of `adj-formula-stdlib`:

> VD = **tidal volume × (PaCO₂ − PeCO₂) / PaCO₂**

with two exact algebraic rearrangements (solve for tidal volume; solve for mixed-expired CO₂). All three formulas carry the SAME verbatim equation, transcribed from the StatPearls **"Physiology, Lung Dead Space"** article on the NCBI Bookshelf ([NBK482501](https://www.ncbi.nlm.nih.gov/books/NBK482501/), current/non-archived):

> `VD = VT × (PaCO2 − PeCO2) / PaCO2`

The `×` (U+00D7) and `−` (U+2212) are transcribed **byte-faithfully** — the only non-ASCII characters in the source strings. The page's equation is **correctly bracketed** (the `(PaCO2 − PeCO2)` numerator is parenthesized before `/ PaCO2`), so strict operator precedence reads it correctly.

## Why this shape

Structurally this is a **product of a value and a difference, over a value that also appears in the difference** (tidal volume × the arterial-minus-expired CO₂ gap, divided by the arterial CO₂ — which is also the difference's minuend) — a shape distinct from all previously shipped clinical libraries. There is **no embedded constant**: the tidal volume and the two CO₂ tensions are all formal parameters bound at apply time, so every value the engine returns is exact (over exact rationals). It opens a **new clinical domain** — respiratory dead space / CO₂ mass balance.

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the three quantities, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case VT = 500 mL, PaCO₂ = 40 mmHg, PeCO₂ = 20 mmHg (500 × (40 − 20) / 40 = **250** mL): each inverse back-solves exactly to recover its own measured input.

## Files
- `clinical/physiologic-dead-space.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/physiologic-dead-space.query.adj` — worked case (VD 250; inverse VT 500)
- `adj-lang-cli/tests/formula_physiologic_dead_space_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the derivation carries the `20` (= 40 − 20) and `10000` (= 500 × 20) intermediates, so the name-anchored adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)