### PR TITLE
content: Latin TIME-DAY/TIME-NIGHT/GREETING-GOODNIGHT arc (new accumulator)

### DIFF
--- a/code/learning/human-languages/arabic/lessons/AR-C25-yawm.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C25-yawm.md
@@ -1,0 +1,68 @@
+---
+id: AR-C25-yawm
+chapter: 25
+type: word
+headword: يوم
+gloss: "day" — a true pan-Semitic word, cognate with Hebrew yom (as in Yom Kippur), and possibly tracing all the way back to an ancient word for "sun"
+concept_tag: AR-TIME-DAY
+prerequisites: [AR-C08-al-ahad-al-khamis]
+sounds: [waw-glide, meem]
+roots: [y-w-m]
+etymology_hook: "يوم (yawm, 'day') ← Proto-Semitic *yawm-, a genuine Common Semitic word shared with Hebrew יוֹם (yōm, as in Yom Kippur), Akkadian ūmum, and Aramaic yawmā; further back, some scholars connect it to Proto-Afroasiatic *yam- ('day'), possibly related to Egyptian ỉmy ('sun, as an eye') — a speculative but genuinely proposed deep link, not settled fact"
+est_minutes: 5
+reviews_of: [AR-C08-al-ahad-al-khamis]
+---
+
+# يوم (yawm) — "day," a word shared across the whole Semitic family
+
+## Warm-up
+
+[PAUSE 2s] This word is bigger than Arabic — it's one of the oldest,
+most widely shared words across the entire Semitic language family.
+
+## يوم — "day"
+
+**يوم** (**yawm**) — "**day**" — root **y-w-m**. Arabic's day-names can
+compound with *yawm* — **يوم الجمعة** (*yawm al-jumʿa*, "day of the
+gathering") is the full, formal way to say "Friday," the exact same
+"day-of-X" construct-state pattern as Latin's *diēs Lūnae* — but
+colloquially, the bare day-name alone (*al-jumʿa*, *as-sabt*, already
+taught earlier) is just as common. *Yawm* itself is also the ordinary,
+standalone word for "a day."
+
+## A true Common Semitic word
+
+**Yawm** traces to **Proto-Semitic** ***\*yawm-*** — and this isn't just an
+Arabic word with foreign relatives, it's a genuinely **Common Semitic**
+word, found with the same shape and meaning across the whole family:
+Hebrew **יוֹם** (*yōm* — yes, the *yom* in **Yom Kippur**, "Day of
+Atonement"), Akkadian **ūmum**, and Aramaic **yawmā**. Four different
+Semitic languages, one shared ancient word for "day."
+
+## A speculative deeper link — honestly flagged
+
+Some scholars push the trail back even further, to a proposed
+**Proto-Afroasiatic** root, ***\*yam-*** ("day") — and speculatively connect
+it to Egyptian **ỉmy**, meaning "**sun**" (literally "the eye"). Be
+honest: this deeper connection is a genuinely **proposed**, citable
+scholarly idea within comparative Afroasiatic linguistics — but a minority
+one, not accepted by most Egyptologists (standard Egyptian dictionaries
+gloss *ỉmy* as a common grammatical form, "who/which is in," not "sun,"
+and ordinary Egyptian for "day" is an unrelated word, *ḥrw*). Not settled
+fact the way the Semitic-family cognates are.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "yawm" — "day"]
+- [YOU SAY: the Semitic family — yawm, yōm (Yom Kippur), ūmum, yawmā]
+- [YOU SAY: the honest deeper speculation — possibly Egyptian "sun," not
+  settled]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Hebrew word, familiar from a well-known holiday name, is
+**yawm**'s direct cognate? (**Yōm**, as in **Yom Kippur**.) Name two other
+Semitic languages that share this exact word for "day." (**Akkadian**
+*ūmum*, **Aramaic** *yawmā*.) Is the proposed Egyptian "sun" connection
+settled fact? (**No** — a genuinely proposed but speculative deeper link.)

--- a/code/learning/human-languages/arabic/lessons/AR-C25-yawm.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C25-yawm.md
@@ -4,7 +4,7 @@ chapter: 25
 type: word
 headword: يوم
 gloss: "day" — a true pan-Semitic word, cognate with Hebrew yom (as in Yom Kippur), and possibly tracing all the way back to an ancient word for "sun"
-concept_tag: AR-TIME-DAY
+concept_tag: TIME-DAY
 prerequisites: [AR-C08-al-ahad-al-khamis]
 sounds: [waw-glide, meem]
 roots: [y-w-m]

--- a/code/learning/human-languages/arabic/lessons/AR-C26-layl.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C26-layl.md
@@ -1,0 +1,62 @@
+---
+id: AR-C26-layl
+chapter: 26
+type: word
+headword: ليل
+gloss: "night" — the word already hiding inside muntaṣaf al-layl ('midnight'), and yawm's pan-Semitic partner, cognate with Hebrew layla
+concept_tag: AR-TIME-NIGHT
+prerequisites: [AR-C15-ad-duhr-muntasaf-al-layl, AR-C25-yawm]
+sounds: [lam-yeh-lam, long-i-glide]
+roots: [l-y-l]
+etymology_hook: "ليل (layl, 'night') ← Proto-Semitic *layl-, cognate with Hebrew לילה (layla/laylah — as in the Passover question 'mah nishtana ha-layla ha-zeh,' 'why is this NIGHT different'), Aramaic/Syriac lēlyā, and Akkadian līliātum; scholars genuinely debate whether Proto-Semitic had this simple triradical *layl- or a reduplicated *laylay- form — an open question, not settled"
+est_minutes: 5
+reviews_of: [AR-C15-ad-duhr-muntasaf-al-layl, AR-C25-yawm]
+---
+
+# ليل (layl) — "night," yawm's partner across the whole Semitic family
+
+## Warm-up
+
+[PAUSE 2s] You've already met *layl* once, tucked inside *muntaṣaf al-layl*
+("midnight"). Now it gets the same standalone treatment *yawm* just did —
+and the same pan-Semitic family story.
+
+## ليل — "night"
+
+**ليل** (**layl**) — "**night**" — is the word already hiding inside
+**muntaṣaf al-layl** ("midnight," Chapter 15, literally "the half of the
+night"). Root **l-y-l**.
+
+## Another true Common Semitic word
+
+Just like *yawm*, **layl** is a genuine **Common Semitic** word, not an
+Arabic-only term with distant relatives. It traces to **Proto-Semitic**
+***\*layl-***, cognate with Hebrew **לילה** (*layla*/*laylah* — the same
+word in the famous Passover question, "*mah nishtana ha-layla ha-zeh*,"
+"why is **this night** different"), Aramaic/Syriac **lēlyā**, and Akkadian
+**līliātum**. Day and night, *yawm* and *layl*, are **both** words the
+whole Semitic family has shared for millennia.
+
+## An honest open question
+
+Be honest about one genuine scholarly debate: linguists don't fully agree
+on whether Proto-Semitic had this simple **triradical** *\*layl-* form, or a
+**reduplicated** *\*laylay-* form instead (the doubled shape possibly
+surviving in some daughter languages' declension patterns). This is a real,
+open question in comparative Semitics — not settled the way the basic
+Hebrew/Aramaic/Akkadian cognate set is.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "layl" — "night," already met inside muntaṣaf al-layl]
+- [YOU SAY: the Semitic family — layl, layla (Hebrew), lēlyā, līliātum]
+- [YOU SAY: yawm and layl — day and night, both pan-Semitic words]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where have you already met **layl** before this lesson?
+(**Muntaṣaf al-layl**, "midnight.") What Hebrew word, from a famous
+Passover question, is *layl*'s direct cognate? (**Layla**/**laylah**.) Is
+the exact Proto-Semitic shape of this word — triradical or reduplicated —
+fully settled? (**No** — a genuine, open scholarly debate.)

--- a/code/learning/human-languages/arabic/lessons/AR-C26-layl.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C26-layl.md
@@ -4,7 +4,7 @@ chapter: 26
 type: word
 headword: ليل
 gloss: "night" — the word already hiding inside muntaṣaf al-layl ('midnight'), and yawm's pan-Semitic partner, cognate with Hebrew layla
-concept_tag: AR-TIME-NIGHT
+concept_tag: TIME-NIGHT
 prerequisites: [AR-C15-ad-duhr-muntasaf-al-layl, AR-C25-yawm]
 sounds: [lam-yeh-lam, long-i-glide]
 roots: [l-y-l]

--- a/code/learning/human-languages/arabic/lessons/AR-C27-tusbih-ala-khayr.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C27-tusbih-ala-khayr.md
@@ -1,0 +1,72 @@
+---
+id: AR-C27-tusbih-ala-khayr
+chapter: 27
+type: phrase
+headword: تصبح على خير
+gloss: "good night" — but honestly, it doesn't wish you a good NIGHT at all; it wishes you a good morning, reusing both roots from ṣabāḥ al-khayr and masāʾ al-khayr
+concept_tag: GREETING-GOODNIGHT
+romanization: tuṣbiḥ ʿalā khayr
+prerequisites: [AR-C01-sabah-al-khayr, AR-C01-masa-al-khayr, AR-C26-layl]
+sounds: [sad-emphatic, kha]
+roots: [ṣ-b-ḥ, kh-y-r]
+etymology_hook: "تصبح على خير (tuṣbiḥ ʿalā khayr), the everyday Arabic 'good night,' literally means 'may you WAKE UP into goodness' — tuṣbiḥ is the ordinary imperfect of aṣbaḥa ('to become morning'), used performatively as a blessing (no special subjunctive/jussive marking), the same ṣ-b-ḥ root as ṣabāḥ al-khayr ('good morning'), plus khayr ('goodness') already met in masāʾ al-khayr; unlike every other language in this arc, Arabic's night-parting phrase points FORWARD to the morning, not to the night itself"
+est_minutes: 5
+reviews_of: [AR-C01-sabah-al-khayr, AR-C01-masa-al-khayr, AR-C26-layl]
+---
+
+# تصبح على خير (tuṣbiḥ ʿalā khayr) — wishing the morning, not the night
+
+## Warm-up
+
+[PAUSE 2s] Every "good night" you've learned in other languages wishes a
+peaceful **night**. Arabic's everyday version does something completely
+different — it skips the night and wishes the **morning** instead.
+
+## تصبح على خير — "may you wake into goodness"
+
+**تصبح على خير** (**tuṣbiḥ ʿalā khayr**) is the most common everyday
+Arabic "good night" — but it literally means "**may you wake up into
+goodness**." Break it down:
+
+- **تصبح** (*tuṣbiḥ*) — the ordinary imperfect ("you become") of
+  **أصبح** (*aṣbaḥa*, "**to become morning, to wake up**") — the **exact
+  same root**, **ص-ب-ح** (ṣ-b-ḥ), as **ṣabāḥ** in **ṣabāḥ al-khayr**
+  ("good morning," Chapter 1). No special subjunctive or jussive form is
+  involved — a plain statement doing the work of a blessing, the same way
+  English "you'll sleep well" can function as a wish without any special
+  grammar.
+- **على** (*ʿalā*) — "upon."
+- **خير** (*khayr*) — "**goodness**" — the same word already met in
+  **masāʾ al-khayr** ("good evening").
+
+Put together: not "sleep well," but "**may your waking be good**." (This
+particular form, *tuṣbiḥ*, addresses one **man**; a woman is *tuṣbiḥī*
+[تصبحي], a group is *tuṣbiḥū* [تصبحوا].)
+
+## Be honest: this points forward, not backward
+
+Here's the genuinely different part: **every** other "good night" in this
+arc — English, French, German, Spanish — wishes something about the
+**night itself**. Arabic's everyday version does the opposite: it's
+grammatically about the **morning that follows**, built from the same
+"waking" root already hiding in *ṣabāḥ*. Notice what's genuinely absent:
+**ليل** (*layl*, "night," last lesson) doesn't appear anywhere in this
+phrase at all. It reuses pieces you already have (*ṣ-b-ḥ*, *khayr*) but
+points them at a **different moment in time** than every other language's
+farewell.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tuṣbiḥ ʿalā khayr" — literally "may you wake into goodness"]
+- [YOU SAY: the shared root — tuṣbiḥ and ṣabāḥ, both from ṣ-b-ḥ]
+- [YOU SAY: the honest twist — this "good night" is really about the
+  morning, not the night]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **تصبح على خير** literally mean? ("**May you wake up
+into goodness**.") What root does *tuṣbiḥ* share with *ṣabāḥ al-khayr*?
+(***Ṣ-b-ḥ***, "morning/to become morning.") Unlike English, French, and
+German's "good night," what moment in time does Arabic's everyday version
+actually point to? (**The morning that follows**, not the night itself.)

--- a/code/learning/human-languages/hindi/lessons/HI-C25-din.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C25-din.md
@@ -1,0 +1,60 @@
+---
+id: HI-C25-din
+chapter: 25
+type: word
+headword: दिन
+gloss: "day" — shares its ultimate PIE root with Latin's diēs, but through a separate derivational branch (din patterns with Baltic/Slavic "day"-words); Sanskrit's own दिव्/द्यु are actually the closer, more direct cousins of diēs
+concept_tag: TIME-DAY
+prerequisites: [HI-C17-dopahar-aadhi-raat]
+sounds: [devanagari-short-i, devanagari-na]
+roots: [sanskrit-dina, pie-dyew-shine]
+etymology_hook: "दिन (din, 'day') ← Sanskrit दिन (dina) ← Proto-Indo-Iranian *dinám ← a SUFFIXED formation on Proto-Indo-European *dyew-/*dyēws- ('to shine, sky') — the same ultimate root as Latin's diēs (*dyēws-, same root at a different ablaut grade), but a SEPARATE derivational branch: din patterns with Lithuanian diena and Proto-Slavic *dьnь, not directly with diēs; Sanskrit's own द्यु (dyu) and दिव् (div) are the unsuffixed root-nouns, actually closer, more direct cousins of diēs than din itself is"
+est_minutes: 5
+reviews_of: [HI-C17-dopahar-aadhi-raat]
+---
+
+# दिन (din) — "day," the same root as diēs, a different branch
+
+## Warm-up
+
+[PAUSE 2s] You've already met this word once, tucked inside *dopahar*
+("noon," literally "two pahars" of the **day**). Now it stands alone —
+and its connection to Latin's *diēs* is real, but more careful than it
+first looks.
+
+## दिन — "day"
+
+**दिन** (**din**) — "**day**" — is the ordinary Hindi word for "day,"
+already implicit in **दोपहर** (*dopahar*, "noon," Chapter 17).
+
+## The same ultimate root as diēs — but a separate branch
+
+**Din** traces to **Sanskrit** **दिन** (*dina*), from **Proto-Indo-Iranian**
+***\*dinám*** — a **suffixed** formation built on **Proto-Indo-European**
+***\*dyew-*** ("**to shine, sky**"), the same ultimate root behind **Latin**'s
+own **diēs**. But be careful: *din* and *diēs* aren't the closest possible
+cousins — they took **separate derivational paths** off that shared root.
+*Din*'s own closest relatives are actually the Baltic/Slavic "day"-words,
+**Lithuanian** *diena* and **Proto-Slavic** ***\*dьnь***. The genuinely
+**direct**, unsuffixed cousins of *diēs* are Sanskrit's own **द्यु** (*dyu*,
+"heaven, sky") and **दिव्** (*div*, "sky") — which give **दिवस** (*divasa*),
+yet another everyday Hindi word for "day." So the honest picture: *din* and
+*diēs* share one distant ancestor, but *dyu*/*div* are the tighter match.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "din" — "day," already met inside dopahar]
+- [YOU SAY: the shared root — din and Latin's diēs, same PIE root
+  *dyew-*, "to shine," but different derivational branches]
+- [YOU SAY: the closer cousins — dyu, div, "heaven/sky" — the tighter,
+  unsuffixed match for diēs]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where have you already met **दिन** before this lesson?
+(**दोपहर**, *dopahar*, "noon.") What ancient PIE root connects Hindi's
+**din** to Latin's **diēs**, and what does it mean? (***\*dyew-***, "to
+shine, sky" — but through **separate branches**, not as the closest
+cousins.) Which Sanskrit words are actually the **tighter, more direct**
+cousins of *diēs*? (**द्यु** *dyu* and **दिव्** *div*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C26-raat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C26-raat.md
@@ -1,0 +1,65 @@
+---
+id: HI-C26-raat
+chapter: 26
+type: word
+headword: रात
+gloss: "night" — already met inside aadhi raat ("midnight"); despite meaning the same thing as Latin's nox, in a related Indo-European language, it comes from a COMPLETELY DIFFERENT PIE root — a genuine false cousin
+concept_tag: TIME-NIGHT
+prerequisites: [HI-C17-dopahar-aadhi-raat, HI-C25-din]
+sounds: [devanagari-long-aa, devanagari-ta]
+roots: [sanskrit-ratri, pie-h1reh1-rest]
+etymology_hook: "रात (raat, 'night') ← Prakrit रत्ति (ratti) ← Sanskrit रात्रि (rātri) ← Proto-Indo-Iranian *HráHtriH ← Proto-Indo-European *h₁reh₁-trih₂ ('rest' + a feminine suffix); despite both being Indo-European 'night' words, this is a COMPLETELY DIFFERENT PIE root from Latin's nox (*nókʷts) — a genuine false cousin, not a true cognate, unlike Hindi's din/Latin's diēs pair"
+est_minutes: 5
+reviews_of: [HI-C17-dopahar-aadhi-raat, HI-C25-din]
+---
+
+# रात (raat) — "night," and an honest false cousin of Latin's nox
+
+## Warm-up
+
+[PAUSE 2s] Last lesson, *din* turned out to be a real (if distant) cousin
+of Latin's *diēs*. This lesson is the mirror image: *raat* looks like it
+should be *nox*'s cousin too — but it genuinely isn't.
+
+## रात — "night"
+
+**रात** (**raat**) — "**night**" — is the word already hiding inside
+**आधी रात** (*ādhī rāt*, "midnight," Chapter 17). It comes down through a
+completely ordinary sound-change chain: **Sanskrit** **रात्रि** (*rātri*) →
+**Prakrit** **रत्ति** (*ratti*, consonant cluster simplifying) → Hindi
+**रात** (*raat*) — the same shape of erosion you've already seen in Hindi's
+numbers (*saptá* → *sāt*, *aṣṭá* → *āṭh*).
+
+## A genuine false cousin — not a true cognate
+
+Here's the honest twist: **रात्रि** (*rātri*) traces to **Proto-Indo-
+Iranian** ***\*HráHtriH***, from **Proto-Indo-European** ***\*h₁reh₁-trih₂***
+— built from a root meaning "**to rest, remain still**," plus a feminine
+suffix. This is a **completely different** PIE root from Latin's **nox**
+(from ***\*nókʷts***, the root behind English "night" itself, German
+*Nacht*, Greek *nyx*). Both *rātri* and *nox* are genuine Indo-European
+"night" words, in related language branches — but they are **not**
+cousins. Unlike *din* and *diēs* last lesson, which really do share one
+ancestor, *raat* and *nox* just happen to both mean "night," from two
+entirely separate ancient roots. Sanskrit actually **does** keep a true
+*nókʷts* cousin of its own — **नक्तम्** (*naktam*, "by night") — but it's
+an archaic, adverbial word; it's *rātri*, not *naktam*, that won the job
+of everyday Hindi's *raat*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "raat" — "night," already met inside ādhī rāt]
+- [YOU SAY: the sound chain — rātri → ratti → raat, the same erosion
+  pattern as saptá → sāt]
+- [YOU SAY: the honest twist — raat and nox are NOT cousins, unlike din
+  and diēs]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where have you already met **रात** before this lesson? (**आधी
+रात**, *ādhī rāt*, "midnight.") What Sanskrit word, and what sound-change
+chain, gives Hindi **raat**? (**रात्रि** *rātri* → Prakrit *ratti* → *raat*.)
+Are *raat* and Latin's *nox* true cognates, the way *din* and *diēs* are?
+(**No** — genuinely different PIE roots, *\*h₁reh₁-* "to rest" vs. *\*nókʷts*
+— a false cousin, despite both meaning "night.")

--- a/code/learning/human-languages/hindi/lessons/HI-C27-shubh-raatri.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C27-shubh-raatri.md
@@ -1,0 +1,63 @@
+---
+id: HI-C27-shubh-raatri
+chapter: 27
+type: phrase
+headword: शुभ रात्रि
+gloss: "good night" — literally "auspicious night," using the formal literary raatri, not the everyday raat just taught, plus shubh, an "auspicious" word that started life meaning "shining"
+concept_tag: GREETING-GOODNIGHT
+prerequisites: [HI-C26-raat]
+sounds: [devanagari-sha, devanagari-bha]
+roots: [sanskrit-shubh-shine, sanskrit-ratri]
+etymology_hook: "शुभ रात्रि (śubh rātri), 'good night,' literally 'auspicious night' — रात्रि here is the FORMAL, literary Sanskrit-derived (tatsama) doublet of the everyday, eroded रात (rāt, tadbhava) from last lesson; शुभ ('auspicious, good') comes from Sanskrit root शुभ् (śubh), 'to be beautiful, splendid,' from a well-sourced PIE root *ḱewbʰ- ('to be beautiful') — a further, more speculative link to *(s)kewh₁-/*ḱew- ('to shine') has also been proposed, but that deeper connection, not *ḱewbʰ- itself, is the genuinely uncertain part"
+est_minutes: 5
+reviews_of: [HI-C26-raat]
+---
+
+# शुभ रात्रि (śubh rātri) — "good night," the formal doublet in action
+
+## Warm-up
+
+[PAUSE 2s] Hindi keeps two versions of "night" side by side — one for
+everyday speech, one for set phrases. Here's where the formal one gets
+used.
+
+## शुभ रात्रि — "auspicious night"
+
+**शुभ रात्रि** (**śubh rātri**) — "**good night**" — literally "**auspicious
+night**." Notice: this uses **रात्रि** (*rātri*), the very Sanskrit word
+last lesson's *raat* descended **from** — but here, kept in its **full,
+unworn Sanskrit** form. This is a classic **tatsama/tadbhava doublet**:
+*rātri* (**tatsama**, a direct, unchanged Sanskrit borrowing) sits
+alongside *raat* (**tadbhava**, the same word worn down by centuries of
+ordinary sound change) — Hindi keeps both, one for everyday speech, one
+for set formal phrases like this one.
+
+## शुभ — "auspicious," from a root meaning "to shine"
+
+**शुभ** (**śubh**) — "**auspicious, good, fortunate**" — comes from the
+Sanskrit verbal root **शुभ्** (*śubh*), whose core sense is "**to be
+beautiful, splendid**." This traces to a well-sourced **Proto-Indo-European**
+root, ***\*ḱewbʰ-*** ("to be beautiful"). Some scholars propose a **further,
+more speculative** connection beyond that — to *\*(s)kewh₁-* ("to perceive")
+or *\*ḱew-* ("to shine") — but that deeper link, not the *\*ḱewbʰ-* root
+itself, is the genuinely uncertain part. Either way, the underlying idea is
+a familiar one: **auspiciousness imagined as a kind of radiance or beauty**
+— something good "shines."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubh rātri" — "good night," literally "auspicious night"]
+- [YOU SAY: the formal doublet — rātri here, raat in everyday speech]
+- [YOU SAY: śubh's own root — śubh, "to shine" → "auspicious"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **शुभ रात्रि** use the everyday *raat* or the formal
+*rātri*? (**The formal *rātri*** — Hindi keeps both versions, one for
+everyday speech, one for set phrases.) What does **शुभ** literally trace
+back to? (A root meaning "**to be beautiful, splendid**," PIE *\*ḱewbʰ-* —
+auspiciousness as a kind of radiance.) Is that root itself uncertain, or is
+a *further* proposed connection the shakier part? (**The root *\*ḱewbʰ-*
+itself is well-sourced** — it's the *deeper* proposed link, to "to shine"
+or "to perceive," that's genuinely speculative.)

--- a/code/learning/human-languages/hindi/lessons/HI-C28-subah.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C28-subah.md
@@ -1,0 +1,64 @@
+---
+id: HI-C28-subah
+chapter: 28
+type: word
+headword: सुबह
+gloss: "morning" (subah) — a Persian/Arabic loanword, NOT Sanskrit tatsama like din/raat; shares its Arabic root with ṣabāḥ, already met in the Arabic arc's "good night" phrase
+concept_tag: TIME-MORNING
+prerequisites: [HI-C25-din, HI-C26-raat]
+sounds: [hindi-ba, hindi-ha]
+roots: [arabic-sbh-dawn]
+etymology_hook: "सुबह (subah, 'morning') is genuinely borrowed — Persian صبح (subh) ← Arabic صبح (ṣubḥ), from the triliteral root ص-ب-ح (ṣ-b-ḥ, 'dawn, to become morning') — the SAME Arabic root already met in this course's Arabic arc, inside تصبح على خير (tuṣbiḥ ʿalā khayr, 'good night,' literally 'may you wake into goodness,' AR-C27); unlike दिन/din and रात/raat (both Sanskrit tatsama, HI-C25/26), Hindi's everyday word for 'morning' isn't Sanskrit at all — a genuine break from the pattern the last two lessons set"
+est_minutes: 6
+reviews_of: [HI-C25-din, HI-C26-raat]
+---
+
+# सुबह (subah) — "morning," and a root you've already met, in Arabic
+
+## Warm-up
+
+[PAUSE 2s] दिन and रात were both Sanskrit words, straight through. This
+one breaks that pattern completely — and lands somewhere you've
+genuinely been before, in a different language entirely.
+
+## सुबह — a real surprise: not Sanskrit at all
+
+**सुबह** (**subah**) — "**morning**" — is Hindi's everyday, ordinary
+word for morning. Unlike **दिन** (*din*) and **रात** (*raat*, both
+Sanskrit tatsama, met the last two lessons), *subah* is genuinely
+**borrowed**: from **Persian** **صبح** (*subh*), itself from **Arabic**
+**صبح** (*ṣubḥ*), built on the Arabic triliteral root **ص-ب-ح**
+(***ṣ-b-ḥ***, "dawn, to become morning").
+
+## A root you've technically already learned — in Arabic
+
+Here's the honest callback: this is the **exact same** Arabic root
+already met in this course's Arabic arc — inside **تصبح على خير**
+(*tuṣbiḥ ʿalā khayr*, "good night," literally "may **you wake into
+goodness**," built on this very root, AR-C27). Hindi's everyday word for
+"morning" and Arabic's own good-night farewell — a phrase that never
+even mentions "night" — both trace to the **same three Arabic
+consonants**, ص-ب-ح, arriving in Hindi by a completely different route
+(via Persian) than they did staying in Arabic.
+
+## Be honest: din and raat didn't prepare you for this
+
+Don't assume every Hindi time-word will be Sanskrit just because *din*
+and *raat* were. *Subah* is a genuine break in the pattern — a reminder
+that "everyday Hindi word" and "Sanskrit tatsama" aren't the same
+category, even when the last two examples made it look that way.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "subah" — "morning," genuinely a Persian/Arabic loan]
+- [YOU SAY: the shared root — ṣ-b-ḥ, the same three consonants inside
+  Arabic's tuṣbiḥ ʿalā khayr]
+- [YOU SAY: the honest break — unlike din and raat, subah is NOT Sanskrit]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is सुबह a Sanskrit tatsama, like दिन and रात? (**No** — a
+genuine Persian/Arabic loanword.) What Arabic phrase, already taught in
+this course, shares सुबह's exact root? (**تصبح على خير**, *tuṣbiḥ ʿalā
+khayr*, "good night" — both trace to the Arabic root ص-ب-ح, *ṣ-b-ḥ*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C29-shaam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C29-shaam.md
@@ -1,0 +1,62 @@
+---
+id: HI-C29-shaam
+chapter: 29
+type: word
+headword: शाम
+gloss: "evening" (shaam) — another genuine Persian loanword, like subah; looks tempting to connect to Sanskrit श्यामा (śyāmā, "night/dark"), but that's a false cognate — different root entirely, despite the resemblance
+concept_tag: TIME-EVENING
+prerequisites: [HI-C28-subah]
+sounds: [hindi-sha, hindi-anusvara]
+roots: [persian-sham-evening]
+etymology_hook: "शाम (shaam, 'evening') is, like सुबह last lesson, a genuine Persian loanword — from Persian شام (šām) ← Proto-Iranian *xšáfnyah ← Proto-Indo-Iranian *kšápā ('night'); be careful here: it LOOKS like it should connect to Sanskrit श्यामा (śyāmā, 'dark, night-colored'), and the resemblance is tempting, but these are NOT related — two separate roots that happened to converge on similar sounds and meanings, a genuine false cognate, not a shared one"
+est_minutes: 6
+reviews_of: [HI-C28-subah]
+---
+
+# शाम (shaam) — "evening," and a tempting false cognate
+
+## Warm-up
+
+[PAUSE 2s] Last lesson's सुबह was Persian, not Sanskrit. This word is the
+same story — but this time there's a Sanskrit look-alike close enough to
+trip you up on purpose.
+
+## शाम — Persian again, not Sanskrit
+
+**शाम** (**shaam**) — "**evening**" — is, like *subah*, a genuine
+**Persian** loanword: from Persian **شام** (*šām*), which traces back
+through **Proto-Iranian** ***\*xšáfnyah*** to **Proto-Indo-Iranian**
+***\*kšápā*** ("**night**"). Hindi's two everyday time-words for
+"morning" and "evening" both entered the language **via Persian**, not
+Sanskrit — though their deeper roots differ: *subah*'s traces further
+back to **Arabic**, while *shaam*'s is native **Indo-Iranian**, a sister
+branch to Sanskrit itself. Persian is what they share directly; their
+ultimate origins are not the same.
+
+## Be careful: a tempting, but FALSE, cognate
+
+Here's the trap: Sanskrit has its own word, **श्यामा** (**śyāmā**,
+"**dark, night-colored**"), that *looks* like it should be *shaam*'s
+cousin — similar sound, overlapping "darkness/night" meaning, right in
+the neighborhood you'd expect. It **isn't**. *Shaam* and *śyāmā* trace to
+**two completely separate roots** that simply converged on similar
+sounds and meanings by coincidence — a genuine **false cognate**, not a
+shared one. Don't let the resemblance fool you into inventing a
+connection that isn't there.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "shaam" — "evening," another genuine Persian loan]
+- [YOU SAY: the tempting trap — Sanskrit śyāmā looks related but ISN'T]
+- [YOU SAY: subah and shaam — both Persian, Hindi's whole "morning and
+  evening" pair borrowed from the same source language]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is शाम Sanskrit or Persian? (**Persian** — from شام, śām, like
+subah.) Is शाम related to Sanskrit श्यामा (śyāmā, "dark")? (**No** — a
+genuine false cognate; the resemblance is coincidental, not a shared
+root.) What do subah and shaam have in common, beyond both meaning a
+time of day? (**Both are Persian loanwords** — Hindi's morning/evening
+pair, unlike din/raat, isn't Sanskrit at all.)

--- a/code/learning/human-languages/hindi/lessons/HI-C30-dopahar-widened.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C30-dopahar-widened.md
@@ -1,0 +1,65 @@
+---
+id: HI-C30-dopahar-widened
+chapter: 30
+type: word
+headword: दोपहर
+gloss: "afternoon" — the same word already met meaning precisely "noon" (two pahars after sunrise, HI-C17), now widened in modern everyday usage to cover the whole afternoon stretch, not just the exact midday moment
+concept_tag: TIME-AFTERNOON
+prerequisites: [HI-C17-dopahar-aadhi-raat, HI-C29-shaam]
+sounds: [devanagari-vowel-sign-o, devanagari-aspirated-pa]
+roots: [do-two, pahar-traditional-watch]
+etymology_hook: "दोपहर (dopahar) is the SAME word already met in HI-C17 meaning precisely 'noon' ('two pahars,' a traditional ~3-hour Indian time-unit, counted from sunrise) — but in modern everyday Hindi, its meaning has genuinely WIDENED: दोपहर now covers the whole afternoon stretch, roughly noon through late afternoon (a meeting 'दोपहर में,' 'in the dopahar,' could mean anywhere from 1pm to 4pm), not just the precise midday instant its etymology points to"
+est_minutes: 5
+reviews_of: [HI-C17-dopahar-aadhi-raat, HI-C29-shaam]
+---
+
+# दोपहर — the same word, a wider job than its etymology promised
+
+## Warm-up
+
+[PAUSE 2s] You already know दोपहर means "noon" — two pahars after
+sunrise, precisely. This lesson's honest twist is that the word doesn't
+stay that precise in everyday use.
+
+## दोपहर — same word, a broader modern meaning
+
+**दोपहर** (**dopahar**) is the exact word you met in Chapter 17, still
+literally "**two pahars**" (traditional ~3-hour watches, counted from
+sunrise) — but in **modern, everyday Hindi**, it no longer points only
+at that precise midday instant. Say **दोपहर में** (*dopahar mein*, "in
+the dopahar") to arrange a meeting, and you're pointing at a stretch of
+time — roughly **noon through late afternoon** — not a single moment.
+The historical etymology gave the word a very specific target (the end
+of the second daytime *pahar*); everyday usage has since widened that
+target into the general block of time most languages call "the
+afternoon."
+
+## Be honest: etymology and modern meaning have drifted apart
+
+This is worth sitting with: दोपहर's **literal** story still holds up
+the way Chapter 17 described it — "two pahars," with noon falling
+around the end of the second — though, as that lesson itself noted,
+treat the exact pahar-count as the general shape of the story rather
+than a precisely dated fact. Either way, the **word's job** in the
+language has moved on well past that etymology. This kind of drift — a word for one precise instant loosening
+into a name for a whole surrounding stretch of time — isn't unique to
+Hindi, but here it's especially visible because Chapter 17 showed you
+exactly how tight the original math was.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "dopahar" — the same word from Chapter 17, "two pahars"]
+- [YOU SAY: "dopahar mein" — "in the afternoon," a modern, widened usage]
+- [YOU SAY: the honest twist — the etymology stayed precise; the word's
+  actual job widened past it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is दोपहर a new word, or the same one from Chapter 17? (**The
+same word** — "two pahars.") Does modern Hindi use दोपहर to mean only
+the exact instant of noon? (**No** — it's widened to cover the whole
+afternoon, roughly noon through late afternoon.) Has दोपहर's etymology
+itself changed to match this wider modern use? (**No** — the etymology
+still points precisely at noon; only the word's everyday job has
+widened.)

--- a/code/learning/human-languages/hindi/lessons/HI-C31-suprabhat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C31-suprabhat.md
@@ -1,0 +1,73 @@
+---
+id: HI-C31-suprabhat
+chapter: 31
+type: phrase
+headword: सुप्रभात
+gloss: "good morning" (suprabhat) — सु ("good") + प्रभात (prabhāt, native Sanskrit "dawn," from prabhā, "light, splendour," itself from bhā, "to shine") — a completely different word from सुबह, the Persian-loan everyday noun; skews formal/written (radio, greeting cards) rather than casual spoken Hindi, where नमस्ते covers mornings too — but there's no strong evidence it's being displaced by English the way some other languages' night greetings were found to be
+concept_tag: GREETING-MORNING
+prerequisites: [HI-C28-subah]
+sounds: [devanagari-conjunct-pra, devanagari-bha]
+roots: [su-good, prabhata-dawn-sanskrit]
+etymology_hook: "सुप्रभात (suprabhāt, 'good morning') = सु ('good') + प्रभात (prabhāta, native Sanskrit 'dawn, daybreak,' from प्रभा/prabhā, 'light, splendour,' itself from भा, 'to shine,' + preverb प्र-, 'forth' + suffix -त) — a COMPLETELY DIFFERENT root from सुबह (subah, HI-C28's Persian/Arabic loan for the everyday noun 'morning'); be honest about its actual register, though: sources describe सुप्रभात as skewing FORMAL and WRITTEN (speeches, radio, greeting-card/WhatsApp-forward culture) rather than casual spoken Hindi, where नमस्ते commonly covers mornings too — this is a genuine formal/everyday split, though there's no strong evidence सुप्रभात itself is being routinely code-switched to English the way some sources (thinly) suggested for other languages' night greetings in this arc"
+est_minutes: 6
+reviews_of: [HI-C28-subah]
+---
+
+# सुप्रभात (suprabhāt) — "good morning," a different root than the noun
+
+## Warm-up
+
+[PAUSE 2s] सुबह was Persian, borrowed whole. This lesson's "good
+morning" isn't built on it at all — it reaches for entirely different,
+native vocabulary.
+
+## सुप्रभात — सु + प्रभात, native Sanskrit throughout
+
+**सुप्रभात** (**suprabhāt**) — "**good morning**" — is built from **सु**
+(*su*, "good") plus **प्रभात** (*prabhāta*, "**dawn, daybreak**") — and
+*prabhāta* is **native Sanskrit**, from **प्रभा** (*prabhā*, "light,
+splendour"), itself from the root **भा** ("to shine") plus the preverb
+**प्र-** ("forth"), plus the suffix ***-त*** (*-ta*). This is a
+**completely different word** from **सुबह** (*subah*, HI-C28), the
+Persian/Arabic loan you use for the everyday noun "morning." Hindi's
+"morning" and "good morning" don't share a root at all.
+
+## Be honest: formal register, not code-switched to English
+
+Here's a genuine, checked-not-assumed finding — hedged carefully, since
+this arc's earlier lesson (Telugu's TE-C25) only ever offered a
+similarly hedged claim itself: some sources describe Telugu speakers
+often code-switching to English "good night" instead of their own
+Sanskrit-descended phrase, though even that lesson admitted the
+evidence was thin and might apply more broadly across South Asian
+languages, not just Telugu. सुप्रभात's own story is different again, and
+just as worth hedging: it skews toward **formal, written** contexts —
+speeches, radio, the well-known Hindi WhatsApp-forward "good morning
+image" culture — rather than casual spoken conversation, where
+**नमस्ते** commonly covers mornings too. That's a real formal/everyday
+split, but it isn't the same thing as being displaced by **English**
+specifically — there's no strong evidence for that particular
+substitution here. Don't assume every "good ___" greeting in every
+language this course covers follows the same displacement story; verify
+each one on its own, and don't flatten a hedge into a fact either way.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "suprabhāt" — "good morning," su + prabhāt]
+- [YOU SAY: the root contrast — subah is Persian, prabhāt is native
+  Sanskrit — completely different words]
+- [YOU SAY: the honest note — suprabhāt skews formal/written; नमस्ते
+  covers casual mornings; no strong evidence of English displacement]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does सुप्रभात share a root with सुबह? (**No** — सुबह is
+Persian/Arabic; प्रभात, inside suprabhāt, is native Sanskrit, ultimately
+from भा, "to shine.") Is सुप्रभात commonly used in casual spoken Hindi?
+(**Not especially** — it skews formal/written, with नमस्ते commonly
+covering mornings in everyday speech.) Is it being displaced by English
+"good morning," the way some sources (thinly) suggested for other
+languages' night greetings in this arc? (**No strong evidence of
+that** — its own story is a formal/everyday split, not an English
+substitution.)

--- a/code/learning/human-languages/hindi/lessons/HI-C32-shubh-sandhya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C32-shubh-sandhya.md
@@ -1,0 +1,75 @@
+---
+id: HI-C32-shubh-sandhya
+chapter: 32
+type: phrase
+headword: शुभ संध्या
+gloss: "good evening" (shubh sandhya) — संध्या is native Sanskrit, "the junction of day and night," with its own tadbhava doublet साँझ; like सुप्रभात, this leans toward written/greeting-card use, with नमस्ते covering evenings casually too
+concept_tag: GREETING-EVENING
+prerequisites: [HI-C29-shaam, HI-C31-suprabhat, HI-C27-shubh-raatri]
+sounds: [devanagari-anusvara, devanagari-conjunct-dhya]
+roots: [su-good, sandhya-junction-sanskrit]
+etymology_hook: "शुभ संध्या (shubh sandhyā, 'good evening') pairs शुभ ('good') with संध्या (sandhyā, native Sanskrit, from सम् + धा, 'to hold together' — literally 'the junction of day and night,' i.e. twilight); संध्या has its own Hindi tadbhava doublet, साँझ (sāñjh, evolved via Prakrit) — but unlike रात्रि/राat's tatsama/tadbhava split (HI-C26/27), साँझ isn't simply the eroded-casual counterpart: sources describe it as used across BOTH literary/poetic and everyday registers, not confined to one; शुभ संध्या itself, like सुप्रभात, shows up heavily in written/greeting-card and social-media culture, with नमस्ते — confirmed usable at any time of day, including evening — covering the casual spoken gap"
+est_minutes: 6
+reviews_of: [HI-C29-shaam, HI-C31-suprabhat]
+---
+
+# शुभ संध्या (shubh sandhyā) — "good evening," a twilight word with two lives
+
+## Warm-up
+
+[PAUSE 2s] शाम was Persian. This greeting reaches for something else
+again — a native Sanskrit word for the exact moment day and night meet.
+
+## संध्या — "the junction of day and night"
+
+**संध्या** (**sandhyā**) — "**evening, twilight**" — is **native
+Sanskrit**, from **सम्** (*sam-*, "together") + **धा** (*dhā*, "to
+hold, to place"), literally "**holding together**" — the **junction**
+where day and night meet. This is a genuinely different word from
+**शाम** (*shaam*, HI-C29's Persian loan): Hindi's everyday evening noun
+and its "good evening" greeting don't share a root, the same pattern
+already found for morning.
+
+## साँझ — a doublet, but not a simple "casual" version
+
+संध्या has its own Hindi **tadbhava** doublet, **साँझ** (**sāñjh**),
+worn down through Prakrit the same way **रात्रि** became **राat**
+(HI-C26/27). But be careful not to force that exact parallel: unlike
+*rātri*/*raat*, where the tadbhava form clearly became the everyday word
+and the tatsama stayed formal, sources describe **साँझ** as used across
+**both** literary/poetic **and** everyday communication — not simply
+"the casual one." The doublet exists; the clean formal/casual split
+doesn't carry over as neatly this time.
+
+## Be honest: written greeting-card culture, and नमस्ते again
+
+Like सुप्रभात last lesson, **शुभ संध्या** shows up heavily in **written
+and social greeting-card culture** — shayari (Hindi greeting-poetry),
+WhatsApp messages, evening well-wishes — more than as something reached
+for mid-conversation. And, confirmed independently this time:
+**नमस्ते** genuinely does work "at any time of day," evenings included,
+and is described as the more commonly used greeting in **casual**
+conversation than either शुभ प्रभात or शुभ संध्या. The same honest
+pattern from last lesson holds: a Sanskrit "good ___" phrase skewing
+formal/written, with नमस्ते filling the everyday spoken gap — not
+English displacing it, just a different native word doing the casual
+work.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "shubh sandhyā" — "good evening," su + sandhyā]
+- [YOU SAY: sandhyā's own meaning — "holding together," the junction of
+  day and night]
+- [YOU SAY: the honest note — शुभ संध्या leans written/greeting-card;
+  नमस्ते covers casual evenings too]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does संध्या literally mean, and what is it built from?
+("**Holding together**" — सम् + धा — i.e. the junction of day and
+night.) Does साँझ work the same way रात्रि/राat's tatsama/tadbhava split
+did — one strictly formal, one strictly casual? (**No** — साँझ is used
+across both literary and everyday registers, not confined to one.) Does
+नमस्ते genuinely work for evenings too? (**Yes** — confirmed usable at
+any time of day, and more common in casual speech than शुभ संध्या.)

--- a/code/learning/human-languages/hindi/lessons/HI-C33-shubh-dopahar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C33-shubh-dopahar.md
@@ -1,0 +1,64 @@
+---
+id: HI-C33-shubh-dopahar
+chapter: 33
+type: phrase
+headword: शुभ दोपहर
+gloss: "good afternoon" (shubh dopahar) — uses दोपहर in its modern, widened "afternoon" sense (HI-C30), not the narrow etymological "noon"; the rarest of this arc's three शुभ+noun greetings in actual casual use, with नमस्ते/नमस्कार covering the afternoon in practice
+concept_tag: GREETING-AFTERNOON
+prerequisites: [HI-C30-dopahar-widened, HI-C32-shubh-sandhya]
+sounds: [devanagari-vowel-sign-o, devanagari-aspirated-pa]
+roots: [su-good, do-two, pahar-traditional-watch]
+etymology_hook: "शुभ दोपहर (shubh dopahar, 'good afternoon') pairs शुभ with दोपहर IN ITS WIDENED MODERN SENSE (HI-C30's 'the whole afternoon,' not the narrow etymological 'exactly noon') — but of this arc's three शुभ+timeword greetings, this is the one described as most clearly rare/uncommon in actual spoken use, more so than सुप्रभात or शुभ संध्या; sources describe it as formal/written only, with casual alternatives like आपका दोपहर शुभ हो ('may your afternoon be good') existing but still uncommon, and नमस्ते/नमस्कार doing the real everyday work, all day including afternoon"
+est_minutes: 5
+reviews_of: [HI-C30-dopahar-widened, HI-C32-shubh-sandhya]
+---
+
+# शुभ दोपहर (shubh dopahar) — "good afternoon," this arc's rarest greeting
+
+## Warm-up
+
+[PAUSE 2s] You already know दोपहर's meaning widened from "precisely
+noon" to "the afternoon." This greeting rides that widened sense — but
+it's the least commonly heard of the three you've now met.
+
+## शुभ दोपहर — "good afternoon," using the widened सense
+
+**शुभ दोपहर** (**shubh dopahar**) — "**good afternoon**" — pairs
+**शुभ** ("good") with **दोपहर** used in the **widened, modern sense**
+from last lesson: "the afternoon" generally, not the narrow etymological
+"exactly noon." Good news for consistency: this greeting confirms
+दोपहर's widened meaning is the one people actually reach for here —
+nobody uses शुभ दोपहर to mean "good [precise instant of] noon."
+
+## Be honest: the rarest of the three, not just another formal phrase
+
+Here's the twist this lesson adds, verified independently rather than
+assumed from सुप्रभात or शुभ संध्या's pattern: of this arc's three
+शुभ+timeword greetings, **शुभ दोपहर is described as the rarest** in
+actual spoken use — even more so than the other two. Sources call it
+formal/written, note that casual alternatives like **आपका दोपहर शुभ
+हो** ("may your afternoon be good") exist but are themselves still
+uncommon, and confirm **नमस्ते**/**नमस्कार** do the real everyday
+greeting work across the whole afternoon, same as for morning and
+evening. This isn't just "another formal Sanskrit-style greeting" —
+it's the weakest-attested of the three, a genuine difference in
+**degree**, not just the same story repeated a third time.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "shubh dopahar" — "good afternoon," using दोपहर's widened
+  modern sense]
+- [YOU SAY: the honest ranking — of सुप्रभात, शुभ संध्या, and शुभ
+  दोपहर, this one is the rarest in actual spoken use]
+- [YOU SAY: नमस्ते/नमस्कार — the real everyday greeting, covering
+  afternoons too]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does शुभ दोपहर use दोपहर's narrow "noon" sense or its
+widened "afternoon" sense? (**The widened sense** — "good afternoon,"
+not "good [exact] noon.") Is शुभ दोपहर the most, or least, commonly
+used of this arc's three शुभ+timeword greetings? (**Least** — described
+as the rarest of the three in actual spoken use.) What covers the real
+everyday afternoon greeting instead? (**नमस्ते**/**नमस्कार**.)

