### PR TITLE
feat(spice): validate MOS drain bulk capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CBD` / `CJD` values
+  before drain-bulk capacitance shaping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CBS` / `CJS` values
   before source-bulk capacitance shaping.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -604,6 +604,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET CJSW must be finite and non-negative")
         elif canonical == "CBS" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET CBS must be finite and non-negative")
+        elif canonical == "CBD" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET CBD must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1185,6 +1185,21 @@ def test_mos_model_card_rejects_negative_or_non_finite_source_bulk_capacitance()
                 )
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_drain_bulk_capacitance() -> None:
+    for parameter in ("CBD", "CJD"):
+        for value in (0.0, 2.0e-10, 1.0):
+            valid = normalize_model_card("Mvalid", "nmos", {parameter: value})
+            assert valid.parameters["CBD"] == pytest.approx(value)
+
+        for invalid_capacitance in (-math.inf, -0.1, math.inf, math.nan):
+            with pytest.raises(
+                ValueError, match="MOSFET CBD must be finite and non-negative"
+            ):
+                normalize_model_card(
+                    "Minvalid", "nmos", {parameter: invalid_capacitance}
+                )
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CBD` / `CJD` values
+  before drain-bulk capacitance shaping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CBS` / `CJS` values
   before source-bulk capacitance shaping.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4437,6 +4437,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET CBS must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "CBD" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET CBD must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1041,6 +1041,24 @@ fn mos_model_card_rejects_negative_or_non_finite_source_bulk_capacitance() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_drain_bulk_capacitance() {
+    for parameter in ["CBD", "CJD"] {
+        for value in [0.0, 2.0e-10, 1.0] {
+            let valid = normalize_model_card("Mvalid", "nmos", &[(parameter, value)]).unwrap();
+            assert_close(*valid.parameters.get("CBD").unwrap(), value);
+        }
+
+        for invalid_capacitance in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+            assert!(matches!(
+                normalize_model_card("Minvalid", "nmos", &[(parameter, invalid_capacitance)]),
+                Err(SpiceError::InvalidElement { reason, .. })
+                    if reason == "MOSFET CBD must be finite and non-negative"
+            ));
+        }
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CBD` / `CJD` values
+  before drain-bulk capacitance shaping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CBS` / `CJS` values
   before source-bulk capacitance shaping.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8491,6 +8491,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0)
     ) {
       throw invalidElement(name, "MOSFET CBS must be finite and non-negative");
+    } else if (
+      canonical === "CBD" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET CBD must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -941,6 +941,30 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS drain-bulk capacitance", () => {
+    for (const parameter of ["CBD", "CJD"]) {
+      for (const value of [0.0, 2.0e-10, 1.0]) {
+        const valid = normalizeModelCard("Mvalid", "nmos", {
+          [parameter]: value,
+        });
+        expect(valid.parameters.CBD).toBe(value);
+      }
+
+      for (const invalidCapacitance of [
+        Number.NEGATIVE_INFINITY,
+        -0.1,
+        Number.POSITIVE_INFINITY,
+        Number.NaN,
+      ]) {
+        expect(() =>
+          normalizeModelCard("Minvalid", "nmos", {
+            [parameter]: invalidCapacitance,
+          }),
+        ).toThrow("MOSFET CBD must be finite and non-negative");
+      }
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS source-bulk-capacitance validation.
+1. Cross-language Level-1 MOS drain-bulk-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `CBS` / `CJS` values before
-     source-bulk depletion-capacitance shaping.
-   - Preserve zero and positive source-bulk capacitances across Rust, Python,
+   - Reject negative or non-finite model-card `CBD` / `CJD` values before
+     drain-bulk depletion-capacitance shaping.
+   - Preserve zero and positive drain-bulk capacitances across Rust, Python,
      and TypeScript.
 
 ## Completed Slices
@@ -3748,6 +3748,13 @@ the Rust, Python, and TypeScript surfaces together.
      sidewall depletion-capacitance shaping.
    - Zero and positive sidewall-junction capacitances remain aligned across
      Rust, Python, and TypeScript.
+
+310. Cross-language Level-1 MOS source-bulk-capacitance validation.
+   - Status: completed in PR 9355.
+   - Negative and non-finite model-card `CBS` / `CJS` values are rejected before
+     source-bulk depletion-capacitance shaping.
+   - Zero and positive source-bulk capacitances remain aligned across Rust,
+     Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CBD` and `CJD` values during normalization
- preserve zero and finite positive drain-bulk capacitances across Rust, Python, and TypeScript
- reconcile the SPICE implementation plan after PR #9355

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff checks
- Python full pytest: 692 passed, 88.97% coverage
- TypeScript full test suite: 435 passed
- TypeScript build