### PR TITLE
feat: add OCaml scaffold infrastructure

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,14 +8,9 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "item_id": "ocaml-lane-contract",
-    "pr_number": 9323,
-    "branch": "codex/ocaml-lane-contract",
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9323"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "0f8bb3b2519ed73fc932a5291b510433e8a71480",
+    "revision": "67dc08ac8fcd8598a0ad5e82952c2aee5087a38d",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1197,
@@ -331,20 +326,38 @@
     {
       "id": "ocaml-lane-contract",
       "title": "Define OCaml emerging-lane and denominator-safe reporter contracts",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-contract"],
       "branch": "codex/ocaml-lane-contract",
       "pr_number": 9323,
-      "notes": "Selected after merged PR #9308 and refreshed against the collision-checked 0f8bb3b25 inventory because this focused contract makes the reporter denominator-safe, classifies OCaml without changing the established 15-language denominator, and unlocks every later OCaml scaffold, resolver, representative-package, capability, build-tool, and promotion tranche. Ready-for-review PR #9323 opened after the 177-test scripts suite, 10 focused reporter tests, 5 dependent learning-report tests, 86% reporter branch coverage, Ruff, Go test/vet/build-tool build, all-format collision checks, diff checks, baseline-comparison BUILD validation, secret scan, and independent final security review."
+      "notes": "Merged PR #9323. The denominator-safe contract classifies OCaml as emerging without changing the established 15-language denominator and unlocks the remaining OCaml bootstrap."
     },
     {
       "id": "ocaml-infrastructure",
       "title": "Add OCaml scaffolding, lane README, and package metadata support",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["ocaml-lane-contract"],
+      "branch": "codex/ocaml-infrastructure",
+      "pr_number": null,
+      "notes": "Add complete Go and TypeScript scaffold templates plus golden tests, repository ignores, capability metadata/schema support, and the lane README. Use OCaml 5.2.1, opam 2.5.2, Dune 3.17.2 with language 3.16, Alcotest 1.9.0, bisect_ppx 2.8.3, and ocamlformat 0.27.0."
+    },
+    {
+      "id": "ocaml-ci-toolchain",
+      "title": "Provision and transitively lock the OCaml toolchain on Ubuntu, macOS, and Windows CI",
+      "status": "pending",
+      "depends_on": ["ocaml-infrastructure"],
       "branch": null,
       "pr_number": null,
-      "notes": "Add complete Go and TypeScript scaffold templates plus golden tests, repository ignores, capability metadata/schema support, and the lane README. Use OCaml 5.2.1, opam 2.5.x, Dune 3.16.x, Alcotest, bisect_ppx, and ocamlformat."
+      "notes": "Discovered during the post-#9323 fixture and ownership audit. Install and cache OCaml 5.2.1, opam 2.5.2, Dune 3.17.2 with language 3.16, Alcotest 1.9.0, bisect_ppx 2.8.3, and ocamlformat 0.27.0 on all three runner families; lock and verify the opam-repository/switch transitive solver state; then prove generated library and program scaffolds run real formatting, test, and coverage commands without skips."
+    },
+    {
+      "id": "adj-lang-cli-capability-profile",
+      "title": "Separate and declare adj-lang-cli runtime and E2E harness capabilities",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the post-#9323 security audit after PR #9324 added argument_verify_e2e.rs. Audit the package's pre-existing filesystem, environment, process, and stdout use; isolate test-harness authority from the publishable runtime profile; add truthful manifests; and obtain Layer-5 approval for every nonempty profile."
     },
     {
       "id": "ocaml-build-substrate",
@@ -359,7 +372,7 @@
       "id": "ocaml-representative-core",
       "title": "Port logic-gates, graph, directed-graph, and state-machine to OCaml",
       "status": "pending",
-      "depends_on": ["ocaml-build-substrate"],
+      "depends_on": ["ocaml-build-substrate", "ocaml-ci-toolchain"],
       "branch": null,
       "pr_number": null,
       "notes": "This dependency chain validates opam metadata, resolver edges, BUILD order, and affected-node expansion."
@@ -394,7 +407,8 @@
       "depends_on": [
         "ocaml-build-tool-and-promotion",
         "ocaml-capability-analyzer",
-        "ocaml-representative-core"
+        "ocaml-representative-core",
+        "ocaml-ci-toolchain"
       ],
       "branch": null,
       "pr_number": null,

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "ocaml-infrastructure",
+    "pr_number": 9336,
+    "branch": "codex/ocaml-infrastructure",
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9336"
+  },
   "last_inventory": {
     "revision": "67dc08ac8fcd8598a0ad5e82952c2aee5087a38d",
     "schema_version": 3,
@@ -335,11 +340,11 @@
     {
       "id": "ocaml-infrastructure",
       "title": "Add OCaml scaffolding, lane README, and package metadata support",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["ocaml-lane-contract"],
       "branch": "codex/ocaml-infrastructure",
-      "pr_number": null,
-      "notes": "Add complete Go and TypeScript scaffold templates plus golden tests, repository ignores, capability metadata/schema support, and the lane README. Use OCaml 5.2.1, opam 2.5.2, Dune 3.17.2 with language 3.16, Alcotest 1.9.0, bisect_ppx 2.8.3, and ocamlformat 0.27.0."
+      "pr_number": 9336,
+      "notes": "Ready-for-review PR #9336 adds complete Go and TypeScript scaffold templates plus golden tests, repository ignores, capability metadata/schema support, and the lane README. It uses OCaml 5.2.1, opam 2.5.2, Dune 3.17.2 with language 3.16, Alcotest 1.9.0, bisect_ppx 2.8.3, and ocamlformat 0.27.0."
     },
     {
       "id": "ocaml-ci-toolchain",

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,13 @@ Cargo.lock
 # Dart
 .dart_tool/
 
+# OCaml
+_opam/
+*.install
+bisect*.coverage
+.merlin
+.merlin-exist-*
+
 # Gradle
 .gradle/
 gradle-build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — OCaml Scaffold Infrastructure
+- Added the OCAML02 contract, lane README, repository ignores, and shared
+  byte-exact library/program fixture trees for the emerging OCaml lane.
+- Added matching Go and TypeScript scaffold-generator support with exact direct
+  OCaml/opam/Dune/Alcotest/`bisect_ppx`/`ocamlformat` metadata, resolved local
+  dependency pins, real formatting/test/coverage build commands, and
+  schema-valid capability profiles.
+- Added OCaml-specific metadata serialization and `*)` injection hardening
+  before any scaffold directory is written.
+- Rejected Dune `%{...}` interpolation openers before output generation.
+- Added a shared OCaml/opam string encoding contract so accepted Unicode remains
+  byte-identical raw UTF-8 across the Go and TypeScript front doors.
+- Added dependency-reader regressions for self-name/metadata decoys,
+  program-to-library pin paths, and direct/transitive symlink rejection.
+
 ### Added — OCaml Emerging-Lane Contract
 - Added OCAML01 to define OCaml as a known emerging implementation lane that
   remains outside the established 15-language parity denominator until its

--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ OCaml is a known emerging implementation lane governed by
 [OCAML01](./code/specs/OCAML01-emerging-lane-contract.md); its packages remain
 outside the established parity denominator until the scaffold, resolver,
 capability, build-tool, package, and three-platform promotion gates pass.
+The two scaffold-generator front doors implement the byte-stable library and
+program contract in
+[OCAML02](./code/specs/OCAML02-scaffold-infrastructure.md), including exact
+direct opam/Dune constraints, Alcotest, formatting, coverage, and capability
+profiles. Transitive switch/repository locking remains a CI-toolchain gate.
 The parity report's JSON schema is version 3, and CSV consumers must select
 presence columns by header name because recognized emerging lanes extend the
 matrix.

--- a/code/packages/ocaml/README.md
+++ b/code/packages/ocaml/README.md
@@ -1,0 +1,42 @@
+# OCaml implementation lane
+
+OCaml is an `emerging_implementation` lane. Its packages are visible to the
+package-parity inventory but remain outside the established 15-language
+denominator until the reviewed promotion gates pass.
+
+## Exact direct conventions
+
+- OCaml `5.2.1`
+- opam `2.5.2`
+- Dune `3.17.2` (Dune language `3.16`)
+- Alcotest `1.9.0`
+- `bisect_ppx` `2.8.3`
+- `ocamlformat` `0.27.0`
+
+Package directories use kebab case. A directory such as `my-pkg` publishes the
+local opam/Dune name `coding-adventures-my-pkg`; OCaml compilation units use
+the `Coding_adventures_my_pkg` prefix. Direct local dependencies are exact
+`0.1.0` opam dependencies, while build scripts pin the complete leaf-first
+sibling closure before installing the current package.
+
+These exact direct constraints do not lock transitive solver output or the
+configured opam-repository snapshot. Three-platform switch/repository locking
+and reproducibility evidence remain owned by the `ocaml-ci-toolchain` roadmap
+item.
+
+Every package checks in `dune-project`, its `.opam` file, `.ocamlformat`,
+Alcotest tests, `BUILD`, `BUILD_windows`, a capability manifest, README, and
+changelog. Both build files must run real formatting, tests, and
+`bisect_ppx` coverage commands—skip-success placeholders are not acceptable.
+
+Generate a starter through either reviewed front door:
+
+```sh
+scaffold-generator my-pkg --language ocaml --description "A pure OCaml package"
+```
+
+The exact library and program contracts live in
+[`OCAML02-scaffold-infrastructure.md`](../../specs/OCAML02-scaffold-infrastructure.md).
+Canonical build-tool integration, three-platform CI provisioning,
+representative packages, capability analysis, the native OCaml build tool, and
+denominator promotion remain explicitly tracked roadmap items.

--- a/code/programs/go/build-tool/internal/discovery/discovery.go
+++ b/code/programs/go/build-tool/internal/discovery/discovery.go
@@ -87,6 +87,7 @@ var skipDirs = map[string]bool{
 	"build":         true,
 	"target":        true,
 	".claude":       true,
+	"specs":         true, // Specification and golden fixture trees are never buildable packages
 	"Pods":          true,
 	".dart_tool":    true,
 	".build":        true, // Swift Package Manager build artefacts and dependency checkouts

--- a/code/programs/go/build-tool/internal/discovery/discovery_test.go
+++ b/code/programs/go/build-tool/internal/discovery/discovery_test.go
@@ -513,3 +513,19 @@ func TestDiscoverSkipsRootLevelSkipDirs(t *testing.T) {
 		t.Errorf("expected python/pkg-a, got %s", packages[0].Name)
 	}
 }
+
+func TestDiscoverSkipsSpecificationFixtureTrees(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"packages/python/pkg-a/BUILD":                     "echo a",
+		"specs/fixtures/scaffold-generator/library/BUILD": "opam exec -- dune build",
+		"specs/fixtures/scaffold-generator/program/BUILD": "opam exec -- dune build",
+	})
+
+	packages := DiscoverPackages(root)
+	if len(packages) != 1 {
+		t.Fatalf("expected only the real package, got %d: %v", len(packages), packages)
+	}
+	if packages[0].Name != "python/pkg-a" {
+		t.Errorf("expected python/pkg-a, got %s", packages[0].Name)
+	}
+}

--- a/code/programs/go/scaffold-generator/CHANGELOG.md
+++ b/code/programs/go/scaffold-generator/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this program will be documented in this file.
 
 ### Added
 
+- **OCaml library and program scaffolds** (`--language ocaml`) with shared
+  byte-exact golden trees, exact direct opam/Dune metadata, Alcotest,
+  ocamlformat, bisect_ppx coverage, resolved local dependency pins, and
+  capability manifests.
 - **C and C++ scaffold templates** (`--language c` / `--language cpp`). Generates
   a pure-ISO package wired to the shared iso-harness: `BUILD`
   (`# build-tool: deps=c/iso-harness` + `sh tools/run.sh`), `BUILD_windows`
@@ -19,6 +23,14 @@ All notable changes to this program will be documented in this file.
 
 ### Fixed
 
+- OCaml descriptions now reject `*)` and use context-safe quoted metadata
+  serialization before any file is written.
+- Dune `%{...}` interpolation openers are rejected before any scaffold output.
+- Accepted Unicode descriptions now remain raw UTF-8 with only OCaml/opam
+  quote and backslash escaping, matching the TypeScript front door byte-for-byte.
+- OCaml dependency discovery reads only the expected opam `depends` field,
+  program scaffolds pin package-tree dependencies by resolved relative path,
+  and direct/transitive dependency symlinks fail closed.
 - Haskell capability metadata now uses the complete shared schema-v1 document,
   with golden output and shared-schema regression coverage instead of the
   legacy one-field JSON object.