--- a/code/learning/human-languages/kannada/lessons/KA-C23-dina.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C23-dina.md
@@ -1,0 +1,67 @@
+---
+id: KA-C23-dina
+chapter: 23
+type: word
+headword: ದಿನ
+gloss: "day" — a Sanskrit tatsama word, kept whole and unworn, unlike Hindi's own eroded din; Kannada also has a real native Dravidian word, hagalu, but it means specifically "daytime," not "a day"
+concept_tag: TIME-DAY
+prerequisites: [KA-C17-madhyaahna-madhyaraatri]
+sounds: [kannada-vowel-sign-i, kannada-na]
+roots: [sanskrit-dina, dravidian-hagalu-daytime]
+etymology_hook: "ದಿನ (dina, 'day') is a Sanskrit tatsama word, borrowed whole and unworn — the SAME Sanskrit दिन already behind Hindi's own दिन (din), but Hindi's din is a tadbhava form, eroded by centuries of ordinary sound change (Sanskrit dina → Prakrit → din), while Kannada's dina keeps the full, unshortened Sanskrit shape; Kannada also has a genuine native Dravidian word, ಹಗಲು (hagalu), but it specifically means 'daytime' (as opposed to night), not 'a day' as a calendar unit"
+est_minutes: 5
+reviews_of: [KA-C17-madhyaahna-madhyaraatri]
+---
+
+# ದಿನ (dina) — "day," Sanskrit kept whole
+
+## Warm-up
+
+[PAUSE 2s] You've already met Sanskrit's "middle" compounds for noon and
+midnight. Here's the plain word for "day" itself — and a genuinely
+interesting twist on how borrowing works.
+
+## ದಿನ — "day"
+
+**ದಿನ** (**dina**) — "**day**" — is a Sanskrit **tatsama** word: borrowed
+**whole**, unchanged, the same way *madhyāhna*/*madhyarātri* were
+(Chapter 17). It's Kannada's ordinary, everyday word for "a day."
+
+## The same word as Hindi's din — but a different kind of relative
+
+Here's the honest twist: Kannada's *dina* and Hindi's **दिन** (*din*) trace
+to the **exact same** Sanskrit word, **दिन** (*dina*) — but they got there
+by **different routes**. Hindi's *din* is a **tadbhava** form: Sanskrit
+*dina* wore down naturally over centuries, through Prakrit, losing its
+final vowel along the way. Kannada's *dina*, by contrast, is a direct
+**tatsama** borrowing — taken straight from Sanskrit, unworn, keeping the
+full shape. So Kannada's *dina* and Hindi's *din* look almost identical,
+but one is an unbroken **inheritance** (eroded), the other a **later
+borrowing** (kept whole) — genuinely different histories landing on nearly
+the same modern word.
+
+## A real native word — but for a different sense
+
+Kannada does have a genuine **native Dravidian** word here too: **ಹಗಲು**
+(*hagalu*) — but be careful, it means specifically "**daytime**" (the
+daylight hours, as opposed to night), not "**a day**" as a calendar unit.
+It's not a synonym for *dina*; it's a different sense of "day" entirely.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "dina" — "day," Sanskrit tatsama, kept whole]
+- [YOU SAY: the twist — dina and Hindi's din, same Sanskrit source, but
+  borrowing vs. natural erosion]
+- [YOU SAY: hagalu — native Dravidian, "daytime," a different sense than
+  dina]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is Kannada's **ದಿನ** a tatsama borrowing or a tadbhava
+inheritance? (**Tatsama** — borrowed whole from Sanskrit.) How does this
+differ from Hindi's **दिन** (*din*), even though both trace to the same
+Sanskrit word? (**Din is tadbhava** — naturally eroded through Prakrit —
+while Kannada's *dina* was borrowed later, unworn.) What does **ಹಗಲು**
+(*hagalu*) mean, and is it a synonym for *dina*? (**"Daytime"** — a
+different sense, not "a day" as a calendar unit.)

--- a/code/learning/human-languages/kannada/lessons/KA-C24-ratri.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C24-ratri.md
@@ -1,0 +1,62 @@
+---
+id: KA-C24-ratri
+chapter: 24
+type: word
+headword: ರಾತ್ರಿ
+gloss: "night" — the same Sanskrit tatsama word already hiding inside madhyarātri; Kannada's real native Dravidian word, irulu, has been pushed into archaism, unlike hagalu's living daytime sense
+concept_tag: TIME-NIGHT
+prerequisites: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina]
+sounds: [kannada-conjunct-tra, kannada-vowel-sign-i]
+roots: [sanskrit-ratri, proto-dravidian-cirvl]
+etymology_hook: "ರಾತ್ರಿ (rātri, 'night') is a Sanskrit tatsama word, the same one already hiding inside ಮಧ್ಯರಾತ್ರಿ (madhyarātri, 'midnight'), now standing alone as Kannada's everyday word for 'night'; Kannada DOES have a genuine native Dravidian word, ಇರುಳು (iruḷu) ← Proto-Dravidian *cirVḷ, cognate with Tamil இருள், Malayalam ഇരുൾ, and Telugu ఇరులు — but unlike ಹಗಲು (hagalu, still a living word for 'daytime'), iruḷu has been pushed into archaism, surviving mainly in older poetry"
+est_minutes: 5
+reviews_of: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina]
+---
+
+# ರಾತ್ರಿ (rātri) — "night," and its native cousin, pushed aside
+
+## Warm-up
+
+[PAUSE 2s] Last lesson's *dina* had a living native partner, *hagalu*.
+This word's native partner tells a different, more honest story — one of
+being pushed out, not living alongside.
+
+## ರಾತ್ರಿ — "night"
+
+**ರಾತ್ರಿ** (**rātri**) — "**night**" — is the same Sanskrit **tatsama**
+word already hiding inside **ಮಧ್ಯರಾತ್ರಿ** (*madhyarātri*, "midnight,"
+Chapter 17), now standing on its own as Kannada's ordinary, everyday word
+for "night."
+
+## ಇರುಳು — a real native word, pushed into archaism
+
+Kannada **does** have a genuine **native Dravidian** word for night:
+**ಇರುಳು** (**iruḷu**), from **Proto-Dravidian** ***\*cirVḷ*** — a real
+pan-Dravidian cognate, matching **Tamil**'s **இருள்** (*iruḷ*),
+**Malayalam**'s **ഇരുൾ** (*iruḷ*), and **Telugu**'s **ఇరులు** (*irulu*).
+But here's the honest difference from last lesson's *hagalu*: while
+*hagalu* is still a **living, everyday** word (just for a different sense,
+"daytime"), *iruḷu* has been genuinely **pushed aside** by the Sanskrit
+loan — it now survives mainly in **older poetry**, carrying extra
+metaphorical weight ("darkness," even "ignorance"), rather than in
+everyday speech. *Rātri* simply **won** the job of "night" in modern
+Kannada.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rātri" — "night," already met inside madhyarātri]
+- [YOU SAY: "iruḷu" — the real native word, now mostly archaic/poetic]
+- [YOU SAY: the honest contrast — hagalu still lives (different sense);
+  iruḷu was pushed aside (same sense, lost the job)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where have you already met **ರಾತ್ರಿ** before this lesson?
+(**ಮಧ್ಯರಾತ್ರಿ**, *madhyarātri*, "midnight.") What genuine native Dravidian
+word for "night" does Kannada have, and what's its status today?
+(**ಇರುಳು**, *iruḷu* — largely **archaic**, surviving mainly in older
+poetry.) How is *iruḷu*'s story different from *hagalu*'s, from last
+lesson? (**Hagalu still lives**, for a different sense ["daytime"];
+**iruḷu was pushed aside** entirely by the Sanskrit loan, for the same
+sense ["night"].)

--- a/code/learning/human-languages/kannada/lessons/KA-C25-shubha-ratri.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C25-shubha-ratri.md
@@ -1,0 +1,73 @@
+---
+id: KA-C25-shubha-ratri
+chapter: 25
+type: phrase
+headword: ಶುಭ ರಾತ್ರಿ
+gloss: "good night" — literally "auspicious night," pairing rātri (already met) with shubha, a word that started life meaning "to be beautiful"
+concept_tag: GREETING-GOODNIGHT
+prerequisites: [KA-C24-ratri]
+sounds: [kannada-sha, kannada-bha]
+roots: [sanskrit-shubha-beautiful, sanskrit-ratri]
+etymology_hook: "ಶುಭ ರಾತ್ರಿ (śubha rātri), 'good night,' literally 'auspicious night' — both pieces are Sanskrit tatsama: ರಾತ್ರಿ (rātri, already met last lesson) plus ಶುಭ (śubha, 'auspicious, good'), from Sanskrit root śubh, 'to be beautiful, splendid,' from a well-sourced PIE root *ḱewbʰ-; the exact same phrase, शुभ रात्रि, is also common in Hindi — most likely shared Sanskrit vocabulary rather than one language directly borrowing the whole phrase from the other, though 'good night' as a farewell is itself a modern convention across Indian languages, so some cross-language reinforcement can't be ruled out"
+est_minutes: 5
+reviews_of: [KA-C24-ratri]
+---
+
+# ಶುಭ ರಾತ್ರಿ (śubha rātri) — "good night," auspicious to the end
+
+## Warm-up
+
+[PAUSE 2s] You already have *rātri*. Pair it with one more Sanskrit word,
+and you have Kannada's everyday "good night" — the same phrase, word for
+word, as Hindi's.
+
+## ಶುಭ ರಾತ್ರಿ — "auspicious night"
+
+**ಶುಭ ರಾತ್ರಿ** (**śubha rātri**) — "**good night**" — literally
+"**auspicious night**." Both pieces are Sanskrit **tatsama**: **ರಾತ್ರಿ**
+(*rātri*, "night," already met last lesson) plus **ಶುಭ** (*śubha*,
+"**auspicious, good**").
+
+## ಶುಭ — from a root meaning "to be beautiful"
+
+**ಶುಭ** (**śubha**) comes from the Sanskrit verbal root **śubh**, whose
+core sense is "**to be beautiful, splendid**" — traceable to a
+well-sourced **Proto-Indo-European** root, ***\*ḱewbʰ-*** ("to be
+beautiful"). A further, more speculative connection to a root meaning "to
+shine" has also been proposed — but either way, the underlying idea is a
+familiar one: **auspiciousness imagined as a kind of radiance or beauty**.
+
+## A phrase shared across two different language families
+
+Here's the honest cross-language note: **ಶುಭ ರಾತ್ರಿ** and Hindi's own
+**शुभ रात्रि** are, word for word, the **exact same phrase** — a Dravidian
+language and an Indo-Aryan language landing on an identical "good night."
+The most likely explanation is **shared Sanskrit vocabulary**, not one
+language directly copying the phrase from the other — but be honest about
+the limits of that claim: "good night" as a farewell greeting is itself a
+**modern** convention across Indian languages, not an ancient one, so some
+degree of cross-language reinforcement (Hindi's wide reach as a pan-Indian
+media language, for instance) can't be ruled out either. Unlike Hindi,
+where *rātri* is the formal member of a live doublet against everyday
+*raat*, Kannada's *rātri* is simply the ordinary word (Chapter 24) — so
+this phrase draws on shared **Sanskrit vocabulary**, not a shared
+"formal-versus-everyday" register split the way it does in Hindi.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubha rātri" — "good night," literally "auspicious night"]
+- [YOU SAY: śubha's own root — śubh, "to be beautiful" → "auspicious"]
+- [YOU SAY: the honest cross-language note — identical to Hindi's shubh
+  rātri, most likely via shared Sanskrit vocabulary, though direct
+  reinforcement can't be fully ruled out]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ಶುಭ ರಾತ್ರಿ** literally mean? ("**Auspicious
+night**.") What does **ಶುಭ** literally trace back to? (A root meaning "**to
+be beautiful, splendid**.") Is Kannada's *śubha rātri* definitely borrowed
+directly from Hindi? (**Most likely not** — shared Sanskrit vocabulary is
+the more parsimonious explanation, though since "good night" as a farewell
+is itself a modern convention, some cross-language reinforcement can't be
+fully ruled out.)

--- a/code/learning/human-languages/kannada/lessons/KA-C26-belagge.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C26-belagge.md
@@ -1,0 +1,63 @@
+---
+id: KA-C26-belagge
+chapter: 26
+type: word
+headword: ಬೆಳಗ್ಗೆ
+gloss: "morning" (beḷagge) — genuine native Dravidian, from beḷagu ("to shine, to dawn") + beḷaku ("light"); unlike Kannada's Sanskrit tatsama day/night/noon words (dina, ratri, madhyāhna), this one is Kannada's own
+concept_tag: TIME-MORNING
+prerequisites: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina, KA-C24-ratri]
+sounds: [kannada-conjunct-gge, kannada-vowel-sign-e]
+roots: [proto-dravidian-belaku-light]
+etymology_hook: "ಬೆಳಗ್ಗೆ (beḷagge, 'morning') is native Dravidian, from ಬೆಳಗು (beḷagu, 'to shine, to become bright, to dawn') and ಬೆಳಕು (beḷaku, 'light') — unlike EVERY other everyday time-word already met in Kannada's arc, ದಿನ/dina ('day'), ರಾತ್ರಿ/ratri ('night'), and ಮಧ್ಯಾಹ್ನ/madhyāhna ('noon') — all genuine Sanskrit tatsama borrowings — ಬೆಳಗ್ಗೆ is the odd one out, Kannada's own word, no Sanskrit involved"
+est_minutes: 6
+reviews_of: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina, KA-C24-ratri]
+---
+
+# ಬೆಳಗ್ಗೆ (beḷagge) — the one time-word that's genuinely Kannada's own
+
+## Warm-up
+
+[PAUSE 2s] Every everyday time-word you've met in Kannada so far —
+day, night, noon, midnight — has been Sanskrit, borrowed whole. This one
+breaks that pattern completely.
+
+## ಬೆಳಗ್ಗೆ — light, dawning, genuinely native
+
+**ಬೆಳಗ್ಗೆ** (**beḷagge**) — "**morning**" — is **native Dravidian**,
+built on **ಬೆಳಗು** (*beḷagu*, "**to shine, to become bright, to
+dawn**") and the related noun **ಬೆಳಕು** (*beḷaku*, "**light**"). Morning
+is, quite literally, "the shining," "the dawning" — a transparent,
+homegrown metaphor, no borrowed vocabulary anywhere in it.
+
+## Be honest: the one word in this whole family that isn't Sanskrit
+
+Here's what makes this lesson different from every other Kannada
+time-word lesson so far: **ದಿನ** (*dina*, "day"), **ರಾತ್ರಿ** (*ratri*,
+"night"), and **ಮಧ್ಯಾಹ್ನ** (*madhyāhna*, "noon") are all genuine
+**Sanskrit tatsama** borrowings, taken whole, doing the plain everyday
+job in Kannada. **ಬೆಳಗ್ಗೆ** breaks that streak — it's the one everyday
+time-word in this set that's actually **Kannada's own**, not a loan from
+anywhere. If you'd only met *dina*, *ratri*, and *madhyāhna*, you might
+start to assume every Kannada time-word is Sanskrit underneath. This one
+is the honest counter-example — though, matching the pattern already
+seen with *hagalu* and *iruḷu* (Chapters 23–24), a native compound for
+"noon" does technically exist too: **ನಡುಹಗಲು** (*naḍuhagalu*,
+"middle-of-daytime," built from *naḍu*, "middle," the same everyday word
+already met, plus *hagalu*). It just lost the everyday job to
+*madhyāhna*, the same way *hagalu* and *iruḷu* were pushed into
+narrower, or archaic, roles by their own Sanskrit competitors.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "beḷagge" — "morning," native Dravidian]
+- [YOU SAY: the root — beḷagu, "to shine, to dawn," and beḷaku, "light"]
+- [YOU SAY: the contrast — dina, ratri, madhyāhna are all Sanskrit;
+  beḷagge is genuinely Kannada's own]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What native root does ಬೆಳಗ್ಗೆ come from, and what does it
+mean? (**ಬೆಳಗು/ಬೆಳಕು** — "to shine/dawn" and "light.") Is ಬೆಳಗ್ಗೆ a
+Sanskrit tatsama, like dina, ratri, and madhyāhna? (**No** — genuinely
+native Dravidian, the odd one out among Kannada's everyday time-words.)

--- a/code/learning/human-languages/kannada/lessons/KA-C27-sanje.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C27-sanje.md
@@ -1,0 +1,64 @@
+---
+id: KA-C27-sanje
+chapter: 27
+type: word
+headword: ಸಂಜೆ
+gloss: "evening" (sañje) — borrowed from Maharashtri Prakrit sañjhā, itself from Sanskrit संध्या (saṃdhyā); a striking cross-family convergence with Hindi's साँझ/sāñjh, same Sanskrit root, arriving via a DIFFERENT sister Prakrit dialect
+concept_tag: TIME-EVENING
+prerequisites: [KA-C24-ratri, KA-C26-belagge]
+sounds: [kannada-anusvara, kannada-ja]
+roots: [sanskrit-sandhya-junction]
+etymology_hook: "ಸಂಜೆ (sañje, 'evening') is borrowed — from Maharashtri Prakrit ಸಂಝಾ (sañjhā), itself from Sanskrit ಸಂಧ್ಯಾ (saṃdhyā, 'twilight, junction of day and night'); unlike dina/ratri/madhyāhna (fresh Sanskrit TATSAMA, taken whole and unworn), ಸಂಜೆ arrived already eroded, in its Prakrit-worn shape; Hindi's साँझ (sāñjh) descends from the SAME Sanskrit word, but via a DIFFERENT, sister Middle Indo-Aryan dialect, Śauraseni Prakrit — two independent erosion paths off one Sanskrit root, converging on near-identical modern forms across two different language families"
+est_minutes: 6
+reviews_of: [KA-C24-ratri, KA-C26-belagge]
+---
+
+# ಸಂಜೆ (sañje) — a Sanskrit word that arrived already worn down
+
+## Warm-up
+
+[PAUSE 2s] ದಿನ, ರಾತ್ರಿ, and ಮಧ್ಯಾಹ್ನ all arrived in Kannada whole,
+unworn, straight from Sanskrit. This word took a very different route —
+and it lands somewhere genuinely surprising.
+
+## ಸಂಜೆ — a Sanskrit word, but already eroded on arrival
+
+**ಸಂಜೆ** (**sañje**) — "**evening**" — traces to **Sanskrit** **ಸಂಧ್ಯಾ**
+(*saṃdhyā*, "**twilight**," literally "the junction of day and night")
+— but it didn't arrive in Kannada as a fresh, whole tatsama the way
+*dina*, *ratri*, and *madhyāhna* did. Instead, it came by way of
+**Maharashtri Prakrit** **ಸಂಝಾ** (*sañjhā*) — Sanskrit's word, already
+worn down by centuries of everyday Middle Indo-Aryan speech, *then*
+borrowed into Kannada in that already-eroded shape.
+
+## A striking convergence: the same Sanskrit word, two independent paths
+
+Here's the genuinely surprising part: Hindi's own evening word,
+**साँझ** (*sāñjh*), comes from the **exact same** Sanskrit **ಸಂಧ್ಯಾ** —
+but by a **different** route. Hindi *inherited* it, generation to
+generation, through **Śauraseni Prakrit** (a different, sister Middle
+Indo-Aryan dialect than the Maharashtri Prakrit Kannada borrowed from).
+Two separate erosion paths — one an unbroken inheritance within the
+Indo-Aryan family, one a loan crossing into a completely different
+language family — and they land on nearly **identical-sounding** modern
+words, *sañje* and *sāñjh*, purely because they share the same Sanskrit
+starting point.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "sañje" — "evening," from Sanskrit sandhyā via Maharashtri
+  Prakrit]
+- [YOU SAY: the contrast with dina/ratri/madhyāhna — those arrived
+  whole; sañje arrived already worn down]
+- [YOU SAY: the striking convergence — Hindi's साँझ, same Sanskrit
+  root, different Prakrit path, nearly the same sound today]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does ಸಂಜೆ arrive in Kannada as a fresh, whole Sanskrit
+tatsama, like *dina* and *ratri* did? (**No** — it arrived already worn
+down, via Maharashtri Prakrit ಸಂಝಾ.) What Hindi word shares ಸಂಜೆ's exact
+Sanskrit root, and by what different path did it get there? (**साँझ**
+(sāñjh) — inherited via a different sister Prakrit, Śauraseni, rather
+than borrowed via Maharashtri.)

--- a/code/learning/human-languages/kannada/lessons/KA-C28-aparahna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C28-aparahna.md
@@ -1,0 +1,67 @@
+---
+id: KA-C28-aparahna
+chapter: 28
+type: word
+headword: ಅಪರಾಹ್ನ
+gloss: "afternoon" (aparāhna) — a genuine Sanskrit tatsama distinct from ಮಧ್ಯಾಹ್ನ/madhyāhna ("noon"), sharing its "-ahna" ("day") suffix; apara ("latter") vs madhya ("middle"), the same clean structure applied to two different day-parts
+concept_tag: TIME-AFTERNOON
+prerequisites: [KA-C17-madhyaahna-madhyaraatri]
+sounds: [kannada-conjunct-hna, kannada-vowel-sign-aa]
+roots: [sanskrit-apara-latter, sanskrit-ahna-day]
+etymology_hook: "ಅಪರಾಹ್ನ (aparāhna, 'afternoon') is a genuine Sanskrit tatsama, distinct from ಮಧ್ಯಾಹ್ನ (madhyāhna, 'noon,' already met in Chapter 17) — both share the SAME '-ahna' suffix ('day,' related to ahan), differing only in the first piece: ಅಪರ (apara, 'latter, further') vs ಮಧ್ಯ (madhya, 'middle') — the classical five-part Sanskrit day division (prāta/saṅgava/madhyāhna/aparāhna/sāyāhna) kept this distinction sharp; in practice, though, some sources describe ಮಧ್ಯಾಹ್ನ ALSO being stretched loosely to cover the whole afternoon in casual modern speech — a MUCH more thinly sourced echo of Hindi's clearer दोपहर-widening story, worth flagging honestly rather than asserting as settled"
+est_minutes: 6
+reviews_of: [KA-C17-madhyaahna-madhyaraatri]
+---
+
+# ಅಪರಾಹ್ನ (aparāhna) — the same "-ahna" pattern, a different first piece
+
+## Warm-up
+
+[PAUSE 2s] You already know ಮಧ್ಯಾಹ್ನ, "noon" — "middle" plus "day." This
+lesson's word for "afternoon" uses the exact same building pattern, just
+with a different first piece.
+
+## ಅಪರಾಹ್ನ — "the latter part of the day"
+
+**ಅಪರಾಹ್ನ** (**aparāhna**) — "**afternoon**" — is a genuine **Sanskrit
+tatsama**: **ಅಪರ** (*apara*, "**latter, further**") + the same **-ಅಹ್ನ**
+(*-ahna*, "**day**") suffix already hiding inside **ಮಧ್ಯಾಹ್ನ**
+(*madhyāhna*, "noon," Chapter 17). Same clean two-piece structure, same
+"day" ending — just swap *madhya* ("middle") for *apara* ("latter,
+further along") and you move from "noon" to "afternoon." This distinction
+comes from a genuine, classical **five-part Sanskrit division of the
+day** — *prāta* (early morning), *saṅgava*, *madhyāhna* (noon),
+*aparāhna* (afternoon), *sāyāhna* (evening) — with *aparāhna* landing
+specifically as the fourth part, after noon and before evening.
+
+## Be honest: a much thinner echo of Hindi's दोपहर story
+
+Here's where this lesson needs real care: some sources describe
+**ಮಧ್ಯಾಹ್ನ** itself being stretched loosely in casual modern speech to
+cover the whole afternoon too — which would echo Hindi's own दोपहर,
+already found in this course to have genuinely widened from "precisely
+noon" to "the whole afternoon." But the evidence for Kannada is **much
+thinner** than what backed the Hindi finding — general dictionary
+listings rather than clear, independently-confirmed usage sources. Treat
+this as a plausible, hedged parallel, not a settled fact the way
+दोपहर's widening was. **ಅಪರಾಹ್ನ** remains the more precisely, formally
+correct word for "afternoon" specifically.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "aparāhna" — "afternoon," apara + ahna]
+- [YOU SAY: the shared piece with madhyāhna — both end in "-ahna," "day"]
+- [YOU SAY: the honest hedge — madhyāhna MAY also loosely cover
+  "afternoon" in casual speech, but this is far less certain than
+  Hindi's dopahar-widening story]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What suffix does ಅಪರಾಹ್ನ share with ಮಧ್ಯಾಹ್ನ, and what does
+it mean? (**-ಅಹ್ನ**, *-ahna*, "day.") What's the difference in their
+first pieces? (**ಅಪರ**, *apara*, "latter/further" vs. **ಮಧ್ಯ**, *madhya*,
+"middle.") Is the claim that ಮಧ್ಯಾಹ್ನ also covers "afternoon" in casual
+speech as well-supported as Hindi's दोपहर-widening finding? (**No** —
+much more thinly sourced; treat it as a hedged possibility, not a
+settled fact.)

--- a/code/learning/human-languages/latin/lessons/LA-C30-bonam-noctem.md
+++ b/code/learning/human-languages/latin/lessons/LA-C30-bonam-noctem.md
@@ -1,0 +1,68 @@
+---
+id: LA-C30-bonam-noctem
+chapter: 30
+type: phrase
+headword: bonam noctem
+gloss: "good night" — genuine Latin grammar (wishes take the accusative, not the nominative), though the fixed phrase itself may be a later/modern convention rather than a directly-attested ancient formula
+concept_tag: GREETING-GOODNIGHT
+prerequisites: [LA-C29-nox]
+sounds: [macron-none-short-vowel, accusative-am-em]
+roots: [bonus-latin, nox-latin]
+etymology_hook: "bonam noctem, 'good night,' uses a genuinely classical Latin grammatical principle — Latin wishes and exclamations conventionally take the ACCUSATIVE case, not the nominative (the same 'Accusative of Exclamation' construction behind Fēlīcem nātālem, 'happy birthday'); be honest, though: while the accusative-of-wishing rule is solid, this SPECIFIC fixed phrase, bonam noctem, is NOT itself attested as a Roman farewell formula in any surviving classical text — a later, post-classical convention"
+est_minutes: 5
+reviews_of: [LA-C29-nox]
+---
+
+# bonam noctem — real grammar, not a real citation
+
+## Warm-up
+
+[PAUSE 2s] You already have *bonus* (good) and *nox* (night, last lesson).
+Put them together for "good night" — but the case they end up in is the
+real lesson here.
+
+## bonam noctem — why accusative, not nominative
+
+**Bonam noctem** = "**good night**" — but notice: **not** *bona nox*
+(nominative). Latin wishes and exclamations conventionally use the
+**accusative** case — the same "**Accusative of Exclamation**" behind the
+genuinely attested *Fēlīcem nātālem!* ("happy birthday!," short for *tibi
+fēlīcem diem nātālem exoptō*, "I wish you a happy birthday"). Grammatically,
+*bonam noctem* is a compressed
+exclamation — something like "[**I wish you**] a good night," with the
+verb left unstated, the same kind of ellipsis you'd find in a letter
+opening like "*Cicero Atticō salūtem* [*dīcit*]" ("Cicero sends
+greetings to Atticus"). The bare nominative *bona nox* would
+work too (with an implied "*sit*," "may it be"), but the accusative is the
+more natural, idiomatic choice for a wish like this.
+
+## Be honest: real grammar, not a real citation
+
+Here's the careful part, matching the same honesty already applied to
+*quōmodo tē habēs?*, *nihil est*, and *crās tē vidēbō* earlier in this
+arc: the **accusative-of-wishing** principle itself is genuine, solid
+Classical Latin grammar. But this **specific fixed phrase**, *bonam
+noctem*, is **not** actually attested as a Roman farewell formula in any
+surviving classical text — it appears to be a later, post-classical
+convention, built correctly from real grammar but not itself a citation.
+Treat the grammar as reliable and the exact phrase as a well-formed
+construction, not a quotation from a Roman text.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bonam noctem" — "good night," accusative]
+- [YOU SAY: the case rule — Latin wishes take the accusative, not the
+  nominative *bona nox*]
+- [YOU SAY: the honest caveat — solid grammar, but not itself an attested
+  ancient farewell]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why is it **bonam noctem** and not **bona nox**? (**Latin
+wishes/exclamations conventionally take the accusative case**, not the
+nominative.) Is the accusative-of-wishing rule itself solid Classical
+Latin grammar? (**Yes.**) Is *bonam noctem* as one specific fixed phrase
+directly attested as a Roman farewell in any surviving classical text?
+(**No** — the grammar is real, but this exact phrase appears to be a
+later, post-classical convention.)

--- a/code/learning/human-languages/latin/lessons/LA-C31-mane.md
+++ b/code/learning/human-languages/latin/lessons/LA-C31-mane.md
@@ -1,0 +1,69 @@
+---
+id: LA-C31-mane
+chapter: 31
+type: word
+headword: māne
+gloss: "morning, early" — the word already hiding inside dē māne (the source of French demain, Italian domani, and Catalan demà, all rebuilt "tomorrow" from this phrase) and, without the dē-, the direct base of Spanish mañana too, now standing alone
+concept_tag: TIME-MORNING
+prerequisites: [LA-C25-cras-te-videbo]
+sounds: [macron-long-vowel]
+roots: [manus-good-latin-archaic]
+etymology_hook: "māne ('morning, early,' an indeclinable neuter noun/adverb — it never changes form) is the same word already hiding inside dē māne ('in the morning,' Chapter 25), the phrase French demain/Italian domani/Catalan demà independently rebuilt 'tomorrow' from — while Spanish mañana, per that same lesson, was built directly on māne alone, without the dē- (Vulgar Latin *maneāna); it derives from mānus, an archaic Latin adjective meaning 'good' — a COMPLETELY DIFFERENT word from the common manus ('hand'), despite the near-identical spelling (mānus has a long ā, manus a short a) — sharing that mānus root with mātūrus ('ripe, timely, early'), itself the source of English mature, and with mātūtīnus ('of the morning,' tied to Matūta, the Roman dawn goddess), the source, via Old French matines/matin, of English matins AND matinee — the same root splitting into 'morning prayers' and 'afternoon show' in English, a genuine semantic drift"
+est_minutes: 6
+reviews_of: [LA-C25-cras-te-videbo]
+---
+
+# māne — the word already hiding inside "tomorrow," in four languages
+
+## Warm-up
+
+[PAUSE 2s] You've already met this word once, without a lesson of its
+own — buried inside the very phrase that replaced *crās* across half the
+Romance family. Time to meet it directly.
+
+## māne — "morning," an indeclinable word
+
+**Māne** — "**morning, early**" — is an **indeclinable** neuter noun (and
+adverb): unlike *diēs* or *nox*, it never changes its ending, no matter
+its grammatical role. You've already met it once, inside **dē māne** ("in
+the morning," Chapter 25) — the exact phrase that **French**'s *demain*,
+**Italian**'s *domani*, and **Catalan**'s *demà* all independently
+rebuilt as their new word for "tomorrow," abandoning *crās*. **Spanish**'s
+*mañana* took a related but distinct path: built directly on **māne**
+itself, without the *dē*- (Vulgar Latin *\*maneāna*) — the same root, one
+step closer to the source.
+
+## A root meaning "good" — and a false friend to watch for
+
+Māne traces to **mānus**, an archaic Latin adjective meaning "**good**."
+Watch the vowel length carefully: this is a **completely different**
+word from the everyday **manus** ("**hand**," short *a*) — same
+spelling once macrons are dropped, unrelated meaning, a genuine false
+friend. From that "good" root comes **mātūrus** ("**ripe, timely,
+early**"), the direct source of English **mature** — and
+**mātūtīnus** ("of the morning," tied to **Matūta**, the Roman goddess of
+dawn), which gives English, via Old French *matines*/*matin*, both
+**matins** ("morning prayers") **and** **matinee** ("afternoon
+performance") — the same root splitting into two very different senses
+of "a scheduled morning-adjacent thing."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "māne" — "morning," already met inside dē māne]
+- [YOU SAY: the false-friend warning — mānus "good" (long ā) vs. manus
+  "hand" (short a)]
+- [YOU SAY: the English cousins — mature, matins, matinee, all from the
+  same root as māne]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where did you already meet **māne** before this lesson? (Inside
+**dē māne**, "in the morning," Chapter 25 — source of French *demain*,
+Italian *domani*, and Catalan *demà*.) Did Spanish *mañana* come from
+*dē māne* too? (**Not quite** — it was built directly on *māne* alone,
+without the *dē*-.) Is māne's root
+*mānus* the same word as *manus*, "hand"? (**No** — a false friend; *mānus*
+"good" has a long ā, *manus* "hand" a short a.) What two very different
+English words both trace to māne's "good" root, via *mātūtīnus*?
+(**Matins** and **matinee**.)

