### PR TITLE
feat(mosaic): compile MSL transitions

### DIFF
--- a/code/grammars/mosstyle/mosstyle.grammar
+++ b/code/grammars/mosstyle/mosstyle.grammar
@@ -68,22 +68,37 @@ part_path = NAME { SLASH NAME } ;
 # ============================================================================
 # Part items
 # ============================================================================
-# Each item is either a property declaration or a state block.
+# Each item is a property declaration, transition declaration, or state block.
 # LL(1) disambiguation:
 #   - First token KEYWORD ("state") → state_block
+#   - First token KEYWORD ("transition") → transition_decl
 #   - First token NAME               → property_decl
 
 part_item = state_block
+          | transition_decl
           | property_decl ;
 
 # ============================================================================
 # State blocks
 # ============================================================================
-# state state-name { property_decl* }
+# state state-name { state_item* }
 # State names (hover, pressed, focused, …) are NAME tokens in the token
 # grammar (not reserved keywords), validated semantically.
 
-state_block = KEYWORD NAME LBRACE { property_decl } RBRACE ;
+state_block = KEYWORD NAME LBRACE { state_item } RBRACE ;
+state_item = transition_decl
+           | property_decl ;
+
+# ============================================================================
+# Transition declarations
+# ============================================================================
+# transition <property-name> <duration> [ <easing> ] ;
+#
+# Durations and easing values may be design-token references or resolved
+# literals. The semantic compiler resolves tokens and supplies `ease-out` when
+# the easing value is omitted.
+
+transition_decl = KEYWORD NAME style_value [ style_value ] SEMICOLON ;
 
 # ============================================================================
 # Property declarations

--- a/code/grammars/mosstyle/mosstyle.tokens
+++ b/code/grammars/mosstyle/mosstyle.tokens
@@ -45,6 +45,7 @@ keywords:
   style
   part
   state
+  transition
 
 # ============================================================================
 # Identifiers

--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -2593,6 +2593,7 @@ mod tests {
         PartStyle {
             name: name.to_string(),
             base,
+            transitions: vec![],
             states,
         }
     }
@@ -2600,6 +2601,7 @@ mod tests {
     fn state(name: &str, props: Vec<StyleProp>) -> StateStyle {
         StateStyle {
             state: name.to_string(),
+            transitions: vec![],
             props,
         }
     }

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -3786,6 +3786,7 @@ mod tests {
                         value: "7px".into(),
                     },
                 ],
+                transitions: vec![],
                 states: Vec::new(),
             }],
         };
@@ -4539,6 +4540,7 @@ mod tests {
                     name: "padding".into(),
                     value: "8".into(),
                 }],
+                transitions: vec![],
                 states: Vec::new(),
             }],
         };
@@ -5660,9 +5662,11 @@ mod tests {
                             value: "right".into(),
                         },
                     ],
+                    transitions: vec![],
                     states: vec![
                         mosstyle_compiler::StateStyle {
                             state: "selected".into(),
+                            transitions: vec![],
                             props: vec![
                                 StyleProp {
                                     name: "background".into(),
@@ -5676,6 +5680,7 @@ mod tests {
                         },
                         mosstyle_compiler::StateStyle {
                             state: "editing".into(),
+                            transitions: vec![],
                             props: vec![StyleProp {
                                 name: "background".into(),
                                 value: "#1f4f3f".into(),
@@ -5707,6 +5712,7 @@ mod tests {
                             value: "#3f3f46".into(),
                         },
                     ],
+                    transitions: vec![],
                     states: vec![],
                 },
             ],

--- a/code/packages/rust/mosaic-emit-html/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-html/src/pipeline.rs
@@ -3676,6 +3676,7 @@ mod tests {
                         value: "#eee".to_string(),
                     },
                 ],
+                transitions: vec![],
                 states: Vec::new(),
             }],
         };
@@ -3730,6 +3731,7 @@ mod tests {
                         value: "0".to_string(),
                     },
                 ],
+                transitions: vec![],
                 states: Vec::new(),
             }],
         };
@@ -3780,6 +3782,7 @@ mod tests {
                         value: "blue".to_string(),
                     },
                 ],
+                transitions: vec![],
                 states: Vec::new(),
             }],
         };

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -5038,6 +5038,7 @@ mod tests {
                         value: "7px".to_string(),
                     },
                 ],
+                transitions: vec![],
                 states: vec![],
             }],
         };
