### PR TITLE
feat(adj-lang-cli): --explain inference + adjudication surfaces (RS-4 PR-E2)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.26.0] — 2026-07-30 — RS-4 PR-E2: `--explain` inference + adjudication surfaces
+
+Extends the `--explain` renderer (ADJ-REASON-MATH §E.8) from the derivations
+surface to the **inference** and **adjudication** surfaces, so a *differential*
+query — not just an arithmetic one — explains itself. Still a projection only: it
+reads the decided differential (`Differential`) the engine already produced and
+re-runs nothing.
+
+```
+Inference for bacterial:
+  prior on bacterial = logit -0.847 [source "x" trust empirical]
+  bacterial contributes logit 2.708 via [source "Straus 2006" trust authoritative] [evidence: [unattributed]]
+
+Decision:
+  bacterial — posterior 0.865 (logit 1.861)
+  => bacterial (determinate; posterior 0.865, margin 0.865; trust empirical)
+```
+
+- **Inference** — the ordered proof steps per hypothesis: prior, likelihood-ratio
+  contributions (each showing the CLAUSE that licensed it *and* the observed
+  evidence it consumed), joint interactions, predicate-gated contributions (the
+  CPU comparison `observed <op> threshold`), rule-derived premises, and
+  negation-as-failure. The walk is **total** over `DerivationOrigin` (a new kind
+  ⇒ compile error), mirroring the JSON `trace_steps_json`.
+- **Adjudication** — the ranked hypotheses with their posteriors, and the
+  comparative decision: `determinate` with its margin, or a `Kickback` rendered as
+  the honest "cannot commit" verdict with its reason (the differential's own
+  abstention). P3: the leader shows the trust tier propagated as the `min`
+  (weakest link) over the graded knowledge — prior, rules, and contribution
+  clauses — it relied on.
+- A pure computation (a `let` with no differential evidence) still renders
+  derivations-only; the JSON trail is byte-for-byte unchanged when `--explain` is
+  absent.
+
+New: `tests/rs4e2_explain_inference_e2e.rs` (4 tests). Extends `src/explain.rs`;
+touches `src/main.rs` (threads the decided `diff` into `explain`).
+
 ## [0.25.0] — 2026-07-30 — RS-4 PR-E1: `--explain` renderer (derivations surface)
 
 Adds the human-readable *"explain its reasoning"* view — `adj-lang-cli --explain <prog.adj>` —

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/explain.rs
+++ b/code/packages/rust/adj-lang-cli/src/explain.rs
@@ -37,16 +37,53 @@
 //!   node in the derivation tree.
 
 use logic_engine::compute::{DerivationNode, RoundSpec};
+use logic_engine::differential::{Differential, DifferentialDecision};
+use logic_engine::proof_dag::DerivationOrigin;
 use logic_engine::{KnowledgeBase, Provenance, RoundingMode, TrustTier};
 
-/// Render the human-readable explanation of a decided knowledge base.
+/// Render the human-readable explanation of a decided query.
 ///
