### PR TITLE
feat(adj-formula-stdlib): arm-span-height — standing-height estimate from arm span (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_arm_span_height_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_arm_span_height_e2e.rs
@@ -1,0 +1,109 @@
+//! End-to-end tests for the `clinical/arm-span-height.adj` library — estimating standing height from arm
+//! span (height = span / 1.06) and its one exact rearrangement — driven through the built CLI binary against
+//! the SHIPPED stdlib. The same invariant as every other formula library: a consumer states NO arithmetic; it
+//! imports the grounded library, binds the measured arm span with `observe`, and the engine applies the cited
+//! formula on the CPU, computing the EXACT value (over exact rationals) and rendering the citation and trust
+//! tier in the `derived` section (the auditable answer). The two formulas INVERT around the worked case
+//! span = 159: 159 / 1.06 = 150 (height), 150 × 1.06 = 159 (span).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation carries the factor 1.06, so a bare numeric substring could spuriously match.
+//! The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped arm-span-height library, resolved from this crate's manifest dir so the test
+/// is location-independent.
+fn shipped_ash_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/arm-span-height.adj")
+        .canonicalize()
+        .expect("shipped arm-span-height.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ash_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_ash_lib()).unwrap();
+    std::fs::write(dir.join("arm-span-height.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// estimated_height — the standing-height estimate: span / 1.06.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_arm_span_height_library_and_computes_it_with_citation() {
+    let dir = scratch("ash");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"arm-span-height.adj\"\n\
+         observe arm_span(159)\n\
+         ? estimated_height(arm_span)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 159 / 1.06 = 150, computed EXACTLY over
+    // rationals (1.06 = 53/50). Match the adjacent name/value pair so the 1.06 factor cannot spuriously satisfy
+    // a bare "value":150.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"estimated_height\",\"value\":150"),
+        "estimated_height(159) = 150: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// arm_span — the same expression solved for the arm span: height × 1.06.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_arm_span_from_height_with_citation() {
+    let dir = scratch("span");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"arm-span-height.adj\"\n\
+         observe estimated_height(150)\n\
+         ? arm_span(estimated_height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 150 × 1.06 = 159, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"arm_span\",\"value\":159"),
+        "arm_span(150) = 159: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "arm_span carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/arm-span-height.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/arm-span-height.adj
@@ -1,0 +1,83 @@
+% ============================================================================
+% arm-span-height.adj — estimating standing height from arm span
+% (height = span / 1.06) in the ADJ standard library.
+% ============================================================================
+% The arm-span-height entry of the *clinical* track — the estimate of a patient's standing height from their
+% ARM SPAN (fingertip-to-fingertip span of the outstretched arms) when height cannot be measured directly.
+% Many patients cannot stand for a stadiometer measurement — kyphoscoliosis and other chest/spine deformities,
+% contractures, amputation, non-ambulatory or bed-bound status — yet a height is still needed to compute
+% spirometry reference values, body-surface-area, BMI and weight-based drug doses. Arm span is close to
+% standing height and can be measured lying down, so it serves as a surrogate: because span slightly EXCEEDS
+% height in most adults, the cited page divides the measured span by a fixed factor to bring it back to an
+% estimated height. THE ESTIMATED HEIGHT IS THE ARM SPAN DIVIDED BY 1.06 — i.e. height = span / 1.06.
+%
+% It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its one exact
+% rearrangement (the arm span a given height implies). As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the measured arm span from its own byte-provenance decomposition,
+% and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "arm-span-height.adj"
+%     observe arm_span(159)   % "…arm span 159 cm…"   (span cited by the model)
+%     ? estimated_height(arm_span)   % engine → 150 (cm, estimated standing height)
+%
+% Structurally this is a SINGLE VALUE OVER A CONSTANT — one measured quantity divided by a fixed factor — a
+% shape distinct from the sum-with-a-constant-over-a-constant (mid-parental-height, expected-aa-gradient),
+% ratio, product-over-constant and constant-scaled forms of the other clinical libraries. The one embedded
+% constant — the span-to-height factor 1.06 — is an exact terminating decimal as the cited expression prints
+% it (1.06 = 53/50), and the arm span is the one formal parameter bound at apply time, so every value the
+% engine returns is exact.
+%
+%   estimated_height(arm_span)     = arm_span / 1.06          % (cm, estimated standing height)
+%   arm_span(estimated_height)     = estimated_height * 1.06  % (cm, the arm span a given height implies)
+%
+% The two formulas COMPOSE and invert cleanly around the worked case arm_span = 159 cm (estimated height =
+% 159 / 1.06 = 150 cm): the `estimated_height` a consumer computes is exactly the value the inverse formula
+% back-solves to recover its own measured input (159).
+%
+% NOTE ON UNITS AND MODELLING: the arm span and estimated height are in the SAME unit (centimetres here) — the
+% factor 1.06 is dimensionless, so the estimate comes out in whatever unit the span was measured in. This is a
+% population SURROGATE: the true span-to-height ratio varies with age, sex and ancestry, and the cited page
+% prints ONE representative factor (1.06); this library grounds exactly that printed factor. The estimate
+% feeds downstream reference equations (spirometry, BSA, BMI); interpreting it in context is the clinician's
+% task, stated by the cited source but applied by the reader.
+%
+% Both formulas are defended by the SAME clause — the quoted height expression — because that one expression
+% (span / 1.06) sanctions the relation read either way. The quote is transcribed verbatim from the StatPearls
+% article "Spirometry", where the arm-span height adjustment is printed as the typed, all-ASCII, operand-
+% complete expression "height = span/1.06". Each `formula` therefore carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored —
+% the formula is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `arm_span` and `estimated_height` each appear BOTH as a derived result and as an input (of the
+% other formula), so each is a single dictionary term used in both roles. The `surface` lists are the everyday
+% names a decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary arm_span_height_vocab {
+    define arm_span          : finding  surface "arm span", "armspan", "arm-span", "span", "wingspan", "fingertip-to-fingertip span" % cm
+    define estimated_height  : finding  surface "estimated height", "predicted height", "height", "standing height", "surrogate height" % cm
+}
+
+% ----------------------------------------------------------------------------
+% The arm-span height estimate, both ways. Each is a named, importable, reusable formula over its formal
+% parameter, bound at apply time, and each carries the height expression from the StatPearls article (a quote
+% is required on a shipped formula). Each is an exact expression in the measured value and the exact factor
+% 1.06, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook arm_span_height_laws {
+    use arm_span_height_vocab
+
+    % Estimated height — the arm span brought back to a standing height by the 1.06 span-to-height factor.
+    formula estimated_height(arm_span) = arm_span / 1.06
+        source "height = span/1.06"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560526/"
+        trust authoritative
+
+    % Arm span — the same expression solved for the arm span a given height implies. Defended by the SAME clause.
+    formula arm_span(estimated_height) = estimated_height * 1.06
+        source "height = span/1.06"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560526/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/arm-span-height.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/arm-span-height.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% arm-span-height.query.adj — worked applications of the arm-span height estimate.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a bedside assessment down to a measured arm span (used
+% when a standing height cannot be obtained): it `import`s the grounded formulabook, `observe`s the span, and
+% asks the engine to APPLY the cited height-estimation formula. No arithmetic is stated by the consumer; the
+% engine computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof,
+% on the CPU, with zero model calls.
+%
+% Worked case (arm span = 159 cm): estimated height = 159 / 1.06 = 150 cm. Each query fixes one input and
+% asks the engine to recover the other quantity; every answer is exact and the inversion COMPOSES (it recovers
+% exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli arm-span-height.query.adj
+% ============================================================================
+
+import "arm-span-height.adj"
+
+% --- Estimated height: the standing height a 159 cm arm span implies (expect 150). -------------------
+observe arm_span(159)
+? estimated_height(arm_span)   % expect 150
+
+% --- Inverse: the arm span a height of 150 implies (expect 159). -------------------------------------
+observe estimated_height(150)
+? arm_span(estimated_height)   % expect 159


### PR DESCRIPTION
## What

Ships a new clinical formulabook grounding the **arm-span → standing-height surrogate** — the height estimate used when a patient's standing height cannot be measured directly (kyphoscoliosis and other chest/spine deformities, contractures, non-ambulatory status), feeding downstream spirometry / BSA / BMI / weight-based dosing.

## Provenance

Source (verbatim, typed, all-ASCII, operand-complete):

> `height = span/1.06`

from StatPearls *"Spirometry"*, [NBK560526](https://www.ncbi.nlm.nih.gov/books/NBK560526/).

## Formulas (both defended by the SAME cited clause)

```
estimated_height(arm_span) = arm_span / 1.06          % cm, estimated standing height
arm_span(estimated_height) = estimated_height * 1.06  % cm, the span a given height implies
```

Structurally a single-value-over-a-constant shape (distinct from the sum-with-a-constant forms of mid-parental-height / expected-aa-gradient). The one embedded constant — the span-to-height factor `1.06` = 53/50 — is an exact terminating decimal as the cited expression prints it; the arm span is a formal parameter bound at apply time, so every value the engine returns is exact.

## Worked case (arm span = 159 cm)

`159 / 1.06 = 150` cm; inverse `150 * 1.06 = 159`. Both render as **exact integers** (verified via render-probe — no f64 noise).

## Discipline checks
- Source clause is **byte-faithful and pure-ASCII** (NUL-scan + non-ASCII scan clean on both source lines).
- Render-probe clean; both values carry `"trust":"authoritative"` + the NBK560526 locator.
- 2 e2e tests pass; clippy `-D warnings` clean; `/security-review` PASSED.
- **Data + test only — no version bump.**

## Files
- `code/specs/data/adj-formula-stdlib/clinical/arm-span-height.adj` (dictionary + formulabook)
- `code/specs/data/adj-formula-stdlib/clinical/arm-span-height.query.adj` (worked case)
- `code/packages/rust/adj-lang-cli/tests/formula_arm_span_height_e2e.rs` (2 e2e tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)