### PR TITLE
Wire Venture macOS wheel scrolling

### DIFF
--- a/code/packages/rust/objc-bridge/CHANGELOG.md
+++ b/code/packages/rust/objc-bridge/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Typed `msg_bool!` and architecture-correct `msg_f64!` Objective-C message
+  dispatch helpers for native event translation.
+
 ## [0.1.0] - 2026-04-01
 
 ### Added

--- a/code/packages/rust/objc-bridge/src/lib.rs
+++ b/code/packages/rust/objc-bridge/src/lib.rs
@@ -284,6 +284,12 @@ extern "C" {
     /// `msg!` macro which casts to the correct function pointer type.
     pub fn objc_msgSend(receiver: Id, sel: Sel, ...) -> Id;
 
+    /// x86_64 Objective-C entry point for floating-point return values.
+    ///
+    /// Apple Silicon uses `objc_msgSend` for the same calls.
+    #[cfg(target_arch = "x86_64")]
+    pub fn objc_msgSend_fpret(receiver: Id, sel: Sel, ...) -> c_double;
+
     // -- Class creation (for delegate/callback classes) -------------------
 
     /// Allocate a new class pair (class + metaclass).
@@ -789,6 +795,35 @@ macro_rules! msg_u64 {
         let f: unsafe extern "C" fn($crate::Id, $crate::Sel) -> u64 =
             ::std::mem::transmute($crate::objc_msgSend as *const ());
         f($receiver, $crate::sel($sel))
+    }};
+}
+
+/// Message dispatch for methods returning an Objective-C `BOOL`.
+#[macro_export]
+macro_rules! msg_bool {
+    ($receiver:expr, $sel:expr) => {{
+        let f: unsafe extern "C" fn($crate::Id, $crate::Sel) -> ::std::ffi::c_schar =
+            ::std::mem::transmute($crate::objc_msgSend as *const ());
+        f($receiver, $crate::sel($sel)) != 0
+    }};
+}
+
+/// Message dispatch for methods returning an `f64`/Objective-C `double`.
+#[macro_export]
+macro_rules! msg_f64 {
+    ($receiver:expr, $sel:expr) => {{
+        #[cfg(target_arch = "x86_64")]
+        {
+            let f: unsafe extern "C" fn($crate::Id, $crate::Sel) -> f64 =
+                ::std::mem::transmute($crate::objc_msgSend_fpret as *const ());
+            f($receiver, $crate::sel($sel))
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            let f: unsafe extern "C" fn($crate::Id, $crate::Sel) -> f64 =
+                ::std::mem::transmute($crate::objc_msgSend as *const ());
+            f($receiver, $crate::sel($sel))
+        }
     }};
 }
 

--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Wire normalized AppKit wheel events into the shared `BrowserSession` scroll
+  model and repaint the translated viewport through Metal.
+
 ## 0.1.0
 
 - Add a runnable macOS Venture host using AppKit, CoreText, and Metal.