-/// Returns the empty string when the program bound no derived values — this
-/// slice explains the derivations surface only, so a pure-differential or
-/// pure-recall program has nothing to render here yet (later PR-E slices add
-/// those sections). Projection-only: the only input is the already-populated
-/// `kb`.
-pub fn explain(kb: &KnowledgeBase) -> String {
+/// Composes the §E.8.1 surfaces in order: **derivations** (the arithmetic behind
+/// each computed value), **inference** (the ordered proof steps behind each
+/// hypothesis — prior, rule-derived premises, likelihood-ratio contributions,
+/// negation-as-failure), and **adjudication** (the ranked leader and the
+/// comparative decision, or the honest kickback when the ranking is not robust).
+/// Premises are shown inline within the inference steps — each cited step names
+/// the fact or clause that licensed it.
+///
+/// Projection-only (P1): the inputs are the already-populated `kb` and the
+/// already-decided `diff`; nothing is re-run. A pure computation (a `let` with no
+/// differential evidence) renders only its derivations; a pure differential
+/// renders only its inference + adjudication. Determinism (P4) rides on the
+/// stable walk order of both.
+pub fn explain(kb: &KnowledgeBase, diff: &Differential) -> String {
+    let mut sections: Vec<String> = Vec::new();
+    let derivations = render_derivations(kb);
+    if !derivations.is_empty() {
+        sections.push(derivations);
+    }
+    // Inference + adjudication only apply when the differential carries actual
+    // evidence (a prior or a contribution produced a proof step). A bare
+    // computation / recall query has empty proofs and renders no differential —
+    // so a `let`-only program stays derivations-only, unchanged from PR-E1.
+    let has_inference = diff
+        .ranked
+        .iter()
+        .any(|r| r.result.dag.proofs.first().is_some_and(|p| !p.steps.is_empty()));
+    if has_inference {
+        let inference = render_inference(kb, diff);
+        if !inference.is_empty() {
+            sections.push(inference);
+        }
+        sections.push(render_adjudication(kb, diff));
+    }
+    sections.join("\n\n")
+}
+
+/// Render the derivations surface — the arithmetic behind each `let`/formula
+/// value, operand-by-operand to cited leaves (PR-E1). Returns "" when the
+/// program bound no derived values.
+fn render_derivations(kb: &KnowledgeBase) -> String {
     // First-seen order, latest value per name — identical to `derived_json`, so
     // the human view and the JSON view agree on which bindings exist and in what
     // order. Determinism (P4) rides on this being a deterministic walk.
@@ -85,7 +122,275 @@ pub fn explain(kb: &KnowledgeBase) -> String {
     while out.last().is_some_and(|l| l.is_empty()) {
         out.pop();
     }
+    if out.is_empty() {
+        return String::new();
+    }
+    format!("Derivations:\n{}", out.join("\n"))
+}
+
+/// Render the inference surface — the ordered proof steps behind each hypothesis
+/// that the differential actually proved. Mirrors the total-walk discipline of
+/// the JSON `trace_steps_json`: the match over `DerivationOrigin` is exhaustive,
+/// so a new step kind must be handled here or the crate fails to compile.
+/// Projection-only: reads `r.result.dag`, re-runs nothing.
+fn render_inference(kb: &KnowledgeBase, diff: &Differential) -> String {
+    let mut out: Vec<String> = Vec::new();
+    for r in &diff.ranked {
+        let Some(proof) = r.result.dag.proofs.first() else {
+            continue;
+        };
+        if proof.steps.is_empty() {
+            continue;
+        }
+        // The graded clauses that can fire for this hypothesis — used to resolve
+        // each contribution step back to the CLAUSE that licensed it (its cited
+        // `source`/`trust`), which is the "why this likelihood ratio applies"
+        // citation, distinct from the observed evidence a step consumed.
+        let contribs = kb.contributions_for(&r.hypothesis);
+        let joints = kb.joint_contributions_for(&r.hypothesis);
+        let predicates = kb.predicate_contributions_for(&r.hypothesis);
+        out.push(format!("Inference for {}:", r.hypothesis));
+        for st in &proof.steps {
+            // Depth addresses the step (P6): a rule's body steps are one level
+            // deeper than the rule step that introduced them.
+            let ind = "  ".repeat(st.depth + 1);
+            let line = match &st.origin {
+                DerivationOrigin::FromFact(id) => {
+                    format!("{ind}{} [fact] {}", st.goal, cite_fact(kb, *id))
+                }
+                DerivationOrigin::FromRule(id) => {
+                    let cite = kb
+                        .find_rule_by_id(*id)
+                        .map(|rule| format!("[{}]", fmt_prov(&rule.provenance)))
+                        .unwrap_or_else(|| "[unattributed]".to_string());
+                    format!("{ind}{} [rule] {cite}", st.goal)
+                }
+                // Negation-as-failure quotes nothing: what licensed the step is
+                // the *absence* of any proof for the negated goal (§E.5).
+                DerivationOrigin::FromNegation { goal } => {
+                    format!("{ind}{} [negation: no proof exists for {}]", st.goal, goal)
+                }
+                DerivationOrigin::FromPrior { prior_logit, .. } => {
+                    let cite = kb
+                        .prior_for(&r.hypothesis)
+                        .map(|p| format!("[{}]", fmt_prov(&p.provenance)))
+                        .unwrap_or_else(|| "[unattributed]".to_string());
+                    format!(
+                        "{ind}prior on {} = logit {} {cite}",
+                        st.goal,
+                        fmt_num(*prior_logit)
+                    )
+                }
+                DerivationOrigin::FromContribution {
+                    clause_id,
+                    evidence_fact_ids,
+                    logit_delta,
+                    ..
+                } => {
+                    let via = contribs
+                        .iter()
+                        .find(|c| c.id == *clause_id)
+                        .map(|c| format!("[{}]", fmt_prov(&c.provenance)))
+                        .unwrap_or_else(|| "[unattributed]".to_string());
+                    format!(
+                        "{ind}{} contributes logit {} via {via} [evidence: {}]",
+                        st.goal,
+                        fmt_num(*logit_delta),
+                        cite_facts(kb, evidence_fact_ids)
+                    )
+                }
+                DerivationOrigin::FromJointContribution {
+                    clause_id,
+                    evidence_fact_ids,
+                    joint_logit_delta,
+                    ..
+                } => {
+                    let via = joints
+                        .iter()
+                        .find(|j| j.id == *clause_id)
+                        .map(|j| format!("[{}]", fmt_prov(&j.provenance)))
+                        .unwrap_or_else(|| "[unattributed]".to_string());
+                    format!(
+                        "{ind}{} interaction logit {} via {via} [evidence: {}]",
+                        st.goal,
+                        fmt_num(*joint_logit_delta),
+                        cite_facts(kb, evidence_fact_ids)
+                    )
+                }
+                // The literal comparison that fired is the justification: the
+                // reader sees `observed <op> threshold`, recomputable, no
+                // model-computed number. The clause that set the threshold
+                // carries the citation for why it applies.
+                DerivationOrigin::FromPredicateContribution {
+                    clause_id,
+                    slot,
+                    op,
+                    threshold,
+                    observed,
+                    logit_delta,
+                } => {
+                    let via = predicates
+                        .iter()
+                        .find(|p| p.id == *clause_id)
+                        .map(|p| format!(" via [{}]", fmt_prov(&p.provenance)))
+                        .unwrap_or_default();
+                    format!(
+                        "{ind}{} {} {} (observed {}) contributes logit {}{via}",
+                        slot,
+                        op.symbol(),
+                        fmt_num(*threshold),
+                        fmt_num(*observed),
+                        fmt_num(*logit_delta)
+                    )
+                }
+            };
+            out.push(line);
+        }
+    }
     out.join("\n")
+}
+
+/// Render the adjudication surface — the ranked hypotheses and the comparative
+/// decision. P3: the leader line shows the trust tier propagated as the `min`
+/// (weakest link) over its proof's cited clauses. A `Kickback` is rendered as
+/// the honest "cannot commit" verdict it is, with its reason — the differential's
+/// own form of abstention.
+fn render_adjudication(kb: &KnowledgeBase, diff: &Differential) -> String {
+    let mut out: Vec<String> = vec!["Decision:".to_string()];
+    for r in &diff.ranked {
+        out.push(format!(
+            "  {} — posterior {} (logit {})",
+            r.hypothesis,
+            fmt_num(r.posterior),
+            fmt_num(r.posterior_logit)
+        ));
+    }
+    match &diff.decision {
+        DifferentialDecision::Empty => {
+            out.push("  abstained: no hypotheses were supplied".to_string());
+        }
+        DifferentialDecision::Determinate {
+            leader,
+            posterior,
+            margin_posterior,
+            ..
+        } => {
+            let trust = min_trust_for(kb, diff, leader);
+            out.push(format!(
+                "  => {} (determinate; posterior {}, margin {}; trust {})",
+                leader,
+                fmt_num(*posterior),
+                fmt_num(*margin_posterior),
+                trust
+            ));
+        }
+        DifferentialDecision::Kickback {
+            leader,
+            runner_up,
+            margin_posterior,
+            reason,
+            ..
+        } => {
+            out.push(format!(
+                "  => KICKBACK: {} vs {} (margin {}) — {} [resolve the flagged uncertainty before committing]",
+                leader,
+                runner_up,
+                fmt_num(*margin_posterior),
+                reason
+            ));
+        }
+    }
+    out.join("\n")
+}
+
+/// The weakest (`min`) trust tier over the cited clauses of `hyp`'s proof — P3's
+/// "trust propagates as the weakest link." Resolves the prior, each rule, and
+/// each contribution's evidence facts; an unresolved or unattributed clause pins
+/// the result at `unattributed`.
+fn min_trust_for(kb: &KnowledgeBase, diff: &Differential, hyp: &logic_core::Term) -> &'static str {
+    let Some(r) = diff.ranked.iter().find(|r| &r.hypothesis == hyp) else {
+        return "unattributed";
+    };
+    let Some(proof) = r.result.dag.proofs.first() else {
+        return "unattributed";
+    };
+    // Rank: higher = stronger; the min (weakest) wins.
+    let rank = |t: &TrustTier| match t {
+        TrustTier::Consensus => 4u8,
+        TrustTier::Authoritative => 3,
+        TrustTier::Empirical => 2,
+        TrustTier::Inferred => 1,
+        TrustTier::Unattributed => 0,
+    };
+    let mut weakest: Option<TrustTier> = None;
+    let mut fold = |t: TrustTier| {
+        weakest = Some(match weakest.take() {
+            Some(w) if rank(&w) <= rank(&t) => w,
+            _ => t,
+        });
+    };
+    // Fold the trust of the graded KNOWLEDGE the reasoning applied — the prior,
+    // each rule, and each contribution/interaction/predicate clause. A raw
+    // observation is an input, not a knowledge claim, so it does not pin the
+    // reasoning's tier here; its own provenance is shown inline per step (P2).
+    let contrib_clauses = kb.contributions_for(hyp);
+    let joint_clauses = kb.joint_contributions_for(hyp);
+    let predicate_clauses = kb.predicate_contributions_for(hyp);
+    for st in &proof.steps {
+        match &st.origin {
+            DerivationOrigin::FromRule(id) => {
+                if let Some(rule) = kb.find_rule_by_id(*id) {
+                    fold(rule.provenance.trust_tier);
+                }
+            }
+            DerivationOrigin::FromPrior { .. } => {
+                if let Some(p) = kb.prior_for(hyp) {
+                    fold(p.provenance.trust_tier);
+                }
+            }
+            DerivationOrigin::FromContribution { clause_id, .. } => {
+                if let Some(c) = contrib_clauses.iter().find(|c| c.id == *clause_id) {
+                    fold(c.provenance.trust_tier);
+                }
+            }
+            DerivationOrigin::FromJointContribution { clause_id, .. } => {
+                if let Some(j) = joint_clauses.iter().find(|j| j.id == *clause_id) {
+                    fold(j.provenance.trust_tier);
+                }
+            }
+            DerivationOrigin::FromPredicateContribution { clause_id, .. } => {
+                if let Some(p) = predicate_clauses.iter().find(|p| p.id == *clause_id) {
+                    fold(p.provenance.trust_tier);
+                }
+            }
+            // A directly-consumed fact is an observation/input; negation cites no
+            // clause. Neither pins the reasoning's knowledge tier.
+            DerivationOrigin::FromFact(_) | DerivationOrigin::FromNegation { .. } => {}
+        }
+    }
+    match weakest {
+        Some(t) => fmt_trust(&t),
+        None => "unattributed",
+    }
+}
+
+/// A fact's citation `[source … trust …]`, or `[unattributed]`.
+fn cite_fact(kb: &KnowledgeBase, id: logic_engine::FactId) -> String {
+    kb.fact(id)
+        .map(|f| fmt_leaf_prov(&f.provenance))
+        .unwrap_or_else(|| "[unattributed]".to_string())
+}
+
+/// The citations for a list of evidence facts, in order — each `[source …]` or
+/// `[unattributed]`, joined for one line.
+fn cite_facts(kb: &KnowledgeBase, ids: &[logic_engine::FactId]) -> String {
+    if ids.is_empty() {
+        return "[none]".to_string();
+    }
+    ids.iter()
+        .map(|id| cite_fact(kb, *id))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// The inline label by which a parent operation refers to this operand: an

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -1045,7 +1045,7 @@ fn main() -> ExitCode {
     // remains the primary, complete artifact (default output); `--explain` is the
     // opt-in human view onto it.
     if explain {
-        println!("{}", explain::explain(&lowered.kb));
+        println!("{}", explain::explain(&lowered.kb, &diff));
         return ExitCode::SUCCESS;
     }
 

--- a/code/packages/rust/adj-lang-cli/tests/rs4e2_explain_inference_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs4e2_explain_inference_e2e.rs
@@ -1,0 +1,153 @@
+//! End-to-end tests for the `--explain` renderer's INFERENCE + ADJUDICATION
+//! surfaces (ADJ-REASON-MATH §E.8, RS-4 PR-E2). Where PR-E1 rendered the
+//! arithmetic behind a computed value, this slice renders the probabilistic
+//! reasoning behind a hypothesis: the ordered proof steps (prior, likelihood-ratio
+//! contributions, rule-derived premises) and the comparative decision.
+//!
+//! The tests pin: the prior step is cited to its source; a contribution step is
+//! rendered; the decision names the leader with its posterior; trust propagates
+//! as the weakest link (P3); determinism holds (P4); and a pure computation with
+//! no differential evidence still renders derivations-only (PR-E1 unchanged).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs4e2_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run_with(args: &[&str], program: &Path) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .args(args)
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+    )
+}
+
+fn explain(program: &Path) -> String {
+    let (ok, out, err) = run_with(&["--explain"], program);
+    assert!(ok, "--explain exited non-zero: {err}");
+    out
+}
+
+fn write(dir: &Path, name: &str, src: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, src).unwrap();
+    p
+}
+
+// A single-hypothesis differential: a cited prior updated by one cited
+// likelihood-ratio contribution over an observed finding.
+const ACS_PROG: &str = "prior 0.10 for acs\n\
+     source \"Pope 1995\" trust authoritative\n\
+     contributes 2.5 from symptom(pressure) to acs\n\
+     source \"Panju 1998\" trust authoritative\n\
+     observe symptom(pressure)\n\
+     ? acs\n";
+
+// ---------------------------------------------------------------------------
+// (1) A differential renders its INFERENCE steps (cited) and its ADJUDICATION.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn renders_cited_inference_steps_and_the_decision() {
+    let dir = scratch("acs");
+    let prog = write(&dir, "case.adj", ACS_PROG);
+    let s = explain(&prog);
+
+    // Inference section, with the prior step cited to its source.
+    assert!(s.contains("Inference for acs:"), "inference section: {s:?}");
+    assert!(
+        s.contains("prior on acs") && s.contains("source \"Pope 1995\""),
+        "prior step is rendered and cited: {s:?}"
+    );
+    // The likelihood-ratio contribution step is rendered.
+    assert!(
+        s.contains("acs contributes logit"),
+        "contribution step is rendered: {s:?}"
+    );
+    // Adjudication: the leader is named with its posterior and the determinate
+    // verdict; the trust tier (P3, weakest link) is shown.
+    assert!(s.contains("Decision:"), "decision section: {s:?}");
+    assert!(
+        s.contains("=> acs (determinate") && s.contains("trust "),
+        "leader named determinate with a trust tier: {s:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) P4 — determinism across two runs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_differential_explanation_is_deterministic() {
+    let dir = scratch("determinism");
+    let prog = write(&dir, "case.adj", ACS_PROG);
+    let a = explain(&prog);
+    let b = explain(&prog);
+    assert_eq!(a, b, "same differential must render identical explanation text");
+    assert!(a.contains("=> acs (determinate"), "non-trivial explanation: {a:?}");
+}
+
+// ---------------------------------------------------------------------------
+// (3) A two-hypothesis differential names the winning leader.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_two_hypothesis_differential_names_the_leader() {
+    let dir = scratch("two");
+    let prog = write(
+        &dir,
+        "case.adj",
+        "prior 0.30 for bacterial\n\
+         source \"x\" trust empirical\n\
+         prior 0.30 for viral\n\
+         source \"x\" trust empirical\n\
+         contributes 15 from csf(neutrophilic) to bacterial\n\
+         source \"Straus 2006\" trust authoritative\n\
+         contributes 1.2 from csf(neutrophilic) to viral\n\
+         source \"y\" trust inferred\n\
+         observe csf(neutrophilic)\n\
+         ? bacterial\n? viral\n",
+    );
+    let s = explain(&prog);
+    // Both hypotheses appear in the ranked list; the strong LR makes bacterial
+    // the determinate leader.
+    assert!(
+        s.contains("Inference for bacterial:") && s.contains("Inference for viral:"),
+        "both hypotheses explained: {s:?}"
+    );
+    assert!(
+        s.contains("=> bacterial (determinate"),
+        "the stronger-evidence hypothesis leads: {s:?}"
+    );
+    assert!(
+        s.contains("source \"Straus 2006\""),
+        "the leading contribution's citation is shown: {s:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (4) PR-E1 regression: a pure computation still renders derivations-only, with
+//     no spurious inference/decision section.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_pure_computation_stays_derivations_only() {
+    let dir = scratch("let");
+    let prog = write(&dir, "case.adj", "let dose = 5 * 60 / 100\n? dose\n");
+    let s = explain(&prog);
+    assert!(s.contains("Derivations:") && s.contains("dose = 3"), "derivations rendered: {s:?}");
+    assert!(
+        !s.contains("Inference for") && !s.contains("Decision:"),
+        "no differential sections for a pure computation: {s:?}"
+    );
+}


