### PR TITLE
fix(mosaic): activate native SwiftUI hover states

### DIFF
--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - Native activation for MSL hover states
+
+SwiftUI output now activates UI15's built-in `state hover` blocks without
+requiring authors to repeat the interaction as a `state-when-hover` layout
+predicate. The emitter generates a small native SwiftUI hover wrapper only
+when the compiled component uses a hover state. Every wrapper owns its own
+`@State`, including wrappers inside `ForEach`, so hovering one repeated row
+does not restyle the whole list. Existing explicit `state-when-hover`
+predicates remain author-controlled and do not install pointer tracking.
+
 ### Added - Native SwiftUI lowering for MSL transitions
 
 Part-level and state-local transitions from `mosstyle-compiler` now lower to

--- a/code/packages/rust/mosaic-emit-swiftui/README.md
+++ b/code/packages/rust/mosaic-emit-swiftui/README.md
@@ -80,6 +80,13 @@ ease-out curve. Standard ease curves and `cubic-bezier(...)` lower to native
 `Animation` constructors. Transitions for style properties that the SwiftUI
 backend does not yet lower are intentionally omitted.
 
+UI15's built-in `state hover` needs no matching layout predicate. When a styled
+part declares it, the generated view is wrapped in a native SwiftUI hover-state
+view whose local `@State` drives the same modifier and animation lowering.
+Wrappers are instantiated inside `ForEach`, so repeated rows retain independent
+hover state. An explicit `state-when-hover` remains available when hover-like
+styling is intentionally driven by application state instead of the pointer.
+
 ## Primitive lowering
 
 | Mosaic primitive | SwiftUI                                       |
@@ -93,20 +100,20 @@ backend does not yet lower are intentionally omitted.
 | `Divider`        | `Divider()`                                   |
 | `Stack`          | `ZStack { ... }` *(v0.2.0; UI29 kernel)*      |
 | `HostScroll`     | `ScrollView { ... }` *(v0.2.0; UI29 kernel)*  |
-| `HostInput`      | `TextField(placeholder, text: .constant(value))` *(v0.2.0; UI29 kernel)* |
+| `HostInput`      | `TextField` with a dispatching `Binding` when `onChange` is wired *(UI29 kernel)* |
 | `HostButton`     | `Button(action: { dispatch(.tap) }) { Text(label) }` *(v0.2.0; UI29 kernel)* |
 | `HostTable`      | `VStack(alignment: .leading, spacing: 0) { HStack { ... } }` *(v0.3.0; UI29 kernel)* |
 | `HostDialog`     | `Color.clear.frame(width: 0, height: 0).sheet(...)` / `.popover(...)` *(v0.5.0; UI29-1 kernel)* |
 
-### `HostInput` binding choice — `.constant(value)`
+### `HostInput` binding choice
 
 SwiftUI `TextField` requires `text: Binding<String>`, but Mosaic components
-receive slots as immutable `let` properties. We thread the slot through
-`.constant(value)`, which means **inline typing does not echo back through
-the slot** — the host's flux dispatch loop owns updates via
-`dispatch(.commit(value: ...))`. This matches UI24's dispatch-driven
-pattern. A future revision will offer a `@State`-proxy lowering that
-dispatches per-keystroke.
+receive slots as immutable `let` properties. When `onChange` is wired, the
+generated binding reads the slot and dispatches the new value from its setter;
+the host's flux loop then supplies the updated slot. Inputs without an
+`onChange` handler use `.constant(value)` as an intentionally read-only
+display. This preserves UI24's dispatch-driven ownership without freezing
+editable fields.
 
 ### `HostInput` platform note — `.onExitCommand`
 
@@ -148,10 +155,6 @@ business logic.
   Per UI28 §4.4 the SwiftUI lowering is
   `Grid → SwiftUI.Table { TableColumn(...) }` with each `Column` becoming
   a `TableColumn` definition.
-- `If`, `For` — UI29 kernel primitives that wait on the moslayout
-  grammar additions (U29-G3). Until those land, this crate returns
-  `UnknownPrimitive` for them so authors get a clear "not yet supported"
-  diagnostic.
 - `HostTable` lowers to a structural `VStack` of `HStack` rows (see
   primitive table above); the data-driven `SwiftUI.Table` form waits on
   a follow-up that wires `For`-inside-table.
