### PR TITLE
feat(spice): validate MOS saturation current density

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `JS` values before
+  bulk-junction leakage-density and temperature preprocessing.
+
 - Reject non-positive and non-finite Level-1 MOS model-card `IS` values before
   bulk-junction leakage and temperature preprocessing.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -614,6 +614,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET CGBO must be finite and non-negative")
         elif canonical == "IS" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET IS must be finite and positive")
+        elif canonical == "JS" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET JS must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1246,6 +1246,18 @@ def test_mos_model_card_rejects_non_positive_or_non_finite_saturation_current() 
             normalize_model_card("Minvalid", "nmos", {"IS": invalid_current})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_saturation_current_density() -> None:
+    for value in (0.0, 2.0e-10, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"JS": value})
+        assert valid.parameters["JS"] == pytest.approx(value)
+
+    for invalid_density in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET JS must be finite and non-negative"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"JS": invalid_density})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `JS` values before
+  bulk-junction leakage-density and temperature preprocessing.
+
 - Reject non-positive and non-finite Level-1 MOS model-card `IS` values before
   bulk-junction leakage and temperature preprocessing.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4462,6 +4462,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET IS must be finite and positive".to_string(),
                 });
+            } else if canonical == "JS" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET JS must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1123,6 +1123,22 @@ fn mos_model_card_rejects_non_positive_or_non_finite_saturation_current() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_saturation_current_density() {
+    for value in [0.0, 2.0e-10, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("JS", value)]).unwrap();
+        assert_close(*valid.parameters.get("JS").unwrap(), value);
+    }
+
+    for invalid_density in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("JS", invalid_density)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET JS must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `JS` values before
+  bulk-junction leakage-density and temperature preprocessing.
+
 - Reject non-positive and non-finite Level-1 MOS model-card `IS` values before
   bulk-junction leakage and temperature preprocessing.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8516,6 +8516,11 @@ export function normalizeModelCard(
       (!Number.isFinite(value) || value <= 0.0)
     ) {
       throw invalidElement(name, "MOSFET IS must be finite and positive");
+    } else if (
+      canonical === "JS" &&
+      (!Number.isFinite(value) || value < 0.0)
+    ) {
+      throw invalidElement(name, "MOSFET JS must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1038,6 +1038,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS saturation current density", () => {
+    for (const value of [0.0, 2.0e-10, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { JS: value });
+      expect(valid.parameters.JS).toBe(value);
+    }
+
+    for (const invalidDensity of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { JS: invalidDensity }),
+      ).toThrow("MOSFET JS must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS saturation-current validation.
+1. Cross-language Level-1 MOS saturation-current-density validation.
    - Status: current PR completion candidate.
-   - Reject non-positive or non-finite model-card `IS` values before
-     bulk-junction leakage and temperature preprocessing.
-   - Preserve positive saturation currents across Rust, Python, and TypeScript.
+   - Reject negative or non-finite model-card `JS` values before bulk-junction
+     leakage-density and temperature preprocessing.
+   - Preserve zero and positive saturation-current densities across Rust,
+     Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3782,6 +3783,13 @@ the Rust, Python, and TypeScript surfaces together.
      gate-bulk overlap-capacitance stamping.
    - Zero and positive gate-bulk overlap capacitances remain aligned across
      Rust, Python, and TypeScript.
+
+315. Cross-language Level-1 MOS saturation-current validation.
+   - Status: completed in PR 9384.
+   - Non-positive and non-finite model-card `IS` values are rejected before
+     bulk-junction leakage and temperature preprocessing.
+   - Positive saturation currents remain aligned across Rust, Python, and
+     TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `JS` values with a stable diagnostic
- preserve zero and positive saturation-current densities across Rust, Python, and TypeScript
- reconcile the SPICE implementation plan after PR #9384

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `ruff check spice-engine/src spice-engine/tests`
- `pytest spice-engine/tests` (697 passed, 88.88% coverage)
- `npm test` (440 passed)
- `npm run build`