### PR TITLE
feat(argument-decompose): AD-6 attack-edge gold — generate, verify, score a paper's dialectic

### DIFF
--- a/code/specs/data/mycin-2026/train/argument_decompose_score.py
+++ b/code/specs/data/mycin-2026/train/argument_decompose_score.py
@@ -31,6 +31,22 @@ Metrics (all ratios in [0, 1] except the integer VETO counts):
   - thesis_derivation — 0/1: does the predicted argument, once compiled, actually DERIVE the gold
     thesis and BYTE-ANCHOR its citations (the real 3-part gate, via gen_argument_data.verify_gold)?
     `None` when the adj-lang-cli / adj-verify binaries are not built (skipped, like AD-2).
+
+ATTACK edges (AD-6) — a paper's DIALECTIC, not just its support. When a later paragraph REBUTS an
+earlier conclusion, the gold-object carries an `attacks` list; these metrics score whether the model
+recovered the rebuttal faithfully AND in the right direction:
+  - attack_precision / attack_recall / attack_f1 — set overlap of predicted vs gold attack edges by
+    identity (kind, directed winner/loser CONCLUSIONS, winner/loser CONTEXTS, normalized-span): an
+    attack matches only if it names the right conflict AND says the right side wins.
+  - attack_wrong_direction (VETO, must be 0) — COUNT of predicted attacks that REVERSE a gold attack
+    (predicted winner == gold loser and vice-versa): the model saw the conflict but backed the loser,
+    which would make the engine withdraw the CORRECT conclusion. The dangerous failure.
+  - attack_fabrication (VETO, must be 0) — COUNT of predicted attacks whose precedence-establishing
+    span is NOT in the note: an invented warrant for a withdrawal the paragraph never licenses.
+  - attack_resolution — 0/1: does the predicted argument, once built with its functional head and
+    context_order and RUN, produce the engine's ADJ73 verdict gold expects — the winner GOVERNS and
+    the loser is WITHDRAWN? `None` when there is no gold attack or the binaries are absent. This is
+    the attack counterpart of thesis_derivation: the engine's governing output is the ground truth.
 """
 
 from __future__ import annotations
@@ -69,6 +85,63 @@ def _pr(pred_keys: list, gold_keys: set) -> tuple[float, float]:
     precision = 1.0 if not pred_keys else len(matched) / len(pred_keys)
     recall = 1.0 if not gold_keys else len({k for k in matched}) / len(gold_keys)
     return precision, recall
+
+
+def _attack_key(a: dict) -> tuple:
+    """An attack edge's identity (AD-6): its kind, the winner/loser CONCLUSIONS, the winner/loser
+    CONTEXTS, and its normalized span. Both the conclusions and the contexts encode the precedence
+    DIRECTION, so an attack that names the right pair but the wrong winner is a different key — it
+    does not match gold."""
+    return (a.get("kind"),
+            _norm(a.get("winner_conclusion", "")), _norm(a.get("loser_conclusion", "")),
+            a.get("winner_context"), a.get("loser_context"), _norm(a.get("span", "")))
+
+
+def _to_attack_builder_spec(predicted: dict, gold: dict) -> dict:
+    """Extend `_to_builder_spec` with the attack surface: carry each predicted inference's `context`
+    tag, take the `functional` head from GOLD (structural, like the thesis), and derive a
+    `context_order` edge from each PREDICTED rebut attack. Building from the PREDICTED precedence is
+    what lets the resolution gate catch a reversed attack — a flipped context_order makes the engine
+    withdraw the wrong conclusion, so the gate returns 0."""
+    spec = _to_builder_spec(predicted, gold.get("thesis", ""))
+    for src, dst in zip(predicted.get("inferences", []) or [], spec["inferences"]):
+        if src.get("context"):
+            dst["context"] = src["context"]
+    spec["functional"] = gold.get("functional")
+    spec["context_order"] = [
+        (a["winner_context"], a["loser_context"])
+        for a in (predicted.get("attacks") or [])
+        if a.get("kind") == "rebut" and a.get("winner_context") and a.get("loser_context")
+    ]
+    return spec
+
+
+def attack_resolution(predicted: dict, gold: dict, note: str) -> int | None:
+    """The real gate for attack edges (AD-6): build the predicted argument WITH its functional head
+    and context_order, run the engine, and check its ADJ73 verdict matches gold — for every gold
+    rebut attack, the winner conclusion GOVERNS and the loser is WITHDRAWN. Returns 1/0, or `None`
+    when there is no gold attack to resolve or the binaries are not built. A reversed or dropped
+    attack scores 0 here: the engine's governing output is the ground truth, not the model's claim."""
+    gold_attacks = [a for a in (gold.get("attacks") or []) if a.get("kind") == "rebut"]
+    if not gold_attacks or not (gad.CLI.exists() and gad.VERIFY.exists()):
+        return None
+    spec = _to_attack_builder_spec(predicted, gold)
+    sb = note.encode("utf-8")
+    try:
+        adj_text, _ = gad.build_argument_adj(spec, sb)
+    except gad.SpanNotFound:
+        return 0  # a fabricated citation can't even be built.
+    try:
+        answers = gad.governing_answers_for(adj_text)
+    except gad.BinariesMissing:
+        return None
+    by_term = {_norm(a["term"]): a for a in answers}
+    for atk in gold_attacks:
+        win = by_term.get(_norm(atk.get("winner_conclusion", "")), {})
+        lose = by_term.get(_norm(atk.get("loser_conclusion", "")), {})
+        if win.get("status") != "governing" or lose.get("status") != "defeated":
+            return 0
+    return 1
 
 
 def _to_builder_spec(predicted: dict, thesis: str) -> dict:
@@ -147,15 +220,39 @@ def score(predicted: dict, gold: dict, note: str, *, run_gate: bool = True) -> d
     # fabrication: a predicted span not present in the note at all (invented bytes).
     fabrication = sum(1 for x in cited if _norm(x["span"]) not in note_n)
 
+    # ATTACK edges (AD-6). Precision/recall/f1 by full identity (kind + directed conclusions/contexts
+    # + span), plus two vetoes mirroring the premise/inference ones:
+    pred_atk = predicted.get("attacks", []) or []
+    gold_atk = gold.get("attacks", []) or []
+    ap, ar = _pr([_attack_key(a) for a in pred_atk], {_attack_key(a) for a in gold_atk})
+    # The DIRECTED conclusion pairs gold asserts, so a REVERSAL (predicted winner == gold loser and
+    # vice-versa) is detectable — the single most dangerous attack error, since it would make the
+    # engine withdraw the correct conclusion.
+    gold_pairs = {(_norm(a.get("winner_conclusion", "")), _norm(a.get("loser_conclusion", "")))
+                  for a in gold_atk}
+    attack_wrong_direction = sum(
+        1 for a in pred_atk
+        if (_norm(a.get("loser_conclusion", "")), _norm(a.get("winner_conclusion", ""))) in gold_pairs
+        and (_norm(a.get("winner_conclusion", "")), _norm(a.get("loser_conclusion", ""))) not in gold_pairs
+    )
+    # A predicted attack whose precedence sentence is not in the note at all — an invented warrant
+    # for a withdrawal the paragraph never licenses.
+    attack_fabrication = sum(1 for a in pred_atk
+                             if a.get("span") and _norm(a["span"]) not in note_n)
+
     out = {
         "premise_precision": pp, "premise_recall": pr_, "premise_f1": _f1(pp, pr_),
         "inference_precision": ip, "inference_recall": ir, "inference_f1": _f1(ip, ir),
         "span_faithfulness": span_faithfulness,
         "discard_recall": discard_recall, "discard_precision": discard_precision,
+        "attack_precision": ap, "attack_recall": ar, "attack_f1": _f1(ap, ar),
         "near_miss_violations": near_miss_violations,
         "fabrication": fabrication,
+        "attack_wrong_direction": attack_wrong_direction,
+        "attack_fabrication": attack_fabrication,
     }
     out["thesis_derivation"] = thesis_derivation(predicted, gold, note) if run_gate else None
+    out["attack_resolution"] = attack_resolution(predicted, gold, note) if run_gate else None
     return out
 
 
@@ -166,11 +263,15 @@ def aggregate(scores: list[dict]) -> dict:
         return {}
     ratio = ("premise_precision", "premise_recall", "premise_f1",
              "inference_precision", "inference_recall", "inference_f1",
-             "span_faithfulness", "discard_recall", "discard_precision")
-    counts = ("near_miss_violations", "fabrication")
+             "span_faithfulness", "discard_recall", "discard_precision",
+             "attack_precision", "attack_recall", "attack_f1")
+    counts = ("near_miss_violations", "fabrication",
+              "attack_wrong_direction", "attack_fabrication")
     out = {m: sum(s[m] for s in scores) / len(scores) for m in ratio}
     out.update({m: sum(s[m] for s in scores) for m in counts})
     gated = [s["thesis_derivation"] for s in scores if s.get("thesis_derivation") is not None]
     out["thesis_derivation"] = (sum(gated) / len(gated)) if gated else None
+    resolved = [s["attack_resolution"] for s in scores if s.get("attack_resolution") is not None]
+    out["attack_resolution"] = (sum(resolved) / len(resolved)) if resolved else None
     out["n"] = len(scores)
     return out

--- a/code/specs/data/mycin-2026/train/gen_argument_data.py
+++ b/code/specs/data/mycin-2026/train/gen_argument_data.py
@@ -157,6 +157,73 @@ SEED: list[dict] = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# The ATTACK seed set (AD-6) — arguments that contain a DIALECTIC, not just support. A paper
+# rarely only argues FOR a thesis; a later paragraph often REBUTS an earlier conclusion. Where the
+# SEED rows above are monotone support chains, each ATTACK_SEED row pairs a support paragraph with a
+# rebuttal paragraph and decomposes BOTH into one `argument` block: two `context:`-tagged `infer`s
+# that reach CONFLICTING conclusions on a `functional` head, plus a `context_order` recording which
+# context supersedes. The engine then WITHDRAWS the defeated conclusion (ADJ73), and `verify_attack_gold`
+# asserts exactly that — the winner GOVERNS, the loser is DEFEATED (defeated_by the winner). This is
+# the argument surface's attack edges (AR-3 in-block rebut) made into checkable training gold.
+#
+# Each attack edge records both the precedence direction (winner/loser context) and the sentence
+# that ESTABLISHES it (`quote`) — so a decomposer that reverses the direction, or invents a
+# precedence the paragraph never states, is a scoreable veto (argument_decompose_score.py).
+# ---------------------------------------------------------------------------
+ATTACK_SEED: list[dict] = [
+    {
+        "id": "arg-planet-reanalysis",
+        "name": "planet_signal",
+        "domain": "astronomy",
+        "source": (
+            "The periodic radial-velocity wobble of the star was first reported as "
+            "the signature of an orbiting planet. A later reanalysis found the same "
+            "period matched the star's rotation, so the signal was attributed to "
+            "stellar activity. Because the reanalysis controlled for activity, its "
+            "conclusion supersedes the initial report."
+        ),
+        "doc": "exoplanet reanalysis",
+        "trust": "authoritative",
+        "premises": [
+            {"name": "obs", "kind": "extracted", "term": "observed(signal, wobble)",
+             "quote": "periodic radial-velocity wobble of the star"},
+            {"name": "rot", "kind": "extracted", "term": "matches(period, rotation)",
+             "quote": "the same period matched the star's rotation"},
+        ],
+        "inferences": [
+            # The SUPPORT step (grounded in the initial report) and the REBUTTAL step (grounded in
+            # the reanalysis) reach conflicting mechanisms for the SAME signal — an in-block rebut.
+            {"name": "support", "connective": "because",
+             "conclusion": "attributed_to(signal, planet)", "from": ["obs"],
+             "quote": "first reported as the signature of an orbiting planet",
+             "context": "initial_report"},
+            {"name": "reanalysis", "connective": "because",
+             "conclusion": "attributed_to(signal, stellar_activity)", "from": ["rot"],
+             "quote": "the signal was attributed to stellar activity",
+             "context": "reanalysis"},
+        ],
+        # The functional head: a signal has ONE attributed mechanism, so `planet` and
+        # `stellar_activity` conflict; the context_order says the reanalysis wins.
+        "functional": "attributed_to(subject, mechanism)",
+        "context_order": [("reanalysis", "initial_report")],
+        "attacks": [
+            {"kind": "rebut", "defeater": "reanalysis", "defeated": "support",
+             "winner_context": "reanalysis", "loser_context": "initial_report",
+             "winner_conclusion": "attributed_to(signal, stellar_activity)",
+             "loser_conclusion": "attributed_to(signal, planet)",
+             "quote": "its conclusion supersedes the initial report"},
+        ],
+        "thesis": "attributed_to(signal, $Mechanism)",
+        # After the attack resolves, ONLY the governing mechanism should stand; the CLI still lists
+        # both answers in `recall`, so the attack check reads the `governing` section, not `recall`.
+        "expect_governing": "attributed_to(signal, stellar_activity)",
+        "expect_defeated": "attributed_to(signal, planet)",
+        "discard": [],
+    },
+]
+
+
 def source_bytes_for(spec: dict) -> bytes:
     """The paragraph bytes a seed pins — either its committed `source_file` (repo-relative
     under CODE, so the axle row is byte-identical to ADR-5) or its inline `source`."""
@@ -196,12 +263,27 @@ def build_argument_adj(spec: dict, source_bytes: bytes) -> tuple[str, str]:
     for inf in spec["inferences"]:
         off = _offset(source_bytes, inf["quote"])
         refs = ", ".join(inf["from"])
+        # AR-3 in-block ATTACK sugar (AD-6). An `infer` may carry `unless <defeater…>` (an
+        # undercut → a `not <defeater>` body literal) BEFORE its annotations, and `context: <ctx>`
+        # AFTER them — exactly the surface order the grammar accepts
+        # (`from … [unless …] {annotation} [context: IDENT]`). Support seeds set neither, so their
+        # emitted line is byte-identical to before this change.
+        unless = f' unless {", ".join(inf["unless"])}' if inf.get("unless") else ""
+        context = f' context: {inf["context"]}' if inf.get("context") else ""
         lines.append(
             f'    infer {inf["name"]} : {inf["connective"]} conclude {inf["conclusion"]} '
-            f'from {refs} quote "{inf["quote"]}" at {off} snapshot "{hexhash}" '
-            f'source "{doc}" trust {trust}'
+            f'from {refs}{unless} quote "{inf["quote"]}" at {off} snapshot "{hexhash}" '
+            f'source "{doc}" trust {trust}{context}'
         )
     lines.append("}")
+    # A REBUT attack needs the two conclusions to share a `functional` head (so they conflict on
+    # the functional argument) plus a `context_order { winner > loser }` per attack edge, both
+    # top-level after the block. The engine then WITHDRAWS the lower-ranked conclusion. Support
+    # seeds carry neither key, so nothing extra is emitted for them.
+    if spec.get("functional"):
+        lines.append(f'functional {spec["functional"]}')
+    for hi, lo in spec.get("context_order", []):
+        lines.append(f'context_order {{ {hi} > {lo} }}')
     lines.append(f'? {spec["thesis"]}')
     return "\n".join(lines) + "\n", hexhash
 
@@ -231,6 +313,83 @@ def to_training_row(spec: dict, source_text: str) -> dict:
             "thesis": spec["thesis"],
             "discard": [{"span": d["quote"], "reason": d["reason"]} for d in spec.get("discard", [])],
         },
+    }
+
+
+def to_attack_training_row(spec: dict, source_text: str) -> dict:
+    """The training row for an ATTACK argument (AD-6). Extends the §3.2 support schema with two
+    fields the decomposer must also learn: each inference carries its `context` tag, the gold-object
+    carries the `functional` head, and an `attacks` list records each attack edge — its kind, the
+    defeater/defeated inference names, the winner/loser CONTEXTS and CONCLUSIONS (the precedence
+    DIRECTION), and the `span` (the sentence establishing precedence). That direction is what a
+    decomposer can get backwards; recording it makes a reversed attack a scoreable veto."""
+    return {
+        "id": spec["id"],
+        "shape": "argument",
+        "domain": spec["domain"],
+        "note": source_text,
+        "gold": {
+            "premises": [
+                {"name": p["name"], "kind": p["kind"], "term": p["term"],
+                 "span": p["quote"], "type": "stated"}
+                for p in spec["premises"]
+            ],
+            "inferences": [
+                {"name": i["name"], "connective": i["connective"], "conclusion": i["conclusion"],
+                 "from": i["from"], "span": i["quote"], "type": "stated", "context": i.get("context")}
+                for i in spec["inferences"]
+            ],
+            "thesis": spec["thesis"],
+            "functional": spec.get("functional"),
+            "attacks": [
+                {"kind": a["kind"], "defeater": a["defeater"], "defeated": a["defeated"],
+                 "winner_context": a["winner_context"], "loser_context": a["loser_context"],
+                 "winner_conclusion": a["winner_conclusion"], "loser_conclusion": a["loser_conclusion"],
+                 "span": a["quote"]}
+                for a in spec.get("attacks", [])
+            ],
+            "discard": [{"span": d["quote"], "reason": d["reason"]} for d in spec.get("discard", [])],
+        },
+    }
+
+
+def governing_answers_for(adj_text: str) -> list[dict]:
+    """Run `adj-lang-cli` on `adj_text` and return the first query's `governing` answers — each a
+    dict with `term`, `status` (`governing`/`defeated`/`conflict`), and (when defeated) `defeated_by`.
+    This is the engine's ADJ73 verdict, the ground truth an attack decomposition is scored against.
+    Raises `BinariesMissing` if the CLI is not built."""
+    if not CLI.exists():
+        raise BinariesMissing(f"build adj-lang-cli first: {RUST_TARGET}")
+    with tempfile.TemporaryDirectory() as td:
+        prog = Path(td) / "arg.adj"
+        prog.write_text(adj_text)
+        run = subprocess.run([str(CLI), str(prog)], capture_output=True, text=True, timeout=60)
+    out = run.stdout.strip()
+    d = json.loads(out) if out.startswith("{") else {}
+    gov = d.get("governing", [])
+    return gov[0]["answers"] if gov else []
+
+
+def verify_attack_gold(spec: dict) -> dict:
+    """The attack counterpart of `verify_gold`'s gate. Builds the attack seed's gold `.adj` and
+    asserts the engine RESOLVES the dialectic: it still byte-anchors every citation (the support
+    gate), AND — reading the `governing` section — the `expect_governing` conclusion GOVERNS while
+    the `expect_defeated` conclusion is WITHDRAWN (`defeated`, `defeated_by` the winner). A wrong
+    context_order would flip these, so this check is what proves the attack edge actually bites."""
+    sb = source_bytes_for(spec)
+    adj_text, _ = build_argument_adj(spec, sb)
+    res = verify_gold(adj_text, sb)
+    by_term = {a["term"]: a for a in res.get("governing_answers", [])}
+    win = by_term.get(spec["expect_governing"], {})
+    lose = by_term.get(spec["expect_defeated"], {})
+    return {
+        "derive_ok": res["derive_ok"],
+        "verify_ok": res["verify_ok"],
+        "verified": res["verified"],
+        "quotes_verified": res["quotes_verified"],
+        "winner_governs": win.get("status") == "governing",
+        "loser_defeated": lose.get("status") == "defeated",
+        "defeated_by_winner": lose.get("defeated_by") == spec["expect_governing"],
     }
 
 
@@ -266,6 +425,11 @@ def verify_gold(adj_text: str, source_bytes: bytes) -> dict:
 
     v = _json(verify.stdout)
     totals = v.get("totals", {})
+    # The CLI's `governing` section (ADJ73 defeasibility) reports, per query, which answers are
+    # `governing` and which are `defeated` (with `defeated_by`). An attack seed reads this to prove
+    # the engine WITHDRAWS the loser; support seeds simply ignore it.
+    d = _json(derive.stdout)
+    gov = d.get("governing", [])
     return {
         "derive_ok": derive.returncode == 0,
         "derive_stdout": derive.stdout,
@@ -274,6 +438,7 @@ def verify_gold(adj_text: str, source_bytes: bytes) -> dict:
         # adj-verify nests the per-run counters under `totals`.
         "quotes_verified": totals.get("quotes_verified"),
         "verified": v.get("verified"),
+        "governing_answers": gov[0]["answers"] if gov else [],
     }
 
 
@@ -298,7 +463,20 @@ def emit(outdir: Path) -> int:
     (outdir / "argument_seed.jsonl").write_text(
         "".join(json.dumps(r) + "\n" for r in rows)
     )
-    print(f"gen_argument_data: emitted {len(SEED)} seed argument(s) -> {outdir}")
+    # ATTACK seeds go to their OWN JSONL so the support `argument_seed.jsonl` schema stays exactly
+    # as AD-2 shipped it (no `attacks`/`functional` fields leaking into support consumers).
+    attack_rows = []
+    for spec in ATTACK_SEED:
+        sb = source_bytes_for(spec)
+        adj_text, _ = build_argument_adj(spec, sb)
+        (outdir / f'{spec["id"]}.source.txt').write_bytes(sb)
+        (outdir / f'{spec["id"]}.adj').write_text(adj_text)
+        attack_rows.append(to_attack_training_row(spec, sb.decode("utf-8")))
+    (outdir / "argument_attack_seed.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in attack_rows)
+    )
+    print(f"gen_argument_data: emitted {len(SEED)} support + {len(ATTACK_SEED)} attack "
+          f"argument(s) -> {outdir}")
     return 0
 
 
@@ -333,17 +511,54 @@ def self_check() -> int:
     return 0
 
 
+def attack_self_check() -> int:
+    """Build each ATTACK seed's gold `.adj` and assert the engine resolves the dialectic: every
+    citation still byte-anchors AND the winner governs while the loser is withdrawn. Non-zero on any
+    failure. Skips (returns 2) when the binaries are not built, like `self_check`."""
+    failures = 0
+    for spec in ATTACK_SEED:
+        try:
+            res = verify_attack_gold(spec)
+        except BinariesMissing as e:
+            print(f"  ⚠ {spec['id']}: {e}", file=sys.stderr)
+            return 2
+        want = total_citations(spec)
+        ok = (
+            res["derive_ok"]
+            and res["verify_ok"]
+            and res["verified"] is True
+            and res["quotes_verified"] == want
+            and res["winner_governs"]
+            and res["loser_defeated"]
+            and res["defeated_by_winner"]
+        )
+        status = "ok" if ok else "FAIL"
+        print(f"  [{status}] {spec['id']}: byte-anchored={res['quotes_verified']}/{want} "
+              f"winner_governs={res['winner_governs']} loser_defeated={res['loser_defeated']} "
+              f"defeated_by_winner={res['defeated_by_winner']}")
+        failures += 0 if ok else 1
+    if failures:
+        print(f"\nattack-self-check: {failures} attack seed(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"\nattack-self-check: all {len(ATTACK_SEED)} attack seed(s) resolve the dialectic ✓")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--emit", type=Path, metavar="DIR",
                     help="write seed .adj + source + JSONL into DIR")
     ap.add_argument("--self-check", action="store_true",
                     help="run the 3-part correctness gate on every seed (needs built binaries)")
+    ap.add_argument("--attack-self-check", action="store_true",
+                    help="run the attack-resolution gate on every ATTACK seed (needs built binaries)")
     args = ap.parse_args()
     if args.emit:
         return emit(args.emit)
     if args.self_check:
         return self_check()
+    if args.attack_self_check:
+        return attack_self_check()
     ap.print_help()
     return 0
 

--- a/code/specs/data/mycin-2026/train/test_argument_attack.py
+++ b/code/specs/data/mycin-2026/train/test_argument_attack.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""test_argument_attack.py — guard the ATTACK-edge round-trip (AD-6).
+
+A paper's argument is rarely monotone: a later paragraph often REBUTS an earlier conclusion. AD-6
+teaches the model-free scaffold to GENERATE such a dialectic as gold, VERIFY the engine resolves it
+(the rebutted conclusion is WITHDRAWN), and SCORE a decomposer's recovery of the attack — including
+the two failure modes that matter most: reversing the precedence, and inventing one.
+
+Layers (mirroring test_gen_argument_data.py / test_argument_decompose_score.py):
+
+  PURE (always run, no binaries):
+    - every attack seed's premise/inference/attack span is a verbatim slice of the paragraph;
+    - the emitted `.adj` carries the two `context:` tags, the `functional` head, and the
+      `context_order` edge;
+    - the attack training row round-trips through JSON and matches the AD-6 schema;
+    - the scorer, given the gold as its own prediction, is all-perfect on the attack metrics with
+      zero vetoes;
+    - a REVERSED attack trips the wrong-direction veto; a FABRICATED attack trips its veto.
+
+  GATE (skipped when adj-lang-cli / adj-verify are not built):
+    - the seed RESOLVES: the engine byte-anchors every citation AND withdraws the defeated
+      conclusion (winner governs, loser defeated_by the winner);
+    - the scorer's attack_resolution gate is 1 for the gold and 0 for a reversed attack.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import argument_decompose_score as s  # noqa: E402
+import gen_argument_data as gad  # noqa: E402
+
+# The attack gold-objects + their notes — the fixtures every check scores against.
+_ATTACK = [
+    (gad.to_attack_training_row(spec, gad.source_bytes_for(spec).decode("utf-8")),
+     gad.source_bytes_for(spec).decode("utf-8"))
+    for spec in gad.ATTACK_SEED
+]
+
+
+# ---------------------------------------------------------------------------
+# PURE — generation faithfulness.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spec", gad.ATTACK_SEED, ids=[s["id"] for s in gad.ATTACK_SEED])
+def test_attack_spans_are_faithful_and_adj_carries_the_attack_surface(spec):
+    """Every premise/inference/attack quote is a verbatim slice of the paragraph, and the emitted
+    `.adj` expresses the attack: each step's `context:` tag, the `functional` head, and one
+    `context_order { winner > loser }` edge per attack."""
+    sb = gad.source_bytes_for(spec)
+    source = sb.decode("utf-8")
+    for item in spec["premises"] + spec["inferences"] + spec["attacks"]:
+        assert item["quote"] in source, f"{spec['id']}: quote not verbatim: {item['quote']!r}"
+    adj_text, _ = gad.build_argument_adj(spec, sb)
+    for inf in spec["inferences"]:
+        assert f'context: {inf["context"]}' in adj_text, "each infer carries its context tag"
+    assert f'functional {spec["functional"]}' in adj_text, "the functional head is emitted"
+    for hi, lo in spec["context_order"]:
+        assert f'context_order {{ {hi} > {lo} }}' in adj_text, "the precedence edge is emitted"
+
+
+@pytest.mark.parametrize("spec", gad.ATTACK_SEED, ids=[s["id"] for s in gad.ATTACK_SEED])
+def test_attack_training_row_matches_schema(spec):
+    """The AD-6 row is JSON-clean and carries the attack fields: inferences with a `context`, a
+    `functional` head, and an `attacks` list whose edges name the directed winner/loser."""
+    source = gad.source_bytes_for(spec).decode("utf-8")
+    row = gad.to_attack_training_row(spec, source)
+    assert json.loads(json.dumps(row)) == row  # JSON-clean
+    gold = row["gold"]
+    assert gold["functional"] and gold["attacks"], "an attack row must have a functional head + edges"
+    for i in gold["inferences"]:
+        assert "context" in i, "each inference records its context tag"
+    for a in gold["attacks"]:
+        assert set(a) == {"kind", "defeater", "defeated", "winner_context", "loser_context",
+                          "winner_conclusion", "loser_conclusion", "span"}
+        assert a["winner_conclusion"] != a["loser_conclusion"], "an attack pits two conclusions"
+
+
+# ---------------------------------------------------------------------------
+# PURE — scoring: self-consistency + the two attack vetoes.
+# ---------------------------------------------------------------------------
+
+def test_attack_gold_scored_as_itself_is_perfect():
+    """Self-consistency: scoring the attack gold against itself is perfect on the attack metrics with
+    no vetoes (mirrors the support self-check)."""
+    for row, note in _ATTACK:
+        gold = row["gold"]
+        m = s.score(gold, gold, note, run_gate=False)
+        assert m["attack_precision"] == 1.0 and m["attack_recall"] == 1.0 and m["attack_f1"] == 1.0
+        assert m["attack_wrong_direction"] == 0 and m["attack_fabrication"] == 0
+
+
+def test_reversed_attack_trips_the_wrong_direction_veto():
+    """A prediction that keeps the right conflict but backs the LOSER (swaps winner/loser) trips the
+    wrong-direction veto — the single most dangerous attack error, since the engine would withdraw
+    the correct conclusion. The span is still verbatim, so only the veto catches it."""
+    row, note = _ATTACK[0]
+    gold = row["gold"]
+    atk = dict(gold["attacks"][0])
+    atk["winner_conclusion"], atk["loser_conclusion"] = atk["loser_conclusion"], atk["winner_conclusion"]
+    atk["winner_context"], atk["loser_context"] = atk["loser_context"], atk["winner_context"]
+    predicted = {**gold, "attacks": [atk]}
+    m = s.score(predicted, gold, note, run_gate=False)
+    assert m["attack_wrong_direction"] == 1, "a reversed attack must be vetoed"
+    assert m["attack_fabrication"] == 0, "the span is real — not a fabrication"
+    assert m["attack_recall"] < 1.0, "a reversed attack does not match the gold edge"
+
+
+def test_fabricated_attack_trips_the_fabrication_veto():
+    """A prediction asserting a precedence whose sentence is not in the paragraph trips the
+    attack-fabrication veto — an invented warrant for a withdrawal the text never licenses."""
+    row, note = _ATTACK[0]
+    gold = row["gold"]
+    atk = dict(gold["attacks"][0])
+    atk["span"] = "the committee unanimously overruled the original authors"  # never in the note
+    predicted = {**gold, "attacks": [atk]}
+    m = s.score(predicted, gold, note, run_gate=False)
+    assert m["attack_fabrication"] == 1, "an attack span absent from the note must be vetoed"
+
+
+# ---------------------------------------------------------------------------
+# GATE — the engine actually resolves the dialectic (needs the built binaries).
+# ---------------------------------------------------------------------------
+
+_HAVE_BINS = gad.CLI.exists() and gad.VERIFY.exists()
+
+
+@pytest.mark.skipif(not _HAVE_BINS, reason="adj-lang-cli / adj-verify not built")
+@pytest.mark.parametrize("spec", gad.ATTACK_SEED, ids=[s["id"] for s in gad.ATTACK_SEED])
+def test_seed_resolves_the_dialectic(spec):
+    """The full attack gate: the seed's gold `.adj` byte-anchors every citation AND the engine
+    withdraws the defeated conclusion — winner governs, loser defeated_by the winner."""
+    res = gad.verify_attack_gold(spec)
+    assert res["derive_ok"] and res["verify_ok"] and res["verified"] is True
+    assert res["quotes_verified"] == gad.total_citations(spec), "every citation byte-anchors"
+    assert res["winner_governs"], "the superseding conclusion must govern"
+    assert res["loser_defeated"] and res["defeated_by_winner"], "the rebutted conclusion is withdrawn"
+
+
+@pytest.mark.skipif(not _HAVE_BINS, reason="adj-lang-cli / adj-verify not built")
+def test_attack_resolution_gate_rewards_the_gold_and_fails_a_reversal():
+    """With the binaries built: the gold decomposition RESOLVES (attack_resolution == 1), and a
+    reversed precedence makes the engine withdraw the wrong conclusion, so the gate returns 0."""
+    row, note = _ATTACK[0]
+    gold = row["gold"]
+    assert s.attack_resolution(gold, gold, note) == 1, "the gold attack must resolve"
+    atk = dict(gold["attacks"][0])
+    atk["winner_context"], atk["loser_context"] = atk["loser_context"], atk["winner_context"]
+    atk["winner_conclusion"], atk["loser_conclusion"] = atk["loser_conclusion"], atk["winner_conclusion"]
+    reversed_pred = {**gold, "attacks": [atk]}
+    assert s.attack_resolution(reversed_pred, gold, note) == 0, "a reversed context_order must not resolve"


### PR DESCRIPTION
## AD-6 — attack-edge gold for the argument decomposer

Extends the model-free argument-decomposer scaffold (AD-2 generator / AD-3 fidelity scorer) from monotone **support** chains to arguments that contain an **attack** — a later paragraph that *rebuts* an earlier conclusion. This is the decomposer counterpart of the now-complete **AR-3 in-block attack surface**: the framework can now author, engine-verify, and score training gold for a paper's **dialectic**, not just its support.

### Generation (`gen_argument_data.py`)
- `build_argument_adj` now emits the AR-3 in-block attack sugar **backward-compatibly** — each `infer` may carry `unless <defeater>` (undercut) and `context: <ctx>`, and a spec may carry a top-level `functional` head + `context_order { winner > loser }` edges. Support seeds set none of these, so their emitted `.adj` is **byte-identical** to before (all AD-2 self-checks unchanged).
- **`ATTACK_SEED`**: one rebut example — an exoplanet radial-velocity signal first attributed to a *planet*, then to *stellar activity* by a reanalysis that *supersedes the initial report*. Two `context:`-tagged infers reach conflicting conclusions on a `functional` head; the reanalysis outranks, so the engine **withdraws** the planet conclusion.
- `verify_attack_gold` / `governing_answers_for` / `attack_self_check` read the CLI's `governing` (ADJ73) section and assert the winner **governs** while the loser is **defeated** (`defeated_by` the winner), on top of the existing byte-anchor gate. New `--attack-self-check` flag runs it.

### Scoring (`argument_decompose_score.py`)
- `attack_precision`/`recall`/`f1` by **directed** identity (kind + winner/loser conclusions + contexts + span): an attack matches only if it names the right conflict **and** the right winner.
- Two **must-be-0 vetoes** mirroring the existing fabrication vetoes:
  - `attack_wrong_direction` — a prediction that **reverses** the precedence (the dangerous error: the engine would withdraw the *correct* conclusion).
  - `attack_fabrication` — a precedence whose span is **not in the note**.
- `attack_resolution` gate (0/1/None) — build the predicted argument with its functional head + `context_order`, **run** it, and check the engine's governing verdict matches gold (the attack counterpart of `thesis_derivation`).

### Tests (`test_argument_attack.py`, 7)
Span faithfulness + emitted attack surface, training-row schema, self-consistency, both vetoes, and the binary-gated round-trip (the seed resolves; the resolution gate is **1** for gold, **0** for a reversed attack). All existing argument-scaffold tests stay green — attack rows live in a separate JSONL so the AD-2 support schema is untouched.

**Model-free** (no MLX/Ollama required); **Python/data only** — no Rust crate touched, so no version bump.

Verification: `python3 gen_argument_data.py --self-check` ✓ (3/3, byte-identical to before) · `--attack-self-check` ✓ (winner governs, loser defeated, 4/4 byte-anchored) · `pytest` 38/38 green (incl. 2 binary-gated attack tests, no skips) · `ruff check` clean · 0 NUL bytes · `/security-review` PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)