### PR TITLE
Wire Venture macOS link activation

### DIFF
--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Wire normalized AppKit wheel events into the shared `BrowserSession` scroll
   model and repaint the translated viewport through Metal.
+- Activate viewport links from primary-button input, update the native title,
+  and repaint across repeated transactional navigation.
 
 ## 0.1.0
 

--- a/code/packages/rust/venture-browser-macos/README.md
+++ b/code/packages/rust/venture-browser-macos/README.md
@@ -26,7 +26,8 @@ Exercise the real AppKit + Metal presentation path and close automatically:
 cargo run -p venture-browser-macos -- --smoke-seconds 1 http://info.cern.ch/
 ```
 
-This host loads and presents one page. Mouse-wheel and trackpad input drive the
-shared clamped viewport and repaint the translated scene through Metal. Native
-controls, input-event translation beyond wheel events, and link activation are
-the next integration layer.
+Mouse-wheel and trackpad input drive the shared clamped viewport and repaint the
+translated scene through Metal. Primary-button input now hit-tests links in
+viewport coordinates, loads the resolved destination through the transactional
+browser session, updates the title, and repaints repeatedly. Native controls,
+keyboard input, and richer pointer behavior remain the next integration layer.

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -16,7 +16,7 @@ use venture_browser_core::{
     BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
     BrowserSession,
 };
-use window_core::{WindowError, WindowEvent};
+use window_core::{ElementState, PointerButton, WindowError, WindowEvent};
 
 #[cfg(target_vendor = "apple")]
 use venture_browser_core::HttpBrowserFetcher;
@@ -115,6 +115,39 @@ where
     Ok(session)
 }
 
+/// Activate the link at a viewport coordinate through the native page
+/// pipeline.
+///
+/// Returns `true` only when a link was hit and a replacement page loaded.
+pub fn activate_link_at<F>(
+    session: &mut BrowserSession,
+    viewport_x: f64,
+    viewport_y: f64,
+    width: f64,
+    height: f64,
+    fetcher: &F,
+) -> Result<bool, BrowserLoadError>
+where
+    F: BrowserResourceFetcher,
+{
+    let theme = mosaic_html_theme();
+    let measurer = NativeMeasurer::new();
+    let shaper = NativeShaper::new();
+    let metrics = NativeMetrics::new();
+    let resolver = NativeResolver::new();
+    let pipeline = BrowserPagePipeline::new(
+        &theme,
+        HtmlPaintViewport::new(width, height, 1.0),
+        &measurer,
+        &shaper,
+        &metrics,
+        &resolver,
+    );
+    Ok(session
+        .activate_link(viewport_x, viewport_y, &pipeline, fetcher)?
+        .is_some())
+}
+
 #[cfg(target_vendor = "apple")]
 pub fn run(start_url: &str) -> Result<(), MacBrowserError> {
     run_with_termination(start_url, None)
@@ -135,7 +168,7 @@ fn run_with_termination(
     terminate_after: Option<f64>,
 ) -> Result<(), MacBrowserError> {
     use window_appkit::AppKitBackend;
-    use window_core::{LogicalSize, SurfacePreference, WindowBuilder};
+    use window_core::{LogicalSize, SurfacePreference, Window, WindowBuilder};
 
     let session = load_initial_session(
         start_url,
@@ -167,9 +200,39 @@ fn run_with_termination(
     let session = Rc::new(RefCell::new(session));
     window.set_event_handler({
         let session = Rc::clone(&session);
+        let mut pointer_position = None;
         move |event| {
             let mut session = session.borrow_mut();
-            if scroll_session(&mut session, &event) {
+            let mut should_repaint = scroll_session(&mut session, &event);
+            if let Some((x, y)) = pointer_link_activation(&mut pointer_position, &event) {
+                match activate_link_at(
+                    &mut session,
+                    x,
+                    y,
+                    DEFAULT_WINDOW_WIDTH,
+                    DEFAULT_WINDOW_HEIGHT,
+                    &HttpBrowserFetcher::default(),
+                ) {
+                    Ok(true) => {
+                        should_repaint = true;
+                        if let Some(viewport) = session.viewport() {
+                            let page = viewport.page();
+                            let title =
+                                window_title(page.document.title.as_deref(), &page.final_url);
+                            if let Err(error) = window.set_title(&title) {
+                                eprintln!(
+                                    "venture-browser-macos: window title update failed: {error}"
+                                );
+                            }
+                        }
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        eprintln!("venture-browser-macos: link navigation failed: {error}");
+                    }
+                }
+            }
+            if should_repaint {
                 if let Some(viewport) = session.viewport() {
                     let scene = viewport.viewport_scene();
                     if let Err(error) =
@@ -205,6 +268,28 @@ pub fn scroll_session(session: &mut BrowserSession, event: &WindowEvent) -> bool
     viewport.scroll_state().offset_y() != previous_offset
 }
 
+/// Track pointer movement and identify a primary-button link activation.
+///
+/// Activation happens on release so dragging away from a link can update the
+/// final viewport coordinate before navigation.
+pub fn pointer_link_activation(
+    pointer_position: &mut Option<(f64, f64)>,
+    event: &WindowEvent,
+) -> Option<(f64, f64)> {
+    match event {
+        WindowEvent::PointerMoved { x, y, .. } => {
+            *pointer_position = Some((*x, *y));
+            None
+        }
+        WindowEvent::PointerButton {
+            button: PointerButton::Primary,
+            state: ElementState::Released,
+            ..
+        } => *pointer_position,
+        _ => None,
+    }
+}
+
 #[cfg(not(target_vendor = "apple"))]
 pub fn run(_start_url: &str) -> Result<(), MacBrowserError> {
     Err(MacBrowserError::UnsupportedPlatform)
@@ -221,7 +306,6 @@ mod tests {
 
     #[cfg(target_vendor = "apple")]
     use venture_browser_core::BrowserFetchResponse;
-    #[cfg(target_vendor = "apple")]
     use window_core::WindowId;
 
     #[test]
@@ -301,6 +385,88 @@ mod tests {
             .expect("scrolling should preserve the viewport");
         assert_eq!(viewport.scroll_state().offset_y(), 96.0);
         assert_ne!(viewport.viewport_scene(), before);
+    }
+
+    #[test]
+    fn primary_release_uses_the_latest_pointer_position() {
+        let mut pointer_position = None;
+        let moved = WindowEvent::PointerMoved {
+            window_id: WindowId(1),
+            x: 12.5,
+            y: 48.0,
+        };
+        let pressed = WindowEvent::PointerButton {
+            window_id: WindowId(1),
+            button: PointerButton::Primary,
+            state: ElementState::Pressed,
+        };
+        let released = WindowEvent::PointerButton {
+            window_id: WindowId(1),
+            button: PointerButton::Primary,
+            state: ElementState::Released,
+        };
+
+        assert_eq!(pointer_link_activation(&mut pointer_position, &moved), None);
+        assert_eq!(
+            pointer_link_activation(&mut pointer_position, &pressed),
+            None
+        );
+        assert_eq!(
+            pointer_link_activation(&mut pointer_position, &released),
+            Some((12.5, 48.0))
+        );
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[test]
+    fn repeated_link_activation_reloads_the_native_viewport_and_history() {
+        let fetcher = |url: &str| {
+            let html = match url {
+                "http://example.test/" => "<title>Start</title><p><a href='next.html'>Next</a></p>",
+                "http://example.test/next.html" => {
+                    "<title>Next</title><p><a href='final.html'>Final</a></p>"
+                }
+                "http://example.test/final.html" => "<title>Final</title><p>Done</p>",
+                other => return Err(format!("unexpected URL: {other}")),
+            };
+            Ok(BrowserFetchResponse::new(
+                url,
+                200,
+                Some("text/html; charset=utf-8".into()),
+                html.as_bytes().to_vec(),
+            ))
+        };
+        let mut session = load_initial_session("http://example.test/", 320.0, 180.0, &fetcher)
+            .expect("initial native page should load");
+
+        for expected_url in [
+            "http://example.test/next.html",
+            "http://example.test/final.html",
+        ] {
+            let link = session
+                .viewport()
+                .and_then(|viewport| viewport.page().paint.links.first())
+                .cloned()
+                .expect("current page should expose a link");
+            assert!(activate_link_at(
+                &mut session,
+                link.x + link.width / 2.0,
+                link.y + link.height / 2.0,
+                320.0,
+                180.0,
+                &fetcher,
+            )
+            .expect("link activation should load"));
+            assert_eq!(session.history().current_url(), Some(expected_url));
+        }
+
+        assert_eq!(session.history().back_stack().len(), 2);
+        assert_eq!(
+            session
+                .viewport()
+                .and_then(|viewport| viewport.page().document.title.as_deref()),
+            Some("Final")
+        );
     }
 
     #[cfg(not(target_vendor = "apple"))]

--- a/code/packages/rust/window-appkit/CHANGELOG.md
+++ b/code/packages/rust/window-appkit/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this package will be documented in this file.
 
 - An AppKit event view that translates wheel input to normalized
   `WindowEvent::Scroll` callbacks.
+- Primary-button translation with top-left logical pointer coordinates.
 - Main-thread event-handler registration on `AppKitWindow`.
 
 ## [0.1.0] - 2026-04-18

--- a/code/packages/rust/window-appkit/README.md
+++ b/code/packages/rust/window-appkit/README.md
@@ -15,11 +15,12 @@ This package supports a real macOS host path while staying small:
 - exposes AppKit render-target handles on the returned `Window`
 - runs the AppKit event loop for native launch testing
 - translates AppKit wheel input into shared `WindowEvent::Scroll` values
+- translates primary-button input into top-left logical pointer events
 - lets a main-thread host install a normalized event handler on its window
 - rejects renderer preferences that belong to other platforms
 
-Metal-layer attachment is available for renderer hosts. Pointer-button,
-keyboard, resize, and close translation remain future event slices.
+Metal-layer attachment is available for renderer hosts. Keyboard, resize, and
+close translation remain future event slices.
 
 ## Dependencies
 

--- a/code/packages/rust/window-appkit/src/lib.rs
+++ b/code/packages/rust/window-appkit/src/lib.rs
@@ -27,16 +27,16 @@ use std::{
 
 #[cfg(target_vendor = "apple")]
 use objc_bridge::{
-    class, msg, msg_bool, msg_f64, msg_send_class, nsstring, object_getInstanceVariable,
-    object_setInstanceVariable, objc_allocateClassPair, objc_registerClassPair, release, sel,
-    ClassPtr, CGPoint, CGRect, Id, Sel, CGSize, NS_BACKING_STORE_BUFFERED,
-    NS_WINDOW_STYLE_MASK_CLOSABLE,
-    NS_WINDOW_STYLE_MASK_MINIATURIZABLE, NS_WINDOW_STYLE_MASK_RESIZABLE,
-    NS_WINDOW_STYLE_MASK_TITLED, NIL, class_addIvar, class_addMethod,
+    class, class_addIvar, class_addMethod, msg, msg_bool, msg_f64, msg_send_class, nsstring,
+    objc_allocateClassPair, objc_registerClassPair, object_getInstanceVariable,
+    object_setInstanceVariable, release, sel, CGPoint, CGRect, CGSize, ClassPtr, Id, Sel, NIL,
+    NS_BACKING_STORE_BUFFERED, NS_WINDOW_STYLE_MASK_CLOSABLE, NS_WINDOW_STYLE_MASK_MINIATURIZABLE,
+    NS_WINDOW_STYLE_MASK_RESIZABLE, NS_WINDOW_STYLE_MASK_TITLED,
 };
 use window_core::{
-    AppKitRenderTarget, LogicalSize, MountTarget, PhysicalSize, RenderTarget, SurfacePreference,
-    Window, WindowAttributes, WindowBackend, WindowError, WindowEvent, WindowId,
+    AppKitRenderTarget, ElementState, LogicalSize, MountTarget, PhysicalSize, PointerButton,
+    RenderTarget, SurfacePreference, Window, WindowAttributes, WindowBackend, WindowError,
+    WindowEvent, WindowId,
 };
 
 /// Crate version, kept explicit for examples and integration tests.
@@ -462,6 +462,18 @@ unsafe fn ensure_event_view_class() -> Result<ClassPtr, WindowError> {
         scroll_wheel as *const _,
         event_method_types.as_ptr(),
     );
+    class_addMethod(
+        view_class,
+        sel("mouseDown:"),
+        mouse_down as *const _,
+        event_method_types.as_ptr(),
+    );
+    class_addMethod(
+        view_class,
+        sel("mouseUp:"),
+        mouse_up as *const _,
+        event_method_types.as_ptr(),
+    );
     objc_registerClassPair(view_class);
     Ok(view_class)
 }
@@ -491,6 +503,37 @@ fn dispatch_scroll_event(view: Id, native_delta_x: f64, native_delta_y: f64) {
     });
 }
 
+#[cfg(target_vendor = "apple")]
+extern "C" fn mouse_down(view: Id, _sel: Sel, event: Id) {
+    dispatch_pointer_button_event(view, event, ElementState::Pressed);
+}
+
+#[cfg(target_vendor = "apple")]
+extern "C" fn mouse_up(view: Id, _sel: Sel, event: Id) {
+    dispatch_pointer_button_event(view, event, ElementState::Released);
+}
+
+#[cfg(target_vendor = "apple")]
+fn dispatch_pointer_button_event(view: Id, event: Id, state: ElementState) {
+    let location = unsafe { msg_send_point(event, "locationInWindow") };
+    let view_height = unsafe { msg_send_bounds(view).size.height };
+    EVENT_HANDLERS.with(|handlers| {
+        let mut handlers = handlers.borrow_mut();
+        if let Some(entry) = handlers.get_mut(&(view as usize)) {
+            for event in normalized_pointer_button_events(
+                entry.window_id,
+                location.x,
+                location.y,
+                view_height,
+                PointerButton::Primary,
+                state,
+            ) {
+                (entry.callback)(event);
+            }
+        }
+    });
+}
+
 /// Translate AppKit's content-motion deltas into viewport scroll direction.
 pub fn normalized_scroll_event(
     window_id: WindowId,
@@ -504,9 +547,46 @@ pub fn normalized_scroll_event(
     }
 }
 
+/// Translate an AppKit button event into top-left viewport coordinates.
+///
+/// AppKit reports content coordinates from the bottom-left. Emitting a
+/// `PointerMoved` event immediately before the button transition makes the
+/// shared button event useful without embedding duplicate coordinates in it.
+pub fn normalized_pointer_button_events(
+    window_id: WindowId,
+    native_x: f64,
+    native_y: f64,
+    view_height: f64,
+    button: PointerButton,
+    state: ElementState,
+) -> [WindowEvent; 2] {
+    let x = finite_or_zero(native_x);
+    let y = if native_y.is_finite() && view_height.is_finite() {
+        finite_or_zero(view_height.max(0.0) - native_y)
+    } else {
+        0.0
+    };
+    [
+        WindowEvent::PointerMoved { window_id, x, y },
+        WindowEvent::PointerButton {
+            window_id,
+            button,
+            state,
+        },
+    ]
+}
+
 fn invert_finite(value: f64) -> f64 {
     if value.is_finite() {
         -value
+    } else {
+        0.0
+    }
+}
+
+fn finite_or_zero(value: f64) -> f64 {
+    if value.is_finite() {
+        value
     } else {
         0.0
     }
@@ -575,6 +655,14 @@ unsafe fn msg_send_bounds(view: Id) -> objc_bridge::CGRect {
     fn_ptr(view, sel("bounds"))
 }
 
+/// Call a selector such as `[event locationInWindow]` that returns CGPoint.
+#[cfg(target_vendor = "apple")]
+unsafe fn msg_send_point(receiver: Id, selector: &str) -> objc_bridge::CGPoint {
+    use objc_bridge::{objc_msgSend, sel};
+    let fn_ptr: unsafe extern "C" fn(Id, objc_bridge::Sel) -> objc_bridge::CGPoint =
+        std::mem::transmute(objc_msgSend as *const ());
+    fn_ptr(receiver, sel(selector))
+}
 
 impl WindowBackend for AppKitBackend {
     type Window = AppKitWindow;
@@ -775,6 +863,47 @@ mod tests {
                 window_id: WindowId(7),
                 delta_x: 0.0,
                 delta_y: 0.0,
+            }
+        );
+    }
+
+    #[test]
+    fn appkit_pointer_buttons_use_top_left_viewport_coordinates() {
+        assert_eq!(
+            normalized_pointer_button_events(
+                WindowId(7),
+                12.5,
+                150.0,
+                200.0,
+                PointerButton::Primary,
+                ElementState::Released,
+            ),
+            [
+                WindowEvent::PointerMoved {
+                    window_id: WindowId(7),
+                    x: 12.5,
+                    y: 50.0,
+                },
+                WindowEvent::PointerButton {
+                    window_id: WindowId(7),
+                    button: PointerButton::Primary,
+                    state: ElementState::Released,
+                },
+            ]
+        );
+        assert_eq!(
+            normalized_pointer_button_events(
+                WindowId(7),
+                f64::NAN,
+                f64::INFINITY,
+                f64::INFINITY,
+                PointerButton::Primary,
+                ElementState::Pressed,
+            )[0],
+            WindowEvent::PointerMoved {
+                window_id: WindowId(7),
+                x: 0.0,
+                y: 0.0,
             }
         );
     }

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -72,10 +72,12 @@ navigation commands and content-link activation through transactional page
 loads, preserving the prior history and viewport on failure. The remaining
 browser gate is now being closed on macOS first: `venture-browser-macos` loads
 an HTTP page with native CoreText services, creates an AppKit `CAMetalLayer`,
-and presents the viewport through `paint-metal`. Native AppKit wheel events now
-drive the shared clamped viewport and Metal repaint path. Pointer-button and
-keyboard translation, controls, link activation, and repeated navigation
-remain before the shell is interactive.
+and presents the viewport through `paint-metal`. Native AppKit wheel events
+drive the shared clamped viewport and Metal repaint path. Primary-button events
+now use top-left viewport coordinates to activate links through transactional
+page loads, update the title, and repaint across repeated navigation. Keyboard
+translation, controls, and richer pointer behavior remain before the shell is
+interactive.
 
 ## Where It Fits
 


### PR DESCRIPTION
## Summary

- translate AppKit primary-button input into normalized top-left viewport pointer events
- activate links on primary release through the existing transactional `BrowserSession` page pipeline
- update the native window title and repaint the Metal viewport after every successful navigation
- add deterministic coverage for coordinate conversion, pointer-release behavior, and repeated link navigation
- update the macOS host and BR01 status without collapsing the remaining keyboard, controls, richer-pointer, or Windows gates

## Why

The macOS host could already load, paint, and scroll a page, but it could not turn native clicks into browser navigation. This slice connects the existing AppKit event seam to scroll-aware link hit-testing and proves that successive page loads replace the viewport while preserving navigation history.

## Validation

- `cargo test -p window-core -p venture-browser-core -p window-appkit -p venture-browser-macos -p objc-bridge -- --nocapture`
- `cargo clippy -p objc-bridge -p window-appkit -p venture-browser-macos --all-targets -- -D warnings`
- `cargo run -p venture-browser-macos -- --smoke-seconds 0.5 http://info.cern.ch/`
- exact upstream coverage audit:
  - WPT tree construction: 1,934 upstream / 2,637 local / 0 missing
  - html5lib tokenizer: 6,806 upstream / 7,015 local raw / 0 missing
  - normalized tokenizer: 7,242 cases / 0 skipped

## Remaining browser gates

Keyboard translation, native navigation controls, richer pointer behavior such as hover/drag semantics, and the later Windows host remain separate follow-up slices.