### PR TITLE
feat(adj-formula-stdlib): transferrin-saturation — TSAT = [serum iron / transferrin] × 70.9 iron-studies library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_transferrin_saturation_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_transferrin_saturation_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end tests for the `clinical/transferrin-saturation.adj` library — the transferrin saturation
+//! (TSAT = [serum iron / transferrin] × 70.9) and its two exact rearrangements — driven through the built
+//! CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a consumer
+//! states NO arithmetic; it imports the grounded library, binds the serum iron and the transferrin with
+//! `observe`, and the engine applies the cited formula on the CPU, computing the EXACT value (over exact
+//! rationals) and rendering the citation and trust tier in the `derived` section (the auditable answer). The
+//! three formulas INVERT around the worked case serum iron = 100, transferrin = 200: 100 / 200 × 70.9 =
+//! 35.45 (TSAT), 35.45 × 200 / 70.9 = 100 (serum iron), 100 × 70.9 / 35.45 = 200 (transferrin).
+//!
+//! The forward value 35.45 is the engine's EXACT rational (709/20) exported once to f64 — it renders cleanly
+//! (no accumulated-error noise) because the engine computes over exact rationals and converts a single time;
+//! the two inversions land on integers. The assertions match the ADJACENT `"name":...,"value":...` pair the
+//! engine renders, rather than a bare `"value":N`, so a substring cannot spuriously match.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped transferrin-saturation library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_tsat_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/transferrin-saturation.adj")
+        .canonicalize()
+        .expect("shipped transferrin-saturation.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_tsat_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_tsat_lib()).unwrap();
+    std::fs::write(dir.join("transferrin-saturation.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// transferrin_saturation — the saturation: [serum iron / transferrin] × 70.9.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_transferrin_saturation_library_and_computes_it_with_citation() {
+    let dir = scratch("tsat");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"transferrin-saturation.adj\"\n\
+         observe serum_iron(100)\n\
+         observe transferrin(200)\n\
+         ? transferrin_saturation(serum_iron, transferrin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 100 / 200 × 70.9 = 35.45, computed
+    // EXACTLY over rationals (709/20) and exported once to f64. Match the adjacent name/value pair.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"transferrin_saturation\",\"value\":35.45"),
+        "transferrin_saturation(100, 200) = 35.45: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_iron — the same equation solved for the serum iron: TSAT × transferrin / 70.9.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_iron_from_saturation_with_citation() {
+    let dir = scratch("fe");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"transferrin-saturation.adj\"\n\
+         observe transferrin_saturation(35.45)\n\
+         observe transferrin(200)\n\
+         ? serum_iron(transferrin_saturation, transferrin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 35.45 × 200 / 70.9 = 7090 / 70.9 = 100, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_iron\",\"value\":100"),
+        "serum_iron(35.45, 200) = 100: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_iron carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// transferrin — the same equation solved for the transferrin: serum iron × 70.9 / TSAT, the third reading
+// of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_transferrin_from_saturation_with_citation() {
+    let dir = scratch("tf");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"transferrin-saturation.adj\"\n\
+         observe transferrin_saturation(35.45)\n\
+         observe serum_iron(100)\n\
+         ? transferrin(transferrin_saturation, serum_iron)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 100 × 70.9 / 35.45 = 7090 / 35.45 = 200, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"transferrin\",\"value\":200"),
+        "transferrin(35.45, 100) = 200: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "transferrin carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/transferrin-saturation.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/transferrin-saturation.adj
@@ -1,0 +1,98 @@
+% ============================================================================
+% transferrin-saturation.adj — the transferrin saturation
+% (TSAT = [serum iron / transferrin] × 70.9) in the ADJ standard library.
+% ============================================================================
+% The transferrin-saturation entry of the *clinical* track — the percentage of the blood's iron-carrying
+% protein (transferrin) that is actually loaded with iron. It is a core iron-study index: a LOW saturation
+% (empty carriers) points to iron-deficiency states, while a HIGH saturation (carriers overfull) points to
+% iron overload such as haemochromatosis. Each milligram per decilitre of transferrin can bind a fixed
+% amount of iron, so multiplying the transferrin concentration by that binding factor gives the total
+% iron-binding capacity; the saturation is then the measured serum iron as a percentage of what the
+% transferrin present could carry. The cited article expresses this directly in terms of the transferrin
+% concentration, folding the unit conversion and the ×100 percentage scale into a single factor of 70.9
+% (serum iron in µg/dL over transferrin in mg/dL). THE TRANSFERRIN SATURATION IS THE SERUM IRON DIVIDED BY
+% THE TRANSFERRIN, TIMES 70.9 — i.e. TSAT = [serum Fe / transferrin] × 70.9. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with two exact rearrangements (the serum iron and the
+% transferrin a given saturation implies). As with every compute library, a consumer states NO arithmetic:
+% it `import`s this file, binds the serum iron and transferrin from its own byte-provenance decomposition,
+% and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "transferrin-saturation.adj"
+%     observe serum_iron(100)     % "…serum iron 100 µg/dL…"   (span cited by the model)
+%     observe transferrin(200)     % "…transferrin 200 mg/dL…"  (span cited by the model)
+%     ? transferrin_saturation(serum_iron, transferrin)   % engine → 35.45 (%)
+%
+% Structurally this is a RATIO SCALED BY A CONSTANT — the serum-iron-to-transferrin ratio times the fixed
+% factor 70.9 — the same product-times-constant family as several other clinical libraries, reused here for a
+% NEW quantity (iron saturation) rather than reinvented; the novelty is the analyte pair and its
+% iron-overload/deficiency role, not the arithmetic. The embedded constant is 70.9 (the µg-per-mg iron-binding
+% factor times the percentage scale, exactly as the cited equation prints it); the serum iron and transferrin
+% are formal parameters bound at apply time. The engine holds 70.9 as an EXACT rational (709/10) and computes
+% each value EXACTLY; the rendered `value` is the engine's single lossless-to-lossy f64 export of that exact
+% result. The three formulas COMPOSE and invert cleanly around the worked case serum iron = 100 µg/dL,
+% transferrin = 200 mg/dL (TSAT = 100 / 200 × 70.9 = 0.5 × 70.9 = 35.45 %): the `transferrin_saturation` a
+% consumer computes is exactly the value each inverse formula back-solves to recover its own measured input
+% (100, 200).
+%
+%   transferrin_saturation(serum_iron, transferrin) = serum_iron / transferrin * 70.9   % (%)
+%   serum_iron(transferrin_saturation, transferrin) = transferrin_saturation * transferrin / 70.9   % (solved for serum iron)
+%   transferrin(transferrin_saturation, serum_iron) = serum_iron * 70.9 / transferrin_saturation     % (solved for transferrin)
+%
+% NOTE ON UNITS AND MODELLING: this specific form pins the units — serum iron in µg/dL and transferrin in
+% mg/dL — because the factor 70.9 encodes exactly that conversion (a mixed-unit factor, unlike the
+% unit-independent "serum iron / TIBC × 100" restatement). Bind the serum iron and transferrin in those
+% units, or the 70.9 factor no longer applies. This library only COMPUTES the saturation; interpreting a low
+% or high value against the iron-study panel is the clinician's task, stated by the cited source but applied
+% by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted saturation equation — because that one
+% equation ([serum Fe / transferrin] × 70.9) sanctions the relation read every way. The quote is transcribed
+% verbatim from the StatPearls "Iron-Binding Capacity" article on the NCBI Bookshelf (a current, non-archived
+% article), which prints it as a fully-bracketed equation with an equals sign; this transferrin-and-70.9 form
+% was grounded because it is the page's TYPED equation, whereas the tidier "serum iron / TIBC × 100"
+% restatement appears there only as prose. Each `formula` therefore carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored
+% — the formula is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `serum_iron`, `transferrin` and `transferrin_saturation` each appear BOTH as a derived result
+% and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary transferrin_saturation_vocab {
+    define serum_iron              : finding  surface "serum iron", "serum Fe", "iron", "Fe"          % µg/dL
+    define transferrin             : finding  surface "transferrin", "Tf", "serum transferrin"        % mg/dL
+    define transferrin_saturation  : finding  surface "transferrin saturation", "TSAT", "iron saturation", "Tsat" % %
+}
+
+% ----------------------------------------------------------------------------
+% The transferrin saturation, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the saturation equation from the StatPearls
+% "Iron-Binding Capacity" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is
+% an exact expression in the measured values and the exact factor 70.9, so the engine returns each value
+% EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook transferrin_saturation_laws {
+    use transferrin_saturation_vocab
+
+    % TSAT — the serum-iron-to-transferrin ratio, scaled by the 70.9 iron-binding-and-percentage factor.
+    formula transferrin_saturation(serum_iron, transferrin) = serum_iron / transferrin * 70.9
+        source "Transferrin saturation (TSAT %) = [serum Fe (µg/dL) / transferrin (mg/dL)] × 70.9"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559119/"
+        trust authoritative
+
+    % Serum iron — the same equation solved for the serum iron. Defended by the SAME equation.
+    formula serum_iron(transferrin_saturation, transferrin) = transferrin_saturation * transferrin / 70.9
+        source "Transferrin saturation (TSAT %) = [serum Fe (µg/dL) / transferrin (mg/dL)] × 70.9"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559119/"
+        trust authoritative
+
+    % Transferrin — the same equation solved for the transferrin, the third reading of the one law.
+    formula transferrin(transferrin_saturation, serum_iron) = serum_iron * 70.9 / transferrin_saturation
+        source "Transferrin saturation (TSAT %) = [serum Fe (µg/dL) / transferrin (mg/dL)] × 70.9"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559119/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/transferrin-saturation.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/transferrin-saturation.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% transferrin-saturation.query.adj — worked applications of the transferrin saturation.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an iron-study panel into a serum iron and a
+% transferrin: it `import`s the grounded formulabook, `observe`s the two values, and asks the engine to
+% APPLY the cited saturation formula. No arithmetic is stated by the consumer; the engine computes each
+% value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with
+% zero model calls.
+%
+% Worked case (serum iron = 100 µg/dL, transferrin = 200 mg/dL): TSAT = 100 / 200 × 70.9 = 0.5 × 70.9 =
+% 35.45 %. Each query fixes one of the two inputs and asks the engine to recover another quantity; every
+% answer is exact and the inversions COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli transferrin-saturation.query.adj
+% ============================================================================
+
+import "transferrin-saturation.adj"
+
+% --- TSAT: the saturation the iron and transferrin imply (expect 35.45). -----------------------------
+observe serum_iron(100)
+observe transferrin(200)
+? transferrin_saturation(serum_iron, transferrin)   % expect 35.45
+
+% --- Inverse: the serum iron a 35.45 % saturation implies at the same transferrin (expect 100). ------
+observe transferrin_saturation(35.45)
+? serum_iron(transferrin_saturation, transferrin)   % expect 100


### PR DESCRIPTION
## Summary

Adds the **transferrin saturation (TSAT)** to the clinical formulabook track of `adj-formula-stdlib`:

> TSAT = **[serum iron / transferrin] × 70.9**

with two exact algebraic rearrangements (solve for serum iron; solve for transferrin). All three formulas carry the SAME verbatim equation, transcribed from the StatPearls **"Iron-Binding Capacity"** article on the NCBI Bookshelf ([NBK559119](https://www.ncbi.nlm.nih.gov/books/NBK559119/), current/non-archived):

> `Transferrin saturation (TSAT %) = [serum Fe (µg/dL) / transferrin (mg/dL)] × 70.9`

The `µ` (U+00B5 micro sign) and `×` (U+00D7) are transcribed **byte-faithfully** — the only non-ASCII characters in the source strings.

## Source-choice note (why this form)

This **transferrin-and-70.9** form was grounded because it is the page's **typed, equals-signed, fully-bracketed** equation. The tidier and more familiar `serum iron / TIBC × 100` restatement appears on that page (and on the "Iron" and "Biochemistry, Transferrin" pages) only as **prose with no operator symbols**, which fails the typed-equation gate — grounding a paraphrase would not be byte-faithful. The 70.9 factor folds the µg-per-mg iron-binding conversion and the ×100 percentage scale into one constant, which is why this form **pins the units** (iron µg/dL, transferrin mg/dL).

## Why this shape

Structurally this is a **ratio scaled by a constant** (serum-iron-to-transferrin ratio × 70.9) — the product-times-constant family, reused here for a **new quantity** (iron saturation / iron-studies domain) rather than reinvented; the novelty is the analyte pair and its iron-overload/deficiency role. The engine holds 70.9 as the **exact rational 709/10** and computes each value EXACTLY; the rendered `value` is the engine's single f64 export of that exact result.

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the two analytes, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case serum iron = 100 µg/dL, transferrin = 200 mg/dL (100 / 200 × 70.9 = 0.5 × 70.9 = **35.45 %**) — a physiologically normal panel. The forward result 35.45 is the exact rational 709/20 exported **once** to f64 and renders cleanly (no accumulated-error noise, verified by render-probe); both inversions land on integers (100, 200), each back-solving exactly to recover its own measured input.

## Files
- `clinical/transferrin-saturation.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/transferrin-saturation.query.adj` — worked case (TSAT 35.45; inverse serum iron 100)
- `adj-lang-cli/tests/formula_transferrin_saturation_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`), so a substring cannot spuriously match.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)