### PR TITLE
Bind build-tool execution cases to retained snapshots

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,7 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": 9371,
   "last_inventory": {
     "revision": "2e067105d718d35fbb85d39eae879479302df82e",
     "schema_version": 3,
@@ -107,11 +107,11 @@
     {
       "id": "build-tool-execution-case-snapshot",
       "title": "Bind execution to the exact approved in-memory case snapshot",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-trusted-authority-bundle"],
       "branch": "codex/build-tool-execution-case-snapshot",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9368 and the collision-clean 2e067105d inventory plus parallel package, fixture, and security audits. Define the currently prose-only typed selector/held-snapshot contract, select the requested direct corpus member from one root-handle/no-follow bounded snapshot, and retain the exact hashed bytes for later execution; reject outside paths, renames, symlinks, hardlinks, case/Unicode aliases, and post-digest mutation. This process-free repository boundary is the smallest critical-path successor and claims no execution authority, backend readiness, adapter conformance, or fixture execution."
+      "pr_number": 9371,
+      "notes": "Ready-for-review PR #9371. Selected after merged PR #9368 and the collision-clean 2e067105d inventory plus parallel package, fixture, contract, and security audits. The process-free boundary defines factory-only typed immutable snapshots and selectors, exact retained bytes and digests, bounded direct corpus membership, Unicode/case alias rejection, POSIX retained no-follow traversal, and Windows fixed-volume non-reparse FileId binding without claiming execution authority, backend readiness, adapter conformance, or fixture execution. Validation: 178 build-tool tests passed with 23 expected platform skips and 81% branch-aware Windows coverage; 10 reporter tests, both process-free contract validators, Ruff, Bandit, compileall, Go test/vet, collision and state-graph checks, diff hygiene, and independent fixture, contract, and security reviews passed. The repository BUILD validator reproduced the same 73 pre-existing Windows BUILD/CI metadata errors on pristine origin/main."
     },
     {
       "id": "build-tool-bootstrap-execution-fixture",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,9 +8,9 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": 9368,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "432e2b6380863aeaa02b83bca6120ec3c32943fe",
+    "revision": "2e067105d718d35fbb85d39eae879479302df82e",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1199,
@@ -107,11 +107,24 @@
     {
       "id": "build-tool-execution-case-snapshot",
       "title": "Bind execution to the exact approved in-memory case snapshot",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-trusted-authority-bundle"],
+      "branch": "codex/build-tool-execution-case-snapshot",
+      "pr_number": null,
+      "notes": "Selected after merged PR #9368 and the collision-clean 2e067105d inventory plus parallel package, fixture, and security audits. Define the currently prose-only typed selector/held-snapshot contract, select the requested direct corpus member from one root-handle/no-follow bounded snapshot, and retain the exact hashed bytes for later execution; reject outside paths, renames, symlinks, hardlinks, case/Unicode aliases, and post-digest mutation. This process-free repository boundary is the smallest critical-path successor and claims no execution authority, backend readiness, adapter conformance, or fixture execution."
+    },
+    {
+      "id": "build-tool-bootstrap-execution-fixture",
+      "title": "Land the inert bootstrap execution case and in-image adapter",
+      "status": "pending",
+      "depends_on": [
+        "build-tool-execution-case-snapshot",
+        "build-tool-execution-status-normalization",
+        "build-tool-linux-oci-enforcement"
+      ],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered during the Linux OCI security review. Select the requested direct corpus member from one root-handle/no-follow bounded snapshot and execute the same hashed bytes; reject outside paths, renames, symlinks, hardlinks, case/Unicode aliases, and post-digest mutation."
+      "notes": "Discovered in the post-#9368 dependency audit. Trusted authority and Linux trusted execution require one exact held case and one selected in-image adapter, but the checked-in execution corpus and adapter inventory are empty while normal adapter work is downstream of the execution-semantics corpus. After the Linux OCI enforcing boundary exists, add one minimal closed schema/semantic-valid bootstrap case and one inert digest-bindable untrusted adapter without claiming conformance, backend readiness, or execution permission; keep the full cross-platform execution corpus and adversarial probes in build-tool-execution-semantics-corpus."
     },
     {
       "id": "build-tool-immutable-runner-attester-provisioning",
@@ -153,11 +166,11 @@
     {
       "id": "build-tool-execution-status-normalization",
       "title": "Normalize dependency-skip terminology and result-state invariants",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-execution-sandbox"],
       "branch": "codex/build-tool-execution-status-normalization",
       "pr_number": 9368,
-      "notes": "Ready-for-review PR #9368. Selected after PR #9363 merged and the e34f26fad collision-clean inventory plus parallel dependency, fixture, and security audits completed, then rebased onto origin/main at 432e2b638 and refreshed to 1,199 identities, 4,341 slots, 749 singletons, zero collisions, and zero unknown buckets. The PR replaces the duplicated schema term dependency-skipped with normative dep-skipped and enforces built, failed, dep-skipped, would-build, return-code, command-state, dry-run, overall-outcome, exact-once result identity, fail-stop, and dependency-propagation invariants before execution cases enter the corpus. Validation: 166 conformance tests passed with 20 expected platform skips; focused execution suites passed 27 tests at 94% branch-aware coverage; both process-free contract validators, 10 reporter tests, Ruff, Bandit, compileall, pip check, JSON, state-graph, diff, secret, Go test/vet/build, and independent security review passed. The canonical diff dry-run found no changed package files; repository-wide BUILD validation still reports unrelated pre-existing BUILD_windows dependency drift on main. This bounded repository-owned contract is on the critical path to trusted execution, the Go oracle, OCaml's build substrate, and every build-tool adapter."
+      "notes": "Merged PR #9368 at 2e067105d718d35fbb85d39eae879479302df82e with green Ubuntu, macOS, Windows, and CodeQL checks. Selected after PR #9363 merged and the e34f26fad collision-clean inventory plus parallel dependency, fixture, and security audits completed, then rebased onto origin/main at 432e2b638 and refreshed to 1,199 identities, 4,341 slots, 749 singletons, zero collisions, and zero unknown buckets. The PR replaces the duplicated schema term dependency-skipped with normative dep-skipped and enforces built, failed, dep-skipped, would-build, return-code, command-state, dry-run, overall-outcome, exact-once result identity, fail-stop, and dependency-propagation invariants before execution cases enter the corpus. Validation: 166 conformance tests passed with 20 expected platform skips; focused execution suites passed 27 tests at 94% branch-aware coverage; both process-free contract validators, 10 reporter tests, Ruff, Bandit, compileall, pip check, JSON, state-graph, diff, secret, Go test/vet/build, and independent security review passed. The canonical diff dry-run found no changed package files; repository-wide BUILD validation still reports unrelated pre-existing BUILD_windows dependency drift on main. This bounded repository-owned contract is on the critical path to trusted execution, the Go oracle, OCaml's build substrate, and every build-tool adapter."
     },
     {
       "id": "build-tool-invariant-probe-authority-profile",
@@ -198,6 +211,7 @@
         "build-tool-invariant-probe-authority-profile",
         "build-tool-linux-oci-enforcement",
         "build-tool-execution-case-snapshot",
+        "build-tool-bootstrap-execution-fixture",
         "build-tool-execution-status-normalization"
       ],
       "branch": null,
@@ -212,6 +226,7 @@
         "build-tool-linux-oci-enforcement",
         "build-tool-trusted-execution-authority-profile",
         "build-tool-execution-case-snapshot",
+        "build-tool-bootstrap-execution-fixture",
         "build-tool-execution-status-normalization"
       ],
       "branch": null,
@@ -585,7 +600,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 553, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 554, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -594,7 +609,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30-31 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, and smart-home-matter-integration; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, and Matter adapter packages as native/service/storage boundary cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic into the Matter contract, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary."
+      "notes": "The July 30-31 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, and smart-home-home-assistant-migration; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, and Home Assistant migration packages as native/service/storage boundary cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. The Home Assistant migration's deterministic export parsing, normalization, planning, diagnostics, IDs, fingerprints, and receipts are portable-core candidates, while runtime application, atomic filesystem writes, CLI behavior, three Rust-only runtime dependencies, and its missing capability manifest require explicit host-boundary review. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic into the Matter contract, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary."
     },
     {
       "id": "matter-portable-core-extraction-and-conformance",

--- a/code/scripts/build_tool_conformance_execution.py
+++ b/code/scripts/build_tool_conformance_execution.py
@@ -20,6 +20,7 @@ import struct
 import sys
 import unicodedata
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -29,12 +30,330 @@ import build_tool_conformance_authority as authority
 DEFAULT_FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
 DEFAULT_EXECUTION_CASE_ROOT = DEFAULT_FIXTURE_ROOT / "execution-cases"
 MAX_EXECUTION_CASE_BYTES = bootstrap.MAX_DOCUMENT_BYTES
+MAX_EXECUTION_CORPUS_MEMBERS = 256
+MAX_EXECUTION_CORPUS_TOTAL_BYTES = 16 * 1024 * 1024
+MAX_EXECUTION_DIRECTORY_ENTRIES = 4096
 SHA256_PATTERN = "0123456789abcdef"
 PLATFORM_BACKEND_KINDS = {
     "darwin": "macos_isolated",
     "linux": "linux_oci",
     "windows": "windows_appcontainer",
 }
+_SNAPSHOT_FACTORY_TOKEN = object()
+
+
+@dataclass(frozen=True, init=False)
+class ExecutionCaseMember:
+    """One direct corpus member retained as immutable exact bytes."""
+
+    relative_path: str
+    raw: bytes
+
+    def __init__(
+        self,
+        *,
+        relative_path: str,
+        raw: bytes,
+        _factory_token: object | None = None,
+    ) -> None:
+        if _factory_token is not _SNAPSHOT_FACTORY_TOKEN:
+            raise TypeError(
+                "execution case members are created only by snapshot_from_entries"
+            )
+        _validate_execution_case_name(
+            relative_path,
+            code="EXECUTION_CORPUS_PATH_UNSAFE",
+            label="execution corpus path",
+        )
+        if not isinstance(raw, bytes):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_BYTES_INVALID",
+                f"execution corpus member is not immutable bytes: {relative_path}",
+            )
+        object.__setattr__(self, "relative_path", relative_path)
+        object.__setattr__(self, "raw", raw)
+
+
+@dataclass(frozen=True, init=False)
+class ExecutionCaseSelection:
+    """One exact member selected from a particular held corpus snapshot."""
+
+    relative_path: str
+    corpus_sha256: str
+    raw: bytes
+
+    def __init__(
+        self,
+        *,
+        relative_path: str,
+        corpus_sha256: str,
+        raw: bytes,
+        _factory_token: object | None = None,
+    ) -> None:
+        if _factory_token is not _SNAPSHOT_FACTORY_TOKEN:
+            raise TypeError(
+                "execution case selections are created only by a held snapshot"
+            )
+        _validate_execution_case_name(
+            relative_path,
+            code="EXECUTION_CASE_SELECTOR_UNSAFE",
+            label="execution case selector",
+        )
+        if not _is_sha256(corpus_sha256) or not isinstance(raw, bytes):
+            raise TypeError("execution case selection identity is invalid")
+        object.__setattr__(self, "relative_path", relative_path)
+        object.__setattr__(self, "corpus_sha256", corpus_sha256)
+        object.__setattr__(self, "raw", raw)
+
+
+@dataclass(frozen=True, init=False)
+class ExecutionCaseSnapshot:
+    """One immutable, digest-bound execution-corpus snapshot."""
+
+    corpus_sha256: str
+    members: tuple[ExecutionCaseMember, ...]
+
+    def __init__(
+        self,
+        *,
+        members: tuple[ExecutionCaseMember, ...],
+        _factory_token: object | None = None,
+    ) -> None:
+        if _factory_token is not _SNAPSHOT_FACTORY_TOKEN:
+            raise TypeError(
+                "execution case snapshots are created only by snapshot_from_entries"
+            )
+        if not isinstance(members, tuple) or any(
+            type(member) is not ExecutionCaseMember for member in members
+        ):
+            raise TypeError("execution case snapshot members are invalid")
+        object.__setattr__(self, "members", members)
+        object.__setattr__(self, "corpus_sha256", _digest_members(members))
+
+    def select(self, relative_path: str) -> ExecutionCaseSelection:
+        """Select one canonical direct member without reopening its pathname."""
+
+        try:
+            _validate_execution_case_name(
+                relative_path,
+                code="EXECUTION_CASE_SELECTOR_UNSAFE",
+                label="execution case selector",
+            )
+        except bootstrap.ConformanceError as error:
+            if isinstance(relative_path, str):
+                normalized = unicodedata.normalize("NFC", relative_path)
+                if normalized != relative_path:
+                    try:
+                        _validate_execution_case_name(
+                            normalized,
+                            code="EXECUTION_CASE_SELECTOR_UNSAFE",
+                            label="execution case selector",
+                        )
+                    except bootstrap.ConformanceError:
+                        pass
+                    else:
+                        normalized_identity = _execution_case_name_identity(normalized)
+                        if any(
+                            _execution_case_name_identity(member.relative_path)
+                            == normalized_identity
+                            for member in self.members
+                        ):
+                            raise bootstrap.ConformanceError(
+                                "EXECUTION_CASE_SELECTOR_ALIAS",
+                                "execution case selector is a Unicode normalization "
+                                "alias of a retained member",
+                            ) from error
+            raise
+        requested_identity = _execution_case_name_identity(relative_path)
+        for member in self.members:
+            if member.relative_path == relative_path:
+                return ExecutionCaseSelection(
+                    relative_path=member.relative_path,
+                    corpus_sha256=self.corpus_sha256,
+                    raw=member.raw,
+                    _factory_token=_SNAPSHOT_FACTORY_TOKEN,
+                )
+            if (
+                _execution_case_name_identity(member.relative_path)
+                == requested_identity
+            ):
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CASE_SELECTOR_ALIAS",
+                    "execution case selector is a case or Unicode alias of "
+                    f"{member.relative_path}",
+                )
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CASE_NOT_FOUND",
+            f"execution case is not present in the held snapshot: {relative_path}",
+        )
+
+
+def _execution_case_name_identity(relative_path: str) -> str:
+    return unicodedata.normalize("NFC", relative_path).casefold()
+
+
+def _validate_execution_case_name(
+    relative_path: Any,
+    *,
+    code: str,
+    label: str,
+) -> None:
+    error = bootstrap.portable_path_error(relative_path)
+    if error is not None or "/" in relative_path or not relative_path.endswith(".json"):
+        detail = error or "name must be one direct lowercase-.json member"
+        raise bootstrap.ConformanceError(
+            code,
+            f"unsafe {label} {relative_path!r}: {detail}",
+        )
+    try:
+        relative_path.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as error:
+        raise bootstrap.ConformanceError(
+            code,
+            f"unsafe {label} {relative_path!r}: name is not strict UTF-8",
+        ) from error
+
+
+def _validated_corpus_entries(
+    entries: Iterable[tuple[str, bytes]],
+) -> tuple[ExecutionCaseMember, ...]:
+    members: list[ExecutionCaseMember] = []
+    identities: dict[str, str] = {}
+    total_bytes = 0
+    for relative_path, raw in entries:
+        _validate_execution_case_name(
+            relative_path,
+            code="EXECUTION_CORPUS_PATH_UNSAFE",
+            label="execution corpus path",
+        )
+        if not isinstance(raw, bytes):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_BYTES_INVALID",
+                f"execution corpus member is not immutable bytes: {relative_path}",
+            )
+        if len(raw) > MAX_EXECUTION_CASE_BYTES:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_FILE_TOO_LARGE",
+                f"execution corpus member exceeds its byte ceiling: {relative_path}",
+            )
+        identity = _execution_case_name_identity(relative_path)
+        previous = identities.get(identity)
+        if previous is not None:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_PATH_DUPLICATE",
+                f"execution corpus path collides with {previous}: {relative_path}",
+            )
+        identities[identity] = relative_path
+        if len(members) >= MAX_EXECUTION_CORPUS_MEMBERS:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_MEMBER_LIMIT_EXCEEDED",
+                "execution corpus exceeds its runner-owned member ceiling",
+            )
+        total_bytes += len(raw)
+        if total_bytes > MAX_EXECUTION_CORPUS_TOTAL_BYTES:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_AGGREGATE_TOO_LARGE",
+                "execution corpus exceeds its runner-owned aggregate byte ceiling",
+            )
+        members.append(
+            ExecutionCaseMember(
+                relative_path=relative_path,
+                raw=raw,
+                _factory_token=_SNAPSHOT_FACTORY_TOKEN,
+            )
+        )
+    return tuple(sorted(members, key=lambda member: member.relative_path))
+
+
+def _digest_members(members: Sequence[ExecutionCaseMember]) -> str:
+    digest = hashlib.sha256()
+    for member in members:
+        path_bytes = member.relative_path.encode("utf-8")
+        digest.update(struct.pack(">Q", len(path_bytes)))
+        digest.update(path_bytes)
+        digest.update(struct.pack(">Q", len(member.raw)))
+        digest.update(member.raw)
+    return digest.hexdigest()
+
+
+def snapshot_from_entries(
+    entries: Iterable[tuple[str, bytes]],
+) -> ExecutionCaseSnapshot:
+    """Create a typed immutable snapshot from already-retained exact bytes."""
+
+    members = _validated_corpus_entries(entries)
+    return ExecutionCaseSnapshot(
+        members=members,
+        _factory_token=_SNAPSHOT_FACTORY_TOKEN,
+    )
+
+
+def _snapshot_file_identity(value: os.stat_result) -> tuple[int, ...]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_nlink,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _is_reparse(value: os.stat_result) -> bool:
+    return bool(
+        getattr(value, "st_file_attributes", 0)
+        & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    )
+
+
+def _read_raw_regular_bound(
+    path: Path,
+    *,
+    max_bytes: int = MAX_EXECUTION_CASE_BYTES,
+) -> tuple[bytes, os.stat_result]:
+    """Read one stable, singly linked regular file without final-link follow."""
+
+    try:
+        with bootstrap._open_regular_no_follow(path) as source:
+            before = os.fstat(source.fileno())
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or _is_reparse(before)
+                or before.st_nlink != 1
+            ):
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_FILE_INVALID",
+                    "execution corpus member is not one regular, non-reparse, "
+                    f"singly linked file: {path.name}",
+                )
+            raw = source.read(max_bytes + 1)
+            after = os.fstat(source.fileno())
+    except bootstrap.ConformanceError as error:
+        if error.code.startswith("DOCUMENT_"):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_FILE_INVALID",
+                f"execution corpus member could not be opened safely: {path.name}",
+            ) from error
+        raise
+    except (OSError, ValueError) as error:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_READ_FAILED",
+            f"could not read execution corpus member: {path.name}",
+        ) from error
+    if len(raw) > max_bytes:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_FILE_TOO_LARGE",
+            f"execution corpus member exceeds {max_bytes} bytes: {path.name}",
+        )
+    if _snapshot_file_identity(before) != _snapshot_file_identity(
+        after
+    ) or before.st_size != len(raw):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_FILE_CHANGED",
+            f"execution corpus member changed while it was read: {path.name}",
+        )
+    return raw, before
 
 
 def _read_raw_regular(
@@ -42,94 +361,614 @@ def _read_raw_regular(
     *,
     max_bytes: int = MAX_EXECUTION_CASE_BYTES,
 ) -> bytes:
-    """Read a bounded regular file without following its final link."""
+    """Read exact bytes from one stable singly linked regular file."""
 
-    try:
-        with bootstrap._open_regular_no_follow(path) as source:
-            if not stat.S_ISREG(os.fstat(source.fileno()).st_mode):
-                raise bootstrap.ConformanceError(
-                    "EXECUTION_CORPUS_FILE_INVALID",
-                    f"execution corpus member is not a regular file: {path}",
-                )
-            raw = source.read(max_bytes + 1)
-    except bootstrap.ConformanceError:
-        raise
-    except (OSError, ValueError) as error:
-        raise bootstrap.ConformanceError(
-            "EXECUTION_CORPUS_READ_FAILED",
-            f"could not read execution corpus member: {path}",
-        ) from error
-    if len(raw) > max_bytes:
-        raise bootstrap.ConformanceError(
-            "EXECUTION_CORPUS_FILE_TOO_LARGE",
-            f"execution corpus member exceeds {max_bytes} bytes: {path}",
-        )
+    raw, _ = _read_raw_regular_bound(path, max_bytes=max_bytes)
     return raw
 
 
 def framed_corpus_digest(entries: Iterable[tuple[str, bytes]]) -> str:
     """Hash sorted portable paths and exact bytes with length framing."""
 
-    digest = hashlib.sha256()
-    previous_path: str | None = None
-    for relative_path, raw in sorted(entries, key=lambda item: item[0]):
-        if error := bootstrap.portable_path_error(relative_path):
+    return _digest_members(_validated_corpus_entries(entries))
+
+
+def _validated_execution_case_names(names: Iterable[str]) -> tuple[str, ...]:
+    candidates: list[str] = []
+    for entry_count, name in enumerate(names, start=1):
+        if entry_count > MAX_EXECUTION_DIRECTORY_ENTRIES:
             raise bootstrap.ConformanceError(
-                "EXECUTION_CORPUS_PATH_UNSAFE",
-                f"unsafe execution corpus path {relative_path!r}: {error}",
+                "EXECUTION_CORPUS_ENUMERATION_LIMIT_EXCEEDED",
+                "execution corpus directory exceeds its runner-owned entry ceiling",
             )
-        if relative_path != unicodedata.normalize("NFC", relative_path):
-            raise bootstrap.ConformanceError(
-                "EXECUTION_CORPUS_PATH_UNSAFE",
-                f"execution corpus path is not NFC-normalized: {relative_path}",
-            )
-        if relative_path == previous_path:
+        if name.casefold().endswith(".json"):
+            candidates.append(name)
+            if len(candidates) > MAX_EXECUTION_CORPUS_MEMBERS:
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_MEMBER_LIMIT_EXCEEDED",
+                    "execution corpus exceeds its runner-owned member ceiling",
+                )
+    candidates.sort()
+    identities: dict[str, str] = {}
+    for name in candidates:
+        _validate_execution_case_name(
+            name,
+            code="EXECUTION_CORPUS_PATH_UNSAFE",
+            label="execution corpus path",
+        )
+        identity = _execution_case_name_identity(name)
+        previous = identities.get(identity)
+        if previous is not None:
             raise bootstrap.ConformanceError(
                 "EXECUTION_CORPUS_PATH_DUPLICATE",
-                f"duplicate execution corpus path: {relative_path}",
+                f"execution corpus path collides with {previous}: {name}",
             )
