### PR TITLE
fix(mosaic): activate native pressed states

### DIFF
--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - Native activation for MSL pressed states
+
+SwiftUI output now connects UI15's built-in `state pressed` blocks on
+`HostButton`, `HostCheckbox`, `HostRadio`, and `HostLink` to a generated local
+`@GestureState`. Pointer and touch presses activate the shared MSL properties
+and transitions without replacing the control's native action, including
+independent instances inside `ForEach`. Explicit `state-when-pressed`
+predicates remain author-controlled. A Task App acceptance gate proves its
+Mosaic-authored add-task button feedback reaches generated, type-checked
+SwiftUI without handwritten AppKit UI.
+
 ### Added - Native activation for MSL focused states
 
 SwiftUI output now connects UI15's built-in `state focused` blocks on native

--- a/code/packages/rust/mosaic-emit-swiftui/README.md
+++ b/code/packages/rust/mosaic-emit-swiftui/README.md
@@ -95,6 +95,14 @@ authored state properties and transitions from that binding. Repeated controls
 retain independent focus state. An explicit `state-when-focused` continues to
 override automatic focus tracking for application-controlled styling.
 
+UI15's built-in `state pressed` is native for pressable host controls
+(`HostButton`, `HostCheckbox`, `HostRadio`, and `HostLink`). The generated
+wrapper owns a row-local `@GestureState` and observes the control's pointer or
+touch press through a simultaneous zero-distance drag gesture, so the authored
+state properties and transitions activate without replacing the control's
+native action. An explicit `state-when-pressed` remains author-controlled and
+does not install automatic press tracking.
+
 ## Primitive lowering
 
 | Mosaic primitive | SwiftUI                                       |
@@ -170,8 +178,8 @@ business logic.
   `UnknownPrimitive` errors today; each lands in its own follow-up.
 - `connects` wiring (gesture / event modifiers beyond what `HostButton` /
   `HostInput` already wire).
-- Automatic activation of the remaining UI15 built-in interaction states
-  (`pressed` and `focused`). Slot- or expression-driven states continue to use
-  `state-when-*`; `hover` is the first built-in state with native activation.
+- Automatic activation of UI15 interaction states not listed above. Hover,
+  focused, and pressed states are native for the supported Host controls;
+  slot- or expression-driven states continue to use `state-when-*`.
 
 See the crate doc-comment for the full deferred list.

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -592,6 +592,24 @@ const FOCUS_STATE_HELPER_SWIFT: &str = r#"private struct _MosaicFocusState<Conte
 }
 "#;
 
+const PRESS_STATE_HELPER_SWIFT: &str = r#"private struct _MosaicPressState<Content: View>: View {
+    @GestureState private var isPressed = false
+    private let content: (Bool) -> Content
+
+    init(@ViewBuilder content: @escaping (Bool) -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        content(isPressed)
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .updating($isPressed) { _, state, _ in state = true }
+            )
+    }
+}
+"#;
+
 // =====================================================================
 // HostTable column-widths threading — TableContext
 // =====================================================================
@@ -783,6 +801,32 @@ fn layout_uses_automatic_focus(node: &LayoutNode, part_styles: &PartStyleMap) ->
             .any(|child| layout_uses_automatic_focus(child, part_styles))
 }
 
+fn primitive_supports_automatic_press(tag: &str) -> bool {
+    matches!(
+        tag,
+        "HostButton" | "HostCheckbox" | "HostRadio" | "HostLink"
+    )
+}
+
+fn automatic_press_style<'a>(
+    node: &LayoutNode,
+    part_styles: &'a PartStyleMap,
+) -> Option<&'a PartStyleEntry> {
+    let part_name = node.part_name.as_deref()?;
+    if !primitive_supports_automatic_press(&node.tag) || has_explicit_state_when(node, "pressed") {
+        return None;
+    }
+    part_styles.get(&format!("{part_name}:pressed"))
+}
+
+fn layout_uses_automatic_press(node: &LayoutNode, part_styles: &PartStyleMap) -> bool {
+    automatic_press_style(node, part_styles).is_some()
+        || node
+            .children
+            .iter()
+            .any(|child| layout_uses_automatic_press(child, part_styles))
+}
+
 /// One state layer collected from a node's `state-when-<X>: ( expr )` props.
 ///
 /// `cond_expr` is the Swift expression for the predicate (already
