### PR TITLE
feat(adj-lang): AR-3 — attack edges compose inside the `argument` block

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -481,7 +481,20 @@ argument_decl = "argument" IDENT LBRACE { arg_premise } { arg_infer } RBRACE ;
 
 arg_premise   = "premise" IDENT COLON IDENT term { annotation } ;
 
-arg_infer     = "infer" IDENT COLON IDENT "conclude" term "from" arg_ref { COMMA arg_ref } { annotation } ;
+# arg_infer (ADJ-ARGUMENT-REBUTTAL AR-3) — an inference may now carry a paper's
+# ATTACK edges, so support AND rebuttal/undercut compose in ONE `argument` block:
+#   * `unless <defeater> { , <defeater> }` — an UNDERCUT guard. Each defeater term
+#     lowers to a `not <term>` body literal (negation-as-failure), so the step fires
+#     only while its warrant is not defeated. Wrapped in an `arg_unless` node so it is
+#     cleanly separable from the `conclude` term (exactly as `from` refs are `arg_ref`s).
+#   * trailing `context: <name>` — the CONTEXT this inference is grounded in, mirroring
+#     `rule_decl` (ADJ73 PR-B). With a `functional` thesis + `context_order`, a rival
+#     inference in an outranking context REBUTS (defeats) this one — the engine withdraws
+#     the loser. Both desugar to the proven `rule`/`context`/NAF machinery — zero new
+#     engine code.
+arg_infer     = "infer" IDENT COLON IDENT "conclude" term "from" arg_ref { COMMA arg_ref } [ arg_unless ] { annotation } [ "context" COLON IDENT ] ;
+
+arg_unless    = "unless" term { COMMA term } ;
 
 arg_ref       = IDENT ;
 

