### PR TITLE
feat(formula-stdlib): percent-of formula library — the inverse of percent (FL-4)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl4_percent_of_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_percent_of_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end tests for ADJ-FORMULA-LIBRARIES FL-4 — the `percent-of.adj`
+//! elementary library — driven through the built CLI binary against the SHIPPED
+//! stdlib. Proves the FL-4 invariant: the library COMPOSES the cited
+//! `arithmetic.adj` `product` primitive (it re-derives no arithmetic), computes
+//! the exact value on the CPU, and carries BOTH its own citation and the
+//! primitive's as corroboration. `percent_of(whole, rate) = (whole·rate)/100` —
+//! the inverse of `percent`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib")
+        .canonicalize()
+        .expect("shipped adj-formula-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fl4po_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy a shipped `.adj` file (by relative path under the stdlib) into `dir`
+/// under its basename, so a consumer's relative `import` resolves.
+fn place(dir: &Path, rel: &str) {
+    let src = stdlib().join(rel);
+    let name = Path::new(rel).file_name().unwrap();
+    std::fs::copy(&src, dir.join(name)).unwrap_or_else(|e| panic!("copy {rel}: {e}"));
+}
+
+fn with_lib(dir: &Path) {
+    place(dir, "arithmetic/arithmetic.adj");
+    place(dir, "arithmetic/percent-of.adj");
+}
+
+// ---------------------------------------------------------------------------
+// percent_of — (whole·rate)/100, composing the cited product primitive.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn percent_of_composes_product_and_carries_both_citations() {
+    let dir = scratch("po");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"percent-of.adj\"\n\
+         observe whole(50)\n\
+         observe rate(20)\n\
+         ? percent_of(whole, rate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 20% of 50 → (50 * 20) / 100 = 10, via the product primitive on the CPU.
+    assert!(
+        s.contains("\"name\":\"percent_of\"") && s.contains("\"value\":10"),
+        "percent_of(50, 20) = 10: {s}"
+    );
+    // Exact integer 10/1 — no f64 round-trip.
+    assert!(s.contains("\"num\":\"10\"") && s.contains("\"den\":\"1\""), "exact value 10/1: {s}");
+    // The primary cites the percent definition.
+    assert!(
+        s.contains("mathworld.wolfram.com/Percent.html"),
+        "primary cites the percent definition: {s}"
+    );
+    // The composed primitive appears as corroboration.
+    assert!(
+        s.contains("mathworld.wolfram.com/Product.html"),
+        "corroboration cites the product primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The compute trace names the division over the product.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_derivation_tree_names_the_division_over_the_product() {
+    let dir = scratch("tree");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"percent-of.adj\"\n\
+         observe whole(50)\n\
+         observe rate(20)\n\
+         ? percent_of(whole, rate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    // Outer op is the /100 division; the inner op is the product (50*20 = 1000).
+    assert!(
+        s.contains("\"node\":\"op\"") && s.contains("\"op\":\"/\"") && s.contains("\"op\":\"*\""),
+        "the derivation names the division over the product: {s}"
+    );
+    assert!(
+        s.contains("\"slot\":\"whole\"") && s.contains("\"slot\":\"rate\""),
+        "the leaves name the observed slots the value was built from: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Honest edge case — 0% of anything is 0; the engine COMPUTES it, never invents.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn zero_percent_of_anything_is_zero() {
+    let dir = scratch("zero");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"percent-of.adj\"\n\
+         observe whole(50)\n\
+         observe rate(0)\n\
+         ? percent_of(whole, rate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(
+        s.contains("\"name\":\"percent_of\"") && s.contains("\"value\":0"),
+        "percent_of(50, 0) = 0: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/percent-of.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/percent-of.adj
@@ -1,0 +1,72 @@
+% ============================================================================
+% percent-of.adj — the "percent OF a number" formula library
+% (ADJ-RULE-SUBSTRATE RS-1 / FL-4).
+% ============================================================================
+% The everyday inverse of `percent`. Where `percent(part, whole)` answers "what
+% PERCENTAGE is this part of the whole?" (= part/whole × 100), `percent_of`
+% answers the reverse question a shopper asks — "what is 20% OF 50?" — and returns
+% the PART:
+%
+%       percent_of(whole, rate) = whole × rate / 100
+%
+% This is the direct application of the cited percent definition: a percentage is
+% a fraction of 100, so `rate`% is the fraction `rate/100`, and taking that
+% fraction OF the whole is multiplying — `whole × rate/100`. The library performs
+% no bare multiplication of its own: it CALLS the cited `product` primitive to
+% form `whole × rate`, then divides by 100 — every arithmetic step named and cited
+% (RS-1 write-once-reuse-many).
+%
+%     import "percent-of.adj"                        % transitively imports arithmetic.adj
+%     observe whole(50)                              % the base amount
+%     observe rate(20)                               % 20 percent (a PERCENT, not 0.20)
+%     ? percent_of(whole, rate)                      % engine → 10   ((50 × 20)/100)
+%
+% Worked check: (50 × 20) / 100 = 1000 / 100 = 10 — twenty percent of fifty is ten.
+% The engine expands `percent_of` → `product` on the CPU and composes the
+% provenance chain: the answer cites the percent definition (primary) AND the
+% `product` primitive it built on (corroboration). Zero arithmetic is performed by
+% the model.
+%
+% Honesty note: `rate` is a PERCENT (20, not 0.20) — the `/100` is exactly the
+% "per hundred". A zero rate correctly yields zero (0% of anything is 0); nothing
+% is invented. This is the algebraic inverse of the shipped `percent` formula: for
+% any part and whole, `percent_of(whole, percent(part, whole)) = part`.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Depends on the elementary primitive `product`. The import is RELATIVE to this
+% file (same directory); a consumer that imports `percent-of.adj` transitively
+% gets `product` (and its siblings), so the body resolves.
+% ----------------------------------------------------------------------------
+import "arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. The two inputs: the `whole` (the base amount) and the `rate` (the
+% percentage, as a number like 20). The result is the part that is that percent of
+% the whole. Rung-0 types each observable slot as `finding`; the `surface`
+% synonyms let a decomposer map everyday phrasing ("of", "out of the total",
+% "percent") onto the canonical terms.
+% ----------------------------------------------------------------------------
+dictionary percent_of_vocab {
+    define whole      : finding  surface "whole", "total", "base", "amount", "of"
+    define rate       : finding  surface "rate", "percent", "percentage", "rate percent"
+    define percent_of : finding  surface "percent of", "part", "amount that is the percent"
+}
+
+% ----------------------------------------------------------------------------
+% The composed formula. `percent_of(whole, rate) = product(whole, rate) / 100`
+% CALLS the cited `product` primitive to form `whole × rate`, then divides by 100
+% (the "per hundred" that turns the percent rate into a fraction). The engine
+% resolves the application on the CPU and carries `product`'s citation alongside
+% this one. The formula asserts its own claim about the world (the part that is
+% `rate`% of the whole) and so carries its own required source — the MathWorld
+% percent definition it directly applies.
+% ----------------------------------------------------------------------------
+formulabook percent_of_book {
+    use percent_of_vocab
+
+    formula percent_of(whole, rate) = product(whole, rate) / 100
+        source "A percentage is a number or ratio expressed as a fraction of 100; it is often denoted by the percent sign, %."
+        locator "https://mathworld.wolfram.com/Percent.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/percent-of.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/percent-of.query.adj
@@ -1,0 +1,25 @@
+% ============================================================================
+% percent-of.query.adj — a worked example of the percent-of formula library.
+% ============================================================================
+% Run against the shipped stdlib:
+%
+%   adj-lang-cli percent-of.query.adj
+%
+% "What is 20% of 50?" → (50 × 20) / 100 = 10, computed on the CPU by composing
+% the cited `product` primitive (50 × 20 = 1000) and dividing by 100. The answer
+% carries BOTH the percent definition (primary) and the `product` primitive it
+% built on (corroboration) — the model performs zero arithmetic.
+% ============================================================================
+import "percent-of.adj"
+
+observe whole(50)
+observe rate(20)
+
+? percent_of(whole, rate)
+
+% ----------------------------------------------------------------------------
+% Honest edge case — 0% OF anything is 0, and the engine COMPUTES it (it does not
+% special-case or invent): (50 × 0) / 100 = 0. (Uncomment to see it.)
+% ----------------------------------------------------------------------------
+% observe rate(0)
+% ? percent_of(whole, rate)


### PR DESCRIPTION
## What

The everyday **"what is 20% OF 50?"** operation — the inverse of the shipped `percent`. `percent_of(whole, rate) = whole × rate / 100` calls the cited `product` primitive to form `whole × rate`, then divides by 100 (the "per hundred" of the percent). It re-derives no arithmetic, computes the exact value on the CPU, and carries its own citation plus the `product` primitive's as corroboration (RS-1 write-once-reuse-many). Placed in `arithmetic/` beside the other elementary compositions (ratio/percent/proportion/simple-interest) so the flat `import "arithmetic.adj"` resolves and its `.query.adj` is runnable in place.

## Grounding

This is the direct application of MathWorld's percent definition — *a percentage is a fraction of 100* — so `rate`% of the whole is `whole × rate/100`. The `source` quotes that definition **verbatim** (the same primary source the shipped `percent.adj` cites), `trust authoritative`. Nothing from memory. Algebraic identity: `percent_of(whole, percent(part, whole)) = part`.

## Honest edge case

0% of anything is 0 — the engine **computes** it (`(50·0)/100 = 0`), not special-cased.

## Files

- `arithmetic/percent-of.adj` — the grounded `formula` + literate header
- `arithmetic/percent-of.query.adj` — worked example (20% of 50 → 10) + the zero-rate edge
- `adj-lang-cli/tests/fl4_percent_of_e2e.rs` — e2e: value 10 (exact 10/1), both citations, derivation tree names `/` over `*`, zero rate → 0

## Verification

- `cargo test -p adj-lang-cli --test fl4_percent_of_e2e` — 3/3 green
- `cargo clippy -p adj-lang-cli --tests` — clean
- Data + one test only; no shipped Rust crate changed (no version bump)
- `/security-review` — PASSED

Front rotation: Libraries/FL rung, honoring alternate-three-fronts after Substrate (--explain #9350) and Facts (solfège #9351).

🤖 Generated with [Claude Code](https://claude.com/claude-code)