### PR TITLE
feat(haskell): enforce scaffold capability contracts

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -429,13 +429,49 @@
       "depends_on": ["haskell-http1"],
       "branch": "codex/haskell-scaffold-capability-schema",
       "pr_number": null,
-      "notes": "Selected after PR #9290 merged because this generator-level prerequisite prevents the remaining Haskell event-loop and brotli ports from reproducing invalid capability metadata. The Go scaffold generator still emits the legacy {capabilities: []} shape for Haskell, and existing Haskell packages retain it. Generate full schema-v1 package/version/justification metadata, add golden/schema tests, and backfill affected Haskell packages in one metadata wave."
+      "notes": "Selected after PR #9290 merged because this generator-level prerequisite prevents the remaining Haskell event-loop and brotli ports from reproducing invalid capability metadata. Repair the Go, TypeScript, and native Haskell scaffold paths; add golden and shared-schema tests; reconcile optional legacy manifests with explicit scaffold-time profiles; and backfill all ten existing invalid Haskell manifests, including truthful nonempty Conduit profiles that require Layer 5 review."
+    },
+    {
+      "id": "haskell-capability-policy-audit",
+      "title": "Audit effective capability profiles across every Haskell package and program",
+      "status": "pending",
+      "depends_on": ["haskell-scaffold-capability-schema"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the Haskell manifest backfill. Absence remains an effective zero-capability legacy profile, but several Haskell directories without explicit manifests perform filesystem, process, environment, console, FFI, or network operations. Inventory all 203 packages and three programs, add truthful nonempty manifests where required, and obtain the capability-approval evidence required by the security contract."
+    },
+    {
+      "id": "haskell-scaffold-convention-reconciliation",
+      "title": "Reconcile TypeScript Haskell scaffolds with canonical Cabal and Hspec conventions",
+      "status": "pending",
+      "depends_on": ["haskell-scaffold-capability-schema"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the capability-schema audit. The TypeScript generator now emits valid Haskell capability metadata, but its older Haskell template still uses prefixed Cabal library names and a placeholder non-Hspec test layout. Bring it to exact parity with the reviewed Go/native Haskell conventions in a separate focused tranche."
+    },
+    {
+      "id": "scaffold-description-injection-hardening",
+      "title": "Harden scaffold descriptions across generated metadata and source comments",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the Haskell scaffold security review. This tranche hardens the Go, TypeScript, and native Haskell generators against unsafe description controls, including */ comment termination where relevant, but the Dart, Elixir, Lua, Python, Ruby, and Rust generators plus every remaining template context still need a complete audit before repository-wide correct-by-construction conformance can be claimed."
+    },
+    {
+      "id": "capability-schema-category-action-constraints",
+      "title": "Encode valid category-action pairs in capability schemas",
+      "status": "pending",
+      "depends_on": ["haskell-scaffold-capability-schema"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during final Haskell capability review. The taxonomy defines category-specific actions, but required_capabilities.schema.json and agent_manifest.schema.json currently use independent global enums and therefore accept nonsensical pairs such as env:listen or stdin:delete. Add conditional or oneOf constraints, shared conformance fixtures, and matching loader/analyzer tests across every enforcement backend."
     },
     {
       "id": "haskell-high-consensus-tail",
       "title": "Close Haskell event-loop and brotli",
       "status": "pending",
-      "depends_on": ["haskell-http1"],
+      "depends_on": ["haskell-http1", "haskell-scaffold-capability-schema"],
       "branch": null,
       "pr_number": null,
       "notes": "Keep the event loop generic and portable; use byte-exact Brotli conformance vectors."

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,20 +8,15 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "item_id": "haskell-http1",
-    "pr_number": 9290,
-    "branch": "codex/haskell-http1-parity",
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9290"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "ad8bbd75a007085635455786498ab8caf1430df5",
+    "revision": "c08e4fa83dd5ecdccfc61f5969bbd7ae471d74e2",
     "schema_version": 2,
     "established_languages": 15,
-    "implementation_identities": 1193,
-    "implementation_package_slots": 4334,
+    "implementation_identities": 1194,
+    "implementation_package_slots": 4336,
     "high_consensus_packages": 172,
-    "high_consensus_missing_slots": 278,
+    "high_consensus_missing_slots": 277,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -412,7 +407,7 @@
     {
       "id": "haskell-http1",
       "title": "Port http1 to Haskell on the new http-core",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["haskell-http-core"],
       "branch": "codex/haskell-http1-parity",
       "pr_number": 9290,
@@ -430,11 +425,11 @@
     {
       "id": "haskell-scaffold-capability-schema",
       "title": "Repair Haskell scaffold capability manifests and legacy package metadata",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["haskell-http1"],
-      "branch": null,
+      "branch": "codex/haskell-scaffold-capability-schema",
       "pr_number": null,
-      "notes": "Newly discovered by the Haskell http1 fixture audit. The Go scaffold generator still emits the legacy {capabilities: []} shape for Haskell, and merged http-core retains it. Generate full schema-v1 package/version/justification metadata, add golden/schema tests, and backfill affected Haskell packages in a dependency-shaped wave."
+      "notes": "Selected after PR #9290 merged because this generator-level prerequisite prevents the remaining Haskell event-loop and brotli ports from reproducing invalid capability metadata. The Go scaffold generator still emits the legacy {capabilities: []} shape for Haskell, and existing Haskell packages retain it. Generate full schema-v1 package/version/justification metadata, add golden/schema tests, and backfill affected Haskell packages in one metadata wave."
     },
     {
       "id": "haskell-high-consensus-tail",
@@ -479,7 +474,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 548, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 549, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -488,7 +483,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, and smart-home-automation-runtime. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, and automation-runtime packages as likely native/service/storage applicability cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port."
+      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, and smart-home-zwave-integration. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, and Z-Wave integration packages as likely native/service/storage applicability cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port."
     },
     {
       "id": "c-cpp-graduation",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -10,11 +10,11 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "c08e4fa83dd5ecdccfc61f5969bbd7ae471d74e2",
+    "revision": "8517e41b1c06fbb453c66b62c87c8b08135838f3",
     "schema_version": 2,
     "established_languages": 15,
-    "implementation_identities": 1194,
-    "implementation_package_slots": 4336,
+    "implementation_identities": 1195,
+    "implementation_package_slots": 4337,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 277,
     "canonical_collisions": 0,
@@ -510,7 +510,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 549, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 550, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -519,7 +519,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, and smart-home-zwave-integration. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, and Z-Wave integration packages as likely native/service/storage applicability cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port."
+      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, and smart-home-zwave-host. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, and Z-Wave serial-host packages as likely native/service/storage applicability cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port."
     },
     {
       "id": "c-cpp-graduation",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "haskell-scaffold-capability-schema",
+    "pr_number": 9308,
+    "branch": "codex/haskell-scaffold-capability-schema",
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9308"
+  },
   "last_inventory": {
     "revision": "8517e41b1c06fbb453c66b62c87c8b08135838f3",
     "schema_version": 2,
@@ -425,11 +430,11 @@
     {
       "id": "haskell-scaffold-capability-schema",
       "title": "Repair Haskell scaffold capability manifests and legacy package metadata",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["haskell-http1"],
       "branch": "codex/haskell-scaffold-capability-schema",
-      "pr_number": null,
-      "notes": "Selected after PR #9290 merged because this generator-level prerequisite prevents the remaining Haskell event-loop and brotli ports from reproducing invalid capability metadata. Repair the Go, TypeScript, and native Haskell scaffold paths; add golden and shared-schema tests; reconcile optional legacy manifests with explicit scaffold-time profiles; and backfill all ten existing invalid Haskell manifests, including truthful nonempty Conduit profiles that require Layer 5 review."
+      "pr_number": 9308,
+      "notes": "PR #9308 repairs the Go, TypeScript, and native Haskell scaffold paths; adds two language-neutral golden fixtures and a Draft 2020-12 CI contract test; backfills all ten invalid Haskell manifests; and records follow-up policy, convention, schema, hardening, and singleton-classification work. Local validation: Go tests/vet/build with 66.7% coverage; native Haskell 9/9 Hspec examples with coverage and -Wall plus real generated library/program builds; TypeScript build and 121/121 tests with 83.97% statement coverage and zero npm-audit findings; 8/8 pure backfill package tests; 16 manifests and 2 fixtures schema-valid with Ruff/Bandit clean; affected build-tool dry-run for 42 packages; parity report 1,195 identities / 4,337 slots / 277 high-consensus gaps / zero collisions or unknown buckets; clean diff; and independent final audits. The nonempty Conduit profiles remain proposed metadata and require Layer 5 review before merge or publish."
     },
     {
       "id": "haskell-capability-policy-audit",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           python3 -m pip install --disable-pip-version-check --quiet jsonschema==4.26.0
           python3 -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_haskell_required_capabilities.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_schema.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_runner.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_schema.py'

--- a/code/packages/haskell/argon2d/required_capabilities.json
+++ b/code/packages/haskell/argon2d/required_capabilities.json
@@ -1,4 +1,7 @@
 {
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/argon2d",
   "capabilities": [],
   "justification": "Pure computation over in-memory byte arrays; no filesystem, network, or process access."
 }

--- a/code/packages/haskell/argon2i/required_capabilities.json
+++ b/code/packages/haskell/argon2i/required_capabilities.json
@@ -1,4 +1,7 @@
 {
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/argon2i",
   "capabilities": [],
   "justification": "Pure computation over in-memory byte arrays; no filesystem, network, or process access."
 }

--- a/code/packages/haskell/argon2id/required_capabilities.json
+++ b/code/packages/haskell/argon2id/required_capabilities.json
@@ -1,4 +1,7 @@
 {
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/argon2id",
   "capabilities": [],
   "justification": "Pure computation over in-memory byte arrays; no filesystem, network, or process access."
 }

--- a/code/packages/haskell/barcode-2d/required_capabilities.json
+++ b/code/packages/haskell/barcode-2d/required_capabilities.json
@@ -1,1 +1,7 @@
-{"capabilities": []}
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/barcode-2d",
+  "capabilities": [],
+  "justification": "Pure in-memory barcode layout and rendering instruction generation with no OS access."
+}

--- a/code/packages/haskell/conduit/required_capabilities.json
+++ b/code/packages/haskell/conduit/required_capabilities.json
@@ -1,1 +1,50 @@
-["rust", "haskell", "cargo", "cabal"]
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/conduit",
+  "capabilities": [
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "conduit_capi",
+      "justification": "Calls the reviewed Rust Conduit C ABI through GHC foreign import ccall bindings."
+    },
+    {
+      "category": "ffi",
+      "action": "load",
+      "target": "conduit_capi",
+      "justification": "Loads the conduit_capi dynamic library through the operating-system loader at process startup."
+    },
+    {
+      "category": "net",
+      "action": "listen",
+      "target": "*:*",
+      "justification": "The public bind API opens caller-selected TCP listeners through conduit_capi."
+    },
+    {
+      "category": "net",
+      "action": "connect",
+      "target": "127.0.0.1:*",
+      "justification": "End-to-end tests connect to the loopback listener with raw HTTP sockets."
+    },
+    {
+      "category": "net",
+      "action": "dns",
+      "target": "127.0.0.1",
+      "justification": "End-to-end tests resolve the numeric loopback host before connecting to the listener."
+    },
+    {
+      "category": "time",
+      "action": "sleep",
+      "target": "*",
+      "justification": "End-to-end tests use bounded thread delays while starting and stopping the server."
+    },
+    {
+      "category": "stdout",
+      "action": "write",
+      "target": "*",
+      "justification": "Error callbacks write caught handler exceptions to the standard error output stream."
+    }
+  ],
+  "justification": "Haskell FFI wrapper over conduit_capi that can bind TCP listeners; its end-to-end tests connect on loopback and wait for server transitions, and error handling writes caught exceptions to standard error."
+}

--- a/code/packages/haskell/http-core/required_capabilities.json
+++ b/code/packages/haskell/http-core/required_capabilities.json
@@ -1,1 +1,7 @@
-{"capabilities": []}
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/http-core",
+  "capabilities": [],
+  "justification": "Pure bounded in-memory HTTP value parsing and formatting with no operating-system access."
+}

--- a/code/packages/haskell/paint-instructions/required_capabilities.json
+++ b/code/packages/haskell/paint-instructions/required_capabilities.json
@@ -1,1 +1,7 @@
-{"capabilities": []}
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/paint-instructions",
+  "capabilities": [],
+  "justification": "Pure in-memory paint instruction modeling with no filesystem, network, process, or environment access."
+}

--- a/code/packages/haskell/sql-execution-engine/required_capabilities.json
+++ b/code/packages/haskell/sql-execution-engine/required_capabilities.json
@@ -1,1 +1,7 @@
-{}
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/sql-execution-engine",
+  "capabilities": [],
+  "justification": "Pure in-memory SQL execution planning and evaluation with no operating-system access."
+}

--- a/code/programs/go/scaffold-generator/CHANGELOG.md
+++ b/code/programs/go/scaffold-generator/CHANGELOG.md
@@ -19,6 +19,11 @@ All notable changes to this program will be documented in this file.
 
 ### Fixed
 
+- Haskell capability metadata now uses the complete shared schema-v1 document,
+  with golden output and shared-schema regression coverage instead of the
+  legacy one-field JSON object.
+- Description validation now rejects Unicode controls, line separators, and
+  block-comment termination before any generated source is written.
 - Haskell scaffolds now follow the repository's current plain Cabal package
   naming, `CodingAdventures.*` module layout, Hspec wiring, `-Wall`, explicit
   Windows skip, empty capability metadata, and plain `cabal test` convention.
@@ -35,9 +40,12 @@ All notable changes to this program will be documented in this file.
 
 ### Added
 
-- `generateCommonFiles` now generates `required_capabilities.json` alongside README.md and CHANGELOG.md
-- New packages scaffold with empty capabilities and a "pure computation" default justification
-- `TestGenerateCommonFiles` now verifies the generated `required_capabilities.json` is valid JSON with all required fields
+- Language templates generate `required_capabilities.json` alongside their
+  package-specific metadata.
+- New schema-supported packages scaffold with empty capabilities and a "pure
+  computation" default justification.
+- Template tests verify generated capability JSON includes the required
+  package identity and fields.
 
 ## [1.0.0] - 2026-03-21
 

--- a/code/programs/go/scaffold-generator/README.md
+++ b/code/programs/go/scaffold-generator/README.md
@@ -4,11 +4,16 @@ A CLI tool that generates CI-ready package scaffolding for the coding-adventures
 monorepo across 14 languages: Python, Go, Ruby, TypeScript, Rust, Elixir, Perl,
 Lua, Swift, Haskell, Java, Kotlin, C, and C++.
 
+Haskell scaffolds include a schema-v1 `required_capabilities.json` whose package
+identity matches the generated directory. The manifest starts with an explicit
+empty capability profile for the pure library template.
+
 ## Why
 
 The lessons.md documents 12+ recurring CI failure categories caused by agents
-hand-crafting packages inconsistently. This tool eliminates those failures by
-producing correct-by-construction packages.
+hand-crafting packages inconsistently. This tool aims to eliminate those
+failures as each language template completes the scaffold contract; remaining
+cross-template exceptions are tracked in the parity backlog.
 
 ## Usage
 

--- a/code/programs/go/scaffold-generator/main.go
+++ b/code/programs/go/scaffold-generator/main.go
@@ -44,6 +44,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	clibuilder "github.com/adhithyan15/coding-adventures/code/packages/go/cli-builder"
 )