--- a/code/packages/rust/adj-lang-cli/tests/argument_inblock_attack_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/argument_inblock_attack_e2e.rs
@@ -1,0 +1,129 @@
+//! AR-3 — a paper's ATTACK edges now compose INSIDE the `argument` block. The AR-2 rebuttal
+//! and undercut required raw `rule`+`functional`+`context_order` bolted alongside the argument;
+//! AR-3 adds two pieces of surface sugar on `infer` so support AND attack live in one block:
+//!
+//!  * REBUT (`rebuttal-inblock.adj`): each `infer` carries a `context:` — the support step in
+//!    `initial_report`, the reanalysis step in `reanalysis`. With a `functional` thesis and
+//!    `context_order { reanalysis > initial_report }`, the engine WITHDRAWS fatigue (marks it
+//!    `defeated`, `defeated_by` overload) and the reanalysis conclusion GOVERNS. `adj-verify`
+//!    byte-anchors both premises.
+//!  * UNDERCUT (`undercut-inblock.adj`): the support `infer` carries `unless warrant_undercut`
+//!    (→ a `not` body literal), and a second `infer` derives that defeater from the contamination
+//!    premise. Contaminated → the thesis ABSTAINS. Remove the deriving `infer` → fatigue returns.
+//!
+//! Both desugar to the proven ADJ73 defeasibility + negation-as-failure — zero new engine code.
+
+use logic_engine::ContentHash;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../specs/data/adj-argument-ir/rebuttal")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("ar3inblock_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Place every `*.source.txt` paragraph as a content-addressed snapshot in `snaps`.
+fn place_all_snapshots(snaps: &Path) -> usize {
+    let mut n = 0;
+    for entry in std::fs::read_dir(data_dir()).unwrap() {
+        let path = entry.unwrap().path();
+        if path.file_name().unwrap().to_string_lossy().ends_with(".source.txt") {
+            let bytes = std::fs::read(&path).unwrap();
+            std::fs::write(snaps.join(ContentHash::of(&bytes).as_hex()), &bytes).unwrap();
+            n += 1;
+        }
+    }
+    n
+}
+
+fn run(args: &[&str]) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .args(args)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// REBUT — the in-block `context:` sugar withdraws the defeated conclusion.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inblock_context_rebuts_the_thesis_via_precedence() {
+    let adj = data_dir().join("rebuttal-inblock.adj");
+    let (ok, s) = run(&[adj.to_str().unwrap()]);
+    assert!(ok, "the in-block rebuttal must run:\n{s}");
+    // The fatigue conclusion — concluded by an `infer … context: initial_report` — is DEFEATED
+    // by the reanalysis `infer … context: reanalysis` under the paper's context_order.
+    assert!(
+        s.contains("\"term\":\"failed_by(axle, fatigue)\"")
+            && s.contains("\"status\":\"defeated\"")
+            && s.contains("\"defeated_by\":\"failed_by(axle, overload)\""),
+        "the in-block fatigue inference must be defeated by the in-block overload inference:\n{s}"
+    );
+    assert!(
+        s.contains("\"term\":\"failed_by(axle, overload)\"") && s.contains("\"status\":\"governing\""),
+        "the reanalysis conclusion must govern:\n{s}"
+    );
+}
+
+#[test]
+fn adj_verify_byte_anchors_the_inblock_rebuttal_premises() {
+    let snaps = scratch("snaps");
+    assert_eq!(place_all_snapshots(&snaps), 3, "three paragraph snapshots");
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-verify"))
+        .arg("--snapshots")
+        .arg(&snaps)
+        .arg(data_dir().join("rebuttal-inblock.adj"))
+        .output()
+        .expect("run adj-verify");
+    let s = String::from_utf8(out.stdout).unwrap();
+    assert!(out.status.success(), "the pinned in-block rebuttal must verify:\n{s}");
+    assert!(s.contains("\"verified\":true"), "{s}");
+    assert!(
+        s.contains("\"quotes_verified\":2"),
+        "both in-block premises (support + rebuttal) must byte-anchor:\n{s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// UNDERCUT — the in-block `unless` guard makes the thesis abstain; removing the
+// defeater-deriving inference restores the derivation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inblock_unless_makes_the_thesis_abstain_and_removing_the_defeater_restores_it() {
+    let adj = data_dir().join("undercut-inblock.adj");
+    // With the contamination-derived undercut present, the fatigue warrant is disabled.
+    let (ok, s) = run(&[adj.to_str().unwrap()]);
+    assert!(ok, "the in-block undercut example must run:\n{s}");
+    assert!(
+        s.contains("\"abstained\":true"),
+        "the in-block `unless` guard must make the thesis abstain:\n{s}"
+    );
+    assert!(!s.contains("\"Mechanism\":\"fatigue\""), "no fatigue answer while undercut holds:\n{s}");
+
+    // Remove the `infer undercut_warrant …` line → warrant_undercut is never derived → the
+    // `unless warrant_undercut` guard is satisfied → the fatigue thesis derives again.
+    let text = std::fs::read_to_string(&adj).unwrap();
+    let restored: String = text
+        .lines()
+        .filter(|l| !l.contains("infer undercut_warrant"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let dir = scratch("restore");
+    let prog = dir.join("no_undercut.adj");
+    std::fs::write(&prog, restored).unwrap();
+    let (ok2, s2) = run(&[prog.to_str().unwrap()]);
+    assert!(ok2, "{s2}");
+    assert!(
+        s2.contains("\"Mechanism\":\"fatigue\""),
+        "removing the defeater-deriving inference must restore the fatigue derivation:\n{s2}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.68.0] — 2026-07-30 — AR-3: attack edges compose INSIDE the `argument` block
+
+A paper's ATTACK edges — rebuttals and undercuts — can now live inside the pure `argument`
+block, so support **and** attack decompose into one construct (`ADJ-ARGUMENT-REBUTTAL.md` §5(b)).
+An `infer` gains two pieces of surface sugar, each desugaring to the already-proven substrate
+(zero new engine/logic code):
+
+- **`unless <defeater> { , <defeater> }`** (UNDERCUT) — each defeater lowers to a `not <term>`
+  body literal (negation-as-failure), so the step fires only while its warrant is not defeated.
+- **trailing `context: <name>`** (REBUT) — mirrors `rule`'s `context:` (ADJ73 PR-B). With a
+  `functional` thesis and a `context_order`, a rival `infer` in an outranking context defeats
+  this one and the engine **withdraws** the loser (`status: defeated`, `defeated_by: …`).
+
+Grammar: `arg_infer` gains an optional `arg_unless` node and a trailing `context: IDENT`; the AST
+`ArgInference` gains `unless: Vec<Term>` and `context: Option<String>`; the lowerer pushes the NAF
+literals and applies `Rule::with_context`. Worked in-block examples
+(`adj-argument-ir/rebuttal/{rebuttal,undercut}-inblock.adj`) prove the engine still withdraws the
+defeated conclusion and `adj-verify` byte-anchors both premises. The `--explain` "withdrawn /
+defeated-by" prose rendering remains a follow-up (the `governing` output already reports the
+`defeated`/`governing` status the CLI computes today).
+
 ## [0.67.0] — 2026-07-30 — ADR-3: structural grounding gate for `argument` (must be sourced)
 
 The first, deterministic layer of the ADJ-ARGUMENT-IR §3 grounding gate: a shipped `argument`

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.67.0"
+version = "0.68.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -800,14 +800,32 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
                         GrammarElement::RuleReference { name: r#"arg_ref"#.to_string() },
                     ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arg_unless"#.to_string() }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"context"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
             ] },
-            line_number: 484,
+            line_number: 495,
+        },
+        GrammarRule {
+            name: r#"arg_unless"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"unless"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 497,
         },
         GrammarRule {
             name: r#"arg_ref"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
-            line_number: 486,
+            line_number: 499,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -815,7 +833,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 502,
+            line_number: 515,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -826,7 +844,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"quote_annotation"#.to_string() },
             ] },
-            line_number: 514,
+            line_number: 527,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -834,7 +852,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 521,
+            line_number: 534,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -842,7 +860,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 522,
+            line_number: 535,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -850,7 +868,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 523,
+            line_number: 536,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -860,7 +878,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 524,
+            line_number: 537,
         },
         GrammarRule {
             name: r#"quote_annotation"#.to_string(),
@@ -872,7 +890,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"snapshot"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 532,
+            line_number: 545,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -883,7 +901,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 534,
+            line_number: 547,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -907,7 +925,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 556,
+            line_number: 569,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1104,12 +1104,34 @@ fn adapt_arg_inference(node: &GrammarASTNode) -> Result<crate::ast::ArgInference
             }
         }
     }
