### PR TITLE
feat(smart-home): collect live Home Assistant exports

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -901,6 +901,7 @@ members = [
     "smart-home-zigbee-integration",
     "smart-home-matter-integration",
     "smart-home-home-assistant-migration",
+    "smart-home-home-assistant-export",
     "smart-home-integration-catalog",
     "smart-home-testkit",
     "hue-core",

--- a/code/packages/rust/smart-home-home-assistant-export/BUILD
+++ b/code/packages/rust/smart-home-home-assistant-export/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-home-assistant-export --all-targets -- --nocapture

--- a/code/packages/rust/smart-home-home-assistant-export/CHANGELOG.md
+++ b/code/packages/rust/smart-home-home-assistant-export/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Add authenticated Home Assistant WebSocket export collection.
+- Collect area, device, and entity registries plus current state.
+- Add deterministic normalization, synthetic entities for unregistered state,
+  atomic output, and an environment-token CLI.
+- Add protocol and process-level tests backed by a real local WebSocket server.

--- a/code/packages/rust/smart-home-home-assistant-export/Cargo.toml
+++ b/code/packages/rust/smart-home-home-assistant-export/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "smart-home-home-assistant-export"
+version = "0.1.0"
+edition = "2021"
+description = "Authenticated live Home Assistant export collection for smart-home migration"
+license = "MIT"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smart-home-home-assistant-migration = { path = "../smart-home-home-assistant-migration" }
+tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+
+[[bin]]
+name = "smart-home-export-home-assistant"
+path = "src/main.rs"

--- a/code/packages/rust/smart-home-home-assistant-export/README.md
+++ b/code/packages/rust/smart-home-home-assistant-export/README.md
@@ -1,0 +1,42 @@
+# smart-home-home-assistant-export
+
+`smart-home-home-assistant-export` collects live topology and current state from
+Home Assistant into the versioned export contract consumed by
+`smart-home-home-assistant-migration`.
+
+The collector connects to Home Assistant's `/api/websocket` endpoint,
+authenticates with a long-lived access token, and requests:
+
+- the area registry;
+- the device registry;
+- the entity registry;
+- all current states.
+
+Results are normalized into stable order. State records missing from the entity
+registry receive synthetic entity records so transient and integration-owned
+state is not silently dropped. Scene definitions, automation definitions, and
+history are not inferred from state-only data and remain explicit follow-up
+collection boundaries.
+
+The token is read from `HOME_ASSISTANT_TOKEN`; it is never accepted as a
+command-line argument or written to the export.
+
+```sh
+HOME_ASSISTANT_TOKEN='...' cargo run \
+  -p smart-home-home-assistant-export \
+  --bin smart-home-export-home-assistant -- \
+  wss://home.example/api/websocket \
+  my-home-instance \
+  home-assistant-export.json
+```
+
+Use `--exported-at-ms <timestamp>` when a reproducible source timestamp is
+required. Socket reads and writes time out after 30 seconds by default; use
+`--timeout-ms <milliseconds>` to set a different bound.
+
+## Validation
+
+```sh
+bash smart-home-home-assistant-export/BUILD
+cargo clippy -p smart-home-home-assistant-export --all-targets -- -D warnings
+```

--- a/code/packages/rust/smart-home-home-assistant-export/src/lib.rs
+++ b/code/packages/rust/smart-home-home-assistant-export/src/lib.rs
@@ -1,0 +1,732 @@
+//! Live Home Assistant export collection for the D23 migration boundary.
+
+#![forbid(unsafe_code)]
+
+use serde::Deserialize;
+use serde_json::{json, Value as JsonValue};
+use smart_home_home_assistant_migration::{
+    HomeAssistantArea, HomeAssistantAutomation, HomeAssistantDevice, HomeAssistantEntity,
+    HomeAssistantExport, HomeAssistantScene, HomeAssistantState, EXPORT_SCHEMA_VERSION,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{connect, Message, WebSocket};
+
+const AREA_REGISTRY_COMMAND: &str = "config/area_registry/list";
+const DEVICE_REGISTRY_COMMAND: &str = "config/device_registry/list";
+const ENTITY_REGISTRY_COMMAND: &str = "config/entity_registry/list";
+const STATES_COMMAND: &str = "get_states";
+const MAX_UNMATCHED_MESSAGES: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HomeAssistantCollectorConfig {
+    pub websocket_url: String,
+    pub access_token: String,
+    pub source_instance_id: String,
+    pub exported_at_ms: u64,
+    pub io_timeout: Duration,
+}
+
+impl HomeAssistantCollectorConfig {
+    pub fn validate(&self) -> Result<(), CollectorError> {
+        if !self.websocket_url.starts_with("ws://") && !self.websocket_url.starts_with("wss://") {
+            return Err(CollectorError::Config(
+                "Home Assistant URL must use ws:// or wss://".to_string(),
+            ));
+        }
+        if self.access_token.trim().is_empty() {
+            return Err(CollectorError::Config(
+                "Home Assistant access token is empty".to_string(),
+            ));
+        }
+        if self.source_instance_id.trim().is_empty() {
+            return Err(CollectorError::Config(
+                "source instance id is empty".to_string(),
+            ));
+        }
+        if self.io_timeout.is_zero() {
+            return Err(CollectorError::Config(
+                "I/O timeout must be greater than zero".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum CollectorError {
+    Config(String),
+    Transport(String),
+    Protocol(String),
+    Decode {
+        resource: &'static str,
+        message: String,
+    },
+    Encode(String),
+    Io {
+        operation: &'static str,
+        path: PathBuf,
+        message: String,
+    },
+    Usage(String),
+}
+
+impl CollectorError {
+    fn decode(resource: &'static str, error: serde_json::Error) -> Self {
+        Self::Decode {
+            resource,
+            message: error.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for CollectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Config(message) => write!(f, "invalid collector configuration: {message}"),
+            Self::Transport(message) => write!(f, "Home Assistant transport failed: {message}"),
+            Self::Protocol(message) => write!(f, "Home Assistant protocol failed: {message}"),
+            Self::Decode { resource, message } => {
+                write!(f, "invalid Home Assistant {resource} response: {message}")
+            }
+            Self::Encode(message) => write!(f, "could not encode Home Assistant export: {message}"),
+            Self::Io {
+                operation,
+                path,
+                message,
+            } => write!(f, "could not {operation} {}: {message}", path.display()),
+            Self::Usage(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for CollectorError {}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CollectionSummary {
+    pub areas: usize,
+    pub devices: usize,
+    pub entities: usize,
+    pub synthetic_entities: usize,
+    pub states: usize,
+}
+
+pub fn collect_export(
+    config: &HomeAssistantCollectorConfig,
+) -> Result<(HomeAssistantExport, CollectionSummary), CollectorError> {
+    config.validate()?;
+    let (mut socket, _) = connect(config.websocket_url.as_str()).map_err(|error| {
+        CollectorError::Transport(redact_transport_error(error.to_string(), config))
+    })?;
+    configure_socket_timeout(&mut socket, config.io_timeout)?;
+
+    authenticate(&mut socket, &config.access_token)?;
+
+    let raw_areas = request(&mut socket, 1, AREA_REGISTRY_COMMAND)?;
+    let raw_devices = request(&mut socket, 2, DEVICE_REGISTRY_COMMAND)?;
+    let raw_entities = request(&mut socket, 3, ENTITY_REGISTRY_COMMAND)?;
+    let raw_states = request(&mut socket, 4, STATES_COMMAND)?;
+
+    let mut areas = decode_areas(raw_areas)?;
+    let mut devices = decode_devices(raw_devices)?;
+    let mut entities = decode_entities(raw_entities)?;
+    let mut states = decode_states(raw_states)?;
+    let synthetic_entities = add_synthetic_entities(&mut entities, &states);
+
+    areas.sort_by(|left, right| left.area_id.cmp(&right.area_id));
+    devices.sort_by(|left, right| left.device_id.cmp(&right.device_id));
+    entities.sort_by(|left, right| left.entity_id.cmp(&right.entity_id));
+    states.sort_by(|left, right| left.entity_id.cmp(&right.entity_id));
+
+    ensure_unique(areas.iter().map(|item| item.area_id.as_str()), "area")?;
+    ensure_unique(devices.iter().map(|item| item.device_id.as_str()), "device")?;
+    ensure_unique(
+        entities.iter().map(|item| item.entity_id.as_str()),
+        "entity",
+    )?;
+    ensure_unique(states.iter().map(|item| item.entity_id.as_str()), "state")?;
+
+    let summary = CollectionSummary {
+        areas: areas.len(),
+        devices: devices.len(),
+        entities: entities.len(),
+        synthetic_entities,
+        states: states.len(),
+    };
+    let _ = socket.close(None);
+
+    Ok((
+        HomeAssistantExport {
+            schema_version: EXPORT_SCHEMA_VERSION,
+            source_instance_id: config.source_instance_id.clone(),
+            exported_at_ms: config.exported_at_ms,
+            areas,
+            devices,
+            entities,
+            states,
+            scenes: Vec::<HomeAssistantScene>::new(),
+            automations: Vec::<HomeAssistantAutomation>::new(),
+        },
+        summary,
+    ))
+}
+
+pub fn write_export_atomically(
+    path: impl AsRef<Path>,
+    export: &HomeAssistantExport,
+) -> Result<(), CollectorError> {
+    let path = path.as_ref();
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| CollectorError::Config("output path has no file name".to_string()))?;
+    let temporary = parent.join(format!(".{file_name}.tmp-{}", std::process::id()));
+    let mut encoded = serde_json::to_vec_pretty(export)
+        .map_err(|error| CollectorError::Encode(error.to_string()))?;
+    encoded.push(b'\n');
+
+    let result = (|| {
+        let mut file = File::create(&temporary).map_err(|error| CollectorError::Io {
+            operation: "create temporary export",
+            path: temporary.clone(),
+            message: error.to_string(),
+        })?;
+        file.write_all(&encoded)
+            .and_then(|()| file.sync_all())
+            .map_err(|error| CollectorError::Io {
+                operation: "write temporary export",
+                path: temporary.clone(),
+                message: error.to_string(),
+            })?;
+        fs::rename(&temporary, path).map_err(|error| CollectorError::Io {
+            operation: "replace export",
+            path: path.to_path_buf(),
+            message: error.to_string(),
+        })
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+type HomeAssistantSocket = WebSocket<MaybeTlsStream<TcpStream>>;
+
+fn configure_socket_timeout(
+    socket: &mut HomeAssistantSocket,
+    timeout: Duration,
+) -> Result<(), CollectorError> {
+    let stream = match socket.get_mut() {
+        MaybeTlsStream::Plain(stream) => stream,
+        MaybeTlsStream::Rustls(stream) => &mut stream.sock,
+        _ => {
+            return Err(CollectorError::Transport(
+                "unsupported WebSocket stream backend".to_string(),
+            ));
+        }
+    };
+    stream
+        .set_read_timeout(Some(timeout))
+        .and_then(|()| stream.set_write_timeout(Some(timeout)))
+        .map_err(|error| CollectorError::Transport(error.to_string()))
+}
+
+fn authenticate(
+    socket: &mut HomeAssistantSocket,
+    access_token: &str,
+) -> Result<(), CollectorError> {
+    let required = read_json(socket)?;
+    if required.get("type").and_then(JsonValue::as_str) != Some("auth_required") {
+        return Err(CollectorError::Protocol(
+            "server did not begin with auth_required".to_string(),
+        ));
+    }
+
+    send_json(
+        socket,
+        &json!({"type": "auth", "access_token": access_token}),
+    )?;
+    let response = read_json(socket)?;
+    match response.get("type").and_then(JsonValue::as_str) {
+        Some("auth_ok") => Ok(()),
+        Some("auth_invalid") => Err(CollectorError::Protocol(
+            "Home Assistant rejected the access token".to_string(),
+        )),
+        _ => Err(CollectorError::Protocol(
+            "server returned an unexpected authentication response".to_string(),
+        )),
+    }
+}
+
+fn request(
+    socket: &mut HomeAssistantSocket,
+    id: u64,
+    command: &'static str,
+) -> Result<JsonValue, CollectorError> {
+    send_json(socket, &json!({"id": id, "type": command}))?;
+    for _ in 0..MAX_UNMATCHED_MESSAGES {
+        let response = read_json(socket)?;
+        if response.get("id").and_then(JsonValue::as_u64) != Some(id) {
+            continue;
+        }
+        if response.get("type").and_then(JsonValue::as_str) != Some("result") {
+            return Err(CollectorError::Protocol(format!(
+                "{command} returned a non-result response"
+            )));
+        }
+        if response.get("success").and_then(JsonValue::as_bool) != Some(true) {
+            let code = response
+                .pointer("/error/code")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("unknown_error");
+            return Err(CollectorError::Protocol(format!(
+                "{command} failed with {code}"
+            )));
+        }
+        return response.get("result").cloned().ok_or_else(|| {
+            CollectorError::Protocol(format!("{command} returned no result payload"))
+        });
+    }
+    Err(CollectorError::Protocol(format!(
+        "{command} did not return a matching response"
+    )))
+}
+
+fn send_json(socket: &mut HomeAssistantSocket, value: &JsonValue) -> Result<(), CollectorError> {
+    socket
+        .send(Message::Text(value.to_string().into()))
+        .map_err(|error| CollectorError::Transport(error.to_string()))
+}
+
+fn read_json(socket: &mut HomeAssistantSocket) -> Result<JsonValue, CollectorError> {
+    loop {
+        let message = socket
+            .read()
+            .map_err(|error| CollectorError::Transport(error.to_string()))?;
+        match message {
+            Message::Text(text) => {
+                return serde_json::from_str(text.as_ref())
+                    .map_err(|error| CollectorError::decode("protocol", error));
+            }
+            Message::Close(_) => {
+                return Err(CollectorError::Protocol(
+                    "connection closed before collection completed".to_string(),
+                ));
+            }
+            Message::Binary(_) => {
+                return Err(CollectorError::Protocol(
+                    "server returned an unexpected binary message".to_string(),
+                ));
+            }
+            Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
+        }
+    }
+}
+
+fn redact_transport_error(mut message: String, config: &HomeAssistantCollectorConfig) -> String {
+    if !config.access_token.is_empty() {
+        message = message.replace(&config.access_token, "[redacted]");
+    }
+    message
+}
+
+#[derive(Debug, Deserialize)]
+struct RawArea {
+    area_id: String,
+    name: String,
+    #[serde(default)]
+    aliases: Vec<String>,
+}
+
+fn decode_areas(value: JsonValue) -> Result<Vec<HomeAssistantArea>, CollectorError> {
+    let raw: Vec<RawArea> = serde_json::from_value(value)
+        .map_err(|error| CollectorError::decode("area registry", error))?;
+    Ok(raw
+        .into_iter()
+        .map(|area| HomeAssistantArea {
+            area_id: area.area_id,
+            name: area.name,
+            aliases: area.aliases,
+        })
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct RawDevice {
+    #[serde(rename = "id")]
+    device_id: String,
+    #[serde(default)]
+    area_id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    name_by_user: Option<String>,
+    #[serde(default)]
+    manufacturer: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    serial_number: Option<String>,
+    #[serde(default)]
+    sw_version: Option<String>,
+    #[serde(default)]
+    identifiers: Vec<(String, String)>,
+}
+
+fn decode_devices(value: JsonValue) -> Result<Vec<HomeAssistantDevice>, CollectorError> {
+    let raw: Vec<RawDevice> = serde_json::from_value(value)
+        .map_err(|error| CollectorError::decode("device registry", error))?;
+    Ok(raw
+        .into_iter()
+        .map(|device| HomeAssistantDevice {
+            device_id: device.device_id,
+            area_id: device.area_id,
+            name: device.name,
+            name_by_user: device.name_by_user,
+            manufacturer: device.manufacturer,
+            model: device.model,
+            serial_number: device.serial_number,
+            sw_version: device.sw_version,
+            identifiers: device.identifiers,
+        })
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct RawEntity {
+    entity_id: String,
+    #[serde(default)]
+    device_id: Option<String>,
+    #[serde(default)]
+    area_id: Option<String>,
+    platform: String,
+    #[serde(default)]
+    unique_id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    original_name: Option<String>,
+    #[serde(default)]
+    disabled_by: Option<String>,
+}
+
+fn decode_entities(value: JsonValue) -> Result<Vec<HomeAssistantEntity>, CollectorError> {
+    let raw: Vec<RawEntity> = serde_json::from_value(value)
+        .map_err(|error| CollectorError::decode("entity registry", error))?;
+    Ok(raw
+        .into_iter()
+        .map(|entity| HomeAssistantEntity {
+            unique_id: entity.unique_id.unwrap_or_else(|| entity.entity_id.clone()),
+            entity_id: entity.entity_id,
+            device_id: entity.device_id,
+            area_id: entity.area_id,
+            platform: entity.platform,
+            name: entity.name,
+            original_name: entity.original_name,
+            disabled_by: entity.disabled_by,
+        })
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct RawState {
+    entity_id: String,
+    state: String,
+    #[serde(default)]
+    attributes: BTreeMap<String, JsonValue>,
+}
+
+fn decode_states(value: JsonValue) -> Result<Vec<HomeAssistantState>, CollectorError> {
+    let raw: Vec<RawState> =
+        serde_json::from_value(value).map_err(|error| CollectorError::decode("states", error))?;
+    Ok(raw
+        .into_iter()
+        .map(|state| HomeAssistantState {
+            entity_id: state.entity_id,
+            state: state.state,
+            attributes: state.attributes,
+        })
+        .collect())
+}
+
+fn add_synthetic_entities(
+    entities: &mut Vec<HomeAssistantEntity>,
+    states: &[HomeAssistantState],
+) -> usize {
+    let mut known = entities
+        .iter()
+        .map(|entity| entity.entity_id.clone())
+        .collect::<BTreeSet<_>>();
+    let mut added = 0;
+    for state in states {
+        if known.insert(state.entity_id.clone()) {
+            let platform = state
+                .entity_id
+                .split_once('.')
+                .map_or("unknown", |(domain, _)| domain);
+            let name = state
+                .attributes
+                .get("friendly_name")
+                .and_then(JsonValue::as_str)
+                .map(str::to_string);
+            entities.push(HomeAssistantEntity {
+                entity_id: state.entity_id.clone(),
+                device_id: None,
+                area_id: None,
+                platform: platform.to_string(),
+                unique_id: state.entity_id.clone(),
+                name,
+                original_name: None,
+                disabled_by: None,
+            });
+            added += 1;
+        }
+    }
+    added
+}
+
+fn ensure_unique<'a>(
+    values: impl IntoIterator<Item = &'a str>,
+    resource: &str,
+) -> Result<(), CollectorError> {
+    let mut seen = BTreeSet::new();
+    for value in values {
+        if !seen.insert(value) {
+            return Err(CollectorError::Protocol(format!(
+                "Home Assistant returned duplicate {resource} id {value}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub fn remove_file_if_exists(path: impl AsRef<Path>) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::thread;
+    use tungstenite::accept;
+
+    fn fixture_server(
+        auth_ok: bool,
+        command_failure: Option<&'static str>,
+    ) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fixture");
+        let address = listener.local_addr().expect("fixture address");
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept fixture");
+            let mut socket = accept(stream).expect("upgrade fixture");
+            socket
+                .send(Message::Text(
+                    json!({"type": "auth_required", "ha_version": "2026.7"})
+                        .to_string()
+                        .into(),
+                ))
+                .expect("send auth required");
+            let auth = read_fixture_json(&mut socket);
+            assert_eq!(auth["type"], "auth");
+            assert_eq!(auth["access_token"], "secret-token");
+            if !auth_ok {
+                socket
+                    .send(Message::Text(
+                        json!({"type": "auth_invalid", "message": "invalid"})
+                            .to_string()
+                            .into(),
+                    ))
+                    .expect("send auth invalid");
+                return;
+            }
+            socket
+                .send(Message::Text(
+                    json!({"type": "auth_ok", "ha_version": "2026.7"})
+                        .to_string()
+                        .into(),
+                ))
+                .expect("send auth ok");
+
+            let fixtures = [
+                (
+                    AREA_REGISTRY_COMMAND,
+                    json!([{"area_id": "kitchen", "name": "Kitchen", "aliases": ["Galley"]}]),
+                ),
+                (
+                    DEVICE_REGISTRY_COMMAND,
+                    json!([{
+                        "id": "device-1",
+                        "area_id": "kitchen",
+                        "name": "Kitchen Lamp",
+                        "manufacturer": "Example",
+                        "model": "L1",
+                        "identifiers": [["demo", "lamp-1"]]
+                    }]),
+                ),
+                (
+                    ENTITY_REGISTRY_COMMAND,
+                    json!([{
+                        "entity_id": "light.kitchen",
+                        "device_id": "device-1",
+                        "area_id": null,
+                        "platform": "demo",
+                        "unique_id": "lamp-1",
+                        "original_name": "Lamp"
+                    }]),
+                ),
+                (
+                    STATES_COMMAND,
+                    json!([
+                        {
+                            "entity_id": "light.kitchen",
+                            "state": "on",
+                            "attributes": {"brightness": 127}
+                        },
+                        {
+                            "entity_id": "sensor.unregistered",
+                            "state": "21.5",
+                            "attributes": {"friendly_name": "Room temperature"}
+                        }
+                    ]),
+                ),
+            ];
+
+            for (index, (command, result)) in fixtures.into_iter().enumerate() {
+                let request = read_fixture_json(&mut socket);
+                assert_eq!(request["id"], (index + 1) as u64);
+                assert_eq!(request["type"], command);
+                let response = if command_failure == Some(command) {
+                    json!({
+                        "id": index + 1,
+                        "type": "result",
+                        "success": false,
+                        "error": {"code": "unauthorized", "message": "denied"}
+                    })
+                } else {
+                    json!({
+                        "id": index + 1,
+                        "type": "result",
+                        "success": true,
+                        "result": result
+                    })
+                };
+                socket
+                    .send(Message::Text(response.to_string().into()))
+                    .expect("send fixture result");
+                if command_failure == Some(command) {
+                    return;
+                }
+            }
+        });
+        (format!("ws://{address}/api/websocket"), handle)
+    }
+
+    fn read_fixture_json<S: io::Read + io::Write>(socket: &mut WebSocket<S>) -> JsonValue {
+        let message = socket.read().expect("read fixture request");
+        serde_json::from_str(message.to_text().expect("text fixture request"))
+            .expect("fixture request JSON")
+    }
+
+    fn config(url: String) -> HomeAssistantCollectorConfig {
+        HomeAssistantCollectorConfig {
+            websocket_url: url,
+            access_token: "secret-token".to_string(),
+            source_instance_id: "home-1".to_string(),
+            exported_at_ms: 1_722_000_000_000,
+            io_timeout: Duration::from_secs(2),
+        }
+    }
+
+    #[test]
+    fn collects_registry_and_state_export_over_websocket() {
+        let (url, server) = fixture_server(true, None);
+        let (export, summary) = collect_export(&config(url)).expect("collect export");
+        server.join().expect("fixture server");
+
+        assert_eq!(export.schema_version, EXPORT_SCHEMA_VERSION);
+        assert_eq!(export.source_instance_id, "home-1");
+        assert_eq!(export.areas[0].area_id, "kitchen");
+        assert_eq!(export.devices[0].identifiers[0].1, "lamp-1");
+        assert_eq!(export.entities.len(), 2);
+        assert_eq!(export.entities[1].entity_id, "sensor.unregistered");
+        assert_eq!(export.entities[1].name.as_deref(), Some("Room temperature"));
+        assert_eq!(export.states.len(), 2);
+        assert!(export.scenes.is_empty());
+        assert!(export.automations.is_empty());
+        assert_eq!(
+            summary,
+            CollectionSummary {
+                areas: 1,
+                devices: 1,
+                entities: 2,
+                synthetic_entities: 1,
+                states: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_auth_without_echoing_token() {
+        let (url, server) = fixture_server(false, None);
+        let error = collect_export(&config(url)).expect_err("auth should fail");
+        server.join().expect("fixture server");
+
+        let message = error.to_string();
+        assert!(message.contains("rejected"));
+        assert!(!message.contains("secret-token"));
+    }
+
+    #[test]
+    fn reports_failed_registry_command() {
+        let (url, server) = fixture_server(true, Some(DEVICE_REGISTRY_COMMAND));
+        let error = collect_export(&config(url)).expect_err("command should fail");
+        server.join().expect("fixture server");
+
+        assert!(error.to_string().contains(DEVICE_REGISTRY_COMMAND));
+        assert!(error.to_string().contains("unauthorized"));
+    }
+
+    #[test]
+    fn writes_export_atomically() {
+        let directory =
+            std::env::temp_dir().join(format!("smart-home-ha-export-test-{}", std::process::id()));
+        fs::create_dir_all(&directory).expect("create test directory");
+        let output = directory.join("export.json");
+        let export = HomeAssistantExport {
+            schema_version: EXPORT_SCHEMA_VERSION,
+            source_instance_id: "home-1".to_string(),
+            exported_at_ms: 10,
+            areas: vec![],
+            devices: vec![],
+            entities: vec![],
+            states: vec![],
+            scenes: vec![],
+            automations: vec![],
+        };
+
+        write_export_atomically(&output, &export).expect("write export");
+        let decoded: HomeAssistantExport =
+            serde_json::from_slice(&fs::read(&output).expect("read export"))
+                .expect("decode export");
+        assert_eq!(decoded, export);
+        assert!(!directory
+            .join(format!(".export.json.tmp-{}", std::process::id()))
+            .exists());
+
+        remove_file_if_exists(&output).expect("remove output");
+        fs::remove_dir(directory).expect("remove directory");
+    }
+}

--- a/code/packages/rust/smart-home-home-assistant-export/src/main.rs
+++ b/code/packages/rust/smart-home-home-assistant-export/src/main.rs
@@ -1,0 +1,79 @@
+use smart_home_home_assistant_export::{
+    collect_export, write_export_atomically, CollectorError, HomeAssistantCollectorConfig,
+};
+use std::env;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("Home Assistant export failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), CollectorError> {
+    let mut positional = Vec::new();
+    let mut exported_at_ms = None;
+    let mut timeout_ms = 30_000;
+    let mut arguments = env::args().skip(1);
+    while let Some(argument) = arguments.next() {
+        if argument == "--exported-at-ms" {
+            let value = arguments.next().ok_or_else(usage)?;
+            exported_at_ms = Some(value.parse::<u64>().map_err(|_| {
+                CollectorError::Usage("--exported-at-ms must be an unsigned integer".to_string())
+            })?);
+        } else if argument == "--timeout-ms" {
+            let value = arguments.next().ok_or_else(usage)?;
+            timeout_ms = value.parse::<u64>().map_err(|_| {
+                CollectorError::Usage("--timeout-ms must be an unsigned integer".to_string())
+            })?;
+        } else {
+            positional.push(argument);
+        }
+    }
+    if positional.len() != 3 {
+        return Err(usage());
+    }
+
+    let access_token = env::var("HOME_ASSISTANT_TOKEN")
+        .map_err(|_| CollectorError::Usage("HOME_ASSISTANT_TOKEN must be set".to_string()))?;
+    let config = HomeAssistantCollectorConfig {
+        websocket_url: positional[0].clone(),
+        access_token,
+        source_instance_id: positional[1].clone(),
+        exported_at_ms: exported_at_ms.unwrap_or(system_time_ms()?),
+        io_timeout: Duration::from_millis(timeout_ms),
+    };
+    let output_path = PathBuf::from(&positional[2]);
+    let (export, summary) = collect_export(&config)?;
+    write_export_atomically(&output_path, &export)?;
+    println!(
+        "collected Home Assistant export {} with {} areas, {} devices, {} entities ({} synthetic), and {} states",
+        output_path.display(),
+        summary.areas,
+        summary.devices,
+        summary.entities,
+        summary.synthetic_entities,
+        summary.states,
+    );
+    Ok(())
+}
+
+fn system_time_ms() -> Result<u64, CollectorError> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| {
+            CollectorError::Config(format!("system clock is before epoch: {error}"))
+        })?;
+    u64::try_from(duration.as_millis()).map_err(|_| {
+        CollectorError::Config("system time does not fit u64 milliseconds".to_string())
+    })
+}
+
+fn usage() -> CollectorError {
+    CollectorError::Usage(
+        "usage: smart-home-export-home-assistant <ws-url> <source-instance-id> <export.json> [--exported-at-ms <timestamp>] [--timeout-ms <milliseconds>]"
+            .to_string(),
+    )
+}

--- a/code/packages/rust/smart-home-home-assistant-export/tests/collector_cli.rs
+++ b/code/packages/rust/smart-home-home-assistant-export/tests/collector_cli.rs
@@ -1,0 +1,105 @@
+use serde_json::{json, Value as JsonValue};
+use smart_home_home_assistant_migration::{plan_export, HomeAssistantExport};
+use std::fs;
+use std::net::TcpListener;
+use std::process::Command;
+use std::thread;
+use tungstenite::{accept, Message};
+
+#[test]
+fn cli_collects_live_export_and_writes_artifact() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fixture");
+    let address = listener.local_addr().expect("fixture address");
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept fixture");
+        let mut socket = accept(stream).expect("upgrade fixture");
+        send(&mut socket, json!({"type": "auth_required"}));
+        let auth = read(&mut socket);
+        assert_eq!(auth["access_token"], "process-secret");
+        send(&mut socket, json!({"type": "auth_ok"}));
+
+        let results = [
+            json!([{"area_id": "office", "name": "Office"}]),
+            json!([{"id": "device-1", "name": "Desk Lamp"}]),
+            json!([{
+                "entity_id": "light.desk",
+                "device_id": "device-1",
+                "platform": "demo",
+                "unique_id": "desk-1"
+            }]),
+            json!([{
+                "entity_id": "light.desk",
+                "state": "off",
+                "attributes": {"friendly_name": "Desk Lamp"}
+            }]),
+        ];
+        for (index, result) in results.into_iter().enumerate() {
+            let request = read(&mut socket);
+            assert_eq!(request["id"], (index + 1) as u64);
+            send(
+                &mut socket,
+                json!({
+                    "id": index + 1,
+                    "type": "result",
+                    "success": true,
+                    "result": result
+                }),
+            );
+        }
+    });
+
+    let directory =
+        std::env::temp_dir().join(format!("smart-home-ha-export-cli-{}", std::process::id()));
+    fs::create_dir_all(&directory).expect("create output directory");
+    let output = directory.join("export.json");
+    let command = Command::new(env!("CARGO_BIN_EXE_smart-home-export-home-assistant"))
+        .arg(format!("ws://{address}/api/websocket"))
+        .arg("process-home")
+        .arg(&output)
+        .arg("--exported-at-ms")
+        .arg("1722000000000")
+        .arg("--timeout-ms")
+        .arg("2000")
+        .env("HOME_ASSISTANT_TOKEN", "process-secret")
+        .output()
+        .expect("run collector CLI");
+    server.join().expect("fixture server");
+
+    assert!(
+        command.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&command.stderr)
+    );
+    assert!(String::from_utf8_lossy(&command.stdout).contains("1 areas"));
+    let export: HomeAssistantExport =
+        serde_json::from_slice(&fs::read(&output).expect("read export")).expect("decode export");
+    assert_eq!(export.source_instance_id, "process-home");
+    assert_eq!(export.exported_at_ms, 1_722_000_000_000);
+    assert_eq!(export.devices[0].device_id, "device-1");
+    assert_eq!(export.entities[0].entity_id, "light.desk");
+    assert_eq!(export.states[0].state, "off");
+    let plan = plan_export(&export).expect("plan collected export");
+    assert!(!plan.is_blocked());
+    assert_eq!(plan.summary.devices, 1);
+    assert_eq!(plan.summary.entities, 1);
+    assert_eq!(plan.summary.states, 1);
+    assert!(!String::from_utf8_lossy(&command.stdout).contains("process-secret"));
+    assert!(!String::from_utf8_lossy(&command.stderr).contains("process-secret"));
+
+    fs::remove_file(output).expect("remove export");
+    fs::remove_dir(directory).expect("remove output directory");
+}
+
+fn send<S: std::io::Read + std::io::Write>(
+    socket: &mut tungstenite::WebSocket<S>,
+    value: JsonValue,
+) {
+    socket
+        .send(Message::Text(value.to_string().into()))
+        .expect("send fixture response");
+}
+
+fn read<S: std::io::Read + std::io::Write>(socket: &mut tungstenite::WebSocket<S>) -> JsonValue {
+    let message = socket.read().expect("read fixture request");
+    serde_json::from_str(message.to_text().expect("fixture text")).expect("fixture JSON")
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -547,6 +547,28 @@ Assistant without silently changing behavior:
   runs, scene and automation mapping, blocking diagnostics, repeat apply, and
   artifact round trips.
 
+## Current Home Assistant Live Export Slice
+
+This slice connects a running Home Assistant instance to the review-first
+migration boundary:
+
+- `smart-home-home-assistant-export` opens Home Assistant's WebSocket API,
+  performs the `auth_required` / token / `auth_ok` handshake, and keeps the
+  long-lived access token out of arguments, artifacts, and error output.
+- The collector requests the area, device, and entity registries plus all
+  current states, then projects the responses into the versioned migration
+  export contract in deterministic identifier order.
+- State records absent from the entity registry receive explicit synthetic
+  entity records instead of being silently discarded. Duplicate identifiers,
+  failed commands, malformed payloads, and premature disconnects fail the
+  collection.
+- The CLI performs atomic output replacement. Protocol tests use a real local
+  WebSocket server to prove authentication, command ordering, normalization,
+  failed authorization, and token redaction.
+- Scene and automation definitions and historical state are not inferred from
+  registry/current-state payloads; their live collection remains explicit
+  follow-up work.
+
 ## Smart Home Remaining Work
 
 These items move toward retiring an existing Home Assistant install:
@@ -556,9 +578,10 @@ These items move toward retiring an existing Home Assistant install:
   Matter commissioning/secure-session/network host, a Thread border-router
   host, a production Zigbee coordinator/join/security host, and production
   Z-Wave inclusion and S2.
-- Extend the completed Home Assistant topology, current-state, scene, and
-  automation importer with live export collection, dashboard migration, and
-  historical state export where feasible.
+- Extend the completed Home Assistant live topology/current-state collection
+  and topology/current-state/scene/automation importer with live scene and
+  automation definition collection, dashboard migration, and historical state
+  export where feasible.
 - Provide a dashboard that can inspect devices, rooms, state, health,
   automations, event history, pairing, and command audit.
 


### PR DESCRIPTION
## Summary
- add an authenticated Home Assistant WebSocket collector for area, device, and entity registries plus current state
- normalize deterministic migration exports, synthesize missing entity records, bound socket I/O, and keep tokens environment-only
- add atomic CLI output and real WebSocket protocol/process tests that feed the collected artifact into the migration planner
- update the D18-D23 completion inventory with the completed live export boundary

## Validation
- `bash smart-home-home-assistant-export/BUILD` (4 unit tests + 1 process test)
- `cargo clippy -p smart-home-home-assistant-export --all-targets -- -D warnings`
- `bash smart-home-home-assistant-migration/BUILD` (7 unit tests + 1 process test)

`code/packages/rust/Cargo.lock` was removed after validation.