### PR TITLE
feat(formula-stdlib): proportion (rule-of-three) formula library (FL-4b)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl4_proportion_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_proportion_e2e.rs
@@ -1,0 +1,149 @@
+//! End-to-end tests for ADJ-FORMULA-LIBRARIES FL-4 — the `proportion.adj`
+//! elementary library — driven through the built CLI binary against the SHIPPED
+//! stdlib. Each proves the FL-4 invariant: the library COMPOSES the cited
+//! `arithmetic.adj` primitives (it re-derives no arithmetic), computes the exact
+//! value on the CPU, and carries BOTH its own citation and the primitives' as
+//! corroborations — write-once-use-many all the way down. The `fourth_proportional`
+//! formula is two levels deep: `quotient(product(b, c), a)` — the rule of three.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib")
+        .canonicalize()
+        .expect("shipped adj-formula-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fl4prop_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy a shipped `.adj` file (by relative path under the stdlib) into `dir`
+/// under its basename, so a consumer's relative `import` resolves.
+fn place(dir: &Path, rel: &str) {
+    let src = stdlib().join(rel);
+    let name = Path::new(rel).file_name().unwrap();
+    std::fs::copy(&src, dir.join(name)).unwrap_or_else(|e| panic!("copy {rel}: {e}"));
+}
+
+fn with_lib(dir: &Path) {
+    place(dir, "arithmetic/arithmetic.adj");
+    place(dir, "arithmetic/proportion.adj");
+}
+
+// ---------------------------------------------------------------------------
+// fourth_proportional — the rule of three, composing product THEN quotient.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fourth_proportional_composes_product_and_quotient_and_carries_all_citations() {
+    let dir = scratch("fourth");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"proportion.adj\"\n\
+         observe first_term(2)\n\
+         observe second_term(3)\n\
+         observe third_term(4)\n\
+         ? fourth_proportional(first_term, second_term, third_term)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2/3 = 4/x → x = (3 * 4) / 2 = 6, via product then quotient on the CPU.
+    assert!(
+        s.contains("\"name\":\"fourth_proportional\"") && s.contains("\"value\":6"),
+        "fourth_proportional(2, 3, 4) = 6: {s}"
+    );
+    // Exact integer 6/1 — no f64 round-trip.
+    assert!(s.contains("\"num\":\"6\"") && s.contains("\"den\":\"1\""), "exact value 6/1: {s}");
+    // The primary cites the cross-multiplication rule of three.
+    assert!(
+        s.contains("en.wikipedia.org/wiki/Cross-multiplication"),
+        "primary cites the rule-of-three source: {s}"
+    );
+    // BOTH composed primitives appear as corroborations.
+    assert!(
+        s.contains("mathworld.wolfram.com/Product.html"),
+        "corroboration cites the product primitive it composed: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Quotient.html"),
+        "corroboration cites the quotient primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The compute trace names both composed ops over the observed slots.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_derivation_tree_names_the_quotient_over_the_product() {
+    let dir = scratch("tree");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"proportion.adj\"\n\
+         observe first_term(2)\n\
+         observe second_term(3)\n\
+         observe third_term(4)\n\
+         ? fourth_proportional(first_term, second_term, third_term)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    // The outer op is the division (12 / 2 = 6); the inner op is the product
+    // (3 * 4 = 12) — the answer is reconstructable operand by operand.
+    assert!(
+        s.contains("\"node\":\"op\"") && s.contains("\"op\":\"/\"") && s.contains("\"op\":\"*\""),
+        "the derivation names the quotient over the product: {s}"
+    );
+    assert!(
+        s.contains("\"slot\":\"first_term\"")
+            && s.contains("\"slot\":\"second_term\"")
+            && s.contains("\"slot\":\"third_term\""),
+        "the leaves name the observed slots the value was built from: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Honest edge case — a degenerate proportion 0/b = c/x has no finite fourth
+// proportional; the engine REFUSES (DivisionByZero), never fabricates a value.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_zero_first_term_is_refused_not_fabricated() {
+    let dir = scratch("zero");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"proportion.adj\"\n\
+         observe first_term(0)\n\
+         observe second_term(3)\n\
+         observe third_term(4)\n\
+         ? fourth_proportional(first_term, second_term, third_term)\n",
+    )
+    .unwrap();
+
+    let (_ok, s) = run(&dir.join("case.adj"));
+    // Dividing by the zero first term is refused: the engine reports
+    // DivisionByZero rather than inventing a fourth proportional.
+    assert!(s.contains("DivisionByZero"), "a zero first term must be refused, not fabricated: {s}");
+    assert!(!s.contains("\"value\":0"), "no fabricated value for a degenerate proportion: {s}");
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/proportion.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/proportion.adj
@@ -1,0 +1,75 @@
+% ============================================================================
+% proportion.adj — the proportion (rule-of-three) formula library
+% (ADJ-RULE-SUBSTRATE RS-1 / FL-4).
+% ============================================================================
+% A PROPORTION states that two ratios are equal — `a/b = c/x`. The everyday
+% question a proportion answers is "a is to b as c is to WHAT?": given three of
+% the four terms, find the missing fourth. The classical recipe is the RULE OF
+% THREE — cross-multiply (`a·x = b·c`) and divide, giving the FOURTH PROPORTIONAL
+%
+%       x = (b · c) / a
+%
+% This library ships that as a single composed formula. Like `ratio` (which
+% APPLIES the cited `quotient` primitive), `fourth_proportional` performs no bare
+% arithmetic of its own: its body is `quotient(product(second, third), first)` —
+% it CALLS the cited `product` primitive to form `b·c`, then CALLS the cited
+% `quotient` primitive to divide by `a`. Two levels of composition, every step
+% named and cited (RS-1 write-once-reuse-many).
+%
+%     import "proportion.adj"                       % transitively imports arithmetic.adj
+%     observe first_term(2)                         % a  — "2 is to 3…"
+%     observe second_term(3)                        % b
+%     observe third_term(4)                         % c  — "…as 4 is to what?"
+%     ? fourth_proportional(first_term, second_term, third_term)
+%                                                   % engine → 6  (since 2/3 = 4/6)
+%
+% Worked check: with a=2, b=3, c=4 the rule of three gives x = (3·4)/2 = 6, and
+% indeed 2/3 = 4/6 = 0.666… — the proportion balances. The engine expands
+% `fourth_proportional` → `product` → `quotient` on the CPU and composes the
+% provenance chain: the answer cites the cross-multiplication rule of three
+% (primary) AND the `product` and `quotient` primitives it built on
+% (corroboration). Zero arithmetic is performed by the model.
+%
+% Honesty note: the rule of three requires the divisor term `a` (first_term) to
+% be non-zero — a proportion `0/b = c/x` has no finite fourth proportional. The
+% formula makes NO special claim there; it simply applies the cited `quotient`,
+% whose divisor-is-zero behaviour it inherits (it does not fabricate a value).
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Depends on the elementary primitives — `product` and `quotient`. The import is
+% RELATIVE to this file; a consumer that imports `proportion.adj` transitively
+% gets `product`/`quotient` (and their siblings), so the body resolves.
+% ----------------------------------------------------------------------------
+import "arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. The three KNOWN terms of the proportion a/b = c/x are named by
+% position; the result is the unknown FOURTH proportional (the x). Rung-0 types
+% each observable slot as `finding`; the `surface` synonyms let a decomposer map
+% everyday "is to … as … is to" phrasing onto the canonical terms.
+% ----------------------------------------------------------------------------
+dictionary proportion_vocab {
+    define first_term          : finding  surface "first term", "antecedent", "a", "first"
+    define second_term         : finding  surface "second term", "consequent", "b", "second"
+    define third_term          : finding  surface "third term", "c", "third"
+    define fourth_proportional : finding  surface "fourth proportional", "fourth term", "missing term", "unknown term", "x"
+}
+
+% ----------------------------------------------------------------------------
+% The composed formula. For the proportion `a/b = c/x` (first/second = third/x),
+% the rule of three gives x = (b·c)/a. The body is a formula CALLING two cited
+% primitives: `product(second_term, third_term)` forms b·c, and `quotient(…,
+% first_term)` divides it by a. The engine resolves both applications on the
+% CPU and carries their citations alongside this one. `fourth_proportional`
+% asserts its own claim about the world (how a missing proportional is found)
+% and so carries its own required source.
+% ----------------------------------------------------------------------------
+formulabook proportions {
+    use proportion_vocab
+
+    formula fourth_proportional(first_term, second_term, third_term) = quotient(product(second_term, third_term), first_term)
+        source "For an equation of the form a/b = c/x, where the variable to be evaluated is in the right-hand denominator, the rule of three states that x = bc/a."
+        locator "https://en.wikipedia.org/wiki/Cross-multiplication"
+        trust consensus
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/proportion.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/proportion.query.adj
@@ -1,0 +1,31 @@
+% ============================================================================
+% proportion.query.adj — a worked example of the proportion formula library.
+% ============================================================================
+% Run against the shipped stdlib:
+%
+%   adj-lang-cli proportion.query.adj
+%
+% "2 is to 3 as 4 is to WHAT?" — the proportion 2/3 = 4/x. The rule of three
+% gives x = (3 × 4) / 2 = 6, computed on the CPU by composing the cited `product`
+% primitive (3 × 4 = 12) and then the cited `quotient` primitive (12 / 2 = 6)
+% from arithmetic.adj. The answer carries the cross-multiplication rule of three
+% (primary) AND both primitives it built on (corroboration) — the model performs
+% zero arithmetic. (Check: 2/3 = 4/6 = 0.666…, so the proportion balances.)
+% ============================================================================
+import "proportion.adj"
+
+observe first_term(2)
+observe second_term(3)
+observe third_term(4)
+
+? fourth_proportional(first_term, second_term, third_term)
+
+% ----------------------------------------------------------------------------
+% Honest edge case — a degenerate proportion 0/b = c/x has NO finite fourth
+% proportional (the rule of three would divide by zero). The formula makes no
+% special claim here; it applies the cited `quotient`, which REFUSES to divide by
+% zero. The engine returns a DivisionByZero error rather than inventing a value —
+% honest abstention, not a fabricated answer. (Uncomment to see it.)
+% ----------------------------------------------------------------------------
+% observe first_term(0)
+% ? fourth_proportional(first_term, second_term, third_term)


### PR DESCRIPTION
## What

A new grounded **arithmetic** formula library, `proportion.adj`, for the classic *"a is to b as c is to WHAT?"* question. `fourth_proportional(a, b, c)` solves the proportion `a/b = c/x` by the **rule of three**: `x = (b·c)/a`.

Two levels of composition over the cited `arithmetic.adj` primitives:

```
formula fourth_proportional(first, second, third) = quotient(product(second, third), first)
```

It re-derives no arithmetic — it CALLS the cited `product` to form `b·c`, then the cited `quotient` to divide by `a` — computes the exact value on the CPU, and carries its own citation **plus** both primitives' as corroborations (RS-1 write-once-reuse-many). A ratio-family sibling of the existing `ratio.adj`.

## Grounding

The rule of three is quoted **verbatim** from Wikipedia's *Cross-multiplication* article (`"…the rule of three states that x = bc/a."`), `trust consensus`. Nothing asserted from memory.

## Honest edge case

A degenerate proportion `0/b = c/x` has no finite fourth proportional. The formula makes no special claim — it applies the cited `quotient`, which **refuses to divide by zero**, so the engine returns a `DivisionByZero` error rather than fabricating a value. This is asserted in the test.

## Files

- `arithmetic/proportion.adj` — the grounded `formula` + literate header
- `arithmetic/proportion.query.adj` — worked example (2:3::4:6 → 6) + the edge case
- `adj-lang-cli/tests/fl4_proportion_e2e.rs` — e2e: value 6 (exact 6/1), all three citations carried, derivation tree names `/` over `*`, zero first term refused

## Verification

- `cargo test -p adj-lang-cli --test fl4_proportion_e2e` — 3/3 green
- `cargo clippy -p adj-lang-cli --tests` — clean
- Data + one test only; no shipped Rust crate changed (no version bump)
- `/security-review` — PASSED

Delivers the `proportion` item spec'd in `ADJ-FORMULA-LIBRARIES.md`'s Middle/HS roadmap row. Front rotation: Libraries/FL rung, honoring alternate-three-fronts after the Facts-front FACTS-K3 (#9344).

🤖 Generated with [Claude Code](https://claude.com/claude-code)