### PR TITLE
feat(spice): validate MOS surface potential

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `PHI` values with a
+  stable diagnostic before electrostatic and temperature preprocessing.
 - Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values with a
   stable diagnostic before current evaluation.
 - Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -584,6 +584,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET VT0 must be finite")
         elif canonical == "LAMBDA" and not math.isfinite(value):
             raise ValueError(f"{name}: MOSFET LAMBDA must be finite")
+        elif canonical == "PHI" and (not math.isfinite(value) or value <= 0.0):
+            raise ValueError(f"{name}: MOSFET PHI must be finite and positive")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1078,6 +1078,18 @@ def test_mos_model_card_rejects_non_finite_channel_modulation() -> None:
             normalize_model_card("Minvalid", "nmos", {"LAM": invalid_modulation})
 
 
+def test_mos_model_card_rejects_non_positive_or_non_finite_surface_potential() -> None:
+    for value in (0.1, 0.84, 2.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"PHI": value})
+        assert valid.parameters["PHI"] == pytest.approx(value)
+
+    for invalid_potential in (-math.inf, -0.1, 0.0, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET PHI must be finite and positive"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"PHI": invalid_potential})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `PHI` values with a
+  stable diagnostic before electrostatic and temperature preprocessing.
 - Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values with a
   stable diagnostic before current evaluation.
 - Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4390,6 +4390,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET LAMBDA must be finite".to_string(),
                 });
+            } else if canonical == "PHI" && (!raw_value.is_finite() || *raw_value <= 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET PHI must be finite and positive".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -895,6 +895,22 @@ fn mos_model_card_rejects_non_finite_channel_modulation() {
 }
 
 #[test]
+fn mos_model_card_rejects_non_positive_or_non_finite_surface_potential() {
+    for value in [0.1, 0.84, 2.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("PHI", value)]).unwrap();
+        assert_close(*valid.parameters.get("PHI").unwrap(), value);
+    }
+
+    for invalid_potential in [f64::NEG_INFINITY, -0.1, 0.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("PHI", invalid_potential)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET PHI must be finite and positive"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `PHI` values with a
+  stable diagnostic before electrostatic and temperature preprocessing.
 - Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values with a
   stable diagnostic before current evaluation.
 - Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8446,6 +8446,11 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET VT0 must be finite");
     } else if (canonical === "LAMBDA" && !Number.isFinite(value)) {
       throw invalidElement(name, "MOSFET LAMBDA must be finite");
+    } else if (
+      canonical === "PHI" &&
+      (!Number.isFinite(value) || value <= 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET PHI must be finite and positive");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -768,6 +768,25 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects non-positive or non-finite MOS surface potential", () => {
+    for (const value of [0.1, 0.84, 2.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { PHI: value });
+      expect(valid.parameters.PHI).toBe(value);
+    }
+
+    for (const invalidPotential of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      0.0,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { PHI: invalidPotential }),
+      ).toThrow("MOSFET PHI must be finite and positive");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS channel-modulation validation.
+1. Cross-language Level-1 MOS surface-potential validation.
    - Status: current PR completion candidate.
-   - Reject non-finite model-card `LAMBDA` / `LAM` values before current
-     evaluation.
-   - Preserve arbitrary finite channel-length modulation coefficients across
-     Rust, Python, and TypeScript.
+   - Reject non-positive or non-finite model-card `PHI` values before
+     electrostatic and temperature preprocessing.
+   - Preserve positive explicit surface potentials across Rust, Python, and
+     TypeScript.
 
 ## Completed Slices
 
@@ -3685,6 +3685,13 @@ the Rust, Python, and TypeScript surfaces together.
      threshold preprocessing and explicit-value precedence.
    - Arbitrary finite NMOS and PMOS threshold voltages remain aligned across
      Rust, Python, and TypeScript.
+
+301. Cross-language Level-1 MOS channel-modulation validation.
+   - Status: completed in PR 9215.
+   - Non-finite model-card `LAMBDA` / `LAM` values are rejected before current
+     evaluation.
+   - Arbitrary finite channel-length modulation coefficients remain aligned
+     across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite Level-1 MOS `PHI` values before electrostatic and temperature preprocessing
- keep Rust, Python, and TypeScript validation behavior and diagnostics aligned
- reconcile the SPICE completion plan by recording PR #9215 and selecting this slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check` for spice-engine source and tests
- Python full spice-engine pytest: 683 passed, 88.95% coverage
- TypeScript `npm test`: 426 passed
- TypeScript `npm run build`