### PR TITLE
feat(adj-formula-stdlib): elimination-half-life — drug half-life from Vd and clearance (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_elimination_half_life_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_elimination_half_life_e2e.rs
@@ -1,0 +1,143 @@
+//! End-to-end tests for the `clinical/elimination-half-life.adj` library — a drug's elimination half-life
+//! (t1/2 = 0.693 × Vd / CL) and its two exact rearrangements — driven through the built CLI binary against the
+//! SHIPPED stdlib. The same invariant as every other formula library: a consumer states NO arithmetic; it
+//! imports the grounded library, binds the volume of distribution and the clearance with `observe`, and the
+//! engine applies the cited formula on the CPU, computing the EXACT value (over exact rationals) and rendering
+//! the citation and trust tier in the `derived` section (the auditable answer). The three formulas INVERT
+//! around the worked case Vd = 2000, CL = 693: 0.693 × 2000 / 693 = 2 (half-life),
+//! 2 × 693 / 0.693 = 2000 (Vd), 0.693 × 2000 / 2 = 693 (CL).
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation carries the factor 0.693 and the intermediate 1386, so a bare numeric substring
+//! could spuriously match. The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped elimination-half-life library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_ehl_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/elimination-half-life.adj")
+        .canonicalize()
+        .expect("shipped elimination-half-life.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ehl_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_ehl_lib()).unwrap();
+    std::fs::write(dir.join("elimination-half-life.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// half_life — the elimination half-life: 0.693 × Vd / CL.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_elimination_half_life_library_and_computes_it_with_citation() {
+    let dir = scratch("ehl");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"elimination-half-life.adj\"\n\
+         observe volume_of_distribution(2000)\n\
+         observe clearance(693)\n\
+         ? half_life(volume_of_distribution, clearance)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 0.693 × 2000 / 693 = 1386 / 693 = 2,
+    // computed EXACTLY over rationals (0.693 = 693/1000). Match the adjacent name/value pair so the 0.693
+    // factor and the 1386 intermediate cannot spuriously satisfy a bare "value":2.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"half_life\",\"value\":2"),
+        "half_life(2000, 693) = 2: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// volume_of_distribution — the same equation solved for Vd: half_life × CL / 0.693.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_volume_of_distribution_from_half_life_with_citation() {
+    let dir = scratch("vd");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"elimination-half-life.adj\"\n\
+         observe half_life(2)\n\
+         observe clearance(693)\n\
+         ? volume_of_distribution(half_life, clearance)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 × 693 / 0.693 = 1386 / 0.693 = 2000, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"volume_of_distribution\",\"value\":2000"),
+        "volume_of_distribution(2, 693) = 2000: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "volume_of_distribution carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// clearance — the same equation solved for CL: 0.693 × Vd / half_life, the third reading of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_clearance_from_half_life_with_citation() {
+    let dir = scratch("cl");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"elimination-half-life.adj\"\n\
+         observe half_life(2)\n\
+         observe volume_of_distribution(2000)\n\
+         ? clearance(half_life, volume_of_distribution)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 0.693 × 2000 / 2 = 1386 / 2 = 693, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"clearance\",\"value\":693"),
+        "clearance(2, 2000) = 693: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "clearance carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/elimination-half-life.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/elimination-half-life.adj
@@ -1,0 +1,104 @@
+% ============================================================================
+% elimination-half-life.adj — a drug's elimination half-life from its volume of distribution and clearance
+% (t1/2 = 0.693 × Vd / CL) in the ADJ standard library.
+% ============================================================================
+% The elimination-half-life entry of the *clinical* track — the time it takes for the plasma concentration of a
+% drug to fall by half during the elimination phase. Half-life sets the dosing interval, the time to steady
+% state (~4-5 half-lives), and the washout time after stopping a drug, so it is one of the most-used bedside
+% pharmacokinetic numbers. It is fixed by two physiological quantities: the VOLUME OF DISTRIBUTION (Vd, how
+% widely the drug spreads into tissues) and the CLEARANCE (CL, how fast the body removes it). A larger Vd
+% lengthens the half-life (more drug hidden in tissue to clear), while a larger CL shortens it (faster
+% removal). The cited page folds this into one relation with the constant 0.693 — the natural log of 2, the
+% factor that turns a rate constant into a halving time. A DRUG'S ELIMINATION HALF-LIFE IS 0.693 TIMES ITS
+% VOLUME OF DISTRIBUTION DIVIDED BY ITS CLEARANCE — i.e. t1/2 = 0.693 × Vd / CL.
+%
+% It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with two exact rearrangements
+% (the volume of distribution and the clearance a given half-life implies). As with every compute library, a
+% consumer states NO arithmetic: it `import`s this file, binds Vd and CL from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "elimination-half-life.adj"
+%     observe volume_of_distribution(2000)   % "…Vd 2000 mL…"       (span cited by the model)
+%     observe clearance(693)                  % "…clearance 693 mL/h…" (span cited by the model)
+%     ? half_life(volume_of_distribution, clearance)   % engine → 2 (h)
+%
+% Structurally this is a CONSTANT-SCALED PRODUCT OVER A VALUE — a fixed factor times one measured quantity,
+% divided by another — a shape distinct from the single-value-over-a-constant (arm-span-height), the
+% sum-with-a-constant-over-a-constant (mid-parental-height, expected-aa-gradient), the ratio and the
+% product-times-constant forms of the other clinical libraries. The one embedded constant — the halving factor
+% 0.693 — is an exact terminating decimal AS THE CITED EXPRESSION PRINTS IT (0.693 = 693/1000; it is the
+% textbook truncation of ln 2, and this library grounds exactly the printed three-digit form, not the
+% irrational). Vd and CL are the two formal parameters bound at apply time, so every value the engine returns
+% is exact.
+%
+%   half_life(volume_of_distribution, clearance)     = 0.693 * volume_of_distribution / clearance % (time)
+%   volume_of_distribution(half_life, clearance)     = half_life * clearance * 1000 / 693         % (solved for Vd)
+%   clearance(half_life, volume_of_distribution)     = 0.693 * volume_of_distribution / half_life % (solved for CL)
+%
+% NOTE on the Vd inversion's form: solving t1/2 = 0.693 × Vd / CL for Vd gives Vd = t1/2 × CL / 0.693. Because
+% the cited constant 0.693 is EXACTLY 693/1000, dividing by 0.693 is identically MULTIPLYING by 1000/693; the
+% inversion is written in that integer-reciprocal form (× 1000 / 693) so the engine keeps the whole computation
+% in exact integer arithmetic. The forward and clearance formulas MULTIPLY by 0.693 (never divide by it), so
+% they carry the literal 0.693 exactly as the source prints it. All three are the same cited relation.
+%
+% The three formulas COMPOSE and invert cleanly around the worked case Vd = 2000, CL = 693 (half-life =
+% 0.693 × 2000 / 693 = 1386 / 693 = 2): the `half_life` a consumer computes is exactly the value each inverse
+% formula back-solves to recover its own measured input (2000, 693).
+%
+% NOTE ON UNITS AND MODELLING: Vd and CL must be in COMPATIBLE units so the volume cancels (e.g. Vd in mL and
+% CL in mL per unit time gives a half-life in that time unit); the 0.693 factor is dimensionless. This is the
+% ONE-COMPARTMENT elimination half-life; multi-compartment drugs have several phases (a different model not
+% grounded here). The half-life feeds dosing-interval and steady-state reasoning; applying it in context is the
+% clinician's task, stated by the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted half-life expression — because that one
+% expression (0.693 × Vd / CL) sanctions the relation read every way. The quote is transcribed verbatim from
+% the StatPearls article "Elimination Half-Life of Drugs", where it is printed as the typed, operand-complete
+% expression "t1/2=0.693×Vd/CL" (multiplication then division read left to right, which is the intended
+% (0.693 × Vd) / CL). Each `formula` therefore carries the provenance envelope every shipped grounded clause
+% carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored — the formula is a
+% verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `volume_of_distribution`, `clearance` and `half_life` each appear BOTH as a derived result and as
+% an input (of the other formulas), so each is a single dictionary term used in both roles. The `surface` lists
+% are the everyday names a decomposer maps onto the canonical term; the trailing comment records the intended
+% unit.
+% ----------------------------------------------------------------------------
+dictionary elimination_half_life_vocab {
+    define volume_of_distribution : finding  surface "volume of distribution", "Vd", "apparent volume of distribution" % volume (e.g. mL)
+    define clearance              : finding  surface "clearance", "CL", "drug clearance", "total clearance"            % volume/time (e.g. mL/h)
+    define half_life              : finding  surface "half-life", "elimination half-life", "t1/2", "t half"            % time (e.g. h)
+}
+
+% ----------------------------------------------------------------------------
+% The elimination half-life, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the half-life expression from the StatPearls article (a
+% quote is required on a shipped formula). Each is an exact expression in the measured values and the exact
+% factor 0.693, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook elimination_half_life_laws {
+    use elimination_half_life_vocab
+
+    % Elimination half-life — 0.693 times the volume of distribution, divided by the clearance.
+    formula half_life(volume_of_distribution, clearance) = 0.693 * volume_of_distribution / clearance
+        source "t1/2=0.693×Vd/CL"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554498/"
+        trust authoritative
+
+    % Volume of distribution — the same expression solved for Vd. Dividing by the cited 0.693 is identically
+    % multiplying by its exact reciprocal 1000/693 (0.693 = 693/1000), written that way so the engine stays in
+    % exact integer arithmetic. Defended by the SAME clause.
+    formula volume_of_distribution(half_life, clearance) = half_life * clearance * 1000 / 693
+        source "t1/2=0.693×Vd/CL"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554498/"
+        trust authoritative
+
+    % Clearance — the same expression solved for CL, the third reading of the one law.
+    formula clearance(half_life, volume_of_distribution) = 0.693 * volume_of_distribution / half_life
+        source "t1/2=0.693×Vd/CL"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554498/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/elimination-half-life.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/elimination-half-life.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% elimination-half-life.query.adj — worked applications of the drug elimination half-life.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a pharmacokinetic assessment into a volume of
+% distribution and a clearance: it `import`s the grounded formulabook, `observe`s the two values, and asks the
+% engine to APPLY the cited half-life formula. No arithmetic is stated by the consumer; the engine computes
+% each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with
+% zero model calls.
+%
+% Worked case (Vd = 2000 mL, CL = 693 mL/h): half-life = 0.693 × 2000 / 693 = 1386 / 693 = 2 h. Each query
+% fixes one input and asks the engine to recover another quantity; every answer is exact and the inversions
+% COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli elimination-half-life.query.adj
+% ============================================================================
+
+import "elimination-half-life.adj"
+
+% --- Half-life: the value Vd and CL imply (expect 2). ------------------------------------------------
+observe volume_of_distribution(2000)
+observe clearance(693)
+? half_life(volume_of_distribution, clearance)   % expect 2
+
+% --- Inverse: the Vd a half-life of 2 implies at the same clearance (expect 2000). -------------------
+observe half_life(2)
+? volume_of_distribution(half_life, clearance)   % expect 2000


### PR DESCRIPTION
## What

Ships a new clinical formulabook grounding the **one-compartment elimination half-life** — one of the most-used bedside pharmacokinetic numbers (sets the dosing interval, time to steady state ~4–5 half-lives, and washout time), fixed by the volume of distribution (Vd) and clearance (CL).

## Provenance

Source (verbatim, typed, operand-complete):

> `t1/2=0.693×Vd/CL`

from StatPearls *"Elimination Half-Life of Drugs"*, [NBK554498](https://www.ncbi.nlm.nih.gov/books/NBK554498/). The `×` is Unicode U+00D7 (faithfully transcribed; the only non-ASCII on the source lines), `/` is ASCII, `0.693` is a terminating decimal (the textbook truncation of ln 2 = 693/1000, grounded exactly as printed).

## Formulas (all three defended by the SAME cited clause)

```
half_life(Vd, CL)                = 0.693 * Vd / CL
volume_of_distribution(t1/2, CL) = t1/2 * CL * 1000 / 693     % = t1/2 * CL / 0.693, exact
clearance(t1/2, Vd)              = 0.693 * Vd / t1/2
```

**Exactness note:** the Vd inversion is written with the exact integer reciprocal (`÷0.693 = ×1000/693`, since `0.693 = 693/1000`) so the engine computes in exact integer arithmetic. Render-probing the *direct* `÷0.693` form exported f64 rounding noise (`2000.0000000000002`); the reciprocal form yields an exact `2000`. The forward and clearance formulas **multiply** by 0.693 (never divide by it), so they carry the literal `0.693` exactly as the source prints it and render clean.

## Worked case (Vd = 2000, CL = 693)

`0.693 × 2000 / 693 = 2` (half-life); inverses recover `Vd = 2000` and `CL = 693`. All three render as **exact integers** (verified via render-probe — no f64 noise).

## Discipline checks
- Source clause byte-faithful; NUL-scan clean; non-ASCII scan shows only the intended `×` (U+00D7).
- Render-probe clean on all three; every value carries `"trust":"authoritative"` + the NBK554498 locator.
- 3 e2e tests pass; clippy `-D warnings` clean; `/security-review` PASSED.
- **Data + test only — no version bump.**

## Files
- `code/specs/data/adj-formula-stdlib/clinical/elimination-half-life.adj` (dictionary + formulabook)
- `code/specs/data/adj-formula-stdlib/clinical/elimination-half-life.query.adj` (worked case)
- `code/packages/rust/adj-lang-cli/tests/formula_elimination_half_life_e2e.rs` (3 e2e tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)