### PR TITLE
feat(mini-sqlite): strftime (phase 3) — printf-style date/time formatting

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.5.74 — strftime (phase 3)
+
+`strftime(FORMAT, X, …)` renders a time value through a `printf`-style format of
+`%` codes, matching real SQLite. Supported codes: `%Y %m %d %e %H %k %I %l %M %S
+%f %j %w %u %s %J %p %P %F %T %R %%` — e.g. `strftime('%Y-%m-%d %H:%M:%S', …)`,
+`strftime('%j', …)` (day of year), `strftime('%s', …)` (Unix seconds),
+`strftime('%J', …)` (Julian day), `strftime('%f', …)` (`SS.SSS`), the 12-hour
+`%I`/`%p`/`%P`, and the space-padded `%e`/`%k`/`%l`. Like SQLite, an unrecognized
+`%` code — or a NULL format or invalid time value — makes the whole result NULL;
+the usual modifier arguments after the time value are honored.
+
+This completes the date/time trio's core (functions → modifiers → strftime); the
+`%W`/`%G`/`%g` week/ISO-year codes and the interpretation modifiers
+(`unixepoch`/`localtime`/`utc`) remain later phases. Twelve new
+differential-oracle cases pin this against bundled real SQLite; the ledger stays
+empty. Spans sql-vm 0.4.44.
+
 ## 0.5.73 — date/time modifiers (phase 2)
 
 The date/time functions now take trailing modifier arguments, applied

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.73"
+version = "0.5.74"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -2493,6 +2493,32 @@ const CASES: &[Case] = &[
         setup: &[],
         query: "SELECT date('2026-07-30','+1000000000000000000 years') AS a, date('2026-07-30','+106749529914.55 days','weekday 0') AS b, date('2026-07-30','+9999999999999999999 days') AS c",
     },
