### PR TITLE
feat(sir-c): 1-arg String query methods (Collections slice 2)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.23.0 — Collections slice 2: 1-arg String query methods
+
+Second Collections slice — the first **argument-taking** built-in methods. No new
+`Feature`.
+
+- `_sir_builtin_method` now **collects its varargs** (via `_sir_va_collect`, the
+  same pattern as `_sir_plus`), split into a `_sir_builtin_method_v` impl over the
+  already-collected args + a thin wrapper that frees them. This unblocks methods
+  that read an argument.
+- New String queries: `include?(sub)`, `start_with?(prefix)`, `end_with?(suffix)`
+  → bool; `index(sub)` → the 0-based Int position or nil. Each guards
+  `argc >= 1` and `args[0].tag == SIR_STR`, raising `NoMethodError` on a wrong
+  receiver/argument type (matching Ruby) — never an out-of-bounds read.
+- The emit already carried `argc` + the arguments through the `__method__`
+  routing (slice 1), so only the `is_builtin_method` allowlist grows; the scan
+  accepts the new names automatically.
+
+**Anti-RCE preserved:** the method name is a compiler-emitted quoted C literal
+used only as a `strcmp` target — never reflection.
+
 ## 0.22.0 — Collections slice 1: built-in String methods
 
 The first slice of the **Collections** batch — the built-in method catalog every

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -145,13 +145,15 @@ methods into a class's instance-method resolution and `extend M`
 (`_sir_register_extend`) into its class-method resolution — completing the C
 OOP surface (**6-backend OOP parity**).
 
-And the **Collections** batch has begun (**slice 1** — String methods): a
-`__method__` dispatch to a built-in name the module never defined routes to the
-runtime dispatcher `_sir_builtin_method`, which type-checks the receiver and
-applies the implementation.  Covered so far: `length`/`size`, `upcase`,
-`downcase`, `reverse`, `empty?`, `to_s` (`length`/`size`/`empty?` polymorphic
-over String/Array/Hash).  A wrong-type receiver raises `NoMethodError`; a
-built-in method not lowered yet is still rejected cleanly.
+And the **Collections** batch has begun: a `__method__` dispatch to a built-in
+name the module never defined routes to the runtime dispatcher
+`_sir_builtin_method`, which type-checks the receiver and applies the
+implementation.  Covered so far — **slice 1** (0-arity String): `length`/`size`,
+`upcase`, `downcase`, `reverse`, `empty?`, `to_s` (`length`/`size`/`empty?`
+polymorphic over String/Array/Hash); **slice 2** (1-arg String queries):
+`include?`, `start_with?`, `end_with?` → bool and `index` → Int/nil (the argument
+a String).  A wrong-type receiver or argument raises `NoMethodError`; a built-in
+method not lowered yet is still rejected cleanly.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, a `class << self` singleton, and

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1751,18 +1751,22 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
     })
 }
 