@@ -7743,6 +7744,7 @@ mod tests {
                         sp("font-family", "monospace"),
                         sp("font-size", "12px"),
                     ],
+                    transitions: vec![],
                     states: vec![],
                 },
                 PartStyle {
@@ -7754,13 +7756,16 @@ mod tests {
                         sp("height", "22px"),
                         sp("text-align", "right"),
                     ],
+                    transitions: vec![],
                     states: vec![
                         StateStyle {
                             state: "selected".to_string(),
+                            transitions: vec![],
                             props: vec![sp("background", "#264f78"), sp("color", "#ffffff")],
                         },
                         StateStyle {
                             state: "editing".to_string(),
+                            transitions: vec![],
                             props: vec![sp("background", "#1f4f3f")],
                         },
                     ],
@@ -8018,6 +8023,7 @@ mod tests {
                     sp("border-width", "1px"),
                     sp("border-color", "#3f3f46"),
                 ],
+                transitions: vec![],
                 states: vec![],
             }],
         };
@@ -8063,6 +8069,7 @@ mod tests {
             parts: vec![PartStyle {
                 name: "screen".to_string(),
                 base: vec![sp("gap", "14"), sp("max-width", "980px")],
+                transitions: vec![],
                 states: vec![],
             }],
         };
@@ -8116,6 +8123,7 @@ mod tests {
                     sp("gap", "16"),
                     sp("padding", "12"),
                 ],
+                transitions: vec![],
                 states: vec![],
             }],
         };
@@ -8178,6 +8186,7 @@ mod tests {
                     sp("font-weight", "700"),
                     sp("text-align", "center"),
                 ],
+                transitions: vec![],
                 states: vec![],
             }],
         };

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -5542,6 +5542,7 @@ mod tests {
                         value: v.to_string(),
                     })
                     .collect(),
+                transitions: vec![],
                 states: Vec::new(),
             }],
         }
@@ -5712,8 +5713,10 @@ mod tests {
                     name: "background".to_string(),
                     value: "#222".to_string(),
                 }],
