### PR TITLE
feat(adj-formula-stdlib): metabolic-alkalosis-compensation — expected PaCO2 for metabolic alkalosis (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_metabolic_alkalosis_compensation_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_metabolic_alkalosis_compensation_e2e.rs
@@ -1,0 +1,113 @@
+//! End-to-end tests for the `clinical/metabolic-alkalosis-compensation.adj` library — the expected
+//! respiratory compensation for metabolic alkalosis (expected PaCO2 = 40 + 0.6 × (HCO3 − 24)) and its one
+//! exact rearrangement — driven through the built CLI binary against the SHIPPED stdlib. The same invariant as
+//! every other formula library: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! serum bicarbonate with `observe`, and the engine applies the cited formula on the CPU, computing the EXACT
+//! value (over exact rationals) and rendering the citation and trust tier in the `derived` section (the
+//! auditable answer). The two formulas INVERT around the worked case HCO3 = 44:
+//! 40 + 0.6 × (44 − 24) = 52 (expected PaCO2), (52 − 40) × 10 / 6 + 24 = 44 (HCO3).
+//!
+//! The slope 0.6 is written in the library as 6/10 (its exact integer form) so the computation stays in exact
+//! integer arithmetic and every rendered value is an exact integer.
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders, rather than a bare
+//! `"value":N`: the derivation carries the constants 40, 6, 10 and 24, so a bare numeric substring could
+//! spuriously match. The name-anchored adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped metabolic-alkalosis-compensation library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_mac_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/metabolic-alkalosis-compensation.adj")
+        .canonicalize()
+        .expect("shipped metabolic-alkalosis-compensation.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_mac_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_mac_lib()).unwrap();
+    std::fs::write(dir.join("metabolic-alkalosis-compensation.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// expected_paco2 — the compensation: 40 + 0.6 × (HCO3 − 24).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_metabolic_alkalosis_compensation_library_and_computes_it_with_citation() {
+    let dir = scratch("mac");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"metabolic-alkalosis-compensation.adj\"\n\
+         observe serum_bicarbonate(44)\n\
+         ? expected_paco2(serum_bicarbonate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 40 + 6 × (44 − 24) / 10 = 40 + 12 = 52,
+    // computed EXACTLY over rationals. Match the adjacent name/value pair so the 40/6/10/24 constants cannot
+    // spuriously satisfy a bare "value":52.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"expected_paco2\",\"value\":52"),
+        "expected_paco2(44) = 52: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_bicarbonate — the same equation solved for HCO3: (PaCO2 − 40) × 10 / 6 + 24.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_bicarbonate_from_expected_paco2_with_citation() {
+    let dir = scratch("hco3");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"metabolic-alkalosis-compensation.adj\"\n\
+         observe expected_paco2(52)\n\
+         ? serum_bicarbonate(expected_paco2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (52 − 40) × 10 / 6 + 24 = 120 / 6 + 24 = 20 + 24 = 44, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_bicarbonate\",\"value\":44"),
+        "serum_bicarbonate(52) = 44: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_bicarbonate carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/metabolic-alkalosis-compensation.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/metabolic-alkalosis-compensation.adj
@@ -1,0 +1,92 @@
+% ============================================================================
+% metabolic-alkalosis-compensation.adj — the expected respiratory compensation for METABOLIC ALKALOSIS
+% (expected PaCO2 = 40 + 0.6 × (HCO3 − 24)) in the ADJ standard library.
+% ============================================================================
+% The metabolic-alkalosis-compensation entry of the *clinical* track — the arterial CO2 tension a patient with
+% a PRIMARY metabolic alkalosis SHOULD settle at once the lungs have compensated. A rising bicarbonate raises
+% the blood pH; the respiratory centre answers by hypoventilating, letting CO2 accumulate to blunt the pH
+% swing. The cited page gives the predicted degree of that compensation as a line anchored at the normal point
+% (PaCO2 40, HCO3 24): for every 1 mmol/L that bicarbonate rises above 24, the expected PaCO2 rises about
+% 0.6 mmHg. THE EXPECTED PaCO2 IS 40 PLUS 0.6 TIMES THE AMOUNT BICARBONATE EXCEEDS 24 — i.e.
+% PaCO2 = 40 + 0.6 × (HCO3 − 24). Comparing a patient's MEASURED PaCO2 against this expected value reveals a
+% superimposed respiratory disorder: a measured PaCO2 far below the expected means a concurrent respiratory
+% alkalosis; far above means a concurrent respiratory acidosis. It is the alkalosis counterpart of Winter's
+% formula (the metabolic-ACIDOSIS compensation grounded separately in winters-formula.adj).
+%
+% It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its one exact
+% rearrangement (the bicarbonate a given expected PaCO2 implies). As with every compute library, a consumer
+% states NO arithmetic: it `import`s this file, binds the serum bicarbonate from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY (over exact rationals), carrying the formula's citation.
+%
+%     import "metabolic-alkalosis-compensation.adj"
+%     observe serum_bicarbonate(44)   % "…HCO3 44 mmol/L…"  (span cited by the model)
+%     ? expected_paco2(serum_bicarbonate)   % engine → 52 (mmHg, expected)
+%
+% Structurally this is a BASELINE PLUS A SCALED DEVIATION — a fixed anchor (40) plus a slope (0.6) times how
+% far one measured quantity sits from its own anchor (24) — a shape distinct from the plain-ratio
+% (respiratory-quotient), constant-scaled-product-over-a-value (elimination-half-life) and
+% single-value-over-a-constant (arm-span-height) forms of the other clinical libraries.
+%
+%   expected_paco2(serum_bicarbonate) = 40 + 6 * (serum_bicarbonate - 24) / 10   % (mmHg, expected)
+%   serum_bicarbonate(expected_paco2) = (expected_paco2 - 40) * 10 / 6 + 24       % (mmol/L, solved for HCO3)
+%
+% NOTE on the form of the slope: the cited slope is 0.6, which is EXACTLY 6/10, so multiplying by 0.6 is
+% identically multiplying by 6 and dividing by 10. The formulas are written in that integer form (× 6 … / 10,
+% and its inverse × 10 / 6) so the engine keeps the whole computation in exact integer arithmetic; the value is
+% identical to the cited "0.6 × (HCO3 − 24)". The three embedded constants — the PaCO2 anchor 40, the slope
+% 0.6 (as 6/10) and the HCO3 anchor 24 — are all exact as the cited expression prints them; the bicarbonate is
+% the one formal parameter bound at apply time, so every value the engine returns is exact.
+%
+% The two formulas COMPOSE and invert cleanly around the worked case serum_bicarbonate = 44 mmol/L (expected
+% PaCO2 = 40 + 0.6 × (44 − 24) = 40 + 0.6 × 20 = 40 + 12 = 52 mmHg): the `expected_paco2` a consumer computes
+% is exactly the value the inverse formula back-solves to recover its own measured input (44).
+%
+% NOTE ON UNITS AND MODELLING: bicarbonate is in mmol/L and the expected PaCO2 comes out in mmHg; the anchors
+% 40 mmHg and 24 mmol/L are the assumed normal values and 0.6 is a dimensionless slope in mmHg per mmol/L. This
+% is the EXPECTED (predicted-normal) compensation only — a reference the MEASURED PaCO2 is judged against; the
+% library COMPUTES the expected value, and reading a measured PaCO2 against it (to detect a mixed disorder) is
+% the clinician's task, stated by the cited source but applied by the reader.
+%
+% Both formulas are defended by the SAME clause — the quoted compensation expression — because that one
+% expression (40 + 0.6 × (HCO3 − 24)) sanctions the relation read either way. The quote is transcribed verbatim
+% from the StatPearls article "Alkalosis", where it is printed as the typed, operand-complete expression
+% "PaCO2 in mm Hg = 40 + 0.6 × (HCO3 − 24 mmol/L)". Each `formula` therefore carries the provenance envelope
+% every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `serum_bicarbonate` and `expected_paco2` each appear BOTH as a derived result and as an input (of
+% the other formula), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary metabolic_alkalosis_compensation_vocab {
+    define serum_bicarbonate : finding  surface "serum bicarbonate", "bicarbonate", "HCO3", "HCO3-", "serum HCO3"        % mmol/L
+    define expected_paco2    : finding  surface "expected PaCO2", "predicted PaCO2", "compensated PaCO2", "expected pCO2" % mmHg
+}
+
+% ----------------------------------------------------------------------------
+% The metabolic-alkalosis respiratory compensation, both ways. Each is a named, importable, reusable formula
+% over its formal parameter, bound at apply time, and each carries the compensation expression from the
+% StatPearls article (a quote is required on a shipped formula). Each is an exact expression in the measured
+% value and the exact constants 40, 6/10 and 24, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook metabolic_alkalosis_compensation_laws {
+    use metabolic_alkalosis_compensation_vocab
+
+    % Expected PaCO2 — the 40 mmHg anchor plus 0.6 (= 6/10) times how far bicarbonate exceeds its 24 anchor.
+    formula expected_paco2(serum_bicarbonate) = 40 + 6 * (serum_bicarbonate - 24) / 10
+        source "PaCO2 in mm Hg = 40 + 0.6 × (HCO3 − 24 mmol/L)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545269/"
+        trust authoritative
+
+    % Serum bicarbonate — the same expression solved for HCO3. Dividing by the cited 0.6 is identically
+    % multiplying by its exact reciprocal 10/6 (0.6 = 6/10), written that way so the engine stays in exact
+    % integer arithmetic. Defended by the SAME clause.
+    formula serum_bicarbonate(expected_paco2) = (expected_paco2 - 40) * 10 / 6 + 24
+        source "PaCO2 in mm Hg = 40 + 0.6 × (HCO3 − 24 mmol/L)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545269/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/metabolic-alkalosis-compensation.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/metabolic-alkalosis-compensation.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% metabolic-alkalosis-compensation.query.adj — worked applications of the metabolic-alkalosis respiratory
+% compensation (expected PaCO2).
+% ============================================================================
+% The shape a consumer produces once it has decomposed an acid-base assessment down to a serum bicarbonate in
+% a primary metabolic alkalosis: it `import`s the grounded formulabook, `observe`s the bicarbonate, and asks
+% the engine to APPLY the cited expected-PaCO2 formula. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof, on the
+% CPU, with zero model calls.
+%
+% Worked case (serum bicarbonate = 44 mmol/L): expected PaCO2 = 40 + 0.6 × (44 − 24) = 40 + 12 = 52 mmHg (the
+% degree of hypoventilation a pure metabolic alkalosis should produce). Each query fixes one input and asks the
+% engine to recover the other quantity; every answer is exact and the inversion COMPOSES (it recovers exactly
+% the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli metabolic-alkalosis-compensation.query.adj
+% ============================================================================
+
+import "metabolic-alkalosis-compensation.adj"
+
+% --- Expected PaCO2: the compensation a bicarbonate of 44 implies (expect 52). ----------------------
+observe serum_bicarbonate(44)
+? expected_paco2(serum_bicarbonate)   % expect 52
+
+% --- Inverse: the bicarbonate an expected PaCO2 of 52 implies (expect 44). ---------------------------
+observe expected_paco2(52)
+? serum_bicarbonate(expected_paco2)   % expect 44


### PR DESCRIPTION
## What

Ships a new clinical formulabook grounding the **expected respiratory compensation for a primary metabolic alkalosis** — the alkalosis counterpart of the already-shipped Winters formula (which covers metabolic *acidosis*). A patient's measured PaCO2 compared against this expected value reveals a superimposed respiratory disorder (below → concurrent respiratory alkalosis; above → concurrent respiratory acidosis).

## Provenance

Source (verbatim, typed, operand-complete):

> `PaCO2 in mm Hg = 40 + 0.6 × (HCO3 − 24 mmol/L)`

from StatPearls *"Alkalosis"*, [NBK545269](https://www.ncbi.nlm.nih.gov/books/NBK545269/). The `×` is Unicode U+00D7 and the `−` is Unicode U+2212 (both unambiguous math operators, faithfully transcribed); `mm Hg` / `mmol/L` are unit annotations, not operands.

## Formulas (both defended by the SAME cited clause)

```
expected_paco2(HCO3)     = 40 + 6 * (HCO3 - 24) / 10      % = 40 + 0.6*(HCO3-24), exact
serum_bicarbonate(PaCO2) = (PaCO2 - 40) * 10 / 6 + 24
```

## Exactness note

The cited slope `0.6` is written in its exact integer form `6/10` (0.6 = 6/10) so the engine computes in exact integer arithmetic. Multiplying/dividing by the non-dyadic decimal 0.6 directly would export f64 rounding noise; the 6/10 form yields exact integers. The rewrite is documented inline; the value is identical to the cited `0.6 × (HCO3 − 24)`.

Structurally a **baseline-plus-scaled-deviation** shape (anchor 40 + slope 0.6 × deviation from anchor 24).

## Worked case (HCO3 = 44)

`40 + 0.6 × (44 − 24) = 40 + 12 = 52` mmHg; inverse recovers `HCO3 = 44`. Both render as **exact integers** (verified via render-probe — no f64 noise).

## Discipline checks
- Source clause byte-faithful; NUL-scan clean; non-ASCII scan shows only the intended `×` (U+00D7) and `−` (U+2212) on the source lines.
- Render-probe clean on both; every value carries `"trust":"authoritative"` + the NBK545269 locator.
- 2 e2e tests pass; clippy `-D warnings` clean; `/security-review` PASSED.
- **Data + test only — no version bump.**

## Files
- `code/specs/data/adj-formula-stdlib/clinical/metabolic-alkalosis-compensation.adj` (dictionary + formulabook)
- `code/specs/data/adj-formula-stdlib/clinical/metabolic-alkalosis-compensation.query.adj` (worked case)
- `code/packages/rust/adj-lang-cli/tests/formula_metabolic_alkalosis_compensation_e2e.rs` (2 e2e tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)