### PR TITLE
fix(mosaic): activate native XAML focus states

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased] — VC2-xaml Grid: WinUI value translation + nested-For + per-column widths
 
+### Added - Native activation for MSL focused states
+
+WinUI output now connects UI15's built-in `state focused` blocks on native
+focus-capable Host controls to `Control.FocusState` through a generated
+`IValueConverter`. Pointer, keyboard, and programmatic focus activate the
+shared MSL properties and transitions; DataTemplate instances remain
+row-local, and explicit `state-when-focused` predicates remain
+author-controlled. A Task App acceptance gate proves its Mosaic-authored
+project-composer focus ring reaches the generated TextBox without handwritten
+Windows UI.
+
 ### Added - Native activation for MSL hover states
 
 WinUI output now activates UI15's built-in `state hover` blocks on Mosaic

--- a/code/packages/rust/mosaic-emit-xaml/README.md
+++ b/code/packages/rust/mosaic-emit-xaml/README.md
@@ -57,6 +57,14 @@ namescope, so hovering one repeated row does not restyle its siblings. An
 explicit `state-when-hover` still wins when hover-like styling is intentionally
 driven by application state instead of the pointer.
 
+UI15's built-in `state focused` is also native for focus-capable Host controls
+(`HostInput`, `HostNumberInput`, `HostButton`, `HostCheckbox`, `HostRadio`,
+and `HostLink`). The emitter binds WinUI's `FocusState` through one generated
+converter resource, so pointer, keyboard, and programmatic focus activate the
+same shared MSL properties and transitions. Repeated controls keep their
+VisualStates in the DataTemplate namescope. An explicit
+`state-when-focused` remains application-controlled.
+
 Named CSS curves lower to native WinUI easing functions. Arbitrary
 `cubic-bezier(...)` curves currently use `CubicEase`; exact control points
 require a future Windows Composition lowering. Template-local predicates are

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -92,8 +92,8 @@ pub struct XamlEmitResult {
     /// PR-2.
     pub for_view_models: Vec<EmittedFile>,
 
-    /// One entry per `If` whose expression is not `{x:Bind}`-able â€” the
-    /// computed-property helper C# source.
+    /// Generated C# helper sources used by component resources, including
+    /// visibility and native-focus value converters.
     ///
     /// PR-1 always returns an empty `Vec`; `If` lowering lands with
     /// PR-2.
@@ -456,6 +456,12 @@ pub fn from_pipeline(
             source: emit_bool_to_vis_converter_source(&options.namespace),
         });
     }
+    if ctx.needs_focus_state_converter {
+        if_helpers.push(EmittedFile {
+            filename: "FocusStateToBoolConverter.cs".to_string(),
+            source: emit_focus_state_to_bool_converter_source(&options.namespace),
+        });
+    }
 
     // Fix B1: when --emit-project is on, populate the full project
     // shell (csproj + App + MainWindow + manifest + build.ps1 + README).
@@ -617,6 +623,10 @@ struct EmitContext<'a> {
     /// emitter writes a `BoolToVisibilityConverter` resource into the
     /// `<UserControl.Resources>` block.
     needs_bool_to_vis: bool,
+    /// Tracks whether a focus-capable Host control consumes UI15's built-in
+    /// `state focused`. The emitter writes a `FocusStateToBoolConverter`
+    /// resource and ships its C# helper alongside the component triple.
+    needs_focus_state_converter: bool,
     /// One `RowVm` per `For` block in the component. Becomes
     /// `XamlEmitResult::for_view_models`.
     row_vms: Vec<RowVm>,
@@ -689,6 +699,7 @@ impl<'a> EmitContext<'a> {
             for_scope: Vec::new(),
             helpers: Vec::new(),
             needs_bool_to_vis: false,
+            needs_focus_state_converter: false,
             row_vms: Vec::new(),
             row_projections: Vec::new(),
             host_handlers: Vec::new(),
@@ -861,6 +872,13 @@ fn button_base_supports_automatic_hover(xaml_tag: &str) -> bool {
     )
 }
 
