### PR TITLE
feat(adj-formula-stdlib): nitrogen-balance — balance = protein / 6.25 − (UUN + 4) nutrition library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_nitrogen_balance_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_nitrogen_balance_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end tests for the `clinical/nitrogen-balance.adj` library — the nitrogen balance
+//! (balance = protein intake / 6.25 − (urine urea nitrogen + 4)) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula
+//! library: a consumer states NO arithmetic; it imports the grounded library, binds the protein intake and
+//! the urine urea nitrogen with `observe`, and the engine applies the cited formula on the CPU, computing the
+//! EXACT value (over exact rationals) and rendering the citation and trust tier in the `derived` section (the
+//! auditable answer). The three formulas INVERT around the worked case protein = 125, UUN = 12:
+//! 125 / 6.25 − (12 + 4) = 4 (balance), (4 + 12 + 4) × 6.25 = 125 (protein), 125 / 6.25 − 4 − 4 = 12 (UUN).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation carries the constants 6.25 and 4 and the intermediates 20/16, so a bare
+//! numeric substring could spuriously match. The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped nitrogen-balance library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_nb_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/nitrogen-balance.adj")
+        .canonicalize()
+        .expect("shipped nitrogen-balance.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_nb_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_nb_lib()).unwrap();
+    std::fs::write(dir.join("nitrogen-balance.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// nitrogen_balance — the balance: protein / 6.25 − (UUN + 4).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_nitrogen_balance_library_and_computes_it_with_citation() {
+    let dir = scratch("nb");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"nitrogen-balance.adj\"\n\
+         observe protein_intake(125)\n\
+         observe urine_urea_nitrogen(12)\n\
+         ? nitrogen_balance(protein_intake, urine_urea_nitrogen)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 125 / 6.25 − (12 + 4) = 20 − 16 = 4,
+    // computed EXACTLY over rationals. Match the adjacent name/value pair so the 6.25/4 constants and the
+    // 20/16 intermediates cannot spuriously satisfy a bare "value":4.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"nitrogen_balance\",\"value\":4"),
+        "nitrogen_balance(125, 12) = 4: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// protein_intake — the same equation solved for the protein intake: (balance + UUN + 4) × 6.25.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_protein_intake_from_balance_with_citation() {
+    let dir = scratch("protein");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"nitrogen-balance.adj\"\n\
+         observe nitrogen_balance(4)\n\
+         observe urine_urea_nitrogen(12)\n\
+         ? protein_intake(nitrogen_balance, urine_urea_nitrogen)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (4 + 12 + 4) × 6.25 = 20 × 6.25 = 125, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"protein_intake\",\"value\":125"),
+        "protein_intake(4, 12) = 125: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "protein_intake carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_urea_nitrogen — the same equation solved for the UUN: protein / 6.25 − 4 − balance, the third
+// reading of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_urea_nitrogen_from_balance_with_citation() {
+    let dir = scratch("uun");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"nitrogen-balance.adj\"\n\
+         observe nitrogen_balance(4)\n\
+         observe protein_intake(125)\n\
+         ? urine_urea_nitrogen(nitrogen_balance, protein_intake)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 125 / 6.25 − 4 − 4 = 20 − 4 − 4 = 12, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_urea_nitrogen\",\"value\":12"),
+        "urine_urea_nitrogen(4, 125) = 12: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_urea_nitrogen carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/nitrogen-balance.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/nitrogen-balance.adj
@@ -1,0 +1,100 @@
+% ============================================================================
+% nitrogen-balance.adj — the nitrogen balance
+% (balance = protein intake / 6.25 − (urine urea nitrogen + 4)) in the ADJ standard library.
+% ============================================================================
+% The nitrogen-balance entry of the *clinical* track — the daily accounting of nitrogen IN versus nitrogen
+% OUT that tells whether a patient (typically in critical care or on nutrition support) is building tissue
+% (anabolic, POSITIVE balance) or breaking it down (catabolic, NEGATIVE balance). Nitrogen IN is estimated
+% from the dietary protein: protein is about 16 % nitrogen, i.e. 6.25 g of protein per gram of nitrogen, so
+% dividing the protein intake by 6.25 converts grams of protein to grams of nitrogen. Nitrogen OUT is the
+% urinary urea nitrogen (the dominant route) PLUS a fixed allowance of 4 g/day for the insensible losses
+% (skin, stool, non-urea urinary nitrogen) that are not measured. THE NITROGEN BALANCE IS THE PROTEIN-DERIVED
+% NITROGEN INTAKE MINUS THE MEASURED-PLUS-INSENSIBLE NITROGEN OUTPUT — i.e. balance = protein / 6.25 −
+% (UUN + 4). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with two exact
+% rearrangements (the protein intake and the urine urea nitrogen a given balance implies). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds the protein intake and the
+% urine urea nitrogen from its own byte-provenance decomposition, and asks the engine to APPLY the cited
+% formula on the CPU. Zero math is performed by the model; the engine computes each value EXACTLY (over exact
+% rationals), carrying the formula's citation.
+%
+%     import "nitrogen-balance.adj"
+%     observe protein_intake(125)         % "…protein 125 g/day…"   (span cited by the model)
+%     observe urine_urea_nitrogen(12)      % "…24h UUN 12 g…"        (span cited by the model)
+%     ? nitrogen_balance(protein_intake, urine_urea_nitrogen)   % engine → 4 (g/day)
+%
+% Structurally this is a QUOTIENT MINUS A SUM-WITH-A-CONSTANT — the protein-derived nitrogen intake less the
+% (measured output + insensible-loss allowance) — a shape distinct from the ratio, ratio-of-ratios,
+% percentage-sum, product-over-constant, chained-division, constant-scaled-difference, product-times-constant,
+% three-way-product-over-divisor, product-of-a-ratio-and-a-value, quotient-over-a-difference,
+% constant-times-a-difference-over-a-divisor, two-variables-and-a-constant-over-a-divisor,
+% product-of-a-value-and-a-difference-over-a-shared-value, ratio-scaled-by-a-constant, and
+% constant-minus-a-scaled-sum forms of the other clinical libraries. There are two embedded constants — the
+% protein-to-nitrogen factor 6.25 (grams protein per gram nitrogen) and the insensible-loss allowance 4 (g),
+% exactly as the cited equation prints them; the protein intake and urine urea nitrogen are formal parameters
+% bound at apply time. The engine holds 6.25 as the EXACT rational 25/4, so every value it returns is exact.
+% The three formulas COMPOSE and invert cleanly around the worked case protein intake = 125 g/day, urine urea
+% nitrogen = 12 g (balance = 125 / 6.25 − (12 + 4) = 20 − 16 = 4 g/day, a positive/anabolic balance): the
+% `nitrogen_balance` a consumer computes is exactly the value each inverse formula back-solves to recover its
+% own measured input (125, 12).
+%
+%   nitrogen_balance(protein_intake, urine_urea_nitrogen) = protein_intake / 6.25 - (urine_urea_nitrogen + 4)   % (g/day)
+%   protein_intake(nitrogen_balance, urine_urea_nitrogen) = (nitrogen_balance + urine_urea_nitrogen + 4) * 6.25  % (solved for protein intake)
+%   urine_urea_nitrogen(nitrogen_balance, protein_intake) = protein_intake / 6.25 - 4 - nitrogen_balance         % (solved for UUN)
+%
+% NOTE ON UNITS AND MODELLING: the protein intake and the nitrogen quantities are all in GRAMS (protein per
+% day; urea nitrogen over a 24-hour collection), and the balance comes out in grams of nitrogen per day. The
+% urine urea nitrogen must be a complete 24-hour collection for the balance to be meaningful, and the fixed
+% 4 g insensible allowance is an approximation (the cited protocol uses 4). This library only COMPUTES the
+% balance; obtaining a reliable 24-hour collection and interpreting positive versus negative balance is the
+% clinician's task, stated by the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted nitrogen-balance equation — because that
+% one equation (protein / 6.25 − (UUN + 4)) sanctions the relation read every way. The quote is transcribed
+% verbatim from the PubMed Central article "Optimizing Protein Intake and Nitrogen Balance (OPINiB) in Adult
+% Critically Ill Patients", where the balance is printed as the typed, operand-complete, correctly-bracketed
+% expression "total protein intake (g)/6.25 -(UUN + 4 g)" (the division binds before the subtraction and the
+% (UUN + 4) output term is parenthesized, so strict precedence reads it correctly). Each `formula` therefore
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `protein_intake`, `urine_urea_nitrogen` and `nitrogen_balance` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary nitrogen_balance_vocab {
+    define protein_intake        : finding  surface "protein intake", "total protein intake", "dietary protein", "protein" % g/day
+    define urine_urea_nitrogen   : finding  surface "urine urea nitrogen", "urinary urea nitrogen", "UUN", "24h UUN"        % g
+    define nitrogen_balance      : finding  surface "nitrogen balance", "N balance", "nitrogen balance study"               % g/day
+}
+
+% ----------------------------------------------------------------------------
+% The nitrogen balance, three ways. Each is a named, importable, reusable formula over its formal parameters,
+% bound at apply time, and each carries the nitrogen-balance equation from the OPINiB PMC article (a quote is
+% required on a shipped formula). Each is an exact expression in the measured values and the exact constants
+% 6.25 and 4, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook nitrogen_balance_laws {
+    use nitrogen_balance_vocab
+
+    % Nitrogen balance — protein-derived nitrogen intake, less measured plus insensible nitrogen output.
+    formula nitrogen_balance(protein_intake, urine_urea_nitrogen) = protein_intake / 6.25 - (urine_urea_nitrogen + 4)
+        source "total protein intake (g)/6.25 -(UUN + 4 g)"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC5442349/"
+        trust authoritative
+
+    % Protein intake — the same equation solved for the protein intake. Defended by the SAME equation.
+    formula protein_intake(nitrogen_balance, urine_urea_nitrogen) = (nitrogen_balance + urine_urea_nitrogen + 4) * 6.25
+        source "total protein intake (g)/6.25 -(UUN + 4 g)"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC5442349/"
+        trust authoritative
+
+    % Urine urea nitrogen — the same equation solved for the UUN, the third reading of the one law.
+    formula urine_urea_nitrogen(nitrogen_balance, protein_intake) = protein_intake / 6.25 - 4 - nitrogen_balance
+        source "total protein intake (g)/6.25 -(UUN + 4 g)"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC5442349/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/nitrogen-balance.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/nitrogen-balance.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% nitrogen-balance.query.adj — worked applications of the nitrogen balance.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a nutrition-support assessment into a protein intake
+% and a 24-hour urine urea nitrogen: it `import`s the grounded formulabook, `observe`s the two values, and
+% asks the engine to APPLY the cited nitrogen-balance formula. No arithmetic is stated by the consumer; the
+% engine computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof,
+% on the CPU, with zero model calls.
+%
+% Worked case (protein intake = 125 g/day, urine urea nitrogen = 12 g): nitrogen balance =
+% 125 / 6.25 − (12 + 4) = 20 − 16 = 4 g/day (a positive, anabolic balance). Each query fixes one input and
+% asks the engine to recover another quantity; every answer is exact and the inversions COMPOSE (each
+% recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli nitrogen-balance.query.adj
+% ============================================================================
+
+import "nitrogen-balance.adj"
+
+% --- Nitrogen balance: the balance the protein and UUN imply (expect 4). -----------------------------
+observe protein_intake(125)
+observe urine_urea_nitrogen(12)
+? nitrogen_balance(protein_intake, urine_urea_nitrogen)   % expect 4
+
+% --- Inverse: the protein intake a balance of 4 implies at the same UUN (expect 125). ----------------
+observe nitrogen_balance(4)
+? protein_intake(nitrogen_balance, urine_urea_nitrogen)   % expect 125


### PR DESCRIPTION
## Summary

Adds the **nitrogen balance** to the clinical formulabook track of `adj-formula-stdlib`:

> balance = **protein intake / 6.25 − (urine urea nitrogen + 4)**

with two exact algebraic rearrangements (solve for protein intake; solve for urine urea nitrogen). All three formulas carry the SAME verbatim expression, transcribed from the PMC article **"Optimizing Protein Intake and Nitrogen Balance (OPINiB) in Adult Critically Ill Patients"** ([PMC5442349](https://pmc.ncbi.nlm.nih.gov/articles/PMC5442349/)):

> `total protein intake (g)/6.25 -(UUN + 4 g)`

The source string is **entirely ASCII** (hyphen-minus, slash, parentheses) — no unicode transcription risk. It is the page's typed, operand-complete, **correctly-bracketed** expression: the division binds before the subtraction and the `(UUN + 4)` output term is parenthesized, so strict operator precedence reads it correctly.

## Why this formula

Nitrogen balance is the daily nitrogen **IN** (protein intake / 6.25, since protein is ~16 % nitrogen = 6.25 g protein per g nitrogen) minus nitrogen **OUT** (measured 24-hour urine urea nitrogen plus a fixed 4 g/day insensible-loss allowance); **positive = anabolic**, **negative = catabolic**. New clinical domain: nutrition support / critical care.

## Why this shape

Structurally this is a **quotient minus a sum-with-a-constant** — distinct from all previously shipped clinical libraries. Two embedded constants (the protein→nitrogen factor 6.25 and the insensible-loss allowance 4, exactly as the cited expression prints them); the protein intake and urine urea nitrogen are formal parameters bound at apply time. The engine holds 6.25 as the exact rational 25/4, so every value it returns is exact (over exact rationals) — render-probe confirms integer outputs with no f64 noise.

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the two quantities, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case protein intake = 125 g/day, urine urea nitrogen = 12 g (125 / 6.25 − (12 + 4) = 20 − 16 = **4** g/day, positive/anabolic): each inverse back-solves exactly to recover its own measured input.

## Files
- `clinical/nitrogen-balance.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/nitrogen-balance.query.adj` — worked case (balance 4; inverse protein 125)
- `adj-lang-cli/tests/formula_nitrogen_balance_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the derivation carries the `6.25`/`4` constants and `20`/`16` intermediates, so the name-anchored adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)