+                transitions: vec![],
                 states: vec![StateStyle {
                     state: "hover".to_string(),
+                    transitions: vec![],
                     props: vec![StyleProp {
                         name: "background".to_string(),
                         value: "#444".to_string(),
@@ -6171,6 +6174,7 @@ mod tests {
         if !even.is_empty() {
             states.push(StateStyle {
                 state: "even".to_string(),
+                transitions: vec![],
                 props: even
                     .iter()
                     .map(|(k, v)| StyleProp {
@@ -6183,6 +6187,7 @@ mod tests {
         if !odd.is_empty() {
             states.push(StateStyle {
                 state: "odd".to_string(),
+                transitions: vec![],
                 props: odd
                     .iter()
                     .map(|(k, v)| StyleProp {
@@ -6197,6 +6202,7 @@ mod tests {
             parts: vec![PartStyle {
                 name: "sheet/data-row".to_string(),
                 base: Vec::new(),
+                transitions: vec![],
                 states,
             }],
         }
@@ -7636,6 +7642,7 @@ mod tests {
                     name: "align".to_string(),
                     value: value.to_string(),
                 }],
+                transitions: vec![],
                 states: vec![],
             }],
         };
@@ -7786,6 +7793,7 @@ mod tests {
                     name: "width".to_string(),
                     value: "10".to_string(),
                 }],
+                transitions: vec![],
                 states: vec![],
             }],
         };
@@ -7861,8 +7869,10 @@ mod tests {
             parts: vec![PartStyle {
                 name: "bar".to_string(),
                 base: vec![],
+                transitions: vec![],
                 states: vec![StateStyle {
                     state: "hover".to_string(),
+                    transitions: vec![],
                     props: vec![StyleProp {
                         name: "width".to_string(),
                         value: "99".to_string(),
@@ -8969,6 +8979,7 @@ mod tests {
                     name: "background".to_string(),
                     value: "blue".to_string(),
                 }],
+                transitions: vec![],
                 states: Vec::new(),
             }],
         };

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -7113,6 +7113,7 @@ mod tests {
             parts: vec![PartStyle {
                 name: part_name.to_string(),
                 base: props,
+                transitions: vec![],
                 states: Vec::new(),
             }],
         }
@@ -7143,11 +7144,13 @@ mod tests {
                 PartStyle {
                     name: "cell".to_string(),
                     base: vec![sp("padding", "2px")],
+                    transitions: vec![],
                     states: Vec::new(),
                 },
                 PartStyle {
                     name: "header".to_string(),
                     base: vec![sp("font-weight", "bold")],
+                    transitions: vec![],
                     states: Vec::new(),
                 },
             ],
@@ -7613,10 +7616,12 @@ mod tests {
             parts: vec![PartStyle {
                 name: part_name.to_string(),
                 base,
+                transitions: vec![],
                 states: states
                     .into_iter()
                     .map(|(name, props)| StateStyle {
                         state: name.to_string(),
+                        transitions: vec![],
                         props,
                     })
                     .collect(),

--- a/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
@@ -3214,6 +3214,7 @@ mod tests {
         PartStyle {
             name: name.to_string(),
             base,
+            transitions: vec![],
             states,
         }
     }
@@ -6204,10 +6205,12 @@ mod tests {
                 vec![
                     StateStyle {
                         state: "selected".to_string(),
+                        transitions: vec![],
                         props: vec![prop("background", "#264f78"), prop("color", "#ffffff")],
                     },
                     StateStyle {
                         state: "editing".to_string(),
+                        transitions: vec![],
                         props: vec![prop("background", "#1f4f3f")],
                     },
                 ],
@@ -6283,6 +6286,7 @@ mod tests {
                 vec![prop("padding", "2px")],
                 vec![StateStyle {
                     state: "selected".to_string(),
+                    transitions: vec![],
                     props: vec![prop("background", "blue")],
                 }],
             )],
@@ -6312,6 +6316,7 @@ mod tests {
                 ],
                 vec![StateStyle {
                     state: "selected".to_string(),
+                    transitions: vec![],
                     props: vec![prop("border-width", "1")],
                 }],
             )],

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -6995,6 +6995,7 @@ mod tests {
                     name: "background".to_string(),
                     value: "#1e1e1e".to_string(),
                 }],
+                transitions: vec![],
                 states: Vec::new(),
             }],
         };
@@ -8705,6 +8706,7 @@ mod tests {
                         value: "8".to_string(),
                     },
                 ],
+                transitions: vec![],
                 states: Vec::new(),
             }],
         };
@@ -9898,6 +9900,7 @@ mod tests {
                         value: v.to_string(),
                     })
                     .collect(),
+                transitions: vec![],
                 states: Vec::new(),
             }],
         }
@@ -10894,6 +10897,7 @@ mod tests {
                         value: "right".to_string(),
                     },
                 ],
+                transitions: vec![],
                 states: Vec::new(),
             }],
         };

--- a/code/packages/rust/mosstyle-compiler/CHANGELOG.md
+++ b/code/packages/rust/mosstyle-compiler/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added - MSL transition declarations
+
+- Added part-level and state-local `transition` declarations with optional
+  easing values.
+- Duration and easing token references are resolved into a typed
+  `StyleTransition` IR and preserved in the backend-neutral style map JSON.
+- Generated Lattice emits deterministic comma-separated `transition`
+  declarations in authored order.
+- Validation now reports `TransitionPropertyNotDeclared` when a transition
+  references a property without a base declaration in the same part.
+
 ### Added - `unmatched_parts()` to catch style parts that match no layout part
 
 New public `unmatched_parts(&StyleDef, part_map_json) -> Vec<UnmatchedPart>`.

