### PR TITLE
Enable ALGOL proper procedures on the IIR chain

### DIFF
--- a/code/packages/rust/algol-iir-compiler/README.md
+++ b/code/packages/rust/algol-iir-compiler/README.md
@@ -111,10 +111,13 @@ out-of-range subscript traps at run time. The five code-gen backends don't lower
 the array ops yet; see the `E5-*` follow-ups in
 `code/specs/LANG-FULL-IMPLEMENTATION.md`.
 
-Unsupported ALGOL 60 features — **multidimensional** and non-numeric arrays,
-arrays as procedure parameters, dynamic string variables/arrays, proper (void)
-procedures, by-name (non-`value`) parameters, parameterless-procedure calls (a
-bare name parses as a variable), enclosing-block **array** capture (only scalars
-are globalised so far), and conditional/nested switch-list elements — return
-explicit compiler
-errors.
+Proper procedures now lower as side-effecting IIR `void` functions when called
+in statement position. They can write enclosing scalar globals and use the same
+literal-backed output path as typed procedures; using a proper procedure in
+value position is a clean type error because it has no return value.
+
+Unsupported ALGOL 60 features — non-numeric arrays, arrays as procedure
+parameters, dynamic string variables/arrays, by-name (non-`value`) parameters,
+parameterless-procedure calls (a bare name parses as a variable),
+enclosing-block **array** capture (only scalars are globalised so far), and
+conditional/nested switch-list elements — return explicit compiler errors.

--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -209,8 +209,9 @@ struct ArrayInfo {
 }
 
 /// A procedure heading read off the AST: `(name, value-params, return-type)`,
-/// where each value parameter is `(name, type)` in declaration order.
-type ProcedureParts = (String, Vec<(String, ScalarType)>, ScalarType);
+/// where each value parameter is `(name, type)` in declaration order. A missing
+/// return type is an ALGOL proper procedure.
+type ProcedureParts = (String, Vec<(String, ScalarType)>, Option<ScalarType>);
 
 /// The compile-time signature of a procedure: the ordered types of its
 /// value parameters plus its return type.
@@ -222,18 +223,15 @@ type ProcedureParts = (String, Vec<(String, ScalarType)>, ScalarType);
 /// looks the name up here to know (a) how many arguments to evaluate,
 /// (b) what type each argument must be, and (c) what type the call yields.
 ///
-/// We deliberately only model **typed** procedures (ALGOL "function
-/// procedures") with **value** parameters.  A proper (void) procedure has
-/// no observable effect on the current executable slice — there is no
-/// output statement and no by-reference / enclosing-scope mutation yet —
-/// so admitting one would be lowering code no test could ever witness.
-/// Those are rejected with a clear message and tracked as follow-up work.
+/// We model typed procedures (ALGOL "function procedures") as value-producing
+/// calls and proper procedures as void functions usable only in statement
+/// position. Parameters are still restricted to `value` parameters.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ProcSig {
     /// Parameter types in declaration order (matches `IIRFunction::params`).
     params: Vec<ScalarType>,
-    /// The procedure's return type (always `Some` on the supported slice).
-    ret: ScalarType,
+    /// The procedure's return type, or `None` for a proper procedure.
+    ret: Option<ScalarType>,
 }
 
 #[derive(Debug, Clone)]