--- a/code/programs/go/scaffold-generator/README.md
+++ b/code/programs/go/scaffold-generator/README.md
@@ -1,12 +1,17 @@
 # scaffold-generator
 
 A CLI tool that generates CI-ready package scaffolding for the coding-adventures
-monorepo across 14 languages: Python, Go, Ruby, TypeScript, Rust, Elixir, Perl,
-Lua, Swift, Haskell, Java, Kotlin, C, and C++.
+monorepo across 15 languages: Python, Go, Ruby, TypeScript, Rust, Elixir, Perl,
+Lua, Swift, Haskell, OCaml, Java, Kotlin, C, and C++.
 
 Haskell scaffolds include a schema-v1 `required_capabilities.json` whose package
 identity matches the generated directory. The manifest starts with an explicit
 empty capability profile for the pure library template.
+
+OCaml library and program scaffolds match the shared OCAML02 golden trees.
+They include exact direct opam/Dune tool constraints, Alcotest, formatting and
+coverage commands, local dependency pins, and schema-v1 capability profiles.
+Transitive opam-repository/switch locking remains a separate CI-toolchain gate.
 
 ## Why
 
@@ -29,6 +34,9 @@ scaffold-generator my-package --dry-run
 
 # Scaffold a program (goes in code/programs/ instead of code/packages/)
 scaffold-generator my-tool --type program --language go