-        previous_path = relative_path
-        path_bytes = relative_path.encode("utf-8")
-        digest.update(struct.pack(">Q", len(path_bytes)))
-        digest.update(path_bytes)
-        digest.update(struct.pack(">Q", len(raw)))
-        digest.update(raw)
-    return digest.hexdigest()
+        identities[identity] = name
+    return tuple(candidates)
 
 
-def _execution_corpus_entries(case_root: Path) -> list[tuple[str, bytes]]:
-    """Open one stable bounded snapshot of direct execution-case members."""
-
+def _scan_posix_execution_case_names(root_descriptor: int) -> tuple[str, ...]:
     try:
-        root_status = case_root.lstat()
-    except OSError as error:
+        with os.scandir(root_descriptor) as iterator:
+            return _validated_execution_case_names(entry.name for entry in iterator)
+    except bootstrap.ConformanceError:
+        raise
+    except (OSError, ValueError) as error:
         raise bootstrap.ConformanceError(
-            "EXECUTION_CORPUS_DIRECTORY_MISSING",
-            f"execution corpus directory does not exist: {case_root}",
+            "EXECUTION_CORPUS_READ_FAILED",
+            "execution corpus could not be enumerated from its retained root",
         ) from error
-    is_reparse = bool(
-        getattr(root_status, "st_file_attributes", 0)
-        & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+
+
+def _snapshot_directory_identity(value: os.stat_result) -> tuple[int, ...]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_nlink,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
     )
