### PR TITLE
Support ALGOL string array elements on the LANG chain

### DIFF
--- a/code/packages/rust/algol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/algol-iir-compiler/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.31.0 — 2026-07-30 — E4d-AL: string arrays
+
+ALGOL `string array` declarations now reuse the shared E5 `array<str>`
+substrate already exercised by Dartmouth BASIC. Literal and initialized-scalar
+string writes lower to `str_const`/`array_set`; subscript reads yield `str` and
+can feed lexical ordering or `print_str`. The regression program stores `HI`
+and `LO`, compares the elements, and prints the selected element across native
+AOT, LLVM, WASM, JVM, CLR, VM, and JIT.
+
+`own`/captured string storage and array parameters remain separate follow-ups.
+
 ## 0.30.0 — 2026-07-30 — E4d-AL: runtime scalar string ordering
 
 Initialized scalar strings carrying a branch-selected `string procedure`

--- a/code/packages/rust/algol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/algol-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "algol-iir-compiler"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
-description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.30.0 (E4d-AL runtime ordering): initialized scalar strings can receive a string-procedure result and participate in lexical ordering across the LANG VM/AOT/JIT chain; v0.29.0 (E4d-AL runtime locals): initialized scalar strings can receive a string-procedure result and then be copied, compared, and printed; v0.28.0 (E4d-AL): `string procedure`s return runtime strings; v0.27.0 (AL-pow): `↑` exponentiation; v0.26.0 (AL-multidim-bounds): multidim arrays with arbitrary/negative per-dimension lower bounds."
+description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.31.0 (E4d-AL string arrays): `string array` reuses the shared array<str> substrate; v0.30.0 (E4d-AL runtime ordering): initialized scalar strings can receive a string-procedure result and participate in lexical ordering across the LANG VM/AOT/JIT chain; v0.29.0 (E4d-AL runtime locals): initialized scalar strings can receive a string-procedure result and then be copied, compared, and printed; v0.28.0 (E4d-AL): `string procedure`s return runtime strings; v0.27.0 (AL-pow): `↑` exponentiation; v0.26.0 (AL-multidim-bounds): multidim arrays with arbitrary/negative per-dimension lower bounds."
 
 [dependencies]
 coding-adventures-algol-parser = { path = "../algol-parser" }

--- a/code/packages/rust/algol-iir-compiler/README.md
+++ b/code/packages/rust/algol-iir-compiler/README.md
@@ -93,7 +93,10 @@ corresponding typed zero comparison before the normal ALGOL conditional branch.
 Initialized scalar locals now also carry runtime string procedure results:
 `string s; s := pick(1); if s < 'LO' then ...; print(s)` uses the shared
 runtime `str_concat`/`str_cmp`/`print_str` path. Reads before assignment still
-fail closed. Captured/`own` strings and string arrays remain unsupported.
+fail closed. `string array A[1:2]` uses the same `array<str>` substrate as
+other LANG frontends; its elements can be written from literals or initialized
+scalar strings, then read for lexical comparison or output. Captured/`own`
+strings remain unsupported.
 
 `real` values lower to the IIR `f64` type and **run on the VM and JIT today**
 (LANG-FULL AL1 / enabler E3 phase 1); `2.5 * 2.0`, `7.0 / 2.0`, and real
@@ -117,8 +120,8 @@ in statement position. They can write enclosing scalar globals and use the same
 literal-backed output path as typed procedures; using a proper procedure in
 value position is a clean type error because it has no return value.
 
-Unsupported ALGOL 60 features — non-numeric arrays, arrays as procedure
-parameters, dynamic string variables/arrays, by-name (non-`value`) parameters,
+Unsupported ALGOL 60 features — non-numeric/non-string arrays, arrays as procedure
+parameters, dynamic string variables, by-name (non-`value`) parameters,
 parameterless-procedure calls (a bare name parses as a variable),
 enclosing-block **array** capture (only scalars are globalised so far), and
 conditional/nested switch-list elements — return explicit compiler errors.

--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -562,9 +562,12 @@ impl Compiler {
             Some(type_node) => self.scalar_type(type_node)?,
             None => ScalarType::Real, // bare `array A[..]` is `real` in ALGOL 60
         };
