### PR TITLE
feat(venture): author browser chrome in Mosaic

### DIFF
--- a/code/packages/rust/mosaic-emit-swiftui/tests/venture_chrome_compiles_to_swiftui.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/tests/venture_chrome_compiles_to_swiftui.rs
@@ -1,0 +1,107 @@
+//! Venture browser-chrome acceptance gate for the SwiftUI backend.
+//!
+//! Venture authors its browser controls once in Mosaic. This test ensures the
+//! checked-in package keeps lowering to native SwiftUI controls and a complete
+//! macOS project shell without app-specific AppKit chrome.
+
+use std::fs;
+use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use std::process::Command;
+
+fn venture_src_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(|path| {
+            path.join("programs")
+                .join("mosaic")
+                .join("venture-browser")
+                .join("src")
+        })
+        .expect("derive Venture source root from CARGO_MANIFEST_DIR")
+}
+
+fn compile_sources(
+    theme: &str,
+) -> (
+    mosmodel_compiler::CompileOutput,
+    moslayout_compiler::CompileOutput,
+    mosstyle_compiler::CompileOutput,
+) {
+    let root = venture_src_root();
+    let mil = fs::read_to_string(root.join("VentureChrome.mil")).expect("read VentureChrome.mil");
+    let mll = fs::read_to_string(root.join("VentureChrome.mll")).expect("read VentureChrome.mll");
+    let msl = fs::read_to_string(root.join(theme)).expect("read VentureChrome theme");
+    let interface = mosmodel_compiler::compile(&mil).expect("compile Venture interface");
+    let layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
+        .expect("compile Venture layout");
+    let style = mosstyle_compiler::compile(&msl, Some(&layout.part_map_json))
+        .expect("compile Venture style");
+    (interface, layout, style)
+}
+
+#[test]
+fn venture_chrome_lowers_to_native_swiftui_controls_and_project_shell() {
+    for theme in ["VentureChrome.light.msl", "VentureChrome.dark.msl"] {
+        let (interface, layout, style) = compile_sources(theme);
+        let options = mosaic_emit_swiftui::pipeline::EmitOptions {
+            emit_project: true,
+            ..Default::default()
+        };
+        let result = mosaic_emit_swiftui::pipeline::from_pipeline_with_options(
+            &interface.component,
+            &layout.def,
+            &style.def,
+            &options,
+        )
+        .expect("emit Venture SwiftUI project");
+
+        assert!(result
+            .output
+            .contains("Button(action: { dispatch(.back) })"));
+        assert!(result.output.contains(".disabled(backDisabled)"));
+        assert!(result.output.contains(".disabled(forwardDisabled)"));
+        assert!(result.output.contains(
+            "TextField(\"Enter a URL\", text: Binding(get: { address }, set: { dispatch(.addressChange(value: $0)) }))"
+        ));
+        assert!(result.output.contains(".onSubmit { dispatch(.navigate) }"));
+        assert!(result
+            .output
+            .contains("_MosaicPressState { __mosaicPressActive in"));
+        assert!(result
+            .output
+            .contains("_MosaicFocusState { __mosaicFocusActive in"));
+
+        let project = result.project.expect("SwiftUI project shell");
+        assert!(project.package_swift.contains(".executableTarget("));
+        assert!(project.package_swift.contains("name: \"App\""));
+        assert!(project.app_swift.contains("VentureChromeView("));
+        assert!(project.app_swift.contains("host.dispatch(event)"));
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn venture_chrome_generated_swift_typechecks() {
+    let (interface, layout, style) = compile_sources("VentureChrome.light.msl");
+    let output = mosaic_emit_swiftui::from_pipeline(&interface.component, &layout.def, &style.def)
+        .expect("emit Venture SwiftUI")
+        .output;
+    let source_path =
+        std::env::temp_dir().join(format!("venture-chrome-{}.swift", std::process::id()));
+    fs::write(&source_path, output).expect("write generated Venture SwiftUI");
+    let result = Command::new("swiftc")
+        .arg("-typecheck")
+        .arg(&source_path)
+        .output()
+        .expect("run swiftc");
+    let _ = fs::remove_file(&source_path);
+
+    assert!(
+        result.status.success(),
+        "generated Venture SwiftUI must typecheck:\n{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}

--- a/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
@@ -1,0 +1,78 @@
+//! Venture browser-chrome acceptance gate for the XAML backend.
+//!
+//! Venture authors its browser controls once in Mosaic. This test ensures the
+//! checked-in package keeps lowering to native WinUI controls and a complete
+//! generated project shell without app-specific Win32 chrome.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn venture_src_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(|path| {
+            path.join("programs")
+                .join("mosaic")
+                .join("venture-browser")
+                .join("src")
+        })
+        .expect("derive Venture source root from CARGO_MANIFEST_DIR")
+}
+
+#[test]
+fn venture_chrome_lowers_to_native_xaml_controls_and_project_shell() {
+    let root = venture_src_root();
+    let mil = fs::read_to_string(root.join("VentureChrome.mil")).expect("read VentureChrome.mil");
+    let mll = fs::read_to_string(root.join("VentureChrome.mll")).expect("read VentureChrome.mll");
+    let interface = mosmodel_compiler::compile(&mil).expect("compile Venture interface");
+    let layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
+        .expect("compile Venture layout");
+
+    for theme in ["VentureChrome.light.msl", "VentureChrome.dark.msl"] {
+        let msl = fs::read_to_string(root.join(theme)).expect("read VentureChrome theme");
+        let style = mosstyle_compiler::compile(&msl, Some(&layout.part_map_json))
+            .expect("compile Venture style");
+        let options = mosaic_emit_xaml::EmitOptions {
+            emit_project: true,
+            ..Default::default()
+        };
+        let result = mosaic_emit_xaml::from_pipeline(
+            &interface.component,
+            &layout.def,
+            &style.def,
+            None,
+            &options,
+        )
+        .expect("emit Venture XAML project");
+
+        assert!(result.xaml.contains(
+            "<Button x:Name=\"BackButton\" Content=\"Back\" IsEnabled=\"{x:Bind Not(BackDisabled)}\""
+        ));
+        assert!(result.xaml.contains(
+            "<TextBox x:Name=\"AddressInput\" Text=\"{x:Bind Address, Mode=TwoWay}\" IsReadOnly=\"{x:Bind NavigationDisabled}\""
+        ));
+        assert!(result
+            .xaml
+            .contains("TextChanged=\"AddressInput_TextChanged\""));
+        assert!(result.xaml.contains("KeyDown=\"AddressInput_KeyDown\""));
+        assert!(result
+            .xaml
+            .contains("Binding IsPressed, ElementName=GoButton"));
+        assert!(result
+            .xaml
+            .contains("Binding FocusState, ElementName=AddressInput"));
+
+        let project = result.project.expect("XAML project shell");
+        assert!(project.csproj.contains("Microsoft.WindowsAppSDK"));
+        assert!(project.main_window_xaml.contains("<gen:VentureChrome"));
+        assert!(project
+            .main_window_cs
+            .contains("case VentureChromeEvent.AddressChange(var payload0) c:"));
+        assert!(project
+            .main_window_cs
+            .contains("await TryHandleMosaicHostEvent(this.Component, ev)"));
+        assert!(project.build_script.contains("dotnet build"));
+    }
+}

--- a/code/programs/mosaic/venture-browser/.gitignore
+++ b/code/programs/mosaic/venture-browser/.gitignore
@@ -1,0 +1,2 @@
+target/
+build/

--- a/code/programs/mosaic/venture-browser/BUILD
+++ b/code/programs/mosaic/venture-browser/BUILD
@@ -1,0 +1,2 @@
+# Compile-check the shared Venture browser-chrome Mosaic package.
+cargo test

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Mosaic-authored Venture browser chrome with light and dark themes.
+- Typed slots for the address, page title, status, and disabled controls.
+- Typed dispatch events for Back, Forward, Home, Reload, address edits, and
+  navigation.
+- An explicit empty `content-surface` boundary reserved for the host-rendered
+  browser viewport; native surface embedding remains a later acceptance gate.

--- a/code/programs/mosaic/venture-browser/Cargo.toml
+++ b/code/programs/mosaic/venture-browser/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+
+[package]
+name = "venture-browser-mosaic-smoke"
+version = "0.1.0"
+edition = "2021"
+description = "Compile and acceptance harness for Venture browser chrome"
+publish = false
+
+[dev-dependencies]
+mosmodel-compiler = { path = "../../../packages/rust/mosmodel-compiler" }
+moslayout-compiler = { path = "../../../packages/rust/moslayout-compiler" }
+mosstyle-compiler = { path = "../../../packages/rust/mosstyle-compiler" }
+mosaic-package-manifest = { path = "../../../packages/rust/mosaic-package-manifest" }
+
+[[test]]
+name = "package_compiles"
+path = "tests/package_compiles.rs"

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -1,0 +1,26 @@
+# Venture browser chrome
+
+This package is the shared Mosaic source of truth for Venture's native browser
+chrome. It authors the title, Back, Forward, Home, Reload, address input, Go
+action, status line, disabled states, and dispatch contract once in MIL, MLL,
+and MSL.
+
+The package intentionally does not draw a web page. `venture-browser-core`
+owns navigation and the URL-to-paint pipeline; the macOS host currently mounts
+its Metal viewport separately. A future explicit Mosaic native-surface
+primitive will replace the empty `content-surface` part with that host-owned
+viewport. Until then, this slice proves the shared chrome compiles and lowers
+to native SwiftUI and WinUI controls without adding parallel AppKit or Win32
+controls.
+
+## Contract
+
+- Slots carry the current address, page title, status text, and host-derived
+  disabled flags.
+- Emits carry Back, Forward, Home, Reload, address edits, and Navigate.
+- Both themes expose the same parts and interaction states.
+- `tests/package_compiles.rs` guards the package contract; emitter integration
+  tests prove SwiftUI and XAML consume these exact sources.
+
+This package is a browser-wiring milestone, not a claim of complete Venture or
+HTML conformance.

--- a/code/programs/mosaic/venture-browser/mosaic-package.toml
+++ b/code/programs/mosaic/venture-browser/mosaic-package.toml
@@ -1,0 +1,11 @@
+[package]
+name = "venture-browser"
+version = "0.1.0"
+description = "Shared Mosaic-authored browser chrome for Venture."
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["VentureChrome"]
+
+[kernel]
+version = "1"

--- a/code/programs/mosaic/venture-browser/src/VentureChrome.dark.msl
+++ b/code/programs/mosaic/venture-browser/src/VentureChrome.dark.msl
@@ -1,0 +1,33 @@
+// VentureChrome — dark native chrome theme. Part and state topology mirrors light.
+
+style VentureChrome {
+  part app-shell { background : "#24211d" ; color : "#f1eadf" ; font-family : "-apple-system, Segoe UI, system-ui, sans-serif" ; gap : 0 ; }
+  part title-bar { background : "#312d27" ; padding : 8 ; gap : 12 ; align : center-vertical ; border-bottom-width : 1 ; border-bottom-color : "#50483d" ; }
+  part brand { color : "#e1a45d" ; font-size : 15 ; font-weight : bold ; }
+  part page-title { color : "#d8d0c4" ; font-size : 13 ; }
+  part toolbar { background : "#2b2823" ; padding : 8 ; gap : 6 ; align : center-vertical ; border-bottom-width : 1 ; border-bottom-color : "#50483d" ; }
+  part back-button {
+    background : "#3b3630" ; color : "#f1eadf" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#62584b" ;
+    state hover { background : "#51483c" ; } state pressed { background : "#6a4a27" ; } state focused { outline-color : "#e1a45d" ; outline-width : 2 ; } state disabled { opacity : 0.45 ; }
+  }
+  part forward-button {
+    background : "#3b3630" ; color : "#f1eadf" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#62584b" ;
+    state hover { background : "#51483c" ; } state pressed { background : "#6a4a27" ; } state focused { outline-color : "#e1a45d" ; outline-width : 2 ; } state disabled { opacity : 0.45 ; }
+  }
+  part home-button {
+    background : "#3b3630" ; color : "#f1eadf" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#62584b" ;
+    state hover { background : "#51483c" ; } state pressed { background : "#6a4a27" ; } state focused { outline-color : "#e1a45d" ; outline-width : 2 ; }
+  }
+  part reload-button {
+    background : "#3b3630" ; color : "#f1eadf" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#62584b" ;
+    state hover { background : "#51483c" ; } state pressed { background : "#6a4a27" ; } state focused { outline-color : "#e1a45d" ; outline-width : 2 ; } state disabled { opacity : 0.45 ; }
+  }
+  part address-input { background : "#171512" ; color : "#f1eadf" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#62584b" ; flex-grow : 1 ; state focused { border-color : "#e1a45d" ; outline-color : "#e1a45d" ; outline-width : 1 ; } }
+  part go-button {
+    background : "#b36f26" ; color : "#ffffff" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#d18b3d" ;
+    state hover { background : "#c27e32" ; } state pressed { background : "#8b501b" ; } state focused { outline-color : "#f0bd7a" ; outline-width : 2 ; } state disabled { opacity : 0.45 ; }
+  }
+  part content-surface { background : "#11100e" ; min-height : 480 ; flex-grow : 1 ; }
+  part status-bar { background : "#312d27" ; padding : 6 ; border-top-width : 1 ; border-top-color : "#50483d" ; }
+  part status-text { color : "#bdb4a7" ; font-size : 11 ; }
+}

--- a/code/programs/mosaic/venture-browser/src/VentureChrome.light.msl
+++ b/code/programs/mosaic/venture-browser/src/VentureChrome.light.msl
@@ -1,0 +1,88 @@
+// VentureChrome — light native chrome theme.
+
+style VentureChrome {
+  part app-shell {
+    background : "#f3f0e8" ;
+    color : "#211f1b" ;
+    font-family : "-apple-system, Segoe UI, system-ui, sans-serif" ;
+    gap : 0 ;
+  }
+  part title-bar {
+    background : "#ded8ca" ;
+    padding : 8 ;
+    gap : 12 ;
+    align : center-vertical ;
+    border-bottom-width : 1 ;
+    border-bottom-color : "#b9b09f" ;
+  }
+  part brand {
+    color : "#6d3d13" ;
+    font-size : 15 ;
+    font-weight : bold ;
+  }
+  part page-title {
+    color : "#39342d" ;
+    font-size : 13 ;
+  }
+  part toolbar {
+    background : "#ece7dc" ;
+    padding : 8 ;
+    gap : 6 ;
+    align : center-vertical ;
+    border-bottom-width : 1 ;
+    border-bottom-color : "#c8c0b1" ;
+  }
+  part back-button {
+    background : "#fffdf8" ; color : "#39342d" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#b9b09f" ;
+    state hover { background : "#f7e6c7" ; }
+    state pressed { background : "#e8c98f" ; }
+    state focused { outline-color : "#9a5b18" ; outline-width : 2 ; }
+    state disabled { opacity : 0.45 ; }
+  }
+  part forward-button {
+    background : "#fffdf8" ; color : "#39342d" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#b9b09f" ;
+    state hover { background : "#f7e6c7" ; }
+    state pressed { background : "#e8c98f" ; }
+    state focused { outline-color : "#9a5b18" ; outline-width : 2 ; }
+    state disabled { opacity : 0.45 ; }
+  }
+  part home-button {
+    background : "#fffdf8" ; color : "#39342d" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#b9b09f" ;
+    state hover { background : "#f7e6c7" ; }
+    state pressed { background : "#e8c98f" ; }
+    state focused { outline-color : "#9a5b18" ; outline-width : 2 ; }
+  }
+  part reload-button {
+    background : "#fffdf8" ; color : "#39342d" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#b9b09f" ;
+    state hover { background : "#f7e6c7" ; }
+    state pressed { background : "#e8c98f" ; }
+    state focused { outline-color : "#9a5b18" ; outline-width : 2 ; }
+    state disabled { opacity : 0.45 ; }
+  }
+  part address-input {
+    background : "#ffffff" ; color : "#211f1b" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#aaa08e" ; flex-grow : 1 ;
+    state focused { border-color : "#9a5b18" ; outline-color : "#9a5b18" ; outline-width : 1 ; }
+  }
+  part go-button {
+    background : "#9a5b18" ; color : "#ffffff" ; padding : 7 ; border-radius : 5 ; border-width : 1 ; border-color : "#74400e" ;
+    state hover { background : "#ad6b24" ; }
+    state pressed { background : "#74400e" ; }
+    state focused { outline-color : "#56300c" ; outline-width : 2 ; }
+    state disabled { opacity : 0.45 ; }
+  }
+  part content-surface {
+    background : "#ffffff" ;
+    min-height : 480 ;
+    flex-grow : 1 ;
+  }
+  part status-bar {
+    background : "#ded8ca" ;
+    padding : 6 ;
+    border-top-width : 1 ;
+    border-top-color : "#b9b09f" ;
+  }
+  part status-text {
+    color : "#5b554b" ;
+    font-size : 11 ;
+  }
+}

--- a/code/programs/mosaic/venture-browser/src/VentureChrome.mil
+++ b/code/programs/mosaic/venture-browser/src/VentureChrome.mil
@@ -1,0 +1,21 @@
+// VentureChrome — shared browser-chrome interface.
+//
+// venture-browser-core owns navigation and page rendering. Native hosts project
+// that engine state into these slots and translate emitted actions back into
+// BrowserNavigation commands.
+
+component VentureChrome {
+  slot address             : text ;
+  slot page-title          : text ;
+  slot status-text         : text ;
+  slot back-disabled       : bool ;
+  slot forward-disabled    : bool ;
+  slot navigation-disabled : bool ;
+
+  emit onBack ;
+  emit onForward ;
+  emit onHome ;
+  emit onReload ;
+  emit onAddressChange ( value : text ) ;
+  emit onNavigate ;
+}

--- a/code/programs/mosaic/venture-browser/src/VentureChrome.mll
+++ b/code/programs/mosaic/venture-browser/src/VentureChrome.mll
@@ -1,0 +1,55 @@
+// VentureChrome — shared browser-chrome layout.
+//
+// `content-surface` is intentionally empty. It reserves the composition boundary
+// where a native Metal or Direct2D page viewport will be mounted after Mosaic has
+// an explicit host-surface primitive; this package does not fake one with widgets.
+
+layout VentureChrome {
+  Column [ app-shell ] {
+    Row [ title-bar ] {
+      Text [ brand ] ( content : "Venture" )
+      Text [ page-title ] ( content : slot: page-title , a11y-role : heading )
+    }
+
+    Row [ toolbar ] {
+      HostButton [ back-button ] (
+        label : "Back" ,
+        disabled : slot: back-disabled ,
+        state-when-disabled : slot: back-disabled ,
+        onClick : emit: onBack
+      )
+      HostButton [ forward-button ] (
+        label : "Forward" ,
+        disabled : slot: forward-disabled ,
+        state-when-disabled : slot: forward-disabled ,
+        onClick : emit: onForward
+      )
+      HostButton [ home-button ] ( label : "Home" , onClick : emit: onHome )
+      HostButton [ reload-button ] (
+        label : "Reload" ,
+        disabled : slot: navigation-disabled ,
+        state-when-disabled : slot: navigation-disabled ,
+        onClick : emit: onReload
+      )
+      HostInput [ address-input ] (
+        value : slot: address ,
+        placeholder : "Enter a URL" ,
+        read-only : slot: navigation-disabled ,
+        onChange : emit: onAddressChange ,
+        onCommit : emit: onNavigate
+      )
+      HostButton [ go-button ] (
+        label : "Go" ,
+        disabled : slot: navigation-disabled ,
+        state-when-disabled : slot: navigation-disabled ,
+        onClick : emit: onNavigate
+      )
+    }
+
+    Box [ content-surface ] { }
+
+    Row [ status-bar ] {
+      Text [ status-text ] ( content : slot: status-text )
+    }
+  }
+}

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -1,0 +1,101 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+fn read(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join(name);
+    fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+#[test]
+fn venture_chrome_sources_compile_with_matching_theme_topology() {
+    let interface =
+        mosmodel_compiler::compile(&read("VentureChrome.mil")).expect("compile interface");
+    let layout = moslayout_compiler::compile(
+        &read("VentureChrome.mll"),
+        Some(&interface.descriptor_json),
+    )
+    .expect("compile layout");
+    let light = mosstyle_compiler::compile(
+        &read("VentureChrome.light.msl"),
+        Some(&layout.part_map_json),
+    )
+    .expect("compile light theme");
+    let dark = mosstyle_compiler::compile(
+        &read("VentureChrome.dark.msl"),
+        Some(&layout.part_map_json),
+    )
+    .expect("compile dark theme");
+
+    assert_eq!(interface.component.component, "VentureChrome");
+    assert_eq!(layout.def.component_name, "VentureChrome");
+    assert_eq!(light.def.component_name, "VentureChrome");
+    assert_eq!(dark.def.component_name, "VentureChrome");
+
+    let topology = |style: &mosstyle_compiler::StyleDef| {
+        style
+            .parts
+            .iter()
+            .map(|part| {
+                let mut states: Vec<_> = part
+                    .states
+                    .iter()
+                    .map(|state| state.state.clone())
+                    .collect();
+                states.sort_unstable();
+                (part.name.clone(), states)
+            })
+            .collect::<BTreeMap<_, _>>()
+    };
+    assert_eq!(topology(&light.def), topology(&dark.def));
+}
+
+#[test]
+fn interface_and_manifest_pin_the_browser_chrome_contract() {
+    let interface =
+        mosmodel_compiler::compile(&read("VentureChrome.mil")).expect("compile interface");
+    let slots: Vec<_> = interface
+        .component
+        .slots
+        .iter()
+        .map(|slot| slot.name.as_str())
+        .collect();
+    assert_eq!(
+        slots,
+        [
+            "address",
+            "page-title",
+            "status-text",
+            "back-disabled",
+            "forward-disabled",
+            "navigation-disabled",
+        ]
+    );
+    let events: Vec<_> = interface
+        .component
+        .emits
+        .iter()
+        .map(|event| event.name.as_str())
+        .collect();
+    assert_eq!(
+        events,
+        [
+            "onBack",
+            "onForward",
+            "onHome",
+            "onReload",
+            "onAddressChange",
+            "onNavigate",
+        ]
+    );
+
+    let manifest = fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("mosaic-package.toml"),
+    )
+    .expect("read manifest");
+    let package = mosaic_package_manifest::parse(&manifest).expect("parse manifest");
+    assert_eq!(package.package.name, "venture-browser");
+    assert_eq!(package.components.exports, ["VentureChrome"]);
+}


### PR DESCRIPTION
## Summary

- add `code/programs/mosaic/venture-browser` as the shared MIL/MLL/MSL package for Venture's title bar, navigation controls, address input, status line, and light/dark interaction states
- lower the same checked-in package to native SwiftUI and WinUI controls, including disabled, hover, pressed, focused, address-change, and commit dispatch behavior
- add emitter acceptance tests that pin both themes and generated macOS/Windows project shells

## Why

Venture needs browser chrome without growing separate handwritten AppKit and Win32 implementations. This establishes Mosaic's package pipeline as the source of truth while keeping the existing browser viewport as an explicit host-surface boundary.

This is a bounded browser-wiring milestone. It does not claim complete browser or HTML conformance, and it does not yet embed Venture's rendered page surface inside the generated Mosaic shell.

## Validation

- `cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml`
- `cargo test -p mosaic-emit-swiftui`
- `cargo test -p mosaic-emit-xaml`
- `cargo clippy -p mosaic-emit-swiftui -p mosaic-emit-xaml --all-targets -- -D warnings`
- generated both SwiftUI and XAML projects with `mosaic-compile pkg --emit-project` for the Venture package
- `swift build` on the generated SwiftUI project
- `cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test`
- `check_whatwg_audit_coverage.py --check` (tree-construction missing: 0)
- `check_generated_html_fixtures.py` (tokenizer skipped: 0; parser missing: 0)

The generated WinUI project restores on macOS and is source-checked here; its direct XAML build remains gated by the Windows CI runner because Microsoft's XAML compiler is a Windows executable.
