### PR TITLE
feat(capabilities): enforce closed category/action taxonomy

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,15 +8,18 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": 9354,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "59155426cf0ce7f9f7af9838b91692f0583ec23d",
+    "revision": "b6d3c60b1a952df4df1d0cbe52d5a4c28e344d13",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1197,
-    "implementation_package_slots": 4339,
+    "implementation_identities": 1198,
+    "implementation_package_slots": 4340,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 277,
+    "singleton_packages": 748,
+    "singleton_missing_slots": 10472,
+    "rust_singletons": 553,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -358,11 +361,11 @@
     {
       "id": "ocaml-ci-toolchain",
       "title": "Provision and transitively lock the OCaml toolchain on Ubuntu, macOS, and Windows CI",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["ocaml-infrastructure"],
       "branch": "codex/ocaml-ci-toolchain",
       "pr_number": 9354,
-      "notes": "Ready-for-review PR #9354 provisions the exact OCaml 5.2.1, opam 2.5.2, Dune 3.17.2 with language 3.16, Alcotest 1.9.0, bisect_ppx 2.8.3, and ocamlformat 0.27.0 toolchain on Linux x64, macOS ARM64, and Windows x64; commit-pins the opam repository and actions; preserves and verifies per-target transitive solver locks and receipts; and proves generated library and program scaffolds run real formatting, tests, and measured coverage without skips. PR-triggered runs 30603982497, 30603982472, and 30603982499 are green, including the contract, all three fresh solves, all three locked fixtures, repository builds, and CodeQL detection. Mutable hosted-runner image metadata remains diagnostic evidence only, not a host-image attestation. The later OCaml build substrate remains blocked on the separately tracked build-tool-go-oracle item."
+      "notes": "Merged PR #9354 at d35079bbbea7da791e1b3e033613f34f0e61825f provisions the exact OCaml 5.2.1, opam 2.5.2, Dune 3.17.2 with language 3.16, Alcotest 1.9.0, bisect_ppx 2.8.3, and ocamlformat 0.27.0 toolchain on Linux x64, macOS ARM64, and Windows x64; commit-pins the opam repository and actions; preserves and verifies per-target transitive solver locks and receipts; and proves generated library and program scaffolds run real formatting, tests, and measured coverage without skips. Final PR-triggered runs 30605415709, 30605415708, 30605413650, and 30605415829 are green, including the contract, all three fresh solves, all three locked fixtures, repository builds, and CodeQL detection. Mutable hosted-runner image metadata remains diagnostic evidence only, not a host-image attestation. The later OCaml build substrate remains blocked on the separately tracked build-tool-go-oracle item."
     },
     {
       "id": "adj-lang-cli-capability-profile",
@@ -546,16 +549,37 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 552, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 553, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
-      "title": "Classify the July 30 Rust singleton additions",
+      "title": "Classify the July 30-31 Rust singleton additions",
       "status": "pending",
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, and smart-home-zigbee-integration. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, and Zigbee adapter packages as native/service/storage boundary cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary."
+      "notes": "The July 30-31 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, and smart-home-matter-integration; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, and Matter adapter packages as native/service/storage boundary cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic into the Matter contract, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary."
+    },
+    {
+      "id": "matter-portable-core-extraction-and-conformance",
+      "title": "Extract and fixture the portable Matter adapter core",
+      "status": "pending",
+      "depends_on": ["rust-singletons-20260730-classification"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the b6d3c60b1 post-merge inventory. Define language-neutral fixtures for Matter endpoint projection, report normalization, command planning, fabric-scoped entity identity, atomic report batches, atomic node installation, duplicate-endpoint rejection, and secret-free host locator validation. Fold or extract that deterministic zero-capability logic through matter-core before expanding lanes; full adapter ports remain blocked on classification of the Rust-only smart-home-core and smart-home-runtime dependencies. Add an explicit empty required_capabilities.json to the current adapter core."
+    },
+    {
+      "id": "smart-home-matter-controller-host",
+      "title": "Implement and capability-review the native Matter controller host",
+      "status": "pending",
+      "depends_on": [
+        "matter-portable-core-extraction-and-conformance",
+        "capability-schema-category-action-constraints"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the b6d3c60b1 post-merge inventory. Scope the native/service boundary to mDNS, commissioning, certificate and fabric validation, PASE/CASE sessions, Interaction Model encoding and subscriptions, retries, terminal outcomes, Vault leases, and reviewed nonempty network, time, BLE, and domain capabilities. Keep Matter-over-Thread as a later dependent tranche until the D27 IPv6/UDP decompression, commissioning, and border-router layers exist."
     },
     {
       "id": "smart-home-mqtt-integration-security-hardening",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -500,11 +500,11 @@
     {
       "id": "capability-schema-category-action-constraints",
       "title": "Encode valid category-action pairs in capability schemas",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["haskell-scaffold-capability-schema"],
-      "branch": null,
+      "branch": "codex/capability-category-action-constraints",
       "pr_number": null,
-      "notes": "Discovered during final Haskell capability review. The taxonomy defines category-specific actions, but required_capabilities.schema.json and agent_manifest.schema.json currently use independent global enums and therefore accept nonsensical pairs such as env:listen or stdin:delete. Add conditional or oneOf constraints, shared conformance fixtures, and matching loader/analyzer tests across every enforcement backend."
+      "notes": "Selected after PR #9354 merged because this bounded, restriction-only contract closes a fail-open taxonomy gap and directly unlocks the OCaml capability analyzer, the adj-lang-cli capability profile, and the native Matter controller host. Encode the 19 valid category-action pairs from spec 13 in required_capabilities.schema.json and agent_manifest.schema.json; add one shared exhaustive conformance corpus covering all 19 valid pairs and all 93 invalid cross-pairs; and fail closed at the Go capability generator, Go capability analyzer loader, Go capability cage constructor, and Rust capability cage ingestion boundary. The repository inventory found zero invalid pairs among manifests already using the current category and action vocabularies; legacy out-of-schema vocabulary remains separately classified."
     },
     {
       "id": "haskell-high-consensus-tail",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -507,6 +507,15 @@
       "notes": "Selected after PR #9354 merged because this bounded, restriction-only contract closes a fail-open taxonomy gap and directly unlocks the OCaml capability analyzer, the adj-lang-cli capability profile, and the native Matter controller host. Encode the 19 valid category-action pairs from spec 13 in required_capabilities.schema.json and agent_manifest.schema.json; add one shared exhaustive conformance corpus covering all 19 valid pairs and all 93 invalid cross-pairs; and fail closed at the Go capability generator, Go capability analyzer loader, Go capability cage constructor, and Rust capability cage ingestion boundary. The repository inventory found zero invalid pairs among manifests already using the current category and action vocabularies; legacy out-of-schema vocabulary remains separately classified."
     },
     {
+      "id": "capability-manifest-legacy-shape-and-vocabulary-migration",
+      "title": "Classify and migrate legacy capability manifest shapes and vocabulary",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while enforcing the closed taxonomy. The tracked tree has 2,885 required_capabilities.json paths: 150 top-level dependency arrays, 82 metadata objects without a capabilities key, 164 object manifests with legacy string-list capabilities, and 2,489 objects whose capability list is empty or contains structured entries; 2,316 of the last group currently validate as schema-v1 manifests. The structured entries total 373: 359 use valid current-vocabulary pairs, zero use an invalid current-vocabulary cross-pair, and 14 use separately owned legacy categories or actions such as hardware, audio, ffi:export, process:spawn, network:listen, and fs:read_write. Inventory semantic owners before migration; do not reinterpret build-dependency arrays or missing-key metadata as Spec 13 security manifests, and require Layer-5 review before normalizing any nonempty authority profile."
+    },
+    {
       "id": "haskell-high-consensus-tail",
       "title": "Close Haskell event-loop and brotli",
       "status": "pending",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,7 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": 9363,
   "last_inventory": {
     "revision": "b6d3c60b1a952df4df1d0cbe52d5a4c28e344d13",
     "schema_version": 3,
@@ -500,11 +500,11 @@
     {
       "id": "capability-schema-category-action-constraints",
       "title": "Encode valid category-action pairs in capability schemas",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["haskell-scaffold-capability-schema"],
       "branch": "codex/capability-category-action-constraints",
-      "pr_number": null,
-      "notes": "Selected after PR #9354 merged because this bounded, restriction-only contract closes a fail-open taxonomy gap and directly unlocks the OCaml capability analyzer, the adj-lang-cli capability profile, and the native Matter controller host. Encode the 19 valid category-action pairs from spec 13 in required_capabilities.schema.json and agent_manifest.schema.json; add one shared exhaustive conformance corpus covering all 19 valid pairs and all 93 invalid cross-pairs; and fail closed at the Go capability generator, Go capability analyzer loader, Go capability cage constructor, and Rust capability cage ingestion boundary. The repository inventory found zero invalid pairs among manifests already using the current category and action vocabularies; legacy out-of-schema vocabulary remains separately classified."
+      "pr_number": 9363,
+      "notes": "PR #9363 is ready for review. This bounded, restriction-only contract closes the fail-open taxonomy gap and directly unlocks the OCaml capability analyzer, the adj-lang-cli capability profile, and the native Matter controller host. Both schemas and the Go generator, Go analyzer, Go cage, and Rust cage now share the exhaustive 19-valid/93-invalid taxonomy fixture; generator batch writes preflight atomically; schema-only changes exercise every consumer in CI. Validation: Python 5 tests plus Ruff/Bandit; Go race/vet with 89.3%, 96.7%, and 87.4% coverage; Rust fmt/clippy plus 67 tests and four downstream suites; zero reachable Go or Rust vulnerabilities; collision report 4,340 slots / 1,198 identities / zero collisions or unknown buckets; clean JSON/YAML, diff, and secret checks. The pre-existing capability-os-sandbox macOS seatbelt fixture failure reproduces unchanged on main. Legacy out-of-schema vocabulary remains separately classified."
     },
     {
       "id": "capability-manifest-legacy-shape-and-vocabulary-migration",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,16 @@ jobs:
         with:
           go-version: '1.23'
 
+      - name: Set up Rust for capability taxonomy conformance
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Test parity metadata contracts
         run: |
           python3 -m pip install --disable-pip-version-check --quiet jsonschema==4.26.0
           python3 -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_haskell_required_capabilities.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_ocaml_toolchain_lock.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_capability_taxonomy.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_schema.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_runner.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_schema.py'
@@ -95,6 +99,10 @@ jobs:
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
+          (cd code/programs/go/capability-cage-generator && go test ./...)
+          (cd code/packages/go/ca-capability-analyzer && go test ./...)
+          (cd code/packages/go/capability-cage && go test ./...)
+          cargo test -p capability-cage --manifest-path code/packages/rust/Cargo.toml
 
       - name: Determine diff base
         id: diff-base

--- a/code/packages/go/ca-capability-analyzer/CHANGELOG.md
+++ b/code/packages/go/ca-capability-analyzer/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+- Reject unknown and invalid cross-category capability pairs while loading a
+  manifest, before exact or wildcard declarations enter the analyzer.
+- Conform the embedded 19-pair table to the shared language-neutral Spec 13
+  taxonomy fixture.
+
 ## [1.0.2] - 2026-04-13
 
 ### Security

--- a/code/packages/go/ca-capability-analyzer/README.md
+++ b/code/packages/go/ca-capability-analyzer/README.md
@@ -8,6 +8,10 @@ Every Go package in this repository declares its OS-level capabilities in a `req
 
 `ca-capability-analyzer` closes the gap: it walks the AST of every `.go` file in a package and reports any raw stdlib calls that bypass the Operations system.
 
+Manifest loading also validates category and action as a closed pair using the
+19-pair Spec 13 taxonomy. Unknown vocabulary and invalid cross-pairs fail
+before the analyzer can synthesize a wildcard declaration.
+
 ```
 Package source files
        │

--- a/code/packages/go/ca-capability-analyzer/manifest.go
+++ b/code/packages/go/ca-capability-analyzer/manifest.go
@@ -100,6 +100,33 @@ func canonicalCapabilityString(category, action, target string) CapabilityString
 	return CapabilityString(category + ":" + action + ":" + target)
 }
 
+// validCapabilityPair implements the closed category/action taxonomy from
+// Spec 13. It prevents malformed cross-pairs from becoming wildcard
+// declarations in the analyzer.
+func validCapabilityPair(category, action string) bool {
+	switch category {
+	case "fs":
+		return action == "read" || action == "write" || action == "create" ||
+			action == "delete" || action == "list"
+	case "net":
+		return action == "connect" || action == "listen" || action == "dns"
+	case "proc":
+		return action == "exec" || action == "fork" || action == "signal"
+	case "env":
+		return action == "read" || action == "write"
+	case "ffi":
+		return action == "call" || action == "load"
+	case "time":
+		return action == "read" || action == "sleep"
+	case "stdin":
+		return action == "read"
+	case "stdout":
+		return action == "write"
+	default:
+		return false
+	}
+}
+
 // canonicalBannedConstructExceptionKey converts a (language, construct) pair
 // into the standard "<language>:<construct>" form used for O(1) exemption checks.
 func canonicalBannedConstructExceptionKey(language, construct string) string {
@@ -162,7 +189,14 @@ func LoadManifestData(dir string) (*ManifestData, error) {
 		Declared:                  make(map[CapabilityString]bool),
 		BannedConstructExceptions: make(map[string]bool),
 	}
-	for _, cap := range mf.Capabilities {
+	for i, cap := range mf.Capabilities {
+		if !validCapabilityPair(cap.Category, cap.Action) {
+			return nil, fmt.Errorf(
+				"LoadManifest: capability %d has invalid category/action pair %q:%q",
+				i, cap.Category, cap.Action,
+			)
+		}
+
 		// Add the exact capability as declared.
 		manifest.Declared[canonicalCapabilityString(cap.Category, cap.Action, cap.Target)] = true
 

--- a/code/packages/go/ca-capability-analyzer/manifest_test.go
+++ b/code/packages/go/ca-capability-analyzer/manifest_test.go
@@ -7,10 +7,72 @@ package main
 // The temp directory is automatically cleaned up after each test.
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+type taxonomyFixture struct {
+	Categories                    map[string][]string `json:"categories"`
+	AllActions                    []string            `json:"all_actions"`
+	ExpectedValidPairCount        int                 `json:"expected_valid_pair_count"`
+	ExpectedInvalidCrossPairCount int                 `json:"expected_invalid_cross_pair_count"`
+}
+
+func loadTaxonomyFixture(t *testing.T) taxonomyFixture {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "specs", "fixtures", "capability-security-v1", "taxonomy.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read shared taxonomy fixture: %v", err)
+	}
+	var fixture taxonomyFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("parse shared taxonomy fixture: %v", err)
+	}
+	return fixture
+}
+
+func containsAction(actions []string, wanted string) bool {
+	for _, action := range actions {
+		if action == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCapabilityTaxonomyMatchesSharedFixture(t *testing.T) {
+	fixture := loadTaxonomyFixture(t)
+	validCount := 0
+	invalidCount := 0
+	for category, allowed := range fixture.Categories {
+		for _, action := range fixture.AllActions {
+			want := containsAction(allowed, action)
+			if got := validCapabilityPair(category, action); got != want {
+				t.Errorf("validCapabilityPair(%q, %q) = %v, want %v", category, action, got, want)
+			}
+			if want {
+				validCount++
+			} else {
+				invalidCount++
+			}
+		}
+	}
+	if validCount != fixture.ExpectedValidPairCount {
+		t.Errorf("valid pair count = %d, want %d", validCount, fixture.ExpectedValidPairCount)
+	}
+	if invalidCount != fixture.ExpectedInvalidCrossPairCount {
+		t.Errorf("invalid cross-pair count = %d, want %d", invalidCount, fixture.ExpectedInvalidCrossPairCount)
+	}
+	if validCapabilityPair("filesystem", "read") {
+		t.Error("unknown category must fail closed")
+	}
+	if validCapabilityPair("fs", "destroy") {
+		t.Error("unknown action must fail closed")
+	}
+}
 
 // writeManifest is a test helper that writes content to
 // required_capabilities.json in dir.
@@ -227,6 +289,28 @@ func TestLoadManifest_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestLoadManifest_InvalidCategoryActionPairRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `{
+		"version": 1,
+		"package": "go/test-pkg",
+		"capabilities": [
+			{
+				"category": "net",
+				"action": "read",
+				"target": "*",
+				"justification": "Invalid cross-pair fixture."
+			}
+		],
+		"justification": "Must fail before declarations are recorded."
+	}`)
+
+	m, err := LoadManifestData(dir)
+	if err == nil {
+		t.Fatalf("expected invalid pair error, got manifest: %#v", m)
+	}
+}
+
 // TestLoadManifest_CanonicalForm verifies that canonical capability strings
 // use the "category:action:target" colon-separated format.
 func TestLoadManifest_CanonicalForm(t *testing.T) {
@@ -237,7 +321,7 @@ func TestLoadManifest_CanonicalForm(t *testing.T) {
 		"capabilities": [
 			{
 				"category": "net",
-				"action": "*",
+				"action": "connect",
 				"target": "*",
 				"justification": "Network access."
 			}
@@ -251,7 +335,7 @@ func TestLoadManifest_CanonicalForm(t *testing.T) {
 	}
 
 	// The canonical form must use colons, not any other separator.
-	expected := CapabilityString("net:*:*")
+	expected := CapabilityString("net:connect:*")
 	if !m[expected] {
 		t.Errorf("expected canonical %q in declared set, got %v", expected, m)
 	}

--- a/code/packages/go/capability-cage/CHANGELOG.md
+++ b/code/packages/go/capability-cage/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Security
+
+- `NewManifest` now rejects category/action combinations outside Spec 13's
+  closed 19-pair taxonomy before a manifest can be observed through `Has`,
+  `Check`, or `Capabilities`.
+- Added exhaustive conformance against the shared language-neutral taxonomy
+  fixture.
+
 ## [1.0.0] - 2026-03-25
 
 ### Added

--- a/code/packages/go/capability-cage/README.md
+++ b/code/packages/go/capability-cage/README.md
@@ -59,6 +59,11 @@ if err != nil {
 | `stdin`   | read                                 | Standard input                |
 | `stdout`  | write                                | Standard output               |
 
+These are 19 valid pairs, not two independently combinable enums.
+`NewManifest` panics on an unknown or invalid cross-pair before constructing a
+manifest. The table is exhaustively checked against the language-neutral Spec
+13 fixture.
+
 ## Target Matching
 
 - `"*"` — matches any target (broad access, use sparingly)
@@ -87,5 +92,6 @@ CageBackend (future)       →  sends JSON-RPC to host (D18 Chief of Staff)
 
 - **No runtime JSON read**: capabilities are compiled in, not read from disk
 - **Immutable manifests**: `NewManifest` copies the slice; callers cannot mutate
+- **Closed taxonomy**: invalid category/action pairs fail at construction
 - **Backend injection**: `WithBackend` allows test doubles without hitting real OS
 - **Zero dependencies**: no external packages required

--- a/code/packages/go/capability-cage/capability_cage.go
+++ b/code/packages/go/capability-cage/capability_cage.go
@@ -43,8 +43,46 @@ type Manifest struct {
 	capabilities []Capability
 }
 
+// validCapabilityPair implements the closed category/action taxonomy from
+// Spec 13.
+func validCapabilityPair(category, action string) bool {
+	switch category {
+	case CategoryFS:
+		return action == ActionRead || action == ActionWrite || action == ActionCreate ||
+			action == ActionDelete || action == ActionList
+	case CategoryNet:
+		return action == ActionConnect || action == ActionListen || action == ActionDNS
+	case CategoryProc:
+		return action == ActionExec || action == ActionFork || action == ActionSignal
+	case CategoryEnv:
+		return action == ActionRead || action == ActionWrite
+	case CategoryFFI:
+		return action == ActionCall || action == ActionLoad
+	case CategoryTime:
+		return action == ActionRead || action == ActionSleep
+	case CategoryStdin:
+		return action == ActionRead
+	case CategoryStdout:
+		return action == ActionWrite
+	default:
+		return false
+	}
+}
+
 // NewManifest constructs an immutable Manifest from a slice of capabilities.
+// It panics if any capability uses a category/action pair outside Spec 13's
+// closed taxonomy, so an invalid manifest can never be observed through Has,
+// Check, or Capabilities.
 func NewManifest(caps []Capability) *Manifest {
+	for i, capability := range caps {
+		if !validCapabilityPair(capability.Category, capability.Action) {
+			panic(fmt.Sprintf(
+				"capability %d has invalid category/action pair %q:%q",
+				i, capability.Category, capability.Action,
+			))
+		}
+	}
+
 	result, _ := StartNew[*Manifest]("capability-cage.NewManifest", nil,
 		func(op *Operation[*Manifest], rf *ResultFactory[*Manifest]) *OperationResult[*Manifest] {
 			copied := make([]Capability, len(caps))

--- a/code/packages/go/capability-cage/taxonomy_conformance_test.go
+++ b/code/packages/go/capability-cage/taxonomy_conformance_test.go
@@ -1,0 +1,83 @@
+package capabilitycage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type taxonomyFixture struct {
+	Categories                    map[string][]string `json:"categories"`
+	AllActions                    []string            `json:"all_actions"`
+	ExpectedValidPairCount        int                 `json:"expected_valid_pair_count"`
+	ExpectedInvalidCrossPairCount int                 `json:"expected_invalid_cross_pair_count"`
+}
+
+func loadTaxonomyFixture(t *testing.T) taxonomyFixture {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "specs", "fixtures", "capability-security-v1", "taxonomy.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read shared taxonomy fixture: %v", err)
+	}
+	var fixture taxonomyFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("parse shared taxonomy fixture: %v", err)
+	}
+	return fixture
+}
+
+func containsAction(actions []string, wanted string) bool {
+	for _, action := range actions {
+		if action == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCapabilityTaxonomyMatchesSharedFixture(t *testing.T) {
+	fixture := loadTaxonomyFixture(t)
+	validCount := 0
+	invalidCount := 0
+	for category, allowed := range fixture.Categories {
+		for _, action := range fixture.AllActions {
+			want := containsAction(allowed, action)
+			if got := validCapabilityPair(category, action); got != want {
+				t.Errorf("validCapabilityPair(%q, %q) = %v, want %v", category, action, got, want)
+			}
+			if want {
+				validCount++
+			} else {
+				invalidCount++
+			}
+		}
+	}
+	if validCount != fixture.ExpectedValidPairCount {
+		t.Errorf("valid pair count = %d, want %d", validCount, fixture.ExpectedValidPairCount)
+	}
+	if invalidCount != fixture.ExpectedInvalidCrossPairCount {
+		t.Errorf("invalid cross-pair count = %d, want %d", invalidCount, fixture.ExpectedInvalidCrossPairCount)
+	}
+	if validCapabilityPair("filesystem", "read") {
+		t.Error("unknown category must fail closed")
+	}
+	if validCapabilityPair("fs", "destroy") {
+		t.Error("unknown action must fail closed")
+	}
+}
+
+func TestNewManifestRejectsInvalidPairBeforeObservation(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected invalid manifest construction to panic")
+		}
+	}()
+	_ = NewManifest([]Capability{{
+		Category:      CategoryFS,
+		Action:        ActionConnect,
+		Target:        "*",
+		Justification: "Invalid cross-pair fixture.",
+	}})
+}

--- a/code/packages/rust/capability-cage/CHANGELOG.md
+++ b/code/packages/rust/capability-cage/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added exhaustive conformance between the embedded 19-pair category/action
+  table and the shared language-neutral Spec 13 taxonomy fixture.
 - Added `CapabilitySurfaceSummary` and `Manifest::capability_surface_summary()`
   for payload-free Chief-of-Staff host/catalog review of manifest category,
   action, target-count, and boundary annotation coverage.

--- a/code/packages/rust/capability-cage/README.md
+++ b/code/packages/rust/capability-cage/README.md
@@ -8,6 +8,12 @@ See `code/specs/capability-cage-rust.md` for the full design and
 `code/specs/13-capability-security.md` for the cross-language
 taxonomy.
 
+The eight categories and 14-action union form exactly 19 valid pairs rather
+than two independently combinable enums. Manifest ingestion rejects unknown
+vocabulary and all other cross-pairs, and the embedded table is exhaustively
+checked against
+`code/specs/fixtures/capability-security-v1/taxonomy.json`.
+
 ## What this crate is
 
 The cage's job is to ensure that no Rust package in this repo
@@ -98,7 +104,6 @@ Spec-defined but landing in subsequent PRs:
 
 - `secure_net` / `secure_proc` / `secure_time` / `secure_stdio` modules
 - `build.rs` codegen for `package_manifest()`
-- Cross-language conformance suite shared with the Go cage
 - The CI lint that rejects raw stdlib usage
 
 ## Dependencies

--- a/code/packages/rust/capability-cage/src/category.rs
+++ b/code/packages/rust/capability-cage/src/category.rs
@@ -179,6 +179,8 @@ pub fn is_valid_combination(category: Category, action: Action) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use coding_adventures_json_value::{parse, JsonNumber, JsonValue};
+    use std::collections::HashSet;
 
     #[test]
     fn category_round_trips() {
@@ -213,51 +215,72 @@ mod tests {
     }
 
     #[test]
-    fn valid_combinations_exhaustive() {
-        // The 19 valid pairs from the spec table.
-        let valid = [
-            (Category::Fs, Action::Read),
-            (Category::Fs, Action::Write),
-            (Category::Fs, Action::Create),
-            (Category::Fs, Action::Delete),
-            (Category::Fs, Action::List),
-            (Category::Net, Action::Connect),
-            (Category::Net, Action::Listen),
-            (Category::Net, Action::Dns),
-            (Category::Proc, Action::Exec),
-            (Category::Proc, Action::Fork),
-            (Category::Proc, Action::Signal),
-            (Category::Env, Action::Read),
-            (Category::Env, Action::Write),
-            (Category::Ffi, Action::Call),
-            (Category::Ffi, Action::Load),
-            (Category::Time, Action::Read),
-            (Category::Time, Action::Sleep),
-            (Category::Stdin, Action::Read),
-            (Category::Stdout, Action::Write),
-        ];
-        for (c, a) in valid {
-            assert!(is_valid_combination(c, a), "expected {c}:{a} to be valid");
-        }
-    }
+    fn shared_fixture_exhaustively_matches_pair_table() {
+        let fixture = parse(include_str!(
+            "../../../../specs/fixtures/capability-security-v1/taxonomy.json"
+        ))
+        .expect("shared taxonomy fixture must parse");
+        let JsonValue::Object(root) = fixture else {
+            panic!("taxonomy fixture must be an object");
+        };
+        let lookup = |key: &str| {
+            root.iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value)
+                .unwrap_or_else(|| panic!("missing fixture field {key}"))
+        };
+        let JsonValue::Object(categories) = lookup("categories") else {
+            panic!("categories must be an object");
+        };
+        let JsonValue::Array(all_actions) = lookup("all_actions") else {
+            panic!("all_actions must be an array");
+        };
+        let actions: Vec<&str> = all_actions
+            .iter()
+            .map(|value| match value {
+                JsonValue::String(action) => action.as_str(),
+                _ => panic!("all_actions entries must be strings"),
+            })
+            .collect();
 
-    #[test]
-    fn invalid_combinations_rejected() {
-        // A few that should NOT be valid.
-        let invalid = [
-            (Category::Fs, Action::Connect),
-            (Category::Net, Action::Read),
-            (Category::Proc, Action::Read),
-            (Category::Env, Action::Connect),
-            (Category::Time, Action::Connect),
-            (Category::Stdin, Action::Write),
-            (Category::Stdout, Action::Read),
-        ];
-        for (c, a) in invalid {
-            assert!(
-                !is_valid_combination(c, a),
-                "expected {c}:{a} to be invalid"
-            );
+        let mut valid_count = 0;
+        let mut invalid_count = 0;
+        for (category_name, allowed_value) in categories {
+            let category: Category = category_name.parse().expect("known fixture category");
+            let JsonValue::Array(allowed_values) = allowed_value else {
+                panic!("category actions must be arrays");
+            };
+            let allowed: HashSet<&str> = allowed_values
+                .iter()
+                .map(|value| match value {
+                    JsonValue::String(action) => action.as_str(),
+                    _ => panic!("category action entries must be strings"),
+                })
+                .collect();
+            for action_name in &actions {
+                let action: Action = action_name.parse().expect("known fixture action");
+                let want = allowed.contains(action_name);
+                assert_eq!(
+                    is_valid_combination(category, action),
+                    want,
+                    "pair mismatch for {category}:{action}"
+                );
+                if want {
+                    valid_count += 1;
+                } else {
+                    invalid_count += 1;
+                }
+            }
         }
+
+        let expected_count = |key: &str| match lookup(key) {
+            JsonValue::Number(JsonNumber::Integer(value)) => *value as usize,
+            _ => panic!("{key} must be an integer"),
+        };
+        assert_eq!(valid_count, expected_count("expected_valid_pair_count"));
+        assert_eq!(
+            invalid_count,
+            expected_count("expected_invalid_cross_pair_count")
+        );
     }
 }

--- a/code/programs/go/capability-cage-generator/CHANGELOG.md
+++ b/code/programs/go/capability-cage-generator/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this program will be documented in this file.
 
+## [Unreleased]
+
+### Security
+
+- Validate every manifest capability against Spec 13's closed 19-pair
+  category/action taxonomy before generating source.
+- Fail explicitly for recognized pairs whose enforcing Go wrapper is not yet
+  implemented. Unsupported pairs no longer produce TODO namespaces or replace
+  an existing generated cage.
+- Conform the embedded pair table to the shared language-neutral taxonomy
+  fixture.
+- Preflight and render every `--all` input before writing, so one invalid or
+  unsupported manifest cannot leave the repository partially regenerated.
+
 ## [1.0.0] - 2026-03-25
 
 ### Added

--- a/code/programs/go/capability-cage-generator/README.md
+++ b/code/programs/go/capability-cage-generator/README.md
@@ -20,6 +20,13 @@ capability-cage-generator --manifest=... --dry-run
 capability-cage-generator --all --dry-run
 ```
 
+`--all` preflights and renders every discovered Go manifest before writing any
+package. If one manifest is malformed or uses a recognized pair whose enforcing
+wrapper is not implemented, the batch returns an aggregate error and leaves
+every existing generated file intact. This makes `--all` a repository-wide
+validation command as well as a generator; it will fail until every discovered
+Go manifest is both valid and supported.
+
 ## What It Generates
 
 Given `required_capabilities.json`:
@@ -60,6 +67,22 @@ For pure-computation packages (empty capabilities):
 ```go
 var Manifest = cage.EmptyManifest
 ```
+
+## Taxonomy Enforcement
+
+Category and action form one closed identity. The generator accepts only the
+19 pairs defined by Spec 13 and exercised by
+`code/specs/fixtures/capability-security-v1/taxonomy.json`. It validates the
+whole manifest before writing output.
+
+The generator currently emits enforcing methods for filesystem read, write,
+create, delete, and list; network connect, listen, and DNS; process exec;
+environment read; time read and sleep; stdin read; and stdout write. Other
+valid Spec 13 pairs fail with an explicit unsupported-pair error. They never
+produce a TODO or a weaker unguarded method, and an existing generated file is
+left intact. Batch generation applies the same rule atomically across the
+preflight phase, including currently valid but unsupported pairs such as
+`ffi:call`.
 
 ## Package Name Derivation
 

--- a/code/programs/go/capability-cage-generator/main.go
+++ b/code/programs/go/capability-cage-generator/main.go
@@ -107,6 +107,48 @@ func hasWildcard(targets []string) bool {
 	return false
 }
 
+// validCapabilityPair implements the closed category/action taxonomy from
+// Spec 13. Category and action are not independent enums: only these 19 pairs
+// are valid capability identities.
+func validCapabilityPair(category, action string) bool {
+	switch category {
+	case "fs":
+		return action == "read" || action == "write" || action == "create" ||
+			action == "delete" || action == "list"
+	case "net":
+		return action == "connect" || action == "listen" || action == "dns"
+	case "proc":
+		return action == "exec" || action == "fork" || action == "signal"
+	case "env":
+		return action == "read" || action == "write"
+	case "ffi":
+		return action == "call" || action == "load"
+	case "time":
+		return action == "read" || action == "sleep"
+	case "stdin":
+		return action == "read"
+	case "stdout":
+		return action == "write"
+	default:
+		return false
+	}
+}
+
+// generatorSupportsCapability reports whether this generator has a concrete,
+// enforcing method for a valid taxonomy pair. Valid but not-yet-supported
+// pairs fail explicitly rather than producing a TODO or weaker cage.
+func generatorSupportsCapability(category, action string) bool {
+	switch category + ":" + action {
+	case "fs:read", "fs:write", "fs:create", "fs:delete", "fs:list",
+		"net:connect", "net:listen", "net:dns",
+		"proc:exec", "env:read", "time:read", "time:sleep",
+		"stdin:read", "stdout:write":
+		return true
+	default:
+		return false
+	}
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Capability grouping
 // ─────────────────────────────────────────────────────────────────────────────
@@ -561,40 +603,6 @@ func emitCapabilityMethod(b *strings.Builder, g capabilityGroup, typeName string
 		fmt.Fprintf(b, "\treturn os.ReadDir(path) //nolint:cap\n")
 		fmt.Fprintf(b, "}\n\n")
 
-	case "fs:open":
-		if hasWildcard(g.Targets) {
-			fmt.Fprintf(b, "// OpenFile opens the named file for reading.\n")
-			fmt.Fprintf(b, "// This package declared a wildcard capability (\"*\").\n")
-			fmt.Fprintf(b, "// No runtime path restriction is enforced — all paths are permitted.\n")
-			fmt.Fprintf(b, "// The path is cleaned with filepath.Clean before use.\n")
-		} else {
-			fmt.Fprintf(b, "// OpenFile opens the named file for reading.\n")
-			fmt.Fprintf(b, "// Only paths declared in required_capabilities.json are permitted.\n")
-			fmt.Fprintf(b, "// The path is cleaned with filepath.Clean before comparison.\n")
-		}
-		fmt.Fprintf(b, "func (c *%s) OpenFile(path string) (*os.File, error) {\n", typeName)
-		fmt.Fprintf(b, "\tpath = filepath.Clean(path)\n")
-		emitScopedCheck(b, g.Targets, "path", true, "fs", "open", targetToVar)
-		fmt.Fprintf(b, "\treturn os.Open(path) //nolint:cap\n")
-		fmt.Fprintf(b, "}\n\n")
-
-	case "fs:mkdir":
-		if hasWildcard(g.Targets) {
-			fmt.Fprintf(b, "// MkdirAll creates a directory named path, along with any necessary parents.\n")
-			fmt.Fprintf(b, "// This package declared a wildcard capability (\"*\").\n")
-			fmt.Fprintf(b, "// No runtime path restriction is enforced — all paths are permitted.\n")
-			fmt.Fprintf(b, "// The path is cleaned with filepath.Clean before use.\n")
-		} else {
-			fmt.Fprintf(b, "// MkdirAll creates a directory named path, along with any necessary parents.\n")
-			fmt.Fprintf(b, "// Only paths declared in required_capabilities.json are permitted.\n")
-			fmt.Fprintf(b, "// The path is cleaned with filepath.Clean before comparison.\n")
-		}
-		fmt.Fprintf(b, "func (c *%s) MkdirAll(path string, perm os.FileMode) error {\n", typeName)
-		fmt.Fprintf(b, "\tpath = filepath.Clean(path)\n")
-		emitScopedCheck(b, g.Targets, "path", false, "fs", "mkdir", targetToVar)
-		fmt.Fprintf(b, "\treturn os.MkdirAll(path, perm) //nolint:cap\n")
-		fmt.Fprintf(b, "}\n\n")
-
 	case "net:connect":
 		fmt.Fprintf(b, "// Connect opens a network connection to addr.\n")
 		fmt.Fprintf(b, "// Only addresses declared in required_capabilities.json are permitted.\n")
@@ -669,7 +677,7 @@ func emitCapabilityMethod(b *strings.Builder, g capabilityGroup, typeName string
 		fmt.Fprintf(b, "}\n\n")
 
 	default:
-		fmt.Fprintf(b, "// TODO: implement capability method for %s:%s\n\n", g.Category, g.Action)
+		panic(fmt.Sprintf("validated unsupported capability reached emitter: %s:%s", g.Category, g.Action))
 	}
 }
 
@@ -904,6 +912,21 @@ func emitCapabilityViolationError(b *strings.Builder) {
 
 // generateSource produces the content of gen_capabilities.go for a given manifest.
 func generateSource(manifestPath string, mf *manifestJSON) (string, error) {
+	for i, capability := range mf.Capabilities {
+		if !validCapabilityPair(capability.Category, capability.Action) {
+			return "", fmt.Errorf(
+				"capability %d has invalid category/action pair %q:%q",
+				i, capability.Category, capability.Action,
+			)
+		}
+		if !generatorSupportsCapability(capability.Category, capability.Action) {
+			return "", fmt.Errorf(
+				"capability %d uses recognized but unsupported category/action pair %q:%q",
+				i, capability.Category, capability.Action,
+			)
+		}
+	}
+
 	pkgName, err := goPackageName(manifestPath, mf.Package)
 	if err != nil {
 		return "", err
@@ -945,47 +968,69 @@ func generateSource(manifestPath string, mf *manifestJSON) (string, error) {
 // Single manifest processing
 // ─────────────────────────────────────────────────────────────────────────────
 
+type preparedManifest struct {
+	outPath string
+	source  string
+}
+
+// prepareManifest reads and renders one Go capability manifest without
+// mutating its package. The boolean result is false for non-Go packages.
+func prepareManifest(manifestPath string) (preparedManifest, bool, error) {
+	data, err := os.ReadFile(manifestPath) //nolint:cap
+	if err != nil {
+		return preparedManifest{}, false, fmt.Errorf("read %s: %w", manifestPath, err)
+	}
+
+	var mf manifestJSON
+	if err := json.Unmarshal(data, &mf); err != nil {
+		return preparedManifest{}, false, fmt.Errorf("parse %s: %w", manifestPath, err)
+	}
+
+	if !strings.HasPrefix(mf.Package, "go/") {
+		return preparedManifest{}, false, nil
+	}
+
+	source, err := generateSource(manifestPath, &mf)
+	if err != nil {
+		return preparedManifest{}, false, fmt.Errorf("generate %s: %w", manifestPath, err)
+	}
+
+	return preparedManifest{
+		outPath: filepath.Join(filepath.Dir(manifestPath), "gen_capabilities.go"),
+		source:  source,
+	}, true, nil
+}
+
+func emitPreparedManifest(prepared preparedManifest, dryRun bool) error {
+	if dryRun {
+		fmt.Printf("=== DRY RUN: would write %s ===\n", prepared.outPath)
+		fmt.Println(prepared.source)
+		return nil
+	}
+
+	if err := os.WriteFile(prepared.outPath, []byte(prepared.source), 0o644); err != nil { //nolint:cap
+		return fmt.Errorf("write %s: %w", prepared.outPath, err)
+	}
+	fmt.Printf("wrote %s\n", prepared.outPath)
+	return nil
+}
+
 // processManifest reads a single required_capabilities.json file, generates
 // the corresponding gen_capabilities.go, and writes it to the same directory.
 //
 // If dryRun is true, the generated source is printed to stdout instead of
 // written to disk.
 func processManifest(manifestPath string, dryRun bool) error {
-	data, err := os.ReadFile(manifestPath) //nolint:cap
+	prepared, isGoPackage, err := prepareManifest(manifestPath)
 	if err != nil {
-		return fmt.Errorf("read %s: %w", manifestPath, err)
+		return err
 	}
-
-	var mf manifestJSON
-	if err := json.Unmarshal(data, &mf); err != nil {
-		return fmt.Errorf("parse %s: %w", manifestPath, err)
-	}
-
-	// Only generate for Go packages.
-	if !strings.HasPrefix(mf.Package, "go/") {
-		fmt.Fprintf(os.Stderr, "skip %s: package %q is not a Go package (prefix not 'go/')\n",
-			manifestPath, mf.Package)
+	if !isGoPackage {
+		fmt.Fprintf(os.Stderr, "skip %s: manifest is not for a Go package (prefix not 'go/')\n",
+			manifestPath)
 		return nil
 	}
-
-	source, err := generateSource(manifestPath, &mf)
-	if err != nil {
-		return fmt.Errorf("generate %s: %w", manifestPath, err)
-	}
-
-	outPath := filepath.Join(filepath.Dir(manifestPath), "gen_capabilities.go")
-
-	if dryRun {
-		fmt.Printf("=== DRY RUN: would write %s ===\n", outPath)
-		fmt.Println(source)
-		return nil
-	}
-
-	if err := os.WriteFile(outPath, []byte(source), 0o644); err != nil { //nolint:cap
-		return fmt.Errorf("write %s: %w", outPath, err)
-	}
-	fmt.Printf("wrote %s\n", outPath)
-	return nil
+	return emitPreparedManifest(prepared, dryRun)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1005,15 +1050,28 @@ func processAll(repoRoot string, dryRun bool) error {
 		return nil
 	}
 
-	var errs []string
+	var (
+		errs     []string
+		prepared []preparedManifest
+	)
 	for _, m := range matches {
-		if err := processManifest(m, dryRun); err != nil {
+		rendered, isGoPackage, err := prepareManifest(m)
+		if err != nil {
 			errs = append(errs, err.Error())
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			continue
+		}
+		if isGoPackage {
+			prepared = append(prepared, rendered)
 		}
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%d error(s) encountered", len(errs))
+	}
+	for _, rendered := range prepared {
+		if err := emitPreparedManifest(rendered, dryRun); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/code/programs/go/capability-cage-generator/main_test.go
+++ b/code/programs/go/capability-cage-generator/main_test.go
@@ -11,11 +11,74 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type taxonomyFixture struct {
+	Categories                    map[string][]string `json:"categories"`
+	AllActions                    []string            `json:"all_actions"`
+	ExpectedValidPairCount        int                 `json:"expected_valid_pair_count"`
+	ExpectedInvalidCrossPairCount int                 `json:"expected_invalid_cross_pair_count"`
+}
+
+func loadTaxonomyFixture(t *testing.T) taxonomyFixture {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "specs", "fixtures", "capability-security-v1", "taxonomy.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read shared taxonomy fixture: %v", err)
+	}
+	var fixture taxonomyFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("parse shared taxonomy fixture: %v", err)
+	}
+	return fixture
+}
+
+func containsAction(actions []string, wanted string) bool {
+	for _, action := range actions {
+		if action == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCapabilityTaxonomyMatchesSharedFixture(t *testing.T) {
+	fixture := loadTaxonomyFixture(t)
+	validCount := 0
+	invalidCount := 0
+	for category, allowed := range fixture.Categories {
+		for _, action := range fixture.AllActions {
+			want := containsAction(allowed, action)
+			if got := validCapabilityPair(category, action); got != want {
+				t.Errorf("validCapabilityPair(%q, %q) = %v, want %v", category, action, got, want)
+			}
+			if want {
+				validCount++
+			} else {
+				invalidCount++
+			}
+		}
+	}
+	if validCount != fixture.ExpectedValidPairCount {
+		t.Errorf("valid pair count = %d, want %d", validCount, fixture.ExpectedValidPairCount)
+	}
+	if invalidCount != fixture.ExpectedInvalidCrossPairCount {
+		t.Errorf("invalid cross-pair count = %d, want %d", invalidCount, fixture.ExpectedInvalidCrossPairCount)
+	}
+	if validCapabilityPair("filesystem", "read") {
+		t.Error("unknown category must fail closed")
+	}
+	if validCapabilityPair("fs", "destroy") {
+		t.Error("unknown action must fail closed")
+	}
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // scopeableCategory
@@ -648,7 +711,24 @@ func TestGenerateSource_WithEnvRead(t *testing.T) {
 	}
 }
 
-func TestGenerateSource_UnknownCapabilityEmitsTODO(t *testing.T) {
+func TestGenerateSource_InvalidCapabilityRejected(t *testing.T) {
+	tmp := t.TempDir()
+	mf := &manifestJSON{
+		Package: "go/future-pkg",
+		Capabilities: []capabilityJSON{
+			{Category: "fs", Action: "connect", Target: "libfoo.so"},
+		},
+	}
+	src, err := generateSource(filepath.Join(tmp, "required_capabilities.json"), mf)
+	if err == nil {
+		t.Fatal("expected invalid category/action pair to fail")
+	}
+	if src != "" {
+		t.Errorf("invalid pair generated source: %q", src)
+	}
+}
+
+func TestGenerateSource_RecognizedUnsupportedCapabilityRejected(t *testing.T) {
 	tmp := t.TempDir()
 	mf := &manifestJSON{
 		Package: "go/future-pkg",
@@ -657,12 +737,11 @@ func TestGenerateSource_UnknownCapabilityEmitsTODO(t *testing.T) {
 		},
 	}
 	src, err := generateSource(filepath.Join(tmp, "required_capabilities.json"), mf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected recognized but unsupported capability to fail closed")
 	}
-	// Unknown category:action should emit a TODO comment.
-	if !strings.Contains(src, "TODO") {
-		t.Error("expected TODO comment for unknown capability ffi:call")
+	if src != "" || strings.Contains(src, "TODO") {
+		t.Errorf("unsupported pair must not emit source or TODO: %q", src)
 	}
 }
 
@@ -902,6 +981,44 @@ func TestProcessManifest_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestProcessManifest_InvalidCapabilityPreservesExistingOutput(t *testing.T) {
+	tmp := t.TempDir()
+	manifestPath := filepath.Join(tmp, "required_capabilities.json")
+	outPath := filepath.Join(tmp, "gen_capabilities.go")
+	sentinel := []byte("package sentinel\n")
+
+	manifest := `{
+		"version": 1,
+		"package": "go/test-pkg",
+		"capabilities": [
+			{
+				"category": "fs",
+				"action": "connect",
+				"target": "*",
+				"justification": "Deliberately invalid cross-pair."
+			}
+		],
+		"justification": "Exercises fail-closed output handling."
+	}`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil { //nolint:cap
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(outPath, sentinel, 0o644); err != nil { //nolint:cap
+		t.Fatalf("write sentinel output: %v", err)
+	}
+
+	if err := processManifest(manifestPath, false); err == nil {
+		t.Fatal("expected invalid capability to fail")
+	}
+	got, err := os.ReadFile(outPath) //nolint:cap
+	if err != nil {
+		t.Fatalf("read sentinel output: %v", err)
+	}
+	if string(got) != string(sentinel) {
+		t.Fatalf("invalid manifest replaced existing output: %q", got)
+	}
+}
+
 func TestProcessManifest_MissingFile(t *testing.T) {
 	err := processManifest("/nonexistent/path/required_capabilities.json", false)
 	if err == nil {
@@ -958,6 +1075,53 @@ func TestProcessAll_ReturnsErrorOnBadManifest(t *testing.T) {
 	err := processAll(tmp, false)
 	if err == nil {
 		t.Error("expected error when manifest is invalid JSON")
+	}
+}
+
+func TestProcessAll_InvalidManifestPreservesEveryExistingOutput(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "code", "packages", "go")
+	sentinel := []byte("package sentinel\n")
+
+	for _, tc := range []struct {
+		name         string
+		capabilities string
+	}{
+		{"a-good", "[]"},
+		{"z-bad", `[{"category":"fs","action":"connect","target":"*","justification":"Invalid cross-pair."}]`},
+	} {
+		pkgDir := filepath.Join(root, tc.name)
+		if err := os.MkdirAll(pkgDir, 0o755); err != nil { //nolint:cap
+			t.Fatalf("create package directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "main.go"), []byte("package testpkg\n"), 0o644); err != nil { //nolint:cap
+			t.Fatalf("write package source: %v", err)
+		}
+		manifest := fmt.Sprintf(`{
+			"version": 1,
+			"package": "go/%s",
+			"capabilities": %s,
+			"justification": "Batch preflight fixture."
+		}`, tc.name, tc.capabilities)
+		if err := os.WriteFile(filepath.Join(pkgDir, "required_capabilities.json"), []byte(manifest), 0o644); err != nil { //nolint:cap
+			t.Fatalf("write manifest: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "gen_capabilities.go"), sentinel, 0o644); err != nil { //nolint:cap
+			t.Fatalf("write sentinel output: %v", err)
+		}
+	}
+
+	if err := processAll(tmp, false); err == nil {
+		t.Fatal("expected batch preflight to reject the invalid manifest")
+	}
+	for _, name := range []string{"a-good", "z-bad"} {
+		got, err := os.ReadFile(filepath.Join(root, name, "gen_capabilities.go")) //nolint:cap
+		if err != nil {
+			t.Fatalf("read %s sentinel output: %v", name, err)
+		}
+		if string(got) != string(sentinel) {
+			t.Fatalf("batch validation failure replaced %s output: %q", name, got)
+		}
 	}
 }
 

--- a/code/scripts/tests/test_capability_taxonomy.py
+++ b/code/scripts/tests/test_capability_taxonomy.py
@@ -1,0 +1,164 @@
+"""Conformance tests for the closed Spec 13 capability taxonomy."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_ROOT = REPO_ROOT / "code/specs/schemas"
+FIXTURE_PATH = (
+    REPO_ROOT / "code/specs/fixtures/capability-security-v1/taxonomy.json"
+)
+
+
+class CapabilityTaxonomyTest(unittest.TestCase):
+    """Keep both manifests on the same exhaustive category/action contract."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.taxonomy = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        cls.taxonomy_schema = cls.load_schema("capability_taxonomy.schema.json")
+        cls.manifest_schemas = {
+            "required": cls.load_schema("required_capabilities.schema.json"),
+            "agent": cls.load_schema("agent_manifest.schema.json"),
+        }
+
+    @staticmethod
+    def load_schema(name: str) -> dict[str, Any]:
+        schema = json.loads((SCHEMA_ROOT / name).read_text(encoding="utf-8"))
+        jsonschema.Draft202012Validator.check_schema(schema)
+        return schema
+
+    def test_taxonomy_fixture_is_schema_valid_and_closed(self) -> None:
+        jsonschema.Draft202012Validator(self.taxonomy_schema).validate(self.taxonomy)
+        categories = self.taxonomy["categories"]
+        actions = self.taxonomy["all_actions"]
+        valid_count = sum(len(allowed) for allowed in categories.values())
+        invalid_count = len(categories) * len(actions) - valid_count
+        self.assertEqual(19, valid_count)
+        self.assertEqual(93, invalid_count)
+        self.assertEqual(self.taxonomy["expected_valid_pair_count"], valid_count)
+        self.assertEqual(
+            self.taxonomy["expected_invalid_cross_pair_count"], invalid_count
+        )
+
+    def test_both_manifest_schemas_accept_all_19_valid_pairs(self) -> None:
+        for schema_name, schema in self.manifest_schemas.items():
+            validator = jsonschema.Draft202012Validator(schema)
+            for category, actions in self.taxonomy["categories"].items():
+                for action in actions:
+                    with self.subTest(
+                        schema=schema_name, category=category, action=action
+                    ):
+                        errors = list(
+                            validator.iter_errors(
+                                self.manifest(schema_name, category, action)
+                            )
+                        )
+                        self.assertEqual([], [error.message for error in errors])
+
+    def test_both_manifest_schemas_reject_all_93_invalid_cross_pairs(self) -> None:
+        for schema_name, schema in self.manifest_schemas.items():
+            validator = jsonschema.Draft202012Validator(schema)
+            for category, allowed in self.taxonomy["categories"].items():
+                for action in self.taxonomy["all_actions"]:
+                    if action in allowed:
+                        continue
+                    with self.subTest(
+                        schema=schema_name, category=category, action=action
+                    ):
+                        errors = list(
+                            validator.iter_errors(
+                                self.manifest(schema_name, category, action)
+                            )
+                        )
+                        self.assertTrue(errors, "invalid cross-pair must fail closed")
+
+    def test_both_manifest_schemas_reject_unknown_vocabulary(self) -> None:
+        for schema_name, schema in self.manifest_schemas.items():
+            validator = jsonschema.Draft202012Validator(schema)
+            for category, action in (("filesystem", "read"), ("fs", "destroy")):
+                with self.subTest(
+                    schema=schema_name, category=category, action=action
+                ):
+                    errors = list(
+                        validator.iter_errors(
+                            self.manifest(schema_name, category, action)
+                        )
+                    )
+                    self.assertTrue(errors, "unknown vocabulary must fail closed")
+
+    def test_repository_required_capabilities_use_only_valid_pairs(self) -> None:
+        known_categories = set(self.taxonomy["categories"])
+        known_actions = set(self.taxonomy["all_actions"])
+        allowed = {
+            (category, action)
+            for category, actions in self.taxonomy["categories"].items()
+            for action in actions
+        }
+        manifest_paths = sorted(REPO_ROOT.glob("code/**/required_capabilities.json"))
+        self.assertGreater(len(manifest_paths), 300)
+        for manifest_path in manifest_paths:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            # Some legacy build-dependency manifests use the same filename but
+            # contain a JSON array, or use a legacy string-list capability
+            # shape. They are not structured Spec 13 capability manifests.
+            if not isinstance(manifest, dict):
+                continue
+            # A separate legacy class contains package metadata objects with
+            # no capability declaration at all. Do not silently treat those
+            # objects as schema-v1 empty manifests.
+            if "capabilities" not in manifest:
+                continue
+            capabilities = manifest["capabilities"]
+            if not isinstance(capabilities, list) or any(
+                not isinstance(capability, dict) for capability in capabilities
+            ):
+                continue
+            for index, capability in enumerate(capabilities):
+                pair = (capability.get("category"), capability.get("action"))
+                # Legacy vocabulary is separately inventoried for migration.
+                # This regression gate proves there are no invalid cross-pairs
+                # among manifests already using the current vocabulary.
+                if pair[0] not in known_categories or pair[1] not in known_actions:
+                    continue
+                with self.subTest(
+                    manifest=manifest_path.relative_to(REPO_ROOT),
+                    capability=index,
+                    pair=pair,
+                ):
+                    self.assertIn(pair, allowed)
+
+    @staticmethod
+    def manifest(schema_name: str, category: str, action: str) -> dict[str, Any]:
+        capability = {
+            "category": category,
+            "action": action,
+            "target": "*",
+            "justification": "Exhaustive taxonomy conformance fixture.",
+        }
+        if schema_name == "required":
+            return {
+                "version": 1,
+                "package": "go/taxonomy-test",
+                "capabilities": [capability],
+                "justification": "Exercises one category and action pair.",
+            }
+        return {
+            "version": 1,
+            "agent": "taxonomy-test",
+            "description": "Exercises one capability taxonomy pair.",
+            "privilege_tier": 0,
+            "channels": {"reads": [], "writes": []},
+            "capabilities": [capability],
+            "justification": "Exercises one category and action pair.",
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/13-capability-security.md
+++ b/code/specs/13-capability-security.md
@@ -295,6 +295,33 @@ category:action:target
 to both standard output and standard error. Both streams therefore use
 `stdout:write:*`.
 
+#### Closed category/action contract
+
+Category and action are a pair, not two independent vocabularies. A manifest
+MUST use one of the 19 pairs in the table above. An action that is valid for a
+different category is still invalid; for example, `fs:connect`, `net:read`,
+and `stdout:read` MUST be rejected.
+
+The language-neutral fixture
+`code/specs/fixtures/capability-security-v1/taxonomy.json` is the executable
+form of this table. It lists the eight categories, the 14-action union, the 19
+allowed pairs, and the expected 93 invalid cross-pairs. Its schema is
+`code/specs/schemas/capability_taxonomy.schema.json`.
+
+Every manifest schema and every ingestion or enforcement boundary MUST:
+
+1. accept all 19 declared category/action pairs;
+2. reject all 93 other combinations drawn from the known category and action
+   vocabularies;
+3. reject unknown categories and unknown actions;
+4. reject the whole manifest before generation, analysis, or cage construction
+   rather than dropping, weakening, or converting an invalid declaration; and
+5. test its local pair table exhaustively against the shared fixture.
+
+The shared fixture is a conformance oracle, not a runtime dependency. Published
+packages embed the closed pair table so validation remains available without a
+repository checkout.
+
 ### Why This Granularity Matters
 
 Consider the difference between these two declarations:

--- a/code/specs/13-capability-security.md
+++ b/code/specs/13-capability-security.md
@@ -310,13 +310,20 @@ allowed pairs, and the expected 93 invalid cross-pairs. Its schema is
 
 Every manifest schema and every ingestion or enforcement boundary MUST:
 
-1. accept all 19 declared category/action pairs;
+1. recognize all 19 declared category/action pairs, with both manifest schemas
+   accepting all 19;
 2. reject all 93 other combinations drawn from the known category and action
    vocabularies;
 3. reject unknown categories and unknown actions;
 4. reject the whole manifest before generation, analysis, or cage construction
    rather than dropping, weakening, or converting an invalid declaration; and
 5. test its local pair table exhaustively against the shared fixture.
+
+An enforcement backend that cannot safely implement one of the 19 recognized
+pairs MUST return an explicit unsupported-capability error before replacing or
+emitting output. It MUST NOT emit an empty namespace, a TODO, or an unguarded
+operation. This permits capability-aware runtimes and analyzers to accept the
+whole taxonomy while allowing narrower code generators to fail closed.
 
 The shared fixture is a conformance oracle, not a runtime dependency. Published
 packages embed the closed pair table so validation remains available without a

--- a/code/specs/fixtures/capability-security-v1/taxonomy.json
+++ b/code/specs/fixtures/capability-security-v1/taxonomy.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/capability_taxonomy.schema.json",
+  "version": 1,
+  "categories": {
+    "fs": ["read", "write", "create", "delete", "list"],
+    "net": ["connect", "listen", "dns"],
+    "proc": ["exec", "fork", "signal"],
+    "env": ["read", "write"],
+    "ffi": ["call", "load"],
+    "time": ["read", "sleep"],
+    "stdin": ["read"],
+    "stdout": ["write"]
+  },
+  "all_actions": [
+    "read",
+    "write",
+    "create",
+    "delete",
+    "list",
+    "connect",
+    "listen",
+    "dns",
+    "exec",
+    "fork",
+    "signal",
+    "call",
+    "load",
+    "sleep"
+  ],
+  "expected_valid_pair_count": 19,
+  "expected_invalid_cross_pair_count": 93
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -806,7 +806,10 @@ TypeScript Haskell Cabal/Hspec templates to full canonical parity; and
 `scaffold-description-injection-hardening` closes structural delimiter
 injection across all generated metadata and source-comment contexts.
 `capability-schema-category-action-constraints` encodes the taxonomy's valid
-category-action pairs in both schemas and every enforcement backend.
+category-action pairs in both schemas and every enforcement backend. It is the
+current post-#9354 slice because this restriction-only contract is bounded,
+fully repository-owned, and directly unlocks the future OCaml analyzer,
+`adj-lang-cli` profile reconciliation, and native Matter controller review.
 
 Recommended family order:
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -811,6 +811,22 @@ current post-#9354 slice because this restriction-only contract is bounded,
 fully repository-owned, and directly unlocks the future OCaml analyzer,
 `adj-lang-cli` profile reconciliation, and native Matter controller review.
 
+The implementation audit also separated a legacy migration instead of
+silently forcing unlike files through the new schema. The tracked tree
+currently has 2,885 `required_capabilities.json` paths: 150 top-level
+dependency arrays, 82 metadata objects without a `capabilities` key, 164 object
+manifests with string-list capabilities, and 2,489 objects whose capability
+list is empty or contains structured entries. Of the last group, 2,316
+currently validate as schema-v1 manifests. The structured entries total 373:
+359 use valid current-vocabulary pairs and 14 use separately owned legacy
+vocabulary such as `hardware`, `audio`, `ffi:export`, `process:spawn`,
+`network:listen`, and `fs:read_write`; no current-vocabulary entry forms an
+invalid cross-pair. The pending
+`capability-manifest-legacy-shape-and-vocabulary-migration` item must classify
+those semantic owners before migration, must not reinterpret build-dependency
+arrays as security manifests, and must obtain Layer-5 review before changing
+any nonempty authority profile.
+
 Recommended family order:
 
 1. Leaf algorithms and data structures.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,24 +106,22 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 30, 2026 at `59155426c` after merged OCaml
-scaffolding and AR-2 conformance-contract work. It retains the new wave of
-Rust-only package families, including `smart-home-zigbee-integration` after
-`smart-home-mqtt-integration`, the Z-Wave host/integration, and earlier
-smart-home additions. It found zero
-canonical collisions or unknown language buckets:
+inventory was regenerated on July 31, 2026 at `b6d3c60b1` after merged OCaml
+toolchain work and the Rust `smart-home-matter-integration`. It contains 1,198
+normalized implementation identities across 4,340 established-lane package
+slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
 | Present in 10-15 languages | 172 | 277 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 747 | 10,458 |
+| Present in one language | 748 | 10,472 |
 
-The loop must not start by attempting 10,458 singleton ports. It should finish
+The loop must not start by attempting 10,472 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
-The July 30 lane audit is:
+The July 31 lane audit is:
 
 | Established lane | Packages present | High-consensus gaps | Rust/Python-core coverage |
 |---|---:|---:|---:|
@@ -139,7 +137,7 @@ The July 30 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 962 | 0 | 100% |
+| Rust | 963 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -845,11 +843,11 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 552 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 553 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30 inventories added twelve Rust singleton identities that now have
-explicit classification work in the loop state: `axiom-to-semantic-ir` is a
+The July 30-31 inventories added thirteen Rust singleton identities that now
+have explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
 `venture-browser-core` needs a portable-core versus native-boundary review.
@@ -866,6 +864,14 @@ discovery/topic/entity/value/payload transforms are candidates for a separately
 fixture-driven portable core. `venture-browser-macos` is an Apple-native
 AppKit/CoreText/Metal host whose expected classification is `native-source`,
 not a blind 14-lane port.
+
+The new `smart-home-matter-integration` is also a mixed split candidate rather
+than a native-source exception: endpoint projection, report normalization, and
+command planning are deterministic zero-capability logic, while D23 keeps the
+residual `SmartHomeRuntime` integration Rust-canonical. The backlog now tracks
+language-neutral fixtures and hardening for the portable core separately from a
+future controller host that owns mDNS, commissioning, certificates, PASE/CASE
+sessions, subscriptions, retries, Vault leases, and reviewed host capabilities.
 
 ### Likely portable Rust-led families
 
@@ -1144,8 +1150,9 @@ Bootstrap order:
    verify lock and package-receipt digests against a fresh solve; and run both
    generated scaffold kinds without skips. Hosted-runner image metadata is
    diagnostic evidence only and is not an immutable host-image attestation.
-   Ready-for-review PR #9354 is open; its contract, three fresh-solve, three
-   locked-fixture, repository CI, and CodeQL detection checks are green.
+   Complete in merged PR #9354. Final runs 30605415709, 30605415708,
+   30605413650, and 30605415829 prove the contract, three fresh solves, three
+   locked fixtures, repository builds, and CodeQL detection are green.
 4. Add OCaml discovery, opam/Dune dependency resolution, source hashing,
    opam-switch serialization, language detection, validator support, shard
    cost, and CI workflow markers to the canonical Go build tool. This begins

--- a/code/specs/schemas/agent_manifest.schema.json
+++ b/code/specs/schemas/agent_manifest.schema.json
@@ -138,7 +138,61 @@
           "minLength": 10,
           "description": "Human-readable explanation of why this specific capability is needed."
         }
-      }
+      },
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "category": { "const": "fs" },
+                "action": { "enum": ["read", "write", "create", "delete", "list"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "net" },
+                "action": { "enum": ["connect", "listen", "dns"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "proc" },
+                "action": { "enum": ["exec", "fork", "signal"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "env" },
+                "action": { "enum": ["read", "write"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "ffi" },
+                "action": { "enum": ["call", "load"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "time" },
+                "action": { "enum": ["read", "sleep"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "stdin" },
+                "action": { "const": "read" }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "stdout" },
+                "action": { "const": "write" }
+              }
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/code/specs/schemas/capability_taxonomy.schema.json
+++ b/code/specs/schemas/capability_taxonomy.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/capability_taxonomy.schema.json",
+  "title": "Capability Category/Action Taxonomy Fixture",
+  "description": "Closed language-neutral conformance data for Spec 13 capability category/action pairs.",
+  "type": "object",
+  "required": [
+    "$schema",
+    "version",
+    "categories",
+    "all_actions",
+    "expected_valid_pair_count",
+    "expected_invalid_cross_pair_count"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/capability_taxonomy.schema.json"
+    },
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "categories": {
+      "type": "object",
+      "required": ["fs", "net", "proc", "env", "ffi", "time", "stdin", "stdout"],
+      "additionalProperties": false,
+      "properties": {
+        "fs": {
+          "$ref": "#/$defs/actions"
+        },
+        "net": {
+          "$ref": "#/$defs/actions"
+        },
+        "proc": {
+          "$ref": "#/$defs/actions"
+        },
+        "env": {
+          "$ref": "#/$defs/actions"
+        },
+        "ffi": {
+          "$ref": "#/$defs/actions"
+        },
+        "time": {
+          "$ref": "#/$defs/actions"
+        },
+        "stdin": {
+          "$ref": "#/$defs/actions"
+        },
+        "stdout": {
+          "$ref": "#/$defs/actions"
+        }
+      }
+    },
+    "all_actions": {
+      "$ref": "#/$defs/actions"
+    },
+    "expected_valid_pair_count": {
+      "type": "integer",
+      "const": 19
+    },
+    "expected_invalid_cross_pair_count": {
+      "type": "integer",
+      "const": 93
+    }
+  },
+  "$defs": {
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "read",
+          "write",
+          "create",
+          "delete",
+          "list",
+          "connect",
+          "listen",
+          "dns",
+          "exec",
+          "fork",
+          "signal",
+          "call",
+          "load",
+          "sleep"
+        ]
+      }
+    }
+  }
+}

--- a/code/specs/schemas/required_capabilities.schema.json
+++ b/code/specs/schemas/required_capabilities.schema.json
@@ -73,7 +73,61 @@
           "minLength": 10,
           "description": "Human-readable explanation of WHY this specific capability is needed. Should be specific enough that a reviewer can evaluate whether the access is legitimate."
         }
-      }
+      },
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "category": { "const": "fs" },
+                "action": { "enum": ["read", "write", "create", "delete", "list"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "net" },
+                "action": { "enum": ["connect", "listen", "dns"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "proc" },
+                "action": { "enum": ["exec", "fork", "signal"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "env" },
+                "action": { "enum": ["read", "write"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "ffi" },
+                "action": { "enum": ["call", "load"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "time" },
+                "action": { "enum": ["read", "sleep"] }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "stdin" },
+                "action": { "const": "read" }
+              }
+            },
+            {
+              "properties": {
+                "category": { "const": "stdout" },
+                "action": { "const": "write" }
+              }
+            }
+          ]
+        }
+      ]
     },
     "banned_construct_exception": {
       "type": "object",


### PR DESCRIPTION
## Summary

- close Spec 13 around the exact 19 valid capability category/action pairs and 93 invalid cross-pairs
- constrain both capability JSON schemas with the same closed taxonomy
- add a language-neutral schema-validated fixture and exhaustive Python, Go, and Rust conformance tests
- fail closed in the Go generator, Go analyzer, Go cage constructor, and Rust cage ingestion boundary
- make generator `--all` preflight every manifest before any write, preventing partial regeneration
- wire all four implementation consumers directly into metadata CI so schema/fixture-only changes cannot skip conformance
- classify the 2,885 tracked `required_capabilities.json` files into dependency arrays, missing-key metadata, string-list legacy objects, and structured candidates; retain legacy migration as a separate reviewed backlog item

## Why

Spec 13 described category and action as separate closed enums, which allowed invalid cross-pairs such as `fs:connect` to pass schema validation and some runtime boundaries. This change makes the pair itself the capability identity and keeps every supported consumer on one exhaustive fixture. Recognized-but-unimplemented generator pairs now fail explicitly instead of emitting a TODO or weaker wrapper.

## Validation

- Python taxonomy/schema conformance: 5 tests; Ruff and Bandit clean
- Go generator: race tests, vet, 89.3% statement coverage
- Go capability analyzer: race tests, vet, 96.7% statement coverage
- Go capability cage: race tests, vet, 87.4% statement coverage
- Rust capability cage: fmt, clippy `-D warnings`, 67 tests
- Rust downstreams: operation-primitives (10), required-capabilities-compiler (3 unit + 1 CLI), smart-home-capability-cage (9), weather-agent-e2e (5 unit + 7 integration; 1 live HTTPS ignored)
- Go vulnerability scans: no reachable vulnerabilities in all three modules
- `cargo audit`: no vulnerabilities; existing allowed unmaintained warnings for `bare-metal` and `paste`
- package parity collision report: 15 lanes, 1,198 normalized implementation identities, 4,340 slots, 1,231 all-reported union, zero collisions, zero unknown buckets
- aggregate generator dry run: reports all 24 current unsupported/legacy Go inputs before emitting output; new sentinel test proves a later failure preserves every existing batch output
- YAML/JSON parsing, diff check, and secret scan clean
- build-tool dry run unchanged: 73 existing build-file gaps (12 Python, 3 Swift, 58 TypeScript)

## Known baseline evidence

`capability-os-sandbox` still has the pre-existing `macos_seatbelt_profile_limits_file_writes_to_manifest_targets` JSON lexer failure on Windows; it reproduces unchanged on current `main`, while its other five tests pass. This PR does not touch that package.
