### PR TITLE
feat(facts-stdlib): Greek alphabet letter→position recall table (FACTS-K3)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_greek_alphabet_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_greek_alphabet_e2e.rs
@@ -1,0 +1,65 @@
+//! End-to-end test for the LANGUAGE FACTS library
+//! (`adj-facts-stdlib/language/greek-alphabet.adj`) driven through the built CLI:
+//! a native `table` of the 24 Greek letters → their 1-based position in the
+//! alphabet resolves forward AND reverse binding-query recalls with the
+//! encyclopedia's citation, and abstains on a Latin letter that has no shipped
+//! row — 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn language_greek_alphabet_recall_binds_position_forward_and_reverse() {
+    let dir = scratch("greek_alphabet");
+    // Copy the shipped Greek-alphabet table beside the entry program and import it.
+    let src = facts_stdlib().join("language/greek-alphabet.adj");
+    std::fs::copy(&src, dir.join("greek-alphabet.adj")).expect("copy shipped greek-alphabet.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"greek-alphabet.adj\"\n\
+         ? greek_letter_position(alpha, $N)\n\
+         ? greek_letter_position(omega, $N)\n\
+         ? greek_letter_position($L, 3)\n\
+         ? greek_letter_position(b, $N)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward: alpha is the first letter, omega is the twenty-fourth (and last).
+    assert!(out.contains("\"N\":\"1\""), "alpha → 1: {out}");
+    assert!(out.contains("\"N\":\"24\""), "omega → 24: {out}");
+    // Reverse: the third letter of the Greek alphabet is gamma (binds the other column).
+    assert!(out.contains("\"L\":\"gamma\""), "position 3 → gamma: {out}");
+    // The answer carries the Wikipedia citation as its proof, at consensus trust.
+    assert!(
+        out.contains("en.wikipedia.org/wiki/Greek_alphabet")
+            && out.contains("\"trust\":\"consensus\""),
+        "carries the encyclopedia citation: {out}"
+    );
+    // `b` is a Latin letter, not one of the 24 Greek rows — honest abstention, never invented.
+    assert!(out.contains("\"abstained\":true"), "Latin letter b abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -117,6 +117,7 @@ per rotation, in parallel):
 | `environment/` | **RANGE table** — AQI value → EPA level of concern, keyed by band minimum (0 → good, 51 → moderate, 101 → unhealthy_for_sensitive_groups, 301 → hazardous, open top band) | EPA AirNow "AQI Basics" (authoritative) |
 | `geography/` | common landform → defining descriptor (mountain → projects_above_surroundings, plateau → flat_elevated, canyon → deep_narrow) | USGS Feature Type Thesaurus (authoritative) |
 | `geography/` | globe reference line → what it marks (equator → zero_degrees_latitude, prime_meridian → zero_degrees_longitude, tropic_of_cancer → northernmost_sun_overhead) | NOAA National Ocean Service / NESDIS (authoritative) |
+| `language/` | Greek letter → its 1-based position in the alphabet (alpha → 1, gamma → 3, pi → 16, omega → 24) | Wikipedia "Greek alphabet" (consensus) |
 | … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/language/greek-alphabet.adj
+++ b/code/specs/data/adj-facts-stdlib/language/greek-alphabet.adj
@@ -1,0 +1,94 @@
+% ============================================================================
+% greek-alphabet — each Greek letter's position in the Greek alphabet
+% (adj-facts-stdlib, LANGUAGE).
+% ============================================================================
+% The Greek alphabet is the ordered sequence every student of mathematics and
+% science eventually leans on: alpha comes first (1), beta next (2), … all the way
+% to omega, the twenty-fourth and last (24). Unlike a set, it is a SEQUENCE — and
+% knowing a letter's NUMBER is what lets you say WHICH letter is meant by "the
+% third variable" (gamma) or read an ordered list of angles α, β, γ in the right
+% order. The names double as the symbols mathematicians reach for constantly (π,
+% Σ, Δ, θ, λ, μ), so the ordering is not trivia — it is the index into that
+% shared notation. This tiny library records that name → position mapping so an
+% ADJ program can ASK where a Greek letter sits, and get a cited answer. Recall is
+% a binding query:
+%
+%     ? greek_letter_position(alpha, $N)   % 1  (alpha is the first letter)
+%     ? greek_letter_position(omega, $N)   % 24 (omega is the last letter)
+%
+% Because the value is a NUMBER, the answer composes into arithmetic — how many
+% letters lie between gamma and pi? 16 − 3 − 1 = 12. A reverse query binds the
+% other column, turning a number back into its letter:
+%
+%     ? greek_letter_position($L, 3)       % gamma  (which letter is third?)
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `greek_letter_position(letter, position)` carrying the table's citation,
+% so every lookup above is the ordinary SLD binding query — the engine returns the
+% position (or the letter, on a reverse query) WITH its source, on the CPU, with
+% zero model calls, and ABSTAINS on anything that is not one of the 24 Greek
+% letters (a Latin letter, a digit, a symbol) rather than guessing.
+%
+% The 24 letters, as an ordered truth table:
+%
+%     letter    position    letter     position    letter      position
+%     -------   --------    --------   --------    ---------   --------
+%     alpha     1           iota       9           rho         17
+%     beta      2           kappa      10          sigma       18
+%     gamma     3           lambda     11          tau         19
+%     delta     4           mu         12          upsilon     20
+%     epsilon   5           nu         13          phi         21
+%     zeta      6           xi         14          chi         22
+%     eta       7           omicron    15          psi         23
+%     theta     8           pi         16          omega       24
+%
+% Only the 24 letter rows are shipped — nothing else. A Latin letter such as `b`
+% has NO row (it belongs to a different alphabet), so a query like
+% `? greek_letter_position(b, $N)` ABSTAINS rather than inventing a position: the
+% table's honest-abstention property means it only ever asserts the ordering it
+% can cite, and stays silent on everything else.
+%
+% Provenance — nothing here is from memory. The 24-letter alpha→omega ordering is
+% the standard Euclidean order recorded in the Wikipedia "Greek alphabet" article,
+% which states verbatim (see `source`) that the 24-letter alphabet is "ordered from
+% alpha to omega," and whose letters table enumerates the names IN that order:
+% Alpha Beta Gamma Delta Epsilon Zeta Eta Theta Iota Kappa Lambda Mu Nu Xi Omicron
+% Pi Rho Sigma Tau Upsilon Phi Chi Psi Omega. Each row below assigns a letter its
+% 1-based position in that stated sequence. The citable artifact is that article's
+% letters table at the `locator`. `trust consensus` — an encyclopedia is a
+% secondary reference, not a primary standards body. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table greek_letter_position {
+    columns letter, position
+
+    row (alpha, 1)
+    row (beta, 2)
+    row (gamma, 3)
+    row (delta, 4)
+    row (epsilon, 5)
+    row (zeta, 6)
+    row (eta, 7)
+    row (theta, 8)
+    row (iota, 9)
+    row (kappa, 10)
+    row (lambda, 11)
+    row (mu, 12)
+    row (nu, 13)
+    row (xi, 14)
+    row (omicron, 15)
+    row (pi, 16)
+    row (rho, 17)
+    row (sigma, 18)
+    row (tau, 19)
+    row (upsilon, 20)
+    row (phi, 21)
+    row (chi, 22)
+    row (psi, 23)
+    row (omega, 24)
+
+    source "by the end of the 4th century BC, the Ionic-based Euclidean alphabet, with 24 letters, ordered from alpha to omega, had become standard"
+    locator "https://en.wikipedia.org/wiki/Greek_alphabet"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/language/greek-alphabet.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/greek-alphabet.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% greek-alphabet.query.adj — a worked recall over the Greek-alphabet library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "where does this Greek letter
+% sit in the alphabet?" — it states no fact of its own — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `greek_letter_position` rows and returns the position (or the letter, on a
+% reverse query) + the encyclopedia's source/locator/trust. Anything that is not
+% one of the 24 Greek letters — a Latin letter, a digit, a symbol — abstains
+% honestly: the engine never invents a position it cannot cite.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli greek-alphabet.query.adj
+% ============================================================================
+
+import "greek-alphabet.adj"
+
+? greek_letter_position(alpha, $N)     % expect 1   (which position is alpha? the first)
+? greek_letter_position(omega, $N)     % expect 24  (omega is the last letter)
+? greek_letter_position($L, 3)         % expect gamma  (reverse: which letter is third?)
+? greek_letter_position(b, $N)         % expect abstain — b is a Latin letter, not a Greek row


### PR DESCRIPTION
## What

A new grounded **LANGUAGE** facts library: the 24 Greek letters mapped to their 1-based position in the alphabet (**alpha → 1 … omega → 24**), as a native `table` (ADJ-TABLES RS-5). Parallels the existing Latin `alphabet.adj`.

- Exact lookup `? greek_letter_position(alpha, $N)` → `1`, cited
- Reverse binding `? greek_letter_position($L, 3)` → `gamma`
- Honest abstention on a non-Greek key (`b` → `abstained: true`) — never invented
- Zero answer-time model calls; every answer carries the table's citation

## Grounding discipline

The letter names and their alpha→omega order are the standard Euclidean order recorded in the Wikipedia *Greek alphabet* article, whose letters table enumerates the names in order. The `source` span quotes the article **verbatim** (`"…the Ionic-based Euclidean alphabet, with 24 letters, ordered from alpha to omega, had become standard"`) and `locator` points at that table. `trust consensus` (secondary reference). Nothing asserted from memory.

## Files

- `language/greek-alphabet.adj` — the grounded `table` + literate header
- `language/greek-alphabet.query.adj` — worked forward / reverse / abstain recall
- `adj-lang-cli/tests/facts_greek_alphabet_e2e.rs` — e2e: alpha→1, omega→24, pos 3→gamma, Latin `b` abstains, Wikipedia citation carried
- `README.md` — add the `language/` sampling row

## Verification

- `cargo test -p adj-lang-cli --test facts_greek_alphabet_e2e` — green
- `cargo clippy -p adj-lang-cli --tests` — clean
- Data-only + one test; no shipped Rust crate changed (no version bump)
- `/security-review` — PASSED

Front rotation: honors the alternate-three-fronts directive (Facts/recall after the argument-thread PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)