### PR TITLE
feat(adj-lang): argument surface — decompose prose into a derivable graph (ADR-2)

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -43,6 +43,7 @@ statement   = prior_decl
             | formulabook_decl
             | table_decl
             | statemachine_decl
+            | argument_decl
             | use_decl
             | import_decl
             ;
@@ -459,6 +460,30 @@ sm_exit       = "exit" "when" sm_guard "yield" expr ;
 sm_guard      = ( apply | IDENT ) [ ( GE | LE | GT | LT | EQEQ ) expr ] ;
 
 sm_action     = "assert" term ;
+
+# ----------------------------------------------------------------
+# Argument graph (ADJ-ARGUMENT-IR — ADR-2). An `argument` decomposes a piece of
+# prose into named PREMISES and INFERENCE steps that DESUGAR to the existing
+# substrate: a premise → a provenanced `relate` fact; an inference → a `rule`
+# whose body is the premises/inferences it cites `from`; the paper's thesis is the
+# derived head a trailing `? thesis(…)` queries. Because it lowers to facts + rules,
+# the engine derives the thesis and `--explain` renders the chain for free (no new
+# evaluator). `argument`/`premise`/`infer`/`conclude`/`from` are IDENT-matched
+# literals — no lexer keywords, exactly like `statemachine`/`table`. A premise's
+# `<kind>` is `extracted | imported | inferred`; an inference's `<connective>` is the
+# open-vocabulary connective as written (because/therefore/suggests/…). Each carries
+# the same `{ annotation }` source/locator/trust envelope every grounded clause does
+# — that is the cite/warrant the ADR-3 grounding gate will check. `from` references
+# are `arg_ref` nodes so they are cleanly separable from the name/connective tokens.
+# ----------------------------------------------------------------
+
+argument_decl = "argument" IDENT LBRACE { arg_premise } { arg_infer } RBRACE ;
+
+arg_premise   = "premise" IDENT COLON IDENT term { annotation } ;
+
+arg_infer     = "infer" IDENT COLON IDENT "conclude" term "from" arg_ref { COMMA arg_ref } { annotation } ;
+
+arg_ref       = IDENT ;
 
 # ----------------------------------------------------------------
 # Import (MYCIN-2026 M3 — composition across files). `import "<path>"`

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.29.0] — 2026-07-30 — ADR-2: `argument` derives + cites its thesis end-to-end
+
+Picks up the new `argument` surface (adj-lang 0.66): a multi-step argument now compiles, and the
+engine **derives** its thesis by chaining the inference rules through the premise facts, with the
+proof carrying every premise's byte citation — the argument is auditable to its sources.
+
+- New e2e (`argument_surface_e2e.rs`, 4): the ADJ-ARGUMENT-IR §8 axle-fatigue argument derives
+  `mechanism(axle, fatigue)` cited to its premises; a dangling `from` reference, an unknown premise
+  kind, and a duplicated element name are each named compile errors with no answer produced.
+- No CLI code change: because `argument` desugars to facts + rules, recall/`--json` render it
+  through the existing path; `--json`/golden output is byte-for-byte unchanged (golden 38 hold).
+- Note: rendering the argument chain in `--explain` (SLD proof chains, distinct from the
+  differential/compute trace it renders today) lands with the `adj-verify` argument pass in ADR-4.
+
 ## [0.28.0] — 2026-07-30 — NUM-6v: `adj-verify` re-checks the precision/format narrowings
 
 `adj-verify` now re-executes the *arithmetic* of a trail, not only its logic

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/tests/argument_surface_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/argument_surface_e2e.rs
@@ -1,0 +1,116 @@
+//! End-to-end tests for the **`argument` surface** (ADJ-ARGUMENT-IR ADR-2), driven
+//! through the built `adj-lang-cli` binary.
+//!
+//! The whole point of the argument construct is that it DESUGARS AWAY into the
+//! existing substrate — premises → provenanced facts, inferences → rules — so the
+//! engine *derives* the thesis by chaining the inference rules, and the proof carries
+//! every premise's byte citation. These tests prove that path works end to end (a
+//! multi-step argument derives its thesis, cited), and that the two things the surface
+//! cannot express — a dangling `from` reference and an unknown premise kind — are clean
+//! compile errors, never a panic or a silently-dropped step.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_arg_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(src: &str, tag: &str) -> (bool, String) {
+    let dir = scratch(tag);
+    let p = dir.join("case.adj");
+    std::fs::write(&p, src).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&p)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+// A three-premise, two-step argument (the ADJ-ARGUMENT-IR §8 axle-fatigue example):
+// operating stress > fatigue limit ⇒ the limit is exceeded; that + beach marks ⇒ the
+// mechanism is fatigue. The thesis chains p1&p2 → s1, then s1&p3 → s2.
+const AXLE: &str = "argument axle_failure {\n\
+    premise p1 : extracted operating_stress(axle, 420) source \"operating stress (420 MPa)\" trust authoritative\n\
+    premise p2 : extracted fatigue_limit(axle, 380) source \"its fatigue limit (380 MPa)\" trust authoritative\n\
+    premise p3 : extracted shows(surface, beach_marks) source \"beach marks\" trust authoritative\n\
+    infer s1 : because conclude exceeds_limit(axle) from p1, p2 source \"exceeded its fatigue limit\" trust authoritative\n\
+    infer s2 : therefore conclude mechanism(axle, fatigue) from s1, p3 source \"beach marks confirm a fatigue mechanism\" trust authoritative\n\
+}\n\
+? mechanism(axle, $M)\n";
+
+#[test]
+fn a_multistep_argument_derives_its_thesis_from_chained_premises() {
+    let (ok, out) = run(AXLE, "derive");
+    assert!(ok, "a well-formed argument must compile and run:\n{out}");
+    // The engine derived the thesis by chaining s2 ← (s1 ← p1,p2), p3.
+    assert!(
+        out.contains("\"M\":\"fatigue\""),
+        "the thesis `mechanism(axle, fatigue)` must be DERIVED, not asserted:\n{out}"
+    );
+    // Chaining reached back through both inferences to the grounding premises, so the
+    // answer carries their byte citations — the argument is auditable to its sources.
+    assert!(
+        out.contains("operating stress (420 MPa)") && out.contains("beach marks"),
+        "the derived thesis must carry the premises' citations:\n{out}"
+    );
+}
+
+#[test]
+fn an_inference_referencing_an_unknown_premise_is_a_compile_error() {
+    // s1 cites `px`, which no premise binds. The lowerer must reject it cleanly (a
+    // dangling `from` would otherwise silently produce a rule that can never fire).
+    let src = "argument bad_ref {\n\
+        premise p1 : extracted a(x) source \"a\" trust authoritative\n\
+        infer s1 : because conclude c(x) from p1, px source \"w\" trust authoritative\n\
+    }\n\
+    ? c(x)\n";
+    let (_ok, out) = run(src, "badref");
+    // A compile error is reported as `{"error":"Lower(...)"}`; the dangling reference
+    // must be named, and no answer produced — never a rule that silently never fires.
+    assert!(
+        out.contains("ArgUnknownReference") && out.contains("px"),
+        "a dangling `from` reference must be a named compile error:\n{out}"
+    );
+    assert!(
+        !out.contains("\"answers\""),
+        "and no answer may be produced for a program that failed to compile:\n{out}"
+    );
+}
+
+#[test]
+fn a_premise_with_an_unknown_kind_is_a_compile_error() {
+    // `assumed` is not one of extracted | imported | inferred.
+    let src = "argument bad_kind {\n\
+        premise p1 : assumed a(x) source \"a\" trust authoritative\n\
+    }\n\
+    ? a(x)\n";
+    let (_ok, out) = run(src, "badkind");
+    assert!(
+        out.contains("ArgUnknownPremiseKind") && out.contains("assumed"),
+        "an unknown premise kind must be a named compile error:\n{out}"
+    );
+    assert!(
+        !out.contains("\"answers\""),
+        "and no answer may be produced for a program that failed to compile:\n{out}"
+    );
+}
+
+#[test]
+fn two_elements_sharing_a_name_is_a_compile_error() {
+    // `p1` is bound twice; a `from p1` reference would then be ambiguous, so a duplicate
+    // name is rejected rather than silently resolving to one of them.
+    let src = "argument dup {\n\
+        premise p1 : extracted a(x) source \"a\" trust authoritative\n\
+        premise p1 : extracted b(x) source \"b\" trust authoritative\n\
+    }\n\
+    ? a(x)\n";
+    let (_ok, out) = run(src, "dup");
+    assert!(
+        out.contains("ArgDuplicateName") && out.contains("p1"),
+        "a duplicated element name must be a named compile error:\n{out}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.66.0] — 2026-07-30 — ADR-2: the `argument` surface (ADJ-ARGUMENT-IR)
+
+Adds the `argument { premise… infer… }` construct — a byte-grounded argument graph that
+**desugars away** into the existing substrate (`ADJ-ARGUMENT-IR.md` §2/§6): a premise → a
+provenanced ground `Fact`; an inference → a `Rule` whose body is the terms it cites `from`;
+the thesis is the derived head a trailing `? thesis(…)` queries. Because it lowers to facts +
+rules, the engine derives the thesis and (later) `--explain`/`adj-verify` operate for free — no
+argument-specific evaluator.
+
+- Grammar: `argument_decl`/`arg_premise`/`arg_infer`/`arg_ref` (IDENT-matched literals, like
+  `statemachine`/`table`); regenerated `_parser_grammar.rs`/`_lexer_grammar.rs`.
+- AST: `Statement::Argument` + `ArgPremise` + `ArgInference`.
+- Adapter: `adapt_argument` (+ `adapt_arg_premise`/`adapt_arg_inference`) faithfully carry the
+  structure; the `from` references are `arg_ref` nodes, cleanly separable from the name/connective
+  tokens.
+- Lower: the `Statement::Argument` arm desugars each premise to a `Fact` and each inference to a
+  `Rule`, resolving `from` references against earlier element names. Three new typed `LowerError`s
+  — `ArgUnknownPremiseKind` (kind ∉ {extracted, imported, inferred}), `ArgUnknownReference` (a
+  dangling `from`), `ArgDuplicateName` (a reused element name) — so the surface's invariants fail
+  cleanly, never a panic or a silently-dropped step.
+- Surface refinement (settled here, spec-sync'd): premises/inferences carry the standard
+  `{ source/locator/trust }` annotation envelope as their cite/warrant, rather than dedicated
+  `cite`/`warrant` keywords — one provenance surface, consistent with `relate`/`rule`.
+
 ## [0.65.0] — 2026-07-30
 
 ### Added — RS-3c: `statemachine` driver + typed outcomes (ADJ-STATEMACHINE §3–§4)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -45,6 +45,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"formulabook_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"table_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"statemachine_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"argument_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"import_decl"#.to_string() },
             ] },
@@ -59,7 +60,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 55,
+            line_number: 56,
         },
         GrammarRule {
             name: r#"contributes_decl"#.to_string(),
@@ -72,7 +73,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 57,
+            line_number: 58,
         },
         GrammarRule {
             name: r#"evidence"#.to_string(),
@@ -80,7 +81,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 68,
+            line_number: 69,
         },
         GrammarRule {
             name: r#"predicate"#.to_string(),
@@ -98,7 +99,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 78,
+            line_number: 79,
         },
         GrammarRule {
             name: r#"interacts_decl"#.to_string(),
@@ -117,7 +118,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 80,
+            line_number: 81,
         },
         GrammarRule {
             name: r#"uncertain_decl"#.to_string(),
@@ -134,7 +135,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 82,
+            line_number: 83,
         },
         GrammarRule {
             name: r#"observe_decl"#.to_string(),
@@ -142,7 +143,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"observe"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 84,
+            line_number: 85,
         },
         GrammarRule {
             name: r#"relate_decl"#.to_string(),
@@ -151,7 +152,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 97,
+            line_number: 98,
         },
         GrammarRule {
             name: r#"rule_decl"#.to_string(),
@@ -181,7 +182,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 119,
+            line_number: 120,
         },
         GrammarRule {
             name: r#"body_literal"#.to_string(),
@@ -189,7 +190,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"not"#.to_string() }) },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 121,
+            line_number: 122,
         },
         GrammarRule {
             name: r#"context_order_decl"#.to_string(),
@@ -207,7 +208,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 132,
+            line_number: 133,
         },
         GrammarRule {
             name: r#"functional_decl"#.to_string(),
@@ -215,7 +216,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"functional"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 143,
+            line_number: 144,
         },
         GrammarRule {
             name: r#"query_decl"#.to_string(),
@@ -226,7 +227,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 145,
+            line_number: 146,
         },
         GrammarRule {
             name: r#"lookup_expr"#.to_string(),
@@ -241,7 +242,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"give"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 156,
+            line_number: 157,
         },
         GrammarRule {
             name: r#"signed_number"#.to_string(),
@@ -249,7 +250,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"MINUS"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
             ] },
