### PR TITLE
feat(adj-argument-ir): --explain renders the argument chain (ADR-6)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.30.3] — 2026-07-30 — ADR-6: `--explain` renders the argument chain
+
+Completes "reason **and** explain" for the `argument` construct — the one explain gap left. A
+binding query (`? failed_by(axle, $M)`) is resolved by SLD enumeration, not the differential, so
+its proof never flowed through `--explain`'s inference surface; an `argument`'s derivation was
+therefore invisible to the human view. `--explain` now renders a new **Argument** section for
+each binding query, projecting the `enumerate_all` proof DAG as the argument it is: grounded
+**premises** (leaf facts) → the **connective** (each inference rule, its warrant cited) → the
+derived **conclusion** — with the answer substitution applied so the conclusion shows the derived
+value (`failed_by(axle, fatigue)`), not the query's open variable. Projection-only (P1: re-runs
+nothing, reads the same DAG the `recall` JSON was built from), per-line provenance (P2),
+deterministic (P4), depth-addressed (P6). An unprovable query renders honest abstention, and a
+budget-truncated search is never laundered into "no proof exists". New e2e
+`rs4e3_explain_argument_e2e.rs` (4) drives the committed `axle-fatigue` worked example plus
+recall/abstention cases. Byte-neutral to `--json`/golden (the section is `--explain`-only and
+absent unless the program has a binding query).
+
 ## [0.30.2] — 2026-07-30 — ADR-5: worked-example capstone (closes the argument-graph arc)
 
 The closing rung of the decompose-argument-graph arc: a committed worked example under

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.30.2"
+version = "0.30.3"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/explain.rs
+++ b/code/packages/rust/adj-lang-cli/src/explain.rs
@@ -39,7 +39,7 @@
 use adj_lang::{LoweredStateMachine, StateMachineOutcome, StateMachineRun};
 use logic_engine::compute::{DerivationNode, RoundSpec};
 use logic_engine::differential::{Differential, DifferentialDecision};
-use logic_engine::proof_dag::DerivationOrigin;
+use logic_engine::proof_dag::{DerivationOrigin, ProofDAG, ProofStep};
 use logic_engine::{KnowledgeBase, Provenance, RoundingMode, TrustTier};
 
 /// Render the human-readable explanation of a decided query.
@@ -61,6 +61,7 @@ pub fn explain(
     kb: &KnowledgeBase,
     diff: &Differential,
     state_machine_runs: &[(&LoweredStateMachine, StateMachineRun)],
+    arguments: &[(logic_core::Term, ProofDAG)],
 ) -> String {
     let mut sections: Vec<String> = Vec::new();
     let derivations = render_derivations(kb);
@@ -81,6 +82,17 @@ pub fn explain(
             sections.push(inference);
         }
         sections.push(render_adjudication(kb, diff));
+    }
+    // ADJ-ARGUMENT-IR ADR-6: the argument surface — for each binding query, the
+    // SLD proof chain read as an argument (premises → connective → conclusion).
+    // A binding query is resolved by `enumerate_all`, not the differential, so
+    // its proof does not flow through the inference/adjudication surface above;
+    // this renders it directly off the proof DAG the CLI already built for the
+    // query's `recall` section (P1 projection-only). Empty for a program with no
+    // binding query, so a differential/computation program renders unchanged.
+    let args = render_arguments(kb, arguments);
+    if !args.is_empty() {
+        sections.push(args);
     }
     // ADJ-STATEMACHINE RS-3c: the run narrative — each machine's ordered,
     // provenance-cited steps ending in its typed terminal outcome. Projection-only
@@ -361,6 +373,130 @@ fn render_adjudication(kb: &KnowledgeBase, diff: &Differential) -> String {
         }
     }
     out.join("\n")
