### PR TITLE
feat(smart-home): collect Home Assistant definitions

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -903,6 +903,7 @@ members = [
     "smart-home-home-assistant-migration",
     "smart-home-home-assistant-export",
     "smart-home-home-assistant-history",
+    "smart-home-home-assistant-definitions",
     "smart-home-integration-catalog",
     "smart-home-testkit",
     "hue-core",

--- a/code/packages/rust/smart-home-home-assistant-definitions/BUILD
+++ b/code/packages/rust/smart-home-home-assistant-definitions/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-home-assistant-definitions --all-targets -- --nocapture

--- a/code/packages/rust/smart-home-home-assistant-definitions/CHANGELOG.md
+++ b/code/packages/rust/smart-home-home-assistant-definitions/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add authenticated live scene and automation definition collection.
+- Emit deterministic, migration-compatible enriched exports with durable diagnostics.
+- Support bounded HTTP, HTTPS, and WebSocket transports with token redaction.

--- a/code/packages/rust/smart-home-home-assistant-definitions/Cargo.toml
+++ b/code/packages/rust/smart-home-home-assistant-definitions/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "smart-home-home-assistant-definitions"
+version = "0.1.0"
+edition = "2021"
+description = "Live Home Assistant scene and automation definition collection"
+license = "MIT"
+
+[dependencies]
+coding_adventures_sha256 = { path = "../sha256" }
+http-core = { path = "../http-core" }
+http1 = { path = "../http1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smart-home-home-assistant-migration = { path = "../smart-home-home-assistant-migration" }
+tls-platform = { path = "../tls-platform" }
+tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+url-parser = { path = "../url-parser" }
+
+[[bin]]
+name = "smart-home-collect-home-assistant-definitions"
+path = "src/main.rs"

--- a/code/packages/rust/smart-home-home-assistant-definitions/README.md
+++ b/code/packages/rust/smart-home-home-assistant-definitions/README.md
@@ -1,0 +1,46 @@
+# smart-home-home-assistant-definitions
+
+`smart-home-home-assistant-definitions` enriches a reviewed Home Assistant
+topology export with live scene and automation definitions. It is the second
+stage after `smart-home-home-assistant-export` and its output remains directly
+readable by `smart-home-home-assistant-migration`.
+
+The collector uses two administrator-authenticated Home Assistant APIs:
+
+- `automation/config` over `/api/websocket` for each discovered automation;
+- `GET /api/config/scene/config/{config-id}` for editable Home Assistant scenes.
+
+Only the migration runtime's executable subset is collected: state and simple
+time-pattern triggers, state conditions, and bounded light, switch, lock,
+thermostat, or scene actions. Definitions with templates, delays, multi-trigger
+semantics, device/area targets, or unsupported services are skipped with a
+durable diagnostic instead of being approximated.
+
+The input export supplies the reviewed entity registry and source instance ID.
+The enriched output adds a `definition_collection` report at the top level;
+serde readers for the original export ignore that extra field, so the artifact
+can be passed directly to the existing migration CLI.
+
+`HOME_ASSISTANT_TOKEN` is read only from the environment. The token is never a
+command-line argument, artifact field, or diagnostic value.
+
+```sh
+HOME_ASSISTANT_TOKEN='...' cargo run \
+  -p smart-home-home-assistant-definitions \
+  --bin smart-home-collect-home-assistant-definitions -- \
+  home-assistant-export.json \
+  wss://home.example/api/websocket \
+  https://home.example \
+  home-assistant-enriched.json
+```
+
+The REST and WebSocket base URLs are separate so reverse proxies and local test
+hosts can expose them on different origins. HTTP and HTTPS responses are size
+bounded; socket operations time out after 30 seconds by default.
+
+## Validation
+
+```sh
+bash smart-home-home-assistant-definitions/BUILD
+cargo clippy -p smart-home-home-assistant-definitions --all-targets -- -D warnings
+```

--- a/code/packages/rust/smart-home-home-assistant-definitions/src/lib.rs
+++ b/code/packages/rust/smart-home-home-assistant-definitions/src/lib.rs
@@ -1,0 +1,1112 @@
+//! Live Home Assistant scene and automation definition collection.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_sha256::sha256_hex;
+use http1::parse_response_head;
+use http_core::BodyKind;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map as JsonMap, Value as JsonValue};
+use smart_home_home_assistant_migration::{
+    HomeAssistantAutomation, HomeAssistantAutomationTrigger, HomeAssistantEntity,
+    HomeAssistantExport, HomeAssistantScene, HomeAssistantServiceAction,
+    HomeAssistantStateCondition, HomeAssistantTargetState, EXPORT_SCHEMA_VERSION,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tls_platform::{default_connector, TlsConfig};
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{connect, Message, WebSocket};
+use url_parser::{percent_encode, Url};
+
+pub const DEFINITION_COLLECTION_SCHEMA_VERSION: u32 = 1;
+const AUTOMATION_CONFIG_COMMAND: &str = "automation/config";
+const MAX_UNMATCHED_MESSAGES: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DefinitionCollectorConfig {
+    pub websocket_url: String,
+    pub rest_base_url: String,
+    pub access_token: String,
+    pub source_instance_id: String,
+    pub collected_at_ms: u64,
+    pub io_timeout: Duration,
+    pub max_response_bytes: usize,
+}
+
+impl DefinitionCollectorConfig {
+    pub fn validate(&self) -> Result<(), DefinitionError> {
+        if !self.websocket_url.starts_with("ws://") && !self.websocket_url.starts_with("wss://") {
+            return Err(DefinitionError::Config(
+                "Home Assistant WebSocket URL must use ws:// or wss://".to_string(),
+            ));
+        }
+        let rest = Url::parse(&self.rest_base_url)
+            .map_err(|error| DefinitionError::Config(format!("invalid REST URL: {error}")))?;
+        if rest.scheme != "http" && rest.scheme != "https" {
+            return Err(DefinitionError::Config(
+                "Home Assistant REST URL must use http:// or https://".to_string(),
+            ));
+        }
+        if rest.userinfo.is_some() || rest.query.is_some() || rest.fragment.is_some() {
+            return Err(DefinitionError::Config(
+                "Home Assistant REST URL cannot contain credentials, a query, or a fragment"
+                    .to_string(),
+            ));
+        }
+        if self.access_token.trim().is_empty() {
+            return Err(DefinitionError::Config(
+                "Home Assistant access token is empty".to_string(),
+            ));
+        }
+        if self.source_instance_id.trim().is_empty() {
+            return Err(DefinitionError::Config(
+                "source instance id is empty".to_string(),
+            ));
+        }
+        if self.io_timeout.is_zero() {
+            return Err(DefinitionError::Config(
+                "I/O timeout must be greater than zero".to_string(),
+            ));
+        }
+        if self.max_response_bytes == 0 {
+            return Err(DefinitionError::Config(
+                "maximum response bytes must be greater than zero".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DefinitionDiagnosticSeverity {
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DefinitionDiagnostic {
+    pub severity: DefinitionDiagnosticSeverity,
+    pub source_kind: String,
+    pub source_id: String,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DefinitionCollectionSummary {
+    pub discovered_scenes: usize,
+    pub collected_scenes: usize,
+    pub skipped_scenes: usize,
+    pub discovered_automations: usize,
+    pub collected_automations: usize,
+    pub skipped_automations: usize,
+    pub diagnostics: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DefinitionCollectionReport {
+    pub schema_version: u32,
+    pub source_instance_id: String,
+    pub topology_fingerprint: String,
+    pub collected_at_ms: u64,
+    pub summary: DefinitionCollectionSummary,
+    pub diagnostics: Vec<DefinitionDiagnostic>,
+}
+
+/// The report is an extra top-level field, so older migration readers can
+/// deserialize this artifact directly as [`HomeAssistantExport`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnrichedHomeAssistantExport {
+    #[serde(flatten)]
+    pub export: HomeAssistantExport,
+    pub definition_collection: DefinitionCollectionReport,
+}
+
+#[derive(Debug)]
+pub enum DefinitionError {
+    Config(String),
+    Validation(String),
+    Transport(String),
+    Protocol(String),
+    Decode(String),
+    Encode(String),
+    Io {
+        operation: &'static str,
+        path: PathBuf,
+        message: String,
+    },
+    Usage(String),
+}
+
+impl fmt::Display for DefinitionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Config(message) => {
+                write!(formatter, "invalid collector configuration: {message}")
+            }
+            Self::Validation(message) => write!(formatter, "invalid definition input: {message}"),
+            Self::Transport(message) => {
+                write!(formatter, "Home Assistant transport failed: {message}")
+            }
+            Self::Protocol(message) => {
+                write!(formatter, "Home Assistant protocol failed: {message}")
+            }
+            Self::Decode(message) => {
+                write!(formatter, "invalid Home Assistant definition: {message}")
+            }
+            Self::Encode(message) => {
+                write!(formatter, "could not encode enriched export: {message}")
+            }
+            Self::Io {
+                operation,
+                path,
+                message,
+            } => {
+                write!(
+                    formatter,
+                    "could not {operation} {}: {message}",
+                    path.display()
+                )
+            }
+            Self::Usage(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for DefinitionError {}
+
+pub fn collect_definitions(
+    topology: &HomeAssistantExport,
+    config: &DefinitionCollectorConfig,
+) -> Result<EnrichedHomeAssistantExport, DefinitionError> {
+    config.validate()?;
+    validate_topology(topology, config)?;
+
+    let mut base = topology.clone();
+    base.scenes.clear();
+    base.automations.clear();
+    let topology_bytes =
+        serde_json::to_vec(&base).map_err(|error| DefinitionError::Encode(error.to_string()))?;
+    let topology_fingerprint = sha256_hex(&topology_bytes);
+    let states = base
+        .states
+        .iter()
+        .map(|state| (state.entity_id.as_str(), state))
+        .collect::<BTreeMap<_, _>>();
+    let mut diagnostics = Vec::new();
+
+    let mut scene_entities = base
+        .entities
+        .iter()
+        .filter(|entity| entity_domain(&entity.entity_id) == "scene")
+        .collect::<Vec<_>>();
+    scene_entities.sort_by(|left, right| left.entity_id.cmp(&right.entity_id));
+    let mut automation_entities = base
+        .entities
+        .iter()
+        .filter(|entity| entity_domain(&entity.entity_id) == "automation")
+        .collect::<Vec<_>>();
+    automation_entities.sort_by(|left, right| left.entity_id.cmp(&right.entity_id));
+
+    let mut automations = Vec::new();
+    if !automation_entities.is_empty() {
+        let (mut socket, _) = connect(config.websocket_url.as_str()).map_err(|error| {
+            DefinitionError::Transport(redact(error.to_string(), &config.access_token))
+        })?;
+        configure_socket_timeout(&mut socket, config.io_timeout)?;
+        authenticate(&mut socket, &config.access_token)?;
+        for (index, entity) in automation_entities.iter().enumerate() {
+            let request_id = u64::try_from(index + 1).map_err(|_| {
+                DefinitionError::Validation("too many automations to request".to_string())
+            })?;
+            match request_automation_config(&mut socket, request_id, &entity.entity_id) {
+                Ok(raw) => match normalize_automation(
+                    entity,
+                    states.get(entity.entity_id.as_str()).copied(),
+                    &raw,
+                ) {
+                    Ok(automation) => automations.push(automation),
+                    Err(message) => diagnostics.push(diagnostic(
+                        "automation",
+                        &entity.entity_id,
+                        "unsupported_automation_definition",
+                        message,
+                    )),
+                },
+                Err(failure) => diagnostics.push(diagnostic(
+                    "automation",
+                    &entity.entity_id,
+                    "automation_definition_unavailable",
+                    failure,
+                )),
+            }
+        }
+        let _ = socket.close(None);
+    }
+
+    let mut scenes = Vec::new();
+    for entity in &scene_entities {
+        if entity.platform != "homeassistant" || entity.unique_id == entity.entity_id {
+            diagnostics.push(diagnostic(
+                "scene",
+                &entity.entity_id,
+                "scene_definition_unavailable",
+                format!(
+                    "scene platform `{}` has no editable Home Assistant config identifier",
+                    entity.platform
+                ),
+            ));
+            continue;
+        }
+        match request_scene_config(config, &entity.unique_id) {
+            Ok(raw) => match normalize_scene(entity, &raw) {
+                Ok(scene) => scenes.push(scene),
+                Err(message) => diagnostics.push(diagnostic(
+                    "scene",
+                    &entity.entity_id,
+                    "unsupported_scene_definition",
+                    message,
+                )),
+            },
+            Err(SceneRequestError::Unavailable(message)) => diagnostics.push(diagnostic(
+                "scene",
+                &entity.entity_id,
+                "scene_definition_unavailable",
+                message,
+            )),
+            Err(SceneRequestError::Fatal(error)) => return Err(error),
+        }
+    }
+
+    scenes.sort_by(|left, right| left.scene_id.cmp(&right.scene_id));
+    automations.sort_by(|left, right| left.automation_id.cmp(&right.automation_id));
+    diagnostics.sort_by(|left, right| {
+        (
+            &left.source_kind,
+            &left.source_id,
+            &left.code,
+            &left.message,
+        )
+            .cmp(&(
+                &right.source_kind,
+                &right.source_id,
+                &right.code,
+                &right.message,
+            ))
+    });
+    ensure_unique(scenes.iter().map(|scene| scene.scene_id.as_str()), "scene")?;
+    ensure_unique(
+        automations
+            .iter()
+            .map(|automation| automation.automation_id.as_str()),
+        "automation",
+    )?;
+
+    let summary = DefinitionCollectionSummary {
+        discovered_scenes: scene_entities.len(),
+        collected_scenes: scenes.len(),
+        skipped_scenes: scene_entities.len().saturating_sub(scenes.len()),
+        discovered_automations: automation_entities.len(),
+        collected_automations: automations.len(),
+        skipped_automations: automation_entities.len().saturating_sub(automations.len()),
+        diagnostics: diagnostics.len(),
+    };
+    base.scenes = scenes;
+    base.automations = automations;
+
+    Ok(EnrichedHomeAssistantExport {
+        export: base,
+        definition_collection: DefinitionCollectionReport {
+            schema_version: DEFINITION_COLLECTION_SCHEMA_VERSION,
+            source_instance_id: config.source_instance_id.clone(),
+            topology_fingerprint,
+            collected_at_ms: config.collected_at_ms,
+            summary,
+            diagnostics,
+        },
+    })
+}
+
+pub fn write_enriched_export_atomically(
+    path: impl AsRef<Path>,
+    export: &EnrichedHomeAssistantExport,
+) -> Result<(), DefinitionError> {
+    let path = path.as_ref();
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| DefinitionError::Config("output path has no file name".to_string()))?;
+    let temporary = parent.join(format!(".{file_name}.tmp-{}", std::process::id()));
+    let mut encoded = serde_json::to_vec_pretty(export)
+        .map_err(|error| DefinitionError::Encode(error.to_string()))?;
+    encoded.push(b'\n');
+    let result = (|| {
+        let mut file = File::create(&temporary).map_err(|error| DefinitionError::Io {
+            operation: "create temporary enriched export",
+            path: temporary.clone(),
+            message: error.to_string(),
+        })?;
+        file.write_all(&encoded)
+            .and_then(|()| file.sync_all())
+            .map_err(|error| DefinitionError::Io {
+                operation: "write temporary enriched export",
+                path: temporary.clone(),
+                message: error.to_string(),
+            })?;
+        fs::rename(&temporary, path).map_err(|error| DefinitionError::Io {
+            operation: "replace enriched export",
+            path: path.to_path_buf(),
+            message: error.to_string(),
+        })
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn validate_topology(
+    topology: &HomeAssistantExport,
+    config: &DefinitionCollectorConfig,
+) -> Result<(), DefinitionError> {
+    if topology.schema_version != EXPORT_SCHEMA_VERSION {
+        return Err(DefinitionError::Validation(format!(
+            "unsupported topology schema version {}",
+            topology.schema_version
+        )));
+    }
+    if topology.source_instance_id != config.source_instance_id {
+        return Err(DefinitionError::Validation(format!(
+            "topology source `{}` does not match collector source `{}`",
+            topology.source_instance_id, config.source_instance_id
+        )));
+    }
+    ensure_unique(
+        topology
+            .entities
+            .iter()
+            .map(|entity| entity.entity_id.as_str()),
+        "entity",
+    )
+}
+
+fn ensure_unique<'a>(
+    values: impl IntoIterator<Item = &'a str>,
+    resource: &str,
+) -> Result<(), DefinitionError> {
+    let mut seen = BTreeSet::new();
+    for value in values {
+        if !seen.insert(value) {
+            return Err(DefinitionError::Validation(format!(
+                "duplicate {resource} id `{value}`"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn diagnostic(
+    source_kind: &str,
+    source_id: &str,
+    code: &str,
+    message: String,
+) -> DefinitionDiagnostic {
+    DefinitionDiagnostic {
+        severity: DefinitionDiagnosticSeverity::Warning,
+        source_kind: source_kind.to_string(),
+        source_id: source_id.to_string(),
+        code: code.to_string(),
+        message,
+    }
+}
+
+type DefinitionSocket = WebSocket<MaybeTlsStream<TcpStream>>;
+
+fn configure_socket_timeout(
+    socket: &mut DefinitionSocket,
+    timeout: Duration,
+) -> Result<(), DefinitionError> {
+    let stream = match socket.get_mut() {
+        MaybeTlsStream::Plain(stream) => stream,
+        MaybeTlsStream::Rustls(stream) => &mut stream.sock,
+        _ => {
+            return Err(DefinitionError::Transport(
+                "unsupported WebSocket stream backend".to_string(),
+            ));
+        }
+    };
+    stream
+        .set_read_timeout(Some(timeout))
+        .and_then(|()| stream.set_write_timeout(Some(timeout)))
+        .map_err(|error| DefinitionError::Transport(error.to_string()))
+}
+
+fn authenticate(socket: &mut DefinitionSocket, access_token: &str) -> Result<(), DefinitionError> {
+    let required = read_socket_json(socket)?;
+    if required.get("type").and_then(JsonValue::as_str) != Some("auth_required") {
+        return Err(DefinitionError::Protocol(
+            "server did not begin with auth_required".to_string(),
+        ));
+    }
+    send_socket_json(
+        socket,
+        &json!({"type": "auth", "access_token": access_token}),
+    )?;
+    let response = read_socket_json(socket)?;
+    match response.get("type").and_then(JsonValue::as_str) {
+        Some("auth_ok") => Ok(()),
+        Some("auth_invalid") => Err(DefinitionError::Protocol(
+            "Home Assistant rejected the access token".to_string(),
+        )),
+        _ => Err(DefinitionError::Protocol(
+            "server did not complete authentication".to_string(),
+        )),
+    }
+}
+
+fn request_automation_config(
+    socket: &mut DefinitionSocket,
+    id: u64,
+    entity_id: &str,
+) -> Result<JsonValue, String> {
+    send_socket_json(
+        socket,
+        &json!({"id": id, "type": AUTOMATION_CONFIG_COMMAND, "entity_id": entity_id}),
+    )
+    .map_err(|error| error.to_string())?;
+    for _ in 0..MAX_UNMATCHED_MESSAGES {
+        let response = read_socket_json(socket).map_err(|error| error.to_string())?;
+        if response.get("id").and_then(JsonValue::as_u64) != Some(id) {
+            continue;
+        }
+        if response.get("type").and_then(JsonValue::as_str) != Some("result") {
+            return Err("response was not a result message".to_string());
+        }
+        if response.get("success").and_then(JsonValue::as_bool) != Some(true) {
+            let code = response
+                .pointer("/error/code")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("unknown");
+            let message = response
+                .pointer("/error/message")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("definition request failed");
+            return Err(format!("Home Assistant returned {code}: {message}"));
+        }
+        return response
+            .get("result")
+            .and_then(|result| result.get("config"))
+            .cloned()
+            .ok_or_else(|| "result did not contain config".to_string());
+    }
+    Err(format!(
+        "no matching result after {MAX_UNMATCHED_MESSAGES} messages"
+    ))
+}
+
+fn send_socket_json(
+    socket: &mut DefinitionSocket,
+    value: &JsonValue,
+) -> Result<(), DefinitionError> {
+    socket
+        .send(Message::Text(value.to_string().into()))
+        .map_err(|error| DefinitionError::Transport(error.to_string()))
+}
+
+fn read_socket_json(socket: &mut DefinitionSocket) -> Result<JsonValue, DefinitionError> {
+    loop {
+        let message = socket
+            .read()
+            .map_err(|error| DefinitionError::Transport(error.to_string()))?;
+        match message {
+            Message::Text(text) => {
+                return serde_json::from_str(&text)
+                    .map_err(|error| DefinitionError::Protocol(error.to_string()));
+            }
+            Message::Binary(bytes) => {
+                return serde_json::from_slice(&bytes)
+                    .map_err(|error| DefinitionError::Protocol(error.to_string()));
+            }
+            Message::Ping(payload) => socket
+                .send(Message::Pong(payload))
+                .map_err(|error| DefinitionError::Transport(error.to_string()))?,
+            Message::Close(_) => {
+                return Err(DefinitionError::Protocol(
+                    "Home Assistant closed the WebSocket".to_string(),
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn normalize_scene(
+    entity: &HomeAssistantEntity,
+    raw: &JsonValue,
+) -> Result<HomeAssistantScene, String> {
+    let object = raw
+        .as_object()
+        .ok_or_else(|| "scene config is not an object".to_string())?;
+    let name = object
+        .get("name")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| "scene config has no name".to_string())?;
+    let entities = object
+        .get("entities")
+        .and_then(JsonValue::as_object)
+        .ok_or_else(|| "scene config has no entity state map".to_string())?;
+    if entities.is_empty() {
+        return Err("scene has no target states".to_string());
+    }
+    let mut states = entities
+        .iter()
+        .map(|(entity_id, value)| normalize_target_state(entity_id, value))
+        .collect::<Result<Vec<_>, _>>()?;
+    states.sort_by(|left, right| left.entity_id.cmp(&right.entity_id));
+    Ok(HomeAssistantScene {
+        scene_id: entity.entity_id.clone(),
+        name: name.to_string(),
+        area_id: entity.area_id.clone(),
+        states,
+    })
+}
+
+fn normalize_target_state(
+    entity_id: &str,
+    value: &JsonValue,
+) -> Result<HomeAssistantTargetState, String> {
+    let (state, attributes) = match value {
+        JsonValue::Object(object) => {
+            let state = object
+                .get("state")
+                .and_then(json_scalar_string)
+                .ok_or_else(|| format!("scene target `{entity_id}` has no scalar state"))?;
+            let attributes = object
+                .iter()
+                .filter(|(name, _)| name.as_str() != "state")
+                .map(|(name, value)| (name.clone(), value.clone()))
+                .collect();
+            (state, attributes)
+        }
+        scalar => (
+            json_scalar_string(scalar)
+                .ok_or_else(|| format!("scene target `{entity_id}` has a non-scalar state"))?,
+            BTreeMap::new(),
+        ),
+    };
+    Ok(HomeAssistantTargetState {
+        entity_id: entity_id.to_string(),
+        state,
+        attributes,
+    })
+}
+
+fn normalize_automation(
+    entity: &HomeAssistantEntity,
+    state: Option<&smart_home_home_assistant_migration::HomeAssistantState>,
+    raw: &JsonValue,
+) -> Result<HomeAssistantAutomation, String> {
+    let object = raw
+        .as_object()
+        .ok_or_else(|| "automation config is not an object".to_string())?;
+    let automation_id = object
+        .get("id")
+        .and_then(json_scalar_string)
+        .unwrap_or_else(|| entity.unique_id.clone());
+    let alias = object
+        .get("alias")
+        .and_then(JsonValue::as_str)
+        .or_else(|| {
+            state.and_then(|state| {
+                state
+                    .attributes
+                    .get("friendly_name")
+                    .and_then(JsonValue::as_str)
+            })
+        })
+        .unwrap_or(&entity.entity_id)
+        .to_string();
+    let triggers = config_items(object, "triggers", "trigger")?;
+    if triggers.len() != 1 {
+        return Err(format!(
+            "automation must have exactly one migratable trigger, found {}",
+            triggers.len()
+        ));
+    }
+    let trigger = normalize_trigger(triggers[0])?;
+    let conditions = config_items_or_empty(object, "conditions", "condition")?
+        .into_iter()
+        .map(normalize_condition)
+        .collect::<Result<Vec<_>, _>>()?;
+    let actions = config_items(object, "actions", "action")?
+        .into_iter()
+        .map(normalize_action)
+        .collect::<Result<Vec<_>, _>>()?;
+    if actions.is_empty() {
+        return Err("automation has no actions".to_string());
+    }
+    Ok(HomeAssistantAutomation {
+        automation_id,
+        alias,
+        enabled: state.is_none_or(|state| state.state != "off"),
+        trigger,
+        conditions,
+        actions,
+    })
+}
+
+fn config_items<'a>(
+    object: &'a JsonMap<String, JsonValue>,
+    plural: &str,
+    singular: &str,
+) -> Result<Vec<&'a JsonValue>, String> {
+    let value = object
+        .get(plural)
+        .or_else(|| object.get(singular))
+        .ok_or_else(|| format!("config has no `{plural}` or `{singular}` field"))?;
+    match value {
+        JsonValue::Array(items) => Ok(items.iter().collect()),
+        JsonValue::Object(_) => Ok(vec![value]),
+        _ => Err(format!("`{plural}` is not an object or array")),
+    }
+}
+
+fn config_items_or_empty<'a>(
+    object: &'a JsonMap<String, JsonValue>,
+    plural: &str,
+    singular: &str,
+) -> Result<Vec<&'a JsonValue>, String> {
+    if !object.contains_key(plural) && !object.contains_key(singular) {
+        return Ok(Vec::new());
+    }
+    let values = config_items(object, plural, singular)?;
+    if values.len() == 1 && values[0].is_null() {
+        Ok(Vec::new())
+    } else {
+        Ok(values)
+    }
+}
+
+fn normalize_trigger(raw: &JsonValue) -> Result<HomeAssistantAutomationTrigger, String> {
+    let object = raw
+        .as_object()
+        .ok_or_else(|| "trigger is not an object".to_string())?;
+    let kind = object
+        .get("trigger")
+        .or_else(|| object.get("platform"))
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| "trigger has no type".to_string())?;
+    match kind {
+        "state" => {
+            if object.contains_key("for") || object.contains_key("from") {
+                return Err(
+                    "state trigger with `from` or `for` is outside the safe subset".to_string(),
+                );
+            }
+            let entity_id = one_entity_id(object.get("entity_id"), "state trigger")?;
+            let to = object.get("to").and_then(json_scalar_string);
+            Ok(HomeAssistantAutomationTrigger::State { entity_id, to })
+        }
+        "time_pattern" => Ok(HomeAssistantAutomationTrigger::Interval {
+            every_ms: time_pattern_interval_ms(object)?,
+            offset_ms: 0,
+        }),
+        other => Err(format!("trigger `{other}` is outside the safe subset")),
+    }
+}
+
+fn time_pattern_interval_ms(object: &JsonMap<String, JsonValue>) -> Result<u64, String> {
+    let fields = [
+        ("seconds", 1_000_u64),
+        ("minutes", 60_000),
+        ("hours", 3_600_000),
+    ];
+    let mut interval = None;
+    for (field, multiplier) in fields {
+        let Some(value) = object.get(field) else {
+            continue;
+        };
+        let Some(text) = json_scalar_string(value) else {
+            return Err(format!("time pattern `{field}` is not scalar"));
+        };
+        if text == "*" {
+            continue;
+        }
+        let Some(step) = text.strip_prefix('/') else {
+            return Err(format!(
+                "time pattern `{field}` must be wildcard or slash interval"
+            ));
+        };
+        let step = step
+            .parse::<u64>()
+            .map_err(|_| format!("time pattern `{field}` has invalid interval"))?;
+        if step == 0 || interval.is_some() {
+            return Err("time pattern must contain one non-zero slash interval".to_string());
+        }
+        interval = Some(step.saturating_mul(multiplier));
+    }
+    interval.ok_or_else(|| "time pattern has no slash interval".to_string())
+}
+
+fn normalize_condition(raw: &JsonValue) -> Result<HomeAssistantStateCondition, String> {
+    let object = raw
+        .as_object()
+        .ok_or_else(|| "condition is not an object".to_string())?;
+    if object.get("condition").and_then(JsonValue::as_str) != Some("state") {
+        return Err("only state conditions are in the safe subset".to_string());
+    }
+    if object.contains_key("for") {
+        return Err("state conditions with `for` are outside the safe subset".to_string());
+    }
+    Ok(HomeAssistantStateCondition {
+        entity_id: one_entity_id(object.get("entity_id"), "state condition")?,
+        state: object
+            .get("state")
+            .and_then(json_scalar_string)
+            .ok_or_else(|| "state condition has no scalar state".to_string())?,
+    })
+}
+
+fn normalize_action(raw: &JsonValue) -> Result<HomeAssistantServiceAction, String> {
+    let object = raw
+        .as_object()
+        .ok_or_else(|| "action is not an object".to_string())?;
+    let service = object
+        .get("action")
+        .or_else(|| object.get("service"))
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| "action has no service".to_string())?;
+    if !matches!(
+        service,
+        "scene.turn_on"
+            | "light.turn_on"
+            | "light.turn_off"
+            | "switch.turn_on"
+            | "switch.turn_off"
+            | "lock.lock"
+            | "lock.unlock"
+            | "climate.set_temperature"
+    ) {
+        return Err(format!("service `{service}` is outside the safe subset"));
+    }
+    let target = object.get("target").and_then(JsonValue::as_object);
+    if target
+        .is_some_and(|target| target.contains_key("device_id") || target.contains_key("area_id"))
+    {
+        return Err(
+            "device and area action targets require expansion before migration".to_string(),
+        );
+    }
+    let data = object
+        .get("data")
+        .and_then(JsonValue::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let entity_source = target
+        .and_then(|target| target.get("entity_id"))
+        .or_else(|| object.get("entity_id"))
+        .or_else(|| data.get("entity_id"));
+    let target_entity_ids = entity_ids(entity_source, "service action")?;
+    if target_entity_ids.is_empty() {
+        return Err(format!("service `{service}` has no entity target"));
+    }
+    let data = data
+        .into_iter()
+        .filter(|(name, _)| name != "entity_id")
+        .collect::<BTreeMap<_, _>>();
+    if service == "climate.set_temperature" && !data.contains_key("temperature") {
+        return Err("climate.set_temperature has no temperature".to_string());
+    }
+    Ok(HomeAssistantServiceAction {
+        service: service.to_string(),
+        target_entity_ids,
+        data,
+    })
+}
+
+fn one_entity_id(value: Option<&JsonValue>, context: &str) -> Result<String, String> {
+    let values = entity_ids(value, context)?;
+    if values.len() != 1 {
+        return Err(format!("{context} must reference exactly one entity"));
+    }
+    values
+        .into_iter()
+        .next()
+        .ok_or_else(|| format!("{context} has no entity"))
+}
+
+fn entity_ids(value: Option<&JsonValue>, context: &str) -> Result<Vec<String>, String> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    match value {
+        JsonValue::String(value) => Ok(vec![value.clone()]),
+        JsonValue::Array(values) => values
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| format!("{context} entity list contains a non-string"))
+            })
+            .collect(),
+        _ => Err(format!("{context} entity target is not a string or list")),
+    }
+}
+
+fn json_scalar_string(value: &JsonValue) -> Option<String> {
+    match value {
+        JsonValue::String(value) => Some(value.clone()),
+        JsonValue::Bool(true) => Some("on".to_string()),
+        JsonValue::Bool(false) => Some("off".to_string()),
+        JsonValue::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn entity_domain(entity_id: &str) -> &str {
+    entity_id.split_once('.').map_or("", |(domain, _)| domain)
+}
+
+enum SceneRequestError {
+    Unavailable(String),
+    Fatal(DefinitionError),
+}
+
+fn request_scene_config(
+    config: &DefinitionCollectorConfig,
+    config_id: &str,
+) -> Result<JsonValue, SceneRequestError> {
+    let mut base = Url::parse(&config.rest_base_url).map_err(|error| {
+        SceneRequestError::Fatal(DefinitionError::Config(format!(
+            "invalid REST URL: {error}"
+        )))
+    })?;
+    let prefix = base.path.trim_end_matches('/');
+    base.path = format!(
+        "{prefix}/api/config/scene/config/{}",
+        percent_encode(config_id)
+    );
+    base.query = None;
+    base.fragment = None;
+    let response = http_get_json(&base, config).map_err(SceneRequestError::Fatal)?;
+    match response.status {
+        200 => serde_json::from_slice(&response.body).map_err(|error| {
+            SceneRequestError::Unavailable(format!("scene response was invalid JSON: {error}"))
+        }),
+        404 => Err(SceneRequestError::Unavailable(
+            "Home Assistant config endpoint returned 404".to_string(),
+        )),
+        401 | 403 => Err(SceneRequestError::Fatal(DefinitionError::Protocol(
+            "Home Assistant scene config endpoint requires an administrator token".to_string(),
+        ))),
+        status => Err(SceneRequestError::Unavailable(format!(
+            "Home Assistant config endpoint returned HTTP {status}"
+        ))),
+    }
+}
+
+struct HttpResponse {
+    status: u16,
+    body: Vec<u8>,
+}
+
+enum HttpStream {
+    Plain(TcpStream),
+    Tls(Box<dyn tls_platform::TlsStream>),
+}
+
+impl Read for HttpStream {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Plain(stream) => stream.read(buffer),
+            Self::Tls(stream) => stream.read(buffer),
+        }
+    }
+}
+
+impl Write for HttpStream {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Plain(stream) => stream.write(buffer),
+            Self::Tls(stream) => stream.write(buffer),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Plain(stream) => stream.flush(),
+            Self::Tls(stream) => stream.flush(),
+        }
+    }
+}
+
+fn http_get_json(
+    url: &Url,
+    config: &DefinitionCollectorConfig,
+) -> Result<HttpResponse, DefinitionError> {
+    let host = url
+        .host
+        .as_deref()
+        .ok_or_else(|| DefinitionError::Config("REST URL has no host".to_string()))?;
+    let port = url
+        .effective_port()
+        .ok_or_else(|| DefinitionError::Config("REST URL has no port".to_string()))?;
+    let mut stream = match url.scheme.as_str() {
+        "http" => HttpStream::Plain(connect_plain(host, port, config.io_timeout)?),
+        "https" => {
+            let mut tls = TlsConfig::https_default();
+            tls.connect_timeout = config.io_timeout;
+            tls.handshake_timeout = config.io_timeout;
+            tls.read_timeout = Some(config.io_timeout);
+            tls.write_timeout = Some(config.io_timeout);
+            HttpStream::Tls(
+                default_connector()
+                    .connect(host, port, &tls)
+                    .map_err(|error| DefinitionError::Transport(error.to_string()))?,
+            )
+        }
+        scheme => {
+            return Err(DefinitionError::Config(format!(
+                "unsupported REST URL scheme `{scheme}`"
+            )));
+        }
+    };
+    let host_header = if url.port.is_some() {
+        format!("{host}:{port}")
+    } else {
+        host.to_string()
+    };
+    let request = format!(
+        "GET {} HTTP/1.1\r\nHost: {host_header}\r\nAuthorization: Bearer {}\r\nAccept: application/json\r\nConnection: close\r\n\r\n",
+        url.path, config.access_token
+    );
+    stream
+        .write_all(request.as_bytes())
+        .and_then(|()| stream.flush())
+        .map_err(|error| DefinitionError::Transport(error.to_string()))?;
+    let bytes = read_bounded(&mut stream, config.max_response_bytes)
+        .map_err(|error| DefinitionError::Transport(error.to_string()))?;
+    decode_http_response(&bytes, config.max_response_bytes)
+}
+
+fn connect_plain(host: &str, port: u16, timeout: Duration) -> Result<TcpStream, DefinitionError> {
+    let addresses = (host, port)
+        .to_socket_addrs()
+        .map_err(|error| DefinitionError::Transport(error.to_string()))?
+        .collect::<Vec<SocketAddr>>();
+    let mut last_error = None;
+    for address in addresses {
+        match TcpStream::connect_timeout(&address, timeout) {
+            Ok(stream) => {
+                stream
+                    .set_read_timeout(Some(timeout))
+                    .and_then(|()| stream.set_write_timeout(Some(timeout)))
+                    .map_err(|error| DefinitionError::Transport(error.to_string()))?;
+                return Ok(stream);
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(DefinitionError::Transport(last_error.map_or_else(
+        || "host resolved to no addresses".to_string(),
+        |error| error.to_string(),
+    )))
+}
+
+fn read_bounded(reader: &mut dyn Read, max_bytes: usize) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    reader.take(max_bytes as u64 + 1).read_to_end(&mut bytes)?;
+    if bytes.len() > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("response exceeds {max_bytes} bytes"),
+        ));
+    }
+    Ok(bytes)
+}
+
+fn decode_http_response(bytes: &[u8], max_bytes: usize) -> Result<HttpResponse, DefinitionError> {
+    let parsed =
+        parse_response_head(bytes).map_err(|error| DefinitionError::Protocol(error.to_string()))?;
+    let available = &bytes[parsed.body_offset..];
+    let body = match parsed.body_kind {
+        BodyKind::None => Vec::new(),
+        BodyKind::ContentLength(expected) => {
+            if available.len() < expected {
+                return Err(DefinitionError::Protocol(format!(
+                    "HTTP body was truncated: expected {expected}, received {}",
+                    available.len()
+                )));
+            }
+            available[..expected].to_vec()
+        }
+        BodyKind::UntilEof => available.to_vec(),
+        BodyKind::Chunked => decode_chunked_body(available, max_bytes)?,
+    };
+    if body.len() > max_bytes {
+        return Err(DefinitionError::Protocol(format!(
+            "HTTP body exceeds {max_bytes} bytes"
+        )));
+    }
+    Ok(HttpResponse {
+        status: parsed.head.status,
+        body,
+    })
+}
+
+fn decode_chunked_body(input: &[u8], max_bytes: usize) -> Result<Vec<u8>, DefinitionError> {
+    let mut cursor = 0usize;
+    let mut output = Vec::new();
+    loop {
+        let line_end = input[cursor..]
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .map(|offset| cursor + offset)
+            .ok_or_else(|| {
+                DefinitionError::Protocol("missing chunk-size terminator".to_string())
+            })?;
+        let size_text = std::str::from_utf8(&input[cursor..line_end])
+            .map_err(|_| DefinitionError::Protocol("chunk size is not ASCII".to_string()))?
+            .split(';')
+            .next()
+            .unwrap_or_default();
+        let size = usize::from_str_radix(size_text.trim(), 16)
+            .map_err(|_| DefinitionError::Protocol("invalid chunk size".to_string()))?;
+        cursor = line_end + 2;
+        if size == 0 {
+            return Ok(output);
+        }
+        if size > max_bytes.saturating_sub(output.len()) {
+            return Err(DefinitionError::Protocol(format!(
+                "chunked HTTP body exceeds {max_bytes} bytes"
+            )));
+        }
+        let end = cursor
+            .checked_add(size)
+            .ok_or_else(|| DefinitionError::Protocol("chunk size overflow".to_string()))?;
+        if end + 2 > input.len() || &input[end..end + 2] != b"\r\n" {
+            return Err(DefinitionError::Protocol(
+                "truncated chunk payload".to_string(),
+            ));
+        }
+        output.extend_from_slice(&input[cursor..end]);
+        cursor = end + 2;
+    }
+}
+
+fn redact(message: String, secret: &str) -> String {
+    if secret.is_empty() {
+        message
+    } else {
+        message.replace(secret, "[REDACTED]")
+    }
+}

--- a/code/packages/rust/smart-home-home-assistant-definitions/src/main.rs
+++ b/code/packages/rust/smart-home-home-assistant-definitions/src/main.rs
@@ -1,0 +1,106 @@
+use smart_home_home_assistant_definitions::{
+    collect_definitions, write_enriched_export_atomically, DefinitionCollectorConfig,
+    DefinitionError,
+};
+use smart_home_home_assistant_migration::HomeAssistantExport;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("Home Assistant definition collection failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), DefinitionError> {
+    let mut positional = Vec::new();
+    let mut collected_at_ms = None;
+    let mut timeout_ms = 30_000_u64;
+    let mut max_response_bytes = 4 * 1024 * 1024_usize;
+    let mut arguments = env::args().skip(1);
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--collected-at-ms" => {
+                let value = arguments.next().ok_or_else(usage)?;
+                collected_at_ms = Some(value.parse::<u64>().map_err(|_| {
+                    DefinitionError::Usage(
+                        "--collected-at-ms must be an unsigned integer".to_string(),
+                    )
+                })?);
+            }
+            "--timeout-ms" => {
+                let value = arguments.next().ok_or_else(usage)?;
+                timeout_ms = value.parse::<u64>().map_err(|_| {
+                    DefinitionError::Usage("--timeout-ms must be an unsigned integer".to_string())
+                })?;
+            }
+            "--max-response-bytes" => {
+                let value = arguments.next().ok_or_else(usage)?;
+                max_response_bytes = value.parse::<usize>().map_err(|_| {
+                    DefinitionError::Usage(
+                        "--max-response-bytes must be an unsigned integer".to_string(),
+                    )
+                })?;
+            }
+            _ => positional.push(argument),
+        }
+    }
+    if positional.len() != 4 {
+        return Err(usage());
+    }
+
+    let topology_path = PathBuf::from(&positional[0]);
+    let topology_bytes = fs::read(&topology_path).map_err(|error| DefinitionError::Io {
+        operation: "read topology export",
+        path: topology_path.clone(),
+        message: error.to_string(),
+    })?;
+    let topology: HomeAssistantExport = serde_json::from_slice(&topology_bytes)
+        .map_err(|error| DefinitionError::Decode(error.to_string()))?;
+    let access_token = env::var("HOME_ASSISTANT_TOKEN")
+        .map_err(|_| DefinitionError::Usage("HOME_ASSISTANT_TOKEN must be set".to_string()))?;
+    let config = DefinitionCollectorConfig {
+        websocket_url: positional[1].clone(),
+        rest_base_url: positional[2].clone(),
+        access_token,
+        source_instance_id: topology.source_instance_id.clone(),
+        collected_at_ms: collected_at_ms.unwrap_or(system_time_ms()?),
+        io_timeout: Duration::from_millis(timeout_ms),
+        max_response_bytes,
+    };
+    let output_path = PathBuf::from(&positional[3]);
+    let enriched = collect_definitions(&topology, &config)?;
+    write_enriched_export_atomically(&output_path, &enriched)?;
+    let summary = enriched.definition_collection.summary;
+    println!(
+        "collected Home Assistant definitions {} with {}/{} scenes, {}/{} automations, and {} diagnostics",
+        output_path.display(),
+        summary.collected_scenes,
+        summary.discovered_scenes,
+        summary.collected_automations,
+        summary.discovered_automations,
+        summary.diagnostics,
+    );
+    Ok(())
+}
+
+fn system_time_ms() -> Result<u64, DefinitionError> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| {
+            DefinitionError::Validation(format!("system clock is before epoch: {error}"))
+        })?;
+    u64::try_from(duration.as_millis()).map_err(|_| {
+        DefinitionError::Validation("system time does not fit u64 milliseconds".to_string())
+    })
+}
+
+fn usage() -> DefinitionError {
+    DefinitionError::Usage(
+        "usage: smart-home-collect-home-assistant-definitions <topology-export.json> <ws-url> <rest-base-url> <enriched-export.json> [--collected-at-ms <timestamp>] [--timeout-ms <milliseconds>] [--max-response-bytes <bytes>]"
+            .to_string(),
+    )
+}

--- a/code/packages/rust/smart-home-home-assistant-definitions/tests/definition_collection.rs
+++ b/code/packages/rust/smart-home-home-assistant-definitions/tests/definition_collection.rs
@@ -1,0 +1,371 @@
+use serde_json::{json, Value as JsonValue};
+use smart_home_home_assistant_definitions::{
+    collect_definitions, DefinitionCollectorConfig, EnrichedHomeAssistantExport,
+};
+use smart_home_home_assistant_migration::{
+    plan_export, HomeAssistantArea, HomeAssistantDevice, HomeAssistantEntity, HomeAssistantExport,
+    HomeAssistantState, EXPORT_SCHEMA_VERSION,
+};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::Command;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+use tungstenite::{accept, Message};
+
+#[test]
+fn collects_deterministic_definitions_and_feeds_existing_migration() {
+    let topology = topology_fixture();
+    let first = collect_fixture(&topology, supported_automation());
+    let second = collect_fixture(&topology, supported_automation());
+
+    assert_eq!(first, second);
+    assert_eq!(first.definition_collection.summary.collected_scenes, 1);
+    assert_eq!(first.definition_collection.summary.collected_automations, 1);
+    assert!(first.definition_collection.diagnostics.is_empty());
+    assert_eq!(first.export.scenes[0].states[0].entity_id, "light.desk");
+    assert_eq!(
+        first.export.automations[0].automation_id,
+        "automation-config-1"
+    );
+
+    let bytes = serde_json::to_vec(&first).expect("encode enriched export");
+    let migration_input: HomeAssistantExport =
+        serde_json::from_slice(&bytes).expect("decode as original export contract");
+    let plan = plan_export(&migration_input).expect("plan enriched export");
+    assert!(!plan.is_blocked(), "diagnostics: {:?}", plan.diagnostics);
+    assert_eq!(plan.summary.scenes, 1);
+    assert_eq!(plan.summary.automations, 1);
+    assert_eq!(plan.summary.automation_actions, 1);
+}
+
+#[test]
+fn unsupported_automation_is_skipped_with_durable_diagnostic() {
+    let mut topology = topology_fixture();
+    topology
+        .entities
+        .retain(|entity| !entity.entity_id.starts_with("scene."));
+    topology
+        .states
+        .retain(|state| !state.entity_id.starts_with("scene."));
+    let (ws_url, ws_server) = websocket_server(json!({
+        "id": "automation-config-1",
+        "alias": "Unsafe wait",
+        "triggers": {"trigger": "state", "entity_id": "binary_sensor.motion", "to": "on"},
+        "actions": {"delay": 30}
+    }));
+    let config = config(ws_url, "http://127.0.0.1:9".to_string());
+
+    let result = collect_definitions(&topology, &config).expect("collect with diagnostic");
+    ws_server.join().expect("join WebSocket fixture");
+
+    assert!(result.export.automations.is_empty());
+    assert_eq!(result.definition_collection.summary.skipped_automations, 1);
+    assert_eq!(result.definition_collection.diagnostics.len(), 1);
+    assert_eq!(
+        result.definition_collection.diagnostics[0].code,
+        "unsupported_automation_definition"
+    );
+}
+
+#[test]
+fn rejected_authentication_does_not_echo_token() {
+    let mut topology = topology_fixture();
+    topology
+        .entities
+        .retain(|entity| !entity.entity_id.starts_with("scene."));
+    topology
+        .states
+        .retain(|state| !state.entity_id.starts_with("scene."));
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind auth fixture");
+    let address = listener.local_addr().expect("auth fixture address");
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept auth fixture");
+        let mut socket = accept(stream).expect("upgrade auth fixture");
+        send_json(&mut socket, json!({"type": "auth_required"}));
+        let auth = read_json(&mut socket);
+        assert_eq!(auth["access_token"], "fixture-secret-token");
+        send_json(
+            &mut socket,
+            json!({
+                "type": "auth_invalid",
+                "message": "fixture-secret-token is invalid"
+            }),
+        );
+    });
+    let config = config(
+        format!("ws://{address}/api/websocket"),
+        "http://127.0.0.1:9".to_string(),
+    );
+
+    let error = collect_definitions(&topology, &config).expect_err("reject auth");
+    server.join().expect("join auth fixture");
+
+    assert!(!error.to_string().contains("fixture-secret-token"));
+    assert!(error.to_string().contains("rejected the access token"));
+}
+
+#[test]
+fn cli_collects_live_definitions_without_leaking_token() {
+    let topology = topology_fixture();
+    let (ws_url, ws_server) = websocket_server(supported_automation());
+    let (rest_url, rest_server) = scene_server();
+    let directory = std::env::temp_dir().join(format!(
+        "smart-home-ha-definitions-cli-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&directory).expect("create temp directory");
+    let topology_path = directory.join("topology.json");
+    let output_path = directory.join("enriched.json");
+    fs::write(
+        &topology_path,
+        serde_json::to_vec_pretty(&topology).expect("encode topology"),
+    )
+    .expect("write topology");
+
+    let output = Command::new(env!(
+        "CARGO_BIN_EXE_smart-home-collect-home-assistant-definitions"
+    ))
+    .arg(&topology_path)
+    .arg(ws_url)
+    .arg(rest_url)
+    .arg(&output_path)
+    .arg("--collected-at-ms")
+    .arg("1722000001000")
+    .arg("--timeout-ms")
+    .arg("2000")
+    .env("HOME_ASSISTANT_TOKEN", "fixture-secret-token")
+    .output()
+    .expect("run definition collector CLI");
+    ws_server.join().expect("join WebSocket fixture");
+    rest_server.join().expect("join REST fixture");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("1/1 scenes"));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("fixture-secret-token"));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("fixture-secret-token"));
+    let enriched: EnrichedHomeAssistantExport =
+        serde_json::from_slice(&fs::read(&output_path).expect("read enriched output"))
+            .expect("decode enriched output");
+    assert_eq!(
+        enriched.definition_collection.collected_at_ms,
+        1_722_000_001_000
+    );
+    assert_eq!(enriched.export.scenes.len(), 1);
+    assert_eq!(enriched.export.automations.len(), 1);
+
+    fs::remove_file(topology_path).expect("remove topology");
+    fs::remove_file(output_path).expect("remove output");
+    fs::remove_dir(directory).expect("remove directory");
+}
+
+fn collect_fixture(
+    topology: &HomeAssistantExport,
+    automation: JsonValue,
+) -> EnrichedHomeAssistantExport {
+    let (ws_url, ws_server) = websocket_server(automation);
+    let (rest_url, rest_server) = scene_server();
+    let result =
+        collect_definitions(topology, &config(ws_url, rest_url)).expect("collect definitions");
+    ws_server.join().expect("join WebSocket fixture");
+    rest_server.join().expect("join REST fixture");
+    result
+}
+
+fn websocket_server(config: JsonValue) -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind WebSocket fixture");
+    let address = listener.local_addr().expect("WebSocket fixture address");
+    let handle = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept WebSocket fixture");
+        let mut socket = accept(stream).expect("upgrade WebSocket fixture");
+        send_json(&mut socket, json!({"type": "auth_required"}));
+        let auth = read_json(&mut socket);
+        assert_eq!(auth["type"], "auth");
+        assert_eq!(auth["access_token"], "fixture-secret-token");
+        send_json(&mut socket, json!({"type": "auth_ok"}));
+        let request = read_json(&mut socket);
+        assert_eq!(request["type"], "automation/config");
+        assert_eq!(request["entity_id"], "automation.night_motion");
+        send_json(
+            &mut socket,
+            json!({
+                "id": request["id"],
+                "type": "result",
+                "success": true,
+                "result": {"config": config}
+            }),
+        );
+    });
+    (format!("ws://{address}/api/websocket"), handle)
+}
+
+fn scene_server() -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind REST fixture");
+    let address = listener.local_addr().expect("REST fixture address");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept REST fixture");
+        let request = read_http_head(&mut stream);
+        let request = String::from_utf8(request).expect("HTTP request text");
+        assert!(request.starts_with("GET /api/config/scene/config/night-config HTTP/1.1\r\n"));
+        assert!(request.contains("Authorization: Bearer fixture-secret-token\r\n"));
+        let body = json!({
+            "id": "night-config",
+            "name": "Night",
+            "entities": {
+                "light.desk": {"state": "off", "transition": 2}
+            }
+        })
+        .to_string();
+        let split = body.len() / 2;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{:x}\r\n{}\r\n{:x}\r\n{}\r\n0\r\n\r\n",
+            split,
+            &body[..split],
+            body.len() - split,
+            &body[split..]
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write REST response");
+    });
+    (format!("http://{address}"), handle)
+}
+
+fn read_http_head(stream: &mut TcpStream) -> Vec<u8> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set REST timeout");
+    let mut request = Vec::new();
+    let mut byte = [0_u8; 1];
+    while !request.ends_with(b"\r\n\r\n") {
+        let count = stream.read(&mut byte).expect("read REST request");
+        if count == 0 {
+            break;
+        }
+        request.push(byte[0]);
+    }
+    request
+}
+
+fn send_json<S: Read + Write>(socket: &mut tungstenite::WebSocket<S>, value: JsonValue) {
+    socket
+        .send(Message::Text(value.to_string().into()))
+        .expect("send fixture JSON");
+}
+
+fn read_json<S: Read + Write>(socket: &mut tungstenite::WebSocket<S>) -> JsonValue {
+    let message = socket.read().expect("read fixture JSON");
+    serde_json::from_str(message.to_text().expect("fixture text")).expect("decode fixture JSON")
+}
+
+fn supported_automation() -> JsonValue {
+    json!({
+        "id": "automation-config-1",
+        "alias": "Night motion",
+        "triggers": {
+            "trigger": "state",
+            "entity_id": "binary_sensor.motion",
+            "to": "on"
+        },
+        "conditions": {
+            "condition": "state",
+            "entity_id": "light.desk",
+            "state": "off"
+        },
+        "actions": {
+            "action": "scene.turn_on",
+            "target": {"entity_id": "scene.night"}
+        }
+    })
+}
+
+fn config(websocket_url: String, rest_base_url: String) -> DefinitionCollectorConfig {
+    DefinitionCollectorConfig {
+        websocket_url,
+        rest_base_url,
+        access_token: "fixture-secret-token".to_string(),
+        source_instance_id: "fixture-home".to_string(),
+        collected_at_ms: 1_722_000_001_000,
+        io_timeout: Duration::from_secs(2),
+        max_response_bytes: 64 * 1024,
+    }
+}
+
+fn topology_fixture() -> HomeAssistantExport {
+    HomeAssistantExport {
+        schema_version: EXPORT_SCHEMA_VERSION,
+        source_instance_id: "fixture-home".to_string(),
+        exported_at_ms: 1_722_000_000_000,
+        areas: vec![HomeAssistantArea {
+            area_id: "office".to_string(),
+            name: "Office".to_string(),
+            aliases: vec![],
+        }],
+        devices: vec![HomeAssistantDevice {
+            device_id: "device-1".to_string(),
+            area_id: Some("office".to_string()),
+            name: Some("Desk".to_string()),
+            name_by_user: None,
+            manufacturer: Some("Fixture".to_string()),
+            model: Some("Lamp".to_string()),
+            serial_number: None,
+            sw_version: None,
+            identifiers: vec![],
+        }],
+        entities: vec![
+            entity("light.desk", "demo", "light-1", Some("device-1")),
+            entity("binary_sensor.motion", "demo", "motion-1", Some("device-1")),
+            entity("scene.night", "homeassistant", "night-config", None),
+            entity(
+                "automation.night_motion",
+                "automation",
+                "automation-config-1",
+                None,
+            ),
+        ],
+        states: vec![
+            state("light.desk", "off", "Desk lamp"),
+            state("binary_sensor.motion", "off", "Motion"),
+            state("scene.night", "unknown", "Night"),
+            state("automation.night_motion", "on", "Night motion"),
+        ],
+        scenes: vec![],
+        automations: vec![],
+    }
+}
+
+fn entity(
+    entity_id: &str,
+    platform: &str,
+    unique_id: &str,
+    device_id: Option<&str>,
+) -> HomeAssistantEntity {
+    HomeAssistantEntity {
+        entity_id: entity_id.to_string(),
+        device_id: device_id.map(str::to_string),
+        area_id: if entity_id == "scene.night" {
+            Some("office".to_string())
+        } else {
+            None
+        },
+        platform: platform.to_string(),
+        unique_id: unique_id.to_string(),
+        name: None,
+        original_name: None,
+        disabled_by: None,
+    }
+}
+
+fn state(entity_id: &str, value: &str, name: &str) -> HomeAssistantState {
+    HomeAssistantState {
+        entity_id: entity_id.to_string(),
+        state: value.to_string(),
+        attributes: BTreeMap::from([("friendly_name".to_string(), json!(name))]),
+    }
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -566,8 +566,8 @@ migration boundary:
   WebSocket server to prove authentication, command ordering, normalization,
   failed authorization, and token redaction.
 - Scene and automation definitions are not inferred from
-  registry/current-state payloads; their live collection remains explicit
-  follow-up work.
+  registry/current-state payloads; their live collection is delegated to the
+  reviewed definition-enrichment stage below.
 
 ## Current Home Assistant Historical State Slice
 
@@ -590,6 +590,30 @@ leaving it as a detached archive:
   process tests prove batched collection, durable replay, repeat idempotency,
   current-state preservation, and token redaction.
 
+## Current Home Assistant Definition Collection Slice
+
+This slice retrieves executable source definitions without approximating
+unsupported Home Assistant behavior:
+
+- `smart-home-home-assistant-definitions` consumes the reviewed topology
+  export, authenticates as an administrator, and requests each automation's
+  raw configuration through `automation/config` over the WebSocket API.
+- Editable Home Assistant scenes are retrieved from
+  `/api/config/scene/config/{config-id}` over bounded HTTP or HTTPS using the
+  entity registry's stable configuration identifier.
+- The collector accepts only the importer's executable subset: state and
+  simple time-pattern triggers, state conditions, and bounded scene, light,
+  switch, lock, and thermostat actions. Templates, delays, multi-trigger
+  semantics, device/area targets, unsupported services, and non-editable scene
+  platforms are skipped with durable diagnostics instead of being guessed.
+- The enriched artifact keeps definitions and a source-fingerprinted
+  collection report in deterministic order. Its extra report field is
+  backward-compatible with the existing migration reader, so the same file
+  can be planned and applied without a conversion step.
+- Real local WebSocket, HTTP, chunked-response, and CLI process tests prove
+  authenticated collection, migration compatibility, deterministic reruns,
+  partial-definition diagnostics, atomic output, and token redaction.
+
 ## Smart Home Remaining Work
 
 These items move toward retiring an existing Home Assistant install:
@@ -599,10 +623,8 @@ These items move toward retiring an existing Home Assistant install:
   Matter commissioning/secure-session/network host, a Thread border-router
   host, a production Zigbee coordinator/join/security host, and production
   Z-Wave inclusion and S2.
-- Extend the completed Home Assistant live topology/current-state and
-  historical-state collection plus topology/current-state/scene/automation
-  importer with live scene and automation definition collection and dashboard
-  migration.
+- Extend the completed Home Assistant topology, current-state, historical-state,
+  scene, and automation migration pipeline with dashboard migration.
 - Provide a dashboard that can inspect devices, rooms, state, health,
   automations, event history, pairing, and command audit.
 


### PR DESCRIPTION
## Summary
- collect administrator-authenticated automation configs over Home Assistant WebSocket and editable scene configs over bounded HTTP/HTTPS
- normalize only the executable migration subset and persist diagnostics for unsupported or unavailable definitions
- emit deterministic enriched exports that remain directly consumable by the existing migration CLI
- mark live scene and automation definition collection complete in the D18-D23 inventory

## Validation
- `bash smart-home-home-assistant-definitions/BUILD` (4 integration/process tests)
- `cargo clippy -p smart-home-home-assistant-definitions --all-targets -- -D warnings`
- `bash smart-home-home-assistant-migration/BUILD` (7 unit + 1 process test)
- `bash smart-home-home-assistant-export/BUILD` (4 unit + 1 process test)
- `bash http1/BUILD` (10 tests)
- `bash tls-platform/BUILD` (8 tests + 1 doc test; live-network test intentionally ignored)

Generated `code/packages/rust/Cargo.lock` was removed after validation.