### PR TITLE
feat(adj-formula-stdlib): mid-parental-height — MPH(boy) = (father + mother + 13) / 2 pediatric-growth library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_mid_parental_height_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_mid_parental_height_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end tests for the `clinical/mid-parental-height.adj` library — the mid-parental (target) height
+//! for a boy (MPH = (father's height + mother's height + 13) / 2) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula
+//! library: a consumer states NO arithmetic; it imports the grounded library, binds the two parental heights
+//! with `observe`, and the engine applies the cited formula on the CPU, computing the EXACT value (over exact
+//! rationals) and rendering the citation and trust tier in the `derived` section (the auditable answer). The
+//! three formulas INVERT around the worked case father = 180, mother = 165: (180 + 165 + 13) / 2 = 179 (MPH),
+//! 179 × 2 − 165 − 13 = 180 (father), 179 × 2 − 180 − 13 = 165 (mother).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation carries the constants 13 and 2 and the intermediate 358, so a bare numeric
+//! substring could spuriously match. The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped mid-parental-height library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_mph_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/mid-parental-height.adj")
+        .canonicalize()
+        .expect("shipped mid-parental-height.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_mph_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_mph_lib()).unwrap();
+    std::fs::write(dir.join("mid-parental-height.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// mid_parental_height — the boy target height: (father + mother + 13) / 2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_mid_parental_height_library_and_computes_it_with_citation() {
+    let dir = scratch("mph");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mid-parental-height.adj\"\n\
+         observe father_height(180)\n\
+         observe mother_height(165)\n\
+         ? mid_parental_height(father_height, mother_height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: (180 + 165 + 13) / 2 = 179, computed
+    // EXACTLY over rationals. Match the adjacent name/value pair so the 13/2 constants and the 358
+    // intermediate cannot spuriously satisfy a bare "value":179.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"mid_parental_height\",\"value\":179"),
+        "mid_parental_height(180, 165) = 179: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// father_height — the same expression solved for the father's height: MPH × 2 − mother − 13.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_father_height_from_mph_with_citation() {
+    let dir = scratch("father");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mid-parental-height.adj\"\n\
+         observe mid_parental_height(179)\n\
+         observe mother_height(165)\n\
+         ? father_height(mid_parental_height, mother_height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 179 × 2 − 165 − 13 = 358 − 178 = 180, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"father_height\",\"value\":180"),
+        "father_height(179, 165) = 180: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "father_height carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// mother_height — the same expression solved for the mother's height: MPH × 2 − father − 13, the third
+// reading of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_mother_height_from_mph_with_citation() {
+    let dir = scratch("mother");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mid-parental-height.adj\"\n\
+         observe mid_parental_height(179)\n\
+         observe father_height(180)\n\
+         ? mother_height(mid_parental_height, father_height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 179 × 2 − 180 − 13 = 358 − 193 = 165, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"mother_height\",\"value\":165"),
+        "mother_height(179, 180) = 165: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "mother_height carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/mid-parental-height.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/mid-parental-height.adj
@@ -1,0 +1,98 @@
+% ============================================================================
+% mid-parental-height.adj — the mid-parental (target) height for BOYS
+% (MPH = (father's height + mother's height + 13) / 2) in the ADJ standard library.
+% ============================================================================
+% The mid-parental-height entry of the *clinical* track — the estimate of a child's GENETIC-POTENTIAL adult
+% height from the parents' heights, used in paediatric growth assessment to decide whether a short (or tall)
+% child is simply tracking their family's stature or is genuinely off-target and warrants work-up. Averaging
+% the two parents' heights gives a mid-point; because adult men are on average about 13 cm taller than adult
+% women, a BOY's expected height is that average shifted UP (and a girl's shifted down) by half that
+% sex-difference. The cited formula folds the shift into the numerator: for a boy, add 13 cm to the sum of the
+% two parental heights before halving — equivalently, the parents' average plus 6.5 cm. THE MID-PARENTAL
+% HEIGHT FOR A BOY IS THE FATHER'S HEIGHT PLUS THE MOTHER'S HEIGHT PLUS 13, ALL DIVIDED BY 2 — i.e.
+% MPH = (father + mother + 13) / 2. It ships as an importable, byte-provenanced, PARAMETERIZED `formula`,
+% together with two exact rearrangements (the father's height and the mother's height a given target implies).
+% As with every compute library, a consumer states NO arithmetic: it `import`s this file, binds the two
+% parental heights from its own byte-provenance decomposition, and asks the engine to APPLY the cited formula
+% on the CPU. Zero math is performed by the model; the engine computes each value EXACTLY (over exact
+% rationals), carrying the formula's citation.
+%
+%     import "mid-parental-height.adj"
+%     observe father_height(180)   % "…father 180 cm…"   (span cited by the model)
+%     observe mother_height(165)    % "…mother 165 cm…"   (span cited by the model)
+%     ? mid_parental_height(father_height, mother_height)   % engine → 179 (cm, boy)
+%
+% Structurally this is a SUM-WITH-A-CONSTANT OVER A CONSTANT — the two heights plus 13, halved — a shape
+% distinct from the ratio, ratio-of-ratios, percentage-sum, product-over-constant, chained-division,
+% constant-scaled-difference, product-times-constant, three-way-product-over-divisor,
+% product-of-a-ratio-and-a-value, quotient-over-a-difference, constant-times-a-difference-over-a-divisor,
+% two-variables-and-a-constant-over-a-divisor, product-of-a-value-and-a-difference-over-a-shared-value,
+% ratio-scaled-by-a-constant, constant-minus-a-scaled-sum, and quotient-minus-a-sum-with-a-constant forms of
+% the other clinical libraries. Two embedded constants — the average sex height difference 13 (cm) and the
+% divisor 2 — both exact integers as the cited expression prints them; the two parental heights are formal
+% parameters bound at apply time, so every value the engine returns is exact. The three formulas COMPOSE and
+% invert cleanly around the worked case father's height = 180 cm, mother's height = 165 cm (MPH =
+% (180 + 165 + 13) / 2 = 358 / 2 = 179 cm): the `mid_parental_height` a consumer computes is exactly the value
+% each inverse formula back-solves to recover its own measured input (180, 165).
+%
+%   mid_parental_height(father_height, mother_height) = (father_height + mother_height + 13) / 2   % (cm, boy)
+%   father_height(mid_parental_height, mother_height) = mid_parental_height * 2 - mother_height - 13 % (solved for father)
+%   mother_height(mid_parental_height, father_height) = mid_parental_height * 2 - father_height - 13 % (solved for mother)
+%
+% NOTE ON UNITS AND MODELLING: the heights are in centimetres and the target height comes out in centimetres.
+% This library grounds the BOY (male-child) form, in which 13 cm is ADDED; the corresponding girl form
+% SUBTRACTS 13 (a different clause not grounded here). The expected adult height of the child falls roughly
+% within ±8–10 cm of this target. This library only COMPUTES the target; interpreting a child's measured
+% height against it (and the growth curve) is the clinician's task, stated by the cited source but applied by
+% the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted mid-parental-height expression — because
+% that one expression ((father + mother + 13) / 2) sanctions the relation read every way. The quote is
+% transcribed verbatim from the PubMed Central article "Electronic Health Record Mid-Parental Height
+% Auto-Calculator for Growth Assessment in Primary Care", where the boy form is printed as the typed,
+% operand-complete, correctly-bracketed expression "(father's height + mother's height + 13)/2" (the whole
+% numerator is parenthesized before the /2, so strict precedence reads it correctly). Each `formula` therefore
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `father_height`, `mother_height` and `mid_parental_height` each appear BOTH as a derived result
+% and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary mid_parental_height_vocab {
+    define father_height        : finding  surface "father's height", "father height", "paternal height", "dad's height" % cm
+    define mother_height        : finding  surface "mother's height", "mother height", "maternal height", "mom's height" % cm
+    define mid_parental_height  : finding  surface "mid-parental height", "midparental height", "target height", "MPH"    % cm
+}
+
+% ----------------------------------------------------------------------------
+% The mid-parental height (boy form), three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the mid-parental-height expression from the PMC
+% article (a quote is required on a shipped formula). Each is an exact expression in the measured values and
+% the exact integers 13 and 2, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook mid_parental_height_laws {
+    use mid_parental_height_vocab
+
+    % Mid-parental height (boy) — the two parental heights plus the 13 cm sex-difference, halved.
+    formula mid_parental_height(father_height, mother_height) = (father_height + mother_height + 13) / 2
+        source "(father's height + mother's height + 13)/2"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC5576174/"
+        trust authoritative
+
+    % Father's height — the same expression solved for the father's height. Defended by the SAME clause.
+    formula father_height(mid_parental_height, mother_height) = mid_parental_height * 2 - mother_height - 13
+        source "(father's height + mother's height + 13)/2"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC5576174/"
+        trust authoritative
+
+    % Mother's height — the same expression solved for the mother's height, the third reading of the one law.
+    formula mother_height(mid_parental_height, father_height) = mid_parental_height * 2 - father_height - 13
+        source "(father's height + mother's height + 13)/2"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC5576174/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/mid-parental-height.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/mid-parental-height.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% mid-parental-height.query.adj — worked applications of the mid-parental (target) height for a boy.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a paediatric growth assessment into a father's height
+% and a mother's height: it `import`s the grounded formulabook, `observe`s the two values, and asks the
+% engine to APPLY the cited mid-parental-height formula (boy form). No arithmetic is stated by the consumer;
+% the engine computes each value EXACTLY (over exact rationals) and carries the article's citation as its
+% proof, on the CPU, with zero model calls.
+%
+% Worked case (father's height = 180 cm, mother's height = 165 cm): mid-parental height =
+% (180 + 165 + 13) / 2 = 358 / 2 = 179 cm (the target adult height for a boy). Each query fixes one input and
+% asks the engine to recover another quantity; every answer is exact and the inversions COMPOSE (each
+% recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli mid-parental-height.query.adj
+% ============================================================================
+
+import "mid-parental-height.adj"
+
+% --- MPH: the boy target height the two parental heights imply (expect 179). -------------------------
+observe father_height(180)
+observe mother_height(165)
+? mid_parental_height(father_height, mother_height)   % expect 179
+
+% --- Inverse: the father's height a target of 179 implies at the same mother's height (expect 180). --
+observe mid_parental_height(179)
+? father_height(mid_parental_height, mother_height)   % expect 180


### PR DESCRIPTION
## Summary

Adds the **mid-parental (target) height for boys** to the clinical formulabook track of `adj-formula-stdlib`:

> MPH = **(father's height + mother's height + 13) / 2**

with two exact algebraic rearrangements (solve for the father's height; solve for the mother's height). All three formulas carry the SAME verbatim expression, transcribed from the PMC article **"Electronic Health Record Mid-Parental Height Auto-Calculator for Growth Assessment in Primary Care"** ([PMC5576174](https://pmc.ncbi.nlm.nih.gov/articles/PMC5576174/)):

> `(father's height + mother's height + 13)/2`

The source string is **entirely ASCII** — no unicode transcription risk. It is the page's typed, operand-complete, **correctly-bracketed** expression: the whole numerator is parenthesized before the `/2`, so strict operator precedence reads it correctly.

## Why this formula

Mid-parental height estimates a child's **genetic-potential** adult height from the parents' heights: average the two, then shift for the child's sex (adult men are ~13 cm taller than women). This library grounds the **boy** form, which ADDS 13 cm in the numerator (equivalently, the parental average + 6.5 cm); the girl form subtracts 13 (a different clause not grounded here). New clinical domain: pediatric growth / endocrinology.

## Why this shape

Structurally this is a **sum-with-a-constant over a constant** (the two heights plus 13, halved) — distinct from all previously shipped clinical libraries. Two embedded exact-integer constants (the 13 cm sex-height difference and the divisor 2); the two parental heights are formal parameters bound at apply time, so every value the engine returns is exact (over exact rationals).

## Invariant

The consumer states **no arithmetic** — it imports the grounded library, `observe`s the two parental heights, and the engine applies the cited formula on the CPU, computing the value EXACTLY and rendering the citation + trust tier in the auditable `derived` section. The three formulas invert around the worked case father's height = 180 cm, mother's height = 165 cm ((180 + 165 + 13) / 2 = 358 / 2 = **179** cm): each inverse back-solves exactly to recover its own measured input.

## Files
- `clinical/mid-parental-height.adj` — dictionary + formulabook (forward + 2 inversions, each cited)
- `clinical/mid-parental-height.query.adj` — worked case (MPH 179; inverse father 180)
- `adj-lang-cli/tests/formula_mid_parental_height_e2e.rs` — 3 e2e tests through the shipped stdlib

The e2e tests match **adjacent** `"name":...,"value":...` pairs (not bare `"value":N`): the derivation carries the `13`/`2` constants and the `358` intermediate, so the name-anchored adjacent form is collision-proof.

**Data + test only — no engine change, no version bump.** Byte-provenanced against a re-fetchable primary source; security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)