### PR TITLE
feat(smart-home): add durable automation runtime

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -894,6 +894,7 @@ members = [
     "smart-home-hue-pairing-service",
     "smart-home-local-http",
     "smart-home-platform-http",
+    "smart-home-automation-runtime",
     "smart-home-integration-catalog",
     "smart-home-testkit",
     "hue-core",

--- a/code/packages/rust/smart-home-automation-runtime/BUILD
+++ b/code/packages/rust/smart-home-automation-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-automation-runtime -- --nocapture

--- a/code/packages/rust/smart-home-automation-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-automation-runtime/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add typed schedule and event triggers, state conditions, command and scene
+  actions, deterministic dry-run planning, stable idempotency, execution
+  through the authorized smart-home command tool, and durable audit snapshots.

--- a/code/packages/rust/smart-home-automation-runtime/Cargo.toml
+++ b/code/packages/rust/smart-home-automation-runtime/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "smart-home-automation-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Deterministic automation planning and execution for the smart-home runtime"
+license = "MIT"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smart-home-core = { path = "../smart-home-core" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }

--- a/code/packages/rust/smart-home-automation-runtime/README.md
+++ b/code/packages/rust/smart-home-automation-runtime/README.md
@@ -1,0 +1,18 @@
+# smart-home-automation-runtime
+
+Deterministic schedule and event automation execution over
+`smart-home-runtime`.
+
+The engine owns typed definitions, conditions, scene expansion, stable
+idempotency keys, dry-run plans, and a durable audit journal. It delegates
+every device mutation to the existing runtime command tool so capability
+authorization and command audit remain on the canonical D23 path.
+
+Definitions and the engine snapshot serialize into the existing
+`smart-home-runtime-store` envelope. That lets the production local controller
+restore definitions, consumed trigger occurrences, and audit records together
+with normalized home state.
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/smart-home-automation-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-automation-runtime/src/lib.rs
@@ -1,0 +1,900 @@
+//! Deterministic automation planning and execution for the smart-home runtime.
+
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+use smart_home_core::{
+    AgentId, CommandResult, CommandType, DeviceEvent, DeviceEventType, EntityId, SceneId, Value,
+};
+use smart_home_runtime::{RuntimeCommandToolRequest, SmartHomeRuntime};
+use smart_home_runtime_store::DurableAutomationDefinition;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+const MAX_AUDIT_RECORDS: usize = 1_000;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationDefinition {
+    pub automation_id: String,
+    pub enabled: bool,
+    pub trigger: AutomationTrigger,
+    #[serde(default)]
+    pub conditions: Vec<AutomationCondition>,
+    pub actions: Vec<AutomationAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AutomationTrigger {
+    Schedule {
+        every_ms: u64,
+        #[serde(default)]
+        offset_ms: u64,
+    },
+    Event {
+        event_type: AutomationEventType,
+        #[serde(default)]
+        entity_id: Option<EntityId>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomationEventType {
+    Discovered,
+    Updated,
+    Removed,
+    Unavailable,
+    Error,
+    Health,
+}
+
+impl AutomationEventType {
+    fn matches(self, event_type: DeviceEventType) -> bool {
+        matches!(
+            (self, event_type),
+            (Self::Discovered, DeviceEventType::Discovered)
+                | (Self::Updated, DeviceEventType::Updated)
+                | (Self::Removed, DeviceEventType::Removed)
+                | (Self::Unavailable, DeviceEventType::Unavailable)
+                | (Self::Error, DeviceEventType::Error)
+                | (Self::Health, DeviceEventType::Health)
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AutomationCondition {
+    StateEquals {
+        entity_id: EntityId,
+        expected: Value,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AutomationAction {
+    Command {
+        entity_id: EntityId,
+        command_type: CommandType,
+        arguments: Value,
+        #[serde(default)]
+        timeout_ms: Option<u64>,
+    },
+    Scene {
+        scene_id: SceneId,
+        #[serde(default)]
+        timeout_ms: Option<u64>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AutomationTriggerInput {
+    Schedule,
+    Event(Box<DeviceEvent>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlannedAutomationCommand {
+    pub entity_id: EntityId,
+    pub command_type: CommandType,
+    pub arguments: Value,
+    pub idempotency_key: String,
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomationAuditOutcome {
+    Planned,
+    Executed,
+    ConditionNotMet,
+    AlreadyExecuted,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationAuditRecord {
+    pub audit_id: String,
+    pub automation_id: String,
+    pub trigger_key: String,
+    pub evaluated_at_ms: u64,
+    pub dry_run: bool,
+    pub outcome: AutomationAuditOutcome,
+    pub condition_results: Vec<bool>,
+    pub planned_commands: Vec<PlannedAutomationCommand>,
+    pub command_results: Vec<CommandResult>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationEvaluationReport {
+    pub evaluated_at_ms: u64,
+    pub dry_run: bool,
+    pub records: Vec<AutomationAuditRecord>,
+}
+
+impl AutomationEvaluationReport {
+    pub fn matched_automation_count(&self) -> usize {
+        self.records.len()
+    }
+
+    pub fn executed_automation_count(&self) -> usize {
+        self.records
+            .iter()
+            .filter(|record| record.outcome == AutomationAuditOutcome::Executed)
+            .count()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationRuntimeSnapshot {
+    pub schema_version: u32,
+    pub definitions: Vec<AutomationDefinition>,
+    pub completed_trigger_keys: Vec<String>,
+    pub audit_records: Vec<AutomationAuditRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SmartHomeAutomationRuntime {
+    definitions: BTreeMap<String, AutomationDefinition>,
+    completed_trigger_keys: BTreeSet<String>,
+    audit_records: Vec<AutomationAuditRecord>,
+}
+
+impl Default for SmartHomeAutomationRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SmartHomeAutomationRuntime {
+    pub fn new() -> Self {
+        Self {
+            definitions: BTreeMap::new(),
+            completed_trigger_keys: BTreeSet::new(),
+            audit_records: Vec::new(),
+        }
+    }
+
+    pub fn restore(
+        durable_definitions: &[DurableAutomationDefinition],
+        snapshot: Option<&serde_json::Value>,
+    ) -> Result<Self, AutomationError> {
+        if let Some(snapshot) = snapshot {
+            let snapshot: AutomationRuntimeSnapshot =
+                serde_json::from_value(snapshot.clone()).map_err(AutomationError::decode)?;
+            return Self::from_snapshot(snapshot);
+        }
+
+        let mut runtime = Self::new();
+        for definition in durable_definitions {
+            let body: DurableDefinitionBody = serde_json::from_value(definition.definition.clone())
+                .map_err(AutomationError::decode)?;
+            runtime.upsert_definition(AutomationDefinition {
+                automation_id: definition.automation_id.clone(),
+                enabled: definition.enabled,
+                trigger: body.trigger,
+                conditions: body.conditions,
+                actions: body.actions,
+            })?;
+        }
+        Ok(runtime)
+    }
+
+    pub fn from_snapshot(snapshot: AutomationRuntimeSnapshot) -> Result<Self, AutomationError> {
+        if snapshot.schema_version != SNAPSHOT_SCHEMA_VERSION {
+            return Err(AutomationError::UnsupportedSchema(snapshot.schema_version));
+        }
+        let mut runtime = Self::new();
+        for definition in snapshot.definitions {
+            runtime.upsert_definition(definition)?;
+        }
+        runtime.completed_trigger_keys = snapshot.completed_trigger_keys.into_iter().collect();
+        runtime.audit_records = snapshot.audit_records;
+        runtime.trim_audit();
+        Ok(runtime)
+    }
+
+    pub fn snapshot(&self) -> AutomationRuntimeSnapshot {
+        AutomationRuntimeSnapshot {
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            definitions: self.definitions.values().cloned().collect(),
+            completed_trigger_keys: self.completed_trigger_keys.iter().cloned().collect(),
+            audit_records: self.audit_records.clone(),
+        }
+    }
+
+    pub fn snapshot_json(&self) -> Result<serde_json::Value, AutomationError> {
+        serde_json::to_value(self.snapshot()).map_err(AutomationError::encode)
+    }
+
+    pub fn durable_definitions(&self) -> Result<Vec<DurableAutomationDefinition>, AutomationError> {
+        self.definitions
+            .values()
+            .map(|definition| {
+                let body = DurableDefinitionBody {
+                    trigger: definition.trigger.clone(),
+                    conditions: definition.conditions.clone(),
+                    actions: definition.actions.clone(),
+                };
+                let value = serde_json::to_value(body).map_err(AutomationError::encode)?;
+                DurableAutomationDefinition::new(
+                    definition.automation_id.clone(),
+                    definition.enabled,
+                    value,
+                )
+                .map_err(|error| AutomationError::Validation(error.to_string()))
+            })
+            .collect()
+    }
+
+    pub fn definitions(&self) -> impl Iterator<Item = &AutomationDefinition> {
+        self.definitions.values()
+    }
+
+    pub fn audit_records(&self) -> &[AutomationAuditRecord] {
+        &self.audit_records
+    }
+
+    pub fn upsert_definition(
+        &mut self,
+        definition: AutomationDefinition,
+    ) -> Result<Option<AutomationDefinition>, AutomationError> {
+        validate_definition(&definition)?;
+        Ok(self
+            .definitions
+            .insert(definition.automation_id.clone(), definition))
+    }
+
+    pub fn remove_definition(&mut self, automation_id: &str) -> Option<AutomationDefinition> {
+        self.definitions.remove(automation_id)
+    }
+
+    pub fn evaluate(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        input: AutomationTriggerInput,
+        dry_run: bool,
+        now_ms: u64,
+    ) -> Result<AutomationEvaluationReport, AutomationError> {
+        let definitions = self.definitions.values().cloned().collect::<Vec<_>>();
+        let mut records = Vec::new();
+
+        for definition in definitions {
+            if !definition.enabled {
+                continue;
+            }
+            let Some(trigger_key) = trigger_key(&definition.trigger, &input, now_ms) else {
+                continue;
+            };
+            let occurrence_key = format!("{}:{trigger_key}", definition.automation_id);
+            if self.completed_trigger_keys.contains(&occurrence_key) {
+                if dry_run {
+                    records.push(audit_record(
+                        &definition,
+                        &trigger_key,
+                        now_ms,
+                        true,
+                        AutomationAuditOutcome::AlreadyExecuted,
+                        Vec::new(),
+                        Vec::new(),
+                        Vec::new(),
+                        Some("trigger occurrence was already consumed".to_string()),
+                    ));
+                }
+                continue;
+            }
+
+            let condition_results = definition
+                .conditions
+                .iter()
+                .map(|condition| condition_matches(condition, runtime))
+                .collect::<Vec<_>>();
+            if condition_results.iter().any(|matched| !matched) {
+                let record = audit_record(
+                    &definition,
+                    &trigger_key,
+                    now_ms,
+                    dry_run,
+                    AutomationAuditOutcome::ConditionNotMet,
+                    condition_results,
+                    Vec::new(),
+                    Vec::new(),
+                    Some("one or more automation conditions did not match".to_string()),
+                );
+                if !dry_run {
+                    self.completed_trigger_keys.insert(occurrence_key);
+                    self.push_audit(record.clone());
+                }
+                records.push(record);
+                continue;
+            }
+
+            let planned_commands = plan_actions(&definition, runtime, &trigger_key)?;
+            if dry_run {
+                records.push(audit_record(
+                    &definition,
+                    &trigger_key,
+                    now_ms,
+                    true,
+                    AutomationAuditOutcome::Planned,
+                    condition_results,
+                    planned_commands,
+                    Vec::new(),
+                    None,
+                ));
+                continue;
+            }
+
+            let previous_runtime = runtime.clone();
+            let mut command_results = Vec::new();
+            let mut failure = None;
+            for command in &planned_commands {
+                let mut request = RuntimeCommandToolRequest::new(
+                    command.entity_id.clone(),
+                    command.command_type,
+                    command.arguments.clone(),
+                )
+                .with_idempotency_key(command.idempotency_key.clone());
+                if let Some(timeout_ms) = command.timeout_ms {
+                    request = request.with_timeout_ms(timeout_ms);
+                }
+                match runtime.execute_command_tool(principal_id.clone(), request, now_ms) {
+                    Ok(result) => command_results.push(result),
+                    Err(error) => {
+                        failure = Some(error.to_string());
+                        break;
+                    }
+                }
+            }
+            if failure.is_some() {
+                *runtime = previous_runtime;
+            }
+            let outcome = if failure.is_some() {
+                AutomationAuditOutcome::Failed
+            } else {
+                AutomationAuditOutcome::Executed
+            };
+            let record = audit_record(
+                &definition,
+                &trigger_key,
+                now_ms,
+                false,
+                outcome,
+                condition_results,
+                planned_commands,
+                command_results,
+                failure,
+            );
+            self.completed_trigger_keys.insert(occurrence_key);
+            self.push_audit(record.clone());
+            records.push(record);
+        }
+
+        Ok(AutomationEvaluationReport {
+            evaluated_at_ms: now_ms,
+            dry_run,
+            records,
+        })
+    }
+
+    fn push_audit(&mut self, record: AutomationAuditRecord) {
+        self.audit_records.push(record);
+        self.trim_audit();
+    }
+
+    fn trim_audit(&mut self) {
+        if self.audit_records.len() > MAX_AUDIT_RECORDS {
+            self.audit_records
+                .drain(..self.audit_records.len() - MAX_AUDIT_RECORDS);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct DurableDefinitionBody {
+    trigger: AutomationTrigger,
+    #[serde(default)]
+    conditions: Vec<AutomationCondition>,
+    actions: Vec<AutomationAction>,
+}
+
+fn validate_definition(definition: &AutomationDefinition) -> Result<(), AutomationError> {
+    if definition.automation_id.trim().is_empty() {
+        return Err(AutomationError::Validation(
+            "automation_id must not be empty".to_string(),
+        ));
+    }
+    if definition.actions.is_empty() {
+        return Err(AutomationError::Validation(
+            "automation actions must not be empty".to_string(),
+        ));
+    }
+    if let AutomationTrigger::Schedule { every_ms, .. } = definition.trigger {
+        if every_ms == 0 {
+            return Err(AutomationError::Validation(
+                "schedule every_ms must be greater than zero".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn trigger_key(
+    trigger: &AutomationTrigger,
+    input: &AutomationTriggerInput,
+    now_ms: u64,
+) -> Option<String> {
+    match (trigger, input) {
+        (
+            AutomationTrigger::Schedule {
+                every_ms,
+                offset_ms,
+            },
+            AutomationTriggerInput::Schedule,
+        ) if now_ms >= *offset_ms => Some(format!("schedule:{}", (now_ms - offset_ms) / every_ms)),
+        (
+            AutomationTrigger::Event {
+                event_type,
+                entity_id,
+            },
+            AutomationTriggerInput::Event(event),
+        ) if event_type.matches(event.event_type)
+            && entity_id
+                .as_ref()
+                .is_none_or(|expected| event.entity_id.as_ref() == Some(expected)) =>
+        {
+            Some(format!("event:{}", event.event_id.as_str()))
+        }
+        _ => None,
+    }
+}
+
+fn condition_matches(condition: &AutomationCondition, runtime: &SmartHomeRuntime) -> bool {
+    match condition {
+        AutomationCondition::StateEquals {
+            entity_id,
+            expected,
+        } => runtime
+            .registry()
+            .state(entity_id)
+            .is_some_and(|snapshot| &snapshot.value == expected),
+    }
+}
+
+fn plan_actions(
+    definition: &AutomationDefinition,
+    runtime: &SmartHomeRuntime,
+    trigger_key: &str,
+) -> Result<Vec<PlannedAutomationCommand>, AutomationError> {
+    let mut planned = Vec::new();
+    for action in &definition.actions {
+        match action {
+            AutomationAction::Command {
+                entity_id,
+                command_type,
+                arguments,
+                timeout_ms,
+            } => planned.push(planned_command(
+                definition,
+                trigger_key,
+                planned.len(),
+                entity_id.clone(),
+                *command_type,
+                arguments.clone(),
+                *timeout_ms,
+            )),
+            AutomationAction::Scene {
+                scene_id,
+                timeout_ms,
+            } => {
+                let scene = runtime.registry().scene(scene_id).ok_or_else(|| {
+                    AutomationError::Validation(format!("unknown scene {}", scene_id.as_str()))
+                })?;
+                for action in &scene.actions {
+                    let (command_type, arguments) = command_for_scene_value(&action.desired_state)?;
+                    planned.push(planned_command(
+                        definition,
+                        trigger_key,
+                        planned.len(),
+                        action.entity_id.clone(),
+                        command_type,
+                        arguments,
+                        *timeout_ms,
+                    ));
+                }
+            }
+        }
+    }
+    Ok(planned)
+}
+
+fn planned_command(
+    definition: &AutomationDefinition,
+    trigger_key: &str,
+    index: usize,
+    entity_id: EntityId,
+    command_type: CommandType,
+    arguments: Value,
+    timeout_ms: Option<u64>,
+) -> PlannedAutomationCommand {
+    PlannedAutomationCommand {
+        entity_id,
+        command_type,
+        arguments,
+        idempotency_key: format!(
+            "automation:{}:{trigger_key}:action:{index}",
+            definition.automation_id
+        ),
+        timeout_ms,
+    }
+}
+
+fn command_for_scene_value(value: &Value) -> Result<(CommandType, Value), AutomationError> {
+    match value {
+        Value::Bool(true) => Ok((CommandType::TurnOn, Value::Null)),
+        Value::Bool(false) => Ok((CommandType::TurnOff, Value::Null)),
+        Value::Percentage(_) => Ok((CommandType::SetBrightness, value.clone())),
+        Value::Object(fields) => {
+            if let Some(Value::Bool(on)) = object_field(fields, "on") {
+                return Ok((
+                    if *on {
+                        CommandType::TurnOn
+                    } else {
+                        CommandType::TurnOff
+                    },
+                    Value::Null,
+                ));
+            }
+            if let Some(brightness) = object_field(fields, "brightness") {
+                return Ok((CommandType::SetBrightness, brightness.clone()));
+            }
+            Err(AutomationError::Validation(
+                "scene object state requires `on` or `brightness`".to_string(),
+            ))
+        }
+        _ => Err(AutomationError::Validation(
+            "scene state must be boolean, percentage, or a supported object".to_string(),
+        )),
+    }
+}
+
+fn object_field<'a>(fields: &'a [(String, Value)], name: &str) -> Option<&'a Value> {
+    fields
+        .iter()
+        .find_map(|(field, value)| (field == name).then_some(value))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn audit_record(
+    definition: &AutomationDefinition,
+    trigger_key: &str,
+    evaluated_at_ms: u64,
+    dry_run: bool,
+    outcome: AutomationAuditOutcome,
+    condition_results: Vec<bool>,
+    planned_commands: Vec<PlannedAutomationCommand>,
+    command_results: Vec<CommandResult>,
+    message: Option<String>,
+) -> AutomationAuditRecord {
+    AutomationAuditRecord {
+        audit_id: format!(
+            "automation-audit:{}:{trigger_key}:{evaluated_at_ms}",
+            definition.automation_id
+        ),
+        automation_id: definition.automation_id.clone(),
+        trigger_key: trigger_key.to_string(),
+        evaluated_at_ms,
+        dry_run,
+        outcome,
+        condition_results,
+        planned_commands,
+        command_results,
+        message,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AutomationError {
+    Validation(String),
+    Encode(String),
+    Decode(String),
+    UnsupportedSchema(u32),
+}
+
+impl AutomationError {
+    fn encode(error: serde_json::Error) -> Self {
+        Self::Encode(error.to_string())
+    }
+
+    fn decode(error: serde_json::Error) -> Self {
+        Self::Decode(error.to_string())
+    }
+}
+
+impl fmt::Display for AutomationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Validation(message) => write!(f, "invalid automation: {message}"),
+            Self::Encode(message) => write!(f, "could not encode automation runtime: {message}"),
+            Self::Decode(message) => write!(f, "could not decode automation runtime: {message}"),
+            Self::UnsupportedSchema(version) => {
+                write!(f, "unsupported automation runtime schema version {version}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AutomationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smart_home_core::{
+        Bridge, BridgeId, BridgeTransport, Capability, CapabilityGrant, CapabilityGrantId, Device,
+        DeviceId, Entity, EntityKind, EventId, Health, IntegrationId, PrivilegeTier, Scene,
+        SceneAction, SceneScope, StateConfidence, StateSnapshot, StateSource,
+    };
+
+    fn fixture() -> (SmartHomeRuntime, AgentId) {
+        let principal = AgentId::trusted("agent:automation");
+        let mut runtime = SmartHomeRuntime::new();
+        runtime
+            .upsert_bridge(Bridge::new(
+                BridgeId::trusted("bridge-1"),
+                IntegrationId::trusted("hue"),
+                BridgeTransport::LanHttp,
+            ))
+            .unwrap();
+        runtime
+            .upsert_device(Device {
+                device_id: DeviceId::trusted("device-1"),
+                bridge_id: BridgeId::trusted("bridge-1"),
+                manufacturer: "Signify".to_string(),
+                model: "Hue".to_string(),
+                name: "Kitchen".to_string(),
+                serial: None,
+                firmware_version: None,
+                room_id: Some("kitchen".to_string()),
+                entity_ids: Vec::new(),
+                identifiers: Vec::new(),
+                health: Health::Online,
+                metadata: Vec::new(),
+            })
+            .unwrap();
+        for entity_id in ["light-kitchen", "light-hall"] {
+            runtime
+                .upsert_entity(Entity {
+                    entity_id: EntityId::trusted(entity_id),
+                    device_id: DeviceId::trusted("device-1"),
+                    kind: EntityKind::Light,
+                    name: entity_id.to_string(),
+                    capabilities: vec![Capability::light_on_off(), Capability::light_brightness()],
+                    state: None,
+                    metadata: Vec::new(),
+                })
+                .unwrap();
+        }
+        runtime
+            .registry_mut()
+            .apply_state_snapshot(StateSnapshot {
+                entity_id: EntityId::trusted("light-kitchen"),
+                value: Value::Bool(true),
+                source: StateSource::Poll,
+                observed_at_ms: 1,
+                received_at_ms: 1,
+                expires_at_ms: None,
+                confidence: StateConfidence::Confirmed,
+            })
+            .unwrap();
+        runtime
+            .upsert_scene(Scene {
+                scene_id: SceneId::trusted("scene-night"),
+                scope: SceneScope::Home,
+                native_ref: None,
+                actions: vec![
+                    SceneAction {
+                        entity_id: EntityId::trusted("light-kitchen"),
+                        desired_state: Value::Bool(false),
+                    },
+                    SceneAction {
+                        entity_id: EntityId::trusted("light-hall"),
+                        desired_state: Value::Percentage(10),
+                    },
+                ],
+                metadata: Vec::new(),
+            })
+            .unwrap();
+        runtime
+            .registry_mut()
+            .upsert_capability_grant(CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant-automation"),
+                principal.clone(),
+                PrivilegeTier::LowRisk,
+                "test",
+                0,
+            ));
+        (runtime, principal)
+    }
+
+    fn schedule_definition() -> AutomationDefinition {
+        AutomationDefinition {
+            automation_id: "night-mode".to_string(),
+            enabled: true,
+            trigger: AutomationTrigger::Schedule {
+                every_ms: 1_000,
+                offset_ms: 500,
+            },
+            conditions: vec![AutomationCondition::StateEquals {
+                entity_id: EntityId::trusted("light-kitchen"),
+                expected: Value::Bool(true),
+            }],
+            actions: vec![AutomationAction::Scene {
+                scene_id: SceneId::trusted("scene-night"),
+                timeout_ms: Some(2_000),
+            }],
+        }
+    }
+
+    #[test]
+    fn schedule_dry_run_expands_scene_without_mutating_or_consuming_trigger() {
+        let (mut runtime, principal) = fixture();
+        let mut automations = SmartHomeAutomationRuntime::new();
+        automations
+            .upsert_definition(schedule_definition())
+            .unwrap();
+
+        let report = automations
+            .evaluate(
+                &mut runtime,
+                principal,
+                AutomationTriggerInput::Schedule,
+                true,
+                1_600,
+            )
+            .unwrap();
+
+        assert_eq!(report.records.len(), 1);
+        assert_eq!(report.records[0].outcome, AutomationAuditOutcome::Planned);
+        assert_eq!(report.records[0].planned_commands.len(), 2);
+        assert!(automations.audit_records().is_empty());
+        assert_eq!(
+            runtime
+                .registry()
+                .state(&EntityId::trusted("light-kitchen"))
+                .unwrap()
+                .value,
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn schedule_executes_once_and_snapshot_restores_idempotency_and_audit() {
+        let (mut runtime, principal) = fixture();
+        let mut automations = SmartHomeAutomationRuntime::new();
+        automations
+            .upsert_definition(schedule_definition())
+            .unwrap();
+
+        let first = automations
+            .evaluate(
+                &mut runtime,
+                principal.clone(),
+                AutomationTriggerInput::Schedule,
+                false,
+                1_600,
+            )
+            .unwrap();
+        let repeated = automations
+            .evaluate(
+                &mut runtime,
+                principal,
+                AutomationTriggerInput::Schedule,
+                false,
+                1_700,
+            )
+            .unwrap();
+
+        assert_eq!(first.executed_automation_count(), 1);
+        assert!(repeated.records.is_empty());
+        assert_eq!(automations.audit_records().len(), 1);
+        assert_eq!(
+            runtime
+                .registry()
+                .state(&EntityId::trusted("light-kitchen"))
+                .unwrap()
+                .value,
+            Value::Object(vec![("light.on_off".to_string(), Value::Bool(false))])
+        );
+
+        let restored = SmartHomeAutomationRuntime::from_snapshot(automations.snapshot()).unwrap();
+        assert_eq!(restored.audit_records().len(), 1);
+        assert_eq!(restored.completed_trigger_keys.len(), 1);
+    }
+
+    #[test]
+    fn event_trigger_respects_entity_and_audits_failed_condition_once() {
+        let (mut runtime, principal) = fixture();
+        let mut automations = SmartHomeAutomationRuntime::new();
+        let mut definition = schedule_definition();
+        definition.automation_id = "updated-night".to_string();
+        definition.trigger = AutomationTrigger::Event {
+            event_type: AutomationEventType::Updated,
+            entity_id: Some(EntityId::trusted("light-hall")),
+        };
+        definition.conditions[0] = AutomationCondition::StateEquals {
+            entity_id: EntityId::trusted("light-kitchen"),
+            expected: Value::Bool(false),
+        };
+        automations.upsert_definition(definition).unwrap();
+        let event = DeviceEvent {
+            event_id: EventId::trusted("event-update-1"),
+            bridge_id: BridgeId::trusted("bridge-1"),
+            device_id: Some(DeviceId::trusted("device-1")),
+            entity_id: Some(EntityId::trusted("light-hall")),
+            observed_at_ms: 2_000,
+            received_at_ms: 2_001,
+            event_type: DeviceEventType::Updated,
+            state_delta: None,
+            raw_ref: None,
+            correlation_id: None,
+            metadata: Vec::new(),
+        };
+
+        let report = automations
+            .evaluate(
+                &mut runtime,
+                principal,
+                AutomationTriggerInput::Event(Box::new(event)),
+                false,
+                2_001,
+            )
+            .unwrap();
+
+        assert_eq!(report.records.len(), 1);
+        assert_eq!(
+            report.records[0].outcome,
+            AutomationAuditOutcome::ConditionNotMet
+        );
+        assert_eq!(automations.audit_records().len(), 1);
+    }
+
+    #[test]
+    fn durable_definitions_round_trip_without_execution_state() {
+        let mut automations = SmartHomeAutomationRuntime::new();
+        automations
+            .upsert_definition(schedule_definition())
+            .unwrap();
+        let durable = automations.durable_definitions().unwrap();
+        let restored = SmartHomeAutomationRuntime::restore(&durable, None).unwrap();
+
+        assert_eq!(
+            restored.definitions().cloned().collect::<Vec<_>>(),
+            vec![schedule_definition()]
+        );
+    }
+}

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Added a restart-safe automation runtime to the production controller, a local
+  schedule worker, and native definition, evaluation, dry-run, and audit API
+  routes with atomic persistence rollback.
 - Added a production `smart-home-local-controller` binary that restores the
   durable runtime store, uses a live clock, and atomically persists authorized
   desired-state and service mutations before returning success.

--- a/code/packages/rust/smart-home-platform-http/Cargo.toml
+++ b/code/packages/rust/smart-home-platform-http/Cargo.toml
@@ -7,7 +7,9 @@ license = "MIT"
 
 [dependencies]
 embeddable-http-server = { path = "../embeddable-http-server" }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+smart-home-automation-runtime = { path = "../smart-home-automation-runtime" }
 smart-home-core = { path = "../smart-home-core" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 smart-home-runtime-store = { path = "../smart-home-runtime-store" }

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -203,17 +203,30 @@ cargo run -p smart-home-platform-http --bin smart-home-local-controller -- \
 
 `SMART_HOME_DATA_DIR` supplies the data folder when `--data-dir` is omitted.
 The controller loads the latest `smart-home-runtime-store` snapshot before it
-binds, restores the opaque automation definitions kept beside runtime state,
-uses wall-clock request timestamps, and saves the local API capability grant.
-Accepted desired-state and service mutations are persisted synchronously before
-the API returns success. A failed write restores the exact pre-request runtime
-and returns HTTP 503, so clients never observe a successful mutation that only
-exists in memory.
+binds, restores automation definitions, consumed trigger occurrences, and
+automation audit, uses wall-clock request timestamps, and saves the local API
+capability grant. A local worker evaluates schedule triggers every 500 ms.
+Accepted desired-state, service, automation-definition, and automation-execution
+mutations are persisted synchronously before the API returns success. A failed
+write restores the exact pre-request runtime and automation engine and returns
+HTTP 503, so clients never observe a successful mutation that only exists in
+memory.
+
+The native automation surface is:
+
+- `GET /api/smart_home/automations`
+- `POST /api/smart_home/automations`
+- `POST /api/smart_home/automations/evaluate`
+- `GET /api/smart_home/automation_audit`
+
+The evaluation endpoint accepts `{"dry_run":true}` for a schedule preview or
+`{"dry_run":false,"event":{...}}` for a normalized device-event trigger.
 
 The controller can start with an empty folder. Discovery, pairing, and
 integration owners can populate the same durable runtime store before launch;
 on later launches the API serves the restored topology, state, event, command,
-pairing, desired-state, authorization, and automation records.
+pairing, desired-state, authorization, automation definitions, idempotency
+state, and automation audit.
 
 ## Fixture Controller
 

--- a/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
+++ b/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
@@ -1,4 +1,5 @@
 use embeddable_http_server::HttpServerOptions;
+use smart_home_automation_runtime::{AutomationTriggerInput, SmartHomeAutomationRuntime};
 use smart_home_platform_http::{
     home_assistant_runtime_web_app, SmartHomePlatformHttpConfig, SmartHomePlatformHttpRuntime,
 };
@@ -10,7 +11,8 @@ use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use storage_local_folder::LocalFolderStorageBackend;
 use web_core::WebServer;
 
@@ -40,27 +42,54 @@ fn main() -> Result<(), Box<dyn Error>> {
         &config.data_dir,
     )));
     let restored = store.load()?;
-    let (runtime, automation_definitions, restored_at_ms) = match restored {
+    let (runtime, automation_definitions, automation_state, restored_at_ms) = match restored {
         Some(restored) => (
             restored.runtime,
             restored.automation_definitions,
+            restored.automation_state,
             Some(restored.saved_at_ms),
         ),
-        None => (SmartHomeRuntime::new(), Vec::new(), None),
+        None => (SmartHomeRuntime::new(), Vec::new(), None, None),
     };
-    let automation_definitions = Arc::new(automation_definitions);
+    let automation_runtime = Arc::new(Mutex::new(SmartHomeAutomationRuntime::restore(
+        &automation_definitions,
+        automation_state.as_ref(),
+    )?));
     let shared_runtime = Arc::new(Mutex::new(runtime));
 
     let persistence_store = Arc::clone(&store);
-    let persistence_automations = Arc::clone(&automation_definitions);
+    let persistence_automations = Arc::clone(&automation_runtime);
+    let automation_persistence_store = Arc::clone(&store);
     let runtime = SmartHomePlatformHttpRuntime::from_shared_runtime(
         Arc::clone(&shared_runtime),
         SmartHomePlatformHttpConfig::new("Codex Home"),
     )
     .with_clock(unix_time_ms)
+    .with_automation_runtime(Arc::clone(&automation_runtime))
     .with_mutation_persistence(move |runtime, saved_at_ms| {
+        let automations = persistence_automations
+            .lock()
+            .map_err(|_| "automation runtime mutex was poisoned".to_string())?;
+        let definitions = automations
+            .durable_definitions()
+            .map_err(|error| error.to_string())?;
+        let state = automations
+            .snapshot_json()
+            .map_err(|error| error.to_string())?;
         persistence_store
-            .save(runtime, persistence_automations.as_slice(), saved_at_ms)
+            .save_with_automation_state(runtime, &definitions, Some(state), saved_at_ms)
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    })
+    .with_automation_persistence(move |runtime, automations, saved_at_ms| {
+        let definitions = automations
+            .durable_definitions()
+            .map_err(|error| error.to_string())?;
+        let state = automations
+            .snapshot_json()
+            .map_err(|error| error.to_string())?;
+        automation_persistence_store
+            .save_with_automation_state(runtime, &definitions, Some(state), saved_at_ms)
             .map(|_| ())
             .map_err(|error| error.to_string())
     })
@@ -70,9 +99,23 @@ fn main() -> Result<(), Box<dyn Error>> {
         let runtime = shared_runtime.lock().map_err(|_| {
             io::Error::other("smart-home runtime mutex was poisoned during startup")
         })?;
-        store.save(&runtime, automation_definitions.as_slice(), unix_time_ms())?;
+        let automations = automation_runtime.lock().map_err(|_| {
+            io::Error::other("automation runtime mutex was poisoned during startup")
+        })?;
+        store.save_with_automation_state(
+            &runtime,
+            &automations.durable_definitions()?,
+            Some(automations.snapshot_json()?),
+            unix_time_ms(),
+        )?;
     }
 
+    let automation_count = automation_runtime
+        .lock()
+        .map_err(|_| io::Error::other("automation runtime mutex was poisoned during startup"))?
+        .definitions()
+        .count();
+    spawn_schedule_worker(runtime.clone());
     let app = Arc::new(home_assistant_runtime_web_app(runtime));
     let options = dashboard_server_options();
 
@@ -97,11 +140,20 @@ fn main() -> Result<(), Box<dyn Error>> {
             server.local_addr(),
             &config.data_dir,
             restored_at_ms,
-            automation_definitions.len(),
+            automation_count,
         )
     );
     server.serve()?;
     Ok(())
+}
+
+fn spawn_schedule_worker(runtime: SmartHomePlatformHttpRuntime) {
+    thread::spawn(move || loop {
+        thread::sleep(Duration::from_millis(500));
+        if let Err(error) = runtime.evaluate_automations(AutomationTriggerInput::Schedule, false) {
+            eprintln!("smart-home automation schedule evaluation failed: {error}");
+        }
+    });
 }
 
 fn default_data_dir() -> PathBuf {

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -7,7 +7,12 @@
 
 #![forbid(unsafe_code)]
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use smart_home_automation_runtime::{
+    AutomationDefinition, AutomationEvaluationReport, AutomationTriggerInput,
+    SmartHomeAutomationRuntime,
+};
 use smart_home_core::{
     AgentId, AuthorizationDecision, AuthorizationOutcome, AuthorizationSubject, Bridge, BridgeId,
     BridgeTransport, Capability, CapabilityGrant, CapabilityGrantId,
@@ -38,6 +43,9 @@ const CONTROLLER_HANDOFF_PATH: &str = "/api/smart_home/controller_handoff";
 type RuntimeClock = Arc<dyn Fn() -> u64 + Send + Sync>;
 type RuntimeMutationPersistence =
     Arc<dyn Fn(&SmartHomeRuntime, u64) -> Result<(), String> + Send + Sync>;
+type AutomationMutationPersistence = Arc<
+    dyn Fn(&SmartHomeRuntime, &SmartHomeAutomationRuntime, u64) -> Result<(), String> + Send + Sync,
+>;
 
 const DASHBOARD_HTML: &str = r##"<!doctype html>
 <html lang="en">
@@ -1950,11 +1958,13 @@ pub struct SmartHomePlatformService {
 #[derive(Clone)]
 pub struct SmartHomePlatformHttpRuntime {
     runtime: Arc<Mutex<SmartHomeRuntime>>,
+    automation_runtime: Option<Arc<Mutex<SmartHomeAutomationRuntime>>>,
     config: SmartHomePlatformHttpConfig,
     event_types: Vec<String>,
     principal_id: AgentId,
     clock: RuntimeClock,
     mutation_persistence: Option<RuntimeMutationPersistence>,
+    automation_persistence: Option<AutomationMutationPersistence>,
 }
 
 impl SmartHomePlatformHttpRuntime {
@@ -1968,11 +1978,13 @@ impl SmartHomePlatformHttpRuntime {
     ) -> Self {
         Self {
             runtime,
+            automation_runtime: None,
             config,
             event_types: default_event_types(),
             principal_id: AgentId::trusted("agent:home-assistant-local-api"),
             clock: Arc::new(|| 0),
             mutation_persistence: None,
+            automation_persistence: None,
         }
     }
 
@@ -2010,6 +2022,94 @@ impl SmartHomePlatformHttpRuntime {
     ) -> Self {
         self.mutation_persistence = Some(Arc::new(persistence));
         self
+    }
+
+    pub fn with_automation_runtime(
+        mut self,
+        automation_runtime: Arc<Mutex<SmartHomeAutomationRuntime>>,
+    ) -> Self {
+        self.automation_runtime = Some(automation_runtime);
+        self
+    }
+
+    pub fn with_automation_persistence(
+        mut self,
+        persistence: impl Fn(&SmartHomeRuntime, &SmartHomeAutomationRuntime, u64) -> Result<(), String>
+            + Send
+            + Sync
+            + 'static,
+    ) -> Self {
+        self.automation_persistence = Some(Arc::new(persistence));
+        self
+    }
+
+    pub fn automation_runtime(&self) -> Option<Arc<Mutex<SmartHomeAutomationRuntime>>> {
+        self.automation_runtime.clone()
+    }
+
+    pub fn evaluate_automations(
+        &self,
+        input: AutomationTriggerInput,
+        dry_run: bool,
+    ) -> Result<AutomationEvaluationReport, String> {
+        let automation_runtime = self
+            .automation_runtime
+            .as_ref()
+            .ok_or_else(|| "automation runtime is not configured".to_string())?;
+        let mut runtime = self
+            .runtime
+            .lock()
+            .map_err(|_| "smart-home runtime mutex was poisoned".to_string())?;
+        let mut automations = automation_runtime
+            .lock()
+            .map_err(|_| "automation runtime mutex was poisoned".to_string())?;
+        let previous_runtime = runtime.clone();
+        let previous_automations = automations.clone();
+        let now_ms = self.now_ms();
+        let report = automations
+            .evaluate(
+                &mut runtime,
+                self.principal_id.clone(),
+                input,
+                dry_run,
+                now_ms,
+            )
+            .map_err(|error| error.to_string())?;
+        if !dry_run && !report.records.is_empty() {
+            if let Err(error) = self.persist_automation_mutation(&runtime, &automations, now_ms) {
+                *runtime = previous_runtime;
+                *automations = previous_automations;
+                return Err(error);
+            }
+        }
+        Ok(report)
+    }
+
+    pub fn upsert_automation_definition(
+        &self,
+        definition: AutomationDefinition,
+    ) -> Result<Option<AutomationDefinition>, String> {
+        let automation_runtime = self
+            .automation_runtime
+            .as_ref()
+            .ok_or_else(|| "automation runtime is not configured".to_string())?;
+        let runtime = self
+            .runtime
+            .lock()
+            .map_err(|_| "smart-home runtime mutex was poisoned".to_string())?;
+        let mut automations = automation_runtime
+            .lock()
+            .map_err(|_| "automation runtime mutex was poisoned".to_string())?;
+        let previous = automations.clone();
+        let replaced = automations
+            .upsert_definition(definition)
+            .map_err(|error| error.to_string())?;
+        if let Err(error) = self.persist_automation_mutation(&runtime, &automations, self.now_ms())
+        {
+            *automations = previous;
+            return Err(error);
+        }
+        Ok(replaced)
     }
 
     pub fn grant_local_full_access(
@@ -2069,6 +2169,18 @@ impl SmartHomePlatformHttpRuntime {
             ));
         }
         Ok(())
+    }
+
+    fn persist_automation_mutation(
+        &self,
+        runtime: &SmartHomeRuntime,
+        automations: &SmartHomeAutomationRuntime,
+        saved_at_ms: u64,
+    ) -> Result<(), String> {
+        let Some(persistence) = &self.automation_persistence else {
+            return Ok(());
+        };
+        persistence(runtime, automations, saved_at_ms)
     }
 }
 
@@ -2508,12 +2620,143 @@ pub fn home_assistant_runtime_web_app(runtime: SmartHomePlatformHttpRuntime) -> 
 
     {
         let runtime = runtime.clone();
+        app.get("/api/smart_home/automations", move |_| {
+            automation_definitions_response(&runtime)
+        });
+    }
+
+    {
+        let runtime = runtime.clone();
+        app.post("/api/smart_home/automations", move |request| {
+            upsert_automation_response(&runtime, request)
+        });
+    }
+
+    {
+        let runtime = runtime.clone();
+        app.get("/api/smart_home/automation_audit", move |_| {
+            automation_audit_response(&runtime)
+        });
+    }
+
+    {
+        let runtime = runtime.clone();
+        app.post("/api/smart_home/automations/evaluate", move |request| {
+            evaluate_automations_response(&runtime, request)
+        });
+    }
+
+    {
+        let runtime = runtime.clone();
         app.post("/api/services/:domain/:service", move |request| {
             service_call_response(&runtime, request)
         });
     }
 
     app
+}
+
+#[derive(Debug, Deserialize)]
+struct AutomationEvaluationRequest {
+    #[serde(default)]
+    dry_run: bool,
+    #[serde(default)]
+    event: Option<DeviceEvent>,
+}
+
+fn automation_definitions_response(runtime: &SmartHomePlatformHttpRuntime) -> WebResponse {
+    let Some(automations) = runtime.automation_runtime.as_ref() else {
+        return json_error(503, "automation runtime is not configured");
+    };
+    let automations = match automations.lock() {
+        Ok(automations) => automations,
+        Err(_) => return json_error(503, "automation runtime mutex was poisoned"),
+    };
+    let definitions = automations.definitions().collect::<Vec<_>>();
+    serialized_json_response(&serde_json::json!({
+        "summary": {
+            "definition_count": definitions.len(),
+            "enabled_count": definitions.iter().filter(|definition| definition.enabled).count(),
+            "audit_record_count": automations.audit_records().len(),
+        },
+        "definitions": definitions,
+    }))
+}
+
+fn automation_audit_response(runtime: &SmartHomePlatformHttpRuntime) -> WebResponse {
+    let Some(automations) = runtime.automation_runtime.as_ref() else {
+        return json_error(503, "automation runtime is not configured");
+    };
+    let automations = match automations.lock() {
+        Ok(automations) => automations,
+        Err(_) => return json_error(503, "automation runtime mutex was poisoned"),
+    };
+    serialized_json_response(&serde_json::json!({
+        "summary": {
+            "record_count": automations.audit_records().len(),
+        },
+        "records": automations.audit_records(),
+    }))
+}
+
+fn upsert_automation_response(
+    runtime: &SmartHomePlatformHttpRuntime,
+    request: &WebRequest,
+) -> WebResponse {
+    let definition: AutomationDefinition = match serde_json::from_slice(request.body()) {
+        Ok(definition) => definition,
+        Err(error) => return json_error(400, format!("invalid automation JSON: {error}")),
+    };
+    let automation_id = definition.automation_id.clone();
+    match runtime.upsert_automation_definition(definition) {
+        Ok(replaced) => serialized_json_response(&serde_json::json!({
+            "automation_id": automation_id,
+            "replaced": replaced.is_some(),
+            "definitions": runtime
+                .automation_runtime
+                .as_ref()
+                .and_then(|automations| automations.lock().ok())
+                .map(|automations| automations.definitions().cloned().collect::<Vec<_>>())
+                .unwrap_or_default(),
+        })),
+        Err(error) if error.starts_with("invalid automation:") => json_error(400, error),
+        Err(error) => json_error(503, error),
+    }
+}
+
+fn evaluate_automations_response(
+    runtime: &SmartHomePlatformHttpRuntime,
+    request: &WebRequest,
+) -> WebResponse {
+    let request = if request.body().is_empty() {
+        AutomationEvaluationRequest {
+            dry_run: false,
+            event: None,
+        }
+    } else {
+        match serde_json::from_slice(request.body()) {
+            Ok(request) => request,
+            Err(error) => {
+                return json_error(400, format!("invalid automation evaluation JSON: {error}"));
+            }
+        }
+    };
+    let input = request
+        .event
+        .map(Box::new)
+        .map(AutomationTriggerInput::Event)
+        .unwrap_or(AutomationTriggerInput::Schedule);
+    match runtime.evaluate_automations(input, request.dry_run) {
+        Ok(report) => serialized_json_response(&report),
+        Err(error) => json_error(503, error),
+    }
+}
+
+fn serialized_json_response(value: &impl Serialize) -> WebResponse {
+    match serde_json::to_vec(value) {
+        Ok(body) => WebResponse::json(body),
+        Err(error) => json_error(500, format!("could not encode JSON response: {error}")),
+    }
 }
 
 pub fn platform_services(state: &SmartHomePlatformHttpState) -> Vec<SmartHomePlatformService> {
@@ -3409,6 +3652,42 @@ const API_ROUTE_CATALOG: &[ApiRouteDescriptor] = &[
         surface: "smart_home",
         mutates_runtime: false,
         runtime_authorized: false,
+        query_params: &[],
+    },
+    ApiRouteDescriptor {
+        method: "GET",
+        path: "/api/smart_home/automations",
+        category: "automations",
+        surface: "smart_home",
+        mutates_runtime: false,
+        runtime_authorized: false,
+        query_params: &[],
+    },
+    ApiRouteDescriptor {
+        method: "POST",
+        path: "/api/smart_home/automations",
+        category: "automations",
+        surface: "smart_home",
+        mutates_runtime: true,
+        runtime_authorized: true,
+        query_params: &[],
+    },
+    ApiRouteDescriptor {
+        method: "GET",
+        path: "/api/smart_home/automation_audit",
+        category: "automations",
+        surface: "smart_home",
+        mutates_runtime: false,
+        runtime_authorized: false,
+        query_params: &[],
+    },
+    ApiRouteDescriptor {
+        method: "POST",
+        path: "/api/smart_home/automations/evaluate",
+        category: "automations",
+        surface: "smart_home",
+        mutates_runtime: true,
+        runtime_authorized: true,
         query_params: &[],
     },
 ];
@@ -9997,6 +10276,7 @@ mod tests {
     use super::*;
     use embeddable_http_server::{HttpRequest, HttpServerOptions};
     use http_core::{Header, HttpVersion, RequestHead};
+    use smart_home_automation_runtime::{AutomationAction, AutomationTrigger};
     use smart_home_core::{BridgeId, DeviceId, EventId};
     use smart_home_runtime_store::SmartHomeRuntimeStore;
     use smart_home_testkit::hue_lighting_runtime;
@@ -11236,7 +11516,7 @@ mod tests {
                 >= 30
         );
         assert_eq!(handoff_json["summary"]["browser_routes"], 3);
-        assert_eq!(handoff_json["summary"]["runtime_authorized_routes"], 4);
+        assert_eq!(handoff_json["summary"]["runtime_authorized_routes"], 6);
         assert_eq!(handoff_json["summary"]["readiness_checks"], 8);
         assert_eq!(handoff_json["summary"]["smoke_checks"], 15);
     }
@@ -11513,7 +11793,7 @@ mod tests {
         );
         let mutating_json: JsonValue =
             serde_json::from_str(&mutating).expect("mutating API catalog response is JSON");
-        assert_eq!(mutating_json["route_count"], 4);
+        assert_eq!(mutating_json["route_count"], 6);
         for route in mutating_json["routes"]
             .as_array()
             .expect("mutating route list is an array")
@@ -11537,6 +11817,112 @@ mod tests {
             .handle(request("GET", "/api/smart_home/api?surface=unknown"))
             .into();
         assert_eq!(invalid_surface.status, 400);
+    }
+
+    #[test]
+    fn runtime_web_app_creates_previews_executes_and_audits_automation() {
+        let automations = Arc::new(Mutex::new(SmartHomeAutomationRuntime::new()));
+        let runtime = fixture_runtime(true).with_automation_runtime(Arc::clone(&automations));
+        let app = home_assistant_runtime_web_app(runtime);
+        let definition = serde_json::to_string(&schedule_automation_definition()).unwrap();
+
+        let created: WebResponse = app
+            .handle(request_with_body(
+                "POST",
+                "/api/smart_home/automations",
+                &definition,
+            ))
+            .into();
+        assert_eq!(created.status, 200);
+        assert!(response_body(created).contains(r#""automation_id":"nightly-off""#));
+
+        let preview: WebResponse = app
+            .handle(request_with_body(
+                "POST",
+                "/api/smart_home/automations/evaluate",
+                r#"{"dry_run":true}"#,
+            ))
+            .into();
+        assert_eq!(preview.status, 200);
+        let preview = response_body(preview);
+        assert!(preview.contains(r#""outcome":"planned""#));
+        assert!(
+            preview.contains(r#""idempotency_key":"automation:nightly-off:schedule:5:action:0""#)
+        );
+        assert_eq!(automations.lock().unwrap().audit_records().len(), 0);
+
+        let executed: WebResponse = app
+            .handle(request_with_body(
+                "POST",
+                "/api/smart_home/automations/evaluate",
+                "{}",
+            ))
+            .into();
+        assert_eq!(executed.status, 200);
+        assert!(response_body(executed).contains(r#""outcome":"executed""#));
+
+        let repeated: WebResponse = app
+            .handle(request_with_body(
+                "POST",
+                "/api/smart_home/automations/evaluate",
+                "{}",
+            ))
+            .into();
+        assert_eq!(repeated.status, 200);
+        assert!(response_body(repeated).contains(r#""records":[]"#));
+
+        let audit = response_body(
+            app.handle(request("GET", "/api/smart_home/automation_audit"))
+                .into(),
+        );
+        assert!(audit.contains(r#""record_count":1"#));
+        assert!(audit.contains(r#""automation_id":"nightly-off""#));
+        assert!(audit.contains(r#""outcome":"executed""#));
+    }
+
+    #[test]
+    fn runtime_web_app_rolls_back_automation_when_persistence_fails() {
+        let mut automation_runtime = SmartHomeAutomationRuntime::new();
+        automation_runtime
+            .upsert_definition(schedule_automation_definition())
+            .unwrap();
+        let automations = Arc::new(Mutex::new(automation_runtime));
+        let runtime = fixture_runtime(true)
+            .with_automation_runtime(Arc::clone(&automations))
+            .with_automation_persistence(|_, _, _| Err("disk full".to_string()));
+        let before = runtime.snapshot();
+        let app = home_assistant_runtime_web_app(runtime.clone());
+
+        let response: WebResponse = app
+            .handle(request_with_body(
+                "POST",
+                "/api/smart_home/automations/evaluate",
+                "{}",
+            ))
+            .into();
+
+        assert_eq!(response.status, 503);
+        assert!(response_body(response).contains("disk full"));
+        assert_eq!(runtime.snapshot(), before);
+        assert!(automations.lock().unwrap().audit_records().is_empty());
+    }
+
+    fn schedule_automation_definition() -> AutomationDefinition {
+        AutomationDefinition {
+            automation_id: "nightly-off".to_string(),
+            enabled: true,
+            trigger: AutomationTrigger::Schedule {
+                every_ms: 1_000,
+                offset_ms: 0,
+            },
+            conditions: Vec::new(),
+            actions: vec![AutomationAction::Command {
+                entity_id: EntityId::trusted("entity-light-1"),
+                command_type: CommandType::TurnOff,
+                arguments: Value::Null,
+                timeout_ms: None,
+            }],
+        }
     }
 
     #[test]

--- a/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
@@ -5,4 +5,6 @@
 - Add versioned, compare-and-swap smart-home runtime snapshots.
 - Restore registry, state, history, pairing, desired state, and automation
   definitions from durable storage.
+- Persist optional versioned automation runtime state for trigger idempotency
+  and audit restoration while retaining backward compatibility.
 - Prove restart recovery with the local-folder storage backend.

--- a/code/packages/rust/smart-home-runtime-store/README.md
+++ b/code/packages/rust/smart-home-runtime-store/README.md
@@ -3,7 +3,8 @@
 `smart-home-runtime-store` persists a versioned `SmartHomeRuntime` snapshot
 through the repository-owned `StorageBackend` contract. It restores normalized
 topology, state, event and command history, pairing sessions, desired state,
-and opaque automation definitions after a process restart.
+automation definitions, consumed trigger occurrences, and automation audit
+after a process restart.
 
 Live discovery workers and event subscriptions are deliberately process-local
 and are rebuilt by their owners.

--- a/code/packages/rust/smart-home-runtime-store/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime-store/src/lib.rs
@@ -56,6 +56,7 @@ impl DurableAutomationDefinition {
 pub struct RestoredSmartHomeRuntime {
     pub runtime: SmartHomeRuntime,
     pub automation_definitions: Vec<DurableAutomationDefinition>,
+    pub automation_state: Option<serde_json::Value>,
     pub saved_at_ms: u64,
     pub revision: Revision,
 }
@@ -66,6 +67,8 @@ struct RuntimeStoreEnvelope {
     saved_at_ms: u64,
     runtime: RuntimeDurableSnapshot,
     automation_definitions: Vec<DurableAutomationDefinition>,
+    #[serde(default)]
+    automation_state: Option<serde_json::Value>,
 }
 
 /// Errors surfaced by durable runtime persistence.
@@ -143,7 +146,26 @@ impl<B: StorageBackend> SmartHomeRuntimeStore<B> {
         automation_definitions: &[DurableAutomationDefinition],
         saved_at_ms: u64,
     ) -> Result<Revision, RuntimeStoreError> {
+        self.save_with_automation_state(runtime, automation_definitions, None, saved_at_ms)
+    }
+
+    pub fn save_with_automation_state(
+        &self,
+        runtime: &SmartHomeRuntime,
+        automation_definitions: &[DurableAutomationDefinition],
+        automation_state: Option<serde_json::Value>,
+        saved_at_ms: u64,
+    ) -> Result<Revision, RuntimeStoreError> {
         validate_automation_definitions(automation_definitions)?;
+        if automation_state
+            .as_ref()
+            .is_some_and(|state| !state.is_object())
+        {
+            return Err(RuntimeStoreError::Validation {
+                field: "automation_state",
+                message: "must be a JSON object".to_string(),
+            });
+        }
         self.backend.initialize()?;
         let previous = self.backend.get(&self.namespace, &self.key)?;
         let envelope = RuntimeStoreEnvelope {
@@ -151,6 +173,7 @@ impl<B: StorageBackend> SmartHomeRuntimeStore<B> {
             saved_at_ms,
             runtime: runtime.durable_snapshot(),
             automation_definitions: automation_definitions.to_vec(),
+            automation_state,
         };
         let body = serde_json::to_vec(&envelope)
             .map_err(|error| RuntimeStoreError::Encode(error.to_string()))?;
@@ -181,6 +204,7 @@ impl<B: StorageBackend> SmartHomeRuntimeStore<B> {
         Ok(Some(RestoredSmartHomeRuntime {
             runtime: SmartHomeRuntime::restore_durable_snapshot(envelope.runtime)?,
             automation_definitions: envelope.automation_definitions,
+            automation_state: envelope.automation_state,
             saved_at_ms: envelope.saved_at_ms,
             revision: record.revision,
         }))
@@ -343,8 +367,18 @@ mod tests {
         .unwrap();
         let runtime = runtime_fixture();
         let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let automation_state = serde_json::json!({
+            "schema_version": 1,
+            "completed_trigger_keys": ["automation-kitchen-off:schedule:1"],
+            "audit_records": [{"outcome": "executed"}]
+        });
         let saved_revision = store
-            .save(&runtime, std::slice::from_ref(&automation), 500)
+            .save_with_automation_state(
+                &runtime,
+                std::slice::from_ref(&automation),
+                Some(automation_state.clone()),
+                500,
+            )
             .unwrap();
         drop(store);
 
@@ -357,6 +391,7 @@ mod tests {
         assert_eq!(restored.saved_at_ms, 500);
         assert_eq!(restored.revision, saved_revision);
         assert_eq!(restored.automation_definitions, vec![automation]);
+        assert_eq!(restored.automation_state, Some(automation_state));
         assert_eq!(restored.runtime.registry().counts().bridges, 1);
         assert_eq!(restored.runtime.registry().counts().devices, 1);
         assert_eq!(restored.runtime.registry().counts().entities, 1);
@@ -406,6 +441,30 @@ mod tests {
             error,
             RuntimeStoreError::Validation {
                 field: "automation_id",
+                ..
+            }
+        ));
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn rejects_non_object_automation_state_before_writing() {
+        let root = temp_root("invalid-automation-state");
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+
+        let error = store
+            .save_with_automation_state(
+                &SmartHomeRuntime::new(),
+                &[],
+                Some(serde_json::json!(["not", "an", "object"])),
+                1,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RuntimeStoreError::Validation {
+                field: "automation_state",
                 ..
             }
         ));

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -399,20 +399,37 @@ controller instead of another fixture wrapper:
   Every accepted service or desired-state mutation is saved synchronously; a
   failed save restores the exact pre-request runtime and returns HTTP 503.
 - The `smart-home-local-controller` binary restores
-  `smart-home-runtime-store` from a D18A local folder, retains the opaque
-  automation definitions stored beside runtime state, installs and persists
+  `smart-home-runtime-store` from a D18A local folder, installs and persists
   its local API capability grant, and serves the existing browser/API surface
   through the repository HTTP stack.
 - Executable tests prove an HTTP desired-state mutation is queryable after a
   fresh store instance and prove failed persistence leaves no in-memory
   mutation behind.
 
+## Current Automation Runtime Slice
+
+This slice turns the previously opaque automation storage boundary into an
+executable, restart-safe rules runtime:
+
+- `smart-home-automation-runtime` owns typed schedule and normalized device
+  event triggers, state-equality conditions, direct commands, scene expansion,
+  stable per-occurrence idempotency keys, dry-run plans, and bounded audit.
+- Every automation mutation delegates to the existing authorized D23 command
+  tool. Definitions, consumed trigger occurrences, and automation audit records
+  persist atomically beside the normalized runtime snapshot.
+- The native local API can create and inspect definitions, preview or execute
+  schedule and event evaluations, and read automation audit records.
+- The production local controller restores the engine, runs schedule
+  evaluation on a local worker, and synchronously persists definition and
+  execution mutations with rollback when storage fails.
+- Executable tests cover scene planning, conditions, event matching,
+  idempotency across snapshot restore, durable state validation, and the full
+  create-preview-execute-audit HTTP lifecycle.
+
 ## Smart Home Remaining Work
 
 These items move toward retiring an existing Home Assistant install:
 
-- Add an automation/rules engine with schedules, triggers, conditions, scenes,
-  idempotency, dry-run planning, and audit.
 - Add platform integrations beyond Hue: MQTT, Matter/Thread, Zigbee, Z-Wave,
   cameras, locks, thermostats, and sensors.
 - Build Home Assistant migration tools for devices, rooms, scenes,


### PR DESCRIPTION
## Summary
- add a typed smart-home automation runtime with schedule and normalized event triggers, state conditions, command and scene planning, stable idempotency keys, dry-run reports, and bounded audit
- persist definitions, consumed trigger occurrences, and automation audit atomically with the D23 runtime, including rollback on failed storage writes
- expose create/list/evaluate/audit routes and run schedule evaluation from the production local controller
- close the automation engine item in the D18-D23 Smart Home completion inventory

## Validation
- `cargo test -p smart-home-automation-runtime -p smart-home-runtime-store -p smart-home-platform-http`
- `cargo clippy -p smart-home-automation-runtime -p smart-home-runtime-store -p smart-home-platform-http --all-targets -- -D warnings`
- `bash smart-home-automation-runtime/BUILD`
- `bash smart-home-runtime-store/BUILD`
- `bash smart-home-platform-http/BUILD`
- generated `code/packages/rust/Cargo.lock` removed