### PR TITLE
fix(mosaic): activate native XAML hover states

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased] — VC2-xaml Grid: WinUI value translation + nested-For + per-column widths
 
+### Added - Native activation for MSL hover states
+
+WinUI output now activates UI15's built-in `state hover` blocks on Mosaic
+controls that lower to the native ButtonBase family: `HostButton`,
+`HostCheckbox`, `HostRadio`, and `HostLink`. The generated `StateTrigger`
+binds directly to the control's native `IsPointerOver` dependency property.
+Bindings inside a `For` remain in the DataTemplate namescope, so each repeated
+row owns independent pointer state. Existing explicit `state-when-hover`
+predicates remain author-controlled and do not install pointer tracking.
+
 ### Added - Native MSL states and transitions for Host controls
 
 `HostInput`, `HostButton`, `HostCheckbox`, `HostRadio`, `HostLink`, and
@@ -23,8 +33,9 @@ Supported easing lowerings are `linear`, `ease`, `ease-in`, `ease-out`, and
 `ease-in-out`. WinUI XAML has no arbitrary cubic-bezier
 `EasingFunctionBase`, so `cubic-bezier(...)` currently uses the closest
 native `CubicEase` curve; an exact Composition-API lowering remains a
-follow-up. Template-local Host controls inside `For` remain a follow-up
-because root-level VisualStates cannot target a DataTemplate namescope.
+follow-up. Template-local Host controls inside `For` keep their VisualStates
+inside the DataTemplate namescope so their triggers and targets remain
+row-local.
 
 ### Added - XAML host intent extension point
 

--- a/code/packages/rust/mosaic-emit-xaml/README.md
+++ b/code/packages/rust/mosaic-emit-xaml/README.md
@@ -49,11 +49,20 @@ durations and easing curves. The groups live on a transparent first-child
 Part-level transitions animate entry and exit; state-local transitions
 override entry.
 
+UI15's built-in `state hover` needs no matching layout predicate on controls
+that lower to WinUI's native ButtonBase family (`HostButton`, `HostCheckbox`,
+`HostRadio`, and `HostLink`). Its trigger binds directly to `IsPointerOver`.
+Inside a `For`, the binding and VisualStates remain in the DataTemplate
+namescope, so hovering one repeated row does not restyle its siblings. An
+explicit `state-when-hover` still wins when hover-like styling is intentionally
+driven by application state instead of the pointer.
+
 Named CSS curves lower to native WinUI easing functions. Arbitrary
 `cubic-bezier(...)` curves currently use `CubicEase`; exact control points