@@ -868,6 +912,7 @@ fn collect_state_layers_for_emission<'a>(
     part_styles: &'a PartStyleMap,
     uses_automatic_hover: bool,
     uses_automatic_focus: bool,
+    uses_automatic_press: bool,
 ) -> Vec<StateLayer<'a>> {
     let mut layers = Vec::new();
     if uses_automatic_hover {
@@ -885,6 +930,15 @@ fn collect_state_layers_for_emission<'a>(
                 cond_expr: "__mosaicFocusActive".to_string(),
                 props: focus_style.props.as_slice(),
                 transitions: focus_style.transitions.as_slice(),
+            });
+        }
+    }
+    if uses_automatic_press {
+        if let Some(press_style) = part_styles.get(&format!("{part_name}:pressed")) {
+            layers.push(StateLayer {
+                cond_expr: "__mosaicPressActive".to_string(),
+                props: press_style.props.as_slice(),
+                transitions: press_style.transitions.as_slice(),
             });
         }
     }
@@ -1684,6 +1738,10 @@ pub fn from_pipeline(
         out.push_str(FOCUS_STATE_HELPER_SWIFT);
         writeln!(out).unwrap();
     }
+    if layout_uses_automatic_press(&layout.root, &part_styles) {
+        out.push_str(PRESS_STATE_HELPER_SWIFT);
+        writeln!(out).unwrap();
+    }
 
     // 3. Event enum (analog of UI24 §3.1 event union).
     out.push_str(&emit_event_union(name, &interface.emits)?);