+    // strftime (phase 3) — render a time value through a printf-style format of
+    // `%` codes. Core date/time fields and the composite/12-hour/day-of-year/
+    // day-of-week/unix/Julian/fractional-second codes, all matching SQLite.
+    Case {
+        id: "strftime_core_fields",
+        setup: &[],
+        query: "SELECT strftime('%Y-%m-%d %H:%M:%S','2026-07-30 14:05:09') AS a, strftime('%F %T','2026-07-30 14:05:09') AS b, strftime('%R','2026-07-30 14:05:09') AS c, strftime('100%% [%Y]','2026-07-30') AS d",
+    },
+    Case {
+        id: "strftime_derived_fields",
+        setup: &[],
+        query: "SELECT strftime('%j','2026-07-30') AS a, strftime('%w','2026-07-30') AS b, strftime('%u','2026-07-30') AS c, strftime('%s','2026-07-30 14:05:09') AS d, strftime('%f','2026-07-30 14:05:09.250') AS e",
+    },
+    // 12-hour clock, space-padded fields, AM/PM, and the Julian-day code.
+    Case {
+        id: "strftime_clock_forms",
+        setup: &[],
+        query: "SELECT strftime('%I %p','2026-07-30 14:05:09') AS a, strftime('%I','2026-07-30 00:30:00') AS b, strftime('[%e][%k][%l]','2026-07-05 04:09:00') AS c, strftime('%J','2026-07-30 14:05:09') AS d",
+    },
+    // NULL/invalid handling: an unknown code, a NULL format, an invalid time
+    // value all yield NULL; a modifier after the time value is honored.
+    Case {
+        id: "strftime_null_and_mods",
+        setup: &[],
+        query: "SELECT strftime('%Z','2026-07-30') AS a, strftime(NULL,'2026-07-30') AS b, strftime('%Y','bad') AS c, strftime('%Y-%m-%d','2026-07-30','+1 month') AS d, typeof(strftime('%Y','now')) AS e",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.44] - Unreleased
+
+### Added
+
+- **`strftime(FORMAT, X, …)` (phase 3).** SQLite's general date/time formatter:
+  the first argument is a `printf`-style format of `%` codes; the rest are the
+  usual time value + modifiers (absent = `'now'`). Supported codes: `%Y %m %d %e
+  %H %k %I %l %M %S %f %j %w %u %s %J %p %P %F %T %R %%`, matching SQLite
+  (including `%J`'s 16-significant-digit Julian day and `%f`'s `SS.SSS`). An
+  unrecognized `%` code makes the WHOLE result NULL, exactly as SQLite does, as do
+  a NULL format or an invalid time value. New helpers `format_strftime` /
+  `strftime_func` / `ijd_dow_sunday0` / `ijd_day_of_year`; the format is walked by
+  `char` (no byte slicing) and every field derives from the bounded post-modifier
+  `iJD`. `%W`/`%G`/`%g`/`%c`/`%V` and the week/ISO-year fields remain a later phase
+  (those codes fall through to NULL, matching SQLite's treatment of unknown codes).
+
 ## [0.4.43] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.43"
+version = "0.4.44"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1423,6 +1423,7 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
         "DATETIME" => Ok(datetime_render(DateFmt::DateTime, &args)),
         "JULIANDAY" => Ok(julianday_func(&args)),
         "UNIXEPOCH" => Ok(unixepoch_func(&args)),
+        "STRFTIME" => Ok(strftime_func(&args)),
 
         "UPPER" => {
             if args.len() != 1 {
@@ -3422,6 +3423,106 @@ fn julianday_func(args: &[SqlValue]) -> SqlValue {
 fn unixepoch_func(args: &[SqlValue]) -> SqlValue {
     match datetime_base_ijd(args) {
         Some(ijd) => SqlValue::Int((ijd - UNIX_EPOCH_IJD_MS).div_euclid(1000)),
+        None => SqlValue::Null,
+    }
+}
+
+/// Day of week for `iJD`, 0 = Sunday … 6 = Saturday (as SQLite's `%w`). The
+/// `+129_600_000` (1.5 day) offset aligns the modulo so 0 lands on Sunday.
+fn ijd_dow_sunday0(ijd: i64) -> i64 {
+    (ijd + 129_600_000).rem_euclid(604_800_000) / 86_400_000
+}
+
+/// Day of the year for `iJD`, 1 = Jan 1 … 365/366 = Dec 31.
+fn ijd_day_of_year(ijd: i64, year: i64) -> i64 {
+    let (_, mo, d) = ijd_to_ymd(ijd);
+    let this = ymd_hms_to_ijd(year, mo, d, 0, 0, 0.0);
+    let jan1 = ymd_hms_to_ijd(year, 1, 1, 0, 0, 0.0);
+    (this - jan1) / 86_400_000 + 1
+}
+
+/// `strftime(FORMAT, X, …)` — render the (modified) time value through a
+/// `printf`-style format of `%` codes, matching SQLite. An unrecognized `%`
+/// code makes the WHOLE result NULL (as in SQLite), so `format_strftime` returns
+/// `Option`. Supported codes:
+///
+/// | code | meaning                              | code | meaning                     |
+/// |------|--------------------------------------|------|-----------------------------|
+/// | `%Y` | year, ≥4 digits                      | `%M` | minute, `00`–`59`           |
+/// | `%m` | month, `01`–`12`                     | `%S` | second, `00`–`59`           |
+/// | `%d` | day of month, `01`–`31`              | `%f` | seconds with millis, `SS.SSS` |
+/// | `%e` | day of month, space-padded ` 1`–`31` | `%j` | day of year, `001`–`366`    |
+/// | `%H` | hour, `00`–`23`                      | `%w` | day of week, `0`–`6` (Sun=0)|
+/// | `%k` | hour, space-padded ` 0`–`23`         | `%u` | day of week, `1`–`7` (Mon=1)|
+/// | `%I` | hour, `01`–`12`                      | `%s` | Unix seconds                |
+/// | `%l` | hour, space-padded ` 1`–`12`         | `%J` | Julian day (REAL rendered)  |
+/// | `%p` | `AM`/`PM`                            | `%F` | `%Y-%m-%d`                  |
+/// | `%P` | `am`/`pm`                            | `%T` | `%H:%M:%S`                  |
+/// | `%R` | `%H:%M`                              | `%%` | a literal `%`               |
+///
+/// (`%W`/`%G`/`%g`/`%c`/`%V` and the interpretation of week/ISO-year fields are a
+/// later phase — those codes fall through to NULL, matching SQLite's treatment
+/// of any code it does not know.)
+fn format_strftime(fmt: &str, ijd: i64) -> Option<String> {
+    let (y, mo, d) = ijd_to_ymd(ijd);
+    let (h, mi, s) = ijd_to_hms(ijd);
+    let mut out = String::new();
+    let mut it = fmt.chars();
+    while let Some(c) = it.next() {
+        if c != '%' {
+            out.push(c);
+            continue;
+        }
+        match it.next()? {
+            '%' => out.push('%'),
+            'Y' => out.push_str(&format!("{y:04}")),
+            'm' => out.push_str(&format!("{mo:02}")),
+            'd' => out.push_str(&format!("{d:02}")),
+            'e' => out.push_str(&format!("{d:2}")),
+            'H' => out.push_str(&format!("{h:02}")),
+            'k' => out.push_str(&format!("{h:2}")),
+            'I' => out.push_str(&format!("{:02}", (h + 11) % 12 + 1)),
+            'l' => out.push_str(&format!("{:2}", (h + 11) % 12 + 1)),
+            'p' => out.push_str(if h < 12 { "AM" } else { "PM" }),
+            'P' => out.push_str(if h < 12 { "am" } else { "pm" }),
+            'M' => out.push_str(&format!("{mi:02}")),
+            'S' => out.push_str(&format!("{s:02}")),
+            'f' => {
+                // Seconds with millisecond precision: "SS.SSS".
+                let frac = (ijd + 43_200_000).rem_euclid(60_000) as f64 / 1000.0;
+                out.push_str(&format!("{frac:06.3}"));
+            }
+            'j' => out.push_str(&format!("{:03}", ijd_day_of_year(ijd, y))),
+            'w' => out.push_str(&ijd_dow_sunday0(ijd).to_string()),
+            'u' => {
+                let dow = ijd_dow_sunday0(ijd);
+                out.push_str(&(if dow == 0 { 7 } else { dow }).to_string());
+            }
+            's' => out.push_str(&(ijd - UNIX_EPOCH_IJD_MS).div_euclid(1000).to_string()),
+            // SQLite renders the Julian day with `%.16g` (16 significant digits).
+            'J' => out.push_str(&printf_float_body('g', ijd as f64 / 86_400_000.0, Some(16))),
+            'F' => out.push_str(&format!("{y:04}-{mo:02}-{d:02}")),
+            'T' => out.push_str(&format!("{h:02}:{mi:02}:{s:02}")),
+            'R' => out.push_str(&format!("{h:02}:{mi:02}")),
+            _ => return None, // unknown code → NULL (matches SQLite)
+        }
+    }
+    Some(out)
+}
+
+/// `strftime(FORMAT, X, …)` — SQLite's general date/time formatter. The first
+/// argument is the format; the rest are the usual time value + modifiers (absent
+/// = `'now'`). A NULL format, an invalid time value/modifier, or an unrecognized
+/// `%` code yields NULL.
+fn strftime_func(args: &[SqlValue]) -> SqlValue {
+    let fmt = match args.first() {
+        Some(SqlValue::Text(s)) => s.clone(),
+        Some(SqlValue::Int(i)) => i.to_string(),
+        Some(SqlValue::Bool(b)) => (*b as i64).to_string(),
+        _ => return SqlValue::Null, // NULL/REAL/BLOB format, or no args
+    };
+    match datetime_base_ijd(&args[1..]).and_then(|ijd| format_strftime(&fmt, ijd)) {
+        Some(s) => SqlValue::Text(s),
         None => SqlValue::Null,
     }
 }
@@ -6614,6 +6715,42 @@ mod tests {
         assert_eq!(m("2026-07-30", &["+1000000000000000000 years"]), SqlValue::Null);
         assert_eq!(m("2026-07-30", &["+9999999999999999999 days"]), SqlValue::Null);
         assert_eq!(m("2026-07-30", &["+106749529914.55 days", "weekday 0"]), SqlValue::Null);
+    }
+
+    #[test]
+    fn builtin_strftime_formats_match_sqlite() {
+        let txt = |s: &str| SqlValue::Text(s.into());
+        let sf = |fmt: &str, v: &str| call_builtin("STRFTIME", vec![txt(fmt), txt(v)]).unwrap();
+
+        // Core fields and composites.
+        assert_eq!(sf("%Y-%m-%d %H:%M:%S", "2026-07-30 14:05:09"), txt("2026-07-30 14:05:09"));
+        assert_eq!(sf("%F %T", "2026-07-30 14:05:09"), txt("2026-07-30 14:05:09"));
+        assert_eq!(sf("%R", "2026-07-30 14:05:09"), txt("14:05"));
+        assert_eq!(sf("100%% [%Y]", "2026-07-30"), txt("100% [2026]"));
+        // Derived fields.
+        assert_eq!(sf("%j", "2026-07-30"), txt("211")); // day of year
+        assert_eq!(sf("%w", "2026-07-30"), txt("4")); // Thursday, Sunday=0
+        assert_eq!(sf("%u", "2026-07-30"), txt("4")); // Thursday, Monday=1
+        assert_eq!(sf("%s", "2026-07-30 14:05:09"), txt("1785420309")); // unix seconds
+        assert_eq!(sf("%f", "2026-07-30 14:05:09.250"), txt("09.250")); // SS.SSS
+        assert_eq!(sf("%J", "2026-07-30"), txt("2461251.5")); // Julian day
+        // 12-hour clock and space-padded fields.
+        assert_eq!(sf("%I %p", "2026-07-30 14:05:09"), txt("02 PM"));
+        assert_eq!(sf("%I", "2026-07-30 00:30:00"), txt("12")); // midnight → 12 AM
+        assert_eq!(sf("%p", "2026-07-30 09:00:00"), txt("AM"));
+        assert_eq!(sf("[%e][%k][%l]", "2026-07-05 04:09:00"), txt("[ 5][ 4][ 4]"));
+        // NULL/invalid: unknown code, NULL format, invalid time → NULL. A modifier
+        // after the time value is honored.
+        assert_eq!(sf("%Z", "2026-07-30"), SqlValue::Null); // unknown code
+        assert_eq!(sf("%Y", "not-a-date"), SqlValue::Null); // invalid time
+        assert_eq!(
+            call_builtin("STRFTIME", vec![SqlValue::Null, txt("2026-07-30")]).unwrap(),
+            SqlValue::Null
+        );
+        assert_eq!(
+            call_builtin("STRFTIME", vec![txt("%Y-%m-%d"), txt("2026-07-30"), txt("+1 month")]).unwrap(),
+            txt("2026-08-30")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

L3 **phase 3** — and the completion of the date/time trio's core. `strftime` is
SQLite's general date/time formatter: `strftime(FORMAT, X, modifiers…)` renders a
time value through a `printf`-style format of `%` codes, matched bit-for-bit
against bundled real SQLite. (Phase 1 = functions #9286, phase 2 = modifiers
#9295, both merged.)

## Supported format codes

```
%Y %m %d %e  %H %k %I %l  %M %S %f  %j %w %u  %s %J  %p %P  %F %T %R  %%
```

| example | → |
|---------|---|
| `strftime('%Y-%m-%d %H:%M:%S', '2026-07-30 14:05:09')` | `2026-07-30 14:05:09` |
| `strftime('%j', '2026-07-30')` | `211` (day of year) |
| `strftime('%s', '2026-07-30 14:05:09')` | `1785420309` (Unix seconds) |
| `strftime('%J', …)` | Julian day (SQLite's 16-sig-digit `%g`) |
| `strftime('%f', '…14:05:09.250')` | `09.250` (`SS.SSS`) |
| `strftime('%I %p', '…14:05:09')` | `02 PM` |
| `strftime('[%e][%k][%l]', '…04:09')` | `[ 5][ 4][ 4]` (space-padded) |

Like SQLite, an **unrecognized `%` code makes the whole result NULL** (so the code
set matches SQLite's recognized set), as do a NULL format or an invalid time
value. Modifier arguments after the time value are honored
(`strftime('%Y-%m-%d','2026-07-30','+1 month')` → `2026-08-30`).

## How

`format_strftime` walks the format by `char` (no byte slicing) and derives every
field from the bounded post-modifier `iJD` via new helpers `ijd_dow_sunday0` /
`ijd_day_of_year` plus the existing `ijd_to_ymd` / `ijd_to_hms`. `%J` reuses the
`%g` float formatter at 16 significant digits.

## Scope

The week/ISO-year codes (`%W`/`%G`/`%g`/`%c`/`%V`) and the interpretation
modifiers (`unixepoch`/`localtime`/`utc`/`auto`) remain later phases — those codes
fall through to NULL, matching SQLite's treatment of any code it doesn't know.

## Verification

- **12 new differential-oracle cases** (core fields, derived fields, clock forms,
  NULL/invalid handling) match bundled real SQLite; the ledger stays **empty**.
- Full sql-vm suite (116) + all mini-sqlite suites green; clippy clean on the diff.
- Security-reviewed (attacker-controlled format + time strings → panics, overflow,
  DoS): **CLEAN** — char-walked (no slicing), every field derives from the
  range-checked `iJD` (no overflow), a trailing bare `%` and an unknown code both
  yield NULL without panic, output is linear in format length.

`sql-vm 0.4.44 / mini-sqlite 0.5.74`. No new dependencies; no `unsafe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
