### PR TITLE
feat(adj-lang): structural grounding gate — a shipped argument must be sourced (ADR-3)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.30.0] — 2026-07-30 — ADR-3: argument grounding gate — an un-sourced argument won't compile
+
+Picks up adj-lang 0.67's structural grounding gate. New e2e (`argument_surface_e2e.rs`, now 6):
+an un-sourced premise and an un-warranted inference are each named `ArgMissingProvenance` compile
+errors, while the sourced axle argument still derives its cited thesis. Byte-neutral to
+`--json`/golden (the gate only rejects; a valid argument is unchanged).
+
 ## [0.29.0] — 2026-07-30 — ADR-2: `argument` derives + cites its thesis end-to-end
 
 Picks up the new `argument` surface (adj-lang 0.66): a multi-step argument now compiles, and the

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/tests/argument_surface_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/argument_surface_e2e.rs
@@ -114,3 +114,38 @@ fn two_elements_sharing_a_name_is_a_compile_error() {
         "a duplicated element name must be a named compile error:\n{out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// ADR-3 — the structural grounding gate: a shipped argument must be SOURCED.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_unsourced_premise_is_a_compile_error() {
+    // A premise with no `source` cite is un-grounded — it names bytes it never quotes.
+    // The grounding gate (§3) rejects it, the same "must be sourced" lint table/
+    // statemachine/formula enforce; it is the precondition for the ADR-4 byte-anchor.
+    let src = "argument u {\n\
+        premise p1 : extracted a(x)\n\
+    }\n\
+    ? a(x)\n";
+    let (_ok, out) = run(src, "unsourced_prem");
+    assert!(
+        out.contains("ArgMissingProvenance") && out.contains("p1"),
+        "an un-sourced premise must be a named compile error:\n{out}"
+    );
+}
+
+#[test]
+fn an_unwarranted_inference_is_a_compile_error() {
+    // An inference with no `source` carries no WARRANT — an un-grounded reasoning step.
+    let src = "argument u {\n\
+        premise p1 : extracted a(x) source \"a\" trust authoritative\n\
+        infer s1 : because conclude c(x) from p1\n\
+    }\n\
+    ? c(x)\n";
+    let (_ok, out) = run(src, "unwarranted");
+    assert!(
+        out.contains("ArgMissingProvenance") && out.contains("s1"),
+        "an un-warranted inference must be a named compile error:\n{out}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.67.0] — 2026-07-30 — ADR-3: structural grounding gate for `argument` (must be sourced)
+
+The first, deterministic layer of the ADJ-ARGUMENT-IR §3 grounding gate: a shipped `argument`
+must be **sourced**. Every premise must cite the bytes it is read from, and every inference must
+cite its warrant — an un-cited element is now a clean `LowerError::ArgMissingProvenance` (argument
++ element name), the same "must be sourced" lint `table`/`statemachine`/`formula` already enforce.
+
+This is the precondition for the deterministic byte-ANCHOR (is that cite a verbatim slice of the
+pinned source?), which is delivered by the ADR-4 `adj-verify` argument pass reusing the existing
+`verify_quote`/`SnapshotStore` machinery; the *semantic* combined-bytes justification (ADJ61/62)
+and underdetermination (ADJ64) are model-in-the-loop layers that sit above the deterministic CLI.
+
 ## [0.66.0] — 2026-07-30 — ADR-2: the `argument` surface (ADJ-ARGUMENT-IR)
 
 Adds the `argument { premise… infer… }` construct — a byte-grounded argument graph that

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.66.0"
+version = "0.67.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -367,6 +367,16 @@ pub enum LowerError {
         argument: String,
         name: String,
     },
+    /// An `argument` element (a premise or an inference) carried no `source` — the
+    /// structural grounding gate (ADJ-ARGUMENT-IR §3, ADR-3). A shipped argument must be
+    /// *sourced*: every premise cites the bytes it is read from, and every inference cites
+    /// its warrant. This mirrors the "must be sourced" lint `table`/`statemachine`/
+    /// `formula` enforce, and is the precondition for the ADR-4 byte-anchor re-check.
+    /// Carries the argument name and the un-sourced element's name.
+    ArgMissingProvenance {
+        argument: String,
+        element: String,
+    },
 }
 
 /// One lowered RANGE / BRACKET lookup (ADJ-TABLES RS-5c) — the validated,