-            line_number: 157,
+            line_number: 158,
         },
         GrammarRule {
             name: r#"let_decl"#.to_string(),
@@ -259,7 +260,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 171,
+            line_number: 172,
         },
         GrammarRule {
             name: r#"expr"#.to_string(),
@@ -273,7 +274,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 173,
+            line_number: 174,
         },
         GrammarRule {
             name: r#"term_expr"#.to_string(),
@@ -287,7 +288,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 175,
+            line_number: 176,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -306,7 +307,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 177,
+            line_number: 178,
         },
         GrammarRule {
             name: r#"agg"#.to_string(),
@@ -322,7 +323,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 179,
+            line_number: 180,
         },
         GrammarRule {
             name: r#"apply"#.to_string(),
@@ -338,7 +339,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 204,
+            line_number: 205,
         },
         GrammarRule {
             name: r#"latex_expr"#.to_string(),
@@ -346,7 +347,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 211,
+            line_number: 212,
         },
         GrammarRule {
             name: r#"asciimath_expr"#.to_string(),
@@ -354,7 +355,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"asciimath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 222,
+            line_number: 223,
         },
         GrammarRule {
             name: r#"mathml_expr"#.to_string(),
@@ -362,7 +363,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"mathml"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 234,
+            line_number: 235,
         },
         GrammarRule {
             name: r#"unicodemath_expr"#.to_string(),
@@ -370,7 +371,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"unicodemath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 246,
+            line_number: 247,
         },
         GrammarRule {
             name: r#"symbol_decl"#.to_string(),
@@ -380,7 +381,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 256,
+            line_number: 257,
         },
         GrammarRule {
             name: r#"constrain_latex_decl"#.to_string(),
@@ -388,7 +389,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"latex_relation"#.to_string() },
             ] },
