### PR TITLE
Wire Venture macOS keyboard scrolling

### DIFF
--- a/code/packages/rust/objc-bridge/CHANGELOG.md
+++ b/code/packages/rust/objc-bridge/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
-- Typed `msg_bool!` and architecture-correct `msg_f64!` Objective-C message
-  dispatch helpers for native event translation.
+- Typed `msg_bool!`, including one-argument calls, and architecture-correct
+  `msg_f64!` Objective-C message dispatch helpers for native event translation.
 
 ## [0.1.0] - 2026-04-01
 

--- a/code/packages/rust/objc-bridge/src/lib.rs
+++ b/code/packages/rust/objc-bridge/src/lib.rs
@@ -806,6 +806,11 @@ macro_rules! msg_bool {
             ::std::mem::transmute($crate::objc_msgSend as *const ());
         f($receiver, $crate::sel($sel)) != 0
     }};
+    ($receiver:expr, $sel:expr, $a1:expr) => {{
+        let f: unsafe extern "C" fn($crate::Id, $crate::Sel, _) -> ::std::ffi::c_schar =
+            ::std::mem::transmute($crate::objc_msgSend as *const ());
+        f($receiver, $crate::sel($sel), $a1) != 0
+    }};
 }
 
 /// Message dispatch for methods returning an `f64`/Objective-C `double`.

--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -6,6 +6,7 @@
   model and repaint the translated viewport through Metal.
 - Activate viewport links from primary-button input, update the native title,
   and repaint across repeated transactional navigation.
+- Drive the clamped viewport and Metal repaint path from named navigation keys.
 
 ## 0.1.0
 

--- a/code/packages/rust/venture-browser-macos/README.md
+++ b/code/packages/rust/venture-browser-macos/README.md
@@ -30,4 +30,6 @@ Mouse-wheel and trackpad input drive the shared clamped viewport and repaint the
 translated scene through Metal. Primary-button input now hit-tests links in
 viewport coordinates, loads the resolved destination through the transactional
 browser session, updates the title, and repaints repeatedly. Native controls,
-keyboard input, and richer pointer behavior remain the next integration layer.
+text input, and richer pointer behavior remain the next integration layer.
+Arrow, Page Up/Down, Home/End, and Space key events now drive the same shared
+clamped viewport and Metal repaint path.

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -16,7 +16,9 @@ use venture_browser_core::{
     BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
     BrowserSession,
 };
-use window_core::{ElementState, PointerButton, WindowError, WindowEvent};
+use window_core::{
+    ElementState, Key, NamedKey, PointerButton, WindowError, WindowEvent,
+};
 
 #[cfg(target_vendor = "apple")]
 use venture_browser_core::HttpBrowserFetcher;
