### PR TITLE
feat(adj-verify): re-check the NUM-6 precision/format narrowings (NUM-6v)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.28.0] — 2026-07-30 — NUM-6v: `adj-verify` re-checks the precision/format narrowings
+
+`adj-verify` now re-executes the *arithmetic* of a trail, not only its logic
+(`ADJ-NUMERIC-SUBSTRATE.md` §4.3, §6, §7). For every `let`-bound derived value it walks the
+derivation tree and, for each `round_to`/`round_sig`/`to_scientific`/`to_percent`/`to_currency`
+narrowing, re-rounds the recorded **exact** source under the recorded mode and confirms the
+recorded result and rendered string reproduce (`logic_engine::recheck_narrowings`).
+
+- New report fields: `totals.narrowings_rechecked` / `narrowings_unverifiable` /
+  `narrowings_mismatched`, and a `narrowings` array (one entry per derived value carrying a
+  narrowing, each check tagged `rechecked` / `unverifiable` / `mismatch`).
+- A `mismatch` is a hard failure: it flips `verified` to `false`, exits non-zero, and is named
+  in `first_failure` (`pass: "narrowing"`, with the binding name, depth, and the disagreeing
+  recorded/recomputed forms) — the same standard the negation and logit re-checks already meet.
+- The four derivation-tree JSON emitters gained the new node field via `..` patterns, so the
+  CLI's `--json` / `derivation` output is byte-for-byte unchanged.
+- 3 e2e tests (built binary): all five narrowing kinds re-check green; a plain formula reports
+  zero narrowings and still verifies; a nested `round_to(to_percent(...))` re-checks both levels.
+
 ## [0.27.0] — 2026-07-30 — RS-3c: `statemachine` driver + typed outcomes + `--explain` of the run
 
 Runs the provenance-stamped `statemachine`s RS-3b lowered (ADJ-STATEMACHINE §3–§4),

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/bin/adj-verify.rs
+++ b/code/packages/rust/adj-lang-cli/src/bin/adj-verify.rs
@@ -53,8 +53,9 @@ use adj_lang_cli::{esc, payload, query_echo, FsProvider};
 use cli_builder::types::ParserOutput;
 use cli_builder::{load_spec_from_str, Parser};
 use logic_engine::{
-    enumerate_all, verify_proof, ContentHash, LogicFailure, LogicStatus, Proof, QuoteMiss,
-    QuoteStatus, SnapshotStore, StepVerification, TraceVerification, UnverifiedReason,
+    enumerate_all, recheck_narrowings, verify_proof, ContentHash, LogicFailure, LogicStatus,
+    NarrowingCheck, Proof, QuoteMiss, QuoteStatus, SnapshotStore, StepVerification,
+    TraceVerification, UnverifiedReason,
 };
 
 const SPEC: &str = r#"{
@@ -427,7 +428,76 @@ fn main() -> ExitCode {
         record("lr", &text, &r.result.dag.proofs, &mut totals);
     }
 
-    let verified = first_failure.is_none() && truncated_queries.is_empty();
+    // NUM-6 audit-exactness re-check (ADJ-NUMERIC-SUBSTRATE §4.3, §6, §7). The SLD
+    // and LR passes above re-derive the *logic*; the compute derivation trees carry
+    // the *arithmetic*, and every `round_to`/`round_sig`/`to_scientific`/`to_percent`/
+    // `to_currency` narrowing recorded a rounded number (and boundary string) that a
+    // confidently-wrong or since-edited artifact prints just as fluently. Here that
+    // testimony becomes evidence: for every `let`-bound derived value we walk its tree
+    // and re-round / re-format each narrowing's recorded EXACT source under the recorded
+    // spec/mode (`recheck_narrowings`), confirming the recorded result and rendering
+    // reproduce. A `Mismatch` is a hard failure — the same "valid-looking number from an
+    // invented rounding" class the negation and logit re-checks guard against on their
+    // own paths.
+    let mut narrowing_blobs: Vec<String> = Vec::new();
+    let mut narrowings_rechecked = 0usize;
+    let mut narrowings_unverifiable = 0usize;
+    let mut narrowings_mismatched = 0usize;
+    for d in lowered.kb.derived_bindings() {
+        let checks = recheck_narrowings(&d.tree);
+        if checks.is_empty() {
+            continue;
+        }
+        let mut check_blobs: Vec<String> = Vec::new();
+        for (depth, check) in &checks {
+            let blob = match check {
+                NarrowingCheck::ReChecked => {
+                    narrowings_rechecked += 1;
+                    format!("{{\"depth\":{depth},\"status\":\"rechecked\"}}")
+                }
+                NarrowingCheck::Unverifiable => {
+                    narrowings_unverifiable += 1;
+                    format!("{{\"depth\":{depth},\"status\":\"unverifiable\"}}")
+                }
+                NarrowingCheck::Mismatch {
+                    why,
+                    recorded,
+                    recomputed,
+                } => {
+                    narrowings_mismatched += 1;
+                    if first_failure.is_none() {
+                        first_failure = Some(format!(
+                            "{{\"pass\":\"narrowing\",\"name\":\"{}\",\"depth\":{},\"why\":\"{}\",\"recorded\":\"{}\",\"recomputed\":\"{}\"}}",
+                            esc(&d.name),
+                            depth,
+                            esc(why),
+                            esc(recorded),
+                            esc(recomputed),
+                        ));
+                    }
+                    format!(
+                        "{{\"depth\":{},\"status\":\"mismatch\",\"why\":\"{}\",\"recorded\":\"{}\",\"recomputed\":\"{}\"}}",
+                        depth,
+                        esc(why),
+                        esc(recorded),
+                        esc(recomputed),
+                    )
+                }
+                // A non-narrowing verdict never appears here — `recheck_narrowings`
+                // only returns entries for actual narrowing nodes.
+                NarrowingCheck::NotANarrowing => continue,
+            };
+            check_blobs.push(blob);
+        }
+        narrowing_blobs.push(format!(
+            "{{\"name\":\"{}\",\"checks\":[{}]}}",
+            esc(&d.name),
+            check_blobs.join(",")
+        ));
+    }
+
+    let verified =
+        first_failure.is_none() && truncated_queries.is_empty() && narrowings_mismatched == 0;
     // `fully_verified` is NOT `verified` with extra steps counted. It requires
     // that every proof had its quotes affirmatively confirmed against a pinned
     // snapshot — and that there was something to check at all. An earlier draft
