### PR TITLE
feat(spice): validate MOS gate-bulk overlap capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CGBO` values before
+  gate-bulk overlap-capacitance stamping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CGDO` values before
   gate-drain overlap-capacitance stamping.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -610,6 +610,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET CGSO must be finite and non-negative")
         elif canonical == "CGDO" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET CGDO must be finite and non-negative")
+        elif canonical == "CGBO" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET CGBO must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1224,6 +1224,18 @@ def test_mos_model_card_rejects_negative_or_non_finite_gate_drain_overlap_capaci
             normalize_model_card("Minvalid", "nmos", {"CGDO": invalid_capacitance})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_gate_bulk_overlap_capacitance() -> None:
+    for value in (0.0, 2.0e-10, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"CGBO": value})
+        assert valid.parameters["CGBO"] == pytest.approx(value)
+
+    for invalid_capacitance in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET CGBO must be finite and non-negative"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"CGBO": invalid_capacitance})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CGBO` values before
+  gate-bulk overlap-capacitance stamping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CGDO` values before
   gate-drain overlap-capacitance stamping.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4452,6 +4452,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET CGDO must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "CGBO" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET CGBO must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1091,6 +1091,22 @@ fn mos_model_card_rejects_negative_or_non_finite_gate_drain_overlap_capacitance(
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_gate_bulk_overlap_capacitance() {
+    for value in [0.0, 2.0e-10, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("CGBO", value)]).unwrap();
+        assert_close(*valid.parameters.get("CGBO").unwrap(), value);
+    }
+
+    for invalid_capacitance in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("CGBO", invalid_capacitance)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET CGBO must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `CGBO` values before
+  gate-bulk overlap-capacitance stamping.
+
 - Reject negative and non-finite Level-1 MOS model-card `CGDO` values before
   gate-drain overlap-capacitance stamping.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8506,6 +8506,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0)
     ) {
       throw invalidElement(name, "MOSFET CGDO must be finite and non-negative");
+    } else if (
+      canonical === "CGBO" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET CGBO must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1001,6 +1001,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS gate-bulk overlap capacitance", () => {
+    for (const value of [0.0, 2.0e-10, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { CGBO: value });
+      expect(valid.parameters.CGBO).toBe(value);
+    }
+
+    for (const invalidCapacitance of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { CGBO: invalidCapacitance }),
+      ).toThrow("MOSFET CGBO must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS gate-drain-overlap-capacitance validation.
+1. Cross-language Level-1 MOS gate-bulk-overlap-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `CGDO` values before gate-drain
+   - Reject negative or non-finite model-card `CGBO` values before gate-bulk
      overlap-capacitance stamping.
-   - Preserve zero and positive gate-drain overlap capacitances across Rust,
+   - Preserve zero and positive gate-bulk overlap capacitances across Rust,
      Python, and TypeScript.
 
 ## Completed Slices
@@ -3768,6 +3768,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `CGSO` values are rejected before
      gate-source overlap-capacitance stamping.
    - Zero and positive gate-source overlap capacitances remain aligned across
+     Rust, Python, and TypeScript.
+
+313. Cross-language Level-1 MOS gate-drain-overlap-capacitance validation.
+   - Status: completed in PR 9364.
+   - Negative and non-finite model-card `CGDO` values are rejected before
+     gate-drain overlap-capacitance stamping.
+   - Zero and positive gate-drain overlap capacitances remain aligned across
      Rust, Python, and TypeScript.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CGBO` values with a stable diagnostic
- preserve zero and positive gate-bulk overlap capacitances across Rust, Python, and TypeScript
- reconcile the SPICE implementation plan after PR #9364

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `python -m ruff check src tests`
- `python -m pytest` (695 passed, 88.98% coverage)
- `npm test` (438 passed)
- `npm run build`