### PR TITLE
feat(axiom): oracle/golden tests + JS runtime support for :/::/has (Wave 7 close-out)

### DIFF
--- a/code/packages/rust/axiom-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/axiom-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## [0.1.1] - 2026-07-30
+
+### Added
+
+- **Oracle/golden tests (`tests/oracle.rs`, HML01 §7 convention)** — the
+  same Axiom source run through (a) `axiom-runtime` (ground truth) and
+  (b) this crate → `semantic-ir-to-javascript` → `node` (compiled),
+  diffed. This closes the gap `0.1.0`'s own CHANGELOG entry disclosed
+  ("No `tests/oracle.rs` in this PR ... an explicitly separate follow-on
+  task"). 29 cases covering arithmetic precedence/associativity/
+  right-associative `^`, every comparison, `:=`, `==` function
+  definition (both declared and undeclared forms, both `f(a, b)` and
+  paren-optional `f a` calls), `if`/`then`/`else`, a `;`-block, a
+  passing and a failing `:` declaration, a passing and a failing `::`
+  coercion, and the book's own two confirmed `has` examples
+  (`Polynomial(Integer) has Ring` → `true`, `List(Integer) has Ring` →
+  `false`). 28 of 29 cases pass with `known_bug: None`; the one
+  exception (a list-literal print) is a disclosed, pre-existing,
+  shared display-convention gap (no `SIR_DISPLAY_AXIOM` infix/bracket
+  printer — see the test file's own module doc, "Finding three"), not
+  an evaluation bug.
+- A new dev-dependency, `coding-adventures-axiom-runtime` (test-only —
+  the crate's main `[dependencies]` still deliberately does not depend
+  on the native runtime, per `0.1.0`'s own disclosed design).
+- Because `axiom.grammar`'s own `program = expr` design means every
+  compiled program is exactly ONE top-level statement even for a
+  `;`-block (which lowers to a single `SymApply(CompoundExpression,
+  [...])` node), the oracle harness includes its own
+  `wrap_axiom_top_level_for_observation` — a harness-only "unroll a
+  top-level `CompoundExpression` into N statements, print only the
+  last" transform, so block-based corpus entries (declare-then-assign,
+  define-then-call) get a REAL value comparison rather than needing
+  `known_bug` for the unrelated, already-documented "no shared-vm
+  handler for `CompoundExpression`" gap (`reduce-to-semantic-ir/tests/
+  oracle.rs`'s own "finding three"). Deliberately does NOT touch
+  `semantic-ir-to-javascript` itself — see that crate's own `0.51.6`
+  CHANGELOG entry for the actual runtime wiring this test corpus
+  exercises.
+- `tests/e2e_node.rs`'s three `__axiom_declare`/`__axiom_coerce`/
+  `__axiom_has` tests now assert on the printed VALUE (`"true"`, `"3"`,
+  `"true"`), not merely "node exited zero" — upgraded now that
+  `semantic-ir-to-javascript` 0.51.6 gives these three reserved heads a
+  real evaluator (see that crate's own CHANGELOG). Renamed to reflect
+  the stronger assertion (`a_declaration_evaluates_to_lowercase_true`,
+  `a_coercion_evaluates_and_prints_the_coerced_value`,
+  `a_has_query_evaluates_to_the_books_own_confirmed_answer`).
+- `src/lower.rs`'s own "Runtime-shim status" module-doc section updated
+  to describe the now-wired state, with a pointer to
+  `semantic-ir-to-javascript`'s own design comment and this crate's new
+  `tests/oracle.rs` — the original deferral text is kept, clearly
+  marked historical, for context rather than deleted.
+
 ## [0.1.0] - 2026-07-29
 
 ### Added

--- a/code/packages/rust/axiom-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/axiom-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-axiom-to-semantic-ir"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Axiom CST -> narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). MA-13e, the last item in Axiom's native pipeline per MA13 §6; front3 of HML01."
 license = "MIT"
@@ -21,11 +21,15 @@ lexer = { path = "../lexer" }
 [dev-dependencies]
 # tests/test_validator.rs (confirms the JS backend structurally accepts every
 # module this frontend produces) and tests/e2e_node.rs (actually runs the
-# compiled JS through `node`). This crate deliberately does NOT depend on
-# `coding-adventures-axiom-runtime` -- lowering only needs the parse-tree
-# shape (`coding-adventures-axiom-parser`), never the evaluator, mirroring
-# every sibling `-to-semantic-ir` frontend's identical choice. Oracle/golden
-# testing against `axiom-runtime` (HML01 §7) is explicitly deferred to a
-# separate follow-on task (see README.md/CHANGELOG.md), so no dev-dependency
-# on that crate is added here either.
+# compiled JS through `node`).
 semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }
+# tests/oracle.rs's ground truth (HML01 §7's oracle/golden-testing
+# convention: the same source run through the native runtime AND through
+# this crate -> semantic-ir-to-javascript -> node, diffed) — mirrors
+# `macsyma-to-semantic-ir`'s/`reduce-to-semantic-ir`'s own identical
+# dev-dependency on their own native runtime crate as ground truth. The
+# main `[dependencies]` above deliberately still does NOT depend on
+# `coding-adventures-axiom-runtime` -- lowering only ever needs the
+# parse-tree shape, never the evaluator, mirroring every sibling
+# `-to-semantic-ir` frontend's identical choice; this is a TEST-ONLY dep.
+coding-adventures-axiom-runtime = { path = "../axiom-runtime" }

--- a/code/packages/rust/axiom-to-semantic-ir/README.md
+++ b/code/packages/rust/axiom-to-semantic-ir/README.md
@@ -17,7 +17,7 @@ spec (MA-13a) → axiom.tokens + axiom-lexer (MA-13b)
               → axiom-runtime + axiom-repl (MA-13d)
               → axiom-to-semantic-ir (MA-13e, THIS crate)
               → oracle/golden testing (native axiom-runtime vs. SIR→JS→node)
-                — a SEPARATE follow-on task, not part of this crate
+                — tests/oracle.rs, DONE (Wave 7 close-out)
 ```
 
 ## Where this fits
@@ -93,25 +93,21 @@ same shape an ordinary function call already has — so it lowers to the exact
 same `SymSymbol`/`SymApply` shapes, via a dedicated `lower_type_expr`
 function rather than a new node kind.
 
-**Runtime-shim status: deferred to the follow-on oracle-testing task, not
-shipped in this PR.** This crate never evaluates anything (the "everything is
-data" design every SIR23 frontend shares), so it does not need a working
-evaluator to emit correct SIR. Verified directly (not assumed from a
-suggestion to extend `sir-runtime-symbolic`): the JS backend's real SIR23
-evaluator (`Symbolic.evalTerm`, `HELD_HEADS`, …) lives **inline** inside
-`semantic-ir-to-javascript/src/runtime.rs`'s own emitted runtime blob, not in
-the published `@coding-adventures/sir-runtime-symbolic` npm package — that
-package (confirmed by reading its own `CHANGELOG.md`) only re-exports the
-structural pattern matcher and leaf-term constructors, with no evaluator at
-all, and only backs the TypeScript backend, which no Stream B oracle test
-exercises yet. So extending it would not, on its own, make `:`/`::`/`has`
-evaluate through the path this repo's `node`-execution oracle tests actually
-use. Given oracle/golden testing for Axiom is this task's own named separate
-follow-on item, and every prior "new reserved head, no evaluator yet"
-precedent in this exact family (`Set`, `CompoundExpression`, `Cons`, `First`,
-`Second`, `Third`, `Rest`, `Part`, `Append`, `Reverse`) shipped its frontend
-first and left the evaluator as later work, this crate follows the identical
-sequence. See `src/lower.rs`'s module doc comment for the full disclosure.
+**Runtime-shim status: UPDATE (Wave 7 close-out) — now wired.** This crate
+itself is unchanged (it still never evaluates anything — the "everything is
+data" design every SIR23 frontend shares — so it never *needed* a working
+evaluator to emit correct SIR), but the JS backend's real SIR23 evaluator
+(`Symbolic.evalTerm`, `HELD_HEADS`, …), which lives **inline** inside
+`semantic-ir-to-javascript/src/runtime.rs`'s own emitted runtime blob, now
+has real handlers for all three reserved heads:
+`axiomDeclareHandler`/`axiomCoerceHandler`/`axiomHasHandler`, a JS-side port
+of `axiom-runtime::domains`'s fixed `AxiomDomain`/`AxiomCategory` table — see
+`semantic-ir-to-javascript`'s own `CHANGELOG.md` (`0.51.6`) for the full
+design. The published `@coding-adventures/sir-runtime-symbolic` npm package
+is unaffected (unchanged) and still only backs the TypeScript backend, which
+this task's own oracle testing does not exercise. See `src/lower.rs`'s
+module doc comment for the full disclosure, including the historical record
+of the original deferral decision this update supersedes.
 
 ## A disclosed widening relative to `axiom-runtime`'s own function bodies
 
@@ -194,6 +190,12 @@ none of these guards themselves:
   lists, `if`/`then`/`else`, a multi-statement block, and `:`/`::`/`has` as
   inert data construction) through `node`, proving the SIR23 codegen path is
   genuinely executable end-to-end.
-- No `tests/oracle.rs` in this PR — oracle/golden testing against
-  `axiom-runtime` is an explicitly separate follow-on task (see
-  `CHANGELOG.md`).
+- `tests/oracle.rs` (Wave 7 close-out) — the real end-to-end diff against
+  `axiom-runtime`: 29 cases, 28 `known_bug: None` (the one exception is a
+  disclosed, pre-existing display-convention gap, not an evaluation bug —
+  see that file's own module doc). Covers arithmetic, every comparison,
+  `:=`, both `==` function-definition forms and both call forms,
+  `if`/`then`/`else`, a `;`-block, a passing AND failing `:` declaration,
+  a passing AND failing `::` coercion, and the book's own two confirmed
+  `has` examples — see `CHANGELOG.md`'s `0.1.1` entry for the full
+  write-up.

--- a/code/packages/rust/axiom-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/src/lower.rs
@@ -134,47 +134,52 @@
 //! these three constructs — they need no new capability declaration, only a
 //! head name a runtime *may* one day choose to interpret specially.
 //!
-//! **Runtime-shim status: implementation deferred to the follow-on
-//! oracle-testing item, not shipped in this PR.** This crate "never
-//! evaluates anything" (the same "everything is data" design every SIR23
-//! frontend shares) — so it does not *need* a working evaluator for
-//! `__axiom_declare`/`__axiom_coerce`/`__axiom_has` to emit correct,
-//! well-formed SIR. Verified directly against the actual shipped
-//! architecture (not assumed from the task's own suggestion of extending
-//! `sir-runtime-symbolic`): the JS backend's real SIR23 evaluator
+//! **Runtime-shim status: UPDATE (Wave 7 close-out) — now wired, in the
+//! follow-on oracle-testing item this section originally deferred to.**
+//! This crate itself is unchanged (it still "never evaluates anything" —
+//! the same "everything is data" design every SIR23 frontend shares — so
+//! it never *needed* a working evaluator to emit correct, well-formed SIR),
+//! but the deferred half of the story below is no longer accurate as a
+//! description of the CURRENT state of the pipeline, only of this crate's
+//! own PR at the time it shipped. Verified directly against the actual
+//! shipped architecture: the JS backend's real SIR23 evaluator
 //! (`Symbolic.evalTerm`, `HELD_HEADS`, the whole held-form/arithmetic
 //! dispatch the SIR23 spec's addendum describes) lives **inline**, inside
 //! `semantic-ir-to-javascript/src/runtime.rs`'s own emitted `RUNTIME` string
-//! blob — confirmed by reading that file directly (`grep -n HELD_HEADS
-//! semantic-ir-to-javascript/src/runtime.rs` finds `const HELD_HEADS = new
-//! Set(["Assign", "Define", "If"])` inside the emitted JS, not inside any
-//! imported package). The published npm package
-//! `@coding-adventures/sir-runtime-symbolic` (`code/packages/typescript/
-//! sir-runtime-symbolic/`), confirmed directly by reading its own
-//! `CHANGELOG.md`, re-exports only `cas-pattern-matching`'s structural
-//! matcher and `symbolic-ir`'s leaf-term constructors — **it has no evaluator
-//! at all**, and is not what `semantic-ir-to-javascript` actually imports for
-//! JS-backend execution; it only backs the TypeScript backend, which no
-//! Stream B frontend's oracle testing exercises yet (SIR23 spec's own
-//! "Scope boundary" section says so explicitly). So extending it would not,
-//! by itself, make `:`/`::`/`has` evaluate through the path this repo's own
-//! `node`-execution oracle tests actually use.
+//! blob — confirmed by reading that file directly. `HELD_HEADS` now also
+//! lists `__axiom_declare`/`__axiom_coerce`/`__axiom_has` (alongside
+//! `Assign`/`Define`/`If`), each with its own handler
+//! (`axiomDeclareHandler`/`axiomCoerceHandler`/`axiomHasHandler`) — a
+//! JS-side port of `axiom-runtime::domains`'s fixed
+//! `AxiomDomain`/`AxiomCategory` table, described in that file's own
+//! "Axiom domain/category table + reserved-head handlers" section. The
+//! published npm package `@coding-adventures/sir-runtime-symbolic`
+//! (`code/packages/typescript/sir-runtime-symbolic/`) still has no
+//! evaluator at all and still only backs the TypeScript backend (confirmed
+//! unchanged) — the JS runtime addition above did not touch it, matching
+//! this crate's own original finding that extending that package would not
+//! reach the path this repo's `node`-execution oracle tests actually use.
 //!
-//! Given that (a) oracle/golden testing for Axiom is this task's own
-//! explicitly-named separate follow-on item, not part of this PR, and (b)
-//! every prior "new reserved head with no runtime evaluator yet" precedent in
-//! this exact family (`Set`, `CompoundExpression`, `Cons`, `First`, `Second`,
-//! `Third`, `Rest`, `Part`, `Append`, `Reverse` — confirmed, none of these
-//! have an evaluation handler in `symbolic-vm` OR `semantic-ir-to-javascript`
-//! today) shipped its *frontend* first and left the evaluator as later,
-//! separate work, this crate follows the identical, already-proven sequence:
-//! ship the lowering now (this PR), and leave "teach a JS/TS runtime the
-//! fixed `AxiomDomain`/`AxiomCategory` table `axiom-runtime::domains` already
-//! has" as the natural first step of the follow-on oracle-testing task, where
-//! it will actually be exercised end-to-end for the first time. This is the
-//! conservative, narrower call this task's own instructions ask for when
-//! genuine ambiguity is hit, not a shortcut — see `CHANGELOG.md`/`README.md`
-//! for the same disclosure.
+//! `axiom-to-semantic-ir/tests/oracle.rs` is the real end-to-end proof:
+//! the same Axiom source run through `axiom-runtime` (ground truth) and
+//! through this crate → `semantic-ir-to-javascript` → `node` (compiled),
+//! diffed, covering both a passing and a failing `:` declaration, a
+//! passing and a failing `::` coercion, and the book's own two confirmed
+//! `has` examples (`Polynomial(Integer) has Ring` → `true`,
+//! `List(Integer) has Ring` → `false`) — see that file's own module doc
+//! for the full corpus and any disclosed native-vs-compiled differences
+//! found while building it.
+//!
+//! The historical record of the ORIGINAL deferral decision, kept below
+//! verbatim for context (every prior "new reserved head with no runtime
+//! evaluator yet" precedent in this exact family — `Set`,
+//! `CompoundExpression`, `Cons`, `First`, `Second`, `Third`, `Rest`, `Part`,
+//! `Append`, `Reverse` — shipped its *frontend* first and left the
+//! evaluator as later, separate work; this crate followed that identical,
+//! already-proven sequence): ship the lowering now (this PR), and leave
+//! "teach a JS/TS runtime the fixed `AxiomDomain`/`AxiomCategory` table
+//! `axiom-runtime::domains` already has" as the natural first step of the
+//! follow-on oracle-testing task — which is exactly what has now happened.
 //!
 //! # Type positions (`type_expr`) are ordinary symbolic data too — no new
 //! representation needed

--- a/code/packages/rust/axiom-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/tests/e2e_node.rs
@@ -16,24 +16,27 @@
 //! instead that every one of these programs compiles to JavaScript that
 //! `node` actually executes without throwing.
 //!
-//! # `__axiom_declare`/`__axiom_coerce`/`__axiom_has` are proven RUNNABLE,
-//! not (yet) evaluable
+//! # `__axiom_declare`/`__axiom_coerce`/`__axiom_has` are now REALLY
+//! evaluated, not just proven runnable
 //!
-//! Per `src/lower.rs`'s own disclosed design decision, this repo's shared JS
-//! backend has no evaluation handler for these three reserved heads today
-//! (deferred to the follow-on oracle-testing task) — but that only means the
-//! compiled program constructs inert `__Sir.Symbolic.apply("__axiom_declare",
-//! …)`-shaped data rather than performing a real domain check; it does not
-//! mean the compiled program fails to run. The tests below include
-//! `:`/`::`/`has` programs for exactly that reason, mirroring
-//! `maple-to-semantic-ir`'s own `Set` construct (also no shared evaluator,
-//! also proven to run cleanly as pure data construction).
+//! UPDATE (Wave 7 close-out): `semantic-ir-to-javascript`'s shared JS
+//! backend now has a real evaluation handler for all three reserved heads
+//! (`axiomDeclareHandler`/`axiomCoerceHandler`/`axiomHasHandler`, a JS-side
+//! port of `axiom-runtime::domains`'s fixed `AxiomDomain`/`AxiomCategory`
+//! table — see that crate's `src/runtime.rs` for the full design). The
+//! three tests below therefore now assert on the printed VALUE, not just
+//! "node exited zero" — the genuine end-to-end oracle diff against
+//! `axiom-runtime` itself lives in `tests/oracle.rs`, which additionally
+//! covers the FAILING half of `:`/`::` (an invalid domain name, a
+//! subdomain-predicate mismatch) that this file's own "runs cleanly, no
+//! crash" framing does not attempt.
 
 use std::fs::OpenOptions;
 use std::io::Write as _;
 use std::process::Command;
 
 use coding_adventures_axiom_to_semantic_ir::compile_source;
+use semantic_ir::{EffectSet, Expr, Module, Stmt};
 
 fn node_available() -> bool {
     Command::new("node")
@@ -43,6 +46,8 @@ fn node_available() -> bool {
         .unwrap_or(false)
 }
 
+/// Compile `src`, validate, emit JS, write to a temp file, and run it under
+/// `node`, asserting a clean exit.
 fn run_via_node(name: &str, src: &str) {
     let module = compile_source(src, "prog").expect("lowering should succeed");
     let report = semantic_ir::validate(&module);
@@ -76,6 +81,66 @@ fn run_via_node(name: &str, src: &str) {
         "node failed for {name}: stderr=\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+/// Wrap `src`'s ONE top-level expression in `print(...)` before compiling —
+/// the harness-only observability pattern every sibling SIR23 oracle file
+/// uses (`wrap_top_level_in_print`), needed here ONLY for the three tests
+/// below that now assert on a printed VALUE rather than merely "ran
+/// cleanly". Simpler than `tests/oracle.rs`'s own
+/// `wrap_axiom_top_level_for_observation` (which additionally unrolls a
+/// top-level `CompoundExpression` block) because none of these three
+/// sources is a `;`-block.
+fn run_via_node_expecting(name: &str, src: &str, expected_stdout: &str) {
+    let mut module = compile_source(src, "prog").expect("lowering should succeed");
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for {name}: {:?}",
+        report.issues
+    );
+    wrap_whole_statement_in_print(&mut module);
+    let artifact = semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("axiom_sir_e2e_{name}_{}.js", std::process::id()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes()).expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim_end_matches(['\n', '\r']), expected_stdout, "for {name}");
+}
+
+fn wrap_whole_statement_in_print(module: &mut Module) {
+    for f in &mut module.functions {
+        if f.name != "main" {
+            continue;
+        }
+        for stmt in &mut f.body.stmts {
+            if let Stmt::ExprStmt { expr, span } = stmt {
+                let inner = std::mem::replace(expr, Expr::NilLit { span: span.clone() });
+                *expr = Expr::BuiltinCall {
+                    name: "print".to_string(),
+                    args: vec![inner],
+                    effects: EffectSet::PURE,
+                    span: span.clone(),
+                };
+            }
+        }
+    }
 }
 
 #[test]
@@ -145,30 +210,30 @@ fn a_multi_statement_block_runs_in_node() {
 }
 
 #[test]
-fn a_declaration_runs_in_node_as_inert_data() {
+fn a_declaration_evaluates_to_lowercase_true() {
     if !node_available() {
-        eprintln!("skipping a_declaration_runs_in_node_as_inert_data: `node` not available");
+        eprintln!("skipping a_declaration_evaluates_to_lowercase_true: `node` not available");
         return;
     }
-    run_via_node("declaration", "a : PositiveInteger");
+    run_via_node_expecting("declaration", "a : PositiveInteger", "true");
 }
 
 #[test]
-fn a_coercion_runs_in_node_as_inert_data() {
+fn a_coercion_evaluates_and_prints_the_coerced_value() {
     if !node_available() {
-        eprintln!("skipping a_coercion_runs_in_node_as_inert_data: `node` not available");
+        eprintln!("skipping a_coercion_evaluates_and_prints_the_coerced_value: `node` not available");
         return;
     }
-    run_via_node("coercion", "3 :: Fraction(Integer)");
+    run_via_node_expecting("coercion", "3 :: Fraction(Integer)", "3");
 }
 
 #[test]
-fn a_has_query_runs_in_node_as_inert_data() {
+fn a_has_query_evaluates_to_the_books_own_confirmed_answer() {
     if !node_available() {
-        eprintln!("skipping a_has_query_runs_in_node_as_inert_data: `node` not available");
+        eprintln!("skipping a_has_query_evaluates_to_the_books_own_confirmed_answer: `node` not available");
         return;
     }
-    run_via_node("has_query", "Polynomial(Integer) has Ring");
+    run_via_node_expecting("has_query", "Polynomial(Integer) has Ring", "true");
 }
 
 #[test]

--- a/code/packages/rust/axiom-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/tests/oracle.rs
@@ -1,0 +1,646 @@
+//! Oracle/golden tests (HML01 §7 convention, Wave 7 close-out): the SAME
+//! Axiom source, run through **two independent implementations**, and
+//! diffed:
+//!
+//!   (a) `axiom-runtime` (`coding_adventures_axiom_runtime::AxiomSession`) —
+//!       the sibling native runtime crate (MA-13d), which lowers arithmetic
+//!       to `symbolic-ir`/evaluates via `symbolic-vm`'s shared handler
+//!       table, plus its own `crate::domains` fixed `AxiomDomain`/
+//!       `AxiomCategory` table for `:`/`::`/`has` — the ground truth.
+//!   (b) `axiom_to_semantic_ir::compile_source` → `semantic_ir::Module` →
+//!       `semantic_ir_to_javascript::compile` → an actual `node` process,
+//!       whose JS runtime now carries a matching port of that same fixed
+//!       table (`axiomDeclareHandler`/`axiomCoerceHandler`/
+//!       `axiomHasHandler`, `semantic-ir-to-javascript/src/runtime.rs`).
+//!
+//! Modeled directly on `macsyma-to-semantic-ir/tests/oracle.rs` (itself
+//! modeled on `wolfram-to-semantic-ir`'s/`maple-to-semantic-ir`'s): same
+//! overall shape (`node_available` skip-not-fail guard, a `Case`/`CORPUS`,
+//! a `ground_truth`/`compiled` pair, one looping `#[test]`, a `known_bug`
+//! field). Axiom is the CAS sibling that ALSO needed a real domain/category
+//! layer (MA13 §2's own finding: `symbolic_ir::IRNode` has no domain/type
+//! tag at all), so this file's corpus additionally covers `:`/`::`/`has`
+//! end-to-end through the compiled path — the actual point of an oracle
+//! test for this language, per this task's own instruction not to just
+//! prove these three constructs compile inertly (`tests/e2e_node.rs`
+//! already did that before this file existed, and now additionally asserts
+//! real values for its own three simplest cases).
+//!
+//! # `program` is ONE expression — `Case::source` is one whole program,
+//! `;`-blocks stand in for multi-statement sessions
+//!
+//! Unlike every prior SIR23 oracle file (`derive-to-semantic-ir`'s,
+//! `reduce-to-semantic-ir`'s, `maple-to-semantic-ir`'s, `macsyma-to-
+//! semantic-ir`'s, `wolfram-to-semantic-ir`'s own `tests/oracle.rs`, which
+//! all lower a REPEATED `{ statement_line }` worksheet in one
+//! `compile_source` call), `axiom.grammar`'s own `program = expr` parses
+//! **exactly one** expression (`axiom-to-semantic-ir::lower`'s own module
+//! doc, "program is a SINGLE expression"). A "declare, then assign" or a
+//! "define, then call" test therefore has to be written as ONE Axiom
+//! parenthesised, semicolon-separated block (`(s1; s2; ...)`, MA13 §4's own
+//! grammar row) rather than as separate `ground_truth`/`compiled` calls —
+//! this is real Axiom syntax (not a harness invention), and it is also
+//! literally one of this task's own required corpus items ("Parenthesized
+//! semicolon-separated blocks").
+//!
+//! # A harness-only "make it observable" step, adapted for Axiom's
+//! single-statement `main`
+//!
+//! Every prior SIR23 oracle file wraps its (possibly MULTIPLE) top-level
+//! statements each in `print(...)` via `wrap_top_level_in_print`, since
+//! `<lang>-to-semantic-ir::compile_source` never does this itself (see
+//! each of those files' own "harness-only" section). Axiom's own
+//! `compile_source` always emits exactly ONE `Stmt::ExprStmt` in `main`
+//! (per the note above) — but when the source is a `;`-block, that ONE
+//! statement's `expr` is itself a single `SymApply(CompoundExpression,
+//! [s1, s2, ..., sN])` node (`axiom-to-semantic-ir::lower`'s own
+//! `COMPOUND_EXPRESSION` constant, spelled identically to
+//! `reduce-to-semantic-ir`'s own `<< ... >>` head for the identical
+//! reason). Naively wrapping the WHOLE block in one `print(...)` call would
+//! only ever observe the OUTER `CompoundExpression(...)` term, never just
+//! its last statement's value — because `CompoundExpression` has **no**
+//! evaluation handler in EITHER `symbolic-vm` or this backend's JS runtime
+//! (a pre-existing, already-disclosed gap: `reduce-to-semantic-ir/tests/
+//! oracle.rs`'s own "finding three" confirms neither the shared engine nor
+//! this JS port has ever had one — `axiom-runtime`'s own block-collapsing
+//! is a completely separate, bespoke interpreter code path,
+//! `eval::eval_group`, that never touches `symbolic-vm`/this JS port at
+//! all).
+//!
+//! [`wrap_axiom_top_level_for_observation`] (below) is this file's own
+//! harness-only fix, deliberately NOT a change to `semantic-ir-to-
+//! javascript` itself (which would touch Reduce too, a broader change than
+//! this task's own narrow three-head scope calls for): it "unrolls" a
+//! top-level `CompoundExpression` into N separate top-level statements —
+//! the first N-1 evaluated bare (mirroring `emit.rs`'s existing
+//! `is_sym23_root_shape` per-statement `evalTerm` wrap, which already runs
+//! each one's side effects in order and discards its value), and the LAST
+//! wrapped in `print(...)` — exactly reproducing what `axiom-runtime`'s own
+//! `eval_group` does natively. A non-`CompoundExpression` root (an ordinary
+//! single statement) is wrapped in one `print(...)` unchanged, matching
+//! every prior oracle file's own `wrap_top_level_in_print` for that case.
+//! This means every corpus entry below — including the block-based
+//! function-definition-then-call and declare-then-assign cases — gets a
+//! REAL value comparison, not a `known_bug` for the display-convention gap
+//! alone, unlike what a naive whole-block `print` wrap would have forced.
+//!
+//! # Findings (confirmed by direct inspection of `semantic-ir-to-
+//! javascript`'s `runtime.rs`, and of `axiom-runtime`'s own `src/`, not
+//! assumed from either crate's scope notes)
+//!
+//! ### Finding one — the SIR23 JS backend's existing arithmetic/comparison/
+//! held-form/user-function machinery (shipped by prior PRs, not this one)
+//! already agrees with `axiom-runtime` for Axiom's own surface
+//!
+//! `Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg` fold numerically exactly like every
+//! other CAS-family language sharing this engine; `Assign`/`Define`/`If`
+//! are real, environment-backed held forms; a `Define`d function is a real,
+//! callable, position-substituted user function on the compiled side too.
+//! Axiom needs no `True`/`False` case-bridging fix of its OWN discovery
+//! here (unlike Maple's, HML01 §5's own "finding four") because THIS task
+//! adds `SIR_DISPLAY_AXIOM_BOOLEAN` (see `runtime.rs`) precisely so the
+//! shared comparison/logic/`has`-query handlers' `True`/`False` render
+//! Axiom's own lowercase `true`/`false` convention — every `known_bug: None`
+//! boolean-result case below depends on that flag.
+//!
+//! ### Finding two — `:`/`::`/`has` now evaluate identically to
+//! `axiom-runtime`, for every ATOMIC operand this corpus exercises
+//!
+//! `axiomDeclareHandler`/`axiomCoerceHandler`/`axiomHasHandler` (this PR,
+//! `runtime.rs`) are direct, one-for-one ports of `axiom-runtime::domains`'s
+//! fixed table, with every error message copied VERBATIM. Confirmed
+//! end-to-end for a passing AND a failing `:` declaration, a passing and a
+//! failing `::` coercion, and the book's own two confirmed `has` examples.
+//!
+//! ### Finding three (disclosed, NOT fixed here) — no per-language
+//! infix/bracket display convention for a COMPOUND (non-atomic) Axiom
+//! value, the same "finding five"-class gap every CAS-family language
+//! without a full `SIR_DISPLAY_<LANG>` printer has
+//!
+//! `Symbolic.toDisplayString`'s generic branch renders any compound term as
+//! `head(args, ...)` — no infix `+`/`-`/`*`/`/`/`^`, no `[...]` bracket
+//! convention for `List`. `axiom-runtime::value::print_axiom`, by contrast,
+//! is fully infix/bracket-aware. So the ONE list-literal case below needs
+//! `known_bug` for this reason alone (the underlying evaluation — folding
+//! each element — is completely correct on both sides; only the RENDERING
+//! disagrees). This is a real, pre-existing, disclosed gap this task's own
+//! narrow three-head scope does not fix (adding a full `SIR_DISPLAY_AXIOM`
+//! infix printer, mirroring Derive's, would be a much larger, separate
+//! change — this task adds only the minimal boolean-case flag needed to
+//! make comparison/`has`-query results checkable at all).
+//!
+//! ## Corpus
+//!
+//! Covers, at minimum (per this task's own required list): arithmetic
+//! precedence/associativity/right-associative `^`; every comparison (`=
+//! ~= < <= > >=`); `:=` immediate assignment; `==` function definition
+//! (both the declared `f(x: T, ...): T == e` and undeclared `f x == e`
+//! forms) and calls (both `f(a, b)` and paren-optional `f a`);
+//! `if`/`then`/`else`; a parenthesised `;`-separated block; a passing AND a
+//! failing `:` declaration; a passing AND a failing `::` coercion; and the
+//! book's own two confirmed `has` examples
+//! (`Polynomial(Integer) has Ring` → `true`, `List(Integer) has Ring` →
+//! `false`).
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use coding_adventures_axiom_runtime::AxiomSession;
+use coding_adventures_axiom_to_semantic_ir::compile_source;
+use semantic_ir::{EffectSet, Expr, Module, Stmt};
+
+/// Is a `node` binary on `PATH`? Mirrors every sibling oracle file's
+/// identical `node_available`: the test below skips (logs, does not fail)
+/// when it is not.
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// What a corpus entry expects on BOTH the native and the compiled side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Expected {
+    /// Both sides must succeed and print exactly this text.
+    Value(&'static str),
+    /// Both sides must FAIL, each error message containing this substring.
+    /// (A substring, not byte-for-byte equality: `axiom-runtime`'s Rust
+    /// `EvalError` and this file's thrown JS `Error` are independently
+    /// constructed strings that happen to match verbatim for every ATOMIC
+    /// operand this corpus uses — see the module doc's "Finding two" — but
+    /// requiring only a shared substring keeps this assertion honest about
+    /// what is actually being checked, rather than baking in an unstated
+    /// assumption that the two error types are byte-identical in general.)
+    Error(&'static str),
+}
+
+/// One oracle corpus entry. `source` is the WHOLE program, byte-for-byte
+/// identical on both the [`ground_truth`] and [`compiled`] sides.
+struct Case {
+    name: &'static str,
+    source: &'static str,
+    expected: Expected,
+    /// `None`: both `ground_truth` and `compiled` must match `expected`.
+    /// `Some(reason)`: only `ground_truth` is checked against `expected`;
+    /// the `compiled`-side call is skipped entirely (not even invoked),
+    /// with `reason` naming which documented finding (module doc) applies.
+    known_bug: Option<&'static str>,
+}
+
+const CORPUS: &[Case] = &[
+    // --- Arithmetic: precedence, right-associative `^`, unary minus
+    // binding LOOSER than `^`, exact-integer vs. genuine-rational
+    // division (MA13 §4's own precedence table; grammar confirmed
+    // directly against `code/grammars/axiom/axiom.grammar`). ---
+    Case {
+        name: "literal_arithmetic_precedence",
+        source: "1 + 2*3",
+        expected: Expected::Value("7"),
+        known_bug: None,
+    },
+    Case {
+        name: "parens_override_precedence",
+        source: "(1 + 2)*3",
+        expected: Expected::Value("9"),
+        known_bug: None,
+    },
+    Case {
+        name: "power_is_right_associative",
+        // 2^3^2 == 2^(3^2) == 2^9 == 512, NOT (2^3)^2 == 64 -- confirmed
+        // directly against `axiom.grammar`'s own `power = postfix [ (CARET
+        // | POW) unary ]` (the RHS `unary` recurses back into `power`).
+        source: "2^3^2",
+        expected: Expected::Value("512"),
+        known_bug: None,
+    },
+    Case {
+        name: "both_power_spellings_agree",
+        source: "2**3**2",
+        expected: Expected::Value("512"),
+        known_bug: None,
+    },
+    Case {
+        name: "unary_minus_binds_looser_than_power",
+        // -2^2 -> Neg(Pow(2, 2)) = Neg(4) = -4, NOT (-2)^2 = 4.
+        source: "-2^2",
+        expected: Expected::Value("-4"),
+        known_bug: None,
+    },
+    Case {
+        name: "exact_integer_division_folds_to_an_integer",
+        source: "10 / 2",
+        expected: Expected::Value("5"),
+        known_bug: None,
+    },
+    Case {
+        name: "inexact_division_folds_to_a_rational",
+        source: "1 / 3",
+        expected: Expected::Value("1/3"),
+        known_bug: None,
+    },
+    // --- Comparisons: Axiom's OWN spelling (`~=` not-equal, confirmed
+    // directly -- NOT Maple's `<>`, NOT Wolfram's `!=`). Every comparison
+    // folds to the shared True/False SYMBOL, rendered lowercase on BOTH
+    // sides thanks to `SIR_DISPLAY_AXIOM_BOOLEAN` (this PR). ---
+    Case {
+        name: "equality_is_true",
+        source: "1 = 1",
+        expected: Expected::Value("true"),
+        known_bug: None,
+    },
+    Case {
+        name: "not_equal_is_true",
+        source: "1 ~= 2",
+        expected: Expected::Value("true"),
+        known_bug: None,
+    },
+    Case {
+        name: "less_than_is_true",
+        source: "1 < 2",
+        expected: Expected::Value("true"),
+        known_bug: None,
+    },
+    Case {
+        name: "greater_than_is_false",
+        source: "3 > 5",
+        expected: Expected::Value("false"),
+        known_bug: None,
+    },
+    Case {
+        name: "less_equal_boundary_is_true",
+        source: "3 <= 3",
+        expected: Expected::Value("true"),
+        known_bug: None,
+    },
+    Case {
+        name: "greater_equal_is_false",
+        source: "3 >= 4",
+        expected: Expected::Value("false"),
+        known_bug: None,
+    },
+    // --- `:=` immediate assignment (bare -- a single top-level statement,
+    // no block needed). ---
+    Case {
+        name: "bare_assignment",
+        source: "x := 5",
+        expected: Expected::Value("5"),
+        known_bug: None,
+    },
+    // --- `==` function definition: the DECLARED form alone (no call) --
+    // register_function's own disclosed presentation convention (echoes
+    // the bare name). ---
+    Case {
+        name: "declared_function_definition_alone",
+        source: "power(x: Integer, n: NonNegativeInteger): Integer == x ** n",
+        expected: Expected::Value("power"),
+        known_bug: None,
+    },
+    // --- `==` function definition (DECLARED form) + call, `f(a, b)`
+    // two-argument explicit-parens form -- a `;`-block, exercising
+    // `wrap_axiom_top_level_for_observation`'s CompoundExpression unroll. ---
+    Case {
+        name: "declared_function_definition_and_call",
+        source: "(power(x: Integer, n: NonNegativeInteger): Integer == x ** n; power(2, 3))",
+        expected: Expected::Value("8"),
+        known_bug: None,
+    },
+    // --- `==` function definition (UNDECLARED, duck-typed form) + call,
+    // paren-optional single-argument `f a` form -- also a `;`-block. ---
+    Case {
+        name: "undeclared_function_definition_and_paren_optional_call",
+        source: "(f x == x * x; f 6)",
+        expected: Expected::Value("36"),
+        known_bug: None,
+    },
+    // --- if/then/else (both branches; `else` mandatory in this cut). ---
+    Case {
+        name: "if_then_else_true_branch",
+        source: "if 1 > 0 then 1 else -1",
+        expected: Expected::Value("1"),
+        known_bug: None,
+    },
+    Case {
+        name: "if_then_else_false_branch",
+        source: "if 1 < 0 then 1 else -1",
+        expected: Expected::Value("-1"),
+        known_bug: None,
+    },
+    // --- Parenthesised, semicolon-separated block: "value is the last
+    // expression's value" (MA13 §4) -- proven end-to-end via the unroll
+    // harness, not just "runs without throwing" (already covered by
+    // `tests/e2e_node.rs`'s own `a_multi_statement_block_runs_in_node`). ---
+    Case {
+        name: "parenthesized_semicolon_block",
+        source: "(x := 1; x + 1)",
+        expected: Expected::Value("2"),
+        known_bug: None,
+    },
+    // --- `a : T` declaration -- PASSING (structural resolve succeeds;
+    // `axiom-runtime::eval_declaration`'s own disclosed presentation
+    // convention: echoes `true`, MA13 §3/§4). ---
+    Case {
+        name: "declaration_of_a_valid_domain_succeeds",
+        source: "a : PositiveInteger",
+        expected: Expected::Value("true"),
+        known_bug: None,
+    },
+    // --- `a : T` declaration -- FAILING: `T` is not one of the fixed
+    // built-in domains (a structural `resolve_domain` rejection, the SAME
+    // failure mode on both sides -- no cross-statement state needed). ---
+    Case {
+        name: "declaration_of_an_unknown_domain_fails_identically",
+        source: "a : Matrix",
+        expected: Expected::Error("is not one of this cut's fixed built-in domains"),
+        known_bug: None,
+    },
+    // --- `a : T` declaration THEN a mismatched `a := v` -- FAILING, via
+    // the book's own confirmed error shape (MA13 §3, quoted verbatim in
+    // both `axiom-runtime::eval_assignment` and `assignHandler`'s own
+    // disclosed cross-head addition, `runtime.rs`). A `;`-block: the
+    // declaration is evaluated bare (populates `axiomDeclaredDomains`),
+    // then the mismatched assignment throws BEFORE the unroll harness's
+    // own `print(...)` wrapper ever runs -- so this case needed no
+    // CompoundExpression handling fix at all to fail correctly (the
+    // exception propagates during argument evaluation, never reaching the
+    // "no handler for CompoundExpression" fallback path either way). ---
+    Case {
+        name: "declaration_then_mismatched_assignment_fails_identically",
+        source: "(a : PositiveInteger; a := -1)",
+        expected: Expected::Error(
+            "Cannot convert right-hand side of assignment -1 to an object of the type \
+             PositiveInteger of the left-hand side.",
+        ),
+        known_bug: None,
+    },
+    // --- `e :: T` coercion -- PASSING (the book's own confirmed example,
+    // paren-optional shorthand spelling). ---
+    Case {
+        name: "coercion_of_an_integer_to_fraction_integer_succeeds",
+        source: "3 :: Fraction Integer",
+        expected: Expected::Value("3"),
+        known_bug: None,
+    },
+    // --- `e :: T` coercion -- FAILING (the `PositiveInteger` subdomain
+    // predicate rejects a negative literal, the book's own confirmed error
+    // shape adapted for the standalone `::` case). ---
+    Case {
+        name: "coercion_of_a_negative_integer_to_positive_integer_fails_identically",
+        source: "-1 :: PositiveInteger",
+        expected: Expected::Error("Cannot convert -1 to an object of the type PositiveInteger."),
+        known_bug: None,
+    },
+    // --- `D has C` category-membership query -- the book's own TWO
+    // confirmed worked examples (MA13 §3/§4), run literally end-to-end
+    // through the compiled JS path. ---
+    Case {
+        name: "polynomial_integer_has_ring_the_books_own_confirmed_true_example",
+        source: "Polynomial(Integer) has Ring",
+        expected: Expected::Value("true"),
+        known_bug: None,
+    },
+    Case {
+        name: "list_integer_has_ring_the_books_own_confirmed_false_example",
+        source: "List(Integer) has Ring",
+        expected: Expected::Value("false"),
+        known_bug: None,
+    },
+    // --- A couple of extra `has` cases beyond the two book-confirmed ones,
+    // spot-checking the rest of the fixed membership table end-to-end. ---
+    Case {
+        name: "boolean_does_not_have_ring",
+        source: "Boolean has Ring",
+        expected: Expected::Value("false"),
+        known_bug: None,
+    },
+    Case {
+        name: "float_has_ordered_set",
+        source: "Float has OrderedSet",
+        expected: Expected::Value("true"),
+        known_bug: None,
+    },
+    // --- List literal: elementwise evaluation is correct on both sides,
+    // but the bracket display convention is missing on the compiled side
+    // (finding three) -- known_bug for DISPLAY only, not evaluation. ---
+    Case {
+        name: "list_literal_evaluates_elementwise",
+        source: "[1 + 1, 2*3]",
+        expected: Expected::Value("[2, 6]"),
+        known_bug: Some(
+            "Finding three (module doc): List(Add(1,1), Mul(2,3)) folds its elements correctly \
+             on the compiled side (List has no HANDLERS entry, but evalApply's applicative-order \
+             argument evaluation folds each element for free) -- this is NOT an evaluation gap. \
+             But the compiled side's generic Symbolic.toDisplayString prints \"List(2, 6)\", never \
+             Axiom's own bracket surface \"[2, 6]\" -- no SIR_DISPLAY_AXIOM infix/bracket \
+             convention exists (only the minimal boolean-case flag this task adds).",
+        ),
+    },
+];
+
+/// Ground truth: run the WHOLE program through `axiom-runtime`'s own
+/// [`AxiomSession::feed`] (a single call, since `source` is always exactly
+/// one top-level Axiom statement/block per `axiom.grammar`'s own `program =
+/// expr` design), then strip the `"(n) "` prompt-index prefix AND any
+/// trailing `" : Domain"` suffix -- `symbolic_ir::IRNode` (and therefore
+/// the whole compiled SIR/JS path) has no domain concept at all (MA13 §2's
+/// own central finding), so the domain suffix has no compiled-side
+/// counterpart to compare against; comparing only the bare VALUE text is
+/// the honest, apples-to-apples comparison. Safe for every value this
+/// corpus's OWN chosen cases can produce: none of them contains the
+/// literal substring `" : "` in its own printed VALUE (only the domain
+/// suffix ever does), so splitting on the FIRST occurrence cannot
+/// mis-truncate a legitimate value.
+fn ground_truth(source: &str) -> Result<String, String> {
+    let mut session = AxiomSession::new();
+    let raw = session.feed(source)?;
+    let trimmed = raw.trim_end_matches('\n');
+    let after_prompt = trimmed.split_once(") ").map_or(trimmed, |(_, rest)| rest);
+    let value_only = after_prompt.split(" : ").next().unwrap_or(after_prompt);
+    Ok(value_only.to_string())
+}
+
+/// Harness-only fix (see the module doc's own "A harness-only 'make it
+/// observable' step" section): `main`'s ONE `Stmt::ExprStmt` is either an
+/// ordinary expression (wrapped in a single `print(...)`, mirroring every
+/// sibling oracle file's own `wrap_top_level_in_print`) or a top-level
+/// `SymApply(CompoundExpression, [s1, ..., sN])` block, which is instead
+/// "unrolled" into N separate statements -- the first N-1 evaluated bare
+/// (side effects only, value discarded, exactly like `emit.rs`'s own
+/// per-statement `evalTerm` wrap for a bare SIR23 root), the LAST wrapped
+/// in `print(...)`. Never touches `semantic-ir-to-javascript` itself.
+fn wrap_axiom_top_level_for_observation(module: &mut Module) {
+    for f in &mut module.functions {
+        if f.name != "main" {
+            continue;
+        }
+        assert_eq!(
+            f.body.stmts.len(),
+            1,
+            "axiom-to-semantic-ir::compile_source always lowers `program` to exactly one \
+             top-level Stmt::ExprStmt (its own module doc: \"program is a SINGLE expression\")"
+        );
+        let Stmt::ExprStmt { expr, span } = f.body.stmts.remove(0) else {
+            panic!("main's sole statement must be an ExprStmt");
+        };
+        let is_compound_expression = matches!(
+            &expr,
+            Expr::SymApply { head, .. }
+                if matches!(head.as_ref(), Expr::SymSymbol { name, .. } if name == "CompoundExpression")
+        );
+        if is_compound_expression {
+            let Expr::SymApply { args, .. } = expr else {
+                unreachable!("just matched SymApply above");
+            };
+            let last_index = args.len().saturating_sub(1);
+            let mut new_stmts = Vec::with_capacity(args.len());
+            for (i, a) in args.into_iter().enumerate() {
+                if i == last_index {
+                    new_stmts.push(Stmt::ExprStmt {
+                        expr: Expr::BuiltinCall {
+                            name: "print".to_string(),
+                            args: vec![a],
+                            effects: EffectSet::PURE,
+                            span: span.clone(),
+                        },
+                        span: span.clone(),
+                    });
+                } else {
+                    new_stmts.push(Stmt::ExprStmt {
+                        expr: a,
+                        span: span.clone(),
+                    });
+                }
+            }
+            f.body.stmts = new_stmts;
+        } else {
+            f.body.stmts = vec![Stmt::ExprStmt {
+                expr: Expr::BuiltinCall {
+                    name: "print".to_string(),
+                    args: vec![expr],
+                    effects: EffectSet::PURE,
+                    span: span.clone(),
+                },
+                span,
+            }];
+        }
+    }
+}
+
+/// Compiled path: run `source` (unchanged) through
+/// `axiom_to_semantic_ir::compile_source`, `semantic_ir::validate`,
+/// [`wrap_axiom_top_level_for_observation`], `semantic_ir_to_javascript::
+/// compile`, and an actual `node` process. Returns `Ok(stdout)` on a clean
+/// exit, `Err(stderr)` otherwise -- both a passing-case AND a failing-case
+/// corpus entry route through this same function; the caller decides which
+/// outcome to expect. Mirrors `macsyma-to-semantic-ir/tests/oracle.rs`'s
+/// own `compiled` helper, down to the `OpenOptions::create_new(true)` temp
+/// file handling (fails instead of silently following an existing symlink
+/// planted at the shared, predictable system temp path).
+fn compiled(name: &str, source: &str) -> Result<String, String> {
+    let mut module = compile_source(source, "prog")
+        .map_err(|e| format!("lowering failed for {name} ({source:?}): {e:?}"))?;
+    let report = semantic_ir::validate(&module);
+    if !report.is_ok() {
+        return Err(format!(
+            "SIR validation failed for {name}: {:?}",
+            report.issues
+        ));
+    }
+    wrap_axiom_top_level_for_observation(&mut module);
+    let artifact = semantic_ir_to_javascript::compile(&module)
+        .map_err(|e| format!("backend emit failed for {name}: {e:?}"))?;
+
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "axiom_sir_oracle_{name}_{}.js",
+        std::process::id()
+    ));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes())
+        .expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node")
+        .arg(&path)
+        .output()
+        .expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .trim_end_matches(['\n', '\r'])
+            .to_string())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).to_string())
+    }
+}
+
+fn matches_expected(result: &Result<String, String>, expected: &Expected) -> bool {
+    match (result, expected) {
+        (Ok(v), Expected::Value(exp)) => v == exp,
+        (Err(e), Expected::Error(sub)) => e.contains(sub),
+        _ => false,
+    }
+}
+
+#[test]
+fn oracle_corpus_matches_native_axiom_runtime() {
+    if !node_available() {
+        eprintln!("skipping oracle_corpus_matches_native_axiom_runtime: `node` not available");
+        return;
+    }
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in CORPUS {
+        let gt = ground_truth(case.source);
+        if !matches_expected(&gt, &case.expected) {
+            failures.push(format!(
+                "{}: axiom-runtime itself disagrees with this corpus entry's own `expected` \
+                 (got {gt:?}, expected {:?}) -- the program or `expected` is wrong, fix the \
+                 corpus rather than this assertion",
+                case.name, case.expected
+            ));
+            continue;
+        }
+
+        match case.known_bug {
+            None => {
+                let got = compiled(case.name, case.source);
+                if !matches_expected(&got, &case.expected) {
+                    failures.push(format!(
+                        "{}: axiom-to-semantic-ir -> semantic-ir-to-javascript -> node disagrees \
+                         with the axiom-runtime ground truth (got {got:?}, expected {:?}) -- see \
+                         this file's module doc for the documented findings before assuming this \
+                         is a new one",
+                        case.name, case.expected
+                    ));
+                }
+            }
+            Some(reason) => {
+                // KNOWN BUG: the compiled-side assertion is deliberately
+                // skipped (not even invoked) for this entry -- see this
+                // file's module doc comment for why, and `reason` for
+                // exactly which documented finding applies here.
+                eprintln!(
+                    "{}: skipping compiled-side assertion (KNOWN BUG, not fixed in this PR): {reason}",
+                    case.name
+                );
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "oracle corpus mismatches ({} of {}):\n{}",
+        failures.len(),
+        CORPUS.len(),
+        failures.join("\n")
+    );
+}

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -84,6 +84,26 @@ the task's own suggestion of extending the separate, evaluator-less
   new flag and the three heads' wiring into `HELD_HEADS`/`HANDLERS`/
   `HELD_HANDLERS`.
 
+### Security (caught by `/security-review` before push)
+
+- **MEDIUM — missing recursion-depth guard.** The six new Axiom
+  domain/category functions (`axiomParseTypeSpec`, `axiomResolveDomain`,
+  `axiomIsPolynomialOverIntegers`, `axiomCoerceValue`,
+  `axiomDomainDisplayName`) were plain recursion with no cap — a real
+  inconsistency with this file's own `MAX_TERM_DEPTH`/`MAX_EVAL_DEPTH`
+  discipline. `axiomCoerceHandler` hands `axiomCoerceValue`/
+  `axiomIsPolynomialOverIntegers` an already-*evaluated* value that only
+  went through `evalTerm`'s own depth cap on the EVALUATION recursion,
+  not a cap on the resulting term's SIZE — `evalTerm`'s own doc comment
+  already establishes "a shallow compiled program can still build an
+  arbitrarily deep runtime value." Fixed: every one of the five functions
+  now threads an explicit `depth` parameter and reuses the existing
+  `MAX_TERM_DEPTH` (512) cap `toDisplayString`/`termEquals` already use
+  (the same justified reuse those two functions' own comments already
+  established, not a fresh measurement) — returning a safe default
+  (`false`/`null`/`"..."`) or throwing a clean, catchable error past the
+  cap, never an uncaught native stack overflow.
+
 ### Verification
 
 - `cargo test` (this crate): 284 tests, 0 failed (147 lib + 94

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,104 @@
 # Changelog
 
+## 0.51.6 — Axiom's three reserved SIR23 heads gain a real JS evaluator (MA13/Wave 7 close-out)
+
+**Wires `__axiom_declare`/`__axiom_coerce`/`__axiom_has`** — the three
+reserved head names `axiom-to-semantic-ir::lower` defines locally (never
+added to shared `semantic-ir`/`symbolic-ir`) for Axiom's `:`/`::`/`has`
+constructs (MA13 §2/§3/§4) — into `Symbolic.evalTerm`'s existing dispatch
+tables, following the exact same "narrow, additive dispatch-table entry"
+pattern every prior CAS-family addition here used (Derive's own
+`SIR_DISPLAY_DERIVE` display convention, J's `tally`/`replicate`/`exp`
+builtins, Q's `SIR_DISPLAY_Q_ASCII_MINUS` convention). Confirmed by direct
+inspection of `axiom-to-semantic-ir`'s own `src/lower.rs` (not assumed from
+the task's own suggestion of extending the separate, evaluator-less
+`sir-runtime-symbolic` npm package) that this crate's inline `RUNTIME` blob
+— not that package — is the actual JS-backend SIR23 evaluator.
+
+### Added
+
+- `HELD_HEADS` gains `__axiom_declare`/`__axiom_coerce`/`__axiom_has`
+  (alongside `Assign`/`Define`/`If`) — each has at least one argument
+  position that must not be evaluated as an ordinary variable reference
+  before dispatch (a declared name, a domain/category type expression).
+- A JS-side port of `axiom-runtime::domains`'s fixed, non-extensible
+  `AxiomDomain`/`AxiomCategory` table (`axiomParseTypeSpec`,
+  `axiomResolveDomain`, `axiomResolveCategory`, `axiomDomainHasCategory`,
+  `axiomIsPolynomialOverIntegers`, `axiomCoerceValue`,
+  `axiomDomainDisplayName`) — every error message copied VERBATIM from its
+  Rust counterpart, so a coercion/declaration/has-query rejection reads
+  identically on both the native and compiled path for any ATOMIC operand
+  (confirmed by `axiom-to-semantic-ir/tests/oracle.rs`'s own failing-case
+  entries).
+- `axiomDeclareHandler` (`__axiom_declare(List(name, ...), typeExpr)`):
+  resolves `typeExpr` against the fixed domain table and records `name ->
+  domain` in a new `axiomDeclaredDomains` map (both arguments held — a
+  declared name is never a variable read, mirroring
+  `axiom-runtime::eval_declaration`'s identical treatment); returns the
+  `True` symbol, matching that function's own disclosed presentation
+  convention.
+- `axiomCoerceHandler` (`__axiom_coerce(value, typeExpr)`): evaluates
+  `value` (real Axiom's own `(a + b) :: Float` coerces a COMPUTED value),
+  leaves `typeExpr` held, and throws the book's own confirmed
+  coercion-failure phrasing on a rejected coercion.
+- `axiomHasHandler` (`__axiom_has(domainTypeExpr, categoryTypeExpr)`):
+  both arguments held; returns the `True`/`False` symbol from the fixed
+  membership table. Confirmed against the book's own two worked examples:
+  `Polynomial(Integer) has Ring` → `true`, `List(Integer) has Ring` →
+  `false`.
+- **`assignHandler`'s own small, disclosed cross-head addition**: consults
+  the new `axiomDeclaredDomains` map (populated only by
+  `axiomDeclareHandler`) and, when a declared-domain constraint exists for
+  the assignment's left-hand name, coerces the right-hand value against it
+  — throwing the book's own confirmed assignment-mismatch error text on
+  failure. A faithful port of `axiom-runtime::eval_assignment`'s own
+  identical design (that function ALSO consults a private `declared`
+  table when handling what is otherwise the shared `:=` construct) — not
+  a new mechanism. Gated entirely on the new map staying empty for every
+  OTHER source language and for any Axiom program with no prior `a : T`
+  declaration for that name, so this is a no-op everywhere else (confirmed:
+  no other frontend in this repo emits `__axiom_declare`).
+- A SIXTH, independent display-convention flag, `SIR_DISPLAY_AXIOM_BOOLEAN`
+  (`emit.rs`/`runtime.rs`) — `true` only when the module's
+  `source_language` is Axiom. Gates a single, narrow spot inside
+  `Symbolic.toDisplayString`'s generic `"symbol"` case so the shared
+  comparison/logic/`has`-query handlers' `True`/`False` symbols render
+  real Axiom's own lowercase `true`/`false` convention
+  (`axiom-runtime::value::print_axiom`'s own render()). Deliberately
+  narrower than `SIR_DISPLAY_DERIVE` (which gates the WHOLE stringifier):
+  Axiom still has no infix/bracket display convention of its own for a
+  COMPOUND term — a disclosed, pre-existing "finding five"-class gap,
+  same as every other CAS-family language without a full
+  `SIR_DISPLAY_<LANG>` printer (see `axiom-to-semantic-ir/tests/
+  oracle.rs`'s own module doc for the one corpus case this affects).
+- `tests/sir23_axiom.rs` (new file, 9 tests): hand-built-SIR-then-run-
+  under-`node` unit tests for the three new handlers in isolation, with
+  no dependency on `axiom-to-semantic-ir` — mirrors `tests/
+  sir23_symbolic.rs`'s own pattern exactly. Covers: declare
+  success/failure, coerce success/failure, both book-confirmed `has`
+  examples, declare-then-matching-assign, declare-then-mismatched-assign,
+  and a regression guard that an undeclared name's assignment stays
+  completely unrestricted (confirming the `assignHandler` addition's
+  narrowness).
+- Two new `#[cfg(test)]` regression tests in `src/runtime.rs` pinning the
+  new flag and the three heads' wiring into `HELD_HEADS`/`HANDLERS`/
+  `HELD_HANDLERS`.
+
+### Verification
+
+- `cargo test` (this crate): 284 tests, 0 failed (147 lib + 94
+  `run_with_node` + 12 `sir22_array` + 9 new `sir23_axiom` + 4
+  `sir23_eval_depth_guard` + 17 `sir23_symbolic` + 1 `compile_and_run_case_eq`).
+- Downstream consumers re-run after this change (this file is shared by
+  every SIR23/SIR22 frontend): `derive-to-semantic-ir`,
+  `reduce-to-semantic-ir`, `macsyma-to-semantic-ir`,
+  `wolfram-to-semantic-ir`, `maple-to-semantic-ir`, `apl-to-semantic-ir`,
+  `j-to-semantic-ir`, `q-to-semantic-ir`, `idl-to-semantic-ir`,
+  `sir-conformance` — all green, 0 failed. The change is additive (new
+  consts, new dispatch-table entries, one new conditional branch in
+  `assignHandler` gated on a map that stays empty for every one of these
+  languages), so this is confirmatory, not merely hopeful.
+
 ## 0.51.5 — `is_js_reserved` was missing `eval`/`arguments` (task #110)
 
 **Not a syntactic-keyword gap — a strict-mode contextual-reserved-word

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.51.5"
+version = "0.51.6"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -480,6 +480,26 @@ frontend with an oracle corpus proving it today; Wolfram/Macsyma/Reduce/
 Maple's own conventions are separate future work following the identical
 recipe (one more `SIR_DISPLAY_*` flag + printer port).
 
+**Axiom's three reserved heads (MA13/Wave 7 close-out): `__axiom_declare`/
+`__axiom_coerce`/`__axiom_has` + a sixth display flag.** `axiom-to-
+semantic-ir` lowers Axiom's `:` (declaration), `::` (coercion), and `has`
+(category-membership query) — a fixed, non-extensible domain/category type
+system with no analogue in any other CAS-family language here (MA13 §2/§3) —
+to three reserved `SymApply` head names, never added to shared
+`semantic-ir`/`symbolic-ir`. `HELD_HEADS`/`HANDLERS`/`HELD_HANDLERS` gain a
+matching JS-side port of `axiom-runtime::domains`'s fixed
+`AxiomDomain`/`AxiomCategory` table (`axiomDeclareHandler`/
+`axiomCoerceHandler`/`axiomHasHandler`), plus a SIXTH, independent
+`SIR_DISPLAY_AXIOM_BOOLEAN` flag — much narrower than `SIR_DISPLAY_DERIVE`
+above: it gates only the `True`/`False` symbol's lowercase spelling inside
+the generic `toDisplayString` branch (Axiom still has no full infix/bracket
+printer of its own). `assignHandler` also gains one small, disclosed
+addition: it consults a new `axiomDeclaredDomains` map (populated only by
+`axiomDeclareHandler`) so a `:`-declared domain constraint is enforced
+against a later `:=` — a no-op for every other source language. See
+`axiom-to-semantic-ir/tests/oracle.rs` for the full end-to-end diff against
+`axiom-runtime` and `runtime.rs`'s own comments for the complete design.
+
 ### Array/matrix domain (SIR22 base cut)
 
 The inlined `__Sir` also carries `Array` — a plain-JS port of the

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -171,7 +171,16 @@ pub fn emit_module(m: &Module) -> String {
     // below never need to arbitrate between them — only one can ever be
     // `true` for a given module.
     //
-    // SECURITY: all five replacement values MUST remain a hardcoded literal
+    // A SIXTH, independent placeholder (MA13/Wave 7 close-out): `true` when
+    // the module's `source_language` is Axiom, else `false`. Gates
+    // `Symbolic.toDisplayString`'s `"symbol"` case (see `runtime.rs`'s
+    // `SIR_DISPLAY_AXIOM_BOOLEAN` for the full writeup) so the shared
+    // comparison/logic/`has`-query handlers' `True`/`False` symbols render
+    // real Axiom's own lowercase `true`/`false` convention. Mutually
+    // exclusive with the five flags above by construction (all six are
+    // computed from the same single `source_language` field).
+    //
+    // SECURITY: all six replacement values MUST remain a hardcoded literal
     // selected by a boolean — never text derived from `source_language` or
     // any other source-controlled field — so this substitution can never
     // inject into the emitted JavaScript.
@@ -180,6 +189,7 @@ pub fn emit_module(m: &Module) -> String {
     let display_j_underscore = m.metadata.source_language.as_deref() == Some("j");
     let display_derive = m.metadata.source_language.as_deref() == Some("derive");
     let display_q_ascii_minus = m.metadata.source_language.as_deref() == Some("q");
+    let display_axiom_boolean = m.metadata.source_language.as_deref() == Some("axiom");
     out.push_str(
         &RUNTIME
             .replace(
@@ -201,6 +211,10 @@ pub fn emit_module(m: &Module) -> String {
             .replace(
                 "__SIR_DISPLAY_Q_ASCII_MINUS__",
                 if display_q_ascii_minus { "true" } else { "false" },
+            )
+            .replace(
+                "__SIR_DISPLAY_AXIOM_BOOLEAN__",
+                if display_axiom_boolean { "true" } else { "false" },
             ),
     );
     emit_ancestry_registration(&mut out, m);

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -4547,14 +4547,48 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // `List(T)` is `{ tag: "List", inner: <AxiomDomain> }`. `AxiomCategory`
     // is simply the string `"Ring"` or `"OrderedSet"`.
 
+    // SECURITY (CWE-674): every one of the six Axiom domain/category
+    // functions below (`axiomParseTypeSpec`, `axiomResolveDomain`,
+    // `axiomIsPolynomialOverIntegers`, `axiomCoerceValue`,
+    // `axiomDomainDisplayName`) is plain recursion with no cap of its own
+    // -- a security-review finding, since `axiomCoerceHandler` hands
+    // `axiomCoerceValue`/`axiomIsPolynomialOverIntegers` an already-
+    // EVALUATED value that only went through `evalTerm`'s OWN depth cap
+    // (`MAX_EVAL_DEPTH`, checked on `evalTerm`'s own recursive descent),
+    // not a cap on the SIZE of the resulting term -- `evalTerm`'s own doc
+    // comment already establishes "a shallow compiled program can still
+    // build an arbitrarily deep runtime VALUE" (the same concern
+    // `toDisplayString`'s own guard, just below in this file, exists to
+    // close for the display path). Every function here now threads an
+    // explicit `depth` parameter and reuses the SAME `MAX_TERM_DEPTH`
+    // (512) cap `toDisplayString`/`termEquals` already use -- a
+    // deliberate REUSE, not a fresh measurement, justified the same way
+    // `termEquals`'s own comment justifies reusing it: each of these six
+    // functions' per-call-frame footprint (a `kind`/`tag` check, a string
+    // comparison or two, at most one more recursive call per level) is no
+    // heavier than `toDisplayString`'s own already-proven-safe-at-
+    // `MAX_TERM_DEPTH` frame. Past the cap, each function returns its own
+    // existing "this failed" value (`false` for the boolean predicate,
+    // `null` for the coerce-or-fail function, `"..."` for the display
+    // function, matching `toDisplayString`'s own truncation convention)
+    // or throws a clean `Error`/`RangeError` (for the two functions whose
+    // contract is already "return a value or throw", where a silent
+    // truncated answer would be worse than a clean, catchable failure) --
+    // never an uncaught native `RangeError: Maximum call stack size
+    // exceeded` that would crash the whole `node` process.
+
     // `axiom-runtime::builtins::parse_type_spec`'s port: read a `typeExpr`
     // TERM (never `evalTerm`'d -- see the three handlers below, all of
     // which pass this a RAW, unevaluated argument) into a `{ name, args }`
     // spec.
-    function axiomParseTypeSpec(term) {
+    function axiomParseTypeSpec(term, depth) {
+      if (depth === undefined) { depth = 0; }
+      if (depth > MAX_TERM_DEPTH) {
+        throw new RangeError("Symbolic.evalTerm: Axiom type expression nesting too deep");
+      }
       if (term.kind === "symbol") { return { name: term.name, args: [] }; }
       if (term.kind === "apply" && term.head.kind === "symbol") {
-        return { name: term.head.name, args: term.args.map(axiomParseTypeSpec) };
+        return { name: term.head.name, args: term.args.map((a) => axiomParseTypeSpec(a, depth + 1)) };
       }
       throw new TypeError("Symbolic.evalTerm: malformed Axiom type expression");
     }
@@ -4562,7 +4596,11 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // `axiom-runtime::domains::resolve_domain`'s port -- every error
     // message is copied VERBATIM from that function so a rejection reads
     // identically on both the native and compiled paths.
-    function axiomResolveDomain(spec) {
+    function axiomResolveDomain(spec, depth) {
+      if (depth === undefined) { depth = 0; }
+      if (depth > MAX_TERM_DEPTH) {
+        throw new RangeError("Symbolic.evalTerm: Axiom domain nesting too deep");
+      }
       const n = spec.args.length;
       switch (spec.name) {
         case "Boolean": if (n === 0) { return "Boolean"; } break;
@@ -4573,7 +4611,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         case "String": if (n === 0) { return "String"; } break;
         case "Fraction":
           if (n === 1) {
-            const inner = axiomResolveDomain(spec.args[0]);
+            const inner = axiomResolveDomain(spec.args[0], depth + 1);
             if (inner === "Integer") { return "FractionInteger"; }
             throw new Error(
               "Fraction(" + axiomDomainDisplayName(inner) + ") is not a valid type -- this cut's "
@@ -4583,7 +4621,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           break;
         case "Polynomial":
           if (n === 1) {
-            const inner = axiomResolveDomain(spec.args[0]);
+            const inner = axiomResolveDomain(spec.args[0], depth + 1);
             if (inner === "Integer") { return "PolynomialInteger"; }
             throw new Error(
               "Polynomial(" + axiomDomainDisplayName(inner) + ") is not a valid type -- this cut's "
@@ -4593,7 +4631,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           break;
         case "List":
           if (n === 1) {
-            const inner = axiomResolveDomain(spec.args[0]);
+            const inner = axiomResolveDomain(spec.args[0], depth + 1);
             if (typeof inner === "object" && inner.tag === "List") {
               throw new Error(
                 "List(" + axiomDomainDisplayName(inner) + ") is not a valid type -- `List`'s element "
@@ -4651,18 +4689,20 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // symbol (including `True`/`False`) counts as "polynomial", matching
     // `IRNode::Integer(_) | IRNode::Symbol(_) => true` exactly -- a
     // faithful port, not a hardening.
-    function axiomIsPolynomialOverIntegers(term) {
+    function axiomIsPolynomialOverIntegers(term, depth) {
+      if (depth === undefined) { depth = 0; }
+      if (depth > MAX_TERM_DEPTH) { return false; } // safe, conservative "not polynomial" answer
       if (term.kind === "integer" || term.kind === "symbol") { return true; }
       if (term.kind !== "apply" || term.head.kind !== "symbol") { return false; }
       const h = term.head.name;
       if (h === "Add" || h === "Sub" || h === "Mul") {
-        return term.args.every(axiomIsPolynomialOverIntegers);
+        return term.args.every((a) => axiomIsPolynomialOverIntegers(a, depth + 1));
       }
       if (h === "Neg") {
-        return term.args.length === 1 && axiomIsPolynomialOverIntegers(term.args[0]);
+        return term.args.length === 1 && axiomIsPolynomialOverIntegers(term.args[0], depth + 1);
       }
       if (h === "Pow") {
-        return term.args.length === 2 && axiomIsPolynomialOverIntegers(term.args[0])
+        return term.args.length === 2 && axiomIsPolynomialOverIntegers(term.args[0], depth + 1)
           && term.args[1].kind === "integer" && term.args[1].value >= 0;
       }
       return false;
@@ -4675,7 +4715,9 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // (`Integer`/`Rational` -> `Float`, matching real Axiom's own
     // `3 :: Float` producing `3.0`); every other domain is a pure
     // membership check that returns the value unchanged.
-    function axiomCoerceValue(term, domain) {
+    function axiomCoerceValue(term, domain, depth) {
+      if (depth === undefined) { depth = 0; }
+      if (depth > MAX_TERM_DEPTH) { return null; } // safe, conservative "coercion failed" answer
       if (domain === "Boolean") {
         return (term.kind === "symbol" && (term.name === "True" || term.name === "False")) ? term : null;
       }
@@ -4697,7 +4739,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         return (term.kind === "rational" || term.kind === "integer") ? term : null;
       }
       if (domain === "PolynomialInteger") {
-        return axiomIsPolynomialOverIntegers(term) ? term : null;
+        return axiomIsPolynomialOverIntegers(term, depth + 1) ? term : null;
       }
       if (typeof domain === "object" && domain.tag === "List") {
         if (!(term.kind === "apply" && term.head.kind === "symbol" && term.head.name === "List")) {
@@ -4705,7 +4747,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         }
         const coercedArgs = [];
         for (const elem of term.args) {
-          const c = axiomCoerceValue(elem, domain.inner);
+          const c = axiomCoerceValue(elem, domain.inner, depth + 1);
           if (c === null) { return null; }
           coercedArgs.push(c);
         }
@@ -4718,9 +4760,11 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // book's own spelling (`Integer`, `Fraction(Integer)`, `List(Float)`,
     // …), used only in error-message text (never the enum/string tag
     // above, which is `"FractionInteger"`/`"PolynomialInteger"`).
-    function axiomDomainDisplayName(domain) {
+    function axiomDomainDisplayName(domain, depth) {
+      if (depth === undefined) { depth = 0; }
+      if (depth > MAX_TERM_DEPTH) { return "..."; } // matches toDisplayString's own truncation marker
       if (typeof domain === "object" && domain.tag === "List") {
-        return "List(" + axiomDomainDisplayName(domain.inner) + ")";
+        return "List(" + axiomDomainDisplayName(domain.inner, depth + 1) + ")";
       }
       if (domain === "FractionInteger") { return "Fraction(Integer)"; }
       if (domain === "PolynomialInteger") { return "Polynomial(Integer)"; }

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -150,6 +150,34 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // never need to arbitrate between them -- only one can ever be `true`
   // for a given module.
   const SIR_DISPLAY_Q_ASCII_MINUS = __SIR_DISPLAY_Q_ASCII_MINUS__;
+  // A SIXTH, independent display-convention flag (MA13/Wave 7 close-out,
+  // `axiom-to-semantic-ir`'s oracle tests): `true` when the module's
+  // `source_language` is Axiom, else `false`. Unlike the five flags above
+  // (which gate `formatSeen`'s bare-number/`SirFloat` branches or, for
+  // `SIR_DISPLAY_DERIVE`, the whole `Symbolic.toDisplayString` stringifier),
+  // this one gates a single, narrow spot inside the GENERIC (non-Derive)
+  // branch of `Symbolic.toDisplayString`'s own `"symbol"` case: real Axiom's
+  // own interactive session renders the `True`/`False` symbols the shared
+  // comparison/logic/`has`-query handlers already produce as LOWERCASE
+  // `true`/`false` (`axiom-runtime::value::print_axiom`'s own render(),
+  // confirmed directly: `IRNode::Symbol(s) if s == "True" => "true"`) --
+  // every OTHER source language in this symbolic (SIR23) domain (Wolfram,
+  // Macsyma, Derive, Reduce, Maple) either has no comparable native
+  // lowercasing convention or (Maple) already gets its own dedicated
+  // case-bridging fix tracked as separate follow-up work, per
+  // `HML01-math-to-semantic-ir.md` §5's own "True/False CASE mismatch"
+  // finding -- so a plain boolean-only flag, mirroring `SIR_DISPLAY_RUBY`'s
+  // minimal shape exactly (NOT Derive's whole precedence-aware printer),
+  // is the correct, narrowest fix here: it does not touch how any
+  // COMPOUND term prints (Axiom still has no infix/bracket display
+  // convention of its own, the same disclosed "finding five"-class gap
+  // every CAS-family language without a `SIR_DISPLAY_<LANG>` flag has --
+  // see `axiom-to-semantic-ir/tests/oracle.rs`'s own module doc for the
+  // corpus cases that document it), only the two atomic boolean symbols.
+  // Mutually exclusive with the five flags above by construction (all six
+  // are computed from the same single `source_language` field in
+  // `emit.rs`).
+  const SIR_DISPLAY_AXIOM_BOOLEAN = __SIR_DISPLAY_AXIOM_BOOLEAN__;
   // ── value model ────────────────────────────────────────────────
   // A symbol is an interned name; `===` on two interned symbols with
   // the same name is therefore identity-equal.
@@ -3296,7 +3324,16 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         return derivePrintAt(node, DERIVE_PREC_LOWEST, depth);
       }
       switch (node.kind) {
-        case "symbol": return node.name;
+        case "symbol":
+          // SIR_DISPLAY_AXIOM_BOOLEAN (see that flag's own comment, above):
+          // real Axiom's own session renders these two symbols lowercase;
+          // every other name (including every OTHER language's True/False,
+          // per the still-open, shared "finding five"/case-mismatch gaps
+          // documented in `HML01-math-to-semantic-ir.md` §5) is unaffected.
+          if (SIR_DISPLAY_AXIOM_BOOLEAN && (node.name === "True" || node.name === "False")) {
+            return node.name === "True" ? "true" : "false";
+          }
+          return node.name;
         case "integer": return String(node.value);
         case "rational": return node.numer + "/" + node.denom;
         case "float": return String(node.value);
@@ -3642,6 +3679,16 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     //   item 3 (this PR) — calculus / elementary-function handlers
     //   item 4 (shipped) — Derive's own SIR23 display convention
     //
+    // A FIFTH addition, layered on top of this same SIR23 addendum after
+    // all four items above shipped (MA13/Wave 7 close-out, not part of
+    // the addendum's own original 4-item plan): Axiom's three reserved
+    // `__axiom_declare`/`__axiom_coerce`/`__axiom_has` heads join
+    // `HELD_HEADS` and `HANDLERS`/`HELD_HANDLERS` below, exactly like any
+    // other new head this dispatch table gains — see
+    // `axiomDeclareHandler`/`axiomCoerceHandler`/`axiomHasHandler`'s own
+    // section comment (further down, right before `HANDLERS`) for the
+    // full design.
+    //
     // `HELD_HEADS` was declared by item 1 — the held-vs-evaluated
     // ARGUMENT treatment below was exercised starting then — but item 1
     // wired up NO handler for any of its three members, so `Assign`/
@@ -3661,7 +3708,19 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // alone folds `List(Add(1,1), Mul(2,3))` into `List(2, 6)` "for
     // free" via the same generic "no handler matched" fallthrough every
     // other unrecognised head (present or future) takes.
-    const HELD_HEADS = new Set(["Assign", "Define", "If"]);
+    // `__axiom_declare`/`__axiom_coerce`/`__axiom_has` (MA13/Wave 7
+    // close-out, `axiom-to-semantic-ir::lower`'s three reserved SIR23
+    // heads) join this set for the identical reason `Assign`'s
+    // left-hand-side name is held: each of the three has at least one
+    // argument position that must NOT be evaluated as an ordinary variable
+    // reference before dispatch (a declared name, a domain/category type
+    // expression) — see each handler's own doc comment, near
+    // `axiomDeclareHandler` above, for exactly which argument(s) each one
+    // evaluates itself versus leaves raw.
+    const HELD_HEADS = new Set([
+      "Assign", "Define", "If",
+      "__axiom_declare", "__axiom_coerce", "__axiom_has",
+    ]);
 
     // SECURITY (CWE-674): `evalTerm`'s OWN recursion-depth cap — this is
     // deliberately NOT a reuse of `MAX_TERM_DEPTH` above. That constant
@@ -3732,6 +3791,21 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // local scope reaches `SymbolicBackend` today), so one flat `Map` is a
     // faithful, not a simplified, port of `BaseBackend.env`.
     const symEnv = new Map();
+
+    // Axiom's own `:`-declared domain-constraint table (MA13 §2/§3/§4) —
+    // a name -> AxiomDomain map, populated ONLY by `axiomDeclareHandler`
+    // (below) and consulted ONLY by `assignHandler`'s own small, disclosed
+    // addition (see that function's comment). Deliberately a SEPARATE map
+    // from `symEnv` immediately above, mirroring `axiom-runtime::
+    // EvalContext`'s own identical separation (`declared: HashMap<String,
+    // AxiomDomain>`, kept apart from the shared VM's own name-binding
+    // environment, "since `symbolic-ir`/`symbolic-vm` have no concept of a
+    // domain at all to store one in") — a faithful port of that same
+    // architectural split, not a new design. Stays permanently EMPTY for
+    // every compiled program that never lowers a `__axiom_declare` call
+    // (i.e. every non-Axiom source language, and any Axiom program with no
+    // `:` declaration), so `assignHandler`'s extra lookup is a no-op there.
+    const axiomDeclaredDomains = new Map();
 
     // ── numeric tower (handlers.rs::Numeric port) ───────────────────
     //
@@ -4428,6 +4502,303 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       return evalTerm(result, depth + 1);
     }
 
+    // ── Axiom domain/category table + reserved-head handlers ─────────
+    //
+    // MA13 §2/§3/§4 (`code/specs/MA13-axiom-language.md`): a JS-side port
+    // of `axiom-runtime::domains`'s fixed, non-extensible
+    // `AxiomDomain`/`AxiomCategory` table -- the ONE piece of genuinely new
+    // evaluator design MA13 needed (`symbolic_ir::IRNode` has no domain/
+    // category/type-tag concept anywhere), reused here for the THREE
+    // reserved SIR23 heads `axiom-to-semantic-ir::lower` defines locally
+    // (never added to shared `semantic-ir`/`symbolic-ir`, per that crate's
+    // own "Decision" section):
+    //
+    //   __axiom_declare(List(name, ...), typeExpr)   -- `a : T` / `(a,b): T`
+    //   __axiom_coerce(value, typeExpr)               -- `e :: T`
+    //   __axiom_has(domainTypeExpr, categoryTypeExpr) -- `D has C`
+    //
+    // `typeExpr` positions are ordinary `SymSymbol`/`SymApply` DATA (a bare
+    // NAME lowers to `SymSymbol`, a parameterized one to
+    // `SymApply(SymSymbol(name), [args...])` -- confirmed directly against
+    // `axiom-to-semantic-ir::lower::Lowerer::lower_type_expr`), the EXACT
+    // same shape an ordinary call already has -- so `axiomParseTypeSpec`
+    // reads a term into the same `{ name, args }` shape
+    // `axiom-runtime::builtins::parse_type_spec` reads a parsed CST node
+    // into, and every function below is a direct, one-for-one port of its
+    // `axiom-runtime::domains` counterpart (same shape, same match arms,
+    // same error TEXT verbatim -- so a coercion/declaration/has-query
+    // failure throws the byte-for-byte SAME message `axiom-runtime` itself
+    // produces for an atomic operand, confirmed by
+    // `axiom-to-semantic-ir/tests/oracle.rs`'s own failing-case entries;
+    // for a COMPOUND operand the message text can still diverge, since it
+    // embeds `toDisplayString`'s generic rendering rather than
+    // `axiom-runtime::value::print_axiom`'s own infix one -- the same
+    // disclosed "no per-language compound-display convention" gap every
+    // CAS-family language without a dedicated `SIR_DISPLAY_<LANG>` printer
+    // has, see `SIR_DISPLAY_AXIOM_BOOLEAN`'s own comment above).
+    //
+    // A JS `AxiomDomain` is represented exactly as compactly as its Rust
+    // counterpart: the eight zero-argument variants are plain STRINGS
+    // (`"Boolean"`, `"Integer"`, `"PositiveInteger"`, `"NonNegativeInteger"`,
+    // `"Float"`, `"String"`, `"FractionInteger"`, `"PolynomialInteger"` --
+    // matching the Rust enum's own variant names, NOT their `display_name()`
+    // spelling, e.g. `"FractionInteger"` not `"Fraction(Integer)"`; see
+    // `axiomDomainDisplayName` below for that separate rendering), and
+    // `List(T)` is `{ tag: "List", inner: <AxiomDomain> }`. `AxiomCategory`
+    // is simply the string `"Ring"` or `"OrderedSet"`.
+
+    // `axiom-runtime::builtins::parse_type_spec`'s port: read a `typeExpr`
+    // TERM (never `evalTerm`'d -- see the three handlers below, all of
+    // which pass this a RAW, unevaluated argument) into a `{ name, args }`
+    // spec.
+    function axiomParseTypeSpec(term) {
+      if (term.kind === "symbol") { return { name: term.name, args: [] }; }
+      if (term.kind === "apply" && term.head.kind === "symbol") {
+        return { name: term.head.name, args: term.args.map(axiomParseTypeSpec) };
+      }
+      throw new TypeError("Symbolic.evalTerm: malformed Axiom type expression");
+    }
+
+    // `axiom-runtime::domains::resolve_domain`'s port -- every error
+    // message is copied VERBATIM from that function so a rejection reads
+    // identically on both the native and compiled paths.
+    function axiomResolveDomain(spec) {
+      const n = spec.args.length;
+      switch (spec.name) {
+        case "Boolean": if (n === 0) { return "Boolean"; } break;
+        case "Integer": if (n === 0) { return "Integer"; } break;
+        case "PositiveInteger": if (n === 0) { return "PositiveInteger"; } break;
+        case "NonNegativeInteger": if (n === 0) { return "NonNegativeInteger"; } break;
+        case "Float": if (n === 0) { return "Float"; } break;
+        case "String": if (n === 0) { return "String"; } break;
+        case "Fraction":
+          if (n === 1) {
+            const inner = axiomResolveDomain(spec.args[0]);
+            if (inner === "Integer") { return "FractionInteger"; }
+            throw new Error(
+              "Fraction(" + axiomDomainDisplayName(inner) + ") is not a valid type -- this cut's "
+              + "`Fraction` is fixed to `Fraction(Integer)` only"
+            );
+          }
+          break;
+        case "Polynomial":
+          if (n === 1) {
+            const inner = axiomResolveDomain(spec.args[0]);
+            if (inner === "Integer") { return "PolynomialInteger"; }
+            throw new Error(
+              "Polynomial(" + axiomDomainDisplayName(inner) + ") is not a valid type -- this cut's "
+              + "`Polynomial` is fixed to `Polynomial(Integer)` only"
+            );
+          }
+          break;
+        case "List":
+          if (n === 1) {
+            const inner = axiomResolveDomain(spec.args[0]);
+            if (typeof inner === "object" && inner.tag === "List") {
+              throw new Error(
+                "List(" + axiomDomainDisplayName(inner) + ") is not a valid type -- `List`'s element "
+                + "type cannot itself be a `List`"
+              );
+            }
+            return { tag: "List", inner };
+          }
+          break;
+        default:
+          break;
+      }
+      if (spec.name === "Fraction" || spec.name === "Polynomial" || spec.name === "List") {
+        throw new Error("`" + spec.name + "` takes exactly 1 type argument, got " + n);
+      }
+      throw new Error(
+        "`" + spec.name + "` is not one of this cut's fixed built-in domains (Boolean, Integer, "
+        + "PositiveInteger, NonNegativeInteger, Float, String, Fraction(Integer), Polynomial(Integer), "
+        + "List(T))"
+      );
+    }
+
+    // `axiom-runtime::domains::resolve_category`'s port.
+    function axiomResolveCategory(spec) {
+      const n = spec.args.length;
+      if (spec.name === "Ring" && n === 0) { return "Ring"; }
+      if (spec.name === "OrderedSet" && n === 0) { return "OrderedSet"; }
+      if (spec.name === "Ring" || spec.name === "OrderedSet") {
+        throw new Error("`" + spec.name + "` takes no type arguments, got " + n);
+      }
+      throw new Error(
+        "`" + spec.name + "` is not one of this cut's fixed built-in categories (Ring, OrderedSet)"
+      );
+    }
+
+    // `axiom-runtime::domains::domain_has_category`'s port -- the fixed
+    // membership table (MA13 §3/§4). `Polynomial(Integer) has Ring` is
+    // `true`; `List(Integer) has Ring` is `false` (the book's own confirmed
+    // examples -- `axiom-to-semantic-ir/tests/oracle.rs`'s own two
+    // headline cases).
+    function axiomDomainHasCategory(domain, category) {
+      if (category === "Ring") {
+        return domain === "Integer" || domain === "FractionInteger" || domain === "PolynomialInteger";
+      }
+      // OrderedSet
+      return domain === "Integer" || domain === "Float"
+        || domain === "PositiveInteger" || domain === "NonNegativeInteger";
+    }
+
+    // `axiom-runtime::domains::is_polynomial_over_integers`'s port -- an
+    // Axiom-runtime-internal STRUCTURAL predicate, not a `symbolic-vm`
+    // change (mirrors that function's own doc comment: "evaluated entirely
+    // within `axiom-runtime`'s own dispatcher, never inside `symbolic-vm`
+    // itself"). Note the same quirk the Rust reference has: ANY bare
+    // symbol (including `True`/`False`) counts as "polynomial", matching
+    // `IRNode::Integer(_) | IRNode::Symbol(_) => true` exactly -- a
+    // faithful port, not a hardening.
+    function axiomIsPolynomialOverIntegers(term) {
+      if (term.kind === "integer" || term.kind === "symbol") { return true; }
+      if (term.kind !== "apply" || term.head.kind !== "symbol") { return false; }
+      const h = term.head.name;
+      if (h === "Add" || h === "Sub" || h === "Mul") {
+        return term.args.every(axiomIsPolynomialOverIntegers);
+      }
+      if (h === "Neg") {
+        return term.args.length === 1 && axiomIsPolynomialOverIntegers(term.args[0]);
+      }
+      if (h === "Pow") {
+        return term.args.length === 2 && axiomIsPolynomialOverIntegers(term.args[0])
+          && term.args[1].kind === "integer" && term.args[1].value >= 0;
+      }
+      return false;
+    }
+
+    // `axiom-runtime::domains::coerce_value`'s port: attempt to coerce an
+    // ALREADY-EVALUATED `term` into `domain`, returning the (possibly
+    // representation-converted) term on success or `null` on failure.
+    // `Float` is the one domain that genuinely CONVERTS representation
+    // (`Integer`/`Rational` -> `Float`, matching real Axiom's own
+    // `3 :: Float` producing `3.0`); every other domain is a pure
+    // membership check that returns the value unchanged.
+    function axiomCoerceValue(term, domain) {
+      if (domain === "Boolean") {
+        return (term.kind === "symbol" && (term.name === "True" || term.name === "False")) ? term : null;
+      }
+      if (domain === "Integer") { return term.kind === "integer" ? term : null; }
+      if (domain === "PositiveInteger") {
+        return (term.kind === "integer" && term.value > 0) ? term : null;
+      }
+      if (domain === "NonNegativeInteger") {
+        return (term.kind === "integer" && term.value >= 0) ? term : null;
+      }
+      if (domain === "Float") {
+        if (term.kind === "float") { return term; }
+        if (term.kind === "integer") { return floatTerm(term.value); }
+        if (term.kind === "rational") { return floatTerm(term.numer / term.denom); }
+        return null;
+      }
+      if (domain === "String") { return term.kind === "string" ? term : null; }
+      if (domain === "FractionInteger") {
+        return (term.kind === "rational" || term.kind === "integer") ? term : null;
+      }
+      if (domain === "PolynomialInteger") {
+        return axiomIsPolynomialOverIntegers(term) ? term : null;
+      }
+      if (typeof domain === "object" && domain.tag === "List") {
+        if (!(term.kind === "apply" && term.head.kind === "symbol" && term.head.name === "List")) {
+          return null;
+        }
+        const coercedArgs = [];
+        for (const elem of term.args) {
+          const c = axiomCoerceValue(elem, domain.inner);
+          if (c === null) { return null; }
+          coercedArgs.push(c);
+        }
+        return applyTerm(symTerm("List"), coercedArgs);
+      }
+      return null;
+    }
+
+    // `axiom-runtime::domains::AxiomDomain::display_name`'s port -- the
+    // book's own spelling (`Integer`, `Fraction(Integer)`, `List(Float)`,
+    // …), used only in error-message text (never the enum/string tag
+    // above, which is `"FractionInteger"`/`"PolynomialInteger"`).
+    function axiomDomainDisplayName(domain) {
+      if (typeof domain === "object" && domain.tag === "List") {
+        return "List(" + axiomDomainDisplayName(domain.inner) + ")";
+      }
+      if (domain === "FractionInteger") { return "Fraction(Integer)"; }
+      if (domain === "PolynomialInteger") { return "Polynomial(Integer)"; }
+      return domain;
+    }
+
+    // `__axiom_declare(List(name, ...), typeExpr)` -- `a : T` / `(a,b,c): T`
+    // (MA13 §3/§4). BOTH arguments are HELD (never `evalTerm`'d): the
+    // names are bare identifiers, not variable reads (evaluating them
+    // would resolve an ALREADY-bound name to its current VALUE instead of
+    // its NAME -- wrong for a declaration, which must restrict the name
+    // going forward regardless of whether it is already bound), and the
+    // type expression is domain/category-shaped data, never an ordinary
+    // variable reference (mirrors `axiom-runtime::eval_declaration`'s own
+    // identical treatment: it walks `type_expr` structurally via
+    // `parse_type_spec`, never through `eval_expr`). Records `name ->
+    // domain` in `axiomDeclaredDomains` for every declared name (consulted
+    // later by `assignHandler`'s own small addition, below) and returns
+    // the `True` symbol -- `axiom-runtime::eval_declaration`'s own
+    // disclosed presentation convention ("a pure declaration has no value
+    // of its own in real Axiom's own interactive session... echoes `true`
+    // to confirm the declaration was accepted").
+    function axiomDeclareHandler(head, args) {
+      if (args.length !== 2) { return applyTerm(head, args); }
+      const namesListTerm = args[0];
+      const typeExprTerm = args[1];
+      if (!(namesListTerm.kind === "apply" && namesListTerm.head.kind === "symbol"
+            && namesListTerm.head.name === "List")) {
+        throw new TypeError("Symbolic.evalTerm: __axiom_declare names must be a List, got " + namesListTerm.kind);
+      }
+      const names = [];
+      for (const n of namesListTerm.args) {
+        if (n.kind !== "symbol") {
+          throw new TypeError("Symbolic.evalTerm: __axiom_declare name list must contain only symbols");
+        }
+        names.push(n.name);
+      }
+      const domain = axiomResolveDomain(axiomParseTypeSpec(typeExprTerm));
+      for (const name of names) { axiomDeclaredDomains.set(name, domain); }
+      return symTerm("True");
+    }
+
+    // `__axiom_coerce(value, typeExpr)` -- `e :: T` (MA13 §3/§4). `value`
+    // IS evaluated (real Axiom's own `(a + b) :: Float` coerces a COMPUTED
+    // value, MA13 §3), `typeExpr` is held (same reasoning as
+    // `axiomDeclareHandler` above). Throws the book's own confirmed
+    // coercion-failure phrasing, adapted for the standalone `::` case
+    // exactly as `axiom-runtime::eval_coercion` itself adapts it (that
+    // function's own comment: "adapted from the book's own confirmed
+    // assignment-mismatch phrase... for the standalone `::` case, which
+    // has no left-hand side of its own to name").
+    function axiomCoerceHandler(head, args, depth) {
+      if (args.length !== 2) { return applyTerm(head, args); }
+      const value = evalTerm(args[0], depth + 1);
+      if (isDepthLimitError(value)) { return value; }
+      const domain = axiomResolveDomain(axiomParseTypeSpec(args[1]));
+      const coerced = axiomCoerceValue(value, domain);
+      if (coerced === null) {
+        throw new Error(
+          "Cannot convert " + toDisplayString(value) + " to an object of the type "
+          + axiomDomainDisplayName(domain) + "."
+        );
+      }
+      return coerced;
+    }
+
+    // `__axiom_has(domainTypeExpr, categoryTypeExpr)` -- `D has C` (MA13
+    // §3/§4). BOTH arguments are held type expressions (neither is ever a
+    // variable read -- mirrors `axiom-runtime::eval_has_query`'s identical
+    // treatment). Returns the `True`/`False` symbol from the fixed lookup
+    // table, never a computed `Join`/conditional-export algebra.
+    function axiomHasHandler(head, args) {
+      if (args.length !== 2) { return applyTerm(head, args); }
+      const domain = axiomResolveDomain(axiomParseTypeSpec(args[0]));
+      const category = axiomResolveCategory(axiomParseTypeSpec(args[1]));
+      return symTerm(axiomDomainHasCategory(domain, category) ? "True" : "False");
+    }
+
     // Per-head dispatch table (arg-evaluated heads only — arithmetic /
     // comparison / logic / elementary-function / calculus; see
     // `HELD_HANDLERS` below for the three `HELD_HEADS` members, whose
@@ -4489,6 +4860,24 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // ported here as a thrown `TypeError` — matching this file's own
     // existing convention of throwing on a domain error no oracle case
     // can even construct (e.g. `divHandler`'s "division by zero" above).
+    //
+    // Axiom's own `:`-declared domain check (MA13 §3/§4) -- a small,
+    // disclosed addition to this otherwise fully shared handler, gated
+    // entirely on `axiomDeclaredDomains` (populated ONLY by
+    // `axiomDeclareHandler`, above). For every OTHER source language, and
+    // for any Axiom program with no prior `a : T` declaration for this
+    // name, that map has no entry for `lhs.name`, so the branch below is a
+    // single, cheap `Map.prototype.get` miss and `assignHandler` behaves
+    // EXACTLY as it did before this addition -- confirmed no other
+    // frontend in this repo ever calls `axiomDeclareHandler` (only
+    // `axiom-to-semantic-ir` emits `__axiom_declare`). This mirrors
+    // `axiom-runtime::eval_assignment`'s own identical design: that
+    // function ALSO consults a private `declared: HashMap<String,
+    // AxiomDomain>` table when handling what is otherwise the shared
+    // `:=` construct, and produces the exact same error text on failure
+    // (the book's own confirmed error shape, quoted verbatim in both
+    // places) -- a faithful port of that cross-construct behaviour, not a
+    // new mechanism invented for the compiled path.
     function assignHandler(head, args, depth) {
       if (args.length !== 2) { return applyTerm(head, args); }
       const [lhs, rhs] = args;
@@ -4497,6 +4886,18 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       }
       const value = evalTerm(rhs, depth + 1);
       if (isDepthLimitError(value)) { return value; }
+      const declaredDomain = axiomDeclaredDomains.get(lhs.name);
+      if (declaredDomain !== undefined) {
+        const coerced = axiomCoerceValue(value, declaredDomain);
+        if (coerced === null) {
+          throw new Error(
+            "Cannot convert right-hand side of assignment " + toDisplayString(value)
+            + " to an object of the type " + axiomDomainDisplayName(declaredDomain) + " of the left-hand side."
+          );
+        }
+        symEnv.set(lhs.name, coerced);
+        return coerced;
+      }
       symEnv.set(lhs.name, value);
       return value;
     }
@@ -4547,6 +4948,9 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       ["Assign", assignHandler],
       ["Define", defineHandler],
       ["If", ifHandler],
+      ["__axiom_declare", axiomDeclareHandler],
+      ["__axiom_coerce", axiomCoerceHandler],
+      ["__axiom_has", axiomHasHandler],
     ]);
 
     // `is_define_record`'s port: true iff `node` is a stored
@@ -6610,6 +7014,58 @@ mod tests {
         assert!(RUNTIME.contains("if (SIR_DISPLAY_J_UNDERSCORE) { return x < 0 ? \"_\" + body : body; }"));
         assert!(RUNTIME.contains("return x < 0 ? \"¯∞\" : \"∞\";"));
         assert!(RUNTIME.contains("return x < 0 ? \"¯\" + body : body;"));
+    }
+
+    // ── Axiom's own display convention + reserved-head handlers
+    // (MA13/Wave 7 close-out, `axiom-to-semantic-ir/tests/oracle.rs`) ────
+
+    #[test]
+    fn todisplaystring_gates_true_false_case_on_the_axiom_boolean_flag() {
+        // Regression guard: real Axiom's own session renders the shared
+        // True/False symbols lowercase; every other source language keeps
+        // the generic, unchanged capitalized spelling.
+        assert!(RUNTIME.contains("const SIR_DISPLAY_AXIOM_BOOLEAN = __SIR_DISPLAY_AXIOM_BOOLEAN__;"));
+        assert!(RUNTIME.contains(
+            "if (SIR_DISPLAY_AXIOM_BOOLEAN && (node.name === \"True\" || node.name === \"False\")) {"
+        ));
+        // The default (flag off) still returns the bare symbol name --
+        // confirming this is a narrow addition, not a replacement of the
+        // generic `"symbol"` case every other language relies on.
+        assert!(RUNTIME.contains("return node.name;"));
+    }
+
+    #[test]
+    fn axiom_reserved_heads_are_wired_into_the_held_dispatch_tables() {
+        // The three reserved SIR23 heads `axiom-to-semantic-ir::lower`
+        // defines locally (never added to shared `semantic-ir`/
+        // `symbolic-ir`) must be held (not argument-evaluated) AND have a
+        // real handler, not just fall through to the generic "rebuild an
+        // inert Apply" policy every OTHER unrecognised head gets.
+        for head in ["__axiom_declare", "__axiom_coerce", "__axiom_has"] {
+            assert!(
+                RUNTIME.contains(&format!("\"{head}\",")),
+                "HELD_HEADS must list `{head}`"
+            );
+        }
+        assert!(RUNTIME.contains("[\"__axiom_declare\", axiomDeclareHandler],"));
+        assert!(RUNTIME.contains("[\"__axiom_coerce\", axiomCoerceHandler],"));
+        assert!(RUNTIME.contains("[\"__axiom_has\", axiomHasHandler],"));
+        // The fixed domain/category table (MA13 §3/§4) — spot-check the
+        // two book-confirmed `has` examples' own membership arm, and that
+        // the coercion-failure message text matches `axiom-runtime`'s own
+        // verbatim.
+        assert!(RUNTIME.contains(
+            "return domain === \"Integer\" || domain === \"FractionInteger\" || domain === \"PolynomialInteger\";"
+        ));
+        assert!(RUNTIME.contains("\"Cannot convert \" + toDisplayString(value) + \" to an object of the type \""));
+        assert!(RUNTIME.contains(
+            "\"Cannot convert right-hand side of assignment \" + toDisplayString(value)"
+        ));
+        // `assignHandler`'s own small, disclosed cross-head addition:
+        // consults `axiomDeclaredDomains`, populated only by
+        // `axiomDeclareHandler` -- a no-op for every other source language.
+        assert!(RUNTIME.contains("const axiomDeclaredDomains = new Map();"));
+        assert!(RUNTIME.contains("const declaredDomain = axiomDeclaredDomains.get(lhs.name);"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_axiom.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_axiom.rs
@@ -24,6 +24,8 @@
 //! Node is optional at test time; when unavailable every test degrades to
 //! a no-op rather than failing (mirroring `sir23_symbolic.rs`).
 
+use std::fs::OpenOptions;
+use std::io::Write as _;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -165,7 +167,20 @@ fn run_module(module: &Module, tag: &str) -> Option<(bool, String, String)> {
     }
     let mut path: PathBuf = std::env::temp_dir();
     path.push(format!("sir_js_axiom_{}_{}.js", tag, std::process::id()));
-    std::fs::write(&path, &artifact.source).expect("write temp js");
+    // `create_new` (not `std::fs::write`) fails loudly on an existing path
+    // (including a symlink) instead of silently following/truncating
+    // through it -- matches `axiom-to-semantic-ir/tests/oracle.rs`'s/
+    // `tests/e2e_node.rs`'s own identical helper (security-review finding).
+    // Each test uses a unique tag+PID, so this should never legitimately
+    // collide.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes())
+        .expect("write temp js");
+    drop(file);
     let output = Command::new("node")
         .arg(&path)
         .output()

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_axiom.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_axiom.rs
@@ -1,0 +1,340 @@
+//! End-to-end integration tests for the Axiom reserved-head handlers
+//! (`__axiom_declare`/`__axiom_coerce`/`__axiom_has`) added to
+//! `semantic-ir-to-javascript`'s SIR23 evaluator (MA13/Wave 7 close-out —
+//! `code/specs/MA13-axiom-language.md`).
+//!
+//! Mirrors `tests/sir23_symbolic.rs`'s own hand-built-SIR-then-run-under-
+//! `node` pattern: these tests exercise the three new heads IN ISOLATION,
+//! with **no dependency on `axiom-to-semantic-ir` at all** (this crate has
+//! no such dependency today and should not gain one just for a test) —
+//! every `SymApply`/`SymSymbol` node below is hand-constructed to the exact
+//! shape `axiom-to-semantic-ir::lower` documents it emits (confirmed
+//! directly against that crate's own `src/lower.rs`: `__axiom_declare(List
+//! (name, ...), typeExpr)`, `__axiom_coerce(value, typeExpr)`,
+//! `__axiom_has(domainTypeExpr, categoryTypeExpr)`, and a bare/
+//! parameterized `type_expr` lowering to a plain `SymSymbol`/`SymApply` —
+//! the same shape an ordinary call already has).
+//!
+//! For the full oracle diff against `axiom-runtime` itself (native vs.
+//! compiled, real Axiom SOURCE text on both sides), see
+//! `axiom-to-semantic-ir/tests/oracle.rs` instead — this file's job is
+//! narrower: prove the three handlers here behave correctly for hand-fed
+//! SIR node shapes, independent of whichever frontend produces them.
+//!
+//! Node is optional at test time; when unavailable every test degrades to
+//! a no-op rather than failing (mirroring `sir23_symbolic.rs`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+};
+use semantic_ir_to_javascript::compile;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn sp() -> Span {
+    Span::synthetic()
+}
+
+fn sym(name: &str) -> Expr {
+    Expr::SymSymbol {
+        name: name.into(),
+        span: sp(),
+    }
+}
+
+fn sym_apply(head: Expr, args: Vec<Expr>) -> Expr {
+    Expr::SymApply {
+        head: Box::new(head),
+        args,
+        span: sp(),
+    }
+}
+
+fn int_lit(value: i64) -> Expr {
+    Expr::IntLit { value, span: sp() }
+}
+
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: sp(),
+    }
+}
+
+/// A statement that prints `arg`'s EVALUATED value — the harness-only
+/// observability pattern every sibling SIR23 oracle/integration test in
+/// this crate uses (`emit.rs`'s `pick_print_of_sym23_root` arm).
+fn print(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: bc("print", vec![arg]),
+        span: sp(),
+    }
+}
+
+/// A statement that evaluates `expr` for its side effects and discards the
+/// result — `emit.rs`'s `is_sym23_root_shape` arm wraps this in exactly
+/// one `evalTerm` call, same as `print` above minus the `console.log`.
+fn bare(expr: Expr) -> Stmt {
+    Stmt::ExprStmt { expr, span: sp() }
+}
+
+/// A `type_expr`-shaped term: a bare `NAME` lowers to `SymSymbol`, a
+/// parameterized `NAME(args...)` to `SymApply(SymSymbol(name), args)` —
+/// mirrors `axiom-to-semantic-ir::lower::Lowerer::lower_type_expr` exactly
+/// (see that function's own doc comment: "the exact same node shapes an
+/// ordinary call already produces").
+fn type_expr(name: &str, args: Vec<Expr>) -> Expr {
+    if args.is_empty() {
+        sym(name)
+    } else {
+        sym_apply(sym(name), args)
+    }
+}
+
+fn names_list(names: &[&str]) -> Expr {
+    sym_apply(sym("List"), names.iter().map(|n| sym(n)).collect())
+}
+
+fn declare(names: &[&str], ty: Expr) -> Expr {
+    sym_apply(sym("__axiom_declare"), vec![names_list(names), ty])
+}
+
+fn coerce(value: Expr, ty: Expr) -> Expr {
+    sym_apply(sym("__axiom_coerce"), vec![value, ty])
+}
+
+fn has(domain: Expr, category: Expr) -> Expr {
+    sym_apply(sym("__axiom_has"), vec![domain, category])
+}
+
+fn assign(name: &str, value: Expr) -> Expr {
+    sym_apply(sym("Assign"), vec![sym(name), value])
+}
+
+/// `source_language("axiom")` — so `SIR_DISPLAY_AXIOM_BOOLEAN` is exercised
+/// too (the shared `True`/`False` symbols must render lowercase here,
+/// unlike every other source language's own hand-built module in
+/// `sir23_symbolic.rs`, which uses `"handbuilt"` and gets the generic,
+/// capitalized spelling).
+fn module_with_main(stmts: Vec<Stmt>, value: Expr) -> Module {
+    Module {
+        name: "sir23_axiom".into(),
+        manifest: FeatureManifest::from_features(&[Feature::SymbolicExpr]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value,
+                span: sp(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: sp(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("axiom")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    }
+}
+
+/// Compile and run `module` under `node`, returning `(exit_success, stdout,
+/// stderr)`. `None` when `node` is unavailable (skip, don't fail).
+fn run_module(module: &Module, tag: &str) -> Option<(bool, String, String)> {
+    let artifact = compile(module).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_axiom_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node")
+        .arg(&path)
+        .output()
+        .expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    let stdout = String::from_utf8_lossy(&output.stdout)
+        .trim_end_matches(['\n', '\r'])
+        .to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    Some((output.status.success(), stdout, stderr))
+}
+
+// ---------------------------------------------------------------------------
+// __axiom_declare
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declare_resolves_and_returns_lowercase_true() {
+    let module = module_with_main(
+        vec![print(declare(&["a"], type_expr("PositiveInteger", vec![])))],
+        int_lit(0),
+    );
+    if let Some((ok, stdout, stderr)) = run_module(&module, "declare_true") {
+        assert!(ok, "node failed: {stderr}");
+        assert_eq!(stdout, "true");
+    }
+}
+
+#[test]
+fn declare_rejects_an_unknown_domain_name_with_the_books_error_shape() {
+    let module = module_with_main(
+        vec![print(declare(&["a"], type_expr("Matrix", vec![])))],
+        int_lit(0),
+    );
+    if let Some((ok, _stdout, stderr)) = run_module(&module, "declare_unknown_domain") {
+        assert!(
+            !ok,
+            "expected node to exit non-zero for an unresolvable domain name"
+        );
+        assert!(
+            stderr.contains("is not one of this cut's fixed built-in domains"),
+            "stderr: {stderr}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// __axiom_coerce
+// ---------------------------------------------------------------------------
+
+#[test]
+fn coerce_integer_to_fraction_integer_succeeds_unchanged() {
+    let module = module_with_main(
+        vec![print(coerce(
+            int_lit(3),
+            type_expr("Fraction", vec![type_expr("Integer", vec![])]),
+        ))],
+        int_lit(0),
+    );
+    if let Some((ok, stdout, stderr)) = run_module(&module, "coerce_fraction") {
+        assert!(ok, "node failed: {stderr}");
+        assert_eq!(stdout, "3");
+    }
+}
+
+#[test]
+fn coerce_a_negative_integer_to_positive_integer_fails_with_the_books_error_shape() {
+    let module = module_with_main(
+        vec![print(coerce(int_lit(-1), type_expr("PositiveInteger", vec![])))],
+        int_lit(0),
+    );
+    if let Some((ok, _stdout, stderr)) = run_module(&module, "coerce_fail") {
+        assert!(!ok, "expected node to exit non-zero for a failed coercion");
+        assert!(
+            stderr.contains("Cannot convert -1 to an object of the type PositiveInteger."),
+            "stderr: {stderr}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// __axiom_has
+// ---------------------------------------------------------------------------
+
+#[test]
+fn has_query_polynomial_integer_ring_is_true_the_books_own_confirmed_example() {
+    let module = module_with_main(
+        vec![print(has(
+            type_expr("Polynomial", vec![type_expr("Integer", vec![])]),
+            type_expr("Ring", vec![]),
+        ))],
+        int_lit(0),
+    );
+    if let Some((ok, stdout, stderr)) = run_module(&module, "has_true") {
+        assert!(ok, "node failed: {stderr}");
+        assert_eq!(stdout, "true");
+    }
+}
+
+#[test]
+fn has_query_list_integer_ring_is_false_the_books_own_confirmed_example() {
+    let module = module_with_main(
+        vec![print(has(
+            type_expr("List", vec![type_expr("Integer", vec![])]),
+            type_expr("Ring", vec![]),
+        ))],
+        int_lit(0),
+    );
+    if let Some((ok, stdout, stderr)) = run_module(&module, "has_false") {
+        assert!(ok, "node failed: {stderr}");
+        assert_eq!(stdout, "false");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Declare + Assign interaction (`assignHandler`'s own small, disclosed
+// addition — see `runtime.rs`'s comment on that function).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declare_then_matching_assignment_succeeds_and_binds() {
+    let module = module_with_main(
+        vec![
+            bare(declare(&["a"], type_expr("PositiveInteger", vec![]))),
+            bare(assign("a", int_lit(5))),
+            print(sym_apply(sym("Add"), vec![sym("a"), int_lit(1)])),
+        ],
+        int_lit(0),
+    );
+    if let Some((ok, stdout, stderr)) = run_module(&module, "declare_then_assign_ok") {
+        assert!(ok, "node failed: {stderr}");
+        assert_eq!(stdout, "6");
+    }
+}
+
+#[test]
+fn declare_then_mismatched_assignment_fails_with_the_books_error_shape() {
+    let module = module_with_main(
+        vec![
+            bare(declare(&["a"], type_expr("PositiveInteger", vec![]))),
+            print(assign("a", int_lit(-1))),
+        ],
+        int_lit(0),
+    );
+    if let Some((ok, _stdout, stderr)) = run_module(&module, "declare_then_assign_fail") {
+        assert!(
+            !ok,
+            "expected node to exit non-zero for a declared-domain mismatch"
+        );
+        assert!(
+            stderr.contains(
+                "Cannot convert right-hand side of assignment -1 to an object of the type \
+                 PositiveInteger of the left-hand side."
+            ),
+            "stderr: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn assign_without_a_prior_declaration_is_unrestricted() {
+    // Confirms `axiomDeclaredDomains`'s lookup is a genuine no-op absent a
+    // `__axiom_declare` call for this name -- `Assign`'s ordinary behaviour
+    // is completely unaffected (regression guard for the narrowness of the
+    // `assignHandler` addition every OTHER SIR23 frontend's own `:=`/`=`/
+    // `:` also routes through).
+    let module = module_with_main(vec![print(assign("z", int_lit(-5)))], int_lit(0));
+    if let Some((ok, stdout, stderr)) = run_module(&module, "assign_unrestricted") {
+        assert!(ok, "node failed: {stderr}");
+        assert_eq!(stdout, "-5");
+    }
+}

--- a/code/specs/HML00-historical-math-languages-roadmap.md
+++ b/code/specs/HML00-historical-math-languages-roadmap.md
@@ -212,7 +212,7 @@ sequence of one-PR items run through the autonomous loop (§8).
   level rather than reusing `matlab-runtime` as a crate dependency the way
   `octave-runtime` does.)*
 - **Wave 7 — Axiom, Julia (subset).** The research-grade lifts (typed CAS;
-  multiple dispatch) — last, and only if warranted. *(Kickoff: see
+  multiple dispatch) — last, and only if warranted. *(Axiom delivered: see
   [`MA13`](MA13-axiom-language.md) for Axiom, Wave 7's first language — verified
   directly against the original 1992 Jenks & Sutor Axiom book (via its
   FriCAS-hosted, continuously-regenerated adaptation, since the language
@@ -231,7 +231,14 @@ sequence of one-PR items run through the autonomous loop (§8).
   book's own Chapters-0/1/2/5/6-vs-Chapters-11-13 structural split — deferring
   whole the *library-language, producer* view (user-defined categories/
   domains/packages via `Join` and conditional exports) that is Axiom's actual
-  reason for existing, exactly as MA11 deferred Q's own tables.)*
+  reason for existing, exactly as MA11 deferred Q's own tables. Axiom's full
+  pipeline — `axiom-lexer`, `axiom-parser`, `axiom-runtime`/`axiom-repl`,
+  `axiom-to-semantic-ir`, and a real oracle-test diff against
+  `semantic-ir-to-javascript` (`:`/`::`/`has` now genuinely evaluate on the
+  compiled path too, not just the native one) — has since landed; see
+  [`HML01`](HML01-math-to-semantic-ir.md) §5's own "A SIXTH Stream B
+  frontend" writeup for the full account. Julia remains Wave 7's one
+  not-yet-started language.)*
 
 ### Item breakdown for the first three waves (illustrative)
 

--- a/code/specs/HML01-math-to-semantic-ir.md
+++ b/code/specs/HML01-math-to-semantic-ir.md
@@ -496,6 +496,50 @@ Macsyma's own `tests/oracle.rs` were the last open item and are done as
 of those two crates landing. All items through JS/TS backend codegen are
 shipped.
 
+**A SIXTH Stream B frontend, Axiom (MA13, HML00 §7 Wave 7), landed after
+this stream's original five and closes out with its own oracle diff too**
+— see `axiom-to-semantic-ir/tests/oracle.rs`, its own 29-case corpus
+cross-checking `axiom-runtime`, 28 of 29 cases `known_bug: None`, against
+the compiled-JS-via-`node` path. Axiom is the one CAS-family language in
+this repo whose own claim to fame — a fixed, non-extensible domain/category
+type system (`:` declares, `::` coerces, `has` queries category
+membership, MA13 §2/§3) — has no analogue in Wolfram/Macsyma/Derive/
+Reduce/Maple, none of which carry any domain/type concept at all
+(`symbolic_ir::IRNode` confirmed to have no such field anywhere, MA13 §2's
+own central finding). `axiom-to-semantic-ir` (MA-13e, #9181) lowers `:`/
+`::`/`has` as ordinary `SymApply` nodes under three new, locally-defined
+reserved head names (`__axiom_declare`/`__axiom_coerce`/`__axiom_has`,
+never added to shared `semantic-ir`/`symbolic-ir`) — the same "new
+construct, no shared-crate change" pattern `reduce-to-semantic-ir`'s
+`CompoundExpression` and `maple-to-semantic-ir`'s `Set` already
+established — but, unlike those two (which shipped with no runtime
+evaluator and remain that way), this stream's own close-out task wired a
+REAL evaluator for all three heads directly into
+`semantic-ir-to-javascript`'s shared `Symbolic.evalTerm` dispatch
+(`axiomDeclareHandler`/`axiomCoerceHandler`/`axiomHasHandler`, a JS-side
+port of `axiom-runtime::domains`'s fixed `AxiomDomain`/`AxiomCategory`
+table, plus a sixth, narrow `SIR_DISPLAY_AXIOM_BOOLEAN` display flag —
+see that crate's own `CHANGELOG.md` `0.51.6` entry). Confirmed
+end-to-end: a passing AND a failing `:` declaration, a passing AND a
+failing `::` coercion (byte-for-byte identical error text on both paths
+for every atomic operand tested), and the book's own two confirmed `has`
+examples (`Polynomial(Integer) has Ring` → `true`,
+`List(Integer) has Ring` → `false`). The one `known_bug` case reconfirms
+finding five/three's own already-documented class of gap (no
+`SIR_DISPLAY_AXIOM` infix/bracket convention for a COMPOUND, non-boolean
+value) rather than discovering a new one. Because `axiom.grammar`'s own
+`program = expr` design (MA13 §5) means every compiled program is exactly
+ONE top-level statement — even a `;`-block, which lowers to a single
+`SymApply(CompoundExpression, [...])` node with no evaluator of its own
+(the same pre-existing, shared gap `reduce-to-semantic-ir/tests/
+oracle.rs`'s own "finding three" already disclosed) — this oracle file
+also introduces its own harness-only `wrap_axiom_top_level_for_observation`
+helper (test-local, no change to `semantic-ir-to-javascript` itself) that
+unrolls a top-level `CompoundExpression` into N statements, printing only
+the last, so block-based corpus entries (declare-then-assign,
+define-then-call) still get a real value comparison instead of needing
+`known_bug` for an unrelated, already-documented gap.
+
 The streams touch disjoint crates except `semantic-ir` core and the two JS
 backends — a short serialization point, not a merge of the whole effort.
 Each item is one PR, following the repo's established one-PR-per-item
@@ -517,12 +561,15 @@ simultaneously, rotating rather than exhausting one before starting another:
    surface, Macsyma's remaining gaps (general multivariate factoring,
    Frobenius ODEs, hypergeometric summation, TS/Rust `Apart` port).
 2. **New math-language additions** — HML00 Wave 4+ has now shipped APL, J,
-   K/Q (as `q-to-semantic-ir`), Scilab, IDL, Reduce, Derive, and Maple —
-   every language this bullet originally tracked except Axiom and Julia,
-   neither of which has a crate or spec anywhere in this repo yet
-   (confirmed: no `axiom-*`/`julia-*` crate under `code/packages/rust/`
-   and no `axiom`/`julia` spec under `code/specs/`). Axiom and Julia
-   remain the two genuinely not-yet-started items on this front.
+   K/Q (as `q-to-semantic-ir`), Scilab, IDL, Reduce, Derive, and Maple, and
+   HML00 §7 Wave 7 has now shipped **Axiom** too (MA13 — kickoff spec
+   #8990, `axiom-lexer` #8997, `axiom-parser` #9022, `axiom-runtime`/
+   `axiom-repl` #9055, `axiom-to-semantic-ir` #9181, oracle tests +
+   `:`/`::`/`has` JS-runtime wiring closing out Wave 7 — see §5's own new
+   "A SIXTH Stream B frontend" paragraph). **Julia remains the one
+   genuinely not-yet-started item** on this front (confirmed: no
+   `julia-*` crate under `code/packages/rust/` and no `julia` spec under
+   `code/specs/`).
 3. **This track (Semantic IR compilation).**
 
 A reasonable cadence: land one PR-sized unit here, then pick up one item from


### PR DESCRIPTION
## Summary

This is Wave 7's Axiom close-out — the sixth Stream B (CAS-family) frontend
in the SIR23 rollout, completing the pipeline all five prior merged Axiom
PRs built:

1. #8990 — `MA13-axiom-language.md` design-only kickoff spec
2. #8997 — `axiom-lexer`
3. #9022 — `axiom-parser`
4. #9055 — `axiom-runtime` + `axiom-repl`
5. #9181 — `axiom-to-semantic-ir` (SIR23 lowering; explicitly deferred the
   JS-runtime evaluator for `:`/`::`/`has` to this follow-on task)

**Task 1 — wire `__axiom_declare`/`__axiom_coerce`/`__axiom_has` into the JS
runtime.** Confirmed directly (not assumed) that the SIR23 symbolic-domain
evaluator every CAS-family language depends on lives inline in
`semantic-ir-to-javascript/src/runtime.rs`'s own `Symbolic.evalTerm`
dispatch (`HELD_HEADS`/`HANDLERS`/`HELD_HANDLERS`), **not** in the separate,
evaluator-less `sir-runtime-symbolic` npm package. Added:

- A JS-side port of `axiom-runtime::domains`'s fixed, non-extensible
  `AxiomDomain`/`AxiomCategory` table, with every error message copied
  verbatim from the Rust reference.
- `axiomDeclareHandler`/`axiomCoerceHandler`/`axiomHasHandler`, registered
  in `HELD_HEADS`/`HELD_HANDLERS` alongside the existing `Assign`/`Define`/
  `If`.
- A small, disclosed addition to the shared `assignHandler`: it now
  consults a new `axiomDeclaredDomains` map (populated only by
  `axiomDeclareHandler`) so a `:`-declared domain constraint is enforced
  against a later `:=` — a faithful port of `axiom-runtime::
  eval_assignment`'s own identical cross-construct design, and a no-op for
  every other source language.
- A sixth, narrow `SIR_DISPLAY_AXIOM_BOOLEAN` display flag (much smaller
  than Derive's whole precedence-aware printer) so the shared True/False
  symbols render Axiom's own lowercase convention.
- `semantic-ir-to-typescript` needs **no** change: confirmed it imports the
  published `@coding-adventures/sir-runtime-symbolic` package rather than
  embedding its own evaluator copy, and that package has no evaluator for
  any reserved head today (same as `Set`/`CompoundExpression`/etc.) — so
  there is nothing to wire there.
- Own unit tests: `tests/sir23_axiom.rs` (9 tests, hand-built SIR run
  through `node`, no dependency on `axiom-to-semantic-ir`).

**Task 2 — oracle/golden tests.** `axiom-to-semantic-ir/tests/oracle.rs`
(29 cases, 28 `known_bug: None`), modeled on `macsyma-to-semantic-ir`'s/
`wolfram-to-semantic-ir`'s own oracle files. Runs the same Axiom source
through (a) `axiom-runtime` (native) and (b) `axiom-to-semantic-ir` →
`semantic-ir-to-javascript` → an actual `node` subprocess (compiled),
diffed. Covers arithmetic precedence/associativity/right-associative `^`,
every comparison, `:=`, both `==` function-definition forms and both call
forms (`f(a,b)` and paren-optional `f a`), `if`/`then`/`else`, a `;`-block,
a passing **and** a failing `:` declaration, a passing **and** a failing
`::` coercion, and the book's own two confirmed `has` examples
(`Polynomial(Integer) has Ring` → `true`, `List(Integer) has Ring` →
`false`).

Because `axiom.grammar`'s own `program = expr` design means every compiled
program is exactly one top-level statement (even a `;`-block, which lowers
to a single `SymApply(CompoundExpression, [...])` node with no evaluator on
either side — a pre-existing, already-disclosed gap,
`reduce-to-semantic-ir/tests/oracle.rs`'s own "finding three"), the oracle
harness includes a test-local `wrap_axiom_top_level_for_observation` helper
that unrolls a top-level `CompoundExpression` into N statements and prints
only the last — so block-based cases (declare-then-assign, define-then-call)
still get a real value comparison instead of needing `known_bug` for an
unrelated gap. This never touches `semantic-ir-to-javascript` itself.

## Disclosed native-vs-compiled differences

- **List display (the one `known_bug` case).** `[1 + 1, 2*3]` evaluates
  identically on both sides (`[2, 6]`), but the compiled side's generic
  `Symbolic.toDisplayString` prints `"List(2, 6)"`, never Axiom's own
  bracket surface — no `SIR_DISPLAY_AXIOM` infix/bracket convention exists
  (only the minimal boolean-case flag this PR adds). Same "finding
  five"/"finding three" class of gap every CAS-family language without a
  full `SIR_DISPLAY_<LANG>` printer already has (Wolfram, Macsyma).
- **Coercion/declaration error text for a COMPOUND operand** would also hit
  this same display gap (the error message embeds the rendered value) —
  every failing corpus case here deliberately uses an atomic operand
  (`-1`) to get byte-identical text on both sides; this is disclosed in
  `runtime.rs`'s own comments, not silently avoided.

## Test plan

- [x] `cargo test` — `semantic-ir-to-javascript`: 284 tests, 0 failed.
- [x] `cargo test` — `axiom-to-semantic-ir`: 127 tests, 0 failed (includes
      the new 29-case `tests/oracle.rs`, which genuinely invokes `node` as
      a subprocess — verified `node --version` succeeds and the corpus's
      own `known_bug` skip message prints on the one expected exception).
- [x] Downstream consumers of the shared `semantic-ir-to-javascript`
      runtime re-run and green: `derive-to-semantic-ir`,
      `reduce-to-semantic-ir`, `macsyma-to-semantic-ir`,
      `wolfram-to-semantic-ir`, `maple-to-semantic-ir`, `apl-to-semantic-ir`,
      `j-to-semantic-ir`, `q-to-semantic-ir`, `idl-to-semantic-ir`,
      `sir-conformance`.
- [x] Repo build-tool (`-diff-base origin/main -clippy`): all 11 affected
      packages `BUILT` (clippy + tests), 0 failed.
- [x] `code/specs/HML01-math-to-semantic-ir.md` §5/§6 and
      `code/specs/HML00-historical-math-languages-roadmap.md` updated to
      record Axiom's completed pipeline.
- [x] `/security-review`: round 1 found MEDIUM (missing recursion-depth
      guard on 5 new JS functions) + LOW (test-only symlink-following temp
      file) — both fixed in a separate commit; round 2 passed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
