### PR TITLE
docs: refresh repository overview and learning coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ symbolic domains to the same semantic hub. See
 ### Dynamic values, exact numerics, and symbolic systems
 
 The runtime stack includes a language-neutral tagged dynamic-value substrate,
-boxing/unboxing, heap values, truthiness, dynamic arithmetic, and a path toward
-garbage-collected dynamic-language execution.
+boxing/unboxing, heap values, truthiness, and dynamic arithmetic. The native
+AOT path now includes precise roots, generational collection, compaction,
+incremental collection, variable-length reference arrays, and GC-managed Twig
+lists, closures, records, unions, and strings.
 
 The numeric and symbolic side includes arbitrary-precision integers, rationals,
 decimals and binary floats; computer algebra packages; rewrite systems;
@@ -139,7 +141,25 @@ language. Exactness and explicit lossy conversions are treated as design
 properties rather than incidental implementation details.
 
 See the [dynamic-value substrate](./code/specs/DVAL01-generic-dynamic-value-substrate.md)
-and [symbolic computation overview](./code/specs/symbolic-computation.md).
+and [Twig native-AOT GC coverage](./code/specs/AOT00-twig-native-gc-coverage.md).
+
+### Rules, formulas, and auditable reasoning
+
+ADJ is a typed rule, fact, table, and formula system for reasoning that can be
+inspected and replayed. Its packages cover exact quantities, bidirectional
+formulas, rule adjudication, provenance, uncertainty, explanation rendering,
+and state-machine composition. Formula and fact libraries exercise the same
+engine across physics, chemistry, biology, medicine, and other domains.
+
+The broader adjudication framework separates source decomposition, structural
+coverage, polarity and modality checks, adversarial verification,
+clarification, execution, and audit trails. This makes a conclusion more than
+an opaque answer: the system can show which facts and rules fired, what evidence
+was missing, and how the result was derived.
+
+See the [ADJ overview](./code/specs/ADJ-OVERVIEW.md),
+[rule substrate](./code/specs/ADJ-RULE-SUBSTRATE.md), and
+[formula libraries](./code/specs/ADJ-FORMULA-LIBRARIES.md).
 
 ### SQL, databases, and storage
 
@@ -197,15 +217,25 @@ Programs are integration surfaces, not just toy examples:
 - **Engram** combines a shared Rust core, native/WASM bridges, Mosaic UI work,
   Electron/browser hosts, and Anki compatibility.
 - **task-app** is applying the same architecture to a general task/project
-  engine. Its pure `task-core` model and operations/formula API have begun
-  landing; the roadmap projects one model as checklist, todo, kanban, Gantt,
-  flowchart, and table views with scheduling.
+  engine. Its pure `task-core` model, operations/formula API, project switching,
+  and structured task UI are landing toward one model exposed as checklist,
+  todo, kanban, Gantt, flowchart, and table views with scheduling.
+- **Venture** composes the repository's URL, HTTP, HTML, layout, paint, image,
+  windowing, and platform bridges into a native educational web browser. The
+  macOS host now supports navigation, links, and keyboard and wheel scrolling.
+- **smart-home** provides a local-first supervised runtime for normalized device
+  state, commands, automations, policy, and audit. Hue, Zigbee, and Z-Wave work
+  exercise the adapter boundary without making one vendor protocol the core.
+- **language-ladder** turns the human-language curriculum into an interactive
+  browser for concepts, scripts, syllabaries, lessons, and review progress.
 - **VisiCalc** exercises spreadsheet, UI, and multi-host compilation paths.
 - Journal, checklist, browser-extension, language-tooling, IRC, ML, document,
   and hardware visualizer programs test other package families end to end.
 
 See [Engram](./code/specs/engram-app.md) and the
-[task-app overview](./code/specs/task-app-overview.md).
+[task-app overview](./code/specs/task-app-overview.md),
+[Venture](./code/specs/BR01-venture-browser.md), and the
+[smart-home runtime](./code/specs/D23-smart-home-runtime.md).
 
 ## Repository Layout
 
@@ -371,9 +401,14 @@ Choose a path based on what you want to understand:
 | Shared execution IR | [Interpreter IR](./code/specs/LANG01-interpreter-ir.md) |
 | Source-level semantic IR | [Semantic IR](./code/specs/SIR00-semantic-ir.md) |
 | Building a new language | [Generic language pipeline](./code/specs/LANG00-generic-language-pipeline.md) |
+| WebAssembly internals | [WebAssembly from bytes to execution](./code/learning/language-tooling/webassembly-from-bytes-to-execution.md) |
+| Rules, formulas, and auditable reasoning | [ADJ overview](./code/specs/ADJ-OVERVIEW.md) |
 | SQL and SQLite | [Mini-SQLite conformance roadmap](./code/specs/mini-sqlite-full-conformance.md) |
 | UI compilation | [Mosaic](./code/specs/UI00-mosaic.md) |
 | Task/project engine | [task-app overview](./code/specs/task-app-overview.md) |
