### PR TITLE
fix(semantic-ir-to-c): cyclic-map/seq display + equality overflow Windows's 1 MB stack

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.22.1 — fix: cyclic-map/seq display + equality no longer overflow the stack on Windows
+
+Fixes `cyclic_map_does_not_stack_overflow` (and the sibling cyclic-sequence
+path): a self-referential aggregate (`h[0] = h`, constructible via the mutable
+`MapSet`/`SeqSet`) is bounded by depth caps in both the display (`_sir_fmt`) and
+equality (`_sir_value_eq_d`) recursions — but both caps were **5000**, and 5000
+stack frames overrun Windows' 1 MB default stack (~875 KB on the display path)
+**before** the cap can trip. So the guard that was supposed to prevent the
+overflow was itself unreachable on Windows; the emitted program crashed with a
+stack overflow instead of printing the `[...]` ellipsis / returning the
+co-inductive `true`. (Linux/macOS give an 8 MB stack, so the same binary passed
+there — the failure was Windows-only.)
+
+- `SIR_MAX_FMT_DEPTH` and `SIR_MAX_EQ_DEPTH` lowered from `5000` to `500`, sized
+  to fit the SMALLEST common C stack (Windows' 1 MB) with wide margin — ~90 KB on
+  the display path, far under the limit — while staying far beyond any real
+  (non-cyclic) nesting. No behaviour change for finite structures shallower than
+  500; deeper-than-cap output is pathological (only a cycle reaches it) and the
+  cap's observable effect (ellipsis / assumed-equal) is unchanged, just reached
+  at a safe depth. No test or cross-backend conformance program pins the old value.
+
 ## 0.22.0 — Collections slice 1: built-in String methods
 
 The first slice of the **Collections** batch — the built-in method catalog every

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -498,8 +498,12 @@ SirValue _sir_ge(SirValue a, SirValue b) {
  * made self-referential (`a[0] = a`). A depth cap keeps such a structure from
  * overflowing the C stack: past the cap two values are ASSUMED equal (the
  * co-inductive answer, so a cyclic comparison terminates). The cap is far
- * beyond any real (non-cyclic) nesting and comfortably under the stack limit. */
-#define SIR_MAX_EQ_DEPTH 5000
+ * beyond any real (non-cyclic) nesting, yet sized to fit the SMALLEST common
+ * C stack — Windows' 1 MB default (Linux/macOS give 8 MB). Each recursion level
+ * is one `_sir_value_eq_d` frame, so ~500 levels stays well under 1 MB even in
+ * an unoptimised build. (A cap of 5000 recursed ~875 KB deep on the display path
+ * and stack-overflowed on Windows before the cap ever tripped.) */
+#define SIR_MAX_EQ_DEPTH 500
 
 int _sir_value_eq_d(SirValue a, SirValue b, int depth) {
     if (depth > SIR_MAX_EQ_DEPTH) return 1;
@@ -914,8 +918,11 @@ void _sir_fmt_pair(FILE *out, SirValue v) {
  * sequence (`a[0] = a`, now constructible via the mutable `SeqSet`) would
  * otherwise recurse forever, so a static depth counter bounds it: past the cap
  * a `[...]` ellipsis is printed instead of descending (the emitted program is
- * single-threaded, so a plain static counter is sufficient). */
-#define SIR_MAX_FMT_DEPTH 5000
+ * single-threaded, so a plain static counter is sufficient). Sized like
+ * `SIR_MAX_EQ_DEPTH` to fit Windows' 1 MB stack: a `_sir_fmt`↔`_sir_fmt_map`
+ * pair is ~175 B per level, so ~500 levels is ~90 KB — far under the limit,
+ * where 5000 overran the 1 MB stack before this cap could print the ellipsis. */
+#define SIR_MAX_FMT_DEPTH 500
 static int _sir_fmt_depth = 0;
 
 void _sir_fmt(FILE *out, SirValue v) {

--- a/lessons.md
+++ b/lessons.md
@@ -1883,3 +1883,28 @@ new, then `git switch -c <fresh-name> origin/main` and `git cherry-pick` only th
 truly-new commits onto a clean base — don't just re-push the stale branch. Delete
 the orphaned remote branch afterward (`git push origin --delete <name>`) so it
 doesn't linger with no PR pointing at it.
+
+## A recursion depth cap sized for an 8 MB stack still overflows Windows' 1 MB stack
+
+The C backend guards cyclic-structure display (`_sir_fmt`) and equality
+(`_sir_value_eq_d`) with a depth cap — past the cap it prints `[...]` / assumes
+equal, so `h[0] = h` terminates instead of recursing forever. The cap was `5000`,
+commented "comfortably under the stack limit." It was: on Linux/macOS (8 MB
+stack) 5000 frames (~875 KB on the display path) fit fine, so CI and the sibling
+cyclic-**sequence** test both passed. But Windows' default stack is **1 MB**, and
+5000 frames overran it **before** the cap could trip — so the very guard meant to
+prevent the overflow was unreachable there. Symptom: `cyclic_map_does_not_stack_
+overflow` failed ONLY on Windows, exit `0xC00000FD` (STACK_OVERFLOW / -1073741571).
+
+Lessons:
+1. **A depth/recursion cap must be sized for the SMALLEST stack the artifact can
+   run on, not the dev box.** Windows 1 MB is the floor for emitted C/Rust; pick
+   caps (here lowered to `500`, ~90 KB) with margin for an *unoptimised* build
+   (debug frames are 2–3× larger than the `-O` frames you might estimate from).
+2. **"Passes in CI" can mean "CI's stack is bigger," not "correct."** A
+   platform-dependent resource limit (stack, fd count, path length, default int
+   width) makes a bug invisible on the CI OS. When a guard is about a resource
+   limit, test against the tightest limit — or assert the guard *fires* (reaches
+   the `[...]` branch), not just that the program happens not to crash.
+3. `0xC00000FD` / exit `-1073741571` on Windows == stack overflow; suspect
+   unbounded (or insufficiently-bounded) recursion.


### PR DESCRIPTION
## Summary

`cyclic_map_does_not_stack_overflow` (in the C backend's own suite) crashed with a **stack overflow on Windows** — exit `0xC00000FD` / `-1073741571`. This was a pre-existing failure, discovered while fixing the SIR conformance bugs in #9131 and flagged for a separate PR (this one).

A self-referential aggregate (`h[0] = h`, constructible via the mutable `MapSet`/`SeqSet`) is bounded by depth caps in **both** the display (`_sir_fmt`) and equality (`_sir_value_eq_d`) recursions — past the cap it prints `[...]` / assumes equal, so a cycle terminates. But both caps were **5000**, and 5000 stack frames overrun Windows's 1 MB default stack (~875 KB on the display path) **before** the cap can trip. So the very guard meant to prevent the overflow was unreachable on Windows.

Linux/macOS give an **8 MB** stack, so the same binary passed there — and CI (Linux) never caught it. The failure was Windows-only.

## Fix

Lower `SIR_MAX_FMT_DEPTH` and `SIR_MAX_EQ_DEPTH` from `5000` to `500`, sized to fit the smallest common C stack (Windows's 1 MB) with wide margin (~90 KB on the display path) while staying far beyond any real non-cyclic nesting.

- No behaviour change for finite structures shallower than 500.
- Deeper-than-cap output is pathological (only a cycle reaches it); the cap's observable effect (ellipsis / assumed-equal) is unchanged, just reached at a safe depth.
- No test or cross-backend conformance program pins the old value.

`semantic-ir-to-c` 0.22.0 → **0.22.1**.

## Testing
- `cargo test -p semantic-ir-to-c` — **all green** (previously `cyclic_map_does_not_stack_overflow` failed on Windows; the sibling cyclic-sequence path and all other suites still pass).
- `cargo test -p sir-conformance --test conformance` — green (the lowered cap doesn't affect any cross-backend program).
- `cargo clippy` clean; security review passed (a pure DoS-hardening change — two numeric literals, no new logic).

## Lesson recorded
`lessons.md`: a recursion depth cap must be sized for the **smallest** stack the artifact can run on (Windows 1 MB), not the dev/CI box — and "passes in CI" can mean "CI's stack is bigger," not "correct." `0xC00000FD` on Windows == stack overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)