@@ -55,9 +56,53 @@ import (
 // validLanguages lists all supported target languages.
 var validLanguages = []string{"python", "go", "ruby", "typescript", "rust", "elixir", "perl", "lua", "swift", "haskell", "java", "kotlin", "c", "cpp"}
 
+const requiredCapabilitiesSchemaURL = "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json"
+
 // kebabCaseRe validates that a package name is kebab-case:
 // lowercase letters and digits, segments separated by single hyphens.
 var kebabCaseRe = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)
+
+func isSafeDescription(description string) bool {
+	if strings.Contains(description, "*/") {
+		return false
+	}
+	for _, char := range description {
+		if unicode.IsControl(char) || char == '\u2028' || char == '\u2029' {
+			return false
+		}
+	}
+	return true
+}
+
+type requiredCapabilitiesManifest struct {
+	Schema        string               `json:"$schema"`
+	Version       int                  `json:"version"`
+	Package       string               `json:"package"`
+	Capabilities  []requiredCapability `json:"capabilities"`
+	Justification string               `json:"justification"`
+}
+
+type requiredCapability struct {
+	Category      string `json:"category"`
+	Action        string `json:"action"`
+	Target        string `json:"target"`
+	Justification string `json:"justification"`
+}
+
+func requiredCapabilitiesJSON(language, packageName string) (string, error) {
+	manifest := requiredCapabilitiesManifest{
+		Schema:        requiredCapabilitiesSchemaURL,
+		Version:       1,
+		Package:       language + "/" + packageName,
+		Capabilities:  []requiredCapability{},
+		Justification: "Pure computation. No filesystem, network, process, or environment access needed.",
+	}
+	encoded, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encoding required capabilities manifest: %w", err)
+	}
+	return string(encoded) + "\n", nil
+}
 
 func intFromFloatFlag(value float64) (int, error) {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
@@ -1779,6 +1824,10 @@ final class %sTests: XCTestCase {
 func generateHaskell(targetDir, pkgName, description, layerCtx string, directDeps, orderedDeps []string) error {
 	moduleName := toCamelCase(pkgName)
 	qualifiedModuleName := "CodingAdventures." + moduleName
+	capabilityManifest, err := requiredCapabilitiesJSON("haskell", pkgName)
+	if err != nil {
+		return err
+	}
 
 	cabal := fmt.Sprintf(`cabal-version: 3.0
 name:          %s
@@ -1863,7 +1912,7 @@ spec =
 		"test/" + moduleName + "Spec.hs":             packageSpecHs,
 		"BUILD":                                      "cabal test\n",
 		"BUILD_windows":                              "echo \"haskell support not enabled in windows CI yet -- skipping\"\n",
-		"required_capabilities.json":                 "{\"capabilities\": []}\n",
+		"required_capabilities.json":                 capabilityManifest,
 	}
 
 	for path, content := range files {
@@ -2622,8 +2671,8 @@ func run(specPath string, argv []string, stdout, stderr io.Writer) int {
 		// Validate description: no newlines or control characters that could
 		// corrupt generated source files (e.g. Swift block-comment terminators
 		// or JSON escape sequences).
-		if strings.ContainsAny(description, "\n\r") {
-			fmt.Fprintf(stderr, "scaffold-generator: description must not contain newline characters\n")
+		if !isSafeDescription(description) {
+			fmt.Fprintf(stderr, "scaffold-generator: description must be one printable line without control characters or structural comment delimiters\n")
 			return 1
 		}
 

--- a/code/programs/go/scaffold-generator/main_test.go
+++ b/code/programs/go/scaffold-generator/main_test.go
@@ -850,6 +850,43 @@ func TestGenerateHaskellUsesRepositoryConventions(t *testing.T) {
 	if string(build) != "cabal test\n" {
 		t.Errorf("BUILD = %q, want plain cabal test", build)
 	}
+
+	capabilityPath := filepath.Join(tmpDir, "required_capabilities.json")
+	capabilities, err := os.ReadFile(capabilityPath)
+	if err != nil {
+		t.Fatalf("cannot read required_capabilities.json: %v", err)
+	}
+	golden, err := os.ReadFile(
+		filepath.Join("..", "..", "..", "specs", "fixtures", "scaffold-generator", "haskell_library_required_capabilities.json"),
+	)
+	if err != nil {
+		t.Fatalf("cannot read Haskell capability golden file: %v", err)
+	}
+	if string(capabilities) != string(golden) {
+		t.Errorf(
+			"required_capabilities.json did not match golden output\n--- got ---\n%s--- want ---\n%s",
+			capabilities,
+			golden,
+		)
+	}
+}
+
+func TestDescriptionSafety(t *testing.T) {
+	for _, description := range []string{
+		"safe\nnext-field",
+		"safe\ttab",
+		"safe\x00nul",
+		"safe\u0085next-field",
+		"safe\u2028next-line",
+		"safe */ injected",
+	} {
+		if isSafeDescription(description) {
+			t.Errorf("isSafeDescription(%q) = true, want false", description)
+		}
+	}
+	if !isSafeDescription("A printable single-line description.") {
+		t.Error("isSafeDescription rejected a printable single-line description")
+	}
 }
 
 func TestReadHaskellDepsUsesCabalProjectSiblingPaths(t *testing.T) {

--- a/code/programs/haskell/conduit-hello/required_capabilities.json
+++ b/code/programs/haskell/conduit-hello/required_capabilities.json
@@ -1,1 +1,68 @@
-["rust", "haskell", "cargo", "cabal"]
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/conduit-hello",
+  "capabilities": [
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "conduit_capi",
+      "justification": "Uses the Haskell Conduit wrapper to call the reviewed Rust Conduit C ABI."
+    },
+    {
+      "category": "ffi",
+      "action": "load",
+      "target": "conduit_capi",
+      "justification": "Loads the conduit_capi dynamic library required by the Haskell Conduit wrapper."
+    },
+    {
+      "category": "net",
+      "action": "listen",
+      "target": "0.0.0.0:*",
+      "justification": "The demo binds a caller-selected TCP port on all interfaces for HTTP requests."
+    },
+    {
+      "category": "net",
+      "action": "listen",
+      "target": "127.0.0.1:*",
+      "justification": "Smoke tests bind an ephemeral TCP listener on the loopback interface."
+    },
+    {
+      "category": "net",
+      "action": "connect",
+      "target": "127.0.0.1:*",
+      "justification": "Smoke tests connect to the loopback listener with raw HTTP sockets."
+    },
+    {
+      "category": "net",
+      "action": "dns",
+      "target": "127.0.0.1",
+      "justification": "Smoke tests resolve the numeric loopback host before connecting to the listener."
+    },
+    {
+      "category": "env",
+      "action": "read",
+      "target": "PORT",
+      "justification": "Reads PORT to select the TCP listening port, defaulting to 8080."
+    },
+    {
+      "category": "env",
+      "action": "read",
+      "target": "APP_ENV",
+      "justification": "Reads APP_ENV to populate the demonstrated application environment setting."
+    },
+    {
+      "category": "time",
+      "action": "sleep",
+      "target": "*",
+      "justification": "Smoke tests use bounded thread delays while starting and stopping the server."
+    },
+    {
+      "category": "stdout",
+      "action": "write",
+      "target": "*",
+      "justification": "Writes the selected listening port to the standard error output stream when the demo starts."
+    }
+  ],
+  "justification": "Demo server calls conduit_capi, listens for HTTP traffic, reads PORT and APP_ENV, logs startup to standard error, and runs loopback smoke tests."
+}

--- a/code/programs/haskell/scaffold-generator/CHANGELOG.md
+++ b/code/programs/haskell/scaffold-generator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Added schema-v1 capability manifests for generated Haskell libraries and
+  programs, including the program template's standard-output declaration.
+- Tightened package names to the repository's ASCII kebab-case contract and
+  rejected control characters and Unicode line separators before descriptions
+  reach Cabal metadata.
+- Added golden tests for both capability profiles.
+
 ## 0.1.0
 
 - Added the first Haskell scaffold-generator implementation for Haskell packages and programs.

--- a/code/programs/haskell/scaffold-generator/README.md
+++ b/code/programs/haskell/scaffold-generator/README.md
@@ -10,6 +10,8 @@ This program creates starter Haskell package or program directories with:
 - a `cabal.project` that links local sibling dependencies
 - starter source and test modules
 - repo-standard `BUILD` files
+- a schema-v1 `required_capabilities.json` with an empty library profile or the
+  generated program's standard-output capability
 - `README.md` and `CHANGELOG.md`
 
 ## Usage

--- a/code/programs/haskell/scaffold-generator/src/ScaffoldGenerator.hs
+++ b/code/programs/haskell/scaffold-generator/src/ScaffoldGenerator.hs
@@ -1,15 +1,17 @@
 module ScaffoldGenerator
     ( ParsedArgs(..)
     , ScaffoldConfig(..)
+    , capabilityManifestContents
     , defaultConfig
     , isKebabCase
+    , isSafeDescription
     , parseArgs
     , runWithArgs
     , toModuleName
     ) where
 
 import Control.Monad (filterM, foldM, forM)
-import Data.Char (isAlphaNum, isLower, toLower, toUpper)
+import Data.Char (isAlphaNum, isControl, toLower, toUpper)
 import Data.List (intercalate, nub, sort)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
@@ -162,6 +164,10 @@ runScaffold cfg = do
                             then do
                                 putStrLn "package type must be 'library' or 'program'"
                                 pure 1
+                            else if not (isSafeDescription (configDescription cfg))
+                                then do
+                                    putStrLn "description must be a single printable line without control characters"
+                                    pure 1
                             else do
                                 registry <- discoverRegistry repoRoot
                                 dependencyClosure <- resolveDependencyClosure registry (configDependsOn cfg)
@@ -342,6 +348,9 @@ generatePackage repoRoot cfg pkgName deps targetDir = do
     writeFile (targetDir </> "CHANGELOG.md") "# Changelog\n\n## 0.1.0\n\n- Initial scaffold.\n"
     writeFile (targetDir </> "BUILD") buildFileContents
     writeFile (targetDir </> "BUILD_windows") "echo \"haskell support not enabled in windows CI yet -- skipping\"\n"
+    writeFile
+        (targetDir </> "required_capabilities.json")
+        (capabilityManifestContents (configPackageType cfg) pkgName)
     writeFile (targetDir </> "cabal.project") (cabalProjectContents relativeDepPaths)
   where
     _ = repoRoot
@@ -506,6 +515,37 @@ buildFileContents :: String
 buildFileContents =
     "if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi\n"
 
+capabilityManifestContents :: String -> String -> String
+capabilityManifestContents packageType pkgName =
+    case packageType of
+        "program" ->
+            unlines
+                [ "{"
+                , "  \"$schema\": \"https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json\","
+                , "  \"version\": 1,"
+                , "  \"package\": \"haskell/" ++ pkgName ++ "\","
+                , "  \"capabilities\": ["
+                , "    {"
+                , "      \"category\": \"stdout\","
+                , "      \"action\": \"write\","
+                , "      \"target\": \"*\","
+                , "      \"justification\": \"Writes the generated program description to standard output.\""
+                , "    }"
+                , "  ],"
+                , "  \"justification\": \"Generated program writes its starter description to standard output and uses no other OS capabilities.\""
+                , "}"
+                ]
+        _ ->
+            unlines
+                [ "{"
+                , "  \"$schema\": \"https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json\","
+                , "  \"version\": 1,"
+                , "  \"package\": \"haskell/" ++ pkgName ++ "\","
+                , "  \"capabilities\": [],"
+                , "  \"justification\": \"Pure computation. No filesystem, network, process, or environment access needed.\""
+                , "}"
+                ]
+
 readmeContents :: ScaffoldConfig -> String -> String -> [String] -> String
 readmeContents cfg pkgName descriptionText dependencyNames =
     unlines
@@ -556,11 +596,24 @@ splitOnComma (char : rest) =
 isKebabCase :: String -> Bool
 isKebabCase [] = False
 isKebabCase (first : rest)
-    | not (isLower first) = False
+    | not (isAsciiLower first) = False
     | otherwise = all validChar rest && lastChar /= '-' && not (hasDoubleDash (first : rest))
   where
-    validChar char = isLower char || isAlphaNum char || char == '-'
+    validChar char = isAsciiLower char || isAsciiDigit char || char == '-'
     lastChar = last (first : rest)
+
+isAsciiLower :: Char -> Bool
+isAsciiLower char = char >= 'a' && char <= 'z'
+
+isAsciiDigit :: Char -> Bool
+isAsciiDigit char = char >= '0' && char <= '9'
+
+isSafeDescription :: String -> Bool
+isSafeDescription = not . any isUnsafeDescriptionChar
+
+isUnsafeDescriptionChar :: Char -> Bool
+isUnsafeDescriptionChar char =
+    isControl char || char == '\x2028' || char == '\x2029'
 
 hasDoubleDash :: String -> Bool
 hasDoubleDash [] = False

--- a/code/programs/haskell/scaffold-generator/test/ScaffoldGeneratorSpec.hs
+++ b/code/programs/haskell/scaffold-generator/test/ScaffoldGeneratorSpec.hs
@@ -12,11 +12,38 @@ scaffoldGeneratorSpec = do
 
         it "rejects invalid names" $ do
             isKebabCase "LogicGates" `shouldBe` False
+            isKebabCase "logic-Gates" `shouldBe` False
             isKebabCase "bad--name" `shouldBe` False
+            isKebabCase "café" `shouldBe` False
+            isKebabCase "logic-١" `shouldBe` False
+
+    describe "isSafeDescription" $ do
+        it "accepts a single printable line" $ do
+            isSafeDescription "A package for in-memory values." `shouldBe` True
+
+        it "rejects metadata-breaking control characters" $ do
+            isSafeDescription "safe\nbuild-type: Custom" `shouldBe` False
+            isSafeDescription "safe\rlicense: NONE" `shouldBe` False
+            isSafeDescription "safe\tfield" `shouldBe` False
+            isSafeDescription "safe\x85next-field" `shouldBe` False
+            isSafeDescription "safe\x2028next-line" `shouldBe` False
 
     describe "toModuleName" $ do
         it "converts kebab case to module case" $ do
             toModuleName "logic-gates" `shouldBe` "LogicGates"
+
+    describe "capabilityManifestContents" $ do
+        it "renders the schema-v1 pure-library golden document" $ do
+            expected <-
+                readFile
+                    "../../../specs/fixtures/scaffold-generator/haskell_library_required_capabilities.json"
+            capabilityManifestContents "library" "my-pkg" `shouldBe` expected
+
+        it "renders the schema-v1 stdout program golden document" $ do
+            expected <-
+                readFile
+                    "../../../specs/fixtures/scaffold-generator/haskell_program_required_capabilities.json"
+            capabilityManifestContents "program" "build-helper" `shouldBe` expected
 
     describe "parseArgs" $ do
         it "parses the basic invocation" $ do

--- a/code/programs/typescript/scaffold-generator/CHANGELOG.md
+++ b/code/programs/typescript/scaffold-generator/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Haskell scaffolds now emit the complete shared schema-v1 capability manifest
+  and keep their starter library and test source pure.
+- Haskell generation rejects control characters before descriptions are
+  interpolated into Cabal metadata, and the CLI rejects structural
+  block-comment delimiters before any template is written.
+- Refreshed the lockfile to use patched PostCSS and its aligned Nano ID
+  resolution.
+
 ## [1.0.0] - 2026-03-21
 
 ### Added

--- a/code/programs/typescript/scaffold-generator/README.md
+++ b/code/programs/typescript/scaffold-generator/README.md
@@ -12,6 +12,10 @@ It is powered by [cli-builder](../../../packages/typescript/cli-builder/) --
 the entire command-line interface is defined in a JSON spec file, and this
 program contains only the business logic.
 
+Generated Haskell libraries include a schema-v1
+`required_capabilities.json` with an explicit pure-computation profile and a
+package identity derived from the on-disk directory.
+
 ## Why It Exists
 
 The lessons.md file documents 12+ recurring categories of CI failures caused
@@ -23,8 +27,9 @@ by agents hand-crafting packages inconsistently:
 - Ruby require ordering (deps before own modules)
 - Rust workspace Cargo.toml not updated
 
-This tool eliminates those failures. Run it, get a package that compiles,
-lints, and passes tests. Then fill in the business logic.
+This tool incrementally eliminates those failures as each language template
+completes the scaffold contract. Remaining cross-template exceptions are
+tracked in the parity backlog.
 
 ## Usage
 

--- a/code/programs/typescript/scaffold-generator/package-lock.json
+++ b/code/programs/typescript/scaffold-generator/package-lock.json
@@ -1634,9 +1634,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1694,9 +1694,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -1714,7 +1714,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/code/programs/typescript/scaffold-generator/src/index.ts
+++ b/code/programs/typescript/scaffold-generator/src/index.ts
@@ -1755,6 +1755,12 @@ export function generateHaskell(
   directDeps: string[],
   orderedDeps: string[],
 ): void {
+  if (/[\p{Cc}\p{Zl}\p{Zp}]/u.test(description) || description.includes("*/")) {
+    throw new Error(
+      "description must be a single printable line without control characters or structural comment delimiters",
+    );
+  }
+
   const pkgNameHaskell = `coding-adventures-${pkgName}`;
   const moduleName = toCamelCase(pkgName);
 
@@ -1794,15 +1800,14 @@ test-suite spec
 
 -- | ${description}
 -- ${layerCtx}
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"
+version :: String
+version = "0.1.0"
 `;
 
-  const specHs = `import ${moduleName}
+const specHs = `import ${moduleName}
 
 main :: IO ()
-main = do
-    putStrLn "Test suite not yet implemented."
+main = pure ()
 `;
 
   let cabalProject = `packages: .\n`;
@@ -1817,6 +1822,22 @@ main = do
   writeFile(path.join(targetDir, "src", `${moduleName}.hs`), libHs);
   writeFile(path.join(targetDir, "test", "Spec.hs"), specHs);
   writeFile(path.join(targetDir, "BUILD"), build);
+  writeFile(
+    path.join(targetDir, "required_capabilities.json"),
+    JSON.stringify(
+      {
+        $schema:
+          "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+        version: 1,
+        package: `haskell/${pkgName}`,
+        capabilities: [],
+        justification:
+          "Pure computation. No filesystem, network, process, or environment access needed.",
+      },
+      null,
+      2,
+    ) + "\n",
+  );
 }
 
 // -------------------------------------------------------------------------
@@ -2174,6 +2195,12 @@ export function scaffoldOne(
   output: (msg: string) => void = (msg) => process.stdout.write(msg + "\n"),
   errOutput: (msg: string) => void = (msg) => process.stderr.write(msg + "\n"),
 ): void {
+  if (/[\p{Cc}\p{Zl}\p{Zp}]/u.test(description) || description.includes("*/")) {
+    throw new Error(
+      "description must be a single printable line without control characters or structural comment delimiters",
+    );
+  }
+
   const baseCategory = pkgType === "library" ? "packages" : "programs";
   const baseDir = path.join(repoRoot, "code", baseCategory, lang);
   const dName = dirName(pkgName, lang);

--- a/code/programs/typescript/scaffold-generator/tests/scaffold-generator.test.ts
+++ b/code/programs/typescript/scaffold-generator/tests/scaffold-generator.test.ts
@@ -970,6 +970,78 @@ describe("generateHaskell", () => {
     expect(content).toMatch(/name:\s+coding-adventures-my-pkg/);
     expect(content).toContain("test-suite spec");
   });
+
+  it("creates the schema-v1 Haskell capability golden document", () => {
+    generateHaskell(tmpDir, "my-pkg", "A test package", "", [], []);
+    const content = fs.readFileSync(
+      path.join(tmpDir, "required_capabilities.json"),
+      "utf-8",
+    );
+    const spec = fs.readFileSync(path.join(tmpDir, "test", "Spec.hs"), "utf-8");
+    expect(spec).toContain("main = pure ()");
+    expect(spec).not.toContain("putStrLn");
+    const golden = fs.readFileSync(
+      path.resolve(
+        process.cwd(),
+        "../../../specs/fixtures/scaffold-generator/haskell_library_required_capabilities.json",
+      ),
+      "utf-8",
+    );
+    expect(content).toBe(golden);
+    expect(JSON.parse(content)).toEqual({
+      $schema:
+        "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+      version: 1,
+      package: "haskell/my-pkg",
+      capabilities: [],
+      justification:
+        "Pure computation. No filesystem, network, process, or environment access needed.",
+    });
+  });
+
+  it("rejects control characters before writing Haskell metadata", () => {
+    expect(() =>
+      generateHaskell(
+        tmpDir,
+        "my-pkg",
+        "safe\nbuild-type: Custom",
+        "",
+        [],
+        [],
+      ),
+    ).toThrow(/description.*control/i);
+    expect(() =>
+      generateHaskell(
+        tmpDir,
+        "my-pkg",
+        "safe\u0085next-field",
+        "",
+        [],
+        [],
+      ),
+    ).toThrow(/description.*control/i);
+    expect(() =>
+      generateHaskell(
+        tmpDir,
+        "my-pkg",
+        "safe\u2028next-line",
+        "",
+        [],
+        [],
+      ),
+    ).toThrow(/description.*control/i);
+    expect(() =>
+      generateHaskell(
+        tmpDir,
+        "my-pkg",
+        "safe */ injected",
+        "",
+        [],
+        [],
+      ),
+    ).toThrow(/description.*structural/i);
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+  });
 });
 
 describe("generatePerl", () => {
@@ -1374,6 +1446,26 @@ describe("scaffoldOne", () => {
 
   afterEach(() => {
     removeDir(tmpDir);
+  });
+
+  it("rejects control characters before creating a target directory", () => {
+    expect(() =>
+      scaffoldOne(
+        "test-pkg",
+        "library",
+        "haskell",
+        [],
+        0,
+        "safe\nbuild-type: Custom",
+        false,
+        repoRoot,
+      ),
+    ).toThrow(/description.*control/i);
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, "code", "packages", "haskell", "test-pkg"),
+      ),
+    ).toBe(false);
   });
 
   it("creates a complete Python package", () => {

--- a/code/scripts/tests/test_haskell_required_capabilities.py
+++ b/code/scripts/tests/test_haskell_required_capabilities.py
@@ -1,0 +1,69 @@
+"""Validate every explicit Haskell capability manifest against the shared schema."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import jsonschema
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = REPO_ROOT / "code/specs/schemas/required_capabilities.schema.json"
+FIXTURE_ROOT = REPO_ROOT / "code/specs/fixtures/scaffold-generator"
+
+
+class HaskellRequiredCapabilitiesTest(unittest.TestCase):
+    """Keep existing and generated Haskell manifests on the schema-v1 contract."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator.check_schema(cls.schema)
+        cls.validator = jsonschema.Draft202012Validator(cls.schema)
+
+    def test_all_explicit_haskell_manifests_are_schema_valid(self) -> None:
+        roots = (
+            REPO_ROOT / "code/packages/haskell",
+            REPO_ROOT / "code/programs/haskell",
+        )
+        paths = sorted(
+            path
+            for root in roots
+            for path in root.glob("*/required_capabilities.json")
+        )
+        self.assertTrue(paths, "expected at least one explicit Haskell manifest")
+
+        for path in paths:
+            with self.subTest(path=path.relative_to(REPO_ROOT)):
+                document = json.loads(path.read_text(encoding="utf-8"))
+                self.assert_schema_valid(document)
+                self.assertEqual(
+                    f"haskell/{path.parent.name}",
+                    document["package"],
+                    "manifest package identity must match its on-disk directory",
+                )
+
+    def test_language_neutral_scaffold_fixtures_are_schema_valid(self) -> None:
+        paths = sorted(FIXTURE_ROOT.glob("haskell_*_required_capabilities.json"))
+        self.assertEqual(2, len(paths), "expected Haskell library and program fixtures")
+
+        for path in paths:
+            with self.subTest(path=path.relative_to(REPO_ROOT)):
+                document = json.loads(path.read_text(encoding="utf-8"))
+                self.assert_schema_valid(document)
+
+    def assert_schema_valid(self, document: object) -> None:
+        errors = sorted(
+            self.validator.iter_errors(document),
+            key=lambda error: list(error.absolute_path),
+        )
+        self.assertEqual(
+            [],
+            [error.message for error in errors],
+            "document must validate against the shared Draft 2020-12 schema",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/13-capability-security.md
+++ b/code/specs/13-capability-security.md
@@ -254,10 +254,13 @@ If any install-time executable code is found, the publish fails.
 
 ### The Core Idea
 
-Every package declares exactly what OS capabilities it needs in a file called
-`required_capabilities.json`. Most packages in this monorepo declare **zero capabilities**
-— they are pure computation that takes values in and returns values out, with no
-interaction with the filesystem, network, processes, or environment.
+Every package has an effective OS-capability profile. New scaffolded packages
+and packages whose metadata is repaired declare that profile explicitly in
+`required_capabilities.json`. Legacy packages may omit the file; absence is the
+equivalent zero-capability profile. Most packages in this monorepo require
+**zero capabilities** — they are pure computation that takes values in and
+returns values out, with no interaction with the filesystem, network,
+processes, or environment.
 
 This is inspired by OpenBSD's `unveil()` system call, which allows a process to declare
 exactly which filesystem paths it will access. After the declaration, all other paths
@@ -288,6 +291,10 @@ category:action:target
 | `stdin` | `read` | `*` | `stdin:read:*` |
 | `stdout` | `write` | `*` | `stdout:write:*` |
 
+`stdout` is the taxonomy's unified process-output category: it covers writes
+to both standard output and standard error. Both streams therefore use
+`stdout:write:*`.
+
 ### Why This Granularity Matters
 
 Consider the difference between these two declarations:
@@ -309,15 +316,20 @@ should operate using the least set of privileges necessary to complete the job.
 The manifest file `required_capabilities.json` lives at the root of the package directory,
 alongside `BUILD` and `pyproject.toml`/`.gemspec`/`go.mod`.
 
-**Default deny: no manifest = zero capabilities.** A package without a
-`required_capabilities.json` file is treated as pure computation with zero OS access. This
-is the common case — most packages in this repo do not have a manifest because they do not
-need one. The absence of the file IS the declaration: "this package needs nothing."
+**Default deny: no manifest = zero capabilities.** A legacy package without a
+`required_capabilities.json` file is treated as pure computation with zero OS access. The
+absence of the file IS the effective declaration: "this package needs nothing."
 
-Only packages that actually need OS capabilities have a manifest file. This means:
-- Adding a manifest to a previously pure package is itself a capability escalation
-- The presence of a new `required_capabilities.json` in a PR is a security-relevant signal
-- Reviewers and CI can flag any PR that adds a manifest file
+Scaffold generators emit explicit schema-v1 profiles so new packages can be
+validated before they enter the repository. Backfilling an explicit empty
+profile onto a legacy pure package is metadata hardening, not a capability
+escalation. Adding a nonempty capability, or changing an existing nonempty
+profile, is security-relevant and requires the Layer 5 approval:
+- The presence of a new nonempty `required_capabilities.json` in a PR is a
+  security-relevant signal.
+- Reviewers and CI flag any new or changed capability object.
+- Empty explicit profiles and absent legacy profiles both enforce zero OS
+  access.
 
 **A package that reads grammar files (the uncommon case):**
 
@@ -960,7 +972,7 @@ kernel cannot be bypassed by application code.
 
 | Step | Attacker Action | Layer Hit | Result |
 |------|----------------|-----------|--------|
-| 1 | Create package, no manifest | Layer 4 (CI Gate) | Publish refuses — no `required_capabilities.json` |
+| 1 | Create package with undeclared network access | Layer 4 (CI Gate) | Static analysis detects `net:connect` outside the effective zero-capability profile |
 | 2 | Add manifest with `net:connect` | Layer 5 (Hardware Key) | **Blocked** — no signed approval |
 | 3 | Even if bypassed, trigger publish | Registry gate | PyPI Trusted Publisher not registered for this name |
 
@@ -1105,7 +1117,9 @@ All security packages use the `ca_` prefix:
 ### Phase 1: Specification and Manifests
 - This specification document
 - JSON Schema for `required_capabilities.json`
-- Add `required_capabilities.json` to all existing packages
+- Emit schema-v1 manifests for new scaffolds and backfill explicit metadata
+  where maintained; absent legacy manifests remain effective zero-capability
+  profiles
 - No enforcement — just the data
 
 ### Phase 2: Static Analyzers

--- a/code/specs/D21-capability-cage.md
+++ b/code/specs/D21-capability-cage.md
@@ -237,8 +237,13 @@ time        read, sleep                      "*" (time is not scoped)
 
 stdin       read                             "*" (stdin is not scoped)
 
-stdout      write                            "*" (stdout is not scoped)
+stdout      write                            "*" (stdout and stderr share this
+                                             unified output category)
 ```
+
+The wire category remains `stdout` for both process output streams. A write to
+standard error therefore requires `stdout:write:*`; no separate `stderr`
+category exists in the eight-category taxonomy.
 
 **The `*` target:** Within a specific `category:action` pair, the target `*` means "any
 resource of this type." For example, `fs:read:*` means "can read any file." This is

--- a/code/specs/fixtures/scaffold-generator/haskell_library_required_capabilities.json
+++ b/code/specs/fixtures/scaffold-generator/haskell_library_required_capabilities.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
   "version": 1,
-  "package": "haskell/sql-backend",
+  "package": "haskell/my-pkg",
   "capabilities": [],
-  "justification": "Pure in-memory SQL backend interfaces and values with no operating-system access."
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
 }

--- a/code/specs/fixtures/scaffold-generator/haskell_program_required_capabilities.json
+++ b/code/specs/fixtures/scaffold-generator/haskell_program_required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/build-helper",
+  "capabilities": [
+    {
+      "category": "stdout",
+      "action": "write",
+      "target": "*",
+      "justification": "Writes the generated program description to standard output."
+    }
+  ],
+  "justification": "Generated program writes its starter description to standard output and uses no other OS capabilities."
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,23 +105,23 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 30, 2026 at `c08e4fa83` after the Haskell
+inventory was regenerated on July 30, 2026 at `8517e41b1` after the Haskell
 `barcode-1d` and `http-core` ports, the Go/Rust `multi-directed-graph` slice,
 the Linux OCI preflight and external-authority contracts, and a new wave of
 Rust-only package families. The latest refresh includes the merged Haskell
-`http1` port and adds the Rust-only `smart-home-zwave-integration` identity
-after `smart-home-automation-runtime`, `venture-browser-macos`, and the earlier
-smart-home additions. It found zero canonical collisions or unknown language
-buckets:
+`http1` port and adds the Rust-only `smart-home-zwave-integration` and
+`smart-home-zwave-host` identities after `smart-home-automation-runtime`,
+`venture-browser-macos`, and the earlier smart-home additions. It found zero
+canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
 | Present in 10-15 languages | 172 | 277 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 744 | 10,416 |
+| Present in one language | 745 | 10,430 |
 
-The loop must not start by attempting 10,416 singleton ports. It should finish
+The loop must not start by attempting 10,430 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The July 30 lane audit is:
@@ -140,7 +140,7 @@ The July 30 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 959 | 0 | 100% |
+| Rust | 960 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -846,17 +846,18 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 549 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 550 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30 inventories added nine Rust singleton identities that now have
+The July 30 inventories added ten Rust singleton identities that now have
 explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
 `venture-browser-core` needs a portable-core versus native-boundary review.
 `smart-home-discovery-service`, `hue-integration`, and
-`smart-home-runtime-store`, `smart-home-automation-runtime`, and the newly
-merged `smart-home-zwave-integration` are likely native/service/storage
+`smart-home-runtime-store`, `smart-home-automation-runtime`,
+`smart-home-zwave-integration`, and the newly merged
+`smart-home-zwave-host` serial host are likely native/service/storage
 applicability cases. `venture-browser-macos` is an Apple-native
 AppKit/CoreText/Metal host whose expected classification is `native-source`,
 not a blind 14-lane port.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,23 +105,23 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 30, 2026 at `ad8bbd75a` after the Haskell
+inventory was regenerated on July 30, 2026 at `c08e4fa83` after the Haskell
 `barcode-1d` and `http-core` ports, the Go/Rust `multi-directed-graph` slice,
 the Linux OCI preflight and external-authority contracts, and a new wave of
-Rust-only package families. The latest refresh added the Rust-only
-`smart-home-automation-runtime` identity after `venture-browser-macos`, an
-Apple-native AppKit/CoreText/Metal host, and the earlier
-`smart-home-runtime-store`, `hue-integration`, and `venture-browser-core`
-additions. It found zero canonical collisions or unknown language buckets:
+Rust-only package families. The latest refresh includes the merged Haskell
+`http1` port and adds the Rust-only `smart-home-zwave-integration` identity
+after `smart-home-automation-runtime`, `venture-browser-macos`, and the earlier
+smart-home additions. It found zero canonical collisions or unknown language
+buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 278 |
+| Present in 10-15 languages | 172 | 277 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 743 | 10,402 |
+| Present in one language | 744 | 10,416 |
 
-The loop must not start by attempting 10,402 singleton ports. It should finish
+The loop must not start by attempting 10,416 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The July 29 lane audit is:
@@ -212,7 +212,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 278
+The 172 packages present in at least ten implementation languages need 277
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -222,7 +222,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; retain as a reference lane and run conformance fixtures |
 | F# | 0 | Complete; paired native package wave |
 | Go | 0 | Complete; primary build-tool and portable-core reference lane |
-| Haskell | 3 | Finish `http1`, then the generic `event-loop` and pure `brotli` gaps |
+| Haskell | 2 | Finish the generic `event-loop` and pure `brotli` gaps |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
 | Lua | 0 | Complete; retain as a reference lane and remediate build-tool drift |
@@ -774,7 +774,7 @@ build-graph dependency discovery so the follow-on `http1` edge is visible to
 incremental CI. The package now spans 12 established lanes, reduces the
 high-consensus backlog to 278 slots, and leaves 3 gaps in the Haskell lane.
 
-The selected thirty-second Haskell slice is `http1`, the direct NET04 consumer
+The merged thirty-second Haskell slice is `http1`, the direct NET04 consumer
 of that merged `http-core` foundation. It closes one ready protocol edge,
 validates the repaired Cabal dependency graph, and unlocks the remaining
 Haskell high-consensus tail. Its security review also exposed a shared NET04
@@ -790,6 +790,11 @@ object, and the merged `http-core` package retains that shape. The current
 `http1` package carries a schema-valid v1 pure-computation manifest;
 `haskell-scaffold-capability-schema` tracks generator golden/schema coverage
 and the existing-package backfill.
+
+The selected thirty-third Haskell slice is that scaffold capability-schema
+repair. It is a generator-level prerequisite for the remaining `event-loop`
+and `brotli` ports: new Haskell packages must receive schema-valid v1 manifests
+instead of propagating the legacy one-field shape.
 
 Recommended family order:
 
@@ -826,17 +831,17 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 548 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 549 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30 inventories added eight Rust singleton identities that now have
+The July 30 inventories added nine Rust singleton identities that now have
 explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
 `venture-browser-core` needs a portable-core versus native-boundary review.
 `smart-home-discovery-service`, `hue-integration`, and
-`smart-home-runtime-store`, plus the newly merged
-`smart-home-automation-runtime`, are likely native/service/storage
+`smart-home-runtime-store`, `smart-home-automation-runtime`, and the newly
+merged `smart-home-zwave-integration` are likely native/service/storage
 applicability cases. `venture-browser-macos` is an Apple-native
 AppKit/CoreText/Metal host whose expected classification is `native-source`,
 not a blind 14-lane port.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -124,7 +124,7 @@ buckets:
 The loop must not start by attempting 10,416 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
-The July 29 lane audit is:
+The July 30 lane audit is:
 
 | Established lane | Packages present | High-consensus gaps | Rust/Python-core coverage |
 |---|---:|---:|---:|
@@ -133,14 +133,14 @@ The July 29 lane audit is:
 | Elixir | 276 | 0 | 69.3% |
 | F# | 195 | 0 | 47.5% |
 | Go | 292 | 0 | 72.4% |
-| Haskell | 202 | 3 | 48.6% |
+| Haskell | 203 | 2 | 48.8% |
 | Java | 126 | 58 | 31.0% |
 | Kotlin | 125 | 58 | 31.0% |
 | Lua | 251 | 0 | 63.3% |
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 957 | 0 | 100% |
+| Rust | 959 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -793,8 +793,23 @@ and the existing-package backfill.
 
 The selected thirty-third Haskell slice is that scaffold capability-schema
 repair. It is a generator-level prerequisite for the remaining `event-loop`
-and `brotli` ports: new Haskell packages must receive schema-valid v1 manifests
-instead of propagating the legacy one-field shape.
+and `brotli` ports: the Go, TypeScript, and native Haskell scaffold paths must
+emit schema-valid v1 manifests instead of propagating the legacy one-field
+shape or omitting explicit scaffold metadata. The backfill covers all ten
+existing invalid Haskell manifests. Eight are explicit pure-computation
+profiles; `conduit` and `conduit-hello` carry proposed FFI, network, time,
+environment, and standard-output declarations under the canonical taxonomy,
+pending the Layer 5 review required for nonempty profiles.
+
+That audit also discovered four independently owned follow-ups:
+`haskell-capability-policy-audit` classifies the effective profiles of every
+Haskell package and program that currently relies on an absent legacy
+manifest; `haskell-scaffold-convention-reconciliation` brings the older
+TypeScript Haskell Cabal/Hspec templates to full canonical parity; and
+`scaffold-description-injection-hardening` closes structural delimiter
+injection across all generated metadata and source-comment contexts.
+`capability-schema-category-action-constraints` encodes the taxonomy's valid
+category-action pairs in both schemas and every enforcement backend.
 
 Recommended family order:
 

--- a/code/specs/scaffold-generator-spec.md
+++ b/code/specs/scaffold-generator-spec.md
@@ -1,7 +1,9 @@
 # Scaffold Generator — Package Scaffolding with a Dart Bootstrap Lane
 
-A CLI tool, powered by CLI Builder, that generates correct-by-construction,
-CI-ready package scaffolding across the monorepo's implementation languages.
+A CLI tool, powered by CLI Builder, whose contract defines
+correct-by-construction, CI-ready package scaffolding across the monorepo's
+implementation languages. Existing generators adopt that contract
+incrementally, with remaining exceptions tracked in the parity backlog.
 The first published versions covered Python, Go, Ruby, Rust, TypeScript, and
 Elixir; this spec now also defines a Dart bootstrap implementation focused on
 generating Dart packages and programs correctly.
@@ -236,6 +238,17 @@ Before generating any files, the tool validates:
 
 4. **Target directory does not exist** — refuse to overwrite. If the directory
    already exists, print an error and exit with code 1.
+
+5. **Description safety** — descriptions must be a single line and must not
+   contain control characters. Implementations must additionally escape or
+   reject any language-specific metadata or comment delimiter that could make
+   the description change the generated file's structure.
+
+   This rule is being adopted incrementally by the existing implementations.
+   The Go, TypeScript, and native Haskell paths enforce it for this Haskell
+   scaffold tranche; the remaining generators and template contexts are
+   tracked by `scaffold-description-injection-hardening` and do not claim this
+   clause until migrated.
 
 ### 2.6 Exit Status
 
@@ -1025,7 +1038,57 @@ mix deps.get --quiet && mix test --cover
 
 ---
 
-### 5.7 Common Files (All Languages)
+### 5.7 Haskell Capability Manifests
+
+#### `required_capabilities.json`
+
+Every scaffold implementation that emits Haskell packages MUST generate a
+complete schema-v1 document that validates against
+`code/specs/schemas/required_capabilities.schema.json`. The manifest for a new
+Haskell library has this shape:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "{language}/{directory-name}",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}
+```
+
+`{directory-name}` is the package's generated on-disk directory name, including
+language-specific normalization. Generators MUST ensure interpolated values
+remain valid JSON. Values that can contain arbitrary text MUST be JSON-encoded;
+identifiers may be interpolated only after strict validation makes every
+accepted character JSON-safe.
+
+The empty capability list is an explicit scaffold-time pure-computation
+declaration. It does not change the default-deny rule in
+`13-capability-security.md`: an older package with no manifest is still treated
+as requiring zero OS capabilities.
+
+Language-neutral Haskell library and program goldens live under
+`code/specs/fixtures/scaffold-generator/`. Every Haskell-emitting generator
+test compares its actual JSON with the applicable shared fixture, and the
+checked-in Python contract test validates both fixtures against the shared
+Draft 2020-12 schema.
+
+Both the Go and native Haskell scaffold generators MUST follow this contract
+for Haskell output. The native Haskell program template writes its starter
+description to standard output, so a generated program MUST replace the empty
+array with this truthful capability:
+
+```json
+{
+  "category": "stdout",
+  "action": "write",
+  "target": "*",
+  "justification": "Writes the generated program description to standard output."
+}
+```
+
+### 5.8 Common Files (All Languages)
 
 #### `README.md`
 
@@ -1283,6 +1346,7 @@ Each implementation must have unit tests covering:
 | Transitive closure | Given a graph, verify complete transitive set | 95% |
 | Topological sort | Verify leaf-first ordering, cycle detection | 95% |
 | Template rendering | For each language, verify generated file content matches expected output | 90% |
+| Capability manifest | Compare generated JSON with a golden document and validate it against the shared Draft 2020-12 schema | 100% |
 | BUILD file generation | Verify transitive deps appear in correct topological order | 100% |
 | Dry-run mode | Verify no files are written, output shows what would be created | 90% |
 

--- a/code/specs/schemas/required_capabilities.schema.json
+++ b/code/specs/schemas/required_capabilities.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
   "title": "Required Capabilities Manifest",
-  "description": "Declares the OS-level capabilities a package requires. This file is OPTIONAL — packages without it are treated as pure computation with zero OS access (default deny). Only packages that need OS capabilities should have this file. Any non-empty capability requires hardware-key-signed approval.",
+  "description": "Declares the OS-level capabilities a package requires. This file is OPTIONAL for legacy packages — packages without it are treated as pure computation with zero OS access (default deny). Scaffolded packages emit explicit schema-v1 profiles, including empty pure-computation profiles. Any non-empty capability requires hardware-key-signed approval.",
   "type": "object",
   "required": ["version", "package", "capabilities", "justification"],
   "additionalProperties": false,


### PR DESCRIPTION
## Summary

- make the Go, TypeScript, and native Haskell scaffold generators emit complete schema-v1 Haskell capability manifests
- add language-neutral Haskell library/program golden fixtures plus a Draft 2020-12 CI contract test covering both fixtures and all 16 explicit Haskell manifests
- backfill the 10 invalid Haskell manifests; the Conduit profiles now truthfully declare FFI load/call, network, environment, timing, and unified process-output access
- harden scaffold descriptions against Unicode controls, line separators, and block-comment termination before generation
- reconcile the capability/security specs, refresh the collision-checked parity inventory, and record newly discovered policy/convention/schema/classification follow-ups
- refresh the touched TypeScript lockfile to patched PostCSS 8.5.25; `npm audit` is clean

## Security review required

The `conduit` and `conduit-hello` profiles are intentionally nonempty. They are proposed least-privilege metadata and require the Layer 5 review described by `13-capability-security.md` before merge/publish. This PR does not merge itself or claim that approval has occurred.

## Validation

- Go scaffold generator: `go test ./... -count=1 -cover` (66.7%), `go vet ./...`, and an explicit temp-output `go build`
- Native Haskell scaffold generator: 9/9 Hspec examples with coverage; `cabal build all --ghc-options=-Wall`; real generated library and program Cabal builds/tests
- TypeScript scaffold generator: `npm run build`; 121/121 Vitest tests; 83.97% statements / 66.8% branches / 75.71% functions / 84.16% lines; `npm audit --audit-level=high` reports 0 vulnerabilities
- Haskell backfill: all 8 pure package test suites pass; Conduit and conduit-hello metadata validate locally, while their documented Windows build contract skips native FFI because `conduit_capi.dll` cross-compile setup is unavailable
- Schema/CI: `test_haskell_required_capabilities.py` passes for 16 manifests and 2 shared fixtures; Ruff, Bandit, Python compile, and workflow YAML parsing pass
- Parity inventory at `8517e41b1`: 1,195 identities, 4,337 implementation slots, 172 high-consensus packages, 277 missing high-consensus slots, 0 collisions, 0 unknown buckets; Haskell remains 203 present / 2 high-consensus gaps / 48.8%
- Build tool: affected-package language detection requests Go, TypeScript, and Haskell; validation-disabled dry-run completes with 42 affected packages. Strict repository-wide BUILD validation still reports the pre-existing standalone-dependency backlog; this PR changes no BUILD file
- `git diff --check` and an added-line secret scan pass

## Follow-ups recorded

- full Haskell capability-policy audit
- TypeScript Haskell Cabal/Hspec convention reconciliation
- remaining cross-generator description-context hardening
- category/action constraints in capability schemas
- classification of the newly discovered Rust-only `smart-home-zwave-host`