### PR TITLE
feat(adj-argument-composition): worked multi-paragraph example + multi-snapshot verify (AC-2)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/composition_worked_example_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/composition_worked_example_e2e.rs
@@ -1,0 +1,124 @@
+//! AC-2 — the worked WHOLE-PAPER example for ADJ-ARGUMENT-COMPOSITION. It drives the
+//! committed multi-paragraph example under `code/specs/data/adj-argument-ir/composition/`
+//! through the built binaries to prove whole-paper composition end to end:
+//!
+//! 1. three short paragraphs (`p2-loading`, `p3-fractography`, `p4-discussion`), each its
+//!    own pinned source document, are composed into ONE `argument` (`axle-paper.adj`)
+//!    whose seven citations each name **their own paragraph's** `snapshot`;
+//! 2. `adj-lang-cli` **derives** the paper's thesis — `failed_by(axle, fatigue)` — by
+//!    chaining across the three paragraphs (`i3` ← `i1` + `i2` ← their premises); and
+//! 3. `adj-verify --snapshots` **byte-anchors all seven citations across the three
+//!    snapshots** (the multi-snapshot proof) and re-derives the thesis.
+//!
+//! This is the empirical proof of the AC-1 finding: whole-paper composition needs zero new
+//! constructs, and grounding stays per-paragraph.
+
+use logic_engine::ContentHash;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The committed worked-example directory, relative to this crate.
+fn data_dir() -> PathBuf {
+    // adj-lang-cli → rust → packages → code, then specs/data/adj-argument-ir/composition.
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../specs/data/adj-argument-ir/composition")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("compwe_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Place every `*.source.txt` paragraph in `data_dir` as a content-addressed snapshot
+/// (filename = its SHA-256 hex) in `snaps` — so `--snapshots` resolves each paragraph's pins.
+fn place_all_snapshots(snaps: &Path) -> usize {
+    let mut n = 0;
+    for entry in std::fs::read_dir(data_dir()).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) == Some("txt")
+            && path.file_name().unwrap().to_string_lossy().ends_with(".source.txt")
+        {
+            let bytes = std::fs::read(&path).unwrap();
+            let hex = ContentHash::of(&bytes).as_hex().to_string();
+            std::fs::write(snaps.join(&hex), &bytes).unwrap();
+            n += 1;
+        }
+    }
+    n
+}
+
+#[test]
+fn the_engine_derives_the_papers_thesis_across_paragraphs() {
+    let adj = data_dir().join("axle-paper.adj");
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&adj)
+        .output()
+        .expect("run adj-lang-cli");
+    let s = String::from_utf8(out.stdout).unwrap();
+    assert!(out.status.success(), "the whole-paper example must compile and run:\n{s}");
+    // The paper's thesis — `failed_by(axle, fatigue)` — is DERIVED by chaining the three
+    // paragraphs' inferences (i3 ← i1 + i2), not asserted.
+    assert!(
+        s.contains("\"Mechanism\":\"fatigue\""),
+        "the engine must derive the paper's thesis (mechanism = fatigue):\n{s}"
+    );
+}
+
+#[test]
+fn adj_verify_byte_anchors_all_citations_across_three_snapshots() {
+    let snaps = scratch("snaps");
+    let placed = place_all_snapshots(&snaps);
+    assert_eq!(placed, 3, "the paper has three paragraph source snapshots");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-verify"))
+        .arg("--snapshots")
+        .arg(&snaps)
+        .arg(data_dir().join("axle-paper.adj"))
+        .output()
+        .expect("run adj-verify");
+    let s = String::from_utf8(out.stdout).unwrap();
+
+    assert!(out.status.success(), "the pinned whole-paper example must verify:\n{s}");
+    assert!(s.contains("\"verified\":true"), "{s}");
+    // All seven citations — 4 premises + 3 inference warrants, spread across THREE paragraph
+    // snapshots — byte-anchor. This is the multi-snapshot proof: each paragraph's citations
+    // re-check against the paragraph they came from.
+    assert!(
+        s.contains("\"quotes_verified\":7"),
+        "all seven citations must byte-anchor across the three snapshots:\n{s}"
+    );
+    // The pins that resolved re-check verbatim at their recorded offsets, and the thesis
+    // re-derives (the cross-paragraph proof DAG, re-executed).
+    assert!(s.contains("\"status\":\"verified\""), "{s}");
+    assert!(
+        s.contains("\"kind\":\"FromRule\"") && s.contains("\"logic\":\"rechecked\""),
+        "the paper thesis must re-derive from the paragraphs' inferences:\n{s}"
+    );
+}
+
+#[test]
+fn explain_renders_the_cross_paragraph_chain_with_per_paragraph_provenance() {
+    let adj = data_dir().join("axle-paper.adj");
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg("--explain")
+        .arg(&adj)
+        .output()
+        .expect("run adj-lang-cli --explain");
+    let s = String::from_utf8(out.stdout).unwrap();
+    assert!(out.status.success(), "--explain must succeed:\n{s}");
+
+    // The conclusion, and the two intermediate paragraph conclusions it rests on, each
+    // render as inference steps — the cross-paragraph chain.
+    assert!(s.contains("failed_by(axle, fatigue)  <= inference"), "{s}");
+    assert!(s.contains("exceeds_endurance(axle)  <= inference"), "{s}");
+    assert!(s.contains("fatigue_indicated(axle)  <= inference"), "{s}");
+    // Each step keeps ITS OWN paragraph's provenance — the discussion thesis, the loading
+    // and fractography intermediates are attributed to their distinct paragraphs.
+    assert!(
+        s.contains("source \"p4-discussion\"")
+            && s.contains("source \"p2-loading\"")
+            && s.contains("source \"p3-fractography\""),
+        "each step must carry its own paragraph's provenance:\n{s}"
+    );
+}

