### PR TITLE
feat(spice): validate MOS saturation current

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-positive and non-finite Level-1 MOS model-card `IS` values before
+  bulk-junction leakage and temperature preprocessing.
+
 - Reject negative and non-finite Level-1 MOS model-card `CGBO` values before
   gate-bulk overlap-capacitance stamping.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -612,6 +612,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET CGDO must be finite and non-negative")
         elif canonical == "CGBO" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET CGBO must be finite and non-negative")
+        elif canonical == "IS" and (not math.isfinite(value) or value <= 0.0):
+            raise ValueError(f"{name}: MOSFET IS must be finite and positive")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1236,6 +1236,16 @@ def test_mos_model_card_rejects_negative_or_non_finite_gate_bulk_overlap_capacit
             normalize_model_card("Minvalid", "nmos", {"CGBO": invalid_capacitance})
 
 
+def test_mos_model_card_rejects_non_positive_or_non_finite_saturation_current() -> None:
+    for value in (1.0e-15, 2.0e-10, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"IS": value})
+        assert valid.parameters["IS"] == pytest.approx(value)
+
+    for invalid_current in (-math.inf, -0.1, 0.0, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET IS must be finite and positive"):
+            normalize_model_card("Minvalid", "nmos", {"IS": invalid_current})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-positive and non-finite Level-1 MOS model-card `IS` values before
+  bulk-junction leakage and temperature preprocessing.
+
 - Reject negative and non-finite Level-1 MOS model-card `CGBO` values before
   gate-bulk overlap-capacitance stamping.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4457,6 +4457,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET CGBO must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "IS" && (!raw_value.is_finite() || *raw_value <= 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET IS must be finite and positive".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1107,6 +1107,22 @@ fn mos_model_card_rejects_negative_or_non_finite_gate_bulk_overlap_capacitance()
 }
 
 #[test]
+fn mos_model_card_rejects_non_positive_or_non_finite_saturation_current() {
+    for value in [1.0e-15, 2.0e-10, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("IS", value)]).unwrap();
+        assert_close(*valid.parameters.get("IS").unwrap(), value);
+    }
+
+    for invalid_current in [f64::NEG_INFINITY, -0.1, 0.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("IS", invalid_current)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET IS must be finite and positive"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-positive and non-finite Level-1 MOS model-card `IS` values before
+  bulk-junction leakage and temperature preprocessing.
+
 - Reject negative and non-finite Level-1 MOS model-card `CGBO` values before
   gate-bulk overlap-capacitance stamping.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8511,6 +8511,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value < 0.0)
     ) {
       throw invalidElement(name, "MOSFET CGBO must be finite and non-negative");
+    } else if (
+      canonical === "IS" &&
+      (!Number.isFinite(value) || value <= 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET IS must be finite and positive");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1019,6 +1019,25 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects non-positive or non-finite MOS saturation current", () => {
+    for (const value of [1.0e-15, 2.0e-10, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { IS: value });
+      expect(valid.parameters.IS).toBe(value);
+    }
+
+    for (const invalidCurrent of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      0.0,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { IS: invalidCurrent }),
+      ).toThrow("MOSFET IS must be finite and positive");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS gate-bulk-overlap-capacitance validation.
+1. Cross-language Level-1 MOS saturation-current validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `CGBO` values before gate-bulk
-     overlap-capacitance stamping.
-   - Preserve zero and positive gate-bulk overlap capacitances across Rust,
-     Python, and TypeScript.
+   - Reject non-positive or non-finite model-card `IS` values before
+     bulk-junction leakage and temperature preprocessing.
+   - Preserve positive saturation currents across Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3775,6 +3774,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `CGDO` values are rejected before
      gate-drain overlap-capacitance stamping.
    - Zero and positive gate-drain overlap capacitances remain aligned across
+     Rust, Python, and TypeScript.
+
+314. Cross-language Level-1 MOS gate-bulk-overlap-capacitance validation.
+   - Status: completed in PR 9380.
+   - Negative and non-finite model-card `CGBO` values are rejected before
+     gate-bulk overlap-capacitance stamping.
+   - Zero and positive gate-bulk overlap capacitances remain aligned across
      Rust, Python, and TypeScript.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite Level-1 MOS model-card `IS` values with a stable diagnostic
- preserve positive saturation currents across Rust, Python, and TypeScript
- reconcile the SPICE implementation plan after PR #9380

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `python -m ruff check src tests`
- `python -m pytest` (696 passed, 88.98% coverage)
- `npm test` (439 passed)
- `npm run build`