-            line_number: 258,
+            line_number: 259,
         },
         GrammarRule {
             name: r#"constrain_asciimath_decl"#.to_string(),
@@ -396,7 +397,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"asciimath_relation"#.to_string() },
             ] },
-            line_number: 268,
+            line_number: 269,
         },
         GrammarRule {
             name: r#"constrain_decl"#.to_string(),
@@ -406,7 +407,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 270,
+            line_number: 271,
         },
         GrammarRule {
             name: r#"latex_relation"#.to_string(),
@@ -414,7 +415,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 272,
+            line_number: 273,
         },
         GrammarRule {
             name: r#"asciimath_relation"#.to_string(),
@@ -422,7 +423,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"asciimath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 274,
+            line_number: 275,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -435,7 +436,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NE"#.to_string() },
             ] },
-            line_number: 276,
+            line_number: 277,
         },
         GrammarRule {
             name: r#"solve_decl"#.to_string(),
@@ -450,12 +451,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 278,
+            line_number: 279,
         },
         GrammarRule {
             name: r#"check_decl"#.to_string(),
             body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 280,
+            line_number: 281,
         },
         GrammarRule {
             name: r#"optimize_decl"#.to_string(),
@@ -466,7 +467,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 287,
+            line_number: 288,
         },
         GrammarRule {
             name: r#"dictionary_decl"#.to_string(),
@@ -477,7 +478,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 299,
+            line_number: 300,
         },
         GrammarRule {
             name: r#"define_decl"#.to_string(),
@@ -488,7 +489,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
             ] },