+}
+
+/// Render the **argument surface** (ADJ-ARGUMENT-IR §E.8 / ADR-6) — the SLD
+/// proof chain behind each binding query, read as the argument it is: grounded
+/// **premises** (leaf facts) → the **connective** that licensed each step (an
+/// inference rule, its warrant bytes cited) → the derived **conclusion** (the
+/// rule head). This is the "explain" half of "reason AND explain" for the
+/// `argument` construct: an `argument` desugars to facts + rules (ADR-2), the
+/// engine derives its thesis by SLD, and this projects that derivation back into
+/// prose a person reads.
+///
+/// Invariants (the §E.8 contract, same as every other surface here):
+/// - **P1 projection-only** — walks the `enumerate_all` proof DAG the CLI already
+///   built for the query's `recall` section; re-runs nothing, asserts nothing not
+///   already in the proof.
+/// - **P2 provenance per line** — a premise carries its fact's `source`/`trust`
+///   (or an explicit `[unattributed]`); a connective carries the inference rule's
+///   cited warrant (the `infer … source "…"` bytes).
+/// - **P4 determinism** — the walk order is `enumerate_all`'s deterministic
+///   fact/rule order and each proof's preorder `steps`; no timestamp or map order.
+/// - **P6 addressed structure** — each step renders at `depth+1` indentation, so a
+///   line maps back to exactly one node of the proof tree (a rule's premises sit
+///   one level under the conclusion they support).
+///
+/// Honest abstention: a query with no proof renders an explicit line, and a
+/// **budget-truncated** search is never laundered into "no proof exists" — the
+/// two are reported distinctly (§proof_dag `truncated`). Returns "" when the
+/// program declared no binding query.
+fn render_arguments(kb: &KnowledgeBase, arguments: &[(logic_core::Term, ProofDAG)]) -> String {
+    if arguments.is_empty() {
+        return String::new();
+    }
+    let mut out: Vec<String> = Vec::new();
+    for (query, dag) in arguments {
+        out.push(format!("Argument for {}:", query));
+        if !dag.has_proof() {
+            // Distinguish "the search ran and found nothing" (evidence of
+            // absence) from "the search gave up" (a statement about budget, not
+            // the world) — never collapse the two into a false claim.
+            if dag.truncated {
+                out.push(
+                    "  (search truncated before a complete chain was found)".to_string(),
+                );
+            } else {
+                out.push("  abstained: no grounded chain derives this".to_string());
+            }
+            continue;
+        }
+        // Each proof is one complete chain deriving one answer. An `argument` has
+        // exactly one; a recall query may have several (one per bound answer),
+        // each a degenerate one-premise argument. Render every step in preorder,
+        // resolving each goal under the proof's answer substitution so the
+        // conclusion shows the DERIVED value (e.g. `failed_by(axle, fatigue)`),
+        // not the query's still-open variable (`failed_by(axle, Mechanism)`).
+        for proof in &dag.proofs {
+            for st in &proof.steps {
+                out.push(render_arg_step(kb, st, &proof.bindings));
+            }
+        }
+    }
+    out.join("\n")
+}
+
+/// Deep-resolve a term under a substitution. The engine's `Substitution::walk`
+/// resolves only the top level; a proof's answer bindings live inside the
+/// conclusion's compound arguments (the query variable is nested), so we recurse
+/// into every argument to show the fully-bound goal.
+fn resolve_deep(term: &logic_core::Term, subst: &logic_core::Substitution) -> logic_core::Term {
+    match subst.walk(term) {
+        logic_core::Term::Compound { functor, args } => logic_core::Term::Compound {
+            functor,
+            args: args.iter().map(|a| resolve_deep(a, subst)).collect(),
+        },
+        other => other,
+    }
+}
+
+/// One line of an argument's SLD proof, addressed by its depth (P6) and carrying
+/// its own citation (P2). A **rule** step is the CONNECTIVE that licensed a
+/// conclusion — rendered `conclusion <= inference [warrant]`; a **fact** step is
+/// a PREMISE (the grounds) — rendered `premise term [source]`; a **negation**
+/// step cites the *absence* of any proof for the negated goal. The match is
+/// TOTAL over `DerivationOrigin` — a new origin kind must be handled here or the
+/// crate fails to compile (the same discipline `render_inference` enforces).
+fn render_arg_step(
+    kb: &KnowledgeBase,
+    st: &ProofStep,
+    bindings: &logic_core::Substitution,
+) -> String {
+    let ind = "  ".repeat(st.depth + 1);
+    // Show the goal fully bound under the proof's answer substitution.
+    let goal = resolve_deep(&st.goal, bindings);
+    match &st.origin {
+        // A fact is a premise: the grounds, carrying its own source/trust.
+        DerivationOrigin::FromFact(id) => {
+            format!("{ind}premise {}  {}", goal, cite_fact(kb, *id))
+        }
+        // A rule is the inference step: the conclusion (its head) licensed by the
+        // rule's warrant. For a desugared `argument`, that warrant is the
+        // connective bytes the `infer … source "…"` cited.
+        DerivationOrigin::FromRule(id) => {
+            let warrant = kb
+                .find_rule_by_id(*id)
+                .map(|rule| fmt_leaf_prov(&rule.provenance))
+                .unwrap_or_else(|| "[unattributed]".to_string());
+            format!("{ind}{}  <= inference {warrant}", goal)
+        }
+        // Negation-as-failure quotes nothing: what licensed the step is the
+        // absence of any proof for the negated goal (§E.5).
+        DerivationOrigin::FromNegation { goal: neg } => {
+            format!("{ind}{}  [negation: no proof exists for {}]", goal, neg)
+        }
+        // Likelihood-ratio aggregation steps (prior / contribution / interaction /
+        // predicate) are produced by `lr_aggregate`, never by the SLD
+        // `enumerate_all` that drives a binding query — so they do not arise on
+        // this path. Handled for match totality and rendered honestly (the goal,
+        // no fabricated citation) in case that invariant ever changes.
+        DerivationOrigin::FromPrior { .. }
+        | DerivationOrigin::FromContribution { .. }
+        | DerivationOrigin::FromJointContribution { .. }
+        | DerivationOrigin::FromPredicateContribution { .. } => {
+            format!("{ind}{}  [inference step]", goal)
+        }
+    }
 }
 
 /// The weakest (`min`) trust tier over the cited clauses of `hyp`'s proof — P3's

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -41,8 +41,8 @@ use logic_core::{atom, compound, var, LogicVar, Term};
 use logic_engine::govern::Standing;
 use logic_engine::{
     enumerate_all, enumerate_governing, numeric_exact_magnitude, DerivationOrigin,
-    DifferentialDecision, Fact, GovernStatus, KnowledgeBase, LRAggregateResult, Proof, Provenance,
-    TrustTier,
+    DifferentialDecision, Fact, GovernStatus, KnowledgeBase, LRAggregateResult, Proof, ProofDAG,
+    Provenance, TrustTier,
 };
 
 mod explain;
