### PR TITLE
feat(spice): validate MOS junction grading

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `MJ` values with a
+  stable diagnostic before depletion-capacitance shaping.
 - Reject non-positive or non-finite Level-1 MOS model-card `PB` values with a
   stable diagnostic before depletion and temperature preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `GAMMA` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -590,6 +590,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET GAMMA must be finite and non-negative")
         elif canonical == "PB" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET PB must be finite and positive")
+        elif canonical == "MJ" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET MJ must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1112,6 +1112,16 @@ def test_mos_model_card_rejects_non_positive_or_non_finite_bulk_junction_potenti
             normalize_model_card("Minvalid", "nmos", {"PB": invalid_potential})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_junction_grading_coefficient() -> None:
+    for value in (0.0, 0.5, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"MJ": value})
+        assert valid.parameters["MJ"] == pytest.approx(value)
+
+    for invalid_coefficient in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET MJ must be finite and non-negative"):
+            normalize_model_card("Minvalid", "nmos", {"MJ": invalid_coefficient})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `MJ` values with a
+  stable diagnostic before depletion-capacitance shaping.
 - Reject non-positive or non-finite Level-1 MOS model-card `PB` values with a
   stable diagnostic before depletion and temperature preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `GAMMA` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4405,6 +4405,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET PB must be finite and positive".to_string(),
                 });
+            } else if canonical == "MJ" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET MJ must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -943,6 +943,22 @@ fn mos_model_card_rejects_non_positive_or_non_finite_bulk_junction_potential() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_junction_grading_coefficient() {
+    for value in [0.0, 0.5, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("MJ", value)]).unwrap();
+        assert_close(*valid.parameters.get("MJ").unwrap(), value);
+    }
+
+    for invalid_coefficient in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("MJ", invalid_coefficient)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET MJ must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `MJ` values with a
+  stable diagnostic before depletion-capacitance shaping.
 - Reject non-positive or non-finite Level-1 MOS model-card `PB` values with a
   stable diagnostic before depletion and temperature preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `GAMMA` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8461,6 +8461,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value <= 0.0)
     ) {
       throw invalidElement(name, "MOSFET PB must be finite and positive");
+    } else if (
+      canonical === "MJ" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET MJ must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -826,6 +826,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS junction grading coefficient", () => {
+    for (const value of [0.0, 0.5, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { MJ: value });
+      expect(valid.parameters.MJ).toBe(value);
+    }
+
+    for (const invalidCoefficient of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { MJ: invalidCoefficient }),
+      ).toThrow("MOSFET MJ must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS bulk-junction-potential validation.
+1. Cross-language Level-1 MOS junction-grading validation.
    - Status: current PR completion candidate.
-   - Reject non-positive or non-finite model-card `PB` values before depletion
-     and temperature preprocessing.
-   - Preserve positive explicit bulk-junction potentials across Rust, Python,
-     and TypeScript.
+   - Reject negative or non-finite model-card `MJ` values before
+     depletion-capacitance shaping.
+   - Preserve zero and positive junction-grading coefficients across Rust,
+     Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3706,6 +3706,13 @@ the Rust, Python, and TypeScript surfaces together.
      body-effect and temperature preprocessing.
    - Zero and positive explicit body-effect coefficients remain aligned across
      Rust, Python, and TypeScript.
+
+304. Cross-language Level-1 MOS bulk-junction-potential validation.
+   - Status: completed in PR 9276.
+   - Non-positive and non-finite model-card `PB` values are rejected before
+     depletion and temperature preprocessing.
+   - Positive explicit bulk-junction potentials remain aligned across Rust,
+     Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS `MJ` values before depletion-capacitance shaping
- preserve zero and positive grading coefficients with aligned Rust, Python, and TypeScript diagnostics
- reconcile the SPICE completion plan by recording PR #9276 and selecting this slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check` for spice-engine source and tests
- Python full spice-engine pytest: 686 passed, 88.96% coverage
- TypeScript `npm test`: 429 passed
- TypeScript `npm run build`