### PR TITLE
feat(facts-stdlib): solfège syllable→scale-degree recall table (new music/ subject)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_solfege_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_solfege_e2e.rs
@@ -1,0 +1,65 @@
+//! End-to-end test for the MUSIC FACTS library
+//! (`adj-facts-stdlib/music/solfege.adj`) driven through the built CLI: a native
+//! `table` of the seven movable-do solfège syllables → their 1-based major-scale
+//! degree resolves forward AND reverse binding-query recalls with the
+//! encyclopedia's citation, and abstains on a chromatic syllable that has no
+//! shipped row — 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn music_solfege_recall_binds_degree_forward_and_reverse() {
+    let dir = scratch("solfege");
+    // Copy the shipped solfège table beside the entry program and import it.
+    let src = facts_stdlib().join("music/solfege.adj");
+    std::fs::copy(&src, dir.join("solfege.adj")).expect("copy shipped solfege.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"solfege.adj\"\n\
+         ? solfege_degree(do, $N)\n\
+         ? solfege_degree(sol, $N)\n\
+         ? solfege_degree($S, 3)\n\
+         ? solfege_degree(di, $N)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward: do is the tonic (1st degree); sol is the dominant (5th).
+    assert!(out.contains("\"N\":\"1\""), "do → 1: {out}");
+    assert!(out.contains("\"N\":\"5\""), "sol → 5: {out}");
+    // Reverse: the third scale degree is mi (binds the other column).
+    assert!(out.contains("\"S\":\"mi\""), "degree 3 → mi: {out}");
+    // The answer carries the Wikipedia Solfège citation as its proof, at consensus trust.
+    assert!(
+        out.contains("wikipedia.org/wiki/Solf") && out.contains("\"trust\":\"consensus\""),
+        "carries the encyclopedia citation: {out}"
+    );
+    // `di` is a chromatic (raised-do) syllable, not one of the 7 diatonic rows —
+    // honest abstention, never invented.
+    assert!(out.contains("\"abstained\":true"), "chromatic syllable di abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -119,6 +119,7 @@ per rotation, in parallel):
 | `geography/` | globe reference line → what it marks (equator → zero_degrees_latitude, prime_meridian → zero_degrees_longitude, tropic_of_cancer → northernmost_sun_overhead) | NOAA National Ocean Service / NESDIS (authoritative) |
 | `language/` | Greek letter → its 1-based position in the alphabet (alpha → 1, gamma → 3, pi → 16, omega → 24) | Wikipedia "Greek alphabet" (consensus) |
 | `language/` | Latin letter → its International Morse code pattern as dot/dash word-atoms (s → dot_dot_dot, o → dash_dash_dash, e → dot) | ITU-R M.1677-1 via Wikipedia "Morse code" (consensus) |
+| `music/` | movable-do solfège syllable → its 1-based major-scale degree (do → 1, sol → 5, ti → 7) | Wikipedia "Solfège" (consensus) |
 | … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/music/solfege.adj
+++ b/code/specs/data/adj-facts-stdlib/music/solfege.adj
@@ -1,0 +1,73 @@
+% ============================================================================
+% solfege — each movable-do solfège syllable's scale degree
+% (adj-facts-stdlib, MUSIC).
+% ============================================================================
+% "Do, a deer, a female deer…" — solfège gives the seven notes of the major scale
+% singable NAMES: do comes first (scale degree 1), re next (2), … all the way to
+% ti, the seventh. In the MOVABLE-DO system these syllables track the note's
+% FUNCTION in the scale (do is always the tonic, wherever the key sits), so the
+% degree number is what a musician means when they say "the fifth is sol" or
+% "resolve ti up to do". This tiny library records that syllable → degree mapping
+% so an ADJ program can ASK where a syllable sits in the scale, and get a cited
+% answer. Recall is a binding query:
+%
+%     ? solfege_degree(do, $N)       % 1  (do is the tonic, the first degree)
+%     ? solfege_degree(sol, $N)      % 5  (sol is the fifth — the dominant)
+%     ? solfege_degree(ti, $N)       % 7  (ti is the leading tone, the seventh)
+%
+% Because the value is a NUMBER, the answer composes into arithmetic — how many
+% steps from mi up to la? 6 − 3 = 3. A reverse query binds the other column,
+% turning a degree back into its syllable:
+%
+%     ? solfege_degree($S, 3)        % mi  (which syllable is the third degree?)
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `solfege_degree(syllable, degree)` carrying the table's citation, so
+% every lookup above is the ordinary SLD binding query — the engine returns the
+% degree (or the syllable, on a reverse query) WITH its source, on the CPU, with
+% zero model calls, and ABSTAINS on anything that is not one of the seven
+% syllables (a random word, a number) rather than guessing.
+%
+% The seven syllables, as an ordered truth table:
+%
+%     syllable   degree      name of the degree
+%     --------   ------      ------------------
+%     do         1           tonic
+%     re         2           supertonic
+%     mi         3           mediant
+%     fa         4           subdominant
+%     sol        5           dominant
+%     la         6           submediant
+%     ti         7           leading tone
+%
+% Only the seven diatonic-scale rows are shipped — nothing else. A chromatic
+% syllable (the raised `di`/`ri`, the lowered `te`/`le`) has NO row, and neither
+% does a non-syllable, so a query like `? solfege_degree(di, $N)` ABSTAINS rather
+% than inventing a degree: the table only ever asserts the mapping it can cite.
+%
+% Provenance — nothing here is from memory. The seven modern syllables and their
+% ascending major-scale order are recorded in the Wikipedia "Solfège" article,
+% which states verbatim (see `source`) the seven syllables "commonly used in
+% English-speaking countries: do …, re, mi, fa, so(l), la, and ti", and whose
+% movable-do degree table pairs them 1..7 (do = 1st degree … ti = 7th). Each row
+% below assigns a syllable its 1-based degree in that stated ascending order (the
+% canonical `sol` spelling is used for the atom). `trust consensus` — an
+% encyclopedia is a secondary reference. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table solfege_degree {
+    columns syllable, degree
+
+    row (do, 1)
+    row (re, 2)
+    row (mi, 3)
+    row (fa, 4)
+    row (sol, 5)
+    row (la, 6)
+    row (ti, 7)
+
+    source "The tonic sol-fa method popularised the seven syllables commonly used in English-speaking countries: do (spelt doh in tonic sol-fa), re, mi, fa, so(l), la, and ti (or si)"
+    locator "https://en.wikipedia.org/wiki/Solf%C3%A8ge"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/music/solfege.query.adj
+++ b/code/specs/data/adj-facts-stdlib/music/solfege.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% solfege.query.adj — a worked recall over the solfège library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which scale degree is this
+% solfège syllable?" — it states no fact of its own — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `solfege_degree` rows and returns the degree (or the syllable, on a reverse
+% query) + the encyclopedia's source/locator/trust. Anything that is not one of
+% the seven diatonic syllables — a chromatic syllable, a random word — abstains
+% honestly: the engine never invents a degree it cannot cite.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli solfege.query.adj
+% ============================================================================
+
+import "solfege.adj"
+
+? solfege_degree(do, $N)       % expect 1   (do is the tonic, the first degree)
+? solfege_degree(sol, $N)      % expect 5   (sol is the fifth — the dominant)
+? solfege_degree($S, 3)        % expect mi  (reverse: which syllable is the third?)
+? solfege_degree(di, $N)       % expect abstain — di is a chromatic syllable, not a diatonic row


### PR DESCRIPTION
## What

A new grounded **MUSIC** facts library (opens a `music/` subject dir): the seven movable-do solfège syllables mapped to their 1-based major-scale degree — **do → 1, re → 2, mi → 3, fa → 4, sol → 5, la → 6, ti → 7**. A native `table` (ADJ-TABLES RS-5), a name→ordinal table exactly parallel to the Latin/Greek/Morse libraries.

- Exact lookup `? solfege_degree(do, $N)` → `1`, cited
- Reverse binding `? solfege_degree($S, 3)` → `mi`
- Honest abstention on a non-diatonic key (chromatic `di` → `abstained: true`) — never invented
- Zero answer-time model calls; every answer carries the citation

## Grounding discipline

The seven syllables and their ascending scale order are recorded in the Wikipedia *Solfège* article, whose movable-do degree table pairs them 1..7. The `source` span quotes the article **verbatim** naming the seven syllables (`"…do …, re, mi, fa, so(l), la, and ti…"`), `locator` points at the article. `trust consensus` (secondary reference). Nothing from memory.

A pure `table` has **no imports**, so a new subject dir is safe (the cross-subdir import trap only bites *formulas* that import arithmetic).

## Files

- `music/solfege.adj` — the grounded `table` + literate header (7 syllables + degree names tonic..leading-tone)
- `music/solfege.query.adj` — worked forward (do→1, sol→5) / reverse (deg3→mi) / abstain (chromatic `di`)
- `adj-lang-cli/tests/facts_solfege_e2e.rs` — e2e: do→1, sol→5, reverse deg3→mi, chromatic `di` abstains, citation carried
- `README.md` — add the `music/` sampling row

## Verification

- `cargo test -p adj-lang-cli --test facts_solfege_e2e` — green
- `cargo clippy -p adj-lang-cli --tests` — clean
- Data + one test only; no shipped Rust crate changed (no version bump)
- `/security-review` — PASSED

Front rotation: Facts/recall rung, honoring alternate-three-fronts after Libraries (simple-interest #9349) and Substrate (--explain #9350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)