### PR TITLE
feat(adj-lang-cli): --explain narrates a rebutted conclusion's WITHDRAWAL (AR-3 §4)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.31.0] — 2026-07-31 — AR-3: `--explain` narrates the WITHDRAWAL of a rebutted conclusion
+
+Completes the argument surface (`ADJ-ARGUMENT-REBUTTAL.md` §4): when a paper's rebuttal DEFEATS a
+conclusion (a `functional` thesis + `context_order` → the engine's `enumerate_governing` marks the
+loser `Defeated`/the winner `Governing`), `--explain` now NARRATES the dialectic instead of listing
+both conclusions as equal peers. The defeated conclusion is tagged **`[WITHDRAWN — defeated by
+<rival> (<hi> outranks <lo>)]`** — naming its defeater and the context precedence that withdrew it —
+and the surviving rival is tagged **`[GOVERNING]`**. The defeated conclusion's own premise chain
+stays rendered (the loser is *withdrawn, not discarded* — still auditable).
+
+The `--explain` argument path now resolves each binding query with `enumerate_governing` (was bare
+`enumerate_all`), so the human view reads the SAME resolution the `governing` JSON already reports —
+it re-decides nothing. Only genuinely CONTESTED results are annotated: an ordinary uncontested
+recall query is left exactly as ADR-6 rendered it, and an UNDERCUT thesis still abstains (never
+falsely "withdrawn"). No logic-engine change. Worked on
+`adj-argument-ir/rebuttal/rebuttal-inblock.adj`; pinned by
+`adj-lang-cli/tests/explain_defeated_by_e2e.rs`.
+
 ## [0.30.3] — 2026-07-30 — ADR-6: `--explain` renders the argument chain
 
 Completes "reason **and** explain" for the `argument` construct — the one explain gap left. A

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.30.3"
+version = "0.31.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/explain.rs
+++ b/code/packages/rust/adj-lang-cli/src/explain.rs
@@ -39,8 +39,8 @@
 use adj_lang::{LoweredStateMachine, StateMachineOutcome, StateMachineRun};
 use logic_engine::compute::{DerivationNode, RoundSpec};
 use logic_engine::differential::{Differential, DifferentialDecision};
-use logic_engine::proof_dag::{DerivationOrigin, ProofDAG, ProofStep};
-use logic_engine::{KnowledgeBase, Provenance, RoundingMode, TrustTier};
+use logic_engine::proof_dag::{DerivationOrigin, ProofStep};
+use logic_engine::{GovernStatus, GovernedResult, KnowledgeBase, Provenance, RoundingMode, TrustTier};
 
 /// Render the human-readable explanation of a decided query.
 ///
