### PR TITLE
feat(dart-scaffold): emit capability manifests

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -10,7 +10,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "d05262d531b180ce5bbbced4d8fbcbc8a43a43d0",
+    "revision": "8c4785535d9e49cbed77d238d1bc596697f28439",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1200,

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,18 +8,18 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": 9371,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "2e067105d718d35fbb85d39eae879479302df82e",
+    "revision": "d05262d531b180ce5bbbced4d8fbcbc8a43a43d0",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1199,
-    "implementation_package_slots": 4341,
+    "implementation_identities": 1200,
+    "implementation_package_slots": 4342,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 277,
-    "singleton_packages": 749,
-    "singleton_missing_slots": 10486,
-    "rust_singletons": 554,
+    "singleton_packages": 750,
+    "singleton_missing_slots": 10500,
+    "rust_singletons": 555,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -107,11 +107,11 @@
     {
       "id": "build-tool-execution-case-snapshot",
       "title": "Bind execution to the exact approved in-memory case snapshot",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-trusted-authority-bundle"],
       "branch": "codex/build-tool-execution-case-snapshot",
       "pr_number": 9371,
-      "notes": "Ready-for-review PR #9371. Selected after merged PR #9368 and the collision-clean 2e067105d inventory plus parallel package, fixture, contract, and security audits. The process-free boundary defines factory-only typed immutable snapshots and selectors, exact retained bytes and digests, bounded direct corpus membership, Unicode/case alias rejection, POSIX retained no-follow traversal, and Windows fixed-volume non-reparse FileId binding without claiming execution authority, backend readiness, adapter conformance, or fixture execution. Validation: 178 build-tool tests passed with 23 expected platform skips and 81% branch-aware Windows coverage; 10 reporter tests, both process-free contract validators, Ruff, Bandit, compileall, Go test/vet, collision and state-graph checks, diff hygiene, and independent fixture, contract, and security reviews passed. The repository BUILD validator reproduced the same 73 pre-existing Windows BUILD/CI metadata errors on pristine origin/main."
+      "notes": "Merged PR #9371 at d05262d531b180ce5bbbced4d8fbcbc8a43a43d0 after all GitHub checks passed. Selected after merged PR #9368 and the collision-clean 2e067105d inventory plus parallel package, fixture, contract, and security audits. The process-free boundary defines factory-only typed immutable snapshots and selectors, exact retained bytes and digests, bounded direct corpus membership, Unicode/case alias rejection, POSIX retained no-follow traversal, and Windows fixed-volume non-reparse FileId binding without claiming execution authority, backend readiness, adapter conformance, or fixture execution. Validation: 178 build-tool tests passed with 23 expected platform skips and 81% branch-aware Windows coverage; 10 reporter tests, both process-free contract validators, Ruff, Bandit, compileall, Go test/vet, collision and state-graph checks, diff hygiene, and independent fixture, contract, and security reviews passed. The repository BUILD validator reproduced the same 73 pre-existing Windows BUILD/CI metadata errors on pristine origin/main."
     },
     {
       "id": "build-tool-bootstrap-execution-fixture",
@@ -461,11 +461,11 @@
     {
       "id": "dart-scaffold-capability-schema",
       "title": "Emit truthful schema-v1 capability manifests from the Dart scaffold generator",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["capability-schema-category-action-constraints"],
-      "branch": null,
+      "branch": "codex/dart-scaffold-capability-schema",
       "pr_number": null,
-      "notes": "Discovered in the e34f26fad post-merge fixture audit. The native Dart generator emits no required_capabilities.json for library or program scaffolds even though Spec 13 requires explicit schema-v1 profiles. Add language-neutral golden/schema coverage, emit empty profiles for libraries and the truthful stdout profile for generated programs, classify the generator's own runtime authority, and leave existing nonempty Dart profile interpretation to the legacy migration owner."
+      "notes": "Selected after merged PR #9371, the collision-clean d05262d inventory, and parallel dependency, fixture, contract, and security audits because it directly unlocks dart-current-14-of-15 and its 13 portable packages. Discovered in the e34f26fad post-merge fixture audit. The native Dart generator emits no required_capabilities.json for library or program scaffolds even though Spec 13 requires explicit schema-v1 profiles. Add language-neutral golden/schema coverage, emit empty profiles for libraries and the truthful stdout profile for generated programs, classify the generator's own runtime authority, and leave existing nonempty Dart profile interpretation to the legacy migration owner."
     },
     {
       "id": "haskell-http1",
@@ -600,7 +600,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 554, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 555, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -609,7 +609,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30-31 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, and smart-home-home-assistant-migration; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, and Home Assistant migration packages as native/service/storage boundary cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. The Home Assistant migration's deterministic export parsing, normalization, planning, diagnostics, IDs, fingerprints, and receipts are portable-core candidates, while runtime application, atomic filesystem writes, CLI behavior, three Rust-only runtime dependencies, and its missing capability manifest require explicit host-boundary review. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic into the Matter contract, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary."
+      "notes": "The July 30-31 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, smart-home-home-assistant-migration, and smart-home-home-assistant-export; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, Home Assistant migration, and Home Assistant export packages as native/service/storage boundary cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. The Home Assistant migration's deterministic export parsing, normalization, planning, diagnostics, IDs, fingerprints, and receipts are portable-core candidates, while runtime application, atomic filesystem writes, CLI behavior, three Rust-only runtime dependencies, and its missing capability manifest require explicit host-boundary review. The new Home Assistant export package similarly mixes deterministic normalization and export-core logic with TLS/WebSocket transport, environment-token intake, filesystem output, wall-clock metadata, console reporting, and a missing capability manifest; keep those host effects under explicit authority review before extracting any portable core. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic into the Matter contract, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary."
     },
     {
       "id": "matter-portable-core-extraction-and-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,7 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": 9375,
   "last_inventory": {
     "revision": "8c4785535d9e49cbed77d238d1bc596697f28439",
     "schema_version": 3,
@@ -461,11 +461,11 @@
     {
       "id": "dart-scaffold-capability-schema",
       "title": "Emit truthful schema-v1 capability manifests from the Dart scaffold generator",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["capability-schema-category-action-constraints"],
       "branch": "codex/dart-scaffold-capability-schema",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9371, the collision-clean d05262d inventory, and parallel dependency, fixture, contract, and security audits because it directly unlocks dart-current-14-of-15 and its 13 portable packages. Discovered in the e34f26fad post-merge fixture audit. The native Dart generator emits no required_capabilities.json for library or program scaffolds even though Spec 13 requires explicit schema-v1 profiles. Add language-neutral golden/schema coverage, emit empty profiles for libraries and the truthful stdout profile for generated programs, classify the generator's own runtime authority, and leave existing nonempty Dart profile interpretation to the legacy migration owner."
+      "pr_number": 9375,
+      "notes": "Ready PR #9375 was opened after merged PR #9371, the collision-clean d05262d selection inventory, a post-rebase 8c4785535 inventory, and parallel dependency, fixture, contract, and adversarial security audits because it directly unlocks dart-current-14-of-15 and its 13 portable packages. It adds language-neutral schema-v1 goldens, emits empty library and truthful stdout-only program manifests, declares the generator's exact runtime authority, fixes repository discovery to the checked-in CLI, removes callable public path overrides, and rejects malicious transitive dependency names before path construction. Validation: all 17 Dart tests and real generated library/program toolchains passed; 91.76% line coverage; all four Go build-tool-selected Dart packages built; shared manifest/taxonomy/reporter tests, Dart format/analyze, Ruff, Bandit, compileall, JSON parsing, Go test/vet, collision inventory, state-graph, diff, secret, and independent final audits passed. Spec 13 Layer 5 hardware-key-signed maintainer approval remains required before merge for the new nonempty generator manifest."
     },
     {
       "id": "haskell-http1",

--- a/code/programs/dart/scaffold-generator/CHANGELOG.md
+++ b/code/programs/dart/scaffold-generator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.2.0] - 2026-07-31
+
+### Added
+
+- Schema-v1 `required_capabilities.json` emission for generated libraries and
+  programs, with byte-exact language-neutral golden fixtures.
+- An explicit reviewed runtime-authority manifest for repository reads,
+  scaffold creation and writes, dated changelogs, and console reporting.
+- Native Dart and shared Draft 2020-12 schema tests for both generated
+  capability profiles.
+
+### Changed
+
+- Removed the callable public library surface so the checked-in fixed-root CLI
+  entrypoint is the only supported path to filesystem authority.
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/code/programs/dart/scaffold-generator/README.md
+++ b/code/programs/dart/scaffold-generator/README.md
@@ -8,7 +8,8 @@ coding-adventures monorepo.
 This is the Dart bootstrap implementation of `scaffold-generator`. It focuses
 on the Dart lane first so future Dart ports can start from a correct package
 layout instead of hand-crafting `pubspec.yaml`, `BUILD`, `README.md`,
-`CHANGELOG.md`, `.gitignore`, `lib/`, `bin/`, and `test/` files.
+`CHANGELOG.md`, `required_capabilities.json`, `.gitignore`, `lib/`, `bin/`,
+and `test/` files.
 
 ## Usage
 
@@ -26,9 +27,27 @@ dart run bin/scaffold_generator.dart parser --dry-run
 - Validates direct dependencies against the existing Dart tree
 - Computes the transitive Dart dependency closure from `pubspec.yaml`
 - Uses the shared Dart `cli-builder` package for argument parsing
+- Emits byte-stable Spec 13 schema-v1 capability metadata: an empty profile for
+  libraries and the generated program's truthful `stdout:write:*` profile
+
+## Capability contract
+
+The generator itself declares the filesystem read/create/write, clock-read,
+and standard-output authority exercised by repository discovery, dependency
+planning, scaffold creation, dated changelogs, previews, and diagnostics. It
+derives a fixed repository root from its own checked-in package location, and
+exposes no callable public library API: the checked-in `bin/` entrypoint imports
+the internal implementation directly. It does not request network, subprocess,
+environment, FFI, or stdin access.
+
+Generated profiles are checked byte-for-byte against language-neutral golden
+fixtures and separately validated against the shared Draft 2020-12 schema.
+Existing nonempty Dart package profiles are outside this generator contract and
+remain subject to their dedicated migration and Layer 5 review.
 
 ## Development
 
 ```bash
 bash BUILD
+dart analyze
 ```

--- a/code/programs/dart/scaffold-generator/bin/scaffold_generator.dart
+++ b/code/programs/dart/scaffold-generator/bin/scaffold_generator.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:scaffold_generator/scaffold_generator.dart';
+import 'package:scaffold_generator/src/scaffold_generator.dart';
 
 void main(List<String> args) {
   exit(run(args));

--- a/code/programs/dart/scaffold-generator/lib/scaffold_generator.dart
+++ b/code/programs/dart/scaffold-generator/lib/scaffold_generator.dart
@@ -1,3 +1,4 @@
 library;
 
-export 'src/scaffold_generator.dart';
+// This monorepo program intentionally exposes no callable library API. The
+// checked-in bin entry point owns repository-relative path resolution.

--- a/code/programs/dart/scaffold-generator/lib/src/scaffold_generator.dart
+++ b/code/programs/dart/scaffold-generator/lib/src/scaffold_generator.dart
@@ -108,28 +108,65 @@ String wrapDescription(String description) {
 
 String dartStringLiteral(String value) => jsonEncode(value);
 
-String findRepoRoot([String? startPath]) {
-  var current = Directory(startPath ?? Directory.current.path).absolute;
-  while (true) {
-    final codeDir = Directory('${current.path}/code');
-    final lessons = File('${current.path}/lessons.md');
-    if (codeDir.existsSync() && lessons.existsSync()) {
-      return current.path;
-    }
+/// Render the explicit Spec 13 capability profile for a generated Dart target.
+///
+/// Library scaffolds begin as pure computation. Program scaffolds add only the
+/// stdout authority exercised by the generated `bin/` entry point. Keeping
+/// this renderer data-driven makes the JSON shape deterministic and lets the
+/// native Dart tests compare it byte-for-byte with the language-neutral
+/// contract fixtures.
+String capabilityManifestContents(
+  PackageType packageType,
+  String packageName,
+) {
+  final isProgram = packageType == PackageType.program;
+  final capabilities = <Map<String, String>>[
+    if (isProgram)
+      <String, String>{
+        'category': 'stdout',
+        'action': 'write',
+        'target': '*',
+        'justification':
+            'Writes the generated program starter message to standard output.',
+      },
+  ];
+  final document = <String, Object>{
+    r'$schema':
+        'https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json',
+    'version': 1,
+    'package': 'dart/$packageName',
+    'capabilities': capabilities,
+    'justification': isProgram
+        ? 'Generated program writes its starter message to standard output and uses no other OS capabilities.'
+        : 'Pure computation. No filesystem, network, process, or environment access needed.',
+  };
+  return '${const JsonEncoder.withIndent('  ').convert(document)}\n';
+}
 
-    final parent = current.parent;
-    if (parent.path == current.path) {
-      throw ArgumentError(
-        'Could not find the coding-adventures repo root from ${current.path}.',
-      );
-    }
-    current = parent;
+String findRepoRoot([String? startPath]) {
+  final candidate = Directory(startPath ?? defaultRepoRoot()).absolute;
+  final codeDir = Directory('${candidate.path}/code');
+  final lessons = File('${candidate.path}/lessons.md');
+  if (codeDir.existsSync() && lessons.existsSync()) {
+    return candidate.path;
   }
+
+  throw ArgumentError(
+    '${candidate.path} is not the coding-adventures repo root.',
+  );
 }
 
 String defaultSpecPath([Uri? script]) {
   final scriptFile = File.fromUri(script ?? Platform.script);
   return '${scriptFile.parent.parent.path}/scaffold-generator.json';
+}
+
+String defaultRepoRoot([Uri? script]) {
+  var current = File(defaultSpecPath(script)).parent;
+  for (var index = 0; index < 4; index += 1) {
+    current = current.parent;
+  }
+  return current.path;
 }
 
 List<String> parseLanguages(String rawValue) {
@@ -202,6 +239,12 @@ CliOptions optionsFromParseResult(ParseResult result) {
 }
 
 DependencyRef resolveDependency(String repoRoot, String dependencyName) {
+  if (!kebabCasePattern.hasMatch(dependencyName)) {
+    throw ArgumentError(
+      'Dependency "$dependencyName" is not valid kebab-case.',
+    );
+  }
+
   final packagePath = '$repoRoot/code/packages/dart/$dependencyName';
   if (Directory(packagePath).existsSync()) {
     return DependencyRef(
@@ -467,6 +510,10 @@ List<ScaffoldFile> generateCommonFiles({
       relativePath: 'CHANGELOG.md',
       content: '${changelog.toString().trimRight()}\n',
     ),
+    ScaffoldFile(
+      relativePath: 'required_capabilities.json',
+      content: capabilityManifestContents(packageType, packageName),
+    ),
   ];
 }
 
@@ -706,7 +753,9 @@ String renderDryRun(ScaffoldPlan plan) {
   return buffer.toString();
 }
 
-int run(
+int run(List<String> args) => runWithOverrides(args);
+
+int runWithOverrides(
   List<String> args, {
   String? repoRoot,
   StringSink? out,

--- a/code/programs/dart/scaffold-generator/pubspec.yaml
+++ b/code/programs/dart/scaffold-generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: scaffold_generator
 description: >
   Generate CI-ready Dart package and program scaffolding for the
   coding-adventures monorepo.
-version: 0.1.0
+version: 0.2.0
 publish_to: none
 
 environment:

--- a/code/programs/dart/scaffold-generator/required_capabilities.json
+++ b/code/programs/dart/scaffold-generator/required_capabilities.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/scaffold-generator",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "scaffold-generator.json",
+      "justification": "Loads the checked-in CLI Builder specification before parsing scaffold arguments."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../../code",
+      "justification": "Confirms the fixed repository root before resolving any generated output path."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../../lessons.md",
+      "justification": "Confirms the fixed repository root before resolving any generated output path."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../packages/dart/*",
+      "justification": "Checks Dart package directory metadata while resolving dependencies and refusing an existing library target."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../../packages/dart/*/pubspec.yaml",
+      "justification": "Reads Dart package metadata to validate dependencies and compute their transitive order."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../*",
+      "justification": "Checks Dart program directory metadata while resolving dependencies and refusing an existing program target."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../*/pubspec.yaml",
+      "justification": "Reads Dart program metadata when a generated target depends on a sibling program."
+    },
+    {
+      "category": "fs",
+      "action": "create",
+      "target": "../../../packages/dart/*/**",
+      "justification": "Creates the selected Dart library scaffold and its standard nested directories."
+    },
+    {
+      "category": "fs",
+      "action": "create",
+      "target": "../*/**",
+      "justification": "Creates the selected Dart program scaffold and its standard nested directories."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "../../../packages/dart/*/**",
+      "justification": "Writes the reviewed library scaffold files beneath the selected target directory."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "../*/**",
+      "justification": "Writes the reviewed program scaffold files beneath the selected target directory."
+    },
+    {
+      "category": "time",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads the current date for the generated package changelog entry."
+    },
+    {
+      "category": "stdout",
+      "action": "write",
+      "target": "*",
+      "justification": "Reports dry-run previews, successful output paths, and argument or validation errors."
+    }
+  ],
+  "justification": "The scaffold generator reads repository metadata, creates and writes one selected Dart target, dates its changelog, and reports through standard output or standard error. It uses no network, subprocess, environment, FFI, or stdin authority."
+}

--- a/code/programs/dart/scaffold-generator/scaffold-generator.json
+++ b/code/programs/dart/scaffold-generator/scaffold-generator.json
@@ -3,7 +3,7 @@
   "name": "scaffold-generator",
   "display_name": "Scaffold Generator",
   "description": "Generate CI-ready Dart package scaffolding for the coding-adventures monorepo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "parsing_mode": "gnu",
   "builtin_flags": { "help": true, "version": true },
   "flags": [

--- a/code/programs/dart/scaffold-generator/test/scaffold_generator_test.dart
+++ b/code/programs/dart/scaffold-generator/test/scaffold_generator_test.dart
@@ -1,12 +1,31 @@
 import 'dart:io';
 
-import 'package:scaffold_generator/scaffold_generator.dart';
+import 'package:scaffold_generator/src/scaffold_generator.dart';
 import 'package:test/test.dart';
 
 void writeFile(String repoRoot, String relativePath, String content) {
   final file = File('$repoRoot/$relativePath');
   file.parent.createSync(recursive: true);
   file.writeAsStringSync(content);
+}
+
+String readCapabilityFixture(String name) => File(
+      '../../../specs/fixtures/scaffold-generator/$name',
+    ).readAsStringSync();
+
+ProcessResult runDart(List<String> arguments, String workingDirectory) {
+  final result = Process.runSync(
+    Platform.resolvedExecutable,
+    arguments,
+    workingDirectory: workingDirectory,
+  );
+  expect(
+    result.exitCode,
+    0,
+    reason:
+        'dart ${arguments.join(' ')} failed in $workingDirectory\n${result.stdout}\n${result.stderr}',
+  );
+  return result;
 }
 
 void writeDartPackage(
@@ -67,6 +86,51 @@ void main() {
     });
   });
 
+  group('capability manifests', () {
+    test('renders the schema-v1 pure-library golden document', () {
+      expect(
+        capabilityManifestContents(PackageType.library, 'my-pkg'),
+        readCapabilityFixture('dart_library_required_capabilities.json'),
+      );
+    });
+
+    test('renders the schema-v1 stdout program golden document', () {
+      expect(
+        capabilityManifestContents(PackageType.program, 'build-helper'),
+        readCapabilityFixture('dart_program_required_capabilities.json'),
+      );
+    });
+  });
+
+  group('repository root', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('dart-scaffold-root-');
+      Directory('${tempDir.path}/code').createSync();
+      File('${tempDir.path}/lessons.md').writeAsStringSync('# Lessons\n');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('accepts only the explicit repository root', () {
+      expect(findRepoRoot(tempDir.path), tempDir.absolute.path);
+      expect(
+        () => findRepoRoot('${tempDir.path}/code'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('derives the default root from the generator package', () {
+      final script = Uri.file(
+        '${tempDir.path}/code/programs/dart/scaffold-generator/bin/scaffold_generator.dart',
+      );
+      expect(defaultRepoRoot(script), tempDir.path);
+    });
+  });
+
   group('Dart dependency parsing', () {
     late Directory tempDir;
     late String repoRoot;
@@ -99,6 +163,30 @@ void main() {
         'lexer',
         'parser',
       ]);
+    });
+
+    test('rejects untrusted transitive names before path resolution', () {
+      writeFile(
+        repoRoot,
+        'code/packages/dart/poisoned/pubspec.yaml',
+        '''
+name: coding_adventures_poisoned
+dependencies:
+  ../../../../outside:
+    path: ../../../../outside
+''',
+      );
+
+      expect(
+        () => transitiveClosure(<String>['poisoned'], repoRoot),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('not valid kebab-case'),
+          ),
+        ),
+      );
     });
   });
 
@@ -151,6 +239,12 @@ void main() {
       expect(
         File('${targetDir.path}/test/nib_parser_test.dart').readAsStringSync(),
         contains('describePackage()'),
+      );
+      expect(
+        File(
+          '${targetDir.path}/required_capabilities.json',
+        ).readAsStringSync(),
+        capabilityManifestContents(PackageType.library, 'nib-parser'),
       );
     });
 
@@ -209,6 +303,12 @@ void main() {
         File('${targetDir.path}/pubspec.yaml').readAsStringSync(),
         contains('path: ../../../packages/dart/lexer'),
       );
+      expect(
+        File(
+          '${targetDir.path}/required_capabilities.json',
+        ).readAsStringSync(),
+        capabilityManifestContents(PackageType.program, 'nib-demo'),
+      );
     });
 
     test('renders dry-run output for a scaffold plan', () {
@@ -228,8 +328,58 @@ void main() {
       final preview = renderDryRun(plan);
       expect(preview, contains('Would create'));
       expect(preview, contains('pubspec.yaml'));
+      expect(preview, contains('required_capabilities.json'));
       expect(preview, contains('Transitive Dart dependencies'));
     });
+
+    test(
+      'generated library and program pass the real Dart toolchain',
+      () {
+        final libraryPlan = scaffoldPlan(
+          repoRoot: repoRoot,
+          options: const CliOptions(
+            packageName: 'generated-library',
+            packageType: PackageType.library,
+            languages: <String>['dart'],
+            directDependencies: <String>[],
+            layer: 1,
+            description: 'Generated downstream library.',
+            dryRun: false,
+          ),
+        );
+        final programPlan = scaffoldPlan(
+          repoRoot: repoRoot,
+          options: const CliOptions(
+            packageName: 'generated-program',
+            packageType: PackageType.program,
+            languages: <String>['dart'],
+            directDependencies: <String>[],
+            layer: null,
+            description: 'Generated downstream program.',
+            dryRun: false,
+          ),
+        );
+        writePlan(libraryPlan);
+        writePlan(programPlan);
+
+        for (final target in <String>[
+          libraryPlan.targetDir,
+          programPlan.targetDir,
+        ]) {
+          runDart(<String>['pub', 'get', '--offline'], target);
+          runDart(<String>['analyze'], target);
+          runDart(<String>['test'], target);
+        }
+
+        final execution = runDart(
+          <String>['run', 'bin/generated_program.dart'],
+          programPlan.targetDir,
+        );
+        expect(
+            execution.stdout, contains('TODO: implement generated-program.'));
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
   });
 
   group('CLI entrypoints', () {
@@ -253,7 +403,7 @@ void main() {
     test('dry-run uses the CLI spec and leaves the tree untouched', () {
       final stdoutBuffer = StringBuffer();
       final stderrBuffer = StringBuffer();
-      final exitCode = run(
+      final exitCode = runWithOverrides(
         <String>[
           'nib-lexer',
           '--depends-on',
@@ -280,7 +430,7 @@ void main() {
 
     test('reports invalid kebab-case names', () {
       final stderrBuffer = StringBuffer();
-      final exitCode = run(
+      final exitCode = runWithOverrides(
         <String>['NibLexer'],
         repoRoot: repoRoot,
         err: stderrBuffer,

--- a/code/scripts/tests/test_haskell_required_capabilities.py
+++ b/code/scripts/tests/test_haskell_required_capabilities.py
@@ -1,4 +1,4 @@
-"""Validate Haskell and OCaml capability manifests against the shared schema."""
+"""Validate scaffold capability manifests against the shared schema."""
 
 from __future__ import annotations
 
@@ -28,9 +28,7 @@ class RequiredCapabilitiesTest(unittest.TestCase):
             REPO_ROOT / "code/programs/haskell",
         )
         paths = sorted(
-            path
-            for root in roots
-            for path in root.glob("*/required_capabilities.json")
+            path for root in roots for path in root.glob("*/required_capabilities.json")
         )
         self.assertTrue(paths, "expected at least one explicit Haskell manifest")
 
@@ -62,6 +60,117 @@ class RequiredCapabilitiesTest(unittest.TestCase):
                 document = json.loads(path.read_text(encoding="utf-8"))
                 self.assert_schema_valid(document)
                 self.assertEqual("ocaml/my-pkg", document["package"])
+
+    def test_dart_scaffold_fixtures_are_schema_valid(self) -> None:
+        paths = sorted(FIXTURE_ROOT.glob("dart_*_required_capabilities.json"))
+        self.assertEqual(2, len(paths), "expected Dart library and program fixtures")
+
+        expected_packages = {"dart/my-pkg", "dart/build-helper"}
+        actual_packages: set[str] = set()
+        for path in paths:
+            with self.subTest(path=path.relative_to(REPO_ROOT)):
+                document = json.loads(path.read_text(encoding="utf-8"))
+                self.assert_schema_valid(document)
+                actual_packages.add(document["package"])
+
+        self.assertEqual(expected_packages, actual_packages)
+
+    def test_dart_generator_declares_its_runtime_authority(self) -> None:
+        path = (
+            REPO_ROOT
+            / "code/programs/dart/scaffold-generator/required_capabilities.json"
+        )
+        document = json.loads(path.read_text(encoding="utf-8"))
+        self.assert_schema_valid(document)
+        self.assertEqual(
+            {
+                "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+                "version": 1,
+                "package": "dart/scaffold-generator",
+                "capabilities": [
+                    {
+                        "category": "fs",
+                        "action": "read",
+                        "target": "scaffold-generator.json",
+                        "justification": "Loads the checked-in CLI Builder specification before parsing scaffold arguments.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "read",
+                        "target": "../../../../code",
+                        "justification": "Confirms the fixed repository root before resolving any generated output path.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "read",
+                        "target": "../../../../lessons.md",
+                        "justification": "Confirms the fixed repository root before resolving any generated output path.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "read",
+                        "target": "../../../packages/dart/*",
+                        "justification": "Checks Dart package directory metadata while resolving dependencies and refusing an existing library target.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "read",
+                        "target": "../../../packages/dart/*/pubspec.yaml",
+                        "justification": "Reads Dart package metadata to validate dependencies and compute their transitive order.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "read",
+                        "target": "../*",
+                        "justification": "Checks Dart program directory metadata while resolving dependencies and refusing an existing program target.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "read",
+                        "target": "../*/pubspec.yaml",
+                        "justification": "Reads Dart program metadata when a generated target depends on a sibling program.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "create",
+                        "target": "../../../packages/dart/*/**",
+                        "justification": "Creates the selected Dart library scaffold and its standard nested directories.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "create",
+                        "target": "../*/**",
+                        "justification": "Creates the selected Dart program scaffold and its standard nested directories.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "write",
+                        "target": "../../../packages/dart/*/**",
+                        "justification": "Writes the reviewed library scaffold files beneath the selected target directory.",
+                    },
+                    {
+                        "category": "fs",
+                        "action": "write",
+                        "target": "../*/**",
+                        "justification": "Writes the reviewed program scaffold files beneath the selected target directory.",
+                    },
+                    {
+                        "category": "time",
+                        "action": "read",
+                        "target": "*",
+                        "justification": "Reads the current date for the generated package changelog entry.",
+                    },
+                    {
+                        "category": "stdout",
+                        "action": "write",
+                        "target": "*",
+                        "justification": "Reports dry-run previews, successful output paths, and argument or validation errors.",
+                    },
+                ],
+                "justification": "The scaffold generator reads repository metadata, creates and writes one selected Dart target, dates its changelog, and reports through standard output or standard error. It uses no network, subprocess, environment, FFI, or stdin authority.",
+            },
+            document,
+        )
 
     def assert_schema_valid(self, document: object) -> None:
         errors = sorted(

--- a/code/specs/fixtures/scaffold-generator/dart_library_required_capabilities.json
+++ b/code/specs/fixtures/scaffold-generator/dart_library_required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/my-pkg",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/specs/fixtures/scaffold-generator/dart_program_required_capabilities.json
+++ b/code/specs/fixtures/scaffold-generator/dart_program_required_capabilities.json
@@ -7,8 +7,8 @@
       "category": "stdout",
       "action": "write",
       "target": "*",
-      "justification": "Writes the generated program description to standard output."
+      "justification": "Writes the generated program starter message to standard output."
     }
   ],
-  "justification": "Generated program writes its starter description to standard output and uses no other OS capabilities."
+  "justification": "Generated program writes its starter message to standard output and uses no other OS capabilities."
 }

--- a/code/specs/fixtures/scaffold-generator/dart_program_required_capabilities.json
+++ b/code/specs/fixtures/scaffold-generator/dart_program_required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/build-helper",
+  "capabilities": [
+    {
+      "category": "stdout",
+      "action": "write",
+      "target": "*",
+      "justification": "Writes the generated program description to standard output."
+    }
+  ],
+  "justification": "Generated program writes its starter description to standard output and uses no other OS capabilities."
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,11 +106,12 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 31, 2026 at `2e067105d` after merged OCaml
-toolchain work, the Rust `smart-home-matter-integration`, and the Rust
-`smart-home-home-assistant-migration`, plus the merged Algol, Mosaic, and
-build-tool status-normalization slices. It contains 1,199 normalized
-implementation identities across 4,341 established-lane package
+inventory was regenerated on July 31, 2026 at `d05262d53` after merged OCaml
+toolchain work, the Rust `smart-home-matter-integration`, the Rust
+`smart-home-home-assistant-migration`, the Rust
+`smart-home-home-assistant-export`, and merged Algol, Mosaic, and build-tool
+contract slices through the execution case snapshot. It contains 1,200
+normalized implementation identities across 4,342 established-lane package
 slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -118,9 +119,9 @@ slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 277 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 749 | 10,486 |
+| Present in one language | 750 | 10,500 |
 
-The loop must not start by attempting 10,486 singleton ports. It should finish
+The loop must not start by attempting 10,500 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The July 31 lane audit is:
@@ -139,7 +140,7 @@ The July 31 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 964 | 0 | 100% |
+| Rust | 965 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -885,10 +886,10 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 554 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 555 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30-31 inventories added fourteen Rust singleton identities that now
+The July 30-31 inventories added fifteen Rust singleton identities that now
 have explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
@@ -913,6 +914,13 @@ parsing, normalization, planning, diagnostics, IDs, fingerprints, and receipts
 are portable-core candidates; runtime application, atomic filesystem writes,
 CLI behavior, three Rust-only runtime dependencies, and the missing capability
 manifest require explicit host-boundary and authority classification.
+
+The fifteenth identity, `smart-home-home-assistant-export`, is another mixed
+boundary. Its deterministic normalization and export-core logic are portable
+candidates, while TLS/WebSocket transport, environment-token intake,
+filesystem output, wall-clock metadata, console reporting, and its missing
+capability manifest remain host-owned authority that must be classified before
+any cross-language extraction.
 
 The new `smart-home-matter-integration` is also a mixed split candidate rather
 than a native-source exception: endpoint projection, report normalization, and
@@ -1120,13 +1128,18 @@ propagation. This bounded schema-and-validator repair lands before execution
 cases, trusted execution, the Go oracle, OCaml's build substrate, or adapter
 work consumes those records.
 
-The selected successor is `build-tool-execution-case-snapshot`. It defines the
-typed selector and held-snapshot boundary that is currently only prose, opens
-one bounded direct-member corpus snapshot through a retained no-follow root,
-and preserves the exact hashed bytes for later execution while rejecting path,
-rename, symlink, hardlink, case/Unicode-alias, and post-digest substitution.
-This process-free slice grants no execution authority and marks no backend or
-adapter ready.
+Merged PR #9371 completed `build-tool-execution-case-snapshot`. It defines the
+typed selector and held-snapshot boundary, opens one bounded direct-member
+corpus snapshot through a retained no-follow root, and preserves the exact
+hashed bytes for later execution while rejecting path, rename, symlink,
+hardlink, case/Unicode-alias, and post-digest substitution. This process-free
+slice grants no execution authority and marks no backend or adapter ready.
+
+The serial parity loop then selected `dart-scaffold-capability-schema`, because
+its merged capability-schema dependency is satisfied and it directly unlocks
+the thirteen-package Dart-only 14-of-15 frontier. The next build-tool successor
+remains `build-tool-bootstrap-execution-fixture`; it does not become active
+while the Dart scaffold PR is open.
 
 The post-#9368 dependency audit also found that trusted authority requires one
 held case and one selected in-image adapter even though both checked-in

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,11 +106,12 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 31, 2026 at `d05262d53` after merged OCaml
+inventory was regenerated on July 31, 2026 at `8c4785535` after merged OCaml
 toolchain work, the Rust `smart-home-matter-integration`, the Rust
 `smart-home-home-assistant-migration`, the Rust
 `smart-home-home-assistant-export`, and merged Algol, Mosaic, and build-tool
-contract slices through the execution case snapshot. It contains 1,200
+contract slices through the execution case snapshot and the unrelated Mosaic
+native pressed-state repair. It contains 1,200
 normalized implementation identities across 4,342 established-lane package
 slots and found zero canonical collisions or unknown language buckets:
 


### PR DESCRIPTION
## Summary

- add language-neutral schema-v1 capability fixtures for generated Dart libraries and programs
- emit byte-stable `required_capabilities.json` files from the Dart scaffold generator
- declare the generator's reviewed runtime authority, constrain repository discovery to its checked-in CLI location, reject untrusted transitive dependency names before path construction, and expose no callable public path override
- refresh the collision-checked parity inventory and roadmap on current `origin/main`

This dependency-shaped slice unlocks the tracked `dart-current-14-of-15` batch and its 13 portable packages without broadening existing nonempty Dart profile interpretation.

## Validation

- `bash BUILD` — 17 Dart tests passed
- `dart format --output=none --set-exit-if-changed ...`
- `dart analyze`
- `dart test --coverage=.dart_tool/coverage` plus LCOV formatting — 345/376 lines, 91.76%
- generated-library and generated-program downstream checks — offline `dart pub get`, `dart analyze`, `dart test`, and real program execution passed
- public checked-in CLI dry-run passed
- Go build-tool affected execution — `dart/cli-builder`, `dart/directed-graph`, `dart/programs/scaffold-generator`, and `dart/state-machine` all built
- Go build-tool `go test ./...` and `go vet ./...`
- shared manifest-schema tests — 5 passed
- shared capability-taxonomy tests — 5 passed
- parity reporter tests — 10 passed
- `ruff check`, `ruff format --check`, Bandit, Python compileall, and JSON parsing passed
- `package_parity_report.py --format json --fail-on-collisions` — 15 established lanes, 1,200 identities, 4,342 slots, zero collisions, zero unknown buckets
- parity state transition/dependency graph, `git diff --check`, and focused secret scan passed
- independent fixture, contract/state, and adversarial security reviews passed with no remaining actionable findings

## Review gate

This PR adds a nonempty generator authority manifest. Spec 13 Layer 5 therefore requires the normal maintainer hardware-key-signed approval before merge. This PR does not grant merge authority and does not attempt to merge itself.
