### PR TITLE
feat(adj-argument-decomposer): decompose→emit→verify→explain e2e pipeline (AD-5)

### DIFF
--- a/code/specs/data/mycin-2026/train/decompose_pipeline.py
+++ b/code/specs/data/mycin-2026/train/decompose_pipeline.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""decompose_pipeline.py — the decompose→emit→verify→explain END-TO-END pipeline (AD-5).
+
+The closing rung of the argument-decomposer scaffold (ADJ-ARGUMENT-DECOMPOSER.md §6). It drives
+a paragraph of prose through all four stages that make a decomposed argument *usable*, proving
+end-to-end that **a paragraph becomes a program the engine runs, audits, and explains**:
+
+  1. EMIT     — the paragraph's argument as an `.adj` program, every citation a verbatim byte
+                slice of the paragraph (gen_argument_data.build_argument_adj).
+  2. DERIVE   — `adj-lang-cli` chains the inference rules over the premise facts to DERIVE the
+                paragraph's thesis (the recall answer), with no argument-specific evaluator.
+  3. VERIFY   — `adj-verify --snapshots` BYTE-ANCHORS every citation against the pinned paragraph
+                (each premise + each inference warrant), re-deriving the thesis.
+  4. EXPLAIN  — `adj-lang-cli --explain` renders the derivation as the argument it is:
+                grounded premises → the connective (inference) → the derived conclusion (ADR-6).
+
+Stages 2–4 shell out to the built binaries; the pipeline skips them gracefully when the binaries
+are absent (the EMIT stage is always pure). `test_decompose_pipeline.py` pins the four-stage flow.
+
+Usage:
+  python3 decompose_pipeline.py            # run every committed seed argument
+  python3 decompose_pipeline.py --seed arg-axle-fatigue
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import gen_argument_data as gad  # noqa: E402
+
+
+def _run_explain(adj_text: str) -> str:
+    """Stage 4: render the argument chain via `adj-lang-cli --explain`. Returns the chain text
+    (premises → connective → conclusion). Raises gad.BinariesMissing when the CLI is not built."""
+    if not gad.CLI.exists():
+        raise gad.BinariesMissing(f"build adj-lang-cli first: {gad.CLI}")
+    with tempfile.TemporaryDirectory() as td:
+        prog = Path(td) / "arg.adj"
+        prog.write_text(adj_text)
+        out = subprocess.run([str(gad.CLI), "--explain", str(prog)],
+                             capture_output=True, text=True, timeout=60)
+        return out.stdout
+
+
+def run_pipeline(spec: dict) -> dict:
+    """Run all four stages on one seed argument spec. Returns a report dict:
+    {emitted, snapshot, derived (recall JSON text), verified, quotes_verified, explained,
+     ran_cli}. When the binaries are absent, `ran_cli` is False and the CLI-stage fields are None —
+     only the pure EMIT stage ran."""
+    sb = gad.source_bytes_for(spec)
+    adj_text, hexhash = gad.build_argument_adj(spec, sb)  # stage 1 (pure)
+    report = {
+        "id": spec["id"], "emitted": adj_text, "snapshot": hexhash,
+        "derived": None, "verified": None, "quotes_verified": None,
+        "explained": None, "ran_cli": False,
+    }
+    if not (gad.CLI.exists() and gad.VERIFY.exists()):
+        return report
+    res = gad.verify_gold(adj_text, sb)  # stages 2 (derive) + 3 (verify)
+    report["ran_cli"] = True
+    report["derived"] = res["derive_stdout"]
+    report["verified"] = res["verified"]
+    report["quotes_verified"] = res["quotes_verified"]
+    report["explained"] = _run_explain(adj_text)  # stage 4
+    return report
+
+
+def print_report(report: dict, spec: dict) -> None:
+    """A human-readable four-stage report for one seed."""
+    print(f"\n=== {report['id']} ({spec.get('domain', '?')}) ===")
+    print("1. EMIT — the paragraph's argument as an .adj program:")
+    for line in report["emitted"].splitlines():
+        print(f"     {line}")
+    if not report["ran_cli"]:
+        print("   (adj-lang-cli / adj-verify not built — stages 2-4 skipped)")
+        return
+    want = gad.total_citations(spec)
+    derived_ok = spec.get("expect", "") in (report["derived"] or "")
+    print(f"2. DERIVE — thesis derived: {derived_ok} (expect '{spec.get('expect', '')}')")
+    print(f"3. VERIFY — byte-anchored: verified={report['verified']} "
+          f"quotes_verified={report['quotes_verified']}/{want}")
+    print("4. EXPLAIN — the argument chain (premises → connective → conclusion):")
+    for line in (report["explained"] or "").splitlines():
+        print(f"     {line}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--seed", help="run only this seed id (default: all)")
+    args = ap.parse_args()
+    specs = [s for s in gad.SEED if not args.seed or s["id"] == args.seed]
+    if not specs:
+        print(f"decompose_pipeline: no seed matches {args.seed!r}", file=sys.stderr)
+        return 2
+    for spec in specs:
+        print_report(run_pipeline(spec), spec)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/code/specs/data/mycin-2026/train/test_decompose_pipeline.py
+++ b/code/specs/data/mycin-2026/train/test_decompose_pipeline.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""test_decompose_pipeline.py — guard the decompose→emit→verify→explain pipeline (AD-5).
+
+Pure structural checks always run (stage 1, EMIT, needs no binaries). The full four-stage
+assertion runs when the adj-lang-cli / adj-verify binaries are built, and skips otherwise — the
+same graceful degradation the rest of the AD scaffold uses.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import decompose_pipeline as dp  # noqa: E402
+import gen_argument_data as gad  # noqa: E402
+
+_HAVE_BINS = gad.CLI.exists() and gad.VERIFY.exists()
+
+
+@pytest.mark.parametrize("spec", gad.SEED, ids=[s["id"] for s in gad.SEED])
+def test_emit_stage_is_pure_and_well_formed(spec):
+    """Stage 1 (EMIT) runs with no binaries: it produces a well-formed .adj for every seed."""
+    report = dp.run_pipeline(spec) if not _HAVE_BINS else None
+    # Emit is pure; verify it directly regardless of binaries.
+    sb = gad.source_bytes_for(spec)
+    adj_text, _ = gad.build_argument_adj(spec, sb)
+    assert adj_text.startswith(f'argument {spec["name"]} {{')
+    assert adj_text.rstrip().endswith(f'? {spec["thesis"]}')
+    if report is not None:
+        assert report["emitted"] == adj_text and report["ran_cli"] is False
+
+
+@pytest.mark.skipif(not _HAVE_BINS, reason="adj-lang-cli / adj-verify not built")
+@pytest.mark.parametrize("spec", gad.SEED, ids=[s["id"] for s in gad.SEED])
+def test_full_four_stage_pipeline(spec):
+    """With the binaries built, the pipeline proves the emission path end to end for every seed:
+    it emits an .adj that DERIVES the thesis, BYTE-ANCHORS every citation, and whose --explain
+    renders the premises → connective → conclusion chain."""
+    report = dp.run_pipeline(spec)
+    assert report["ran_cli"] is True
+
+    # Stage 2 — DERIVE: the paragraph's thesis is reached (the expected bound value appears).
+    assert spec["expect"] in (report["derived"] or ""), f"{spec['id']}: thesis must derive"
+
+    # Stage 3 — VERIFY: every citation byte-anchored.
+    assert report["verified"] is True
+    assert report["quotes_verified"] == gad.total_citations(spec)
+
+    # Stage 4 — EXPLAIN: the chain renders as premises → connective → conclusion.
+    ex = report["explained"] or ""
+    assert ex.startswith("Argument for "), f"{spec['id']}: --explain must render an argument section"
+    assert "<= inference" in ex, "the conclusion(s) render as inference (connective) steps"
+    assert "premise " in ex, "the grounded premises render as premise lines"
+    # The derived conclusion value appears in the rendered chain (not the open query variable).
+    assert spec["expect"] in ex, f"{spec['id']}: the derived conclusion shows in the chain"
+
+
+@pytest.mark.skipif(not _HAVE_BINS, reason="adj-lang-cli / adj-verify not built")
+def test_pipeline_is_deterministic():
+    """The whole flow is deterministic — two runs of a seed produce identical reports."""
+    spec = gad.SEED[0]
+    a, b = dp.run_pipeline(spec), dp.run_pipeline(spec)
+    assert a == b, "the pipeline must be byte-identical across runs"


