### PR TITLE
feat(adj-formula-stdlib): expected-aa-gradient — age-predicted normal alveolar–arterial O2 gradient (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_expected_aa_gradient_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_expected_aa_gradient_e2e.rs
@@ -1,0 +1,110 @@
+//! End-to-end tests for the `clinical/expected-aa-gradient.adj` library — the age-predicted NORMAL
+//! alveolar–arterial oxygen gradient (expected A-a gradient = (age + 10) / 4) and its one exact
+//! rearrangement — driven through the built CLI binary against the SHIPPED stdlib. The same invariant as every
+//! other formula library: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! patient's age with `observe`, and the engine applies the cited formula on the CPU, computing the EXACT
+//! value (over exact rationals) and rendering the citation and trust tier in the `derived` section (the
+//! auditable answer). The two formulas INVERT around the worked case age = 50:
+//! (50 + 10) / 4 = 15 (expected gradient), 15 × 4 − 10 = 50 (age).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation carries the constants 10 and 4 and the intermediate 60, so a bare numeric
+//! substring could spuriously match. The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped expected-aa-gradient library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_eaag_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/expected-aa-gradient.adj")
+        .canonicalize()
+        .expect("shipped expected-aa-gradient.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_eaag_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_eaag_lib()).unwrap();
+    std::fs::write(dir.join("expected-aa-gradient.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// expected_aa_gradient — the age-predicted upper limit of normal: (age + 10) / 4.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_expected_aa_gradient_library_and_computes_it_with_citation() {
+    let dir = scratch("eaag");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"expected-aa-gradient.adj\"\n\
+         observe patient_age(50)\n\
+         ? expected_aa_gradient(patient_age)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: (50 + 10) / 4 = 60 / 4 = 15, computed
+    // EXACTLY over rationals. Match the adjacent name/value pair so the 10/4 constants and the 60 intermediate
+    // cannot spuriously satisfy a bare "value":15.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"expected_aa_gradient\",\"value\":15"),
+        "expected_aa_gradient(50) = 15: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// patient_age — the same equation solved for the age: expected × 4 − 10.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_patient_age_from_expected_gradient_with_citation() {
+    let dir = scratch("age");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"expected-aa-gradient.adj\"\n\
+         observe expected_aa_gradient(15)\n\
+         ? patient_age(expected_aa_gradient)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 15 × 4 − 10 = 60 − 10 = 50, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"patient_age\",\"value\":50"),
+        "patient_age(15) = 50: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "patient_age carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/expected-aa-gradient.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/expected-aa-gradient.adj
@@ -1,0 +1,90 @@
+% ============================================================================
+% expected-aa-gradient.adj — the age-predicted NORMAL alveolar–arterial oxygen gradient
+% (expected A-a gradient = (Age + 10) / 4) in the ADJ standard library.
+% ============================================================================
+% The expected-A-a-gradient entry of the *clinical* track — the UPPER-BOUND-OF-NORMAL alveolar-to-arterial
+% oxygen tension difference a healthy person of a given age should have. The measured A-a gradient (the
+% alveolar PO2 minus the arterial PO2) rises slowly with age as the lungs' ventilation–perfusion matching
+% loosens, so a raw gradient cannot be judged "high" without an age-adjusted reference. The cited page gives
+% that reference as a compact rule of thumb: take the patient's age, add 10, and divide by 4 — the result is
+% the largest A-a gradient (in mmHg) still considered normal at that age. THE EXPECTED A-a GRADIENT IS THE AGE
+% PLUS 10, ALL DIVIDED BY 4 — i.e. expected = (age + 10) / 4. A measured gradient (computed by the separate
+% `alveolar-arterial-gradient` library as alveolar PO2 − arterial PO2) is then compared against THIS expected
+% value to decide whether oxygenation is age-appropriate.
+%
+% It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its one exact
+% rearrangement (the age at which a given gradient is exactly the upper limit of normal). As with every compute
+% library, a consumer states NO arithmetic: it `import`s this file, binds the patient's age from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% formula's citation.
+%
+%     import "expected-aa-gradient.adj"
+%     observe patient_age(50)   % "…a 50-year-old…"   (span cited by the model)
+%     ? expected_aa_gradient(patient_age)   % engine → 15 (mmHg, upper limit of normal at 50)
+%
+% Structurally this is a SUM-WITH-A-CONSTANT OVER A CONSTANT — the age plus 10, quartered — the same shape as
+% the mid-parental-height library ((father + mother + 13) / 2), but over a SINGLE variable (the age) rather
+% than two, and with a distinct clinical meaning (a normal-value nomogram, not a sum of measurements). Two
+% embedded constants — the offset 10 (mmHg) and the divisor 4 — both exact integers as the cited expression
+% prints them; the patient's age is the one formal parameter bound at apply time, so every value the engine
+% returns is exact.
+%
+%   expected_aa_gradient(patient_age)     = (patient_age + 10) / 4        % (mmHg, upper limit of normal)
+%   patient_age(expected_aa_gradient)     = expected_aa_gradient * 4 - 10 % (solved for the age)
+%
+% The two formulas COMPOSE and invert cleanly around the worked case patient_age = 50 years (expected A-a
+% gradient = (50 + 10) / 4 = 60 / 4 = 15 mmHg): the `expected_aa_gradient` a consumer computes is exactly the
+% value the inverse formula back-solves to recover its own measured input (50).
+%
+% NOTE ON UNITS AND MODELLING: the age is in years and the expected gradient comes out in mmHg. This is a
+% linear age-adjustment RULE OF THUMB — a bedside approximation of the true (mildly non-linear) rise of the
+% normal A-a gradient with age, printed by the cited page as (Age + 10) / 4. It gives the UPPER LIMIT OF NORMAL
+% only; interpreting a patient's measured gradient against it (and looking for a cause when it is exceeded) is
+% the clinician's task, stated by the cited source but applied by the reader. The MEASURED gradient itself is
+% grounded separately in `alveolar-arterial-gradient.adj` (alveolar PO2 − arterial PO2); this library grounds
+% the AGE-BASED EXPECTED value the measurement is compared against — a distinct relation over a distinct
+% variable, from the same page.
+%
+% Both formulas are defended by the SAME clause — the quoted expected-gradient expression — because that one
+% expression ((Age + 10) / 4) sanctions the relation read either way. The quote is transcribed verbatim from
+% the StatPearls article "Physiology, Alveolar to Arterial Oxygen Gradient", where the age-based normal is
+% printed as the typed, operand-complete, correctly-bracketed expression "A-a gradient = (Age + 10) / 4" (the
+% whole numerator is parenthesized before the / 4, so strict precedence reads it correctly). Each `formula`
+% therefore carries the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not
+% asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `patient_age` and `expected_aa_gradient` each appear BOTH as a derived result and as an input
+% (of the other formula), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary expected_aa_gradient_vocab {
+    define patient_age           : finding  surface "age", "patient age", "patient's age", "years old"                                       % years
+    define expected_aa_gradient  : finding  surface "expected A-a gradient", "normal A-a gradient", "predicted A-a gradient", "upper limit of normal A-a gradient" % mmHg
+}
+
+% ----------------------------------------------------------------------------
+% The age-predicted normal A-a gradient, both ways. Each is a named, importable, reusable formula over its
+% formal parameter, bound at apply time, and each carries the expected-gradient expression from the StatPearls
+% article (a quote is required on a shipped formula). Each is an exact expression in the measured age and the
+% exact integers 10 and 4, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook expected_aa_gradient_laws {
+    use expected_aa_gradient_vocab
+
+    % Expected A-a gradient — the age plus the 10 mmHg offset, quartered: the upper limit of normal at that age.
+    formula expected_aa_gradient(patient_age) = (patient_age + 10) / 4
+        source "A-a gradient = (Age + 10) / 4"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545153/"
+        trust authoritative
+
+    % Age — the same expression solved for the age at which a given gradient is exactly the upper limit of
+    % normal. Defended by the SAME clause.
+    formula patient_age(expected_aa_gradient) = expected_aa_gradient * 4 - 10
+        source "A-a gradient = (Age + 10) / 4"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545153/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/expected-aa-gradient.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/expected-aa-gradient.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% expected-aa-gradient.query.adj — worked applications of the age-predicted normal A-a gradient.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an oxygenation assessment down to the patient's age: it
+% `import`s the grounded formulabook, `observe`s the age, and asks the engine to APPLY the cited
+% expected-A-a-gradient formula. No arithmetic is stated by the consumer; the engine computes each value
+% EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with zero model
+% calls.
+%
+% Worked case (patient age = 50 years): expected A-a gradient = (50 + 10) / 4 = 60 / 4 = 15 mmHg (the upper
+% limit of normal at 50). Each query fixes one input and asks the engine to recover the other quantity; every
+% answer is exact and the inversion COMPOSES (it recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli expected-aa-gradient.query.adj
+% ============================================================================
+
+import "expected-aa-gradient.adj"
+
+% --- Expected A-a gradient: the upper limit of normal at age 50 (expect 15). -------------------------
+observe patient_age(50)
+? expected_aa_gradient(patient_age)   % expect 15
+
+% --- Inverse: the age at which a gradient of 15 is exactly the upper limit of normal (expect 50). ----
+observe expected_aa_gradient(15)
+? patient_age(expected_aa_gradient)   % expect 50


### PR DESCRIPTION
## What

Ships a new clinical formulabook grounding the **age-based expected (upper-limit-of-normal) alveolar–arterial oxygen gradient** — a distinct relation over a distinct variable from the already-shipped *measured* form in `alveolar-arterial-gradient.adj` (alveolar PO2 − arterial PO2), grounded on a **typed, all-ASCII** equation from the same source page.

## Provenance

Source (verbatim, typed, operand-complete, correctly bracketed):

> `A-a gradient = (Age + 10) / 4`

from StatPearls *"Physiology, Alveolar to Arterial Oxygen Gradient"*, [NBK545153](https://www.ncbi.nlm.nih.gov/books/NBK545153/).

## Formulas (both defended by the SAME cited clause)

```
expected_aa_gradient(patient_age) = (patient_age + 10) / 4        % mmHg, upper limit of normal
patient_age(expected_aa_gradient) = expected_aa_gradient * 4 - 10 % solved for age
```

Structurally a sum-with-a-constant over a constant (same shape as mid-parental-height, over a single variable). Both embedded constants (offset 10, divisor 4) are exact integers as the cited expression prints them; the age is a formal parameter bound at apply time, so every value the engine returns is exact.

## Worked case (age = 50)

`(50 + 10) / 4 = 60 / 4 = 15` mmHg; inverse `15 * 4 - 10 = 50`. Both render as **exact integers** (verified via render-probe — no f64 noise).

## Discipline checks
- Source clause is **byte-faithful and pure-ASCII** (NUL-scan + non-ASCII scan clean on both source lines).
- Render-probe clean; both values carry `"trust":"authoritative"` + the NBK545153 locator.
- 2 e2e tests pass; clippy `-D warnings` clean; `/security-review` PASSED.
- **Data + test only — no version bump.**

## Files
- `code/specs/data/adj-formula-stdlib/clinical/expected-aa-gradient.adj` (dictionary + formulabook)
- `code/specs/data/adj-formula-stdlib/clinical/expected-aa-gradient.query.adj` (worked case)
- `code/packages/rust/adj-lang-cli/tests/formula_expected_aa_gradient_e2e.rs` (2 e2e tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)