-/// Collections slice 1: the built-in *method* names the C runtime's
-/// `_sir_builtin_method` dispatches (all 0-arity in this slice).  A `__method__`
-/// call to one of these — when the module has NOT defined a user method of the
-/// same name — routes to the runtime dispatcher instead of the user method
-/// table, and the structural scan accepts it (rather than deferring it to a
-/// later Collections batch).  `length`/`size`/`empty?` are polymorphic over
-/// String/Array/Hash; the rest are String-only (the dispatcher raises
-/// `NoMethodError` on an unsupported receiver type, matching Ruby).
+/// Collections: the built-in *method* names the C runtime's `_sir_builtin_method`
+/// dispatches.  A `__method__` call to one of these — when the module has NOT
+/// defined a user method of the same name — routes to the runtime dispatcher
+/// instead of the user method table, and the structural scan accepts it (rather
+/// than deferring it to a later Collections batch).  Slice 1 = 0-arity String
+/// methods (`length`/`size`/`empty?` polymorphic over String/Array/Hash); slice 2
+/// = 1-arg String queries (`include?`/`start_with?`/`end_with?`/`index`, the arg
+/// a String).  The dispatcher raises `NoMethodError` on an unsupported receiver
+/// type, matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
     matches!(
         name,
+        // slice 1 — 0-arity
         "length" | "size" | "upcase" | "downcase" | "reverse" | "empty?" | "to_s"
+        // slice 2 — 1-arg String queries (the arg is a String)
+        | "include?" | "start_with?" | "end_with?" | "index"
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1426,8 +1426,10 @@ SirValue _sir_call_class_method(const char *cls, const char *method, int argc, .
  * quoted literal, so this is not reflection (anti-RCE holds).  Slice 1 covers
  * common 0-arity methods; the `argc`/varargs are carried for later arg-taking
  * methods. */
-SirValue _sir_builtin_method(SirValue recv, const char *m, int argc, ...) {
-    (void)argc;  /* every built-in method in this slice is 0-arity */
+/* The switch, over the already-collected `args` (so an arg-taking method reads
+ * `args[0]` after guarding `argc >= 1` and its type).  `_sir_builtin_method`
+ * wraps this to collect/free the varargs, exactly like `_sir_plus`. */
+static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, SirValue *args) {
     if (strcmp(m, "length") == 0 || strcmp(m, "size") == 0) {
         if (recv.tag == SIR_STR) return _sir_int((int64_t)strlen(recv.as.s));
         if (recv.tag == SIR_SEQ) return _sir_int(recv.as.seq->len);
@@ -1445,8 +1447,39 @@ SirValue _sir_builtin_method(SirValue recv, const char *m, int argc, ...) {
     } else if (strcmp(m, "to_s") == 0) {
         if (recv.tag == SIR_STR) return recv;  /* String#to_s is the string itself */
     }
+    /* Collections slice 2: 1-arg String queries (arg is a String). */
+    else if (strcmp(m, "include?") == 0) {
+        if (recv.tag == SIR_STR && argc >= 1 && args[0].tag == SIR_STR)
+            return _sir_bool(strstr(recv.as.s, args[0].as.s) != NULL);
+    } else if (strcmp(m, "start_with?") == 0) {
+        if (recv.tag == SIR_STR && argc >= 1 && args[0].tag == SIR_STR) {
+            size_t pl = strlen(args[0].as.s);
+            return _sir_bool(strncmp(recv.as.s, args[0].as.s, pl) == 0);
+        }
+    } else if (strcmp(m, "end_with?") == 0) {
+        if (recv.tag == SIR_STR && argc >= 1 && args[0].tag == SIR_STR) {
+            size_t rl = strlen(recv.as.s), sl = strlen(args[0].as.s);
+            return _sir_bool(rl >= sl && strcmp(recv.as.s + rl - sl, args[0].as.s) == 0);
+        }
+    } else if (strcmp(m, "index") == 0) {
+        if (recv.tag == SIR_STR && argc >= 1 && args[0].tag == SIR_STR) {
+            const char *p = strstr(recv.as.s, args[0].as.s);
+            return p ? _sir_int((int64_t)(p - recv.as.s)) : _sir_nil();
+        }
+    }
     return _sir_raise(
         _sir_error("NoMethodError", _sir_str(_sir_cat("undefined method ", m))));
+}
+
+SirValue _sir_builtin_method(SirValue recv, const char *m, int argc, ...) {
+    va_list ap;
+    SirValue *args, r;
+    va_start(ap, argc);
+    args = _sir_va_collect(argc, ap);
+    va_end(ap);
+    r = _sir_builtin_method_v(recv, m, argc, args);
+    if (args) free(args);
+    return r;
 }
 
 /* ---- OOP slice 6: class variables (@@x) ------------------------------------

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_queries.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_queries.rs
@@ -1,0 +1,88 @@
+//! Execution proof for Collections slice 2 (1-arg String query methods) on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run, assert
+//! stdout.  Skips gracefully when no `cc` is present.
+//!
+//! `"str".include?("x")` lowers to `__method__(recv, "include?", "x")`; the
+//! runtime `_sir_builtin_method` now collects the argument and applies the String
+//! query (`include?`/`start_with?`/`end_with?` → bool, `index` → Int or nil),
+//! raising `NoMethodError` on a wrong-type receiver or argument.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    let stem = format!("sirc_strq_{}_{}", std::process::id(), src.len());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn include_predicate_in_control_flow() {
+    // `include?` returns a bool; exercised in `if` so the assertion doesn't depend
+    // on the boolean *display* convention (a separate pre-existing frontend gap).
+    match run_ruby(
+        "if \"hello world\".include?(\"world\")\n  puts \"yes\"\nend\n\
+         if \"hello\".include?(\"zzz\")\n  puts \"never\"\nelse\n  puts \"no\"\nend\n",
+    ) {
+        Some(out) => assert_eq!(out, "yes\nno\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn start_with_and_end_with() {
+    match run_ruby(
+        "if \"hello\".start_with?(\"he\")\n  puts \"s-ok\"\nend\n\
+         if \"hello\".end_with?(\"lo\")\n  puts \"e-ok\"\nend\n\
+         if \"hello\".start_with?(\"lo\")\n  puts \"never\"\nelse\n  puts \"s-no\"\nend\n",
+    ) {
+        Some(out) => assert_eq!(out, "s-ok\ne-ok\ns-no\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn index_returns_position_or_nil() {
+    // `index` returns the 0-based position of the substring, or nil when absent.
+    match run_ruby("puts \"hello\".index(\"l\")\nputs \"hello\".index(\"z\")\n") {
+        Some(out) => assert_eq!(out, "2\nnil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -313,6 +313,24 @@ fn collection_string_methods_route_to_the_builtin_dispatcher() {
 }
 
 #[test]
+fn collection_string_query_passes_its_argument() {
+    // Collections slice 2: a 1-arg built-in query (`include?`) routes to the
+    // dispatcher AND carries its argument (the substring) through.
+    let m = lower_ruby("puts \"hello\".include?(\"ell\")");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_builtin_method("),
+        "the query routes to the runtime dispatcher\n{src}"
+    );
+    // The `?` in `include?` is trigraph-escaped (`\?`) by `quote_c_string`; what
+    // matters is that argc=1 and the substring argument are passed through.
+    assert!(
+        src.contains(", 1, _sir_str(\"ell\"))"),
+        "the dispatcher is passed argc=1 and the quoted substring argument\n{src}"
+    );
+}
+
+#[test]
 fn sanitize_ident_maps_into_c() {
     assert_eq!(sanitize_ident("foo"), "foo");
     assert_eq!(sanitize_ident("foo_bar1"), "foo_bar1");

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -365,7 +365,10 @@ lockstep:
    `_sir_builtin_method` runtime dispatcher (`length`/`size`, `upcase`,
    `downcase`, `reverse`, `empty?`, `to_s`; `length`/`size`/`empty?` polymorphic
    over String/Array/Hash) — a built-in name the module did not define routes
-   there instead of the user method table; the rest of the catalog follows.
+   there instead of the user method table.  Slice 2 (0.23.0) added the first
+   argument-taking methods (the dispatcher now collects its varargs): the 1-arg
+   String queries `include?`/`start_with?`/`end_with?` (→ bool) and `index`
+   (→ Int/nil).  The rest of the catalog (Array/Hash/Numeric, blocks) follows.
 5. **Exceptions** — `setjmp`/`longjmp` + typed runtime errors.
 6. **OOP** (mirroring the Ruby backend's landed 7-slice arc) — slice 1
    (`Classes` + `Constants`: the `SIR_INSTANCE` runtime, an empty class, `Foo.new`


### PR DESCRIPTION
## What

Second Collections slice — the first **argument-taking** built-in methods. Off fresh main (not stacked). No new `Feature`.

- `_sir_builtin_method` now **collects its varargs** (via `_sir_va_collect`, the same pattern as `_sir_plus`), split into a `_sir_builtin_method_v` impl over the already-collected args + a thin wrapper that frees them — unblocking methods that read an argument.
- New String queries: `include?(sub)` / `start_with?(prefix)` / `end_with?(suffix)` → bool; `index(sub)` → the 0-based Int position or nil. Each guards `argc >= 1` and `args[0].tag == SIR_STR`, raising `NoMethodError` on a wrong receiver/argument type (matching Ruby) — never an OOB read.
- The `__method__` emit already carried `argc` + the arguments through (slice 1), so only the `is_builtin_method` allowlist grows; the scan accepts the new names automatically.

## Anti-RCE

The method name is a compiler-emitted quoted C literal used only as a `strcmp` target; the string argument is a `SirValue` read only via `strstr`/`strncmp`/`strcmp` — never a format string, never eval'd.

## Tests / quality

- **Emit-shape**: `collection_string_query_passes_its_argument` (19/19 emit tests; note `?` is trigraph-escaped to `\?`).
- **cc-exec e2e** (`compile_and_run_string_queries.rs`): `include?` in control flow, `start_with?`/`end_with?`, `index` → 2/nil. 3/3 pass.
- **Regression**: slice-1 String methods (4) green; clippy clean; security review passed (Rust+C: guarded arg access, no OOB/NULL-deref, anti-RCE intact).

Bumps `semantic-ir-to-c` 0.22.0 → 0.23.0; updates CHANGELOG, README, SIR24 spec. Next: `split` (→ Array) and Array/Hash/Numeric methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)