--- a/code/packages/rust/venture-browser-macos/README.md
+++ b/code/packages/rust/venture-browser-macos/README.md
@@ -26,5 +26,7 @@ Exercise the real AppKit + Metal presentation path and close automatically:
 cargo run -p venture-browser-macos -- --smoke-seconds 1 http://info.cern.ch/
 ```
 
-This first host slice loads and presents one page. Native controls, input-event
-translation, scrolling, and link activation are the next integration layer.
+This host loads and presents one page. Mouse-wheel and trackpad input drive the
+shared clamped viewport and repaint the translated scene through Metal. Native
+controls, input-event translation beyond wheel events, and link activation are
+the next integration layer.

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -9,12 +9,16 @@ use html_to_layout::mosaic_html_theme;
 use html_to_paint::HtmlPaintViewport;
 use layout_text_measure_native::NativeMeasurer;
 use std::fmt;
+#[cfg(target_vendor = "apple")]
+use std::{cell::RefCell, rc::Rc};
 use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 use venture_browser_core::{
     BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
     BrowserSession,
 };
 use window_core::WindowError;
+#[cfg(target_vendor = "apple")]
+use window_core::WindowEvent;
 
 #[cfg(target_vendor = "apple")]
 use venture_browser_core::HttpBrowserFetcher;
@@ -162,11 +166,45 @@ fn run_with_termination(
     paint_metal::render_to_metal_layer(&scene, layer as objc_bridge::Id)
         .map_err(|error| MacBrowserError::Paint(error.to_string()))?;
 
+    let session = Rc::new(RefCell::new(session));
+    window.set_event_handler({
+        let session = Rc::clone(&session);
+        move |event| {
+            let mut session = session.borrow_mut();
+            if scroll_session(&mut session, &event) {
+                if let Some(viewport) = session.viewport() {
+                    let scene = viewport.viewport_scene();
+                    if let Err(error) =
+                        paint_metal::render_to_metal_layer(&scene, layer as objc_bridge::Id)
+                    {
+                        eprintln!("venture-browser-macos: Metal repaint failed: {error}");
+                    }
+                }
+            }
+        }
+    })?;
+
     if let Some(seconds) = terminate_after {
         backend.terminate_after(seconds)?;
     }
     backend.run()?;
     Ok(())
+}
+
+/// Apply a normalized scroll event to the current browser viewport.
+///
+/// Returns `true` only when the clamped offset changed and the host should
+/// repaint.
+pub fn scroll_session(session: &mut BrowserSession, event: &WindowEvent) -> bool {
+    let WindowEvent::Scroll { delta_y, .. } = event else {
+        return false;
+    };
+    let Some(viewport) = session.viewport_mut() else {
+        return false;
+    };
+    let previous_offset = viewport.scroll_state().offset_y();
+    viewport.scroll_by(*delta_y);
+    viewport.scroll_state().offset_y() != previous_offset
 }
 
 #[cfg(not(target_vendor = "apple"))]
@@ -185,6 +223,8 @@ mod tests {
 
     #[cfg(target_vendor = "apple")]
     use venture_browser_core::BrowserFetchResponse;
+    #[cfg(target_vendor = "apple")]
+    use window_core::WindowId;
 
     #[test]
     fn window_title_includes_page_and_final_url() {
@@ -229,6 +269,40 @@ mod tests {
             .data
             .chunks_exact(4)
             .any(|pixel| pixel != [192, 192, 192, 255]));
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[test]
+    fn normalized_wheel_event_scrolls_and_reprojects_the_loaded_viewport() {
+        let fetcher = |url: &str| {
+            let paragraphs = (0..80)
+                .map(|index| format!("<p>Scrollable Venture paragraph {index}</p>"))
+                .collect::<String>();
+            Ok(BrowserFetchResponse::new(
+                url,
+                200,
+                Some("text/html; charset=utf-8".into()),
+                format!("<title>Scroll</title>{paragraphs}").into_bytes(),
+            ))
+        };
+        let mut session = load_initial_session("http://example.test/", 320.0, 180.0, &fetcher)
+            .expect("native browser pipeline should load tall canned HTML");
+        let before = session
+            .viewport()
+            .expect("loaded session should have a viewport")
+            .viewport_scene();
+        let event = WindowEvent::Scroll {
+            window_id: WindowId(1),
+            delta_x: 0.0,
+            delta_y: 96.0,
+        };
+
+        assert!(scroll_session(&mut session, &event));
+        let viewport = session
+            .viewport()
+            .expect("scrolling should preserve the viewport");
+        assert_eq!(viewport.scroll_state().offset_y(), 96.0);
+        assert_ne!(viewport.viewport_scene(), before);
     }
 
     #[cfg(not(target_vendor = "apple"))]

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -16,9 +16,7 @@ use venture_browser_core::{
     BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
     BrowserSession,
 };
-use window_core::WindowError;
-#[cfg(target_vendor = "apple")]
-use window_core::WindowEvent;
+use window_core::{WindowError, WindowEvent};
 
 #[cfg(target_vendor = "apple")]
 use venture_browser_core::HttpBrowserFetcher;

--- a/code/packages/rust/window-appkit/CHANGELOG.md
+++ b/code/packages/rust/window-appkit/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- An AppKit event view that translates wheel input to normalized
+  `WindowEvent::Scroll` callbacks.
+- Main-thread event-handler registration on `AppKitWindow`.
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/code/packages/rust/window-appkit/README.md
+++ b/code/packages/rust/window-appkit/README.md
@@ -8,21 +8,23 @@ This package is part of Layer 11 of the coding-adventures computing stack.
 
 ## What It Contains
 
-This first slice now supports a real macOS smoke path while staying small:
+This package supports a real macOS host path while staying small:
 
 - validates which `window-core` requests make sense on AppKit
 - creates an `NSApplication` and `NSWindow`
 - exposes AppKit render-target handles on the returned `Window`
 - runs the AppKit event loop for native launch testing
+- translates AppKit wheel input into shared `WindowEvent::Scroll` values
+- lets a main-thread host install a normalized event handler on its window
 - rejects renderer preferences that belong to other platforms
 
-The backend still does not translate live AppKit events into `WindowEvent`
-values yet, and Metal-layer attachment is still the next step after the window
-launch path.
+Metal-layer attachment is available for renderer hosts. Pointer-button,
+keyboard, resize, and close translation remain future event slices.
 
 ## Dependencies
 
 - window-core
+- objc-bridge
 
 ## Development
 

--- a/code/packages/rust/window-appkit/src/lib.rs
+++ b/code/packages/rust/window-appkit/src/lib.rs
@@ -19,13 +19,18 @@
 use std::ffi::{c_int, c_ulong};
 
 #[cfg(target_vendor = "apple")]
-use std::ffi::{c_void, CString};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    ffi::{c_void, CString},
+};
 
 #[cfg(target_vendor = "apple")]
 use objc_bridge::{
-    class, msg, msg_send_class, nsstring, object_getInstanceVariable, object_setInstanceVariable,
-    objc_allocateClassPair, objc_registerClassPair, release, sel, ClassPtr, CGPoint, CGRect, Id,
-    Sel, CGSize, NS_BACKING_STORE_BUFFERED, NS_WINDOW_STYLE_MASK_CLOSABLE,
+    class, msg, msg_bool, msg_f64, msg_send_class, nsstring, object_getInstanceVariable,
+    object_setInstanceVariable, objc_allocateClassPair, objc_registerClassPair, release, sel,
+    ClassPtr, CGPoint, CGRect, Id, Sel, CGSize, NS_BACKING_STORE_BUFFERED,
+    NS_WINDOW_STYLE_MASK_CLOSABLE,
     NS_WINDOW_STYLE_MASK_MINIATURIZABLE, NS_WINDOW_STYLE_MASK_RESIZABLE,
     NS_WINDOW_STYLE_MASK_TITLED, NIL, class_addIvar, class_addMethod,
 };
@@ -36,6 +41,21 @@ use window_core::{
 
 /// Crate version, kept explicit for examples and integration tests.
 pub const VERSION: &str = "0.1.0";
+
+#[cfg(target_vendor = "apple")]
+type AppKitEventHandler = Box<dyn FnMut(WindowEvent)>;
+
+#[cfg(target_vendor = "apple")]
+struct EventHandlerEntry {
+    window_id: WindowId,
+    callback: AppKitEventHandler,
+}
+
+#[cfg(target_vendor = "apple")]
+thread_local! {
+    static EVENT_HANDLERS: RefCell<HashMap<usize, EventHandlerEntry>> =
+        RefCell::new(HashMap::new());
+}
 
 /// Which AppKit-side surface family the renderer should expect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +89,38 @@ impl AppKitWindow {
             ns_window: self.ns_window,
             ns_view: self.ns_view,
             metal_layer: self.metal_layer,
+        }
+    }
+
+    /// Install the main-thread handler for normalized events from this view.
+    ///
+    /// AppKit invokes the handler synchronously from its normal application
+    /// run loop. The handler is replaced when this method is called again and
+    /// removed when the window closes.
+    pub fn set_event_handler<F>(&self, handler: F) -> Result<(), WindowError>
+    where
+        F: FnMut(WindowEvent) + 'static,
+    {
+        #[cfg(target_vendor = "apple")]
+        {
+            EVENT_HANDLERS.with(|handlers| {
+                handlers.borrow_mut().insert(
+                    self.ns_view,
+                    EventHandlerEntry {
+                        window_id: self.id,
+                        callback: Box::new(handler),
+                    },
+                );
+            });
+            Ok(())
+        }
+
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            let _ = handler;
+            Err(WindowError::UnsupportedPlatform(
+                "AppKit windows are only available on Apple platforms",
+            ))
         }
     }
 }
@@ -319,11 +371,13 @@ impl AppKitBackend {
         msg!(window, "setTitle:", title_ns);
         objc_bridge::CFRelease(title_ns);
 
-        let view: Id = msg!(window, "contentView");
-        if view.is_null() {
+        let default_view: Id = msg!(window, "contentView");
+        if default_view.is_null() {
             release(window);
             return Err(WindowError::backend("NSWindow contentView returned nil"));
         }
+        let view = create_event_view(msg_send_bounds(default_view))?;
+        msg!(window, "setContentView:", view);
 
         setup_window_delegate(window, app)?;
 
@@ -370,6 +424,91 @@ impl AppKitBackend {
             ns_view: view as usize,
             metal_layer,
         })
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+unsafe fn create_event_view(frame: CGRect) -> Result<Id, WindowError> {
+    let view_class = ensure_event_view_class()?;
+    let view: Id = msg!(view_class as Id, "alloc");
+    let view = msg!(view, "initWithFrame:", frame);
+    if view.is_null() {
+        return Err(WindowError::backend(
+            "WindowAppKitEventView allocation failed",
+        ));
+    }
+    Ok(view)
+}
+
+#[cfg(target_vendor = "apple")]
+unsafe fn ensure_event_view_class() -> Result<ClassPtr, WindowError> {
+    let class_name = CString::new("WindowAppKitEventView").expect("static class name");
+    let existing = objc_bridge::objc_getClass(class_name.as_ptr());
+    if !existing.is_null() {
+        return Ok(existing);
+    }
+
+    let view_class = objc_allocateClassPair(class("NSView"), class_name.as_ptr(), 0);
+    if view_class.is_null() {
+        return Err(WindowError::backend(
+            "objc_allocateClassPair failed for WindowAppKitEventView",
+        ));
+    }
+
+    let event_method_types = CString::new("v@:@").expect("static method type");
+    class_addMethod(
+        view_class,
+        sel("scrollWheel:"),
+        scroll_wheel as *const _,
+        event_method_types.as_ptr(),
+    );
+    objc_registerClassPair(view_class);
+    Ok(view_class)
+}
+
+#[cfg(target_vendor = "apple")]
+extern "C" fn scroll_wheel(view: Id, _sel: Sel, event: Id) {
+    unsafe {
+        let precise = msg_bool!(event, "hasPreciseScrollingDeltas");
+        let line_scale = if precise { 1.0 } else { 40.0 };
+        let native_delta_x = msg_f64!(event, "scrollingDeltaX") * line_scale;
+        let native_delta_y = msg_f64!(event, "scrollingDeltaY") * line_scale;
+        dispatch_scroll_event(view, native_delta_x, native_delta_y);
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+fn dispatch_scroll_event(view: Id, native_delta_x: f64, native_delta_y: f64) {
+    EVENT_HANDLERS.with(|handlers| {
+        let mut handlers = handlers.borrow_mut();
+        if let Some(entry) = handlers.get_mut(&(view as usize)) {
+            (entry.callback)(normalized_scroll_event(
+                entry.window_id,
+                native_delta_x,
+                native_delta_y,
+            ));
+        }
+    });
+}
+
+/// Translate AppKit's content-motion deltas into viewport scroll direction.
+pub fn normalized_scroll_event(
+    window_id: WindowId,
+    native_delta_x: f64,
+    native_delta_y: f64,
+) -> WindowEvent {
+    WindowEvent::Scroll {
+        window_id,
+        delta_x: invert_finite(native_delta_x),
+        delta_y: invert_finite(native_delta_y),
+    }
+}
+
+fn invert_finite(value: f64) -> f64 {
+    if value.is_finite() {
+        -value
+    } else {
+        0.0
     }
 }
 
@@ -522,6 +661,14 @@ unsafe fn ensure_delegate_class() -> Result<ClassPtr, WindowError> {
 #[cfg(target_vendor = "apple")]
 extern "C" fn window_will_close(this: Id, _sel: Sel, _notification: Id) {
     unsafe {
+        let window: Id = msg!(_notification, "object");
+        if !window.is_null() {
+            let view: Id = msg!(window, "contentView");
+            EVENT_HANDLERS.with(|handlers| {
+                handlers.borrow_mut().remove(&(view as usize));
+            });
+        }
+
         let ivar_name = CString::new("_app").expect("static ivar name");
         let mut app_ptr: *mut c_void = std::ptr::null_mut();
         object_getInstanceVariable(this, ivar_name.as_ptr(), &mut app_ptr);
@@ -608,6 +755,26 @@ mod tests {
                 ns_window: 10,
                 ns_view: 20,
                 metal_layer: None
+            }
+        );
+    }
+
+    #[test]
+    fn appkit_scroll_deltas_follow_viewport_direction_and_sanitize_non_finite_values() {
+        assert_eq!(
+            normalized_scroll_event(WindowId(7), 2.5, -8.0),
+            WindowEvent::Scroll {
+                window_id: WindowId(7),
+                delta_x: -2.5,
+                delta_y: 8.0,
+            }
+        );
+        assert_eq!(
+            normalized_scroll_event(WindowId(7), f64::NAN, f64::INFINITY),
+            WindowEvent::Scroll {
+                window_id: WindowId(7),
+                delta_x: 0.0,
+                delta_y: 0.0,
             }
         );
     }

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -72,9 +72,10 @@ navigation commands and content-link activation through transactional page
 loads, preserving the prior history and viewport on failure. The remaining
 browser gate is now being closed on macOS first: `venture-browser-macos` loads
 an HTTP page with native CoreText services, creates an AppKit `CAMetalLayer`,
-and presents the viewport through `paint-metal`. Native event translation,
-controls, scrolling, and repeated navigation remain before the shell is
-interactive.
+and presents the viewport through `paint-metal`. Native AppKit wheel events now
+drive the shared clamped viewport and Metal repaint path. Pointer-button and
+keyboard translation, controls, link activation, and repeated navigation
+remain before the shell is interactive.
 
 ## Where It Fits
 


### PR DESCRIPTION
## Summary

- add architecture-correct Objective-C helpers for `BOOL` and `double` returns
- install an AppKit content view that translates wheel and trackpad input into shared `WindowEvent::Scroll` values
- apply normalized wheel events to Venture's clamped `BrowserSession` viewport and repaint through the existing Metal layer
- update BR01 and package documentation to keep the remaining macOS interaction gates explicit

## Why

The first runnable macOS host could load and present a page, but it handed control entirely to AppKit after the initial paint. That left the already-implemented shared scroll model disconnected from native input. This slice establishes the reusable main-thread event seam and proves scrolling end to end without mixing in pointer activation, toolbar controls, or repeated navigation.

## Validation

- `cargo test -p window-core -p venture-browser-core -p window-appkit -p venture-browser-macos -p objc-bridge -- --nocapture`
- `cargo clippy -p objc-bridge -p window-appkit -p venture-browser-macos --all-targets -- -D warnings`
- `cargo run -p venture-browser-macos -- --smoke-seconds 0.5 http://info.cern.ch/`
- exact upstream coverage audit:
  - WPT tree construction: 1,934 upstream / 2,637 local / 0 missing
  - html5lib tokenizer: 6,806 upstream / 7,015 local raw / 0 missing
  - normalized tokenizer: 7,242 cases / 0 skipped

## Remaining browser gates

Pointer-button and keyboard translation, link activation and repeated navigation, native controls, and the later Windows host remain separate follow-up slices.