@@ -1101,6 +1111,19 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                         });
                     }
                     let prov = annotations_to_provenance(&p.annotations)?;
+                    // Structural grounding gate (ADJ-ARGUMENT-IR §3, ADR-3): a shipped
+                    // argument must be *sourced* — every premise cites the bytes it is
+                    // read from, the same "must be sourced" lint `table`/`statemachine`/
+                    // `formula` enforce. The deterministic byte-ANCHOR (is that cite a
+                    // verbatim slice of the pinned source?) is delivered by the ADR-4
+                    // `adj-verify` argument pass, which reuses `verify_quote`; this lint is
+                    // its precondition — an un-cited premise cannot even be anchored.
+                    if prov.source.trim().is_empty() {
+                        return Err(LowerError::ArgMissingProvenance {
+                            argument: name.clone(),
+                            element: p.name.clone(),
+                        });
+                    }
                     kb.add_fact(Fact::certain(lower_term(&p.claim)).with_provenance(prov));
                     bound.insert(p.name.as_str(), &p.claim);
                 }
@@ -1128,6 +1151,16 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                         body_lits.push(BodyLiteral::Pos(lower_term_scoped(ref_term, &mut vars)));
                     }
                     let prov = annotations_to_provenance(&inf.annotations)?;
+                    // Same structural grounding gate for the inference's WARRANT (§3): an
+                    // inference step must cite why its antecedents entail its conclusion —
+                    // an un-warranted step is exactly the un-grounded reasoning move this
+                    // gate exists to reject.
+                    if prov.source.trim().is_empty() {
+                        return Err(LowerError::ArgMissingProvenance {
+                            argument: name.clone(),
+                            element: inf.name.clone(),
+                        });
+                    }
                     kb.add_rule(Rule::certain(head_term, body_lits).with_provenance(prov));
                     bound.insert(inf.name.as_str(), &inf.conclusion);
                 }

--- a/code/specs/ADJ-ARGUMENT-IR.md
+++ b/code/specs/ADJ-ARGUMENT-IR.md
@@ -126,6 +126,17 @@ is the ADJ61/62/64 stack, applied **per premise and per inference-connective**:
    an `imported` premise, of the cited source's snapshot). Fabricated citations are rejected
    before any semantic check. Coverage of `D` is tiled and checked (ADJ25 flat-coverage), so the
    decomposition cannot *silently drop* an argumentative move.
+
+   > **Staging (settled ADR-3/ADR-4).** This deterministic layer splits in two. (a) The
+   > **structural** precondition — *a shipped argument must be sourced: every premise carries a
+   > `source` cite and every inference a warrant* — is enforced at lowering as
+   > `LowerError::ArgMissingProvenance` ✅ **shipped (ADR-3**, adj-lang 0.67), the same "must be
+   > sourced" lint `table`/`statemachine`/`formula` use. (b) The **byte-anchor itself** — *is that
+   > cite a verbatim slice of the pinned source at the recorded offset?* — is delivered by the
+   > **ADR-4 `adj-verify` argument pass**, which reuses the existing `logic_engine::verify_quote` /
+   > `SnapshotStore` machinery `adj-verify` already runs over every fact's provenance (so it is not
+   > re-implemented here). An un-sourced element cannot even be anchored, so (a) is (b)'s
+   > precondition.
 2. **Justification (semantic, adversarial).** For each `extracted` premise the cited bytes must
    *state* it (strict); for each `inference` the antecedents' bytes **combined with** the
    connective bytes must *warrant* the consequent (hedged). An independent adversary, blind to the
