### PR TITLE
feat(adj-formula-stdlib): respiratory-quotient — RQ from CO2 production and O2 consumption (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_respiratory_quotient_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_respiratory_quotient_e2e.rs
@@ -1,0 +1,143 @@
+//! End-to-end tests for the `clinical/respiratory-quotient.adj` library — the respiratory quotient
+//! (RQ = VCO2 / VO2) and its two exact rearrangements — driven through the built CLI binary against the
+//! SHIPPED stdlib. The same invariant as every other formula library: a consumer states NO arithmetic; it
+//! imports the grounded library, binds CO2 production and O2 consumption with `observe`, and the engine
+//! applies the cited formula on the CPU, computing the EXACT value (over exact rationals) and rendering the
+//! citation and trust tier in the `derived` section (the auditable answer). The three formulas INVERT around
+//! the worked case VCO2 = 300, VO2 = 400: 300 / 400 = 0.75 (RQ), 0.75 × 400 = 300 (VCO2),
+//! 300 / 0.75 = 400 (VO2). The worked RQ is the DYADIC value 0.75 (= 3/4, exactly representable in f64) so
+//! every rendered value is exact.
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: a bare numeric substring could spuriously match another node. The name-anchored adjacent form
+//! is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped respiratory-quotient library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_rq_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/respiratory-quotient.adj")
+        .canonicalize()
+        .expect("shipped respiratory-quotient.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rq_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_rq_lib()).unwrap();
+    std::fs::write(dir.join("respiratory-quotient.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// respiratory_quotient — the ratio: VCO2 / VO2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_respiratory_quotient_library_and_computes_it_with_citation() {
+    let dir = scratch("rq");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"respiratory-quotient.adj\"\n\
+         observe co2_production(300)\n\
+         observe o2_consumption(400)\n\
+         ? respiratory_quotient(co2_production, o2_consumption)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 300 / 400 = 0.75, computed EXACTLY over
+    // rationals (3/4). Match the adjacent name/value pair.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"respiratory_quotient\",\"value\":0.75"),
+        "respiratory_quotient(300, 400) = 0.75: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// co2_production — the same expression solved for VCO2: RQ × VO2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_co2_production_from_rq_with_citation() {
+    let dir = scratch("vco2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"respiratory-quotient.adj\"\n\
+         observe respiratory_quotient(0.75)\n\
+         observe o2_consumption(400)\n\
+         ? co2_production(respiratory_quotient, o2_consumption)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 0.75 × 400 = 300, computed on the CPU (0.75 = 3/4 is exact in f64).
+    assert!(
+        s.contains("\"name\":\"co2_production\",\"value\":300"),
+        "co2_production(0.75, 400) = 300: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "co2_production carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// o2_consumption — the same expression solved for VO2: VCO2 / RQ, the third reading of the one law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_o2_consumption_from_rq_with_citation() {
+    let dir = scratch("vo2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"respiratory-quotient.adj\"\n\
+         observe co2_production(300)\n\
+         observe respiratory_quotient(0.75)\n\
+         ? o2_consumption(co2_production, respiratory_quotient)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 300 / 0.75 = 400, computed on the CPU (0.75 = 3/4 is exact in f64).
+    assert!(
+        s.contains("\"name\":\"o2_consumption\",\"value\":400"),
+        "o2_consumption(300, 0.75) = 400: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "o2_consumption carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/respiratory-quotient.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/respiratory-quotient.adj
@@ -1,0 +1,92 @@
+% ============================================================================
+% respiratory-quotient.adj — the respiratory quotient from CO2 production and O2 consumption
+% (RQ = VCO2 / VO2) in the ADJ standard library.
+% ============================================================================
+% The respiratory-quotient entry of the *clinical* track — the ratio of the carbon dioxide a person PRODUCES
+% to the oxygen they CONSUME over the same period, measured at the whole-body level by indirect calorimetry.
+% RQ is a window onto which fuel is being burned: oxidising pure carbohydrate gives an RQ of 1.0 (equal CO2 out
+% and O2 in), pure fat about 0.7, and a mixed diet roughly 0.8. It is used in nutrition support (to titrate
+% feeding and avoid overfeeding, which drives RQ up toward and past 1.0) and it feeds the respiratory-exchange
+% term of the alveolar gas equation. THE RESPIRATORY QUOTIENT IS THE VOLUME OF CO2 PRODUCED DIVIDED BY THE
+% VOLUME OF O2 CONSUMED — i.e. RQ = VCO2 / VO2.
+%
+% It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with two exact rearrangements
+% (the CO2 production and the O2 consumption a given RQ implies). As with every compute library, a consumer
+% states NO arithmetic: it `import`s this file, binds VCO2 and VO2 from its own byte-provenance decomposition,
+% and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "respiratory-quotient.adj"
+%     observe co2_production(300)   % "…VCO2 300 mL/min…"  (span cited by the model)
+%     observe o2_consumption(400)    % "…VO2 400 mL/min…"   (span cited by the model)
+%     ? respiratory_quotient(co2_production, o2_consumption)   % engine → 0.75 (dimensionless)
+%
+% Structurally this is a PLAIN RATIO — one measured quantity over another, no constants at all — a shape
+% distinct from the constant-scaled-product-over-a-value (elimination-half-life), single-value-over-a-constant
+% (arm-span-height) and sum-with-a-constant (mid-parental-height, expected-aa-gradient) forms of the other
+% clinical libraries. There are NO embedded constants; VCO2 and VO2 are the two formal parameters bound at
+% apply time, so every value the engine returns is exact.
+%
+%   respiratory_quotient(co2_production, o2_consumption) = co2_production / o2_consumption % (dimensionless)
+%   co2_production(respiratory_quotient, o2_consumption) = respiratory_quotient * o2_consumption % (solved for VCO2)
+%   o2_consumption(co2_production, respiratory_quotient) = co2_production / respiratory_quotient % (solved for VO2)
+%
+% The three formulas COMPOSE and invert cleanly around the worked case VCO2 = 300, VO2 = 400 (RQ =
+% 300 / 400 = 0.75): the `respiratory_quotient` a consumer computes is exactly the value each inverse formula
+% back-solves to recover its own measured input (300, 400).
+%
+% NOTE ON UNITS AND MODELLING: VCO2 and VO2 are volumes per unit time in the SAME unit (e.g. mL/min), so RQ is
+% dimensionless; it must lie between about 0.7 (pure fat) and 1.0 (pure carbohydrate) physiologically. This is
+% the WHOLE-BODY respiratory quotient measured by indirect calorimetry; the closely related respiratory
+% EXCHANGE ratio (R) can differ transiently from RQ during hyperventilation or non-steady state (a distinction
+% the source notes but this library does not model). Interpreting a measured RQ (fuel mix, overfeeding) is the
+% clinician's task, stated by the cited source but applied by the reader.
+%
+% All three formulas are defended by the SAME clause — the quoted RQ expression — because that one expression
+% (VCO2 / VO2) sanctions the relation read every way. The quote is transcribed verbatim from the StatPearls
+% article "Physiology, Respiratory Quotient", where it is printed as the typed, all-ASCII, operand-complete
+% expression "RQ = Vol CO2 released/Vol O2 absorbed". Each `formula` therefore carries the provenance envelope
+% every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `co2_production`, `o2_consumption` and `respiratory_quotient` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary respiratory_quotient_vocab {
+    define co2_production        : finding  surface "CO2 production", "VCO2", "carbon dioxide production", "volume of CO2 released" % vol/time (e.g. mL/min)
+    define o2_consumption        : finding  surface "O2 consumption", "VO2", "oxygen consumption", "volume of O2 absorbed"          % vol/time (e.g. mL/min)
+    define respiratory_quotient  : finding  surface "respiratory quotient", "RQ", "respiratory ratio"                               % dimensionless
+}
+
+% ----------------------------------------------------------------------------
+% The respiratory quotient, three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the RQ expression from the StatPearls article (a quote is
+% required on a shipped formula). Each is an exact expression in the measured values, so the engine returns
+% each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook respiratory_quotient_laws {
+    use respiratory_quotient_vocab
+
+    % Respiratory quotient — the CO2 produced over the O2 consumed.
+    formula respiratory_quotient(co2_production, o2_consumption) = co2_production / o2_consumption
+        source "RQ = Vol CO2 released/Vol O2 absorbed"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK531494/"
+        trust authoritative
+
+    % CO2 production — the same expression solved for VCO2. Defended by the SAME clause.
+    formula co2_production(respiratory_quotient, o2_consumption) = respiratory_quotient * o2_consumption
+        source "RQ = Vol CO2 released/Vol O2 absorbed"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK531494/"
+        trust authoritative
+
+    % O2 consumption — the same expression solved for VO2, the third reading of the one law.
+    formula o2_consumption(co2_production, respiratory_quotient) = co2_production / respiratory_quotient
+        source "RQ = Vol CO2 released/Vol O2 absorbed"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK531494/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/respiratory-quotient.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/respiratory-quotient.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% respiratory-quotient.query.adj — worked applications of the respiratory quotient.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an indirect-calorimetry assessment into a CO2
+% production and an O2 consumption: it `import`s the grounded formulabook, `observe`s the two values, and asks
+% the engine to APPLY the cited RQ formula. No arithmetic is stated by the consumer; the engine computes each
+% value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with zero
+% model calls.
+%
+% Worked case (VCO2 = 300 mL/min, VO2 = 400 mL/min): RQ = 300 / 400 = 0.75 (a fat-leaning mixed-fuel value).
+% Each query fixes one input and asks the engine to recover another quantity; every answer is exact and the
+% inversions COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli respiratory-quotient.query.adj
+% ============================================================================
+
+import "respiratory-quotient.adj"
+
+% --- RQ: the ratio VCO2 and VO2 imply (expect 0.75). ------------------------------------------------
+observe co2_production(300)
+observe o2_consumption(400)
+? respiratory_quotient(co2_production, o2_consumption)   % expect 0.75
+
+% --- Inverse: the VO2 an RQ of 0.75 implies at the same VCO2 (expect 400). ---------------------------
+observe respiratory_quotient(0.75)
+? o2_consumption(co2_production, respiratory_quotient)   % expect 400


### PR DESCRIPTION
## What

Ships a new clinical formulabook grounding the **respiratory quotient (RQ)** — the whole-body ratio of CO2 produced to O2 consumed, measured by indirect calorimetry: a window onto fuel utilization (≈1.0 carbohydrate, ≈0.7 fat, ≈0.8 mixed diet), used in nutrition support and the alveolar gas equation. Genuinely new domain (metabolism / indirect calorimetry).

## Provenance

Source (verbatim, typed, all-ASCII, operand-complete):

> `RQ = Vol CO2 released/Vol O2 absorbed`

from StatPearls *"Physiology, Respiratory Quotient"*, [NBK531494](https://www.ncbi.nlm.nih.gov/books/NBK531494/).

## Formulas (all three defended by the SAME cited clause)

```
respiratory_quotient(VCO2, VO2) = VCO2 / VO2
co2_production(RQ, VO2)         = RQ * VO2
o2_consumption(VCO2, RQ)        = VCO2 / RQ
```

Structurally a **plain ratio** — no embedded constants at all — distinct from the constant-scaled and sum-with-a-constant shapes of the other clinical libraries.

## Render note (dyadic worked value)

The worked RQ is chosen as the **dyadic** value `0.75` (= 3/4, exactly representable in f64) rather than the textbook `0.8` (= 4/5, not dyadic). Because 0.75 is exact in f64, both the `÷RQ` inversion (`300/0.75 = 400`) and the `×RQ` inversion (`0.75*400 = 300`) render as exact integers, avoiding the f64 export noise a non-dyadic decimal divisor would produce. The forward ratio `300/400` computes over exact rationals and exports the exact `0.75`.

## Worked case (VCO2 = 300, VO2 = 400)

`RQ = 300/400 = 0.75`; inverses recover `VCO2 = 300` and `VO2 = 400`. All three render clean (verified via render-probe — no f64 noise).

## Discipline checks
- Source clause byte-faithful and pure-ASCII (NUL-scan + non-ASCII scan clean on all three source lines).
- Render-probe clean on all three; every value carries `"trust":"authoritative"` + the NBK531494 locator.
- 3 e2e tests pass; clippy `-D warnings` clean; `/security-review` PASSED.
- **Data + test only — no version bump.**

## Files
- `code/specs/data/adj-formula-stdlib/clinical/respiratory-quotient.adj` (dictionary + formulabook)
- `code/specs/data/adj-formula-stdlib/clinical/respiratory-quotient.query.adj` (worked case)
- `code/packages/rust/adj-lang-cli/tests/formula_respiratory_quotient_e2e.rs` (3 e2e tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)