@@ -203,7 +205,8 @@ fn run_with_termination(
         let mut pointer_position = None;
         move |event| {
             let mut session = session.borrow_mut();
-            let mut should_repaint = scroll_session(&mut session, &event);
+            let mut should_repaint = scroll_session(&mut session, &event)
+                || keyboard_scroll_session(&mut session, &event);
             if let Some((x, y)) = pointer_link_activation(&mut pointer_position, &event) {
                 match activate_link_at(
                     &mut session,
@@ -268,6 +271,56 @@ pub fn scroll_session(session: &mut BrowserSession, event: &WindowEvent) -> bool
     viewport.scroll_state().offset_y() != previous_offset
 }
 
+/// Apply host-level named scrolling keys to the current browser viewport.
+pub fn keyboard_scroll_session(session: &mut BrowserSession, event: &WindowEvent) -> bool {
+    let WindowEvent::Key {
+        key: Key::Named(key),
+        state: ElementState::Pressed,
+        modifiers,
+        ..
+    } = event
+    else {
+        return false;
+    };
+    if modifiers.control || modifiers.alt || modifiers.meta {
+        return false;
+    }
+    let Some(viewport) = session.viewport_mut() else {
+        return false;
+    };
+    let previous_offset = viewport.scroll_state().offset_y();
+    let viewport_height = viewport.scroll_state().viewport_height();
+    match key {
+        NamedKey::ArrowUp => {
+            viewport.scroll_by(-40.0);
+        }
+        NamedKey::ArrowDown => {
+            viewport.scroll_by(40.0);
+        }
+        NamedKey::PageUp => {
+            viewport.scroll_by(-viewport_height * 0.9);
+        }
+        NamedKey::PageDown => {
+            viewport.scroll_by(viewport_height * 0.9);
+        }
+        NamedKey::Space if modifiers.shift => {
+            viewport.scroll_by(-viewport_height * 0.9);
+        }
+        NamedKey::Space => {
+            viewport.scroll_by(viewport_height * 0.9);
+        }
+        NamedKey::Home => {
+            viewport.set_scroll_offset_y(0.0);
+        }
+        NamedKey::End => {
+            let max_offset = viewport.scroll_state().max_offset_y();
+            viewport.set_scroll_offset_y(max_offset);
+        }
+        _ => return false,
+    }
+    viewport.scroll_state().offset_y() != previous_offset
+}
+
 /// Track pointer movement and identify a primary-button link activation.
 ///
 /// Activation happens on release so dragging away from a link can update the
@@ -303,6 +356,7 @@ pub fn run_for_smoke(_start_url: &str, _seconds: f64) -> Result<(), MacBrowserEr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use window_core::ModifiersState;
 
     #[cfg(target_vendor = "apple")]
     use venture_browser_core::BrowserFetchResponse;
@@ -415,6 +469,83 @@ mod tests {
             pointer_link_activation(&mut pointer_position, &released),
             Some((12.5, 48.0))
         );
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[test]
+    fn named_keys_scroll_and_clamp_the_native_viewport() {
+        let fetcher = |url: &str| {
+            let paragraphs = (0..80)
+                .map(|index| format!("<p>Keyboard Venture paragraph {index}</p>"))
+                .collect::<String>();
+            Ok(BrowserFetchResponse::new(
+                url,
+                200,
+                Some("text/html; charset=utf-8".into()),
+                format!("<title>Keyboard</title>{paragraphs}").into_bytes(),
+            ))
+        };
+        let mut session = load_initial_session("http://example.test/", 320.0, 180.0, &fetcher)
+            .expect("native browser pipeline should load tall canned HTML");
+        let key_event = |key, modifiers| WindowEvent::Key {
+            window_id: WindowId(1),
+            key: Key::Named(key),
+            state: ElementState::Pressed,
+            modifiers,
+            text: None,
+        };
+
+        assert!(keyboard_scroll_session(
+            &mut session,
+            &key_event(NamedKey::ArrowDown, ModifiersState::default())
+        ));
+        assert_eq!(
+            session
+                .viewport()
+                .expect("viewport should remain loaded")
+                .scroll_state()
+                .offset_y(),
+            40.0
+        );
+        assert!(keyboard_scroll_session(
+            &mut session,
+            &key_event(NamedKey::End, ModifiersState::default())
+        ));
+        let max_offset = session
+            .viewport()
+            .expect("viewport should remain loaded")
+            .scroll_state()
+            .max_offset_y();
+        assert_eq!(
+            session
+                .viewport()
+                .expect("viewport should remain loaded")
+                .scroll_state()
+                .offset_y(),
+            max_offset
+        );
+        assert!(keyboard_scroll_session(
+            &mut session,
+            &key_event(NamedKey::Home, ModifiersState::default())
+        ));
+        assert_eq!(
+            session
+                .viewport()
+                .expect("viewport should remain loaded")
+                .scroll_state()
+                .offset_y(),
+            0.0
+        );
+        assert!(!keyboard_scroll_session(
+            &mut session,
+            &key_event(
+                NamedKey::ArrowDown,
+                ModifiersState {
+                    meta: true,
+                    ..ModifiersState::default()
+                }
+            )
+        ));
     }
 
     #[cfg(target_vendor = "apple")]

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -356,6 +356,8 @@ pub fn run_for_smoke(_start_url: &str, _seconds: f64) -> Result<(), MacBrowserEr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_vendor = "apple")]
     use window_core::ModifiersState;
 
     #[cfg(target_vendor = "apple")]

--- a/code/packages/rust/window-appkit/CHANGELOG.md
+++ b/code/packages/rust/window-appkit/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this package will be documented in this file.
 - An AppKit event view that translates wheel input to normalized
   `WindowEvent::Scroll` callbacks.
 - Primary-button translation with top-left logical pointer coordinates.
+- Named navigation-key and modifier translation into shared key events.
 - Main-thread event-handler registration on `AppKitWindow`.
 
 ## [0.1.0] - 2026-04-18

--- a/code/packages/rust/window-appkit/README.md
+++ b/code/packages/rust/window-appkit/README.md
@@ -16,11 +16,12 @@ This package supports a real macOS host path while staying small:
 - runs the AppKit event loop for native launch testing
 - translates AppKit wheel input into shared `WindowEvent::Scroll` values
 - translates primary-button input into top-left logical pointer events
+- translates named navigation keys and modifiers into shared key events
 - lets a main-thread host install a normalized event handler on its window
 - rejects renderer preferences that belong to other platforms
 
-Metal-layer attachment is available for renderer hosts. Keyboard, resize, and
-close translation remain future event slices.
+Metal-layer attachment is available for renderer hosts. Text input, resize,
+and close translation remain future event slices.
 
 ## Dependencies
 

--- a/code/packages/rust/window-appkit/src/lib.rs
+++ b/code/packages/rust/window-appkit/src/lib.rs
@@ -16,7 +16,7 @@
 // Platform-conditional: code for the non-native platform is intentionally inactive; allow the resulting dead_code/unused lints only where it does not compile in.
 #![cfg_attr(not(target_vendor = "apple"), allow(dead_code, unused_imports))]
 
-use std::ffi::{c_int, c_ulong};
+use std::ffi::{c_int, c_schar, c_ulong};
 
 #[cfg(target_vendor = "apple")]
 use std::{
@@ -27,16 +27,16 @@ use std::{
 
 #[cfg(target_vendor = "apple")]
 use objc_bridge::{
-    class, class_addIvar, class_addMethod, msg, msg_bool, msg_f64, msg_send_class, nsstring,
-    objc_allocateClassPair, objc_registerClassPair, object_getInstanceVariable,
+    class, class_addIvar, class_addMethod, msg, msg_bool, msg_f64, msg_send_class, msg_usize,
+    nsstring, objc_allocateClassPair, objc_registerClassPair, object_getInstanceVariable,
     object_setInstanceVariable, release, sel, CGPoint, CGRect, CGSize, ClassPtr, Id, Sel, NIL,
     NS_BACKING_STORE_BUFFERED, NS_WINDOW_STYLE_MASK_CLOSABLE, NS_WINDOW_STYLE_MASK_MINIATURIZABLE,
     NS_WINDOW_STYLE_MASK_RESIZABLE, NS_WINDOW_STYLE_MASK_TITLED,
 };
 use window_core::{
-    AppKitRenderTarget, ElementState, LogicalSize, MountTarget, PhysicalSize, PointerButton,
-    RenderTarget, SurfacePreference, Window, WindowAttributes, WindowBackend, WindowError,
-    WindowEvent, WindowId,
+    AppKitRenderTarget, ElementState, Key, LogicalSize, ModifiersState, MountTarget, NamedKey,
+    PhysicalSize, PointerButton, RenderTarget, SurfacePreference, Window, WindowAttributes,
+    WindowBackend, WindowError, WindowEvent, WindowId,
 };
 
 /// Crate version, kept explicit for examples and integration tests.
@@ -378,6 +378,7 @@ impl AppKitBackend {
         }
         let view = create_event_view(msg_send_bounds(default_view))?;
         msg!(window, "setContentView:", view);
+        let _ = msg_bool!(window, "makeFirstResponder:", view);
 
         setup_window_delegate(window, app)?;
 
@@ -474,6 +475,25 @@ unsafe fn ensure_event_view_class() -> Result<ClassPtr, WindowError> {
         mouse_up as *const _,
         event_method_types.as_ptr(),
     );
+    class_addMethod(
+        view_class,
+        sel("keyDown:"),
+        key_down as *const _,
+        event_method_types.as_ptr(),
+    );
+    class_addMethod(
+        view_class,
+        sel("keyUp:"),
+        key_up as *const _,
+        event_method_types.as_ptr(),
+    );
+    let bool_method_types = CString::new("c@:").expect("static BOOL method type");
+    class_addMethod(
+        view_class,
+        sel("acceptsFirstResponder"),
+        accepts_first_responder as *const _,
+        bool_method_types.as_ptr(),
+    );
     objc_registerClassPair(view_class);
     Ok(view_class)
 }
@@ -534,6 +554,37 @@ fn dispatch_pointer_button_event(view: Id, event: Id, state: ElementState) {
     });
 }
 