@@ -159,7 +162,8 @@ business logic.
   `UnknownPrimitive` errors today; each lands in its own follow-up.
 - `connects` wiring (gesture / event modifiers beyond what `HostButton` /
   `HostInput` already wire).
-- `mosstyle::StyleDef` inlining (accepted in the signature so callers can
-  build against the stable interface, not yet applied).
+- Automatic activation of the remaining UI15 built-in interaction states
+  (`pressed` and `focused`). Slot- or expression-driven states continue to use
+  `state-when-*`; `hover` is the first built-in state with native activation.
 
 See the crate doc-comment for the full deferred list.

--- a/code/packages/rust/mosaic-emit-swiftui/src/lib.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/lib.rs
@@ -49,6 +49,9 @@
 //!    camelCased) and ends with a single required `dispatch` closure
 //!    property. This is the SwiftUI analog of the React UI24 promise.
 //! 3. The **`body` computed property** walks the moslayout tree.
+//! 4. A part with UI15's built-in `state hover` is wrapped in a local native
+//!    hover-state view. Each wrapper instance owns its own `@State`, so
+//!    repeated `ForEach` content does not share pointer state.
 //!
 //! ## Primitive coverage in this first cut
 //!
@@ -79,11 +82,9 @@
 //! SwiftUI's data-driven `Table` view: the data-driven form needs a
 //! row-shape that the IR does not yet carry. See the per-function doc
 //! comment on `pipeline::emit_host_table` for the full rationale. The
-//! remaining UI29 kernel primitives — `If`, `For` — still lower to
-//! `UnknownPrimitive` errors; they wait on the moslayout
-//! grammar additions (U29-G3). Legacy primitives
-//! (`Icon`, `Grid` v2) also still return `UnknownPrimitive` and will land
-//! in their own follow-up PRs. `Cell` + `Column`-as-metadata + `Grid` v3
+//! Legacy primitives (`Icon`, `Grid` v2) still return `UnknownPrimitive`
+//! and will land in their own follow-up PRs. `Cell` +
+//! `Column`-as-metadata + `Grid` v3
 //! from UI28 §2 are deliberately deferred — the `Column` primitive in
 //! this PR still maps to `VStack` (i.e. UI14 `Column`, not UI28
 //! `Column`-metadata).

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -557,6 +557,26 @@ struct PartStyleEntry {
 
 type PartStyleMap = HashMap<String, PartStyleEntry>;
 
+const HOVER_STATE_HELPER_SWIFT: &str = r#"private struct _MosaicHoverState<Content: View>: View {
+    @State private var isHovered = false
+    private let content: (Bool) -> Content
+
+    init(@ViewBuilder content: @escaping (Bool) -> Content) {
+        self.content = content
+    }
+
+    @ViewBuilder
+    var body: some View {
+#if os(macOS)
+        content(isHovered)
+            .onHover { isHovered = $0 }
+#else
+        content(false)
+#endif
+    }
+}
+"#;
+
 // =====================================================================
 // HostTable column-widths threading — TableContext
 // =====================================================================
@@ -698,6 +718,30 @@ fn build_part_style_map(style: &StyleDef) -> PartStyleMap {
     out
 }
 
+fn has_explicit_state_when(node: &LayoutNode, state_name: &str) -> bool {
+    let prop_name = format!("state-when-{state_name}");
+    node.props.iter().any(|prop| prop.name == prop_name)
+}
+
+fn automatic_hover_style<'a>(
+    node: &LayoutNode,
+    part_styles: &'a PartStyleMap,
+) -> Option<&'a PartStyleEntry> {
+    let part_name = node.part_name.as_deref()?;
+    if has_explicit_state_when(node, "hover") {
+        return None;
+    }
+    part_styles.get(&format!("{part_name}:hover"))
+}
+
+fn layout_uses_automatic_hover(node: &LayoutNode, part_styles: &PartStyleMap) -> bool {
+    automatic_hover_style(node, part_styles).is_some()
+        || node
+            .children
+            .iter()
+            .any(|child| layout_uses_automatic_hover(child, part_styles))
+}
+
 /// One state layer collected from a node's `state-when-<X>: ( expr )` props.
 ///
 /// `cond_expr` is the Swift expression for the predicate (already
