### PR TITLE
feat(adj-argument-rebuttal): worked rebuttal + undercut example (AR-2)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rebuttal_worked_example_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rebuttal_worked_example_e2e.rs
@@ -1,0 +1,130 @@
+//! AR-2 — the worked REBUTTAL + UNDERCUT example for ADJ-ARGUMENT-REBUTTAL. It drives the
+//! committed example under `code/specs/data/adj-argument-ir/rebuttal/` through the built
+//! binaries to prove a paper's *dialectic* end to end — the engine WITHDRAWS what its
+//! counterarguments defeat, and every attack is byte-anchored to its paragraph:
+//!
+//! * REBUT (`rebuttal.adj`): a support paragraph concludes `failed_by(axle, fatigue)`; a
+//!   reanalysis paragraph rebuts it with `failed_by(axle, overload)` under higher
+//!   `context_order` precedence. With the conclusion predicate `functional`, the `governing`
+//!   query marks fatigue **defeated** (`defeated_by` overload) and overload **governing**;
+//!   `adj-verify --snapshots` byte-anchors both `relate` premises across their snapshots.
+//! * UNDERCUT (`undercut.adj`): a limitation paragraph grounds a `not`-guarded warrant defeater,
+//!   so the fatigue thesis **abstains** — no rival mechanism asserted. Remove the undercut
+//!   condition and the thesis derives again.
+//!
+//! Both attack kinds reuse ADJ73 defeasibility + negation-as-failure — zero new engine code.
+
+use logic_engine::ContentHash;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../specs/data/adj-argument-ir/rebuttal")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("rebutwe_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Place every `*.source.txt` paragraph as a content-addressed snapshot in `snaps`.
+fn place_all_snapshots(snaps: &Path) -> usize {
+    let mut n = 0;
+    for entry in std::fs::read_dir(data_dir()).unwrap() {
+        let path = entry.unwrap().path();
+        if path.file_name().unwrap().to_string_lossy().ends_with(".source.txt") {
+            let bytes = std::fs::read(&path).unwrap();
+            std::fs::write(snaps.join(ContentHash::of(&bytes).as_hex()), &bytes).unwrap();
+            n += 1;
+        }
+    }
+    n
+}
+
+fn run(args: &[&str]) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .args(args)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// REBUT — the rebutted thesis is WITHDRAWN by the engine, and byte-anchored.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_rebuttal_defeats_the_thesis_via_context_precedence() {
+    let adj = data_dir().join("rebuttal.adj");
+    let (ok, s) = run(&[adj.to_str().unwrap()]);
+    assert!(ok, "the rebuttal example must run:\n{s}");
+    // The initial thesis is DEFEATED — withdrawn by the engine — by the reanalysis rival.
+    assert!(
+        s.contains("\"term\":\"failed_by(axle, fatigue)\"")
+            && s.contains("\"status\":\"defeated\"")
+            && s.contains("\"defeated_by\":\"failed_by(axle, overload)\""),
+        "the fatigue thesis must be defeated by the overload rebuttal:\n{s}"
+    );
+    // The reanalysis conclusion GOVERNS.
+    assert!(
+        s.contains("\"term\":\"failed_by(axle, overload)\"") && s.contains("\"status\":\"governing\""),
+        "the reanalysis conclusion must govern:\n{s}"
+    );
+}
+
+#[test]
+fn adj_verify_byte_anchors_the_rebuttal_premises() {
+    let snaps = scratch("snaps");
+    assert_eq!(place_all_snapshots(&snaps), 3, "three paragraph snapshots");
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-verify"))
+        .arg("--snapshots")
+        .arg(&snaps)
+        .arg(data_dir().join("rebuttal.adj"))
+        .output()
+        .expect("run adj-verify");
+    let s = String::from_utf8(out.stdout).unwrap();
+    assert!(out.status.success(), "the pinned rebuttal must verify:\n{s}");
+    assert!(s.contains("\"verified\":true"), "{s}");
+    // Both the support and the rebuttal premise are byte-anchored to their paragraphs.
+    assert!(
+        s.contains("\"quotes_verified\":2"),
+        "both grounded premises (support + rebuttal) must byte-anchor:\n{s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// UNDERCUT — a grounded undercut removes the warrant; the thesis abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_undercut_makes_the_thesis_abstain_and_removing_it_restores_derivation() {
+    let adj = data_dir().join("undercut.adj");
+    // With the undercut condition present, the fatigue warrant is disabled → no answer.
+    let (ok, s) = run(&[adj.to_str().unwrap()]);
+    assert!(ok, "the undercut example must run:\n{s}");
+    assert!(
+        s.contains("\"abstained\":true"),
+        "the undercut warrant must make the thesis abstain (no rival asserted):\n{s}"
+    );
+    assert!(!s.contains("\"Mechanism\":\"fatigue\""), "no fatigue answer while undercut holds:\n{s}");
+
+    // Remove the undercutting `relate contaminated(sample)` line → the warrant is not undercut →
+    // the fatigue thesis derives again. (The break test: the undercut is load-bearing.)
+    let text = std::fs::read_to_string(&adj).unwrap();
+    let restored: String = text
+        .lines()
+        .filter(|l| !l.contains("relate contaminated(sample)"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let dir = scratch("restore");
+    let prog = dir.join("no_undercut.adj");
+    std::fs::write(&prog, restored).unwrap();
+    let (ok2, s2) = run(&[prog.to_str().unwrap()]);
+    assert!(ok2, "{s2}");
+    assert!(
+        s2.contains("\"Mechanism\":\"fatigue\""),
+        "removing the undercut condition must restore the fatigue derivation:\n{s2}"
+    );
+}

--- a/code/specs/data/adj-argument-ir/rebuttal/README.md
+++ b/code/specs/data/adj-argument-ir/rebuttal/README.md
@@ -1,0 +1,41 @@
+# ADJ-ARGUMENT-REBUTTAL — worked rebuttal + undercut example (AR-2)
+
+The worked example for [`ADJ-ARGUMENT-REBUTTAL.md`](../../../ADJ-ARGUMENT-REBUTTAL.md): a paper
+whose thesis is **attacked**, proving end-to-end that ADJ represents *and resolves* a paper's
+dialectic — a defeated conclusion is **withdrawn by the engine** (not filtered in Python), and
+every attacking premise is byte-anchored like any other. Both attack kinds reuse existing
+machinery with zero new engine code (§2 of the spec).
+
+## Paragraph sources (each its own pinned snapshot)
+
+- **`pA-support.source.txt`** — the support: beach marks ⇒ *fatigue*.
+- **`pB-reanalysis.source.txt`** — the **rebuttal**: a single-shear lip ⇒ *overload* (a rival
+  conclusion).
+- **`pC-limitation.source.txt`** — the **undercut**: a contaminated sample (a methods limitation).
+
+## `rebuttal.adj` — REBUT (attack a conclusion)
+
+The support paragraph concludes `failed_by(axle, fatigue)` under `context: initial_report`; the
+reanalysis paragraph concludes `failed_by(axle, overload)` under `context: reanalysis`; the paper's
+`context_order { reanalysis > initial_report }` says the reanalysis outranks. With
+`functional failed_by(subject, mechanism)`, the two conclusions **conflict**, and the `governing`
+query resolves it:
+
+- `failed_by(axle, fatigue)` → **`status: defeated`**, `defeated_by: failed_by(axle, overload)`;
+- `failed_by(axle, overload)` → **`status: governing`**.
+
+`adj-verify --snapshots` byte-anchors both `relate` premises against their paragraphs
+(`quotes_verified: 2`, `verified: true`). The rebuttal is grounded exactly like the support.
+
+## `undercut.adj` — UNDERCUT (attack a warrant)
+
+The fatigue inference fires only `when: shows(surface, beach_marks), not warrant_undercut`; a
+limitation paragraph grounds `warrant_undercut` from `contaminated(sample)`. When the contamination
+holds, the thesis **abstains** — `? failed_by(axle, $M)` returns no answer — because the *licence*
+for the inference is removed; **no rival mechanism is asserted**. Remove the contamination and the
+fatigue thesis derives again. (An undercut blocks the proof, so there is no derivation to
+byte-anchor — the point is the honest abstention, not a citation count.)
+
+Both are driven by `adj-lang-cli/tests/rebuttal_worked_example_e2e.rs`. Together they show a paper's
+disagreements are first-class: **the engine withdraws what its counterarguments defeat, and every
+attack is auditable back to the paragraph that makes it.**

--- a/code/specs/data/adj-argument-ir/rebuttal/pA-support.source.txt
+++ b/code/specs/data/adj-argument-ir/rebuttal/pA-support.source.txt
@@ -1,0 +1,1 @@
+The fracture surface exhibited beach marks, which are diagnostic of fatigue.

--- a/code/specs/data/adj-argument-ir/rebuttal/pB-reanalysis.source.txt
+++ b/code/specs/data/adj-argument-ir/rebuttal/pB-reanalysis.source.txt
@@ -1,0 +1,1 @@
+On reanalysis the surface showed a single-shear lip, indicating a one-time overload.

--- a/code/specs/data/adj-argument-ir/rebuttal/pC-limitation.source.txt
+++ b/code/specs/data/adj-argument-ir/rebuttal/pC-limitation.source.txt
@@ -1,0 +1,1 @@
+A methods audit found the fracture sample had been contaminated during handling.

--- a/code/specs/data/adj-argument-ir/rebuttal/rebuttal.adj
+++ b/code/specs/data/adj-argument-ir/rebuttal/rebuttal.adj
@@ -1,0 +1,10 @@
+% ADJ-ARGUMENT-REBUTTAL AC/AR-2 — a paper whose thesis is REBUTTED. The support paragraph
+% concludes fatigue; the reanalysis paragraph rebuts it with a single-shear overload finding.
+% Under context_order the reanalysis outranks the initial report, so the engine WITHDRAWS fatigue.
+functional failed_by(subject, mechanism)
+relate shows(surface, beach_marks)  quote "exhibited beach marks" at 21 snapshot "1baf6c66bb4db1f3ce48c03cdd93e8cf1c8d1c3a7e955e67c7693b65638fdf17" source "pA-support" trust authoritative
+relate shows(surface, single_shear) quote "showed a single-shear lip" at 26 snapshot "e1d6c446ec0106f702b556b52c972eddce2e52b04c5cc925b9e15e548cbc2b9d" source "pB-reanalysis" trust authoritative
+rule { head: failed_by(axle, fatigue)  when: shows(surface, beach_marks) context: initial_report }
+rule { head: failed_by(axle, overload) when: shows(surface, single_shear) context: reanalysis }
+context_order { reanalysis > initial_report }
+? failed_by(axle, $Mechanism)

--- a/code/specs/data/adj-argument-ir/rebuttal/undercut.adj
+++ b/code/specs/data/adj-argument-ir/rebuttal/undercut.adj
@@ -1,0 +1,8 @@
+% ADJ-ARGUMENT-REBUTTAL AR-2 — a paper whose thesis is UNDERCUT. The fatigue inference fires only
+% if its warrant is not undercut; a methods-limitation paragraph grounds the undercut, so the
+% thesis ABSTAINS (no rival mechanism is asserted — the licence is simply removed).
+relate shows(surface, beach_marks) quote "exhibited beach marks" at 21 snapshot "1baf6c66bb4db1f3ce48c03cdd93e8cf1c8d1c3a7e955e67c7693b65638fdf17" source "pA-support" trust authoritative
+relate contaminated(sample)        quote "contaminated during handling" at 51 snapshot "efbe3aa4966754c5860376306c96d0220baa3e0f3fde4a0643e1582a6d0cdcbb" source "pC-limitation" trust authoritative
+rule { head: failed_by(axle, fatigue) when: shows(surface, beach_marks), not warrant_undercut }
+rule { head: warrant_undercut when: contaminated(sample) }
+? failed_by(axle, $Mechanism)


### PR DESCRIPTION
## AR-2 — the worked dialectic: a paper whose thesis is attacked

Following the AR-1 spec (#9340), this commits the worked example proving both attack kinds end-to-end: a defeated conclusion is **withdrawn by the engine** (not filtered in Python), and every attacking premise is byte-anchored like any other. Both reuse existing machinery — **zero new engine code**.

### `rebuttal.adj` — REBUT (attack a conclusion)
Support concludes `failed_by(axle, fatigue)` under `context: initial_report`; a reanalysis rebuttal concludes `failed_by(axle, overload)` under `context: reanalysis`; `functional failed_by(subject, mechanism)` + `context_order { reanalysis > initial_report }` make them conflict, and the `governing` query **withdraws fatigue**:
```
failed_by(axle, fatigue)  → status: defeated,  defeated_by: failed_by(axle, overload)
failed_by(axle, overload) → status: governing
```
`adj-verify --snapshots` byte-anchors **both grounded premises** across their snapshots (`quotes_verified: 2`).

### `undercut.adj` — UNDERCUT (attack a warrant)
The fatigue inference fires only `when: …, not warrant_undercut`; a limitation paragraph grounds `warrant_undercut` from `contaminated(sample)`, so the thesis **abstains** — no rival mechanism asserted. Remove the undercut condition and the thesis derives again (the undercut is load-bearing).

### Changes
- `code/specs/data/adj-argument-ir/rebuttal/` — 3 paragraph sources (each its own snapshot) + `rebuttal.adj` + `undercut.adj` + README.
- `rebuttal_worked_example_e2e.rs` (**3 tests**): the rebuttal defeats the thesis via context precedence; `adj-verify` byte-anchors the rebuttal premises; the undercut makes the thesis abstain and removing it restores derivation.

### Verification
`cargo test` → **3 passed**; `clippy -D warnings` clean; NUL-scan clean; `/security-review` PASSED. Test + data only — no shipped-code change, no version bump.

Follow-up: **AR-3** — the `argument`-surface `context:`/`unless` sugar on `infer` + the `--explain` "defeated-by" rendering (so support and attack compose in one block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)