--- a/code/packages/rust/mosstyle-compiler/README.md
+++ b/code/packages/rust/mosstyle-compiler/README.md
@@ -21,6 +21,7 @@ style Grid {
   part root {
     background-color: $color-surface ;
     border-radius: 6px ;
+    transition background-color $duration-fast $easing-out ;
   }
 
   part cell-grid {
@@ -39,6 +40,26 @@ Design tokens such as `$token-name` resolve to literal values using the UI15
 dark-mode palette baked into the compiler. Full Lattice token file support is
 planned for a later pass.
 
+Transitions may be declared at the part level, where they apply to every state
+change, or inside a `state` block, where they apply when entering that state:
+
+```msl
+part root {
+  opacity: 1 ;
+  transition opacity $duration-normal ; // easing defaults to ease-out
+
+  state disabled {
+    opacity: $opacity-disabled ;
+    transition opacity $duration-slow linear ;
+  }
+}
+```
+
+The transitioned property must have a base declaration in the same part. The
+compiler resolves duration and easing tokens, validates the property reference,
+emits a Lattice `transition` declaration, and preserves structured transition
+entries in the backend-neutral style map JSON for native emitters.
+
 ## Lattice Output
 
 Class names follow the `.mos-{ComponentName}-{part-name}` convention:
@@ -47,6 +68,7 @@ Class names follow the `.mos-{ComponentName}-{part-name}` convention:
 .mos-Grid-root {
   background-color: #1e1e1e;
   border-radius: 6px;
+  transition: background-color 80ms ease-out;
 }
 .mos-Grid-cell-grid {
   width: 100%;

--- a/code/packages/rust/mosstyle-compiler/src/_grammar.rs
+++ b/code/packages/rust/mosstyle-compiler/src/_grammar.rs
@@ -132,6 +132,7 @@ pub fn token_grammar() -> TokenGrammar {
             r#"style"#.to_string(),
             r#"part"#.to_string(),
             r#"state"#.to_string(),
+            r#"transition"#.to_string(),
         ],
         mode: None,
         skip_definitions: vec![
@@ -275,6 +276,9 @@ pub fn parser_grammar() -> ParserGrammar {
                             name: r#"state_block"#.to_string(),
                         },
                         GrammarElement::RuleReference {
+                            name: r#"transition_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
                             name: r#"property_decl"#.to_string(),
                         },
                     ],
@@ -296,7 +300,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                         GrammarElement::Repetition {
                             element: Box::new(GrammarElement::RuleReference {
-                                name: r#"property_decl"#.to_string(),
+                                name: r#"state_item"#.to_string(),
                             }),
                         },
                         GrammarElement::TokenReference {
@@ -304,7 +308,46 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 76,
+                line_number: 88,
+            },
+            GrammarRule {
+                name: r#"state_item"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"transition_decl"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"property_decl"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 89,
+            },
+            GrammarRule {
+                name: r#"transition_decl"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"KEYWORD"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"style_value"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"style_value"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"SEMICOLON"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 101,
             },
             // property_decl = NAME COLON style_value { style_value } SEMICOLON ;
             //
@@ -336,7 +379,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 83,
+                line_number: 118,
             },
             GrammarRule {
                 name: r#"style_value"#.to_string(),
@@ -362,7 +405,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 96,
+                line_number: 131,
             },
         ],
         version: 1,

--- a/code/packages/rust/mosstyle-compiler/src/lib.rs
+++ b/code/packages/rust/mosstyle-compiler/src/lib.rs
@@ -86,6 +86,9 @@ pub struct PartStyle {
     pub name: String,
     /// Base-state properties (always applied).
     pub base: Vec<StyleProp>,
+    /// Transitions that apply to every state change for this part.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transitions: Vec<StyleTransition>,
     /// Per-interaction-state overrides.
     pub states: Vec<StateStyle>,
 }
@@ -99,6 +102,17 @@ pub struct StyleProp {
     pub value: String,
 }
 
+/// A transition applied when a style property changes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StyleTransition {
+    /// Property whose changes should be animated.
+    pub property: String,
+    /// Resolved duration, such as `80ms`.
+    pub duration: String,
+    /// Resolved easing curve, such as `ease-out`.
+    pub easing: String,
+}
+
 /// Style overrides for one interaction state.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StateStyle {
@@ -106,6 +120,9 @@ pub struct StateStyle {
     pub state: String,
     /// Properties that override the base in this state.
     pub props: Vec<StyleProp>,
+    /// Transitions used when entering this state.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transitions: Vec<StyleTransition>,
 }
 
 // ===========================================================================
@@ -149,6 +166,8 @@ pub enum ErrorKind {
     UnknownState,
     /// A `$token-ref` has no definition in the token map.
     UnresolvedToken,
+    /// A transition names a property that is not declared in the part's base style.
+    TransitionPropertyNotDeclared,
     /// The AST has an unexpected shape (internal error).
     InternalError,
 }