-            line_number: 301,
+            line_number: 302,
         },
         GrammarRule {
             name: r#"define_kind"#.to_string(),
@@ -516,7 +517,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 ] },
             ] },
-            line_number: 303,
+            line_number: 304,
         },
         GrammarRule {
             name: r#"surface_clause"#.to_string(),
@@ -528,7 +529,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 309,
+            line_number: 310,
         },
         GrammarRule {
             name: r#"rulebook_decl"#.to_string(),
@@ -539,7 +540,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 326,
+            line_number: 327,
         },
         GrammarRule {
             name: r#"use_decl"#.to_string(),
@@ -547,7 +548,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"use"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 328,
+            line_number: 329,
         },
         GrammarRule {
             name: r#"formulabook_decl"#.to_string(),
@@ -558,7 +559,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"formulabook_item"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 359,
+            line_number: 360,
         },
         GrammarRule {
             name: r#"formulabook_item"#.to_string(),
@@ -566,7 +567,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"formula_decl"#.to_string() },
             ] },
-            line_number: 361,
+            line_number: 362,
         },
         GrammarRule {
             name: r#"formula_decl"#.to_string(),
@@ -579,7 +580,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"formula_body"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 363,
+            line_number: 364,
         },
         GrammarRule {
             name: r#"formula_params"#.to_string(),
@@ -590,7 +591,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                     ] }) },
             ] },
-            line_number: 365,
+            line_number: 366,
         },
         GrammarRule {
             name: r#"formula_body"#.to_string(),
@@ -606,7 +607,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
                 ] },
             ] },
-            line_number: 378,
+            line_number: 379,
         },
         GrammarRule {
             name: r#"formula_step"#.to_string(),
@@ -616,7 +617,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 380,
+            line_number: 381,
         },
         GrammarRule {
             name: r#"table_decl"#.to_string(),
@@ -630,7 +631,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 414,
+            line_number: 415,
         },
         GrammarRule {
             name: r#"columns_decl"#.to_string(),
@@ -642,7 +643,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                     ] }) },
             ] },
-            line_number: 416,
+            line_number: 417,
         },
         GrammarRule {
             name: r#"table_row"#.to_string(),
@@ -661,7 +662,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
                     ] }) },
             ] },
-            line_number: 424,
+            line_number: 425,
         },
         GrammarRule {
             name: r#"row_item"#.to_string(),
@@ -670,7 +671,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 426,
+            line_number: 427,
         },
         GrammarRule {
             name: r#"statemachine_decl"#.to_string(),
@@ -689,7 +690,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 439,
+            line_number: 440,
         },
         GrammarRule {
             name: r#"sm_state"#.to_string(),
@@ -700,7 +701,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"sm_transition"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 448,
+            line_number: 449,
         },
         GrammarRule {
             name: r#"sm_transition"#.to_string(),
@@ -719,7 +720,7 @@ pub fn parser_grammar() -> ParserGrammar {
                             ] }) },
                     ] }) },
             ] },
-            line_number: 455,
+            line_number: 456,
         },
         GrammarRule {
             name: r#"sm_exit"#.to_string(),
@@ -730,7 +731,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 457,
+            line_number: 458,
         },
         GrammarRule {
             name: r#"sm_guard"#.to_string(),
@@ -750,7 +751,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 459,
+            line_number: 460,
         },
         GrammarRule {
             name: r#"sm_action"#.to_string(),
@@ -758,7 +759,55 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"assert"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 461,
+            line_number: 462,
+        },
+        GrammarRule {
+            name: r#"argument_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"argument"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"arg_premise"#.to_string() }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"arg_infer"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 480,
+        },
+        GrammarRule {
+            name: r#"arg_premise"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"premise"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 482,
+        },
+        GrammarRule {
+            name: r#"arg_infer"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"infer"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Literal { value: r#"conclude"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Literal { value: r#"from"#.to_string() },
+                GrammarElement::RuleReference { name: r#"arg_ref"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"arg_ref"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 484,
+        },
+        GrammarRule {
+            name: r#"arg_ref"#.to_string(),
+            body: GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+            line_number: 486,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -766,7 +815,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 477,
+            line_number: 502,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -777,7 +826,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"quote_annotation"#.to_string() },
             ] },