+    // AR-3 UNDERCUT — the optional `unless <defeater> { , <defeater> }` wraps its
+    // defeater terms in an `arg_unless` node, so they are cleanly separable from the
+    // single `conclude` term (which `expect_term_child` already picked above).
+    let mut unless = Vec::new();
+    for c in &node.children {
+        if let ASTNodeOrToken::Node(u) = c {
+            if u.rule_name == "arg_unless" {
+                for gc in &u.children {
+                    if let ASTNodeOrToken::Node(t) = gc {
+                        if t.rule_name == "term" {
+                            unless.push(adapt_term(t)?);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // AR-3 REBUT — the optional trailing `context: <name>`, the first Name token after
+    // the `context` keyword literal (same extraction as `rule_decl`'s `context:`).
+    let context = ident_after_keyword(node, "context");
     let annotations = collect_annotations(node)?;
     Ok(crate::ast::ArgInference {
         name,
         connective,
         conclusion,
         from,
+        unless,
+        context,
         annotations,
     })
 }

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -710,6 +710,17 @@ pub struct ArgInference {
     /// must resolve to an earlier `name` in the same argument (an unknown reference is a
     /// clean `LowerError`); the referenced terms become the rule's body literals.
     pub from: Vec<String>,
+    /// ADJ-ARGUMENT-REBUTTAL AR-3: an optional `unless <defeater> { , <defeater> }`
+    /// UNDERCUT guard. Each defeater lowers to a `not <term>` body literal
+    /// (negation-as-failure), so the step fires only while its warrant is not defeated.
+    /// Empty = no undercut. Unlike `from`, these are RAW terms (the defeater proposition,
+    /// derived elsewhere), not references to sibling premise/inference names.
+    pub unless: Vec<Term>,
+    /// ADJ-ARGUMENT-REBUTTAL AR-3: the optional trailing `context: <name>` — the CONTEXT
+    /// this inference is grounded in (mirroring [`Statement::Rule`]'s `context`). With a
+    /// `functional` thesis + a `context_order`, a rival inference in an outranking context
+    /// REBUTS (defeats) this one. `None` = context-free. Lowers to `Rule::with_context`.
+    pub context: Option<String>,
     /// Warrant/source provenance (`source`/`locator`/`trust`).
     pub annotations: Vec<Annotation>,
 }

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1150,6 +1150,14 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                             })?;
                         body_lits.push(BodyLiteral::Pos(lower_term_scoped(ref_term, &mut vars)));
                     }
+                    // AR-3 UNDERCUT — each `unless <defeater>` lowers to a NAF (`not`)
+                    // body literal, in the SAME variable scope as head+body, so the step
+                    // fires only WHILE its warrant is not defeated. Unlike a `from` ref,
+                    // a defeater is a raw proposition (derived by another step/fact), so it
+                    // does NOT resolve against `bound` — it is lowered as written.
+                    for u in &inf.unless {
+                        body_lits.push(BodyLiteral::Neg(lower_term_scoped(u, &mut vars)));
+                    }
                     let prov = annotations_to_provenance(&inf.annotations)?;
                     // Same structural grounding gate for the inference's WARRANT (§3): an
                     // inference step must cite why its antecedents entail its conclusion —
@@ -1161,7 +1169,15 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                             element: inf.name.clone(),
                         });
                     }
