### PR TITLE
content: Dravidian TIME-MORNING/EVENING/AFTERNOON arc (new accumulator, continuing from #9265)

### DIFF
--- a/code/learning/human-languages/kannada/lessons/KA-C29-shubhodaya.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C29-shubhodaya.md
@@ -1,0 +1,73 @@
+---
+id: KA-C29-shubhodaya
+chapter: 29
+type: phrase
+headword: ಶುಭೋದಯ
+gloss: "good morning" (śubhōdaya) — śubha ("good") + udaya ("rising, sunrise," ← ud- "up" + i "to go"), a DIFFERENT root from ಬೆಳಗ್ಗೆ; sources conflict on its everyday spoken commonality, but the more careful ones describe it skewing formal/written, similar to Hindi's सुप्रभात, with ನಮಸ್ಕಾರ likely covering casual mornings
+concept_tag: GREETING-MORNING
+prerequisites: [KA-C26-belagge]
+sounds: [kannada-vowel-sign-oo, kannada-bha]
+roots: [su-good, udaya-sanskrit-rise]
+etymology_hook: "ಶುಭೋದಯ (śubhōdaya, 'good morning') = ಶುಭ (śubha, 'good, auspicious') + ಉದಯ (udaya, 'rising, sunrise,' ← Sanskrit ud- 'up' + i 'to go' — the same root behind sūryodaya, 'sunrise') — a COMPLETELY DIFFERENT root from ಬೆಳಗ್ಗೆ (beḷagge, KA-C26's native word for 'morning'); be honest about register: sources genuinely CONFLICT here — some describe ಶುಭೋದಯ as common in everyday speech, but a more careful source describes it as reserved for formal or written contexts (speeches, greeting cards, WhatsApp images) and 'not as frequently used in daily conversations' as ನಮಸ್ಕಾರ/ನಮಸ್ತೆ, with at least one native-speaker account suggesting casual spoken Kannada often reaches for English 'good morning' instead — the SAME formal/written skew pattern already found for Hindi's सुप्रभात, not a genuine cross-language contrast"
+est_minutes: 6
+reviews_of: [KA-C26-belagge]
+---
+
+# ಶುಭೋದಯ (śubhōdaya) — "good morning," a third root for morning
+
+## Warm-up
+
+[PAUSE 2s] You already have ಬೆಳಗ್ಗೆ, the everyday word for "morning."
+This greeting reaches for a completely different word for the same idea
+— and, honestly, this lesson's twist is about how uncertain its own
+"everyday" status turns out to be, once you look closely.
+
+## ಶುಭೋದಯ — ಶುಭ + ಉದಯ, a third morning-root
+
+**ಶುಭೋದಯ** (**śubhōdaya**) — "**good morning**" — is built from **ಶುಭ**
+(*śubha*, "**good, auspicious**") plus **ಉದಯ** (*udaya*, "**rising,
+sunrise**," from Sanskrit **ud-** "up" + **i** "to go" — the same root
+behind **ಸೂರ್ಯೋದಯ**, *sūryōdaya*, "sunrise" itself). This is a
+**completely different word** from **ಬೆಳಗ್ಗೆ** (*beḷagge*, Chapter 26's
+native "morning") — Kannada now has (at least) two unrelated roots
+circling the idea of morning: one native ("the shining"), one Sanskrit
+("the rising").
+
+## Be honest: sources conflict, and the careful ones point to Hindi's own story
+
+Here's where this lesson needs real care. Some sources describe
+**ಶುಭೋದಯ** as the most common everyday way to say "good morning" in
+Kannada — but these are largely the same genre of generic phrasebook
+site whose claims about Hindi's सुप्रभात turned out, on closer
+inspection, to be overstated. A more careful source instead describes
+ಶುಭೋದಯ as reserved mainly for **formal or written** contexts — speeches,
+greeting cards, WhatsApp images — calling it "not as frequently used in
+daily conversations" as **ನಮಸ್ಕಾರ**/**ನಮಸ್ತೆ**, and at least one
+native-speaker account suggests casual spoken Kannada often reaches for
+**English** "good morning" instead of ಶುಭೋದಯ entirely. Taken together,
+this looks like the **same** formal/written skew already found for
+Hindi's सुप्रभात, not the genuine cross-language contrast a first pass
+at the sources might suggest. A native alternate, **ಶುಭ ಮುಂಜಾನೆ**
+(*śubha muñjāne*, using *muñjāne*, "the early morning, before sunrise"),
+also exists as a real, attested greeting construction — but its own
+register isn't independently confirmed here either.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubhōdaya" — "good morning," śubha + udaya]
+- [YOU SAY: the root contrast — beḷagge is native "shining"; udaya is
+  Sanskrit "rising"]
+- [YOU SAY: the honest note — sources conflict, but the more careful
+  ones point to the same formal/written skew already found for Hindi]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does ಶುಭೋದಯ share a root with ಬೆಳಗ್ಗೆ? (**No** — ಉದಯ,
+"rising," is a completely different Sanskrit root from native ಬೆಳಗ್ಗೆ's
+"shining.") Is ಶುಭೋದಯ genuinely common in everyday casual Kannada
+speech? (**Unclear, and possibly not** — sources conflict; the more
+careful ones describe it skewing formal/written, with ನಮಸ್ಕಾರ/ನಮಸ್ತೆ
+covering casual mornings instead, and one native-speaker account
+suggests English "good morning" often gets used in casual speech
+instead of ಶುಭೋದಯ entirely.)

--- a/code/learning/human-languages/kannada/lessons/KA-C30-shubha-sanje.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C30-shubha-sanje.md
@@ -1,0 +1,66 @@
+---
+id: KA-C30-shubha-sanje
+chapter: 30
+type: phrase
+headword: ಶುಭ ಸಂಜೆ
+gloss: "good evening" (śubha sañje) — pairs with ಸಂಜೆ, already established (KA-C27) as Sanskrit-via-Prakrit, NOT native Dravidian, whatever an unverified claim you might encounter elsewhere says; leans formal, with ನಮಸ್ಕಾರ likely covering casual use, echoing (with real hedging) the formal-skew question already raised for सुप्रभात and ಶುಭೋದಯ
+concept_tag: GREETING-EVENING
+prerequisites: [KA-C27-sanje, KA-C29-shubhodaya]
+sounds: [kannada-sha, kannada-anusvara]
+roots: [su-good, sanskrit-sandhya-junction]
+reviews_of: [KA-C27-sanje, KA-C29-shubhodaya]
+etymology_hook: "ಶುಭ ಸಂಜೆ (śubha sañje, 'good evening') pairs śubha with ಸಂಜೆ (sañje, 'evening,' already met in Chapter 27 as a Sanskrit tatsama borrowed via Maharashtri Prakrit — NOT native Dravidian, despite a plausible-sounding claim you might encounter elsewhere that it's a native word); register evidence here is genuinely thin — a general, leans-formal impression (with ನಮಸ್ಕಾರ or, among younger urban speakers, English 'hello,' likely covering casual use) rather than a specific, well-sourced usage-context claim; this echoes, cautiously, the same formal-skew QUESTION already raised (not settled) for Hindi's सुप्रभात and Kannada's own ಶುಭೋದಯ, without overstating either lesson's own hedged conclusion into flat fact"
+est_minutes: 6
+---
+
+# ಶುಭ ಸಂಜೆ (śubha sañje) — formal, and correctly citing where ಸಂಜೆ comes from
+
+## Warm-up
+
+[PAUSE 2s] You already have ಸಂಜೆ, "evening" — and you already know it's
+a Sanskrit word that arrived in Kannada already worn down, via Prakrit.
+Keep that fact straight here, since it's an easy one to second-guess.
+
+## ಶುಭ ಸಂಜೆ — built correctly on Chapter 27's word
+
+**ಶುಭ ಸಂಜೆ** (**śubha sañje**) — "**good evening**" — pairs **ಶುಭ**
+("good, auspicious") with **ಸಂಜೆ**, the exact word from Chapter 27:
+Sanskrit **ಸಂಧ್ಯಾ** (*saṃdhyā*), borrowed into Kannada via **Maharashtri
+Prakrit** ಸಂಝಾ (*sañjhā*). You might run across a plausible-sounding
+claim elsewhere that ಸಂಜೆ is "native Dravidian" — it isn't, and you
+already have the real answer from Chapter 27. Don't let a claim that
+merely *sounds* plausible override something you've already verified.
+
+## Be honest: a genuinely thin evidence base, not a settled pattern
+
+Here's where this lesson needs to be careful about its own sourcing, not
+just the etymology's. General impressions lean toward **ಶುಭ ಸಂಜೆ**
+skewing **formal**, with the all-purpose **ನಮಸ್ಕಾರ** — or, among
+younger urban speakers, borrowed English "**hello**" — more likely to
+cover ordinary casual conversation. But the evidence for this specific
+register claim is genuinely **thin**: it's the same kind of impression
+that, for both Hindi's सुप्रभात and Kannada's own ಶುಭೋದಯ, needed real
+digging to confirm or correct, and here that deeper digging hasn't
+turned up anything more solid than a general leaning. Treat this as an
+open **question**, echoing the same one already raised for those two
+greetings, not a third confirmed data point — this lesson doesn't have
+strong enough sourcing to settle it either way.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubha sañje" — "good evening," a genuinely Sanskrit-rooted
+  pairing]
+- [YOU SAY: the correction — ಸಂಜೆ is Sanskrit-via-Prakrit, NOT native
+  Dravidian, whatever a plausible-sounding claim elsewhere might say]
+- [YOU SAY: ನಮಸ್ಕಾರ — the likely all-purpose everyday alternative,
+  though this greeting's own register remains an open question]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is ಸಂಜೆ native Dravidian? (**No** — Sanskrit ಸಂಧ್ಯಾ via
+Maharashtri Prakrit, already established in Chapter 27; be skeptical of
+any claim otherwise.) Is it settled that ಶುಭ ಸಂಜೆ is formal/rare in
+casual speech, the way सुप्रभात and ಶುಭೋದಯ turned out to be? (**Not
+settled** — the impression leans that way, with ನಮಸ್ಕಾರ likely covering
+casual use, but the sourcing here is too thin to call it confirmed.)