-            line_number: 489,
+            line_number: 514,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -785,7 +834,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 496,
+            line_number: 521,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -793,7 +842,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 497,
+            line_number: 522,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -801,7 +850,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 498,
+            line_number: 523,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -811,7 +860,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 499,
+            line_number: 524,
         },
         GrammarRule {
             name: r#"quote_annotation"#.to_string(),
@@ -823,7 +872,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"snapshot"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 507,
+            line_number: 532,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -834,7 +883,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 509,
+            line_number: 534,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -858,7 +907,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 531,
+            line_number: 556,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -161,6 +161,7 @@ fn adapt_statement(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         "formulabook_decl" => adapt_formulabook(child),
         "table_decl" => adapt_table(child),
         "statemachine_decl" => adapt_statemachine(child),
+        "argument_decl" => adapt_argument(child),
         "use_decl" => adapt_use(child),
         "import_decl" => adapt_import(child),
         other => Err(AdapterError::UnexpectedRule {
@@ -996,6 +997,119 @@ fn adapt_formula(node: &GrammarASTNode) -> Result<FormulaDef, AdapterError> {
         params,
         steps,
         body,
+        annotations,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Argument graph (ADJ-ARGUMENT-IR ADR-2). Modelled on `table`/`statemachine`:
+// `argument`/`premise`/`infer`/`conclude`/`from` are IDENT-matched literals that
+// surface as `Name` tokens; premises, inferences, and `from` references are nested
+// nodes (`arg_premise`/`arg_infer`/`arg_ref`). The adapter faithfully carries the
+// STRUCTURE; the well-formedness checks (known premise kind, resolvable `from`
+// references, unique names) are the lowerer's job (§2.3).
+// ---------------------------------------------------------------------------
+
+/// The direct `Name`-token values of a node, in source order. The IDENT-matched
+/// keyword literals surface here alongside the user's identifiers, so a caller reads
+/// them off by position against the fixed grammar shape.
+fn direct_name_tokens(node: &GrammarASTNode) -> Vec<String> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.type_ == TokenType::Name => Some(t.value.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn adapt_argument(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
+    // argument_decl = "argument" IDENT LBRACE { arg_premise } { arg_infer } RBRACE
+    // The name is the only direct Name token that isn't the `argument` keyword (every
+    // premise/inference identifier lives inside a nested node).
+    let name = first_name_not(node, "argument")
+        .ok_or(AdapterError::MissingChild {
+            rule: "argument_decl".into(),
+            position: "argument name",
+        })?
+        .to_string();
+    let mut premises = Vec::new();
+    let mut inferences = Vec::new();
+    for c in &node.children {
+        if let ASTNodeOrToken::Node(item) = c {
+            match item.rule_name.as_str() {
+                "arg_premise" => premises.push(adapt_arg_premise(item)?),
+                "arg_infer" => inferences.push(adapt_arg_inference(item)?),
+                _ => {}
+            }
+        }
+    }
+    Ok(Statement::Argument {
+        name,
+        premises,
+        inferences,
+    })
+}
+
+fn adapt_arg_premise(node: &GrammarASTNode) -> Result<crate::ast::ArgPremise, AdapterError> {
+    // arg_premise = "premise" IDENT COLON IDENT term { annotation }
+    // Direct Name tokens are exactly [premise, <name>, <kind>] (the claim's functor is
+    // nested in the `term` node, so it is never a direct token here).
+    let names = direct_name_tokens(node);
+    let name = names.get(1).cloned().ok_or(AdapterError::MissingChild {
+        rule: "arg_premise".into(),
+        position: "premise name",
+    })?;
+    let kind = names.get(2).cloned().ok_or(AdapterError::MissingChild {
+        rule: "arg_premise".into(),
+        position: "premise kind",
+    })?;
+    let claim = expect_term_child(node, "arg_premise")?;
+    let annotations = collect_annotations(node)?;
+    Ok(crate::ast::ArgPremise {
+        name,
+        kind,
+        claim,
+        annotations,
+    })
+}
+
+fn adapt_arg_inference(node: &GrammarASTNode) -> Result<crate::ast::ArgInference, AdapterError> {
+    // arg_infer = "infer" IDENT COLON IDENT "conclude" term "from" arg_ref {COMMA arg_ref} {ann}
+    // Direct Name tokens are [infer, <name>, <connective>, conclude, from] — the `from`
+    // references are `arg_ref` NODES (not direct tokens), so name/connective sit at the
+    // fixed positions 1 and 2 regardless of what the author named them.
+    let names = direct_name_tokens(node);
+    let name = names.get(1).cloned().ok_or(AdapterError::MissingChild {
+        rule: "arg_infer".into(),
+        position: "inference name",
+    })?;
+    let connective = names.get(2).cloned().ok_or(AdapterError::MissingChild {
+        rule: "arg_infer".into(),
+        position: "inference connective",
+    })?;
+    // `conclude <term>` is the only `term` child; the references are `arg_ref` nodes.
+    let conclusion = expect_term_child(node, "arg_infer")?;
+    let mut from = Vec::new();
+    for c in &node.children {
+        if let ASTNodeOrToken::Node(r) = c {
+            if r.rule_name == "arg_ref" {
+                let refname = direct_name_tokens(r).into_iter().next().ok_or({
+                    AdapterError::MissingChild {
+                        rule: "arg_ref".into(),
+                        position: "reference name",
+                    }
+                })?;
+                from.push(refname);
+            }
+        }
+    }
+    let annotations = collect_annotations(node)?;
+    Ok(crate::ast::ArgInference {
+        name,
+        connective,
+        conclusion,
+        from,
         annotations,
     })
 }

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -553,6 +553,23 @@ pub enum Statement {
         budget: u64,
         annotations: Vec<Annotation>,
     },
+    /// `argument <name> { premise… infer… }` — a byte-grounded **argument graph**
+    /// (ADJ-ARGUMENT-IR, `code/specs/ADJ-ARGUMENT-IR.md` §2/§6; ADR-2). Decomposes a
+    /// piece of prose into named [`ArgPremise`]s (asserted propositions) and
+    /// [`ArgInference`] steps (a conclusion derived `from` earlier premises/inferences).
+    ///
+    /// A sibling of [`Statement::Table`]/[`Statement::StateMachine`], but it **lowers
+    /// away entirely** into existing constructs (§2.3): each premise → a provenanced
+    /// [`Statement::Relate`]-style `Fact`; each inference → a [`Statement::Rule`]-style
+    /// `Rule` whose body is the terms it cites `from`. The engine then *derives* the
+    /// thesis (a trailing `? thesis(…)` query), `--explain` renders the chain, and
+    /// `adj-verify` re-checks it — all for free, because the argument IS adj-lang. No
+    /// argument-specific evaluator, node table, or renderer exists past lowering.
+    Argument {
+        name: String,
+        premises: Vec<ArgPremise>,
+        inferences: Vec<ArgInference>,
+    },
     /// `use <dictionary>` — bind a `dictionary` (by name) as the controlled
     /// vocabulary the enclosing scope's clauses are checked against (MYCIN-2026
     /// M2). Legal at top level or inside a `rulebook`.
@@ -651,6 +668,49 @@ pub struct TableRow {
     /// not the table's first sentence: with one envelope, a six-band table made
     /// every answer in every band quote the same cell, which is an accounting
     /// error the moment the selected row is explicit (as a range lookup makes it).
+    pub annotations: Vec<Annotation>,
+}
+
+/// One `premise <name> : <kind> <claim> { … }` of a [`Statement::Argument`]
+/// (ADJ-ARGUMENT-IR §2.1). An asserted proposition the argument starts from; it
+/// lowers to a provenanced ground `Fact` (§2.3), and its `name` is how later
+/// [`ArgInference`]s cite it in their `from` list. The `annotations` are the same
+/// `source`/`locator`/`trust` envelope every grounded clause carries — the byte
+/// citation the ADR-3 grounding gate will check.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArgPremise {
+    /// The local name this premise binds, referenced by an inference's `from`.
+    pub name: String,
+    /// `extracted` (stated in the source) | `imported` (an external cited premise) |
+    /// `inferred` (a hedged reading). Validated against that closed set by the lowerer
+    /// (an unknown kind is a clean `LowerError`, never silently accepted). At ADR-2 the
+    /// kind is recorded for the audit; the strict per-kind grounding is ADR-3.
+    pub kind: String,
+    /// The proposition itself, as an ADJ term — lowers to the fact's edge.
+    pub claim: Term,
+    /// Cite/source provenance (`source`/`locator`/`trust`).
+    pub annotations: Vec<Annotation>,
+}
+
+/// One `infer <name> : <connective> conclude <conclusion> from <refs> { … }` of a
+/// [`Statement::Argument`] (ADJ-ARGUMENT-IR §2.1). A step that derives `conclusion`
+/// from the premises/inferences it names in `from`; it lowers to a `Rule` whose head
+/// is `conclusion` and whose body is those referenced terms (§2.3), so the engine
+/// chains the steps by SLD resolution. The `connective` is the open-vocabulary word as
+/// written (because/therefore/suggests/…); the `annotations` carry the warrant.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArgInference {
+    /// The local name this inference's conclusion binds, referenced by a later `from`.
+    pub name: String,
+    /// The open-vocabulary inference connective as written in the source.
+    pub connective: String,
+    /// The derived proposition — lowers to the rule head.
+    pub conclusion: Term,
+    /// Names of the premises/inferences this step derives its conclusion `from`. Each
+    /// must resolve to an earlier `name` in the same argument (an unknown reference is a
+    /// clean `LowerError`); the referenced terms become the rule's body literals.
+    pub from: Vec<String>,
+    /// Warrant/source provenance (`source`/`locator`/`trust`).
     pub annotations: Vec<Annotation>,
 }
 

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -345,6 +345,28 @@ pub enum LowerError {
     SmMissingProvenance {
         machine: String,
     },
+    /// An `argument` premise declared a `kind` outside the closed set
+    /// `extracted | imported | inferred` (ADJ-ARGUMENT-IR §2.1). Carries the argument
+    /// name and the offending kind — never silently accepted.
+    ArgUnknownPremiseKind {
+        argument: String,
+        kind: String,
+    },
+    /// An `argument` inference's `from` list named a premise/inference that no earlier
+    /// element in the same argument binds (ADJ-ARGUMENT-IR §2.3). A reference must
+    /// resolve to a prior `name`, or the inference's body would cite nothing. Carries
+    /// the argument name and the dangling reference.
+    ArgUnknownReference {
+        argument: String,
+        reference: String,
+    },
+    /// Two elements of the same `argument` share a `name` (ADJ-ARGUMENT-IR §2.1). Names
+    /// are the handles `from` references resolve against, so they must be unique within
+    /// the argument. Carries the argument name and the duplicated name.
+    ArgDuplicateName {
+        argument: String,
+        name: String,
+    },
 }
 
 /// One lowered RANGE / BRACKET lookup (ADJ-TABLES RS-5c) — the validated,
@@ -1047,6 +1069,68 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                     budget: *budget,
                     provenance: prov,
                 });
+            }
+            // ---- argument graph (ADJ-ARGUMENT-IR ADR-2) ----
+            // The argument DESUGARS AWAY into the existing substrate (§2.3): each
+            // premise → a provenanced ground `Fact`; each inference → a `Rule` whose
+            // body is the terms it cites `from`. After this arm there is no argument
+            // object left in the KB — the engine derives the thesis from the facts +
+            // rules, `--explain` renders that proof DAG as the argument, and `adj-verify`
+            // re-checks it, all via the machinery `relate`/`rule` already feed. We
+            // validate three things the surface cannot: known premise kinds, unique
+            // element names, and that every `from` reference resolves to a prior name.
+            Statement::Argument {
+                name,
+                premises,
+                inferences,
+            } => {
+                // name → the AST term this element binds (a premise's claim or an
+                // inference's conclusion), so a later `from` resolves to its term.
+                let mut bound: HashMap<&str, &AstTerm> = HashMap::new();
+                for p in premises {
+                    if !matches!(p.kind.as_str(), "extracted" | "imported" | "inferred") {
+                        return Err(LowerError::ArgUnknownPremiseKind {
+                            argument: name.clone(),
+                            kind: p.kind.clone(),
+                        });
+                    }
+                    if bound.contains_key(p.name.as_str()) {
+                        return Err(LowerError::ArgDuplicateName {
+                            argument: name.clone(),
+                            name: p.name.clone(),
+                        });
+                    }
+                    let prov = annotations_to_provenance(&p.annotations)?;
+                    kb.add_fact(Fact::certain(lower_term(&p.claim)).with_provenance(prov));
+                    bound.insert(p.name.as_str(), &p.claim);
+                }
+                for inf in inferences {
+                    if bound.contains_key(inf.name.as_str()) {
+                        return Err(LowerError::ArgDuplicateName {
+                            argument: name.clone(),
+                            name: inf.name.clone(),
+                        });
+                    }
+                    // Head and the (resolved) body share ONE variable scope, exactly
+                    // like a `rule { head when: … }`, so a `$Var` in the conclusion
+                    // unifies with the same `$Var` in a referenced premise term.
+                    let mut vars = HashMap::new();
+                    let head_term = lower_term_scoped(&inf.conclusion, &mut vars);
+                    let mut body_lits: Vec<BodyLiteral> = Vec::with_capacity(inf.from.len());
+                    for r in &inf.from {
+                        let ref_term: &AstTerm =
+                            bound.get(r.as_str()).copied().ok_or_else(|| {
+                                LowerError::ArgUnknownReference {
+                                    argument: name.clone(),
+                                    reference: r.clone(),
+                                }
+                            })?;
+                        body_lits.push(BodyLiteral::Pos(lower_term_scoped(ref_term, &mut vars)));
+                    }
+                    let prov = annotations_to_provenance(&inf.annotations)?;
+                    kb.add_rule(Rule::certain(head_term, body_lits).with_provenance(prov));
+                    bound.insert(inf.name.as_str(), &inf.conclusion);
+                }
             }
             // ---- import (MYCIN-2026 M3) ----
             // Imports are resolved away by `crate::resolve` before lowering; one

--- a/code/specs/ADJ-ARGUMENT-IR.md
+++ b/code/specs/ADJ-ARGUMENT-IR.md
@@ -213,10 +213,18 @@ grounding payload the §3 gate checks. Final syntax fixed in ADR-2.
 - **ADR-1 (this PR, spec-first):** this document — the model, the desugaring table, the gate, the
   verification story, the native-vs-IR decision, the worked example (§8). Cross-links ADJ01/25/40/
   41/42/61-64, ADJ-RULE-SUBSTRATE, ADJ-REASON-MATH §E.8, ADJ-NUMERIC-SUBSTRATE. No code.
-- **ADR-2 — argument surface:** the `argument { premise/infer/conclude/rebut }` grammar + AST +
-  lowering to `relate`/`rule`/`? goal`, with an end-to-end test: a 3-premise argument derives its
-  thesis and `--explain` renders it as premises → connective → conclusion. (Grammar via
-  `regen_grammars`; mirrors the `statemachine` wiring.)
+- **ADR-2 — argument surface** ✅ **shipped** (adj-lang 0.66, adj-lang-cli 0.29): the
+  `argument { premise/infer }` grammar + AST + adapter + lowering to `Fact`/`Rule`, so the engine
+  **derives** the thesis by chaining the inference rules through the premise facts, and the proof
+  carries every premise's byte citation (verified e2e on the §8 axle example). Three typed
+  `LowerError`s guard the surface's invariants (unknown premise kind, dangling `from` reference,
+  duplicate element name). **Two refinements settled here vs. §6's sketch:** (a) premises/inferences
+  carry the standard `{ source/locator/trust }` annotation envelope as their cite/warrant, rather
+  than dedicated `cite`/`warrant` keywords — one provenance surface, consistent with `relate`/`rule`;
+  (b) the `rebut`/attack edge is **deferred to a later sub-rung** (it needs the ADJ73 defeasible-
+  precedence wiring, §2.2) to keep ADR-2 to the support spine. Rendering the argument chain in
+  `--explain` (an *SLD* proof chain, distinct from the differential/compute trace `--explain` renders
+  today) lands with ADR-4's `adj-verify` argument pass.
 - **ADR-3 — the open-vocab grounding gate over the argument:** per-premise byte-anchor +
   combined-justification, adversarial reader, decision-sensitivity, applied to a lowered argument
   program; the gate's verdict (grounded / determined / underdetermined) emitted in the JSON.