--- a/code/specs/data/adj-argument-ir/composition/README.md
+++ b/code/specs/data/adj-argument-ir/composition/README.md
@@ -1,0 +1,41 @@
+# ADJ-ARGUMENT-COMPOSITION — worked whole-paper example (AC-2)
+
+The first **multi-paragraph** worked example for [`ADJ-ARGUMENT-COMPOSITION.md`](../../../ADJ-ARGUMENT-COMPOSITION.md):
+a three-paragraph "paper" composed into one `argument` the engine **derives**, `adj-verify`
+**byte-anchors across three separate source snapshots**, and `--explain` renders as a
+cross-paragraph chain. It is the empirical proof of the AC-1 finding — whole-paper composition
+needs **zero new constructs**, and grounding stays **per-paragraph** (multi-snapshot).
+
+## The paper
+
+Three short paragraphs (illustrative, our own words, not attributed to any real paper), each its
+own pinned source document (its SHA-256 is the `snapshot` its citations name):
+
+- **`p2-loading.source.txt`** — the loading paragraph. Grounds `stress_amplitude(axle, 420)` and
+  `endurance_limit(axle, 380)`, from which paragraph's own inference concludes
+  `exceeds_endurance(axle)`.
+- **`p3-fractography.source.txt`** — the fractography paragraph. Grounds `shows(surface,
+  beach_marks)` and `diagnostic_of(beach_marks, fatigue)`, concluding `fatigue_indicated(axle)`.
+- **`p4-discussion.source.txt`** — the discussion paragraph. Its inference `i3` takes the **two
+  earlier paragraphs' conclusions** (`i1`, `i2`) as premises-by-reference (`from i1, i2`) and
+  reaches the paper's thesis, `failed_by(axle, fatigue)`.
+
+`axle-paper.adj` is the composed argument — one block whose seven citations (4 premises + 3
+inference warrants) each name **their own paragraph's** snapshot.
+
+## What it proves
+
+- `adj-lang-cli axle-paper.adj` **derives `failed_by(axle, fatigue)`** by chaining across the three
+  paragraphs: `i3` (discussion) ← `i1` (loading) + `i2` (fractography) ← their paragraphs' premises.
+  The proof DAG *is* the paper's argument graph; each step keeps **its own paragraph's provenance**.
+- `adj-verify --snapshots <dir> axle-paper.adj` — with all three paragraph sources placed as
+  content-addressed snapshots in `<dir>` — **byte-anchors all seven citations across the three
+  snapshots** (`quotes_verified: 7`, `verified: true`). This is the *multi-snapshot* proof: every
+  paragraph's citations re-check against the paragraph they came from, not a single blob.
+- `adj-lang-cli --explain axle-paper.adj` renders the cross-paragraph chain — the thesis
+  (`source "p4-discussion"`) resting on `exceeds_endurance` (`source "p2-loading"`) and
+  `fatigue_indicated` (`source "p3-fractography"`), each grounded in its paragraph's premises.
+
+Together: **a whole paper's argument becomes one program the engine runs, and every step is
+auditable back to the specific paragraph's bytes it came from.** Driven end to end by
+`adj-lang-cli/tests/composition_worked_example_e2e.rs`.

