### PR TITLE
feat(spice): validate MOS junction potential

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `PB` values with a
+  stable diagnostic before depletion and temperature preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `GAMMA` values with a
   stable diagnostic before body-effect and temperature preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `PHI` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -588,6 +588,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET PHI must be finite and positive")
         elif canonical == "GAMMA" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET GAMMA must be finite and non-negative")
+        elif canonical == "PB" and (not math.isfinite(value) or value <= 0.0):
+            raise ValueError(f"{name}: MOSFET PB must be finite and positive")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1102,6 +1102,16 @@ def test_mos_model_card_rejects_negative_or_non_finite_body_effect_coefficient()
             normalize_model_card("Minvalid", "nmos", {"GAMMA": invalid_coefficient})
 
 
+def test_mos_model_card_rejects_non_positive_or_non_finite_bulk_junction_potential() -> None:
+    for value in (0.1, 0.8, 2.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"PB": value})
+        assert valid.parameters["PB"] == pytest.approx(value)
+
+    for invalid_potential in (-math.inf, -0.1, 0.0, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET PB must be finite and positive"):
+            normalize_model_card("Minvalid", "nmos", {"PB": invalid_potential})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `PB` values with a
+  stable diagnostic before depletion and temperature preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `GAMMA` values with a
   stable diagnostic before body-effect and temperature preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `PHI` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4400,6 +4400,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET GAMMA must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "PB" && (!raw_value.is_finite() || *raw_value <= 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET PB must be finite and positive".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -927,6 +927,22 @@ fn mos_model_card_rejects_negative_or_non_finite_body_effect_coefficient() {
 }
 
 #[test]
+fn mos_model_card_rejects_non_positive_or_non_finite_bulk_junction_potential() {
+    for value in [0.1, 0.8, 2.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("PB", value)]).unwrap();
+        assert_close(*valid.parameters.get("PB").unwrap(), value);
+    }
+
+    for invalid_potential in [f64::NEG_INFINITY, -0.1, 0.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("PB", invalid_potential)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET PB must be finite and positive"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `PB` values with a
+  stable diagnostic before depletion and temperature preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `GAMMA` values with a
   stable diagnostic before body-effect and temperature preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `PHI` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8456,6 +8456,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0)
     ) {
       throw invalidElement(name, "MOSFET GAMMA must be finite and non-negative");
+    } else if (
+      canonical === "PB" &&
+      (!Number.isFinite(value) || value <= 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET PB must be finite and positive");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -807,6 +807,25 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects non-positive or non-finite MOS bulk-junction potential", () => {
+    for (const value of [0.1, 0.8, 2.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { PB: value });
+      expect(valid.parameters.PB).toBe(value);
+    }
+
+    for (const invalidPotential of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      0.0,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { PB: invalidPotential }),
+      ).toThrow("MOSFET PB must be finite and positive");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS body-effect validation.
+1. Cross-language Level-1 MOS bulk-junction-potential validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `GAMMA` values before body-effect
+   - Reject non-positive or non-finite model-card `PB` values before depletion
      and temperature preprocessing.
-   - Preserve zero and positive explicit body-effect coefficients across Rust,
-     Python, and TypeScript.
+   - Preserve positive explicit bulk-junction potentials across Rust, Python,
+     and TypeScript.
 
 ## Completed Slices
 
@@ -3699,6 +3699,13 @@ the Rust, Python, and TypeScript surfaces together.
      electrostatic and temperature preprocessing.
    - Positive explicit surface potentials remain aligned across Rust, Python,
      and TypeScript.
+
+303. Cross-language Level-1 MOS body-effect validation.
+   - Status: completed in PR 9271.
+   - Negative and non-finite model-card `GAMMA` values are rejected before
+     body-effect and temperature preprocessing.
+   - Zero and positive explicit body-effect coefficients remain aligned across
+     Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite Level-1 MOS `PB` values before depletion and temperature preprocessing
- preserve positive bulk-junction potentials with aligned Rust, Python, and TypeScript diagnostics
- reconcile the SPICE completion plan by recording PR #9271 and selecting this slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check` for spice-engine source and tests
- Python full spice-engine pytest: 685 passed, 88.95% coverage
- TypeScript `npm test`: 428 passed
- TypeScript `npm run build`