### PR DESCRIPTION
## ADJ-ARGUMENT-IR ADR-2 — the `argument` surface (first code rung of the decompose arc)

Adds the `argument { premise… infer… }` construct — the surface for decomposing prose into premises, inference steps, and a conclusion the **engine reasons over**. Its defining property: it **desugars away** into the existing substrate (ADJ-ARGUMENT-IR §2.3), so the engine derives the thesis for free.

```
argument axle_failure {
    premise p1 : extracted operating_stress(axle, 420) source "operating stress (420 MPa)" trust authoritative
    premise p2 : extracted fatigue_limit(axle, 380) source "its fatigue limit (380 MPa)" trust authoritative
    premise p3 : extracted shows(surface, beach_marks) source "beach marks" trust authoritative
    infer s1 : because   conclude exceeds_limit(axle)         from p1, p2  source "exceeded its fatigue limit"    trust authoritative
    infer s2 : therefore conclude mechanism(axle, fatigue)    from s1, p3  source "beach marks confirm a fatigue mechanism" trust authoritative
}
? mechanism(axle, $M)      %  →  M = fatigue, cited to p1/p2/p3
```

- A **premise** → a provenanced ground `Fact`; an **inference** → a `Rule` whose body is the terms it cites `from`; the **thesis** is the derived head. The engine chains `s2 ← (s1 ← p1,p2), p3` and the proof carries every premise's byte citation — verified end-to-end.