+#[cfg(target_vendor = "apple")]
+extern "C" fn accepts_first_responder(_view: Id, _sel: Sel) -> c_schar {
+    1
+}
+
+#[cfg(target_vendor = "apple")]
+extern "C" fn key_down(view: Id, _sel: Sel, event: Id) {
+    dispatch_key_event(view, event, ElementState::Pressed);
+}
+
+#[cfg(target_vendor = "apple")]
+extern "C" fn key_up(view: Id, _sel: Sel, event: Id) {
+    dispatch_key_event(view, event, ElementState::Released);
+}
+
+#[cfg(target_vendor = "apple")]
+fn dispatch_key_event(view: Id, event: Id, state: ElementState) {
+    let key_code = unsafe { msg_usize!(event, "keyCode") };
+    let modifier_flags = unsafe { msg_usize!(event, "modifierFlags") };
+    EVENT_HANDLERS.with(|handlers| {
+        let mut handlers = handlers.borrow_mut();
+        if let Some(entry) = handlers.get_mut(&(view as usize)) {
+            if let Some(event) =
+                normalized_key_event(entry.window_id, key_code, modifier_flags, state)
+            {
+                (entry.callback)(event);
+            }
+        }
+    });
+}
+
 /// Translate AppKit's content-motion deltas into viewport scroll direction.
 pub fn normalized_scroll_event(
     window_id: WindowId,
@@ -574,6 +625,47 @@ pub fn normalized_pointer_button_events(
             state,
         },
     ]