@@ -352,6 +371,7 @@ fn analyze_part(part_def: &GrammarASTNode) -> Result<PartStyle, CompileError> {
     //   becomes the PartStyle.name and gets matched at emit time.
     let mut name: Option<String> = None;
     let mut base: Vec<StyleProp> = Vec::new();
+    let mut transitions: Vec<StyleTransition> = Vec::new();
     let mut states: Vec<StateStyle> = Vec::new();
 
     for child in &part_def.children {
@@ -373,6 +393,9 @@ fn analyze_part(part_def: &GrammarASTNode) -> Result<PartStyle, CompileError> {
                                 "property_decl" => {
                                     base.push(analyze_property(inner)?);
                                 }
+                                "transition_decl" => {
+                                    transitions.push(analyze_transition(inner)?);
+                                }
                                 "state_block" => {
                                     states.push(analyze_state(inner)?);
                                 }
@@ -392,6 +415,7 @@ fn analyze_part(part_def: &GrammarASTNode) -> Result<PartStyle, CompileError> {
             message: "part_def missing name".to_string(),
         })?,
         base,
+        transitions,
         states,
     })
 }
@@ -412,10 +436,11 @@ fn analyze_part_path(part_path: &GrammarASTNode) -> String {
 }
 
 fn analyze_state(state_block: &GrammarASTNode) -> Result<StateStyle, CompileError> {
-    // state_block = KEYWORD("state") NAME LBRACE { property_decl } RBRACE
+    // state_block = KEYWORD("state") NAME LBRACE { state_item } RBRACE
     let mut saw_keyword = false;
     let mut state_name: Option<String> = None;
     let mut props: Vec<StyleProp> = Vec::new();
+    let mut transitions: Vec<StyleTransition> = Vec::new();
 
     for child in &state_block.children {
         match child {
@@ -426,8 +451,18 @@ fn analyze_state(state_block: &GrammarASTNode) -> Result<StateStyle, CompileErro
                     state_name = Some(t.value.clone());
                 }
             }
-            ASTNodeOrToken::Node(n) if n.rule_name == "property_decl" => {
-                props.push(analyze_property(n)?);
+            ASTNodeOrToken::Node(n) if n.rule_name == "state_item" => {
+                for item_child in &n.children {
+                    if let ASTNodeOrToken::Node(inner) = item_child {
+                        match inner.rule_name.as_str() {
+                            "property_decl" => props.push(analyze_property(inner)?),
+                            "transition_decl" => {
+                                transitions.push(analyze_transition(inner)?);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
             }
             _ => {}
         }
@@ -439,6 +474,47 @@ fn analyze_state(state_block: &GrammarASTNode) -> Result<StateStyle, CompileErro
             message: "state_block missing state name".to_string(),
         })?,
         props,
+        transitions,
+    })
+}
+
+fn analyze_transition(transition_decl: &GrammarASTNode) -> Result<StyleTransition, CompileError> {
+    // transition_decl = KEYWORD("transition") NAME style_value [ style_value ] SEMICOLON
+    let mut saw_keyword = false;
+    let mut property: Option<String> = None;
+    let mut values: Vec<String> = Vec::new();
+
+    for child in &transition_decl.children {
+        match child {
+            ASTNodeOrToken::Token(t) => {
+                if t.type_ == TokenType::Keyword && t.value == "transition" {
+                    saw_keyword = true;
+                } else if saw_keyword && t.type_ == TokenType::Name && property.is_none() {
+                    property = Some(t.value.clone());
+                }
+            }
+            ASTNodeOrToken::Node(n) if n.rule_name == "style_value" => {
+                values.push(extract_style_value(n)?);
+            }
+            _ => {}
+        }
+    }
+
+    let duration = values.first().cloned().ok_or_else(|| CompileError {
+        kind: ErrorKind::InternalError,
+        message: "transition_decl missing duration".to_string(),
+    })?;
+    let easing = values.get(1).cloned().unwrap_or_else(|| {
+        resolve_token("easing-out", &HashMap::new()).unwrap_or_else(|| "ease-out".to_string())
+    });
+
+    Ok(StyleTransition {
+        property: property.ok_or_else(|| CompileError {
+            kind: ErrorKind::InternalError,
+            message: "transition_decl missing property".to_string(),
+        })?,
+        duration,
+        easing,
     })
 }
 
@@ -576,6 +652,27 @@ pub fn validate(def: &StyleDef, part_map_json: Option<&str>) -> Result<(), Vec<C
                         state.state,
                         part.name,
                         VALID_STATES.join(", ")