### PR DESCRIPTION
## What

Extends the `--explain` renderer ([ADJ-REASON-MATH §E.8](code/specs/ADJ-REASON-MATH.md); PR-E1 = #9284) from the **derivations** surface to the **inference** and **adjudication** surfaces — so a *differential* query explains itself, not just an arithmetic one. This completes the diagnostic-reasoning half of the "explain its reasoning" keystone. Third PR of the Substrate/RS campaign.

Still a **projection only**: threads the already-decided `Differential` into `explain()` and re-runs nothing.

```
Inference for bacterial:
  prior on bacterial = logit -0.847 [source "x" trust empirical]
  bacterial contributes logit 2.708 via [source "Straus 2006" trust authoritative] [evidence: [unattributed]]

Decision:
  bacterial — posterior 0.865 (logit 1.861)
  => bacterial (determinate; posterior 0.865, margin 0.865; trust empirical)
```

## Surfaces added

- **Inference** — ordered proof steps per hypothesis: prior, likelihood-ratio contributions (each showing the *clause* that licensed it **and** the observed evidence it consumed), joint interactions, predicate-gated contributions (the CPU comparison `observed <op> threshold`), rule-derived premises, negation-as-failure. Total walk over `DerivationOrigin` (new kind ⇒ compile error), mirroring the JSON `trace_steps_json`.
- **Adjudication** — ranked hypotheses + posteriors, then the decision: `determinate` with its margin, or a `Kickback` rendered as the honest "cannot commit" verdict with its reason (the differential's own abstention). **P3**: the leader shows the trust tier propagated as the `min` (weakest link) over the graded knowledge — prior, rules, contribution clauses — it relied on.
- A pure computation still renders derivations-only; the default (no-flag) JSON trail is **byte-for-byte unchanged**.

## Verification

- `cargo build -p adj-lang-cli` clean; `cargo test -p adj-lang-cli --test rs4e_explain_e2e --test rs4e2_explain_inference_e2e` → **8 passed**; JSON-path regression `cli_golden` (38) + `rs4_trace_e2e` (7) → **pass**; `cargo clippy -p adj-lang-cli --tests -- -D warnings` → **exit 0**.
- NUL-byte scan clean.
- `/security-review`: **PASSED** — no panics/unwraps on untrusted input; the per-step clause `.find` is bounded by the engine's own enumeration (no DoS beyond the existing JSON path); projection-only property confirmed (shared refs only, no mutation, no re-run).

New: `tests/rs4e2_explain_inference_e2e.rs`. Extends `src/explain.rs`; `src/main.rs` threads `diff` into `explain`. adj-lang-cli 0.25.0 → 0.26.0 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)