+
+# Scaffold an OCaml library
+scaffold-generator my-package --language ocaml --description "Pure OCaml logic"
 ```
 
 ## Build

--- a/code/programs/go/scaffold-generator/main.go
+++ b/code/programs/go/scaffold-generator/main.go
@@ -54,7 +54,7 @@ import (
 // =========================================================================
 
 // validLanguages lists all supported target languages.
-var validLanguages = []string{"python", "go", "ruby", "typescript", "rust", "elixir", "perl", "lua", "swift", "haskell", "java", "kotlin", "c", "cpp"}
+var validLanguages = []string{"python", "go", "ruby", "typescript", "rust", "elixir", "perl", "lua", "swift", "haskell", "ocaml", "java", "kotlin", "c", "cpp"}
 
 const requiredCapabilitiesSchemaURL = "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json"
 
@@ -63,7 +63,9 @@ const requiredCapabilitiesSchemaURL = "https://raw.githubusercontent.com/adhithy
 var kebabCaseRe = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)
 
 func isSafeDescription(description string) bool {
-	if strings.Contains(description, "*/") {
+	if strings.Contains(description, "*/") ||
+		strings.Contains(description, "*)") ||
+		strings.Contains(description, "%{") {
 		return false
 	}
 	for _, char := range description {
@@ -200,6 +202,8 @@ func readDeps(pkgDir, lang string) ([]string, error) {
 		return readSwiftDeps(pkgDir)
 	case "haskell":
 		return readHaskellDeps(pkgDir)
+	case "ocaml":
+		return readOcamlDeps(pkgDir)
 	case "java":
 		return readJavaDeps(pkgDir)
 	case "kotlin":
@@ -577,6 +581,98 @@ func readHaskellDeps(pkgDir string) ([]string, error) {
 	return deps, nil
 }
 
+// readOcamlDeps reads checked-in opam metadata and returns only local
+// coding-adventures package names. External opam dependencies are ignored.
+func readOcamlDeps(pkgDir string) ([]string, error) {
+	metadataPath := filepath.Join(
+		pkgDir,
+		"coding-adventures-"+filepath.Base(pkgDir)+".opam",
+	)
+	// #nosec G304 -- scaffold dependency directories are lstat-checked and contained before this fixed-name read.
+	data, err := os.ReadFile(metadataPath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	dependsRe := regexp.MustCompile(`(?ms)^depends[ \t]*:\s*\[(.*?)\]`)
+	depends := dependsRe.FindStringSubmatch(string(data))
+	if len(depends) != 2 {
+		return nil, nil
+	}
+	re := regexp.MustCompile(`"coding-adventures-([a-z][a-z0-9]*(?:-[a-z0-9]+)*)"`)
+	matches := re.FindAllStringSubmatch(depends[1], -1)
+	seen := map[string]bool{}
+	deps := make([]string, 0, len(matches))
+	for _, match := range matches {
+		dep := match[1]
+		if !seen[dep] {
+			seen[dep] = true
+			deps = append(deps, dep)
+		}
+	}
+	return deps, nil
+}
+
+// resolveDepDir locates a dependency in either the packages or programs tree.
+// Packages are preferred because they are the standard reusable module location.
+func resolveDepDir(repoRoot, lang, dep string) string {
+	dName := dirName(dep, lang)
+	pkgDir := filepath.Join(repoRoot, "code", "packages", lang, dName)
+	if info, err := os.Stat(pkgDir); err == nil && info.IsDir() {
+		return pkgDir
+	}
+	programDir := filepath.Join(repoRoot, "code", "programs", lang, dName)
+	if info, err := os.Stat(programDir); err == nil && info.IsDir() {
+		return programDir
+	}
+	return pkgDir
+}
+
+func validateDependencyDir(repoRoot, depDir string) error {
+	info, err := os.Lstat(depDir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("dependency directory must not be a symlink: %s", depDir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("dependency path is not a directory: %s", depDir)
+	}
+
+	realRoot, err := filepath.EvalSymlinks(repoRoot)
+	if err != nil {
+		return fmt.Errorf("resolving repository root: %w", err)
+	}
+	realDep, err := filepath.EvalSymlinks(depDir)
+	if err != nil {
+		return fmt.Errorf("resolving dependency directory: %w", err)
+	}
+	relative, err := filepath.Rel(realRoot, realDep)
+	if err != nil ||
+		filepath.IsAbs(relative) ||
+		relative == ".." ||
+		strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("dependency directory escapes repository root: %s", depDir)
+	}
+	return nil
+}
+
+func validateResolvedDependency(
+	depDir string,
+	validators []func(string) error,
+) error {
+	for _, validate := range validators {
+		if err := validate(depDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // jvmDepRe matches local composite-build dependency coordinates in Gradle.
 var jvmDepRe = regexp.MustCompile(`com\.codingadventures:([a-z0-9-]+)`)
 
@@ -617,6 +713,17 @@ func readJVMDeps(pkgDir string) ([]string, error) {
 // the given direct dependencies. Returns the full set (not including the
 // package itself).
 func transitiveClosure(directDeps []string, lang, baseDir string) ([]string, error) {
+	return transitiveClosureWithResolver(directDeps, lang, func(dep string) string {
+		return filepath.Join(baseDir, dirName(dep, lang))
+	})
+}
+
+func transitiveClosureWithResolver(
+	directDeps []string,
+	lang string,
+	resolve func(string) string,
+	validators ...func(string) error,
+) ([]string, error) {
 	visited := make(map[string]bool)
 	queue := make([]string, len(directDeps))
 	copy(queue, directDeps)
@@ -629,7 +736,10 @@ func transitiveClosure(directDeps []string, lang, baseDir string) ([]string, err
 		}
 		visited[dep] = true
 
-		depDir := filepath.Join(baseDir, dirName(dep, lang))
+		depDir := resolve(dep)
+		if err := validateResolvedDependency(depDir, validators); err != nil {
+			return nil, fmt.Errorf("validating dependency %s: %w", dep, err)
+		}
 		depDeps, err := readDeps(depDir, lang)
 		if err != nil {
 			return nil, fmt.Errorf("reading deps of %s: %w", dep, err)
@@ -653,6 +763,17 @@ func transitiveClosure(directDeps []string, lang, baseDir string) ([]string, err
 // that have no dependencies of their own come first). This is the install
 // order needed for BUILD files.
 func topologicalSort(allDeps []string, lang, baseDir string) ([]string, error) {
+	return topologicalSortWithResolver(allDeps, lang, func(dep string) string {
+		return filepath.Join(baseDir, dirName(dep, lang))
+	})
+}
+
+func topologicalSortWithResolver(
+	allDeps []string,
+	lang string,
+	resolve func(string) string,
+	validators ...func(string) error,
+) ([]string, error) {
 	// Build adjacency: dep -> its deps (within the allDeps set)
 	depSet := make(map[string]bool)
 	for _, d := range allDeps {
@@ -667,8 +788,14 @@ func topologicalSort(allDeps []string, lang, baseDir string) ([]string, error) {
 	}
 
 	for _, dep := range allDeps {
-		depDir := filepath.Join(baseDir, dirName(dep, lang))
-		depDeps, _ := readDeps(depDir, lang)
+		depDir := resolve(dep)
+		if err := validateResolvedDependency(depDir, validators); err != nil {
+			return nil, fmt.Errorf("validating dependency %s: %w", dep, err)
+		}
+		depDeps, err := readDeps(depDir, lang)
+		if err != nil {
+			return nil, fmt.Errorf("reading deps of %s: %w", dep, err)
+		}
 		for _, dd := range depDeps {
 			if depSet[dd] {
 				graph[dep] = append(graph[dep], dd)
@@ -1931,6 +2058,202 @@ spec =
 // File generation — Java
 // =========================================================================
 
+func quoteOcamlString(value string) string {
+	escaped := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+	).Replace(value)
+	return `"` + escaped + `"`
+}
+
+func generateOcaml(
+	targetDir, pkgName, pkgType, description, layerCtx string,
+	directDeps, orderedDeps []string,
+	depDirs map[string]string,
+) error {
+	if !kebabCaseRe.MatchString(pkgName) {
+		return fmt.Errorf("invalid OCaml package name %q", pkgName)
+	}
+	if pkgType != "library" && pkgType != "program" {
+		return fmt.Errorf("invalid OCaml package type %q", pkgType)
+	}
+	if !isSafeDescription(description) {
+		return fmt.Errorf("description must be one printable line without control characters or structural delimiters")
+	}
+	for _, dep := range append(append([]string{}, directDeps...), orderedDeps...) {
+		if !kebabCaseRe.MatchString(dep) {
+			return fmt.Errorf("invalid OCaml dependency name %q", dep)
+		}
+	}
+
+	testBase := toSnakeCase(pkgName)
+	moduleBase := "coding_adventures_" + testBase
+	moduleRef := strings.ToUpper(moduleBase[:1]) + moduleBase[1:]
+	publicName := "coding-adventures-" + pkgName
+	quotedDescription := quoteOcamlString(description)
+
+	duneProject := fmt.Sprintf(`(lang dune 3.16)
+(name %s)
+(generate_opam_files false)
+(package
+ (name %s)
+ (synopsis %s)
+ (description %s))
+`, publicName, publicName, quotedDescription, quotedDescription)
+
+	var opam strings.Builder
+	fmt.Fprintf(&opam, `opam-version: "2.0"
+name: %s
+version: "0.1.0"
+synopsis: %s
+description: %s
+maintainer: "Adhithya Rajasekaran"
+authors: "Adhithya Rajasekaran"
+license: "MIT"
+homepage: "https://github.com/adhithyan15/coding-adventures"
+bug-reports: "https://github.com/adhithyan15/coding-adventures/issues"
+dev-repo: "git+https://github.com/adhithyan15/coding-adventures.git"
+depends: [
+  "ocaml" {= "5.2.1"}
+  "dune" {= "3.17.2"}
+  "alcotest" {with-test & = "1.9.0"}
+  "bisect_ppx" {with-test & = "2.8.3"}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+`, quoteOcamlString(publicName), quotedDescription, quotedDescription)
+	sortedDirect := append([]string{}, directDeps...)
+	sort.Strings(sortedDirect)
+	for _, dep := range sortedDirect {
+		fmt.Fprintf(&opam, "  %s {= \"0.1.0\"}\n", quoteOcamlString("coding-adventures-"+dep))
+	}
+	opam.WriteString(`]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+`)
+
+	srcDune := fmt.Sprintf(`(library
+ (name %s)
+ (public_name %s)
+ (wrapped false)
+ (instrumentation
+  (backend bisect_ppx)))
+`, moduleBase, publicName)
+	source := fmt.Sprintf(`let version () = "0.1.0"
+let package_name = %s
+`, quoteOcamlString(publicName))
+	if layerCtx != "" {
+		source += fmt.Sprintf("let layer = Some %s\n", quoteOcamlString(layerCtx))
+	} else {
+		source += "let layer = None\n"
+	}
+	iface := `val version : unit -> string
+val package_name : string
+val layer : string option
+`
+	testDune := fmt.Sprintf(`(test
+ (name test_%s)
+ (libraries alcotest %s))
+`, testBase, moduleBase)
+	testSource := fmt.Sprintf(`let () =
+  Alcotest.run %s
+    [
+      ( "metadata",
+        [
+          Alcotest.test_case "version" `+"`Quick"+` (fun () ->
+              Alcotest.(check string)
+                "version" "0.1.0"
+                (%s.version ()));
+        ] );
+    ]
+`, quoteOcamlString(publicName), moduleRef)
+
+	build := ""
+	buildWindows := ""
+	for _, dep := range orderedDeps {
+		pinPath := filepath.ToSlash(filepath.Join("..", dep))
+		if depDir, ok := depDirs[dep]; ok {
+			relative, err := filepath.Rel(targetDir, depDir)
+			if err != nil {
+				return fmt.Errorf("resolving OCaml dependency path for %s: %w", dep, err)
+			}
+			pinPath = filepath.ToSlash(relative)
+		}
+		build += fmt.Sprintf("opam pin add --no-action -y coding-adventures-%s %s\n", dep, pinPath)
+		buildWindows += fmt.Sprintf("opam pin add --no-action -y coding-adventures-%s %s\n", dep, pinPath)
+	}
+	build += fmt.Sprintf(`opam install . --deps-only --with-test --with-dev-setup -y
+opam exec -- dune build @fmt
+BISECT_FILE="$PWD/bisect" opam exec -- dune runtest --force --instrument-with bisect_ppx
+opam exec -- bisect-ppx-report summary --per-file --expect src/%s.ml bisect*.coverage
+`, moduleBase)
+	buildWindows += fmt.Sprintf(`opam install . --deps-only --with-test --with-dev-setup -y
+opam exec -- dune build @fmt
+set BISECT_FILE=%%CD%%\bisect&& opam exec -- dune runtest --force --instrument-with bisect_ppx
+for %%f in (bisect*.coverage) do opam exec -- bisect-ppx-report summary --per-file --expect src/%s.ml %%f
+`, moduleBase)
+
+	capabilityManifest, err := requiredCapabilitiesJSON("ocaml", pkgName)
+	if err != nil {
+		return err
+	}
+	if pkgType == "program" {
+		manifest := requiredCapabilitiesManifest{
+			Schema:  requiredCapabilitiesSchemaURL,
+			Version: 1,
+			Package: "ocaml/" + pkgName,
+			Capabilities: []requiredCapability{{
+				Category:      "stdout",
+				Action:        "write",
+				Target:        "*",
+				Justification: "The generated command prints its deterministic package identity.",
+			}},
+			Justification: "The command only writes its deterministic result to standard output.",
+		}
+		encoded, marshalErr := json.MarshalIndent(manifest, "", "  ")
+		if marshalErr != nil {
+			return marshalErr
+		}
+		capabilityManifest = string(encoded) + "\n"
+	}
+
+	files := map[string]string{
+		".gitignore":                    "_build/\n_opam/\nbisect*.coverage\n",
+		".ocamlformat":                  "version = 0.27.0\nprofile = default\nocaml-version = 5.2\n",
+		"BUILD":                         build,
+		"BUILD_windows":                 buildWindows,
+		publicName + ".opam":            opam.String(),
+		"dune-project":                  duneProject,
+		"required_capabilities.json":    capabilityManifest,
+		"src/" + moduleBase + ".ml":     source,
+		"src/" + moduleBase + ".mli":    iface,
+		"src/dune":                      srcDune,
+		"test/dune":                     testDune,
+		"test/test_" + testBase + ".ml": testSource,
+	}
+	if pkgType == "program" {
+		files["bin/dune"] = fmt.Sprintf(`(executable
+ (name main)
+ (public_name %s)
+ (libraries %s))
+`, pkgName, moduleBase)
+		files["bin/main.ml"] = fmt.Sprintf("let () = print_endline %s.package_name\n", moduleRef)
+	}
+	for path, content := range files {
+		fullPath := filepath.Join(targetDir, path)
+		// #nosec G301 -- generated source trees intentionally use conventional 0755 directories.
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			return err
+		}
+		// #nosec G306 -- generated source and metadata files intentionally use conventional 0644 permissions.
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func generateJava(targetDir, pkgName, description, layerCtx string, directDeps []string) error {
 	camel := toCamelCase(pkgName)
 	joined := toJoinedLower(pkgName)
@@ -2273,10 +2596,10 @@ int main(void) {
 	runPs1 := isoRunPs1(pkgName, symbol, "c", fmt.Sprintf("\"tests\\%s_test.c\", \"src\\%s.c\"", symbol, symbol))
 
 	return writeCFamilyFiles(targetDir, map[string]string{
-		filepath.Join("include", symbol+".h"):     header,
-		filepath.Join("src", symbol+".c"):         source,
-		filepath.Join("tests", symbol+"_test.c"):  test,
-		"BUILD":                                   build,
+		filepath.Join("include", symbol+".h"):    header,
+		filepath.Join("src", symbol+".c"):        source,
+		filepath.Join("tests", symbol+"_test.c"): test,
+		"BUILD":                                  build,
 		"BUILD_windows":                           buildWin,
 		filepath.Join("tools", "run.sh"):          runSh,
 		filepath.Join("tools", "run.ps1"):         runPs1,
@@ -2332,7 +2655,7 @@ int main() {
 	return writeCFamilyFiles(targetDir, map[string]string{
 		filepath.Join("include", symbol+".hpp"):    header,
 		filepath.Join("tests", symbol+"_test.cpp"): test,
-		"BUILD":                                    build,
+		"BUILD":                           build,
 		"BUILD_windows":                            buildWin,
 		filepath.Join("tools", "run.sh"):           runSh,
 		filepath.Join("tools", "run.ps1"):           runPs1,
@@ -2489,28 +2812,49 @@ func scaffold(cfg scaffoldConfig, lang string, stdout, stderr io.Writer) error {
 	dName := dirName(cfg.packageName, lang)
 	targetDir := filepath.Join(baseDir, dName)
 
-	// Check target doesn't exist
-	if _, err := os.Stat(targetDir); err == nil {
+	// Refuse existing directories and every symlink, including dangling links.
+	if _, err := os.Lstat(targetDir); err == nil {
 		return fmt.Errorf("directory already exists: %s", targetDir)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking target directory: %w", err)
 	}
 
-	// Validate dependencies exist
+	// Validate dependencies exist.
+	resolver := func(dep string) string {
+		return filepath.Join(baseDir, dirName(dep, lang))
+	}
+	if lang == "ocaml" {
+		resolver = func(dep string) string {
+			return resolveDepDir(cfg.repoRoot, lang, dep)
+		}
+	}
+	resolvedDepDirs := make(map[string]string)
 	for _, dep := range cfg.directDeps {
-		depDir := filepath.Join(baseDir, dirName(dep, lang))
+		depDir := resolver(dep)
 		if _, err := os.Stat(depDir); os.IsNotExist(err) {
 			return fmt.Errorf("dependency %q not found for %s at %s", dep, lang, depDir)
 		}
+		if err := validateDependencyDir(cfg.repoRoot, depDir); err != nil {
+			return fmt.Errorf("dependency %q is unsafe: %w", dep, err)
+		}
+		resolvedDepDirs[dep] = depDir
 	}
 
 	// Compute transitive closure and topological sort
-	allDeps, err := transitiveClosure(cfg.directDeps, lang, baseDir)
+	validateDep := func(depDir string) error {
+		return validateDependencyDir(cfg.repoRoot, depDir)
+	}
+	allDeps, err := transitiveClosureWithResolver(cfg.directDeps, lang, resolver, validateDep)
 	if err != nil {
 		return fmt.Errorf("resolving transitive deps for %s: %w", lang, err)
 	}
 
-	orderedDeps, err := topologicalSort(allDeps, lang, baseDir)
+	orderedDeps, err := topologicalSortWithResolver(allDeps, lang, resolver, validateDep)
 	if err != nil {
 		return fmt.Errorf("topological sort for %s: %w", lang, err)
+	}
+	for _, dep := range orderedDeps {
+		resolvedDepDirs[dep] = resolver(dep)
 	}
 
 	layerCtx := ""
@@ -2573,6 +2917,19 @@ func scaffold(cfg scaffoldConfig, lang string, stdout, stderr io.Writer) error {
 		if err := generateHaskell(targetDir, cfg.packageName, cfg.description, layerCtx, cfg.directDeps, orderedDeps); err != nil {
 			return err
 		}
+	case "ocaml":
+		if err := generateOcaml(
+			targetDir,
+			cfg.packageName,
+			cfg.pkgType,
+			cfg.description,
+			layerCtx,
+			cfg.directDeps,
+			orderedDeps,
+			resolvedDepDirs,
+		); err != nil {
+			return err
+		}
 	case "java":
 		if err := generateJava(targetDir, cfg.packageName, cfg.description, layerCtx, cfg.directDeps); err != nil {
 			return err
@@ -2615,6 +2972,8 @@ func scaffold(cfg scaffoldConfig, lang string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(stdout, "  After other packages depend on this, run go mod tidy in those too\n")
 	case "java", "kotlin":
 		fmt.Fprintf(stdout, "  Run: cd %s && gradle test\n", targetDir)
+	case "ocaml":
+		fmt.Fprintf(stdout, "  Run: cd %s && opam exec -- dune runtest\n", targetDir)
 	}
 
 	return nil
@@ -2672,7 +3031,7 @@ func run(specPath string, argv []string, stdout, stderr io.Writer) int {
 		// corrupt generated source files (e.g. Swift block-comment terminators
 		// or JSON escape sequences).
 		if !isSafeDescription(description) {
-			fmt.Fprintf(stderr, "scaffold-generator: description must be one printable line without control characters or structural comment delimiters\n")
+			fmt.Fprintf(stderr, "scaffold-generator: description must be one printable line without control characters or structural delimiters\n")
 			return 1
 		}
 

--- a/code/programs/go/scaffold-generator/main_test.go
+++ b/code/programs/go/scaffold-generator/main_test.go
@@ -879,6 +879,8 @@ func TestDescriptionSafety(t *testing.T) {
 		"safe\u0085next-field",
 		"safe\u2028next-line",
 		"safe */ injected",
+		"safe *) injected",
+		"safe %{workspace_root} injected",
 	} {
 		if isSafeDescription(description) {
 			t.Errorf("isSafeDescription(%q) = true, want false", description)
@@ -886,6 +888,313 @@ func TestDescriptionSafety(t *testing.T) {
 	}
 	if !isSafeDescription("A printable single-line description.") {
 		t.Error("isSafeDescription rejected a printable single-line description")
+	}
+}
+
+func TestGenerateOcamlMatchesGoldenTrees(t *testing.T) {
+	for _, pkgType := range []string{"library", "program"} {
+		t.Run(pkgType, func(t *testing.T) {
+			target := t.TempDir()
+			if err := generateOcaml(
+				target,
+				"my-pkg",
+				pkgType,
+				"A test package",
+				"",
+				nil,
+				nil,
+				nil,
+			); err != nil {
+				t.Fatalf("generateOcaml: %v", err)
+			}
+
+			golden := filepath.Join(
+				"..", "..", "..", "specs", "fixtures", "scaffold-generator", "ocaml-"+pkgType,
+			)
+			assertTreesEqual(t, target, golden)
+		})
+	}
+}
+
+func TestGenerateOcamlEncodesDependenciesAndDescriptions(t *testing.T) {
+	target := t.TempDir()
+	description := `Quotes " backslash \ hash # parens () ; backticks ` + "`" + " and $(shell) plus\u00a0space"
+	if err := generateOcaml(
+		target,
+		"my-pkg",
+		"library",
+		description,
+		"Layer 4 in the computing stack.",
+		[]string{"graph"},
+		[]string{"bitset", "graph"},
+		nil,
+	); err != nil {
+		t.Fatalf("generateOcaml: %v", err)
+	}
+
+	opam, err := os.ReadFile(filepath.Join(target, "coding-adventures-my-pkg.opam"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	opamText := string(opam)
+	for _, want := range []string{
+		`"coding-adventures-graph" {= "0.1.0"}`,
+		"synopsis: \"Quotes \\\" backslash \\\\ hash # parens () ; backticks ` and $(shell) plus\u00a0space\"",
+	} {
+		if !strings.Contains(opamText, want) {
+			t.Errorf("opam metadata missing encoded %q", want)
+		}
+	}
+
+	build, err := os.ReadFile(filepath.Join(target, "BUILD"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buildText := string(build)
+	for _, want := range []string{
+		"opam pin add --no-action -y coding-adventures-bitset ../bitset",
+		"opam pin add --no-action -y coding-adventures-graph ../graph",
+		"opam exec -- dune build @fmt",
+		"opam exec -- dune runtest --force",
+		"opam exec -- bisect-ppx-report summary --per-file --expect src/coding_adventures_my_pkg.ml bisect*.coverage",
+	} {
+		if !strings.Contains(buildText, want) {
+			t.Errorf("BUILD missing %q", want)
+		}
+	}
+	if strings.Contains(buildText, description) {
+		t.Error("BUILD must not contain user-controlled description text")
+	}
+	if strings.Contains(opamText, `\u00a0`) {
+		t.Error("opam metadata must preserve accepted Unicode as UTF-8, not Go escapes")
+	}
+	duneProject, err := os.ReadFile(filepath.Join(target, "dune-project"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(duneProject), "plus\u00a0space") {
+		t.Error("Dune metadata did not preserve accepted Unicode")
+	}
+}
+
+func TestReadOcamlDepsUsesCheckedInOpamMetadata(t *testing.T) {
+	pkgDir := filepath.Join(t.TempDir(), "my-pkg")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := `opam-version: "2.0"
+name: "coding-adventures-my-pkg"
+synopsis: "depends: [ \"coding-adventures-synopsis-decoy\" ]"
+depends: [
+  "ocaml" {= "5.2.1"}
+  "coding-adventures-graph" {= "0.1.0"}
+  "coding-adventures-state-machine" {= "0.1.0"}
+]
+build: [ "echo coding-adventures-build-decoy" ]
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "coding-adventures-my-pkg.opam"), []byte(metadata), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(pkgDir, "aaa-decoy.opam"),
+		[]byte("depends: [ \"coding-adventures-wrong-file\" ]\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	deps, err := readOcamlDeps(pkgDir)
+	if err != nil {
+		t.Fatalf("readOcamlDeps: %v", err)
+	}
+	if got := strings.Join(deps, ","); got != "graph,state-machine" {
+		t.Fatalf("readOcamlDeps = %v", deps)
+	}
+}
+
+func TestGeneratedOcamlMetadataHasNoSelfDependency(t *testing.T) {
+	baseDir := t.TempDir()
+	pkgDir := filepath.Join(baseDir, "my-pkg")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := generateOcaml(
+		pkgDir,
+		"my-pkg",
+		"library",
+		"A test package",
+		"",
+		nil,
+		nil,
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := readOcamlDeps(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 0 {
+		t.Fatalf("generated dependency metadata includes false deps: %v", deps)
+	}
+	closure, err := transitiveClosure([]string{"my-pkg"}, "ocaml", baseDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	order, err := topologicalSort(closure, "ocaml", baseDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(order, ","); got != "my-pkg" {
+		t.Fatalf("topological order = %q, want my-pkg", got)
+	}
+}
+
+func TestScaffoldOcamlProgramResolvesLibraryDependencies(t *testing.T) {
+	repoRoot := t.TempDir()
+	packagesDir := filepath.Join(repoRoot, "code", "packages", "ocaml")
+	leafDir := filepath.Join(packagesDir, "leaf")
+	baseDir := filepath.Join(packagesDir, "base")
+	for _, dir := range []string{leafDir, baseDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := generateOcaml(leafDir, "leaf", "library", "Leaf", "", nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := generateOcaml(
+		baseDir,
+		"base",
+		"library",
+		"Base",
+		"",
+		[]string{"leaf"},
+		[]string{"leaf"},
+		map[string]string{"leaf": leafDir},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := scaffold(scaffoldConfig{
+		packageName: "tool",
+		pkgType:     "program",
+		directDeps:  []string{"base"},
+		description: "An OCaml tool",
+		repoRoot:    repoRoot,
+	}, "ocaml", &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+
+	buildPath := filepath.Join(repoRoot, "code", "programs", "ocaml", "tool", "BUILD")
+	build, err := os.ReadFile(buildPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buildText := string(build)
+	leafPin := "coding-adventures-leaf ../../../packages/ocaml/leaf"
+	basePin := "coding-adventures-base ../../../packages/ocaml/base"
+	if !strings.Contains(buildText, leafPin) || !strings.Contains(buildText, basePin) {
+		t.Fatalf("program BUILD has incorrect package pin paths:\n%s", buildText)
+	}
+	if strings.Index(buildText, leafPin) > strings.Index(buildText, basePin) {
+		t.Fatalf("program BUILD is not leaf-first:\n%s", buildText)
+	}
+}
+
+func TestScaffoldRejectsSymlinkDependency(t *testing.T) {
+	repoRoot := t.TempDir()
+	baseDir := filepath.Join(repoRoot, "code", "packages", "ocaml")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	depDir := filepath.Join(baseDir, "linked-dep")
+	if err := os.Symlink(outside, depDir); err != nil {
+		t.Skipf("symlink creation is unavailable on this platform: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := scaffold(scaffoldConfig{
+		packageName: "consumer",
+		pkgType:     "library",
+		directDeps:  []string{"linked-dep"},
+		description: "A consumer",
+		dryRun:      true,
+		repoRoot:    repoRoot,
+	}, "ocaml", &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink dependency rejection, got %v", err)
+	}
+}
+
+func assertTreesEqual(t *testing.T, gotRoot, wantRoot string) {
+	t.Helper()
+	wantFiles := map[string]string{}
+	err := filepath.Walk(wantRoot, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(wantRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		wantFiles[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking golden tree: %v", err)
+	}
+
+	gotFiles := map[string]string{}
+	err = filepath.Walk(gotRoot, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(gotRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		gotFiles[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking generated tree: %v", err)
+	}
+
+	if len(gotFiles) != len(wantFiles) {
+		t.Fatalf("generated %d files, golden has %d\ngot: %v\nwant: %v", len(gotFiles), len(wantFiles), gotFiles, wantFiles)
+	}
+	for path, want := range wantFiles {
+		if got, ok := gotFiles[path]; !ok {
+			t.Errorf("generated tree missing %s", path)
+		} else if got != want {
+			t.Errorf("%s differs from golden\n--- got ---\n%s--- want ---\n%s", path, got, want)
+		}
+	}
+	for path := range gotFiles {
+		if _, ok := wantFiles[path]; !ok {
+			t.Errorf("generated tree has unexpected %s", path)
+		}
 	}
 }
 
@@ -1085,6 +1394,33 @@ func TestRefusesToOverwrite(t *testing.T) {
 // File generation tests — C and C++ (pure ISO, iso-harness)
 // =========================================================================
 
+func TestRefusesDanglingSymlinkTarget(t *testing.T) {
+	repoRoot := t.TempDir()
+	baseDir := filepath.Join(repoRoot, "code", "packages", "ocaml")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("create OCaml package directory: %v", err)
+	}
+
+	targetDir := filepath.Join(baseDir, "linked-pkg")
+	if err := os.Symlink(filepath.Join(repoRoot, "missing-target"), targetDir); err != nil {
+		t.Skipf("symlink creation is unavailable on this platform: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := scaffold(scaffoldConfig{
+		packageName: "linked-pkg",
+		pkgType:     "library",
+		description: "A linked package",
+		repoRoot:    repoRoot,
+	}, "ocaml", &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected dangling symlink target to be refused")
+	}
+	if !strings.Contains(err.Error(), "directory already exists") {
+		t.Fatalf("expected existing-directory error, got %v", err)
+	}
+}
+
 func TestGenerateC(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := generateC(tmpDir, "ring-buf", "A ring buffer", ""); err != nil {
@@ -1209,6 +1545,15 @@ func TestCFamilyLanguagesAreValid(t *testing.T) {
 			t.Errorf("%q missing from validLanguages", lang)
 		}
 	}
+}
+
+func TestOcamlLanguageIsValid(t *testing.T) {
+	for _, lang := range validLanguages {
+		if lang == "ocaml" {
+			return
+		}
+	}
+	t.Fatal(`"ocaml" missing from validLanguages`)
 }
 
 // readDeps must not error for C/C++ (they have no manifest; deps live in the

--- a/code/programs/go/scaffold-generator/scaffold-generator.json
+++ b/code/programs/go/scaffold-generator/scaffold-generator.json
@@ -26,7 +26,7 @@
       "id": "language",
       "short": "l",
       "long": "language",
-      "description": "Target language(s). Comma-separated or 'all'. Languages: python, go, ruby, typescript, rust, elixir, perl, lua, swift, haskell, java, kotlin, c, cpp",
+      "description": "Target language(s). Comma-separated or 'all'. Languages: python, go, ruby, typescript, rust, elixir, perl, lua, swift, haskell, ocaml, java, kotlin, c, cpp",
       "type": "string",
       "default": "all"
     },

--- a/code/programs/scaffold-generator.json
+++ b/code/programs/scaffold-generator.json
@@ -20,7 +20,7 @@
       "id": "language",
       "short": "l",
       "long": "language",
-      "description": "Target language(s). Comma-separated or 'all' for all 14 scaffold languages: python, go, ruby, typescript, rust, elixir, perl, lua, swift, haskell, csharp, fsharp, java, kotlin",
+      "description": "Target language(s). Comma-separated or 'all' for all 13 implemented scaffold languages: python, go, ruby, typescript, rust, elixir, perl, lua, swift, haskell, ocaml, csharp, fsharp",
       "type": "string",
       "default": "all"
     },

--- a/code/programs/typescript/scaffold-generator/CHANGELOG.md
+++ b/code/programs/typescript/scaffold-generator/CHANGELOG.md
@@ -4,8 +4,22 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added OCaml library and program scaffolds with the shared byte-exact OCAML02
+  fixtures, exact direct opam/Dune metadata, Alcotest, ocamlformat, bisect_ppx
+  coverage, resolved local dependency pins, and capability manifests.
+
 ### Fixed
 
+- OCaml metadata rejects `*)` and safely quotes printable descriptions before
+  any output is written.
+- Dune `%{...}` interpolation openers are rejected before any scaffold output.
+- Accepted Unicode descriptions now remain raw UTF-8 with only OCaml/opam
+  quote and backslash escaping, matching the Go front door byte-for-byte.
+- OCaml dependency discovery reads only the expected opam `depends` field,
+  program scaffolds pin package-tree dependencies by resolved relative path,
+  and direct/transitive dependency symlinks fail closed.
 - Haskell scaffolds now emit the complete shared schema-v1 capability manifest
   and keep their starter library and test source pure.
 - Haskell generation rejects control characters before descriptions are

--- a/code/programs/typescript/scaffold-generator/README.md
+++ b/code/programs/typescript/scaffold-generator/README.md
@@ -6,7 +6,7 @@ Generate CI-ready package scaffolding for the coding-adventures monorepo.
 
 This CLI tool generates correctly-structured, CI-ready package directories
 for the package ecosystems currently scaffolded in the repo: Python, Go,
-Ruby, TypeScript, Rust, Elixir, Perl, Lua, Swift, Haskell, C#, and F#.
+Ruby, TypeScript, Rust, Elixir, Perl, Lua, Swift, Haskell, OCaml, C#, and F#.
 
 It is powered by [cli-builder](../../../packages/typescript/cli-builder/) --
 the entire command-line interface is defined in a JSON spec file, and this
@@ -15,6 +15,11 @@ program contains only the business logic.
 Generated Haskell libraries include a schema-v1
 `required_capabilities.json` with an explicit pure-computation profile and a
 package identity derived from the on-disk directory.
+
+Generated OCaml libraries and programs match the shared OCAML02 golden trees,
+with exact direct opam/Dune metadata, Alcotest, formatting and coverage
+commands, safe local dependency pins, and schema-v1 capability profiles.
+Transitive opam-repository/switch locking remains a separate CI-toolchain gate.
 
 ## Why It Exists
 
@@ -42,6 +47,10 @@ npx tsx src/index.ts my-package -l typescript --description "TS only"
 
 # Generate a program (goes in code/programs/ instead of code/packages/)
 npx tsx src/index.ts my-tool -t program -l go
+
+# Generate an OCaml library or program
+npx tsx src/index.ts my-package -l ocaml --description "Pure OCaml logic"
+npx tsx src/index.ts my-tool -t program -l ocaml
 
 # Generate a .NET package
 npx tsx src/index.ts graph -l csharp --description "Undirected graph"

--- a/code/programs/typescript/scaffold-generator/src/index.ts
+++ b/code/programs/typescript/scaffold-generator/src/index.ts
@@ -59,6 +59,7 @@ export const VALID_LANGUAGES = [
   "lua",
   "swift",
   "haskell",
+  "ocaml",
   "csharp",
   "fsharp",
 ] as const;
@@ -169,6 +170,27 @@ export function resolveDepDir(repoRoot: string, lang: string, dep: string): stri
   return pkgDir; // Default to packages for clearer error messages
 }
 
+function validateDependencyDir(repoRoot: string, depDir: string): void {
+  const info = fs.lstatSync(depDir);
+  if (info.isSymbolicLink()) {
+    throw new Error(`dependency directory must not be a symlink: ${depDir}`);
+  }
+  if (!info.isDirectory()) {
+    throw new Error(`dependency path is not a directory: ${depDir}`);
+  }
+
+  const realRoot = fs.realpathSync(repoRoot);
+  const realDep = fs.realpathSync(depDir);
+  const relative = path.relative(realRoot, realDep);
+  if (
+    path.isAbsolute(relative) ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error(`dependency directory escapes repository root: ${depDir}`);
+  }
+}
+
 // =========================================================================
 // Dependency resolution
 // =========================================================================
@@ -203,6 +225,7 @@ export function readDeps(pkgDir: string, lang: string): string[] {
     lua: () => [],
     swift: () => [],
     haskell: readHaskellDeps,
+    ocaml: readOcamlDeps,
     csharp: readDotnetDeps,
     fsharp: readDotnetDeps,
   };
@@ -466,6 +489,29 @@ export function readHaskellDeps(pkgDir: string): string[] {
   return deps;
 }
 
+export function readOcamlDeps(pkgDir: string): string[] {
+  const metadata = `coding-adventures-${path.basename(pkgDir)}.opam`;
+  const metadataPath = path.join(pkgDir, metadata);
+  if (!fs.existsSync(metadataPath)) {
+    return [];
+  }
+  const content = fs.readFileSync(metadataPath, "utf-8");
+  const depends = content.match(/^depends[ \t]*:\s*\[([\s\S]*?)\]/m)?.[1];
+  if (depends === undefined) {
+    return [];
+  }
+  const deps: string[] = [];
+  const seen = new Set<string>();
+  const pattern = /"coding-adventures-([a-z][a-z0-9]*(?:-[a-z0-9]+)*)"/g;
+  for (const match of depends.matchAll(pattern)) {
+    if (!seen.has(match[1])) {
+      seen.add(match[1]);
+      deps.push(match[1]);
+    }
+  }
+  return deps;
+}
+
 export function readDotnetDeps(pkgDir: string): string[] {
   let files: string[];
   try {
@@ -537,6 +583,7 @@ export function transitiveClosure(
     }
     visited.add(dep);
     const depDir = resolveDepDir(repoRoot, lang, dep);
+    validateDependencyDir(repoRoot, depDir);
     for (const dd of readDeps(depDir, lang)) {
       if (!visited.has(dd)) {
         queue.push(dd);
@@ -585,6 +632,7 @@ export function topologicalSort(
   for (const dep of allDeps) {
     graph[dep] = [];
     const depDir = resolveDepDir(repoRoot, lang, dep);
+    validateDependencyDir(repoRoot, depDir);
     for (const dd of readDeps(depDir, lang)) {
       if (depSet.has(dd)) {
         graph[dep].push(dd);
@@ -1755,9 +1803,14 @@ export function generateHaskell(
   directDeps: string[],
   orderedDeps: string[],
 ): void {
-  if (/[\p{Cc}\p{Zl}\p{Zp}]/u.test(description) || description.includes("*/")) {
+  if (
+    /[\p{Cc}\p{Zl}\p{Zp}]/u.test(description) ||
+    description.includes("*/") ||
+    description.includes("*)") ||
+    description.includes("%{")
+  ) {
     throw new Error(
-      "description must be a single printable line without control characters or structural comment delimiters",
+      "description must be a single printable line without control characters or structural delimiters",
     );
   }
 
@@ -1843,6 +1896,198 @@ main = pure ()
 // -------------------------------------------------------------------------
 // C# generator
 // -------------------------------------------------------------------------
+
+function quoteOcamlString(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+export function generateOcaml(
+  targetDir: string,
+  pkgName: string,
+  pkgType: string,
+  description: string,
+  layerCtx: string,
+  directDeps: string[],
+  orderedDeps: string[],
+  depDirs: ReadonlyMap<string, string> = new Map(),
+): void {
+  if (!KEBAB_RE.test(pkgName)) {
+    throw new Error(`invalid OCaml package name '${pkgName}'`);
+  }
+  if (pkgType !== "library" && pkgType !== "program") {
+    throw new Error(`invalid OCaml package type '${pkgType}'`);
+  }
+  if (
+    /[\p{Cc}\p{Zl}\p{Zp}]/u.test(description) ||
+    description.includes("*/") ||
+    description.includes("*)") ||
+    description.includes("%{")
+  ) {
+    throw new Error(
+      "description must be a single printable line without control characters or structural delimiters",
+    );
+  }
+  for (const dep of [...directDeps, ...orderedDeps]) {
+    if (!KEBAB_RE.test(dep)) {
+      throw new Error(`invalid OCaml dependency name '${dep}'`);
+    }
+  }
+
+  const testBase = toSnakeCase(pkgName);
+  const moduleBase = `coding_adventures_${testBase}`;
+  const moduleRef = moduleBase[0].toUpperCase() + moduleBase.slice(1);
+  const publicName = `coding-adventures-${pkgName}`;
+  const quotedDescription = quoteOcamlString(description);
+  const duneProject = `(lang dune 3.16)
+(name ${publicName})
+(generate_opam_files false)
+(package
+ (name ${publicName})
+ (synopsis ${quotedDescription})
+ (description ${quotedDescription}))
+`;
+
+  let opam = `opam-version: "2.0"
+name: ${quoteOcamlString(publicName)}
+version: "0.1.0"
+synopsis: ${quotedDescription}
+description: ${quotedDescription}
+maintainer: "Adhithya Rajasekaran"
+authors: "Adhithya Rajasekaran"
+license: "MIT"
+homepage: "https://github.com/adhithyan15/coding-adventures"
+bug-reports: "https://github.com/adhithyan15/coding-adventures/issues"
+dev-repo: "git+https://github.com/adhithyan15/coding-adventures.git"
+depends: [
+  "ocaml" {= "5.2.1"}
+  "dune" {= "3.17.2"}
+  "alcotest" {with-test & = "1.9.0"}
+  "bisect_ppx" {with-test & = "2.8.3"}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+`;
+  for (const dep of [...directDeps].sort()) {
+    opam += `  ${quoteOcamlString(`coding-adventures-${dep}`)} {= "0.1.0"}\n`;
+  }
+  opam += `]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+`;
+
+ const srcDune = `(library
+ (name ${moduleBase})
+ (public_name ${publicName})
+ (wrapped false)
+ (instrumentation
+  (backend bisect_ppx)))
+`;
+  let source = `let version () = "0.1.0"
+let package_name = ${quoteOcamlString(publicName)}
+`;
+  source += layerCtx
+    ? `let layer = Some ${quoteOcamlString(layerCtx)}\n`
+    : "let layer = None\n";
+  const iface = `val version : unit -> string
+val package_name : string
+val layer : string option
+`;
+  const testDune = `(test
+ (name test_${testBase})
+ (libraries alcotest ${moduleBase}))
+`;
+  const testSource = `let () =
+  Alcotest.run ${quoteOcamlString(publicName)}
+    [
+      ( "metadata",
+        [
+          Alcotest.test_case "version" \`Quick (fun () ->
+              Alcotest.(check string)
+                "version" "0.1.0"
+                (${moduleRef}.version ()));
+        ] );
+    ]
+`;
+
+  let build = "";
+  let buildWindows = "";
+  for (const dep of orderedDeps) {
+    const depDir = depDirs.get(dep);
+    const pinPath = depDir
+      ? path.relative(targetDir, depDir).split(path.sep).join("/")
+      : `../${dep}`;
+    build += `opam pin add --no-action -y coding-adventures-${dep} ${pinPath}\n`;
+    buildWindows += `opam pin add --no-action -y coding-adventures-${dep} ${pinPath}\n`;
+  }
+  build += `opam install . --deps-only --with-test --with-dev-setup -y
+opam exec -- dune build @fmt
+BISECT_FILE="$PWD/bisect" opam exec -- dune runtest --force --instrument-with bisect_ppx
+opam exec -- bisect-ppx-report summary --per-file --expect src/${moduleBase}.ml bisect*.coverage
+`;
+  buildWindows += `opam install . --deps-only --with-test --with-dev-setup -y
+opam exec -- dune build @fmt
+set BISECT_FILE=%CD%\\bisect&& opam exec -- dune runtest --force --instrument-with bisect_ppx
+for %f in (bisect*.coverage) do opam exec -- bisect-ppx-report summary --per-file --expect src/${moduleBase}.ml %f
+`;
+
+  const capability =
+    pkgType === "program"
+      ? {
+          $schema:
+            "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+          version: 1,
+          package: `ocaml/${pkgName}`,
+          capabilities: [
+            {
+              category: "stdout",
+              action: "write",
+              target: "*",
+              justification:
+                "The generated command prints its deterministic package identity.",
+            },
+          ],
+          justification:
+            "The command only writes its deterministic result to standard output.",
+        }
+      : {
+          $schema:
+            "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+          version: 1,
+          package: `ocaml/${pkgName}`,
+          capabilities: [],
+          justification:
+            "Pure computation. No filesystem, network, process, or environment access needed.",
+        };
+
+  const files: Record<string, string> = {
+    ".gitignore": "_build/\n_opam/\nbisect*.coverage\n",
+    ".ocamlformat":
+      "version = 0.27.0\nprofile = default\nocaml-version = 5.2\n",
+    BUILD: build,
+    BUILD_windows: buildWindows,
+    [`${publicName}.opam`]: opam,
+    "dune-project": duneProject,
+    "required_capabilities.json": JSON.stringify(capability, null, 2) + "\n",
+    [`src/${moduleBase}.ml`]: source,
+    [`src/${moduleBase}.mli`]: iface,
+    "src/dune": srcDune,
+    "test/dune": testDune,
+    [`test/test_${testBase}.ml`]: testSource,
+  };
+  if (pkgType === "program") {
+    files["bin/dune"] = `(executable
+ (name main)
+ (public_name ${pkgName})
+ (libraries ${moduleBase}))
+`;
+    files["bin/main.ml"] =
+      `let () = print_endline ${moduleRef}.package_name\n`;
+  }
+  for (const [relativePath, content] of Object.entries(files)) {
+    writeFile(path.join(targetDir, relativePath), content);
+  }
+}
 
 export function generateCSharp(
   targetDir: string,
@@ -2195,9 +2440,14 @@ export function scaffoldOne(
   output: (msg: string) => void = (msg) => process.stdout.write(msg + "\n"),
   errOutput: (msg: string) => void = (msg) => process.stderr.write(msg + "\n"),
 ): void {
-  if (/[\p{Cc}\p{Zl}\p{Zp}]/u.test(description) || description.includes("*/")) {
+  if (
+    /[\p{Cc}\p{Zl}\p{Zp}]/u.test(description) ||
+    description.includes("*/") ||
+    description.includes("*)") ||
+    description.includes("%{")
+  ) {
     throw new Error(
-      "description must be a single printable line without control characters or structural comment delimiters",
+      "description must be a single printable line without control characters or structural delimiters",
     );
   }
 
@@ -2206,8 +2456,19 @@ export function scaffoldOne(
   const dName = dirName(pkgName, lang);
   const targetDir = path.join(baseDir, dName);
 
-  if (fs.existsSync(targetDir)) {
+  try {
+    fs.lstatSync(targetDir);
     throw new Error(`directory already exists: ${targetDir}`);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      // Expected: target does not exist.
+    } else {
+      throw error;
+    }
   }
 
   for (const dep of directDeps) {
@@ -2217,10 +2478,22 @@ export function scaffoldOne(
         `dependency '${dep}' not found for ${lang} at ${depDir}`,
       );
     }
+    try {
+      validateDependencyDir(repoRoot, depDir);
+    } catch (error) {
+      throw new Error(
+        `dependency '${dep}' is unsafe: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 
   const allDeps = transitiveClosure(directDeps, lang, repoRoot);
   const orderedDeps = topologicalSort(allDeps, lang, repoRoot);
+  const resolvedDepDirs = new Map(
+    orderedDeps.map((dep) => [dep, resolveDepDir(repoRoot, lang, dep)]),
+  );
 
   const layerCtx = layer > 0 ? `Layer ${layer} in the computing stack.` : "";
 
@@ -2303,6 +2576,17 @@ export function scaffoldOne(
         directDeps,
         orderedDeps,
       ),
+    ocaml: () =>
+      generateOcaml(
+        targetDir,
+        pkgName,
+        pkgType,
+        description,
+        layerCtx,
+        directDeps,
+        orderedDeps,
+        resolvedDepDirs,
+      ),
     csharp: () =>
       generateCSharp(targetDir, pkgName, description, layerCtx, directDeps),
     fsharp: () =>
@@ -2331,6 +2615,8 @@ export function scaffoldOne(
     output(`  Run: cd ${targetDir} && go mod tidy`);
   } else if (lang === "csharp" || lang === "fsharp") {
     output(`  Run: cd ${targetDir} && dotnet test`);
+  } else if (lang === "ocaml") {
+    output(`  Run: cd ${targetDir} && opam exec -- dune runtest`);
   }
 }
 

--- a/code/programs/typescript/scaffold-generator/tests/scaffold-generator.test.ts
+++ b/code/programs/typescript/scaffold-generator/tests/scaffold-generator.test.ts
@@ -33,6 +33,7 @@ import {
   generateElixir,
   generatePerl,
   generateHaskell,
+  generateOcaml,
   generateCSharp,
   generateFSharp,
   generateCommonFiles,
@@ -459,7 +460,13 @@ describe("transitiveClosure", () => {
 
   it("returns direct deps when they have no further deps", () => {
     // Create a package with no BUILD (so no deps)
-    const depDir = path.join(tmpDir, "logic-gates");
+    const depDir = path.join(
+      tmpDir,
+      "code",
+      "packages",
+      "python",
+      "logic-gates",
+    );
     fs.mkdirSync(depDir, { recursive: true });
 
     const result = transitiveClosure(["logic-gates"], "python", tmpDir);
@@ -528,7 +535,7 @@ describe("topologicalSort", () => {
   });
 
   it("returns single dep as-is", () => {
-    const depDir = path.join(tmpDir, "solo");
+    const depDir = path.join(tmpDir, "code", "packages", "python", "solo");
     fs.mkdirSync(depDir, { recursive: true });
     writeTestFile(depDir, "BUILD", "python -m pip install -e .[dev] --quiet\n");
 
@@ -538,12 +545,13 @@ describe("topologicalSort", () => {
 
   it("orders leaves before dependents", () => {
     // leaf has no deps
-    const leafDir = path.join(tmpDir, "leaf");
+    const pkgBase = path.join(tmpDir, "code", "packages", "python");
+    const leafDir = path.join(pkgBase, "leaf");
     fs.mkdirSync(leafDir, { recursive: true });
     writeTestFile(leafDir, "BUILD", "python -m pip install -e .[dev] --quiet\n");
 
     // mid depends on leaf
-    const midDir = path.join(tmpDir, "mid");
+    const midDir = path.join(pkgBase, "mid");
     fs.mkdirSync(midDir, { recursive: true });
     writeTestFile(midDir, "BUILD", "python -m pip install -e ../leaf -e .[dev] --quiet\n");
 
@@ -553,17 +561,18 @@ describe("topologicalSort", () => {
 
   it("handles diamond dependency graph", () => {
     // base has no deps
-    const baseDir = path.join(tmpDir, "base");
+    const pkgBase = path.join(tmpDir, "code", "packages", "python");
+    const baseDir = path.join(pkgBase, "base");
     fs.mkdirSync(baseDir, { recursive: true });
     writeTestFile(baseDir, "BUILD", "python -m pip install -e .[dev] --quiet\n");
 
     // left depends on base
-    const leftDir = path.join(tmpDir, "left");
+    const leftDir = path.join(pkgBase, "left");
     fs.mkdirSync(leftDir, { recursive: true });
     writeTestFile(leftDir, "BUILD", "python -m pip install -e ../base -e .[dev] --quiet\n");
 
     // right depends on base
-    const rightDir = path.join(tmpDir, "right");
+    const rightDir = path.join(pkgBase, "right");
     fs.mkdirSync(rightDir, { recursive: true });
     writeTestFile(rightDir, "BUILD", "python -m pip install -e ../base -e .[dev] --quiet\n");
 
@@ -1107,6 +1116,142 @@ describe("generatePerl", () => {
   });
 });
 
+describe("generateOcaml", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    removeDir(tmpDir);
+  });
+
+  for (const pkgType of ["library", "program"] as const) {
+    it(`matches the shared ${pkgType} golden tree`, () => {
+      generateOcaml(tmpDir, "my-pkg", pkgType, "A test package", "", [], []);
+      const golden = path.resolve(
+        process.cwd(),
+        `../../../specs/fixtures/scaffold-generator/ocaml-${pkgType}`,
+      );
+      expect(readTree(tmpDir)).toEqual(readTree(golden));
+    });
+  }
+
+  it("encodes metadata and pins the full local closure leaf-first", () => {
+    const description =
+      'Quotes " backslash \\\\ hash # parens () ; backticks ` and $(shell) plus\u00a0space';
+    generateOcaml(
+      tmpDir,
+      "my-pkg",
+      "library",
+      description,
+      "Layer 4 in the computing stack.",
+      ["graph"],
+      ["bitset", "graph"],
+    );
+    const opam = fs.readFileSync(
+      path.join(tmpDir, "coding-adventures-my-pkg.opam"),
+      "utf-8",
+    );
+    expect(opam).toContain('"coding-adventures-graph" {= "0.1.0"}');
+    expect(opam).toContain(
+      'synopsis: "Quotes \\" backslash \\\\\\\\ hash # parens () ; backticks ` and $(shell) plus\u00a0space"',
+    );
+    const build = fs.readFileSync(path.join(tmpDir, "BUILD"), "utf-8");
+    expect(build).toContain(
+      "opam pin add --no-action -y coding-adventures-bitset ../bitset",
+    );
+    expect(build).toContain(
+      "opam pin add --no-action -y coding-adventures-graph ../graph",
+    );
+    expect(build).toContain("opam exec -- dune build @fmt");
+    expect(build).toContain("opam exec -- dune runtest --force");
+    expect(build).toContain(
+      "opam exec -- bisect-ppx-report summary --per-file --expect src/coding_adventures_my_pkg.ml bisect*.coverage",
+    );
+    expect(build).not.toContain(description);
+    expect(opam).not.toContain("\\u00a0");
+    expect(
+      fs.readFileSync(path.join(tmpDir, "dune-project"), "utf-8"),
+    ).toContain("plus\u00a0space");
+  });
+
+  it("rejects OCaml comment termination before writing", () => {
+    for (const description of [
+      "safe *) injected",
+      "safe %{workspace_root} injected",
+    ]) {
+      expect(() =>
+        generateOcaml(tmpDir, "my-pkg", "library", description, "", [], []),
+      ).toThrow(/description.*structural/i);
+    }
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+  });
+
+  it("reads only local coding-adventures dependencies from opam metadata", () => {
+    const pkgDir = path.join(tmpDir, "my-pkg");
+    writeTestFile(
+      pkgDir,
+      "coding-adventures-my-pkg.opam",
+      `opam-version: "2.0"
+name: "coding-adventures-my-pkg"
+synopsis: "depends: [ \\"coding-adventures-synopsis-decoy\\" ]"
+depends: [
+  "ocaml" {= "5.2.1"}
+  "coding-adventures-graph" {= "0.1.0"}
+  "coding-adventures-state-machine" {= "0.1.0"}
+]
+build: [ "echo coding-adventures-build-decoy" ]
+`,
+    );
+    writeTestFile(
+      pkgDir,
+      "aaa-decoy.opam",
+      'depends: [ "coding-adventures-wrong-file" ]\n',
+    );
+    expect(readDeps(pkgDir, "ocaml")).toEqual(["graph", "state-machine"]);
+  });
+
+  it("round-trips generated metadata without creating a self-dependency", () => {
+    const baseDir = path.join(tmpDir, "packages");
+    const pkgDir = path.join(baseDir, "my-pkg");
+    fs.mkdirSync(pkgDir, { recursive: true });
+    generateOcaml(pkgDir, "my-pkg", "library", "A test package", "", [], []);
+
+    expect(readDeps(pkgDir, "ocaml")).toEqual([]);
+    const repoRoot = path.join(tmpDir, "repo");
+    const repoPkgDir = path.join(
+      repoRoot,
+      "code",
+      "packages",
+      "ocaml",
+      "my-pkg",
+    );
+    fs.mkdirSync(path.dirname(repoPkgDir), { recursive: true });
+    fs.renameSync(pkgDir, repoPkgDir);
+    const closure = transitiveClosure(["my-pkg"], "ocaml", repoRoot);
+    expect(topologicalSort(closure, "ocaml", repoRoot)).toEqual(["my-pkg"]);
+  });
+});
+
+function readTree(root: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const visit = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(full);
+      } else {
+        result[path.relative(root, full).split(path.sep).join("/")] =
+          fs.readFileSync(full, "utf-8");
+      }
+    }
+  };
+  visit(root);
+  return result;
+}
+
 describe("generateCSharp", () => {
   let tmpDir: string;
 
@@ -1405,7 +1550,7 @@ describe("findRepoRoot", () => {
 
 describe("VALID_LANGUAGES", () => {
   it("contains all supported languages, including C# and F#", () => {
-    expect(VALID_LANGUAGES).toHaveLength(12);
+    expect(VALID_LANGUAGES).toHaveLength(13);
     expect(VALID_LANGUAGES).toContain("python");
     expect(VALID_LANGUAGES).toContain("go");
     expect(VALID_LANGUAGES).toContain("ruby");
@@ -1416,6 +1561,7 @@ describe("VALID_LANGUAGES", () => {
     expect(VALID_LANGUAGES).toContain("lua");
     expect(VALID_LANGUAGES).toContain("swift");
     expect(VALID_LANGUAGES).toContain("haskell");
+    expect(VALID_LANGUAGES).toContain("ocaml");
     expect(VALID_LANGUAGES).toContain("csharp");
     expect(VALID_LANGUAGES).toContain("fsharp");
   });
@@ -1464,6 +1610,31 @@ describe("scaffoldOne", () => {
     expect(
       fs.existsSync(
         path.join(repoRoot, "code", "packages", "haskell", "test-pkg"),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects OCaml structural delimiters before dry-run or directory creation", () => {
+    for (const description of [
+      "safe *) injected",
+      "safe %{workspace_root} injected",
+    ]) {
+      expect(() =>
+        scaffoldOne(
+          "test-pkg",
+          "library",
+          "ocaml",
+          [],
+          0,
+          description,
+          true,
+          repoRoot,
+        ),
+      ).toThrow(/description.*structural/i);
+    }
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, "code", "packages", "ocaml", "test-pkg"),
       ),
     ).toBe(false);
   });
@@ -1551,6 +1722,133 @@ describe("scaffoldOne", () => {
     expect(() =>
       scaffoldOne("existing", "library", "python", [], 0, "test", false, repoRoot),
     ).toThrow("directory already exists");
+  });
+
+  it("throws when the target is a dangling symlink", () => {
+    const pkgDir = path.join(
+      repoRoot,
+      "code",
+      "packages",
+      "ocaml",
+      "linked-pkg",
+    );
+    fs.mkdirSync(path.dirname(pkgDir), { recursive: true });
+    try {
+      fs.symlinkSync(path.join(repoRoot, "missing-target"), pkgDir, "dir");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EPERM") {
+        return;
+      }
+      throw error;
+    }
+
+    expect(() =>
+      scaffoldOne(
+        "linked-pkg",
+        "library",
+        "ocaml",
+        [],
+        0,
+        "test",
+        false,
+        repoRoot,
+      ),
+    ).toThrow("directory already exists");
+  });
+
+  it("resolves OCaml program dependencies from the packages tree", () => {
+    const packagesDir = path.join(repoRoot, "code", "packages", "ocaml");
+    const leafDir = path.join(packagesDir, "leaf");
+    const baseDir = path.join(packagesDir, "base");
+    fs.mkdirSync(leafDir, { recursive: true });
+    fs.mkdirSync(baseDir, { recursive: true });
+    generateOcaml(leafDir, "leaf", "library", "Leaf", "", [], []);
+    generateOcaml(
+      baseDir,
+      "base",
+      "library",
+      "Base",
+      "",
+      ["leaf"],
+      ["leaf"],
+      new Map([["leaf", leafDir]]),
+    );
+
+    scaffoldOne(
+      "tool",
+      "program",
+      "ocaml",
+      ["base"],
+      0,
+      "An OCaml tool",
+      false,
+      repoRoot,
+      () => {},
+    );
+
+    const build = fs.readFileSync(
+      path.join(repoRoot, "code", "programs", "ocaml", "tool", "BUILD"),
+      "utf-8",
+    );
+    const leafPin =
+      "coding-adventures-leaf ../../../packages/ocaml/leaf";
+    const basePin =
+      "coding-adventures-base ../../../packages/ocaml/base";
+    expect(build).toContain(leafPin);
+    expect(build).toContain(basePin);
+    expect(build.indexOf(leafPin)).toBeLessThan(build.indexOf(basePin));
+  });
+
+  it("rejects direct and transitive dependency symlinks", () => {
+    const packagesDir = path.join(repoRoot, "code", "packages", "ocaml");
+    const outsideDir = path.join(tmpDir, "outside-dep");
+    fs.mkdirSync(outsideDir, { recursive: true });
+    const linkedDir = path.join(packagesDir, "linked-dep");
+    try {
+      fs.symlinkSync(outsideDir, linkedDir, "dir");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EPERM") {
+        return;
+      }
+      throw error;
+    }
+
+    expect(() =>
+      scaffoldOne(
+        "direct-consumer",
+        "library",
+        "ocaml",
+        ["linked-dep"],
+        0,
+        "Direct consumer",
+        true,
+        repoRoot,
+      ),
+    ).toThrow(/dependency.*symlink/i);
+
+    const baseDir = path.join(packagesDir, "base");
+    fs.mkdirSync(baseDir, { recursive: true });
+    generateOcaml(
+      baseDir,
+      "base",
+      "library",
+      "Base",
+      "",
+      ["linked-dep"],
+      ["linked-dep"],
+    );
+    expect(() =>
+      scaffoldOne(
+        "transitive-consumer",
+        "library",
+        "ocaml",
+        ["base"],
+        0,
+        "Transitive consumer",
+        true,
+        repoRoot,
+      ),
+    ).toThrow(/dependency.*symlink/i);
   });
 
   it("throws when dependency not found", () => {

--- a/code/scripts/tests/test_haskell_required_capabilities.py
+++ b/code/scripts/tests/test_haskell_required_capabilities.py
@@ -1,4 +1,4 @@
-"""Validate every explicit Haskell capability manifest against the shared schema."""
+"""Validate Haskell and OCaml capability manifests against the shared schema."""
 
 from __future__ import annotations
 
@@ -13,8 +13,8 @@ SCHEMA_PATH = REPO_ROOT / "code/specs/schemas/required_capabilities.schema.json"
 FIXTURE_ROOT = REPO_ROOT / "code/specs/fixtures/scaffold-generator"
 
 
-class HaskellRequiredCapabilitiesTest(unittest.TestCase):
-    """Keep existing and generated Haskell manifests on the schema-v1 contract."""
+class RequiredCapabilitiesTest(unittest.TestCase):
+    """Keep existing and generated manifests on the schema-v1 contract."""
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -52,6 +52,16 @@ class HaskellRequiredCapabilitiesTest(unittest.TestCase):
             with self.subTest(path=path.relative_to(REPO_ROOT)):
                 document = json.loads(path.read_text(encoding="utf-8"))
                 self.assert_schema_valid(document)
+
+    def test_ocaml_scaffold_fixtures_are_schema_valid(self) -> None:
+        paths = sorted(FIXTURE_ROOT.glob("ocaml-*/required_capabilities.json"))
+        self.assertEqual(2, len(paths), "expected OCaml library and program fixtures")
+
+        for path in paths:
+            with self.subTest(path=path.relative_to(REPO_ROOT)):
+                document = json.loads(path.read_text(encoding="utf-8"))
+                self.assert_schema_valid(document)
+                self.assertEqual("ocaml/my-pkg", document["package"])
 
     def assert_schema_valid(self, document: object) -> None:
         errors = sorted(

--- a/code/specs/OCAML01-emerging-lane-contract.md
+++ b/code/specs/OCAML01-emerging-lane-contract.md
@@ -1,6 +1,6 @@
 # OCAML01 — Emerging implementation lane contract
 
-Status: in progress
+Status: complete in PR #9323
 
 ## Purpose
 

--- a/code/specs/OCAML02-scaffold-infrastructure.md
+++ b/code/specs/OCAML02-scaffold-infrastructure.md
@@ -1,0 +1,106 @@
+# OCAML02 — Scaffold and metadata infrastructure
+
+Status: in progress
+
+## Purpose
+
+This contract makes OCaml a scaffoldable emerging lane without promoting it
+into the established-language denominator. It owns deterministic Go and
+TypeScript front doors, checked-in opam and Dune metadata, starter tests,
+formatting and coverage commands, capability metadata, repository ignores, and
+the lane README. Canonical build-tool discovery, CI toolchain provisioning,
+representative packages, capability analysis, the native build tool, and lane
+promotion remain separate roadmap items.
+
+## Exact direct tool metadata
+
+Generated metadata uses these exact reviewed versions:
+
+- OCaml `5.2.1`;
+- opam `2.5.2` for CI/toolchain provisioning;
+- Dune `3.17.2` (while emitting the stable Dune language `3.16`);
+- Alcotest `1.9.0`;
+- `bisect_ppx` `2.8.3`; and
+- `ocamlformat` `0.27.0`.
+
+No generated file may contain a network pin, bootstrap download, `depext`,
+install/remove hook, or user-controlled command.
+
+These are exact direct constraints, not a transitive opam solver lock. The
+repository snapshot, switch state, and generated `.opam.locked`/equivalent
+proof are owned by the separately tracked `ocaml-ci-toolchain` item before
+three-platform CI can claim reproducibility.
+
+## Names and dependencies
+
+The input directory name is validated kebab case. For `my-pkg`:
+
+- opam and Dune project/package name: `coding-adventures-my-pkg`;
+- private library and OCaml module basename: `coding_adventures_my_pkg`; and
+- local dependency `graph`: opam package `coding-adventures-graph`, with a pin
+  path resolved relative to the generated target (`../graph` for package
+  siblings or `../../../packages/ocaml/graph` from a program).
+
+Only validated repository package/program directories may become local
+dependencies. Symlinked or repository-escaping dependency paths fail closed.
+The checked-in opam file lists direct dependencies. `BUILD` and
+`BUILD_windows` pin the complete leaf-first local closure before installing the
+current package dependencies. The generator dependency reader recognizes only
+`"coding-adventures-<kebab>"` entries from the `depends` list.
+
+## Exact output trees
+
+Both front doors MUST match the shared byte-for-byte golden trees under
+`code/specs/fixtures/scaffold-generator/ocaml-library` and
+`ocaml-program`. Common `README.md` and `CHANGELOG.md` files remain governed by
+the existing scaffold contract and are intentionally outside the golden tree.
+
+Library:
+
+```text
+.gitignore
+.ocamlformat
+BUILD
+BUILD_windows
+coding-adventures-my-pkg.opam
+dune-project
+required_capabilities.json
+src/coding_adventures_my_pkg.ml
+src/coding_adventures_my_pkg.mli
+src/dune
+test/dune
+test/test_my_pkg.ml
+```
+
+Program adds `bin/dune` and `bin/main.ml` to the same testable library core.
+Its capability manifest declares only `stdout:write` to `*`; the library
+manifest is the explicit empty pure-computation profile.
+
+## Build behavior
+
+Both platform build files contain real fixed commands and no skip-success path.
+They pin local siblings without running them, install the exact direct
+metadata constraints with test and development flags, verify formatting with
+`dune build @fmt`, run Alcotest through `dune runtest`, and emit a
+`bisect-ppx-report` coverage summary. Instrumentation is test-only.
+
+## Input and serialization safety
+
+All validation completes before the target directory is created. Package and
+dependency names reject traversal, separators, dot segments, uppercase, and
+invalid opam names. Descriptions reject controls, NUL, U+0085, U+2028, U+2029,
+`*/`, OCaml comment termination `*)`, and Dune interpolation opener `%{`.
+Printable descriptions, including quotes, backslashes, hashes, parentheses,
+semicolons, backticks, and shell-like text, are encoded as data in Dune/opam
+strings and never enter a build command.
+Accepted Unicode remains identical raw UTF-8 across both front doors; only
+quotes and backslashes receive OCaml/opam-compatible escapes. Dry-run writes
+nothing; existing or symlink targets fail closed.
+
+## Conformance
+
+Tests MUST cover language registration, library and program generation, empty
+and local dependency cases, byte identity against both shared golden trees,
+dependency parsing, dry-run, overwrite/symlink refusal, invalid names,
+adversarial description serialization, capability-schema validation, fixed
+build commands, and absence of dangerous starter constructs.

--- a/code/specs/OCAML02-scaffold-infrastructure.md
+++ b/code/specs/OCAML02-scaffold-infrastructure.md
@@ -1,6 +1,6 @@
 # OCAML02 — Scaffold and metadata infrastructure
 
-Status: in progress
+Status: complete in PR #9336
 
 ## Purpose
 

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/.gitignore
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/.gitignore
@@ -1,0 +1,3 @@
+_build/
+_opam/
+bisect*.coverage

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/.ocamlformat
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/.ocamlformat
@@ -1,0 +1,3 @@
+version = 0.27.0
+profile = default
+ocaml-version = 5.2

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/BUILD
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/BUILD
@@ -1,0 +1,4 @@
+opam install . --deps-only --with-test --with-dev-setup -y
+opam exec -- dune build @fmt
+BISECT_FILE="$PWD/bisect" opam exec -- dune runtest --force --instrument-with bisect_ppx
+opam exec -- bisect-ppx-report summary --per-file --expect src/coding_adventures_my_pkg.ml bisect*.coverage

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/BUILD_windows
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/BUILD_windows
@@ -1,0 +1,4 @@
+opam install . --deps-only --with-test --with-dev-setup -y
+opam exec -- dune build @fmt
+set BISECT_FILE=%CD%\bisect&& opam exec -- dune runtest --force --instrument-with bisect_ppx
+for %f in (bisect*.coverage) do opam exec -- bisect-ppx-report summary --per-file --expect src/coding_adventures_my_pkg.ml %f

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/coding-adventures-my-pkg.opam
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/coding-adventures-my-pkg.opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+name: "coding-adventures-my-pkg"
+version: "0.1.0"
+synopsis: "A test package"
+description: "A test package"
+maintainer: "Adhithya Rajasekaran"
+authors: "Adhithya Rajasekaran"
+license: "MIT"
+homepage: "https://github.com/adhithyan15/coding-adventures"
+bug-reports: "https://github.com/adhithyan15/coding-adventures/issues"
+dev-repo: "git+https://github.com/adhithyan15/coding-adventures.git"
+depends: [
+  "ocaml" {= "5.2.1"}
+  "dune" {= "3.17.2"}
+  "alcotest" {with-test & = "1.9.0"}
+  "bisect_ppx" {with-test & = "2.8.3"}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/dune-project
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/dune-project
@@ -1,0 +1,7 @@
+(lang dune 3.16)
+(name coding-adventures-my-pkg)
+(generate_opam_files false)
+(package
+ (name coding-adventures-my-pkg)
+ (synopsis "A test package")
+ (description "A test package"))

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/required_capabilities.json
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ocaml/my-pkg",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/src/coding_adventures_my_pkg.ml
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/src/coding_adventures_my_pkg.ml
@@ -1,0 +1,3 @@
+let version () = "0.1.0"
+let package_name = "coding-adventures-my-pkg"
+let layer = None

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/src/coding_adventures_my_pkg.mli
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/src/coding_adventures_my_pkg.mli
@@ -1,0 +1,3 @@
+val version : unit -> string
+val package_name : string
+val layer : string option

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/src/dune
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/src/dune
@@ -1,0 +1,6 @@
+(library
+ (name coding_adventures_my_pkg)
+ (public_name coding-adventures-my-pkg)
+ (wrapped false)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/test/dune
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_my_pkg)
+ (libraries alcotest coding_adventures_my_pkg))

--- a/code/specs/fixtures/scaffold-generator/ocaml-library/test/test_my_pkg.ml
+++ b/code/specs/fixtures/scaffold-generator/ocaml-library/test/test_my_pkg.ml
@@ -1,0 +1,11 @@
+let () =
+  Alcotest.run "coding-adventures-my-pkg"
+    [
+      ( "metadata",
+        [
+          Alcotest.test_case "version" `Quick (fun () ->
+              Alcotest.(check string)
+                "version" "0.1.0"
+                (Coding_adventures_my_pkg.version ()));
+        ] );
+    ]

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/.gitignore
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/.gitignore
@@ -1,0 +1,3 @@
+_build/
+_opam/
+bisect*.coverage

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/.ocamlformat
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/.ocamlformat
@@ -1,0 +1,3 @@
+version = 0.27.0
+profile = default
+ocaml-version = 5.2

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/BUILD
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/BUILD
@@ -1,0 +1,4 @@
+opam install . --deps-only --with-test --with-dev-setup -y
+opam exec -- dune build @fmt
+BISECT_FILE="$PWD/bisect" opam exec -- dune runtest --force --instrument-with bisect_ppx
+opam exec -- bisect-ppx-report summary --per-file --expect src/coding_adventures_my_pkg.ml bisect*.coverage

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/BUILD_windows
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/BUILD_windows
@@ -1,0 +1,4 @@
+opam install . --deps-only --with-test --with-dev-setup -y
+opam exec -- dune build @fmt
+set BISECT_FILE=%CD%\bisect&& opam exec -- dune runtest --force --instrument-with bisect_ppx
+for %f in (bisect*.coverage) do opam exec -- bisect-ppx-report summary --per-file --expect src/coding_adventures_my_pkg.ml %f

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/bin/dune
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/bin/dune
@@ -1,0 +1,4 @@
+(executable
+ (name main)
+ (public_name my-pkg)
+ (libraries coding_adventures_my_pkg))

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/bin/main.ml
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/bin/main.ml
@@ -1,0 +1,1 @@
+let () = print_endline Coding_adventures_my_pkg.package_name

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/coding-adventures-my-pkg.opam
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/coding-adventures-my-pkg.opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+name: "coding-adventures-my-pkg"
+version: "0.1.0"
+synopsis: "A test package"
+description: "A test package"
+maintainer: "Adhithya Rajasekaran"
+authors: "Adhithya Rajasekaran"
+license: "MIT"
+homepage: "https://github.com/adhithyan15/coding-adventures"
+bug-reports: "https://github.com/adhithyan15/coding-adventures/issues"
+dev-repo: "git+https://github.com/adhithyan15/coding-adventures.git"
+depends: [
+  "ocaml" {= "5.2.1"}
+  "dune" {= "3.17.2"}
+  "alcotest" {with-test & = "1.9.0"}
+  "bisect_ppx" {with-test & = "2.8.3"}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/dune-project
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/dune-project
@@ -1,0 +1,7 @@
+(lang dune 3.16)
+(name coding-adventures-my-pkg)
+(generate_opam_files false)
+(package
+ (name coding-adventures-my-pkg)
+ (synopsis "A test package")
+ (description "A test package"))

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/required_capabilities.json
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "ocaml/my-pkg",
+  "capabilities": [
+    {
+      "category": "stdout",
+      "action": "write",
+      "target": "*",
+      "justification": "The generated command prints its deterministic package identity."
+    }
+  ],
+  "justification": "The command only writes its deterministic result to standard output."
+}

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/src/coding_adventures_my_pkg.ml
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/src/coding_adventures_my_pkg.ml
@@ -1,0 +1,3 @@
+let version () = "0.1.0"
+let package_name = "coding-adventures-my-pkg"
+let layer = None

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/src/coding_adventures_my_pkg.mli
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/src/coding_adventures_my_pkg.mli
@@ -1,0 +1,3 @@
+val version : unit -> string
+val package_name : string
+val layer : string option

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/src/dune
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/src/dune
@@ -1,0 +1,6 @@
+(library
+ (name coding_adventures_my_pkg)
+ (public_name coding-adventures-my-pkg)
+ (wrapped false)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/test/dune
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_my_pkg)
+ (libraries alcotest coding_adventures_my_pkg))

--- a/code/specs/fixtures/scaffold-generator/ocaml-program/test/test_my_pkg.ml
+++ b/code/specs/fixtures/scaffold-generator/ocaml-program/test/test_my_pkg.ml
@@ -1,0 +1,11 @@
+let () =
+  Alcotest.run "coding-adventures-my-pkg"
+    [
+      ( "metadata",
+        [
+          Alcotest.test_case "version" `Quick (fun () ->
+              Alcotest.(check string)
+                "version" "0.1.0"
+                (Coding_adventures_my_pkg.version ()));
+        ] );
+    ]

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -1131,7 +1131,7 @@ Bootstrap order:
    Complete in PR #9323.
 2. Add complete Go and TypeScript scaffold templates plus golden tests,
    repository ignores, capability metadata/schema support, and the
-   `code/packages/ocaml/` lane README.
+   `code/packages/ocaml/` lane README. Complete in PR #9336.
 3. Provision the exact direct OCaml/opam/Dune/Alcotest/`bisect_ppx`/
    `ocamlformat` toolchain on Ubuntu, macOS, and Windows; lock the
    opam-repository/switch transitive solver state; and run both generated

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,7 +106,7 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 30, 2026 at `0f8bb3b25` after the merged
+inventory was regenerated on July 30, 2026 at `67dc08ac8` after the merged
 Haskell `http1` and scaffold-capability tranches plus a new wave of Rust-only
 package families. The refresh adds `smart-home-zigbee-integration` after
 `smart-home-mqtt-integration`, the Z-Wave host/integration, and earlier
@@ -1103,14 +1103,21 @@ The Linux OCI review discovered eight additional dependency gates:
   containment enforcement, aggregate resource accounting, lifecycle cleanup,
   and protected runner-owned probe evidence.
 
+The post-#9323 security audit also found that `adj-lang-cli` has a legacy
+effective zero-capability profile despite filesystem, environment, process, and
+stdout use in its runtime/tests, with PR #9324 adding another E2E instance.
+Keep that unrelated repair in the dedicated `adj-lang-cli-capability-profile`
+item: separate harness authority from the publishable runtime profile, declare
+truthful capabilities, and obtain Layer-5 approval for every nonempty profile.
+
 ## Cross-Cutting Stream B: Introduce OCaml Safely
 
 OCaml begins as an `emerging_implementation` lane. It must not silently change
 the current 15-language denominator until its package, build, security, and CI
-substrate is real. Use OCaml 5.2.1, opam 2.5.x, Dune 3.16.x, Alcotest,
-`bisect_ppx`, and `ocamlformat`.
+substrate is real. Use OCaml 5.2.1, opam 2.5.2, Dune 3.17.2 with Dune language
+3.16, Alcotest 1.9.0, `bisect_ppx` 2.8.3, and `ocamlformat` 0.27.0.
 
-The selected post-#9308 tranche is `ocaml-lane-contract`. OCAML01 classifies
+Merged PR #9323 delivered `ocaml-lane-contract`. OCAML01 classifies
 OCaml as a known emerging bucket, keeps it outside established coverage and
 missing-slot calculations, and derives the reporter's upper completion-band
 bound from the established-language count. This is the denominator-safe
@@ -1121,22 +1128,27 @@ Bootstrap order:
 1. Add an OCaml lane contract. Make the reporter's hard-coded `10-15`
    completion band denominator-safe, classify OCaml as emerging, and test that
    OCaml packages create neither unknown buckets nor 15-lane missing slots.
+   Complete in PR #9323.
 2. Add complete Go and TypeScript scaffold templates plus golden tests,
    repository ignores, capability metadata/schema support, and the
    `code/packages/ocaml/` lane README.
-3. Add OCaml discovery, opam/Dune dependency resolution, source hashing,
+3. Provision the exact direct OCaml/opam/Dune/Alcotest/`bisect_ppx`/
+   `ocamlformat` toolchain on Ubuntu, macOS, and Windows; lock the
+   opam-repository/switch transitive solver state; and run both generated
+   scaffold kinds without skips.
+4. Add OCaml discovery, opam/Dune dependency resolution, source hashing,
    opam-switch serialization, language detection, validator support, shard
    cost, and CI workflow markers to the canonical Go build tool.
-4. Exercise the full path with a real dependency chain:
+5. Exercise the full path with a real dependency chain:
    `logic-gates`, then `graph -> directed-graph -> state-machine`. Every package
    needs native tests, formatting, measured coverage, README, changelog,
    capability metadata, opam/Dune manifests, and BUILD/BUILD_windows.
-5. Add an OCaml capability analyzer over compiler-libs ASTs, covering process
+6. Add an OCaml capability analyzer over compiler-libs ASTs, covering process
    execution, dynamic loading, unsafe marshaling, and `Obj.magic` under the
    repository's explicit capability/exception policy.
-6. Implement the OCaml build tool on `directed-graph` and require two-way
+7. Implement the OCaml build tool on `directed-graph` and require two-way
    build-plan interchange plus the shared conformance corpus.
-7. Promote OCaml into the implementation denominator only when Ubuntu, macOS,
+8. Promote OCaml into the implementation denominator only when Ubuntu, macOS,
    and Windows run real tests without a skip path, the representative chain and
    build tool are green, capability enforcement is active, and the generated
    16-lane backlog has been explicitly reviewed.

--- a/code/specs/scaffold-generator-spec.md
+++ b/code/specs/scaffold-generator-spec.md
@@ -8,6 +8,10 @@ The first published versions covered Python, Go, Ruby, Rust, TypeScript, and
 Elixir; this spec now also defines a Dart bootstrap implementation focused on
 generating Dart packages and programs correctly.
 
+OCaml scaffolds additionally conform to
+[OCAML02](OCAML02-scaffold-infrastructure.md), which fixes their byte-stable
+library/program trees, metadata versions, safety boundary, and golden fixtures.
+
 ---
 
 ## 1. Overview

--- a/code/specs/schemas/required_capabilities.schema.json
+++ b/code/specs/schemas/required_capabilities.schema.json
@@ -18,7 +18,7 @@
     },
     "package": {
       "type": "string",
-      "pattern": "^(csharp|dart|elixir|fsharp|go|haskell|java|kotlin|lua|perl|python|ruby|rust|starlark|swift|typescript|wasm)/[a-z0-9][a-z0-9_-]*$",
+      "pattern": "^(csharp|dart|elixir|fsharp|go|haskell|java|kotlin|lua|ocaml|perl|python|ruby|rust|starlark|swift|typescript|wasm)/[a-z0-9][a-z0-9_-]*$",
       "description": "Qualified package name matching the build tool's naming: {language}/{dirname}. Examples: python/logic-gates, ruby/lexer, go/cache, rust/json-value, elixir/json_value, lua/grammar_tools."
     },
     "capabilities": {


### PR DESCRIPTION
## Summary

- define OCAML02 and the emerging-lane package conventions without adding OCaml to the established parity denominator
- add byte-identical OCaml library/program scaffold support to both Go and TypeScript front doors
- add exact shared fixtures, opam/Dune metadata, Alcotest, ocamlformat, bisect coverage, capability manifests, repository ignores, and lane documentation
- resolve local dependencies across package/program trees in leaf-first order while rejecting target/dependency symlinks, path escape, metadata decoys, comment/Dune interpolation injection, and incompatible Unicode serialization
- refresh the parity roadmap/state and assign transitive opam switch/repository locking to the separate three-platform CI-toolchain item

## Why

PR #9323 established OCaml as a known emerging implementation lane. This is the next dependency-shaped tranche: it makes the lane scaffoldable and gives later build-tool, CI, representative-package, analyzer, native-build-tool, and promotion work one reviewed package contract.

Users can now run `scaffold-generator <name> --language ocaml` through either implementation and receive the same native-valid output. OCaml remains outside the 15-language denominator until the remaining promotion gates pass.

## Validation

- Go scaffold generator:
  - `go test -cover ./...` — pass, 69.0% statement coverage
  - `go vet ./...` — pass
  - `go build` — pass
- TypeScript scaffold generator:
  - `npm run build` — pass
  - `npm run test:coverage` — 131/131 pass; 85.10% statements, 85.28% lines, 69.39% branches, 77.63% functions
  - `npm audit --audit-level=low` — 0 vulnerabilities
- repository script tests:
  - `py -3.13 -m pytest code/scripts/tests -q` — 158 passed, 20 skipped, 155 subtests passed
  - targeted Ruff — pass
- native OCaml 5.2.1 / opam 2.5.2 / Dune 3.17.2 on Windows:
  - library and program `opam lint` — pass
  - exact `BUILD_windows` formatting, Alcotest, and bisect commands — pass
  - both fixtures report 100% starter-source coverage
  - generated program prints `coding-adventures-my-pkg`
  - Go/TypeScript U+00A0 metadata outputs are SHA-256 byte-identical, pass `opam lint`, and pass `dune build @fmt`
- parity inventory at `67dc08ac8`:
  - schema 3; 15 established languages; 1,197 identities; 4,339 slots
  - 172 high-consensus identities / 277 missing slots
  - 0 canonical collisions; 0 unknown buckets
  - JSON, Markdown, and CSV collision gates pass
- canonical Go build-tool dry-run:
  - 73 pre-existing BUILD/CI validation gaps, unchanged from `main`
  - post-CI fix: full Go tests, vet, and build pass; the repository dry-run no longer discovers golden fixtures as `unknown/ocaml-*` packages
- security/diff:
  - gosec: 45 findings, identical to `main`; 3 narrowly justified suppressions
  - Bandit: 0 findings added versus `main`
  - changed-line secret scan — pass
  - `git diff --check` — pass
  - independent contract, fixture/schema, and security audits completed

## Follow-up gates

- provision and transitively lock the OCaml toolchain on Ubuntu, macOS, and Windows CI
- add canonical Go build-tool OCaml discovery/resolution/capability/reporting support
- add the representative `logic-gates -> graph -> directed-graph -> state-machine` chain
- add the OCaml capability analyzer, native OCaml build tool, and final lane-promotion review