+}
+
+/// Translate macOS virtual key codes for host-level navigation input.
+pub fn normalized_key_event(
+    window_id: WindowId,
+    key_code: usize,
+    modifier_flags: usize,
+    state: ElementState,
+) -> Option<WindowEvent> {
+    let key = match key_code {
+        0x35 => NamedKey::Escape,
+        0x24 => NamedKey::Enter,
+        0x30 => NamedKey::Tab,
+        0x33 => NamedKey::Backspace,
+        0x31 => NamedKey::Space,
+        0x7b => NamedKey::ArrowLeft,
+        0x7c => NamedKey::ArrowRight,
+        0x7e => NamedKey::ArrowUp,
+        0x7d => NamedKey::ArrowDown,
+        0x73 => NamedKey::Home,
+        0x77 => NamedKey::End,
+        0x74 => NamedKey::PageUp,
+        0x79 => NamedKey::PageDown,
+        _ => return None,
+    };
+    Some(WindowEvent::Key {
+        window_id,
+        key: Key::Named(key),
+        state,
+        modifiers: normalized_modifiers(modifier_flags),
+        text: None,
+    })
+}
+
+fn normalized_modifiers(flags: usize) -> ModifiersState {
+    ModifiersState {
+        shift: flags & (1 << 17) != 0,
+        control: flags & (1 << 18) != 0,
+        alt: flags & (1 << 19) != 0,
+        meta: flags & (1 << 20) != 0,
+    }
 }
 
 fn invert_finite(value: f64) -> f64 {
@@ -905,6 +997,34 @@ mod tests {
                 x: 0.0,
                 y: 0.0,
             }
+        );
+    }
+
+    #[test]
+    fn appkit_named_keys_and_modifiers_are_normalized() {
+        assert_eq!(
+            normalized_key_event(
+                WindowId(7),
+                0x7d,
+                (1 << 17) | (1 << 20),
+                ElementState::Pressed,
+            ),
+            Some(WindowEvent::Key {
+                window_id: WindowId(7),
+                key: Key::Named(NamedKey::ArrowDown),
+                state: ElementState::Pressed,
+                modifiers: ModifiersState {
+                    shift: true,
+                    control: false,
+                    alt: false,
+                    meta: true,
+                },
+                text: None,
+            })
+        );
+        assert_eq!(
+            normalized_key_event(WindowId(7), 0xffff, 0, ElementState::Pressed),
+            None
         );
     }
 }

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -75,8 +75,9 @@ an HTTP page with native CoreText services, creates an AppKit `CAMetalLayer`,
 and presents the viewport through `paint-metal`. Native AppKit wheel events
 drive the shared clamped viewport and Metal repaint path. Primary-button events
 now use top-left viewport coordinates to activate links through transactional
-page loads, update the title, and repaint across repeated navigation. Keyboard
-translation, controls, and richer pointer behavior remain before the shell is
+page loads, update the title, and repaint across repeated navigation. Named
+AppKit navigation keys now drive clamped viewport scrolling and Metal repaint.
+Text input, controls, and richer pointer behavior remain before the shell is
 interactive.
 
 ## Where It Fits


### PR DESCRIPTION
## Summary

- normalize AppKit named navigation keys and modifier flags into shared `WindowEvent::Key` events
- make the native event view first responder and dispatch key press/release callbacks with the correct Objective-C BOOL ABI
- drive Venture's clamped viewport and Metal repaint path from Arrow, Page Up/Down, Home/End, and Space keys
- document the new macOS host capability while leaving text input, controls, richer pointer behavior, and Windows integration as separate follow-up slices

## Why

The macOS shell could load, scroll by wheel, and activate links, but it did not yet expose host keyboard navigation. This closes that bounded native-input gap without folding text editing or control semantics into the browser host.

## Validation

- `cargo test -p window-core -p venture-browser-core -p window-appkit -p venture-browser-macos -p objc-bridge --quiet`
- `cargo clippy -p objc-bridge -p window-appkit -p venture-browser-macos --all-targets -- -D warnings`
- `cargo run -p venture-browser-macos -- --smoke-seconds 0.5 http://info.cern.ch/`
- exact HTML conformance audit: tree missing `0`, tokenizer missing `0`, normalized skipped `0`
- `git diff --check`

The native smoke validates startup, page loading, and rendering. Direct interactive GUI keyboard acceptance remains a separate manual acceptance gate.