+| Native browser pipeline | [Venture browser](./code/specs/BR01-venture-browser.md) |
+| Smart-home runtime | [Smart-home runtime](./code/specs/D23-smart-home-runtime.md) |
+| Learning-content backlog | [Learning coverage roadmap](./code/learning/ROADMAP.md) |
 | Vault/security architecture | [Vault master spec](./code/specs/VLT00-vault-master.md) |
 | Dependency planning | [Kahn's algorithm](./code/learning/algorithms/kahns-algorithm.md) and [build-tool README](./code/programs/go/build-tool/README.md) |
 | Current engineering pitfalls | [Lessons learned](./lessons.md) |

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1155 | 39 | 57 | 48 | 6 | 1044 |
+| 1227 | 1080 | 98 | 58 | 6 | 1065 |
 
 ## Method
 
@@ -24,10 +24,10 @@ mention provides a complete lesson.
 
 | Priority | Dedicated | Related | Index only | Missing |
 | --- | ---: | ---: | ---: | ---: |
-| P0 | 46 | 21 | 5 | 99 |
-| P1 | 8 | 19 | 0 | 95 |
+| P0 | 86 | 25 | 5 | 56 |
+| P1 | 9 | 22 | 0 | 90 |
 | P2 | 1 | 3 | 1 | 152 |
-| P3 | 2 | 5 | 0 | 698 |
+| P3 | 2 | 8 | 0 | 767 |
 
 ## P0 Backlog
 
@@ -36,54 +36,38 @@ mention provides a complete lesson.
 | Concept | Languages | Status |
 | --- | ---: | --- |
 | `neural-graph-vm` | 15 | missing |
-| `hash-set` | 11 | missing |
+| `hash-set` | 13 | missing |
 
 ### documents-media
 
 | Concept | Languages | Status |
 | --- | ---: | --- |
-| `barcode-2d` | 15 | missing |
+| `image-geometric-transforms` | 15 | missing |
 | `image-point-ops` | 15 | missing |
-| `pdf417` | 15 | missing |
-| `image-geometric-transforms` | 14 | missing |
-| `barcode-1d` | 11 | missing |
-| `barcode-layout-1d` | 11 | missing |
 
 ### graphics-ui
 
 | Concept | Languages | Status |
 | --- | ---: | --- |
-| `paint-instructions` | 15 | missing |
-| `paint-vm-ascii` | 10 | missing |
+| `paint-vm-ascii` | 11 | missing |
 
 ### hardware-architecture
 
 | Concept | Languages | Status |
 | --- | ---: | --- |
-| `fpga` | 10 | missing |
+| `fpga` | 12 | missing |
 
 ### language-tooling
 
 | Concept | Languages | Status |
 | --- | ---: | --- |
-| `csv-parser` | 15 | missing |
-| `json-lexer` | 15 | missing |
-| `json-parser` | 15 | missing |
-| `wasm-execution` | 15 | missing |
-| `wasm-leb128` | 15 | missing |
-| `wasm-module-parser` | 15 | missing |
-| `wasm-opcodes` | 15 | missing |
-| `wasm-runtime` | 15 | missing |
-| `wasm-types` | 15 | missing |
-| `wasm-validator` | 15 | missing |
-| `algol-lexer` | 14 | missing |
-| `algol-parser` | 14 | missing |
-| `mosaic-lexer` | 14 | missing |
-| `mosaic-parser` | 14 | missing |
-| `toml-lexer` | 14 | missing |
+| `algol-lexer` | 15 | missing |
+| `algol-parser` | 15 | missing |
+| `mosaic-lexer` | 15 | missing |
+| `mosaic-parser` | 15 | missing |
+| `document-ast` | 14 | missing |
 | `csharp-lexer` | 13 | missing |
 | `csharp-parser` | 13 | missing |
-| `document-ast` | 13 | missing |
 | `excel-lexer` | 13 | missing |
 | `excel-parser` | 13 | missing |
 | `java-lexer` | 13 | missing |
@@ -95,90 +79,53 @@ mention provides a complete lesson.
 | `ruby-parser` | 13 | index-only |
 | `starlark-lexer` | 13 | missing |
 | `starlark-parser` | 13 | missing |
-| `toml-parser` | 13 | missing |
 | `typescript-parser` | 13 | index-only |
 | `verilog-lexer` | 13 | missing |
 | `verilog-parser` | 13 | missing |
 | `vhdl-lexer` | 13 | missing |
 | `vhdl-parser` | 13 | missing |
+| `asciidoc-parser` | 12 | missing |
 | `commonmark-parser` | 12 | missing |
-| `brainfuck-wasm-compiler` | 11 | missing |
+| `dartmouth-basic-lexer` | 12 | missing |
+| `dartmouth-basic-parser` | 12 | missing |
+| `font-parser` | 12 | missing |
+| `python-parser` | 12 | index-only |
 | `compiler-source-map` | 11 | missing |
 | `gfm-parser` | 11 | missing |
-| `nib-wasm-compiler` | 11 | missing |
-| `python-parser` | 11 | index-only |
-| `asciidoc-parser` | 10 | missing |
-| `dartmouth-basic-lexer` | 10 | missing |
-| `dartmouth-basic-parser` | 10 | missing |
-| `font-parser` | 10 | missing |
-| `wasm-module-encoder` | 10 | missing |
-| `xml-lexer` | 10 | missing |
-
-### math-ml-logic
-
-| Concept | Languages | Status |
-| --- | ---: | --- |
-| `data-matrix` | 15 | missing |
 
 ### networking-systems
 
 | Concept | Languages | Status |
 | --- | ---: | --- |
 | `two-layer-network` | 15 | missing |
+| `in-memory-data-store-protocol` | 13 | missing |
+| `resp-protocol` | 13 | missing |
+| `http-core` | 12 | missing |
 | `url-parser` | 12 | missing |
-| `http-core` | 11 | missing |
 | `http1` | 11 | missing |
-| `in-memory-data-store-protocol` | 11 | missing |
-| `resp-protocol` | 11 | missing |
-| `type-checker-protocol` | 10 | missing |
+| `type-checker-protocol` | 11 | missing |
 
 ### other
 
 | Concept | Languages | Status |
 | --- | ---: | --- |
-| `aztec-code` | 15 | missing |
+| `cli-builder` | 15 | missing |
 | `conduit` | 15 | missing |
-| `gf256` | 15 | missing |
-| `micro-qr` | 15 | missing |
 | `note-frequency` | 15 | missing |
 | `pixel-container` | 15 | missing |
-| `polynomial` | 15 | missing |
-| `qr-code` | 15 | missing |
 | `rng` | 15 | missing |
-| `cli-builder` | 14 | missing |
-| `feature-normalization` | 13 | missing |
-| `state-machine` | 13 | missing |
-| `trig` | 13 | missing |
-| `uuid` | 13 | missing |
+| `feature-normalization` | 14 | missing |
+| `trig` | 14 | missing |
+| `uuid` | 14 | missing |
+| `in-memory-data-store` | 13 | missing |
+| `in-memory-data-store-engine` | 13 | missing |
+| `affine2d` | 12 | missing |
+| `arc2d` | 12 | missing |
+| `bezier2d` | 12 | missing |
+| `block-ram` | 12 | missing |
 | `json-rpc` | 12 | missing |
-| `json-serializer` | 12 | missing |
-| `json-value` | 12 | missing |
-| `affine2d` | 11 | missing |
-| `arc2d` | 11 | missing |
-| `bezier2d` | 11 | missing |
-| `brainfuck` | 11 | missing |
-| `codabar` | 11 | missing |
-| `code128` | 11 | missing |
-| `code39` | 11 | missing |
-| `ean-13` | 11 | missing |
-| `itf` | 11 | missing |
-| `point2d` | 11 | missing |
-| `upc-a` | 11 | missing |
-| `block-ram` | 10 | missing |
+| `point2d` | 12 | missing |
 | `event-loop` | 10 | missing |
-| `in-memory-data-store` | 10 | missing |
-| `in-memory-data-store-engine` | 10 | missing |
-
-### sql-storage
-
-| Concept | Languages | Status |
-| --- | ---: | --- |
-| `mini-sqlite` | 15 | missing |
-| `sql-backend` | 15 | missing |
-| `sql-execution-engine` | 14 | missing |
-| `sql-lexer` | 13 | missing |
-| `sql-parser` | 13 | missing |
-| `sql-csv-source` | 12 | missing |
 
 
 ## P1 Backlog
@@ -232,7 +179,6 @@ mention provides a complete lesson.
 | `css-lexer` | 9 | missing |
 | `css-parser` | 9 | missing |
 | `document-ast-to-html` | 9 | missing |
-| `ir-to-wasm-compiler` | 9 | missing |
 | `ir-to-wasm-validator` | 9 | missing |
 | `lisp-lexer` | 9 | missing |
 | `lisp-parser` | 9 | missing |
@@ -266,11 +212,8 @@ mention provides a complete lesson.
 
 | Concept | Languages | Status |
 | --- | ---: | --- |
-| `asciidoc` | 9 | missing |
-| `commonmark` | 9 | missing |
 | `correlation-vector` | 9 | missing |
 | `ct-compare` | 9 | missing |
-| `des` | 9 | missing |
 | `ls00` | 9 | missing |
 | `markov-chain` | 9 | missing |
 | `mosaic-analyzer` | 9 | missing |
@@ -284,7 +227,6 @@ mention provides a complete lesson.
 | `rpc` | 9 | missing |
 | `actor` | 8 | missing |
 | `device-driver-framework` | 8 | missing |
-| `gfm` | 8 | missing |
 | `intel4004-gatelevel` | 8 | missing |
 | `interrupt-handler` | 8 | missing |
 | `process-manager` | 8 | missing |
@@ -349,6 +291,7 @@ mention provides a complete lesson.
 
 | Concept | Languages | Status |
 | --- | ---: | --- |
+| `multi-directed-graph` | 4 | missing |
 | `cas-list-operations` | 3 | missing |
 | `directed-graph-native` | 3 | missing |
 | `graph-native` | 3 | missing |
@@ -356,7 +299,6 @@ mention provides a complete lesson.
 | `tree-set-native` | 3 | missing |
 | `diagram-layout-graph` | 2 | missing |
 | `heap-native` | 2 | missing |
-| `multi-directed-graph` | 2 | missing |
 
 ### documents-media
 
@@ -549,6 +491,8 @@ mention provides a complete lesson.
 | `browser-extension-toolkit` | 1 | missing |
 | `forme-doc-page-shell` | 1 | missing |
 | `forme-style-to-terminal` | 1 | missing |
+| `venture-browser-core` | 1 | missing |
+| `venture-browser-macos` | 1 | missing |
 | `mosaic-pkg-card-browser` | 0 | missing |
 | `mosaic-pkg-note-editor` | 0 | missing |
 | `mosaic-pkg-note-type-editor` | 0 | missing |
@@ -595,6 +539,7 @@ mention provides a complete lesson.
 | `fenwick-tree-native` | 1 | missing |
 | `forme-doc-search-client-js` | 1 | missing |
 | `radix-tree-native` | 1 | missing |
+| `sir-runtime-array` | 1 | missing |
 | `trie-native` | 1 | missing |
 | `vault-search` | 1 | missing |
 
@@ -631,6 +576,8 @@ mention provides a complete lesson.
 | `forme-aot-html-doc-emitter` | 1 | missing |
 | `forme-render-static` | 1 | missing |
 | `forme-style-to-css` | 1 | missing |
+| `html-to-layout` | 1 | missing |
+| `html-to-paint` | 1 | missing |
 | `layout-flexbox` | 1 | missing |
 | `layout-grid` | 1 | missing |
 | `layout-text-measure-canvas` | 1 | missing |
@@ -720,6 +667,10 @@ mention provides a complete lesson.
 | `algol-wasm-compiler` | 1 | missing |
 | `apl-lexer` | 1 | missing |
 | `apl-parser` | 1 | missing |
+| `apl-to-semantic-ir` | 1 | missing |
+| `axiom-lexer` | 1 | missing |
+| `axiom-parser` | 1 | missing |
+| `axiom-to-semantic-ir` | 1 | missing |
 | `basic-semantic-tokens` | 1 | missing |
 | `beam-bytecode-disassembler` | 1 | missing |
 | `beam-bytecode-encoder` | 1 | missing |
@@ -728,11 +679,15 @@ mention provides a complete lesson.
 | `c-to-semantic-ir` | 1 | missing |
 | `cil-bytecode-builder` | 1 | missing |
 | `clr-bytecode-disassembler` | 1 | missing |
+| `cobol-iir-compiler` | 1 | missing |
 | `cobol-lexer` | 1 | missing |
 | `cobol-parser` | 1 | missing |
 | `dartmouth-basic-iir-compiler` | 1 | missing |
 | `dartmouth-basic-jvm-compiler` | 1 | missing |
 | `dartmouth-basic-wasm-compiler` | 1 | missing |
+| `derive-lexer` | 1 | missing |
+| `derive-parser` | 1 | missing |
+| `derive-to-semantic-ir` | 1 | missing |
 | `document-ast-to-docx` | 1 | missing |
 | `dot-lexer` | 1 | missing |
 | `engram-core-wasm` | 1 | missing |
@@ -749,11 +704,17 @@ mention provides a complete lesson.
 | `grammar-wasm-support` | 1 | missing |
 | `html-lexer` | 1 | missing |
 | `html-parser` | 1 | missing |
+| `idl-lexer` | 1 | missing |
+| `idl-parser` | 1 | missing |
+| `idl-to-semantic-ir` | 1 | missing |
 | `iir-to-cil-bytecode` | 1 | missing |
 | `iir-to-wasm` | 1 | missing |
 | `ir-to-wasm-assembly` | 1 | missing |
 | `iso-prolog-lexer` | 1 | missing |
 | `iso-prolog-parser` | 1 | missing |
+| `j-lexer` | 1 | missing |
+| `j-parser` | 1 | missing |
+| `j-to-semantic-ir` | 1 | missing |
 | `javascript-ast` | 1 | missing |
 | `javascript-to-semantic-ir` | 1 | missing |
 | `jsdoc-lexer` | 1 | missing |
@@ -761,11 +722,16 @@ mention provides a complete lesson.
 | `jvm-bytecode-disassembler` | 1 | missing |
 | `logic-bytecode` | 1 | missing |
 | `logic-bytecode-vm` | 1 | missing |
+| `macsyma-to-semantic-ir` | 1 | missing |
 | `macsyma-wasm` | 1 | missing |
 | `macsyma-wasm-runtime` | 1 | missing |
+| `maple-lexer` | 1 | missing |
+| `maple-parser` | 1 | missing |
+| `maple-to-semantic-ir` | 1 | missing |
 | `matlab-lexer` | 1 | missing |
 | `matlab-parser` | 1 | missing |
 | `matlab-to-semantic-ir` | 1 | missing |
+| `maxima-to-semantic-ir` | 1 | missing |
 | `mccarthy-lisp-iir-compiler` | 1 | missing |
 | `mccarthy-lisp-lexer` | 1 | missing |
 | `mccarthy-lisp-parser` | 1 | missing |
@@ -786,12 +752,21 @@ mention provides a complete lesson.
 | `prolog-operator-parser` | 1 | missing |
 | `prolog-vm-compiler` | 1 | missing |
 | `python-to-semantic-ir` | 1 | missing |
+| `q-lexer` | 1 | missing |
+| `q-parser` | 1 | missing |
+| `q-to-semantic-ir` | 1 | missing |
 | `r-lexer` | 1 | missing |
 | `r-parser` | 1 | missing |
+| `reduce-lexer` | 1 | missing |
+| `reduce-parser` | 1 | missing |
+| `reduce-to-semantic-ir` | 1 | missing |
 | `required-capabilities-compiler` | 1 | missing |
 | `ruby-to-semantic-ir` | 1 | missing |
 | `s-lexer` | 1 | missing |
 | `s-parser` | 1 | missing |
+| `scilab-lexer` | 1 | missing |
+| `scilab-parser` | 1 | missing |
+| `scilab-to-semantic-ir` | 1 | missing |
 | `semantic-ir-to-c` | 1 | missing |
 | `semantic-ir-to-go` | 1 | missing |
 | `semantic-ir-to-javascript` | 1 | missing |
@@ -805,6 +780,7 @@ mention provides a complete lesson.
 | `state-machine-tokenizer` | 1 | missing |
 | `swi-prolog-lexer` | 1 | missing |
 | `swi-prolog-parser` | 1 | missing |
+| `task-wasm` | 1 | missing |
 | `tetrad-compiler` | 1 | missing |
 | `tetrad-lexer` | 1 | missing |
 | `tetrad-parser` | 1 | missing |
@@ -854,6 +830,7 @@ mention provides a complete lesson.
 | `embeddable-tcp-server` | 1 | missing |
 | `executor-protocol` | 1 | missing |
 | `generic-job-protocol` | 1 | missing |
+| `http1-client` | 1 | missing |
 | `irc-net-reactor` | 1 | missing |
 | `irc-net-selectors` | 1 | missing |
 | `irc-server-capi` | 1 | missing |
@@ -865,6 +842,8 @@ mention provides a complete lesson.
 | `tcp-runtime` | 1 | missing |
 | `tls-platform` | 1 | missing |
 | `udp-client` | 1 | missing |
+| `http-server` | 0 | missing |
+| `resp-server` | 0 | missing |
 
 ### other
 
@@ -897,6 +876,8 @@ mention provides a complete lesson.
 | `apl-runtime` | 1 | missing |
 | `artifact-store` | 1 | missing |
 | `asciimath` | 1 | missing |
+| `axiom-repl` | 1 | missing |
+| `axiom-runtime` | 1 | missing |
 | `basic-dap` | 1 | missing |
 | `basic-formatter` | 1 | missing |
 | `basic-lsp-bridge` | 1 | missing |
@@ -937,9 +918,11 @@ mention provides a complete lesson.
 | `capability-os-sandbox` | 1 | missing |
 | `cfb` | 1 | missing |
 | `cfb-writer` | 1 | missing |
+| `chief-of-staff-host-runtime` | 1 | missing |
 | `chief-of-staff-smart-home-tools` | 1 | missing |
 | `chief-of-staff-tool-api` | 1 | missing |
 | `chief-of-staff-tool-audit-store` | 1 | missing |
+| `chief-of-staff-vault-runtime` | 1 | missing |
 | `cli-assembly-writer` | 1 | missing |
 | `cli-runtime-model` | 1 | missing |
 | `closure-emitter` | 1 | missing |
@@ -975,6 +958,8 @@ mention provides a complete lesson.
 | `dap-adapter-core` | 1 | missing |
 | `data-frame` | 1 | missing |
 | `datetime-core` | 1 | missing |
+| `derive-repl` | 1 | missing |
+| `derive-runtime` | 1 | missing |
 | `doc` | 1 | missing |
 | `doc-writer` | 1 | missing |
 | `dom-core` | 1 | missing |
@@ -1043,6 +1028,7 @@ mention provides a complete lesson.
 | `forme-types` | 1 | missing |
 | `fsrs` | 1 | missing |
 | `gc-core` | 1 | missing |
+| `gc-core-capi` | 1 | missing |
 | `ge225-backend` | 1 | missing |
 | `ge225-encoder` | 1 | missing |
 | `generic-job-runtime` | 1 | missing |
@@ -1051,8 +1037,11 @@ mention provides a complete lesson.
 | `host-vm-lowering` | 1 | missing |
 | `hue-client` | 1 | missing |
 | `hue-core` | 1 | missing |
+| `hue-integration` | 1 | missing |
 | `ibm704-backend` | 1 | missing |
 | `ibm704-encoder` | 1 | missing |
+| `idl-repl` | 1 | missing |
+| `idl-runtime` | 1 | missing |
 | `ieee802154-core` | 1 | missing |
 | `ieee802154-security` | 1 | missing |
 | `iir-builtin-lowering` | 1 | missing |
@@ -1073,6 +1062,8 @@ mention provides a complete lesson.
 | `intel8008-backend` | 1 | missing |
 | `intel8008-encoder` | 1 | missing |
 | `iocp` | 1 | missing |
+| `j-repl` | 1 | missing |
+| `j-runtime` | 1 | missing |
 | `jit-loader-macos` | 1 | missing |
 | `jni-bridge` | 1 | missing |
 | `jsdoc-comment-extractor` | 1 | missing |
@@ -1086,7 +1077,6 @@ mention provides a complete lesson.
 | `lang-refinement-checker` | 1 | missing |
 | `lang-runtime-core` | 1 | missing |
 | `language-core` | 1 | missing |
-| `latex` | 1 | missing |
 | `ldp-format` | 1 | missing |
 | `linux-job-backend-systemd-files` | 1 | missing |
 | `llm-cache` | 1 | missing |
@@ -1096,6 +1086,8 @@ mention provides a complete lesson.
 | `lookup-core` | 1 | missing |
 | `lua-bridge` | 1 | missing |
 | `macos-job-backend-launchd-files` | 1 | missing |
+| `maple-repl` | 1 | missing |
+| `maple-runtime` | 1 | missing |
 | `math-core` | 1 | missing |
 | `math-frontend` | 1 | missing |
 | `mathml` | 1 | missing |
@@ -1155,14 +1147,20 @@ mention provides a complete lesson.
 | `prolog-core` | 1 | missing |
 | `protobuf` | 1 | missing |
 | `python-bridge` | 1 | missing |
+| `q-repl` | 1 | missing |
+| `q-runtime` | 1 | missing |
 | `r-repl` | 1 | missing |
 | `r-runtime` | 1 | missing |
 | `r-vector` | 1 | missing |
 | `read-write-separation` | 1 | missing |
+| `reduce-repl` | 1 | missing |
+| `reduce-runtime` | 1 | missing |
 | `regex-engine` | 1 | missing |
 | `ruby-bridge` | 1 | missing |
 | `s-repl` | 1 | missing |
 | `s-runtime` | 1 | missing |
+| `scilab-repl` | 1 | missing |
+| `scilab-runtime` | 1 | missing |
 | `sealed-sender` | 1 | missing |
 | `silicon-rust-cgo` | 1 | missing |
 | `silicon-rust-go` | 1 | missing |
@@ -1172,17 +1170,24 @@ mention provides a complete lesson.
 | `silicon-rust-python` | 1 | missing |
 | `silicon-rust-ruby` | 1 | missing |
 | `silicon-rust-ruby-native` | 1 | missing |
+| `sir-bench` | 1 | missing |
 | `sir-conformance` | 1 | missing |
+| `sir-runtime-symbolic` | 1 | missing |
 | `sixlowpan` | 1 | missing |
 | `skill-store` | 1 | missing |
+| `smart-home-automation-runtime` | 1 | missing |
 | `smart-home-capability-cage` | 1 | missing |
 | `smart-home-core` | 1 | missing |
 | `smart-home-discovery` | 1 | missing |
+| `smart-home-discovery-service` | 1 | missing |
 | `smart-home-event-streams` | 1 | missing |
+| `smart-home-hue-pairing-service` | 1 | missing |
 | `smart-home-integration-catalog` | 1 | missing |
 | `smart-home-registry` | 1 | missing |
 | `smart-home-runtime` | 1 | missing |
+| `smart-home-runtime-store` | 1 | missing |
 | `smart-home-testkit` | 1 | missing |
+| `smart-home-zwave-integration` | 1 | missing |
 | `smt-lib-format` | 1 | missing |
 | `sparc-v8-gatelevel` | 1 | missing |
 | `state-machine-markup-deserializer` | 1 | missing |
@@ -1265,6 +1270,7 @@ mention provides a complete lesson.
 | `zwave-core` | 1 | missing |
 | `zwave-serial-api` | 1 | missing |
 | `builtins` | 0 | missing |
+| `float-math` | 0 | missing |
 | `iso-harness` | 0 | missing |
 | `library-rules` | 0 | missing |
 | `mini-redis` | 0 | missing |
@@ -1281,9 +1287,14 @@ mention provides a complete lesson.
 | `mosaic-pkg-review-history` | 0 | missing |
 | `mosaic-pkg-session-progress` | 0 | missing |
 | `mosaic-pkg-toolkit` | 0 | missing |
+| `os-platform` | 0 | missing |
+| `platform-harness` | 0 | missing |
+| `plugin-host` | 0 | missing |
 | `program-rules` | 0 | missing |
+| `reactor` | 0 | missing |
 | `ringbuf` | 0 | missing |
 | `static-vector` | 0 | missing |
+| `wide-int` | 0 | missing |
 
 ### sql-storage
 

--- a/code/learning/README.md
+++ b/code/learning/README.md
@@ -20,8 +20,13 @@ There are four kinds of material in this directory:
 - [Computer Architecture](./computer-architecture/README.md)
 - [Cryptography](./cryptography/README.md)
 - [Language Tooling](./language-tooling/README.md)
+- [Documents and Media](./documents-media/README.md)
+- [SQL and Storage](./sql-storage/README.md)
 - [Python Ecosystem](./programming-languages/python-ecosystem.md)
 - [Human Languages](./human-languages/README.md) — personal curriculum, not a package companion
+
+The hand-authored [Learning Coverage Roadmap](./ROADMAP.md) explains how the
+generated inventory is prioritized and records the baseline survey.
 
 The generated [Learning Coverage Inventory](./COVERAGE.md) is the complete
 package-to-learning backlog. Regenerate it after adding or renaming packages or
@@ -47,6 +52,10 @@ This table is the current answer to "what learning entry explains this package f
 | Deep micro-architecture | `cache`, `branch-predictor`, `hazard-detection`, `pipeline`, `core` | [Pipelines, caches, and speculation](./computer-architecture/pipelines-caches-and-speculation.md) |
 | Frontend and compiler pipeline | `grammar-tools`, `lexer`, `parser`, `bytecode-compiler`, `virtual-machine`, `assembler`, `jit-compiler` | [Language tooling index](./language-tooling/README.md) |
 | Intermediate representations | semantic IR, compiler IR, interpreter IR, lowering, source identity | [Intermediate representations](./language-tooling/intermediate-representations.md) |
+| WebAssembly | binary modules, LEB128, validation, instantiation, stack execution | [WebAssembly from bytes to execution](./language-tooling/webassembly-from-bytes-to-execution.md) |
+| Structured text | JSON, CSV, TOML, XML, lexing, parsing, values, serialization | [Structured text from bytes to values](./language-tooling/structured-text-from-bytes-to-values.md) |
+| SQL execution | lexing, parsing, logical query order, backends, SQLite | [From SQL text to stored rows](./sql-storage/from-sql-text-to-stored-rows.md) |
+| Barcodes | 1D/2D symbols, finite fields, Reed-Solomon correction, layout | [Barcodes and error correction](./documents-media/barcodes-and-error-correction.md) |
 | Python project conventions | packaging, linting, types, `uv`, `ruff`, `pyproject.toml` | [Modern Python ecosystem](./programming-languages/python-ecosystem.md) |
 
 ## Relationship To Specs

--- a/code/learning/ROADMAP.md
+++ b/code/learning/ROADMAP.md
@@ -1,0 +1,118 @@
+# Learning Coverage Roadmap
+
+This document turns the generated package coverage inventory into an editorial
+plan. The inventory answers "is there evidence of learning material for this
+package concept?" This roadmap answers "what should we teach next, and why?"
+
+## Baseline Survey
+
+The survey was refreshed from the live package tree on 2026-07-30, before the
+first content batch in this roadmap:
+
+| Measure | Baseline |
+| --- | ---: |
+| Distinct package concepts | 1,227 |
+| Dedicated learning coverage | 57 |
+| Related coverage | 52 |
+| Index-only coverage | 6 |
+| Missing coverage | 1,112 |
+| P0 concepts with missing coverage | 99 |
+| P1 concepts with missing coverage | 94 |
+
+P0 means a concept has implementations in at least 10 established language
+ecosystems. P1 means it appears in 5 to 9. Breadth is a useful signal because a
+single conceptual lesson can support many package implementations.
+
+The raw document count is not a useful measure of package-companion depth by
+itself. The independent human-language curriculum contains many lesson files
+and follows its own coverage model. For package learning, the meaningful
+measures are concept status and the quality of the linked explanation.
+
+## What The Inventory Can And Cannot Tell Us
+
+The generated report recognizes four structural states:
+
+- **Dedicated:** the filename or a `learning-concepts` annotation claims the
+  concept.
+- **Related:** a non-index lesson mentions the concept.
+- **Index only:** the concept appears only in a learning index.
+- **Missing:** no structural evidence was found.
+
+This is intentionally mechanical. An annotation makes work discoverable, but it
+does not prove that the prose is correct, complete, or approachable. Editorial
+review still needs to ask:
+
+1. Does the lesson explain the problem before presenting the mechanism?
+2. Is there a worked example a reader can calculate or trace?
+3. Are invariants and failure modes explicit?
+4. Does the lesson separate durable ideas from this repository's API choices?
+5. Does it point readers toward the packages and specs that make the idea real?
+
+## Priority Model
+
+The learning backlog should be worked in four lanes.
+
+### Lane 1: Broad shared foundations
+
+Start with P0 families that have several related packages. One lesson can give
+readers a map across all language mirrors without duplicating package READMEs.
+
+Initial batch:
+
+- WebAssembly binary format, validation, instantiation, and execution
+- structured text parsing across JSON, CSV, TOML, and XML
+- SQL parsing, logical evaluation, planning, execution, and storage
+- one-dimensional and two-dimensional barcodes plus error correction
+
+That batch raised dedicated coverage from 57 to 98 concepts and reduced missing
+coverage from 1,112 to 1,065. More importantly, it reduced the P0 missing
+backlog from 99 to 56 concepts. These numbers exclude local untracked package
+work and are recorded in the generated `COVERAGE.md`.
+
+### Lane 2: Existing notes that are too shallow
+
+Convert `related` and `index-only` concepts into dedicated lessons when the
+current material only names them. This is often higher leverage than starting a
+new subject because the surrounding curriculum and examples already exist.
+
+### Lane 3: Deep single-language systems
+
+Breadth alone underrates major Rust-first systems such as ADJ, native AOT and
+GC, Venture, smart-home, SPICE, and the Semantic IR backends. These may appear
+as P3 even when they are among the repository's most important integration
+tracks. Each quarterly pass should reserve capacity for these systems.
+
+### Lane 4: Learning maintenance
+
+Every new package family should either link to an existing lesson or add a
+backlog entry. Regenerate `COVERAGE.md` in the same change as new learning
+material so drift remains visible.
+
+## Next Recommended Batches
+
+After the initial batch, the strongest breadth-weighted candidates are:
+
+1. paint instructions, affine geometry, paths, and rendering VMs
+2. HTTP, URLs, RESP, and protocol framing
+3. state machines, event loops, and supervised reactors
+4. image point operations and geometric transforms
+5. document ASTs, CommonMark/GFM, AsciiDoc, and sanitization
+6. mini-SQLite storage pages, B-trees, WAL, and transaction semantics
+
+The first depth-weighted candidates are:
+
+1. tagged dynamic values and native garbage collection
+2. ADJ rules, formulas, provenance, and explanations
+3. the Venture URL-to-pixels browser pipeline
+4. local-first smart-home events, commands, policy, and supervision
+
+## Regenerating The Evidence
+
+```bash
+python3 code/scripts/learning_coverage_report.py \
+  --output code/learning/COVERAGE.md
+```
+
+The report is a backlog generator, not a score to optimize blindly. A smaller
+number of clear, connected lessons is preferable to hundreds of files that only
+repeat package summaries.

--- a/code/learning/documents-media/README.md
+++ b/code/learning/documents-media/README.md
@@ -1,0 +1,13 @@
+# Documents And Media
+
+Documents and media turn structured information into forms people and machines
+can exchange: text formats, page models, images, audio, and printed symbols.
+The lessons here focus on the reusable representations and algorithms beneath
+individual file formats.
+
+## Lessons
+
+- [Barcodes and error correction](./barcodes-and-error-correction.md)
+
+Future lessons will cover document ASTs, markup parsing and sanitization, image
+operations, codecs, fonts, and page layout.

--- a/code/learning/documents-media/barcodes-and-error-correction.md
+++ b/code/learning/documents-media/barcodes-and-error-correction.md
@@ -1,0 +1,183 @@
+<!-- learning-concepts: barcode-1d, barcode-layout-1d, barcode-2d, codabar, code128, code39, ean-13, itf, upc-a, qr-code, micro-qr, data-matrix, aztec-code, pdf417, gf256, polynomial, reed-solomon -->
+# Barcodes And Error Correction
+
+A barcode is a physical communication channel. Software chooses symbols, a
+printer turns them into light and dark regions, a surface damages or distorts
+them, a camera or scanner samples the result, and a decoder tries to recover
+the original message.
+
+```text
+message -> encode -> lay out modules -> print/display
+                                      -> noisy image
+message <- decode <- sample modules <-
+```
+
+Thinking of the whole channel explains why encoding, layout, checksums, error
+correction, and rendering belong in separate layers.
+
+## One-Dimensional Symbols
+
+A 1D barcode encodes information along one axis as alternating bars and spaces.
+The other axis mainly provides height so a scanning line can intersect the
+symbol reliably.
+
+Different symbologies make different tradeoffs:
+
+| Family | Typical design |
+| --- | --- |
+| Code 39 | simple, discrete characters with a small alphabet |
+| Code 128 | dense full-ASCII-oriented encoding with code-set switching |
+| Codabar | small alphabet designed for easy printing |
+| ITF | pairs of digits interleaved across bars and spaces |
+| EAN-13 / UPC-A | fixed retail identifiers with guard patterns and checks |
+
+An encoder should first produce an abstract sequence of module widths or bits.
+A layout layer then adds quiet zones, bar height, text placement, scaling, and
+device coordinates. If encoding writes pixels directly, it becomes hard to
+test the symbol independently from a particular renderer.
+
+## Checksums Detect Common Errors
+
+Retail codes use weighted modular checks. A check digit does not hide the data
+or correct arbitrary damage; it rejects many likely substitutions and
+transpositions.
+
+For a weighted checksum:
+
+```text
+sum = w0*d0 + w1*d1 + ... + wn*dn
+check = value that makes sum divisible by the modulus
+```
+
+The decoder recomputes the sum. A mismatch means the scan should not be trusted.
+Always specify digit order and weight order: reversing either can produce a
+plausible but incompatible implementation.
+
+## Two-Dimensional Symbols
+
+A 2D barcode arranges modules in a matrix. It can carry more data and spread
+redundancy across both axes. The decoder also needs landmarks that answer:
+
+- Where is the symbol?
+- How is it rotated?
+- What is the module size?
+- Which cells contain metadata rather than payload?
+- How should damaged cells be reconstructed?
+
+QR Code uses finder, timing, alignment, format, and version regions around
+masked payload modules. Micro QR reduces overhead for smaller messages. Data
+Matrix uses an L-shaped finder boundary. Aztec Code uses a central bullseye.
+PDF417 uses stacked rows of codewords rather than a square module grid.
+
+These formats differ, but their encoder pipelines rhyme:
+
+```text
+choose mode
+  -> encode payload bits
+  -> add length and control information
+  -> pad into codewords
+  -> add error-correction codewords
+  -> place fixed patterns and data
+  -> choose/apply mask when required
+  -> render with quiet zone
+```
+
+## Finite Fields Make Byte Correction Possible
+
+Many 2D formats use Reed-Solomon codes over GF(256), a finite field with 256
+elements. Field addition is bitwise XOR. Multiplication treats bytes as
+polynomials whose coefficients are bits, then reduces the result by a chosen
+irreducible polynomial.
+
+For example, the byte:
+
+```text
+0b10010110
+```
+
+represents:
+
+```text
+x^7 + x^4 + x^2 + x
+```
+
+The important field property is that every nonzero element has a multiplicative
+inverse. That allows division and polynomial algorithms without leaving the
+finite set of byte values.
+
+Implementations commonly precompute exponent and logarithm tables:
+
+```text
+a * b = exp(log(a) + log(b))
+```
+
+with exponents wrapped by the field's multiplicative period. Zero needs a
+separate branch because it has no logarithm.
+
+## Reed-Solomon Works On Polynomials
+
+Treat data codewords as coefficients of a polynomial. The encoder appends
+redundancy so the transmitted polynomial is divisible by a generator
+polynomial.
+
+The decoder evaluates the received polynomial at selected field points. A
+zero result at every point means the codeword is internally consistent. Nonzero
+results are syndromes: evidence describing the error pattern.
+
+A full decoder then:
+
+1. computes syndromes;
+2. derives an error-locator polynomial;
+3. finds error positions;
+4. computes error magnitudes;
+5. corrects the damaged codewords;
+6. verifies that all syndromes are now zero.
+
+With `r` correction codewords, a Reed-Solomon code can generally correct up to
+`r/2` unknown erroneous codewords, or up to `r` erasures whose positions are
+already known. Errors cost more than erasures because the decoder must discover
+both location and value.
+
+## Placement And Masking
+
+After correction codewords are produced, a 2D encoder maps bits into available
+cells while skipping reserved regions. Off-by-one errors here are common because
+placement may zigzag, wrap, or change direction.
+
+Some formats mask data modules to avoid visual patterns that are hard to scan,
+such as large solid regions or finder-like shapes. QR evaluates several masks
+and chooses the lowest penalty. The decoder learns the chosen mask from protected
+format metadata and reverses it before reading codewords.
+
+Masking is not encryption. It improves the physical signal.
+
+## Rendering Is Part Of Correctness
+
+A mathematically valid symbol can still be unreadable if rendered badly.
+
+- Preserve the quiet zone around the symbol.
+- Scale modules by an integer number of pixels when possible.
+- Avoid antialiasing between dark and light modules.
+- Preserve sufficient contrast.
+- Do not crop finder or guard patterns.
+- Keep 1D bar widths proportional after device scaling.
+
+Renderers should consume a logical matrix or bar sequence, not repeat encoding
+rules. This lets text, SVG, raster, terminal, and native paint backends share
+the same tested symbol.
+
+## Testing The Channel
+
+Useful tests operate at several levels:
+
+1. compare codewords against standard examples;
+2. verify checksums and syndromes independently;
+3. round-trip payload through encoder and decoder;
+4. rotate and scale rendered symbols;
+5. flip modules within the advertised correction budget;
+6. reject damage beyond that budget;
+7. compare output with an independent scanner;
+8. fuzz dimensions, lengths, and truncated inputs.
+
+The central lesson is that a barcode is not merely a black-and-white picture.
+It is a layered protocol whose final medium happens to be light.

--- a/code/learning/language-tooling/README.md
+++ b/code/learning/language-tooling/README.md
@@ -17,6 +17,8 @@ Relevant packages include:
 ## Topics
 
 - [Intermediate representations](./intermediate-representations.md)
+- [WebAssembly from bytes to execution](./webassembly-from-bytes-to-execution.md)
+- [Structured text from bytes to values](./structured-text-from-bytes-to-values.md)
 
 ## Why This Track Matters
 

--- a/code/learning/language-tooling/structured-text-from-bytes-to-values.md
+++ b/code/learning/language-tooling/structured-text-from-bytes-to-values.md
@@ -1,0 +1,184 @@
+<!-- learning-concepts: csv-parser, json-lexer, json-parser, json-value, json-serializer, toml-lexer, toml-parser, xml-lexer -->
+# Structured Text From Bytes To Values
+
+JSON, CSV, TOML, and XML all turn text into structure, but they do not have the
+same shape. Treating every format as "split strings and fill a map" works only
+until quoting, nesting, escapes, or duplicate keys appear.
+
+The reusable pipeline is:
+
+```text
+bytes -> decoded text -> tokens or fields -> syntax tree -> semantic values
+```
+
+Not every format needs every stage. The important habit is to name the stage
+whose rules you are applying.
+
+## Bytes Are Not Yet Characters
+
+A parser should receive text in a known character encoding. UTF-8 decoding can
+fail, a byte-order mark may be permitted only at the beginning, and line ending
+rules vary by format. Source positions should track enough information to point
+back to the original input, commonly a byte offset plus line and column.
+
+This distinction matters because one displayed character can occupy several
+UTF-8 bytes. A byte offset is useful for slicing; a line and column are useful
+for a person reading an error.
+
+## Lexing Separates Local Decisions
+
+A lexer recognizes local units such as punctuation, strings, numbers, names,
+and comments:
+
+```json
+{"ready": true, "count": 3}
+```
+
+becomes roughly:
+
+```text
+LBRACE STRING COLON TRUE COMMA STRING COLON NUMBER RBRACE
+```
+
+String scanning is more than searching for the next quote. The scanner must
+handle escapes, reject unescaped control characters, and report an unfinished
+escape at its actual source position. Number scanning must implement the
+format's grammar rather than whatever the host language happens to parse.
+
+JSON benefits from a conventional lexer/parser split. TOML does too because
+dates, dotted keys, arrays, inline tables, comments, and several string forms
+create substantial local syntax. XML lexing changes mode between markup and
+character data, so `<` means something different inside and outside a tag.
+
+## Parsing Enforces Structure
+
+The parser combines local tokens according to a grammar. JSON values are
+recursive:
+
+```text
+value  := object | array | string | number | true | false | null
+object := "{" members? "}"
+array  := "[" values? "]"
+```
+
+Recursion makes nesting easy to express but dangerous to leave unbounded. A
+production parser should limit source size, nesting depth, token count, and
+possibly the size of any one collection.
+
+An AST should preserve syntax when later tools need source ranges, comments, or
+exact spellings. A semantic value model can be smaller:
+
+```text
+Null
+Boolean
+Number
+String
+Array<Value>
+Object<String, Value>
+```
+
+Keeping AST and value conversion separate lets a formatter preserve source
+details while an application consumes convenient values.
+
+## CSV Is A State Machine, Not A Split
+
+CSV looks flat, but quoted fields may contain delimiters and line breaks:
+
+```csv
+name,notes
+Ada,"first line
+second line"
+```
+
+Splitting by newline first destroys the second record. Splitting by comma then
+misreads commas inside quotes. A CSV parser instead moves through states:
+
+```text
+field start -> unquoted field -> delimiter/end
+            -> quoted field -> quote seen -> delimiter/end or escaped quote
+```
+
+The dialect must define delimiter, quote character, record terminator policy,
+and whether whitespace outside quotes is data. Row-width validation is a
+semantic choice: some consumers reject ragged rows, while others preserve them.
+
+## TOML Adds Assignment Semantics
+
+TOML syntax constructs a configuration tree over time. These lines:
+
+```toml
+[server]
+host = "localhost"
+ports = [8080, 8081]
+```
+
+do more than parse isolated values. The table header changes the destination
+for later keys. Dotted keys create paths. A correct implementation must reject
+conflicting redefinitions, such as treating the same path as both a scalar and
+a table.
+
+Dates and times are another reason not to lower immediately into host-language
+primitives. A format-specific value can preserve whether an input represented
+a local date, local time, local date-time, or offset date-time.
+
+## XML Mixes Trees And Streams
+
+XML elements naturally form a tree, but large documents are often processed as
+events:
+
+```text
+start_element("book")
+text("...")
+end_element("book")
+```
+
+A tree API is convenient for random access. A streaming API bounds memory and
+can begin work before the final byte arrives. The lexer must distinguish tags,
+attributes, entity references, comments, CDATA, and text. The parser must match
+start and end tags and enforce a single document root.
+
+Entity expansion is a security boundary. Implementations need explicit limits
+on expansion count and output size, and applications should not grant ambient
+filesystem or network access to external entities.
+
+## Serialization Is Not `toString`
+
+A serializer chooses a valid representation for semantic values. It must:
+
+- escape strings according to the target format;
+- reject or define non-finite numbers;
+- choose deterministic key ordering when reproducibility matters;
+- detect cycles in host objects;
+- enforce depth and output-size limits;
+- distinguish absent values from explicit `null` where the format does.
+
+Parsing and serialization are not perfect inverses when a value model discards
+comments, key spelling, numeric spelling, or ordering. State the promised
+round-trip:
+
+```text
+semantic round-trip: parse(serialize(value)) == value
+syntax round-trip:   print(parse(source)) == source
+```
+
+Most data APIs promise the first. Formatters and source editors need the second
+or a documented normalized form.
+
+## A Practical Test Matrix
+
+For each format, include:
+
+1. a small valid example;
+2. every escape and delimiter boundary;
+3. empty values and empty collections;
+4. deeply nested or very wide input at configured limits;
+5. truncated input at every token boundary;
+6. duplicate or conflicting keys;
+7. invalid Unicode or encoding boundaries;
+8. parse/serialize semantic round-trips;
+9. differential cases against a trusted implementation.
+
+The durable lesson is not that all text formats are alike. It is that decoding,
+local recognition, structural parsing, semantic conversion, and serialization
+are different contracts. Bugs become much easier to locate once the contracts
+stop bleeding into one another.

--- a/code/learning/language-tooling/webassembly-from-bytes-to-execution.md
+++ b/code/learning/language-tooling/webassembly-from-bytes-to-execution.md
@@ -1,0 +1,179 @@
+<!-- learning-concepts: wasm-execution, wasm-leb128, wasm-module-parser, wasm-opcodes, wasm-runtime, wasm-types, wasm-validator, wasm-module-encoder, brainfuck-wasm-compiler, nib-wasm-compiler, ir-to-wasm-compiler -->
+# WebAssembly From Bytes To Execution
+
+WebAssembly is often introduced as "assembly for the web." That description
+misses its most useful idea: WebAssembly is a compact, typed, portable machine
+format with a deliberately small contract between producers and runtimes.
+
+A compiler does not need to know which CPU will eventually run the program. A
+runtime does not need to understand the source language. They meet at a
+validated module.
+
+```text
+source language
+    |
+    v
+Wasm module bytes
+    |
+    +--> decode --> validate --> instantiate --> execute
+```
+
+Each arrow has a different responsibility. Keeping those responsibilities
+separate makes malformed input easier to reject and execution easier to test.
+
+## The Binary Container
+
+A binary module begins with a magic number and version, followed by sections.
+Sections describe types, imports, functions, tables, memories, globals, exports,
+code, and data. Most sections contain a vector:
+
+```text
+count, item 0, item 1, ... item n
+```
+
+Integers use LEB128, a variable-length encoding. Seven bits of each byte carry
+data; the high bit says whether another byte follows. For unsigned 624485:
+
+```text
+data groups:  0x65  0x08  0x26
+wire bytes:   0xE5  0x88  0x26
+               ^     ^
+               more  more
+```
+
+Variable-length integers save space for common small values, but they create a
+security boundary. A decoder must cap the number of bytes, detect overflow, and
+reject an input that never terminates. "Keep reading while the high bit is set"
+is not sufficient for hostile bytes.
+
+The module parser turns bytes into structure. It should answer questions such
+as "what functions are declared?" and "what instructions are in this body?"
+It should not execute those instructions or assume they are type-correct.
+
+## Types And Opcodes
+
+WebAssembly 1.0 has four basic numeric value types:
+
+| Type | Meaning |
+| --- | --- |
+| `i32` | 32-bit bit pattern used by signed and unsigned integer operations |
+| `i64` | 64-bit bit pattern used by signed and unsigned integer operations |
+| `f32` | IEEE 754 binary32 floating point |
+| `f64` | IEEE 754 binary64 floating point |
+
+Signedness belongs to an operation, not to an integer value. The same `i32`
+can flow into `i32.lt_s` or `i32.lt_u` and be interpreted differently.
+
+An opcode identifies an instruction. Some instructions carry immediate data:
+a local index, branch depth, memory alignment, or constant. An opcode table is
+therefore shared knowledge between decoders, validators, encoders, disassemblers,
+and execution engines.
+
+## Validation Is Abstract Execution
+
+Parsing proves that bytes have a legal shape. Validation proves that the module
+could execute without violating WebAssembly's static rules.
+
+The validator tracks an abstract operand stack. For:
+
+```wat
+i32.const 6
+i32.const 7
+i32.mul
+```
+
+the stack evolves as:
+
+```text
+[] -> [i32] -> [i32, i32] -> [i32]
+```
+
+`i32.mul` requires two `i32` operands and produces one. If the second constant
+were `f64`, the bytes could still parse, but validation would fail.
+
+Validation also checks index bounds, branch result types, mutability, function
+signatures, memory and table limits, and the special stack-polymorphic rules for
+unreachable code. The key invariant is:
+
+> A validated instruction sequence has one consistent type effect at every
+> reachable control-flow edge.
+
+This is why a runtime should validate before instantiation instead of scattering
+type checks through every hot execution path.
+
+## Instantiation Connects A Module To A World
+
+A module is still a template after validation. Instantiation:
+
+1. resolves imported functions, memories, tables, and globals;
+2. allocates module-defined state;
+3. evaluates constant initializers;
+4. applies element and data segments;
+5. exposes the requested exports;
+6. optionally invokes a start function.
+
+Imports are capability boundaries. A pure module cannot print, open a file, or
+read a clock unless the host gives it a function that does so. WASI is one
+standardized host interface, but a small educational runtime can define a much
+narrower one.
+
+## Execution Uses Two Stacks
+
+The operand stack stores values. The call stack stores function activations:
+locals, return position, and control state.
+
+```text
+call add
+  call stack:    [caller, add]
+  operand stack: [..., 6, 7]
+
+return 13
+  call stack:    [caller]
+  operand stack: [..., 13]
+```
+
+Structured control instructions such as `block`, `loop`, `if`, and `br` avoid
+arbitrary jumps. A branch targets a nesting depth, so the runtime can restore
+the operand stack to the target block's expected shape.
+
+Linear memory is a growable byte array divided into 64 KiB pages. Loads and
+stores calculate an effective address and must trap when the requested range is
+out of bounds. Tables hold references used by indirect calls, whose signatures
+must still match at runtime.
+
+## Producers And Consumers
+
+A module encoder performs the parser's job in reverse: it writes canonical
+section structure, lengths, opcodes, and immediates. Source compilers such as
+the Brainfuck and Nib Wasm compilers are producers. They choose a memory layout
+and lower source operations into typed Wasm instructions.
+
+The clean composition is:
+
+```text
+frontend -> typed IR -> Wasm encoder -> module bytes
+                                      |
+                                      v
+parser -> validator -> runtime -> observable result
+```
+
+Round-trip and differential tests connect both sides. Encode a module, parse it
+again, validate it, run it here, and compare its result with a mature external
+runtime. Each comparison catches a different class of mistake.
+
+## Failure Checklist
+
+When implementing or reviewing a Wasm layer, ask:
+
+- Can a length or LEB128 value overflow?
+- Are section and index bounds checked before allocation or lookup?
+- Does validation model unreachable control flow correctly?
+- Are memory address additions checked for overflow?
+- Are instruction and call budgets available for untrusted modules?
+- Are host functions explicit capabilities?
+- Do encoder and parser agree on canonical forms?
+
+The repository's detailed contract is
+[`W01-wasm-runtime.md`](../../specs/W01-wasm-runtime.md). The package split
+mirrors this lesson: bytes, types, opcodes, parsing, validation, execution, and
+runtime orchestration remain independently testable.

--- a/code/learning/sql-storage/README.md
+++ b/code/learning/sql-storage/README.md
@@ -1,0 +1,12 @@
+# SQL And Storage
+
+SQL systems are easiest to understand when query meaning and storage mechanics
+are treated as separate layers. This track follows a statement from source text
+through execution and then down into the structures that preserve rows.
+
+## Lessons
+
+- [From SQL text to stored rows](./from-sql-text-to-stored-rows.md)
+
+Future lessons will cover SQLite pages and B-trees, indexes, transactions,
+write-ahead logging, and durability.

--- a/code/learning/sql-storage/from-sql-text-to-stored-rows.md
+++ b/code/learning/sql-storage/from-sql-text-to-stored-rows.md
@@ -1,0 +1,192 @@
+<!-- learning-concepts: mini-sqlite, sql-backend, sql-execution-engine, sql-lexer, sql-parser, sql-csv-source -->
+# From SQL Text To Stored Rows
+
+SQL is declarative: a query describes the result you want, not the loop that
+produces it. A database therefore has to translate one statement through
+several representations before it can touch stored data.
+
+```text
+SQL text
+  -> tokens
+  -> syntax tree
+  -> bound and planned operations
+  -> executable operators
+  -> backend reads and writes
+  -> result rows
+```
+
+Each stage removes one kind of ambiguity.
+
+## Lexing And Parsing
+
+The lexer recognizes keywords, identifiers, literals, punctuation, and
+operators. Context matters: quoted identifiers and string literals may use
+similar delimiters but have different escaping rules. Numeric tokens should
+not silently inherit the host language's number grammar.
+
+The parser turns tokens into structure. For:
+
+```sql
+SELECT department, COUNT(*) AS people
+FROM employees
+WHERE active = TRUE
+GROUP BY department
+HAVING COUNT(*) >= 2
+ORDER BY people DESC
+LIMIT 5;
+```
+
+the AST records clauses and expressions, but it still does not know whether
+`employees` exists or what type `active` has.
+
+## Binding Gives Names Meaning
+
+Binding resolves table names, columns, aliases, functions, and parameters
+against a catalog or data-source interface. It should detect an unknown or
+ambiguous column before execution.
+
+Names pass through scopes. A table alias is visible to expressions that read
+input rows; a select-list alias may be visible to `ORDER BY` but not necessarily
+to `WHERE`. SQL dialects differ, so these rules belong in an explicit contract.
+
+Binding can also assign types and insert legal coercions. This keeps execution
+operators focused on values whose shapes are already known.
+
+## Written Order Is Not Evaluation Order
+
+The logical order of a `SELECT` query is approximately:
+
+```text
+FROM and JOIN
+WHERE
+GROUP BY and aggregates
+HAVING
+SELECT
+DISTINCT
+ORDER BY
+OFFSET and LIMIT
+```
+
+This explains several otherwise surprising rules:
+
+- `WHERE` cannot filter on an aggregate because groups do not exist yet.
+- `HAVING` can filter groups because it runs after grouping.
+- `DISTINCT` applies to projected rows, not raw input rows.
+- `LIMIT` must run after sorting if the query asks for the top rows by order.
+
+An educational engine can materialize the complete row set between stages. A
+production-oriented engine often uses iterator operators that request one row
+at a time:
+
+```text
+Limit
+  -> Sort
+    -> Project
+      -> Filter
+        -> TableScan
+```
+
+The materialized model is easier to inspect. The iterator model can stream and
+stop early. Both should implement the same logical semantics.
+
+## Rows, Values, And NULL
+
+A row maps columns to SQL values. SQL `NULL` means unknown or absent, not zero,
+an empty string, or false.
+
+Comparisons use three-valued logic:
+
+| Expression | Result |
+| --- | --- |
+| `1 = 1` | true |
+| `1 = 2` | false |
+| `1 = NULL` | unknown |
+| `NULL = NULL` | unknown |
+
+`WHERE` retains only true; false and unknown are filtered out. Testing host
+language truthiness instead of SQL truth tables creates subtle errors in joins,
+filters, and constraints.
+
+Aggregates also define NULL behavior. `COUNT(*)` counts rows, `COUNT(column)`
+counts non-NULL values, and most other aggregates ignore NULL inputs but return
+NULL when no non-NULL value exists.
+
+## The Backend Boundary
+
+The query engine should not know whether rows came from a CSV file, an in-memory
+table, or SQLite pages. A backend contract can expose operations such as:
+
+```text
+list tables
+describe columns
+scan rows
+insert, update, delete
+begin, commit, rollback
+```
+
+A CSV source is a useful first backend. It proves that SQL evaluation can be
+separated from storage mechanics. It also exposes schema questions: are all
+fields strings, are types inferred, and what happens when rows have different
+widths?
+
+Pushdown is an optimization across this boundary. Instead of scanning every row
+and filtering later, the engine may ask a capable backend to apply a predicate,
+projection, or limit. The result must remain identical whether pushdown occurs.
+
+## Planning And Optimization
+
+A logical plan says what operations implement the query. A physical plan chooses
+how:
+
+```text
+logical join
+  -> nested-loop join
+  -> hash join
+  -> index lookup join
+```
+
+An optimizer uses equivalence rules and cost estimates. It may push a filter
+closer to a scan, reorder inner joins, replace a full scan with an index lookup,
+or remove unused columns. Every rewrite needs two arguments:
+
+1. the new plan is semantically equivalent;
+2. the estimated execution cost is better.
+
+Correctness comes first. Differential tests can execute optimized and
+unoptimized plans and compare complete results.
+
+## What Mini-SQLite Adds
+
+A SQLite-compatible engine composes SQL semantics with a durable file format.
+Below the query layer it must understand:
+
+- fixed-size pages and page 1 metadata;
+- B-tree interior and leaf cells;
+- variable-length records and serial types;
+- overflow pages for large payloads;
+- indexes and row identifiers;
+- transactions, locking, journals, or WAL;
+- SQLite's detailed function, coercion, ordering, and NULL behavior.
+
+Compatibility is observable behavior, not merely accepting the same syntax.
+The strongest test is differential:
+
+```text
+same database + same SQL
+    |
+    +--> repository engine -> rows or error
+    +--> SQLite oracle     -> rows or error
+                              |
+                              v
+                         compare exactly
+```
+
+When results differ, classify the fault by stage: tokenization, parsing,
+binding, expression semantics, logical order, planning, execution, or storage.
+That classification turns a giant "SQL is wrong" problem into a tractable one.
+
+Detailed repository contracts live in
+[`sql-execution-engine.md`](../../specs/sql-execution-engine.md),
+[`sql-backend.md`](../../specs/sql-backend.md), and the
+[`mini-sqlite-full-conformance.md`](../../specs/mini-sqlite-full-conformance.md)
+roadmap.


### PR DESCRIPTION
## Summary

- refresh the root README to reflect shipped native GC/AOT capabilities and the current ADJ, Venture, smart-home, task-app, and language-ladder tracks
- add a hand-authored learning coverage roadmap with a tracked-package baseline and prioritization model
- add foundational lessons for WebAssembly execution, structured text parsing, SQL execution/storage, and barcodes/error correction
- add Documents and Media and SQL and Storage learning indexes
- regenerate the learning coverage inventory while excluding unrelated local untracked package work

## Why

The repository has changed rapidly since the previous README rewrite, and the learning inventory showed a large gap between package breadth and teaching material. This change updates the durable project overview and starts a breadth-weighted learning program focused on concepts implemented across many language ecosystems.

The first content batch raises dedicated learning coverage from 57 to 98 concepts, reduces missing tracked-package coverage from 1,112 to 1,065, and reduces the P0 missing backlog from 99 to 56.

## Impact

Readers get an accurate map of the current repository and four connected, implementation-grounded lessons. Maintainers get a durable roadmap and regenerated backlog for selecting future learning work.

## Validation

- `python3 -m unittest tests/test_learning_coverage_report.py tests/test_package_parity_report.py` from `code/scripts` (11 tests)
- `git diff --check`
- verified every new local Markdown link resolves
- documentation-focused security review completed with no findings