-                    kb.add_rule(Rule::certain(head_term, body_lits).with_provenance(prov));
+                    // AR-3 REBUT — tag the inference's grounding CONTEXT, exactly as
+                    // `rule { … context: … }` does (ADJ73 PR-B). With a `functional` thesis
+                    // and a `context_order`, a rival inference in an outranking context
+                    // defeats this one — the engine withdraws the loser.
+                    let mut rule = Rule::certain(head_term, body_lits).with_provenance(prov);
+                    if let Some(ctx) = &inf.context {
+                        rule = rule.with_context(ctx.clone());
+                    }
+                    kb.add_rule(rule);
                     bound.insert(inf.name.as_str(), &inf.conclusion);
                 }
             }

--- a/code/specs/ADJ-ARGUMENT-REBUTTAL.md
+++ b/code/specs/ADJ-ARGUMENT-REBUTTAL.md
@@ -105,14 +105,19 @@ cannot be written *inside* the pure `argument` block yet. Two honest paths, both
   `functional` + `context_order` (rebut) or a `not`-guarded `rule` (undercut). This mixes the two
   surfaces but needs **no new code** and is fully grounded/verifiable — it proves the dialectic
   end-to-end now.
-- **(b) Ergonomic sugar (deferred, AR-3).** Extend the `argument` surface: allow `infer` to carry
-  a `context:` (mirroring `rule`) and an optional `unless <defeater>` guard (desugaring to a
-  `not` body literal), plus a `functional` note on the argument's thesis. This lets a whole paper
-  — support **and** attack — live in one `argument` block. It is pure surface over the *same*
-  proven desugaring; worth doing only once (a) shows the shape at paper scale.
+- **(b) Ergonomic sugar — SHIPPED (AR-3, adj-lang 0.68.0).** The `argument` surface now lets an
+  `infer` carry a trailing `context:` (mirroring `rule`, for rebut precedence) and an optional
+  `unless <defeater> { , <defeater> }` guard (desugaring to `not` body literals, for undercut), so
+  a whole paper — support **and** attack — lives in one `argument` block. Pure surface over the
+  *same* proven desugaring (§2): `unless` → NAF literals, `context:` → `Rule::with_context`. The
+  thesis `functional` note stays a top-level `functional` declaration (paper-level, not
+  per-inference). Worked in-block examples:
+  `adj-argument-ir/rebuttal/{rebuttal,undercut}-inblock.adj`.
 
-AR-1 commits to **(a)** as the working model and specs **(b)** as the optional follow-up — the
-same reuse-first stance AC-1 took for composition.
+AR-1 committed to **(a)** as the working model and specced **(b)** as the follow-up; AR-3 delivered
+**(b)** — the same reuse-first stance AC-1 took for composition. The one remaining piece is the
+`--explain` "withdrawn / defeated-by" prose rendering (§4), which reads the `governing` resolution
+the CLI already computes and reports today.
 
 ## 6. Worked sketch + staging
 
@@ -129,8 +134,12 @@ sample; the fatigue warrant is undercut and the thesis abstains rather than asse
   byte-anchored to its paragraph's snapshot). Proves the engine **withdraws** the defeated
   conclusion (`governing` → `defeated`), `adj-verify` byte-anchors the rebuttal, and the winner
   governs. A companion **undercut** example (NAF-guarded warrant → thesis abstains when undercut).
