### PR TITLE
feat(spice): validate MOS sidewall grading

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `MJSW` values with a
+  stable diagnostic before sidewall depletion-capacitance shaping.
 - Reject Level-1 MOS model-card `FC` values outside `[0, 1)` or non-finite
   values with a stable diagnostic before depletion-capacitance shaping.
 - Reject negative or non-finite Level-1 MOS model-card `MJ` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -596,6 +596,8 @@ def normalize_model_card(
             not math.isfinite(value) or value < 0.0 or value >= 1.0
         ):
             raise ValueError(f"{name}: MOSFET FC must be finite and in [0, 1)")
+        elif canonical == "MJSW" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET MJSW must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1134,6 +1134,18 @@ def test_mos_model_card_rejects_out_of_range_or_non_finite_depletion_coefficient
             normalize_model_card("Minvalid", "nmos", {"FC": invalid_coefficient})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_sidewall_grading_coefficient() -> None:
+    for value in (0.0, 0.33, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"MJSW": value})
+        assert valid.parameters["MJSW"] == pytest.approx(value)
+
+    for invalid_coefficient in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET MJSW must be finite and non-negative"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"MJSW": invalid_coefficient})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `MJSW` values with a
+  stable diagnostic before sidewall depletion-capacitance shaping.
 - Reject Level-1 MOS model-card `FC` values outside `[0, 1)` or non-finite
   values with a stable diagnostic before depletion-capacitance shaping.
 - Reject negative or non-finite Level-1 MOS model-card `MJ` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4417,6 +4417,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET FC must be finite and in [0, 1)".to_string(),
                 });
+            } else if canonical == "MJSW" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET MJSW must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -975,6 +975,22 @@ fn mos_model_card_rejects_out_of_range_or_non_finite_depletion_coefficient() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_sidewall_grading_coefficient() {
+    for value in [0.0, 0.33, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("MJSW", value)]).unwrap();
+        assert_close(*valid.parameters.get("MJSW").unwrap(), value);
+    }
+
+    for invalid_coefficient in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("MJSW", invalid_coefficient)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET MJSW must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `MJSW` values with a
+  stable diagnostic before sidewall depletion-capacitance shaping.
 - Reject Level-1 MOS model-card `FC` values outside `[0, 1)` or non-finite
   values with a stable diagnostic before depletion-capacitance shaping.
 - Reject negative or non-finite Level-1 MOS model-card `MJ` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8471,6 +8471,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0 || value >= 1.0)
     ) {
       throw invalidElement(name, "MOSFET FC must be finite and in [0, 1)");
+    } else if (
+      canonical === "MJSW" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET MJSW must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -863,6 +863,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS sidewall grading coefficient", () => {
+    for (const value of [0.0, 0.33, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { MJSW: value });
+      expect(valid.parameters.MJSW).toBe(value);
+    }
+
+    for (const invalidCoefficient of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { MJSW: invalidCoefficient }),
+      ).toThrow("MOSFET MJSW must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS depletion-coefficient validation.
+1. Cross-language Level-1 MOS sidewall-grading validation.
    - Status: current PR completion candidate.
-   - Reject model-card `FC` values outside `[0, 1)` or non-finite values before
+   - Reject negative or non-finite model-card `MJSW` values before sidewall
      depletion-capacitance shaping.
-   - Preserve finite forward-bias depletion coefficients in `[0, 1)` across
-     Rust, Python, and TypeScript.
+   - Preserve zero and positive sidewall-grading coefficients across Rust,
+     Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3720,6 +3720,13 @@ the Rust, Python, and TypeScript surfaces together.
      depletion-capacitance shaping.
    - Zero and positive junction-grading coefficients remain aligned across
      Rust, Python, and TypeScript.
+
+306. Cross-language Level-1 MOS depletion-coefficient validation.
+   - Status: completed in PR 9294.
+   - Model-card `FC` values outside `[0, 1)` and non-finite values are rejected
+     before depletion-capacitance shaping.
+   - Finite forward-bias depletion coefficients in `[0, 1)` remain aligned
+     across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS `MJSW` values before sidewall depletion-capacitance shaping
- preserve zero and positive sidewall grading coefficients with aligned Rust, Python, and TypeScript diagnostics
- reconcile the SPICE completion plan by recording PR #9294 and selecting this slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check` for spice-engine source and tests
- Python full spice-engine pytest: 688 passed, 88.96% coverage
- TypeScript `npm test`: 431 passed
- TypeScript `npm run build`