### PR TITLE
feat(adj-argument-decomposer): model-free fidelity scorer (AD-3)

### DIFF
--- a/code/specs/data/mycin-2026/train/argument_decompose_score.py
+++ b/code/specs/data/mycin-2026/train/argument_decompose_score.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""argument_decompose_score.py — score an ARGUMENT decomposer's fidelity (model-free).
+
+The counterpart to decompose_score.py for the OPEN-VOCAB `argument` shape
+(ADJ-ARGUMENT-DECOMPOSER.md §4). Where decompose_score scores flat findings/chart-facts,
+this scores a decomposed ARGUMENT: did the model extract the right premises and inference
+steps, cite VERBATIM spans, reach the paragraph's thesis, and — the headline — NOT coin a
+premise from something the gold says to DISCARD, and NOT fabricate a citation whose bytes
+are not in the paragraph at all?
+
+It is a PURE function over `(predicted, gold, note)` — no model, no network — so it is
+fully unit-testable on synthetic predictions. `predicted` and `gold` are gold-objects in the
+AD-2 training-row `gold` schema (ADJ-ARGUMENT-DECOMPOSER.md §3.2):
+    {premises:[{name,kind,term,span,type}], inferences:[{name,connective,conclusion,from,span,type}],
+     thesis:"…", discard:[{span,reason}]}
+
+Metrics (all ratios in [0, 1] except the integer VETO counts):
+  - premise_precision / premise_recall / premise_f1 — set overlap of predicted vs gold premises
+    by identity (kind, term, normalized-span): a premise matches only if its SPAN is right too, so
+    a fluent-but-unfaithful premise scores 0.
+  - inference_precision / inference_recall / inference_f1 — same over inferences by identity
+    (connective, conclusion, {from…}, normalized-span): an inference must cite the right premises
+    AND the right connective bytes.
+  - span_faithfulness — fraction of predicted premise+inference spans that are a VERBATIM
+    (whitespace/case-normalized) substring of the note. Byte-provenance measured directly.
+  - discard_recall / discard_precision — overlap of predicted vs gold discard spans.
+  - near_miss_violations (VETO, must be 0) — COUNT of predicted premises/inferences whose span is
+    a GOLD DISCARD span: the model turned a set-aside near-miss into a premise.
+  - fabrication (VETO, must be 0) — COUNT of predicted premise/inference spans NOT present in the
+    note at all: invented bytes, the strongest faithfulness failure.
+  - thesis_derivation — 0/1: does the predicted argument, once compiled, actually DERIVE the gold
+    thesis and BYTE-ANCHOR its citations (the real 3-part gate, via gen_argument_data.verify_gold)?
+    `None` when the adj-lang-cli / adj-verify binaries are not built (skipped, like AD-2).
+"""
+
+from __future__ import annotations
+
+import gen_argument_data as gad
+
+
+def _norm(s: str) -> str:
+    """Lowercase + collapse whitespace — the framework's citation-matching normalization
+    (mirrors decompose_score._norm / gen_data._norm)."""
+    return " ".join(str(s).lower().split())
+
+
+def _f1(precision: float, recall: float) -> float:
+    return 0.0 if precision + recall == 0 else 2 * precision * recall / (precision + recall)
+
+
+def _prem_key(p: dict) -> tuple:
+    """A premise's identity: its kind, its term, and its NORMALIZED span. Span is part of the
+    key so a premise only matches when it is grounded on the right bytes."""
+    return (p.get("kind"), _norm(p.get("term", "")), _norm(p.get("span", "")))
+
+
+def _infer_key(i: dict) -> tuple:
+    """An inference's identity: its connective, its conclusion, the SET of premises it cites, and
+    its normalized span. `from` is a set so citation ORDER doesn't change identity."""
+    return (i.get("connective"), _norm(i.get("conclusion", "")),
+            frozenset(i.get("from", []) or []), _norm(i.get("span", "")))
+
+
+def _pr(pred_keys: list, gold_keys: set) -> tuple[float, float]:
+    """(precision, recall) with the abstain-friendly empty-set conventions decompose_score uses:
+    no predicted AND no gold → (1, 1); no predicted but some gold → (1, 0); predicted but no gold
+    → (0, 1)."""
+    matched = [k for k in pred_keys if k in gold_keys]
+    precision = 1.0 if not pred_keys else len(matched) / len(pred_keys)
+    recall = 1.0 if not gold_keys else len({k for k in matched}) / len(gold_keys)
+    return precision, recall
+
+
+def _to_builder_spec(predicted: dict, thesis: str) -> dict:
+    """Map a predicted gold-object to a gen_argument_data.build_argument_adj spec — the gold
+    schema names the cited bytes `span`, the builder names them `quote`. Uses the GOLD `thesis`
+    as the query, so the derivation check asks "do the predicted premises/inferences reach the
+    paragraph's thesis?" A default doc/trust is fine: the byte-anchor is what's under test."""
+    return {
+        "name": "predicted",
+        "doc": "predicted argument",
+        "trust": "authoritative",
+        "premises": [
+            {"name": p.get("name"), "kind": p.get("kind"), "term": p.get("term"),
+             "quote": p.get("span", "")}
+            for p in predicted.get("premises", []) or []
+        ],
+        "inferences": [
+            {"name": i.get("name"), "connective": i.get("connective"),
+             "conclusion": i.get("conclusion"), "from": i.get("from", []) or [],
+             "quote": i.get("span", "")}
+            for i in predicted.get("inferences", []) or []
+        ],
+        "thesis": thesis,
+    }
+
+
+def thesis_derivation(predicted: dict, gold: dict, note: str) -> int | None:
+    """Run the real 3-part gate on the predicted argument against the GOLD thesis: it must compile,
+    let adj-lang-cli derive a NON-EMPTY answer for the gold thesis, and let adj-verify byte-anchor
+    every citation. Returns 1/0, or `None` when the binaries are not built (not scored)."""
+    if not (gad.CLI.exists() and gad.VERIFY.exists()):
+        return None
+    spec = _to_builder_spec(predicted, gold.get("thesis", ""))
+    sb = note.encode("utf-8")
+    try:
+        adj_text, _ = gad.build_argument_adj(spec, sb)
+    except gad.SpanNotFound:
+        # A fabricated citation can't even be built — it cannot faithfully derive anything.
+        return 0
+    try:
+        res = gad.verify_gold(adj_text, sb)
+    except gad.BinariesMissing:
+        return None
+    derived = res["derive_ok"] and '"abstained":false' in res["derive_stdout"]
+    anchored = res["verified"] is True and res["quotes_verified"] == gad.total_citations(spec)
+    return 1 if (derived and anchored) else 0
+
+
+def score(predicted: dict, gold: dict, note: str, *, run_gate: bool = True) -> dict:
+    """Score one predicted argument against the gold argument for `note`. Pure over the metrics
+    documented above; the optional `thesis_derivation` shells out to the built binaries (skipped
+    when `run_gate` is False or the binaries are absent). Returns the metrics dict."""
+    note_n = _norm(note)
+    pred_prem = predicted.get("premises", []) or []
+    gold_prem = gold.get("premises", []) or []
+    pred_inf = predicted.get("inferences", []) or []
+    gold_inf = gold.get("inferences", []) or []
+
+    pp, pr_ = _pr([_prem_key(p) for p in pred_prem], {_prem_key(p) for p in gold_prem})
+    ip, ir = _pr([_infer_key(i) for i in pred_inf], {_infer_key(i) for i in gold_inf})
+
+    # Every predicted premise/inference makes a byte-provenance claim (a cited span).
+    cited = [x for x in (pred_prem + pred_inf) if x.get("span")]
+    grounded = [x for x in cited if _norm(x["span"]) in note_n]
+    span_faithfulness = 1.0 if not cited else len(grounded) / len(cited)
+
+    pred_disc = {_norm(d.get("span", "")) for d in (predicted.get("discard") or []) if d.get("span")}
+    gold_disc = {_norm(d.get("span", "")) for d in (gold.get("discard") or []) if d.get("span")}
+    matched_disc = pred_disc & gold_disc
+    discard_recall = 1.0 if not gold_disc else len(matched_disc) / len(gold_disc)
+    discard_precision = 1.0 if not pred_disc else len(matched_disc) / len(pred_disc)
+
+    # VETOES. near-miss: a predicted premise/inference whose span the gold says to DISCARD.
+    near_miss_violations = sum(1 for x in (pred_prem + pred_inf)
+                               if x.get("span") and _norm(x["span"]) in gold_disc)
+    # fabrication: a predicted span not present in the note at all (invented bytes).
+    fabrication = sum(1 for x in cited if _norm(x["span"]) not in note_n)
+
+    out = {
+        "premise_precision": pp, "premise_recall": pr_, "premise_f1": _f1(pp, pr_),
+        "inference_precision": ip, "inference_recall": ir, "inference_f1": _f1(ip, ir),
+        "span_faithfulness": span_faithfulness,
+        "discard_recall": discard_recall, "discard_precision": discard_precision,
+        "near_miss_violations": near_miss_violations,
+        "fabrication": fabrication,
+    }
+    out["thesis_derivation"] = thesis_derivation(predicted, gold, note) if run_gate else None
+    return out
+
+
+def aggregate(scores: list[dict]) -> dict:
+    """Mean each ratio metric, SUM the veto counts, mean thesis_derivation over the examples that
+    ran it (skips `None`). Empty input → {}."""
+    if not scores:
+        return {}
+    ratio = ("premise_precision", "premise_recall", "premise_f1",
+             "inference_precision", "inference_recall", "inference_f1",
+             "span_faithfulness", "discard_recall", "discard_precision")
+    counts = ("near_miss_violations", "fabrication")
+    out = {m: sum(s[m] for s in scores) / len(scores) for m in ratio}
+    out.update({m: sum(s[m] for s in scores) for m in counts})
+    gated = [s["thesis_derivation"] for s in scores if s.get("thesis_derivation") is not None]
+    out["thesis_derivation"] = (sum(gated) / len(gated)) if gated else None
+    out["n"] = len(scores)
+    return out