@@ -1079,9 +1079,19 @@ fn main() -> ExitCode {
     // remains the primary, complete artifact (default output); `--explain` is the
     // opt-in human view onto it.
     if explain {
+        // ADJ-ARGUMENT-IR ADR-6: the SLD proof chain behind each binding query —
+        // the argument's premises → connective → conclusion. Re-resolve each
+        // binding query to the same proof DAG the `recall` section was built from
+        // (projection-only: `enumerate_all` is deterministic and side-effect
+        // free), so `--explain` can render the derivation as an argument. Empty
+        // for a program with no binding query, leaving all other output unchanged.
+        let argument_chains: Vec<(Term, ProofDAG)> = binding_queries
+            .iter()
+            .map(|q| (q.clone(), enumerate_all(q, &lowered.kb)))
+            .collect();
         println!(
             "{}",
-            explain::explain(&lowered.kb, &diff, &state_machine_runs)
+            explain::explain(&lowered.kb, &diff, &state_machine_runs, &argument_chains)
         );
         return ExitCode::SUCCESS;
     }

--- a/code/packages/rust/adj-lang-cli/tests/rs4e3_explain_argument_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs4e3_explain_argument_e2e.rs
@@ -1,0 +1,161 @@
+//! End-to-end tests for the `--explain` renderer's ARGUMENT surface
+//! (ADJ-ARGUMENT-IR ADR-6 / ADJ-REASON-MATH §E.8). This is the "explain" half of
+//! "reason AND explain" for the `argument` construct: an `argument` desugars to
+//! facts + rules (ADR-2), the engine derives its thesis by SLD over those, and
+//! this surface projects that derivation back into prose a person reads — the
+//! argument's grounded **premises** → the **connective** (inference rule) that
+//! licensed each step → the derived **conclusion**.
+//!
+//! Where PR-E1/E2 rendered a differential's arithmetic and probabilistic
+//! reasoning, a binding query (`? failed_by(axle, $M)`) is resolved by SLD
+//! enumeration, not the differential — so its proof never flowed through the
+//! `--explain` inference surface. These tests pin the new surface end to end on
+//! the committed `axle-fatigue` worked example: the chain is rendered with the
+//! DERIVED conclusion (not the still-open query variable), every line carries its
+//! own provenance, and the render is deterministic (P4).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The committed worked-example directory (shared with `argument_worked_example_e2e`).
+fn data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../specs/data/adj-argument-ir")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs4e3_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(dir: &Path, name: &str, src: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, src).unwrap();
+    p
+}
+
+fn explain(program: &Path) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg("--explain")
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    assert!(
+        out.status.success(),
+        "--explain exited non-zero: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// (1) The worked example's argument renders as premises → connective →
+//     conclusion, with the DERIVED thesis and per-line provenance.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn renders_the_argument_chain_premises_connective_conclusion() {
+    let adj = data_dir().join("axle-fatigue.adj");
+    let s = explain(&adj);
+
+    // The section header names the query the argument answers.
+    assert!(
+        s.contains("Argument for failed_by(axle, Mechanism):"),
+        "argument section header: {s:?}"
+    );
+    // The CONCLUSION is the DERIVED thesis — `fatigue` bound from the query
+    // variable — reached via an inference connective (not asserted, not the
+    // still-open `$Mechanism`).
+    assert!(
+        s.contains("failed_by(axle, fatigue)  <= inference"),
+        "the derived conclusion is rendered as an inference step: {s:?}"
+    );
+    // The intermediate sub-conclusion is itself an inference step (the two-step
+    // chain: exceeds_endurance feeds failed_by).
+    assert!(
+        s.contains("exceeds_endurance(axle)  <= inference"),
+        "the intermediate conclusion is an inference step: {s:?}"
+    );
+    // The grounded PREMISES are rendered as premises — the argument's leaves.
+    assert!(
+        s.contains("premise stress_amplitude(axle, 420)")
+            && s.contains("premise endurance_limit(axle, 380)")
+            && s.contains("premise shows(surface, beach_marks)")
+            && s.contains("premise diagnostic_of(beach_marks, fatigue)"),
+        "all four grounded premises are rendered: {s:?}"
+    );
+    // P2 — every line carries its own provenance: the premises and the
+    // connectives all cite the source document at authoritative trust.
+    assert!(
+        s.contains("source \"axle failure report\" trust authoritative"),
+        "lines carry their provenance: {s:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) P4 — the argument explanation is deterministic across runs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_argument_explanation_is_deterministic() {
+    let adj = data_dir().join("axle-fatigue.adj");
+    let a = explain(&adj);
+    let b = explain(&adj);
+    assert_eq!(a, b, "the same argument must render identical explanation text");
+    assert!(
+        a.contains("failed_by(axle, fatigue)  <= inference"),
+        "non-trivial explanation: {a:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (3) An unprovable binding query renders honest abstention — never a
+//     fabricated chain (the argument surface's form of "I cannot commit").
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_unprovable_query_renders_honest_abstention() {
+    let dir = scratch("abstain");
+    // A relate fact grounds one edge; the query asks for a DIFFERENT subject that
+    // no fact or rule derives — so the search runs to completion with no proof.
+    let prog = write(
+        &dir,
+        "case.adj",
+        "relate causes(hepatitis_b, cirrhosis)\n\
+         source \"ref\" trust authoritative\n\
+         ? causes(measles, $Outcome)\n",
+    );
+    let s = explain(&prog);
+    assert!(
+        s.contains("Argument for causes(measles, Outcome):"),
+        "the query still gets a section: {s:?}"
+    );
+    assert!(
+        s.contains("abstained: no grounded chain derives this"),
+        "an unprovable query abstains honestly, not a fabricated chain: {s:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (4) A one-premise recall query is a degenerate argument: the grounding fact
+//     IS the premise, rendered with its citation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_recall_query_renders_its_grounding_fact_as_a_premise() {
+    let dir = scratch("recall");
+    let prog = write(
+        &dir,
+        "case.adj",
+        "relate causes(hepatitis_b, cirrhosis)\n\
+         source \"hepatology ref\" trust authoritative\n\
+         ? causes(hepatitis_b, $Outcome)\n",
+    );
+    let s = explain(&prog);
+    assert!(
+        s.contains("premise causes(hepatitis_b, cirrhosis)")
+            && s.contains("source \"hepatology ref\" trust authoritative"),
+        "the grounding fact is rendered as a cited premise: {s:?}"
+    );
+}

--- a/code/specs/ADJ-ARGUMENT-IR.md
+++ b/code/specs/ADJ-ARGUMENT-IR.md
@@ -181,9 +181,9 @@ shared or cached argument that has since drifted from its sources is caught, not
 > Verified end-to-end: a snapshot-pinned argument confirms its premise cite (`quotes_verified ≥ 1`,
 > `status: verified`) and re-derives its thesis; a **drifted** citation — a quote that is not a
 > verbatim slice of the pinned source — fails the run (`verified: false`, `quote_missing`). The
-> warrant re-refutation of §3.2 (an *adversarial* re-read) and rendering the argument chain in
-> `--explain` (an SLD proof chain, which `--explain` does not render today) are the remaining
-> follow-ups; the byte-anchor + re-derivation of §4 are done.
+> warrant re-refutation of §3.2 (an *adversarial* re-read) is the remaining follow-up; the
+> byte-anchor + re-derivation of §4 are done, and rendering the argument chain in `--explain`
+> (an SLD proof chain, premises → connective → conclusion) shipped as **ADR-6** (see §7).
 
 ---
 
@@ -272,6 +272,19 @@ grounding payload the §3 gate checks. Final syntax fixed in ADR-2.
   (`quotes_verified: 6`) and re-derives the thesis. Driven by `argument_worked_example_e2e.rs`;
   see the directory `README.md`. The argument a paragraph makes is a program the engine runs, every
   step auditable back to the paragraph's own bytes.
+- **ADR-6 — `--explain` renders the argument chain** ✅ **shipped**: completes "reason **and**
+  explain" for the `argument` construct — the one explain gap ADR-4 flagged. A binding query is
+  resolved by SLD `enumerate_all`, not the differential, so its proof never flowed through
+  `--explain`'s inference surface; an argument's derivation was invisible to the human view.
+  `--explain` now renders a new **Argument** section per binding query, projecting the proof DAG
+  as the argument it is: grounded **premises** (leaf facts) → the **connective** (each inference
+  rule, its warrant cited) → the derived **conclusion**, with the answer substitution applied so
+  the conclusion shows the derived value (`failed_by(axle, fatigue)`), not the query's open
+  variable. Projection-only (P1), per-line provenance (P2), deterministic (P4), depth-addressed
+  (P6); an unprovable query abstains honestly and a budget-truncated search is never laundered
+  into "no proof exists". Driven by `rs4e3_explain_argument_e2e.rs` (4) over the ADR-5 worked
+  example. This is the SLD-proof-chain `--explain` the ADR-4 follow-up named; the *adversarial*
+  warrant re-refutation (§3.2, model-in-the-loop) remains the last follow-up.
 - **Later:** the trained decomposer that *emits* this adj-lang from prose (reuses the F3 training
   harness, retargeted from closed-vocab findings to the open-vocab argument surface); multi-
   paragraph / whole-paper composition (a paper is a DAG of paragraph arguments sharing conclusions).


### PR DESCRIPTION
## ADR-6 — `--explain` renders the argument chain

Completes **"reason AND explain"** for the `argument` construct — the one explain gap ADR-4 flagged, and the rotation the decompose-argument-graph arc pointed to after its capstone (#9329).

### The gap
A binding query (`? failed_by(axle, $M)`) is resolved by SLD `enumerate_all`, **not** the differential — so its proof never flowed through `--explain`'s inference/adjudication surface. An `argument`'s derivation was therefore invisible to the human view: `--explain` on the axle worked example printed nothing.

### The fix
`--explain` now renders a new **Argument** section per binding query, projecting the `enumerate_all` proof DAG as the argument it is:

```
Argument for failed_by(axle, Mechanism):
  failed_by(axle, fatigue)  <= inference [source "axle failure report" trust authoritative]
    exceeds_endurance(axle)  <= inference [source "axle failure report" trust authoritative]
      premise stress_amplitude(axle, 420)  [source "axle failure report" trust authoritative]
      premise endurance_limit(axle, 380)  [source "axle failure report" trust authoritative]
    premise shows(surface, beach_marks)  [source "axle failure report" trust authoritative]
    premise diagnostic_of(beach_marks, fatigue)  [source "axle failure report" trust authoritative]
```

Grounded **premises** (leaf facts) → the **connective** (each inference rule, its warrant cited) → the derived **conclusion**, with the proof's answer substitution applied so the conclusion shows the derived value (`failed_by(axle, fatigue)`), not the query's open `$Mechanism`.

### Invariants (the §E.8 contract)
- **P1 projection-only** — reads the same proof DAG the `recall` JSON was built from; re-runs nothing.
- **P2 provenance per line** — a premise cites its fact's `source`/`trust`; a connective cites the inference rule's warrant.
- **P4 deterministic** — `enumerate_all` order + preorder `steps`; no timestamp/map order.
- **P6 depth-addressed** — each step at `depth+1` indent maps to one proof-tree node.
- Honest abstention: an unprovable query says so; a **budget-truncated** search is never laundered into "no proof exists".

### Changes
- `explain.rs`: `render_arguments` / `render_arg_step` + local deep `resolve_deep`; new `arguments: &[(Term, ProofDAG)]` param on `explain()`. The `DerivationOrigin` match is total.
- `main.rs`: compute each binding query's proof DAG inside the `--explain` block (projection-only) and pass it through.
- New e2e `rs4e3_explain_argument_e2e.rs` (4): the axle worked example renders premises → connective → conclusion with the derived thesis; determinism; honest abstention; a recall query as a degenerate one-premise argument.
- Spec-sync: ADR-6 added to `ADJ-ARGUMENT-IR.md` §7; the ADR-4 follow-up note updated.

### Verification
- New e2e (4) + existing explain e2e (`rs4e_explain_e2e` 4, `rs4e2_explain_inference_e2e` 4) + `argument_worked_example_e2e` (2) all green.
- `cli_golden` (38) green — **byte-neutral to `--json`/golden** (the section is `--explain`-only, absent unless the program has a binding query).
- clippy `-D warnings` clean; NUL-scan clean; `/security-review` PASSED.

This is the SLD-proof-chain `--explain` the ADR-4 follow-up named. The remaining follow-up is the *adversarial* warrant re-refutation (§3.2, model-in-the-loop). adj-lang-cli 0.30.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)