@@ -61,7 +61,7 @@ pub fn explain(
     kb: &KnowledgeBase,
     diff: &Differential,
     state_machine_runs: &[(&LoweredStateMachine, StateMachineRun)],
-    arguments: &[(logic_core::Term, ProofDAG)],
+    arguments: &[(logic_core::Term, GovernedResult)],
 ) -> String {
     let mut sections: Vec<String> = Vec::new();
     let derivations = render_derivations(kb);
@@ -401,12 +401,13 @@ fn render_adjudication(kb: &KnowledgeBase, diff: &Differential) -> String {
 /// **budget-truncated** search is never laundered into "no proof exists" — the
 /// two are reported distinctly (§proof_dag `truncated`). Returns "" when the
 /// program declared no binding query.
-fn render_arguments(kb: &KnowledgeBase, arguments: &[(logic_core::Term, ProofDAG)]) -> String {
+fn render_arguments(kb: &KnowledgeBase, arguments: &[(logic_core::Term, GovernedResult)]) -> String {
     if arguments.is_empty() {
         return String::new();
     }
     let mut out: Vec<String> = Vec::new();
-    for (query, dag) in arguments {
+    for (query, gov) in arguments {
+        let dag = &gov.dag;
         out.push(format!("Argument for {}:", query));
         if !dag.has_proof() {
             // Distinguish "the search ran and found nothing" (evidence of
@@ -427,13 +428,67 @@ fn render_arguments(kb: &KnowledgeBase, arguments: &[(logic_core::Term, ProofDAG
         // resolving each goal under the proof's answer substitution so the
         // conclusion shows the DERIVED value (e.g. `failed_by(axle, fatigue)`),
         // not the query's still-open variable (`failed_by(axle, Mechanism)`).
+        //
+        // AR-3 §4: when a paper's rebuttal DEFEATS a conclusion (a `functional`
+        // thesis + `context_order` → `enumerate_governing` marks the loser
+        // `Defeated`/the winner `Governing`), the FIRST step of each proof is that
+        // proof's top conclusion — annotate it with the DIALECTICAL outcome
+        // (WITHDRAWN / GOVERNING / CONFLICT) read straight off `gov.answers`. We
+        // don't re-decide anything here; we narrate the resolution the engine
+        // already computed.
         for proof in &dag.proofs {
-            for st in &proof.steps {
-                out.push(render_arg_step(kb, st, &proof.bindings));
+            let conclusion = proof
+                .steps
+                .first()
+                .map(|st| resolve_deep(&st.goal, &proof.bindings));
+            for (i, st) in proof.steps.iter().enumerate() {
+                let mut line = render_arg_step(kb, st, &proof.bindings);
+                if i == 0 {
+                    if let Some(c) = &conclusion {
+                        line.push_str(&govern_suffix(c, &gov.answers));
+                    }
+                }
+                out.push(line);
             }
         }
     }
     out.join("\n")
+}
+
+/// AR-3 §4 — the dialectical outcome suffix for a rendered argument's top
+/// conclusion, read off the `enumerate_governing` answers the CLI already
+/// computed. Only annotates when the result is genuinely CONTESTED (some answer
+/// is defeated or a conflict peer), so an ordinary uncontested recall query is
+/// left exactly as ADR-6 rendered it. A defeated conclusion is named WITHDRAWN
+/// and cites its defeater plus the context precedence that withdrew it
+/// (`reanalysis outranks initial_report`); the surviving rival is GOVERNING.
+fn govern_suffix(conclusion: &logic_core::Term, answers: &[logic_engine::GovernedAnswer]) -> String {
+    let contested = answers
+        .iter()
+        .any(|a| !matches!(a.status, GovernStatus::Governing));
+    if !contested {
+        return String::new();
+    }
+    let Some(ans) = answers.iter().find(|a| &a.term == conclusion) else {
+        return String::new();
+    };
+    match &ans.status {
+        GovernStatus::Governing => "  [GOVERNING]".to_string(),
+        GovernStatus::ConflictPeer => "  [CONFLICT — unresolved peer, abstain]".to_string(),
+        GovernStatus::Defeated { by } => {
+            // Name the context precedence that withdrew it, when both the loser
+            // and its defeater carry a `context:` (the ADJ73 `context_order` win).
+            let by_context = answers
+                .iter()
+                .find(|a| &a.term == by)
+                .and_then(|a| a.context.clone());
+            let ctx = match (&ans.context, &by_context) {
+                (Some(lo), Some(hi)) => format!(" ({} outranks {})", hi, lo),
+                _ => String::new(),
+            };
+            format!("  [WITHDRAWN — defeated by {}{}]", by, ctx)
+        }
+    }
 }
 
 /// Deep-resolve a term under a substitution. The engine's `Substitution::walk`

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -41,8 +41,8 @@ use logic_core::{atom, compound, var, LogicVar, Term};
 use logic_engine::govern::Standing;
 use logic_engine::{
     enumerate_all, enumerate_governing, numeric_exact_magnitude, DerivationOrigin,
-    DifferentialDecision, Fact, GovernStatus, KnowledgeBase, LRAggregateResult, Proof, ProofDAG,
-    Provenance, TrustTier,
+    DifferentialDecision, Fact, GovernStatus, GovernedResult, KnowledgeBase, LRAggregateResult,
+    Proof, Provenance, TrustTier,
 };
 
 mod explain;
@@ -1085,9 +1085,14 @@ fn main() -> ExitCode {
         // (projection-only: `enumerate_all` is deterministic and side-effect
         // free), so `--explain` can render the derivation as an argument. Empty
         // for a program with no binding query, leaving all other output unchanged.
-        let argument_chains: Vec<(Term, ProofDAG)> = binding_queries
+        // AR-3 §4: resolve each binding query with `enumerate_governing` (not bare
+        // `enumerate_all`), so `--explain` sees the SAME dialectical resolution the
+        // `governing` JSON section reports — a rebutted conclusion tagged
+        // `Defeated`/its rival `Governing`. The `GovernedResult` carries both the
+        // proof DAG (the chains ADR-6 renders) and the per-answer status.
+        let argument_chains: Vec<(Term, GovernedResult)> = binding_queries
             .iter()
-            .map(|q| (q.clone(), enumerate_all(q, &lowered.kb)))
+            .map(|q| (q.clone(), enumerate_governing(q, &lowered.kb)))
             .collect();
         println!(
             "{}",

--- a/code/packages/rust/adj-lang-cli/tests/explain_defeated_by_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/explain_defeated_by_e2e.rs
@@ -1,0 +1,107 @@
+//! AR-3 §4 — the `--explain` DIALECTICAL rendering: when a paper's rebuttal
+//! DEFEATS a conclusion (a `functional` thesis + `context_order` → the engine's
+//! `enumerate_governing` marks the loser `Defeated`/the winner `Governing`),
+//! `--explain` now NARRATES the withdrawal — it names the defeated conclusion
+//! WITHDRAWN, cites its defeater and the context precedence that withdrew it, and
+//! marks the surviving rival GOVERNING. The `--explain` renderer reads the SAME
+//! `governing` resolution the plain JSON already reports; it re-decides nothing.
+//! An uncontested recall query is left exactly as ADR-6 rendered it (no noise).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn arg_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../specs/data/adj-argument-ir/rebuttal")
+}
+
+fn facts_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../specs/data/adj-facts-stdlib")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_defby_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn explain(program: &Path) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg("--explain")
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    assert!(out.status.success(), "--explain exited non-zero: {}", String::from_utf8_lossy(&out.stderr));
+    String::from_utf8(out.stdout).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// A rebutted conclusion is narrated as WITHDRAWN (defeated by, under precedence);
+// the surviving rival is GOVERNING.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explain_narrates_the_withdrawal_and_the_governing_rival() {
+    let s = explain(&arg_dir().join("rebuttal-inblock.adj"));
+    // The fatigue conclusion (context initial_report) is WITHDRAWN, defeated by
+    // the overload conclusion under the paper's context precedence.
+    assert!(
+        s.contains("failed_by(axle, fatigue)")
+            && s.contains("[WITHDRAWN — defeated by failed_by(axle, overload)"),
+        "the fatigue conclusion must be narrated as withdrawn, defeated by overload:\n{s}"
+    );
+    // The context precedence that withdrew it is named (reanalysis outranks initial_report).
+    assert!(
+        s.contains("reanalysis outranks initial_report"),
+        "the withdrawal must cite the context precedence that resolved it:\n{s}"
+    );
+    // The reanalysis conclusion GOVERNS.
+    assert!(
+        s.contains("failed_by(axle, overload)") && s.contains("[GOVERNING]"),
+        "the reanalysis conclusion must be marked governing:\n{s}"
+    );
+    // We narrate the resolution, we don't discard the loser — the withdrawn
+    // conclusion's own premise chain is still rendered (auditable).
+    assert!(
+        s.contains("premise shows(surface, beach_marks)"),
+        "the defeated conclusion's grounds stay visible for audit:\n{s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// An UNDERCUT thesis abstains — it is not falsely narrated as "withdrawn".
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explain_undercut_abstains_not_withdrawn() {
+    let s = explain(&arg_dir().join("undercut-inblock.adj"));
+    assert!(s.contains("abstained: no grounded chain derives this"), "{s}");
+    assert!(!s.contains("WITHDRAWN"), "an undercut abstention is not a defeat:\n{s}");
+    assert!(!s.contains("GOVERNING"), "no rival is asserted under an undercut:\n{s}");
+}
+
+// ---------------------------------------------------------------------------
+// An ordinary uncontested recall query is unchanged — no dialectical suffix.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explain_uncontested_recall_carries_no_govern_suffix() {
+    let dir = scratch("recall");
+    std::fs::copy(
+        facts_dir().join("language/greek-alphabet.adj"),
+        dir.join("greek-alphabet.adj"),
+    )
+    .expect("copy shipped greek-alphabet.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"greek-alphabet.adj\"\n? greek_letter_position(alpha, $N)\n",
+    )
+    .unwrap();
+
+    let s = explain(&dir.join("case.adj"));
+    assert!(s.contains("greek_letter_position(alpha, 1)"), "the recall still renders: {s}");
+    assert!(
+        !s.contains("GOVERNING") && !s.contains("WITHDRAWN") && !s.contains("CONFLICT"),
+        "an uncontested recall must carry no dialectical suffix:\n{s}"
+    );
+}

--- a/code/specs/ADJ-ARGUMENT-REBUTTAL.md
+++ b/code/specs/ADJ-ARGUMENT-REBUTTAL.md
@@ -81,11 +81,13 @@ So the dialectic inherits the whole audit stack: a rebuttal that drifts from its
 - **DERIVE / govern**: the `governing` section already reports each answer's `status`
   (`governing` / `defeated` / `conflict_peer`) and its resolving `context` — that IS the rebuttal
   outcome, today.
-- **`--explain`**: the ADR-6 renderer shows an argument's SLD chain. Rendering the *defeat* — "X
-  was concluded (paragraph A) but is **withdrawn**, defeated by Y (paragraph B) under
-  `reanalysis > initial_report`" — is a small addition to the argument surface of `--explain`
-  (it reads the `governing` resolution the CLI already computes). This is an AR-3 rung, not new
-  engine work.
+- **`--explain` — SHIPPED (adj-lang-cli 0.31.0).** The ADR-6 renderer now NARRATES the *defeat*:
+  a rebutted conclusion is tagged **`[WITHDRAWN — defeated by <rival> (<hi> outranks <lo>)]`** and
+  the surviving rival **`[GOVERNING]`** (e.g. `failed_by(axle, fatigue) … [WITHDRAWN — defeated by
+  failed_by(axle, overload) (reanalysis outranks initial_report)]`). It reads the same `governing`
+  resolution the CLI already computes (`enumerate_governing`) — no new engine work, and it
+  re-decides nothing. Only genuinely contested results are annotated; an uncontested recall or an
+  undercut abstention is untouched. Pinned by `adj-lang-cli/tests/explain_defeated_by_e2e.rs`.
 - **`adj-verify`**: unchanged — it byte-anchors the attacking premises and re-derives; the
   defeat is a resolution over already-verified rules.
 
@@ -115,9 +117,10 @@ cannot be written *inside* the pure `argument` block yet. Two honest paths, both
   `adj-argument-ir/rebuttal/{rebuttal,undercut}-inblock.adj`.
 
 AR-1 committed to **(a)** as the working model and specced **(b)** as the follow-up; AR-3 delivered
-**(b)** — the same reuse-first stance AC-1 took for composition. The one remaining piece is the
-`--explain` "withdrawn / defeated-by" prose rendering (§4), which reads the `governing` resolution
-the CLI already computes and reports today.
+**(b)** — the same reuse-first stance AC-1 took for composition. The `--explain`
+"withdrawn / defeated-by" prose rendering (§4) is now **also shipped** (adj-lang-cli 0.31.0), so the
+argument surface — support, attack, and the human-readable narration of the withdrawal — is
+**complete**.
 
 ## 6. Worked sketch + staging
 
@@ -139,7 +142,8 @@ sample; the fatigue warrant is undercut and the thesis abstains rather than asse
   ONE `argument` block. Worked `adj-argument-ir/rebuttal/{rebuttal,undercut}-inblock.adj` +
   `adj-lang-cli/tests/argument_inblock_attack_e2e.rs` (engine still withdraws the defeated
   conclusion; `adj-verify` byte-anchors both premises). The `--explain` "withdrawn / defeated-by"
-  prose rendering remains the follow-up (the `governing` output already reports the status today).
+  prose rendering is **also shipped** (adj-lang-cli 0.31.0, `explain_defeated_by_e2e.rs`) — the
+  argument surface is now complete.
 - **Later** — the trained decomposer emits attack edges from a paper's rebuttal/limitation
   paragraphs (retarget the AD-1..5 scaffold to the attack surface).
 


### PR DESCRIPTION
## What

Completes the argument surface (`ADJ-ARGUMENT-REBUTTAL.md` §4). When a paper's rebuttal **DEFEATS** a conclusion (a `functional` thesis + `context_order` → the engine's `enumerate_governing` marks the loser `Defeated` / the winner `Governing`), `--explain` now **narrates the dialectic** instead of listing both conclusions as equal peers:

```
Argument for failed_by(axle, Mechanism):
  failed_by(axle, fatigue)  <= inference [...]  [WITHDRAWN — defeated by failed_by(axle, overload) (reanalysis outranks initial_report)]
    premise shows(surface, beach_marks)  [...]
  failed_by(axle, overload)  <= inference [...]  [GOVERNING]
    premise shows(surface, single_shear)  [...]
```

The defeated conclusion is named **WITHDRAWN**, cites its defeater and the context precedence that withdrew it, and the surviving rival is **GOVERNING** — while the loser's own premise chain stays rendered (withdrawn, not discarded: still auditable).

## Wiring (adj-lang-cli 0.30.3 → 0.31.0) — no logic-engine change

- the `--explain` argument path resolves each binding query with `enumerate_governing` (was bare `enumerate_all`), so the human view reads the **same** resolution the `governing` JSON already reports — it re-decides nothing.
- `render_arguments` takes `&[(Term, GovernedResult)]`; a new `govern_suffix` helper annotates each proof's top conclusion from `gov.answers`. Only genuinely **contested** results are annotated — an uncontested recall is left exactly as ADR-6 rendered it, and an **undercut** thesis still abstains (never falsely "withdrawn").

## Verification

- `cargo test -p adj-lang-cli --test explain_defeated_by_e2e` — 3/3 (withdrawal + defeated-by + precedence + governing; undercut abstains; uncontested recall unannotated)
- All existing argument/explain e2e (`rs4e3_explain_argument`, `rebuttal_worked_example`, `argument_inblock_attack`, `rs3c_statemachine_run`) — green
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- adj-lang-cli version-bumped + CHANGELOG; spec §4/§5/§6 synced
- `/security-review` — PASSED

With this, the argument surface — **support, attack, and the human-readable narration of the withdrawal** — is complete. Front rotation: Substrate/RS rung, after Facts (Morse #9348) and Libraries (simple-interest #9349).

🤖 Generated with [Claude Code](https://claude.com/claude-code)