--- a/code/specs/data/mycin-2026/train/test_argument_decompose_score.py
+++ b/code/specs/data/mycin-2026/train/test_argument_decompose_score.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""test_argument_decompose_score.py — guard the ARGUMENT fidelity scorer (AD-3).
+
+Pure, model-free checks (the thesis-derivation gate self-skips when the binaries are absent):
+  - SELF-CONSISTENCY: the AD-2 seed gold, scored as its own prediction, is all-perfect — every
+    ratio 1.0, every veto 0 (mirrors eval_decompose --self-check).
+  - the NEAR-MISS veto fires when a prediction turns a gold DISCARD span into a premise.
+  - the FABRICATION veto fires when a prediction cites bytes not in the paragraph.
+  - a dropped premise LOWERS recall (and, via the gate when built, breaks thesis-derivation).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import argument_decompose_score as s  # noqa: E402
+import gen_argument_data as gad  # noqa: E402
+
+# The gold-objects + notes from the AD-2 seed set — the fixtures every check scores against.
+_GOLD = [
+    (gad.to_training_row(spec, gad.source_bytes_for(spec).decode("utf-8")),
+     gad.source_bytes_for(spec).decode("utf-8"))
+    for spec in gad.SEED
+]
+
+
+def test_gold_scored_as_itself_is_perfect():
+    """Self-consistency: scoring the gold against itself yields perfect fidelity and no vetoes."""
+    for row, note in _GOLD:
+        gold = row["gold"]
+        m = s.score(gold, gold, note, run_gate=False)
+        for ratio in ("premise_precision", "premise_recall", "premise_f1",
+                      "inference_precision", "inference_recall", "inference_f1",
+                      "span_faithfulness"):
+            assert m[ratio] == 1.0, f"{row['id']}: {ratio} must be 1.0, got {m[ratio]}"
+        assert m["near_miss_violations"] == 0 and m["fabrication"] == 0
+
+
+def test_near_miss_span_turned_into_a_premise_is_vetoed():
+    """A prediction that coins a premise from a gold DISCARD span trips the near-miss veto — even
+    though that span IS in the paragraph (span_faithfulness stays 1.0), so only the veto catches it."""
+    row = next(r for r, _ in _GOLD if r["id"] == "arg-pump-outbreak")
+    note = next(n for r, n in _GOLD if r["id"] == "arg-pump-outbreak")
+    gold = row["gold"]
+    discard_span = gold["discard"][0]["span"]  # the coincidental-factory near-miss
+    predicted = {
+        "premises": gold["premises"] + [
+            {"name": "pX", "kind": "extracted", "term": "changed_schedule(factory)",
+             "span": discard_span, "type": "stated"}
+        ],
+        "inferences": gold["inferences"], "thesis": gold["thesis"], "discard": [],
+    }
+    m = s.score(predicted, gold, note, run_gate=False)
+    assert m["near_miss_violations"] == 1, "coining a premise from a discard span must be vetoed"
+    assert m["fabrication"] == 0, "the discard span IS in the note — not a fabrication"
+    assert m["span_faithfulness"] == 1.0, "every span is verbatim — only the near-miss veto fires"
+
+
+def test_fabricated_span_is_vetoed():
+    """A prediction citing bytes absent from the paragraph trips the fabrication veto and drops
+    span-faithfulness below 1.0."""
+    row = next(r for r, _ in _GOLD if r["id"] == "arg-galaxy-redshift")
+    note = next(n for r, n in _GOLD if r["id"] == "arg-galaxy-redshift")
+    gold = row["gold"]
+    predicted = {
+        "premises": gold["premises"] + [
+            {"name": "pF", "kind": "extracted", "term": "invented(claim)",
+             "span": "this sentence never appears in the source paragraph", "type": "stated"}
+        ],
+        "inferences": gold["inferences"], "thesis": gold["thesis"], "discard": [],
+    }
+    m = s.score(predicted, gold, note, run_gate=False)
+    assert m["fabrication"] == 1, "a span absent from the note must be vetoed as fabrication"
+    assert m["span_faithfulness"] < 1.0, "an ungrounded span lowers span-faithfulness"
+
+
+def test_dropped_premise_lowers_recall():
+    """Omitting a real premise lowers premise recall (a partial decomposition is not perfect)."""
+    row = next(r for r, _ in _GOLD if r["id"] == "arg-axle-fatigue")
+    note = next(n for r, n in _GOLD if r["id"] == "arg-axle-fatigue")
+    gold = row["gold"]
+    predicted = {
+        "premises": gold["premises"][:-1],  # drop one premise
+        "inferences": gold["inferences"], "thesis": gold["thesis"], "discard": [],
+    }
+    m = s.score(predicted, gold, note, run_gate=False)
+    assert m["premise_recall"] < 1.0, "a dropped premise must lower recall"
+    assert m["premise_precision"] == 1.0, "the kept premises are still all correct"
+
+
+def test_wrong_span_breaks_the_premise_match():
+    """A premise with the right term but the WRONG span does not match gold — fidelity is about
+    provenance, not just the extracted proposition."""
+    row = next(r for r, _ in _GOLD if r["id"] == "arg-axle-fatigue")
+    note = next(n for r, n in _GOLD if r["id"] == "arg-axle-fatigue")
+    gold = row["gold"]
+    tampered = [dict(p) for p in gold["premises"]]
+    tampered[0]["span"] = "cyclic loading"  # a real substring, but not the premise's span
+    predicted = {"premises": tampered, "inferences": gold["inferences"],
+                 "thesis": gold["thesis"], "discard": []}
+    m = s.score(predicted, gold, note, run_gate=False)
+    assert m["premise_recall"] < 1.0, "a wrong span must break the premise match"
+    assert m["span_faithfulness"] == 1.0, "the wrong span is still a real substring (verbatim)"
+
+
+def test_aggregate_means_ratios_and_sums_vetoes():
+    """aggregate averages ratios and sums the veto counts across examples."""
+    scores = [s.score(r["gold"], r["gold"], n, run_gate=False) for r, n in _GOLD]
+    agg = s.aggregate(scores)
+    assert agg["n"] == len(_GOLD)
+    assert agg["premise_f1"] == 1.0 and agg["inference_f1"] == 1.0
+    assert agg["near_miss_violations"] == 0 and agg["fabrication"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GATE — the real thesis-derivation check (needs the built binaries).
+# ---------------------------------------------------------------------------
+
+_HAVE_BINS = gad.CLI.exists() and gad.VERIFY.exists()
+
+
+@pytest.mark.skipif(not _HAVE_BINS, reason="adj-lang-cli / adj-verify not built")
+def test_gold_derives_its_thesis_and_a_dropped_premise_does_not():
+    """With the binaries built: the gold argument DERIVES its thesis (thesis_derivation == 1), and a
+    prediction that drops a load-bearing premise fails to derive it (== 0)."""
+    row = next(r for r, _ in _GOLD if r["id"] == "arg-galaxy-redshift")
+    note = next(n for r, n in _GOLD if r["id"] == "arg-galaxy-redshift")
+    gold = row["gold"]
+    assert s.thesis_derivation(gold, gold, note) == 1, "the gold argument must derive its thesis"
+    broken = {"premises": gold["premises"][:1], "inferences": gold["inferences"],
+              "thesis": gold["thesis"], "discard": []}
+    assert s.thesis_derivation(broken, gold, note) == 0, "dropping a premise must break derivation"


### PR DESCRIPTION
## AD-3 — the model-free argument fidelity scorer

The counterpart to `decompose_score.py` for the open-vocab `argument` shape ([`ADJ-ARGUMENT-DECOMPOSER.md`](../blob/main/code/specs/ADJ-ARGUMENT-DECOMPOSER.md) §4), following AD-2 (#9332). A **pure** function `score(predicted, gold, note)` — no model, no network — that scores a decomposed argument's fidelity directly and offline.

### Metrics (spec §4)
- **premise** & **inference** precision/recall/F1 — set overlap by identity that **includes the normalized span**: a premise matches only when grounded on the right bytes; an inference must cite the right premises **and** the right connective bytes (`from` compared as a set, so citation order is irrelevant).
- **span_faithfulness** — fraction of predicted premise+inference spans that are verbatim substrings of the note.
- **near_miss_violations** (VETO, must be 0) — a predicted premise/inference whose span the gold says to **discard** (turning a set-aside near-miss into a premise).
- **fabrication** (VETO, must be 0) — a predicted span not present in the note at all (invented bytes).
- **thesis_derivation** (0/1) — the **real 3-part gate**: does the predicted argument compile, derive the gold thesis (non-empty recall via `adj-lang-cli`), and byte-anchor every citation (`adj-verify`)? Reuses `gen_argument_data.verify_gold`; `None` (skipped) when the binaries aren't built.

### Tests (7)
- **Self-consistency**: the AD-2 seed gold scored as its own prediction → every ratio 1.0, every veto 0 (mirrors `eval_decompose --self-check`).
- The **near-miss veto** fires even though the span is verbatim (only the veto catches it); the **fabrication veto** fires and lowers span-faithfulness; a **dropped premise** lowers recall; a **wrong span** breaks the match (fidelity is about provenance, not just the proposition); `aggregate` means ratios / sums vetoes.
- With binaries built: the gold **derives its thesis** (==1) while a dropped-premise prediction **does not** (==0).

### Verification
`pytest` → **7 passed** (incl. the gated derivation test). `ruff check` clean; pure + CI-safe (the gate self-skips without binaries). `/security-review` PASSED (no new subprocess calls; delegates to the already-reviewed AD-2 helper).

Follow-ups: AD-4 (held-out eval + runner) → AD-5 (decompose→emit→verify→explain e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)