+
+
+def _lexical_absolute_case_root(case_root: Path) -> Path:
+    if any(part in {".", ".."} for part in case_root.parts):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            "execution corpus root contains a dot segment",
+        )
+    if case_root.is_absolute():
+        return case_root
+    return Path.cwd() / case_root
+
+
+def _open_posix_case_root(case_root: Path) -> int:
     if (
-        not stat.S_ISDIR(root_status.st_mode)
-        or stat.S_ISLNK(root_status.st_mode)
-        or is_reparse
+        os.name != "posix"
+        or not hasattr(os, "O_NOFOLLOW")
+        or os.open not in os.supports_dir_fd
     ):
         raise bootstrap.ConformanceError(
             "EXECUTION_CORPUS_DIRECTORY_INVALID",
-            f"execution corpus path is not a regular directory: {case_root}",
+            "retained-root execution corpus capture is unavailable",
         )
-    return [
-        (path.relative_to(case_root).as_posix(), _read_raw_regular(path))
-        for path in sorted(case_root.glob("*.json"), key=lambda item: item.name)
-    ]
+    absolute = _lexical_absolute_case_root(case_root)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | os.O_NOFOLLOW
+    )
+    descriptor: int | None = None
+    try:
+        descriptor = os.open("/", flags)
+        for part in absolute.parts[1:]:
+            child = os.open(part, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+        root_status = os.fstat(descriptor)
+        if not stat.S_ISDIR(root_status.st_mode):
+            raise OSError("execution corpus root is not a directory")
+        return descriptor
+    except FileNotFoundError as error:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_DIRECTORY_MISSING",
+            "execution corpus directory does not exist",
+        ) from error
+    except (OSError, ValueError) as error:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            "execution corpus root could not be retained without following links",
+        ) from error
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise
+
+
+def _read_posix_snapshot_member(
+    root_descriptor: int,
+    relative_path: str,
+    *,
+    max_bytes: int,
+) -> tuple[bytes, tuple[int, int]]:
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            relative_path,
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=root_descriptor,
+        )
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_FILE_INVALID",
+                "execution corpus member must be one regular, singly linked file: "
+                f"{relative_path}",
+            )
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = os.read(
+                descriptor,
+                min(1_048_576, max_bytes + 1 - total),
+            )
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > max_bytes:
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_FILE_TOO_LARGE",
+                    f"execution corpus member exceeds {max_bytes} bytes: "
+                    f"{relative_path}",
+                )
+        after = os.fstat(descriptor)
+        if (
+            _snapshot_file_identity(before) != _snapshot_file_identity(after)
+            or before.st_size != total
+        ):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_FILE_CHANGED",
+                f"execution corpus member changed while it was read: {relative_path}",
+            )
+        return b"".join(chunks), (before.st_dev, before.st_ino)
+    except bootstrap.ConformanceError:
+        raise
+    except (OSError, ValueError) as error:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_FILE_INVALID",
+            "execution corpus member could not be opened relative to the retained "
+            f"root: {relative_path}",
+        ) from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _capture_posix_execution_entries(
+    case_root: Path,
+    *,
+    max_bytes: int,
+) -> list[tuple[str, bytes]]:
+    root_descriptor = _open_posix_case_root(case_root)
+    try:
+        before = os.fstat(root_descriptor)
+        first_names = _scan_posix_execution_case_names(root_descriptor)
+        entries: list[tuple[str, bytes]] = []
+        file_identities: set[tuple[int, int]] = set()
+        total_bytes = 0
+        for name in first_names:
+            raw, identity = _read_posix_snapshot_member(
+                root_descriptor,
+                name,
+                max_bytes=max_bytes,
+            )
+            if identity in file_identities:
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_FILE_INVALID",
+                    f"execution corpus members alias one file identity: {name}",
+                )
+            file_identities.add(identity)
+            total_bytes += len(raw)
+            if total_bytes > MAX_EXECUTION_CORPUS_TOTAL_BYTES:
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_AGGREGATE_TOO_LARGE",
+                    "execution corpus exceeds its runner-owned aggregate byte ceiling",
+                )
+            entries.append((name, raw))
+        second_names = _scan_posix_execution_case_names(root_descriptor)
+        after = os.fstat(root_descriptor)
+        if first_names != second_names or _snapshot_directory_identity(
+            before
+        ) != _snapshot_directory_identity(after):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_CHANGED",
+                "execution corpus membership changed during snapshot capture",
+            )
+        return entries
+    except bootstrap.ConformanceError:
+        raise
+    except (OSError, ValueError) as error:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_READ_FAILED",
+            "execution corpus could not be enumerated from its retained root",
+        ) from error
+    finally:
+        os.close(root_descriptor)
+
+
+def _capture_windows_execution_entries(
+    case_root: Path,
+    *,
+    max_bytes: int,
+) -> list[tuple[str, bytes]]:
+    import ctypes
+    from ctypes import wintypes
+
+    absolute = _lexical_absolute_case_root(case_root)
+    path_text = str(absolute)
+    if not absolute.drive or path_text.startswith("\\\\"):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            "Windows execution corpus root must be one local drive path",
+        )
+
+    class FileAttributeTagInfo(ctypes.Structure):
+        _fields_ = [
+            ("file_attributes", wintypes.DWORD),
+            ("reparse_tag", wintypes.DWORD),
+        ]
+
+    class FileBasicInfo(ctypes.Structure):
+        _fields_ = [
+            ("creation_time", ctypes.c_longlong),
+            ("last_access_time", ctypes.c_longlong),
+            ("last_write_time", ctypes.c_longlong),
+            ("change_time", ctypes.c_longlong),
+            ("file_attributes", wintypes.DWORD),
+        ]
+
+    class FileIdBothDirectoryInfo(ctypes.Structure):
+        _fields_ = [
+            ("next_entry_offset", wintypes.DWORD),
+            ("file_index", wintypes.DWORD),
+            ("creation_time", ctypes.c_longlong),
+            ("last_access_time", ctypes.c_longlong),
+            ("last_write_time", ctypes.c_longlong),
+            ("change_time", ctypes.c_longlong),
+            ("end_of_file", ctypes.c_longlong),
+            ("allocation_size", ctypes.c_longlong),
+            ("file_attributes", wintypes.DWORD),
+            ("file_name_length", wintypes.DWORD),
+            ("ea_size", wintypes.DWORD),
+            ("short_name_length", ctypes.c_byte),
+            ("short_name", wintypes.WCHAR * 12),
+            ("file_id", ctypes.c_ulonglong),
+        ]
+
+    class ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("file_attributes", wintypes.DWORD),
+            ("creation_time_low", wintypes.DWORD),
+            ("creation_time_high", wintypes.DWORD),
+            ("last_access_time_low", wintypes.DWORD),
+            ("last_access_time_high", wintypes.DWORD),
+            ("last_write_time_low", wintypes.DWORD),
+            ("last_write_time_high", wintypes.DWORD),
+            ("volume_serial_number", wintypes.DWORD),
+            ("file_size_high", wintypes.DWORD),
+            ("file_size_low", wintypes.DWORD),
+            ("number_of_links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+    get_info = kernel32.GetFileInformationByHandleEx
+    get_info.argtypes = (
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    )
+    get_info.restype = wintypes.BOOL
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = (wintypes.HANDLE,)
+    close_handle.restype = wintypes.BOOL
+    get_handle_info = kernel32.GetFileInformationByHandle
+    get_handle_info.argtypes = (
+        wintypes.HANDLE,
+        ctypes.POINTER(ByHandleFileInformation),
+    )
+    get_handle_info.restype = wintypes.BOOL
+    get_drive_type = kernel32.GetDriveTypeW
+    get_drive_type.argtypes = (wintypes.LPCWSTR,)
+    get_drive_type.restype = wintypes.UINT
+    query_dos_device = kernel32.QueryDosDeviceW
+    query_dos_device.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+    )
+    query_dos_device.restype = wintypes.DWORD
+
+    file_list_directory = 0x0001
+    file_read_attributes = 0x0080
+    file_share_read = 0x00000001
+    file_share_write = 0x00000002
+    open_existing = 3
+    file_flag_backup_semantics = 0x02000000
+    file_flag_open_reparse_point = 0x00200000
+    file_attribute_directory = 0x00000010
+    file_attribute_reparse_point = 0x00000400
+    drive_fixed = 3
+    invalid_handle = ctypes.c_void_p(-1).value
+
+    drive_name = absolute.drive
+    drive_root = f"{drive_name}\\"
+    device_target_buffer = ctypes.create_unicode_buffer(1024)
+    if (
+        get_drive_type(drive_root) != drive_fixed
+        or query_dos_device(
+            drive_name,
+            device_target_buffer,
+            len(device_target_buffer),
+        )
+        == 0
+    ):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            "Windows execution corpus root must use one fixed local volume",
+        )
+    device_target = device_target_buffer.value
+    harddisk_volume_prefix = "\\Device\\HarddiskVolume"
+    if (
+        not device_target.startswith(harddisk_volume_prefix)
+        or not device_target[len(harddisk_volume_prefix) :].isdecimal()
+    ):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            "Windows execution corpus root uses a remappable device namespace",
+        )
+
+    def open_directory(path: Path, *, final: bool) -> int:
+        handle = create_file(
+            str(path),
+            file_read_attributes | (file_list_directory if final else 0),
+            file_share_read if final else file_share_read | file_share_write,
+            None,
+            open_existing,
+            file_flag_backup_semantics | file_flag_open_reparse_point,
+            None,
+        )
+        if handle == invalid_handle:
+            error_code = ctypes.get_last_error()
+            code = (
+                "EXECUTION_CORPUS_DIRECTORY_MISSING"
+                if error_code in {2, 3}
+                else "EXECUTION_CORPUS_DIRECTORY_INVALID"
+            )
+            raise bootstrap.ConformanceError(
+                code,
+                "execution corpus directory could not be retained",
+            )
+        info = FileAttributeTagInfo()
+        if not get_info(handle, 9, ctypes.byref(info), ctypes.sizeof(info)):
+            error_code = ctypes.get_last_error()
+            close_handle(handle)
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_DIRECTORY_INVALID",
+                f"execution corpus directory attributes are unavailable: {error_code}",
+            )
+        if (
+            not info.file_attributes & file_attribute_directory
+            or info.file_attributes & file_attribute_reparse_point
+        ):
+            close_handle(handle)
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_DIRECTORY_INVALID",
+                "execution corpus path is linked, reparse, or non-directory",
+            )
+        return handle
+
+    def basic_identity(handle: int) -> tuple[int, ...]:
+        info = FileBasicInfo()
+        if not get_info(handle, 0, ctypes.byref(info), ctypes.sizeof(info)):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_DIRECTORY_INVALID",
+                "execution corpus directory identity is unavailable",
+            )
+        return (
+            info.creation_time,
+            info.last_write_time,
+            info.change_time,
+            info.file_attributes,
+        )
+
+    def volume_serial(handle: int) -> int:
+        info = ByHandleFileInformation()
+        if not get_handle_info(handle, ctypes.byref(info)):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_DIRECTORY_INVALID",
+                "execution corpus root volume identity is unavailable",
+            )
+        return int(info.volume_serial_number)
+
+    def enumerate_directory(handle: int) -> tuple[tuple[Any, ...], ...]:
+        records: list[tuple[Any, ...]] = []
+        entry_count = 0
+        while True:
+            buffer = ctypes.create_string_buffer(65_536)
+            if not get_info(handle, 10, buffer, len(buffer)):
+                error_code = ctypes.get_last_error()
+                if error_code == 18:
+                    break
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_READ_FAILED",
+                    f"execution corpus handle enumeration failed: {error_code}",
+                )
+            offset = 0
+            while True:
+                record = FileIdBothDirectoryInfo.from_buffer_copy(buffer, offset)
+                name = ctypes.wstring_at(
+                    ctypes.addressof(buffer)
+                    + offset
+                    + ctypes.sizeof(FileIdBothDirectoryInfo),
+                    record.file_name_length // 2,
+                )
+                if name not in {".", ".."}:
+                    entry_count += 1
+                    if entry_count > MAX_EXECUTION_DIRECTORY_ENTRIES:
+                        raise bootstrap.ConformanceError(
+                            "EXECUTION_CORPUS_ENUMERATION_LIMIT_EXCEEDED",
+                            "execution corpus directory exceeds its runner-owned "
+                            "entry ceiling",
+                        )
+                    records.append(
+                        (
+                            name,
+                            int(record.file_id),
+                            int(record.file_attributes),
+                            int(record.end_of_file),
+                            int(record.last_write_time),
+                            int(record.change_time),
+                        )
+                    )
+                if record.next_entry_offset == 0:
+                    break
+                offset += record.next_entry_offset
+        return tuple(records)
+
+    chain_paths = [Path(absolute.anchor)]
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:]:
+        current /= part
+        chain_paths.append(current)
+
+    handles: list[int] = []
+    try:
+        for index, path in enumerate(chain_paths):
+            handles.append(open_directory(path, final=index == len(chain_paths) - 1))
+        root_handle = handles[-1]
+        before = basic_identity(root_handle)
+        root_volume_serial = volume_serial(root_handle)
+        first_records = enumerate_directory(root_handle)
+        record_by_name = {str(record[0]): record for record in first_records}
+        names = _validated_execution_case_names(record_by_name)
+        entries: list[tuple[str, bytes]] = []
+        identities: set[tuple[int, int]] = set()
+        total_bytes = 0
+        for name in names:
+            record = record_by_name[name]
+            attributes = int(record[2])
+            if (
+                attributes & file_attribute_directory
+                or attributes & file_attribute_reparse_point
+            ):
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_FILE_INVALID",
+                    f"execution corpus member is linked or non-regular: {name}",
+                )
+            member_path = absolute / name
+            raw, status = _read_raw_regular_bound(
+                member_path,
+                max_bytes=max_bytes,
+            )
+            identity = (status.st_dev, status.st_ino)
+            if (
+                status.st_dev != root_volume_serial
+                or status.st_ino != int(record[1])
+                or identity in identities
+            ):
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_FILE_INVALID",
+                    f"execution corpus member identity is aliased or changed: {name}",
+                )
+            identities.add(identity)
+            total_bytes += len(raw)
+            if total_bytes > MAX_EXECUTION_CORPUS_TOTAL_BYTES:
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_AGGREGATE_TOO_LARGE",
+                    "execution corpus exceeds its runner-owned aggregate byte ceiling",
+                )
+            entries.append((name, raw))
+
+        second_handle = open_directory(absolute, final=True)
+        try:
+            second_records = enumerate_directory(second_handle)
+        finally:
+            close_handle(second_handle)
+        after = basic_identity(root_handle)
+        first_cases = tuple(record_by_name[name] for name in names)
+        second_by_name = {str(record[0]): record for record in second_records}
+        second_cases = tuple(second_by_name.get(name) for name in names)
+        second_names = _validated_execution_case_names(second_by_name)
+        if before != after or names != second_names or first_cases != second_cases:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_CHANGED",
+                "execution corpus membership changed during snapshot capture",
+            )
+        return entries
+    finally:
+        for handle in reversed(handles):
+            close_handle(handle)
+
+
+def capture_execution_case_snapshot(
+    case_root: Path,
+    *,
+    max_bytes: int = MAX_EXECUTION_CASE_BYTES,
+) -> ExecutionCaseSnapshot:
+    """Capture one retained-root, exact-byte, immutable corpus snapshot."""
+
+    if (
+        not isinstance(max_bytes, int)
+        or isinstance(max_bytes, bool)
+        or not 0 <= max_bytes <= MAX_EXECUTION_CASE_BYTES
+    ):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_LIMIT_INVALID",
+            "execution corpus member byte ceiling must be a non-negative integer",
+        )
+    entries = (
+        _capture_windows_execution_entries(case_root, max_bytes=max_bytes)
+        if os.name == "nt"
+        else _capture_posix_execution_entries(case_root, max_bytes=max_bytes)
+    )
+    return snapshot_from_entries(entries)
+
+
+def _execution_corpus_entries(case_root: Path) -> list[tuple[str, bytes]]:
+    """Compatibility view over one immutable corpus snapshot."""
+
+    snapshot = capture_execution_case_snapshot(case_root)
+    return [(member.relative_path, member.raw) for member in snapshot.members]
 
 
 def execution_corpus_digest(case_root: Path) -> str:
     """Compute the reviewed execution-corpus digest without JSON decoding."""
 