### PR DESCRIPTION
## AD-5 — the closing rung: the decompose→emit→verify→explain pipeline

The final rung of the argument-decomposer scaffold ([`ADJ-ARGUMENT-DECOMPOSER.md`](../blob/main/code/specs/ADJ-ARGUMENT-DECOMPOSER.md) §6 AD-5), following AD-4 (#9334). A driver that runs a paragraph through all **four stages** that make a decomposed argument usable — proving end-to-end that **a paragraph becomes a program the engine runs, audits, and explains**:

1. **EMIT** — the paragraph's argument as an `.adj` (every citation a verbatim byte slice; pure).
2. **DERIVE** — `adj-lang-cli` chains the inference rules over the premise facts to derive the paragraph's thesis.
3. **VERIFY** — `adj-verify --snapshots` byte-anchors every citation against the pinned paragraph.
4. **EXPLAIN** — `adj-lang-cli --explain` renders the derivation as premises → connective → conclusion (ADR-6).

Running it on the epidemiology seed, end to end:
```
2. DERIVE — thesis derived: True (expect 'outbreak')
3. VERIFY — byte-anchored: verified=True quotes_verified=3/3
4. EXPLAIN — the argument chain (premises → connective → conclusion):
     Argument for source_of(pump, What):
       source_of(pump, outbreak)  <= inference [source "outbreak field report" trust authoritative]
         premise clustered_around(illness, pump)  [source "outbreak field report" trust authoritative]
         premise fell_after_closure(pump)  [source "outbreak field report" trust authoritative]
```

### Changes
- `decompose_pipeline.py` — `run_pipeline` (4 stages → report) + `print_report` + a `--seed`/all CLI. Reuses `gen_argument_data` (emit/derive/verify) + the ADR-6 `adj-lang-cli --explain`. Stages 2–4 skip gracefully when binaries are absent.
- `test_decompose_pipeline.py` (**7**) — the EMIT stage is pure + well-formed for every seed (always runs); with binaries built, the full four-stage flow derives the thesis, byte-anchors all citations, and `--explain` renders the premises→connective→conclusion chain with the derived conclusion; the flow is deterministic.

### Verification
`pytest` → **7 passed**; `ruff check` clean; pure + CI-safe (CLI stages self-skip without binaries). `/security-review` PASSED.

**This closes the AD-1..5 decomposer scaffold arc:** spec → gold generator → scorer → held-out eval → end-to-end pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)