-        if !matches!(elem_ty, ScalarType::Integer | ScalarType::Real) {
+        if !matches!(
+            elem_ty,
+            ScalarType::Integer | ScalarType::Real | ScalarType::String
+        ) {
             return Err(CompileError::Unsupported(format!(
-                "{} arrays (only integer/real element types so far)",
+                "{} arrays (only integer/real/string element types so far)",
                 elem_ty.name()
             )));
         }
@@ -1790,9 +1793,32 @@ impl Compiler {
                 let var_node = first_direct_node(left, "variable")
                     .ok_or_else(|| CompileError::Malformed("left_part has no variable".into()))?;
                 if array_subscripts(var_node).is_some() {
-                    return Err(CompileError::Unsupported(
-                        "string array assignments".into(),
+                    let (binding, zero) = self.resolve_array_index(var_node)?;
+                    if binding.ty != ScalarType::String {
+                        return Err(CompileError::Type(format!(
+                            "cannot assign string expression to {} array element",
+                            binding.ty.name()
+                        )));
+                    }
+                    let value = self.fresh_temp();
+                    self.emit(IIRInstr::new(
+                        "str_const",
+                        Some(value.clone()),
+                        vec![Operand::Str(literal.clone())],
+                        "str",
                     ));
+                    self.emit(IIRInstr::new(
+                        "array_set",
+                        None,
+                        vec![
+                            Operand::Var(binding.slot),
+                            Operand::Var(zero),
+                            Operand::Var(value),
+                        ],
+                        "str",
+                    ));
+                    saw_string_target = true;
+                    continue;
                 }
                 let name = self.simple_variable_name(var_node)?;
                 let binding = self.require_var(&name)?;
@@ -1834,9 +1860,25 @@ impl Compiler {
                         CompileError::Malformed("left_part has no variable".into())
                     })?;
                     if array_subscripts(var_node).is_some() {
-                        return Err(CompileError::Unsupported(
-                            "string array assignments".into(),
+                        let (binding, zero) = self.resolve_array_index(var_node)?;
+                        if binding.ty != ScalarType::String {
+                            return Err(CompileError::Type(format!(
+                                "cannot assign string expression to {} array element",
+                                binding.ty.name()
+                            )));
+                        }
+                        self.emit(IIRInstr::new(
+                            "array_set",
+                            None,
+                            vec![
+                                Operand::Var(binding.slot),
+                                Operand::Var(zero),
+                                Operand::Var(src_slot.clone()),
+                            ],
+                            "str",
                         ));
+                        saw_string_target = true;
+                        continue;
                     }
                     let name = self.simple_variable_name(var_node)?;
                     let binding = self.require_var(&name)?;
@@ -5134,6 +5176,40 @@ mod tests {
         let src = "begin real array A[1:2]; real result; \
                    A[1] := 2.5; result := A[1] end";
         assert_eq!(run_f64(src), 2.5);
+    }
+
+    /// A `string array` shares the E5 aggregate substrate with numeric arrays:
+    /// literals store as `str` elements, reads feed lexical ordering, and the
+    /// VM observes the selected element as a real string value.
+    #[test]
+    fn string_array_elements_feed_lexical_ordering() {
+        let src = "begin string array words[1:2]; integer result; \
+                   words[1] := 'HI'; words[2] := 'LO'; \
+                   if words[1] < words[2] then result := 42 else result := 0 end";
+        assert_eq!(run_i64(src), 42);
+
+        let module = compile_source(src, "test").expect("string array program compiles");
+        let main = module.get_function("main").expect("has main");
+        assert!(
+            main.instructions.iter().any(|instr| instr.op == "alloc_array" && instr.type_hint == "array<str>"),
+            "string array declaration must retain the str element type: {:?}",
+            main.instructions
+        );
+        assert!(
+            main.instructions.iter().any(|instr| instr.op == "array_get" && instr.type_hint == "str"),
+            "string array read must produce a str value: {:?}",
+            main.instructions
+        );
+    }
+
+    /// An initialized scalar string can populate an array element without
+    /// losing its runtime handle; the read then remains a normal `str` value.
+    #[test]
+    fn string_array_accepts_initialized_scalar_values() {
+        let src = "begin string array words[1:1]; string greeting; integer result; \
+                   greeting := 'HI'; words[1] := greeting; \
+                   if words[1] = greeting then result := 42 else result := 0 end";
+        assert_eq!(run_i64(src), 42);
     }
 
     // ── AL-pow: ALGOL 60 `↑` exponentiation (spelled `^`) ───────────────────

--- a/code/packages/rust/algol-iir-compiler/tests/aot_smoke.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/aot_smoke.rs
@@ -64,3 +64,19 @@ fn algol_runtime_string_ordering_program_compiles_to_aot_snapshot() {
     let snapshot = read(&bytes).expect("AOT snapshot should parse");
     assert!(!snapshot.native_code.is_empty());
 }
+
+#[test]
+fn algol_string_array_program_compiles_to_aot_snapshot() {
+    let source = "begin string array words[1:2]; integer result; \
+                  words[1] := 'HI'; words[2] := 'LO'; \
+                  if words[1] < words[2] then result := 42 else result := 0; \
+                  print(words[1]) end";
+    let module = compile_source(source, "algol_string_array_aot")
+        .expect("ALGOL string array should compile");
+
+    let mut aot = AOTCore::new(Box::new(NullBackend), None, 2);
+    let bytes = aot.compile(&module).expect("AOT compile should succeed");
+    assert!(bytes.starts_with(b"AOT\0"));
+    let snapshot = read(&bytes).expect("AOT snapshot should parse");
+    assert!(!snapshot.native_code.is_empty());
+}

--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -26,6 +26,8 @@ const ALGOL_RUNTIME_STRING_LOCAL: &str = "begin string s; integer result; string
 
 const ALGOL_RUNTIME_STRING_ORDERING: &str = "begin string s; integer result; string procedure pick(n); value n; integer n; if n > 0 then pick := 'HI' else pick := 'LO'; s := pick(1); if s < 'LO' then result := 42 else result := 0; print(s) end";
 
+const ALGOL_STRING_ARRAY: &str = "begin string array words[1:2]; integer result; words[1] := 'HI'; words[2] := 'LO'; if words[1] < words[2] then result := 42 else result := 0; print(words[1]) end";
+
 fn compile_case(source: &str, module_name: &str) -> interpreter_ir::IIRModule {
     compile_source(source, module_name).expect("ALGOL source should compile")
 }
@@ -218,6 +220,40 @@ fn algol_runtime_string_ordering_lowers_to_wasm_jvm_clr_beam_and_llvm() {
         &iir_to_llvm::IIRLlvmConfig::new("algol_runtime_string_ordering"),
     )
     .expect("runtime string ordering should lower to LLVM");
+    assert!(llvm.contains("@__twig_str_cmp"));
+}
+
+#[test]
+fn algol_string_array_lowers_to_every_standard_backend() {
+    let module = compile_case(ALGOL_STRING_ARRAY, "algol_string_array_backend_compat");
+
+    let wasm = iir_to_wasm::lower_iir_to_wasm(
+        &module,
+        &iir_to_wasm::IIRWasmConfig::new("AlgolStringArray"),
+    )
+    .expect("string array should lower to WASM");
+    assert!(iir_to_wasm::encode_module(&wasm).expect("WASM should encode").starts_with(b"\0asm"));
+
+    let jvm = iir_to_jvm_class_file::lower_iir_to_jvm(
+        &module,
+        &iir_to_jvm_class_file::IIRJvmConfig::new("AlgolStringArray"),
+    )
+    .expect("string array should lower to JVM");
+    assert!(!jvm.methods.is_empty());
+
+    let clr = iir_to_cil_bytecode::emit_il(
+        &module,
+        &iir_to_cil_bytecode::IIRClrConfig::new("AlgolStringArray"),
+    )
+    .expect("string array should emit CLR IL");
+    assert!(clr.contains("newarr [System.Runtime]System.String"));
+
+    let llvm = iir_to_llvm::lower_iir_to_llvm(
+        &module,
+        &iir_to_llvm::IIRLlvmConfig::new("algol_string_array"),
+    )
+    .expect("string array should lower to LLVM");
+    assert!(llvm.contains("store i64"));
     assert!(llvm.contains("@__twig_str_cmp"));
 }
 

--- a/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
@@ -239,3 +239,26 @@ fn algol_runtime_string_ordering_program_runs_through_generic_jit() {
     }
     assert_eq!(result.as_i64(), Some(42));
 }
+
+#[test]
+fn algol_string_array_program_runs_through_generic_jit() {
+    let source = "begin string array words[1:2]; integer result; \
+                  words[1] := 'HI'; words[2] := 'LO'; \
+                  if words[1] < words[2] then result := 42 else result := 0 end";
+    let mut module = compile_source(source, "algol_string_array_jit")
+        .expect("ALGOL string array should compile");
+
+    let mut vm = VMCore::new();
+    let backend = GenericCirJit::new();
+    let error_handle = backend.error_handle();
+    let mut jit = JITCore::new(&mut vm, Box::new(backend));
+    let result = jit
+        .execute_with_jit(&mut vm, &mut module, "main", &[])
+        .expect("JIT execution should succeed")
+        .unwrap_or(Value::Null);
+
+    if let Some(err) = error_handle.lock().unwrap().clone() {
+        panic!("GenericCirJit reported an error: {err}");
+    }
+    assert_eq!(result.as_i64(), Some(42));
+}

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1311,6 +1311,19 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Exit(42),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // ALGOL 60 — string arrays reuse the shared E5 `array<str>` substrate.
+    // The element reads feed runtime lexical ordering before output, proving
+    // arrays carry real string values rather than a literal-only frontend path.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin string array words[1:2]; integer result; \
+                  words[1] := 'HI'; words[2] := 'LO'; \
+                  if words[1] < words[2] then result := 42 else result := 0; \
+                  print(words[1]) end",
+        expect: Expect::Stdout("HI"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // ALGOL 60 — scalar string variables on the direct literal fast path. A
     // `string` scalar assigned from a literal emits `str_const` directly to its
     // slot; the preceding row covers a runtime procedure-result copy, while
@@ -4893,6 +4906,36 @@ fn algol_runtime_string_ordering_runs_on_every_available_standard_backend() {
                 "{backend:?} must preserve the procedure-result string for output"
             );
         }
+    }
+}
+
+#[test]
+fn algol_string_array_runs_on_every_available_standard_backend() {
+    let program = PROGRAMS
+        .iter()
+        .find(|program| {
+            program.lang == Language::Algol60
+                && program.src.contains("string array words")
+                && program.src.contains("words[1] < words[2]")
+        })
+        .expect("the ALGOL string array program must remain in the matrix");
+
+    for backend in [NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit] {
+        let toolchain_available = match backend {
+            NativeAot => cfg!(any(target_os = "linux", target_os = "macos")),
+            Llvm => clang_ok(),
+            Wasm | Vm | Jit => true,
+            Jvm => java_ok(),
+            Clr => dotnet_ok() && clr_support::find_ilasm().is_some(),
+        };
+        let Some(result) = run(backend, program) else {
+            assert!(
+                !toolchain_available,
+                "{backend:?} toolchain is present but string array execution did not complete"
+            );
+            continue;
+        };
+        assert_cell(backend, program, result);
     }
 }
 

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -14,7 +14,7 @@ program per language**, and each frontend is a **deliberate subset**:
 | Brainfuck | 1-loop "print A", nested-loop multiply (`"HA"`), two sequential loops (`"OK"`), stdin echo/transform, and canonical cat all run on all 7 backends | all 8 ops are cross-backend-proven by B1/B1-stdin/B1-eof; no current BF subset gap remains beyond adding more regression programs |
 | Dartmouth BASIC | `PRINT 42`, `PRINT "HELLO"` on all 7 backends, `GOSUB`/`RETURN`, arrays, data, functions, scalar real arithmetic, historical real formatting | literal-backed string variables, literal reassignment, literal `+` concat, variable-backed and chained concat assignment, `PRINT`/`IF` string concat expressions, multi-item string `PRINT` with `;` and `,`, literal-backed scalar string copy, copied-slot string equality, and equality/inequality/lexical-ordering string branches ✅ (BA4/E4); integer-literal `^` ✅ (BA-^); string arrays/input and general runtime-math `^` remain; `FOR`/`NEXT`, `IF`/`GOTO`, `DEF FN` (BA5), `DIM` real arrays incl. multi-dimensional `DIM A(m,n)` (BA3/BA7/BA-DIM-2D), `READ`/`DATA`/`RESTORE` over real data (BA6/BA7), `GOSUB`/`RETURN` (BA1), and BA7 `f64` arithmetic/formatting all run on every backend |
 | Oct | `let`/`if` | rejects **all 10 Intel-8008 intrinsics** (its raison d'être); `&&`/`||` short-circuit ✅ (O1), u8 wrap + `~` ✅ (O2), `static` module globals ✅ (O3), logical `!` ✅ (O-!); intrinsics remain |
-| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures (including `real procedure` returning f64) ✅ (AL13, all 7 backends), switches, 1-D arrays ✅, N-dimensional integer & real arrays ✅ (AL-multidim / AL-multidim-real, all 7 backends), `own` static-lifetime variables ✅ (AL6, all 7 backends), `abs`/`sign`/`entier`/`sqrt`/`sin`/`cos`/`ln`/`exp`/`arctan` standard functions ✅ (AL8 + E8, all 7 backends), `↑` exponentiation ✅ (AL-pow, all 7 backends), string I/O plus initialized scalar locals carrying string-procedure results through runtime equality and lexical ordering ✅ (AL4/E4d-AL; also executed on BEAM's ASCII character-list subset); no call-by-name, captured/`own` strings, or string arrays |
+| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures (including `real procedure` returning f64) ✅ (AL13, all 7 backends), switches, 1-D arrays ✅, N-dimensional integer & real arrays ✅ (AL-multidim / AL-multidim-real, all 7 backends), `string array` ✅ (E4d-AL, all 7 standard backends), `own` static-lifetime variables ✅ (AL6, all 7 backends), `abs`/`sign`/`entier`/`sqrt`/`sin`/`cos`/`ln`/`exp`/`arctan` standard functions ✅ (AL8 + E8, all 7 backends), `↑` exponentiation ✅ (AL-pow, all 7 backends), string I/O plus initialized scalar locals carrying string-procedure results through runtime equality and lexical ordering ✅ (AL4/E4d-AL; also executed on BEAM's ASCII character-list subset); no call-by-name or captured/`own` strings |
 
 **Goal of this campaign:** make every language a *full* implementation —
 every construct in its grammar lowered to the shared IIR, running correctly on
@@ -721,7 +721,9 @@ backend immediately) come before the enabler-dependent items.
   Runtime string procedure results can now be copied into initialized scalar
   locals, compared for equality or lexical ordering, and printed across the
   standard seven backends; the same program is executed on BEAM using
-  printable-ASCII character lists. `own`/captured strings, string arrays, and
+  printable-ASCII character lists. `string array A[1:2]` now reuses the E5
+  `array<str>` substrate on all seven standard backends: literal elements can
+  be read for lexical ordering and output. `own`/captured strings and
   Unicode-aware BEAM strings remain.
 - ✅ **AL5** — switches (computed goto) + conditional designational expressions.
   `switch s := a1,a2,a3; … goto s[3]` ⇒ exit 49, **verified by running** across


### PR DESCRIPTION
## Summary
- Enable ALGOL string arrays through the shared array<str> substrate.
- Support literal and initialized scalar string writes, element ordering, and output.
- Add compiler, AOT, backend, JIT, and standard-backend execution coverage.

## Validation
- Passed algol-iir-compiler all-target tests.
- Passed the focused all-standard-backends LANG matrix execution test.
- Passed strict Clippy and security review.

## Known Baseline
- The full LANG matrix remains blocked by the documented unrelated JVM/Twig null-list case.