### Wiring (mirrors `statemachine`/`table`)
- Grammar `argument_decl`/`arg_premise`/`arg_infer`/`arg_ref` (IDENT-matched literals); regenerated parser/lexer.
- AST `Statement::Argument` + `ArgPremise` + `ArgInference`; adapter `adapt_argument` (fixed-position token reads, all `.get()` guarded); lower arm desugars to `Fact`/`Rule`.
- Three typed `LowerError`s guard the surface: `ArgUnknownPremiseKind`, `ArgUnknownReference` (dangling `from` — no forward/self-reference), `ArgDuplicateName` (dup-check before insert — no shadowing).

### Safety & compatibility
- **/security-review PASSED**: total on untrusted input — every malformed-but-parseable argument yields a typed `AdapterError`/`LowerError`, never a panic or a silently-broken rule; validation complete; linear; no new unescaped output interpolation.
- **Byte-neutral**: because `argument` desugars, `--json`/golden output is unchanged (golden 38 hold). clippy `-D warnings` clean; adj-lang lib 177, arg e2e 4 green.

### Scope (kept to the support spine, per "ADR-2 small")
- `rebut`/attack edges deferred to a later sub-rung (they need the ADJ73 defeasible-precedence wiring).
- `--explain` of the *SLD* argument chain (distinct from the differential/compute trace it renders today) lands with **ADR-4**'s `adj-verify` argument pass.
- Surface refinement vs the §6 sketch: cite/warrant ride the standard `source/locator/trust` annotation envelope, not dedicated keywords — one provenance surface, consistent with `relate`/`rule`. Spec §7 synced.

adj-lang 0.65→0.66, adj-lang-cli 0.28→0.29; both CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)