@@ -225,9 +236,14 @@ grounding payload the §3 gate checks. Final syntax fixed in ADR-2.
   precedence wiring, §2.2) to keep ADR-2 to the support spine. Rendering the argument chain in
   `--explain` (an *SLD* proof chain, distinct from the differential/compute trace `--explain` renders
   today) lands with ADR-4's `adj-verify` argument pass.
-- **ADR-3 — the open-vocab grounding gate over the argument:** per-premise byte-anchor +
-  combined-justification, adversarial reader, decision-sensitivity, applied to a lowered argument
-  program; the gate's verdict (grounded / determined / underdetermined) emitted in the JSON.
+- **ADR-3 — the grounding gate (structural layer)** ✅ **shipped** (adj-lang 0.67): a shipped
+  argument must be *sourced* — every premise cites its bytes, every inference its warrant — enforced
+  as `LowerError::ArgMissingProvenance`. This is the deterministic precondition (§3.1a). The
+  remaining layers of the gate are staged onto where their machinery already lives: the **byte-anchor**
+  (verbatim-slice check) rides **ADR-4**'s `adj-verify` pass (`verify_quote`); the **semantic**
+  combined-bytes justification (ADJ61/62), decision-sensitivity, and underdetermination (ADJ64) are
+  **model-in-the-loop** layers (the `justify_gate.py` / `underdetermination.py` path) that sit
+  *above* the deterministic CLI — not re-implemented inside it.
 - **ADR-4 — `adj-verify` argument pass:** the §4 re-checks (warrant re-refutation + re-derivation
   + attack-set stability) folded into `adj-verify`, with a tampered-warrant e2e that fails hard.
 - **ADR-5 — worked research-paper decomposition end-to-end:** a real (open-access) paragraph →


### PR DESCRIPTION
## ADJ-ARGUMENT-IR ADR-3 — the grounding gate (deterministic structural layer)

The first, deterministic layer of the §3 grounding gate: **a shipped `argument` must be sourced.** Every premise must cite the bytes it is read from, and every inference must cite its warrant — an un-cited element is now `LowerError::ArgMissingProvenance` (argument + element name), the same "must be sourced" lint `table`/`statemachine`/`formula` already enforce. An un-sourced premise (or un-warranted inference) that silently compiled before now fails cleanly.

### Why this is the right ADR-3 slice
Scouting the existing gate machinery settled the design (spec §3/§7 synced):
- The **byte-anchor** itself — *is that cite a verbatim slice of the pinned source at the recorded offset?* — is already a mature primitive (`logic_engine::verify_quote` over a content-hashed `SnapshotStore`) that `adj-verify` runs over every fact's provenance. So it rides **ADR-4**'s adj-verify argument pass, **not re-implemented** here.
- The **semantic** combined-bytes justification (ADJ61/62), decision-sensitivity, and underdetermination (ADJ64) are **model-in-the-loop** layers (`justify_gate.py`/`underdetermination.py`) that sit *above* the deterministic CLI.
- What was genuinely missing and deterministic: the **structural** precondition — no un-cited element ships. An un-sourced element can't even be anchored, so this is the byte-anchor's precondition.

### Change
- `lower.rs`: two `prov.source.trim().is_empty()` guards in the `Statement::Argument` arm (premise + inference), inserted after `annotations_to_provenance` and before the KB mutation; new `ArgMissingProvenance` LowerError.
- **/security-review PASSED**: purely additive (rejects more, loosens nothing), no panic, no bypass of the kind/reference/dup checks, no new output injection.
- e2e (`argument_surface_e2e.rs`, now 6): an un-sourced premise and an un-warranted inference are each named compile errors; the sourced axle argument still derives its cited thesis.
- Byte-neutral to `--json`/golden (the gate only rejects; golden 38 hold). clippy `-D warnings` clean; adj-lang lib 177.

adj-lang 0.66→0.67, adj-lang-cli 0.29→0.30; both CHANGELOGs + spec §3/§7 synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)