### PR TITLE
feat(adj-formula-stdlib): fractional-excretion-of-calcium — FeCa (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_calcium_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_calcium_e2e.rs
@@ -1,0 +1,148 @@
+//! End-to-end tests for the `clinical/fractional-excretion-of-calcium.adj` library — the fractional excretion
+//! of calcium (FeCa = (UCa × PCr) / (PCa × UCr)) and its four exact rearrangements — driven through the built
+//! CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a consumer states
+//! NO arithmetic; it imports the grounded library, binds the four measured values with `observe`, and the
+//! engine applies the cited formula on the CPU, computing the EXACT value (over exact rationals) and rendering
+//! the citation and trust tier in the `derived` section (the auditable answer). The five formulas INVERT
+//! around the worked case UCa = 1, PCr = 1, PCa = 8, UCr = 8 (FeCa = 1/64 = 0.015625).
+//!
+//! This source types FeCa as the bare fraction (NO × 100), so the result is a small fraction; the worked FeCa
+//! is the DYADIC value 1/64 (a power-of-2 denominator, exactly representable in f64) so every rendered value —
+//! the fraction and the integer inverses — is exact.
+//!
+//! The assertions match the ADJACENT `"name":...,"value":...` pair the engine renders. The name-anchored
+//! adjacent form is collision-proof.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped fractional-excretion-of-calcium library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_feca_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-calcium.adj")
+        .canonicalize()
+        .expect("shipped fractional-excretion-of-calcium.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_feca_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_feca_lib()).unwrap();
+    std::fs::write(dir.join("fractional-excretion-of-calcium.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// fractional_excretion_calcium — the FeCa: (UCa × PCr) / (PCa × UCr).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_feca_library_and_computes_it_with_citation() {
+    let dir = scratch("feca");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-calcium.adj\"\n\
+         observe urinary_calcium(1)\n\
+         observe serum_creatinine(1)\n\
+         observe serum_calcium(8)\n\
+         observe urinary_creatinine(8)\n\
+         ? fractional_excretion_calcium(urinary_calcium, serum_creatinine, serum_calcium, urinary_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (1 × 1) / (8 × 8) = 1/64 = 0.015625, computed EXACTLY over rationals (a dyadic fraction).
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"fractional_excretion_calcium\",\"value\":0.015625"),
+        "FeCa(1, 1, 8, 8) = 0.015625: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_calcium — solved for PCa: (UCa × PCr) / (FeCa × UCr).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_calcium_from_feca_with_citation() {
+    let dir = scratch("pca");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-calcium.adj\"\n\
+         observe fractional_excretion_calcium(0.015625)\n\
+         observe urinary_calcium(1)\n\
+         observe serum_creatinine(1)\n\
+         observe urinary_creatinine(8)\n\
+         ? serum_calcium(fractional_excretion_calcium, urinary_calcium, serum_creatinine, urinary_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (1 × 1) / (0.015625 × 8) = 1 / 0.125 = 8 (0.015625 = 1/64 is exact in f64).
+    assert!(
+        s.contains("\"name\":\"serum_calcium\",\"value\":8"),
+        "serum_calcium(0.015625, 1, 1, 8) = 8: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_calcium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urinary_calcium — solved for UCa: FeCa × PCa × UCr / PCr.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urinary_calcium_from_feca_with_citation() {
+    let dir = scratch("uca");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fractional-excretion-of-calcium.adj\"\n\
+         observe fractional_excretion_calcium(0.015625)\n\
+         observe serum_creatinine(1)\n\
+         observe serum_calcium(8)\n\
+         observe urinary_creatinine(8)\n\
+         ? urinary_calcium(fractional_excretion_calcium, serum_creatinine, serum_calcium, urinary_creatinine)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 0.015625 × 8 × 8 / 1 = 0.015625 × 64 = 1.
+    assert!(
+        s.contains("\"name\":\"urinary_calcium\",\"value\":1"),
+        "urinary_calcium(0.015625, 1, 8, 8) = 1: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urinary_calcium carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-calcium.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-calcium.adj
@@ -1,0 +1,118 @@
+% ============================================================================
+% fractional-excretion-of-calcium.adj — the fractional excretion of calcium
+% (FeCa = (UCa × PCr) / (PCa × UCr)) in the ADJ standard library.
+% ============================================================================
+% The fractional-excretion-of-calcium entry of the *clinical* track — the fraction of the calcium filtered by
+% the glomerulus that is excreted in the urine. It is central to the work-up of hypercalcemia: a LOW FeCa
+% (< 0.01) in a hypercalcemic patient points to FAMILIAL HYPOCALCIURIC HYPERCALCEMIA (FHH, an inactivating
+% calcium-sensing-receptor defect that makes the kidney reabsorb calcium avidly), whereas primary
+% hyperparathyroidism runs a higher FeCa — the single test that most often separates the two before parathyroid
+% surgery. It joins the fractional-excretion family alongside the shipped FE-sodium, FE-potassium,
+% FE-phosphate, FE-urea and FE-magnesium, normalising the urine-to-plasma calcium ratio by the urine-to-plasma
+% creatinine ratio so a spot sample stands in for a timed collection. THE FRACTIONAL EXCRETION OF CALCIUM IS
+% THE URINE-CALCIUM TIMES PLASMA-CREATININE, DIVIDED BY (PLASMA-CALCIUM TIMES URINE-CREATININE) — i.e.
+% FeCa = (UCa × PCr) / (PCa × UCr).
+%
+% It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with the four exact
+% rearrangements (each of the four measured inputs recovered from the other three plus the FeCa). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds the four values from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited formula on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals), carrying the formula's
+% citation.
+%
+%     import "fractional-excretion-of-calcium.adj"
+%     observe urinary_calcium(1)       % "…urine Ca 1 mg/dL…"     (span cited by the model)
+%     observe serum_creatinine(1)      % "…serum Cr 1 mg/dL…"     (span cited by the model)
+%     observe serum_calcium(8)         % "…serum Ca 8 mg/dL…"     (span cited by the model)
+%     observe urinary_creatinine(8)    % "…urine Cr 8 mg/dL…"     (span cited by the model)
+%     ? fractional_excretion_calcium(urinary_calcium, serum_creatinine, serum_calcium, urinary_creatinine)
+%       % engine → 0.015625 (a fraction ≈ 1.6% — a low FeCa)
+%
+% Structurally this is a PRODUCT-OVER-PRODUCT — the FE family shape — but UNLIKE the other fractional
+% excretions this source types it as the bare FRACTION, with NO "× 100" percent-scaling and no extra constant
+% (magnesium's version alone carries a 0.7 free-fraction factor). There are therefore NO embedded constants at
+% all; the four measured quantities are the formal parameters bound at apply time, so every value the engine
+% returns is exact.
+%
+%   fractional_excretion_calcium(UCa, PCr, PCa, UCr) = UCa * PCr / (PCa * UCr)   % (dimensionless fraction)
+%   urinary_calcium(FeCa, PCr, PCa, UCr)             = FeCa * PCa * UCr / PCr     % (solved for UCa)
+%   serum_creatinine(FeCa, UCa, PCa, UCr)            = FeCa * PCa * UCr / UCa     % (solved for PCr)
+%   serum_calcium(FeCa, UCa, PCr, UCr)               = UCa * PCr / (FeCa * UCr)   % (solved for PCa)
+%   urinary_creatinine(FeCa, UCa, PCr, PCa)          = UCa * PCr / (FeCa * PCa)   % (solved for UCr)
+%
+% The five formulas COMPOSE and invert cleanly around the worked case UCa = 1, PCr = 1, PCa = 8, UCr = 8
+% (FeCa = (1 × 1) / (8 × 8) = 1/64 = 0.015625): the `fractional_excretion_calcium` a consumer computes is
+% exactly the value each inverse formula back-solves to recover its own measured input (1, 1, 8, 8). The worked
+% FeCa is the DYADIC value 1/64 (a fraction with a power-of-2 denominator, exactly representable), so every
+% rendered value is exact.
+%
+% NOTE ON UNITS AND MODELLING: UCa/PCa and UCr/PCr must each be in the SAME units (the concentration ratios are
+% dimensionless), so FeCa is a pure fraction; multiply by 100 to read it as a percent (this source states the
+% fraction directly). This library only COMPUTES FeCa; interpreting it (the < 0.01 FHH threshold, in the
+% context of the serum calcium and PTH) is the clinician's task, stated by the cited source but applied by the
+% reader.
+%
+% All five formulas are defended by the SAME clause — the quoted FeCa expression — because that one expression
+% sanctions the relation read every way. The quote is transcribed verbatim from the StatPearls article
+% "Calcium", where it is printed as the typed, operand-complete, correctly-bracketed expression
+% "FeCa = (UCa x Serum creatinine) / (Serum calcium × Urinary creatinine)" (the source mixes an ASCII 'x' in
+% the numerator with a Unicode '×' in the denominator; both are transcribed faithfully). Each `formula`
+% therefore carries the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the formula is a verbatim span of the cited page, not
+% asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each of the five quantities appears BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the everyday names
+% a decomposer maps onto the canonical term; the trailing comment records the intended unit. (serum_creatinine
+% and urinary_creatinine share their names with the other fractional-excretion libraries — each FE file is
+% standalone and defines its own dictionary.)
+% ----------------------------------------------------------------------------
+dictionary fractional_excretion_calcium_vocab {
+    define urinary_calcium               : finding  surface "urine calcium", "urinary calcium", "UCa", "urine Ca"           % mg/dL
+    define serum_creatinine              : finding  surface "serum creatinine", "plasma creatinine", "PCr", "serum Cr"      % mg/dL
+    define serum_calcium                 : finding  surface "serum calcium", "plasma calcium", "PCa", "serum Ca"            % mg/dL
+    define urinary_creatinine            : finding  surface "urine creatinine", "urinary creatinine", "UCr", "urine Cr"     % mg/dL
+    define fractional_excretion_calcium  : finding  surface "fractional excretion of calcium", "FeCa", "FE calcium", "fractional excretion calcium" % fraction
+}
+
+% ----------------------------------------------------------------------------
+% The fractional excretion of calcium, all five ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the FeCa expression from the StatPearls article (a
+% quote is required on a shipped formula). Each is an exact expression in the measured values (no constants at
+% all), so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook fractional_excretion_calcium_laws {
+    use fractional_excretion_calcium_vocab
+
+    % FeCa — urine-Ca × plasma-Cr over (plasma-Ca × urine-Cr), the bare fraction (no × 100).
+    formula fractional_excretion_calcium(urinary_calcium, serum_creatinine, serum_calcium, urinary_creatinine) = urinary_calcium * serum_creatinine / (serum_calcium * urinary_creatinine)
+        source "FeCa = (UCa x Serum creatinine) / (Serum calcium × Urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557683/"
+        trust authoritative
+
+    % Urine calcium — the same expression solved for UCa. Defended by the SAME clause.
+    formula urinary_calcium(fractional_excretion_calcium, serum_creatinine, serum_calcium, urinary_creatinine) = fractional_excretion_calcium * serum_calcium * urinary_creatinine / serum_creatinine
+        source "FeCa = (UCa x Serum creatinine) / (Serum calcium × Urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557683/"
+        trust authoritative
+
+    % Serum creatinine — the same expression solved for PCr. Defended by the SAME clause.
+    formula serum_creatinine(fractional_excretion_calcium, urinary_calcium, serum_calcium, urinary_creatinine) = fractional_excretion_calcium * serum_calcium * urinary_creatinine / urinary_calcium
+        source "FeCa = (UCa x Serum creatinine) / (Serum calcium × Urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557683/"
+        trust authoritative
+
+    % Serum calcium — the same expression solved for PCa. Defended by the SAME clause.
+    formula serum_calcium(fractional_excretion_calcium, urinary_calcium, serum_creatinine, urinary_creatinine) = urinary_calcium * serum_creatinine / (fractional_excretion_calcium * urinary_creatinine)
+        source "FeCa = (UCa x Serum creatinine) / (Serum calcium × Urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557683/"
+        trust authoritative
+
+    % Urine creatinine — the same expression solved for UCr, the fifth reading of the one law.
+    formula urinary_creatinine(fractional_excretion_calcium, urinary_calcium, serum_creatinine, serum_calcium) = urinary_calcium * serum_creatinine / (fractional_excretion_calcium * serum_calcium)
+        source "FeCa = (UCa x Serum creatinine) / (Serum calcium × Urinary creatinine)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557683/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-calcium.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-calcium.query.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% fractional-excretion-of-calcium.query.adj — worked applications of the fractional excretion of calcium.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a hypercalcemia work-up (e.g. FHH vs primary
+% hyperparathyroidism) into a urine calcium, a serum creatinine, a serum calcium and a urine creatinine: it
+% `import`s the grounded formulabook, `observe`s the four values, and asks the engine to APPLY the cited FeCa
+% formula. No arithmetic is stated by the consumer; the engine computes each value EXACTLY (over exact
+% rationals) and carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (UCa = 1, PCr = 1, PCa = 8, UCr = 8 mg/dL): FeCa = (1 × 1) / (8 × 8) = 1/64 = 0.015625 (a low
+% fraction ≈ 1.6%, the kind that suggests familial hypocalciuric hypercalcemia). The worked FeCa is the DYADIC
+% value 1/64, so every answer is exact. Each query fixes one input and asks the engine to recover another
+% quantity; the inversions COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli fractional-excretion-of-calcium.query.adj
+% ============================================================================
+
+import "fractional-excretion-of-calcium.adj"
+
+% --- FeCa: the fraction the four inputs imply (expect 0.015625). -------------------------------------
+observe urinary_calcium(1)
+observe serum_creatinine(1)
+observe serum_calcium(8)
+observe urinary_creatinine(8)
+? fractional_excretion_calcium(urinary_calcium, serum_creatinine, serum_calcium, urinary_creatinine)   % expect 0.015625
+
+% --- Inverse: the serum calcium a FeCa of 0.015625 implies at the same other three inputs (expect 8). -
+observe fractional_excretion_calcium(0.015625)
+? serum_calcium(fractional_excretion_calcium, urinary_calcium, serum_creatinine, urinary_creatinine)   % expect 8


### PR DESCRIPTION
## What

Ships a new clinical formulabook grounding the **fractional excretion of calcium (FeCa)** — the single test that most often separates **familial hypocalciuric hypercalcemia** (low FeCa < 0.01) from primary hyperparathyroidism before parathyroid surgery. It extends the fractional-excretion family (FE-sodium/potassium/phosphate/urea/magnesium already shipped).

## Provenance

Source (verbatim, typed, operand-complete, correctly bracketed):

> `FeCa = (UCa x Serum creatinine) / (Serum calcium × Urinary creatinine)`

from StatPearls *"Calcium"*, [NBK557683](https://www.ncbi.nlm.nih.gov/books/NBK557683/). The source **mixes** an ASCII `x` (numerator) with a Unicode `×` U+00D7 (denominator) — both transcribed faithfully. Unlike the other FEs, this source types the **bare fraction** (no `× 100`, no extra constant), so FeCa here is dimensionless.

## Formulas — all five readings (forward + four inversions), defended by the SAME clause

```
fractional_excretion_calcium(UCa,PCr,PCa,UCr) = UCa*PCr / (PCa*UCr)
urinary_calcium(FeCa,PCr,PCa,UCr)             = FeCa*PCa*UCr / PCr
serum_creatinine(FeCa,UCa,PCa,UCr)            = FeCa*PCa*UCr / UCa
serum_calcium(FeCa,UCa,PCr,UCr)               = UCa*PCr / (FeCa*UCr)
urinary_creatinine(FeCa,UCa,PCr,PCa)          = UCa*PCr / (FeCa*PCa)
```

## Render note (dyadic worked value)

Because the inversions divide by the decimal FeCa, the worked FeCa is the **dyadic** value `1/64 = 0.015625` (power-of-2 denominator, exactly representable in f64, and clinically realistic at ≈1.6%). Worked case (UCa=1, PCr=1, PCa=8, UCr=8): `FeCa = (1*1)/(8*8) = 1/64 = 0.015625`; all four inverses recover their inputs (1, 1, 8, 8) exactly. All five render as exact values — no f64 noise.

## Discipline checks
- Source clause byte-faithful; NUL-scan clean; non-ASCII scan shows only the intended `×` (U+00D7) on the source lines.
- Render-probe clean on all five; every value carries `"trust":"authoritative"` + the NBK557683 locator.
- 3 e2e tests pass; clippy `-D warnings` clean; `/security-review` PASSED.
- **Data + test only — no version bump.**

## Files
- `code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-calcium.adj` (dictionary + 5-formula formulabook)
- `code/specs/data/adj-formula-stdlib/clinical/fractional-excretion-of-calcium.query.adj` (worked case)
- `code/packages/rust/adj-lang-cli/tests/formula_fractional_excretion_of_calcium_e2e.rs` (3 e2e tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)