### PR TITLE
feat(spice): validate MOS source bulk capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CBS` / `CJS` values
+  before source-bulk capacitance shaping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CJSW` values before
   sidewall-junction capacitance shaping.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -602,6 +602,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET CJ must be finite and non-negative")
         elif canonical == "CJSW" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET CJSW must be finite and non-negative")
+        elif canonical == "CBS" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET CBS must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1170,6 +1170,21 @@ def test_mos_model_card_rejects_negative_or_non_finite_sidewall_junction_capacit
             normalize_model_card("Minvalid", "nmos", {"CJSW": invalid_capacitance})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_source_bulk_capacitance() -> None:
+    for parameter in ("CBS", "CJS"):
+        for value in (0.0, 2.0e-10, 1.0):
+            valid = normalize_model_card("Mvalid", "nmos", {parameter: value})
+            assert valid.parameters["CBS"] == pytest.approx(value)
+
+        for invalid_capacitance in (-math.inf, -0.1, math.inf, math.nan):
+            with pytest.raises(
+                ValueError, match="MOSFET CBS must be finite and non-negative"
+            ):
+                normalize_model_card(
+                    "Minvalid", "nmos", {parameter: invalid_capacitance}
+                )
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CBS` / `CJS` values
+  before source-bulk capacitance shaping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CJSW` values before
   sidewall-junction capacitance shaping.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4432,6 +4432,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET CJSW must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "CBS" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET CBS must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1023,6 +1023,24 @@ fn mos_model_card_rejects_negative_or_non_finite_sidewall_junction_capacitance()
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_source_bulk_capacitance() {
+    for parameter in ["CBS", "CJS"] {
+        for value in [0.0, 2.0e-10, 1.0] {
+            let valid = normalize_model_card("Mvalid", "nmos", &[(parameter, value)]).unwrap();
+            assert_close(*valid.parameters.get("CBS").unwrap(), value);
+        }
+
+        for invalid_capacitance in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+            assert!(matches!(
+                normalize_model_card("Minvalid", "nmos", &[(parameter, invalid_capacitance)]),
+                Err(SpiceError::InvalidElement { reason, .. })
+                    if reason == "MOSFET CBS must be finite and non-negative"
+            ));
+        }
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CBS` / `CJS` values
+  before source-bulk capacitance shaping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CJSW` values before
   sidewall-junction capacitance shaping.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8486,6 +8486,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0)
     ) {
       throw invalidElement(name, "MOSFET CJSW must be finite and non-negative");
+    } else if (
+      canonical === "CBS" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET CBS must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -917,6 +917,30 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS source-bulk capacitance", () => {
+    for (const parameter of ["CBS", "CJS"]) {
+      for (const value of [0.0, 2.0e-10, 1.0]) {
+        const valid = normalizeModelCard("Mvalid", "nmos", {
+          [parameter]: value,
+        });
+        expect(valid.parameters.CBS).toBe(value);
+      }
+
+      for (const invalidCapacitance of [
+        Number.NEGATIVE_INFINITY,
+        -0.1,
+        Number.POSITIVE_INFINITY,
+        Number.NaN,
+      ]) {
+        expect(() =>
+          normalizeModelCard("Minvalid", "nmos", {
+            [parameter]: invalidCapacitance,
+          }),
+        ).toThrow("MOSFET CBS must be finite and non-negative");
+      }
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS sidewall-junction-capacitance validation.
+1. Cross-language Level-1 MOS source-bulk-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `CJSW` values before sidewall
-     depletion-capacitance shaping.
-   - Preserve zero and positive sidewall-junction capacitances across Rust,
-     Python, and TypeScript.
+   - Reject negative or non-finite model-card `CBS` / `CJS` values before
+     source-bulk depletion-capacitance shaping.
+   - Preserve zero and positive source-bulk capacitances across Rust, Python,
+     and TypeScript.
 
 ## Completed Slices
 
@@ -3741,6 +3741,13 @@ the Rust, Python, and TypeScript surfaces together.
      bottom-junction depletion-capacitance shaping.
    - Zero and positive bottom-junction capacitances remain aligned across Rust,
      Python, and TypeScript.
+
+309. Cross-language Level-1 MOS sidewall-junction-capacitance validation.
+   - Status: completed in PR 9311.
+   - Negative and non-finite model-card `CJSW` values are rejected before
+     sidewall depletion-capacitance shaping.
+   - Zero and positive sidewall-junction capacitances remain aligned across
+     Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CBS` and `CJS` values during normalization
- preserve zero and finite positive source-bulk capacitances across Rust, Python, and TypeScript
- reconcile the SPICE implementation plan after PR #9311

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff checks
- Python full pytest: 691 passed, 88.97% coverage
- TypeScript full test suite: 434 passed
- TypeScript build