--- a/code/learning/human-languages/kannada/lessons/KA-C31-shubha-madhyahna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C31-shubha-madhyahna.md
@@ -1,0 +1,70 @@
+---
+id: KA-C31-shubha-madhyahna
+chapter: 31
+type: phrase
+headword: ಶುಭ ಮಧ್ಯಾಹ್ನ
+gloss: "good afternoon" (śubha madhyāhna) — reuses ಮಧ್ಯಾಹ್ನ, KA-C17's "noon" word, not the more precise ಅಪರಾಹ್ನ from KA-C28; one directly-fetched source describes it leaning formal/workplace, though this wasn't cross-corroborated the way ನಮಸ್ಕಾರ's universal, any-time-of-day status was
+concept_tag: GREETING-AFTERNOON
+prerequisites: [KA-C17-madhyaahna-madhyaraatri, KA-C28-aparahna, KA-C30-shubha-sanje]
+sounds: [kannada-conjunct-dhya, kannada-vowel-sign-aa]
+roots: [su-good, sanskrit-madhya-middle]
+etymology_hook: "ಶುಭ ಮಧ್ಯಾಹ್ನ (śubha madhyāhna, 'good afternoon') is the standard afternoon greeting — but notice which noun it reuses: ಮಧ್ಯಾಹ್ನ (madhyāhna, 'noon,' KA-C17), NOT ಅಪರಾಹ್ನ (aparāhna, the more precisely-'afternoon' word from KA-C28) — a real-world data point for KA-C28's own hedge about whether madhyāhna has loosely widened to cover the afternoon too; be careful with the register claim here: one source, fetched directly rather than trusted from a search summary, describes ಶುಭ ಮಧ್ಯಾಹ್ನ as leaning FORMAL or semi-formal, workplaces and official meetings — but this wasn't cross-corroborated by a second source the way ನಮಸ್ಕಾರ's genuinely universal, any-time-of-day status was (confirmed independently across multiple fetched sources), so treat the workplace/formal framing as a single data point, not a settled fact"
+est_minutes: 6
+reviews_of: [KA-C17-madhyaahna-madhyaraatri, KA-C28-aparahna, KA-C30-shubha-sanje]
+---
+
+# ಶುಭ ಮಧ್ಯಾಹ್ನ (śubha madhyāhna) — the "noon" word doing the afternoon's job
+
+## Warm-up
+
+[PAUSE 2s] Two lessons ago you met a careful hedge: does ಮಧ್ಯಾಹ್ನ,
+"noon," also loosely cover "afternoon"? This greeting hands you a real
+data point.
+
+## ಶುಭ ಮಧ್ಯಾಹ್ನ — reusing the "noon" word, not the "afternoon" one
+
+**ಶುಭ ಮಧ್ಯಾಹ್ನ** (**śubha madhyāhna**) — "**good afternoon**" — is the
+standard greeting for this concept. Notice which noun it actually
+reuses: **ಮಧ್ಯಾಹ್ನ** (*madhyāhna*, "noon," Chapter 17) — **not**
+**ಅಪರಾಹ್ನ** (*aparāhna*, the word Chapter 28 established as the more
+precisely "afternoon"-specific term). This is exactly the kind of
+concrete usage evidence that bears on Chapter 28's own hedge: if the
+standard **greeting** for "good afternoon" reaches for *madhyāhna*
+rather than *aparāhna*, that's a real (if still not fully conclusive)
+sign that *madhyāhna*'s job has genuinely stretched to cover the
+afternoon in everyday use, not just at noon itself.
+
+## Be honest: one verified claim, one still just a single data point
+
+Here's the useful discipline this lesson followed: checking a claim
+against an actual, directly fetched source page, not just trusting a
+search-engine's own summary of one. That check turned up **two** claims
+of very different strength. **ನಮಸ್ಕಾರ**'s status as a genuinely
+**universal** greeting — suited to any time of day, any occasion — is
+independently confirmed across multiple fetched sources; that one's
+solid. The claim that **ಶುಭ ಮಧ್ಯಾಹ್ನ** leans **formal or semi-formal**
+— workplaces, official meetings — traces back to just **one** source.
+It's a real, directly-verified data point, worth taking seriously — but
+it isn't cross-corroborated the way the ನಮಸ್ಕಾರ claim is, so treat it as
+a single well-checked impression, not a settled fact.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubha madhyāhna" — "good afternoon," reusing the "noon"
+  word, not "aparāhna"]
+- [YOU SAY: why that matters — real evidence for madhyāhna's meaning
+  stretching to cover "afternoon"]
+- [YOU SAY: ನಮಸ್ಕಾರ — the confirmed universal, any-time-of-day greeting,
+  cross-checked across multiple sources]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does ಶುಭ ಮಧ್ಯಾಹ್ನ use ಮಧ್ಯಾಹ್ನ ("noon") or ಅಪರಾಹ್ನ (the more
+precise "afternoon" word)? (**ಮಧ್ಯಾಹ್ನ** — real evidence for its
+meaning stretching to cover "afternoon" too.) Is the "formal/workplace"
+register claim for ಶುಭ ಮಧ್ಯಾಹ್ನ as solidly confirmed as ನಮಸ್ಕಾರ's
+universal status? (**No** — the workplace claim rests on a single
+directly-verified source, not cross-corroborated the way ನಮಸ್ಕಾರ's is.)
+What's the confirmed universal, any-time-of-day alternative?
+(**ನಮಸ್ಕಾರ**.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C26-raavile.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C26-raavile.md
@@ -1,0 +1,78 @@
+---
+id: ML-C26-raavile
+chapter: 26
+type: word
+headword: രാവിലെ
+gloss: "morning" (rāvile) — a compound of രാവ് (rāvŭ, "night," a cognate doublet of ഇരവ്/iravŭ already met in ML-C24 — same root, not literally the same word) + locative-ish suffixes -il/-e; literally built from NIGHT, not light or rising — a genuinely different strategy than Kannada's "the shining" or Telugu's Sanskrit "rise"; പ്രഭാതം (Sanskrit tatsama, same prabhāta root as Telugu's TE-C29) and പുലർച്ച (native, thinner etymology) also exist as alternatives
+concept_tag: TIME-MORNING
+prerequisites: [ML-C24-rathri]
+sounds: [malayalam-vowel-sign-e, malayalam-virama-va]
+roots: [proto-dravidian-cira-darkness, sanskrit-prabhata-shine]
+etymology_hook: "രാവിലെ (rāvile, 'morning') is, per Wiktionary, a compound of രാവ് (rāvŭ) + -il + -e; രാവ് is confirmed cognate with Tamil ரா/இரவு and shares its Proto-Dravidian *cira ('darkness') root with ഇരവ് (iravŭ), already met in ML-C24 as a literary register synonym for 'night' — a cognate doublet, not literally the same word — meaning Malayalam's everyday 'morning' word is, transparently, built from NIGHT plus locative suffixes, not from light or rising; hedge the exact semantic mechanism (why 'at night' shifted to mean 'morning') since no source spells out the intermediate step, but the morphological composition itself is Wiktionary-confirmed; two alternatives exist too: പ്രഭാതം (prabhātaṁ), a Sanskrit tatsama sharing its root, prabhāta ('shine, become bright'), with Telugu's own సుప్రభాతం (TE-C29) — a genuine cross-language callback within this very arc — and പുലർച്ച (pulaṟcca), native Dravidian but with a thinner, less certain etymology (a Starling-database entry links it to a 'subsist/live' sense that may or may not be the same root as 'dawn,' so treat that connection as unconfirmed, not settled)"
+est_minutes: 6
+reviews_of: [ML-C24-rathri]
+---
+
+# രാവിലെ (rāvile) — "morning," built from "night"
+
+## Warm-up
+
+[PAUSE 2s] Kannada's morning word means "the shining." Telugu's means
+"rise." Malayalam's most common morning word means something stranger
+on its face: night.
+
+## രാവിലെ — night, plus place, somehow becomes morning
+
+**രാവിലെ** (**rāvile**) — "**morning**" — is, per Wiktionary, a
+compound: **രാവ്** (*rāvŭ*) plus the suffixes **-il** and **-e**.
+Here's the honest surprise: **രാവ്** shares its root — not its
+exact form — with the word already met in Chapter 24, **ഇരവ്**
+(*iravŭ*), there a **literary-register synonym for "night" itself**.
+Wiktionary confirms both as cognates, both tracing to
+**Proto-Dravidian** ***\*cira*** ("**darkness**") — a cognate doublet
+within Malayalam, not literally one word in two spellings. So Malayalam's
+everyday word for "morning" is, transparently, built from **night**
+plus locative-ish suffixes — not from light, dawn, or rising, the
+strategies Kannada's **ಬೆಳಗ್ಗೆ** ("the shining") and Telugu's
+**ఉదయం** (Sanskrit "rise") both reach for instead.
+
+## Be honest: the compound is confirmed, the exact shift isn't explained
+
+No source spells out **why** "at/in the night" came to mean
+"morning" specifically — it's a plausible semantic path (perhaps
+"the night just ending," the pre-dawn hours) rather than one directly
+documented step by step. Treat the **morphological composition** as
+confirmed (Wiktionary is explicit about the rāvŭ+il+e breakdown); treat
+the **semantic mechanism** as a reasonable but unconfirmed inference,
+not a settled fact.
+
+## Two alternatives — one with a striking callback, one thinly sourced
+
+Malayalam keeps two other words for "morning" too. **പ്രഭാതം**
+(*prabhātaṁ*) is a Sanskrit **tatsama** sharing its root — **prabhāta**,
+"to shine, become bright" — with Telugu's own **సుప్రభాతం**
+(*suprabhātam*, TE-C29, this very arc's Telugu morning-greeting word) —
+a genuine cross-language callback within this project. **പുലർച്ച**
+(*pulaṟcca*) is native Dravidian, but be honest about its etymology:
+one database entry links it to a root meaning "to subsist, live,"
+which may or may not be the same root behind its "dawn" sense — treat
+that specific connection as unconfirmed, not settled.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rāvile" — "morning," built from rāvŭ ("night") + locative
+  suffixes]
+- [YOU SAY: the honest surprise — a cognate doublet of the night-word
+  already met as iravŭ (Chapter 24), same root, now doing morning's job]
+- [YOU SAY: prabhātaṁ — same Sanskrit root as Telugu's suprabhātam]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is രാവിലെ literally built from? (**രാവ്** —
+"night" — plus locative suffixes -il/-e; a cognate doublet, same
+root, as ഇരവ് met in Chapter 24 — not literally the same word.) Is the exact reason "night" came to mean "morning"
+fully documented? (**No** — the compound itself is confirmed, but the
+semantic shift is a plausible, unconfirmed inference.) What root does
+പ്രഭാതം share with a word from Telugu's arc? (**prabhāta** —
+the same root behind Telugu's సుప్రభాతం, TE-C29.)

--- a/code/learning/human-languages/telugu/lessons/TE-C26-udayam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C26-udayam.md
@@ -1,0 +1,70 @@
+---
+id: TE-C26-udayam
+chapter: 26
+type: word
+headword: ఉదయం
+gloss: "morning" (udayam) — Sanskrit tatsama from udaya ("rise") + Telugu -mu, Telugu's most general everyday word, though genuine native competitors (poddu/podduna, vēkuva) also do real everyday work; unlike Kannada, where the same Sanskrit root (udaya) shows up ONLY inside the greeting śubhōdaya, Telugu's everyday noun and its greeting-root are the SAME word
+concept_tag: TIME-MORNING
+prerequisites: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
+sounds: [telugu-anusvara, telugu-da]
+roots: [sanskrit-udaya-rise]
+etymology_hook: "ఉదయం (udayam, 'morning') is a Sanskrit tatsama — from ఉదయ (udaya, 'rise, appearance') + Telugu's own -ము (-mu) suffix — and it's genuinely Telugu's most common, general everyday word for 'morning'; be honest, though: it doesn't have the field entirely to itself — పొద్దు/పొద్దున (poddu/podduna), genuine Proto-Dravidian vocabulary cognate with Tamil pozhudu and Kannada hottu, does real everyday work too, and వేకువ (vēkuva, 'dawn, early morning') is labeled colloquial, not archaic; be honest also about the contrast with Kannada: Kannada has this exact Sanskrit root (udaya), but only inside its GREETING, ಶುಭೋದಯ (śubhōdaya) — Kannada's everyday morning noun is the unrelated native ಬೆಳಗ್ಗೆ; Telugu's ఉదయం, by contrast, covers BOTH the everyday-noun and greeting-root jobs at once — no such twist here, unlike the Persian-loan surprise already found for Telugu's 'day' word (rōju, TE-C23)"
+est_minutes: 6
+reviews_of: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
+---
+
+# ఉదయం (udayam) — the same Sanskrit root, a different job than in Kannada
+
+## Warm-up
+
+[PAUSE 2s] Last lesson's రోజు was a genuine Persian surprise. This
+lesson's word for "morning" goes the other way — straight Sanskrit,
+doing double duty in a way its Kannada cousin doesn't.
+
+## ఉదయం — Sanskrit, and genuinely everyday
+
+**ఉదయం** (**udayam**) — "**morning**" — is a Sanskrit **tatsama**: from
+**ఉదయ** (*udaya*, "**rise, appearance**") plus Telugu's own **-ము**
+(*-mu*) nominal suffix. This is Telugu's most common, general everyday
+word for "morning" — but be honest: it doesn't have the field entirely
+to itself. **పొద్దు**/**పొద్దున** (*poddu*/*podduna*) is genuine
+**Proto-Dravidian** vocabulary — cognate with Tamil **pozhudu** and
+Kannada **hottu** — and does real everyday work too ("**పొద్దున్నే
+లేచాను**," "I woke up in the morning"). **వేకువ** (*vēkuva*, "dawn,
+early morning") is labeled **colloquial**, not archaic or purely
+poetic. ఉదయం is the broadest, most general word — but not an
+uncontested one.
+
+## Be honest: the same root, doing a different job than in Kannada
+
+Here's the honest cross-language twist. Kannada also has this **exact**
+Sanskrit root, **ఉదయ** (*udaya*) — but only inside its **greeting**,
+**ಶುಭೋದಯ** (*śubhōdaya*, "good morning"). Kannada's actual everyday
+**noun** for "morning" is a completely unrelated **native** word,
+**ಬೆಳಗ್ಗೆ** (*beḷagge*, "the shining"). Telugu doesn't split the job
+that way: **ఉదయం** covers both the everyday noun AND, in
+**శుభోదయం**, the greeting root — one word, doing what Kannada spreads
+across two unrelated ones. And unlike **రోజు** (last lesson's genuine
+Persian surprise for "day"), Telugu's morning word holds no such twist —
+straightforwardly Sanskrit, start to finish.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "udayam" — "morning," Sanskrit tatsama, the broadest word,
+  though poddu/podduna and vēkuva are real native alternatives too]
+- [YOU SAY: the cross-language twist — Kannada's ఉదయ root only shows up
+  in ITS greeting; Telugu uses ఉదయం for both the noun and the greeting]
+- [YOU SAY: the contrast with రోజు — no Persian surprise here, just
+  straightforward Sanskrit]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is ఉదయం the ONLY word Telugu speakers use for "morning"?
+(**No** — it's the broadest, most common one, but పొద్దు/పొద్దున and
+వేకువ, both genuinely native, do real everyday work too.) Does Kannada's
+everyday
+morning-noun share ఉదయం's root? (**No** — Kannada's ಬೆಳಗ್ಗೆ is native;
+the shared root, udaya, shows up only inside Kannada's GREETING,
+ಶುಭೋದಯ.) Does ఉదయం hold a surprise the way రోజు did? (**No** —
+straightforwardly Sanskrit throughout.)

--- a/code/learning/human-languages/telugu/lessons/TE-C27-sayantram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C27-sayantram.md
@@ -1,0 +1,63 @@
+---
+id: TE-C27-sayantram
+chapter: 27
+type: word
+headword: సాయంత్రం
+gloss: "evening" (sāyantram) — Sanskrit tatsama from సాయం (sāyam, "in the evening") + a "-tana" time-adjective suffix; సాయం itself traces to PIE *seh₁- ("long, lasting"), the SAME root as Latin's sērus — already taught in this course as the root of French soir and Italian sera — a genuine distant cognate across two completely different Indo-European branches
+concept_tag: TIME-EVENING
+prerequisites: [TE-C26-udayam]
+sounds: [telugu-anusvara, telugu-conjunct-tra]
+roots: [sanskrit-sayam-evening]
+etymology_hook: "సాయంత్రం (sāyantram, 'evening') is a Sanskrit tatsama — from సాయం (sāyam, 'in the evening') plus a Sanskrit '-tana' suffix that turns time-adverbs into adjectives (cf. divātana, 'of the day'; sanātana, 'eternal'); సాయం itself, per Wiktionary, traces to PIE *seh₁- ('long, lasting') — and Wiktionary explicitly states this root is 'distantly related to Latin sērus,' independently confirmed on sērus's own Wiktionary page (Proto-Italic *sēros ← PIE *seh₁-, 'to be long, lasting, slow'); sērus is already established in this course as the root of French soir and Italian sera (LA-C33-vesper) — meaning Telugu's everyday evening word and the Romance family's everyday evening word are genuine, if very distant, cognates, one route through Sanskrit tatsama borrowing, one through Vulgar Latin erosion"
+est_minutes: 6
+reviews_of: [TE-C26-udayam]
+---
+
+# సాయంత్రం (sāyantram) — a distant cousin of French "soir"
+
+## Warm-up
+
+[PAUSE 2s] This lesson's word for "evening" reaches back to a PIE root
+you've technically already met — in a completely different language,
+on a completely different continent's language family.
+
+## సాయంత్రం — Sanskrit, built from "evening" plus a time-suffix
+
+**సాయంత్రం** (**sāyantram**) — "**evening**" — is a Sanskrit
+**tatsama**: from **సాయం** (*sāyam*, "**in the evening**") plus a
+Sanskrit **-tana** suffix that turns time-adverbs into adjectives — the
+same suffix pattern behind Sanskrit **divātana** ("of the day") and
+**sanātana** ("eternal, lasting").
+
+## A genuine distant cousin: the same PIE root as Latin's sērus
+
+Here's the striking part, checked directly against primary sources
+rather than assumed: **సాయం** itself traces to **Proto-Indo-European**
+***\*seh₁-*** ("**long, lasting**") — and this is **explicitly**
+documented as "distantly related to **Latin sērus**" ("late"), itself
+confirmed independently to trace to the very same *\*seh₁-* root
+(via Proto-Italic *\*sēros*). You've technically already met *sērus*: it's
+the Latin root already established in this course as the source of
+**French soir** and **Italian sera** — French and Italian's own everyday
+"evening" words. That makes **సాయంత్రం** and **soir**/**sera** genuine
+distant cognates — one route through Sanskrit tatsama borrowing into
+Telugu, one route through centuries of Vulgar Latin erosion into French
+and Italian, both ultimately the same Proto-Indo-European idea of
+something "long, lasting" stretching into "late in the day."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "sāyantram" — "evening," sāyam + the -tana time-suffix]
+- [YOU SAY: the deep root — PIE *seh₁-, "long, lasting"]
+- [YOU SAY: the cross-family cognate — the same root behind French soir
+  and Italian sera, via Latin sērus]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is సాయంత్రం built from? (**సాయం**, "in the evening," +
+a Sanskrit "-tana" time-adjective suffix.) What PIE root does సాయం trace
+to? (***\*seh₁-***, "long, lasting.") What two Romance words are genuine
+distant cognates of సాయంత్రం, and through which Latin word? (**French
+soir and Italian sera** — both through Latin **sērus**, "late," which
+traces to the same *\*seh₁-* root.)

--- a/code/learning/human-languages/telugu/lessons/TE-C28-madhyahnam-widened.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C28-madhyahnam-widened.md
@@ -1,0 +1,69 @@
+---
+id: TE-C28-madhyahnam-widened
+chapter: 28
+type: word
+headword: మధ్యాహ్నం
+gloss: "afternoon" — the same word already met meaning precisely "noon" (TE-C17), confirmed via a directly-fetched source to also cover "the time between noon and evening" in modern usage — the same kind of semantic widening already found for Hindi's दोपहर and, more thinly, Kannada's మధ్యాహ్న
+concept_tag: TIME-AFTERNOON
+prerequisites: [TE-C17-madhyaahnam-ardharaatri, TE-C27-sayantram]
+sounds: [telugu-conjunct-dhya, telugu-vowel-sign-aa]
+roots: [sanskrit-madhya-middle]
+etymology_hook: "మధ్యాహ్నం (madhyāhnam) is the SAME word already met in TE-C17 meaning precisely 'noon' ('middle' + 'day') — but a directly-fetched source confirms it also covers 'the time between noon and evening' in modern usage, the same kind of widening already found for Hindi's दोपहर (well-confirmed) and Kannada's మధ్యాహ్న (more thinly hedged); a separate, more precise word for 'later afternoon' specifically, అపరాహ్నం (aparāhnam, from the same classical five-part Sanskrit day division as Kannada's అపరాహ్న), also exists; thin, informal evidence (native-speaker forum discussion, dictionary usage notes) converges on మధ్యాహ్నం winning colloquially while అపరాహ్నం stays the formally precise term — a hedged, KA-C28-style parallel, not a fully settled comparison"
+est_minutes: 6
+reviews_of: [TE-C17-madhyaahnam-ardharaatri, TE-C27-sayantram]
+---
+
+# మధ్యాహ్నం — the same "noon" word, now also "afternoon"
+
+## Warm-up
+
+[PAUSE 2s] You already know మధ్యాహ్నం means "noon" — precisely, "middle
+of the day." This lesson's honest twist: the word doesn't stay that
+precise in modern use.
+
+## మధ్యాహ్నం — same word, a genuinely wider modern meaning
+
+**మధ్యాహ్నం** (**madhyāhnam**) is the exact word from Chapter 17,
+still literally "middle" + "day" — but a source fetched directly (not
+just a search summary) confirms it now covers "**the time between noon
+and evening**" in modern usage — a genuine widened sense, not just the
+precise midday instant its etymology points to. This mirrors what
+this course already found for Hindi's **दोपहर** (clearly, well-
+confirmed widened from "noon" to "afternoon") and, more thinly, for
+Kannada's own **మధ్యాహ్న** (a hedged, single-source impression of the
+same kind of stretch).
+
+## A more precise word exists too — a thin but real comparison
+
+Telugu also has **అపరాహ్నం** (**aparāhnam**), from the same classical
+**five-part Sanskrit day division** already found behind Kannada's
+**అపరాహ్న** — *prāta/udaya* (sunrise), *saṅgava*, *madhyāhna* (noon),
+*aparāhna* ("later afternoon" specifically), *sāyāhna* (evening). Be
+honest about the sourcing here, echoing the same hedge already applied
+to Kannada's *aparāhna* in KA-C28: thin, informal evidence — a
+native-speaker forum discussion, general dictionary usage notes — points
+toward **మధ్యాహ్నం winning colloquially**, with **అపరాహ్నం** staying the
+more **formally precise** term. Real, but not corpus-linguistics-grade
+sourcing — treat it the same cautious way KA-C28 treated its own
+equivalent finding, not as fully settled.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "madhyāhnam" — the same word from Chapter 17, "middle of
+  the day"]
+- [YOU SAY: the confirmed widening — now also covers "the time between
+  noon and evening"]
+- [YOU SAY: "aparāhnam" — the more precise classical word for later
+  afternoon, staying the more formal term per thin but real evidence]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is మధ్యాహ్నం a new word, or the same one from Chapter 17?
+(**The same word** — "middle" + "day.") Does modern usage confirm
+మధ్యాహ్నం covers only the exact instant of noon? (**No** — a directly-
+fetched source confirms it now covers "the time between noon and
+evening" too.) Is it confirmed whether అపరాహ్నం or widened మధ్యాహ్నం is
+more common today? (**Thin but real evidence** points to మధ్యాహ్నం
+winning colloquially, అపరాహ్నం staying formally precise — not fully
+settled, but not silent either.)

--- a/code/learning/human-languages/telugu/lessons/TE-C29-subhodayam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C29-subhodayam.md
@@ -1,0 +1,71 @@
+---
+id: TE-C29-subhodayam
+chapter: 29
+type: phrase
+headword: శుభోదయం
+gloss: "good morning" (subhodayam) — శుభ + ఉదయం, the traditional phrase; one directly-fetched source (a Telugu-learning blog, the same low-authority genre already found overstated for Hindi/Kannada) claims it's archaic, displaced by English "good morning" — treat with real skepticism, not as confirmed; నమస్కారం remains a safer everyday-greeting bet regardless
+concept_tag: GREETING-MORNING
+prerequisites: [TE-C26-udayam]
+sounds: [telugu-sha, telugu-conjunct-bha]
+roots: [su-good, sanskrit-udaya-rise]
+etymology_hook: "శుభోదయం (śubhōdayam, 'good morning') = శుభ ('good') + ఉదయం (already met, TE-C26); be honest about sourcing here: one directly-fetched source — a Telugu-learning content blog, the SAME low-authority genre already found overstated for Hindi's सुप्रभात and Kannada's ಶುಭೋದಯ — claims this is OUT OF TREND, displaced by ENGLISH 'good morning,' with children taught the English phrase from preschool; treat this with real skepticism, since a directly-fetched page isn't automatically an authoritative source; the same page also calls a SEPARATE alternative, సుప్రభాతం (suprabhātam, built on ప్రభాత/prabhāta — a genuinely DIFFERENT Sanskrit root from ఉదయ/udaya, NOT the same root as Kannada's ಶುಭೋದಯ, which itself uses udaya) 'archaic'; a third option, ప్రొద్దుటి వందనాలు ('morning greetings,' built on పొద్దు, TE-C26's genuine native competitor), also exists but isn't confirmed common; నమస్కారం is the safer everyday-greeting bet, matching the నమస్కార/नमस्ते pattern already found for Kannada and Hindi"
+est_minutes: 6
+reviews_of: [TE-C26-udayam]
+---
+
+# శుభోదయం (śubhōdayam) — a claim worth real skepticism, not a settled fact
+
+## Warm-up
+
+[PAUSE 2s] You already have ఉదయం. This lesson's honest twist is about
+a dramatic-sounding claim — and about being skeptical of it, even
+though it came from a source fetched directly.
+
+## శుభోదయం — శుభ + ఉదయం, the traditional phrase
+
+**శుభోదయం** (**śubhōdayam**) — "**good morning**" — is built from
+**శుభ** ("good") plus **ఉదయం** (already met, Chapter 26). Grammatically
+and etymologically, this is the straightforward, traditional Telugu
+"good morning."
+
+## Be honest: a dramatic claim, from a source worth real skepticism
+
+Here's the twist, and the honesty this time cuts against the source
+itself: one directly-fetched page describes **శుభోదయం** as **out of
+trend**, displaced by **English** "good morning," with children taught
+the English phrase from **preschool**. That's a vivid, quotable claim —
+but "fetched directly" doesn't make a source authoritative. This is the
+**same genre** of Telugu/Kannada/Hindi-learning content blog already
+found **overstated** for Hindi's सुप्रभात and Kannada's own
+**ಶುಭೋದಯ** (a single uncredentialed listicle, no sociolinguistic
+methodology, no citations) — treat this claim the same skeptical way,
+not as settled.
+
+Genuinely worth separating from that dramatic claim: **సుప్రభాతం**
+(*suprabhātam*) also exists — built on **ప్రభాత** (*prabhāta*), a
+**completely different** Sanskrit root from **ఉదయ** (*udaya*). This is
+**not** the same root behind Kannada's **ಶುಭೋದಯ**, which itself uses
+*udaya* — don't conflate the two Sanskrit "morning" roots. A third
+option, **ప్రొద్దుటి వందనాలు** ("morning greetings," built on
+**పొద్దు**, Chapter 26's genuine native competitor to ఉదయం), also
+exists but isn't confirmed common either. **నమస్కారం** is the safer bet
+for everyday use — matching the same నమస్కార/नमस्ते pattern already
+found doing the real everyday work for both Kannada and Hindi.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubhōdayam" — "good morning," śubha + udayam]
+- [YOU SAY: the honest twist — one low-authority source claims it's
+  out of trend, displaced by English; treat with real skepticism]
+- [YOU SAY: నమస్కారం — the safer everyday-greeting bet]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is శుభోదయం built from? (**శుభ** + **ఉదయం**.) Is the
+claim that శుభోదయం has been displaced by English a confirmed,
+well-sourced fact? (**No** — it comes from one low-authority
+content-blog source, the same genre already found overstated for
+Hindi/Kannada; treat it skeptically, not as settled.) Does సుప్రభాతం
+share ఉదయం's root, or Kannada's ಶುಭೋದಯ's root? (**Neither** — its own
+root, ప్రభాత/prabhāta, is a genuinely different Sanskrit word.)

--- a/code/learning/human-languages/telugu/lessons/TE-C30-subha-sayantram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C30-subha-sayantram.md
@@ -1,0 +1,67 @@
+---
+id: TE-C30-subha-sayantram
+chapter: 30
+type: phrase
+headword: శుభ సాయంత్రం
+gloss: "good evening" (śubha sāyantram) — pairs with సాయంత్రం (TE-C27, the word with the striking Latin sērus/French soir cognate); unlike GREETING-MORNING's single, dramatic "displaced by English" source, TWO independently-fetched sources agree this one is genuinely, commonly used in both formal and casual speech, with నమస్కారం as a time-independent alternative rather than a replacement
+concept_tag: GREETING-EVENING
+prerequisites: [TE-C27-sayantram]
+sounds: [telugu-sha, telugu-anusvara]
+roots: [su-good, sanskrit-sayam-evening]
+etymology_hook: "శుభ సాయంత్రం (śubha sāyantram, 'good evening') pairs శుభ with సాయంత్రం (TE-C27's word with the striking distant cognate to Latin sērus/French soir); unlike GREETING-MORNING's శుభోదయం, which rested on ONE dramatic, low-authority source claiming displacement by English, TWO independently fetched sources here agree it's genuinely, commonly used in BOTH formal and informal contexts — a real difference in evidence quality, worth noting explicitly rather than treating every 'good ___' greeting in this arc the same way; నమస్కారం remains confirmed as a time-independent, any-occasion alternative rather than something that has displaced this specific greeting"
+est_minutes: 6
+reviews_of: [TE-C27-sayantram]
+---
+
+# శుభ సాయంత్రం (śubha sāyantram) — a claim that actually holds up on checking
+
+## Warm-up
+
+[PAUSE 2s] Last lesson's morning greeting rested on one dramatic,
+shaky source. This one is different — and the difference itself is
+worth noticing.
+
+## శుభ సాయంత్రం — paired with సాయంత్రం's own striking story
+
+**శుభ సాయంత్రం** (**śubha sāyantram**) — "**good evening**" — pairs
+**శుభ** ("good") with **సాయంత్రం** (already met, Chapter 27 — the word
+whose PIE root, *seh₁-, turned out to be a genuine distant cognate of
+Latin's *sērus*, and so of French **soir** and Italian **sera**).
+
+## Be honest: this claim actually checked out, unlike the last one
+
+Here's the honest contrast worth drawing explicitly: last lesson's
+**శుభోదయం** rested on **one** dramatic, low-authority source claiming
+it had been displaced by English entirely. This time, **two**
+independently fetched sources — not just search-engine summaries —
+**agree**: **శుభ సాయంత్రం** is genuinely, commonly used, in **both**
+formal and informal contexts, appropriate for greeting people after
+work or arriving at an evening gathering. Neither source flags it as
+archaic or displaced. This doesn't mean these sources are beyond
+question — they're still the same general genre of language-learning
+content that's needed hedging elsewhere in this arc — but **being
+independently cross-corroborated** is a real, meaningful difference in
+evidence quality from a single dramatic claim, and it's worth being
+just as honest about a claim holding up as about one that doesn't.
+**నమస్కారం**, as before, remains a genuine time-independent alternative
+— but nothing here suggests it has **displaced** this greeting the way
+English reportedly displaced శుభోదయం.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubha sāyantram" — "good evening," śubha + sāyantram]
+- [YOU SAY: the honest contrast — this claim is cross-corroborated by
+  two sources, unlike last lesson's single dramatic one]
+- [YOU SAY: నమస్కారం — a time-independent alternative, not a
+  replacement here]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What word does శుభ సాయంత్రం pair with, and what's that
+word's own striking cross-language story? (**సాయంత్రం** — a genuine
+distant PIE cognate of Latin sērus/French soir/Italian sera.) Is the
+"genuinely commonly used" claim for శుభ సాయంత్రం as thinly sourced as
+శుభోదయం's "displaced by English" claim was? (**No** — two independent
+sources agree here, versus one dramatic claim last lesson — a real
+difference in evidence quality.)

--- a/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam.md
@@ -1,0 +1,79 @@
+---
+id: TE-C31-subha-madhyahnam
+chapter: 31
+type: phrase
+headword: శుభ మధ్యాహ్నం
+gloss: "good afternoon" (śubha madhyāhnam) — built on మధ్యాహ్నం (TE-C17/TE-C28), NOT అపరాహ్నం, matching Kannada's exact same choice (KA-C31); one directly-fetched source (talkpal.ai) explicitly ranks it less common than morning/evening greetings; a second (preply.com) independently confirms it's real and formal/workplace-timed but does NOT itself make the frequency comparison
+concept_tag: GREETING-AFTERNOON
+prerequisites: [TE-C28-madhyahnam-widened, TE-C29-subhodayam, TE-C30-subha-sayantram]
+sounds: [telugu-conjunct-dhya, telugu-anusvara]
+roots: [su-good, sanskrit-madhya-middle]
+etymology_hook: "శుభ మధ్యాహ్నం (śubha madhyāhnam, 'good afternoon') pairs శుభ with మధ్యాహ్నం (TE-C17/TE-C28's word — literally 'noon,' widened to also cover the afternoon stretch), NOT with అపరాహ్నం, the more formally precise classical word for later afternoon — this is the EXACT SAME choice already found for Kannada's ಶುಭ ಮಧ್ಯಾಹ್ನ (KA-C31), a genuine cross-language parallel; two independently-fetched sources (talkpal.ai, preply.com) both confirm this greeting is real, correctly formed, and formal/workplace-timed — but only talkpal.ai explicitly ranks it LESS common in everyday speech than the morning/evening greetings; preply.com confirms the timing/register but doesn't itself make that frequency comparison, so it isn't double-counted as a second source for the ranking — a third, more even-keeled register than either TE-C29's morning greeting (contested displacement claim) or TE-C30's evening greeting (confirmed common, both registers)"
+est_minutes: 6
+reviews_of: [TE-C28-madhyahnam-widened, TE-C29-subhodayam, TE-C30-subha-sayantram]
+---
+
+# శుభ మధ్యాహ్నం (śubha madhyāhnam) — completing Telugu's greeting triplet
+
+## Warm-up
+
+[PAUSE 2s] Telugu's morning greeting had a contested claim behind it.
+Its evening greeting turned out genuinely well-supported. This
+afternoon greeting lands somewhere honestly in between.
+
+## శుభ మధ్యాహ్నం — built on the SAME word Kannada chose too
+
+**శుభ మధ్యాహ్నం** (**śubha madhyāhnam**) — "**good afternoon**" —
+pairs **శుభ** ("good") with **మధ్యాహ్నం** (already met, Chapters
+17 and 28 — literally "noon," confirmed to have widened to also cover
+"the time between noon and evening" in modern usage). Worth noting
+directly: this greeting is built on **మధ్యాహ్నం**, **not**
+**అపరాహ్నం** (the more formally precise classical word for later
+afternoon specifically). That's the **exact same choice** already found
+for Kannada's own afternoon greeting, ಶುಭ ಮಧ್ಯಾಹ್ನ (Chapter KA-C31) —
+a genuine cross-language parallel, not a coincidence of similar
+etymology alone, since both languages had a real choice between two
+distinct classical words and both settled on the "noon, widened" one.
+
+## Be honest: real, but genuinely less common than its siblings
+
+Two independently-fetched sources (not just search summaries) confirm
+**శుభ మధ్యాహ్నం** is a real, correctly-formed greeting used in
+**formal, workplace** contexts specifically (roughly noon to
+mid-afternoon) — but only ONE of the two, talkpal.ai, explicitly ranks
+it as genuinely **less common** in everyday conversation than the
+morning or evening greetings. The second source, preply.com, confirms
+the timing and formal register but makes no such frequency comparison
+itself — worth being precise about which claim each source actually
+supports, rather than treating both as independently confirming the
+same "less common" ranking. This gives this
+Telugu greeting triplet a genuinely honest, three-way spread rather
+than a single uniform story: **శుభోదయం** (morning) carried one
+shaky, low-authority displacement claim worth real skepticism;
+**శుభ సాయంత్రం** (evening) turned out confirmed common in both
+formal and informal speech by two independent sources; and this
+afternoon greeting is real but the most narrowly formal of the three —
+neither displaced nor especially casual. **నమస్కారం** remains the
+safer, time-independent bet for everyday use across all three, exactly
+as already found for Kannada and Hindi.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubha madhyāhnam" — "good afternoon," śubha + madhyāhnam]
+- [YOU SAY: the word choice — built on మధ్యాహ్నం, not అపరాహ్నం, matching
+  Kannada's exact same choice]
+- [YOU SAY: the honest three-way spread — morning shaky, evening
+  confirmed common, afternoon real but more narrowly formal]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is శుభ మధ్యాహ్నం built on మధ్యాహ్నం or అపరాహ్నం?
+(**మధ్యాహ్నం** — the "noon, widened" word, not the more formal
+classical term — matching Kannada's exact same choice.) Is this
+greeting as commonly used in casual speech as శుభ సాయంత్రం?
+(**No** — talkpal.ai explicitly ranks it less common than the morning
+or evening greetings; preply.com independently confirms it's real and
+formal/workplace-timed, though it doesn't itself make that frequency
+comparison.) What's the safer, time-independent everyday greeting across
+all three? (**నమస్కారం**.)


### PR DESCRIPTION
## What
This is a **new single accumulator PR**, continuing the standing workflow after the previous accumulator PR ([#9265](https://github.com/adhithyan15/coding-adventures/pull/9265)) was merged. Per the user's standing instruction: keep adding commits to this branch until it's reviewed and merged; never self-merge.

### TIME-MORNING / TIME-EVENING / TIME-AFTERNOON + GREETING-MORNING / GREETING-EVENING / GREETING-AFTERNOON

Continuing the arc opened in PR #9265: this 6-tag cluster is now complete for **Latin** and **Hindi**, and in progress for **Kannada**.

Latin (LA-C31–C36, merged in #9265): māne, bonum māne (+ the real Roman salūtātiō ritual), vesper, bonum vesperum, merīdiēs, and a novel "honest absence" lesson for the afternoon greeting (no coherent Latin phrase exists).

Hindi (HI-C28–C33, merged in #9265): सुबह, शाम, दोपहर (widened from "noon" to "afternoon"), सुप्रभात, शुभ संध्या, शुभ दोपहर — all three greetings independently found to skew formal/written, with नमस्ते/नमस्कार covering casual use.

Kannada (in progress, this PR):
- **KA-C26-belagge** (TIME-MORNING): ಬೆಳಗ್ಗೆ, native Dravidian, the one everyday time-word in Kannada's set that isn't Sanskrit tatsama.
- **KA-C27-sanje** (TIME-EVENING): ಸಂಜೆ, Sanskrit via Maharashtri Prakrit — a striking cognate with Hindi's साँझ via a different sister Prakrit dialect (Śauraseni).
- **KA-C28-aparahna** (TIME-AFTERNOON): ಅಪರಾಹ್ನ, Sanskrit tatsama sharing ಮಧ್ಯಾಹ್ನ's "-ahna" suffix, with a carefully-calibrated hedge on whether madhyāhna itself has also widened to cover afternoon.
- **KA-C29-shubhodaya** (GREETING-MORNING): ಶುಭೋದಯ — first draft overclaimed everyday commonality (contrasting cleanly against Hindi's सुप्रभात); corrected after independent research found the same formal/written skew pattern, with ನಮಸ್ಕಾರ/ನಮಸ್ತೆ as the likely real everyday default.

## Process notes
Every lesson: codepoint verification (Python `unicodedata`) before writing any non-Latin-script word, a NUL-byte scan, a mixed-script contamination scanner, both test suites (38/38 + 268/268), and a linguistics-review subagent scoped to the exact files plus named siblings — explicitly instructed to independently re-verify register/commonality claims rather than trust the draft's framing, and to check whether "the only X" framings overreach. Real required fixes applied in the majority of lessons this arc.

## Next
Kannada still needs GREETING-EVENING and GREETING-AFTERNOON. Then the same 6 tags for Telugu, Malayalam, and Tamil (Tamil last, flagged for the maintainer's own personal review — everything else in this PR has been reviewed only by an automated linguistics subagent, no human check).

## Note on workflow
New accumulator PR, branch `content/dravidian-mornings-evenings`. Do not self-merge — only treat this as done once the user merges it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
