### PR TITLE
feat(parity): define OCaml emerging-lane contract

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,18 +8,13 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "item_id": "haskell-scaffold-capability-schema",
-    "pr_number": 9308,
-    "branch": "codex/haskell-scaffold-capability-schema",
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9308"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "8517e41b1c06fbb453c66b62c87c8b08135838f3",
+    "revision": "3b025282ee7000cda3478de51abac9b01ec7a5ff",
     "schema_version": 2,
     "established_languages": 15,
-    "implementation_identities": 1195,
-    "implementation_package_slots": 4337,
+    "implementation_identities": 1196,
+    "implementation_package_slots": 4338,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 277,
     "canonical_collisions": 0,
@@ -331,11 +326,11 @@
     {
       "id": "ocaml-lane-contract",
       "title": "Define OCaml emerging-lane and denominator-safe reporter contracts",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-contract"],
-      "branch": null,
+      "branch": "codex/ocaml-lane-contract",
       "pr_number": null,
-      "notes": "OCaml remains outside the established denominator until all promotion gates pass."
+      "notes": "Selected after merged PR #9308 and the collision-checked 3b025282e inventory because this focused contract makes the reporter denominator-safe, classifies OCaml without changing the established 15-language denominator, and unlocks every later OCaml scaffold, resolver, representative-package, capability, build-tool, and promotion tranche."
     },
     {
       "id": "ocaml-infrastructure",
@@ -430,11 +425,11 @@
     {
       "id": "haskell-scaffold-capability-schema",
       "title": "Repair Haskell scaffold capability manifests and legacy package metadata",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["haskell-http1"],
       "branch": "codex/haskell-scaffold-capability-schema",
       "pr_number": 9308,
-      "notes": "PR #9308 repairs the Go, TypeScript, and native Haskell scaffold paths; adds two language-neutral golden fixtures and a Draft 2020-12 CI contract test; backfills all ten invalid Haskell manifests; and records follow-up policy, convention, schema, hardening, and singleton-classification work. Local validation: Go tests/vet/build with 66.7% coverage; native Haskell 9/9 Hspec examples with coverage and -Wall plus real generated library/program builds; TypeScript build and 121/121 tests with 83.97% statement coverage and zero npm-audit findings; 8/8 pure backfill package tests; 16 manifests and 2 fixtures schema-valid with Ruff/Bandit clean; affected build-tool dry-run for 42 packages; parity report 1,195 identities / 4,337 slots / 277 high-consensus gaps / zero collisions or unknown buckets; clean diff; and independent final audits. The nonempty Conduit profiles remain proposed metadata and require Layer 5 review before merge or publish."
+      "notes": "Merged PR #9308 repairs the Go, TypeScript, and native Haskell scaffold paths; adds two language-neutral golden fixtures and a Draft 2020-12 CI contract test; backfills all ten invalid Haskell manifests; and records follow-up policy, convention, schema, hardening, and singleton-classification work. Local validation: Go tests/vet/build with 66.7% coverage; native Haskell 9/9 Hspec examples with coverage and -Wall plus real generated library/program builds; TypeScript build and 121/121 tests with 83.97% statement coverage and zero npm-audit findings; 8/8 pure backfill package tests; 16 manifests and 2 fixtures schema-valid with Ruff/Bandit clean; affected build-tool dry-run for 42 packages; parity report 1,195 identities / 4,337 slots / 277 high-consensus gaps / zero collisions or unknown buckets; clean diff; and independent final audits. GitHub recorded no review decision before merge; Layer 5 approval evidence for the nonempty Conduit profiles remains tracked by haskell-capability-policy-audit before publish or consumer use."
     },
     {
       "id": "haskell-capability-policy-audit",
@@ -524,7 +519,16 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, and smart-home-zwave-host. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, and Z-Wave serial-host packages as likely native/service/storage applicability cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port."
+      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, and smart-home-mqtt-integration. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, and MQTT integration packages as native/service/storage applicability cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core."
+    },
+    {
+      "id": "smart-home-mqtt-integration-security-hardening",
+      "title": "Declare MQTT host capabilities and replace ambient credentials with Vault leases",
+      "status": "pending",
+      "depends_on": ["rust-singletons-20260730-classification"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the 3b025282e post-merge singleton audit. The Rust MQTT integration owns live network, environment, clock, console, credential, and runtime-mutation behavior but has no required_capabilities.json, and its CLI reads MQTT username/password directly from ambient environment variables despite D23's Vault-lease rule. Add truthful reviewed capability metadata, Vault-mediated credential delivery, redacted error paths, and focused integration tests before treating the native-source classification as complete."
     },
     {
       "id": "c-cpp-graduation",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "ocaml-lane-contract",
+    "pr_number": 9323,
+    "branch": "codex/ocaml-lane-contract",
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9323"
+  },
   "last_inventory": {
     "revision": "0f8bb3b2519ed73fc932a5291b510433e8a71480",
     "schema_version": 3,
@@ -326,11 +331,11 @@
     {
       "id": "ocaml-lane-contract",
       "title": "Define OCaml emerging-lane and denominator-safe reporter contracts",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-contract"],
       "branch": "codex/ocaml-lane-contract",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9308 and refreshed against the collision-checked 0f8bb3b25 inventory because this focused contract makes the reporter denominator-safe, classifies OCaml without changing the established 15-language denominator, and unlocks every later OCaml scaffold, resolver, representative-package, capability, build-tool, and promotion tranche."
+      "pr_number": 9323,
+      "notes": "Selected after merged PR #9308 and refreshed against the collision-checked 0f8bb3b25 inventory because this focused contract makes the reporter denominator-safe, classifies OCaml without changing the established 15-language denominator, and unlocks every later OCaml scaffold, resolver, representative-package, capability, build-tool, and promotion tranche. Ready-for-review PR #9323 opened after the 177-test scripts suite, 10 focused reporter tests, 5 dependent learning-report tests, 86% reporter branch coverage, Ruff, Go test/vet/build-tool build, all-format collision checks, diff checks, baseline-comparison BUILD validation, secret scan, and independent final security review."
     },
     {
       "id": "ocaml-infrastructure",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -10,11 +10,11 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "3b025282ee7000cda3478de51abac9b01ec7a5ff",
-    "schema_version": 2,
+    "revision": "0f8bb3b2519ed73fc932a5291b510433e8a71480",
+    "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1196,
-    "implementation_package_slots": 4338,
+    "implementation_identities": 1197,
+    "implementation_package_slots": 4339,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 277,
     "canonical_collisions": 0,
@@ -330,7 +330,7 @@
       "depends_on": ["build-tool-contract"],
       "branch": "codex/ocaml-lane-contract",
       "pr_number": null,
-      "notes": "Selected after merged PR #9308 and the collision-checked 3b025282e inventory because this focused contract makes the reporter denominator-safe, classifies OCaml without changing the established 15-language denominator, and unlocks every later OCaml scaffold, resolver, representative-package, capability, build-tool, and promotion tranche."
+      "notes": "Selected after merged PR #9308 and refreshed against the collision-checked 0f8bb3b25 inventory because this focused contract makes the reporter denominator-safe, classifies OCaml without changing the established 15-language denominator, and unlocks every later OCaml scaffold, resolver, representative-package, capability, build-tool, and promotion tranche."
     },
     {
       "id": "ocaml-infrastructure",
@@ -510,7 +510,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 550, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 552, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -519,7 +519,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, and smart-home-mqtt-integration. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, and MQTT integration packages as native/service/storage applicability cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core."
+      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, and smart-home-zigbee-integration. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, and Zigbee adapter packages as native/service/storage boundary cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary."
     },
     {
       "id": "smart-home-mqtt-integration-security-hardening",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Made the package-parity reporter derive its high-consensus completion-band
   upper bound and Markdown missing-slot heading from the established-language
   count instead of embedding `15`.
+- Advanced the package-parity JSON output to schema version 3 for its explicit
+  denominator and ordered completion-band metadata, and documented the CSV
+  presence matrix as header-addressed when emerging buckets add columns.
 - Added reporter conformance coverage proving OCaml packages are inventoried
   without creating unknown buckets, established identities, completion-band
   entries, or missing slots.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — OCaml Emerging-Lane Contract
+- Added OCAML01 to define OCaml as a known emerging implementation lane that
+  remains outside the established 15-language parity denominator until its
+  package, build, security, documentation, and three-platform promotion gates
+  pass.
+- Made the package-parity reporter derive its high-consensus completion-band
+  upper bound and Markdown missing-slot heading from the established-language
+  count instead of embedding `15`.
+- Added reporter conformance coverage proving OCaml packages are inventoried
+  without creating unknown buckets, established identities, completion-band
+  entries, or missing slots.
+
 ### Added — Learning Coverage Backfill
 - Added a generated inventory that maps all 1,155 package concepts to dedicated,
   related, index-only, or missing learning material and prioritizes the backlog

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ decoders, barcodes, and strict bounds-checked binary parsing.
 The C and C++ lanes compile pure-ISO ports under GCC, Clang, Apple Clang, and
 MSVC with strict conformance flags. See the
 [C/C++ multi-compiler lane](./code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md).
+OCaml is a known emerging implementation lane governed by
+[OCAML01](./code/specs/OCAML01-emerging-lane-contract.md); its packages remain
+outside the established parity denominator until the scaffold, resolver,
+capability, build-tool, package, and three-platform promotion gates pass.
 
 ### Documents, graphics, and UI compilation
 
@@ -258,10 +262,11 @@ See [Engram](./code/specs/engram-app.md) and the
 \-- lessons.md        accumulated engineering failures and durable fixes
 ```
 
-Package implementations currently span C, C++, C#, Dart, Elixir, F#, Go,
-Haskell, Java, Kotlin, Lua, Perl, Python, Ruby, Rust, Swift, TypeScript, and
-WebAssembly. Mosaic and Twig are domain-language buckets; Starlark is used for
-build configuration rather than as an implementation ecosystem.
+Package inventory buckets currently recognize C, C++, C#, Dart, Elixir, F#,
+Go, Haskell, Java, Kotlin, Lua, OCaml, Perl, Python, Ruby, Rust, Swift,
+TypeScript, and WebAssembly. C, C++, and OCaml are emerging rather than
+established parity lanes. Mosaic and Twig are domain-language buckets; Starlark
+is used for build configuration rather than as an implementation ecosystem.
 
 ## Build System
 
@@ -341,6 +346,10 @@ python code/scripts/learning_coverage_report.py --output code/learning/COVERAGE.
 # Test the build tool itself.
 cd code/programs/go/build-tool && go test ./...
 ```
+
+The parity report distinguishes established implementation lanes from emerging
+ones. Emerging OCaml packages are visible in JSON, Markdown, and CSV output but
+do not create missing slots until the explicit promotion contract is completed.
 
 ## CI and Quality Gates
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ OCaml is a known emerging implementation lane governed by
 [OCAML01](./code/specs/OCAML01-emerging-lane-contract.md); its packages remain
 outside the established parity denominator until the scaffold, resolver,
 capability, build-tool, package, and three-platform promotion gates pass.
+The parity report's JSON schema is version 3, and CSV consumers must select
+presence columns by header name because recognized emerging lanes extend the
+matrix.
 
 ### Documents, graphics, and UI compilation
 

--- a/code/scripts/package_parity_report.py
+++ b/code/scripts/package_parity_report.py
@@ -249,9 +249,9 @@ def completion_band(
 ) -> str:
     """Classify breadth without embedding the current denominator in the label."""
 
-    if not 0 <= language_count <= established_language_count:
+    if not 1 <= language_count <= established_language_count:
         raise ValueError(
-            "language count must be between zero and the established denominator"
+            "language count must be between one and the established denominator"
         )
     if language_count >= HIGH_CONSENSUS_MIN_LANGUAGES:
         return completion_band_labels(established_language_count)[0]
@@ -370,7 +370,7 @@ def build_report(
     }
 
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "bucket_classes": {key: list(value) for key, value in BUCKET_CLASSES.items()},
         "package_count": {
             "established_languages": established_language_count,

--- a/code/scripts/package_parity_report.py
+++ b/code/scripts/package_parity_report.py
@@ -43,13 +43,30 @@ IMPLEMENTATION_LANGUAGES = (
 
 BUCKET_CLASSES = {
     "implementation": IMPLEMENTATION_LANGUAGES,
-    "emerging_implementation": ("c", "cpp"),
+    "emerging_implementation": ("c", "cpp", "ocaml"),
     "execution_target": ("wasm",),
     "domain_language": ("mosaic", "twig"),
     "build_language": ("starlark",),
 }
 
-ALL_BUCKETS = tuple(bucket for buckets in BUCKET_CLASSES.values() for bucket in buckets)
+
+def classified_buckets(
+    bucket_classes: Mapping[str, Sequence[str]],
+) -> tuple[str, ...]:
+    """Flatten disjoint bucket classes and reject an ambiguous lane state."""
+
+    buckets = tuple(
+        bucket for class_buckets in bucket_classes.values() for bucket in class_buckets
+    )
+    duplicates = sorted(bucket for bucket in set(buckets) if buckets.count(bucket) > 1)
+    if duplicates:
+        raise ValueError(
+            "package buckets must belong to exactly one class: " + ", ".join(duplicates)
+        )
+    return buckets
+
+
+ALL_BUCKETS = classified_buckets(BUCKET_CLASSES)
 
 DISPLAY_PRIORITY = (
     "rust",
@@ -67,6 +84,7 @@ DISPLAY_PRIORITY = (
     "perl",
     "dart",
     "swift",
+    "ocaml",
     "cpp",
     "c",
     "wasm",
@@ -209,9 +227,34 @@ def display_names(
     return sorted(preferred_display_name(identity, packages) for identity in identities)
 
 
-def completion_band(language_count: int) -> str:
-    if language_count >= 10:
-        return "10-15"
+def completion_band_labels(established_language_count: int) -> tuple[str, ...]:
+    """Return breadth labels derived from the established denominator."""
+
+    if established_language_count < HIGH_CONSENSUS_MIN_LANGUAGES:
+        raise ValueError(
+            "established language count cannot be smaller than "
+            f"the {HIGH_CONSENSUS_MIN_LANGUAGES}-language consensus floor"
+        )
+    return (
+        f"{HIGH_CONSENSUS_MIN_LANGUAGES}-{established_language_count}",
+        "5-9",
+        "2-4",
+        "1",
+    )
+
+
+def completion_band(
+    language_count: int,
+    established_language_count: int = len(IMPLEMENTATION_LANGUAGES),
+) -> str:
+    """Classify breadth without embedding the current denominator in the label."""
+
+    if not 0 <= language_count <= established_language_count:
+        raise ValueError(
+            "language count must be between zero and the established denominator"
+        )
+    if language_count >= HIGH_CONSENSUS_MIN_LANGUAGES:
+        return completion_band_labels(established_language_count)[0]
     if language_count >= 5:
         return "5-9"
     if language_count >= 2:
@@ -223,6 +266,8 @@ def build_report(
     packages: dict[str, dict[str, set[str]]], unknown_buckets: set[str]
 ) -> dict[str, Any]:
     sets = identity_sets(packages)
+    established_language_count = len(IMPLEMENTATION_LANGUAGES)
+    band_order = completion_band_labels(established_language_count)
     implementation_union: set[str] = set().union(
         *(sets[language] for language in IMPLEMENTATION_LANGUAGES)
     )
@@ -310,15 +355,12 @@ def build_report(
                 )
 
     breadth: dict[str, dict[str, int]] = {
-        "10-15": {"packages": 0, "missing_slots": 0},
-        "5-9": {"packages": 0, "missing_slots": 0},
-        "2-4": {"packages": 0, "missing_slots": 0},
-        "1": {"packages": 0, "missing_slots": 0},
+        band: {"packages": 0, "missing_slots": 0} for band in band_order
     }
     for language_count in implementation_frequency.values():
-        band = completion_band(language_count)
+        band = completion_band(language_count, established_language_count)
         breadth[band]["packages"] += 1
-        breadth[band]["missing_slots"] += len(IMPLEMENTATION_LANGUAGES) - language_count
+        breadth[band]["missing_slots"] += established_language_count - language_count
 
     singleton_by_language = {
         language: sum(
@@ -331,6 +373,7 @@ def build_report(
         "schema_version": 2,
         "bucket_classes": {key: list(value) for key, value in BUCKET_CLASSES.items()},
         "package_count": {
+            "established_languages": established_language_count,
             "all_reported_union": len(all_reported_union),
             "implementation_union": len(implementation_union),
             "implementation_directories": sum(
@@ -362,6 +405,7 @@ def build_report(
             packages,
         ),
         "singleton_by_language": singleton_by_language,
+        "completion_band_order": list(band_order),
         "completion_bands": breadth,
         "coverage": coverage,
         "package_frequency": package_frequency,
@@ -383,6 +427,7 @@ def build_report(
 
 def render_markdown(report: Mapping[str, Any]) -> str:
     counts = report["package_count"]
+    established_language_count = counts["established_languages"]
     lines = [
         "# Package Parity Report",
         "",
@@ -393,7 +438,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         "",
         "| Baseline | Count |",
         "|---|---:|",
-        f"| Established implementation languages | {len(IMPLEMENTATION_LANGUAGES)} |",
+        f"| Established implementation languages | {established_language_count} |",
         f"| Implementation package directories | {counts['implementation_directories']} |",
         f"| Distinct implementation package identities | {counts['implementation_union']} |",
         f"| Packages present in at least {HIGH_CONSENSUS_MIN_LANGUAGES} languages | {counts['high_consensus']} |",
@@ -418,11 +463,14 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             "",
             "## Completion Bands",
             "",
-            "| Present In | Packages | Missing Slots To All 15 |",
+            (
+                f"| Present In | Packages | Missing Slots To All "
+                f"{established_language_count} |"
+            ),
             "|---|---:|---:|",
         ]
     )
-    for band in ("10-15", "5-9", "2-4", "1"):
+    for band in report["completion_band_order"]:
         row = report["completion_bands"][band]
         language_label = "language" if band == "1" else "languages"
         lines.append(

--- a/code/scripts/tests/test_package_parity_report.py
+++ b/code/scripts/tests/test_package_parity_report.py
@@ -56,13 +56,17 @@ class PackageInventoryTests(unittest.TestCase):
             package_path("ruby", "b_tree"),
             package_path("rust", "b-tree"),
             package_path("python", "b-tree"),
+            package_path("mystery", "b-tree"),
         ]
         packages, unknown = parity.parse_package_paths(paths)
         report = parity.build_report(packages, unknown)
+        markdown = parity.render_markdown(report)
 
         self.assertEqual(len(report["collisions"]), 1)
         self.assertEqual(report["collisions"][0]["language"], "ruby")
         self.assertEqual(report["collisions"][0]["directories"], ["b-tree", "b_tree"])
+        self.assertIn("`ruby/b-tree`: `b-tree`, `b_tree`", markdown)
+        self.assertIn("Unclassified package buckets: `mystery`", markdown)
 
     def test_report_builds_completion_bands_and_gap_lists(self) -> None:
         paths: list[str] = []
@@ -93,6 +97,77 @@ class PackageInventoryTests(unittest.TestCase):
         self.assertEqual(report["singleton_by_language"]["rust"], 1)
         self.assertEqual(report["singleton_by_language"]["python"], 1)
 
+    def test_ocaml_is_known_but_excluded_from_established_denominator(self) -> None:
+        paths = [
+            package_path(language, "universal")
+            for language in parity.IMPLEMENTATION_LANGUAGES
+        ]
+        paths.extend(
+            [
+                package_path("ocaml", "universal"),
+                package_path("ocaml", "ocaml-only"),
+            ]
+        )
+
+        packages, unknown = parity.parse_package_paths(paths)
+        report = parity.build_report(packages, unknown)
+        by_package = {row["package"]: row for row in report["package_frequency"]}
+        ocaml_summary = next(
+            row for row in report["special_buckets"] if row["language"] == "ocaml"
+        )
+
+        self.assertEqual(unknown, set())
+        self.assertIn("ocaml", report["bucket_classes"]["emerging_implementation"])
+        self.assertEqual(report["package_count"]["established_languages"], 15)
+        self.assertEqual(report["package_count"]["implementation_union"], 1)
+        self.assertEqual(
+            report["package_count"]["implementation_package_slots"],
+            len(parity.IMPLEMENTATION_LANGUAGES),
+        )
+        self.assertEqual(report["completion_bands"]["10-15"]["packages"], 1)
+        self.assertEqual(report["completion_bands"]["10-15"]["missing_slots"], 0)
+        self.assertEqual(by_package["universal"]["language_count"], 15)
+        self.assertIn("ocaml", by_package["universal"]["languages"])
+        self.assertEqual(by_package["ocaml-only"]["language_count"], 0)
+        self.assertEqual(by_package["ocaml-only"]["implementation_languages"], [])
+        self.assertEqual(ocaml_summary["class"], "emerging_implementation")
+        self.assertEqual(ocaml_summary["present"], 2)
+
+    def test_completion_band_tracks_the_established_denominator(self) -> None:
+        self.assertEqual(parity.completion_band_labels(15)[0], "10-15")
+        self.assertEqual(parity.completion_band_labels(16)[0], "10-16")
+        self.assertEqual(parity.completion_band(16, 16), "10-16")
+        self.assertEqual(parity.completion_band(9, 16), "5-9")
+        self.assertEqual(parity.completion_band(4, 16), "2-4")
+        self.assertEqual(parity.completion_band(1, 16), "1")
+        with self.assertRaises(ValueError):
+            parity.completion_band_labels(9)
+        with self.assertRaises(ValueError):
+            parity.completion_band(17, 16)
+
+    def test_bucket_classes_are_disjoint(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exactly one class: ocaml"):
+            parity.classified_buckets(
+                {
+                    "implementation": ("ocaml",),
+                    "emerging_implementation": ("ocaml",),
+                }
+            )
+
+    def test_markdown_uses_reported_denominator_and_band_order(self) -> None:
+        paths = [
+            package_path(language, "universal")
+            for language in parity.IMPLEMENTATION_LANGUAGES
+        ]
+        packages, unknown = parity.parse_package_paths(paths)
+        report = parity.build_report(packages, unknown)
+
+        markdown = parity.render_markdown(report)
+
+        self.assertIn("| Established implementation languages | 15 |", markdown)
+        self.assertIn("| Present In | Packages | Missing Slots To All 15 |", markdown)
+        self.assertIn("| 10-15 languages | 1 | 0 |", markdown)
+
     def test_csv_is_a_complete_presence_matrix(self) -> None:
         packages, unknown = parity.parse_package_paths(
             [
@@ -110,6 +185,7 @@ class PackageInventoryTests(unittest.TestCase):
         self.assertEqual(by_package["heap"]["python"], "1")
         self.assertEqual(by_package["heap"]["dart"], "0")
         self.assertEqual(by_package["builtins"]["starlark"], "1")
+        self.assertEqual(by_package["builtins"]["ocaml"], "0")
 
 
 if __name__ == "__main__":

--- a/code/scripts/tests/test_package_parity_report.py
+++ b/code/scripts/tests/test_package_parity_report.py
@@ -117,6 +117,7 @@ class PackageInventoryTests(unittest.TestCase):
         )
 
         self.assertEqual(unknown, set())
+        self.assertEqual(report["schema_version"], 3)
         self.assertIn("ocaml", report["bucket_classes"]["emerging_implementation"])
         self.assertEqual(report["package_count"]["established_languages"], 15)
         self.assertEqual(report["package_count"]["implementation_union"], 1)
@@ -126,12 +127,28 @@ class PackageInventoryTests(unittest.TestCase):
         )
         self.assertEqual(report["completion_bands"]["10-15"]["packages"], 1)
         self.assertEqual(report["completion_bands"]["10-15"]["missing_slots"], 0)
+        self.assertEqual(report["completion_bands"]["5-9"]["packages"], 0)
+        self.assertEqual(report["completion_bands"]["2-4"]["packages"], 0)
+        self.assertEqual(report["completion_bands"]["1"]["packages"], 0)
+        self.assertEqual(
+            sum(band["packages"] for band in report["completion_bands"].values()),
+            report["package_count"]["implementation_union"],
+        )
         self.assertEqual(by_package["universal"]["language_count"], 15)
         self.assertIn("ocaml", by_package["universal"]["languages"])
         self.assertEqual(by_package["ocaml-only"]["language_count"], 0)
         self.assertEqual(by_package["ocaml-only"]["implementation_languages"], [])
         self.assertEqual(ocaml_summary["class"], "emerging_implementation")
         self.assertEqual(ocaml_summary["present"], 2)
+        markdown = parity.render_markdown(report)
+        self.assertIn("| ocaml | emerging_implementation | 2 |", markdown)
+
+        csv_rows = {
+            row["package"]: row
+            for row in csv.DictReader(io.StringIO(parity.render_csv(report)))
+        }
+        self.assertEqual(csv_rows["universal"]["ocaml"], "1")
+        self.assertEqual(csv_rows["ocaml-only"]["ocaml"], "1")
 
     def test_completion_band_tracks_the_established_denominator(self) -> None:
         self.assertEqual(parity.completion_band_labels(15)[0], "10-15")
@@ -144,6 +161,8 @@ class PackageInventoryTests(unittest.TestCase):
             parity.completion_band_labels(9)
         with self.assertRaises(ValueError):
             parity.completion_band(17, 16)
+        with self.assertRaises(ValueError):
+            parity.completion_band(0, 16)
 
     def test_bucket_classes_are_disjoint(self) -> None:
         with self.assertRaisesRegex(ValueError, "exactly one class: ocaml"):
@@ -177,8 +196,10 @@ class PackageInventoryTests(unittest.TestCase):
             ]
         )
         report = parity.build_report(packages, unknown)
-        rows = list(csv.DictReader(io.StringIO(parity.render_csv(report))))
+        reader = csv.DictReader(io.StringIO(parity.render_csv(report)))
+        rows = list(reader)
 
+        self.assertEqual(reader.fieldnames, ["package", *parity.ALL_BUCKETS])
         self.assertEqual(len(rows), 2)
         by_package = {row["package"]: row for row in rows}
         self.assertEqual(by_package["heap"]["rust"], "1")

--- a/code/specs/OCAML01-emerging-lane-contract.md
+++ b/code/specs/OCAML01-emerging-lane-contract.md
@@ -49,6 +49,15 @@ The package-parity reporter MUST:
 An OCaml-only package therefore has an implementation `language_count` of zero
 while its complete `languages` list contains `ocaml`. A package present in all
 15 established lanes remains complete even when an OCaml directory exists.
+The JSON additions are report schema version 3; consumers must not treat the
+earlier version 2 shape as interchangeable. The CSV matrix remains
+self-describing through its header, and adding a recognized bucket appends that
+bucket's column in bucket-class declaration order. Consumers must select CSV
+columns by header name rather than fixed position.
+
+Only packages present in at least one established lane belong to a completion
+band. The band-classification helper rejects a zero established-language count
+instead of silently treating an emerging-only package as a singleton.
 
 ## Promotion boundary
 

--- a/code/specs/OCAML01-emerging-lane-contract.md
+++ b/code/specs/OCAML01-emerging-lane-contract.md
@@ -1,0 +1,79 @@
+# OCAML01 — Emerging implementation lane contract
+
+Status: in progress
+
+## Purpose
+
+OCaml is the repository's next implementation lane, but an empty directory or
+one experimental package must not silently turn every existing portable package
+into a new missing slot. This contract introduces OCaml as an explicitly known
+`emerging_implementation` bucket while preserving the established
+15-language denominator until the promotion gates in the package-parity roadmap
+are reviewed and satisfied.
+
+This tranche owns only classification and reporter behavior. Scaffolds, package
+metadata, dependency resolution, capability analysis, CI toolchains,
+representative packages, a native build tool, and denominator promotion remain
+separate dependency-shaped items.
+
+## Lane states
+
+An implementation lane has exactly one of these parity states:
+
+| State | Reporter class | Counts toward portable parity |
+|---|---|---|
+| Established | `implementation` | Yes |
+| Emerging | `emerging_implementation` | No |
+| Promoted | moved atomically from emerging to established | Yes |
+
+OCaml begins in the emerging state alongside C and C++. Its packages are
+inventory evidence, not denominator evidence.
+
+## Reporter invariants
+
+The package-parity reporter MUST:
+
+1. recognize `code/packages/ocaml/<package>/...` as a known bucket;
+2. include OCaml in `bucket_classes.emerging_implementation`, the special-bucket
+   summary, package presence rows, and the CSV matrix;
+3. exclude OCaml packages from the established implementation union, per-lane
+   coverage, high-consensus counts, singleton counts, completion bands, and
+   missing-slot totals;
+4. keep the established denominator explicit in report metadata;
+5. derive the upper bound of the high-consensus completion band from the
+   established-language count instead of embedding `15` in report logic or
+   Markdown; and
+6. continue to fail on genuinely unknown package buckets and within-bucket
+   canonical identity collisions.
+
+An OCaml-only package therefore has an implementation `language_count` of zero
+while its complete `languages` list contains `ocaml`. A package present in all
+15 established lanes remains complete even when an OCaml directory exists.
+
+## Promotion boundary
+
+Promotion is a reviewed, atomic contract change. It must:
+
+- satisfy every package, build, security, documentation, and three-platform CI
+  gate in the roadmap;
+- move `ocaml` from `emerging_implementation` to `implementation`;
+- update the established-language count from 15 to 16;
+- cause the reporter's top completion band to become `10-16`;
+- recompute all missing slots and the portable backlog; and
+- classify every new 16-lane gap or reviewed exception before completion is
+  claimed.
+
+No scaffold, package, resolver, analyzer, build-tool, or CI change may promote
+the lane implicitly.
+
+## Conformance cases
+
+Reporter tests MUST cover:
+
+- an OCaml package is classified and never reported as unknown;
+- an OCaml-only identity does not enter established counts or completion bands;
+- adding an OCaml copy of an established package does not change its established
+  `language_count` or missing slots;
+- Markdown names the actual established denominator; and
+- the completion-band helper produces `10-16` when evaluated against a
+  hypothetical 16-language established denominator.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -52,8 +52,9 @@ multiple directories for the same identity.
 
 ### Separately classified lanes
 
-- C++ is an emerging implementation lane. It needs package/scaffold maturity
-  before it can join the all-language completion denominator.
+- C, C++, and OCaml are emerging implementation lanes. They need their
+  respective package, scaffold, build, security, and CI maturity gates before
+  they can join the all-language completion denominator.
 - WASM is an execution-target lane, not a requirement for every source package.
 - Mosaic and Twig are domain/source-language lanes.
 - Starlark is a build/configuration lane.
@@ -105,13 +106,10 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 30, 2026 at `8517e41b1` after the Haskell
-`barcode-1d` and `http-core` ports, the Go/Rust `multi-directed-graph` slice,
-the Linux OCI preflight and external-authority contracts, and a new wave of
-Rust-only package families. The latest refresh includes the merged Haskell
-`http1` port and adds the Rust-only `smart-home-zwave-integration` and
-`smart-home-zwave-host` identities after `smart-home-automation-runtime`,
-`venture-browser-macos`, and the earlier smart-home additions. It found zero
+inventory was regenerated on July 30, 2026 at `3b025282e` after the merged
+Haskell `http1` and scaffold-capability tranches plus a new wave of Rust-only
+package families. The refresh adds `smart-home-mqtt-integration` after the
+Z-Wave host/integration and earlier smart-home additions. It found zero
 canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -119,9 +117,9 @@ canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 277 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 745 | 10,430 |
+| Present in one language | 746 | 10,444 |
 
-The loop must not start by attempting 10,430 singleton ports. It should finish
+The loop must not start by attempting 10,444 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The July 30 lane audit is:
@@ -140,7 +138,7 @@ The July 30 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 960 | 0 | 100% |
+| Rust | 961 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -846,19 +844,22 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 550 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 551 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30 inventories added ten Rust singleton identities that now have
+The July 30 inventories added eleven Rust singleton identities that now have
 explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
 `venture-browser-core` needs a portable-core versus native-boundary review.
 `smart-home-discovery-service`, `hue-integration`, and
 `smart-home-runtime-store`, `smart-home-automation-runtime`,
-`smart-home-zwave-integration`, and the newly merged
-`smart-home-zwave-host` serial host are likely native/service/storage
-applicability cases. `venture-browser-macos` is an Apple-native
+`smart-home-zwave-integration`, the newly merged `smart-home-zwave-host` serial
+host, and `smart-home-mqtt-integration` are native/service/storage applicability
+cases. The MQTT host also needs explicit capability metadata and Vault-mediated
+credentials before that classification is complete; its deterministic
+discovery/topic/entity/value/payload transforms are candidates for a separately
+fixture-driven portable core. `venture-browser-macos` is an Apple-native
 AppKit/CoreText/Metal host whose expected classification is `native-source`,
 not a blind 14-lane port.
 
@@ -1104,6 +1105,12 @@ OCaml begins as an `emerging_implementation` lane. It must not silently change
 the current 15-language denominator until its package, build, security, and CI
 substrate is real. Use OCaml 5.2.1, opam 2.5.x, Dune 3.16.x, Alcotest,
 `bisect_ppx`, and `ocamlformat`.
+
+The selected post-#9308 tranche is `ocaml-lane-contract`. OCAML01 classifies
+OCaml as a known emerging bucket, keeps it outside established coverage and
+missing-slot calculations, and derives the reporter's upper completion-band
+bound from the established-language count. This is the denominator-safe
+prerequisite for every remaining bootstrap step.
 
 Bootstrap order:
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,10 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 30, 2026 at `3b025282e` after the merged
+inventory was regenerated on July 30, 2026 at `0f8bb3b25` after the merged
 Haskell `http1` and scaffold-capability tranches plus a new wave of Rust-only
-package families. The refresh adds `smart-home-mqtt-integration` after the
-Z-Wave host/integration and earlier smart-home additions. It found zero
+package families. The refresh adds `smart-home-zigbee-integration` after
+`smart-home-mqtt-integration`, the Z-Wave host/integration, and earlier
+smart-home additions. It found zero
 canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -117,9 +118,9 @@ canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 277 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 746 | 10,444 |
+| Present in one language | 747 | 10,458 |
 
-The loop must not start by attempting 10,444 singleton ports. It should finish
+The loop must not start by attempting 10,458 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The July 30 lane audit is:
@@ -138,7 +139,7 @@ The July 30 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 961 | 0 | 100% |
+| Rust | 962 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -844,10 +845,10 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 551 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 552 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30 inventories added eleven Rust singleton identities that now have
+The July 30 inventories added twelve Rust singleton identities that now have
 explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
@@ -855,9 +856,12 @@ protocol core separated from native transport behavior; and
 `smart-home-discovery-service`, `hue-integration`, and
 `smart-home-runtime-store`, `smart-home-automation-runtime`,
 `smart-home-zwave-integration`, the newly merged `smart-home-zwave-host` serial
-host, and `smart-home-mqtt-integration` are native/service/storage applicability
-cases. The MQTT host also needs explicit capability metadata and Vault-mediated
-credentials before that classification is complete; its deterministic
+host, `smart-home-mqtt-integration`, and `smart-home-zigbee-integration` are
+native/service/storage-boundary applicability cases. The Zigbee adapter is pure
+logic above coordinator transport and carries only an opaque `VaultRef`, so its
+likely portable adapter core should be separated conceptually from a future
+native coordinator host. The MQTT host also needs explicit capability metadata
+and Vault-mediated credentials before that classification is complete; its deterministic
 discovery/topic/entity/value/payload transforms are candidates for a separately
 fixture-driven portable core. `venture-browser-macos` is an Apple-native
 AppKit/CoreText/Metal host whose expected classification is `native-source`,


### PR DESCRIPTION
## Summary

- define OCaml as a recognized `emerging_implementation` lane without adding it to the established 15-language parity denominator
- make completion-band labels and Markdown missing-slot headings derive from the established-language count
- advance the JSON report contract to schema version 3 and document header-addressed CSV evolution
- add cross-format tests proving OCaml-only packages are inventoried but excluded from established coverage, singleton, band, and missing-slot calculations
- refresh the collision-checked inventory, roadmap, and durable loop state on `origin/main` `0f8bb3b25`, including the new Rust Zigbee singleton

## Why

OCaml needs a first-class scaffold, resolver, capability analyzer, build tool, representative packages, and three-platform CI before it can safely join the all-language denominator. Without an explicit emerging state, the first OCaml directory would either be reported as unknown or could prematurely create a new parity denominator.

This contract establishes the fail-closed promotion boundary and removes the reporter's hard-coded upper denominator before OCaml package work begins.

## Validation

- `python code/scripts/tests/test_package_parity_report.py` — 10 passed
- `python code/scripts/tests/test_learning_coverage_report.py` — 5 passed
- `python -m unittest discover -s code/scripts/tests -p "test_*.py"` — 177 passed, 20 skipped
- branch coverage for `package_parity_report.py` — 86%
- Ruff selected lint rules and formatter check — passed
- package-parity JSON, Markdown, and CSV generation with `--fail-on-collisions` — passed
- live inventory — schema 3, 15 established lanes, 1,197 identities, 4,339 slots, 0 collisions, 0 unknown buckets
- learning coverage regeneration — passed
- Go build-tool `go test ./...`, `go vet ./...`, and local build — passed
- diff-aware build-tool dry run — no package source changes to build
- strict BUILD metadata validation reproduced the same 73 pre-existing findings on the branch and `origin/main`; this source-only reporter change adds none
- `git diff --check` and state JSON parse — passed
- Bandit — 0 high, 0 medium, 3 unchanged low findings also present on `origin/main`
- diff secret scan — 0 findings
- independent final security review — no actionable findings