### PR TITLE
feat(spice): validate MOS gate-source overlap capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CGSO` values before
+  gate-source overlap-capacitance stamping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CBD` / `CJD` values
   before drain-bulk capacitance shaping.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -606,6 +606,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET CBS must be finite and non-negative")
         elif canonical == "CBD" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET CBD must be finite and non-negative")
+        elif canonical == "CGSO" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET CGSO must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1200,6 +1200,18 @@ def test_mos_model_card_rejects_negative_or_non_finite_drain_bulk_capacitance() 
                 )
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_gate_source_overlap_capacitance() -> None:
+    for value in (0.0, 2.0e-10, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"CGSO": value})
+        assert valid.parameters["CGSO"] == pytest.approx(value)
+
+    for invalid_capacitance in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET CGSO must be finite and non-negative"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"CGSO": invalid_capacitance})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CGSO` values before
+  gate-source overlap-capacitance stamping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CBD` / `CJD` values
   before drain-bulk capacitance shaping.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4442,6 +4442,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET CBD must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "CGSO" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET CGSO must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1059,6 +1059,22 @@ fn mos_model_card_rejects_negative_or_non_finite_drain_bulk_capacitance() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_gate_source_overlap_capacitance() {
+    for value in [0.0, 2.0e-10, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("CGSO", value)]).unwrap();
+        assert_close(*valid.parameters.get("CGSO").unwrap(), value);
+    }
+
+    for invalid_capacitance in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("CGSO", invalid_capacitance)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET CGSO must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CGSO` values before
+  gate-source overlap-capacitance stamping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CBD` / `CJD` values
   before drain-bulk capacitance shaping.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8496,6 +8496,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0)
     ) {
       throw invalidElement(name, "MOSFET CBD must be finite and non-negative");
+    } else if (
+      canonical === "CGSO" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET CGSO must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -965,6 +965,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS gate-source overlap capacitance", () => {
+    for (const value of [0.0, 2.0e-10, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { CGSO: value });
+      expect(valid.parameters.CGSO).toBe(value);
+    }
+
+    for (const invalidCapacitance of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { CGSO: invalidCapacitance }),
+      ).toThrow("MOSFET CGSO must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS drain-bulk-capacitance validation.
+1. Cross-language Level-1 MOS gate-source-overlap-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `CBD` / `CJD` values before
-     drain-bulk depletion-capacitance shaping.
-   - Preserve zero and positive drain-bulk capacitances across Rust, Python,
-     and TypeScript.
+   - Reject negative or non-finite model-card `CGSO` values before gate-source
+     overlap-capacitance stamping.
+   - Preserve zero and positive gate-source overlap capacitances across Rust,
+     Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3754,6 +3754,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `CBS` / `CJS` values are rejected before
      source-bulk depletion-capacitance shaping.
    - Zero and positive source-bulk capacitances remain aligned across Rust,
+     Python, and TypeScript.
+
+311. Cross-language Level-1 MOS drain-bulk-capacitance validation.
+   - Status: completed in PR 9358.
+   - Negative and non-finite model-card `CBD` / `CJD` values are rejected before
+     drain-bulk depletion-capacitance shaping.
+   - Zero and positive drain-bulk capacitances remain aligned across Rust,
      Python, and TypeScript.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CGSO` values with a stable diagnostic
- preserve zero and positive gate-source overlap capacitances across Rust, Python, and TypeScript
- reconcile the SPICE implementation plan after PR #9358

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `python -m ruff check src tests`
- `python -m pytest` (693 passed, 88.97% coverage)
- `npm test` (436 passed)
- `npm run build`