@@ -774,6 +818,26 @@ fn collect_state_layers<'a>(
             transitions: state_style.transitions.as_slice(),
         });
     }
+    layers
+}
+
+fn collect_state_layers_for_emission<'a>(
+    node: &LayoutNode,
+    part_name: &str,
+    part_styles: &'a PartStyleMap,
+    uses_automatic_hover: bool,
+) -> Vec<StateLayer<'a>> {
+    let mut layers = Vec::new();
+    if uses_automatic_hover {
+        if let Some(hover_style) = part_styles.get(&format!("{part_name}:hover")) {
+            layers.push(StateLayer {
+                cond_expr: "__mosaicHoverActive".to_string(),
+                props: hover_style.props.as_slice(),
+                transitions: hover_style.transitions.as_slice(),
+            });
+        }
+    }
+    layers.extend(collect_state_layers(node, part_name, part_styles));
     layers
 }
 
@@ -1561,6 +1625,11 @@ pub fn from_pipeline(
     writeln!(out, "import SwiftUI").unwrap();
     writeln!(out).unwrap();
 
+    if layout_uses_automatic_hover(&layout.root, &part_styles) {
+        out.push_str(HOVER_STATE_HELPER_SWIFT);
+        writeln!(out).unwrap();
+    }
+
     // 3. Event enum (analog of UI24 §3.1 event union).
     out.push_str(&emit_event_union(name, &interface.emits)?);
     writeln!(out).unwrap();
@@ -1852,6 +1921,13 @@ fn emit_view_tree(
     // width-thread path for where `Some(...)` originates.
     injected_width: Option<&str>,
 ) -> Result<String, PipelineEmitError> {
+    let outer_indent = indent;
+    let uses_automatic_hover = automatic_hover_style(node, part_styles).is_some();
+    let indent = if uses_automatic_hover {
+        indent + 4
+    } else {
+        indent
+    };
     let pad = " ".repeat(indent);
 
     let mut inner = match node.tag.as_str() {
@@ -2065,7 +2141,8 @@ fn emit_view_tree(
         let base_transitions = base_style
             .map(|style| style.transitions.as_slice())
             .unwrap_or(&[]);
-        let state_layers = collect_state_layers(node, part, part_styles);
+        let state_layers =
+            collect_state_layers_for_emission(node, part, part_styles, uses_automatic_hover);
         // When a width is injected we MUST run the chain even if the part
         // carries no styles, so the frame still emits.
         if !base_props.is_empty() || !state_layers.is_empty() || injected_width.is_some() {
@@ -2103,6 +2180,13 @@ fn emit_view_tree(
             spliced.push('\n');
             inner = spliced;
         }
+    }
+
+    if uses_automatic_hover {
+        let outer_pad = " ".repeat(outer_indent);
+        inner = format!(
+            "{outer_pad}_MosaicHoverState {{ __mosaicHoverActive in\n{inner}{outer_pad}}}\n"
+        );
     }
 
     Ok(inner)
@@ -8477,6 +8561,129 @@ mod tests {
             out.contains(
                 ".animation(Animation.easeOut(duration: 0.15), value: ((( disabled )) ? 0.4 : 1))"
             ),
+            "out = {out}"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // T29 — UI15's built-in hover state is activated without requiring a
+    //       redundant state-when-hover layout predicate.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn built_in_hover_state_emits_row_local_wrapper_and_animation() {
+        let m = component("HoverCard", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "HoverCard".to_string(),
+            root: box_node_with_part_and_props("card", vec![]),
+        };
+        let s = StyleDef {
+            component_name: "HoverCard".to_string(),
+            parts: vec![PartStyle {
+                name: "card".to_string(),
+                base: vec![sp("background", "#ffffff")],
+                transitions: vec![transition("background", "80ms", "ease-out")],
+                states: vec![StateStyle {
+                    state: "hover".to_string(),
+                    props: vec![sp("background", "#e8f0ff")],
+                    transitions: vec![],
+                }],
+            }],
+        };
+
+        let out = from_pipeline(&m, &l, &s).expect("emit ok").output;
+        assert!(
+            out.contains("private struct _MosaicHoverState<Content: View>: View"),
+            "out = {out}"
+        );
+        assert!(
+            out.contains("_MosaicHoverState { __mosaicHoverActive in"),
+            "out = {out}"
+        );
+        assert!(
+            out.contains(
+                ".background(((__mosaicHoverActive) ? Color(red: 0.91, green: 0.941, blue: 1) : Color(red: 1, green: 1, blue: 1)))"
+            ),
+            "out = {out}"
+        );
+        assert!(
+            out.contains(
+                ".animation(Animation.easeOut(duration: 0.08), value: ((__mosaicHoverActive) ? Color(red: 0.91, green: 0.941, blue: 1) : Color(red: 1, green: 1, blue: 1)))"
+            ),
+            "out = {out}"
+        );
+    }
+
+    #[test]
+    fn built_in_hover_state_is_local_to_each_for_iteration() {
+        let m = component(
+            "HoverRows",
+            vec![slot(
+                "rows",
+                SlotType::List(Box::new(ListInnerType::Text)),
+                true,
+            )],
+            vec![],
+        );
+        let mut row = box_node_with_part_and_props("row", vec![]);
+        row.children.push(node_with_props(
+            "Text",
+            vec![prop_keyword("value", "row")],
+            vec![],
+        ));
+        let l = LayoutDef {
+            component_name: "HoverRows".to_string(),
+            root: node_with_props(
+                "For",
+                vec![prop_slot_ref("each", "rows"), prop_keyword("as", "row")],
+                vec![row],
+            ),
+        };
+        let s = style_with_part_and_states(
+            "HoverRows",
+            "row",
+            vec![sp("opacity", "0.8")],
+            vec![("hover", vec![sp("opacity", "1")])],
+        );
+
+        let out = from_pipeline(&m, &l, &s).expect("emit ok").output;
+        let for_pos = out
+            .find("ForEach(rows, id: \\.self) { row in")
+            .expect("ForEach");
+        let hover_pos = out[for_pos..]
+            .find("_MosaicHoverState { __mosaicHoverActive in")
+            .expect("row-local hover wrapper");
+        assert!(hover_pos > 0, "out = {out}");
+        assert!(
+            out[for_pos..].contains(".opacity(((__mosaicHoverActive) ? 1 : 0.8))"),
+            "out = {out}"
+        );
+    }
+
+    #[test]
+    fn explicit_hover_predicate_remains_author_controlled() {
+        let m = component("ManualHover", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "ManualHover".to_string(),
+            root: box_node_with_part_and_props(
+                "root",
+                vec![prop_expr("state-when-hover", "( forceHover )")],
+            ),
+        };
+        let s = style_with_part_and_states(
+            "ManualHover",
+            "root",
+            vec![sp("opacity", "0.8")],
+            vec![("hover", vec![sp("opacity", "1")])],
+        );
+
+        let out = from_pipeline(&m, &l, &s).expect("emit ok").output;
+        assert!(
+            !out.contains("_MosaicHoverState"),
+            "explicit predicate should not install native hover tracking:\n{out}"
+        );
+        assert!(
+            out.contains(".opacity(((( forceHover )) ? 1 : 0.8))"),
             "out = {out}"
         );
     }


### PR DESCRIPTION
## Summary

- activate UI15 built-in hover styles with native SwiftUI pointer tracking
- keep hover state local to each generated view, including each ForEach row
- preserve explicit state-when-hover predicates as author-controlled state
- emit the helper only for components that actually use automatic hover

## Why

MSL could describe hover styles and transitions, but SwiftUI output never activated them unless authors duplicated hover as an explicit layout predicate. That made authored interaction styling inert in native macOS output and prevented Mosaic from being the source of truth for polished browser chrome.

## Validation

- cargo test -p mosaic-emit-swiftui --offline (140 passed)
- cargo clippy -p mosaic-emit-swiftui --all-targets --offline -- -D warnings
- generated hover fixture compiled through mosaic-compile and typechecked with xcrun swiftc
- Task App generated nine independent native hover wrappers
- cargo test -p mosaic-package-artifact-builder -p mosaic-package-resolver --offline
- Task App package source tests (2 passed)
- Engram package tests (18 passed)
- HTML coverage audit: tree missing 0; tokenizer missing 0
- cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test --offline

## Follow-up

Full Task App Swift typechecking still reaches a pre-existing MIL/layout mismatch where text project-row markers are emitted as Boolean conditions. This PR does not broaden into that separate type-lowering repair.