### PR TITLE
feat(spice): validate MOS sidewall capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CJSW` values before
+  sidewall-junction capacitance shaping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CJ` values before
   bottom-junction capacitance shaping.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -600,6 +600,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET MJSW must be finite and non-negative")
         elif canonical == "CJ" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET CJ must be finite and non-negative")
+        elif canonical == "CJSW" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET CJSW must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1158,6 +1158,18 @@ def test_mos_model_card_rejects_negative_or_non_finite_bottom_junction_capacitan
             normalize_model_card("Minvalid", "nmos", {"CJ": invalid_capacitance})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_sidewall_junction_capacitance() -> None:
+    for value in (0.0, 2.0e-10, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"CJSW": value})
+        assert valid.parameters["CJSW"] == pytest.approx(value)
+
+    for invalid_capacitance in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET CJSW must be finite and non-negative"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"CJSW": invalid_capacitance})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CJSW` values before
+  sidewall-junction capacitance shaping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CJ` values before
   bottom-junction capacitance shaping.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4427,6 +4427,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET CJ must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "CJSW" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET CJSW must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1007,6 +1007,22 @@ fn mos_model_card_rejects_negative_or_non_finite_bottom_junction_capacitance() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_sidewall_junction_capacitance() {
+    for value in [0.0, 2.0e-10, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("CJSW", value)]).unwrap();
+        assert_close(*valid.parameters.get("CJSW").unwrap(), value);
+    }
+
+    for invalid_capacitance in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("CJSW", invalid_capacitance)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET CJSW must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CJSW` values before
+  sidewall-junction capacitance shaping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CJ` values before
   bottom-junction capacitance shaping.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8481,6 +8481,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0)
     ) {
       throw invalidElement(name, "MOSFET CJ must be finite and non-negative");
+    } else if (
+      canonical === "CJSW" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET CJSW must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -899,6 +899,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS sidewall-junction capacitance", () => {
+    for (const value of [0.0, 2.0e-10, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { CJSW: value });
+      expect(valid.parameters.CJSW).toBe(value);
+    }
+
+    for (const invalidCapacitance of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { CJSW: invalidCapacitance }),
+      ).toThrow("MOSFET CJSW must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS bottom-junction-capacitance validation.
+1. Cross-language Level-1 MOS sidewall-junction-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `CJ` values before bottom-junction
+   - Reject negative or non-finite model-card `CJSW` values before sidewall
      depletion-capacitance shaping.
-   - Preserve zero and positive bottom-junction capacitances across Rust, Python,
-     and TypeScript.
+   - Preserve zero and positive sidewall-junction capacitances across Rust,
+     Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3733,6 +3733,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `MJSW` values are rejected before
      sidewall depletion-capacitance shaping.
    - Zero and positive sidewall-grading coefficients remain aligned across Rust,
+     Python, and TypeScript.
+
+308. Cross-language Level-1 MOS bottom-junction-capacitance validation.
+   - Status: completed in PR 9305.
+   - Negative and non-finite model-card `CJ` values are rejected before
+     bottom-junction depletion-capacitance shaping.
+   - Zero and positive bottom-junction capacitances remain aligned across Rust,
      Python, and TypeScript.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CJSW` values during normalization
- preserve zero and finite positive sidewall-junction capacitances across Rust, Python, and TypeScript
- reconcile the SPICE implementation plan after PR #9305

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff checks
- Python full pytest: 690 passed, 88.97% coverage
- TypeScript full test suite: 433 passed
- TypeScript build