### PR TITLE
feat(spice): validate MOS gate-drain overlap capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CGDO` values before
+  gate-drain overlap-capacitance stamping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CGSO` values before
   gate-source overlap-capacitance stamping.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -608,6 +608,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET CBD must be finite and non-negative")
         elif canonical == "CGSO" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET CGSO must be finite and non-negative")
+        elif canonical == "CGDO" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET CGDO must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1212,6 +1212,18 @@ def test_mos_model_card_rejects_negative_or_non_finite_gate_source_overlap_capac
             normalize_model_card("Minvalid", "nmos", {"CGSO": invalid_capacitance})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_gate_drain_overlap_capacitance() -> None:
+    for value in (0.0, 2.0e-10, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"CGDO": value})
+        assert valid.parameters["CGDO"] == pytest.approx(value)
+
+    for invalid_capacitance in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET CGDO must be finite and non-negative"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"CGDO": invalid_capacitance})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CGDO` values before
+  gate-drain overlap-capacitance stamping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CGSO` values before
   gate-source overlap-capacitance stamping.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4447,6 +4447,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET CGSO must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "CGDO" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET CGDO must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1075,6 +1075,22 @@ fn mos_model_card_rejects_negative_or_non_finite_gate_source_overlap_capacitance
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_gate_drain_overlap_capacitance() {
+    for value in [0.0, 2.0e-10, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("CGDO", value)]).unwrap();
+        assert_close(*valid.parameters.get("CGDO").unwrap(), value);
+    }
+
+    for invalid_capacitance in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("CGDO", invalid_capacitance)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET CGDO must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CGDO` values before
+  gate-drain overlap-capacitance stamping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CGSO` values before
   gate-source overlap-capacitance stamping.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8501,6 +8501,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0)
     ) {
       throw invalidElement(name, "MOSFET CGSO must be finite and non-negative");
+    } else if (
+      canonical === "CGDO" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET CGDO must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -983,6 +983,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS gate-drain overlap capacitance", () => {
+    for (const value of [0.0, 2.0e-10, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { CGDO: value });
+      expect(valid.parameters.CGDO).toBe(value);
+    }
+
+    for (const invalidCapacitance of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { CGDO: invalidCapacitance }),
+      ).toThrow("MOSFET CGDO must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS gate-source-overlap-capacitance validation.
+1. Cross-language Level-1 MOS gate-drain-overlap-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `CGSO` values before gate-source
+   - Reject negative or non-finite model-card `CGDO` values before gate-drain
      overlap-capacitance stamping.
-   - Preserve zero and positive gate-source overlap capacitances across Rust,
+   - Preserve zero and positive gate-drain overlap capacitances across Rust,
      Python, and TypeScript.
 
 ## Completed Slices
@@ -3762,6 +3762,13 @@ the Rust, Python, and TypeScript surfaces together.
      drain-bulk depletion-capacitance shaping.
    - Zero and positive drain-bulk capacitances remain aligned across Rust,
      Python, and TypeScript.
+
+312. Cross-language Level-1 MOS gate-source-overlap-capacitance validation.
+   - Status: completed in PR 9360.
+   - Negative and non-finite model-card `CGSO` values are rejected before
+     gate-source overlap-capacitance stamping.
+   - Zero and positive gate-source overlap capacitances remain aligned across
+     Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CGDO` values with a stable diagnostic
- preserve zero and positive gate-drain overlap capacitances across Rust, Python, and TypeScript
- reconcile the SPICE implementation plan after PR #9360

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `python -m ruff check src tests`
- `python -m pytest` (694 passed, 88.98% coverage)
- `npm test` (437 passed)
- `npm run build`