### PR TITLE
content: Malayalam + Tamil TIME/GREETING arcs — completes all 6 languages (continuing from #9310)

### DIFF
--- a/code/learning/human-languages/malayalam/lessons/ML-C27-vaikunneram.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C27-vaikunneram.md
@@ -1,0 +1,68 @@
+---
+id: ML-C27-vaikunneram
+chapter: 27
+type: word
+headword: വൈകുന്നേരം
+gloss: "evening" (vaikunnēraṁ) — native Dravidian compound, Wiktionary-glossed "latening time," from വൈക് (vaikŭ, plausibly the root of വൈകുക, "to get late" — a reasonable inference, not something Wiktionary's compound entry states outright) + -ഉം (-uṁ) + നേരം (nēraṁ, "time," itself native Dravidian, not Sanskrit); Wiktionary itself ALSO lists "afternoon" as a second sense, though phrasebook sources cleanly split evening (this word) from afternoon (a separate compound built on ഉച്ച, ML-C17's "noon," plus കഴിഞ്ഞ്) — an honest source-tension worth flagging, not smoothing over
+concept_tag: TIME-EVENING
+prerequisites: [ML-C17-ucha-paathira]
+sounds: [malayalam-vowel-sign-ai, malayalam-conjunct-nn]
+roots: [dravidian-vaikuka-late, dravidian-neram-time]
+etymology_hook: "വൈകുന്നേരം (vaikunnēraṁ, 'evening') is, per Wiktionary, a compound of വൈക് (vaikŭ) + -ഉം (-uṁ) + നേരം (nēraṁ, 'time') — literally 'latening time'; നേരം is itself confirmed native Proto-Dravidian (*nēram, cognate Tamil நேரம்), not a Sanskrit borrowing, so this whole compound is native Dravidian start to finish; the വൈക് root is a reasonable morphological link to the everyday verb വൈകുക (vaikuka), confirmed 'to get late' on its own separate Wiktionary page (the compound's own page doesn't state the verb link explicitly, so treat that specific connection as the author's own inference, not a directly Wiktionary-sourced one); be honest about a real source tension: Wiktionary's own entry lists BOTH 'afternoon' and 'evening' as senses of this single word, but two independently-fetched phrasebook sources (ling-app.com, talkpal.ai) cleanly separate the two — evening = വൈകുന്നേരം, afternoon = a distinct compound built on ഉച്ച (ML-C17's 'noon') + കഴിഞ്ഞ് (kazhinju, 'passed, gone by') — don't smooth over this tension by picking whichever source is convenient; note it as a genuine open question about how cleanly the afternoon/evening boundary is drawn in practice"
+est_minutes: 6
+reviews_of: [ML-C17-ucha-paathira]
+---
+
+# വൈകുന്നേരം (vaikunnēraṁ) — "evening," built from a verb meaning "to get late"
+
+## Warm-up
+
+[PAUSE 2s] Telugu reached for Sanskrit to name the evening. Malayalam's
+most common word takes a completely different route — an everyday
+verb, not a borrowed noun.
+
+## വൈകുന്നേരം — literally, "latening time"
+
+**വൈകുന്നേരം** (**vaikunnēraṁ**) — "**evening**" — is, per
+Wiktionary, a compound: **വൈക്** (*vaikŭ*) + **-ഉം** (*-uṁ*) +
+**നേരം** (*nēraṁ*, "**time**"), literally "**latening time**."
+**നേരം** is itself confirmed native **Proto-Dravidian** (cognate
+Tamil நேரம்), not a Sanskrit borrowing — so unlike Telugu's Sanskrit
+**సాయంత్రం**, this whole compound is native Dravidian, start to finish.
+The **വൈക്** root plausibly connects to an everyday Malayalam verb,
+**വൈകുക** (*vaikuka*), confirmed "**to get late**" — though be
+honest that this specific link is the author's own reasonable
+inference, not something Wiktionary's compound entry states outright.
+
+## Be honest: the sources genuinely disagree on the boundary
+
+Here's a real tension, not smoothed over: Wiktionary's own entry lists
+**both** "afternoon" **and** "evening" as senses of this single word.
+But two independently-fetched phrasebook sources (ling-app.com,
+talkpal.ai) draw a cleaner line — **evening** is
+**വൈകുന്നേരം**, while **afternoon** gets its own, separate compound
+built on **ഉച്ച** (already met, Chapter 17, "noon") plus **കഴിഞ്ഞ്**
+(*kazhinju*, "passed, gone by"). This project's discipline is to flag
+genuine disagreement rather than quietly pick whichever source is more
+convenient — so treat the afternoon/evening boundary here as **genuinely
+blurry** in the dictionary sense, even though the two everyday
+phrasebook sources agree on a cleaner practical split.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vaikunnēraṁ" — "evening," literally "latening time"]
+- [YOU SAY: the everyday verb root — vaikuka, "to get late"]
+- [YOU SAY: the honest tension — Wiktionary blurs afternoon/evening;
+  phrasebooks split them cleanly]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does വൈകുന്നേരം literally mean, and what verb is it
+plausibly built from? (**"Latening time"** — from **വൈകുക**, "to get
+late.") Do all sources agree on where "afternoon" ends and "evening"
+begins for this word? (**No** — Wiktionary lists it as covering both
+senses; phrasebook sources instead draw a clean line, treating afternoon
+as a separate compound.) Is വൈകുന്നേരം a Sanskrit borrowing, like
+Telugu's సాయంత్రం? (**No** — it's a native Dravidian compound,
+built from an everyday verb and a native "time" word, നേരം.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C28-uchakazhinju.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C28-uchakazhinju.md
@@ -1,0 +1,72 @@
+---
+id: ML-C28-uchakazhinju
+chapter: 28
+type: phrase
+headword: ഉച്ചകഴിഞ്ഞ്
+gloss: "afternoon" (uchakaḻiññ) — a transparent two-word phrase, not a single dictionary headword: ഉച്ച (ML-C17's "noon") + കഴിഞ്ഞ്, the past converb form of കഴിയുക (kaḻiyuka, Wiktionary-confirmed Proto-Dravidian *kaẓi, "to be over, spent") — Wiktionary itself directly shows only the finite past tense കഴിഞ്ഞു (kaḻiññu); the converb form used in this compound is a reasonable grammatical inference, not itself the form Wiktionary lists; literally "noon having passed" — a structurally different strategy than Telugu's TE-C28, where the SAME noon-word (మధ్యాహ్నం) simply widened its own meaning rather than compounding with a second word
+concept_tag: TIME-AFTERNOON
+prerequisites: [ML-C17-ucha-paathira, ML-C27-vaikunneram]
+sounds: [malayalam-geminate-cha, malayalam-zha]
+roots: [sanskrit-ucca-high, proto-dravidian-kazi-spent]
+etymology_hook: "ഉച്ചകഴിഞ്ഞ് (uchakaḻiññ, 'afternoon') is a transparent two-word phrase, not a single lexicalized dictionary entry (no Wiktionary page exists for the compound itself) — ഉച്ച (already met, ML-C17, 'noon,' likely from Sanskrit ucca 'high') plus കഴിഞ്ഞ്, the past converb form ('having passed') of കഴിയുക (kaḻiyuka), itself Wiktionary-confirmed as inherited from Proto-Dravidian *kaẓi ('to be over, spent, finished') — note that Wiktionary's own conjugation line shows only the finite past tense കഴിഞ്ഞു (kaḻiññu), not this converb form directly; the converb is the grammatically correct choice for chaining into a compound like this one, but treat the specific written form as the author's own grammatical inference, not a directly Wiktionary-sourced citation; so this phrase literally means 'noon having passed/elapsed' — a transparent, compositional way of naming the afternoon, genuinely different in STRATEGY from Telugu's TE-C28, where the exact same noon-word (మధ్యాహ్నం) simply widened its own meaning to also cover 'afternoon' rather than reaching for a second word; Malayalam instead keeps 'noon' unwidened and builds a new phrase on top of it"
+est_minutes: 6
+reviews_of: [ML-C17-ucha-paathira, ML-C27-vaikunneram]
+---
+
+# ഉച്ചകഴിഞ്ഞ് (uchakaḻiññ) — "noon, having passed"
+
+## Warm-up
+
+[PAUSE 2s] Telugu let its noon-word quietly widen to also mean
+"afternoon." Malayalam solves the same problem with a completely
+different strategy: it builds a new phrase instead.
+
+## ഉച്ചകഴിഞ്ഞ് — literally, "noon having passed"
+
+**ഉച്ചകഴിഞ്ഞ്** (**uchakaḻiññ**) — "**afternoon**" — is a
+transparent **two-word phrase**, not a single dictionary headword (no
+Wiktionary entry exists for the compound as a whole). It's built from
+**ഉച്ച** (already met, Chapter 17, "**noon**") plus **കഴിഞ്ഞ്**,
+the **past converb form** of **കഴിയുക** (*kaḻiyuka*), itself
+Wiktionary-confirmed **Proto-Dravidian** ***\*kaẓi***
+("**to be over, spent, finished**"). Be honest about the citation:
+Wiktionary's own conjugation line shows only the finite past tense,
+**കഴിഞ്ഞു** (*kaḻiññu*) — not this converb form directly. The
+converb is the grammatically correct choice for chaining into a
+compound like this one, but treat the exact written form as a
+reasonable grammatical inference, not a directly Wiktionary-sourced
+citation. Put together: "**noon having
+passed**" — afternoon is, quite literally, the time after noon is
+done.
+
+## A genuinely different strategy than Telugu's
+
+Here's the honest structural contrast: Telugu's own afternoon word
+(TE-C28, **మధ్యాహ్నం**) is the exact **same word** as its
+"noon," simply **widened** to also cover "afternoon" — one word,
+stretched. Malayalam does something structurally different: **ഉച്ച**
+itself stays put, meaning only "noon," and a **second word** —
+കഴിഞ്ഞ്, "passed" — gets bolted on to build a new phrase for
+"afternoon." Same problem (naming the stretch of time after noon),
+two genuinely different solutions: semantic widening in Telugu,
+compositional phrase-building in Malayalam.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "uchakaḻiññ" — "afternoon," literally "noon having passed"]
+- [YOU SAY: the verb behind it — kaḻiyuka, "to be over, spent" —
+  Proto-Dravidian *kaẓi]
+- [YOU SAY: the honest contrast — Telugu widens the same noon-word;
+  Malayalam builds a new phrase on top of it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does ഉച്ചകഴിഞ്ഞ് literally mean? (**"Noon having
+passed"** — ഉച്ച, "noon," plus the past tense of **കഴിയുക**,
+"to be over, spent.") Is ഉച്ചകഴിഞ്ഞ് a single dictionary word, like
+ഉച്ച itself? (**No** — it's a transparent two-word phrase; no
+Wiktionary entry exists for the compound as a whole.) How does
+Malayalam's strategy for naming "afternoon" differ from Telugu's?
+(**Telugu widens its existing noon-word's meaning; Malayalam instead
+builds a new phrase, keeping the noon-word unchanged.**)

--- a/code/learning/human-languages/malayalam/lessons/ML-C29-suprabhaatham.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C29-suprabhaatham.md
@@ -1,0 +1,75 @@
+---
+id: ML-C29-suprabhaatham
+chapter: 29
+type: phrase
+headword: സുപ്രഭാതം
+gloss: "good morning" (suprabhātaṁ) — Malayalam's actual, most common morning greeting, confirmed used in BOTH formal and informal contexts, and independently corroborated as the "most general" morning greeting by a SECOND directly-fetched source (not just one); built from su- ("good") + പ്രഭാതം (already met, ML-C26, "morning/dawn"), NOT from ശുഭ (ML-C25's "auspicious," used for Malayalam's own GREETING-GOODNIGHT) — a genuinely different Sanskrit "good" morpheme; the SAME word as Telugu's సుప్రభాతం (TE-C29), but with an inverted role: PRIMARY greeting in Malayalam, only a SECONDARY alternative in Telugu (where శుభోదయం, a different root, is primary)
+concept_tag: GREETING-MORNING
+prerequisites: [ML-C26-raavile]
+sounds: [malayalam-conjunct-pra, malayalam-anusvara]
+roots: [sanskrit-su-good, sanskrit-prabhata-shine]
+etymology_hook: "സുപ്രഭാതം (suprabhātaṁ, 'good morning') is Malayalam's actual, most common morning greeting — confirmed via two independently-fetched sources: talkpal.ai states it is 'used in both formal and informal situations,' and ling-app.com separately, without prompting, calls it 'the most general greeting' for good morning — genuine two-source corroboration, a stronger evidentiary footing than a single directly-fetched source alone (a distinction this arc has learned to care about, per TE-C29's own 'fetched directly is not the same as authoritative' finding); it's built from the Sanskrit prefix su- ('good') plus പ്രഭാതം (already met, ML-C26, as an alternative Malayalam word for 'morning'), NOT from ശുഭ (ML-C25's 'auspicious,' the word Malayalam's own GREETING-GOODNIGHT is built on) — a genuinely different Sanskrit 'good' morpheme, a bound prefix rather than a standalone adjective; be honest about a striking cross-language structural inversion: this is the exact SAME Sanskrit tatsama word as Telugu's own సుప్రభాతం (TE-C29) — but the two languages give it OPPOSITE roles: it's Malayalam's PRIMARY, most-used morning greeting, while in Telugu it's only a SECONDARY alternative to శుభోదయం (built on a completely different root, udaya, not ప్రభాత/prabhāta)"
+est_minutes: 6
+reviews_of: [ML-C26-raavile]
+---
+
+# സുപ്രഭാതം (suprabhātaṁ) — Malayalam's real "good morning," a familiar word wearing a new hat
+
+## Warm-up
+
+[PAUSE 2s] You might expect Malayalam's "good morning" to pair ML-C25's
+"auspicious" word with ML-C26's morning word. It doesn't — Malayalam
+reaches for a completely different Sanskrit "good," and for a word
+you've technically already half-met.
+
+## സുപ്രഭാതം — not built on ശുഭ at all
+
+**സുപ്രഭാതം** (**suprabhātaṁ**) — "**good morning**" — is
+Malayalam's actual, most common morning greeting: two independently-fetched
+sources confirm it: one states it's used in **both formal and
+informal** contexts, the second separately calls it "the most general
+greeting" for good morning — genuine corroboration, not a single
+source's claim taken on faith. Here's the honest surprise: it is
+**not**
+built on **ശുഭ** (ML-C25's "auspicious," the word behind
+Malayalam's own "good night") at all. Instead, it's built from the
+Sanskrit **prefix su-** ("good") fused directly onto **പ്രഭാതം**
+— already met, Chapter 26, as an alternative Malayalam word for
+"morning." Two genuinely different Sanskrit "good" morphemes:
+**ശുഭ** is a standalone adjective; **su-** here is a bound prefix
+that only ever attaches to another word.
+
+## A striking structural inversion with Telugu
+
+Here's the honest cross-language twist: **സുപ്രഭാതം** is the
+**exact same Sanskrit tatsama word** as Telugu's own
+**సుప్రభాతం** (TE-C29) — same su- prefix, same
+ప్రభాత/prabhāta root. But the two languages hand it **opposite
+jobs**. In Malayalam, it's the **primary**, most commonly used morning
+greeting. In Telugu, it's only a **secondary** alternative — Telugu's
+primary greeting, **శుభోదయం**, is built on a completely
+different Sanskrit root (*udaya*, "rise," not *prabhāta*). Same
+borrowed word, opposite roles across two closely related languages.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "suprabhātaṁ" — "good morning," su- ("good") + prabhāta
+  ("shine, dawn," ML-C26)]
+- [YOU SAY: the honest surprise — NOT built on śubha; a different
+  Sanskrit "good" morpheme entirely]
+- [YOU SAY: the cross-language inversion — Malayalam's primary
+  greeting is Telugu's secondary alternative]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is സുപ്രഭാതം built on ശുഭ, ML-C25's "auspicious"
+word? (**No** — it's built on the Sanskrit prefix su-, a different
+"good" morpheme, fused onto പ്രഭാതം, ML-C26's alternative
+morning word.) Is സുപ്രഭാതം the primary morning greeting in both
+Malayalam and Telugu? (**No** — it's PRIMARY in Malayalam but only a
+SECONDARY alternative in Telugu, where శుభోదయం — built on a
+different root — is primary.) Is the "used in both formal and informal
+contexts" claim as shaky as Telugu's own morning-greeting claim?
+(**No** — it's confirmed by TWO independently-fetched sources, a
+genuinely stronger evidentiary footing than resting on just one.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C30-shubha-sayaahnam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C30-shubha-sayaahnam.md
@@ -1,0 +1,75 @@
+---
+id: ML-C30-shubha-sayaahnam
+chapter: 30
+type: phrase
+headword: ശുഭ സായാഹ്നം
+gloss: "good evening" (śubha sāyāhnaṁ) — confirmed real, used "from late afternoon until sunset" per a directly-fetched source; built on ശുഭ (ML-C25) + സായാഹ്നം (sāyāhnaṁ), a SEPARATE Sanskrit tatsama for "evening," Wiktionary-labeled "poetic" — NOT built on ML-C27's native വൈകുന്നേരം; സായാഹ്നം's own root, साय ("end"), is CONFIRMED via Wiktionary's separate साय entry to trace to the same PIE *seh₁- as Telugu's TE-C27 సాయంత్రం (sāyam) and Latin sērus — a properly-verified cognate, not just a plausible guess
+concept_tag: GREETING-EVENING
+prerequisites: [ML-C25-shubha-rathri, ML-C27-vaikunneram]
+sounds: [malayalam-vowel-sign-aa, malayalam-conjunct-hna]
+roots: [sanskrit-shubha-beautiful, sanskrit-saya-end]
+etymology_hook: "ശുഭ സായാഹ്നം (śubha sāyāhnaṁ, 'good evening') is confirmed real by a directly-fetched source (preply.com), used 'from late afternoon until sunset' — built on ശുഭ (ML-C25, already verified PIE *ḱewbʰ- root, shared with Hindi/Kannada/Telugu) plus സായാഹ്നം (sāyāhnaṁ, 'evening, eventide'); be honest about a genuine surprise: this is NOT built on ML-C27's native വൈകുന്നേരം at all — സായാഹ്നം is a SEPARATE word, a Sanskrit tatsama that Wiktionary's own part-of-speech label calls 'poetic' (a real, citable register signal, not an unverifiable blog claim, that this greeting likely skews formal/literary); a Sanskrit dictionary page confirms സായാഹ്നം is a karmadhāraya compound of साय ('end') + अह्न ('day'), and Wiktionary's own separate साय entry directly confirms साय traces to PIE *seh₁- ('long, lasting'), explicitly listing सायम् (sāyam, TE-C27's own root), Latin sērus, and Gothic seiþus as cognates — meaning സായാഹ്നം's root and Telugu's TE-C27 సాయంత్రం (built on sāyam) share a genuinely, properly-verified common PIE ancestor, not just a plausible guess; a claim that ordinary Malayalis rarely say this phrase, favoring നമസ്കാരം instead, could NOT be independently verified (the pages making that claim returned 403 errors) — so it is deliberately NOT asserted here, only the Wiktionary 'poetic' register label, which IS independently verifiable"
+est_minutes: 6
+reviews_of: [ML-C25-shubha-rathri, ML-C27-vaikunneram]
+---
+
+# ശുഭ സായാഹ്നം (śubha sāyāhnaṁ) — "good evening," a different evening-word than expected
+
+## Warm-up
+
+[PAUSE 2s] You might expect this greeting to pair śubha with the
+evening-word you already know. It doesn't — Malayalam reaches for a
+completely different word instead, one with a poetic edge.
+
+## ശുഭ സായാഹ്നം — a SEPARATE evening word, not vaikunnēraṁ
+
+**ശുഭ സായാഹ്നം** (**śubha sāyāhnaṁ**) — "**good evening**" —
+is confirmed real by a directly-fetched source, used "**from late
+afternoon until sunset**." It's built from **ശുഭ** (ML-C25,
+"auspicious") plus **സായാഹ്നം** (*sāyāhnaṁ*, "**evening,
+eventide**"). Here's the honest surprise: this is **not** built on
+**വൈകുന്നേരം**, the native word already met in Chapter 27, at all.
+**സായാഹ്നം** is a **completely separate** word — a Sanskrit
+**tatsama**, which Wiktionary's own part-of-speech label calls
+"**poetic**." That's a real, independently-checkable signal (not an
+unverifiable blog claim) that this particular greeting likely leans
+formal or literary, even though the phrase itself is confirmed correct
+and genuinely used.
+
+## A striking, properly-confirmed cross-language echo
+
+**സായാഹ്നം** is, per a Sanskrit dictionary, a compound of **साय**
+("**end**") plus **अह्न** ("**day**") — the same "-ahna" day-part
+suffix already met in words like *madhyāhna* and *aparāhna*. Following
+the etymology one hop further, Wiktionary's own **साय** entry
+explicitly confirms this root traces to **Proto-Indo-European**
+***\*seh₁-*** ("**long, lasting**"), directly naming **सायम्**
+(*sāyam* — Telugu's own TE-C27 root) and **Latin sērus** as cognates.
+So this is a genuinely, properly-verified shared ancestor with
+Telugu's **సాయంత్రం** (TE-C27) — the same striking PIE chain to
+Latin *sērus*, French **soir**, and Italian **sera** — not merely a
+plausible guess, but a confirmed cognate, reached by chaining through
+two Wiktionary pages rather than stopping at the first.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubha sāyāhnaṁ" — "good evening," confirmed real, used
+  from late afternoon until sunset]
+- [YOU SAY: the honest surprise — NOT built on vaikunnēraṁ; a separate,
+  Wiktionary-labeled "poetic" Sanskrit word instead]
+- [YOU SAY: the confirmed echo — sāyāhnaṁ's साय root genuinely shares
+  TE-C27's PIE *seh₁-/Latin sērus connection]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is ശുഭ സായാഹ്നം built on വൈകുന്നേരം, ML-C27's
+native evening word? (**No** — സായാഹ്നം is a completely separate
+Sanskrit tatsama.) What does Wiktionary's own part-of-speech label for
+സായാഹ്നം suggest about its register? (**"Poetic"** — a real,
+checkable signal it likely skews formal or literary.) Is it
+confirmed that സായാഹ്നം shares TE-C27's spectacular PIE root?
+(**Yes** — Wiktionary's separate साय entry directly confirms the same
+PIE *seh₁- ancestry, naming sāyam and Latin sērus as cognates — a
+genuinely verified shared root, reached by following the etymology one
+hop further.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C31-shubha-madhyaahnam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C31-shubha-madhyaahnam.md
@@ -1,0 +1,81 @@
+---
+id: ML-C31-shubha-madhyaahnam
+chapter: 31
+type: phrase
+headword: ശുഭ മധ്യാഹ്നം
+gloss: "good afternoon" (śubha madhyāhnaṁ) — a genuinely formal, "official/ceremonial" greeting per a directly-fetched source; built on ശുഭ (ML-C25) + മധ്യാഹ്നം (madhyāhnaṁ, Wiktionary-confirmed SYNONYM of ML-C17's ഉച്ച, "noon") — NOT on ML-C28's ഉച്ചകഴിഞ്ഞ് compound; a striking 3-way Dravidian convergence: Kannada's ಶುಭ ಮಧ್ಯಾಹ್ನ (KA-C31) and Telugu's శుభ మధ్యాహ్నం (TE-C31) use the EXACT SAME śubha+madhyāhna structure, even though all three languages' own separate TIME-AFTERNOON words diverged
+concept_tag: GREETING-AFTERNOON
+prerequisites: [ML-C17-ucha-paathira, ML-C28-uchakazhinju]
+sounds: [malayalam-conjunct-dhya, malayalam-anusvara]
+roots: [sanskrit-shubha-beautiful, sanskrit-madhya-middle]
+etymology_hook: "ശുഭ മധ്യാഹ്നം (śubha madhyāhnaṁ, 'good afternoon') is confirmed, by a directly-fetched source (talkpal.ai's 'most common greetings in Kerala'), as a genuinely formal greeting, 'mainly used in official or ceremonial settings' and 'not as commonly used in daily conversation' — a real, hedged qualitative finding, NOT the suspiciously precise 'fewer than 1%' statistic a WebSearch summary attached to this claim, which could not be traced to either directly-fetched source and is therefore deliberately excluded as an apparent confabulation; the greeting is built from ശുഭ (ML-C25) plus മധ്യാഹ്നം (madhyāhnaṁ, 'noon'), which Wiktionary confirms as a direct SYNONYM of ML-C17's ഉച്ച — meaning Malayalam has BOTH a 'high/peak' noon-word (ucca, ML-C17's primary) and a 'middle' noon-word (madhya, this lesson's) all along, it simply wasn't the one ML-C17 highlighted; notably, this greeting is NOT built on ML-C28's ഉച്ചകഴിഞ്ഞ് compound (the actual TIME-AFTERNOON phrase already taught) at all; be honest about a striking 3-way Dravidian convergence: Kannada's ಶುಭ ಮಧ್ಯಾಹ್ನ (KA-C31) and Telugu's శుభ మధ్యాహ్నం (TE-C31) use the EXACT SAME śubha+madhyāhna structure for their own afternoon greetings — even though all three languages' separate TIME-AFTERNOON words (this arc's earlier lessons) diverged completely: Telugu confirmed-widened its own madhya-based noon-word directly to also mean 'afternoon'; Kannada instead built a SEPARATE Sanskrit tatsama, ಅಪರಾಹ್ನ (aparāhna, apara+ahna, KA-C28) — not a widening of madhyāhna at all; Malayalam built an unrelated ucca+kazhinju compound — three genuinely different strategies, not two-vs-one — yet the greeting layer converges on the exact same word in all three"
+est_minutes: 6
+reviews_of: [ML-C17-ucha-paathira, ML-C28-uchakazhinju]
+---
+
+# ശുഭ മധ്യാഹ്നം (śubha madhyāhnaṁ) — completing Malayalam's arc, and a 3-way convergence
+
+## Warm-up
+
+[PAUSE 2s] Morning broke the pattern entirely. Evening kept the pattern
+but swapped in an unexpected word. This final greeting brings a
+different kind of surprise: a word you haven't met, that turns out to
+connect Malayalam right back to Kannada and Telugu.
+
+## ശുഭ മധ്യാഹ്നം — a genuine synonym you haven't met yet
+
+**ശുഭ മധ്യാഹ്നം** (**śubha madhyāhnaṁ**) — "**good afternoon**"
+— is confirmed, by a directly-fetched source, as a genuinely **formal**
+greeting: "**mainly used in official or ceremonial settings**" and
+"**not as commonly used in daily conversation**." (A suspiciously
+precise "fewer than 1%" statistic turned up in an initial search
+summary for this claim — but it couldn't be traced to either page
+actually fetched, so it's deliberately left out here as an apparent
+confabulation; the real, hedged qualitative finding stands on its
+own.) It's built from **ശുഭ** (ML-C25) plus **മധ്യാഹ്നം**
+(*madhyāhnaṁ*, "**noon**") — which Wiktionary confirms is a direct
+**synonym** of ML-C17's **ഉച്ച**. Here's the honest surprise:
+Malayalam had this "middle"-based noon-word all along — ML-C17 simply
+didn't highlight it, teaching **ഉച്ച** ("peak, high") instead.
+And this greeting is **not** built on ML-C28's **ഉച്ചകഴിഞ്ഞ്**
+compound (the actual TIME-AFTERNOON phrase already taught) at all.
+
+## A striking 3-way convergence, right where the TIME-words diverged
+
+Here's the honest cross-language payoff: Kannada's own afternoon
+greeting, **ಶುಭ ಮಧ್ಯಾಹ್ನ** (KA-C31), and Telugu's own,
+**శుభ మధ్యాహ్నం** (TE-C31), use the **exact same śubha + madhyāhna**
+structure as this Malayalam greeting. All three Dravidian languages
+converge here — even though, earlier in this very arc, their separate
+TIME-AFTERNOON words **diverged completely** — and in three
+genuinely different directions, not just two-vs-one: **Telugu**
+confirmed-widened its own *madhya*-based noon-word directly to also
+mean "afternoon"; **Kannada** instead built a **separate** Sanskrit
+tatsama, **ಅಪರಾಹ್ನ** (*aparāhna*, "apara" + "ahna," KA-C28) — not
+a widening of *madhyāhna* at all; **Malayalam** built an unrelated
+*ucca* + "passed" compound. Three different everyday-noun strategies —
+yet the formal greeting lands on the exact same word, in all three
+languages.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śubha madhyāhnaṁ" — "good afternoon," a formal,
+  ceremonial-register greeting]
+- [YOU SAY: the honest surprise — madhyāhnaṁ is a genuine synonym of
+  ucca, Malayalam's own "noon" word, just not the one taught first]
+- [YOU SAY: the 3-way convergence — the exact same greeting structure
+  as Kannada and Telugu, even though their TIME-AFTERNOON words differ]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is ശുഭ മധ്യാഹ്നം built on ML-C28's ഉച്ചകഴിഞ്ഞ്?
+(**No** — it's built on മധ്യാഹ്നം, a genuine Wiktionary-confirmed
+synonym of ML-C17's ഉച്ച, not the TIME-AFTERNOON compound.) Is the
+"fewer than 1% use this" statistic something this lesson confirms?
+(**No** — it couldn't be traced to any directly-fetched source and is
+deliberately excluded; only the hedged "formal, not common in daily
+conversation" finding is asserted.) Does Malayalam's afternoon greeting
+match Kannada's and Telugu's own afternoon greetings? (**Yes** — all
+three use the exact same śubha + madhyāhna structure, even though all
+three languages' separate TIME-AFTERNOON words diverged.)

--- a/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
@@ -3,7 +3,7 @@ id: TA-C26-kaalai
 chapter: 26
 type: word
 headword: காலை
-gloss: "morning" (kālai) — Wiktionary itself HEDGES the etymology ("possibly from Sanskrit काल्य/kālya"), not a confirmed Dravidian root; genuinely uncertain, unlike Kannada's confidently-native or Telugu's confidently-Sanskrit morning-words; பகல் (already met, TA-C17, "daytime") is Wiktionary's own listed coordinate term; அதிகாலை ("early dawn") is a transparent ati-+kālai compound
+gloss: morning (kālai) — Wiktionary itself HEDGES the etymology ("possibly from Sanskrit काल्य/kālya"), not a confirmed Dravidian root; genuinely uncertain, unlike Kannada's confidently-native or Telugu's confidently-Sanskrit morning-words; பகல் (already met, TA-C17, "daytime") is Wiktionary's own listed coordinate term; அதிகாலை ("early dawn") is a transparent ati-+kālai compound
 concept_tag: TIME-MORNING
 prerequisites: [TA-C17-nanpakal-nalliravu, TA-C24-iravu]
 sounds: [tamil-vowel-sign-ai, tamil-long-aa]

--- a/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
@@ -1,0 +1,67 @@
+---
+id: TA-C26-kaalai
+chapter: 26
+type: word
+headword: காலை
+gloss: "morning" (kālai) — Wiktionary itself HEDGES the etymology ("possibly from Sanskrit काल्य/kālya"), not a confirmed Dravidian root; genuinely uncertain, unlike Kannada's confidently-native or Telugu's confidently-Sanskrit morning-words; பகல் (already met, TA-C17, "daytime") is Wiktionary's own listed coordinate term; அதிகாலை ("early dawn") is a transparent ati-+kālai compound
+concept_tag: TIME-MORNING
+prerequisites: [TA-C17-nanpakal-nalliravu, TA-C24-iravu]
+sounds: [tamil-vowel-sign-ai, tamil-long-aa]
+roots: [uncertain-etymology, sanskrit-kalya-time-possible]
+etymology_hook: "காலை (kālai, 'morning') has a genuinely UNCERTAIN etymology — Wiktionary itself hedges with 'possibly from Sanskrit काल्य (kālya),' not a confident claim, and separately notes கால் (kāl) has SIX distinct etymologies, one of which ('time,' from Sanskrit काल/kāla) may or may not be what காலை derives from as an accusative-type form; be honest that this is genuinely less settled than Kannada's ಬೆಳಗ್ಗೆ (confidently native) or Telugu's ఉదయం (confidently Sanskrit tatsama) — don't manufacture false confidence where the primary source itself hedges; Wiktionary lists பகல் (already met, TA-C17, 'daytime') as a coordinate term; அதிகாலை ('early dawn') is a transparent compound of ati- ('excessive, very') + kālai, per the Tamil Lexicon (DDSA, University of Madras)"
+est_minutes: 6
+reviews_of: [TA-C17-nanpakal-nalliravu, TA-C24-iravu]
+---
+
+# காலை (kālai) — "morning," an honestly uncertain etymology
+
+## Warm-up
+
+[PAUSE 2s] Every other language in this arc had a confidently-sourced
+story for its "morning" word — Sanskrit, or clearly native. Tamil's
+own word for morning is different: even Wiktionary itself isn't sure
+where it comes from.
+
+## காலை — genuinely uncertain, and worth saying so plainly
+
+**காலை** (**kālai**) — "**morning**" — has an etymology that
+Wiktionary itself only hedges at: "**possibly** from Sanskrit
+**काल्य** (*kālya*)." That's a real hedge from the source itself, not
+one this lesson is adding for caution's sake. Complicating things
+further: the related word **கால்** (*kāl*) carries **six** entirely
+distinct etymologies in Tamil — "leg/foot," "irrigation channel,"
+"forest," "wind," a Sanskrit-derived "time" sense, and a conjunction
+meaning "if, when" — and **காலை** may be an accusative-type form
+built on the "time" sense specifically, or may not be. Be honest: this
+is genuinely **less settled** than Kannada's confidently-native
+morning word or Telugu's confidently-Sanskrit one. Don't manufacture
+certainty the primary source itself doesn't have.
+
+## What IS confirmed: a coordinate term and a transparent compound
+
+Wiktionary does confirm one solid fact: **பகல்** (already met,
+Chapter 17, "**daytime**") is listed as காலை's **coordinate term**
+— the two words sit side by side in the same semantic field, whatever
+காலை's deeper root turns out to be. And **அதிகாலை** ("**early
+dawn**") is confirmed, per the Tamil Lexicon, as a fully transparent
+compound: **ati-** ("excessive, very") + **காலை**, glossed simply
+as "early dawn" by the Tamil Lexicon.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kālai" — "morning," an honestly uncertain etymology]
+- [YOU SAY: the hedge itself — Wiktionary says "possibly" Sanskrit
+  kālya, not a confident claim]
+- [YOU SAY: "atikaalai" — "early dawn," a transparent ati- + kālai
+  compound]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is காலை's etymology as confidently sourced as Kannada's
+or Telugu's morning words? (**No** — Wiktionary itself only says
+"possibly" Sanskrit kālya; genuinely uncertain, not settled.) What
+coordinate term does Wiktionary list alongside காலை? (**பகல்**,
+"daytime," already met in Chapter 17.) What does அதிகாலை literally
+build on? (**ati-** ("very") + **காலை** — a transparent compound
+for "early dawn.")

--- a/code/learning/human-languages/tamil/lessons/TA-C27-maalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C27-maalai.md
@@ -1,0 +1,73 @@
+---
+id: TA-C27-maalai
+chapter: 27
+type: word
+headword: மாலை
+gloss: evening (mālai) — a genuine HOMONYM: Wiktionary lists TWO separate etymologies for this exact spelling — "garland/necklace" (possibly a Dravidian word BORROWED INTO Sanskrit as माला/mālā, a reverse-direction loan) and, unrelated, "evening" (compared to மால், Proto-Dravidian *mā/*māl, whose senses include "கருமை," darkness); confidently native for the evening sense, unlike TA-C26's uncertain காலை, though the exact semantic mechanism ("evening" ← "darkness" specifically) isn't spelled out with full certainty by the source
+concept_tag: TIME-EVENING
+prerequisites: [TA-C26-kaalai]
+sounds: [tamil-vowel-sign-aa, tamil-vowel-sign-ai]
+roots: [proto-dravidian-maal, proto-dravidian-maal-darkness-possible]
+etymology_hook: "மாலை (mālai, 'evening') is a genuine HOMONYM, not one word with two meanings: Wiktionary lists it under TWO entirely separate etymologies. Etymology 1 is 'மாலை' meaning 'garland, wreath, necklace' — traced to Old Tamil, and compared to Sanskrit माला (mālā) with the note 'probably borrowed FROM Dravidian languages' (a reverse-direction loan, Dravidian-into-Sanskrit, a genuine contrast with this project's usual Sanskrit-into-Dravidian pattern). Etymology 2 is the completely separate 'மாலை' meaning 'evening' — also from Old Tamil, but compared instead to மால் (māl), which Wiktionary traces to Proto-Dravidian *mā/*māl and glosses with several senses including 'கருமை' ('blackness, darkness'), plus 'illusion/confusion' and, as a proper noun, the Hindu deity Vishnu; be honest that Wiktionary's etymology for the 'evening' sense only says 'compare māl,' not an explicit 'evening derives specifically from the darkness sense' claim — a natural, plausible connection (evening = growing dark), but not spelled out with full certainty by the source itself; still, this is confidently NATIVE Dravidian vocabulary, a genuine contrast with TA-C26's uncertain காலை"
+est_minutes: 6
+reviews_of: [TA-C26-kaalai]
+---
+
+# மாலை (mālai) — "evening," and a garland that only looks like the same word
+
+## Warm-up
+
+[PAUSE 2s] Last lesson's morning word had an uncertain origin. This
+evening word is different — confidently native — but it comes with
+its own honest twist: it looks exactly like a completely unrelated
+word.
+
+## மாலை — a genuine homonym, not one word wearing two meanings
+
+**மாலை** (**mālai**) — "**evening**" — happens to be spelled
+identically to another, completely **unrelated** Tamil word: **மாலை**
+meaning "**garland, wreath, necklace**." Wiktionary treats these as
+**two separate etymologies**, not one word with two senses. The
+garland sense traces to Old Tamil and is compared to Sanskrit **माला**
+(*mālā*) — with a genuinely interesting note: it's "**probably
+borrowed FROM Dravidian languages**" **into** Sanskrit, not the other
+way around. A rare reverse-direction loan, worth noticing against this
+whole project's usual Sanskrit-into-Dravidian pattern.
+
+## The evening sense — confidently native, plausibly "the dark one"
+
+The **evening** sense of **மாலை** is a **separate** Old Tamil
+word entirely, compared instead to **மால்** (*māl*) — which
+Wiktionary traces to **Proto-Dravidian** ***\*mā/\*māl***, with senses
+including "**கருமை**" ("**blackness, darkness**"), plus archaic
+senses of "illusion, confusion" and, as a proper noun, the Hindu deity
+**Vishnu**. Be honest about the exact mechanism here: Wiktionary's own
+etymology for "evening" only says "**compare māl**" — it does **not**
+explicitly state that "evening" derives specifically from the
+**darkness** sense rather than some other sense of this multi-meaning
+root. The connection (evening = the time it grows dark) is natural and
+plausible, but not nailed down with full certainty by the source
+itself. What IS certain: this is confidently **native** Dravidian
+vocabulary, a genuine contrast with TA-C26's uncertain காலை.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mālai" — "evening," confidently native Dravidian
+  vocabulary]
+- [YOU SAY: the homonym twist — a completely separate word, mālai,
+  means "garland," probably borrowed INTO Sanskrit from Dravidian]
+- [YOU SAY: the honest hedge — "evening" plausibly connects to māl's
+  "darkness" sense, but Wiktionary doesn't spell out that exact link]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are evening-mālai and garland-mālai the same word with two
+meanings? (**No** — Wiktionary treats them as two entirely separate
+etymologies; a genuine homonym, not one word stretched.) Which
+direction did the garland sense's Sanskrit connection likely travel?
+(**Dravidian into Sanskrit** — a reverse-direction loan, per
+Wiktionary's own "probably borrowed from Dravidian languages" note.)
+Is it fully certain that "evening" derives from māl's "darkness" sense
+specifically? (**No** — plausible and natural, but Wiktionary only
+says "compare māl," without spelling out that exact mechanism.)

--- a/code/learning/human-languages/tamil/lessons/TA-C28-pirpakal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C28-pirpakal.md
@@ -1,0 +1,86 @@
+---
+id: TA-C28-pirpakal
+chapter: 28
+type: word
+headword: பிற்பகல்
+gloss: afternoon (piṟpakal) — a transparent compound, பின் (piṉ, "after") + நண்பகல்'s own பகல் ("daytime"), with பின் surfacing as பிற்- before ப, a SIMILAR kind of consonant sandhi to the one already taught in TA-C17 (நள்→நண்) — though Wiktionary itself does not discuss the sandhi mechanism, and the two changes move in different phonetic directions (nasal→stop vs. lateral→nasal), so this is the lesson's own analysis, not a sourced claim; Wiktionary-listed formal register; a real, citable overlap worth flagging honestly: Wiktionary's OWN afternoon-word page ALSO lists நடுப்பகல் as a synonym, even though TA-C17 established நடுப்பகல் as a synonym of NOON specifically; also related but distinct: மதியம், a Sanskrit tatsama (from madhya, "middle") meaning "noon," a synonym of நண்பகல் — NOT specifically "afternoon," despite an unverified WebSearch claim that matiyam "originally meant moon," which does not appear anywhere on its actual Wiktionary page and is therefore not asserted here
+concept_tag: TIME-AFTERNOON
+prerequisites: [TA-C17-nanpakal-nalliravu]
+sounds: [tamil-retroflex-rra, tamil-pulli-virama]
+roots: [tamil-pin-after, sanskrit-madhya-middle]
+etymology_hook: "பிற்பகல் (piṟpakal, 'afternoon') is, per Wiktionary, a transparent compound of பின் (piṉ, 'after') + பகல் (pakal, 'daytime,' already met inside நண்பகல், TA-C17) — with பின் surfacing as பிற்- before the following ப — a similar kind of consonant sandhi to the one already taught in TA-C17 for நள்→நண் before ப, though be honest that Wiktionary's own etymology for பிற்பகல் doesn't discuss the sandhi mechanism at all, and the two changes move in different phonetic directions (nasal→stop here, vs. lateral→nasal there) — this comparison is the lesson's own linguistic observation, not a Wiktionary-sourced equivalence claim; Wiktionary labels பிற்பகல் formal register. Be honest about a genuine citable tension: Wiktionary's OWN பிற்பகல் page lists நடுப்பகல் as ITS synonym too — even though TA-C17 established நடுப்பகல் as a synonym of நண்பகல் specifically (noon, not afternoon); this looks like the same kind of noon/afternoon boundary-blur already seen elsewhere in this arc (Malayalam's TIME-AFTERNOON widening), not a contradiction to paper over. Separately, மதியம் is a Sanskrit tatsama (from madhya, 'middle,' the SAME root Kannada and Telugu both reach for) meaning specifically 'noon,' Wiktionary-listed as a synonym of நண்பகல் — NOT 'afternoon' specifically, despite it being the closest Tamil gets to the madhya-based words seen elsewhere in this arc; an unverified claim (from a search summary, not the actual Wiktionary page) that matiyam 'originally meant moon' is deliberately NOT asserted here, since it doesn't appear on the fetched source at all"
+est_minutes: 6
+reviews_of: [TA-C17-nanpakal-nalliravu]
+---
+
+# பிற்பகல் (piṟpakal) — "afternoon," a similar sandhi trick to நண்பகல்
+
+## Warm-up
+
+[PAUSE 2s] You already met a sandhi-driven surface change in Chapter
+17 — நள் resurfacing as நண். This lesson's afternoon word does a
+similar kind of trick, with a different word — though be honest that
+the two changes aren't identical.
+
+## பிற்பகல் — பின் (after) + பகல் (daytime), a similar sandhi story
+
+**பிற்பகல்** (**piṟpakal**) — "**afternoon**" — is a transparent
+compound: **பின்** (*piṉ*, "**after**") plus **பகல்** (*pakal*,
+"**daytime**," already met inside நண்பகல், TA-C17 — though be aware the பிற்பகல்
+Wiktionary page itself glosses பகல் as "noon" in its own etymology
+line, a small inconsistency across Wiktionary's own entries, not
+something this lesson introduces). Here's the
+familiar pattern: பின் doesn't stay பின் in this compound — it
+surfaces as **பிற்-** before the following ப — a **similar** kind
+of consonant sandhi to the one already taught in Chapter 17, where
+**நள்** became **நண்** before its own following ப. Be honest, though:
+Wiktionary's own etymology for பிற்பகல் doesn't discuss this
+mechanism at all, and the two changes move in different phonetic
+directions (nasal→stop here, lateral→nasal there) — this is the
+lesson's own observation, not a sourced equivalence. Wiktionary labels this word
+**formal register**.
+
+## Be honest: a real, citable overlap with TA-C17's own words
+
+Here's a genuine tension worth flagging, not smoothing over: Wiktionary's
+own பிற்பகல் page lists **நடுப்பகல்** as **its** synonym — but
+TA-C17 established நடுப்பகல் as a synonym of **நண்பகல்**
+specifically, "**noon**," not "afternoon." This looks like the same
+kind of noon/afternoon **boundary blur** already seen elsewhere in this
+arc (Malayalam's own TIME-AFTERNOON widening), not a mistake to paper
+over — dictionaries genuinely don't always draw a hard line here.
+
+## A related but distinct word: matiyam, the closest Tamil gets to madhya
+
+Separately, Tamil also has **மதியம்** — a Sanskrit **tatsama**,
+from **madhya** ("middle"), the **same** root Kannada and Telugu both
+reach for. But be precise: Wiktionary lists மதியம் meaning
+specifically "**noon**," a synonym of நண்பகல் — **not** "afternoon"
+on its own. And be honest about a claim that did NOT check out: an
+initial search summary suggested மதியம் "originally meant moon" —
+but that claim appears **nowhere** on மதியம்'s actual Wiktionary
+page, so it is deliberately **not** asserted here.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "piṟpakal" — "afternoon," piṉ ("after") + pakal
+  ("daytime")]
+- [YOU SAY: the sandhi echo — piṉ surfaces as piṟ-, a similar kind
+  of change to TA-C17's naḷ→naṇ, though not phonetically identical]
+- [YOU SAY: "matiyam" — Sanskrit tatsama for "noon," from madhya,
+  Tamil's closest word to Kannada/Telugu's own noon-words]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does பிற்பகல் literally build from, and what
+sandhi change happens to the first piece? (**பின்** "after" + பகல்
+"daytime" — பின் surfaces as பிற்-, a similar kind of sandhi to
+TA-C17's naḷ→naṇ, though the two changes move in different phonetic
+directions, not identical mechanisms.) Does Wiktionary draw a hard line between நடுப்பகல்'s
+noon-sense and பிற்பகல்'s afternoon-sense? (**No** — நடுப்பகல்
+is listed as a synonym of BOTH, a real boundary-blur, not a mistake.)
+Is மதியம் confirmed to have originally meant "moon"? (**No** —
+that claim doesn't appear on its actual Wiktionary page; only its
+Sanskrit madhya ("middle") etymology and "noon" meaning are asserted
+here.)

--- a/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
@@ -1,0 +1,69 @@
+---
+id: TA-C29-kaalai-vanakkam
+chapter: 29
+type: phrase
+headword: காலை வணக்கம்
+gloss: good morning (kālai vaṇakkam), literally "morning greetings" — a transparent compound of காலை (already met, TA-C26) + வணக்கம் (already met, TA-C01, "reverence, homage"); confirmed via TWO independently-fetched sources as the standard, formal greeting, used from sunrise until around 11 AM; NOT a śubha-equivalent construction, breaking the pattern seen in every other language in this arc; a WebSearch summary's claim that a Sanskrit-borrowed "suprabhatham" is a casual alternative could NOT be traced to either directly-fetched source and is therefore not asserted here
+concept_tag: GREETING-MORNING
+prerequisites: [TA-C26-kaalai, TA-C01-vanakkam]
+sounds: [tamil-geminate-kka, tamil-vowel-sign-ai]
+roots: [vaṇaṅku]
+etymology_hook: "காலை வணக்கம் (kālai vaṇakkam, 'good morning'), literally 'morning greetings/salutations,' is confirmed by TWO independently-fetched sources (talkpal.ai, preply.com — practical language-learning content, not lexicographic/scholarly references like TA-C26's Wiktionary and Tamil Lexicon; worth naming that source-tier difference explicitly) as Tamil's standard greeting for this time of day — talkpal.ai glosses it directly as காலை ('morning') + வணக்கம் ('a respectful greeting, similar to hello or salutations'), and preply.com independently labels it 'formal,' 'used before noon'; both agree on timing (roughly sunrise to 11 AM). Be honest about what this ISN'T: unlike Hindi/Kannada/Telugu/Malayalam, which each build their morning greeting on a śubha-equivalent word ('good, auspicious') plus a time-word, Tamil's own greeting is entirely different in structure — it's simply its own general greeting word, வணக்கம் (already met, TA-C01, 'reverence, homage,' Tamil's everyday word for 'hello'), specified with the time-of-day word காலை (already met, TA-C26) in front of it. Also be honest about a claim that did NOT check out: an initial WebSearch summary suggested a Sanskrit-borrowed word, 'suprabhatham,' serves as a casual alternative — but this claim appears on NEITHER of the two directly-fetched pages, so it is deliberately NOT asserted here"
+est_minutes: 6
+reviews_of: [TA-C26-kaalai, TA-C01-vanakkam]
+---
+
+# காலை வணக்கம் (kālai vaṇakkam) — "morning greetings," built from two words you already know
+
+## Warm-up
+
+[PAUSE 2s] Every other language in this arc built its "good morning"
+on a word meaning "good" or "auspicious." Tamil does something
+completely different: it just puts its everyday greeting word after
+its word for "morning."
+
+## காலை வணக்கம் — literally, "morning greetings"
+
+**காலை வணக்கம்** (**kālai vaṇakkam**) — "**good morning**" —
+is confirmed, by two independently-fetched sources, as Tamil's
+standard greeting for this time of day, used "**from sunrise until
+around 11 AM**." It's built from two words you already have:
+**காலை** (already met, Chapter 26, "**morning**") plus
+**வணக்கம்** (already met, Chapter 1, "**reverence, homage**" —
+Tamil's everyday word for "hello"). Literally: "**morning
+salutations**."
+
+## Be honest: this breaks the pattern every other language followed
+
+Here's the honest structural surprise: Hindi, Kannada, Telugu, and
+Malayalam each build their morning greeting on a **śubha**-equivalent
+word ("good, auspicious") plus a time-word. Tamil does something
+genuinely **different** — there's no "good/auspicious" word here at
+all. It's simply **வணக்கம்**, Tamil's own general greeting,
+specified with **காலை** in front of it to mean "morning" greetings
+specifically. Also be honest about a claim that didn't hold up: an
+initial search summary suggested a Sanskrit-borrowed word,
+"suprabhatham," serves as a casual alternative — but that claim
+appears on **neither** of the two pages actually fetched, so it's
+deliberately **not** asserted here.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kālai vaṇakkam" — "good morning," literally "morning
+  greetings"]
+- [YOU SAY: the honest structural surprise — no śubha-equivalent word
+  here at all, unlike every other language in this arc]
+- [YOU SAY: the two pieces you already know — kālai (Chapter 26) +
+  vaṇakkam (Chapter 1)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two already-known words does காலை வணக்கம் build
+from? (காலை, "morning" + வணக்கம், "reverence/hello.") Does
+Tamil's morning greeting follow the śubha-equivalent + time-word
+pattern used by Hindi/Kannada/Telugu/Malayalam? (**No** — it's simply
+வணக்கம், Tamil's own general greeting, specified with காலை in
+front.) Is the "suprabhatham as a casual alternative" claim confirmed?
+(**No** — it appears on neither of the two sources actually fetched;
+deliberately not asserted here.)

--- a/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
@@ -1,0 +1,72 @@
+---
+id: TA-C30-maalai-vanakkam
+chapter: 30
+type: phrase
+headword: மாலை வணக்கம்
+gloss: good evening (mālai vaṇakkam), literally "evening greetings" — the SAME compositional pattern as TA-C29's kālai vaṇakkam: மாலை (already met, TA-C27, "evening") + வணக்கம் (already met, TA-C01); confirmed via TWO independently-fetched sources (talkpal.ai, preply.com — same practical-content tier as TA-C29's sources) as real and used from afternoon/late-afternoon through nightfall, one labeling it formal; no śubha-equivalent word here either, consistent with TA-C29's finding, not just assumed to carry over automatically
+concept_tag: GREETING-EVENING
+prerequisites: [TA-C27-maalai, TA-C29-kaalai-vanakkam]
+sounds: [tamil-vowel-sign-aa, tamil-geminate-kka]
+roots: [vaṇaṅku]
+etymology_hook: "மாலை வணக்கம் (mālai vaṇakkam, 'good evening'), literally 'evening greetings/salutations,' is confirmed by TWO independently-fetched sources (talkpal.ai, preply.com — practical language-learning content, the same source tier as TA-C29's) as a real, standard Tamil evening greeting — preply.com labels it formal and gives timing 'used after noon through evening,' while talkpal.ai independently gives 'can be used from late afternoon until nightfall'; both agree on the general afternoon-into-evening window, with some looseness in exact boundaries (unsurprising, matching the boundary-blur already seen in TA-C28's noon/afternoon overlap). Structurally, this follows the EXACT SAME compositional pattern as TA-C29's kālai vaṇakkam: மாலை (already met, TA-C27, 'evening') plus வணக்கம் (already met, TA-C01, Tamil's general greeting) — this pattern was independently re-verified here, not just assumed to automatically carry over from the morning greeting, since this whole arc has repeatedly found that greeting formation doesn't reliably generalize even within a single language"
+est_minutes: 6
+reviews_of: [TA-C27-maalai, TA-C29-kaalai-vanakkam]
+---
+
+# மாலை வணக்கம் (mālai vaṇakkam) — "evening greetings," the same pattern, re-verified
+
+## Warm-up
+
+[PAUSE 2s] Last chapter's morning greeting followed its own pattern.
+This lesson checks whether the evening greeting follows the same
+one — rather than assuming it automatically does.
+
+## மாலை வணக்கம் — the same compositional pattern, independently confirmed
+
+**மாலை வணக்கம்** (**mālai vaṇakkam**) — "**good evening**" — is
+confirmed, by two independently-fetched sources, as a real, standard
+Tamil evening greeting, used roughly from **afternoon through
+nightfall** (the two sources give slightly different exact windows —
+"after noon through evening" versus "late afternoon until nightfall"
+— a small, unsurprising looseness, matching the noon/afternoon
+boundary-blur already seen in TA-C28). It's built exactly the same way
+as TA-C29's morning greeting: **மாலை** (already met, Chapter 27,
+"**evening**") plus **வணக்கம்** (already met, Chapter 1, Tamil's
+general greeting). Literally: "**evening salutations**."
+
+## Be honest: this pattern was re-checked, not assumed
+
+Here's the honest methodological point: just because TA-C29's morning
+greeting followed the "time-word + vaṇakkam" pattern doesn't mean this
+evening greeting was assumed to follow it automatically. This arc has
+repeatedly found that greeting formation doesn't reliably generalize,
+even within the very same language — Malayalam's own morning greeting
+broke from the śubha+time-word pattern its afternoon and evening
+greetings both share, so "the pattern probably repeats" was never a
+safe assumption on its own. So this greeting was independently
+verified via direct fetch before confirming
+the pattern really does repeat here — and it does, cleanly: no
+śubha-equivalent word appears in Tamil's evening greeting either, same
+as the morning one.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mālai vaṇakkam" — "good evening," literally "evening
+  greetings"]
+- [YOU SAY: the two pieces you already know — mālai (Chapter 27) +
+  vaṇakkam (Chapter 1)]
+- [YOU SAY: the honest methodological point — this pattern was
+  re-verified, not assumed to carry over automatically]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two already-known words does மாலை வணக்கம் build
+from? (மாலை, "evening" + வணக்கம், "greetings.") Was it assumed
+that the evening greeting would follow the same pattern as the
+morning one, or was it independently checked? (**Independently
+checked** — via direct fetch, not assumed, since this arc has learned
+that greeting patterns don't reliably generalize.) Does மாலை வணக்கம்
+use a śubha-equivalent word, like Hindi/Kannada/Telugu/Malayalam's
+evening greetings do? (**No** — same as Tamil's morning greeting, no
+śubha-equivalent word appears here either.)

--- a/code/learning/human-languages/tamil/lessons/TA-C31-matiya-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C31-matiya-vanakkam.md
@@ -1,0 +1,76 @@
+---
+id: TA-C31-matiya-vanakkam
+chapter: 31
+type: phrase
+headword: மதிய வணக்கம்
+gloss: good afternoon (matiya vaṇakkam), literally "afternoon-ish greetings" — confirmed via TWO independently-fetched sources (ling-app.com, talkpal.ai) as used roughly noon to 4 PM; a genuine surprise worth flagging: this greeting is built on மதிய (per Wiktionary's declension table, the adjectival form of TA-C28's noun மதியம், "noon," a Sanskrit tatsama synonym of நண்பகல் — but மதிய itself is separately Wiktionary-glossed "of or pertaining to afternoon," a semantic drift from its own parent noun's "noon" meaning), NOT on TA-C28's own native afternoon word, பிற்பகல்; a third source (preply.com) doesn't list a distinct afternoon greeting at all, treating morning and evening as bookending the day — an honest extension of TA-C28's own noon/afternoon boundary-blur into the greeting layer itself
+concept_tag: GREETING-AFTERNOON
+prerequisites: [TA-C28-pirpakal, TA-C29-kaalai-vanakkam]
+sounds: [tamil-vowel-sign-i, tamil-geminate-kka]
+roots: [sanskrit-madhya-middle, vaṇaṅku]
+etymology_hook: "மதிய வணக்கம் (matiya vaṇakkam, 'good afternoon'), literally 'afternoon-ish greetings,' is confirmed by TWO independently-fetched sources (ling-app.com, talkpal.ai) as Tamil's afternoon greeting, used roughly 'noon to around 4 PM'; a THIRD source (preply.com), already used for TA-C29/TA-C30, doesn't list a distinct afternoon greeting at all — it only covers morning ('before noon') and evening ('after noon through evening'), implicitly treating the two as bookending the whole day without a separate afternoon slot; this is an honest extension of TA-C28's own established noon/afternoon boundary-blur into the greeting layer itself, not a new problem. Be honest about a genuine structural surprise: this greeting is built on மதிய — per Wiktionary's declension table for மதியம், its ADJECTIVAL form (Wiktionary: 'Adjectival of மதியம்') — and NOT on TA-C28's own dedicated afternoon word, பிற்பகல் (built from piṉ + pakal). மதியம் itself means 'noon' (a Sanskrit tatsama from madhya, already established as a synonym of நண்பகல்), but மதிய, the adjective, is separately Wiktionary-glossed 'of or pertaining to afternoon' — a genuine semantic drift between the noun and its own adjectival form. So the TIME-AFTERNOON lesson's headword and the GREETING-AFTERNOON lesson's headword don't share a root at all — a genuinely different pairing than every other language's afternoon greeting in this arc, and a fitting final honest surprise to close out the whole 6-tag arc on"
+est_minutes: 6
+reviews_of: [TA-C28-pirpakal, TA-C29-kaalai-vanakkam]
+---
+
+# மதிய வணக்கம் (matiya vaṇakkam) — "afternoon-ish greetings," the arc's final surprise
+
+## Warm-up
+
+[PAUSE 2s] This is the last lesson in the whole arc — and it saves one
+more honest surprise for the end: the afternoon greeting doesn't build
+on the afternoon word you already know.
+
+## மதிய வணக்கம் — confirmed real, built on a word you half-know
+
+**மதிய வணக்கம்** (**matiya vaṇakkam**) — "**good afternoon**" —
+is confirmed, by two independently-fetched sources, as Tamil's
+afternoon greeting, used roughly "**noon to around 4 PM**." A third
+source, already used for the morning and evening greetings, doesn't
+list a distinct afternoon greeting at all — it only covers "before
+noon" and "after noon through evening," implicitly treating those two
+as bookending the whole day. This is an honest extension of TA-C28's
+own noon/afternoon boundary-blur into the greeting layer, not a new
+problem to worry about.
+
+## Be honest: the arc's final surprise — a different root entirely
+
+Here's the last honest twist of the whole arc: **மதிய வணக்கம்**
+is built on **மதிய** — per Wiktionary's declension table, the
+**adjectival form** of TA-C28's noun **மதியம்** ("noon," a Sanskrit
+tatsama from *madhya*, already established as a synonym of
+**நண்பகல்**) — **not** on TA-C28's own dedicated afternoon word,
+**பிற்பகல்** (built from *piṉ* + *pakal*). Wiktionary separately
+glosses **மதிய** itself "of or pertaining to **afternoon**" — a real
+semantic drift from its own parent noun's "noon" meaning.
+So the TIME-AFTERNOON word and the GREETING-AFTERNOON word don't share
+a root at all. A fitting way to close out this arc: even after five
+lessons of finding that greeting formation doesn't reliably generalize
+from one time-of-day to another, or from one language to another, the
+very last lesson finds one more way for it to surprise you — the
+greeting doesn't even build on its own language's dedicated word for
+the same time of day.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "matiya vaṇakkam" — "good afternoon," confirmed real, used
+  roughly noon to 4 PM]
+- [YOU SAY: the final surprise — built on matiya/matiyam ("noon"), NOT
+  on pirpakal (TA-C28's dedicated "afternoon" word)]
+- [YOU SAY: the honest wrap-up — greeting formation never reliably
+  generalizes, right through the very last lesson]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is மதிய வணக்கம் built on TA-C28's dedicated afternoon
+word, பிற்பகல்? (**No** — it's built on மதிய, the adjectival
+form of மதியம், "noon," a completely different root.) Do all three
+fetched sources agree on a distinct "afternoon" greeting slot? (**No**
+— two confirm மதிய வணக்கம் directly; a third doesn't list a
+separate afternoon greeting at all, treating morning and evening as
+bookending the day.) What has this whole arc repeatedly found about
+greeting formation, confirmed one final time here? (**It doesn't
+reliably generalize** — not across languages, not across a single
+language's own greetings, and not even between a language's
+TIME-word and its own matching GREETING-word.)


### PR DESCRIPTION
## Summary

Accumulator PR, continuing the Spanish-parity curriculum content program after #9310 was merged. This PR covers Malayalam's and Tamil's full 6-tag TIME/GREETING arcs (TIME-MORNING/EVENING/AFTERNOON + GREETING-MORNING/EVENING/AFTERNOON).

**🎉 This PR completes the entire multi-week, six-language Spanish-parity TIME/GREETING project**: Hindi, Latin, Kannada, Telugu, Malayalam, and now Tamil all have complete 6-tag arcs.

### Malayalam (COMPLETE — 6/6 lessons, no human review needed)
- **ML-C26-raavile.md** (TIME-MORNING) — രാവിലെ, built from ML-C24's night-word, not light or rising.
- **ML-C27-vaikunneram.md** (TIME-EVENING) — വൈകുന്നേരം, "latening time," native Dravidian.
- **ML-C28-uchakazhinju.md** (TIME-AFTERNOON) — ഉച്ചകഴിഞ്ഞ്, "noon having passed."
- **ML-C29-suprabhaatham.md** (GREETING-MORNING) — സുപ്രഭാതം, same Sanskrit word as Telugu's TE-C29 but with inverted primary/secondary roles.
- **ML-C30-shubha-sayaahnam.md** (GREETING-EVENING) — ശുഭ സായാഹ്നം, with a properly-verified PIE *seh₁- cognate to Telugu's TE-C27 and Latin sērus.
- **ML-C31-shubha-madhyaahnam.md** (GREETING-AFTERNOON) — a striking 3-way Dravidian convergence with Kannada's and Telugu's own afternoon greetings.

### Tamil (COMPLETE — 6/6 lessons — *** AWAITS THE USER'S OWN PERSONAL REVIEW BEFORE MERGE ***)
Tamil is the user's own native language and the only language in this entire project personally reviewed by them; every other language was shipped with no human check.
- **TA-C26-kaalai.md** (TIME-MORNING) — காலை, a genuinely uncertain etymology (Wiktionary itself only hedges).
- **TA-C27-maalai.md** (TIME-EVENING) — மாலை, a genuine homonym with "garland" (a rare reverse-direction Dravidian→Sanskrit loan).
- **TA-C28-pirpakal.md** (TIME-AFTERNOON) — பிற்பகல், with an honest dictionary-level noon/afternoon boundary-blur flagged.
- **TA-C29-kaalai-vanakkam.md** (GREETING-MORNING) — காலை வணக்கம், breaking the śubha-equivalent pattern entirely.
- **TA-C30-maalai-vanakkam.md** (GREETING-EVENING) — மாலை வணக்கம், pattern independently re-verified, not assumed.
- **TA-C31-matiya-vanakkam.md** (GREETING-AFTERNOON) — மதிய வணக்கம், the arc's final surprise: Tamil's TIME-AFTERNOON and GREETING-AFTERNOON words share no root at all.

Every commit went through an independent linguistics-review subagent (verifying etymology against primary sources, script purity, cross-lesson consistency) before shipping — see individual commit messages for review findings and fixes applied. Tamil commits applied extra rigor throughout, given the personal-review stakes.

## Notable findings this PR
- This arc repeatedly demonstrated that greeting formation does **not** reliably follow a simple "śubha-equivalent + time-word" compositional pattern — not across languages, and not even within a single language's own greetings (Malayalam's morning greeting broke its own afternoon/evening pattern; Tamil's morning/evening greetings use a totally different structure than Hindi/Kannada/Telugu/Malayalam, and Tamil's own afternoon greeting doesn't even share a root with its own afternoon time-word).
- Discovered and partially fixed a **systemic, pre-existing bug**: 63 already-shipped lesson files across multiple languages have an "orphan leading quote" in their `gloss:` frontmatter field (the tiny hand-rolled parser only strips quotes if both ends of the value match), causing a stray `"` to render in the UI. Fixed in the Tamil files inside this PR; flagged via a spawn_task chip for a dedicated follow-up on the other 61 files.

## Test plan
- [x] `code/packages/typescript/human-language-data` test suite: 38/38 passing
- [x] `code/programs/typescript/language-ladder` test suite: 268/268 passing
- [x] Every commit's frontmatter verified complete (12/12 required YAML fields)
- [x] Every commit's non-Latin-script content scanned for NUL bytes and script-block-identity (per-codepoint Unicode block verification, not just internal-consistency checks)
- [x] Every commit independently reviewed by a linguistics-focused subagent before shipping, with cross-language citations verified byte-identical to their source files
- [ ] **Tamil content (TA-C26 through TA-C31) awaits the user's own personal review before merge**

🤖 Generated with [Claude Code](https://claude.com/claude-code)