### PR TITLE
feat(spice): validate MOS body effect

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `GAMMA` values with a
+  stable diagnostic before body-effect and temperature preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `PHI` values with a
   stable diagnostic before electrostatic and temperature preprocessing.
 - Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -586,6 +586,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET LAMBDA must be finite")
         elif canonical == "PHI" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET PHI must be finite and positive")
+        elif canonical == "GAMMA" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET GAMMA must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1090,6 +1090,18 @@ def test_mos_model_card_rejects_non_positive_or_non_finite_surface_potential() -
             normalize_model_card("Minvalid", "nmos", {"PHI": invalid_potential})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_body_effect_coefficient() -> None:
+    for value in (0.0, 0.27, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"GAMMA": value})
+        assert valid.parameters["GAMMA"] == pytest.approx(value)
+
+    for invalid_coefficient in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET GAMMA must be finite and non-negative"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"GAMMA": invalid_coefficient})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `GAMMA` values with a
+  stable diagnostic before body-effect and temperature preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `PHI` values with a
   stable diagnostic before electrostatic and temperature preprocessing.
 - Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4395,6 +4395,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET PHI must be finite and positive".to_string(),
                 });
+            } else if canonical == "GAMMA" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET GAMMA must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -911,6 +911,22 @@ fn mos_model_card_rejects_non_positive_or_non_finite_surface_potential() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_body_effect_coefficient() {
+    for value in [0.0, 0.27, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("GAMMA", value)]).unwrap();
+        assert_close(*valid.parameters.get("GAMMA").unwrap(), value);
+    }
+
+    for invalid_coefficient in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("GAMMA", invalid_coefficient)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET GAMMA must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `GAMMA` values with a
+  stable diagnostic before body-effect and temperature preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `PHI` values with a
   stable diagnostic before electrostatic and temperature preprocessing.
 - Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8451,6 +8451,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value <= 0.0)
     ) {
       throw invalidElement(name, "MOSFET PHI must be finite and positive");
+    } else if (
+      canonical === "GAMMA" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET GAMMA must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -787,6 +787,26 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS body-effect coefficient", () => {
+    for (const value of [0.0, 0.27, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { GAMMA: value });
+      expect(valid.parameters.GAMMA).toBe(value);
+    }
+
+    for (const invalidCoefficient of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", {
+          GAMMA: invalidCoefficient,
+        }),
+      ).toThrow("MOSFET GAMMA must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS surface-potential validation.
+1. Cross-language Level-1 MOS body-effect validation.
    - Status: current PR completion candidate.
-   - Reject non-positive or non-finite model-card `PHI` values before
-     electrostatic and temperature preprocessing.
-   - Preserve positive explicit surface potentials across Rust, Python, and
-     TypeScript.
+   - Reject negative or non-finite model-card `GAMMA` values before body-effect
+     and temperature preprocessing.
+   - Preserve zero and positive explicit body-effect coefficients across Rust,
+     Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3692,6 +3692,13 @@ the Rust, Python, and TypeScript surfaces together.
      evaluation.
    - Arbitrary finite channel-length modulation coefficients remain aligned
      across Rust, Python, and TypeScript.
+
+302. Cross-language Level-1 MOS surface-potential validation.
+   - Status: completed in PR 9266.
+   - Non-positive and non-finite model-card `PHI` values are rejected before
+     electrostatic and temperature preprocessing.
+   - Positive explicit surface potentials remain aligned across Rust, Python,
+     and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS `GAMMA` values before body-effect and temperature preprocessing
- preserve zero and positive coefficients with aligned Rust, Python, and TypeScript diagnostics
- reconcile the SPICE completion plan by recording PR #9266 and selecting this slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check` for spice-engine source and tests
- Python full spice-engine pytest: 684 passed, 88.95% coverage
- TypeScript `npm test`: 427 passed
- TypeScript `npm run build`