### PR TITLE
feat(adj-lang-cli): --explain renderer, derivations surface (RS-4 PR-E1)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.25.0] — 2026-07-30 — RS-4 PR-E1: `--explain` renderer (derivations surface)
+
+Adds the human-readable *"explain its reasoning"* view — `adj-lang-cli --explain <prog.adj>` —
+specified by ADJ-REASON-MATH §E.8. Where the default output is the byte-cited JSON trail (the
+machine artifact `adj-verify` re-checks), `--explain` renders the *same* reasoning as text a
+person reads. It is a **projection only**: it reads the derivation trees the engine already
+built and re-runs nothing, so the explanation can never say more than the proof.
+
+This first slice renders the **derivations** surface — the arithmetic behind each `let`/formula
+value, shown operand-by-operand down to its cited leaves (the §E.8.4 shape):
+
+```
+total = 5 [scalar]   <= source "…" locator "…" trust authoritative
+  5 = a + b
+    a = 2   [unattributed]
+    b = 3   [unattributed]
+```
+
+- **P1 projection-only** — walks `derived_bindings`; no engine re-run, no new value computed.
+- **P2 provenance on every line** — a computed value carries its applied `formula`'s citation;
+  an observed leaf with no attribution renders an explicit `[unattributed]`, never silently blank.
+  A literal constant asserts nothing new and is shown inline in its parent expression.
+- **P4 determinism** — first-seen binding order, stable numeric `Display`, no time/locale/map-order;
+  the same program renders byte-identical text every run (pinned by a test).
+- **P6 addressed structure** — each operand renders on its own line, indented one level deeper.
+
+The default (no-flag) output is byte-for-byte unchanged; the JSON trail is untouched. Later PR-E
+slices extend `--explain` to the premises / inference / adjudication / abstention surfaces of the
+§E.8.1 linearization (this slice discharges the derivations portion of FL-7's explanation renderer).
+
+New: `src/explain.rs`, `tests/rs4e_explain_e2e.rs`. Touches: `src/main.rs` (`--explain` flag +
+branch).
+
 ## [0.24.0] — 2026-07-24 — RS-5f: nearest / nearest-neighbour table lookup tactic
 
 Adds the fourth member of the `table` lookup family. A `? lookup … mode nearest give <val>`

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/explain.rs
+++ b/code/packages/rust/adj-lang-cli/src/explain.rs
@@ -1,0 +1,297 @@
+//! The `explain` renderer — a human-readable projection of the reasoning trace
+//! (ADJ-REASON-MATH §E.8, RS-4 PR-E).
+//!
+//! Everything else the CLI prints is a *machine* trail: byte-cited JSON that
+//! `adj-verify` re-checks. That is necessary and it is not an explanation a
+//! person reads. This module is the missing human view. It is governed by the
+//! §E.8 invariants, and the one that matters most is **P1 — projection only**:
+//! this code *reads* the derivation trees the engine already built and never
+//! re-runs the engine or asserts anything not already in the trace. The
+//! explanation can therefore never say more than the proof.
+//!
+//! # Staging (this slice = PR-E1: the DERIVATIONS surface)
+//!
+//! §E.8.1 linearizes a query into premises → derivations → inference →
+//! adjudication → abstention. This first slice renders the **derivations**: for
+//! every `let`/formula value the engine bound, the arithmetic is shown
+//! operand-by-operand down to its cited leaves — the *how* of each computed
+//! number (the §E.8.4 shape). The premises / inference / adjudication / abstention
+//! sections are added by later PR-E slices; they append to the same output.
+//!
+//! # Invariants honored here
+//!
+//! - **P1 projection-only** — reads `KnowledgeBase::derived_bindings`; no engine
+//!   re-run, no new value computed.
+//! - **P2 provenance on every line** — a computed value carries its applied
+//!   `formula`'s citation; a leaf grounded in an observed fact carries that
+//!   fact's `source`/`locator`/`trust`, or renders an explicit `[unattributed]`
+//!   when the fact bears no attribution. A *literal* constant written into the
+//!   formula asserts nothing new (it is shown inline in its parent expression and
+//!   carries no citation — that is honest, not a gap).
+//! - **P4 determinism** — bindings are walked in first-seen order (mirroring the
+//!   JSON `derived` section), values via `f64`/exact `Display` which is stable,
+//!   and the output carries no timestamp, map-iteration order, or locale. The
+//!   same KB renders byte-identical text on every run and platform.
+//! - **P6 addressed structure** — each operand of an op renders on its own line,
+//!   indented one level deeper, so a line in the prose maps back to exactly one
+//!   node in the derivation tree.
+
+use logic_engine::compute::{DerivationNode, RoundSpec};
+use logic_engine::{KnowledgeBase, Provenance, RoundingMode, TrustTier};
+
+/// Render the human-readable explanation of a decided knowledge base.
+///
+/// Returns the empty string when the program bound no derived values — this
+/// slice explains the derivations surface only, so a pure-differential or
+/// pure-recall program has nothing to render here yet (later PR-E slices add
+/// those sections). Projection-only: the only input is the already-populated
+/// `kb`.
+pub fn explain(kb: &KnowledgeBase) -> String {
+    // First-seen order, latest value per name — identical to `derived_json`, so
+    // the human view and the JSON view agree on which bindings exist and in what
+    // order. Determinism (P4) rides on this being a deterministic walk.
+    let all = kb.derived_bindings();
+    let mut order: Vec<&str> = Vec::new();
+    for d in all {
+        if !order.contains(&d.name.as_str()) {
+            order.push(d.name.as_str());
+        }
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    for name in &order {
+        let Some(d) = kb.derived_for(name) else {
+            continue;
+        };
+        // The exact-first display (NUM-5): all digits when the value has a finite
+        // decimal expansion, else the labeled-lossy f64 — matching `value_json`.
+        let value = d
+            .exact
+            .as_ref()
+            .and_then(|e| e.to_exact_decimal_string())
+            .unwrap_or_else(|| fmt_num(d.value));
+        // P2: a value produced by applying a provenanced `formula` carries the
+        // formula's citation (why the formula is trusted). A plain `let` has no
+        // library claim; its audit trail is the derivation tree itself.
+        let cited = match &d.provenance {
+            Some(p) => format!("   <= {}", fmt_prov(p)),
+            None => String::new(),
+        };
+        out.push(format!("{} = {} [{}]{}", d.name, value, d.dim.tag(), cited));
+        expand(&d.tree, 1, kb, &mut out);
+        out.push(String::new()); // blank line between bindings
+    }
+    // Drop the trailing separator so the output has no dangling blank line.
+    while out.last().is_some_and(|l| l.is_empty()) {
+        out.pop();
+    }
+    out.join("\n")
+}
+
+/// The inline label by which a parent operation refers to this operand: an
+/// atom's name, a constant's value, or a nested result (parenthesized). The
+/// child's own line — printed by [`expand`] — carries the detail.
+fn label(n: &DerivationNode) -> String {
+    match n {
+        DerivationNode::Leaf { slot, .. } => slot.clone(),
+        DerivationNode::DerivedRef { name, .. } => name.clone(),
+        DerivationNode::Lit { value } => fmt_num(*value),
+        DerivationNode::Op { result, .. } => format!("({})", fmt_num(*result)),
+        DerivationNode::Round { result, .. }
+        | DerivationNode::ToScientific { result, .. }
+        | DerivationNode::ToPercent { result, .. }
+        | DerivationNode::ToCurrency { result, .. } => fmt_num(*result),
+    }
+}
+
+/// Whether this node earns its own expanded line. A literal constant asserts
+/// nothing new (§E.8: it is shown inline in its parent and quotes nothing), so
+/// it is the one node kind that does not expand; everything else does.
+fn expands(n: &DerivationNode) -> bool {
+    !matches!(n, DerivationNode::Lit { .. })
+}
+
+/// Emit the lines for one derivation node at `depth`, then recurse into the
+/// operands that expand. The match is **total** over `DerivationNode` (no
+/// wildcard): a new node kind must be handled here or the crate fails to
+/// compile — the same totality discipline the JSON walker enforces (§E.8.1).
+fn expand(n: &DerivationNode, depth: usize, kb: &KnowledgeBase, out: &mut Vec<String>) {
+    let ind = "  ".repeat(depth);
+    match n {
+        DerivationNode::Op {
+            op,
+            operands,
+            result,
+        } => {
+            let sep = format!(" {} ", op.symbol());
+            let expr = operands.iter().map(label).collect::<Vec<_>>().join(&sep);
+            out.push(format!("{ind}{} = {}", fmt_num(*result), expr));
+            for c in operands {
+                if expands(c) {
+                    expand(c, depth + 1, kb, out);
+                }
+            }
+        }
+        DerivationNode::Leaf {
+            slot,
+            value,
+            fact_id,
+        } => {
+            let prov = kb
+                .fact(*fact_id)
+                .map(|f| fmt_leaf_prov(&f.provenance))
+                .unwrap_or_else(|| "[unattributed]".to_string());
+            out.push(format!("{ind}{slot} = {}   {}", fmt_num(*value), prov));
+        }
+        DerivationNode::DerivedRef { name, value } => {
+            out.push(format!("{ind}{name} = {}   (derived above)", fmt_num(*value)));
+        }
+        // A `Lit` operand never reaches here (guarded by `expands`); handled for
+        // totality — a bare literal used as the whole tree just shows its value.
+        DerivationNode::Lit { value } => {
+            out.push(format!("{ind}{}", fmt_num(*value)));
+        }
+        DerivationNode::Round {
+            spec,
+            mode,
+            operand,
+            result,
+        } => {
+            out.push(format!(
+                "{ind}{} = round({}, {}) [{}]",
+                fmt_num(*result),
+                label(operand),
+                fmt_round_spec(spec),
+                fmt_mode(*mode)
+            ));
+            if expands(operand) {
+                expand(operand, depth + 1, kb, out);
+            }
+        }
+        DerivationNode::ToScientific {
+            figures,
+            mode,
+            rendered,
+            operand,
+            result,
+        } => {
+            out.push(format!(
+                "{ind}{} (\"{}\") = to_scientific({}, {} sig figs) [{}]",
+                fmt_num(*result),
+                rendered,
+                label(operand),
+                figures,
+                fmt_mode(*mode)
+            ));
+            if expands(operand) {
+                expand(operand, depth + 1, kb, out);
+            }
+        }
+        DerivationNode::ToPercent {
+            places,
+            mode,
+            rendered,
+            operand,
+            result,
+        } => {
+            out.push(format!(
+                "{ind}{} (\"{}\") = to_percent({}, {} places) [{}]",
+                fmt_num(*result),
+                rendered,
+                label(operand),
+                places,
+                fmt_mode(*mode)
+            ));
+            if expands(operand) {
+                expand(operand, depth + 1, kb, out);
+            }
+        }
+        DerivationNode::ToCurrency {
+            code,
+            places,
+            mode,
+            rendered,
+            operand,
+            result,
+        } => {
+            out.push(format!(
+                "{ind}{} (\"{}\") = to_currency({}, {}, {} places) [{}]",
+                fmt_num(*result),
+                rendered,
+                label(operand),
+                code,
+                places,
+                fmt_mode(*mode)
+            ));
+            if expands(operand) {
+                expand(operand, depth + 1, kb, out);
+            }
+        }
+    }
+}
+
+/// A node value as stable text. Rust's `f64` `Display` is deterministic and
+/// drops a trailing `.0` (so `3.0` prints `3`, matching the JSON `value`), which
+/// is exactly the stability P4 requires.
+fn fmt_num(v: f64) -> String {
+    format!("{}", v)
+}
+
+/// The provenance of a leaf's grounding fact, or `[unattributed]`. P2: a fact
+/// with no `source` or an `Unattributed` trust tier is not silently blank — it
+/// is marked, so an uncited magnitude is visible as such.
+fn fmt_leaf_prov(p: &Provenance) -> String {
+    if p.source.is_empty() || p.trust_tier == TrustTier::Unattributed {
+        "[unattributed]".to_string()
+    } else {
+        format!("[{}]", fmt_prov(p))
+    }
+}
+
+/// `source "S" locator "L" trust T` — the citation fields, with `locator`
+/// omitted when the clause has none.
+fn fmt_prov(p: &Provenance) -> String {
+    let loc = match &p.locator {
+        Some(l) => format!(" locator \"{}\"", l),
+        None => String::new(),
+    };
+    format!(
+        "source \"{}\"{} trust {}",
+        p.source,
+        loc,
+        fmt_trust(&p.trust_tier)
+    )
+}
+
+/// The stable spelling of a trust tier (mirrors the JSON `trust` field).
+fn fmt_trust(t: &TrustTier) -> &'static str {
+    match t {
+        TrustTier::Consensus => "consensus",
+        TrustTier::Authoritative => "authoritative",
+        TrustTier::Empirical => "empirical",
+        TrustTier::Inferred => "inferred",
+        TrustTier::Unattributed => "unattributed",
+    }
+}
+
+/// The rounding precision as text: decimal places for `round_to`, significant
+/// figures for `round_sig`.
+fn fmt_round_spec(spec: &RoundSpec) -> String {
+    match spec {
+        RoundSpec::Places(p) => format!("{p} places"),
+        RoundSpec::SigFigures(n) => format!("{n} sig figs"),
+    }
+}
+
+/// The stable spelling of a rounding mode (mirrors `rounding_mode_name`).
+fn fmt_mode(mode: RoundingMode) -> &'static str {
+    match mode {
+        RoundingMode::Down => "down",
+        RoundingMode::Up => "up",
+        RoundingMode::Floor => "floor",
+        RoundingMode::Ceiling => "ceiling",
+        RoundingMode::HalfUp => "half_up",
+        RoundingMode::HalfDown => "half_down",
+        RoundingMode::HalfEven => "half_even",
+    }
+}

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -42,6 +42,8 @@ use logic_engine::{
     TrustTier,
 };
 