--- a/code/specs/data/adj-argument-ir/composition/axle-paper.adj
+++ b/code/specs/data/adj-argument-ir/composition/axle-paper.adj
@@ -1,0 +1,13 @@
+% ADJ-ARGUMENT-COMPOSITION AC-2 — a whole-PAPER argument: three paragraphs, each pinned to its
+% own source snapshot, composed into one argument the engine derives and adj-verify byte-anchors
+% across all three snapshots. See README.md.
+argument axle_paper {
+    premise p1 : extracted stress_amplitude(axle, 420) quote "a stress amplitude of 420 MPa" at 30 snapshot "e0300bcba3f76e0e22564382f4e6d2f3608353046ac8bb6f26c7f70ee4e1a1f4" source "p2-loading" trust authoritative
+    premise p2 : extracted endurance_limit(axle, 380) quote "its endurance limit was measured at 380 MPa" at 69 snapshot "e0300bcba3f76e0e22564382f4e6d2f3608353046ac8bb6f26c7f70ee4e1a1f4" source "p2-loading" trust authoritative
+    premise p3 : extracted shows(surface, beach_marks) quote "exhibited beach marks" at 21 snapshot "00bac1ff0adf2e7b7041810e3fd3ec2cea4e4e6bd487fb99564e37c1787f5908" source "p3-fractography" trust authoritative
+    premise p4 : extracted diagnostic_of(beach_marks, fatigue) quote "diagnostic of progressive fatigue crack growth" at 54 snapshot "00bac1ff0adf2e7b7041810e3fd3ec2cea4e4e6bd487fb99564e37c1787f5908" source "p3-fractography" trust authoritative
+    infer i1 : because conclude exceeds_endurance(axle) from p1, p2 quote "its endurance limit was measured at 380 MPa" at 69 snapshot "e0300bcba3f76e0e22564382f4e6d2f3608353046ac8bb6f26c7f70ee4e1a1f4" source "p2-loading" trust authoritative
+    infer i2 : therefore conclude fatigue_indicated(axle) from p3, p4 quote "diagnostic of progressive fatigue crack growth" at 54 snapshot "00bac1ff0adf2e7b7041810e3fd3ec2cea4e4e6bd487fb99564e37c1787f5908" source "p3-fractography" trust authoritative
+    infer i3 : therefore conclude failed_by(axle, fatigue) from i1, i2 quote "the axle failed by fatigue" at 101 snapshot "c6be8c920970dbd011e8ddefd6f4f6704da6aca8d296ca1d7ce1d261bf80f969" source "p4-discussion" trust authoritative
+}
+? failed_by(axle, $Mechanism)

--- a/code/specs/data/adj-argument-ir/composition/p2-loading.source.txt
+++ b/code/specs/data/adj-argument-ir/composition/p2-loading.source.txt
@@ -1,0 +1,1 @@
+The examined axle experienced a stress amplitude of 420 MPa, whereas its endurance limit was measured at 380 MPa.

--- a/code/specs/data/adj-argument-ir/composition/p3-fractography.source.txt
+++ b/code/specs/data/adj-argument-ir/composition/p3-fractography.source.txt
@@ -1,0 +1,1 @@
+Its fracture surface exhibited beach marks, which are diagnostic of progressive fatigue crack growth.

--- a/code/specs/data/adj-argument-ir/composition/p4-discussion.source.txt
+++ b/code/specs/data/adj-argument-ir/composition/p4-discussion.source.txt
@@ -1,0 +1,1 @@
+Because the operating stress exceeded the endurance limit and the surface markings indicate fatigue, the axle failed by fatigue.


### PR DESCRIPTION
## AC-2 — the first whole-paper worked example, with multi-snapshot verify

Following the AC-1 spec (#9337), this commits the **empirical proof** of its finding: a three-paragraph "paper" composed into one `argument` the engine derives, `adj-verify` byte-anchors **across three separate source snapshots**, and `--explain` renders as a cross-paragraph chain.

### The paper (`code/specs/data/adj-argument-ir/composition/`)
Three short paragraphs (illustrative, our words), each its **own pinned snapshot**:
- `p2-loading` → grounds the loading premises → concludes `exceeds_endurance(axle)` (`i1`).
- `p3-fractography` → grounds the fractography premises → concludes `fatigue_indicated(axle)` (`i2`).
- `p4-discussion` → `i3 : … from i1, i2` takes **the two earlier paragraphs' conclusions** as premises-by-reference → the paper thesis `failed_by(axle, fatigue)`.

`axle-paper.adj` is one `argument` block; each of its **7 citations** (4 premises + 3 inference warrants) names *its own paragraph's* snapshot.

### Proven end to end (`composition_worked_example_e2e.rs`, 3 tests)
- `adj-lang-cli` **derives** the thesis by chaining across the three paragraphs (`i3 ← i1 + i2`).
- `adj-verify --snapshots` byte-anchors **all seven citations across the three snapshots** (`quotes_verified: 7`, `verified: true`) and re-derives — **the multi-snapshot proof**: each paragraph's citations re-check against the paragraph they came from.
- `--explain` renders the cross-paragraph chain, each step carrying **its own paragraph's provenance** (`p4-discussion` / `p2-loading` / `p3-fractography`):
```
failed_by(axle, fatigue)  <= inference [source "p4-discussion" …]
  exceeds_endurance(axle) <= inference [source "p2-loading" …]
    premise stress_amplitude(axle, 420)  [source "p2-loading" …]
    premise endurance_limit(axle, 380)   [source "p2-loading" …]
  fatigue_indicated(axle) <= inference [source "p3-fractography" …]
    premise shows(surface, beach_marks)  [source "p3-fractography" …]
    premise diagnostic_of(beach_marks, fatigue)  [source "p3-fractography" …]
```

**Finding confirmed:** multi-snapshot `adj-verify` needs no engine changes — whole-paper composition is delivered by the existing surface + verifier.

### Verification
`cargo test` → **3 passed**; `clippy -D warnings` clean; NUL-scan clean; `/security-review` PASSED. Test + data only — no shipped-code change, no version bump.

Follow-up: **AC-3** — a compose driver (extend `decompose_pipeline.py` to a whole-paper, multi-snapshot run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)