@@ -1978,8 +2036,10 @@ fn emit_view_tree(
 ) -> Result<String, PipelineEmitError> {
     let uses_automatic_hover = automatic_hover_style(node, part_styles).is_some();
     let uses_automatic_focus = automatic_focus_style(node, part_styles).is_some();
-    let automatic_wrapper_count =
-        usize::from(uses_automatic_hover) + usize::from(uses_automatic_focus);
+    let uses_automatic_press = automatic_press_style(node, part_styles).is_some();
+    let automatic_wrapper_count = usize::from(uses_automatic_hover)
+        + usize::from(uses_automatic_focus)
+        + usize::from(uses_automatic_press);
     let indent = indent + automatic_wrapper_count * 4;
     let pad = " ".repeat(indent);
 
@@ -2200,6 +2260,7 @@ fn emit_view_tree(
             part_styles,
             uses_automatic_hover,
             uses_automatic_focus,
+            uses_automatic_press,
         );
         // When a width is injected we MUST run the chain even if the part
         // carries no styles, so the frame still emits.
@@ -2241,6 +2302,13 @@ fn emit_view_tree(
     }
 
     let mut wrapper_indent = indent;
+    if uses_automatic_press {
+        wrapper_indent -= 4;
+        let wrapper_pad = " ".repeat(wrapper_indent);
+        inner = format!(
+            "{wrapper_pad}_MosaicPressState {{ __mosaicPressActive in\n{inner}{wrapper_pad}}}\n"
+        );
+    }
     if uses_automatic_focus {
         wrapper_indent -= 4;
         let wrapper_pad = " ".repeat(wrapper_indent);
@@ -8756,7 +8824,112 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------
-    // T30 — UI15's built-in focused state is activated by native SwiftUI
+    // T30 — UI15's built-in pressed state is activated by row-local native
+    //       SwiftUI gesture state for pressable host controls.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn built_in_pressed_state_emits_native_press_wrapper_and_animation() {
+        let m = component("PressedButton", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "PressedButton".to_string(),
+            root: LayoutNode {
+                tag: "HostButton".to_string(),
+                part_name: Some("button".to_string()),
+                props: vec![prop_string("label", "Save")],
+                children: vec![],
+            },
+        };
+        let s = StyleDef {
+            component_name: "PressedButton".to_string(),
+            parts: vec![PartStyle {
+                name: "button".to_string(),
+                base: vec![sp("opacity", "1")],
+                transitions: vec![transition("opacity", "80ms", "ease-out")],
+                states: vec![StateStyle {
+                    state: "pressed".to_string(),
+                    props: vec![sp("opacity", "0.7")],
+                    transitions: vec![],
+                }],
+            }],
+        };
+
+        let out = from_pipeline(&m, &l, &s).expect("emit ok").output;
+        assert!(
+            out.contains("private struct _MosaicPressState<Content: View>: View"),
+            "out = {out}"
+        );
+        assert!(
+            out.contains("@GestureState private var isPressed = false"),
+            "out = {out}"
+        );
+        assert!(
+            out.contains("_MosaicPressState { __mosaicPressActive in"),
+            "out = {out}"
+        );
+        assert!(
+            out.contains("DragGesture(minimumDistance: 0)"),
+            "out = {out}"
+        );
+        assert!(
+            out.contains(".opacity(((__mosaicPressActive) ? 0.7 : 1))"),
+            "out = {out}"
+        );
+    }
+
+    #[test]
+    fn explicit_pressed_predicate_remains_author_controlled() {
+        let m = component("ManualPress", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "ManualPress".to_string(),
+            root: LayoutNode {
+                tag: "HostButton".to_string(),
+                part_name: Some("button".to_string()),
+                props: vec![
+                    prop_string("label", "Save"),
+                    prop_expr("state-when-pressed", "( forcePress )"),
+                ],
+                children: vec![],
+            },
+        };
+        let s = style_with_part_and_states(
+            "ManualPress",
+            "button",
+            vec![sp("opacity", "1")],
+            vec![("pressed", vec![sp("opacity", "0.7")])],
+        );
+
+        let out = from_pipeline(&m, &l, &s).expect("emit ok").output;
+        assert!(
+            !out.contains("_MosaicPressState"),
+            "explicit predicate should not install native press tracking:\n{out}"
+        );
+        assert!(out.contains("forcePress"), "out = {out}");
+    }
+
+    #[test]
+    fn non_pressable_layout_node_does_not_install_press_tracking() {
+        let m = component("DecorativePress", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "DecorativePress".to_string(),
+            root: box_node_with_part_and_props("panel", vec![]),
+        };
+        let s = style_with_part_and_states(
+            "DecorativePress",
+            "panel",
+            vec![sp("opacity", "1")],
+            vec![("pressed", vec![sp("opacity", "0.7")])],
+        );
+
+        let out = from_pipeline(&m, &l, &s).expect("emit ok").output;
+        assert!(
+            !out.contains("_MosaicPressState"),
+            "non-pressable layout nodes must not gain native press tracking:\n{out}"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // T31 — UI15's built-in focused state is activated by native SwiftUI
     //       focus for focus-capable host controls.
     // ---------------------------------------------------------------------
 

--- a/code/packages/rust/mosaic-emit-swiftui/tests/task_app_press_compiles_to_swiftui.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/tests/task_app_press_compiles_to_swiftui.rs
@@ -1,0 +1,124 @@
+//! Complex-app acceptance gate for native MSL pressed-state activation.
+//!
+//! Task App authors its primary action feedback in Mosaic. The SwiftUI
+//! backend must connect that shared `state pressed` block to native gesture
+//! state without app-specific AppKit code.
+
+use std::fs;
+use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use std::process::Command;
+
+fn task_app_src_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(|path| {
+            path.join("programs")
+                .join("mosaic")
+                .join("task-app")
+                .join("src")
+        })
+        .expect("derive Task App source root from CARGO_MANIFEST_DIR")
+}
+
+#[test]
+fn task_app_pressed_state_lowers_to_native_swiftui_press_state() {
+    let root = task_app_src_root();
+    let mil = fs::read_to_string(root.join("TaskApp.mil")).expect("read TaskApp.mil");
+    let mll = fs::read_to_string(root.join("TaskApp.mll")).expect("read TaskApp.mll");
+    let interface = mosmodel_compiler::compile(&mil).expect("compile Task App interface");
+    let layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
+        .expect("compile Task App layout");
+
+    for theme in ["TaskApp.light.msl", "TaskApp.dark.msl"] {
+        let msl = fs::read_to_string(root.join(theme)).expect("read Task App style");
+        let style = mosstyle_compiler::compile(&msl, Some(&layout.part_map_json))
+            .expect("compile Task App style");
+        let output =
+            mosaic_emit_swiftui::from_pipeline(&interface.component, &layout.def, &style.def)
+                .expect("emit Task App SwiftUI")
+                .output;
+
+        assert!(
+            output.contains("private struct _MosaicPressState<Content: View>: View"),
+            "{theme} must generate native pressed-state support:\n{output}"
+        );
+        assert_eq!(
+            output
+                .matches("_MosaicPressState { __mosaicPressActive in")
+                .count(),
+            1,
+            "{theme} has one authored pressed surface:\n{output}"
+        );
+        let press_start = output
+            .find("_MosaicPressState { __mosaicPressActive in")
+            .expect("press wrapper");
+        let press_region = &output[press_start..output.len().min(press_start + 2_500)];
+        assert!(
+            press_region.contains("Button(action: { dispatch(.addTask) })")
+                && press_region.contains("Text(\"Add task\")"),
+            "the primary action must own the {theme} native press wrapper:\n{press_region}"
+        );
+        assert!(
+            press_region.contains("__mosaicPressActive"),
+            "the {theme} pressed background must consume native press state:\n{press_region}"
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn native_press_wrapper_typechecks_with_swiftui() {
+    let interface = mosmodel_compiler::compile(
+        r#"
+component PressButton {
+  emit onSave ;
+}
+"#,
+    )
+    .expect("compile press fixture interface");
+    let layout = moslayout_compiler::compile(
+        r#"
+layout PressButton {
+  HostButton [ button ] ( label : "Save" , onClick : emit: onSave )
+}
+"#,
+        Some(&interface.descriptor_json),
+    )
+    .expect("compile press fixture layout");
+    let style = mosstyle_compiler::compile(
+        r##"
+style PressButton {
+  part button {
+    background : "#e0942a" ;
+    state pressed {
+      background : "#a96816" ;
+    }
+  }
+}
+"##,
+        Some(&layout.part_map_json),
+    )
+    .expect("compile press fixture style");
+    let output = mosaic_emit_swiftui::from_pipeline(&interface.component, &layout.def, &style.def)
+        .expect("emit press fixture SwiftUI")
+        .output;
+
+    let source_path =
+        std::env::temp_dir().join(format!("mosaic-press-{}.swift", std::process::id()));
+    fs::write(&source_path, output).expect("write generated Swift fixture");
+    let result = Command::new("swiftc")
+        .arg("-typecheck")
+        .arg(&source_path)
+        .output()
+        .expect("run swiftc");
+    let _ = fs::remove_file(&source_path);
+
+    assert!(
+        result.status.success(),
+        "generated native press wrapper must typecheck:\n{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}

--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased] — VC2-xaml Grid: WinUI value translation + nested-For + per-column widths
 
+### Added - Native activation for MSL pressed states
+
+WinUI output now connects UI15's built-in `state pressed` blocks on
+`HostButton`, `HostCheckbox`, `HostRadio`, and `HostLink` directly to
+`ButtonBase.IsPressed`. DataTemplate instances remain row-local, pressed takes
+precedence over simultaneous focused or hover states, and explicit
+`state-when-pressed` predicates remain author-controlled. A Task App
+acceptance gate proves its Mosaic-authored add-task button feedback reaches
+generated XAML without handwritten Win32 UI.
+
 ### Added - Native activation for MSL focused states
 
 WinUI output now connects UI15's built-in `state focused` blocks on native

--- a/code/packages/rust/mosaic-emit-xaml/README.md
+++ b/code/packages/rust/mosaic-emit-xaml/README.md
@@ -65,6 +65,12 @@ same shared MSL properties and transitions. Repeated controls keep their
 VisualStates in the DataTemplate namescope. An explicit
 `state-when-focused` remains application-controlled.
 
+UI15's built-in `state pressed` is native for the same ButtonBase family used
+by hover (`HostButton`, `HostCheckbox`, `HostRadio`, and `HostLink`). Its
+trigger binds directly to `IsPressed`, remains row-local inside DataTemplates,
+and takes precedence over simultaneous focused or hover styling. An explicit
+`state-when-pressed` remains application-controlled.
+
 Named CSS curves lower to native WinUI easing functions. Arbitrary
 `cubic-bezier(...)` curves currently use `CubicEase`; exact control points
 require a future Windows Composition lowering. Template-local predicates are

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -872,6 +872,13 @@ fn button_base_supports_automatic_hover(xaml_tag: &str) -> bool {
     )
 }
 
+fn button_base_supports_automatic_press(xaml_tag: &str) -> bool {
+    matches!(
+        xaml_tag,
+        "Button" | "CheckBox" | "RadioButton" | "HyperlinkButton"
+    )
+}
+
 fn control_supports_automatic_focus(xaml_tag: &str) -> bool {
     matches!(
         xaml_tag,
@@ -916,6 +923,15 @@ fn register_host_visual_states(
             continue;
         };
         state_layers.push((state_name, trigger_value, state_style));
+    }
+    if button_base_supports_automatic_press(xaml_tag) && !has_explicit_state_when(node, "pressed") {
+        if let Some(press_style) = part.states.get("pressed") {
+            state_layers.push((
+                "pressed",
+                format!("{{Binding IsPressed, ElementName={target_name}}}"),
+                press_style,
+            ));
+        }
     }
     if control_supports_automatic_focus(xaml_tag) && !has_explicit_state_when(node, "focused") {
         if let Some(focus_style) = part.states.get("focused") {
@@ -11844,6 +11860,90 @@ mod tests {
     }
 
     #[test]
+    fn native_pressed_state_uses_button_base_is_pressed() {
+        let c = component("PressedButton", vec![], vec![]);
+        let l = layout_with_root("PressedButton", styled_host_button(vec![]));
+        let s = StyleDef {
+            component_name: "PressedButton".to_string(),
+            parts: vec![PartStyle {
+                name: "button".to_string(),
+                base: vec![StyleProp {
+                    name: "opacity".to_string(),
+                    value: "1".to_string(),
+                }],
+                transitions: vec![transition("opacity", "80ms", "ease-out")],
+                states: vec![StateStyle {
+                    state: "pressed".to_string(),
+                    props: vec![StyleProp {
+                        name: "opacity".to_string(),
+                        value: "0.7".to_string(),
+                    }],
+                    transitions: Vec::new(),
+                }],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        assert!(
+            r.xaml
+                .contains("<StateTrigger IsActive=\"{Binding IsPressed, ElementName=Button}\"/>"),
+            "pressed state must bind directly to ButtonBase.IsPressed:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml
+                .contains("<Setter Target=\"Button.Opacity\" Value=\"0.7\"/>"),
+            "got:\n{}",
+            r.xaml
+        );
+    }
+
+    #[test]
+    fn explicit_pressed_predicate_remains_author_controlled() {
+        let c = component(
+            "ManualPress",
+            vec![slot("force-press", SlotType::Bool, true)],
+            vec![],
+        );
+        let l = layout_with_root(
+            "ManualPress",
+            styled_host_button(vec![LayoutProp {
+                name: "state-when-pressed".to_string(),
+                value: LayoutPropValue::SlotRef("force-press".to_string()),
+            }]),
+        );
+        let s = StyleDef {
+            component_name: "ManualPress".to_string(),
+            parts: vec![PartStyle {
+                name: "button".to_string(),
+                base: Vec::new(),
+                transitions: Vec::new(),
+                states: vec![StateStyle {
+                    state: "pressed".to_string(),
+                    props: vec![StyleProp {
+                        name: "opacity".to_string(),
+                        value: "0.7".to_string(),
+                    }],
+                    transitions: Vec::new(),
+                }],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        assert!(
+            r.xaml
+                .contains("<StateTrigger IsActive=\"{x:Bind ForcePress, Mode=OneWay}\"/>"),
+            "got:\n{}",
+            r.xaml
+        );
+        assert!(
+            !r.xaml.contains("Binding IsPressed"),
+            "explicit press state must not install native tracking:\n{}",
+            r.xaml
+        );
+    }
+
+    #[test]
     fn native_focused_state_uses_focus_state_converter() {
         let c = component("FocusField", vec![], vec![]);
         let l = layout_with_root(
@@ -12071,6 +12171,59 @@ mod tests {
         assert!(
             focus < hover,
             "WinUI's first-active trigger precedence must match SwiftUI's focused-over-hover layering:\n{}",
+            r.xaml
+        );
+    }
+
+    #[test]
+    fn native_pressed_precedes_focus_and_hover_when_all_are_active() {
+        let c = component("PressFocusHoverButton", vec![], vec![]);
+        let l = layout_with_root("PressFocusHoverButton", styled_host_button(vec![]));
+        let s = StyleDef {
+            component_name: "PressFocusHoverButton".to_string(),
+            parts: vec![PartStyle {
+                name: "button".to_string(),
+                base: vec![StyleProp {
+                    name: "opacity".to_string(),
+                    value: "0.6".to_string(),
+                }],
+                transitions: Vec::new(),
+                states: vec![
+                    StateStyle {
+                        state: "hover".to_string(),
+                        props: vec![StyleProp {
+                            name: "opacity".to_string(),
+                            value: "0.8".to_string(),
+                        }],
+                        transitions: Vec::new(),
+                    },
+                    StateStyle {
+                        state: "focused".to_string(),
+                        props: vec![StyleProp {
+                            name: "opacity".to_string(),
+                            value: "0.9".to_string(),
+                        }],
+                        transitions: Vec::new(),
+                    },
+                    StateStyle {
+                        state: "pressed".to_string(),
+                        props: vec![StyleProp {
+                            name: "opacity".to_string(),
+                            value: "1".to_string(),
+                        }],
+                        transitions: Vec::new(),
+                    },
+                ],
+            }],
+        };
+
+        let r = compile(&c, &l, &s);
+        let pressed = r.xaml.find("Binding IsPressed").expect("pressed trigger");
+        let focus = r.xaml.find("Binding FocusState").expect("focus trigger");
+        let hover = r.xaml.find("Binding IsPointerOver").expect("hover trigger");
+        assert!(
+            pressed < focus && focus < hover,
+            "WinUI first-active precedence must be pressed, focused, hover:\n{}",
             r.xaml
         );
     }

--- a/code/packages/rust/mosaic-emit-xaml/tests/task_app_press_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/task_app_press_compiles_to_xaml.rs
@@ -1,0 +1,66 @@
+//! Complex-app acceptance gate for native MSL pressed-state activation.
+//!
+//! Task App authors its primary action feedback in Mosaic. The XAML backend
+//! must connect that shared `state pressed` block to WinUI ButtonBase state
+//! without app-specific code-behind.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn task_app_src_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(|path| {
+            path.join("programs")
+                .join("mosaic")
+                .join("task-app")
+                .join("src")
+        })
+        .expect("derive Task App source root from CARGO_MANIFEST_DIR")
+}
+
+#[test]
+fn task_app_pressed_state_lowers_to_native_xaml_button_state() {
+    let root = task_app_src_root();
+    let mil = fs::read_to_string(root.join("TaskApp.mil")).expect("read TaskApp.mil");
+    let mll = fs::read_to_string(root.join("TaskApp.mll")).expect("read TaskApp.mll");
+    let interface = mosmodel_compiler::compile(&mil).expect("compile Task App interface");
+    let layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
+        .expect("compile Task App layout");
+
+    for (theme, pressed_color) in [
+        ("TaskApp.light.msl", "#a96816"),
+        ("TaskApp.dark.msl", "#b87822"),
+    ] {
+        let msl = fs::read_to_string(root.join(theme)).expect("read Task App style");
+        let style = mosstyle_compiler::compile(&msl, Some(&layout.part_map_json))
+            .expect("compile Task App style");
+        let result = mosaic_emit_xaml::from_pipeline(
+            &interface.component,
+            &layout.def,
+            &style.def,
+            None,
+            &mosaic_emit_xaml::EmitOptions::default(),
+        )
+        .expect("emit Task App XAML");
+
+        assert_eq!(
+            result
+                .xaml
+                .matches("Binding IsPressed, ElementName=AddBtn")
+                .count(),
+            1,
+            "{theme} has one property-scoped pressed override:\n{}",
+            result.xaml
+        );
+        assert!(
+            result.xaml.contains(&format!(
+                "<Setter Target=\"AddBtn.(Control.Background).(SolidColorBrush.Color)\" Value=\"{pressed_color}\"/>"
+            )),
+            "the {theme} pressed background must target the native Button:\n{}",
+            result.xaml
+        );
+    }
+}

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - native pressed feedback through Mosaic
+
+The add-task button now declares its pressed background in the shared MSL
+themes. SwiftUI and WinUI project generation consume that same authored state,
+so the proving app gets platform-native press feedback without parallel AppKit
+or Win32 chrome.
+
 ### Changed - the app now looks like the design
 
 A polish pass bringing the real app up to `design/ui-prototype.html`, which it had

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -288,6 +288,9 @@ style TaskApp {
     state hover {
       background : "#d4922f" ;
     }
+    state pressed {
+      background : "#b87822" ;
+    }
   }
 
   part task-list {

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -288,6 +288,9 @@ style TaskApp {
     state hover {
       background : "#c67f1e" ;
     }
+    state pressed {
+      background : "#a96816" ;
+    }
   }
 
   part task-list {


### PR DESCRIPTION
## Summary

- activate built-in Mosaic pressed states on pressable Host controls while keeping explicit state-when-pressed predicates author-controlled
- lower the shared state to row-local SwiftUI gesture state and native WinUI ButtonBase.IsPressed, with pressed styling taking precedence over focused and hover styling
- author Task App add-button feedback once in both MSL themes and add direct SwiftUI/XAML complex-app acceptance gates

## Why

Hover and focused states already reached native SwiftUI and WinUI controls, but pressed styling still required application predicates. That left a common interaction state disconnected from the shared MIL/MLL/MSL pipeline and encouraged platform-specific workarounds.

## Validation

- cargo test -p mosaic-emit-swiftui
- cargo test -p mosaic-emit-xaml
- cargo test --manifest-path code/programs/mosaic/task-app/Cargo.toml
- cargo clippy -p mosaic-emit-swiftui -p mosaic-emit-xaml --all-targets -- -D warnings
- cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_coverage.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- generated SwiftUI press wrapper type-checked with swiftc on macOS
- checked parser audit remains tree missing 0, tokenizer missing 0, normalized skipped 0

Windows project compilation remains covered by the PR CI matrix. This is a bounded Mosaic UI-pipeline slice and does not claim complete Venture browser conformance.