@@ -440,7 +510,7 @@ fn main() -> ExitCode {
         && totals.proofs_fully_verified == totals.proofs
         && totals.quotes_verified > 0;
     println!(
-        "{{\"verified\":{},\"fully_verified\":{},\"totals\":{{\"proofs\":{},\"proofs_fully_verified\":{},\"steps\":{},\"rechecked\":{},\"quotes_verified\":{}}},\"truncated_queries\":[{}],\"first_failure\":{},\"queries\":[{}]}}",
+        "{{\"verified\":{},\"fully_verified\":{},\"totals\":{{\"proofs\":{},\"proofs_fully_verified\":{},\"steps\":{},\"rechecked\":{},\"quotes_verified\":{},\"narrowings_rechecked\":{},\"narrowings_unverifiable\":{},\"narrowings_mismatched\":{}}},\"truncated_queries\":[{}],\"narrowings\":[{}],\"first_failure\":{},\"queries\":[{}]}}",
         verified,
         fully,
         totals.proofs,
@@ -448,7 +518,11 @@ fn main() -> ExitCode {
         totals.steps,
         totals.rechecked,
         totals.quotes_verified,
+        narrowings_rechecked,
+        narrowings_unverifiable,
+        narrowings_mismatched,
         truncated_queries.join(","),
+        narrowing_blobs.join(","),
         first_failure.as_deref().unwrap_or("null"),
         per_query.join(",")
     );

--- a/code/packages/rust/adj-lang-cli/src/explain.rs
+++ b/code/packages/rust/adj-lang-cli/src/explain.rs
@@ -520,6 +520,7 @@ fn expand(n: &DerivationNode, depth: usize, kb: &KnowledgeBase, out: &mut Vec<St
             spec,
             mode,
             operand,
+            operand_exact: _,
             result,
         } => {
             out.push(format!(
@@ -538,6 +539,7 @@ fn expand(n: &DerivationNode, depth: usize, kb: &KnowledgeBase, out: &mut Vec<St
             mode,
             rendered,
             operand,
+            operand_exact: _,
             result,
         } => {
             out.push(format!(
@@ -557,6 +559,7 @@ fn expand(n: &DerivationNode, depth: usize, kb: &KnowledgeBase, out: &mut Vec<St
             mode,
             rendered,
             operand,
+            operand_exact: _,
             result,
         } => {
             out.push(format!(
@@ -577,6 +580,7 @@ fn expand(n: &DerivationNode, depth: usize, kb: &KnowledgeBase, out: &mut Vec<St
             mode,
             rendered,
             operand,
+            operand_exact: _,
             result,
         } => {
             out.push(format!(

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -167,6 +167,7 @@ fn derivation_tree_json(
             spec,
             mode,
             operand,
+            operand_exact: _,
             result,
         } => {
             // The precision field names the KIND of narrowing: `places` for
@@ -195,6 +196,7 @@ fn derivation_tree_json(
             mode,
             rendered,
             operand,
+            operand_exact: _,
             result,
         } => format!(
             "{{\"node\":\"to_scientific\",\"figures\":{},\"mode\":\"{}\",\"rendered\":\"{}\",\"value\":{},\"operand\":{}}}",
@@ -214,6 +216,7 @@ fn derivation_tree_json(
             mode,
             rendered,
             operand,
+            operand_exact: _,
             result,
         } => format!(
             "{{\"node\":\"to_percent\",\"places\":{},\"mode\":\"{}\",\"rendered\":\"{}\",\"value\":{},\"operand\":{}}}",
@@ -234,6 +237,7 @@ fn derivation_tree_json(
             mode,
             rendered,
             operand,
+            operand_exact: _,
             result,
         } => format!(
             "{{\"node\":\"to_currency\",\"code\":\"{}\",\"places\":{},\"mode\":\"{}\",\"rendered\":\"{}\",\"value\":{},\"operand\":{}}}",

--- a/code/packages/rust/adj-lang-cli/tests/num6v_adj_verify_narrowing_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/num6v_adj_verify_narrowing_e2e.rs
@@ -1,0 +1,112 @@
+//! End-to-end tests for **NUM-6v — `adj-verify` re-checks the precision/format
+//! narrowings** (`ADJ-NUMERIC-SUBSTRATE.md` §4.3, §6, §7), driven through the
+//! built binary.
+//!
+//! The rest of `adj-verify` re-executes the *logic* of a trail — unification,
+//! log-odds, negation, quotes. The compute derivation trees carry the
+//! *arithmetic*, and every `round_to`/`round_sig`/`to_scientific`/`to_percent`/
+//! `to_currency` narrowing had, until now, one part a checker took on faith: the
+//! rounded number (and the boundary string) it printed. These tests confirm that
+//! `adj-verify` now re-rounds each narrowing's recorded exact source under the
+//! recorded mode and confirms the rendered result — so a rounding is evidence,
+//! not testimony (the same standard the logic re-checks already meet).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("num6v_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(dir: &Path, name: &str, src: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, src).unwrap();
+    p
+}
+
+fn verify(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-verify"))
+        .arg(program)
+        .output()
+        .expect("run adj-verify");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// (1) Every narrowing kind is re-rounded and confirmed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn each_narrowing_is_rechecked_from_its_exact_source() {
+    // One derived value per narrowing kind, each an exact rational so the
+    // re-round is well-defined. All must re-check, and the run must stay green.
+    let dir = scratch("all");
+    let src = "let a = round_to(10 / 3, 2)\n\
+         let b = round_sig(31459, 3)\n\
+         let c = to_scientific(1 / 3, 4)\n\
+         let d = to_percent(1 / 3, 2)\n\
+         let e = to_currency(100 / 3, usd, 2)\n\
+     ? a\n";
+    let p = write(&dir, "narrow.adj", src);
+    let (ok, out) = verify(&p);
+
+    assert!(ok, "a sound set of narrowings must exit 0:\n{out}");
+    assert!(out.contains("\"verified\":true"), "{out}");
+    // Five derived narrowings, all re-rounded from their exact source.
+    assert!(
+        out.contains("\"narrowings_rechecked\":5"),
+        "every narrowing must be independently re-rounded:\n{out}"
+    );
+    assert!(
+        out.contains("\"narrowings_mismatched\":0"),
+        "and none may disagree with its exact source:\n{out}"
+    );
+    // The per-value section names WHICH bindings were checked and how.
+    assert!(
+        out.contains("\"status\":\"rechecked\""),
+        "the report must show the per-narrowing verdict:\n{out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) A plain arithmetic formula has nothing to re-check — and says so.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_formula_with_no_narrowing_reports_zero_and_still_verifies() {
+    // A bare division carries no narrowing node. The narrowing counters are zero,
+    // honestly — not silently "all checked" over an empty set.
+    let dir = scratch("none");
+    let src = "let q = 10 / 3\n? q\n";
+    let p = write(&dir, "plain.adj", src);
+    let (ok, out) = verify(&p);
+
+    assert!(ok, "{out}");
+    assert!(out.contains("\"verified\":true"), "{out}");
+    assert!(out.contains("\"narrowings_rechecked\":0"), "{out}");
+    assert!(out.contains("\"narrowings_mismatched\":0"), "{out}");
+}
+
+// ---------------------------------------------------------------------------
+// (3) A nested narrowing (round_to over to_percent) re-checks both levels.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_nested_narrowing_rechecks_the_outer_and_inner_steps() {
+    // `round_to(to_percent(1/3, 4), 2)`: the outer round and the inner percentage
+    // are both narrowings, and the tree walk must find and re-round BOTH.
+    let dir = scratch("nested");
+    let src = "let r = round_to(to_percent(1 / 3, 4), 2)\n? r\n";
+    let p = write(&dir, "nested.adj", src);
+    let (ok, out) = verify(&p);
+
+    assert!(ok, "{out}");
+    assert!(
+        out.contains("\"narrowings_rechecked\":2"),
+        "both the outer round and the inner to_percent must be re-checked:\n{out}"
+    );
+    assert!(out.contains("\"narrowings_mismatched\":0"), "{out}");
+}

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.50.0] — 2026-07-30 — NUM-6v: audit re-check of the precision/format narrowings
+
+Closes the NUM-6 audit-exactness promise (`ADJ-NUMERIC-SUBSTRATE.md` §4.3, §6, §7): the
+compute narrowing nodes now **carry their operand's exact source**, and a new re-check turns
+their recorded rounding from testimony into evidence.
+
+- Each narrowing `DerivationNode` (`Round`/`ToScientific`/`ToPercent`/`ToCurrency`) gains an
+  `operand_exact: Option<ExactRational>` field, populated at eval time with the exact rational
+  the narrowing consumed (`None` only for a genuinely-inexact operand, e.g. a transcendental
+  with no exact sidecar). This is byte-neutral to the CLI JSON — the emitters match with `..`.
+- `recheck_narrowing(&DerivationNode) -> NarrowingCheck` re-runs the *same* exact narrowing
+  (`round_rational`/`scientific`/`percent`/`currency`) on the recorded exact source under the
+  recorded `spec`/`mode` and confirms the recorded `result` (and `rendered` string, for the
+  formatters) reproduces: `ReChecked` / `Mismatch { why, recorded, recomputed }` /
+  `Unverifiable` (no exact source) / `NotANarrowing`.
+- `recheck_narrowings(&DerivationNode) -> Vec<(usize, NarrowingCheck)>` walks a derivation
+  tree pre-order and re-checks every narrowing it contains (nested narrowings included),
+  reporting each with its depth.
+- New API re-exported from the crate root: `recheck_narrowing`, `recheck_narrowings`,
+  `NarrowingCheck`.
+- 8 unit tests: each kind re-checks; a tampered `result` and a tampered `rendered` string are
+  both caught; an inexact operand is `Unverifiable`; the walk finds nested narrowings and is
+  empty for a plain formula.
+
 ## [0.49.0] — 2026-07-23 — NUM-6c: `to_currency` — money rendering (base-10-exact)
 
 Completes the NUM-6c formatter trio (`ADJ-NUMERIC-SUBSTRATE.md` §4.1, §4.3): a **rendering**

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -520,10 +520,19 @@ pub enum DerivationNode {
     /// operand's exact value and confirm the rendered `result`
     /// (ADJ-NUMERIC-SUBSTRATE §4.3: rounding is a first-class, checkable step,
     /// never a silent lossy coercion).
+    ///
+    /// `operand_exact` is the operand's **exact** source rational (the
+    /// [`ExactRational`] the narrowing consumed), captured so an independent checker
+    /// can re-round it under the recorded `spec`/`mode` without re-running the whole
+    /// formula — the value [`recheck_narrowing`] re-rounds. `None` when the operand
+    /// was genuinely inexact (a transcendental with no exact sidecar): the narrowing
+    /// then rounded an already-approximate `f64`, so there is no exact source to
+    /// re-round and the re-check is honestly [`NarrowingCheck::Unverifiable`].
     Round {
         spec: RoundSpec,
         mode: RoundingMode,
         operand: Box<DerivationNode>,
+        operand_exact: Option<ExactRational>,
         result: f64,
     },
     /// A **scientific-notation rendering** node (NUM-6c) — the audit record for a
@@ -538,6 +547,10 @@ pub enum DerivationNode {
         mode: RoundingMode,
         rendered: String,
         operand: Box<DerivationNode>,
+        /// The operand's exact source rational (see [`DerivationNode::Round`]'s
+        /// `operand_exact`), re-narrowed by [`recheck_narrowing`] to confirm both
+        /// `rendered` and `result`. `None` for a genuinely-inexact operand.
+        operand_exact: Option<ExactRational>,
         result: f64,
     },
     /// A **percentage rendering** node (NUM-6c) — the audit record for a
@@ -551,6 +564,10 @@ pub enum DerivationNode {
         mode: RoundingMode,
         rendered: String,
         operand: Box<DerivationNode>,
+        /// The operand's exact source ratio (see [`DerivationNode::Round`]'s
+        /// `operand_exact`), re-scaled and re-rounded by [`recheck_narrowing`] to
+        /// confirm both `rendered` and `result`. `None` for an inexact operand.
+        operand_exact: Option<ExactRational>,
         result: f64,
     },
     /// A **currency rendering** node (NUM-6c) — the audit record for a
@@ -565,6 +582,10 @@ pub enum DerivationNode {
         mode: RoundingMode,
         rendered: String,
         operand: Box<DerivationNode>,
+        /// The operand's exact source amount (see [`DerivationNode::Round`]'s
+        /// `operand_exact`), re-rounded by [`recheck_narrowing`] to confirm both
+        /// `rendered` and `result`. `None` for an inexact operand.
+        operand_exact: Option<ExactRational>,
         result: f64,
     },
 }
@@ -1278,6 +1299,9 @@ fn eval_round(
             spec,
             mode,
             operand: Box::new(operand),
+            // The operand's exact source — the value `round_rational` above narrowed —
+            // captured so `adj-verify` can re-round it independently (§4.3).
+            operand_exact: exact,
             result,
         },
         dim,
@@ -1385,6 +1409,9 @@ fn eval_to_scientific(
             mode,
             rendered,
             operand: Box::new(operand),
+            // The operand's exact source — re-narrowed by `adj-verify` to reproduce
+            // both the rendered string and the numeric result (§4.3).
+            operand_exact: exact,
             result,
         },
         dim,
@@ -1510,6 +1537,9 @@ fn eval_to_percent(
             mode,
             rendered,
             operand: Box::new(operand),
+            // The operand's exact source ratio — re-scaled and re-rounded by
+            // `adj-verify` to reproduce the percentage string and result (§4.3).
+            operand_exact: exact,
             result,
         },
         dim,
@@ -1604,6 +1634,9 @@ fn eval_to_currency(
             mode,
             rendered,
             operand: Box::new(operand),
+            // The operand's exact source amount — re-rounded by `adj-verify` to
+            // reproduce the money string and result (§4.3).
+            operand_exact: exact,
             result,
         },
         dim,
@@ -1635,6 +1668,219 @@ fn currency(r: &ExactRational, places: u32, mode: RoundingMode) -> (String, Exac
     // Narrowed amount = C / 10^places.
     let narrowed = ExactRational::from_ratio(BigRational::new(c, ten_to(places)));
     (amount, narrowed)
+}
+
+// ---------------------------------------------------------------------------
+// NUM-6 audit re-check — rounding/formatting is a first-class, checkable step
+// ---------------------------------------------------------------------------
+
+/// The verdict of independently re-checking one NUM-6 narrowing node
+/// (`round_to` / `round_sig` / `to_scientific` / `to_percent` / `to_currency`)
+/// against the exact source it recorded (ADJ-NUMERIC-SUBSTRATE §4.3).
+///
+/// A trail is **testimony**: the engine describing its own rounding. The audit
+/// records the exact source, the target precision, the rounding mode, and the
+/// rendered result — but a confidently-wrong (or since-tampered) artifact prints
+/// a plausible rounded number just as fluently. [`recheck_narrowing`] turns that
+/// testimony into **evidence**: it re-runs the *same* exact narrowing on the
+/// recorded exact source under the recorded spec/mode and confirms the recorded
+/// result (and rendered string, for the formatters) reproduces.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NarrowingCheck {
+    /// The node is not a narrowing (`Leaf`/`Lit`/`Op`/…): nothing to re-round.
+    NotANarrowing,
+    /// Re-narrowing the recorded exact source reproduced the recorded result and
+    /// rendered form exactly — the narrowing is sound.
+    ReChecked,
+    /// The recorded result/rendering did **not** reproduce from the exact source
+    /// under the recorded spec/mode: a drifted or tampered narrowing. Carries a
+    /// stable machine-readable reason and both the `recorded` and `recomputed`
+    /// forms so a reviewer can see the disagreement.
+    Mismatch {
+        why: &'static str,
+        recorded: String,
+        recomputed: String,
+    },
+    /// No exact source was carried (`operand_exact == None`): the operand was
+    /// genuinely inexact (a transcendental with no exact sidecar), so the engine
+    /// rounded an already-approximate `f64` and there is nothing exact to re-round.
+    /// Honest — never counted as a pass, never a hard failure (§4.3 can only make
+    /// the promise it can keep: an exact source is re-checkable, an approximate one
+    /// is labeled unverifiable).
+    Unverifiable,
+}
+
+impl NarrowingCheck {
+    /// Whether this node's narrowing was affirmatively re-derived. `false` for a
+    /// non-narrowing node, an unverifiable (inexact-source) narrowing, or a
+    /// mismatch — so a caller counting "how many narrowings did I confirm" only
+    /// counts the ones actually re-rounded.
+    pub fn is_rechecked(&self) -> bool {
+        matches!(self, NarrowingCheck::ReChecked)
+    }
+
+    /// Whether this is a hard failure — a narrowing whose recorded output does not
+    /// reproduce from its exact source. A non-narrowing / unverifiable / rechecked
+    /// verdict is not a failure.
+    pub fn is_mismatch(&self) -> bool {
+        matches!(self, NarrowingCheck::Mismatch { .. })
+    }
+}
+
+/// Re-check a **single** [`DerivationNode`] if it is a NUM-6 narrowing: re-round /
+/// re-format its recorded exact source ([`operand_exact`](DerivationNode::Round))
+/// under the recorded `spec`/`mode` and confirm the recorded `result` (and
+/// `rendered` string, for the formatters) reproduces (ADJ-NUMERIC-SUBSTRATE §4.3).
+///
+/// This calls the *same* exact narrowing primitives the engine used to produce the
+/// node ([`round_rational`], [`scientific`], [`percent`], [`currency`]) — the point
+/// is a second, independent evaluation from the recorded exact source, not a second
+/// copy of the arithmetic. Because those primitives are total and deterministic, a
+/// [`NarrowingCheck::Mismatch`] can only mean the recorded output did not come from
+/// the recorded source under the recorded mode — exactly the "valid-looking number
+/// from an invented rounding" this re-check exists to catch.
+///
+/// Does **not** recurse — see [`recheck_narrowings`] for the whole-tree walk.
+pub fn recheck_narrowing(node: &DerivationNode) -> NarrowingCheck {
+    match node {
+        DerivationNode::Round {
+            spec,
+            mode,
+            operand_exact,
+            result,
+            ..
+        } => match operand_exact {
+            None => NarrowingCheck::Unverifiable,
+            Some(src) => {
+                let recomputed = round_rational(src, *spec, *mode).to_f64();
+                // The recorded `result` is `round_rational(src, …).to_f64()` from the
+                // emit path; re-running the same exact rounding reproduces the same
+                // `f64` bit-for-bit, so equality (not tolerance) is the honest test.
+                if recomputed == *result {
+                    NarrowingCheck::ReChecked
+                } else {
+                    NarrowingCheck::Mismatch {
+                        why: "result_differs",
+                        recorded: format!("{result}"),
+                        recomputed: format!("{recomputed}"),
+                    }
+                }
+            }
+        },
+        DerivationNode::ToScientific {
+            figures,
+            mode,
+            rendered,
+            operand_exact,
+            result,
+            ..
+        } => match operand_exact {
+            None => NarrowingCheck::Unverifiable,
+            Some(src) => {
+                let (s, narrowed) = scientific(src, *figures, *mode);
+                check_rendered(&s, narrowed.to_f64(), rendered, *result)
+            }
+        },
+        DerivationNode::ToPercent {
+            places,
+            mode,
+            rendered,
+            operand_exact,
+            result,
+            ..
+        } => match operand_exact {
+            None => NarrowingCheck::Unverifiable,
+            Some(src) => {
+                let (s, narrowed) = percent(src, *places, *mode);
+                check_rendered(&s, narrowed.to_f64(), rendered, *result)
+            }
+        },
+        DerivationNode::ToCurrency {
+            code,
+            places,
+            mode,
+            rendered,
+            operand_exact,
+            result,
+            ..
+        } => match operand_exact {
+            None => NarrowingCheck::Unverifiable,
+            Some(src) => {
+                let (amount, narrowed) = currency(src, *places, *mode);
+                // The node's `rendered` is the code-prefixed form; reconstruct it the
+                // same way the emit path did (`"{code} {amount}"`).
+                check_rendered(&format!("{code} {amount}"), narrowed.to_f64(), rendered, *result)
+            }
+        },
+        _ => NarrowingCheck::NotANarrowing,
+    }
+}
+
+/// Shared verdict for the three **formatter** narrowings: confirm both the
+/// re-derived rendered string and the re-derived numeric result reproduce what the
+/// node recorded. The rendered string is checked first because it is the boundary
+/// artifact a consumer reads; a value that reproduces under a *different* string
+/// (or vice versa) is still a mismatch, so both must hold for `ReChecked`.
+fn check_rendered(
+    recomputed_rendered: &str,
+    recomputed_result: f64,
+    recorded_rendered: &str,
+    recorded_result: f64,
+) -> NarrowingCheck {
+    if recomputed_rendered != recorded_rendered {
+        NarrowingCheck::Mismatch {
+            why: "rendered_differs",
+            recorded: recorded_rendered.to_string(),
+            recomputed: recomputed_rendered.to_string(),
+        }
+    } else if recomputed_result != recorded_result {
+        NarrowingCheck::Mismatch {
+            why: "result_differs",
+            recorded: format!("{recorded_result}"),
+            recomputed: format!("{recomputed_result}"),
+        }
+    } else {
+        NarrowingCheck::ReChecked
+    }
+}
+
+/// Walk a derivation `tree` in pre-order and re-check **every** NUM-6 narrowing node
+/// it contains, returning one `(depth, verdict)` per narrowing found (a narrowing can
+/// be nested inside another node's operand — `round_to(to_percent(x))` — so the walk
+/// recurses through operands). Non-narrowing nodes contribute nothing. The `depth` is
+/// the node's nesting level under `tree` (root = 0), so a caller can point a reviewer
+/// at *which* narrowing in a multi-step formula failed.
+pub fn recheck_narrowings(tree: &DerivationNode) -> Vec<(usize, NarrowingCheck)> {
+    let mut out = Vec::new();
+    collect_narrowings(tree, 0, &mut out);
+    out
+}
+
+/// Pre-order helper for [`recheck_narrowings`]: re-check `node` if it is a narrowing,
+/// then recurse into its children. Depth-bounded implicitly by the tree the engine
+/// built (a compute expression is capped at [`MAX_EVAL_DEPTH`] when produced), so this
+/// cannot recurse deeper than a value the engine already accepted.
+fn collect_narrowings(node: &DerivationNode, depth: usize, out: &mut Vec<(usize, NarrowingCheck)>) {
+    let verdict = recheck_narrowing(node);
+    if !matches!(verdict, NarrowingCheck::NotANarrowing) {
+        out.push((depth, verdict));
+    }
+    match node {
+        DerivationNode::Op { operands, .. } => {
+            for child in operands {
+                collect_narrowings(child, depth + 1, out);
+            }
+        }
+        DerivationNode::Round { operand, .. }
+        | DerivationNode::ToScientific { operand, .. }
+        | DerivationNode::ToPercent { operand, .. }
+        | DerivationNode::ToCurrency { operand, .. } => {
+            collect_narrowings(operand, depth + 1, out);
+        }
+        DerivationNode::Leaf { .. }
+        | DerivationNode::DerivedRef { .. }
+        | DerivationNode::Lit { .. } => {}
+    }
 }
 
 /// Round an `f64` to `spec`'s precision — the fallback for an operand that carried
@@ -3108,6 +3354,7 @@ mod tests {
                 mode,
                 result,
                 operand,
+                operand_exact,
             } => {
                 assert_eq!(*spec, RoundSpec::Places(2));
                 assert_eq!(*mode, RoundingMode::HalfEven);
@@ -3115,6 +3362,9 @@ mod tests {
                 // The operand subtree is the exact source the narrowing rounded —
                 // 10/3 usd, a division node — so a checker can re-round it.
                 assert!(matches!(operand.as_ref(), DerivationNode::Op { .. }));
+                // And the exact source is captured on the node itself (NUM-6v), so
+                // `adj-verify` can re-round 10/3 without re-walking the subtree.
+                assert_eq!(*operand_exact, ExactRational::new(10, 3));
             }
             other => panic!("expected Round node, got {other:?}"),
         }
@@ -3342,5 +3592,105 @@ mod tests {
         assert_eq!(cur_rendered_of(&d), "USD 33.33");
         assert_eq!(d.exact, ExactRational::new(3333, 100)); // 33.33 exactly
         assert_eq!(d.dim, Dimension::Money("usd".into()));
+    }
+
+    // ---- NUM-6v: adj-verify re-check of the narrowing nodes (ADJ-NUMERIC §4.3) ----
+
+    #[test]
+    fn recheck_confirms_a_genuine_rounding() {
+        let kb = KnowledgeBase::new();
+        // 10/3 → 2 places = 3.33; re-rounding the recorded exact source reproduces it.
+        let d = compute("r", &round_places(2, frac(10, 3)), &kb).unwrap();
+        assert_eq!(recheck_narrowing(&d.tree), NarrowingCheck::ReChecked);
+    }
+
+    #[test]
+    fn recheck_confirms_every_formatter() {
+        let kb = KnowledgeBase::new();
+        // to_scientific, to_percent, to_currency all re-derive their rendered string
+        // AND their numeric result from the recorded exact source.
+        let sci = compute("r", &to_sci(4, frac(1, 3)), &kb).unwrap();
+        assert_eq!(recheck_narrowing(&sci.tree), NarrowingCheck::ReChecked);
+        let pct = compute("r", &to_pct(2, frac(1, 3)), &kb).unwrap();
+        assert_eq!(recheck_narrowing(&pct.tree), NarrowingCheck::ReChecked);
+        let cur = compute("r", &to_cur("usd", 2, frac(100, 3)), &kb).unwrap();
+        assert_eq!(recheck_narrowing(&cur.tree), NarrowingCheck::ReChecked);
+    }
+
+    #[test]
+    fn recheck_catches_a_tampered_result() {
+        let kb = KnowledgeBase::new();
+        // Compute a genuine rounding, then tamper the recorded `result` (the kind of
+        // drift a since-edited or fabricated artifact carries): the re-check must
+        // catch it, because re-rounding the still-honest exact source disagrees.
+        let mut d = compute("r", &round_places(2, frac(10, 3)), &kb).unwrap();
+        if let DerivationNode::Round { result, .. } = &mut d.tree {
+            *result = 9.99; // was 3.33
+        }
+        assert!(recheck_narrowing(&d.tree).is_mismatch());
+    }
+
+    #[test]
+    fn recheck_catches_a_tampered_rendered_string() {
+        let kb = KnowledgeBase::new();
+        // Tamper only the boundary STRING of a currency rendering, leaving the exact
+        // source and numeric result intact: still a mismatch, because the string a
+        // consumer reads no longer matches what the exact source renders to.
+        let mut d = compute("r", &to_cur("usd", 2, frac(100, 3)), &kb).unwrap();
+        if let DerivationNode::ToCurrency { rendered, .. } = &mut d.tree {
+            *rendered = "USD 99.99".to_string(); // was "USD 33.33"
+        }
+        match recheck_narrowing(&d.tree) {
+            NarrowingCheck::Mismatch { why, .. } => assert_eq!(why, "rendered_differs"),
+            other => panic!("expected a rendered_differs mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn recheck_is_unverifiable_without_an_exact_source() {
+        // A narrowing node whose operand carried no exact value (a transcendental
+        // result) cannot be re-rounded exactly — honestly reported, never a pass.
+        let node = DerivationNode::Round {
+            spec: RoundSpec::Places(2),
+            mode: RoundingMode::HalfEven,
+            operand: Box::new(DerivationNode::Lit { value: 3.333 }),
+            operand_exact: None,
+            result: 3.33,
+        };
+        assert_eq!(recheck_narrowing(&node), NarrowingCheck::Unverifiable);
+    }
+
+    #[test]
+    fn recheck_a_non_narrowing_node_is_inert() {
+        let node = DerivationNode::Lit { value: 1.0 };
+        assert_eq!(recheck_narrowing(&node), NarrowingCheck::NotANarrowing);
+    }
+
+    #[test]
+    fn recheck_narrowings_walks_a_nested_tree() {
+        let kb = KnowledgeBase::new();
+        // round_to(to_percent(1/3, 2), 2): a narrowing whose operand is itself a
+        // narrowing — the walk must find and re-check BOTH, at depths 0 and 1.
+        let inner = to_pct(2, frac(1, 3));
+        let expr = round_places(2, inner);
+        let d = compute("r", &expr, &kb).unwrap();
+        let checks = recheck_narrowings(&d.tree);
+        assert_eq!(checks.len(), 2, "expected the outer round and inner to_percent");
+        assert_eq!(checks[0].0, 0); // outer round at the root
+        assert_eq!(checks[1].0, 1); // inner to_percent one level down
+        assert!(checks.iter().all(|(_, c)| c.is_rechecked()));
+    }
+
+    #[test]
+    fn recheck_narrowings_is_empty_for_a_plain_formula() {
+        let kb = kb_with(vec![money("a", 10, "usd"), money("b", 3, "usd")]);
+        // A plain division carries no narrowing node, so there is nothing to re-check.
+        let expr = ComputeExpr::Bin(
+            ComputeOp::Div,
+            Box::new(refexpr("a")),
+            Box::new(refexpr("b")),
+        );
+        let d = compute("r", &expr, &kb).unwrap();
+        assert!(recheck_narrowings(&d.tree).is_empty());
     }
 }

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -50,7 +50,8 @@ use std::collections::{HashMap, HashSet};
 use logic_core::{unify, LogicVar, Number, Substitution, Term};
 
 pub use compute::{
-    compute, ComputeError, ComputeExpr, ComputeOp, DerivationNode, Derived, RoundSpec,
+    compute, recheck_narrowing, recheck_narrowings, ComputeError, ComputeExpr, ComputeOp,
+    DerivationNode, Derived, NarrowingCheck, RoundSpec,
 };
 /// Re-exported so consumers can name the rounding mode of a
 /// [`ComputeExpr::Round`]/[`DerivationNode::Round`] without depending on

--- a/code/specs/ADJ-NUMERIC-SUBSTRATE.md
+++ b/code/specs/ADJ-NUMERIC-SUBSTRATE.md
@@ -145,6 +145,15 @@ and confirms the rendered result — so a rounded number is auditable back to th
 came from, never asserted. Rounding is thus an explicit, checkable step in the trail, not a
 silent lossy coercion (§3).
 
+> **Shipped (NUM-6v).** The re-check is implemented end-to-end. Each narrowing
+> `DerivationNode` carries its operand's exact source (`operand_exact`), and
+> `logic_engine::recheck_narrowing` / `recheck_narrowings` re-run the *same* exact narrowing
+> primitive on that source under the recorded mode, confirming the recorded numeric result and
+> (for the formatters) the rendered string reproduce. `adj-verify` walks every `let`-bound
+> derived value's tree and re-checks every narrowing; a disagreement is a hard failure
+> (`verified: false`, non-zero exit, named in `first_failure`). An operand with no exact
+> sidecar (a transcendental result) is honestly reported `unverifiable`, never a pass.
+
 ### 4.4 Engine shape + sub-staging
 
 `ComputeExpr::Unary(ComputeOp, …)` carries no parameter, so the precision-carrying roundings
@@ -187,8 +196,19 @@ tests → impl → security-review → babysit:
   normalized to the canonical uppercase ISO-4217 form; a non-identifier code is a compile error),
   `places` optional (default 2, `≥ 0`) — the §4.3 audit record
   (`node:to_currency`, `code`, `places`, `mode`, `rendered`, operand subtree), and an
-  end-to-end formula test. Per-`KnowledgeBase` `BigDouble` precision (the configurable default
-  §3 defers here) follows.
+  end-to-end formula test.
+- **NUM-6v** — the **`adj-verify` precision re-check** ✅ **shipped** (§4.3, §7): each narrowing
+  node carries its operand's exact source (`operand_exact`), the engine exposes
+  `recheck_narrowing`/`recheck_narrowings`, and `adj-verify` re-rounds every narrowing in every
+  derived value's tree, failing hard on any disagreement. This is the audit-exactness leg of
+  NUM-6 — a rounded/formatted number is now re-derivable from the exact source it came from, not
+  asserted.
+- **Remaining (the only open NUM-6 item):** per-`KnowledgeBase` `BigDouble` precision — the
+  configurable working precision the §3 default (256 bits) defers here. This depends on the
+  `Number::Real(BigDouble)` compute path of §5, which is **not yet wired into the engine**
+  (roots and transcendentals still evaluate on the `f64` fallback with the exact-rational
+  sidecar going `None`); it is therefore its own substrate rung — wire the `Real` contagion
+  into `compute`, then make its precision a per-`KnowledgeBase` setting — not a small closer.
 
 ---
 


### PR DESCRIPTION
## NUM-6v — `adj-verify` re-checks the precision/format narrowings

Closes the NUM-6 **audit-exactness** promise (`ADJ-NUMERIC-SUBSTRATE.md` §4.3/§6/§7). `adj-verify` already re-executes the *logic* of a trail — re-unifies facts, re-multiplies log-odds, re-runs negated subgoals, re-checks quotes. The compute derivation trees carry the *arithmetic*, and every `round_to`/`round_sig`/`to_scientific`/`to_percent`/`to_currency` narrowing had one part a checker took **on faith**: the rounded number (and boundary string) it printed. The node doc-comments literally promised "so `adj-verify` can re-round the operand's exact value and confirm the rendered result" — yet nothing did. This makes that real.

### Engine (`logic-engine`)
- Each narrowing `DerivationNode` (`Round`/`ToScientific`/`ToPercent`/`ToCurrency`) now carries `operand_exact: Option<ExactRational>` — the exact rational the narrowing consumed, captured at eval time (`None` only for a genuinely-inexact operand, e.g. a transcendental with no exact sidecar).
- `recheck_narrowing(&DerivationNode) -> NarrowingCheck` re-runs the **same** exact primitive (`round_rational`/`scientific`/`percent`/`currency`) on the recorded exact source under the recorded `spec`/`mode` and confirms the recorded `result` (and `rendered` string, for the formatters) reproduces: `ReChecked` / `Mismatch{why,recorded,recomputed}` / `Unverifiable` / `NotANarrowing`.
- `recheck_narrowings(&DerivationNode)` walks a tree pre-order, re-checking nested narrowings too (each with its depth). Both exported at the crate root.

### Verifier (`adj-verify`)
- Walks every `let`-bound derived value's tree, re-checks each narrowing, and adds `totals.narrowings_rechecked/unverifiable/mismatched` plus a `narrowings` array (per-value, per-check verdicts).
- A **mismatch is a hard failure**: `verified` → false, non-zero exit, named in `first_failure` (`pass:"narrowing"`, binding name, depth, disagreeing recorded/recomputed forms) — the same standard the negation/logit re-checks already meet.
- The four derivation-tree JSON emitters gained the field via `..`, so `--json`/`derivation` output is **byte-for-byte unchanged** (golden pins hold).

### Termination & safety
The tree is produced by the engine's own `compute` (depth-capped at `MAX_EVAL_DEPTH`), so the walk cannot recurse deeper than a value the engine already accepted, and the per-node re-check is the same bounded exact work `compute` already did. Verified adversarially in `/security-review` (halting, no-OOM, `verified`-gate correctness, `esc` escaping of all attacker strings, sound f64 `==` on deterministic re-derivation) — **PASSED**.

### Tests
- 8 engine unit tests: each kind re-checks; a tampered `result` and a tampered `rendered` string are both caught; an inexact operand is `Unverifiable`; the walk finds nested narrowings and is empty for a plain formula.
- 3 `adj-verify` e2e (built binary): all five narrowing kinds re-check green; a plain formula reports zero and still verifies; a nested `round_to(to_percent(...))` re-checks both levels.
- Regression: `cli_golden` (38), `num6a`/`num6c`, `rs4d2_adj_verify` (8), explain suites, full `logic-engine` lib (201) — all green. clippy `-D warnings` clean.

### Scope note
This is the audit-exactness leg of NUM-6. The **only remaining NUM-6 item** — per-`KnowledgeBase` `BigDouble` precision — depends on the `Number::Real(BigDouble)` compute path of §5, which is **not yet wired** (roots/transcendentals still fall to the `f64` path); it is its own substrate rung, recorded as such in §6. Spec-synced §4.3/§6.

adj-lang 0.49→0.50, adj-lang-cli 0.27→0.28; both CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)