-require a future Windows Composition lowering. State predicates inside a
-`For` template are also deferred because DataTemplates introduce a separate
-XAML namescope.
+require a future Windows Composition lowering. Template-local predicates are
+lowered when they can bind directly to the row view-model or be projected into
+it; unsupported cross-namescope expressions are omitted instead of generating
+invalid XAML.
 
 Any moslayout primitive not in the table above currently surfaces as
 `PipelineEmitError::UnsupportedPrimitive` so authors get a clear "not yet

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -780,7 +780,8 @@ struct PartStateStyle {
 /// A part-style entry keeps the already-lowered base attribute fragment
 /// together with the structured MSL state and transition data. Base-only
 /// consumers remain a cheap string lookup; native controls can additionally
-/// lower `state-when-*` predicates to WinUI VisualStates.
+/// lower `state-when-*` predicates and ButtonBase pointer hover to WinUI
+/// VisualStates.
 #[derive(Debug, Clone)]
 struct PartStyleEntry {
     base_fragment: String,
@@ -848,6 +849,18 @@ fn build_part_style_map(style: &StyleDef) -> PartStyleMap {
     out
 }
 
+fn has_explicit_state_when(node: &LayoutNode, state_name: &str) -> bool {
+    let prop_name = format!("state-when-{state_name}");
+    node.props.iter().any(|prop| prop.name == prop_name)
+}
+
+fn button_base_supports_automatic_hover(xaml_tag: &str) -> bool {
+    matches!(
+        xaml_tag,
+        "Button" | "CheckBox" | "RadioButton" | "HyperlinkButton"
+    )
+}
+
 /// Register MSL state overrides for one native WinUI control.
 ///
 /// Each property gets its own VisualStateGroup. This is deliberate:
@@ -885,6 +898,15 @@ fn register_host_visual_states(
             continue;
         };
         state_layers.push((state_name, trigger_value, state_style));
+    }
+    if button_base_supports_automatic_hover(xaml_tag) && !has_explicit_state_when(node, "hover") {
+        if let Some(hover_style) = part.states.get("hover") {
+            state_layers.push((
+                "hover",
+                format!("{{Binding IsPointerOver, ElementName={target_name}}}"),
+                hover_style,
+            ));
+        }
     }
 
     let mut by_property: std::collections::BTreeMap<String, Vec<PendingXamlVisualState>> =
@@ -11594,6 +11616,155 @@ mod tests {
             r.xaml
         );
         assert!(!r.xaml.contains("x:Bind True"), "got:\n{}", r.xaml);
+    }
+
+    #[test]
+    fn button_base_hover_state_uses_native_pointer_binding() {
+        let c = component("HoverButton", vec![], vec![]);
+        let l = layout_with_root("HoverButton", styled_host_button(vec![]));
+        let s = StyleDef {
+            component_name: "HoverButton".to_string(),
+            parts: vec![PartStyle {
+                name: "button".to_string(),
+                base: vec![StyleProp {
+                    name: "background".to_string(),
+                    value: "#202020".to_string(),
+                }],
+                transitions: vec![transition("background", "80ms", "ease-out")],
+                states: vec![StateStyle {
+                    state: "hover".to_string(),
+                    props: vec![StyleProp {
+                        name: "background".to_string(),
+                        value: "#264f78".to_string(),
+                    }],
+                    transitions: Vec::new(),
+                }],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        assert!(
+            r.xaml.contains(
+                "<StateTrigger IsActive=\"{Binding IsPointerOver, ElementName=Button}\"/>"
+            ),
+            "built-in hover must bind directly to native ButtonBase pointer state:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml.contains(
+                "<Setter Target=\"Button.(Control.Background).(SolidColorBrush.Color)\" Value=\"#264f78\"/>"
+            ),
+            "got:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml
+                .contains("<VisualTransition GeneratedDuration=\"0:0:0.08\">"),
+            "got:\n{}",
+            r.xaml
+        );
+    }
+
+    #[test]
+    fn button_base_hover_is_local_to_each_for_template_instance() {
+        let c = component(
+            "HoverRows",
+            vec![slot(
+                "rows",
+                SlotType::List(Box::new(ListInnerType::Text)),
+                true,
+            )],
+            vec![],
+        );
+        let l = layout_with_root(
+            "HoverRows",
+            for_node(
+                LayoutPropValue::SlotRef("rows".to_string()),
+                "row",
+                None,
+                vec![styled_host_button(vec![])],
+            ),
+        );
+        let s = StyleDef {
+            component_name: "HoverRows".to_string(),
+            parts: vec![PartStyle {
+                name: "button".to_string(),
+                base: vec![StyleProp {
+                    name: "opacity".to_string(),
+                    value: "0.8".to_string(),
+                }],
+                transitions: Vec::new(),
+                states: vec![StateStyle {
+                    state: "hover".to_string(),
+                    props: vec![StyleProp {
+                        name: "opacity".to_string(),
+                        value: "1".to_string(),
+                    }],
+                    transitions: Vec::new(),
+                }],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        assert!(
+            r.xaml.contains(
+                "<DataTemplate x:DataType=\"local:HoverRows_RowVm\">\n                <Grid>\n                    <VisualStateManager.VisualStateGroups>"
+            ),
+            "hover groups must live in the repeated row namescope:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml.contains(
+                "<StateTrigger IsActive=\"{Binding IsPointerOver, ElementName=Button}\"/>"
+            ),
+            "each template instance must bind to its own Button:\n{}",
+            r.xaml
+        );
+    }
+
+    #[test]
+    fn explicit_hover_predicate_remains_author_controlled() {
+        let c = component(
+            "ManualHover",
+            vec![slot("force-hover", SlotType::Bool, true)],
+            vec![],
+        );
+        let l = layout_with_root(
+            "ManualHover",
+            styled_host_button(vec![LayoutProp {
+                name: "state-when-hover".to_string(),
+                value: LayoutPropValue::SlotRef("force-hover".to_string()),
+            }]),
+        );
+        let s = StyleDef {
+            component_name: "ManualHover".to_string(),
+            parts: vec![PartStyle {
+                name: "button".to_string(),
+                base: Vec::new(),
+                transitions: Vec::new(),
+                states: vec![StateStyle {
+                    state: "hover".to_string(),
+                    props: vec![StyleProp {
+                        name: "opacity".to_string(),
+                        value: "0.8".to_string(),
+                    }],
+                    transitions: Vec::new(),
+                }],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        assert!(
+            r.xaml
+                .contains("<StateTrigger IsActive=\"{x:Bind ForceHover, Mode=OneWay}\"/>"),
+            "got:\n{}",
+            r.xaml
+        );
+        assert!(
+            !r.xaml.contains("Binding IsPointerOver"),
+            "explicit hover state must not install native pointer tracking:\n{}",
+            r.xaml
+        );
     }
 
     #[test]

--- a/code/packages/rust/mosaic-emit-xaml/tests/task_app_hover_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/task_app_hover_compiles_to_xaml.rs
@@ -1,0 +1,67 @@
+//! Complex-app acceptance gate for native MSL hover activation.
+//!
+//! Task App deliberately authors all interaction styling in Mosaic. Its light
+//! theme exercises nine independently named HostButton hover surfaces,
+//! including controls inside repeated project and task DataTemplates.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn task_app_src_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(|path| {
+            path.join("programs")
+                .join("mosaic")
+                .join("task-app")
+                .join("src")
+        })
+        .expect("derive Task App source root from CARGO_MANIFEST_DIR")
+}
+
+#[test]
+fn task_app_hover_states_lower_to_native_row_local_xaml() {
+    let root = task_app_src_root();
+    let mil = fs::read_to_string(root.join("TaskApp.mil")).expect("read TaskApp.mil");
+    let mll = fs::read_to_string(root.join("TaskApp.mll")).expect("read TaskApp.mll");
+    let msl = fs::read_to_string(root.join("TaskApp.light.msl")).expect("read TaskApp.light.msl");
+
+    let interface = mosmodel_compiler::compile(&mil).expect("compile TaskApp interface");
+    let layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
+        .expect("compile TaskApp layout");
+    let style = mosstyle_compiler::compile(&msl, Some(&layout.part_map_json))
+        .expect("compile TaskApp light style");
+    let output = mosaic_emit_xaml::from_pipeline(
+        &interface.component,
+        &layout.def,
+        &style.def,
+        None,
+        &mosaic_emit_xaml::EmitOptions::default(),
+    )
+    .expect("emit TaskApp XAML")
+    .xaml;
+
+    assert_eq!(
+        output.matches("Binding IsPointerOver").count(),
+        12,
+        "each property-scoped hover state must use native pointer state:\n{output}"
+    );
+    for target in [
+        "ProjectOff",
+        "ProjectAdd",
+        "ProjectSub",
+        "SegListOff",
+        "SegTlOff",
+        "AddBtn",
+        "Toggle",
+        "TaskName",
+        "DelBtn",
+    ] {
+        assert!(
+            output.contains(&format!("ElementName={target}")),
+            "missing native hover target {target}:\n{output}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- activate UI15 built-in hover styles through WinUI ButtonBase IsPointerOver state
- keep hover state local to each generated control, including controls inside For DataTemplates
- preserve explicit state-when-hover predicates as author-controlled state
- add a complex Task App acceptance gate covering nine independent hover surfaces

## Why

MSL hover states and transitions were preserved in the XAML IR, but they only became active when authors duplicated hover as an explicit layout predicate. That left Task App and future Venture browser chrome without their authored native Windows hover feedback.

The emitter now uses a native ElementName binding to each ButtonBase control IsPointerOver dependency property. No app state or handwritten Win32 UI is introduced.

## Validation

- cargo test -p mosaic-emit-xaml --offline (186 unit tests, 6 integration tests)
- cargo clippy -p mosaic-emit-xaml --all-targets --offline -- -D warnings
- Task App light theme generated 12 property-scoped groups across nine native hover targets
- xmllint accepted the generated TaskApp.xaml
- cargo test -p mosaic-package-artifact-builder -p mosaic-package-resolver --offline
- Task App package source tests (2 passed)
- Engram package tests (18 passed)
- HTML coverage audit: tree missing 0; tokenizer missing 0
- cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test --offline

## Scope

Automatic activation is intentionally limited to controls that lower to WinUI ButtonBase: HostButton, HostCheckbox, HostRadio, and HostLink. Other native control families can gain their own platform-appropriate interaction signals in bounded follow-ups.