--- a/code/learning/human-languages/latin/lessons/LA-C32-bonum-mane.md
+++ b/code/learning/human-languages/latin/lessons/LA-C32-bonum-mane.md
@@ -1,0 +1,75 @@
+---
+id: LA-C32-bonum-mane
+chapter: 32
+type: phrase
+headword: bonum māne
+gloss: "good morning" — a modern, pedagogical phrase (not classically attested); unlike bonam noctem, its grammar is genuinely invisible, since māne is neuter and Latin neuters never distinguish nominative from accusative — Romans instead had a real, richly documented morning GREETING RITUAL, the salūtātiō, whose root is a doublet of salvē's own
+concept_tag: GREETING-MORNING
+prerequisites: [LA-C31-mane, LA-C01-salve]
+sounds: [macron-long-vowel]
+roots: [bonus-latin, mane-latin, salus-latin]
+etymology_hook: "bonum māne, 'good morning,' is a modern, pedagogical phrase — like bonam noctem, not classically attested as a fixed Roman farewell/greeting formula; but unlike bonam noctem, its grammar is genuinely INVISIBLE rather than just uncertain: māne is neuter, and Latin neuter nouns never distinguish nominative from accusative (bonum works either way), so the Accusative-of-Exclamation rule that bonam noctem demonstrated so clearly simply can't be shown here; what Romans DID have, richly documented, was the salūtātiō (mātūtīna salūtātiō) — clients visiting their patron's house at dawn to pay respects — from salūtāre ('to greet'), itself derived from salūs ('health, safety, wholeness'), a genuine DOUBLET of salvus (the root of salvē, Chapter 1's first word) — both descend from the same PIE root, *solh₂- ('whole'); a morning greeting Romans actually had, just as an ACTION, not a phrase"
+est_minutes: 6
+reviews_of: [LA-C31-mane, LA-C01-salve]
+---
+
+# bonum māne — a phrase Romans didn't say, and a ritual they actually did
+
+## Warm-up
+
+[PAUSE 2s] You have *bonus* (good) and *māne* (morning, last lesson). Put
+them together for "good morning" — but this time, watch for what's
+**missing**, not just what's uncertain.
+
+## bonum māne — grammatically invisible, not just unattested
+
+**Bonum māne** = "**good morning**." Like *bonam noctem* two lessons ago,
+this specific phrase is **not** classically attested as a fixed Roman
+greeting. But here the honesty runs one level deeper: *bonam noctem*
+showed you real, solid grammar — the accusative *noctem*, distinct from
+nominative *nox*, demonstrating Latin's genuine "Accusative of Exclamation."
+**Māne**, though, is **neuter** and **indeclinable** — and Latin neuter
+nouns **never** distinguish nominative from accusative, in any word, ever.
+*Bonum* works identically whether you imagine it as nominative or
+accusative. The grammar point that made *bonam noctem* interesting simply
+**isn't visible** here — not because it's missing, but because neuter
+words never show it, for anyone, anywhere in Latin.
+
+## The salūtātiō — a morning greeting Romans really had, as an action
+
+Here's what Romans **did** have, richly documented: the **salūtātiō**
+(*mātūtīna salūtātiō*, "morning greeting") — clients arriving at their
+patron's house at **dawn**, formally dressed, to pay respects, ask
+favors, and sometimes receive the *sportula* (a small cash or food
+allowance) in return. It structured the start of the Roman day the way a
+verbal "good morning" structures yours — just as a **ritual visit**, not
+a **spoken phrase**.
+
+**Salūtātiō** comes from **salūtāre** ("to greet"), which comes from
+**salūs** ("health, safety, wholeness") — and *salūs* is a genuine
+**doublet** of **salvus** ("safe, sound"), the very root behind **salvē**
+(Chapter 1's first word, "hello," literally "be well"). Both *salūs* and
+*salvus* descend from the same **Proto-Indo-European** root,
+***\*solh₂-*** ("whole"). So Rome's real morning greeting and its very
+first "hello" share one root, arrived at by two separate paths — a wish
+for someone's wholeness, whether spoken as *salvē* or enacted at dawn as
+the *salūtātiō*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bonum māne" — "good morning," a modern phrase, not classical]
+- [YOU SAY: why its grammar is invisible — māne is neuter, and neuters
+  never show nominative vs. accusative]
+- [YOU SAY: "salūtātiō" — the real Roman morning greeting, a dawn visit,
+  not a phrase — from the same root as salvē]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does *bonum māne* show the same accusative-of-wishing grammar
+that *bonam noctem* did? (**No** — māne is neuter, and Latin neuters never
+distinguish nominative from accusative, so the case is invisible either
+way.) What was Rome's real, richly documented "morning greeting"? (The
+**salūtātiō** — clients visiting a patron's house at dawn.) What word,
+already taught in Chapter 1, shares its root with salūtātiō? (**Salvē** —
+both salūs and salvus descend from the same PIE root, *\*solh₂-*, "whole.")

--- a/code/learning/human-languages/latin/lessons/LA-C33-vesper.md
+++ b/code/learning/human-languages/latin/lessons/LA-C33-vesper.md
@@ -1,0 +1,78 @@
+---
+id: LA-C33-vesper
+chapter: 33
+type: word
+headword: vesper
+gloss: "evening" — a genuine everyday classical Latin word, sharing a root with English west (via the direction of sunset) and Greek Hesperos, but largely abandoned by French and Italian, who built their own "evening" from a different Latin root, "late," instead
+concept_tag: TIME-EVENING
+prerequisites: []
+sounds: [macron-none-short-vowel]
+roots: [vesper-latin]
+etymology_hook: "vesper/vespera ('evening') is a genuine, ordinary Classical Latin word (vespere, 'in the evening,' is common in Cicero's letters); it traces to PIE *wekero- ('evening, night'), possibly an enlarged form of a root *we- some reconstructions gloss as 'down' (the direction the sun sets, though this specific sub-root is more contested than the vesper/west link itself) — the SAME conceptual root, via a separate Germanic branch, behind English west itself; its Greek cognate, hesperos, gives Hesperus (the evening star, the planet Venus) and Hesperia ('land of the west' — the Greeks used it for Italy, the Romans for Spain, since 'west' is always relative to where you're standing); vesper gives English vespers and vespertine directly, but French soir and Italian sera did NOT come from vesper — both were rebuilt from a completely different Latin root, sērus ('late'), already the story behind French soir per that lesson; Spanish kept vespera as víspera, but its meaning narrowed to 'the eve, the day before,' not 'evening' itself anymore"
+est_minutes: 6
+reviews_of: []
+---
+
+# vesper — the evening word its own daughters mostly abandoned
+
+## Warm-up
+
+[PAUSE 2s] A genuinely ordinary Latin word for "evening" — and a root
+that quietly reaches all the way to the English word *west*.
+
+## vesper/vespera — an everyday classical word
+
+**Vesper** (also **vespera**) — "**evening**" — is a genuine, ordinary
+Classical Latin word, not a rare or poetic one: **vespere** ("in the
+evening") shows up routinely in Cicero's own letters. It traces to
+**Proto-Indo-European** ***\*wekero-*** ("evening, night"), itself an
+enlarged form of a root ***\*we-***, which some reconstructions gloss as
+"down" (the direction the sun sets) — though this specific piece is more
+contested than the vesper/west link itself. That
+same conceptual root, through a completely separate **Germanic** branch,
+gives English its own word for "**west**" — evening and west, sharing
+one deep idea: the direction the sun goes down.
+
+## Hesperus, Hesperia — the Greek cognate's afterlife
+
+Vesper's Greek cognate, **hesperos**, survives directly in English as
+**Hesperus** (the evening star — the planet Venus at dusk) and
+**Hesperia** ("**land of the west**") — a name that's always relative:
+the **Greeks** called **Italy** *Hesperia*, since Italy lay west of
+Greece; the **Romans**, in turn, sometimes called **Spain** *Hesperia*,
+since Spain lay west of Italy. "West" depends entirely on where you're
+standing.
+
+## Be honest: vesper's own daughters mostly walked away from it
+
+Here's the twist: despite being a perfectly ordinary classical word,
+**vesper** was largely **abandoned** by the mainstream Romance
+daughters for their everyday "evening" word. French's **soir** and
+Italian's **sera** come from a **completely different** Latin root —
+**sērus** ("late"), via **sēra diēs** ("late day") — not from *vesper* at
+all. Spanish did keep *vespera*, as **víspera** — but its meaning
+**narrowed**: *víspera* means "**the eve, the day before**" an event
+today, not "evening" itself anymore. *Vesper* survives most directly, and
+unchanged in sense, in **English** — as **vespers** (the evening prayer
+service) and **vespertine** ("of the evening") — borrowed straight from
+Latin rather than inherited through a Romance daughter at all.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vesper" — "evening," genuinely everyday Classical Latin]
+- [YOU SAY: the deep root — *wekero-*, shared with English "west," the
+  direction of sunset]
+- [YOU SAY: the honest twist — French soir and Italian sera come from a
+  DIFFERENT root, "late," not from vesper at all]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What English word shares vesper's deep PIE root, and what's
+the connecting idea? (**West** — both trace to the direction the sun
+sets.) What did the Greeks call Italy, and why? (**Hesperia**, "land of
+the west" — because Italy lies west of Greece.) Do French *soir* and
+Italian *sera* come from *vesper*? (**No** — a completely different Latin
+root, *sērus*, "late.") What does Spanish *víspera* mean today, and how
+does that differ from vesper's original sense? (**"Eve, the day
+before"** — narrowed from "evening" itself.)

--- a/code/learning/human-languages/latin/lessons/LA-C34-bonum-vesperum.md
+++ b/code/learning/human-languages/latin/lessons/LA-C34-bonum-vesperum.md
@@ -1,0 +1,70 @@
+---
+id: LA-C34-bonum-vesperum
+chapter: 34
+type: phrase
+headword: bonum vesperum
+gloss: "good evening" — a modern, pedagogical phrase (not classically attested), but unlike bonum māne, this one CAN show the real Accusative-of-Exclamation grammar again, since vesper is masculine, not neuter
+concept_tag: GREETING-EVENING
+prerequisites: [LA-C33-vesper, LA-C30-bonam-noctem, LA-C32-bonum-mane]
+sounds: [macron-none-short-vowel, accusative-am-em]
+roots: [bonus-latin, vesper-latin]
+etymology_hook: "bonum vesperum, 'good evening,' is a modern, pedagogical phrase — like bonam noctem and bonum māne, not attested as a fixed Roman greeting in any surviving classical text; but unlike bonum māne (where the grammar point was invisible, since māne is neuter), this one CAN show real grammar again: vesper is MASCULINE, and Latin masculine nouns DO distinguish nominative (vesper) from accusative (vesperum) — so bonum vesperum genuinely demonstrates the same Accusative-of-Exclamation rule as bonam noctem, just with a different gender's endings; a separate feminine noun, vespera, gives the alternate bonam vesperam, agreeing the SAME WAY bonam noctem does — the adjective bonam matches bonam exactly — but the noun endings themselves differ, since vespera is 1st declension (accusative -am) while nox is 3rd declension (accusative -em, noctem, NOT -am)"
+est_minutes: 6
+reviews_of: [LA-C33-vesper, LA-C30-bonam-noctem, LA-C32-bonum-mane]
+---
+
+# bonum vesperum — the accusative rule returns, this time visibly
+
+## Warm-up
+
+[PAUSE 2s] Two lessons ago, *bonum māne* couldn't show you Latin's real
+wish-grammar, because *māne* is neuter. This time it's back — because
+*vesper* isn't.
+
+## bonum vesperum — masculine, and the case shows again
+
+**Bonum vesperum** = "**good evening**." Like *bonam noctem* and *bonum
+māne*, this specific phrase is **not** classically attested as a fixed
+Roman greeting — the same honest gap, a third time. But the grammar here
+is different from *bonum māne*'s: **vesper** is **masculine**, and Latin
+masculine nouns genuinely **do** distinguish nominative (*vesper*) from
+accusative (*vesperum*) — unlike neuter *māne*, where the two forms were
+always identical. So *bonum vesperum* **does** demonstrate the real
+Accusative-of-Exclamation rule again, the same wish-construction behind
+*bonam noctem* and the genuinely attested *Fēlīcem nātālem!* — just
+dressed in masculine endings instead of feminine ones.
+
+## A feminine alternate: bonam vesperam
+
+Latin also has a separate **feminine** noun for evening, **vespera**
+(distinct from masculine *vesper*, though built from the same root —
+both headwords appeared together last lesson, though without their
+genders spelled out). Paired with *bonus*, its accusative gives **bonam
+vesperam** — agreeing the **same way** *bonam noctem* does: the
+adjective, *bonam*, matches *bonam* exactly. But watch the **nouns**
+carefully — they do **not** share an ending. *Vespera* is **1st
+declension** (accusative *-am*, *vesperam*), while *nox* is **3rd
+declension** (accusative *-em*, *noctem* — **not** *-am*). Same
+adjective agreement, genuinely different noun declensions underneath.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bonum vesperum" — "good evening," masculine accusative]
+- [YOU SAY: why this one shows the case rule, unlike bonum māne — vesper
+  is masculine, not neuter]
+- [YOU SAY: "bonam vesperam" — the feminine alternate, matching bonam
+  noctem's own shape]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is *bonum vesperum* itself directly attested as a classical
+Roman greeting? (**No** — a modern, pedagogical phrase, like *bonam
+noctem* and *bonum māne*.) Why does *bonum vesperum* show the real
+Accusative-of-Exclamation rule, when *bonum māne* couldn't? (**Vesper is
+masculine**, and masculine nouns distinguish nominative from accusative;
+*māne* is neuter, where the two are always identical.) What's the
+feminine alternate, and how does its adjective agreement compare to
+*bonam noctem*'s? (**Bonam vesperam** — the adjective *bonam* matches
+*bonam* exactly, but the NOUNS don't share an ending: *vesperam* is 1st
+declension *-am*, while *noctem* is 3rd declension *-em*, not *-am*.)

--- a/code/learning/human-languages/latin/lessons/LA-C35-meridies.md
+++ b/code/learning/human-languages/latin/lessons/LA-C35-meridies.md
@@ -1,0 +1,77 @@
+---
+id: LA-C35-meridies
+chapter: 35
+type: word
+headword: merīdiēs
+gloss: "midday, noon" — the same medius diēs you already know, contracted into one word; Romans split the day around IT (ante/post merīdiem), not into a separate colloquial "afternoon" the way Spanish's tarde or French's après-midi do
+concept_tag: TIME-AFTERNOON
+prerequisites: [LA-C12-medius-dies-nox, LA-C13-hora]
+sounds: [macron-long-vowel]
+roots: [medius-latin, dies-latin]
+etymology_hook: "merīdiēs ('midday, noon') is the SAME phrase as medius diēs (Chapter 12), contracted by sound dissimilation from an earlier medīdiēs into merīdiēs — a fifth-declension noun (acc. merīdiem), and the ultimate root of English meridian (via the Latin adjective merīdiānus, 'of midday'); be honest: Romans did NOT have a colloquial 'afternoon' word the way Spanish's tarde or French's après-midi do — instead, they split the whole day around merīdiēs into ante merīdiem ('before noon') and post merīdiem ('after noon'), the direct ancestors of English's own a.m./p.m., a genuinely load-bearing legal distinction under the Twelve Tables (a court case had to be argued before noon with both parties present; a magistrate could rule in absentia only after noon); Latin's tardus ('slow, late') — the very word Spanish tarde comes from, per that lesson — stayed a plain adjective in Latin itself and never meant 'afternoon' there"
+est_minutes: 6
+reviews_of: [LA-C12-medius-dies-nox, LA-C13-hora]
+---
+
+# merīdiēs — the word you already know, one sound-change later
+
+## Warm-up
+
+[PAUSE 2s] You already have *medius diēs*. This lesson's honest twist is
+that Rome never really had a separate word for "afternoon" — it had this
+word instead, and split the whole day around it.
+
+## merīdiēs — medius diēs, worn down by one sound rule
+
+**Merīdiēs** — "**midday, noon**" — is the **exact same phrase** as
+**medius diēs** (Chapter 12), just **contracted**: an earlier
+*medīdiēs* dropped its repeated *d*-sound (dissimilation) to become
+*merīdiēs*, a fifth-declension noun in its own right (accusative
+*merīdiem*). It's the ultimate root of English **meridian**, via the
+Latin adjective **merīdiānus** ("of midday").
+
+## Be honest: no "afternoon," just a line drawn at noon
+
+Here's the twist: Spanish has *tarde*, French has *après-midi*, German
+has *Nachmittag* — a single word naming "the afternoon" as its own block
+of time. **Latin doesn't.** Instead, Romans split the **entire day**
+around *merīdiēs* into two large halves: **ante merīdiem** ("**before
+noon**") and **post merīdiem** ("**after noon**") — the direct ancestors
+of English's own **a.m.** and **p.m.**, used on every clock and phone
+today, almost always without anyone realizing they're speaking Latin.
+
+This wasn't just a loose figure of speech — it carried real legal
+weight. Under the **Twelve Tables**, Rome's foundational law code, a
+civil case had to be argued **before noon**, with both parties present;
+if one party failed to appear, the magistrate could rule **against
+them, in absentia, once it passed noon**. *Ante* and *post merīdiem*
+divided not just clock time, but courtroom procedure.
+
+## A familiar root, staying put
+
+You've already met *tardus* ("slow, late") through Spanish's own *tarde*
+— the very word Spanish reshaped into its "afternoon." In Latin itself,
+*tardus* never made that leap: it stayed a plain adjective, "slow,
+late," and never became a Latin noun for "afternoon." Spanish's shift
+from "late" to "the afternoon" happened entirely on its own, after
+Latin.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "merīdiēs" — the same medius diēs, contracted]
+- [YOU SAY: "ante merīdiem," "post merīdiem" — before/after noon, the
+  source of a.m./p.m.]
+- [YOU SAY: the honest twist — no separate Latin word for "afternoon,"
+  just a line drawn at noon]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What earlier phrase is *merīdiēs* a contracted form of? (*Medius
+diēs*, Chapter 12.) What two English abbreviations, used on every clock,
+come directly from *ante merīdiem* and *post merīdiem*? (**a.m.** and
+**p.m.**.) Did this noon-based division matter beyond just telling time?
+(**Yes** — under the Twelve Tables, Roman court cases had a real legal
+deadline at noon.) Does Latin have its own separate word for "afternoon,"
+the way Spanish has *tarde*? (**No** — Romans split the whole day around
+*merīdiēs* instead.)

--- a/code/learning/human-languages/latin/lessons/LA-C36-salve-post-meridiem.md
+++ b/code/learning/human-languages/latin/lessons/LA-C36-salve-post-meridiem.md
@@ -1,0 +1,78 @@
+---
+id: LA-C36-salve-post-meridiem
+chapter: 36
+type: phrase
+headword: salvē (post merīdiem)
+gloss: "good afternoon" — no two-word phrase for it exists the way bonum vesperum does, because Latin has no simplex noun for "afternoon"; a grammatical three-word workaround (bonum tempus pōmerīdiānum) exists but isn't attested as an actual greeting — the honest answer is that Romans just used salvē, the same everyday greeting from Chapter 1, with no time-of-day restriction
+concept_tag: GREETING-AFTERNOON
+prerequisites: [LA-C35-meridies, LA-C01-salve]
+sounds: [macron-long-vowel, v-as-w]
+roots: [salvere, medius-latin, dies-latin]
+etymology_hook: "unlike bonam noctem, bonum māne, and bonum vesperum — each a modern/pedagogical two-word phrase, but grammatically real — 'good afternoon' can't take that same two-word shape, because LA-C35 already established Latin has no simplex noun for 'afternoon' the way nox/māne/vesper exist for night/morning/evening; a three-word workaround, bonum tempus pōmerīdiānum ('good afternoon time'), IS grammatically valid — pōmerīdiānus is a real, Cicero-used adjective, and tempus gives bonus a genuine neuter noun to agree with — but it's a periphrasis, not a direct parallel to the other three phrases, and isn't itself attested as a greeting formula anywhere; the honest answer is that Romans just used salvē (Chapter 1), an everyday greeting with no time-of-day restriction built into it at all, rather than inventing a dedicated afternoon phrase"
+est_minutes: 5
+reviews_of: [LA-C35-meridies, LA-C01-salve]
+---
+
+# salvē (post merīdiem) — the one that isn't there
+
+## Warm-up
+
+[PAUSE 2s] Three lessons in a row, you've met a modern phrase built on
+real (if sometimes invisible) Latin grammar for "good ___." This lesson
+is different: there's honestly nothing to build.
+
+## Be honest: no two-word phrase exists here
+
+**Bonam noctem**, **bonum māne**, and **bonum vesperum** are all modern,
+pedagogical phrases — not classically attested — but each pairs *bonus*
+directly with a **single noun** in the accusative: *noctem*, *māne*,
+*vesperum*. "Good afternoon" can't take that same shape, because you
+already learned last lesson that Latin has **no simplex noun** for
+"afternoon" at all — there's no *afternoonem* for *bonus* to modify.
+**Bonum post merīdiem** doesn't work: *post merīdiem* ("after noon") is
+a whole **prepositional phrase**, not a noun, so *bonus* has nothing to
+agree with. A three-word workaround, **bonum tempus pōmerīdiānum**
+("good afternoon time"), actually **is** grammatical — *pōmerīdiānus*
+("of the afternoon") is a real word Cicero himself uses, and here
+*bonus* agrees with a genuine noun, *tempus* ("time"). But it's a
+**periphrasis**, not a direct two-word match for the other three
+phrases — and it isn't itself attested anywhere as something Romans
+actually said as a greeting.
+
+## What Romans actually did instead: nothing time-specific at all
+
+Here's the real answer: Romans didn't need an afternoon-specific
+greeting, because **salvē**/**salvēte** — the very first word of this
+course, Chapter 1 — carries no time-of-day restriction at all in its own
+right; it's simply "be well," said whenever you meet someone. There was
+no gap to fill with a modern convention, because Romans never divided
+their **everyday** greetings by time of day the way "good
+morning/afternoon/evening/night" does in English. *Morning* got a real
+institution instead of a phrase (the *salūtātiō*, Chapter 32); *evening*
+and *night* got attested grammar wrapped around invented phrases. But
+*afternoon* gets neither a genuine two-word phrase nor a substitute —
+just the same timeless *salvē* you already knew.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "salvē" — the same word from Chapter 1, no time-of-day
+  restriction attached]
+- [YOU SAY: why "bonum post merīdiem" doesn't work — no noun for bonus
+  to agree with; why "bonum tempus pōmerīdiānum" DOES work, but isn't
+  attested as a real greeting]
+- [YOU SAY: the honest takeaway — Romans never split EVERYDAY greetings
+  by time of day the way English does]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does Latin have a two-word phrase for "good afternoon" the
+way it has *bonum vesperum* for evening? (**No** — Latin has no simplex
+noun for "afternoon" for *bonus* to pair with.) Is there ANY grammatical
+Latin phrase at all? (**Yes** — *bonum tempus pōmerīdiānum* is real
+grammar, but a three-word periphrasis, not attested as an actual
+greeting.) What did Romans say in the afternoon instead? (**Salvē** —
+the same everyday greeting from Chapter 1, with no time-of-day
+restriction.) Why
+doesn't *bonum post merīdiem* work grammatically? (*Post merīdiem* is a
+whole prepositional phrase, not a single noun *bonus* can agree with.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C23-divasam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C23-divasam.md
@@ -1,0 +1,80 @@
+---
+id: ML-C23-divasam
+chapter: 23
+type: word
+headword: ദിവസം
+gloss: "day" — the common everyday Sanskrit-tatsama word; Malayalam's own native day-word (nāḷ, already met in "tomorrow") is also still alive, echoing Kannada's hagalu — narrowed to specific uses rather than erased
+concept_tag: TIME-DAY
+prerequisites: [ML-C04-naale-kaanaam, ML-C17-ucha-paathira]
+sounds: [malayalam-vowel-sign-i, malayalam-anusvara]
+roots: [sanskrit-divasa-day, sanskrit-dina, proto-dravidian-naal-day]
+etymology_hook: "ദിവസം (divasam, 'day') is a Sanskrit tatsama, borrowed whole from दिवस (divasa) ← PIE *dyew- ('to shine') via the root दिव् (div); this is the SAME ultimate PIE root as Hindi/Kannada's दिन/ದಿನ (dina) and Latin's diēs, but divasa and dina are different Sanskrit derivational formations off that root (an -asa formation vs. Sanskrit's own -nó- formation), not the same word — a repeat of the din/diēs 'hidden branching' pattern, this time inside Sanskrit itself; Malayalam ALSO has ദിനം (dinam), the very word Kannada uses plainly, but here it's the more literary/formal alternate to divasam; and Malayalam's native word നാൾ (nāḷ, Proto-Dravidian *nāḷ, already met inside നാളെ/nāḷe 'tomorrow' in Chapter 4) is also still alive today, echoing Kannada's own hagalu (Chapter 23 of that language's arc) — a native day-related word that survived not by staying the default counting word, but by narrowing to specific senses/compounds: nāḷ in the narrative phrase 'oru nāḷ' ('one day') and in the living compound പിറന്നാൾ (piṟannāḷ, 'birthday,' literally 'day of birth')"
+est_minutes: 6
+reviews_of: [ML-C04-naale-kaanaam, ML-C17-ucha-paathira]
+---
+
+# ദിവസം (divasam) — "day," and a native word that refused to fade
+
+## Warm-up
+
+[PAUSE 2s] You already met Malayalam's native word for "day" back in
+Chapter 4 — hiding inside "tomorrow." This lesson gives it, and its
+Sanskrit rival, their own honest reckoning.
+
+## ദിവസം — Malayalam's everyday word, a Sanskrit tatsama
+
+**ദിവസം** (**divasam**) — "**day**" — is Malayalam's common, everyday word
+for counting a day (as in **മൂന്ന് ദിവസം**, *mūnnu divasam*, "three days").
+It's a Sanskrit **tatsama**, borrowed whole from **दिवस** (*divasa*), which
+itself traces to **Proto-Indo-European** ***\*dyew-*** ("**to shine**"),
+via the Sanskrit root **दिव्** (*div*). That's the **same ultimate PIE
+root** behind Hindi/Kannada's **दिन/ದಿನ** (*dina*) and Latin's own *diēs* —
+but be careful here: *divasa* and *dina* are **two different Sanskrit
+formations** off that shared root (one built with an *-asa* suffix, one
+with Sanskrit's own *-nó-* formation), not the same word wearing two
+scripts. Same root, different branch — the *din*/*diēs* pattern, replaying
+itself one level deeper, inside Sanskrit.
+
+## ദിനം — the same word Kannada uses plainly, here just the formal one
+
+Malayalam also has **ദിനം** (**dinam**) — the **exact same** Sanskrit
+tatsama word as Kannada's plain, everyday *dina*. But in Malayalam,
+**dinam** is the more **literary, formal** alternate (think **ജന്മദിനം**,
+*janmadinam*, "birthday," the modern calque-style term) — **divasam** does
+the everyday counting work instead.
+
+## നാൾ — a native word that narrowed its job, rather than losing it
+
+Here's the honest twist of this lesson: Malayalam's own native Dravidian
+word for "day," **നാൾ** (**nāḷ**, Proto-Dravidian ***\*nāḷ***, cognate with
+Tamil's **நாள்** and Kannada's **ನಾಳು**) — the very word you already met
+inside **നാളെ** (*nāḷe*, "tomorrow," Chapter 4) — is **also still alive**
+today, in a shape that echoes Kannada's own **ಹಗಲು** (*hagalu*): a native
+word that didn't get erased by the Sanskrit loan so much as **narrowed** to
+specific uses, rather than staying the default, everyday counting word
+(that job belongs to *divasam* now). Concretely: **ഒരു നാൾ** (*oru nāḷ*,
+"one day," in the storytelling sense — "once upon a day") is still real,
+narrative-register Malayalam, and *nāḷ* stays **productive** in living
+compounds today, like **പിറന്നാൾ** (*piṟannāḷ*, "**birthday**," literally
+"day of birth") — itself considered the more **traditional** of
+Malayalam's two birthday words, next to the newer Sanskrit calque
+*janmadinam*. Three words, three honest jobs: *divasam* counts days,
+*dinam* writes formally, *nāḷ* still tells stories and marks birthdays.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "divasam" — "day," the everyday counting word]
+- [YOU SAY: "dinam" — the same Sanskrit word as Kannada's dina, but formal here]
+- [YOU SAY: "nāḷ" — the native word, still alive, from "tomorrow" and "birthday"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What PIE root does **ദിവസം** ultimately share with Hindi/Kannada's
+*dina* and Latin's *diēs*? (***\*dyew-***, "to shine" — though *divasa* and
+*dina* are different Sanskrit formations off it, not the same word.) Where
+did you already meet **നാൾ** before this lesson? (Inside **നാളെ**, *nāḷe*,
+"tomorrow," Chapter 4.) Has Malayalam's native day-word been erased by the
+Sanskrit loan? (**No** — like Kannada's *hagalu*, it's still alive, just
+narrowed to specific uses rather than staying the default counting word:
+*oru nāḷ* in storytelling, and the living compound *piṟannāḷ*, "birthday.")

--- a/code/learning/human-languages/malayalam/lessons/ML-C24-rathri.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C24-rathri.md
@@ -1,0 +1,85 @@
+---
+id: ML-C24-rathri
+chapter: 24
+type: word
+headword: രാത്രി
+gloss: "night" — the same Sanskrit tatsama word already hiding (shortened) inside pāthirā, "midnight"; native competitors exist too, but split into two different words with two different jobs, neither of them a plain synonym
+concept_tag: TIME-NIGHT
+prerequisites: [ML-C17-ucha-paathira, ML-C23-divasam]
+sounds: [malayalam-virama-ta, malayalam-vowel-sign-i]
+roots: [sanskrit-ratri, proto-dravidian-cira-darkness, proto-dravidian-cirvl]
+etymology_hook: "രാത്രി (rāthri, 'night') is a Sanskrit tatsama, likely the same word already hiding, shortened to just 'rā,' inside പാതിരാ (pāthirā, 'midnight,' Chapter 17); like Hindi's രാത്/raat, this രാത്രി traces to PIE *h₁reh₁- ('to rest'), a COMPLETELY DIFFERENT root from Latin nox's *nókʷts — a genuine false cognate, not a shared-family word; Malayalam also keeps two native words, but they split the job rather than competing head-on: ഇരവ് (iravŭ, cognate Tamil இரவு/iravu, traced by one source to Proto-Dravidian *cira, 'darkness') survives mainly as a literary/classical synonym for 'night' itself, while ഇരുൾ (iruḷ, Proto-Dravidian *cirVḷ, cognate Kannada's ಇರುಳು/Tamil's இருள்/Telugu's ఇరులు, already cited in the Kannada sibling of this arc) is still current in modern Malayalam (a 2021 film is literally titled Irul) but means specifically 'darkness,' not 'night' as a time period"
+est_minutes: 6
+reviews_of: [ML-C17-ucha-paathira, ML-C23-divasam]
+---
+
+# രാത്രി (rāthri) — "night," already hiding inside "midnight"
+
+## Warm-up
+
+[PAUSE 2s] Last lesson's *divasam* had three words doing three honest jobs.
+This word's family is smaller, but the split is just as real — and one
+piece of it, you've technically already heard.
+
+## രാത്രി — hiding, shortened, inside a word you already know
+
+**രാത്രി** (**rāthri**) — "**night**" — is a Sanskrit **tatsama**. You've
+likely already met a piece of it: **പാതിരാ** (*pāthirā*, "midnight,"
+Chapter 17) is built from **പാതി** (*pāthi*, "half") fused with what's most
+plausibly a **shortened form** of this very word — "**rā**" standing in for
+the whole of *rāthri* (Chapter 17 itself didn't spell out which word was
+being shortened, but the parallel Tamil compound, *pāti-y-irāttiri*, points
+the same way). This lesson gives it its own, full standing.
+
+## The same PIE surprise as Hindi's raat — not Latin's nox
+
+Here's the honest echo from earlier in this arc: just like Hindi's own
+**रात** (*raat*, ultimately from the same Sanskrit **रात्रि**), Malayalam's
+*rāthri* traces to **Proto-Indo-European** ***\*h₁reh₁-*** ("**to rest**")
+— a **completely different** PIE root from Latin's *nox* (***\*nókʷts***).
+Two Indo-European languages, two words for "night," that **look** like they
+might be old cousins — but genuinely **aren't**. Same false-cognate story,
+now confirmed across a second Indo-Aryan-rooted borrowing.
+
+## Two native words, two different jobs — not one clean synonym
+
+Malayalam keeps native Dravidian words here too, but be honest: they
+**split the work**, rather than one cleanly standing in for *rāthri*.
+
+- **ഇരവ്** (**iravŭ**) — cognate with Tamil's **இரவு** (*iravu*), traced by
+  at least one source to **Proto-Dravidian** ***\*cira*** ("darkness") —
+  survives today mainly as a **literary, classical-register** synonym for
+  "night" itself. You'd meet it in poetry before you'd hear it in
+  conversation.
+- **ഇരുൾ** (**iruḷ**) — Proto-Dravidian ***\*cirVḷ***, the very same
+  pan-Dravidian cognate already named in this arc's Kannada lesson
+  (matching Kannada's **ಇರುಳು**, Tamil's **இருள்**, Telugu's **ఇరులు**) —
+  is still genuinely **current** in modern Malayalam (a 2021 film is
+  titled, simply, *Irul*). But its everyday sense is specifically
+  "**darkness**," not "night" as a stretch of time — a close cousin of the
+  idea, not a plain interchangeable word for it.
+
+So it's not "one native night-word, simply pushed into archaism" the way
+Kannada's *iruḷu* was. It's **two different native words**, each carrying
+only part of *rāthri*'s job — one gone formal/poetic, one still common but
+narrower in meaning.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rāthri" — "night," already hiding, shortened, inside pāthirā]
+- [YOU SAY: the honest PIE echo — *h₁reh₁-, "to rest," like Hindi's raat,
+  NOT related to Latin's nox]
+- [YOU SAY: "iravŭ" (literary "night") vs. "iruḷ" (everyday "darkness") —
+  two native words, two different jobs]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where did you already, technically, meet a piece of **രാത്രി**
+before this lesson? (Shortened to "**rā**" inside **പാതിരാ**, *pāthirā*,
+"midnight," Chapter 17.) Does *rāthri*'s PIE root match Latin *nox*'s?
+(**No** — ***\*h₁reh₁-*** "to rest," a completely different root, the same
+false-cognate pattern already seen with Hindi's *raat*.) Do Malayalam's two
+native words, *iravŭ* and *iruḷ*, mean the same thing? (**No** — *iravŭ* is
+a literary synonym for "night" itself; *iruḷ* is still common but means
+specifically "darkness.")

--- a/code/learning/human-languages/malayalam/lessons/ML-C25-shubha-rathri.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C25-shubha-rathri.md
@@ -1,0 +1,69 @@
+---
+id: ML-C25-shubha-rathri
+chapter: 25
+type: phrase
+headword: ശുഭ രാത്രി
+gloss: "good night" — the standard Sanskrit-tatsama phrase (rāthri already met, śubha new); some sources describe modern Malayalam speakers often code-switching to English "good night" instead — the same claim already made, similarly thinly sourced, for Telugu earlier in this arc
+concept_tag: GREETING-GOODNIGHT
+prerequisites: [ML-C24-rathri]
+sounds: [malayalam-sha, malayalam-bha]
+roots: [sanskrit-shubha-beautiful, sanskrit-ratri]
+etymology_hook: "ശുഭ രാത്രി (śubha rāthri), 'good night,' literally 'auspicious night' — both pieces Sanskrit tatsama: രാത്രി (already met last lesson) plus ശുഭ (śubha, 'auspicious,' from root śubh, 'to be beautiful,' well-sourced PIE *ḱewbʰ- — the same etymology already verified for the Hindi, Kannada, and Telugu siblings of this arc); some sources describe modern Malayalam speakers, especially casually, code-switching to English 'good night' rather than saying śubha rāthri aloud — but hedge this carefully: the SAME claim was already made, and only weakly sourced, for Telugu earlier in this arc, so this looks like a recurring pattern across South Asian languages generally (or a sourcing artifact of which languages happen to get commented on), not a Malayalam-specific discovery"
+est_minutes: 5
+reviews_of: [ML-C24-rathri]
+---
+
+# ശുഭ രാത്രി (śubha rāthri) — "good night," and a pattern seen before
+
+## Warm-up
+
+[PAUSE 2s] You already have *rāthri*. One more Sanskrit word, already
+familiar from three earlier languages in this arc, completes Malayalam's
+"good night" — and this lesson's honest twist is one you've technically
+seen before, just in a different language.
+
+## ശുഭ രാത്രി — "auspicious night"
+
+**ശുഭ രാത്രി** (**śubha rāthri**) — "**good night**" — literally
+"**auspicious night**." Both pieces are Sanskrit **tatsama**: **രാത്രി**
+(*rāthri*, "night," already met last lesson) plus **ശുഭ** (*śubha*,
+"**auspicious**," from root **śubh**, "to be beautiful," ultimately PIE
+***\*ḱewbʰ-*** — the same word, the same root, already verified for the
+Hindi, Kannada, and Telugu siblings of this exact arc).
+
+## Be careful: a claim you've already seen fail to hold up once
+
+Here's the honest twist, hedged deliberately: some sources describe
+modern Malayalam speakers, especially in casual settings, **code-switching
+to English** "**good night**" rather than saying **ശുഭ രാത്രി** aloud —
+treating it more as the standard, correct-but-formal translation than an
+everyday spoken phrase. But this lesson isn't presenting that as a fresh
+Malayalam discovery. The **exact same claim**, sourced from similarly thin
+blogs and forum posts, was already made for **Telugu** earlier in this
+arc — and there, it was left genuinely **unclear** whether the pattern
+was Telugu-specific or something broader. Seeing the same claim turn up again
+for Malayalam **strengthens the suspicion that this is a broader South
+Asian pattern** (or simply a sourcing artifact — the languages that happen
+to get commented on in casual sources), not a language-specific trait
+worth treating as a genuine discovery each time. Either way, *śubha
+rāthri* itself remains perfectly correct, understood Malayalam.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubha rāthri" — "good night," literally "auspicious night"]
+- [YOU SAY: śubha's own root — śubh, "to be beautiful" → "auspicious" —
+  the same root already met for Hindi, Kannada, and Telugu]
+- [YOU SAY: the honest twist — this code-switching claim isn't uniquely
+  Malayalam's; the same weakly-sourced claim already appeared for Telugu]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ശുഭ രാത്രി** literally mean? ("**Auspicious
+night**.") Is the "Malayalam speakers code-switch to English instead"
+claim a fresh discovery in this lesson? (**No** — the identical claim,
+similarly thinly sourced, already appeared for **Telugu** earlier in this
+arc, suggesting a broader pattern or a sourcing artifact, not a
+Malayalam-specific fact.) Does this affect whether *śubha rāthri* itself is
+correct? (**No** — it's perfectly correct and understood Malayalam,
+whatever its actual spoken frequency.)

--- a/code/learning/human-languages/tamil/lessons/TA-C23-naal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C23-naal.md
@@ -1,0 +1,78 @@
+---
+id: TA-C23-naal
+chapter: 23
+type: word
+headword: நாள்
+gloss: "day" — Tamil's everyday, native Dravidian word, already met inside "tomorrow"; unlike Kannada's dina, Telugu's rōju, and Malayalam's divasam, Tamil's plain day-word is NOT a loanword at all — நாள் just is the everyday word, no Sanskrit or Persian substitute doing that job
+concept_tag: TIME-DAY
+prerequisites: [TA-C04-naalai, TA-C17-nanpakal-nalliravu]
+sounds: [tamil-retroflex-lla, tamil-vowel-sign-aa]
+roots: [proto-dravidian-naal-day, sanskrit-dina]
+etymology_hook: "நாள் (nāḷ, 'day') is native Dravidian, from Proto-Dravidian *nāḷ, already met inside நாளை (nāḷai, 'tomorrow,' Chapter 4) — and it is genuinely Tamil's plain, everyday, unmarked word for counting a day (as in மூன்று நாள், mūnṟu nāḷ, 'three days'); this makes Tamil the odd one out among this arc's Dravidian languages so far — Kannada's ದಿನ/dina and Malayalam's ദിവസം/divasam are both Sanskrit tatsama words doing the everyday job, and Telugu's రోజు/rōju is a Persian loanword doing it — Tamil is the only one where a NATIVE word holds that plain, everyday spot, uncontested; Tamil ALSO has தினம் (tiṉam), the exact same Sanskrit tatsama as Kannada's dina/Malayalam's dinam (← Sanskrit दिन/dina ← PIE *dyew-, 'to shine'), but here it functions mainly in formal/adverbial and compound use — சுதந்திர தினம் (sutantira tiṉam, 'Independence Day') and தினசரி (tiṉacari, 'daily') — not as the plain everyday noun"
+est_minutes: 6
+reviews_of: [TA-C04-naalai, TA-C17-nanpakal-nalliravu]
+---
+
+# நாள் (nāḷ) — "day," the one this arc's Dravidian languages didn't lose
+
+## Warm-up
+
+[PAUSE 2s] You've now seen three Dravidian languages reach for a
+loanword — Sanskrit, twice, and Persian once — to name their everyday
+word for "day." Tamil doesn't. This lesson is about the one that didn't.
+
+## நாள் — genuinely native, genuinely everyday
+
+**நாள்** (**nāḷ**) — "**day**" — is native **Dravidian**, from
+**Proto-Dravidian** ***\*nāḷ***. You've already met it, hiding inside
+**நாளை** (*nāḷai*, "tomorrow," Chapter 4). But here's the honest headline
+of this lesson: நாள் isn't a survivor clinging to one narrow sense the way
+some native words elsewhere in this arc have been — it is simply Tamil's
+**plain, everyday, unmarked** word for counting a day, as ordinary as
+**மூன்று நாள்** (*mūnṟu nāḷ*, "**three days**").
+
+## The odd one out — every other Dravidian day-word in this arc is borrowed
+
+Look back at what this arc already found, language by language, all
+comparing the **same** everyday-day-word job:
+
+- **Kannada**: **ದಿನ** (*dina*) — a Sanskrit **tatsama**, doing the plain,
+  everyday job.
+- **Telugu**: **రోజు** (*rōju*) — a **Persian** loanword, doing the plain,
+  everyday job.
+- **Malayalam**: **ദിവസം** (*divasam*) — a Sanskrit **tatsama**, doing the
+  plain, everyday job.
+- **Tamil**: **நாள்** (*nāḷ*) — **native Dravidian**, doing the plain,
+  everyday job.
+
+Tamil is the only one of the four where a genuinely native word still
+holds that everyday spot, uncontested by a loan.
+
+## தினம் — the same Sanskrit word as Kannada's dina, here pushed to the formal side
+
+Tamil does have **தினம்** (**tiṉam**) — the **exact same** Sanskrit
+tatsama as Kannada's *dina* and Malayalam's *dinam* (← Sanskrit **दिन**,
+*dina* ← PIE ***\*dyew-***, "to shine," the root behind Latin's *diēs*
+too). But in Tamil it leans **formal and compound-forming**, rather than
+doing the plain counting work: **சுதந்திர தினம்** (*sutantira tiṉam*,
+"**Independence Day**") and **தினசரி** (*tiṉacari*, "**daily**") are where
+you meet it, not in casual "how many days" counting — that's நாள்'s job.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāḷ" — "day," native Dravidian, already met inside "tomorrow"]
+- [YOU SAY: the contrast — Kannada's dina, Malayalam's divasam (Sanskrit),
+  Telugu's rōju (Persian), all loans; Tamil's nāḷ, native]
+- [YOU SAY: "tiṉam" — the same Sanskrit word as Kannada's dina, here
+  formal/compound use like "Independence Day"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where did you already meet **நாள்** before this lesson? (Inside
+**நாளை**, *nāḷai*, "tomorrow," Chapter 4.) Is Tamil's everyday day-word a
+loanword, the way Kannada's, Telugu's, and Malayalam's are? (**No** —
+**நாள்** is native Dravidian; Tamil is the only one of the four where the
+plain everyday word isn't borrowed.) What job does **தினம்** do instead of
+competing with நாள் for everyday use? (**Formal/compound** use — "
+**சுதந்திர தினம்**," Independence Day, and "**தினசரி**," daily.)

--- a/code/learning/human-languages/tamil/lessons/TA-C24-iravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C24-iravu.md
@@ -1,0 +1,90 @@
+---
+id: TA-C24-iravu
+chapter: 24
+type: word
+headword: இரவு
+gloss: "night" — native Dravidian, already used standalone inside "midnight" (naḷḷiravu); a Sanskrit loan alternative, rāttiri, also exists — and per at least one dictionary source, rāttiri may actually be the MORE common word in everyday spoken Tamil, the opposite direction from நாள்'s story last lesson
+concept_tag: TIME-NIGHT
+prerequisites: [TA-C17-nanpakal-nalliravu, TA-C23-naal]
+sounds: [tamil-vowel-sign-u, tamil-retroflex-lla]
+roots: [proto-dravidian-cira-darkness, sanskrit-ratri, proto-dravidian-cirvl]
+etymology_hook: "இரவு (iravu, 'night') is native Dravidian, from Proto-Dravidian *cira ('darkness') — already used standalone inside நள்ளிரவு (naḷḷiravu, 'midnight,' Chapter 17: 'இரவு, a word every Tamil speaker still uses on its own'); Tamil also has ராத்திரி (rāttiri), a Sanskrit tatsama from रात्रि (rātri) ← PIE *h₁reh₁- ('to rest') — the SAME PIE root already confirmed, specifically, for Hindi's raat and Malayalam's rāthri in this arc (Kannada's and Telugu's rātri lessons note the Sanskrit tatsama status but don't independently make this same PIE-root/nox comparison), a completely different root from Latin nox's *nókʷts; be honest about register here, and flag it clearly for a native speaker's own read: at least one Tamil dictionary source states plainly that 'colloquially, ராத்திரி is more common,' implying இரவு leans more literary/formal — if accurate, this runs the OPPOSITE direction from நாள்'s story last lesson, where the native word was the uncontested everyday choice and no loanword competed; this claim rests on limited dictionary-level sourcing, not deep confirmation, and register judgments about Sanskrit-loan versus native-Tamil vocabulary are exactly the kind of thing a native speaker's own ear should settle, not a scraped source"
+est_minutes: 6
+reviews_of: [TA-C17-nanpakal-nalliravu, TA-C23-naal]
+---
+
+# இரவு (iravu) — "night," and a register question worth a native speaker's ear
+
+## Warm-up
+
+[PAUSE 2s] Last lesson, Tamil's native day-word had no real competition.
+This lesson's honest twist, hedged carefully, is that "night" may not tell
+the same story — and this is exactly the kind of claim worth checking
+against your own ear, not just a dictionary's.
+
+## இரவு — already standing on its own, inside "midnight"
+
+**இரவு** (**iravu**) — "**night**" — is native **Dravidian**, from
+**Proto-Dravidian** ***\*cira*** ("darkness"). You've technically already
+met it standing fully on its own: Chapter 17, while explaining
+**நள்ளிரவு** (*naḷḷiravu*, "midnight," நள் + இரவு), noted directly that
+இரவு itself is a word every Tamil speaker still uses on its own. This
+lesson gives it its own full chapter.
+
+## ராத்திரி — the same PIE root, and the same false-cognate story already drawn twice
+
+Tamil also keeps **ராத்திரி** (**rāttiri**), a Sanskrit **tatsama** from
+**रात्रि** (*rātri*) — the same word already met, as a tatsama, in
+Kannada's *ratri* and Telugu's *ratri* (though those two lessons didn't
+draw out its PIE ancestry). It traces to **Proto-Indo-European**
+***\*h₁reh₁-*** ("**to rest**"), a **completely different** root from
+Latin *nox*'s ***\*nókʷts*** — the same specific comparison already drawn
+for Hindi's *raat* and Malayalam's *rāthri* earlier in this arc, now a
+third confirmation, same false-cognate pattern, same honest
+non-relationship to *nox*.
+
+## Be honest, and hedge carefully: a register claim worth your own ear
+
+Here's the twist, offered deliberately as a **flag for your own
+judgment**, not a settled fact: at least one Tamil dictionary source
+states plainly that "**colloquially, ராத்திரி is more common**" — meaning
+**இரவு** may lean more toward the **literary, written** register, while
+the **Sanskrit loanword** does more of the everyday spoken work. If
+that's accurate, it's the **opposite direction** from நாள்'s story last
+lesson, where the native word was the plain, uncontested everyday choice
+and no loanword competed for the job at all. But this rests on limited,
+dictionary-level sourcing — and register judgments about native-Tamil
+versus Sanskrit-loan vocabulary are exactly the kind of thing where a
+native speaker's own sense of actual usage matters more than a single
+scraped source. Treat this one as worth double-checking against your own
+ear, not something to take as given.
+
+## Not to be confused: இருள் means "darkness," not "night" itself
+
+One more honest note, matching what's already been established for the
+sibling Dravidian languages in this arc: **இருள்** (**iruḷ**) — from
+Proto-Dravidian ***\*cirVḷ***, cognate with Kannada's **ಇರುಳು**, Telugu's
+**ఇరులు**, and Malayalam's **ഇരുൾ** — is a **different** word, from a
+**different** Proto-Dravidian root than இரவு's *cira. It means
+specifically "**darkness**," not "night" as a stretch of time — don't let
+the similar sound and shared root-family lead you to treat them as
+interchangeable.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "iravu" — "night," native, already met inside naḷḷiravu]
+- [YOU SAY: "rāttiri" — Sanskrit loan, same PIE *h₁reh₁- already drawn for
+  Hindi and Malayalam, NOT related to Latin nox]
+- [YOU SAY: the honest, hedged twist — one source says rāttiri is more
+  common in colloquial speech than iravu; worth checking against your own ear]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where did you already meet **இரவு** before this lesson? (Inside
+**நள்ளிரவு**, *naḷḷiravu*, "midnight," Chapter 17.) Does **ராத்திரி**'s PIE
+root match Latin *nox*'s? (**No** — ***\*h₁reh₁-*** "to rest," the same
+false-cognate pattern already drawn for Hindi and Malayalam earlier in
+this arc.) Is
+**இருள்** the same word as இரவு? (**No** — a different Proto-Dravidian
+root, meaning specifically "darkness," not "night" as a time period.)

--- a/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
@@ -1,0 +1,79 @@
+---
+id: TA-C25-iniya-iravu
+chapter: 25
+type: phrase
+headword: இனிய இரவு
+gloss: "good night" — fully native Dravidian, "sweet/pleasant night," unlike Hindi, Kannada, Telugu, and Malayalam's shared Sanskrit-descended śubha rātri phrase; Tamil breaks the pattern this arc found in every other language
+concept_tag: GREETING-GOODNIGHT
+prerequisites: [TA-C24-iravu]
+sounds: [tamil-nnna, tamil-vowel-sign-i]
+roots: [proto-dravidian-in-sweet, tamil-nal-good, vaṇaṅku]
+etymology_hook: "இனிய இரவு (iṉiya iravu), 'good night,' literally 'sweet/pleasant night' — இனிய (iṉiya, 'sweet, pleasant, dear') is native Dravidian, from Proto-Dravidian *in- ('sweet'), the same root behind இனிப்பு (iṉippu, 'sweet, dessert'); paired with இரவு (iravu, 'night,' already met last lesson). Unlike Hindi's, Kannada's, Telugu's, and Malayalam's shared śubh(a) rātri/rāthri phrase — all four built on the same Sanskrit tatsama pair (śubh 'to be beautiful' + rātri 'night') — Tamil's standard 'good night' phrase reaches for NO Sanskrit at all; the phrasebook sources checked did not surface a Tamil śubha-rāttiri equivalent as a commonly used form. Tamil also keeps நல்ல இரவு (nalla iravu, 'good night,' literally using நல்ல/nalla, 'good,' the same nal- root already met in நலம்/nalam and நன்றி/naṉṟi), and — for close friends and family — இரவு வணக்கம் (iravu vaṇakkam, 'night greetings'), built ENTIRELY from two words already taught in this course: இரவு ('night,' last lesson) and வணக்கம் ('greetings,' Chapter 1's very first word, from வணங்கு/vaṇaṅku, 'to bow')"
+est_minutes: 6
+reviews_of: [TA-C24-iravu]
+---
+
+# இனிய இரவு (iṉiya iravu) — "good night," and Tamil breaking the pattern one more time
+
+## Warm-up
+
+[PAUSE 2s] Four languages in this arc all reached for the same Sanskrit
+phrase to say "good night." This lesson closes the arc with the one that
+didn't — and it's a pattern you've actually seen from Tamil before, all
+the way back in Chapter 1.
+
+## இனிய இரவு — "sweet night," fully native
+
+**இனிய இரவு** (**iṉiya iravu**) — "**good night**" — literally "**sweet,
+pleasant night**." **இனிய** (*iṉiya*, "sweet, pleasant, dear") is native
+**Dravidian**, from **Proto-Dravidian** ***\*in-*** ("sweet") — the same
+root behind **இனிப்பு** (*iṉippu*, "sweet, dessert"). Paired with
+**இரவு** (*iravu*, "night," already met last lesson), the whole phrase is
+built from Tamil's own word-stock, start to finish.
+
+## The pattern this breaks
+
+Every other language in this arc's GREETING-GOODNIGHT lesson reached for
+the **same** Sanskrit phrase: Hindi's **शुभ रात्रि**, Kannada's **ಶುಭ
+ರಾತ್ರಿ**, Telugu's **శుభ రాత్రి**, Malayalam's **ശുഭ രാത്രി** — all four
+built from the identical tatsama pair, **śubh** ("to be beautiful") +
+**rātri** ("night"). Tamil's standard phrase reaches for **none** of
+that — no śubha-descended "good night" turned up as a commonly used
+Tamil form in the phrasebook sources checked for this lesson. Instead,
+Tamil built its own phrase from its own vocabulary.
+
+## Echo of Chapter 1: the same loyalty, twice
+
+This is the **same story** already told in this course's very first
+lesson. **வணக்கம்** (*vaṇakkam*, "hello," Chapter 1) is native Dravidian,
+from **வணங்கு** (*vaṇaṅku*, "to bow") — while Kannada, Telugu, Malayalam,
+and Hindi all borrowed Sanskrit's *namas-* for their own "hello." Tamil
+now does it again at the **other end of the day**: a native "good night"
+where its neighbors share one Sanskrit phrase.
+
+Tamil also keeps **நல்ல இரவு** (*nalla iravu*, "good night," using
+**நல்ல**, *nalla*, "good" — the same **நல்-** root already met in
+**நலம்** and **நன்றி**), and, for close friends and family, **இரவு
+வணக்கம்** (*iravu vaṇakkam*, "night greetings") — a phrase built entirely
+from two words you already have: **இரவு** from last lesson, and
+**வணக்கம்** from Chapter 1.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "iṉiya iravu" — "good night," literally "sweet night," fully native]
+- [YOU SAY: the pattern it breaks — every other language this arc shares
+  one Sanskrit śubh(a) rātri phrase; Tamil doesn't]
+- [YOU SAY: "iravu vaṇakkam" — "night greetings," built from two words
+  you already knew]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **இனிய இரவு** literally mean, and what root does
+**இனிய** come from? ("**Sweet/pleasant night**" — Proto-Dravidian ***in-***,
+"sweet.") Does Tamil's "good night" share the same Sanskrit śubha rātri
+phrase as Hindi, Kannada, Telugu, and Malayalam? (**No** — no such form
+turned up in the sources checked for this lesson; Tamil's standard phrase
+is fully native, breaking the pattern shared by all four other languages.)
+What two already-known words combine to make **இரவு வணக்கம்**? (**இரவு**,
+"night," from last lesson; **வணக்கம்**, "greetings," from Chapter 1.)

--- a/code/learning/human-languages/telugu/lessons/TE-C23-roju.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C23-roju.md
@@ -1,0 +1,61 @@
+---
+id: TE-C23-roju
+chapter: 23
+type: word
+headword: రోజు
+gloss: "day" — a genuine surprise: Telugu's everyday word isn't Sanskrit or native Dravidian at all, it's a Persian loanword; దినము, the Sanskrit tatsama form, is the more formal alternate here — the mirror image of Kannada's pattern
+concept_tag: TIME-DAY
+prerequisites: [TE-C17-madhyaahnam-ardharaatri]
+sounds: [telugu-vowel-sign-oo, telugu-ja]
+roots: [persian-roz-day, sanskrit-dinamu]
+etymology_hook: "రోజు (rōju, 'day') is genuinely borrowed from Classical Persian روز (rōz), itself from PIE *lewk- ('bright') — a completely different route and root from Latin diēs/Hindi din/Kannada dina's *dyew- family, though both ultimately trace to 'shining, bright' senses independently; దినము (dinamu) is the Sanskrit tatsama word (same root as Kannada's dina), but here it's the more FORMAL alternate — Telugu's everyday/formal split runs the OPPOSITE way from Kannada's"
+est_minutes: 6
+reviews_of: [TE-C17-madhyaahnam-ardharaatri]
+---
+
+# రోజు (rōju) — "day," a genuine Persian surprise
+
+## Warm-up
+
+[PAUSE 2s] You might expect Telugu's word for "day" to be Sanskrit, like
+Kannada's *dina*, or native Dravidian. It's neither — it's Persian.
+
+## రోజు — a genuine Persian loanword
+
+**రోజు** (**rōju**) — "**day**" — is Telugu's everyday, ordinary word for
+"a day." Here's the real surprise: it's **borrowed from Classical
+Persian** **روز** (*rōz*) — the same root, ultimately, as the Persian day
+names hiding in words like "Nowruz" ("new day"). Persian *rōz* itself
+traces to a Proto-Indo-European root, ***\*lewk-*** ("**bright**") — a
+**completely different** PIE root from the ***\*dyew-*** family behind
+Latin's *diēs*, Hindi's *din*, and Kannada's *dina*. Both roots
+independently mean something like "shining, bright" — but they are **not**
+cousins; this is convergent meaning, not shared ancestry.
+
+## దినము — Sanskrit tatsama, but the FORMAL alternate here
+
+Telugu also has **దినము** (**dinamu**) — the same Sanskrit **tatsama**
+word as Kannada's *dina*. But here's the honest twist: unlike Kannada,
+where *dina* is the plain, everyday word, Telugu's **దినము** is the more
+**formal, literary** alternate — *rōju* does the everyday work instead.
+Telugu's formal/everyday split runs the **opposite direction** from
+Kannada's.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rōju" — "day," a genuine Persian loanword]
+- [YOU SAY: the honest surprise — from Persian rōz, PIE *lewk-, NOT the
+  same root as diēs/din/dina]
+- [YOU SAY: the reversed pattern — dinamu is Telugu's FORMAL word, unlike
+  Kannada's plain dina]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What language does Telugu's everyday **రోజు** (*rōju*) come
+from? (**Persian** — *rōz*.) Is Persian *rōz*'s PIE root the same as
+Latin *diēs*/Hindi *din*/Kannada *dina*'s root? (**No** — a completely
+different PIE root, *\*lewk-*, "bright," vs. *\*dyew-* — related in
+meaning, not in ancestry.) Is Telugu's Sanskrit word, *దినము* (*dinamu*),
+the everyday word or the formal one? (**The formal one** — the opposite of
+Kannada, where *dina* is plain and everyday.)

--- a/code/learning/human-languages/telugu/lessons/TE-C24-ratri.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C24-ratri.md
@@ -1,0 +1,67 @@
+---
+id: TE-C24-ratri
+chapter: 24
+type: word
+headword: రాత్రి
+gloss: "night" — the same Sanskrit tatsama word already hiding inside ardharātri; unlike day's Persian surprise, night genuinely follows the Sanskrit-tatsama-as-everyday pattern, matching Kannada
+concept_tag: TIME-NIGHT
+prerequisites: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
+sounds: [telugu-conjunct-tra, telugu-vowel-sign-i]
+roots: [sanskrit-ratri, telugu-native-reyi-maapu]
+etymology_hook: "రాత్రి (rātri, 'night') is a Sanskrit tatsama word, already hiding inside అర్ధరాత్రి (ardharātri, 'midnight'), and — unlike rōju's genuine Persian surprise last lesson — it really is Telugu's everyday word for night; genuine native Telugu words exist too — రేయి (rēyi, most sources treat it as inherited Dravidian, though some grammars link it to rātri itself), మాపు (māpu, whose primary sense is actually 'evening/dusk,' as in రేపుమాపు, 'morning and evening'), and ఇరులు (irulu, cognate with Kannada's ಇರುಳು/iruḷu, primarily 'darkness') — a messier, three-way version of Kannada's cleaner two-word replacement story, not a tidy mirror of it"
+est_minutes: 5
+reviews_of: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
+---
+
+# రాత్రి (rātri) — "night," this time matching the expected pattern
+
+## Warm-up
+
+[PAUSE 2s] Last lesson's *rōju* broke every expectation. This one is more
+straightforward — but still worth checking honestly, not assuming.
+
+## రాత్రి — Telugu's genuine everyday word
+
+**రాత్రి** (**rātri**) — "**night**" — is a Sanskrit **tatsama** word,
+already hiding inside **అర్ధరాత్రి** (*ardharātri*, "midnight," Chapter 17).
+Unlike *rōju*'s Persian surprise, *rātri* really **is** Telugu's ordinary,
+everyday word for "night" — matching Kannada's own pattern this time, not
+breaking it.
+
+## A messier story than Kannada's — three words, not one
+
+Telugu **does** have native words here — but be honest: it's a **messier**
+picture than Kannada's clean two-word story, not a tidy mirror of it.
+
+- **రేయి** (**rēyi**) — attested in older Telugu literature; most sources
+  treat it as inherited Dravidian, though some grammars instead link it to
+  *rātri* itself, so its native status is less than fully settled.
+- **మాపు** (**māpu**) — its **primary** sense is actually "**evening,
+  dusk**" (as in **రేపుమాపు**, "morning and evening"), with "night" only a
+  secondary, extended sense — not a clean synonym for *rātri*.
+- **ఇరులు** (**irulu**) — a genuine cognate of Kannada's **ಇರುಳು** (*iruḷu*),
+  but its primary modern sense is "**darkness**," archaic even in that use.
+
+All three have been effectively pushed aside by the Sanskrit loan — but
+unlike Kannada's single native competitor, Telugu's "native" side is split
+across three words in three different, overlapping senses.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rātri" — "night," already met inside ardharātri]
+- [YOU SAY: rēyi, māpu, irulu — three native words, three overlapping
+  senses, all pushed aside]
+- [YOU SAY: the contrast with last lesson — day broke the pattern, night
+  matches it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where have you already met **రాత్రి** before this lesson?
+(**అర్ధరాత్రి**, *ardharātri*, "midnight.") Does *rātri* follow the same
+"Sanskrit-as-everyday" pattern as Kannada's *rātri*, or does it break the
+pattern the way *rōju* did for "day"? (**It matches** — *rātri* really is
+Telugu's everyday word.) Does Telugu's native-word story cleanly mirror
+Kannada's single-word *iruḷu*? (**No** — it's messier: three words,
+**రేయి**/**మాపు**/**ఇరులు**, in three overlapping senses, not one clean
+replacement.)

--- a/code/learning/human-languages/telugu/lessons/TE-C25-shubha-ratri.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C25-shubha-ratri.md
@@ -1,0 +1,62 @@
+---
+id: TE-C25-shubha-ratri
+chapter: 25
+type: phrase
+headword: శుభ రాత్రి
+gloss: "good night" — the standard Sanskrit-tatsama translation (rātri already met, śubha new); some sources describe everyday speakers often code-switching to English "good night" instead
+concept_tag: GREETING-GOODNIGHT
+prerequisites: [TE-C24-ratri]
+sounds: [telugu-sha, telugu-bha]
+roots: [sanskrit-shubha-beautiful, sanskrit-ratri]
+etymology_hook: "శుభ రాత్రి (śubha rātri), 'good night,' literally 'auspicious night' — both pieces Sanskrit tatsama: రాత్రి (already met last lesson) plus శుభ (śubha, 'auspicious,' from root śubh, 'to be beautiful,' PIE *ḱewbʰ-); some sources describe modern Telugu speakers often code-switching to English 'good night' in casual conversation instead of saying śubha rātri aloud — though this same code-switching pattern for farewells plausibly shows up across other South Asian languages too, so it's honestly unclear whether this is Telugu-specific or just where the available sources happened to comment on it"
+est_minutes: 5
+reviews_of: [TE-C24-ratri]
+---
+
+# శుభ రాత్రి (śubha rātri) — the standard translation, honestly checked against real speech
+
+## Warm-up
+
+[PAUSE 2s] You have both pieces already: *rātri* from last lesson, and one
+more Sanskrit word. But this lesson's honest twist is about who actually
+says the result out loud.
+
+## శుభ రాత్రి — "auspicious night"
+
+**శుభ రాత్రి** (**śubha rātri**) — "**good night**" — literally
+"**auspicious night**." Both pieces are Sanskrit **tatsama**: **రాత్రి**
+(*rātri*, "night," already met) plus **శుభ** (*śubha*, "**auspicious**,"
+from root **śubh**, "to be beautiful," ultimately PIE ***\*ḱewbʰ-***).
+
+## Be honest: a claim worth flagging, not overstating
+
+Here's a genuinely interesting wrinkle, hedged appropriately: some sources
+describe modern Telugu speakers, especially casually, often **code-
+switching to English** "**good night**" rather than saying **శుభ రాత్రి**
+aloud — treating it more as the standard written/dictionary translation
+than an everyday spoken phrase. Be careful with this claim, though: the
+evidence for it comes mainly from informal language-learning blogs and
+forum posts, not rigorous sociolinguistic sources, and the same
+"code-switch to English for casual farewells" pattern plausibly shows up
+across other South Asian languages too — it isn't clearly something
+unique to Telugu, just something the available sources happened to mention
+for Telugu specifically. Either way, *śubha rātri* itself is perfectly
+correct and understood Telugu, whatever its actual spoken frequency turns
+out to be.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubha rātri" — "good night," literally "auspicious night"]
+- [YOU SAY: śubha's own root — śubh, "to be beautiful" → "auspicious"]
+- [YOU SAY: the honest twist — the standard translation, but many speakers
+  code-switch to English instead]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **శుభ రాత్రి** literally mean? ("**Auspicious
+night**.") Is *śubha rātri* actually the phrase most Telugu speakers say
+aloud for "good night"? (**Often not** — many code-switch to English
+"good night" in casual speech; *śubha rātri* is the standard written/
+formal translation.) Does this mean *śubha rātri* is wrong or ungrammatical?
+(**No** — perfectly correct, just less commonly spoken than expected.)


### PR DESCRIPTION
## What
This is a **single accumulator PR**, continuing the standing workflow after the previous accumulator PR ([#9213](https://github.com/adhithyan15/coding-adventures/pull/9213)) was merged. Per the user's standing instruction: keep adding commits to this branch until it's reviewed and merged; never self-merge.

### TIME-DAY / TIME-NIGHT / GREETING-GOODNIGHT — now COMPLETE across all 10 languages

A frontier survey found this 3-tag cluster existed for Spanish, French, and German but was missing from Latin, Arabic, Hindi, and all four Dravidian languages. **This PR closes that gap completely — all 10 languages now have all 3 tags.**

**⚠️ Tamil content (TA-C23, TA-C24, TA-C25) is flagged for the maintainer's own review** — per standing project convention, Tamil is the one language the maintainer personally reviews as a native speaker; everything else in this PR has been reviewed only by an automated linguistics-review subagent, no human check.

#### Latin (LA-C28–C30)
*diēs* ("day," already hiding in *diēs Lūnae*/*medius diēs*; derivative *diurnum* → English *diurnal* and, via a separate Old French line, *journal*/*journey* — NOT via "diary," a sibling derivative *diārium*). *nox* ("night," *\*nókʷts*, one of the most solid PIE reconstructions; *nocturnus* coined on direct analogy to *diurnum*). *bonam noctem* ("good night," genuine classical Accusative-of-Exclamation grammar, honestly flagged as not itself an attested Roman farewell formula).

#### Arabic (AR-C25–C27)
يوم/*yawm* ("day," Proto-Semitic *\*yawm-*, cognate Hebrew *yōm*/Yom Kippur). ليل/*layl* ("night," Proto-Semitic *\*layl-*, cognate Hebrew *layla*/Passover). تصبح على خير/*tuṣbiḥ ʿalā khayr* ("good night" — literally "may you wake into goodness," reusing the root of *ṣabāḥ al-khayr*; Arabic's good-night phrase never mentions "night" at all).

#### Hindi (HI-C25–C27)
दिन/*din* ("day," PIE *\*dyew-*, a different derivational branch than Latin *diēs* — Sanskrit's own द्यु/दिव् are the tighter cousins). रात/*raat* ("night," PIE *\*h₁reh₁-*, a genuine false cognate with Latin *nox*'s *\*nókʷts*). शुभ रात्रि/*shubh raatri* ("good night," tatsama/tadbhava doublet with *raat*; *shubh* ← PIE *\*ḱewbʰ-*).

#### Kannada (KA-C23–C25)
ದಿನ/*dina* ("day," Sanskrit tatsama, plain everyday word; native ಹగలు/*hagalu* survives for "daytime" only). ರಾತ್ರಿ/*ratri* ("night," tatsama; native ಇరుಳు/*iruḷu* pushed to archaism). ಶుభ ರాత్రి/*shubha ratri* ("good night," shared vocabulary with Hindi's phrase, not a direct borrowing).

#### Telugu (TE-C23–C25)
రోజు/*rōju* ("day," genuine **Persian** loanword ← *rōz* ← PIE *\*lewk-*, unrelated to the *\*dyew-* family; దినము/*dinamu*, the Sanskrit tatsama, is here the FORMAL alternate — register reversed from Kannada). రాత్రి/*rātri* ("night," tatsama, matching Kannada's pattern; messier native-word picture: రేయి/మాపు/ఇరులు, three overlapping senses). శుభ రాత్రి/*shubha ratri* ("good night," honest note on possible code-switching to English, hedged as likely a broader pattern rather than Telugu-specific).

#### Malayalam (ML-C23–C25)
ദിവసం/*divasam* ("day," Sanskrit tatsama ← *divasa*, a DIFFERENT Sanskrit formation than *dina* off the same PIE root — "hidden branching" one level deeper; native നాൾ/*nāḷ* still alive, echoing Kannada's *hagalu*). രാత്రി/*rāthri* ("night," tatsama, same PIE *\*h₁reh₁-* as Hindi; two native words split the job — ഇரവ്/*iravŭ* literary, ഇరుൾ/*iruḷ* "darkness" only). ശుభ రాత్రి/*śubha rāthri* ("good night," same hedged code-switching note as Telugu, explicitly NOT presented as a fresh discovery).

#### Tamil (TA-C23–C25) — **flagged for maintainer review**
நాள்/*nāḷ* ("day," native Dravidian — the ONLY one of the 4 Dravidian TIME-DAY words that's NOT a loanword; தினం/*tiṉam*, the same Sanskrit word as Kannada's *dina*, here formal/compound-only). இరవు/*iravu* ("night," native, PD *\*cira*; ராత్రి/*rāttiri* Sanskrit alternative also exists — one dictionary source suggests it may be MORE common colloquially, the opposite direction from *nāḷ*'s story, flagged explicitly for the reviewer's own ear). இனிய இரవు/*iṉiya iravu* ("good night," fully native — unlike all 4 other languages above, no Sanskrit-descended phrase found in use; echoes Tamil's own Chapter-1 finding that it kept a native "hello" while its neighbors borrowed Sanskrit *namas-*).

## Process notes
Every lesson went through: codepoint verification (Python `unicodedata`) before writing any non-Latin-script word, a NUL-byte scan, a mixed-script contamination scanner (a recurring self-caught bug this arc — 9 instances, all fixed via precise codepoint reconstruction, never manual retyping), both test suites (38/38 + 268/268), and a linguistics-review subagent scoped to the exact files plus named sibling lessons, with real REQUIRED fixes applied in the majority of lessons (overclaimed cross-language contrasts, wrong-sibling citations, garbled PIE splices, fabricated cross-lesson callbacks — all caught and corrected before commit).

## Next
This arc is complete. Next up: a fresh frontier survey (concept_tag aggregation across all 10 languages, cross-checked against sibling body text, not just tag strings) to find the next concept gap.

## Note on workflow
Standing accumulator PR, branch `content/latin-time-greetings`. Do not self-merge — only treat this as done once the user merges it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
