### PR TITLE
feat(venture): share Mosaic chrome host contract

### DIFF
--- a/code/packages/rust/venture-browser-core/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.0
+
+- Add the host-neutral `BrowserChromeController` reducer and
+  `BrowserChromeProps` projection for the Mosaic-authored Venture chrome.
+- Pin the exact shared MIL slot and event names so host wiring cannot silently
+  drift from the package contract.
+
 ## 0.4.0
 
 - Add transactional `BrowserSession` navigation across page loading, redirect

--- a/code/packages/rust/venture-browser-core/Cargo.toml
+++ b/code/packages/rust/venture-browser-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "venture-browser-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Host-neutral navigation and page-loading orchestration for the Venture browser."
 

--- a/code/packages/rust/venture-browser-core/README.md
+++ b/code/packages/rust/venture-browser-core/README.md
@@ -40,6 +40,14 @@ replaces redirect history with the final URL, and updates the viewport only
 after a successful load. Pointer activation uses viewport coordinates and
 follows the resolved link through the same transactional path.
 
+`BrowserChromeController` is the matching host-neutral reducer for the shared
+Mosaic `VentureChrome` package. It preserves address edits as a draft, maps the
+six MIL events to `BrowserNavigation`, synchronizes redirects only after a
+successful load, and projects one coherent `BrowserChromeProps` snapshot for
+the six MIL slots. Native SwiftUI and WinUI bridges can consume this contract
+instead of implementing browser behavior independently; mounting those bridges
+into the runnable shells remains a separate acceptance gate.
+
 ## Development
 
 ```bash

--- a/code/packages/rust/venture-browser-core/src/lib.rs
+++ b/code/packages/rust/venture-browser-core/src/lib.rs
@@ -16,7 +16,27 @@ use paint_instructions::{PaintBase, PaintGroup, PaintInstruction, PaintScene};
 use std::fmt;
 use text_interfaces::{FontMetrics, FontResolver, TextShaper};
 
-pub const VERSION: &str = "0.4.0";
+pub const VERSION: &str = "0.5.0";
+
+/// Mosaic `VentureChrome` slot names, in interface declaration order.
+pub const VENTURE_CHROME_SLOT_NAMES: [&str; 6] = [
+    "address",
+    "page-title",
+    "status-text",
+    "back-disabled",
+    "forward-disabled",
+    "navigation-disabled",
+];
+
+/// Mosaic `VentureChrome` event names, in interface declaration order.
+pub const VENTURE_CHROME_EVENT_NAMES: [&str; 6] = [
+    "onBack",
+    "onForward",
+    "onHome",
+    "onReload",
+    "onAddressChange",
+    "onNavigate",
+];
 
 /// In-memory browser navigation state.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -334,6 +354,135 @@ pub enum BrowserNavigation {
     Reload,
 }
 
+/// An event emitted by the shared Mosaic `VentureChrome` component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BrowserChromeEvent {
+    Back,
+    Forward,
+    Home,
+    Reload,
+    AddressChange(String),
+    Navigate,
+}
+
+impl BrowserChromeEvent {
+    pub const fn mosaic_name(&self) -> &'static str {
+        match self {
+            Self::Back => "onBack",
+            Self::Forward => "onForward",
+            Self::Home => "onHome",
+            Self::Reload => "onReload",
+            Self::AddressChange(_) => "onAddressChange",
+            Self::Navigate => "onNavigate",
+        }
+    }
+}
+
+/// Values projected into the shared Mosaic `VentureChrome` slots.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BrowserChromeProps {
+    pub address: String,
+    pub page_title: String,
+    pub status_text: String,
+    pub back_disabled: bool,
+    pub forward_disabled: bool,
+    pub navigation_disabled: bool,
+}
+
+/// Host-neutral reducer for Venture's Mosaic-authored browser chrome.
+///
+/// Address edits remain a draft until the host successfully executes the
+/// returned navigation command and calls [`Self::synchronize`]. This keeps a
+/// failed load from replacing the user's input or the session's current URL.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BrowserChromeController {
+    address_draft: String,
+}
+
+impl BrowserChromeController {
+    pub fn new(session: &BrowserSession) -> Self {
+        Self {
+            address_draft: session
+                .history()
+                .current_url()
+                .unwrap_or_else(|| session.history().home_url())
+                .to_string(),
+        }
+    }
+
+    pub fn address_draft(&self) -> &str {
+        &self.address_draft
+    }
+
+    /// Synchronize the address slot after a successful page load or redirect.
+    pub fn synchronize(&mut self, session: &BrowserSession) {
+        if let Some(current_url) = session.history().current_url() {
+            self.address_draft = current_url.to_string();
+        }
+    }
+
+    /// Reduce a Mosaic event to a Venture navigation command when appropriate.
+    pub fn handle_event(
+        &mut self,
+        event: BrowserChromeEvent,
+        session: &BrowserSession,
+        navigation_disabled: bool,
+    ) -> Option<BrowserNavigation> {
+        if navigation_disabled {
+            return None;
+        }
+
+        match event {
+            BrowserChromeEvent::AddressChange(value) => {
+                self.address_draft = value;
+                None
+            }
+            BrowserChromeEvent::Navigate => {
+                let address = self.address_draft.trim();
+                (!address.is_empty()).then(|| BrowserNavigation::Navigate(address.to_string()))
+            }
+            BrowserChromeEvent::Back if session.history().can_go_back() => {
+                Some(BrowserNavigation::Back)
+            }
+            BrowserChromeEvent::Forward if session.history().can_go_forward() => {
+                Some(BrowserNavigation::Forward)
+            }
+            BrowserChromeEvent::Home => Some(BrowserNavigation::Home),
+            BrowserChromeEvent::Reload if session.history().current_url().is_some() => {
+                Some(BrowserNavigation::Reload)
+            }
+            BrowserChromeEvent::Back | BrowserChromeEvent::Forward | BrowserChromeEvent::Reload => {
+                None
+            }
+        }
+    }
+
+    /// Project one coherent snapshot for all six Mosaic chrome slots.
+    pub fn props(
+        &self,
+        session: &BrowserSession,
+        status_text: impl Into<String>,
+        navigation_disabled: bool,
+    ) -> BrowserChromeProps {
+        let page_title = session
+            .viewport()
+            .and_then(|viewport| viewport.page().document.title.as_deref())
+            .map(str::trim)
+            .filter(|title| !title.is_empty())
+            .unwrap_or("")
+            .to_string();
+
+        BrowserChromeProps {
+            address: self.address_draft.clone(),
+            page_title,
+            status_text: status_text.into(),
+            back_disabled: navigation_disabled || !session.history().can_go_back(),
+            forward_disabled: navigation_disabled || !session.history().can_go_forward(),
+            navigation_disabled,
+        }
+    }
+}
+
 /// Host-neutral browser state spanning navigation, loading, and the viewport.
 ///
 /// Navigation is transactional: a failed page load leaves both history and the
@@ -627,6 +776,124 @@ mod tests {
         assert_eq!(
             history.replace_current("http://home.test/index.html"),
             Some("http://home.test/index.html")
+        );
+    }
+
+    #[test]
+    fn mosaic_chrome_reduces_events_and_projects_session_state() {
+        let home_url = "http://home.test/";
+        let page_url = "http://example.test/guide";
+        let fetcher = |url: &str| {
+            Ok(BrowserFetchResponse::new(
+                url,
+                200,
+                Some("text/html".into()),
+                b"<title> Venture Guide </title><p>Ready</p>".to_vec(),
+            ))
+        };
+        let theme = mosaic_html_theme();
+        let pipeline = BrowserPagePipeline::new(
+            &theme,
+            HtmlPaintViewport::new(220.0, 100.0, 1.0),
+            &MonoMeasurer,
+            &FakeShaper,
+            &FakeMetrics,
+            &FakeResolver,
+        );
+        let mut session = BrowserSession::new(home_url, 40.0);
+        let mut chrome = BrowserChromeController::new(&session);
+
+        assert_eq!(chrome.address_draft(), home_url);
+        assert_eq!(
+            chrome.props(&session, "Ready", false),
+            BrowserChromeProps {
+                address: home_url.into(),
+                page_title: String::new(),
+                status_text: "Ready".into(),
+                back_disabled: true,
+                forward_disabled: true,
+                navigation_disabled: false,
+            }
+        );
+        assert_eq!(
+            chrome.handle_event(BrowserChromeEvent::Back, &session, false),
+            None
+        );
+        assert_eq!(
+            chrome.handle_event(BrowserChromeEvent::Reload, &session, false),
+            None
+        );
+
+        session
+            .execute(BrowserNavigation::Home, &pipeline, &fetcher)
+            .expect("home should load")
+            .expect("home should create a viewport");
+        chrome.synchronize(&session);
+
+        assert_eq!(
+            chrome.handle_event(
+                BrowserChromeEvent::AddressChange(format!("  {page_url}  ")),
+                &session,
+                false,
+            ),
+            None
+        );
+        let navigation = chrome
+            .handle_event(BrowserChromeEvent::Navigate, &session, false)
+            .expect("non-empty address should navigate");
+        assert_eq!(navigation, BrowserNavigation::Navigate(page_url.into()));
+        session
+            .execute(navigation, &pipeline, &fetcher)
+            .expect("chrome navigation should load")
+            .expect("chrome navigation should create a viewport");
+        chrome.synchronize(&session);
+
+        assert_eq!(
+            chrome.props(&session, "Status: 200", false),
+            BrowserChromeProps {
+                address: page_url.into(),
+                page_title: "Venture Guide".into(),
+                status_text: "Status: 200".into(),
+                back_disabled: false,
+                forward_disabled: true,
+                navigation_disabled: false,
+            }
+        );
+        assert_eq!(
+            chrome.handle_event(BrowserChromeEvent::Back, &session, false),
+            Some(BrowserNavigation::Back)
+        );
+
+        chrome.handle_event(
+            BrowserChromeEvent::AddressChange("http://draft.test/".into()),
+            &session,
+            false,
+        );
+        chrome.handle_event(
+            BrowserChromeEvent::AddressChange("ignored while loading".into()),
+            &session,
+            true,
+        );
+        assert_eq!(chrome.address_draft(), "http://draft.test/");
+        let disabled = chrome.props(&session, "Loading", true);
+        assert!(disabled.back_disabled);
+        assert!(disabled.forward_disabled);
+        assert!(disabled.navigation_disabled);
+    }
+
+    #[test]
+    fn mosaic_chrome_event_names_match_the_generated_bridge_contract() {
+        let events = [
+            BrowserChromeEvent::Back,
+            BrowserChromeEvent::Forward,
+            BrowserChromeEvent::Home,
+            BrowserChromeEvent::Reload,
+            BrowserChromeEvent::AddressChange(String::new()),
+            BrowserChromeEvent::Navigate,
+        ];
+        assert_eq!(
+            events.map(|event| event.mosaic_name()),
+            VENTURE_CHROME_EVENT_NAMES
         );
     }
 

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -8,5 +8,7 @@
 - Typed slots for the address, page title, status, and disabled controls.
 - Typed dispatch events for Back, Forward, Home, Reload, address edits, and
   navigation.
+- A compile-time ratchet tying the MIL slots and events to Venture's shared
+  host-neutral chrome reducer.
 - An explicit empty `content-surface` boundary reserved for the host-rendered
   browser viewport; native surface embedding remains a later acceptance gate.

--- a/code/programs/mosaic/venture-browser/Cargo.toml
+++ b/code/programs/mosaic/venture-browser/Cargo.toml
@@ -12,6 +12,7 @@ mosmodel-compiler = { path = "../../../packages/rust/mosmodel-compiler" }
 moslayout-compiler = { path = "../../../packages/rust/moslayout-compiler" }
 mosstyle-compiler = { path = "../../../packages/rust/mosstyle-compiler" }
 mosaic-package-manifest = { path = "../../../packages/rust/mosaic-package-manifest" }
+venture-browser-core = { path = "../../../packages/rust/venture-browser-core" }
 
 [[test]]
 name = "package_compiles"

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -18,6 +18,8 @@ controls.
 - Slots carry the current address, page title, status text, and host-derived
   disabled flags.
 - Emits carry Back, Forward, Home, Reload, address edits, and Navigate.
+- `venture-browser-core::BrowserChromeController` is the shared reducer and
+  slot projection for that exact contract.
 - Both themes expose the same parts and interaction states.
 - `tests/package_compiles.rs` guards the package contract; emitter integration
   tests prove SwiftUI and XAML consume these exact sources.

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -64,14 +64,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         .collect();
     assert_eq!(
         slots,
-        [
-            "address",
-            "page-title",
-            "status-text",
-            "back-disabled",
-            "forward-disabled",
-            "navigation-disabled",
-        ]
+        venture_browser_core::VENTURE_CHROME_SLOT_NAMES
     );
     let events: Vec<_> = interface
         .component
@@ -81,14 +74,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         .collect();
     assert_eq!(
         events,
-        [
-            "onBack",
-            "onForward",
-            "onHome",
-            "onReload",
-            "onAddressChange",
-            "onNavigate",
-        ]
+        venture_browser_core::VENTURE_CHROME_EVENT_NAMES
     );
 
     let manifest = fs::read_to_string(

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -70,17 +70,25 @@ scroll-aware link hit-testing, and viewport scene translation.
 scroll coherently when the page changes. `BrowserSession` now dispatches native
 navigation commands and content-link activation through transactional page
 loads, preserving the prior history and viewport on failure. The remaining
-browser gate is now being closed on macOS first: `venture-browser-macos` loads
-an HTTP page with native CoreText services, creates an AppKit `CAMetalLayer`,
-and presents the viewport through `paint-metal`. Native AppKit wheel events
+browser gate is now being closed on macOS first. The shared
+`programs/mosaic/venture-browser` package authors Venture's title bar,
+navigation controls, address input, status line, and interaction states once
+in MIL, MLL, and MSL, with acceptance coverage for native SwiftUI and WinUI
+lowering. `BrowserChromeController` maps that exact slot/event contract onto
+`BrowserSession`, including transactional address drafts, redirect
+synchronization, and history-derived disabled states.
+`venture-browser-macos` loads an HTTP page with native CoreText services,
+creates an AppKit `CAMetalLayer`, and presents the viewport through
+`paint-metal`. Native AppKit wheel events
 drive the shared clamped viewport and Metal repaint path. Primary-button events
 now use top-left viewport coordinates to activate links through transactional
 page loads, update the title, and repaint across repeated navigation. Named
 AppKit navigation keys now drive clamped viewport scrolling and Metal repaint.
 Command-Left/Right now reload Back/Forward history entries through the shared
-transactional session, update the native title, and repaint. Text input,
-controls, resize/reflow, and richer pointer behavior remain before the shell is
-interactive.
+transactional session, update the native title, and repaint. Mounting the
+generated Mosaic chrome and native page surface into one shell, resize/reflow,
+richer pointer behavior, and Windows build/interaction acceptance remain before
+the browser shell is complete.
 
 ## Where It Fits
 


### PR DESCRIPTION
## Summary

- add a host-neutral `BrowserChromeController` that preserves address drafts, maps Mosaic chrome events to `BrowserNavigation`, and synchronizes successful redirects
- project the exact six `VentureChrome` slot values from `BrowserSession`, including history/loading disabled states
- ratchet the MIL slot and event names against the core contract and update the Venture implementation status

This is a browser-wiring milestone, not a claim of complete browser or HTML conformance. Mounting the generated chrome and native page surface into runnable macOS/Windows shells remains a separate acceptance gate.

## Validation

- `cargo clippy --manifest-path code/packages/rust/venture-browser-core/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path code/packages/rust/venture-browser-core/Cargo.toml -- --nocapture`
- `cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml -- --nocapture`
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p venture-browser-macos -- --nocapture`
- SwiftUI Venture chrome generation and Swift typecheck acceptance
- XAML Venture chrome and generated project-shell acceptance
- checked HTML fixture generation/audit: tree missing 0, stale 0; tokenizer normalized skipped 0