+fn control_supports_automatic_focus(xaml_tag: &str) -> bool {
+    matches!(
+        xaml_tag,
+        "TextBox" | "NumberBox" | "Button" | "CheckBox" | "RadioButton" | "HyperlinkButton"
+    )
+}
+
 /// Register MSL state overrides for one native WinUI control.
 ///
 /// Each property gets its own VisualStateGroup. This is deliberate:
@@ -898,6 +916,18 @@ fn register_host_visual_states(
             continue;
         };
         state_layers.push((state_name, trigger_value, state_style));
+    }
+    if control_supports_automatic_focus(xaml_tag) && !has_explicit_state_when(node, "focused") {
+        if let Some(focus_style) = part.states.get("focused") {
+            ctx.needs_focus_state_converter = true;
+            state_layers.push((
+                "focused",
+                format!(
+                    "{{Binding FocusState, ElementName={target_name}, Converter={{StaticResource FocusStateToBoolConverter}}}}"
+                ),
+                focus_style,
+            ));
+        }
     }
     if button_base_supports_automatic_hover(xaml_tag) && !has_explicit_state_when(node, "hover") {
         if let Some(hover_style) = part.states.get("hover") {
@@ -1859,14 +1889,19 @@ fn emit_xaml(
             .and_then(|p| s[p..].find(">\n").map(|q| p + q))
     };
 
-    // After walking, if any `If` was emitted we must declare the
-    // converter resource. We splice it in after the open root tag.
-    if ctx.needs_bool_to_vis {
+    // After walking, declare any generated converter resources exactly once.
+    // We splice them in after the open root tag.
+    if ctx.needs_bool_to_vis || ctx.needs_focus_state_converter {
         let resources_tag = match shape {
             RootShape::UserControl => "UserControl.Resources",
             RootShape::ContentDialog => "ContentDialog.Resources",
         };
-        let resources = emit_bool_to_vis_resource_block(4, resources_tag);
+        let resources = emit_converter_resource_block(
+            4,
+            resources_tag,
+            ctx.needs_bool_to_vis,
+            ctx.needs_focus_state_converter,
+        );
         let split_at = find_root_open_close(&out)
             .map(|p| p + 2)
             .unwrap_or(out.len());
@@ -3393,19 +3428,32 @@ fn emit_if(
     Ok(out)
 }
 
-/// The `<UserControl.Resources>` block carrying the
-/// `BoolToVisibilityConverter` resource. Added exactly once per
-/// UserControl when any `If` is emitted.
-fn emit_bool_to_vis_resource_block(indent: usize, resources_tag: &str) -> String {
+/// The generated converter resources required by this component. Added
+/// exactly once beneath the root resources tag.
+fn emit_converter_resource_block(
+    indent: usize,
+    resources_tag: &str,
+    needs_bool_to_vis: bool,
+    needs_focus_state: bool,
+) -> String {
     let pad = " ".repeat(indent);
     let pad2 = " ".repeat(indent + 4);
     let mut out = String::new();
     writeln!(out, "{pad}<{resources_tag}>").unwrap();
-    writeln!(
-        out,
-        "{pad2}<local:BoolToVisibilityConverter x:Key=\"BoolToVisibilityConverter\"/>"
-    )
-    .unwrap();
+    if needs_bool_to_vis {
+        writeln!(
+            out,
+            "{pad2}<local:BoolToVisibilityConverter x:Key=\"BoolToVisibilityConverter\"/>"
+        )
+        .unwrap();
+    }
+    if needs_focus_state {
+        writeln!(
+            out,
+            "{pad2}<local:FocusStateToBoolConverter x:Key=\"FocusStateToBoolConverter\"/>"
+        )
+        .unwrap();
+    }
     writeln!(out, "{pad}</{resources_tag}>").unwrap();
     out
 }
@@ -3439,6 +3487,34 @@ fn emit_bool_to_vis_converter_source(namespace: &str) -> String {
                  var b = value is bool x && x;\n        \
                  if (parameter is string p && p == \"invert\") b = !b;\n        \
                  return b ? Visibility.Visible : Visibility.Collapsed;\n    \
+             }}\n\n    \
+             public object ConvertBack(object value, Type targetType, object parameter, string language)\n    \
+             {{\n        \
+                 throw new NotImplementedException();\n    \
+             }}\n\
+         }}\n"
+    )
+}
+
+/// C# source for the converter that activates UI15's built-in `focused`
+/// state from WinUI's native `Control.FocusState` enum.
+fn emit_focus_state_to_bool_converter_source(namespace: &str) -> String {
+    format!(
+        "// Auto-generated by mosaic-emit-xaml. Do not edit.\n\
+         //\n\
+         // Native WinUI focus state → Mosaic focused-state activation.\n\
+         using System;\n\
+         using Microsoft.UI.Xaml;\n\
+         using Microsoft.UI.Xaml.Data;\n\
+         \n\
+         namespace {namespace};\n\
+         \n\
+         public sealed class FocusStateToBoolConverter : IValueConverter\n\
+         {{\n    \
+             public object Convert(object value, Type targetType, object parameter, string language)\n    \
+             {{\n        \
+                 if (value is FocusState state) return state != FocusState.Unfocused;\n        \
+                 return DependencyProperty.UnsetValue;\n    \
              }}\n\n    \
              public object ConvertBack(object value, Type targetType, object parameter, string language)\n    \
              {{\n        \
@@ -11763,6 +11839,238 @@ mod tests {
         assert!(
             !r.xaml.contains("Binding IsPointerOver"),
             "explicit hover state must not install native pointer tracking:\n{}",
+            r.xaml
+        );
+    }
+
+    #[test]
+    fn native_focused_state_uses_focus_state_converter() {
+        let c = component("FocusField", vec![], vec![]);
+        let l = layout_with_root(
+            "FocusField",
+            LayoutNode {
+                tag: "HostInput".to_string(),
+                part_name: Some("field".to_string()),
+                props: Vec::new(),
+                children: Vec::new(),
+            },
+        );
+        let s = StyleDef {
+            component_name: "FocusField".to_string(),
+            parts: vec![PartStyle {
+                name: "field".to_string(),
+                base: vec![StyleProp {
+                    name: "border-color".to_string(),
+                    value: "#d0d0d0".to_string(),
+                }],
+                transitions: vec![transition("border-color", "80ms", "ease-out")],
+                states: vec![StateStyle {
+                    state: "focused".to_string(),
+                    props: vec![StyleProp {
+                        name: "border-color".to_string(),
+                        value: "#e0942a".to_string(),
+                    }],
+                    transitions: Vec::new(),
+                }],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        assert!(
+            r.xaml
+                .contains("<local:FocusStateToBoolConverter x:Key=\"FocusStateToBoolConverter\"/>"),
+            "native focus requires one generated converter resource:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml.contains(
+                "<StateTrigger IsActive=\"{Binding FocusState, ElementName=Field, Converter={StaticResource FocusStateToBoolConverter}}\"/>"
+            ),
+            "focused state must bind to the control's native FocusState:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml.contains(
+                "<Setter Target=\"Field.(Control.BorderBrush).(SolidColorBrush.Color)\" Value=\"#e0942a\"/>"
+            ),
+            "got:\n{}",
+            r.xaml
+        );
+        let helper = r
+            .if_helpers
+            .iter()
+            .find(|file| file.filename == "FocusStateToBoolConverter.cs")
+            .expect("focus converter helper");
+        assert!(
+            helper.source.contains("state != FocusState.Unfocused"),
+            "converter must include pointer, keyboard, and programmatic focus:\n{}",
+            helper.source
+        );
+        assert!(
+            helper.source.contains("DependencyProperty.UnsetValue"),
+            "invalid converter inputs must not throw:\n{}",
+            helper.source
+        );
+    }
+
+    #[test]
+    fn native_focused_state_is_local_to_each_for_template_instance() {
+        let c = component(
+            "FocusRows",
+            vec![slot(
+                "rows",
+                SlotType::List(Box::new(ListInnerType::Text)),
+                true,
+            )],
+            vec![],
+        );
+        let l = layout_with_root(
+            "FocusRows",
+            for_node(
+                LayoutPropValue::SlotRef("rows".to_string()),
+                "row",
+                None,
+                vec![LayoutNode {
+                    tag: "HostInput".to_string(),
+                    part_name: Some("field".to_string()),
+                    props: Vec::new(),
+                    children: Vec::new(),
+                }],
+            ),
+        );
+        let s = StyleDef {
+            component_name: "FocusRows".to_string(),
+            parts: vec![PartStyle {
+                name: "field".to_string(),
+                base: vec![StyleProp {
+                    name: "opacity".to_string(),
+                    value: "0.8".to_string(),
+                }],
+                transitions: Vec::new(),
+                states: vec![StateStyle {
+                    state: "focused".to_string(),
+                    props: vec![StyleProp {
+                        name: "opacity".to_string(),
+                        value: "1".to_string(),
+                    }],
+                    transitions: Vec::new(),
+                }],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        assert!(
+            r.xaml.contains(
+                "<DataTemplate x:DataType=\"local:FocusRows_RowVm\">\n                <Grid>\n                    <VisualStateManager.VisualStateGroups>"
+            ),
+            "focus groups must live in the repeated row namescope:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml.contains(
+                "<StateTrigger IsActive=\"{Binding FocusState, ElementName=Field, Converter={StaticResource FocusStateToBoolConverter}}\"/>"
+            ),
+            "each template instance must bind to its own TextBox:\n{}",
+            r.xaml
+        );
+    }
+
+    #[test]
+    fn explicit_focused_predicate_remains_author_controlled() {
+        let c = component(
+            "ManualFocus",
+            vec![slot("force-focus", SlotType::Bool, true)],
+            vec![],
+        );
+        let l = layout_with_root(
+            "ManualFocus",
+            LayoutNode {
+                tag: "HostInput".to_string(),
+                part_name: Some("field".to_string()),
+                props: vec![LayoutProp {
+                    name: "state-when-focused".to_string(),
+                    value: LayoutPropValue::SlotRef("force-focus".to_string()),
+                }],
+                children: Vec::new(),
+            },
+        );
+        let s = StyleDef {
+            component_name: "ManualFocus".to_string(),
+            parts: vec![PartStyle {
+                name: "field".to_string(),
+                base: Vec::new(),
+                transitions: Vec::new(),
+                states: vec![StateStyle {
+                    state: "focused".to_string(),
+                    props: vec![StyleProp {
+                        name: "opacity".to_string(),
+                        value: "0.8".to_string(),
+                    }],
+                    transitions: Vec::new(),
+                }],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        assert!(
+            r.xaml
+                .contains("<StateTrigger IsActive=\"{x:Bind ForceFocus, Mode=OneWay}\"/>"),
+            "got:\n{}",
+            r.xaml
+        );
+        assert!(
+            !r.xaml.contains("FocusStateToBoolConverter"),
+            "explicit focus state must not install native focus tracking:\n{}",
+            r.xaml
+        );
+        assert!(
+            !r.if_helpers
+                .iter()
+                .any(|file| file.filename == "FocusStateToBoolConverter.cs"),
+            "explicit focus state must not ship an unused converter"
+        );
+    }
+
+    #[test]
+    fn native_focus_precedes_hover_when_both_are_active() {
+        let c = component("FocusHoverButton", vec![], vec![]);
+        let l = layout_with_root("FocusHoverButton", styled_host_button(vec![]));
+        let s = StyleDef {
+            component_name: "FocusHoverButton".to_string(),
+            parts: vec![PartStyle {
+                name: "button".to_string(),
+                base: vec![StyleProp {
+                    name: "opacity".to_string(),
+                    value: "0.7".to_string(),
+                }],
+                transitions: Vec::new(),
+                states: vec![
+                    StateStyle {
+                        state: "hover".to_string(),
+                        props: vec![StyleProp {
+                            name: "opacity".to_string(),
+                            value: "0.9".to_string(),
+                        }],
+                        transitions: Vec::new(),
+                    },
+                    StateStyle {
+                        state: "focused".to_string(),
+                        props: vec![StyleProp {
+                            name: "opacity".to_string(),
+                            value: "1".to_string(),
+                        }],
+                        transitions: Vec::new(),
+                    },
+                ],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        let focus = r.xaml.find("Binding FocusState").expect("focus trigger");
+        let hover = r.xaml.find("Binding IsPointerOver").expect("hover trigger");
+        assert!(
+            focus < hover,
+            "WinUI's first-active trigger precedence must match SwiftUI's focused-over-hover layering:\n{}",
             r.xaml
         );
     }

--- a/code/packages/rust/mosaic-emit-xaml/tests/task_app_focus_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/task_app_focus_compiles_to_xaml.rs
@@ -1,0 +1,80 @@
+//! Complex-app acceptance gate for native MSL focus activation.
+//!
+//! Task App authors its project-composer focus ring in Mosaic. The XAML
+//! backend must connect that shared `state focused` block to WinUI focus
+//! without app-specific code-behind.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn task_app_src_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(|path| {
+            path.join("programs")
+                .join("mosaic")
+                .join("task-app")
+                .join("src")
+        })
+        .expect("derive Task App source root from CARGO_MANIFEST_DIR")
+}
+
+#[test]
+fn task_app_focused_state_lowers_to_native_xaml_focus() {
+    let root = task_app_src_root();
+    let mil = fs::read_to_string(root.join("TaskApp.mil")).expect("read TaskApp.mil");
+    let mll = fs::read_to_string(root.join("TaskApp.mll")).expect("read TaskApp.mll");
+    let msl = fs::read_to_string(root.join("TaskApp.light.msl")).expect("read TaskApp.light.msl");
+
+    let interface = mosmodel_compiler::compile(&mil).expect("compile Task App interface");
+    let layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
+        .expect("compile Task App layout");
+    let style = mosstyle_compiler::compile(&msl, Some(&layout.part_map_json))
+        .expect("compile Task App light style");
+    let result = mosaic_emit_xaml::from_pipeline(
+        &interface.component,
+        &layout.def,
+        &style.def,
+        None,
+        &mosaic_emit_xaml::EmitOptions::default(),
+    )
+    .expect("emit Task App XAML");
+
+    assert_eq!(
+        result
+            .xaml
+            .matches("<local:FocusStateToBoolConverter x:Key=")
+            .count(),
+        1,
+        "Task App must declare one native focus converter:\n{}",
+        result.xaml
+    );
+    assert_eq!(
+        result
+            .xaml
+            .matches("Binding FocusState, ElementName=ProjectInput")
+            .count(),
+        1,
+        "Task App has one property-scoped focused override:\n{}",
+        result.xaml
+    );
+    assert!(
+        result.xaml.contains(
+            "<Setter Target=\"ProjectInput.(Control.BorderBrush).(SolidColorBrush.Color)\" Value=\"#e0942a\"/>"
+        ),
+        "the shared project-input focus ring must target the native TextBox:\n{}",
+        result.xaml
+    );
+    let helper = result
+        .if_helpers
+        .iter()
+        .find(|file| file.filename == "FocusStateToBoolConverter.cs")
+        .expect("Task App focus converter helper");
+    assert!(
+        helper.source.contains("state != FocusState.Unfocused"),
+        "native pointer, keyboard, and programmatic focus must activate the shared state:\n{}",
+        helper.source
+    );
+}

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] - preserve XAML emitter support files
+
+XAML package builds now write emitter-owned C# support files, report them in
+`BuildResult.artifacts`, and include them in `MosaicPackage.props`. Generated
+ViewModels and value converters referenced by component XAML therefore travel
+through the same package pipeline as the component triple.
+
 ## [Unreleased] - theme axis for style resolution
 
 `BuildOptions` gains a `theme: Option<String>` field — the style (`.msl`)

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -476,6 +476,7 @@ pub fn build_package(opts: &BuildOptions) -> Result<BuildResult, BuildError> {
         &components_built,
         opts.backend,
         &manifest.package.name,
+        &artifacts,
     )?;
     artifacts.push(index_path);
 
@@ -1562,6 +1563,7 @@ fn compile_one_component(
         None => out_dir.join(format!("{component}.{ext}")),
     };
 
+    let mut backend_artifacts = Vec::new();
     let primary_bytes: String = match backend {
         Backend::React | Backend::Electron => mosaic_emit_react::pipeline::from_pipeline(
             &mosmodel_out.component,
@@ -1636,6 +1638,22 @@ fn compile_one_component(
             };
             write_file(&code_behind_path, result.code_behind.as_bytes())?;
             write_file(&events_path, result.events.as_bytes())?;
+            backend_artifacts.push(code_behind_path);
+            backend_artifacts.push(events_path);
+
+            // XAML can reference generated C# support files from its markup
+            // (for example a ViewModel or an IValueConverter). Package mode
+            // must preserve those emitter-owned side files just as project
+            // shell mode does; otherwise the packaged XAML cannot compile.
+            for side_file in result
+                .for_view_models
+                .iter()
+                .chain(result.if_helpers.iter())
+            {
+                let side_file_path = out_dir.join(&side_file.filename);
+                write_file(&side_file_path, side_file.source.as_bytes())?;
+                backend_artifacts.push(side_file_path);
+            }
 
             result.xaml
         }
@@ -1658,6 +1676,7 @@ fn compile_one_component(
     // ----- 4. Write the primary artifact and backend-agnostic style sidecar --
     write_file(&primary_path, primary_bytes.as_bytes())?;
     let mut artifacts = vec![primary_path];
+    artifacts.extend(backend_artifacts);
     if !lattice.trim().is_empty() {
         let lattice_path = match variant {
             Some(v) => out_dir.join(format!("{component}.{v}.lattice")),
@@ -2140,6 +2159,7 @@ fn emit_index_file(
     components: &[String],
     backend: Backend,
     package_name: &str,
+    component_artifacts: &[PathBuf],
 ) -> Result<PathBuf, BuildError> {
     match backend {
         Backend::React | Backend::Electron => {
@@ -2361,6 +2381,20 @@ fn emit_index_file(
                     "    <Compile Include=\"{c}.xaml.cs\"><DependentUpon>{c}.xaml</DependentUpon></Compile>\n"
                 ));
                 body.push_str(&format!("    <Compile Include=\"{c}.Event.cs\"/>\n"));
+            }
+            let mut support_files = component_artifacts
+                .iter()
+                .filter_map(|artifact| artifact.file_name().and_then(|name| name.to_str()))
+                .filter(|name| {
+                    name.ends_with(".cs")
+                        && !name.ends_with(".xaml.cs")
+                        && !name.ends_with(".Event.cs")
+                })
+                .collect::<Vec<_>>();
+            support_files.sort_unstable();
+            support_files.dedup();
+            for support_file in support_files {
+                body.push_str(&format!("    <Compile Include=\"{support_file}\"/>\n"));
             }
             body.push_str("  </ItemGroup>\n");
             body.push_str("</Project>\n");
@@ -3099,6 +3133,68 @@ files = [
         assert!(props.contains("<Compile Include=\"Grid.xaml.cs\""));
         assert!(props.contains("DependentUpon>Grid.xaml<"));
         assert!(props.contains("<Compile Include=\"Grid.Event.cs\""));
+    }
+
+    #[test]
+    fn xaml_package_pipeline_writes_native_focus_converter_side_file() {
+        let pkg = make_package("mosaic-pkg-focus", &["FocusField"]);
+        write_component_sources(
+            pkg.path(),
+            "FocusField",
+            "component FocusField { }\n",
+            r#"
+layout FocusField {
+  HostInput [ field ] ( placeholder : "Search" )
+}
+"#,
+            r##"
+style FocusField {
+  part field {
+    border-color : "#d0d0d0" ;
+    state focused {
+      border-color : "#e0942a" ;
+    }
+  }
+}
+"##,
+        );
+        let out = TempDir::new().unwrap();
+        let result = build_package(&BuildOptions {
+            package_root: pkg.path().to_path_buf(),
+            output_root: out.path().to_path_buf(),
+            backend: Backend::Xaml,
+            emit_project: false,
+            theme: None,
+        })
+        .expect("xaml focus package build");
+
+        let xaml_dir = out.path().join("xaml");
+        let xaml = fs::read_to_string(xaml_dir.join("FocusField.xaml")).unwrap();
+        assert!(
+            xaml.contains(
+                "Binding FocusState, ElementName=Field, Converter={StaticResource FocusStateToBoolConverter}"
+            ),
+            "package output must preserve native focus activation:\n{xaml}"
+        );
+        let converter_path = xaml_dir.join("FocusStateToBoolConverter.cs");
+        assert!(
+            converter_path.exists(),
+            "package pipeline must write the converter referenced by XAML"
+        );
+        let converter = fs::read_to_string(&converter_path).unwrap();
+        assert!(converter.contains("state != FocusState.Unfocused"));
+        let props = fs::read_to_string(xaml_dir.join("MosaicPackage.props")).unwrap();
+        assert!(
+            props.contains("<Compile Include=\"FocusStateToBoolConverter.cs\"/>"),
+            "package import must compile the converter referenced by XAML:\n{props}"
+        );
+        assert!(
+            result
+                .artifacts
+                .iter()
+                .any(|artifact| artifact == &converter_path),
+            "generated converter must be reported as a package artifact"
+        );
     }
 
     /// Flutter backend: writes one `.dart` file per component, an


### PR DESCRIPTION
## Summary

- lower shared MSL `state focused` styling to native WinUI `Control.FocusState` for focus-capable Mosaic Host controls
- generate one reusable `FocusStateToBoolConverter` resource/helper while preserving explicit app-controlled focus predicates and template-local namescopes
- preserve emitter-owned XAML C# support files through package builds and include them in `MosaicPackage.props`
- add direct Task App acceptance for the Mosaic-authored project-input focus ring

## Why

Task App already authors its focus ring in shared MSL. SwiftUI gained native focus activation in #9365, but XAML still emitted the focused VisualState without a native trigger. The package builder also discarded emitter-owned helper files, so generated XAML that referenced a converter could not compile when consumed as a package.

## Validation

- `cargo test -p mosaic-emit-xaml --offline`
- `cargo clippy -p mosaic-emit-xaml --all-targets --offline -- -D warnings`
- `cargo test -p mosaic-package-artifact-builder -p mosaic-package-resolver --offline`
- `cargo clippy -p mosaic-package-artifact-builder --all-targets --offline -- -D warnings`
- Task App standalone `cargo test --offline`
- exact current WPT audit: tree-construction missing `0`; tokenizer missing `0`; tokenizer skipped `0`
- HTML parser legacy coverage audit test

This is a bounded generator/package-wiring slice. It does not claim direct Windows build/interaction acceptance or full browser conformance.