### PR TITLE
feat(adj-formula-stdlib): corrected-reticulocyte-count — retic % × (patient Hct / normal Hct) hematology library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_corrected_reticulocyte_count_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_corrected_reticulocyte_count_e2e.rs
@@ -1,0 +1,148 @@
+//! End-to-end tests for the `clinical/corrected-reticulocyte-count.adj` library — the corrected
+//! reticulocyte count (corrected retic = reticulocyte % × (patient Hct / normal Hct)) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same invariant as
+//! every other formula library: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! reticulocyte percentage, the patient haematocrit, and the normal haematocrit with `observe`, and the
+//! engine applies the cited formula on the CPU, computing the EXACT value (over exact rationals) and
+//! rendering the citation and trust tier in the `derived` section (the auditable answer). The three formulas
+//! INVERT around the worked case retic = 4, patient Hct = 20, normal Hct = 40: 4 × (20 / 40) = 2 (corrected),
+//! 2 × 40 / 20 = 4 (retic %), 2 × 40 / 4 = 20 (patient Hct).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the result 2 is a leading-digit prefix of the patient-Hct 20 and the normal-Hct 40, so a
+//! bare `"value":2` substring could spuriously match. The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped corrected-reticulocyte-count library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_crc_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/corrected-reticulocyte-count.adj")
+        .canonicalize()
+        .expect("shipped corrected-reticulocyte-count.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_crc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_crc_lib()).unwrap();
+    std::fs::write(dir.join("corrected-reticulocyte-count.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// corrected_reticulocyte_count — the corrected percentage: retic × (patient Hct / normal Hct).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_corrected_reticulocyte_library_and_computes_it_with_citation() {
+    let dir = scratch("crc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-reticulocyte-count.adj\"\n\
+         observe reticulocyte_percent(4)\n\
+         observe patient_hematocrit(20)\n\
+         observe normal_hematocrit(40)\n\
+         ? corrected_reticulocyte_count(reticulocyte_percent, patient_hematocrit, normal_hematocrit)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 4 × (20 / 40) = 2, computed EXACTLY
+    // over rationals. Match the adjacent name/value pair so the 20/40 inputs cannot spuriously satisfy a
+    // bare "value":2.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"corrected_reticulocyte_count\",\"value\":2"),
+        "corrected_reticulocyte_count(4, 20, 40) = 2: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// reticulocyte_percent — the same equation solved for the raw retic %: corrected × normal Hct / patient Hct.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_reticulocyte_percent_from_corrected_with_citation() {
+    let dir = scratch("retic");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-reticulocyte-count.adj\"\n\
+         observe corrected_reticulocyte_count(2)\n\
+         observe patient_hematocrit(20)\n\
+         observe normal_hematocrit(40)\n\
+         ? reticulocyte_percent(corrected_reticulocyte_count, patient_hematocrit, normal_hematocrit)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 × 40 / 20 = 80 / 20 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"reticulocyte_percent\",\"value\":4"),
+        "reticulocyte_percent(2, 20, 40) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "reticulocyte_percent carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// patient_hematocrit — the same equation solved for the patient Hct: corrected × normal Hct / retic %, the
+// third reading of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_patient_hematocrit_from_corrected_with_citation() {
+    let dir = scratch("hct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-reticulocyte-count.adj\"\n\
+         observe corrected_reticulocyte_count(2)\n\
+         observe reticulocyte_percent(4)\n\
+         observe normal_hematocrit(40)\n\
+         ? patient_hematocrit(corrected_reticulocyte_count, reticulocyte_percent, normal_hematocrit)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 × 40 / 4 = 80 / 4 = 20, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"patient_hematocrit\",\"value\":20"),
+        "patient_hematocrit(2, 4, 40) = 20: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "patient_hematocrit carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/corrected-reticulocyte-count.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/corrected-reticulocyte-count.adj
@@ -1,0 +1,99 @@
+% ============================================================================
+% corrected-reticulocyte-count.adj — the corrected reticulocyte count
+% (corrected retic = reticulocyte % × (patient hematocrit / normal hematocrit)) in the ADJ stdlib.
+% ============================================================================
+% The corrected-reticulocyte-count entry of the *clinical* track — the reticulocyte percentage adjusted for
+% the degree of anaemia, so that a marrow's true erythropoietic effort can be read off a single number. The
+% raw reticulocyte percentage is a FRACTION of the red cells present, so in anaemia the same absolute number
+% of young cells looks like a bigger percentage simply because the denominator (the total red-cell mass) has
+% shrunk. Scaling the percentage by the patient's haematocrit over a normal haematocrit undoes that
+% inflation: a reticulocyte count that looks reassuringly high in a severely anaemic patient is revealed, once
+% corrected, to be an inadequate response. THE CORRECTED RETICULOCYTE COUNT IS THE RETICULOCYTE PERCENTAGE
+% TIMES THE PATIENT-TO-NORMAL HAEMATOCRIT RATIO — i.e. corrected retic = reticulocyte % × (patient Hct /
+% normal Hct). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with two exact
+% rearrangements (the raw reticulocyte percentage and the patient haematocrit a given corrected count
+% implies). It is the input to the reticulocyte production index (reticulocyte-production-index.adj), which
+% then divides by a maturation factor; this library computes the CORRECTION step alone. As with every compute
+% library, a consumer states NO arithmetic: it `import`s this file, binds the reticulocyte percentage, the
+% patient haematocrit, and the normal haematocrit from its own byte-provenance decomposition, and asks the
+% engine to APPLY the cited formula on the CPU. Zero math is performed by the model; the engine computes each
+% value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "corrected-reticulocyte-count.adj"
+%     observe reticulocyte_percent(4)    % "…retics 4%…"        (span cited by the model)
+%     observe patient_hematocrit(20)      % "…Hct 20%…"          (span cited by the model)
+%     observe normal_hematocrit(40)       % "…normal Hct 40%…"   (span cited by the model)
+%     ? corrected_reticulocyte_count(reticulocyte_percent, patient_hematocrit, normal_hematocrit)   % engine → 2
+%
+% Structurally this is a VALUE TIMES A RATIO — the reticulocyte percentage scaled by the haematocrit ratio —
+% the same product-of-a-value-and-a-ratio family as the gravity IV drip rate, reused here for a NEW quantity
+% (the anaemia-corrected reticulocyte count) rather than reinvented; the novelty is the haematologic role,
+% not the arithmetic. There is NO embedded constant: the normal haematocrit is itself a formal parameter
+% (the cited equation writes it as a symbol, "Normal Hematocrit", not a fixed 45 — a reader binds 45 for men
+% or 40 for women, or whatever reference their laboratory uses), so all three quantities are bound at apply
+% time and every value the engine returns is exact. The three formulas COMPOSE and invert cleanly around the
+% worked case reticulocyte % = 4, patient haematocrit = 20, normal haematocrit = 40 (corrected retic =
+% 4 × (20 / 40) = 4 × 0.5 = 2 %): the `corrected_reticulocyte_count` a consumer computes is exactly the value
+% each inverse formula back-solves to recover its own measured input (4, 20).
+%
+%   corrected_reticulocyte_count(reticulocyte_percent, patient_hematocrit, normal_hematocrit) = reticulocyte_percent * patient_hematocrit / normal_hematocrit   % (%)
+%   reticulocyte_percent(corrected_reticulocyte_count, patient_hematocrit, normal_hematocrit) = corrected_reticulocyte_count * normal_hematocrit / patient_hematocrit   % (solved for raw retic %)
+%   patient_hematocrit(corrected_reticulocyte_count, reticulocyte_percent, normal_hematocrit) = corrected_reticulocyte_count * normal_hematocrit / reticulocyte_percent  % (solved for patient Hct)
+%
+% NOTE ON UNITS AND MODELLING: the reticulocyte figure is a PERCENTAGE and the corrected count is likewise a
+% percentage; the two haematocrits must share a unit (both as percentages, or both as fractions) because they
+% enter only as a ratio, so the answer is unit-independent in that ratio. The choice of normal haematocrit
+% (≈ 45 % for men, ≈ 40 % for women) is a reference value the reader supplies, which is why it is a parameter
+% here rather than a baked-in constant. This library only COMPUTES the correction; interpreting whether the
+% corrected count reflects an adequate marrow response (and going on to the production index) is the
+% clinician's task, stated by the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted corrected-reticulocyte equation — because
+% that one equation (reticulocyte % × (patient Hct / normal Hct)) sanctions the relation read every way. The
+% quote is transcribed verbatim from the StatPearls "Anemia" article on the NCBI Bookshelf, where it is
+% printed as a fully-bracketed equation with an equals sign, so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `reticulocyte_percent`, `patient_hematocrit`, `normal_hematocrit` and
+% `corrected_reticulocyte_count` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the everyday
+% names a decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary corrected_reticulocyte_count_vocab {
+    define reticulocyte_percent           : finding  surface "reticulocyte percentage", "reticulocyte count", "retic %", "retics" % %
+    define patient_hematocrit             : finding  surface "patient hematocrit", "patient's hematocrit", "Hct", "hematocrit"    % %
+    define normal_hematocrit              : finding  surface "normal hematocrit", "reference hematocrit", "expected hematocrit"    % %
+    define corrected_reticulocyte_count   : finding  surface "corrected reticulocyte count", "corrected reticulocyte percentage", "corrected retic" % %
+}
+
+% ----------------------------------------------------------------------------
+% The corrected reticulocyte count, three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the corrected-reticulocyte equation from the
+% StatPearls "Anemia" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact expression in the measured values, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook corrected_reticulocyte_count_laws {
+    use corrected_reticulocyte_count_vocab
+
+    % Corrected retic — the raw reticulocyte percentage scaled by the patient-to-normal haematocrit ratio.
+    formula corrected_reticulocyte_count(reticulocyte_percent, patient_hematocrit, normal_hematocrit) = reticulocyte_percent * patient_hematocrit / normal_hematocrit
+        source "Corrected Reticulocyte Count (%) = Reticulocyte Count (%) × (Patient Hematocrit / Normal Hematocrit)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499994/"
+        trust authoritative
+
+    % Reticulocyte % — the same equation solved for the raw reticulocyte percentage. Defended by the SAME equation.
+    formula reticulocyte_percent(corrected_reticulocyte_count, patient_hematocrit, normal_hematocrit) = corrected_reticulocyte_count * normal_hematocrit / patient_hematocrit
+        source "Corrected Reticulocyte Count (%) = Reticulocyte Count (%) × (Patient Hematocrit / Normal Hematocrit)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499994/"
+        trust authoritative
+
+    % Patient haematocrit — the same equation solved for the patient Hct, the third reading of the one law.
+    formula patient_hematocrit(corrected_reticulocyte_count, reticulocyte_percent, normal_hematocrit) = corrected_reticulocyte_count * normal_hematocrit / reticulocyte_percent
+        source "Corrected Reticulocyte Count (%) = Reticulocyte Count (%) × (Patient Hematocrit / Normal Hematocrit)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499994/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/corrected-reticulocyte-count.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/corrected-reticulocyte-count.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% corrected-reticulocyte-count.query.adj — worked applications of the corrected reticulocyte count.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an anaemia work-up into a reticulocyte percentage, a
+% patient haematocrit, and a normal (reference) haematocrit: it `import`s the grounded formulabook,
+% `observe`s the three values, and asks the engine to APPLY the cited corrected-reticulocyte formula. No
+% arithmetic is stated by the consumer; the engine computes each value EXACTLY (over exact rationals) and
+% carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (reticulocyte % = 4, patient haematocrit = 20 %, normal haematocrit = 40 %): corrected retic =
+% 4 × (20 / 40) = 4 × 0.5 = 2 %. Each query fixes two of the three inputs and asks the engine to recover
+% another quantity; every answer is exact and the inversions COMPOSE (each recovers exactly the worked
+% value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli corrected-reticulocyte-count.query.adj
+% ============================================================================
+
+import "corrected-reticulocyte-count.adj"
+
+% --- Corrected retic: the corrected percentage the raw retic and haematocrits imply (expect 2). ------
+observe reticulocyte_percent(4)
+observe patient_hematocrit(20)
+observe normal_hematocrit(40)
+? corrected_reticulocyte_count(reticulocyte_percent, patient_hematocrit, normal_hematocrit)   % expect 2
+
+% --- Inverse: the raw reticulocyte % a corrected count of 2 implies at the same haematocrits (expect 4). -
+observe corrected_reticulocyte_count(2)
+? reticulocyte_percent(corrected_reticulocyte_count, patient_hematocrit, normal_hematocrit)   % expect 4


### PR DESCRIPTION
## Summary

Adds the **corrected reticulocyte count** to the clinical formulabook track of `adj-formula-stdlib`:

> corrected retic = **reticulocyte % × (patient hematocrit / normal hematocrit)**

with two exact algebraic rearrangements (solve for the raw reticulocyte %; solve for the patient hematocrit). All three formulas carry the SAME verbatim equation, transcribed from the StatPearls **"Anemia"** article on the NCBI Bookshelf ([NBK499994](https://www.ncbi.nlm.nih.gov/books/NBK499994/)):

> `Corrected Reticulocyte Count (%) = Reticulocyte Count (%) × (Patient Hematocrit / Normal Hematocrit)`

The `×` (U+00D7) is transcribed **byte-faithfully** — the only non-ASCII character in the source strings. The equation is **correctly bracketed** (`(Patient Hematocrit / Normal Hematocrit)` is parenthesized before the `×`), so strict operator precedence reads it correctly.

## Why this formula

The corrected reticulocyte count adjusts the raw reticulocyte percentage for the degree of anaemia — a fixed absolute number of young cells looks like a larger percentage when the total red-cell mass has shrunk — so a marrow's true erythropoietic effort can be read off one number. It is the **input to the reticulocyte production index** (already shipped); this library computes the correction step alone.

## Why this shape

Structurally this is a **value times a ratio** (reticulocyte % × the hematocrit ratio) — the product-of-a-value-and-a-ratio family, reused here for a **new quantity** (anaemia-corrected reticulocyte count / hematology domain). Notably **constant-free**: the cited equation writes the reference as a symbol (`Normal Hematocrit`), *not* a fixed 45, so the normal hematocrit is a formal parameter (a reader binds 45 for men, 40 for women, or their lab's reference), and all three quantities are bound at apply time — every value the engine returns is exact (over exact rationals).

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the three quantities, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case reticulocyte % = 4, patient Hct = 20, normal Hct = 40 (4 × (20 / 40) = 4 × 0.5 = **2 %**): each inverse back-solves exactly to recover its own measured input.

## Files
- `clinical/corrected-reticulocyte-count.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/corrected-reticulocyte-count.query.adj` — worked case (corrected 2; inverse raw retic 4)
- `adj-lang-cli/tests/formula_corrected_reticulocyte_count_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the result `2` is a leading-digit prefix of the `20`/`40` inputs, so the name-anchored adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)