-    return framed_corpus_digest(_execution_corpus_entries(case_root))
+    return capture_execution_case_snapshot(case_root).corpus_sha256
 
 
 def _is_sha256(value: Any) -> bool:
@@ -534,7 +1373,9 @@ def validate_contract(
 ) -> dict[str, Any]:
     """Validate schemas, policy, digest, and inert execution cases."""
 
-    fixture_root = fixture_root.resolve()
+    # Keep the caller's lexical path so the snapshot capture can reject linked
+    # ancestors instead of silently replacing them with their targets.
+    fixture_root = Path(os.path.abspath(os.fspath(fixture_root)))
     (
         case_schema,
         result_schema,
@@ -562,8 +1403,8 @@ def validate_contract(
     )
     summary = validate_policy_semantics(policy)
     case_root = fixture_root / "execution-cases"
-    corpus_entries = _execution_corpus_entries(case_root)
-    digest = framed_corpus_digest(corpus_entries)
+    corpus_snapshot = capture_execution_case_snapshot(case_root)
+    digest = corpus_snapshot.corpus_sha256
     if digest != policy["execution_corpus_sha256"]:
         raise bootstrap.ConformanceError(
             "EXECUTION_POLICY_CORPUS_MISMATCH",
@@ -571,8 +1412,8 @@ def validate_contract(
         )
 
     case_ids: set[str] = set()
-    for relative_path, raw in corpus_entries:
-        case = bootstrap.strict_load_bytes(raw)
+    for member in corpus_snapshot.members:
+        case = bootstrap.strict_load_bytes(member.raw)
         bootstrap._validate_schema(
             case,
             case_schema,
@@ -605,13 +1446,13 @@ def validate_contract(
         if case_id in case_ids:
             raise bootstrap.ConformanceError(
                 "EXECUTION_CASE_ID_DUPLICATE",
-                f"duplicate execution case id in {relative_path}: {case_id}",
+                f"duplicate execution case id in {member.relative_path}: {case_id}",
             )
         case_ids.add(case_id)
 
     return {
         "schema_version": 1,
-        "execution_case_count": len(corpus_entries),
+        "execution_case_count": len(corpus_snapshot.members),
         "execution_corpus_sha256": digest,
         "ready_backend_count": summary["ready_backend_count"],
         "adapter_count": summary["adapter_count"],
@@ -717,6 +1558,14 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _public_failure_message(command: str) -> str:
+    """Return one host-independent CLI error message; the code carries detail."""
+
+    if command == "validate-contract":
+        return "trusted-execution contract validation failed"
+    return "trusted-execution request failed"
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     try:
@@ -744,7 +1593,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             json.dumps(
                 {
                     "code": error.code,
-                    "message": error.message,
+                    "message": _public_failure_message(arguments.command),
                     "status": "error",
                 },
                 sort_keys=True,

--- a/code/scripts/tests/test_build_tool_conformance_execution_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_execution_runner.py
@@ -4,6 +4,7 @@ import copy
 import io
 import json
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -17,6 +18,7 @@ import build_tool_conformance_execution as execution
 
 FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
 EMPTY_DIGEST = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
 
 class ExecutionPolicyRunnerTests(unittest.TestCase):
     def test_checked_in_contract_validates_without_execution(self) -> None:
@@ -198,6 +200,28 @@ class ExecutionPolicyRunnerTests(unittest.TestCase):
 
         with redirect_stderr(io.StringIO()):
             self.assertEqual(execution.main([]), 2)
+
+    def test_cli_errors_redact_host_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            secret_root = Path(directory) / "host-secret-root"
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                exit_code = execution.main(
+                    [
+                        "validate-contract",
+                        "--fixture-root",
+                        str(secret_root),
+                    ]
+                )
+        self.assertEqual(exit_code, 2)
+        error = json.loads(stderr.getvalue())
+        self.assertEqual(error["code"], "DOCUMENT_READ_FAILED")
+        self.assertEqual(
+            error["message"],
+            "trusted-execution contract validation failed",
+        )
+        self.assertNotIn(str(secret_root), stderr.getvalue())
+        self.assertNotIn(Path(directory).name, stderr.getvalue())
 
     def test_fixture_arguments_environment_and_manifest_never_select_authority(
         self,

--- a/code/scripts/tests/test_build_tool_conformance_execution_schema.py
+++ b/code/scripts/tests/test_build_tool_conformance_execution_schema.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 import shutil
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS_DIR))
@@ -107,7 +109,8 @@ class ExecutionSchemaTests(unittest.TestCase):
 
     def projection(self, case: dict[str, object]) -> dict[str, object]:
         expected = case["expected"]
-        assert isinstance(expected, dict)
+        if not isinstance(expected, dict):
+            self.fail("base execution case expected record is not an object")
         return {
             "domain": case["domain"],
             "outcome": expected["outcome"],
@@ -473,6 +476,327 @@ class ExecutionSchemaTests(unittest.TestCase):
                 execution.framed_corpus_digest([("a.json", b'{ "changed": true }')]),
             )
 
+    def test_corpus_snapshot_retains_exact_hashed_bytes_after_path_mutation(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            case_path = root / "selected.json"
+            original = b'{"value":"approved"}'
+            case_path.write_bytes(original)
+
+            snapshot = execution.capture_execution_case_snapshot(root)
+            expected_digest = execution.framed_corpus_digest(
+                [("selected.json", original)]
+            )
+            self.assertEqual(snapshot.corpus_sha256, expected_digest)
+            self.assertEqual(len(snapshot.members), 1)
+            self.assertEqual(
+                snapshot.members[0].relative_path,
+                "selected.json",
+            )
+            self.assertEqual(snapshot.members[0].raw, original)
+
+            case_path.write_bytes(b'{"value":"changed-after-capture"}')
+            case_path.rename(root / "renamed.json")
+            selection = snapshot.select("selected.json")
+            self.assertEqual(selection.relative_path, "selected.json")
+            self.assertEqual(selection.corpus_sha256, expected_digest)
+            self.assertEqual(selection.raw, original)
+
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                snapshot.select("renamed.json")
+            self.assertEqual(raised.exception.code, "EXECUTION_CASE_NOT_FOUND")
+
+    def test_corpus_snapshot_canonicalizes_filesystem_enumeration_order(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "z-last.json").write_bytes(b"z")
+            (root / "a-first.json").write_bytes(b"a")
+            snapshot = execution.capture_execution_case_snapshot(root)
+            self.assertEqual(
+                tuple(member.relative_path for member in snapshot.members),
+                ("a-first.json", "z-last.json"),
+            )
+            self.assertEqual(
+                execution._execution_corpus_entries(root),
+                [("a-first.json", b"a"), ("z-last.json", b"z")],
+            )
+            self.assertEqual(
+                execution._read_raw_regular(root / "a-first.json"),
+                b"a",
+            )
+
+    def test_corpus_snapshot_rejects_invalid_limits_names_and_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "oversized.json").write_bytes(b"12")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.capture_execution_case_snapshot(root, max_bytes=1)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_FILE_TOO_LARGE",
+            )
+
+            for invalid_limit in (-1, True, 1.5):
+                with self.subTest(invalid_limit=invalid_limit):
+                    with self.assertRaises(bootstrap.ConformanceError) as raised:
+                        execution.capture_execution_case_snapshot(  # type: ignore[arg-type]
+                            root,
+                            max_bytes=invalid_limit,
+                        )
+                    self.assertEqual(
+                        raised.exception.code,
+                        "EXECUTION_CORPUS_LIMIT_INVALID",
+                    )
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.capture_execution_case_snapshot(
+                    root,
+                    max_bytes=execution.MAX_EXECUTION_CASE_BYTES + 1,
+                )
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_LIMIT_INVALID",
+            )
+
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.snapshot_from_entries([("case\ud800.json", b"{}")])
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_PATH_UNSAFE",
+        )
+
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution._validated_execution_case_names(["Case.json", "case.json"])
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_PATH_DUPLICATE",
+        )
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution._validated_execution_case_names(["Straße.json", "strasse.json"])
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_PATH_DUPLICATE",
+        )
+
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution._lexical_absolute_case_root(Path("child/../cases"))
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_DIRECTORY_INVALID",
+        )
+
+    def test_corpus_snapshot_selector_rejects_outside_and_alias_names(self) -> None:
+        snapshot = execution.snapshot_from_entries([("Case.json", b"{}")])
+
+        for unsafe in (
+            "../Case.json",
+            "nested/Case.json",
+            r"nested\Case.json",
+            "Case.JSON",
+            "C:Case.json",
+            "",
+        ):
+            with self.subTest(unsafe=unsafe):
+                with self.assertRaises(bootstrap.ConformanceError) as raised:
+                    snapshot.select(unsafe)
+                self.assertEqual(
+                    raised.exception.code,
+                    "EXECUTION_CASE_SELECTOR_UNSAFE",
+                )
+
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            snapshot.select("case.json")
+        self.assertEqual(raised.exception.code, "EXECUTION_CASE_SELECTOR_ALIAS")
+
+        unicode_snapshot = execution.snapshot_from_entries([("é.json", b"{}")])
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            unicode_snapshot.select("e\u0301.json")
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CASE_SELECTOR_ALIAS",
+        )
+
+    def test_corpus_snapshot_rejects_casefold_aliases_and_non_bytes(self) -> None:
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.snapshot_from_entries(
+                [("Case.json", b"{}"), ("case.json", b"{}")]
+            )
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_PATH_DUPLICATE",
+        )
+
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.snapshot_from_entries([("case.json", bytearray(b"{}"))])  # type: ignore[list-item]
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_BYTES_INVALID",
+        )
+
+    def test_corpus_snapshot_factories_enforce_closed_types_and_aggregate_limits(
+        self,
+    ) -> None:
+        for constructor, arguments in (
+            (
+                execution.ExecutionCaseMember,
+                {"relative_path": "case.json", "raw": b"forged"},
+            ),
+            (
+                execution.ExecutionCaseSnapshot,
+                {"members": ()},
+            ),
+            (
+                execution.ExecutionCaseSelection,
+                {
+                    "relative_path": "case.json",
+                    "corpus_sha256": "0" * 64,
+                    "raw": b"forged",
+                },
+            ),
+        ):
+            with (
+                self.subTest(constructor=constructor.__name__),
+                self.assertRaises(TypeError),
+            ):
+                constructor(**arguments)
+
+        too_many = (
+            (f"case-{index:03d}.json", b"")
+            for index in range(execution.MAX_EXECUTION_CORPUS_MEMBERS + 1)
+        )
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.snapshot_from_entries(too_many)
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_MEMBER_LIMIT_EXCEEDED",
+        )
+
+        with (
+            mock.patch.object(
+                execution,
+                "MAX_EXECUTION_CASE_BYTES",
+                3,
+            ),
+            self.assertRaises(bootstrap.ConformanceError) as raised,
+        ):
+            execution.snapshot_from_entries([("case.json", b"1234")])
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_FILE_TOO_LARGE",
+        )
+
+        with (
+            mock.patch.object(
+                execution,
+                "MAX_EXECUTION_CORPUS_TOTAL_BYTES",
+                3,
+            ),
+            self.assertRaises(bootstrap.ConformanceError) as raised,
+        ):
+            execution.snapshot_from_entries([("a.json", b"12"), ("b.json", b"34")])
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_AGGREGATE_TOO_LARGE",
+        )
+
+        too_many_directory_entries = (
+            f"ignored-{index}.txt"
+            for index in range(execution.MAX_EXECUTION_DIRECTORY_ENTRIES + 1)
+        )
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution._validated_execution_case_names(too_many_directory_entries)
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_CORPUS_ENUMERATION_LIMIT_EXCEEDED",
+        )
+
+    def test_corpus_snapshot_detects_file_and_directory_change_races(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            case_path = root / "case.json"
+            case_path.write_bytes(b"{}")
+            before = case_path.stat()
+            changed = os.stat_result(
+                (
+                    before.st_mode,
+                    before.st_ino,
+                    before.st_dev,
+                    before.st_nlink,
+                    before.st_uid,
+                    before.st_gid,
+                    before.st_size,
+                    before.st_atime,
+                    before.st_mtime + 1,
+                    before.st_ctime,
+                )
+            )
+            with (
+                mock.patch.object(
+                    execution.os,
+                    "fstat",
+                    side_effect=[before, changed],
+                ),
+                self.assertRaises(bootstrap.ConformanceError) as raised,
+            ):
+                execution._read_raw_regular_bound(case_path)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_FILE_CHANGED",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "case.json").write_bytes(b"{}")
+            if os.name == "nt":
+                original_reader = execution._read_raw_regular_bound
+
+                def mutate_windows(
+                    path: Path,
+                    *,
+                    max_bytes: int,
+                ) -> tuple[bytes, os.stat_result]:
+                    result = original_reader(path, max_bytes=max_bytes)
+                    (root / "added.json").write_bytes(b"{}")
+                    return result
+
+                patcher = mock.patch.object(
+                    execution,
+                    "_read_raw_regular_bound",
+                    side_effect=mutate_windows,
+                )
+            else:
+                original_reader = execution._read_posix_snapshot_member
+
+                def mutate_posix(
+                    root_descriptor: int,
+                    relative_path: str,
+                    *,
+                    max_bytes: int,
+                ) -> tuple[bytes, tuple[int, int]]:
+                    result = original_reader(
+                        root_descriptor,
+                        relative_path,
+                        max_bytes=max_bytes,
+                    )
+                    (root / "added.json").write_bytes(b"{}")
+                    return result
+
+                patcher = mock.patch.object(
+                    execution,
+                    "_read_posix_snapshot_member",
+                    side_effect=mutate_posix,
+                )
+            with (
+                patcher,
+                self.assertRaises(bootstrap.ConformanceError) as raised,
+            ):
+                execution.capture_execution_case_snapshot(root)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_CHANGED",
+            )
+
     def test_corpus_digest_rejects_unsafe_duplicate_and_missing_inputs(self) -> None:
         with self.assertRaises(bootstrap.ConformanceError) as raised:
             execution.framed_corpus_digest([("../escape.json", b"{}")])
