### PR TITLE
feat(spice): validate MOS depletion coefficient

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject Level-1 MOS model-card `FC` values outside `[0, 1)` or non-finite
+  values with a stable diagnostic before depletion-capacitance shaping.
 - Reject negative or non-finite Level-1 MOS model-card `MJ` values with a
   stable diagnostic before depletion-capacitance shaping.
 - Reject non-positive or non-finite Level-1 MOS model-card `PB` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -592,6 +592,10 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET PB must be finite and positive")
         elif canonical == "MJ" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET MJ must be finite and non-negative")
+        elif canonical == "FC" and (
+            not math.isfinite(value) or value < 0.0 or value >= 1.0
+        ):
+            raise ValueError(f"{name}: MOSFET FC must be finite and in [0, 1)")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1122,6 +1122,18 @@ def test_mos_model_card_rejects_negative_or_non_finite_junction_grading_coeffici
             normalize_model_card("Minvalid", "nmos", {"MJ": invalid_coefficient})
 
 
+def test_mos_model_card_rejects_out_of_range_or_non_finite_depletion_coefficient() -> None:
+    for value in (0.0, 0.5, 0.999):
+        valid = normalize_model_card("Mvalid", "nmos", {"FC": value})
+        assert valid.parameters["FC"] == pytest.approx(value)
+
+    for invalid_coefficient in (-math.inf, -0.1, 1.0, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match=r"MOSFET FC must be finite and in \[0, 1\)"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"FC": invalid_coefficient})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject Level-1 MOS model-card `FC` values outside `[0, 1)` or non-finite
+  values with a stable diagnostic before depletion-capacitance shaping.
 - Reject negative or non-finite Level-1 MOS model-card `MJ` values with a
   stable diagnostic before depletion-capacitance shaping.
 - Reject non-positive or non-finite Level-1 MOS model-card `PB` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4410,6 +4410,13 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET MJ must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "FC"
+                && (!raw_value.is_finite() || !(0.0..1.0).contains(raw_value))
+            {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET FC must be finite and in [0, 1)".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -959,6 +959,22 @@ fn mos_model_card_rejects_negative_or_non_finite_junction_grading_coefficient() 
 }
 
 #[test]
+fn mos_model_card_rejects_out_of_range_or_non_finite_depletion_coefficient() {
+    for value in [0.0, 0.5, 0.999] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("FC", value)]).unwrap();
+        assert_close(*valid.parameters.get("FC").unwrap(), value);
+    }
+
+    for invalid_coefficient in [f64::NEG_INFINITY, -0.1, 1.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("FC", invalid_coefficient)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET FC must be finite and in [0, 1)"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject Level-1 MOS model-card `FC` values outside `[0, 1)` or non-finite
+  values with a stable diagnostic before depletion-capacitance shaping.
 - Reject negative or non-finite Level-1 MOS model-card `MJ` values with a
   stable diagnostic before depletion-capacitance shaping.
 - Reject non-positive or non-finite Level-1 MOS model-card `PB` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8466,6 +8466,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0)
     ) {
       throw invalidElement(name, "MOSFET MJ must be finite and non-negative");
+    } else if (
+      canonical === "FC" &&
+      (!Number.isFinite(value) || value < 0.0 || value >= 1.0)
+    ) {
+      throw invalidElement(name, "MOSFET FC must be finite and in [0, 1)");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -844,6 +844,25 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects out-of-range or non-finite MOS depletion coefficient", () => {
+    for (const value of [0.0, 0.5, 0.999]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { FC: value });
+      expect(valid.parameters.FC).toBe(value);
+    }
+
+    for (const invalidCoefficient of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      1.0,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { FC: invalidCoefficient }),
+      ).toThrow("MOSFET FC must be finite and in [0, 1)");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS junction-grading validation.
+1. Cross-language Level-1 MOS depletion-coefficient validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `MJ` values before
+   - Reject model-card `FC` values outside `[0, 1)` or non-finite values before
      depletion-capacitance shaping.
-   - Preserve zero and positive junction-grading coefficients across Rust,
-     Python, and TypeScript.
+   - Preserve finite forward-bias depletion coefficients in `[0, 1)` across
+     Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3713,6 +3713,13 @@ the Rust, Python, and TypeScript surfaces together.
      depletion and temperature preprocessing.
    - Positive explicit bulk-junction potentials remain aligned across Rust,
      Python, and TypeScript.
+
+305. Cross-language Level-1 MOS junction-grading validation.
+   - Status: completed in PR 9281.
+   - Negative and non-finite model-card `MJ` values are rejected before
+     depletion-capacitance shaping.
+   - Zero and positive junction-grading coefficients remain aligned across
+     Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-finite Level-1 MOS `FC` values and values outside `[0, 1)` before depletion-capacitance shaping
- preserve valid forward-bias depletion coefficients with aligned Rust, Python, and TypeScript diagnostics
- reconcile the SPICE completion plan by recording PR #9281 and selecting this slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check` for spice-engine source and tests
- Python full spice-engine pytest: 687 passed, 88.96% coverage
- TypeScript `npm test`: 430 passed
- TypeScript `npm run build`