+                    ),
+                });
+            }
+        }
+
+        // A transition can only animate a property with a stable base value.
+        // This keeps every backend's lowering deterministic and catches typos
+        // before a platform silently drops the animation.
+        let base_properties: HashSet<&str> =
+            part.base.iter().map(|prop| prop.name.as_str()).collect();
+        for transition in part.transitions.iter().chain(
+            part.states
+                .iter()
+                .flat_map(|state| state.transitions.iter()),
+        ) {
+            if !base_properties.contains(transition.property.as_str()) {
+                errors.push(CompileError {
+                    kind: ErrorKind::TransitionPropertyNotDeclared,
+                    message: format!(
+                        "Transition on '{}' in part '{}' references a property not declared in the part's base style",
+                        transition.property, part.name
                     ),
                 });
             }
@@ -724,18 +821,21 @@ fn emit_scoped_rule_blocks(def: &StyleDef) -> Vec<String> {
         let class = format!(".mos-{}-{}", comp, part.name);
 
         // Base styles.
-        if !part.base.is_empty() {
-            let props: Vec<String> = part
+        if !part.base.is_empty() || !part.transitions.is_empty() {
+            let mut props: Vec<String> = part
                 .base
                 .iter()
                 .map(|p| format!("  {}: {};", p.name, p.value))
                 .collect();
+            if let Some(transition) = format_transitions(&part.transitions) {
+                props.push(format!("  transition: {transition};"));
+            }
             blocks.push(format!("{} {{\n{}\n}}", class, props.join("\n")));
         }
 
         // State overrides.
         for state in &part.states {
-            if state.props.is_empty() {
+            if state.props.is_empty() && state.transitions.is_empty() {
                 continue;
             }
             let selector = match state.state.as_str() {
@@ -748,16 +848,37 @@ fn emit_scoped_rule_blocks(def: &StyleDef) -> Vec<String> {
                 "error" => format!("{}.error", class),
                 other => format!("{}.{}", class, other),
             };
-            let props: Vec<String> = state
+            let mut props: Vec<String> = state
                 .props
                 .iter()
                 .map(|p| format!("  {}: {};", p.name, p.value))
                 .collect();
+            if let Some(transition) = format_transitions(&state.transitions) {
+                props.push(format!("  transition: {transition};"));
+            }
             blocks.push(format!("{} {{\n{}\n}}", selector, props.join("\n")));
         }
     }
 
     blocks
+}
+
+fn format_transitions(transitions: &[StyleTransition]) -> Option<String> {
+    if transitions.is_empty() {
+        return None;
+    }
+    Some(
+        transitions
+            .iter()
+            .map(|transition| {
+                format!(
+                    "{} {} {}",
+                    transition.property, transition.duration, transition.easing
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
 }
 
 /// Emit the backend-agnostic style map as JSON.
@@ -928,6 +1049,66 @@ mod tests {
     }
 
     #[test]
+    fn test_transition_resolves_tokens() {
+        let src = r#"
+          style Button {
+            part root {
+              background: #1e1e1e ;
+              transition background $duration-fast $easing-out ;
+            }
+          }
+        "#;
+        let def = parse_and_analyze(src);
+        assert_eq!(
+            def.parts[0].transitions,
+            vec![StyleTransition {
+                property: "background".to_string(),
+                duration: "80ms".to_string(),
+                easing: "ease-out".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_transition_defaults_to_ease_out() {
+        let src = r#"
+          style Button {
+            part root {
+              opacity: 1 ;
+              transition opacity $duration-normal ;
+            }
+          }
+        "#;
+        let def = parse_and_analyze(src);
+        assert_eq!(def.parts[0].transitions[0].duration, "150ms");
+        assert_eq!(def.parts[0].transitions[0].easing, "ease-out");
+    }
+
+    #[test]
+    fn test_state_local_transition() {
+        let src = r#"
+          style Button {
+            part root {
+              background: #1e1e1e ;
+              state hover {
+                background: #2e2e2e ;
+                transition background 150ms linear ;
+              }
+            }
+          }
+        "#;
+        let def = parse_and_analyze(src);
+        assert_eq!(
+            def.parts[0].states[0].transitions,
+            vec![StyleTransition {
+                property: "background".to_string(),
+                duration: "150ms".to_string(),
+                easing: "linear".to_string(),
+            }]
+        );
+    }
+
+    #[test]
     fn test_dimension_value() {
         let src = r#"
           style Grid {
@@ -969,6 +1150,46 @@ mod tests {
         let result = compile(src, None).unwrap();
         assert!(result.lattice.contains(".mos-Button-root:hover"));
         assert!(result.lattice.contains("background: #2e2e2e"));
+    }
+
+    #[test]
+    fn test_lattice_emits_transitions_in_authored_order() {
+        let src = r#"
+          style Button {
+            part root {
+              background: #1e1e1e ;
+              border-color: #333333 ;
+              transition background $duration-fast $easing-out ;
+              transition border-color $duration-normal linear ;
+            }
+          }
+        "#;
+        let result = compile(src, None).unwrap();
+        assert!(result
+            .lattice
+            .contains("transition: background 80ms ease-out, border-color 150ms linear;"));
+    }
+
+    #[test]
+    fn test_state_local_transition_emits_in_state_rule() {
+        let src = r#"
+          style Button {
+            part root {
+              opacity: 1 ;
+              state disabled {
+                opacity: 0.4 ;
+                transition opacity 300ms ease-in ;
+              }
+            }
+          }
+        "#;
+        let result = compile(src, None).unwrap();
+        let disabled_rule = result
+            .lattice
+            .split(".mos-Button-root.disabled")
+            .nth(1)
+            .expect("disabled rule");
+        assert!(disabled_rule.contains("transition: opacity 300ms ease-in;"));
     }
 
     #[test]
@@ -1144,6 +1365,79 @@ mod tests {
         assert!(result.is_err());
         let errs = result.unwrap_err();
         assert!(errs.iter().any(|e| e.kind == ErrorKind::UnknownPart));
+    }
+
+    #[test]
+    fn test_transition_property_must_exist_in_base_style() {
+        let src = r#"
+          style Button {
+            part root {
+              color: #ffffff ;
+              transition background $duration-fast ;
+            }
+          }
+        "#;
+        let errs = compile(src, None).unwrap_err();
+        assert!(errs
+            .iter()
+            .any(|e| e.kind == ErrorKind::TransitionPropertyNotDeclared));
+    }
+
+    #[test]
+    fn test_state_transition_property_must_exist_in_base_style() {
+        let src = r#"
+          style Button {
+            part root {
+              color: #ffffff ;
+              state hover {
+                background: #1e1e1e ;
+                transition background $duration-fast ;
+              }
+            }
+          }
+        "#;
+        let errs = compile(src, None).unwrap_err();
+        assert!(errs
+            .iter()
+            .any(|e| e.kind == ErrorKind::TransitionPropertyNotDeclared));
+    }
+
+    #[test]
+    fn test_transition_unresolved_token_is_an_error() {
+        let src = r#"
+          style Button {
+            part root {
+              opacity: 1 ;
+              transition opacity $duration-instant ;
+            }
+          }
+        "#;
+        let ast = parse_style(src).expect("parse failed");
+        let error = analyze(&ast).expect_err("unknown transition token should fail");
+        assert_eq!(error.kind, ErrorKind::UnresolvedToken);
+    }
+
+    #[test]
+    fn test_style_map_json_contains_structured_transition() {
+        let src = r#"
+          style Button {
+            part root {
+              opacity: 1 ;
+              transition opacity $duration-fast ;
+            }
+          }
+        "#;
+        let result = compile(src, None).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&result.style_map_json).expect("valid style JSON");
+        assert_eq!(
+            value["parts"][0]["transitions"][0],
+            serde_json::json!({
+                "property": "opacity",
+                "duration": "80ms",
+                "easing": "ease-out"
+            })
+        );
     }
 
     // ── Sub-parts (UI27 §3) ──────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- add part-level and state-local `transition` syntax to MSL
- resolve duration/easing tokens into a typed backend-neutral `StyleTransition` IR
- validate that animated properties have stable base declarations
- emit deterministic Lattice transition declarations and structured style-map JSON
- update existing emitter test fixtures for the additive style IR field

## Why

UI15 already specifies transitions and the default Mosaic token palette already includes durations/easing, but the checked-in grammar and compiler dropped that contract. This slice makes motion authorable once in MSL and preserves it for subsequent native SwiftUI and XAML lowering. It does not claim native transition lowering or keyframe animation support yet.

## Validation

- `cargo test -p mosstyle-compiler` (39 tests + docs)
- full downstream emitter matrix: React, HTML, Web Components, SwiftUI, XAML, Qt, Flutter, Compose, and package artifact builder
- `cargo test -p mosaic-emit-swiftui -p mosaic-emit-xaml -p mosaic-package-artifact-builder` after rebasing onto live `origin/main`
- `cargo test` in `code/programs/mosaic/engram-app` (18 multi-backend and native-shell tests)