### PR TITLE
feat(facts-stdlib): International Morse code letter→pattern recall table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_morse_code_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_morse_code_e2e.rs
@@ -1,0 +1,67 @@
+//! End-to-end test for the LANGUAGE FACTS library
+//! (`adj-facts-stdlib/language/morse-code.adj`) driven through the built CLI:
+//! a native `table` of the 26 Latin letters → their International Morse code
+//! pattern (as ASCII word-atoms like `dot_dot_dot`) resolves forward AND reverse
+//! binding-query recalls with the ITU-standard citation, and abstains on a digit
+//! that has no shipped row — 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn language_morse_code_recall_binds_pattern_forward_and_reverse() {
+    let dir = scratch("morse_code");
+    // Copy the shipped Morse table beside the entry program and import it.
+    let src = facts_stdlib().join("language/morse-code.adj");
+    std::fs::copy(&src, dir.join("morse-code.adj")).expect("copy shipped morse-code.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"morse-code.adj\"\n\
+         ? morse_code(s, $P)\n\
+         ? morse_code(o, $P)\n\
+         ? morse_code(e, $P)\n\
+         ? morse_code($L, dash)\n\
+         ? morse_code(5, $P)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward: the S/O/E of the classic SOS distress rhythm, and E = the single dot.
+    assert!(out.contains("\"P\":\"dot_dot_dot\""), "s → dot_dot_dot: {out}");
+    assert!(out.contains("\"P\":\"dash_dash_dash\""), "o → dash_dash_dash: {out}");
+    assert!(out.contains("\"P\":\"dot\""), "e → dot: {out}");
+    // Reverse: a single dash is the letter t (binds the other column).
+    assert!(out.contains("\"L\":\"t\""), "pattern dash → t: {out}");
+    // The answer carries the ITU / Wikipedia citation as its proof, at consensus trust.
+    assert!(
+        out.contains("en.wikipedia.org/wiki/Morse_code") && out.contains("\"trust\":\"consensus\""),
+        "carries the Morse-code citation: {out}"
+    );
+    // `5` is a digit (Morse numerals are a separate set), not one of the 26 letter
+    // rows — honest abstention, never invented.
+    assert!(out.contains("\"abstained\":true"), "digit 5 abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -118,6 +118,7 @@ per rotation, in parallel):
 | `geography/` | common landform → defining descriptor (mountain → projects_above_surroundings, plateau → flat_elevated, canyon → deep_narrow) | USGS Feature Type Thesaurus (authoritative) |
 | `geography/` | globe reference line → what it marks (equator → zero_degrees_latitude, prime_meridian → zero_degrees_longitude, tropic_of_cancer → northernmost_sun_overhead) | NOAA National Ocean Service / NESDIS (authoritative) |
 | `language/` | Greek letter → its 1-based position in the alphabet (alpha → 1, gamma → 3, pi → 16, omega → 24) | Wikipedia "Greek alphabet" (consensus) |
+| `language/` | Latin letter → its International Morse code pattern as dot/dash word-atoms (s → dot_dot_dot, o → dash_dash_dash, e → dot) | ITU-R M.1677-1 via Wikipedia "Morse code" (consensus) |
 | … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/language/morse-code.adj
+++ b/code/specs/data/adj-facts-stdlib/language/morse-code.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% morse-code — each Latin letter's International Morse code pattern
+% (adj-facts-stdlib, LANGUAGE).
+% ============================================================================
+% Morse code encodes each letter as a short sequence of DOTS (·, "dits") and
+% DASHES (—, "dahs"). It is the code behind the telegraph, the distress call SOS
+% (· · · — — — · · ·), and amateur radio: a letter is not a shape here but a
+% RHYTHM. This tiny library records that letter → pattern mapping so an ADJ
+% program can ASK how a letter is keyed, and get a cited answer. Because a `.adj`
+% atom must lex as an identifier (no raw "·—"), each pattern is written as an
+% ASCII word-atom joining its symbols with underscores — `dot_dash`, `dot_dot_dot`,
+% `dash_dash_dash` — so it round-trips cleanly through parse → store → query.
+% Recall is a binding query:
+%
+%     ? morse_code(s, $P)        % dot_dot_dot   (· · ·, three dits)
+%     ? morse_code(o, $P)        % dash_dash_dash (— — —, three dahs)
+%     ? morse_code(e, $P)        % dot           (·, the shortest code)
+%
+% A reverse query binds the other column, turning a pattern back into its letter:
+%
+%     ? morse_code($L, dash)     % t   (which letter is a single dash?)
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `morse_code(letter, pattern)` carrying the table's citation, so every
+% lookup above is the ordinary SLD binding query — the engine returns the pattern
+% (or the letter, on a reverse query) WITH its source, on the CPU, with zero model
+% calls, and ABSTAINS on anything that is not one of the 26 letters (a digit, a
+% symbol) rather than guessing.
+%
+% The 26 letters, as a truth table (· = dot, — = dash):
+%
+%     letter  code   pattern            letter  code   pattern
+%     ------  -----  -----------------  ------  -----  -----------------
+%     a       ·—     dot_dash           n       —·     dash_dot
+%     b       —···   dash_dot_dot_dot   o       ———    dash_dash_dash
+%     c       —·—·   dash_dot_dash_dot  p       ·——·   dot_dash_dash_dot
+%     d       —··    dash_dot_dot       q       ——·—   dash_dash_dot_dash
+%     e       ·      dot                r       ·—·    dot_dash_dot
+%     f       ··—·   dot_dot_dash_dot   s       ···    dot_dot_dot
+%     g       ——·    dash_dash_dot      t       —      dash
+%     h       ····   dot_dot_dot_dot    u       ··—    dot_dot_dash
+%     i       ··     dot_dot            v       ···—   dot_dot_dot_dash
+%     j       ·———   dot_dash_dash_dash w       ·——    dot_dash_dash
+%     k       —·—    dash_dot_dash      x       —··—   dash_dot_dot_dash
+%     l       ·—··   dot_dash_dot_dot   y       —·——   dash_dot_dash_dash
+%     m       ——     dash_dash          z       ——··   dash_dash_dot_dot
+%
+% Only the 26 letter rows are shipped — nothing else. A digit such as `5` has NO
+% row here (Morse numerals are a separate set), so a query like `? morse_code(5, $P)`
+% ABSTAINS rather than inventing a pattern: the table only ever asserts the codes
+% it can cite, and stays silent on everything else.
+%
+% Provenance — nothing here is from memory. The letter → dot/dash codes are the
+% International Morse code as reproduced in the Wikipedia "Morse code" article,
+% which states verbatim (see `source`) that the code is specified in the current
+% international standard, ITU-R Recommendation M.1677-1 (the "International Morse
+% Code Recommendation") — the authoritative document that fixes every letter's
+% dot/dash sequence. Each row below reads a letter's code off that standard chart
+% at the `locator`. `trust consensus` — an encyclopedia reproducing the ITU chart
+% is a secondary reference, not the primary ITU document itself. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table morse_code {
+    columns letter, pattern
+
+    row (a, dot_dash)
+    row (b, dash_dot_dot_dot)
+    row (c, dash_dot_dash_dot)
+    row (d, dash_dot_dot)
+    row (e, dot)
+    row (f, dot_dot_dash_dot)
+    row (g, dash_dash_dot)
+    row (h, dot_dot_dot_dot)
+    row (i, dot_dot)
+    row (j, dot_dash_dash_dash)
+    row (k, dash_dot_dash)
+    row (l, dot_dash_dot_dot)
+    row (m, dash_dash)
+    row (n, dash_dot)
+    row (o, dash_dash_dash)
+    row (p, dot_dash_dash_dot)
+    row (q, dash_dash_dot_dash)
+    row (r, dot_dash_dot)
+    row (s, dot_dot_dot)
+    row (t, dash)
+    row (u, dot_dot_dash)
+    row (v, dot_dot_dot_dash)
+    row (w, dot_dash_dash)
+    row (x, dash_dot_dot_dash)
+    row (y, dash_dot_dash_dash)
+    row (z, dash_dash_dot_dot)
+
+    source "The Morse code, as specified in the current international standard, International Morse Code Recommendation, ITU-R M.1677-1, was derived from a much-improved proposal by Friedrich Gerke in 1848."
+    locator "https://en.wikipedia.org/wiki/Morse_code"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/language/morse-code.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/morse-code.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% morse-code.query.adj — a worked recall over the Morse-code library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how is this letter keyed in
+% Morse?" — it states no fact of its own — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the `morse_code`
+% rows and returns the pattern (or the letter, on a reverse query) + the ITU
+% standard's source/locator/trust. Anything that is not one of the 26 letters —
+% a digit, a symbol — abstains honestly: the engine never invents a pattern it
+% cannot cite.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli morse-code.query.adj
+% ============================================================================
+
+import "morse-code.adj"
+
+? morse_code(s, $P)        % expect dot_dot_dot    (· · ·  — the S in SOS)
+? morse_code(o, $P)        % expect dash_dash_dash (— — —  — the O in SOS)
+? morse_code(e, $P)        % expect dot            (·      — the shortest code)
+? morse_code($L, dash)     % expect t              (reverse: which letter is a single dash?)
+? morse_code(5, $P)        % expect abstain — 5 is a digit, not one of the 26 letter rows


### PR DESCRIPTION
## What

A new grounded **LANGUAGE** facts library: the 26 Latin letters mapped to their International Morse code pattern, written as ASCII **dot/dash word-atoms** so each value lexes as an identifier (`s → dot_dot_dot`, `o → dash_dash_dash`, `e → dot`, `t → dash`). A native `table` (ADJ-TABLES RS-5). Parallels the Latin `alphabet.adj` and Greek `greek-alphabet.adj` under `language/`.

- Exact lookup `? morse_code(s, $P)` → `dot_dot_dot`, cited
- Reverse binding `? morse_code($L, dash)` → `t`
- Honest abstention on a non-letter key (`5` → `abstained: true`) — Morse numerals are a separate set, never invented
- Zero answer-time model calls; every answer carries the standard's citation

## Grounding discipline

The letter → dot/dash codes are the International Morse code fixed by **ITU-R Recommendation M.1677-1**, as reproduced in the Wikipedia *Morse code* article. The `source` span quotes the article **verbatim** naming that standard (`"…International Morse Code Recommendation, ITU-R M.1677-1…"`), `locator` points at the article's Morse chart. `trust consensus` (an encyclopedia reproducing the ITU chart is a secondary reference). Nothing asserted from memory. The unicode `·`/`—` appear only in literate comments; every stored value is an ASCII word-atom.

## Files

- `language/morse-code.adj` — the grounded `table` + literate header (full ·/— truth table for all 26 letters)
- `language/morse-code.query.adj` — worked forward (the SOS letters) / reverse / abstain recall
- `adj-lang-cli/tests/facts_morse_code_e2e.rs` — e2e: s→dot_dot_dot, o→dash_dash_dash, e→dot, reverse dash→t, digit 5 abstains, citation carried
- `README.md` — add the `language/` sampling row

## Verification

- `cargo test -p adj-lang-cli --test facts_morse_code_e2e` — green
- `cargo clippy -p adj-lang-cli --tests` — clean
- Data + one test only; no shipped Rust crate changed (no version bump)
- `/security-review` — PASSED

Front rotation: Facts/recall rung, honoring alternate-three-fronts after Libraries (FL-4b #9346) and Substrate (AR-3 #9347).

🤖 Generated with [Claude Code](https://claude.com/claude-code)