-- **AR-3** — the argument-surface sugar of §5(b) (`context:` + `unless` on `infer`) so support and
-  attack compose in one block, plus the `--explain` "withdrawn / defeated-by" rendering.
+- **AR-3 (SHIPPED, adj-lang 0.68.0)** — the argument-surface sugar of §5(b): `unless` (undercut →
+  NAF) and a trailing `context:` (rebut → precedence) on `infer`, so support and attack compose in
+  ONE `argument` block. Worked `adj-argument-ir/rebuttal/{rebuttal,undercut}-inblock.adj` +
+  `adj-lang-cli/tests/argument_inblock_attack_e2e.rs` (engine still withdraws the defeated
+  conclusion; `adj-verify` byte-anchors both premises). The `--explain` "withdrawn / defeated-by"
+  prose rendering remains the follow-up (the `governing` output already reports the status today).
 - **Later** — the trained decomposer emits attack edges from a paper's rebuttal/limitation
   paragraphs (retarget the AD-1..5 scaffold to the attack surface).
 

--- a/code/specs/data/adj-argument-ir/rebuttal/README.md
+++ b/code/specs/data/adj-argument-ir/rebuttal/README.md
@@ -39,3 +39,18 @@ byte-anchor — the point is the honest abstention, not a citation count.)
 Both are driven by `adj-lang-cli/tests/rebuttal_worked_example_e2e.rs`. Together they show a paper's
 disagreements are first-class: **the engine withdraws what its counterarguments defeat, and every
 attack is auditable back to the paragraph that makes it.**
+
+## `rebuttal-inblock.adj` / `undercut-inblock.adj` — AR-3, attack IN the `argument` block
+
+The same two papers, but the attack now lives **inside** the `argument` block using the AR-3
+surface sugar (adj-lang 0.68.0), instead of raw `rule`s bolted alongside:
+
+- **`rebuttal-inblock.adj`** — each `infer` carries a trailing `context:` (support in
+  `initial_report`, reanalysis in `reanalysis`); with the top-level `functional` +
+  `context_order`, the engine withdraws fatigue exactly as `rebuttal.adj` does.
+- **`undercut-inblock.adj`** — the support `infer` carries `unless warrant_undercut` (→ a `not`
+  body literal) and a second `infer` derives that defeater from the contamination premise; the
+  thesis abstains while the contamination holds.
+
+Driven by `adj-lang-cli/tests/argument_inblock_attack_e2e.rs`. Same desugaring, same audit — the
+whole dialectic (support **and** attack) now decomposes into one construct.

--- a/code/specs/data/adj-argument-ir/rebuttal/rebuttal-inblock.adj
+++ b/code/specs/data/adj-argument-ir/rebuttal/rebuttal-inblock.adj
@@ -1,0 +1,15 @@
+% ADJ-ARGUMENT-REBUTTAL AR-3 — the SAME rebutted paper as rebuttal.adj, but now the support AND
+% the rebuttal live in ONE `argument` block. Each `infer` carries its own `context:` (AR-3 surface
+% sugar): the support step is grounded in `initial_report`, the reanalysis step in `reanalysis`.
+% With a `functional` thesis + `context_order { reanalysis > initial_report }`, the reanalysis
+% conclusion OUTRANKS and the engine WITHDRAWS fatigue — the rebuttal is expressed inside the
+% argument, not as a raw `rule` bolted alongside it. Desugars to exactly the AR-2 machinery.
+argument bridge_failure {
+    premise beach : extracted shows(surface, beach_marks) quote "exhibited beach marks" at 21 snapshot "1baf6c66bb4db1f3ce48c03cdd93e8cf1c8d1c3a7e955e67c7693b65638fdf17" source "pA-support" trust authoritative
+    premise shear : extracted shows(surface, single_shear) quote "showed a single-shear lip" at 26 snapshot "e1d6c446ec0106f702b556b52c972eddce2e52b04c5cc925b9e15e548cbc2b9d" source "pB-reanalysis" trust authoritative
+    infer support    : because   conclude failed_by(axle, fatigue)  from beach source "beach marks are diagnostic of fatigue" trust authoritative context: initial_report
+    infer reanalysis : therefore conclude failed_by(axle, overload) from shear source "a single-shear lip indicates a one-time overload" trust authoritative context: reanalysis
+}
+functional failed_by(subject, mechanism)
+context_order { reanalysis > initial_report }
+? failed_by(axle, $Mechanism)

