### PR TITLE
feat(formula-stdlib): simple-interest formula library (FL-4)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl4_simple_interest_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_simple_interest_e2e.rs
@@ -1,0 +1,146 @@
+//! End-to-end tests for ADJ-FORMULA-LIBRARIES FL-4 — the `simple-interest.adj`
+//! elementary library — driven through the built CLI binary against the SHIPPED
+//! stdlib. Proves the FL-4 invariant: the library COMPOSES the cited
+//! `arithmetic.adj` `product` primitive (twice) — it re-derives no arithmetic,
+//! computes the exact value on the CPU, and carries BOTH its own citation and the
+//! primitive's as corroboration. `simple_interest(P, R, T) = (P·R·T)/100`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib")
+        .canonicalize()
+        .expect("shipped adj-formula-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fl4si_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy a shipped `.adj` file (by relative path under the stdlib) into `dir`
+/// under its basename, so a consumer's relative `import` resolves.
+fn place(dir: &Path, rel: &str) {
+    let src = stdlib().join(rel);
+    let name = Path::new(rel).file_name().unwrap();
+    std::fs::copy(&src, dir.join(name)).unwrap_or_else(|e| panic!("copy {rel}: {e}"));
+}
+
+fn with_lib(dir: &Path) {
+    place(dir, "arithmetic/arithmetic.adj");
+    place(dir, "arithmetic/simple-interest.adj");
+}
+
+// ---------------------------------------------------------------------------
+// simple_interest — (P·R·T)/100, composing the cited product primitive twice.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn simple_interest_composes_product_twice_and_carries_both_citations() {
+    let dir = scratch("si");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"simple-interest.adj\"\n\
+         observe principal(1000)\n\
+         observe rate(5)\n\
+         observe time(2)\n\
+         ? simple_interest(principal, rate, time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // $1000 at 5%/yr for 2 yr → (1000 * 5 * 2) / 100 = 100, via product then product.
+    assert!(
+        s.contains("\"name\":\"simple_interest\"") && s.contains("\"value\":100"),
+        "simple_interest(1000, 5, 2) = 100: {s}"
+    );
+    // Exact integer 100/1 — no f64 round-trip.
+    assert!(s.contains("\"num\":\"100\"") && s.contains("\"den\":\"1\""), "exact value 100/1: {s}");
+    // The primary cites the simple-interest definition.
+    assert!(
+        s.contains("cuemath.com/commercial-math/simple-interest"),
+        "primary cites the simple-interest source: {s}"
+    );
+    // The composed primitive appears as corroboration.
+    assert!(
+        s.contains("mathworld.wolfram.com/Product.html"),
+        "corroboration cites the product primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The compute trace names the division over the nested products.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_derivation_tree_names_the_division_over_the_products() {
+    let dir = scratch("tree");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"simple-interest.adj\"\n\
+         observe principal(1000)\n\
+         observe rate(5)\n\
+         observe time(2)\n\
+         ? simple_interest(principal, rate, time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    // Outer op is the /100 division; the inner ops are the two products
+    // (1000*5 = 5000, *2 = 10000) — reconstructable operand by operand.
+    assert!(
+        s.contains("\"node\":\"op\"") && s.contains("\"op\":\"/\"") && s.contains("\"op\":\"*\""),
+        "the derivation names the division over the products: {s}"
+    );
+    assert!(
+        s.contains("\"slot\":\"principal\"")
+            && s.contains("\"slot\":\"rate\"")
+            && s.contains("\"slot\":\"time\""),
+        "the leaves name the observed slots the value was built from: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Honest edge case — a zero rate earns zero interest; the engine COMPUTES it
+// (it does not special-case or invent), (1000 * 0 * 2)/100 = 0.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_zero_rate_earns_zero_interest() {
+    let dir = scratch("zero");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"simple-interest.adj\"\n\
+         observe principal(1000)\n\
+         observe rate(0)\n\
+         observe time(2)\n\
+         ? simple_interest(principal, rate, time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(
+        s.contains("\"name\":\"simple_interest\"") && s.contains("\"value\":0"),
+        "simple_interest(1000, 0, 2) = 0: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/simple-interest.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/simple-interest.adj
@@ -1,0 +1,76 @@
+% ============================================================================
+% simple-interest.adj — the simple-interest formula library
+% (ADJ-RULE-SUBSTRATE RS-1 / FL-4).
+% ============================================================================
+% SIMPLE INTEREST is the first money formula a student meets: the interest an
+% amount earns (or owes) is charged only on the original PRINCIPAL, never on the
+% interest already accrued. The elementary schoolbook form multiplies three
+% quantities and divides by a hundred (because the rate is quoted as a PERCENT
+% per year):
+%
+%       S.I. = (P · R · T) / 100
+%
+% where P is the principal (the starting amount), R is the annual rate of
+% interest IN PERCENT (so 5, not 0.05), and T is the time in years. It sits with
+% the other elementary compositions in `arithmetic/` — a percent-of-a-quantity
+% application, not a bare new primitive. Like `ratio`, `percent`, and
+% `proportion`, it performs no multiplication of its own: it CALLS the cited
+% `product` primitive twice to form `P·R·T`, then divides by 100 (the "per
+% hundred" of the percent) — every arithmetic step named and cited (RS-1
+% write-once-reuse-many).
+%
+%     import "simple-interest.adj"                   % transitively imports arithmetic.adj
+%     observe principal(1000)                        % $1000 deposited
+%     observe rate(5)                                % 5% per year (a PERCENT, not 0.05)
+%     observe time(2)                                % for 2 years
+%     ? simple_interest(principal, rate, time)       % engine → 100   ((1000·5·2)/100)
+%
+% Worked check: (1000 · 5 · 2) / 100 = 10000 / 100 = 100 — the deposit earns $100
+% of simple interest over the two years. The engine expands `simple_interest` →
+% `product` → `product` on the CPU and composes the provenance chain: the answer
+% cites the simple-interest definition (primary) AND the `product` primitive it
+% built on (corroboration). Zero arithmetic is performed by the model.
+%
+% Honesty note: the rate here is a PERCENT PER YEAR and the time is in YEARS — the
+% `/100` is exactly the "per hundred" of the percent. A zero rate (or zero time)
+% correctly yields zero interest; nothing is invented. For interest that itself
+% earns interest, see COMPOUND interest — a different formula (a later rung).
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Depends on the elementary primitive `product`. The import is RELATIVE to this
+% file (same directory); a consumer that imports `simple-interest.adj`
+% transitively gets `product` (and its siblings), so the body resolves.
+% ----------------------------------------------------------------------------
+import "arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. The three inputs of S.I. = (P·R·T)/100, named for readability; the
+% result is the simple interest earned/owed. Rung-0 types each observable slot as
+% `finding`; the `surface` synonyms let a decomposer map everyday phrasing
+% ("deposit", "annual rate", "for N years") onto the canonical terms.
+% ----------------------------------------------------------------------------
+dictionary simple_interest_vocab {
+    define principal       : finding  surface "principal", "starting amount", "deposit", "amount borrowed", "p"
+    define rate            : finding  surface "rate", "interest rate", "annual rate", "rate percent", "r"
+    define time            : finding  surface "time", "years", "term", "duration", "t"
+    define simple_interest : finding  surface "simple interest", "interest earned", "interest", "si"
+}
+
+% ----------------------------------------------------------------------------
+% The composed formula. `simple_interest(principal, rate, time) =
+% product(product(principal, rate), time) / 100` is a formula CALLING the cited
+% `product` primitive twice — `product(principal, rate)` forms P·R, the outer
+% `product(…, time)` forms P·R·T — then divides by 100 (the "per hundred" that
+% turns the percent rate into a fraction). The engine resolves the applications
+% on the CPU and carries `product`'s citation alongside this one. The formula
+% asserts its own claim about the world and so carries its own required source.
+% ----------------------------------------------------------------------------
+formulabook simple_interest_book {
+    use simple_interest_vocab
+
+    formula simple_interest(principal, rate, time) = product(product(principal, rate), time) / 100
+        source "S.I. = (P × R × T)/100"
+        locator "https://www.cuemath.com/commercial-math/simple-interest/"
+        trust consensus
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/simple-interest.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/simple-interest.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% simple-interest.query.adj — a worked example of the simple-interest library.
+% ============================================================================
+% Run against the shipped stdlib:
+%
+%   adj-lang-cli simple-interest.query.adj
+%
+% "$1000 at 5% per year for 2 years" → (1000 × 5 × 2) / 100 = 100, computed on the
+% CPU by composing the cited `product` primitive twice (1000 × 5 = 5000, then
+% × 2 = 10000) and dividing by 100. The answer carries BOTH the simple-interest
+% definition (primary) and the `product` primitive it built on (corroboration) —
+% the model performs zero arithmetic.
+% ============================================================================
+import "simple-interest.adj"
+
+observe principal(1000)
+observe rate(5)
+observe time(2)
+
+? simple_interest(principal, rate, time)
+
+% ----------------------------------------------------------------------------
+% Honest edge case — a ZERO rate earns ZERO interest, and the engine computes it
+% (it does not special-case or invent): (1000 × 0 × 2) / 100 = 0. (Uncomment to
+% see it.)
+% ----------------------------------------------------------------------------
+% observe rate(0)
+% ? simple_interest(principal, rate, time)


### PR DESCRIPTION
## What

The first money formula in the compute stdlib: **simple interest** `S.I. = (P × R × T)/100`, where P is the principal, R the annual rate **in percent**, and T the time in years.

```
formula simple_interest(principal, rate, time) = product(product(principal, rate), time) / 100
```

`simple_interest` composes the cited `arithmetic.adj` `product` primitive **twice** — `product(principal, rate)` forms P·R, the outer `product(…, time)` forms P·R·T — then divides by 100. It re-derives no arithmetic, computes the exact value on the CPU, and carries its own citation plus the `product` primitive's as corroboration (RS-1 write-once-reuse-many). Placed in `arithmetic/` alongside the other elementary compositions (ratio/percent/average/proportion) so its flat `import "arithmetic.adj"` resolves and the `.query.adj` is runnable in place.

## Grounding

The schoolbook form is quoted **verbatim** from Cuemath's *Simple Interest* page (`"S.I. = (P × R × T)/100"`), `trust consensus`. Nothing asserted from memory.

## Honest edge case

A zero rate earns zero interest — the engine **computes** it (`(1000·0·2)/100 = 0`), it does not special-case or invent.

## Files

- `arithmetic/simple-interest.adj` — the grounded `formula` + literate header
- `arithmetic/simple-interest.query.adj` — worked example ($1000 @ 5% for 2y → 100) + the zero-rate edge case
- `adj-lang-cli/tests/fl4_simple_interest_e2e.rs` — e2e: value 100 (exact 100/1), both citations carried, derivation tree names `/` over `*` over `*`, zero rate → 0

## Verification

- `cargo test -p adj-lang-cli --test fl4_simple_interest_e2e` — 3/3 green
- `cargo clippy -p adj-lang-cli --tests` — clean
- Data + one test only; no shipped Rust crate changed (no version bump)
- `/security-review` — PASSED

Front rotation: Libraries/FL rung, honoring alternate-three-fronts after Facts (Morse #9348) and Substrate (AR-3 #9347).

🤖 Generated with [Claude Code](https://claude.com/claude-code)