### PR TITLE
feat(adj-formula-stdlib): stool-osmotic-gap — gap = 290 − 2 × (stool Na + stool K) GI/diarrhea library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_stool_osmotic_gap_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_stool_osmotic_gap_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end tests for the `clinical/stool-osmotic-gap.adj` library — the stool (fecal) osmotic gap
+//! (gap = 290 − 2 × (stool sodium + stool potassium)) and its two exact rearrangements — driven through the
+//! built CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a
+//! consumer states NO arithmetic; it imports the grounded library, binds the stool sodium and the stool
+//! potassium with `observe`, and the engine applies the cited formula on the CPU, computing the EXACT value
+//! (over exact rationals) and rendering the citation and trust tier in the `derived` section (the auditable
+//! answer). The three formulas INVERT around the worked case Na = 30, K = 20: 290 − 2 × (30 + 20) = 190
+//! (gap), (290 − 190) / 2 − 20 = 30 (Na), (290 − 190) / 2 − 30 = 20 (K).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation carries the constants 290 and 2 and the intermediates 50/100, so a bare
+//! numeric substring could spuriously match. The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped stool-osmotic-gap library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_sog_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/stool-osmotic-gap.adj")
+        .canonicalize()
+        .expect("shipped stool-osmotic-gap.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_sog_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_sog_lib()).unwrap();
+    std::fs::write(dir.join("stool-osmotic-gap.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// stool_osmotic_gap — the gap: 290 − 2 × (Na + K).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_stool_osmotic_gap_library_and_computes_it_with_citation() {
+    let dir = scratch("sog");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"stool-osmotic-gap.adj\"\n\
+         observe stool_sodium(30)\n\
+         observe stool_potassium(20)\n\
+         ? stool_osmotic_gap(stool_sodium, stool_potassium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 290 − 2 × (30 + 20) = 190, computed
+    // EXACTLY over rationals. Match the adjacent name/value pair so the 290/2 constants and the 50/100
+    // intermediates cannot spuriously satisfy a bare "value":190.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"stool_osmotic_gap\",\"value\":190"),
+        "stool_osmotic_gap(30, 20) = 190: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// stool_sodium — the same expression solved for the stool sodium: (290 − gap) / 2 − K.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_stool_sodium_from_gap_with_citation() {
+    let dir = scratch("na");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"stool-osmotic-gap.adj\"\n\
+         observe stool_osmotic_gap(190)\n\
+         observe stool_potassium(20)\n\
+         ? stool_sodium(stool_osmotic_gap, stool_potassium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (290 − 190) / 2 − 20 = 100 / 2 − 20 = 50 − 20 = 30, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"stool_sodium\",\"value\":30"),
+        "stool_sodium(190, 20) = 30: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "stool_sodium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// stool_potassium — the same expression solved for the stool potassium: (290 − gap) / 2 − Na, the third
+// reading of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_stool_potassium_from_gap_with_citation() {
+    let dir = scratch("k");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"stool-osmotic-gap.adj\"\n\
+         observe stool_osmotic_gap(190)\n\
+         observe stool_sodium(30)\n\
+         ? stool_potassium(stool_osmotic_gap, stool_sodium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (290 − 190) / 2 − 30 = 100 / 2 − 30 = 50 − 30 = 20, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"stool_potassium\",\"value\":20"),
+        "stool_potassium(190, 30) = 20: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "stool_potassium carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/stool-osmotic-gap.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/stool-osmotic-gap.adj
@@ -1,0 +1,99 @@
+% ============================================================================
+% stool-osmotic-gap.adj — the stool (fecal) osmotic gap
+% (gap = 290 − 2 × (stool sodium + stool potassium)) in the ADJ standard library.
+% ============================================================================
+% The stool-osmotic-gap entry of the *clinical* track — the bedside test that separates OSMOTIC diarrhoea
+% (an unabsorbed solute dragging water into the lumen) from SECRETORY diarrhoea (the gut actively pumping
+% electrolytes and water out). Stool osmolality in vivo is assumed to equal plasma osmolality (≈ 290
+% mOsm/kg); the electrolytes the gut secretes are sodium and potassium, each osmotically accompanied by an
+% anion, so twice their summed concentration estimates the electrolyte-driven osmoles. Whatever osmolality
+% is LEFT OVER after subtracting that electrolyte contribution is the "gap" — the part of the stool
+% osmolality carried by SOMETHING ELSE (an unabsorbed osmotic agent). A WIDE gap therefore means osmotic
+% diarrhoea; a NARROW gap means the osmoles are all electrolytes, i.e. secretory. THE STOOL OSMOTIC GAP IS
+% 290 MINUS TWICE THE SUM OF STOOL SODIUM AND STOOL POTASSIUM — i.e. gap = 290 − 2 × (stool Na + stool K).
+% It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with two exact
+% rearrangements (the stool sodium and the stool potassium a given gap implies). As with every compute
+% library, a consumer states NO arithmetic: it `import`s this file, binds the stool sodium and potassium
+% from its own byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU.
+% Zero math is performed by the model; the engine computes each value EXACTLY (over exact rationals),
+% carrying the formula's citation.
+%
+%     import "stool-osmotic-gap.adj"
+%     observe stool_sodium(30)      % "…stool Na 30…"   (span cited by the model)
+%     observe stool_potassium(20)    % "…stool K 20…"    (span cited by the model)
+%     ? stool_osmotic_gap(stool_sodium, stool_potassium)   % engine → 190 (mOsm/kg)
+%
+% Structurally this is a CONSTANT MINUS A SCALED SUM — the assumed stool osmolality (290) less twice the
+% electrolyte sum — a shape distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant,
+% chained-division, constant-scaled-difference, product-times-constant, three-way-product-over-divisor,
+% product-of-a-ratio-and-a-value, quotient-over-a-difference, constant-times-a-difference-over-a-divisor,
+% two-variables-and-a-constant-over-a-divisor, product-of-a-value-and-a-difference-over-a-shared-value, and
+% ratio-scaled-by-a-constant forms of the other clinical libraries. There are two embedded constants — the
+% assumed stool osmolality 290 (mOsm/kg) and the factor 2 (each electrolyte's accompanying anion), both
+% exact integers as the cited expression prints them; the two electrolyte concentrations are formal
+% parameters bound at apply time, so every value the engine returns is exact. The three formulas COMPOSE and
+% invert cleanly around the worked case stool sodium = 30, stool potassium = 20 (gap = 290 − 2 × (30 + 20) =
+% 290 − 100 = 190 mOsm/kg): the `stool_osmotic_gap` a consumer computes is exactly the value each inverse
+% formula back-solves to recover its own measured input (30, 20).
+%
+%   stool_osmotic_gap(stool_sodium, stool_potassium) = 290 - 2 * (stool_sodium + stool_potassium)   % (mOsm/kg)
+%   stool_sodium(stool_osmotic_gap, stool_potassium) = (290 - stool_osmotic_gap) / 2 - stool_potassium % (solved for stool Na)
+%   stool_potassium(stool_osmotic_gap, stool_sodium) = (290 - stool_osmotic_gap) / 2 - stool_sodium     % (solved for stool K)
+%
+% NOTE ON UNITS AND MODELLING: the stool electrolytes are in mmol/L and the gap in mOsm/kg; the 290 is the
+% ASSUMED stool osmolality (some laboratories substitute a directly MEASURED stool osmolality in its place —
+% that variant is a different formula and is not what this library grounds). Interpretation bands
+% (a gap > ~125 mOsm/kg → osmotic, < ~50 → secretory) are the clinician's to apply. This library only
+% COMPUTES the gap; obtaining reliable stool electrolytes and reading the result is the clinician's task,
+% stated by the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted osmotic-gap expression — because that one
+% expression (290 − 2 × (Na + K)) sanctions the relation read every way. The quote is transcribed verbatim
+% from the StatPearls "Chronic Diarrhea" article on the NCBI Bookshelf, where the gap is printed as the typed,
+% operand-complete, correctly-bracketed expression "290 mOsm/kg - 2(Na[feces]+K[feces])" (the 2( … ) is an
+% implicit multiplication and the (Na + K) sum is parenthesized, so strict precedence reads it correctly).
+% Each `formula` therefore carries the provenance envelope every shipped grounded clause carries; the linter
+% rejects an unsourced one. (See feedback_nothing_human_authored — the formula is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `stool_sodium`, `stool_potassium` and `stool_osmotic_gap` each appear BOTH as a derived result
+% and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary stool_osmotic_gap_vocab {
+    define stool_sodium        : finding  surface "stool sodium", "stool Na", "fecal sodium", "Na[feces]"      % mmol/L
+    define stool_potassium     : finding  surface "stool potassium", "stool K", "fecal potassium", "K[feces]" % mmol/L
+    define stool_osmotic_gap   : finding  surface "stool osmotic gap", "fecal osmotic gap", "osmotic gap"      % mOsm/kg
+}
+
+% ----------------------------------------------------------------------------
+% The stool osmotic gap, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the osmotic-gap expression from the StatPearls "Chronic
+% Diarrhea" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% expression in the measured values and the exact integers 290 and 2, so the engine returns each value
+% EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook stool_osmotic_gap_laws {
+    use stool_osmotic_gap_vocab
+
+    % Osmotic gap — the assumed stool osmolality 290, less twice the electrolyte sum.
+    formula stool_osmotic_gap(stool_sodium, stool_potassium) = 290 - 2 * (stool_sodium + stool_potassium)
+        source "290 mOsm/kg - 2(Na[feces]+K[feces])"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544337/"
+        trust authoritative
+
+    % Stool sodium — the same expression solved for the stool sodium. Defended by the SAME clause.
+    formula stool_sodium(stool_osmotic_gap, stool_potassium) = (290 - stool_osmotic_gap) / 2 - stool_potassium
+        source "290 mOsm/kg - 2(Na[feces]+K[feces])"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544337/"
+        trust authoritative
+
+    % Stool potassium — the same expression solved for the stool potassium, the third reading of the one law.
+    formula stool_potassium(stool_osmotic_gap, stool_sodium) = (290 - stool_osmotic_gap) / 2 - stool_sodium
+        source "290 mOsm/kg - 2(Na[feces]+K[feces])"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544337/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/stool-osmotic-gap.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/stool-osmotic-gap.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% stool-osmotic-gap.query.adj — worked applications of the stool (fecal) osmotic gap.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a diarrhoea work-up into a stool sodium and a stool
+% potassium: it `import`s the grounded formulabook, `observe`s the two values, and asks the engine to APPLY
+% the cited osmotic-gap formula. No arithmetic is stated by the consumer; the engine computes each value
+% EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with zero
+% model calls.
+%
+% Worked case (stool sodium = 30 mmol/L, stool potassium = 20 mmol/L): osmotic gap = 290 − 2 × (30 + 20) =
+% 290 − 100 = 190 mOsm/kg (a wide gap → osmotic diarrhoea). Each query fixes one input and asks the engine
+% to recover another quantity; every answer is exact and the inversions COMPOSE (each recovers exactly the
+% worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli stool-osmotic-gap.query.adj
+% ============================================================================
+
+import "stool-osmotic-gap.adj"
+
+% --- Osmotic gap: the gap the two electrolytes imply (expect 190). -----------------------------------
+observe stool_sodium(30)
+observe stool_potassium(20)
+? stool_osmotic_gap(stool_sodium, stool_potassium)   % expect 190
+
+% --- Inverse: the stool sodium a gap of 190 implies at the same potassium (expect 30). ---------------
+observe stool_osmotic_gap(190)
+? stool_sodium(stool_osmotic_gap, stool_potassium)   % expect 30


### PR DESCRIPTION
## Summary

Adds the **stool (fecal) osmotic gap** to the clinical formulabook track of `adj-formula-stdlib`:

> gap = **290 − 2 × (stool sodium + stool potassium)**

with two exact algebraic rearrangements (solve for stool sodium; solve for stool potassium). All three formulas carry the SAME verbatim expression, transcribed from the StatPearls **"Chronic Diarrhea"** article on the NCBI Bookshelf ([NBK544337](https://www.ncbi.nlm.nih.gov/books/NBK544337/)):

> `290 mOsm/kg - 2(Na[feces]+K[feces])`

The source string is **entirely ASCII** (hyphen-minus, parentheses, brackets) — no unicode transcription risk. It is the page's typed, operand-complete, **correctly-bracketed** expression: the `2( … )` is an implicit multiplication and the `(Na + K)` sum is parenthesized, so strict operator precedence reads it correctly. (The clean `=` form is not typed on this or the "Malabsorption Syndromes" page — both give the tidier restatement only as prose — so the typed bracketed expression is what is grounded.)

## Why this formula

The stool osmotic gap separates **osmotic** diarrhoea (an unabsorbed solute pulling in water → wide gap) from **secretory** diarrhoea (the gut pumping electrolytes → narrow gap): stool osmolality is assumed ≈ 290 mOsm/kg, twice the Na+K sum estimates the electrolyte osmoles, and whatever is left over is the gap.

## Why this shape

Structurally this is a **constant minus a scaled sum** (290 less twice the electrolyte sum) — a shape distinct from all previously shipped clinical libraries. Two embedded exact-integer constants (the assumed osmolality 290 and the factor 2, both as the cited expression prints them); the two electrolyte concentrations are formal parameters bound at apply time, so every value the engine returns is exact (over exact rationals). New clinical domain: gastroenterology / diarrhoea evaluation.

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the two electrolytes, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case stool Na = 30, stool K = 20 (290 − 2 × (30 + 20) = 290 − 100 = **190** mOsm/kg, a wide gap → osmotic): each inverse back-solves exactly to recover its own measured input.

## Files
- `clinical/stool-osmotic-gap.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/stool-osmotic-gap.query.adj` — worked case (gap 190; inverse stool Na 30)
- `adj-lang-cli/tests/formula_stool_osmotic_gap_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the derivation carries the `290`/`2` constants and `50`/`100` intermediates, so the name-anchored adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)