--- a/code/specs/data/adj-argument-ir/rebuttal/undercut-inblock.adj
+++ b/code/specs/data/adj-argument-ir/rebuttal/undercut-inblock.adj
@@ -1,0 +1,13 @@
+% ADJ-ARGUMENT-REBUTTAL AR-3 — the SAME undercut paper as undercut.adj, but the undercut now lives
+% IN the `argument` block. The support `infer` carries `unless warrant_undercut` (AR-3 surface
+% sugar → a `not warrant_undercut` body literal), and a second `infer` derives that defeater from
+% the contamination premise. When the sample is contaminated the warrant is undercut, so the fatigue
+% thesis ABSTAINS — no rival mechanism is asserted, the licence is simply removed. Desugars to the
+% proven negation-as-failure machinery.
+argument bridge_undercut {
+    premise beach  : extracted shows(surface, beach_marks) quote "exhibited beach marks" at 21 snapshot "1baf6c66bb4db1f3ce48c03cdd93e8cf1c8d1c3a7e955e67c7693b65638fdf17" source "pA-support" trust authoritative
+    premise contam : extracted contaminated(sample) quote "contaminated during handling" at 51 snapshot "efbe3aa4966754c5860376306c96d0220baa3e0f3fde4a0643e1582a6d0cdcbb" source "pC-limitation" trust authoritative
+    infer support          : because conclude failed_by(axle, fatigue) from beach unless warrant_undercut source "beach marks are diagnostic of fatigue" trust authoritative
+    infer undercut_warrant : because conclude warrant_undercut from contam source "a contaminated sample invalidates the beach-mark reading" trust authoritative
+}
+? failed_by(axle, $Mechanism)


### PR DESCRIPTION
## What

A paper's **rebuttals and undercuts** can now live INSIDE the pure `argument` block, so support **and** attack decompose into one construct — closing `ADJ-ARGUMENT-REBUTTAL.md` §5(b). An `infer` gains two pieces of surface sugar, each desugaring to the already-proven substrate (**zero new engine/logic code**):

- **`unless <defeater> { , <defeater> }`** (UNDERCUT) → each defeater lowers to a `not <term>` body literal (negation-as-failure); the step fires only while its warrant is not defeated.
- **trailing `context: <name>`** (REBUT) → mirrors `rule`'s `context:` (ADJ73 PR-B); with a `functional` thesis + `context_order`, a rival `infer` in an outranking context defeats this one and the engine **withdraws** the loser (`status: defeated`, `defeated_by: …`).

## Wiring (adj-lang 0.67.0 → 0.68.0)

- **grammar**: `arg_infer` gains an optional `arg_unless` node + trailing `context: IDENT` (regenerated `_parser_grammar.rs`; **no new tokens** — both are IDENT-matched literals, so `_lexer_grammar.rs` is unchanged)
- **ast**: `ArgInference` gains `unless: Vec<Term>` + `context: Option<String>`
- **adapter**: extract the `arg_unless` terms + reuse `ident_after_keyword(node, "context")` (same as `rule_decl`)
- **lower**: push `BodyLiteral::Neg` per `unless`; apply `Rule::with_context`

## Worked in-block examples + e2e

- `adj-argument-ir/rebuttal/rebuttal-inblock.adj` — in-block REBUT: fatigue withdrawn (`defeated`, `defeated_by` overload), overload governs; `adj-verify` byte-anchors both premises (`quotes_verified 2`, `verified true`)
- `adj-argument-ir/rebuttal/undercut-inblock.adj` — in-block UNDERCUT: thesis abstains while contaminated; removing the defeater-deriving `infer` restores the derivation
- `adj-lang-cli/tests/argument_inblock_attack_e2e.rs` — 3 e2e (rebut, adj-verify, undercut + restore), all green

## Verification

- `cargo test -p adj-lang -p adj-lang-cli` (incl. all existing argument e2e) — green
- `cargo clippy -p adj-lang -p adj-lang-cli --tests` — clean
- adj-lang version-bumped + CHANGELOG; spec + rebuttal README synced
- `/security-review` — PASSED

The `--explain` "withdrawn / defeated-by" prose rendering remains a follow-up (the `governing` output already reports the defeated/governing status today). Front rotation: Substrate/RS rung (north-star: decompose research papers incl. their dialectic), after Facts (#9344) and Libraries (#9346).

🤖 Generated with [Claude Code](https://claude.com/claude-code)