### PR TITLE
feat(sir-c): built-in String methods (Collections slice 1)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.22.0 — Collections slice 1: built-in String methods
+
+The first slice of the **Collections** batch — the built-in method catalog every
+OOP slice deferred (`"hi".length` used to be rejected as "the Collections
+batch"). No new `Feature` (a built-in method is a `__method__` dispatch).
+
+- A new runtime dispatcher `_sir_builtin_method(recv, "m", argc, …)` implements
+  common 0-arity String methods — `length`/`size`, `upcase`, `downcase`,
+  `reverse`, `empty?`, `to_s` — by an explicit `strcmp` switch on the method name
+  plus a receiver-type check. `length`/`size`/`empty?` are **polymorphic** over
+  String/Array/Hash; the rest are String-only. A wrong-type receiver raises
+  `NoMethodError`, exactly as Ruby's dynamic dispatch would — never a crash.
+- `__method__` emit now **routes** by name: a user-registered method (OOP) still
+  goes through the class method table (`_sir_call_method`); a built-in name that
+  the module did *not* define routes to `_sir_builtin_method`. The structural
+  scan's allowlist widens to accept the built-in names, so `"str".upcase` etc.
+  compile instead of being deferred. A built-in method **not** in this slice yet
+  (e.g. `strip`) is still rejected cleanly.
+- **Anti-RCE preserved.** The method name is a compiler-emitted quoted C literal
+  and only ever a `strcmp` target — never reflection.
+
 ## 0.21.0 — OOP mirror slice 7: modules / mixins (final OOP slice)
 
 Modules and mixins — the **final** slice of the C OOP mirror. Accepts

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -112,8 +112,9 @@ table).  Class/constant names are quoted C string literals (no injection).  And
 closure` into an explicit table (`_sir_def_method`), and `__method__` dispatches
 via `_sir_call_method` (resolve `(recv's class, method)`, apply the closure; miss
 → `NoMethodError`).  Dispatch is an explicit data lookup — **never reflection** on