@@ -495,6 +819,103 @@ class ExecutionSchemaTests(unittest.TestCase):
             regular.write_text("not a directory", encoding="utf-8")
             with self.assertRaises(bootstrap.ConformanceError) as raised:
                 execution.execution_corpus_digest(regular)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            )
+
+    def test_corpus_snapshot_rejects_links_and_identity_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            original = root / "original.json"
+            original.write_bytes(b"{}")
+            linked = root / "linked.json"
+            try:
+                os.link(original, linked)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"hard links unavailable: {error}")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.capture_execution_case_snapshot(root)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_FILE_INVALID",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "target"
+            target.mkdir()
+            linked_root = root / "linked-root"
+            try:
+                linked_root.symlink_to(target, target_is_directory=True)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"directory symlinks unavailable: {error}")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.capture_execution_case_snapshot(linked_root)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            )
+
+    def test_corpus_snapshot_rejects_symlink_and_nonregular_json_members(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "directory.json").mkdir()
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.capture_execution_case_snapshot(root)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_FILE_INVALID",
+            )
+
+    def test_corpus_snapshot_rejects_linked_intermediate_root_component(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target_parent = root / "target-parent"
+            case_root = target_parent / "execution-cases"
+            case_root.mkdir(parents=True)
+            linked_parent = root / "linked-parent"
+            try:
+                linked_parent.symlink_to(target_parent, target_is_directory=True)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"directory symlinks unavailable: {error}")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.capture_execution_case_snapshot(
+                    linked_parent / "execution-cases"
+                )
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "target"
+            target.write_bytes(b"{}")
+            linked = root / "linked.json"
+            try:
+                linked.symlink_to(target)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"file symlinks unavailable: {error}")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.capture_execution_case_snapshot(root)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_FILE_INVALID",
+            )
+
+    def test_contract_rejects_linked_fixture_root_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "target"
+            shutil.copytree(FIXTURE_ROOT, target)
+            linked_root = root / "linked-fixture"
+            try:
+                linked_root.symlink_to(target, target_is_directory=True)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"directory symlinks unavailable: {error}")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.validate_contract(linked_root)
             self.assertEqual(
                 raised.exception.code,
                 "EXECUTION_CORPUS_DIRECTORY_INVALID",

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -675,10 +675,10 @@ Trusted execution is delivered in independently reviewable layers. A policy or
 schema layer MUST NOT be treated as an execution sandbox:
 
 1. The process-free policy layer closes the execution input and result records,
-   computes a framed SHA-256 digest over the execution corpus, validates
-   runner-owned adapter and backend identities, and returns stable
-   non-passing results for unavailable backends. It imports no process API and
-   never materializes a workspace.
+   captures one immutable exact-byte execution-corpus snapshot, computes its
+   framed SHA-256 digest, validates runner-owned adapter and backend identities,
+   and returns stable non-passing results for unavailable backends. It imports
+   no process API and never materializes a workspace.
 2. The Linux layer may execute only through a pinned, already-present OCI image
    identity. The runner MUST NOT pull, build, tag, or resolve a mutable image
    name during a conformance run. The container uses private mount, user, PID,
@@ -1011,12 +1011,49 @@ runner-owned filesystem, network, environment, namespace, resource, output,
 cancellation, and descendant-termination probe in a protected Linux
 workflow. Preflight success alone never marks the backend ready.
 
-The execution-corpus digest is SHA-256 over all `*.json` cases sorted by their
-portable path relative to `execution-cases/`. For each case, append the
-unsigned 64-bit big-endian path-byte length, UTF-8 path bytes, unsigned 64-bit
-big-endian raw-content length, and exact raw bytes. The empty corpus therefore
-has the standard SHA-256 empty digest. Any byte, filename, addition, or removal
-changes the internal corpus identity; it does not grant authority.
+The execution-corpus snapshot is a closed, process-free exact-byte boundary:
+
+1. Capture opens the absolute `execution-cases/` directory without following a
+   link or reparse point and retains that root while it enumerates and reads
+   members. POSIX capture traverses and opens members relative to retained
+   directory descriptors. Windows capture requires a fixed local drive whose
+   DOS target is one non-remappable hard-disk volume, retains a non-reparse
+   directory chain, enumerates the final root by handle, matches each member's
+   volume serial and file identity to that enumeration, and prevents pathname
+   mutation while each no-follow member handle is opened. An implementation
+   that cannot provide these guarantees fails closed.
+2. The corpus contains only direct, lowercase-`.json` members. Names are
+   portable relative paths in exact NFC form, contain no separator, and are
+   unique under NFC plus Unicode case folding. Non-regular, linked, reparse,
+   multiply linked, oversized, or identity-aliased members fail closed.
+   Enumeration stops after 4096 directory entries, the corpus contains at most
+   256 cases, each case is at most 2000000 raw bytes, and the complete retained
+   snapshot is at most 16777216 raw bytes.
+3. Each member is opened once, read under the runner byte ceiling, and checked
+   for a stable device/file identity, link count, size, and modification/change
+   identity before and after the read. The directory membership is checked
+   again before capture completes. The snapshot retains the sorted names and
+   immutable raw `bytes`; later validation or selection does not reopen a
+   pathname.
+4. A typed selector accepts exactly one canonical direct member name. An unsafe
+   name, a case- or normalization-alias of a retained member, and a missing
+   member are distinct stable failures. A successful selection binds the
+   requested name, the snapshot's corpus digest, and the already-retained exact
+   bytes. Renaming, replacing, linking, or mutating the pathname after capture
+   cannot change the selected bytes. Member, snapshot, and selection records
+   have factory-only constructors; the snapshot factory revalidates every
+   member and computes the digest rather than accepting one from a caller.
+5. Snapshot capture, digesting, and selection do not parse a case, import a
+   process API, confer authority, mark an adapter or backend ready, or execute
+   fixture content.
+
+The execution-corpus digest is SHA-256 over the snapshot's members sorted by
+their direct portable name relative to `execution-cases/`. For each case,
+append the unsigned 64-bit big-endian path-byte length, UTF-8 path bytes,
+unsigned 64-bit big-endian raw-content length, and exact retained bytes. The
+empty corpus therefore has the standard SHA-256 empty digest. Any byte,
+filename, addition, or removal changes the internal corpus identity; it does
+not grant authority.
 
 The process-free `validate-corpus` and `validate-result` bootstrap commands
 remain unchanged and MUST reject execution intent. A separate execution

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 2026-07-31
 
+- Replaced pathname `lstat`/glob/reopen execution-corpus reads with one
+  retained-root, bounded, exact-byte snapshot on POSIX and Windows.
+- Added frozen typed member, snapshot, and selection records so the selected
+  case bytes are exactly the bytes covered by the framed corpus digest.
+- Made those typed records factory-only and added fixed enumeration, member,
+  per-case, and aggregate-byte ceilings so callers cannot forge a digest-bound
+  record or grow an unbounded in-memory snapshot.
+- Required Windows snapshots to come from a fixed non-remappable local volume,
+  bound member volume/file identities to the retained root enumeration, and
+  made CLI error JSON host-path-independent.
+- Added stable rejection of unsafe or aliased selectors, case/Unicode filename
+  collisions, links and reparses, multiply linked or identity-aliased members,
+  unstable reads, changed directory membership, and post-digest pathname
+  substitution without granting execution authority.
 - Replaced the duplicated `dependency-skipped` execution status with the
   normative `dep-skipped` vocabulary.
 - Closed command status/exit-code and package status/return-code combinations

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -83,6 +83,21 @@ unavailable. The empty `execution-cases/*.json` set therefore has the standard
 empty SHA-256 digest. Execution cases are added only after an enforcing backend
 is reviewed.
 
+The process-free execution validator captures that corpus once as a typed,
+immutable exact-byte snapshot. POSIX uses retained directory descriptors;
+Windows requires a fixed non-remappable local volume, retains a non-reparse
+directory chain, enumerates the root by handle, and matches each member's
+volume and file identity while topology changes are blocked. Direct
+lowercase-`.json` names must be portable, exact NFC, unique after case folding,
+regular, singly linked, bounded, and identity-stable. Digesting, semantic
+validation, and typed selection all consume the retained bytes instead of
+reopening a pathname. A successful selection binds the canonical member name,
+corpus digest, and those exact bytes, but it grants no authority and does not
+make an adapter or backend ready. Capture admits at most 4096 directory
+entries, 256 corpus members, 2000000 raw bytes per member, and 16777216 raw
+bytes across the retained snapshot. Only the validating factory constructs
+member, snapshot, and selection records; callers cannot supply a digest.
+
 `linux-oci-backend.schema.json` closes the separate immutable identity document
 for the first Linux backend tranche. It binds exact statically linked rootless
 Podman, `crun`, Conmon,
@@ -256,6 +271,13 @@ The corpus now closes all process-free v1 domains:
 Execution now has a closed data model and authority policy, but no execution
 backend. This distinction is deliberate: schemas and digests are prerequisites
 for a sandbox, not evidence that one exists.
+
+The exact-byte corpus snapshot closes only a repository read boundary. Unsafe,
+outside, case-alias, and normalization-alias selectors fail before lookup;
+linked, reparse, multiply linked, identity-aliased, changed, or oversized
+members fail during capture. Later pathname replacement cannot change selected
+bytes because selection reads only the immutable snapshot. No execution case is
+decoded by an authority verifier, and no snapshot digest is authorization.
 
 The platform delivery order is explicit:
 

--- a/code/specs/fixtures/build-tool-v1/execution-cases/README.md
+++ b/code/specs/fixtures/build-tool-v1/execution-cases/README.md
@@ -5,9 +5,24 @@ The process-free policy tranche intentionally contains no cases, so its framed
 corpus SHA-256 is the standard empty digest. Execution semantics enter this
 directory only after an enforcing platform backend is reviewed.
 
+The process-free validator captures one immutable snapshot before it computes
+that digest or validates a case. Members are direct portable lowercase-`.json`
+names, unique under NFC plus case folding, and exact raw bytes are retained
+after a stable singly linked no-follow read. A typed selector returns only
+those already-hashed bytes; it never reopens a requested pathname. Outside
+paths, case or normalization aliases, links, reparses, hardlinks, identity
+aliases, directory changes, and post-digest pathname substitution fail closed
+or cannot affect the held selection. Runner-owned ceilings admit at most 4096
+enumerated directory entries, 256 cases, 2000000 bytes per case, and 16777216
+retained bytes in aggregate.
+
 The bootstrap `cases/` directory remains process-free. Never move an execution
 case there or add an execution-enabling flag to the bootstrap validator.
 
 The Linux OCI backend identity schema and process-owning capability preflight
 do not change this gate. They validate and probe runner-owned containment
 inputs only; they never decode or execute a case from this directory.
+
+Snapshot capture and selection likewise do not authorize execution, mark a
+backend ready, or prove adapter conformance. The later trusted-execution
+authority profile must bind the exact selected snapshot separately.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,9 +106,10 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 31, 2026 at `432e2b638` after merged OCaml
+inventory was regenerated on July 31, 2026 at `2e067105d` after merged OCaml
 toolchain work, the Rust `smart-home-matter-integration`, and the Rust
-`smart-home-home-assistant-migration`. It contains 1,199 normalized
+`smart-home-home-assistant-migration`, plus the merged Algol, Mosaic, and
+build-tool status-normalization slices. It contains 1,199 normalized
 implementation identities across 4,341 established-lane package
 slots and found zero canonical collisions or unknown language buckets:
 
@@ -884,10 +885,10 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 553 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 554 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30-31 inventories added thirteen Rust singleton identities that now
+The July 30-31 inventories added fourteen Rust singleton identities that now
 have explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
@@ -905,6 +906,13 @@ discovery/topic/entity/value/payload transforms are candidates for a separately
 fixture-driven portable core. `venture-browser-macos` is an Apple-native
 AppKit/CoreText/Metal host whose expected classification is `native-source`,
 not a blind 14-lane port.
+
+The fourteenth identity, `smart-home-home-assistant-migration`, is a mixed
+boundary rather than an automatic fifteen-lane port. Its deterministic export
+parsing, normalization, planning, diagnostics, IDs, fingerprints, and receipts
+are portable-core candidates; runtime application, atomic filesystem writes,
+CLI behavior, three Rust-only runtime dependencies, and the missing capability
+manifest require explicit host-boundary and authority classification.
 
 The new `smart-home-matter-integration` is also a mixed split candidate rather
 than a native-source exception: endpoint projection, report normalization, and
@@ -1103,14 +1111,32 @@ Delivery order:
 14. Gate completion in CI: every supported implementation runs the same
    conformance corpus on its applicable operating systems.
 
-Ready-for-review PR #9368 is the selected repository-owned build-tool slice,
-`build-tool-execution-status-normalization`. It replaces the duplicated
+Merged PR #9368 completed the repository-owned
+`build-tool-execution-status-normalization` slice. It replaces the duplicated
 `dependency-skipped` schema term with normative `dep-skipped` and closes
 contradictory command exit codes, package return codes, dry-run states, overall
 outcomes, duplicate result identities, fail-stop ordering, and dependency
 propagation. This bounded schema-and-validator repair lands before execution
 cases, trusted execution, the Go oracle, OCaml's build substrate, or adapter
 work consumes those records.
+
+The selected successor is `build-tool-execution-case-snapshot`. It defines the
+typed selector and held-snapshot boundary that is currently only prose, opens
+one bounded direct-member corpus snapshot through a retained no-follow root,
+and preserves the exact hashed bytes for later execution while rejecting path,
+rename, symlink, hardlink, case/Unicode-alias, and post-digest substitution.
+This process-free slice grants no execution authority and marks no backend or
+adapter ready.
+
+The post-#9368 dependency audit also found that trusted authority requires one
+held case and one selected in-image adapter even though both checked-in
+inventories are empty and normal adapter work sits downstream of the execution
+semantics corpus. The new `build-tool-bootstrap-execution-fixture` item follows
+the snapshot, status normalization, and Linux OCI enforcing boundary, then
+lands one inert schema-valid case plus one untrusted digest-bindable bootstrap
+adapter without claiming conformance or execution permission. Trusted authority
+and Linux trusted execution explicitly depend on that bootstrap; the full
+cross-platform corpus remains downstream of every platform sandbox boundary.
 
 Pull-request CI may validate the policy, schemas, digests, and fake-backend
 tests, but it must not authorize execution from branch-modifiable code or


### PR DESCRIPTION
## Summary

- define the typed, immutable execution-case snapshot and selector contract before any backend can execute fixtures
- capture exact retained bytes once, with deterministic names/digests and explicit case, member, directory-entry, and aggregate ceilings
- enforce retained no-follow traversal on POSIX and fixed-volume, non-reparse, volume/FileId-bound capture on Windows
- validate contracts from the retained snapshot without reopening pathnames, while keeping the slice process-free and making no readiness, authority, or execution claim
- update the fixture documentation, changelog, parity roadmap, and durable parity-loop state

## Why

The build-tool execution contract needs a stable case identity boundary before trusted backends and bootstrap execution fixtures can be introduced. Path-based validation could otherwise observe different bytes or follow a remapped ancestor between validation and execution.

## Validation

- `python -m coverage run --branch -m unittest discover -s code/scripts/tests -p "test_build_tool_conformance*.py"` — 178 tests passed, 23 expected platform skips
- `python -m coverage report --include="*/build_tool_conformance_execution.py"` — 81% branch coverage on Windows
- package-parity reporter suite — 10 tests passed
- `build_tool_conformance.py validate-corpus` — 30 cases, 15 established languages, 16 implementations, no conformance execution
- `build_tool_conformance_execution.py validate-contract` — valid empty execution corpus, zero ready backends/adapters
- collision-checked package inventory — 1,199 implementation identities, 4,341 slots, 0 collisions, 0 unknown buckets
- Ruff check and format check passed
- Bandit, compileall, `git diff --check`, and process-spawn static scan passed
- Go build-tool `go test ./...` and `go vet ./...` passed
- state graph — 61 unique items, no missing dependencies or cycles, one coherent in-progress item before publication
- independent fixture/schema, contract reconciliation, and security reviews passed

The repository BUILD validator still reports the same 73 known Windows BUILD/CI metadata errors on this branch and on a pristine worktree at base `2e067105d`; this change introduces no BUILD-file regression. POSIX retained-fd runtime branches are covered by Linux CI because WSL is not installed on the local Windows host.