@@ -318,6 +316,16 @@ impl Compiler {
                 return Err(CompileError::Unsupported(
                     "string result variables as main return values".into(),
                 ));
+            }
+            Some(binding) if binding.is_global => {
+                let dest = self.fresh_temp();
+                self.emit(IIRInstr::new(
+                    "global_load",
+                    Some(dest.clone()),
+                    vec![Operand::Str(binding.slot)],
+                    binding.ty.iir(),
+                ));
+                (binding.ty.iir(), Operand::Var(dest))
             }
             Some(binding) => (binding.ty.iir(), Operand::Var(binding.slot)),
             None => {
@@ -860,9 +868,9 @@ impl Compiler {
     /// * each `spec_part` declares the *type* of one or more parameters.
     ///
     /// On the supported slice every parameter must be a `value` parameter
-    /// (call-by-name / Jensen's device is not modelled), the procedure must
-    /// have a return type (proper/void procedures are inert here), and every
-    /// parameter must be specified exactly once.
+    /// (call-by-name / Jensen's device is not modelled), and every parameter
+    /// must be specified exactly once. A missing heading type is a proper
+    /// procedure and lowers to an IIR `void` function.
     fn procedure_parts(
         &self,
         proc_decl: &GrammarASTNode,
@@ -873,15 +881,9 @@ impl Compiler {
             .map(|t| t.value.clone())
             .ok_or_else(|| CompileError::Malformed("procedure_decl missing name".into()))?;
 
-        let ret = match first_direct_node(proc_decl, "type") {
-            Some(type_node) => self.scalar_type(type_node)?,
-            None => {
-                return Err(CompileError::Unsupported(format!(
-                    "proper (void) procedure {name:?}: only typed procedures with a return \
-                     value are observable on the current ALGOL slice"
-                )))
-            }
-        };
+        let ret = first_direct_node(proc_decl, "type")
+            .map(|type_node| self.scalar_type(type_node))
+            .transpose()?;
         // E4-dyn payoff (E4d-AL): `string procedure`s are now supported. The
         // result variable (the procedure name) holds a runtime string handle,
         // which every backend can carry and `print` since the E4-dyn foothold
@@ -1008,7 +1010,8 @@ impl Compiler {
             }
         }
 
-        // Bind value parameters and the result variable (the procedure name).
+        // Bind value parameters and, for typed procedures, the result variable
+        // (the procedure name).
         let mut param_pairs: Vec<(String, String)> = Vec::with_capacity(params.len());
         for (pname, pty) in &params {
             // Parameters and the result slot are real registers, never `own`.
@@ -1023,30 +1026,35 @@ impl Compiler {
             }
             param_pairs.push((slot, pty.iir().to_string()));
         }
-        // The procedure's name is an in-scope variable holding the return
-        // value; seed it with a default so a path that never assigns it still
-        // returns a defined value.
-        let result_slot = self.declare_var(&name, ret, false)?;
-        if ret == ScalarType::String {
-            // A string result is a runtime handle, so its default must be a real
-            // (empty) string buffer, not a `const 0`. Seed it with `str_const ""`
-            // — the same shape a literal assignment produces — and mark it
-            // literal-backed so an unassigned path still yields a printable value.
-            self.emit(IIRInstr::new(
-                "str_const",
-                Some(result_slot.clone()),
-                vec![Operand::Str(String::new())],
-                "str",
-            ));
-            self.literal_string_slots.insert(result_slot.clone());
+        let result_slot = if let Some(ret) = ret {
+            // The procedure's name is an in-scope variable holding the return
+            // value; seed it with a default so a path that never assigns it
+            // still returns a defined value.
+            let result_slot = self.declare_var(&name, ret, false)?;
+            if ret == ScalarType::String {
+                // A string result is a runtime handle, so its default must be a real
+                // (empty) string buffer, not a `const 0`. Seed it with `str_const ""`
+                // — the same shape a literal assignment produces — and mark it
+                // literal-backed so an unassigned path still yields a printable value.
+                self.emit(IIRInstr::new(
+                    "str_const",
+                    Some(result_slot.clone()),
+                    vec![Operand::Str(String::new())],
+                    "str",
+                ));
+                self.literal_string_slots.insert(result_slot.clone());
+            } else {
+                self.emit(IIRInstr::new(
+                    "const",
+                    Some(result_slot.clone()),
+                    vec![ret.default_operand()],
+                    ret.iir(),
+                ));
+            }
+            Some(result_slot)
         } else {
-            self.emit(IIRInstr::new(
-                "const",
-                Some(result_slot.clone()),
-                vec![ret.default_operand()],
-                ret.iir(),
-            ));
-        }
+            None
+        };
 
         // ── lower the body ───────────────────────────────────────────────
         let body = first_direct_node(proc_decl, "proc_body")
@@ -1075,17 +1083,23 @@ impl Compiler {
             }
         }
 
-        self.emit(IIRInstr::new(
-            "ret",
-            None,
-            vec![Operand::Var(result_slot)],
-            ret.iir(),
-        ));
+        let return_type = if let (Some(ret), Some(result_slot)) = (ret, result_slot) {
+            self.emit(IIRInstr::new(
+                "ret",
+                None,
+                vec![Operand::Var(result_slot)],
+                ret.iir(),
+            ));
+            ret.iir()
+        } else {
+            self.emit(IIRInstr::new("ret_void", None, vec![], "void"));
+            "void"
+        };
 
         // ── assemble the function and restore the caller's context ───────
         let body_instrs = std::mem::take(&mut self.instrs);
         let body_len = body_instrs.len();
-        let mut func = IIRFunction::new(name, param_pairs, ret.iir(), body_instrs);
+        let mut func = IIRFunction::new(name, param_pairs, return_type, body_instrs);
         func.type_status = FunctionTypeStatus::FullyTyped;
         func.register_count = self.register_names.len().saturating_add(8).max(8);
         let mut sm = std::mem::take(&mut self.source_map);
@@ -1111,12 +1125,14 @@ impl Compiler {
     /// slot that holds the result.  Used from `emit_expr`.
     fn emit_proc_call(&mut self, node: &GrammarASTNode) -> Result<ExprValue, CompileError> {
         self.set_loc(node);
-        let dest = self.emit_call_common(node)?;
-        Ok(dest)
+        self.emit_call_common(node, true)?.ok_or_else(|| {
+            CompileError::Type("proper procedure call has no return value".into())
+        })
     }
 
-    /// Lower a procedure *call* in statement position (`bump(3)`).  The
-    /// returned value is computed but discarded.
+    /// Lower a procedure *call* in statement position (`bump(3)`).  A typed
+    /// procedure's returned value is computed but discarded; a proper procedure
+    /// emits a void call with no destination.
     fn emit_proc_stmt(&mut self, node: &GrammarASTNode) -> Result<(), CompileError> {
         self.set_loc(node);
         let name = direct_tokens(node)
@@ -1127,7 +1143,7 @@ impl Compiler {
         if self.try_emit_standard_output_stmt(&name, node)? {
             return Ok(());
         }
-        self.emit_call_common(node)?;
+        self.emit_call_common(node, false)?;
         Ok(())
     }
 
@@ -1222,7 +1238,11 @@ impl Compiler {
     /// whose `srcs[0]` names the callee and whose remaining `srcs` are the
     /// argument slots, matching the IIR calling convention every backend
     /// understands.
-    fn emit_call_common(&mut self, node: &GrammarASTNode) -> Result<ExprValue, CompileError> {
+    fn emit_call_common(
+        &mut self,
+        node: &GrammarASTNode,
+        require_value: bool,
+    ) -> Result<Option<ExprValue>, CompileError> {
         let name = direct_tokens(node)
             .into_iter()
             .find(|t| t.effective_type_name() == "NAME")
@@ -1239,7 +1259,7 @@ impl Compiler {
             Some(sig) => sig,
             None => {
                 if let Some(result) = self.try_emit_standard_function(&name, node)? {
-                    return Ok(result);
+                    return Ok(Some(result));
                 }
                 return Err(CompileError::Type(format!(
                     "call to undeclared procedure {name:?}"
@@ -1275,19 +1295,23 @@ impl Compiler {
             arg_slots.push(value.slot);
         }
 
-        let dest = self.fresh_temp();
+        if require_value && sig.ret.is_none() {
+            return Err(CompileError::Type(format!(
+                "proper procedure {name:?} has no return value"
+            )));
+        }
+
+        let (dest, type_hint) = match sig.ret {
+            Some(ret) => (Some(self.fresh_temp()), ret.iir()),
+            None => (None, "void"),
+        };
         let mut srcs = Vec::with_capacity(arg_slots.len() + 1);
         srcs.push(Operand::Var(name));
         srcs.extend(arg_slots.into_iter().map(Operand::Var));
-        self.emit(IIRInstr::new(
-            "call",
-            Some(dest.clone()),
-            srcs,
-            sig.ret.iir(),
-        ));
-        Ok(ExprValue {
-            slot: dest,
-            ty: sig.ret,
+        self.emit(IIRInstr::new("call", dest.clone(), srcs, type_hint));
+        Ok(match (dest, sig.ret) {
+            (Some(slot), Some(ty)) => Some(ExprValue { slot, ty }),
+            _ => None,
         })
     }
 
@@ -4501,7 +4525,7 @@ mod tests {
         assert_eq!(main.type_status, FunctionTypeStatus::FullyTyped);
     }
 
-    // ---- AL3: typed procedures with value parameters ----
+    // ---- AL3: procedures with value parameters ----
 
     #[test]
     fn compiles_and_runs_value_procedure() {
@@ -4567,13 +4591,47 @@ mod tests {
     }
 
     #[test]
-    fn rejects_void_procedure_cleanly() {
+    fn proper_procedure_statement_mutates_enclosing_scalar() {
+        let src = "begin integer result; procedure bump(d); value d; integer d; \
+                   result := result + d; result := 40; bump(2) end";
+        assert_eq!(run_i64(src), 42);
+    }
+
+    #[test]
+    fn proper_procedure_emits_void_function_and_no_dest_call() {
+        let module = compile_source(
+            "begin integer result; procedure bump(d); value d; integer d; \
+             result := result + d; result := 40; bump(2) end",
+            "proper_proc",
+        )
+        .expect("proper procedure should compile");
+        let bump = module
+            .get_function("bump")
+            .expect("bump is a sibling function");
+        assert_eq!(bump.params, vec![("d".to_string(), "i64".to_string())]);
+        assert_eq!(bump.return_type, "void");
+        assert!(bump.instructions.iter().any(|i| i.op == "ret_void"));
+
+        let main = module.get_function("main").expect("main exists");
+        let call = main
+            .instructions
+            .iter()
+            .find(|i| i.op == "call")
+            .expect("main calls bump");
+        assert!(call.dest.is_none(), "proper procedure calls have no dest");
+        assert_eq!(call.type_hint, "void");
+        assert!(matches!(call.srcs.first(), Some(Operand::Var(s)) if s == "bump"));
+    }
+
+    #[test]
+    fn rejects_proper_procedure_in_value_position() {
         let err = compile_source(
-            "begin integer result; procedure noop; result := 1; result := 42 end",
+            "begin integer result; procedure bump(d); value d; integer d; \
+             result := result + d; result := bump(2) end",
             "bad",
         )
-        .expect_err("proper (void) procedures are outside this slice");
-        assert!(err.to_string().contains("void"));
+        .expect_err("proper procedure does not yield a value");
+        assert!(err.to_string().contains("no return value"));
     }
 
     #[test]

--- a/code/packages/rust/algol-iir-compiler/tests/aot_smoke.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/aot_smoke.rs
@@ -16,3 +16,15 @@ fn algol_scalar_program_compiles_to_aot_snapshot() {
     let snapshot = read(&bytes).expect("AOT snapshot should parse");
     assert!(!snapshot.native_code.is_empty());
 }
+
+#[test]
+fn algol_proper_procedure_program_compiles_to_aot_snapshot() {
+    let source = "begin integer result; procedure bump(d); value d; integer d; result := result + d; result := 40; bump(2) end";
+    let module = compile_source(source, "algol_proper_proc_aot").expect("ALGOL should compile");
+
+    let mut aot = AOTCore::new(Box::new(NullBackend), None, 2);
+    let bytes = aot.compile(&module).expect("AOT compile should succeed");
+    assert!(bytes.starts_with(b"AOT\0"));
+    let snapshot = read(&bytes).expect("AOT snapshot should parse");
+    assert!(!snapshot.native_code.is_empty());
+}

--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -20,6 +20,8 @@ const ALGOL_COND_EXPR: &str = "begin boolean flag; integer i, result; flag := tr
 
 const ALGOL_NESTED_BLOCKS: &str = "begin integer x, result; boolean flag; x := 1; flag := true; result := 0; begin integer x; boolean flag; x := 10; flag := false; begin integer x; x := 31; if not flag then result := x else result := 1 end; result := result + x end; if flag then result := result + x else result := 0 end";
 
+const ALGOL_PROPER_PROC: &str = "begin integer result; procedure bump(d); value d; integer d; d := d + 1; result := 40; bump(2); result := result + 2 end";
+
 fn compile_case(source: &str, module_name: &str) -> interpreter_ir::IIRModule {
     compile_source(source, module_name).expect("ALGOL source should compile")
 }
@@ -52,6 +54,10 @@ fn algol_iir_validates_for_every_direct_backend() {
         (
             "nested_blocks",
             compile_case(ALGOL_NESTED_BLOCKS, "algol_nested_blocks_backend_compat"),
+        ),
+        (
+            "proper_proc",
+            compile_case(ALGOL_PROPER_PROC, "algol_proper_proc_backend_compat"),
         ),
     ] {
         let checks = [
@@ -389,4 +395,65 @@ fn algol_nested_blocks_lower_to_wasm_jvm_clr_beam_and_llvm() {
     )
     .expect("ALGOL nested-block IIR should lower to LLVM");
     assert!(llvm.contains("define i64 @main()"));
+}
+
+#[test]
+fn algol_proper_procedure_lowers_to_wasm_jvm_clr_beam_and_llvm() {
+    let module = compile_case(ALGOL_PROPER_PROC, "algol_proper_proc_backend_compat");
+    let bump = module.get_function("bump").expect("bump exists");
+    assert_eq!(bump.return_type, "void");
+    assert!(bump.instructions.iter().any(|instr| instr.op == "ret_void"));
+    let main = module.get_function("main").expect("main exists");
+    assert!(
+        main.instructions
+            .iter()
+            .any(|instr| instr.op == "call" && instr.dest.is_none() && instr.type_hint == "void"),
+        "proper procedure should lower to a no-destination void call"
+    );
+
+    let wasm = iir_to_wasm::lower_iir_to_wasm(
+        &module,
+        &iir_to_wasm::IIRWasmConfig::new("AlgolProperProc"),
+    )
+    .expect("ALGOL proper-procedure IIR should lower to WASM");
+    let wasm_bytes = iir_to_wasm::encode_module(&wasm).expect("WASM module should encode");
+    assert!(wasm_bytes.starts_with(b"\0asm"));
+
+    let jvm = iir_to_jvm_class_file::lower_iir_to_jvm(
+        &module,
+        &iir_to_jvm_class_file::IIRJvmConfig::new("AlgolProperProc"),
+    )
+    .expect("ALGOL proper-procedure IIR should lower to JVM");
+    assert!(!jvm.methods.is_empty());
+
+    let clr = iir_to_cil_bytecode::lower_iir_to_cil(
+        &module,
+        &iir_to_cil_bytecode::IIRClrConfig::default(),
+    )
+    .expect("ALGOL proper-procedure IIR should lower to CLR");
+    assert!(!clr.methods.is_empty());
+    let clr_main = clr
+        .methods
+        .iter()
+        .find(|method| method.name == "main")
+        .expect("CLR main method exists");
+    assert!(
+        !clr_main.body.contains(&0x26),
+        "void proper-procedure call must not emit CIL pop"
+    );
+
+    let beam = iir_to_beam::lower_iir_to_beam(
+        &module,
+        &iir_to_beam::IIRBeamConfig::new("algol_proper_proc"),
+    )
+    .expect("ALGOL proper-procedure IIR should lower to BEAM");
+    let beam_bytes = iir_to_beam::encode_beam(&beam);
+    assert!(beam_bytes.starts_with(b"FOR1"));
+
+    let llvm = iir_to_llvm::lower_iir_to_llvm(
+        &module,
+        &iir_to_llvm::IIRLlvmConfig::new("algol_proper_proc"),
+    )
+    .expect("ALGOL proper-procedure IIR should lower to LLVM");
+    assert!(llvm.contains("define void @bump"));
 }

--- a/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
@@ -111,6 +111,32 @@ fn algol_dynamic_step_program_runs_through_generic_jit() {
 }
 
 #[test]
+fn algol_proper_procedure_program_runs_through_generic_jit() {
+    let source = "begin integer result; procedure bump(d); value d; integer d; result := result + d; result := 40; bump(2) end";
+    let mut module = compile_source(source, "algol_proper_proc_jit").expect("ALGOL should compile");
+    let main = module.get_function("main").expect("main exists");
+    assert_eq!(
+        main.type_status,
+        interpreter_ir::FunctionTypeStatus::FullyTyped
+    );
+
+    let mut vm = VMCore::new();
+    let backend = GenericCirJit::new();
+    let error_handle = backend.error_handle();
+    let mut jit = JITCore::new(&mut vm, Box::new(backend));
+
+    let result = jit
+        .execute_with_jit(&mut vm, &mut module, "main", &[])
+        .expect("JIT execution should succeed")
+        .unwrap_or(Value::Null);
+
+    if let Some(err) = error_handle.lock().unwrap().clone() {
+        panic!("GenericCirJit reported an error: {err}");
+    }
+    assert_eq!(result.as_i64(), Some(42));
+}
+
+#[test]
 fn algol_conditional_expression_program_runs_through_generic_jit() {
     let source = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i; if if result = 6 then flag else false then result := 42 else result := result end";
     let mut module = compile_source(source, "algol_cond_expr_jit").expect("ALGOL should compile");

--- a/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
@@ -1236,8 +1236,8 @@ pub fn lower_iir_to_cil(
                     if let Some(dest_name) = &instr.dest {
                         let dest = reg_info!(dest_name).clone();
                         emit_store(&mut builder, &dest, fn_name)?;
-                    } else {
-                        // No destination: discard the return value with `pop`.
+                    } else if module.functions[callee_idx].return_type != "void" {
+                        // No destination for a value-returning call: discard it.
                         builder.emit_pop();
                     }
                 }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1498,6 +1498,18 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Exit(49),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // ALGOL 60 — a *proper procedure* (`procedure bump`) has no return value,
+    // so the frontend emits an IIR `void` sibling function and a no-destination
+    // `call` in statement position. This matrix cell keeps the body local so it
+    // isolates void call/return lowering across all backend columns.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin integer result; procedure bump(d); value d; integer d; \
+               d := d + 1; result := 40; bump(2); result := result + 2 end",
+        expect: Expect::Exit(42),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // ALGOL 60 — a procedure that *reads and writes a variable from the enclosing
     // block* (LANG-FULL enabler **E6**, layer 1 — typed module globals).
     // `counter` is declared in the outer block and accessed by both `incr` and the

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -151,6 +151,20 @@ fn algol_dynamic_step_emits_and_runs_on_wasm() {
 }
 
 #[test]
+fn algol_proper_procedure_emits_and_runs_on_wasm() {
+    let source = "begin integer result; procedure bump(d); value d; integer d; result := result + d; result := 40; bump(2) end";
+    let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_proper_proc")
+        .expect("ALGOL proper procedure should emit wasm");
+    assert_wellformed(&bytes, "(ALGOL proper procedure)");
+
+    let rt = WasmRuntime::new();
+    let result = rt
+        .load_and_run(&bytes, "main", &[])
+        .expect("ALGOL proper-procedure wasm must run");
+    assert_eq!(result, vec![42], "ALGOL proper procedure should return 42");
+}
+
+#[test]
 fn algol_conditional_expressions_emit_and_run_on_wasm() {
     let source = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i; if if result = 6 then flag else false then result := 42 else result := result end";
     let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_cond_expr")


### PR DESCRIPTION
## Summary
- lower ALGOL proper procedures as void IIR sibling functions with statement-position no-destination calls
- reject proper procedures in value position with a type error
- avoid emitting CLR pop after no-destination void calls and add ALGOL AOT/JIT/WASM/backend coverage

## Validation
- cargo test -p algol-iir-compiler
- cargo test -p lang-aot algol_proper_procedure -- --nocapture
- cargo test -p iir-to-cil-bytecode ret_void -- --nocapture
- git diff --check
- security review: searched touched files for unsafe/process/fs/env/file APIs; no new unsafe or external process/file access in implementation; new hits are existing test-harness patterns
- cargo audit/deny unavailable in this environment

## Known unrelated
- cargo test -p lang-aot matrix_every_proven_cell_agrees -- --nocapture currently fails before the new ALGOL cell at existing Jvm Twig: expected exit 1, got None