-a source string — so it is anti-RCE by construction; a dispatch to an
-un-registered (built-in) method is rejected cleanly (the Collections batch).  And
+a source string — so it is anti-RCE by construction; a dispatch to a built-in
+method the module never defined routes to the Collections runtime (below) or, if
+not lowered yet, is rejected cleanly.  And
 **slice 3** — `InstanceVars`: `@v = x` / `@v` (`Scope::Instance`) →
 `_sir_ivar_set` / `_sir_ivar_get` on the receiver's lazily-allocated `@name →
 value` map (an unset `@v` reads nil), and a bare `self` → `_sir_self()`.  The
@@ -143,6 +144,14 @@ methods register like a class's, `include M` (`_sir_register_include`) folds M's
 methods into a class's instance-method resolution and `extend M`
 (`_sir_register_extend`) into its class-method resolution — completing the C
 OOP surface (**6-backend OOP parity**).
+
+And the **Collections** batch has begun (**slice 1** — String methods): a
+`__method__` dispatch to a built-in name the module never defined routes to the
+runtime dispatcher `_sir_builtin_method`, which type-checks the receiver and
+applies the implementation.  Covered so far: `length`/`size`, `upcase`,
+`downcase`, `reverse`, `empty?`, `to_s` (`length`/`size`/`empty?` polymorphic
+over String/Array/Hash).  A wrong-type receiver raises `NoMethodError`; a
+built-in method not lowered yet is still rejected cleanly.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, a `class << self` singleton, and

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1539,7 +1539,18 @@ fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usiz
     if name == "__method__" {
         if let (Some(recv), Some(Expr::StrLit { value: m, .. })) = (args.first(), args.get(1)) {
             let call_args = &args[2..];
-            out.push_str("_sir_call_method(");
+            // A user-registered method (OOP) dispatches through the class method
+            // table; otherwise a KNOWN built-in name (Collections) routes to the
+            // runtime dispatcher.  Both take the same `(recv, "m", argc, args…)`
+            // shape, so only the helper name differs.  (The scan guarantees the
+            // name is one or the other; a truly unknown name is rejected there.)
+            let user = DEFINED_METHODS.with(|d| d.borrow().contains(m));
+            let helper = if !user && is_builtin_method(m) {
+                "_sir_builtin_method"
+            } else {
+                "_sir_call_method"
+            };
+            let _ = write!(out, "{helper}(");
             emit_expr(out, recv, indent);
             let _ = write!(out, ", {}, {}", quote_c_string(m), call_args.len());
             for a in call_args {
@@ -1738,6 +1749,21 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
         "puts" => "_sir_puts",
         _ => return None,
     })
+}
+
+/// Collections slice 1: the built-in *method* names the C runtime's
+/// `_sir_builtin_method` dispatches (all 0-arity in this slice).  A `__method__`
+/// call to one of these — when the module has NOT defined a user method of the
+/// same name — routes to the runtime dispatcher instead of the user method
+/// table, and the structural scan accepts it (rather than deferring it to a
+/// later Collections batch).  `length`/`size`/`empty?` are polymorphic over
+/// String/Array/Hash; the rest are String-only (the dispatcher raises
+/// `NoMethodError` on an unsupported receiver type, matching Ruby).
+fn is_builtin_method(name: &str) -> bool {
+    matches!(
+        name,
+        "length" | "size" | "upcase" | "downcase" | "reverse" | "empty?" | "to_s"
+    )
 }
 
 /// The builtins the v0 emitter can lower directly.  Anything else — the
@@ -2164,18 +2190,21 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
                     span.clone(),
                 ));
             }
-            // `__method__(recv, "m", …)` dispatch to a method the module never
-            // registers via `__def_method__` is a BUILT-IN method call (the
-            // Collections batch) — rejected cleanly (dispatch is already anti-RCE
-            // by construction; this preserves clean compile-time rejection).
+            // `__method__(recv, "m", …)` dispatch: accepted if `m` is a
+            // user-registered method (OOP, via the class table) OR a built-in
+            // method the Collections runtime dispatches (`is_builtin_method`).  A
+            // name that is NEITHER is a built-in method not in this slice yet —
+            // rejected cleanly (dispatch is anti-RCE by construction; this keeps
+            // the clean compile-time rejection for the not-yet-lowered names).
             if name == "__method__" {
                 if let Some(Expr::StrLit { value, .. }) = args.get(1) {
-                    let known = DEFINED_METHODS.with(|d| d.borrow().contains(value));
+                    let known = DEFINED_METHODS.with(|d| d.borrow().contains(value))
+                        || is_builtin_method(value);
                     if !known {
                         return Some((
                             format!(
-                                "a call to the built-in method `{value}` (only \
-                                 user-defined methods dispatch this slice)"
+                                "a call to the built-in method `{value}` \
+                                 (not lowered by the C backend yet)"
                             ),
                             span.clone(),
                         ));

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -142,6 +142,32 @@ char *_sir_cat(const char *a, const char *b) {
     return p;
 }
 
+/* Collections slice 1: String transforms.  Each returns a FRESH arena buffer
+ * (leak-on-exit, like every heap value) so the source string is never mutated.
+ * Case mapping is ASCII-only — no `<ctype.h>` locale surprises, matching the
+ * conformance corpus. */
+char *_sir_str_upcase(const char *s) {
+    size_t n = strlen(s), i;
+    char *p = (char *)_sir_alloc(n + 1);
+    for (i = 0; i < n; i++) { char c = s[i]; p[i] = (c >= 'a' && c <= 'z') ? (char)(c - 32) : c; }
+    p[n] = '\0';
+    return p;
+}
+char *_sir_str_downcase(const char *s) {
+    size_t n = strlen(s), i;
+    char *p = (char *)_sir_alloc(n + 1);
+    for (i = 0; i < n; i++) { char c = s[i]; p[i] = (c >= 'A' && c <= 'Z') ? (char)(c + 32) : c; }
+    p[n] = '\0';
+    return p;
+}
+char *_sir_str_reverse(const char *s) {
+    size_t n = strlen(s), i;
+    char *p = (char *)_sir_alloc(n + 1);
+    for (i = 0; i < n; i++) p[i] = s[n - 1 - i];
+    p[n] = '\0';
+    return p;
+}
+
 /* ---- symbol interning --------------------------------------- */
 
 #define SIR_INTERN_MAX 8192
@@ -1387,6 +1413,40 @@ SirValue _sir_call_class_method(const char *cls, const char *method, int argc, .
     }
     if (args) free(args);
     return r;
+}
+
+/* ---- Collections slice 1: built-in String methods --------------------------
+ *
+ * A `__method__` dispatch whose name is a KNOWN built-in method — and which the
+ * module did NOT define as a user method — routes here instead of the user
+ * method table.  Dispatch is an explicit `strcmp` switch on the method name plus
+ * a receiver-type check (Ruby's built-in methods are polymorphic: `length` works
+ * on a String, Array, or Hash), so a wrong-type receiver raises `NoMethodError`
+ * exactly as Ruby would — never a crash.  The method name is a compiler-emitted
+ * quoted literal, so this is not reflection (anti-RCE holds).  Slice 1 covers
+ * common 0-arity methods; the `argc`/varargs are carried for later arg-taking
+ * methods. */
+SirValue _sir_builtin_method(SirValue recv, const char *m, int argc, ...) {
+    (void)argc;  /* every built-in method in this slice is 0-arity */
+    if (strcmp(m, "length") == 0 || strcmp(m, "size") == 0) {
+        if (recv.tag == SIR_STR) return _sir_int((int64_t)strlen(recv.as.s));
+        if (recv.tag == SIR_SEQ) return _sir_int(recv.as.seq->len);
+        if (recv.tag == SIR_MAP) return _sir_int(recv.as.map->len);
+    } else if (strcmp(m, "upcase") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str(_sir_str_upcase(recv.as.s));
+    } else if (strcmp(m, "downcase") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str(_sir_str_downcase(recv.as.s));
+    } else if (strcmp(m, "reverse") == 0) {
+        if (recv.tag == SIR_STR) return _sir_str(_sir_str_reverse(recv.as.s));
+    } else if (strcmp(m, "empty?") == 0) {
+        if (recv.tag == SIR_STR) return _sir_bool(recv.as.s[0] == '\0');
+        if (recv.tag == SIR_SEQ) return _sir_bool(recv.as.seq->len == 0);
+        if (recv.tag == SIR_MAP) return _sir_bool(recv.as.map->len == 0);
+    } else if (strcmp(m, "to_s") == 0) {
+        if (recv.tag == SIR_STR) return recv;  /* String#to_s is the string itself */
+    }
+    return _sir_raise(
+        _sir_error("NoMethodError", _sir_str(_sir_cat("undefined method ", m))));
 }
 
 /* ---- OOP slice 6: class variables (@@x) ------------------------------------

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods.rs
@@ -1,0 +1,94 @@
+//! Execution proof for Collections slice 1 (built-in String methods) on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run, assert
+//! stdout.  Skips gracefully when no `cc` is present.
+//!
+//! A `"str".method` call lowers to `__method__(recv, "method")`; when `method`
+//! is a built-in name (not a user-defined method) it routes to the runtime
+//! `_sir_builtin_method` dispatcher, which type-checks the receiver and applies
+//! the String implementation (or raises `NoMethodError` on a wrong-type receiver,
+//! matching Ruby).
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    let stem = format!("sirc_strm_{}_{}", std::process::id(), src.len());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn string_length_upcase_downcase_reverse() {
+    match run_ruby(
+        "puts \"hello\".length\nputs \"hello\".upcase\nputs \"WORLD\".downcase\nputs \"abc\".reverse\n",
+    ) {
+        Some(out) => assert_eq!(out, "5\nHELLO\nworld\ncba\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn string_to_s_is_the_string_itself() {
+    match run_ruby("puts \"hi\".to_s\n") {
+        Some(out) => assert_eq!(out, "hi\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn string_empty_predicate_in_control_flow() {
+    // `empty?` returns a bool; used in an `if` so the assertion doesn't depend on
+    // the boolean *display* convention (a separate pre-existing frontend gap).
+    match run_ruby(
+        "if \"\".empty?\n  puts \"blank\"\nend\nif \"x\".empty?\n  puts \"never\"\nelse\n  puts \"filled\"\nend\n",
+    ) {
+        Some(out) => assert_eq!(out, "blank\nfilled\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn methods_chain() {
+    // `upcase` returns a String, so another built-in method dispatches on it.
+    match run_ruby("puts \"hello\".upcase.reverse\n") {
+        Some(out) => assert_eq!(out, "OLLEH\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -143,16 +143,17 @@ fn string_literals_are_trigraph_safe() {
 
 #[test]
 fn builtin_method_dispatch_is_rejected() {
-    // `"hi".length` lowers to a `__method__` dispatch to `length` — a BUILT-IN
-    // method the module never registers via `__def_method__`.  OOP slice 2 now
-    // lowers user-defined instance methods, but a built-in method call is the
-    // separate Collections batch, so the allowlist rejects it cleanly (rather
-    // than emitting a call that `NoMethodError`s at runtime).
-    let m = lower_ruby("puts \"hi\".length");
-    let err = compile(&m).expect_err("rejects a built-in method dispatch");
+    // A built-in method NOT in the Collections slice yet (`strip`) lowers to a
+    // `__method__` dispatch the module never registers via `__def_method__`, so
+    // the allowlist rejects it cleanly (rather than emitting a call that
+    // `NoMethodError`s at runtime).  (`length`/`upcase`/… ARE lowered now — see
+    // `collection_string_methods_route_to_the_builtin_dispatcher` and the
+    // `compile_and_run_string_methods` execution proof.)
+    let m = lower_ruby("puts \"hi\".strip");
+    let err = compile(&m).expect_err("rejects a not-yet-lowered built-in method dispatch");
     assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
     assert!(
-        err.message.contains("length"),
+        err.message.contains("strip"),
         "names the built-in method: {}",
         err.message
     );
@@ -291,6 +292,23 @@ fn modules_register_include_and_extend() {
     assert!(
         src.contains("_sir_def_method(\"Greet\", \"hi\""),
         "a module method is registered like a class method, keyed on the module\n{src}"
+    );
+}
+
+#[test]
+fn collection_string_methods_route_to_the_builtin_dispatcher() {
+    // Collections slice 1: a `__method__` dispatch to a built-in method name
+    // (`upcase`) that is NOT a user-defined method routes to
+    // `_sir_builtin_method` (the runtime dispatcher), not the user method table.
+    let m = lower_ruby("puts \"hi\".upcase");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_builtin_method("),
+        "a built-in method dispatches through the runtime dispatcher\n{src}"
+    );
+    assert!(
+        src.contains("\"upcase\""),
+        "the method name is a quoted C string literal\n{src}"
     );
 }
 

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -361,6 +361,11 @@ lockstep:
    + call-time prologue).
 4. **Collections** — the `__method__` dispatch catalog
    (String / Array / Hash / Numeric / Symbol / Object, block and non-block).
+   Slice 1 (0.22.0) landed the common 0-arity String methods via a
+   `_sir_builtin_method` runtime dispatcher (`length`/`size`, `upcase`,
+   `downcase`, `reverse`, `empty?`, `to_s`; `length`/`size`/`empty?` polymorphic
+   over String/Array/Hash) — a built-in name the module did not define routes
+   there instead of the user method table; the rest of the catalog follows.
 5. **Exceptions** — `setjmp`/`longjmp` + typed runtime errors.
 6. **OOP** (mirroring the Ruby backend's landed 7-slice arc) — slice 1
    (`Classes` + `Constants`: the `SIR_INSTANCE` runtime, an empty class, `Foo.new`


### PR DESCRIPTION
## What

First slice of the **Collections** batch — the built-in method catalog every OOP slice deferred (`"hi".length` used to be rejected as "the Collections batch"). No new `Feature` (a built-in method is a `__method__` dispatch). Branched fresh off main (not stacked).

- New runtime dispatcher **`_sir_builtin_method(recv, "m", argc, …)`** implements common 0-arity String methods — `length`/`size`, `upcase`, `downcase`, `reverse`, `empty?`, `to_s` — via an explicit `strcmp` switch on the method name + a receiver-type check. `length`/`size`/`empty?` are **polymorphic** over String/Array/Hash; the rest are String-only. A wrong-type receiver raises `NoMethodError` (matching Ruby's dynamic dispatch) — never a crash. String transforms return fresh arena buffers; case mapping is ASCII-only.
- **`__method__` emit routes by name:** a user-registered method (OOP) still goes through the class method table (`_sir_call_method`); a built-in name the module did *not* define routes to `_sir_builtin_method`. The scan allowlist widens to accept the built-in names, so `"str".upcase` compiles instead of being deferred; a built-in method not in this slice yet (e.g. `strip`) is still rejected cleanly.
- **Anti-RCE preserved:** the method name is a compiler-emitted quoted C literal, only ever a `strcmp` target — never reflection.

## Tests / quality

- **Emit-shape**: `collection_string_methods_route_to_the_builtin_dispatcher`; retargeted the stale `builtin_method_dispatch_is_rejected` test to `strip` (`length` now accepted). 18/18 emit tests pass.
- **cc-exec e2e** (`compile_and_run_string_methods.rs`): length/upcase/downcase/reverse; `to_s`; `empty?` in control flow; method chaining (`"hello".upcase.reverse` → `OLLEH`). 4/4 pass.
- **Regression**: OOP dispatch (methods 3, modules 4) green; clippy clean; security review passed (Rust+C: no OOB/type-confusion, bounded, anti-RCE intact).

Bumps `semantic-ir-to-c` 0.21.0 → 0.22.0; updates CHANGELOG, README, SIR24 spec. Next Collections slices: String arg-taking methods (`include?`, `split`, `[]`), then Array/Hash/Numeric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)