+mod explain;
+
 const SPEC: &str = r#"{
   "cli_builder_spec_version": "1.0",
   "name": "adj-lang-cli",
@@ -49,6 +51,9 @@ const SPEC: &str = r#"{
   "version": "0.1.0",
   "arguments": [
     {"id": "program", "name": "PROGRAM", "description": "Path to a .adj program (rulebook + case)", "type": "string", "required": true}
+  ],
+  "flags": [
+    {"id": "explain", "long": "explain", "description": "Render a deterministic, human-readable explanation of the reasoning instead of the JSON trail (ADJ-REASON-MATH §E.8). Projection-only: no engine re-run.", "type": "boolean"}
   ]
 }"#;
 
@@ -827,6 +832,13 @@ fn main() -> ExitCode {
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
+    // §E.8: opt-in human-readable explanation instead of the JSON trail.
+    let explain = result
+        .flags
+        .get("explain")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
     // Resolve the program (and any `import`s) through the filesystem provider.
     // The sandbox root is the directory of the program file; no `import` may
     // read outside it. The canonical id of the root file seeds the resolver.
@@ -1026,6 +1038,16 @@ fn main() -> ExitCode {
     } else {
         format!(",\"derived\":{}", derived)
     };
+
+    // `--explain` (ADJ-REASON-MATH §E.8): render the human-readable view of the
+    // reasoning instead of the JSON trail. Projection-only — it reads the same
+    // `lowered.kb` the JSON above was built from and re-runs nothing. The JSON
+    // remains the primary, complete artifact (default output); `--explain` is the
+    // opt-in human view onto it.
+    if explain {
+        println!("{}", explain::explain(&lowered.kb));
+        return ExitCode::SUCCESS;
+    }
 
     println!(
         "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}{}{}{}{}{}{}}}",

--- a/code/packages/rust/adj-lang-cli/tests/rs4e_explain_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs4e_explain_e2e.rs
@@ -1,0 +1,163 @@
+//! End-to-end tests for the `explain` renderer (ADJ-REASON-MATH §E.8, RS-4 PR-E)
+//! — the human-readable, projection-only view of the reasoning, driven through
+//! the built CLI binary with `--explain`.
+//!
+//! This first slice renders the DERIVATIONS surface: the arithmetic behind each
+//! `let`/formula value, shown operand-by-operand down to its cited leaves. The
+//! tests pin the invariants that make the explanation trustworthy rather than
+//! merely pretty:
+//!
+//! - the §E.8.4 op-tree shape (operand-by-operand, literals inline),
+//! - P2 provenance on every line (the applied formula's citation on the value
+//!   line; an observed leaf without attribution marked `[unattributed]`, never
+//!   silently blank),
+//! - P4 determinism (the same program renders byte-identical text twice),
+//! - and that the JSON trail is unchanged when `--explain` is absent (the human
+//!   view is opt-in, not a replacement).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs4e_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Run the CLI with the given extra args before the program path; returns
+/// (success, stdout, stderr).
+fn run_with(args: &[&str], program: &Path) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .args(args)
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+    )
+}
+
+fn explain(program: &Path) -> String {
+    let (ok, out, err) = run_with(&["--explain"], program);
+    assert!(ok, "--explain exited non-zero: {err}");
+    out
+}
+
+fn write(dir: &Path, name: &str, src: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, src).unwrap();
+    p
+}
+
+// ---------------------------------------------------------------------------
+// (1) A pure `let` renders the arithmetic operand-by-operand (the §E.8.4 shape),
+//     with literal constants shown inline (they assert nothing new).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_pure_let_renders_the_op_tree_operand_by_operand() {
+    let dir = scratch("let");
+    let prog = write(&dir, "case.adj", "let dose = 5 * 60 / 100\n? dose\n");
+    let s = explain(&prog);
+
+    // The bound value and its dimension head the block.
+    assert!(
+        s.contains("dose = 3 [scalar]"),
+        "value line present: {s:?}"
+    );
+    // The division is shown over its two operands (the product, parenthesized,
+    // and the literal 100)...
+    assert!(
+        s.contains("3 = (300) / 100"),
+        "outer division shown operand-by-operand: {s:?}"
+    );
+    // ...and the product is expanded one level deeper.
+    assert!(
+        s.contains("300 = 5 * 60"),
+        "inner product expanded a level deeper: {s:?}"
+    );
+    // A pure `let` has no library claim, so no formula citation is attached.
+    assert!(
+        !s.contains("<= source"),
+        "no formula citation on a plain let: {s:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) A provenanced `formula` puts its citation on the value line (P2), and an
+//     observed leaf with no attribution renders `[unattributed]` (P2) — never a
+//     silent blank.
+// ---------------------------------------------------------------------------
+
+const FORMULA_PROG: &str = "dictionary d {\n\
+     define a : finding surface \"a\"\n\
+     define b : finding surface \"b\"\n\
+     }\n\
+     formulabook fb {\n\
+     use d\n\
+     formula total(a, b) = a + b source \"test source\" locator \"L1\" trust authoritative\n\
+     }\n\
+     observe a(2)\n\
+     observe b(3)\n\
+     ? total(a, b)\n";
+
+#[test]
+fn a_formula_value_carries_its_citation_and_marks_unattributed_leaves() {
+    let dir = scratch("formula");
+    let prog = write(&dir, "case.adj", FORMULA_PROG);
+    let s = explain(&prog);
+
+    // P2: the applied formula's citation is on the value line.
+    assert!(
+        s.contains("total = 5 [scalar]")
+            && s.contains("<= source \"test source\" locator \"L1\" trust authoritative"),
+        "formula value carries its cited provenance: {s:?}"
+    );
+    // The sum is shown over its named operands.
+    assert!(s.contains("5 = a + b"), "sum shown operand-by-operand: {s:?}");
+    // P2: the observed leaves carry no attribution, so they are marked — not blank.
+    assert!(
+        s.contains("a = 2   [unattributed]") && s.contains("b = 3   [unattributed]"),
+        "unattributed observed leaves are marked, never silently blank: {s:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (3) P4 — determinism: the same program renders BYTE-IDENTICAL text twice.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_explanation_is_byte_deterministic() {
+    let dir = scratch("determinism");
+    let prog = write(&dir, "case.adj", FORMULA_PROG);
+    let a = explain(&prog);
+    let b = explain(&prog);
+    assert_eq!(a, b, "same program must render identical explanation text");
+    // And it is non-trivial (guards against "identical because both empty").
+    assert!(a.contains("total = 5"), "explanation is non-empty: {a:?}");
+}
+
+// ---------------------------------------------------------------------------
+// (4) The JSON trail is unchanged when `--explain` is absent — the human view is
+//     opt-in, not a replacement for the machine trail (§E.8.3).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn without_the_flag_the_json_trail_is_unchanged() {
+    let dir = scratch("json");
+    let prog = write(&dir, "case.adj", FORMULA_PROG);
+    let (ok, out, err) = run_with(&[], &prog);
+    assert!(ok, "default run exited non-zero: {err}");
+    // Default output is the JSON object, not the explanation text.
+    assert!(
+        out.trim_start().starts_with('{') && out.contains("\"derived\":["),
+        "default output is the JSON trail: {out:?}"
+    );
+    assert!(
+        !out.contains("[unattributed]") && !out.contains("<= source"),
+        "explanation prose does not leak into the default JSON: {out:?}"
+    );
+}


### PR DESCRIPTION
## What

Implements the human-readable **"explain its reasoning"** view specified by [ADJ-REASON-MATH §E.8](code/specs/ADJ-REASON-MATH.md) (landed in #9278). `adj-lang-cli --explain <prog.adj>` renders the *same* reasoning the default JSON trail carries — as text a person reads.

Second PR of the Substrate/RS campaign; the code that fills the §E.8 contract (PR-E).

## The one invariant that matters

It is a **projection only**: `--explain` reads the derivation trees the engine already built and **re-runs nothing** (P1). The explanation therefore can never say more than the proof — the opposite of a fresh model-paraphrase that could sound right while over-claiming.

## This slice = the derivations surface

Each `let`/formula value is shown operand-by-operand down to its cited leaves (the §E.8.4 shape):

```
total = 5 [scalar]   <= source "…" locator "…" trust authoritative
  5 = a + b
    a = 2   [unattributed]
    b = 3   [unattributed]
```

Invariants enforced + tested:
- **P1** projection-only — walks `derived_bindings`; no engine re-run, no new value.
- **P2** provenance on every line — applied formula's citation on the value line; an observed leaf with no attribution marked `[unattributed]`, never silently blank; literal constants shown inline (they assert nothing).
- **P4** byte-determinism — first-seen order, stable numeric `Display`, no time/locale/map-order (pinned by a test).
- **P6** addressed indentation — each operand on its own line, one level deeper.
- Node walk is **total** over `DerivationNode` (new kind ⇒ compile error), mirroring the JSON walker.

Default (no-flag) output is **byte-for-byte unchanged**. Later PR-E slices extend `--explain` to premises / inference / adjudication / abstention (the rest of the §E.8.1 linearization); this slice discharges the derivations portion of FL-7's explanation renderer.

## Verification

- `cargo build -p adj-lang-cli` clean; `cargo test -p adj-lang-cli --test rs4e_explain_e2e` → **4 passed** (op-tree shape, formula citation + `[unattributed]` leaves, determinism, JSON-unchanged); `cargo clippy -p adj-lang-cli --tests -- -D warnings` → **exit 0**.
- NUL-byte scan of new files clean.
- `/security-review`: **PASSED** — recursion bounded by the engine's `MAX_EVAL_DEPTH=128` (no new unbounded recursion vs the existing JSON render); no panics on untrusted input; projection-only confirmed.

New: `src/explain.rs`, `tests/rs4e_explain_e2e.rs`. Touches `src/main.rs` (`--explain` flag + branch). adj-lang-cli 0.24.0 → 0.25.0 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)