### PR TITLE
feat(smart-home): migrate Home Assistant dashboards

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -904,6 +904,7 @@ members = [
     "smart-home-home-assistant-export",
     "smart-home-home-assistant-history",
     "smart-home-home-assistant-definitions",
+    "smart-home-home-assistant-dashboard-migration",
     "smart-home-integration-catalog",
     "smart-home-testkit",
     "hue-core",

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/BUILD
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-home-assistant-dashboard-migration --all-targets -- --nocapture

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Add authenticated collection of Lovelace dashboard metadata, configurations,
+  and frontend resources through Home Assistant's WebSocket API.
+- Add deterministic compilation of standard entity, control, and history cards
+  into a repository-owned smart-home dashboard manifest.
+- Add dry-run and applied artifacts, source fingerprints, migration receipts,
+  durable unsupported-content diagnostics, and atomic CLI output.

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/Cargo.toml
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "smart-home-home-assistant-dashboard-migration"
+version = "0.1.0"
+edition = "2021"
+description = "Live Home Assistant Lovelace collection and native smart-home dashboard migration"
+license = "MIT"
+
+[dependencies]
+coding_adventures_sha256 = { path = "../sha256" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smart-home-home-assistant-migration = { path = "../smart-home-home-assistant-migration" }
+tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+
+[[bin]]
+name = "smart-home-migrate-home-assistant-dashboards"
+path = "src/main.rs"

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/README.md
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/README.md
@@ -1,0 +1,39 @@
+# smart-home-home-assistant-dashboard-migration
+
+`smart-home-home-assistant-dashboard-migration` collects live Lovelace
+dashboards after the Home Assistant topology has been reviewed and exports a
+repository-owned dashboard manifest. It uses the concrete
+`lovelace/dashboards/list`, `lovelace/config`, and
+`lovelace/resources/list` WebSocket commands.
+
+Standard entity, light, thermostat, sensor, tile, button, entities, glance,
+and history-graph cards are compiled to native entity-control, entity-list,
+and history widgets. Vertical stacks, horizontal stacks, grids, and section
+views are flattened without changing source order. Entity references are
+accepted only when present in the reviewed topology export and become the same
+`ha:<entity-id>` identifiers used by the executable runtime migration.
+
+Custom cards, custom resources, unsupported actions, and unknown entity
+references are never approximated. They are retained as durable diagnostics
+for manual replacement. A failed fetch for a dashboard that Home Assistant
+listed is an error and blocks applied output; use `--dry-run` to retain the
+complete review plan.
+
+`HOME_ASSISTANT_TOKEN` is read only from the environment and is never written
+to artifacts or diagnostics.
+
+```sh
+HOME_ASSISTANT_TOKEN='...' cargo run \
+  -p smart-home-home-assistant-dashboard-migration \
+  --bin smart-home-migrate-home-assistant-dashboards -- \
+  home-assistant-enriched.json \
+  wss://home.example/api/websocket \
+  smart-home-dashboards.json
+```
+
+## Validation
+
+```sh
+bash smart-home-home-assistant-dashboard-migration/BUILD
+cargo clippy -p smart-home-home-assistant-dashboard-migration --all-targets -- -D warnings
+```

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/src/lib.rs
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/src/lib.rs
@@ -1,0 +1,1062 @@
+//! Live Home Assistant Lovelace collection and native dashboard migration.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_sha256::sha256_hex;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use smart_home_home_assistant_migration::{HomeAssistantExport, EXPORT_SCHEMA_VERSION};
+use std::collections::BTreeSet;
+use std::fmt;
+use std::fs::{self, File};
+use std::io::Write;
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{connect, Message, WebSocket};
+
+pub const DASHBOARD_MIGRATION_SCHEMA_VERSION: u32 = 1;
+const MAX_UNMATCHED_MESSAGES: usize = 64;
+
+type HomeAssistantSocket = WebSocket<MaybeTlsStream<TcpStream>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DashboardCollectorConfig {
+    pub websocket_url: String,
+    pub access_token: String,
+    pub source_instance_id: String,
+    pub collected_at_ms: u64,
+    pub io_timeout: Duration,
+}
+
+impl DashboardCollectorConfig {
+    pub fn validate(&self) -> Result<(), DashboardMigrationError> {
+        if !self.websocket_url.starts_with("ws://") && !self.websocket_url.starts_with("wss://") {
+            return Err(DashboardMigrationError::Config(
+                "Home Assistant WebSocket URL must use ws:// or wss://".to_string(),
+            ));
+        }
+        if self.access_token.trim().is_empty() {
+            return Err(DashboardMigrationError::Config(
+                "Home Assistant access token is empty".to_string(),
+            ));
+        }
+        if self.source_instance_id.trim().is_empty() {
+            return Err(DashboardMigrationError::Config(
+                "source instance id is empty".to_string(),
+            ));
+        }
+        if self.io_timeout.is_zero() {
+            return Err(DashboardMigrationError::Config(
+                "I/O timeout must be greater than zero".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DashboardDiagnosticSeverity {
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardDiagnostic {
+    pub severity: DashboardDiagnosticSeverity,
+    pub source_kind: String,
+    pub source_id: String,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeDashboardCardKind {
+    EntityControl,
+    EntityList,
+    History,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeDashboardCard {
+    pub card_id: String,
+    pub kind: NativeDashboardCardKind,
+    pub source_type: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    pub entity_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeDashboardView {
+    pub view_id: String,
+    pub title: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub icon: Option<String>,
+    pub cards: Vec<NativeDashboardCard>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeDashboard {
+    pub dashboard_id: String,
+    pub url_path: String,
+    pub title: String,
+    #[serde(default)]
+    pub icon: Option<String>,
+    pub require_admin: bool,
+    pub show_in_sidebar: bool,
+    pub views: Vec<NativeDashboardView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HomeAssistantDashboardResource {
+    pub resource_id: String,
+    pub url: String,
+    pub resource_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeDashboardManifest {
+    pub schema_version: u32,
+    pub source_instance_id: String,
+    pub generated_at_ms: u64,
+    pub dashboards: Vec<NativeDashboard>,
+    pub source_resources: Vec<HomeAssistantDashboardResource>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardMigrationSummary {
+    pub dashboards_discovered: usize,
+    pub dashboards_collected: usize,
+    pub views: usize,
+    pub cards_discovered: usize,
+    pub cards_migrated: usize,
+    pub entity_references: usize,
+    pub resources: usize,
+    pub warnings: usize,
+    pub errors: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardMigrationPlan {
+    pub source_instance_id: String,
+    pub source_fingerprint: String,
+    pub collected_at_ms: u64,
+    pub manifest: NativeDashboardManifest,
+    pub diagnostics: Vec<DashboardDiagnostic>,
+    pub summary: DashboardMigrationSummary,
+}
+
+impl DashboardMigrationPlan {
+    pub fn is_blocked(&self) -> bool {
+        self.summary.errors > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardMigrationReceipt {
+    pub migration_id: String,
+    pub source_instance_id: String,
+    pub source_fingerprint: String,
+    pub applied_at_ms: u64,
+    pub dashboards: usize,
+    pub views: usize,
+    pub cards: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardMigrationArtifact {
+    pub schema_version: u32,
+    pub dry_run: bool,
+    pub plan: DashboardMigrationPlan,
+    #[serde(default)]
+    pub receipt: Option<DashboardMigrationReceipt>,
+}
+
+#[derive(Debug)]
+pub enum DashboardMigrationError {
+    Config(String),
+    Validation(String),
+    Transport(String),
+    Protocol(String),
+    Decode(String),
+    Encode(String),
+    Blocked(String),
+    Io {
+        operation: &'static str,
+        path: PathBuf,
+        message: String,
+    },
+    Usage(String),
+}
+
+impl fmt::Display for DashboardMigrationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Config(message) => {
+                write!(formatter, "invalid collector configuration: {message}")
+            }
+            Self::Validation(message) => write!(formatter, "invalid dashboard input: {message}"),
+            Self::Transport(message) => {
+                write!(formatter, "Home Assistant transport failed: {message}")
+            }
+            Self::Protocol(message) => {
+                write!(formatter, "Home Assistant protocol failed: {message}")
+            }
+            Self::Decode(message) => write!(formatter, "dashboard decode failed: {message}"),
+            Self::Encode(message) => write!(formatter, "dashboard encode failed: {message}"),
+            Self::Blocked(message) => write!(formatter, "dashboard migration blocked: {message}"),
+            Self::Io {
+                operation,
+                path,
+                message,
+            } => {
+                write!(
+                    formatter,
+                    "could not {operation} {}: {message}",
+                    path.display()
+                )
+            }
+            Self::Usage(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for DashboardMigrationError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SourceDashboard {
+    #[serde(default)]
+    id: Option<String>,
+    url_path: String,
+    title: String,
+    #[serde(default)]
+    icon: Option<String>,
+    #[serde(default)]
+    require_admin: bool,
+    #[serde(default = "default_true")]
+    show_in_sidebar: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct CollectedDashboard {
+    metadata: SourceDashboard,
+    config: JsonValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct CollectedSource {
+    dashboards: Vec<CollectedDashboard>,
+    resources: Vec<HomeAssistantDashboardResource>,
+}
+
+pub fn migrate_live_dashboards(
+    topology: &HomeAssistantExport,
+    config: &DashboardCollectorConfig,
+    dry_run: bool,
+) -> Result<DashboardMigrationArtifact, DashboardMigrationError> {
+    config.validate()?;
+    validate_topology(topology, config)?;
+    let (source, mut diagnostics, discovered) = collect_source(config)?;
+    let plan = plan_collected(topology, config, source, &mut diagnostics, discovered)?;
+    if !dry_run && plan.is_blocked() {
+        return Err(DashboardMigrationError::Blocked(format!(
+            "{} collection or validation errors require review",
+            plan.summary.errors
+        )));
+    }
+    let receipt = (!dry_run).then(|| DashboardMigrationReceipt {
+        migration_id: format!("ha-dashboard:{}", &plan.source_fingerprint[..16]),
+        source_instance_id: plan.source_instance_id.clone(),
+        source_fingerprint: plan.source_fingerprint.clone(),
+        applied_at_ms: config.collected_at_ms,
+        dashboards: plan.summary.dashboards_collected,
+        views: plan.summary.views,
+        cards: plan.summary.cards_migrated,
+    });
+    Ok(DashboardMigrationArtifact {
+        schema_version: DASHBOARD_MIGRATION_SCHEMA_VERSION,
+        dry_run,
+        plan,
+        receipt,
+    })
+}
+
+fn validate_topology(
+    topology: &HomeAssistantExport,
+    config: &DashboardCollectorConfig,
+) -> Result<(), DashboardMigrationError> {
+    if topology.schema_version != EXPORT_SCHEMA_VERSION {
+        return Err(DashboardMigrationError::Validation(format!(
+            "unsupported topology schema {}, expected {EXPORT_SCHEMA_VERSION}",
+            topology.schema_version
+        )));
+    }
+    if topology.source_instance_id != config.source_instance_id {
+        return Err(DashboardMigrationError::Validation(format!(
+            "source instance `{}` does not match topology `{}`",
+            config.source_instance_id, topology.source_instance_id
+        )));
+    }
+    Ok(())
+}
+
+fn collect_source(
+    config: &DashboardCollectorConfig,
+) -> Result<(CollectedSource, Vec<DashboardDiagnostic>, usize), DashboardMigrationError> {
+    let (mut socket, _) = connect(config.websocket_url.as_str()).map_err(|error| {
+        DashboardMigrationError::Transport(redact(error.to_string(), &config.access_token))
+    })?;
+    configure_socket_timeout(&mut socket, config.io_timeout)?;
+    authenticate(&mut socket, &config.access_token)?;
+
+    let raw_dashboards = request(&mut socket, 1, json!({"type": "lovelace/dashboards/list"}))?;
+    let mut dashboards: Vec<SourceDashboard> = serde_json::from_value(raw_dashboards)
+        .map_err(|error| DashboardMigrationError::Decode(error.to_string()))?;
+    dashboards.sort_by(|left, right| left.url_path.cmp(&right.url_path));
+    let discovered = dashboards.len();
+
+    let raw_resources = request(&mut socket, 2, json!({"type": "lovelace/resources/list"}))?;
+    let mut resources = normalize_resources(&raw_resources)?;
+    resources.sort_by(|left, right| left.resource_id.cmp(&right.resource_id));
+
+    let mut collected = Vec::new();
+    let mut diagnostics = Vec::new();
+    for (index, metadata) in dashboards.into_iter().enumerate() {
+        let id = u64::try_from(index + 3).map_err(|_| {
+            DashboardMigrationError::Validation("too many dashboards to request".to_string())
+        })?;
+        match request(
+            &mut socket,
+            id,
+            json!({"type": "lovelace/config", "url_path": metadata.url_path}),
+        ) {
+            Ok(configuration) => collected.push(CollectedDashboard {
+                metadata,
+                config: configuration,
+            }),
+            Err(error) => diagnostics.push(diagnostic(
+                DashboardDiagnosticSeverity::Error,
+                "dashboard",
+                &metadata.url_path,
+                "dashboard_config_unavailable",
+                error.to_string(),
+            )),
+        }
+    }
+    Ok((
+        CollectedSource {
+            dashboards: collected,
+            resources,
+        },
+        diagnostics,
+        discovered,
+    ))
+}
+
+fn normalize_resources(
+    raw: &JsonValue,
+) -> Result<Vec<HomeAssistantDashboardResource>, DashboardMigrationError> {
+    let items = raw.as_array().ok_or_else(|| {
+        DashboardMigrationError::Decode("Lovelace resources result is not an array".to_string())
+    })?;
+    items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let object = item.as_object().ok_or_else(|| {
+                DashboardMigrationError::Decode("Lovelace resource is not an object".to_string())
+            })?;
+            let url = object
+                .get("url")
+                .and_then(JsonValue::as_str)
+                .ok_or_else(|| {
+                    DashboardMigrationError::Decode("resource has no URL".to_string())
+                })?;
+            let resource_type = object
+                .get("res_type")
+                .or_else(|| object.get("type"))
+                .and_then(JsonValue::as_str)
+                .unwrap_or("module");
+            let resource_id = object
+                .get("id")
+                .and_then(JsonValue::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("resource-{}", index + 1));
+            Ok(HomeAssistantDashboardResource {
+                resource_id,
+                url: url.to_string(),
+                resource_type: resource_type.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn plan_collected(
+    topology: &HomeAssistantExport,
+    config: &DashboardCollectorConfig,
+    source: CollectedSource,
+    diagnostics: &mut Vec<DashboardDiagnostic>,
+    discovered: usize,
+) -> Result<DashboardMigrationPlan, DashboardMigrationError> {
+    let mut enabled_entity_ids = topology
+        .entities
+        .iter()
+        .filter(|entity| entity.disabled_by.is_none())
+        .map(|entity| entity.entity_id.as_str())
+        .collect::<Vec<_>>();
+    enabled_entity_ids.sort_unstable();
+    let fingerprint_bytes = serde_json::to_vec(&(&source, &enabled_entity_ids))
+        .map_err(|error| DashboardMigrationError::Encode(error.to_string()))?;
+    let source_fingerprint = sha256_hex(&fingerprint_bytes);
+    let known_entities = enabled_entity_ids.into_iter().collect::<BTreeSet<_>>();
+    let mut counters = CompileCounters::default();
+    let mut dashboards = Vec::new();
+    for dashboard in &source.dashboards {
+        dashboards.push(compile_dashboard(
+            dashboard,
+            &known_entities,
+            diagnostics,
+            &mut counters,
+        ));
+    }
+    for resource in &source.resources {
+        diagnostics.push(diagnostic(
+            DashboardDiagnosticSeverity::Warning,
+            "resource",
+            &resource.resource_id,
+            "external_resource_requires_manual_review",
+            format!(
+                "Home Assistant resource `{}` ({}) is preserved but not executed",
+                resource.url, resource.resource_type
+            ),
+        ));
+    }
+    diagnostics.sort_by(|left, right| {
+        left.source_kind
+            .cmp(&right.source_kind)
+            .then_with(|| left.source_id.cmp(&right.source_id))
+            .then_with(|| left.code.cmp(&right.code))
+    });
+    let warnings = diagnostics
+        .iter()
+        .filter(|item| item.severity == DashboardDiagnosticSeverity::Warning)
+        .count();
+    let errors = diagnostics
+        .iter()
+        .filter(|item| item.severity == DashboardDiagnosticSeverity::Error)
+        .count();
+    let summary = DashboardMigrationSummary {
+        dashboards_discovered: discovered,
+        dashboards_collected: dashboards.len(),
+        views: counters.views,
+        cards_discovered: counters.cards_discovered,
+        cards_migrated: counters.cards_migrated,
+        entity_references: counters.entity_references,
+        resources: source.resources.len(),
+        warnings,
+        errors,
+    };
+    Ok(DashboardMigrationPlan {
+        source_instance_id: config.source_instance_id.clone(),
+        source_fingerprint,
+        collected_at_ms: config.collected_at_ms,
+        manifest: NativeDashboardManifest {
+            schema_version: DASHBOARD_MIGRATION_SCHEMA_VERSION,
+            source_instance_id: config.source_instance_id.clone(),
+            generated_at_ms: config.collected_at_ms,
+            dashboards,
+            source_resources: source.resources,
+        },
+        diagnostics: diagnostics.clone(),
+        summary,
+    })
+}
+
+#[derive(Default)]
+struct CompileCounters {
+    views: usize,
+    cards_discovered: usize,
+    cards_migrated: usize,
+    entity_references: usize,
+}
+
+fn compile_dashboard(
+    source: &CollectedDashboard,
+    known_entities: &BTreeSet<&str>,
+    diagnostics: &mut Vec<DashboardDiagnostic>,
+    counters: &mut CompileCounters,
+) -> NativeDashboard {
+    let mut views = Vec::new();
+    let raw_views = source
+        .config
+        .get("views")
+        .and_then(JsonValue::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if source.config.get("strategy").is_some() {
+        diagnostics.push(diagnostic(
+            DashboardDiagnosticSeverity::Warning,
+            "dashboard",
+            &source.metadata.url_path,
+            "generated_strategy_requires_manual_review",
+            "generated dashboard strategies cannot be reproduced deterministically".to_string(),
+        ));
+    }
+    for (view_index, raw_view) in raw_views.iter().enumerate() {
+        let view_source_id = format!("{}:view:{}", source.metadata.url_path, view_index + 1);
+        let Some(object) = raw_view.as_object() else {
+            diagnostics.push(diagnostic(
+                DashboardDiagnosticSeverity::Warning,
+                "view",
+                &view_source_id,
+                "invalid_view",
+                "view is not an object".to_string(),
+            ));
+            continue;
+        };
+        let title = object
+            .get("title")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("Untitled view")
+            .to_string();
+        let mut raw_cards = object
+            .get("cards")
+            .and_then(JsonValue::as_array)
+            .cloned()
+            .unwrap_or_default();
+        if let Some(sections) = object.get("sections").and_then(JsonValue::as_array) {
+            for section in sections {
+                if let Some(cards) = section.get("cards").and_then(JsonValue::as_array) {
+                    raw_cards.extend(cards.iter().cloned());
+                }
+            }
+        }
+        let mut cards = Vec::new();
+        for raw_card in &raw_cards {
+            compile_card(
+                raw_card,
+                &view_source_id,
+                known_entities,
+                diagnostics,
+                counters,
+                &mut cards,
+            );
+        }
+        counters.views += 1;
+        views.push(NativeDashboardView {
+            view_id: format!(
+                "dashboard:{}:view:{}",
+                source.metadata.url_path,
+                view_index + 1
+            ),
+            title,
+            path: string_field(object, "path"),
+            icon: string_field(object, "icon"),
+            cards,
+        });
+    }
+    NativeDashboard {
+        dashboard_id: source
+            .metadata
+            .id
+            .clone()
+            .unwrap_or_else(|| source.metadata.url_path.clone()),
+        url_path: source.metadata.url_path.clone(),
+        title: source.metadata.title.clone(),
+        icon: source.metadata.icon.clone(),
+        require_admin: source.metadata.require_admin,
+        show_in_sidebar: source.metadata.show_in_sidebar,
+        views,
+    }
+}
+
+fn compile_card(
+    raw: &JsonValue,
+    view_source_id: &str,
+    known_entities: &BTreeSet<&str>,
+    diagnostics: &mut Vec<DashboardDiagnostic>,
+    counters: &mut CompileCounters,
+    output: &mut Vec<NativeDashboardCard>,
+) {
+    counters.cards_discovered += 1;
+    let source_id = format!("{view_source_id}:card:{}", counters.cards_discovered);
+    let Some(object) = raw.as_object() else {
+        diagnostics.push(diagnostic(
+            DashboardDiagnosticSeverity::Warning,
+            "card",
+            &source_id,
+            "invalid_card",
+            "card is not an object".to_string(),
+        ));
+        return;
+    };
+    let card_type = object
+        .get("type")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("unknown");
+    if matches!(card_type, "vertical-stack" | "horizontal-stack" | "grid") {
+        if let Some(cards) = object.get("cards").and_then(JsonValue::as_array) {
+            for card in cards {
+                compile_card(
+                    card,
+                    view_source_id,
+                    known_entities,
+                    diagnostics,
+                    counters,
+                    output,
+                );
+            }
+        } else {
+            diagnostics.push(diagnostic(
+                DashboardDiagnosticSeverity::Warning,
+                "card",
+                &source_id,
+                "empty_layout_container",
+                format!("{card_type} card has no cards array"),
+            ));
+        }
+        return;
+    }
+    if has_unsupported_action(object) {
+        diagnostics.push(diagnostic(
+            DashboardDiagnosticSeverity::Warning,
+            "card",
+            &source_id,
+            "unsupported_card_action",
+            format!("{card_type} card contains an action that requires manual review"),
+        ));
+        return;
+    }
+    let (kind, raw_entities) = match card_type {
+        "entity" | "light" | "thermostat" | "sensor" | "tile" | "button" => (
+            NativeDashboardCardKind::EntityControl,
+            object.get("entity").into_iter().collect::<Vec<_>>(),
+        ),
+        "entities" | "glance" => (
+            NativeDashboardCardKind::EntityList,
+            object
+                .get("entities")
+                .and_then(JsonValue::as_array)
+                .map(|items| items.iter().collect())
+                .unwrap_or_default(),
+        ),
+        "history-graph" => (
+            NativeDashboardCardKind::History,
+            object
+                .get("entities")
+                .and_then(JsonValue::as_array)
+                .map(|items| items.iter().collect())
+                .unwrap_or_default(),
+        ),
+        _ => {
+            diagnostics.push(diagnostic(
+                DashboardDiagnosticSeverity::Warning,
+                "card",
+                &source_id,
+                "unsupported_card_type",
+                format!("Lovelace card type `{card_type}` is not in the native subset"),
+            ));
+            return;
+        }
+    };
+    let mut entities = Vec::new();
+    let mut seen_entities = BTreeSet::new();
+    for item in raw_entities {
+        let source_entity = match item {
+            JsonValue::String(value) => Some(value.as_str()),
+            JsonValue::Object(row) if row.get("type").is_none() && !has_unsupported_action(row) => {
+                row.get("entity").and_then(JsonValue::as_str)
+            }
+            _ => None,
+        };
+        let Some(source_entity) = source_entity else {
+            diagnostics.push(diagnostic(
+                DashboardDiagnosticSeverity::Warning,
+                "card",
+                &source_id,
+                "unsupported_entity_row",
+                "card contains an entity row without a scalar entity id".to_string(),
+            ));
+            continue;
+        };
+        if !known_entities.contains(source_entity) {
+            diagnostics.push(diagnostic(
+                DashboardDiagnosticSeverity::Warning,
+                "card",
+                &source_id,
+                "unknown_entity_reference",
+                format!("entity `{source_entity}` is not enabled in the reviewed topology"),
+            ));
+            continue;
+        }
+        let migrated = format!("ha:{source_entity}");
+        if seen_entities.insert(migrated.clone()) {
+            entities.push(migrated);
+        }
+    }
+    if entities.is_empty() {
+        diagnostics.push(diagnostic(
+            DashboardDiagnosticSeverity::Warning,
+            "card",
+            &source_id,
+            "card_has_no_migratable_entities",
+            format!("{card_type} card has no migratable entity references"),
+        ));
+        return;
+    }
+    counters.cards_migrated += 1;
+    counters.entity_references += entities.len();
+    output.push(NativeDashboardCard {
+        card_id: format!("dashboard-card:{}", counters.cards_migrated),
+        kind,
+        source_type: card_type.to_string(),
+        title: string_field(object, "title").or_else(|| string_field(object, "name")),
+        entity_ids: entities,
+    });
+}
+
+fn has_unsupported_action(object: &serde_json::Map<String, JsonValue>) -> bool {
+    ["tap_action", "hold_action", "double_tap_action"]
+        .iter()
+        .filter_map(|name| object.get(*name))
+        .any(|action| {
+            action
+                .get("action")
+                .and_then(JsonValue::as_str)
+                .is_some_and(|kind| !matches!(kind, "more-info" | "none"))
+        })
+}
+
+fn string_field(object: &serde_json::Map<String, JsonValue>, name: &str) -> Option<String> {
+    object
+        .get(name)
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+}
+
+fn diagnostic(
+    severity: DashboardDiagnosticSeverity,
+    source_kind: &str,
+    source_id: &str,
+    code: &str,
+    message: String,
+) -> DashboardDiagnostic {
+    DashboardDiagnostic {
+        severity,
+        source_kind: source_kind.to_string(),
+        source_id: source_id.to_string(),
+        code: code.to_string(),
+        message,
+    }
+}
+
+fn configure_socket_timeout(
+    socket: &mut HomeAssistantSocket,
+    timeout: Duration,
+) -> Result<(), DashboardMigrationError> {
+    match socket.get_mut() {
+        MaybeTlsStream::Plain(stream) => {
+            stream
+                .set_read_timeout(Some(timeout))
+                .and_then(|()| stream.set_write_timeout(Some(timeout)))
+                .map_err(|error| DashboardMigrationError::Transport(error.to_string()))?;
+        }
+        MaybeTlsStream::Rustls(stream) => {
+            stream
+                .get_mut()
+                .set_read_timeout(Some(timeout))
+                .and_then(|()| stream.get_mut().set_write_timeout(Some(timeout)))
+                .map_err(|error| DashboardMigrationError::Transport(error.to_string()))?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn authenticate(
+    socket: &mut HomeAssistantSocket,
+    access_token: &str,
+) -> Result<(), DashboardMigrationError> {
+    let required = read_socket_json(socket)?;
+    if required.get("type").and_then(JsonValue::as_str) != Some("auth_required") {
+        return Err(DashboardMigrationError::Protocol(
+            "server did not begin with auth_required".to_string(),
+        ));
+    }
+    send_socket_json(
+        socket,
+        &json!({"type": "auth", "access_token": access_token}),
+    )?;
+    let response = read_socket_json(socket)?;
+    match response.get("type").and_then(JsonValue::as_str) {
+        Some("auth_ok") => Ok(()),
+        Some("auth_invalid") => Err(DashboardMigrationError::Protocol(
+            "Home Assistant rejected authentication".to_string(),
+        )),
+        _ => Err(DashboardMigrationError::Protocol(
+            "unexpected authentication response".to_string(),
+        )),
+    }
+}
+
+fn request(
+    socket: &mut HomeAssistantSocket,
+    id: u64,
+    mut command: JsonValue,
+) -> Result<JsonValue, DashboardMigrationError> {
+    command
+        .as_object_mut()
+        .ok_or_else(|| DashboardMigrationError::Protocol("command is not an object".to_string()))?
+        .insert("id".to_string(), JsonValue::from(id));
+    send_socket_json(socket, &command)?;
+    for _ in 0..MAX_UNMATCHED_MESSAGES {
+        let response = read_socket_json(socket)?;
+        if response.get("id").and_then(JsonValue::as_u64) != Some(id) {
+            continue;
+        }
+        if response.get("success").and_then(JsonValue::as_bool) != Some(true) {
+            let code = response
+                .pointer("/error/code")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("request_failed");
+            let message = response
+                .pointer("/error/message")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("request failed");
+            return Err(DashboardMigrationError::Protocol(format!(
+                "Home Assistant returned {code}: {message}"
+            )));
+        }
+        return response.get("result").cloned().ok_or_else(|| {
+            DashboardMigrationError::Protocol("result response has no result".to_string())
+        });
+    }
+    Err(DashboardMigrationError::Protocol(format!(
+        "no matching result after {MAX_UNMATCHED_MESSAGES} messages"
+    )))
+}
+
+fn send_socket_json(
+    socket: &mut HomeAssistantSocket,
+    value: &JsonValue,
+) -> Result<(), DashboardMigrationError> {
+    socket
+        .send(Message::Text(value.to_string().into()))
+        .map_err(|error| DashboardMigrationError::Transport(error.to_string()))
+}
+
+fn read_socket_json(
+    socket: &mut HomeAssistantSocket,
+) -> Result<JsonValue, DashboardMigrationError> {
+    loop {
+        let message = socket
+            .read()
+            .map_err(|error| DashboardMigrationError::Transport(error.to_string()))?;
+        match message {
+            Message::Text(text) => {
+                return serde_json::from_str(&text)
+                    .map_err(|error| DashboardMigrationError::Protocol(error.to_string()));
+            }
+            Message::Binary(bytes) => {
+                return serde_json::from_slice(&bytes)
+                    .map_err(|error| DashboardMigrationError::Protocol(error.to_string()));
+            }
+            Message::Ping(payload) => socket
+                .send(Message::Pong(payload))
+                .map_err(|error| DashboardMigrationError::Transport(error.to_string()))?,
+            Message::Close(_) => {
+                return Err(DashboardMigrationError::Protocol(
+                    "Home Assistant closed the WebSocket".to_string(),
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn redact(message: String, secret: &str) -> String {
+    if secret.is_empty() {
+        message
+    } else {
+        message.replace(secret, "[REDACTED]")
+    }
+}
+
+pub fn write_artifact_atomically(
+    path: &Path,
+    artifact: &DashboardMigrationArtifact,
+) -> Result<(), DashboardMigrationError> {
+    let bytes = serde_json::to_vec_pretty(artifact)
+        .map_err(|error| DashboardMigrationError::Encode(error.to_string()))?;
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).map_err(|error| DashboardMigrationError::Io {
+        operation: "create output directory",
+        path: parent.to_path_buf(),
+        message: error.to_string(),
+    })?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("dashboard.json");
+    let temporary = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
+    let result = (|| {
+        let mut file = File::create(&temporary).map_err(|error| DashboardMigrationError::Io {
+            operation: "create temporary output",
+            path: temporary.clone(),
+            message: error.to_string(),
+        })?;
+        file.write_all(&bytes)
+            .and_then(|()| file.sync_all())
+            .map_err(|error| DashboardMigrationError::Io {
+                operation: "write temporary output",
+                path: temporary.clone(),
+                message: error.to_string(),
+            })?;
+        fs::rename(&temporary, path).map_err(|error| DashboardMigrationError::Io {
+            operation: "replace dashboard artifact",
+            path: path.to_path_buf(),
+            message: error.to_string(),
+        })
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smart_home_home_assistant_migration::HomeAssistantEntity;
+
+    #[test]
+    fn standard_cards_and_layouts_compile_to_native_manifest() {
+        let topology = topology();
+        let source = CollectedSource {
+            dashboards: vec![CollectedDashboard {
+                metadata: SourceDashboard {
+                    id: Some("overview".to_string()),
+                    url_path: "lovelace".to_string(),
+                    title: "Overview".to_string(),
+                    icon: None,
+                    require_admin: false,
+                    show_in_sidebar: true,
+                },
+                config: json!({"views": [{
+                    "title": "Home",
+                    "cards": [
+                        {"type": "entities", "entities": ["light.kitchen", {"entity": "sensor.temperature"}]},
+                        {"type": "grid", "cards": [
+                            {"type": "light", "entity": "light.kitchen"},
+                            {"type": "history-graph", "entities": ["sensor.temperature"]}
+                        ]}
+                    ]
+                }]}),
+            }],
+            resources: Vec::new(),
+        };
+        let config = config();
+        let mut diagnostics = Vec::new();
+        let plan = plan_collected(&topology, &config, source, &mut diagnostics, 1)
+            .expect("plan dashboard");
+
+        assert_eq!(plan.summary.cards_discovered, 4);
+        assert_eq!(plan.summary.cards_migrated, 3);
+        assert_eq!(plan.summary.entity_references, 4);
+        assert_eq!(plan.manifest.dashboards[0].views[0].cards.len(), 3);
+        assert_eq!(
+            plan.manifest.dashboards[0].views[0].cards[0].entity_ids,
+            vec!["ha:light.kitchen", "ha:sensor.temperature"]
+        );
+        assert!(plan.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unsupported_content_is_durable_and_never_approximated() {
+        let topology = topology();
+        let source = CollectedSource {
+            dashboards: vec![CollectedDashboard {
+                metadata: SourceDashboard {
+                    id: None,
+                    url_path: "energy".to_string(),
+                    title: "Energy".to_string(),
+                    icon: None,
+                    require_admin: true,
+                    show_in_sidebar: false,
+                },
+                config: json!({"views": [{"title": "Energy", "cards": [
+                    {"type": "custom:power-flow-card", "entity": "sensor.temperature"},
+                    {"type": "entity", "entity": "sensor.missing"},
+                    {"type": "button", "entity": "light.kitchen", "tap_action": {"action": "call-service"}}
+                ]}]}),
+            }],
+            resources: vec![HomeAssistantDashboardResource {
+                resource_id: "power-flow".to_string(),
+                url: "/local/power-flow.js".to_string(),
+                resource_type: "module".to_string(),
+            }],
+        };
+        let mut diagnostics = Vec::new();
+        let plan = plan_collected(&topology, &config(), source, &mut diagnostics, 1)
+            .expect("plan dashboard");
+
+        assert_eq!(plan.summary.cards_discovered, 3);
+        assert_eq!(plan.summary.cards_migrated, 0);
+        assert_eq!(plan.summary.warnings, 5);
+        assert!(plan
+            .diagnostics
+            .iter()
+            .any(|item| item.code == "unsupported_card_type"));
+        assert!(plan
+            .diagnostics
+            .iter()
+            .any(|item| item.code == "external_resource_requires_manual_review"));
+    }
+
+    fn topology() -> HomeAssistantExport {
+        HomeAssistantExport {
+            schema_version: EXPORT_SCHEMA_VERSION,
+            source_instance_id: "home-1".to_string(),
+            exported_at_ms: 1,
+            areas: Vec::new(),
+            devices: Vec::new(),
+            entities: vec![entity("light.kitchen"), entity("sensor.temperature")],
+            states: Vec::new(),
+            scenes: Vec::new(),
+            automations: Vec::new(),
+        }
+    }
+
+    fn entity(entity_id: &str) -> HomeAssistantEntity {
+        HomeAssistantEntity {
+            entity_id: entity_id.to_string(),
+            device_id: None,
+            area_id: None,
+            platform: "fixture".to_string(),
+            unique_id: entity_id.to_string(),
+            name: None,
+            original_name: None,
+            disabled_by: None,
+        }
+    }
+
+    fn config() -> DashboardCollectorConfig {
+        DashboardCollectorConfig {
+            websocket_url: "ws://127.0.0.1:8123/api/websocket".to_string(),
+            access_token: "secret".to_string(),
+            source_instance_id: "home-1".to_string(),
+            collected_at_ms: 10,
+            io_timeout: Duration::from_secs(1),
+        }
+    }
+}

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/src/main.rs
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/src/main.rs
@@ -1,0 +1,100 @@
+use smart_home_home_assistant_dashboard_migration::{
+    migrate_live_dashboards, write_artifact_atomically, DashboardCollectorConfig,
+    DashboardMigrationError,
+};
+use smart_home_home_assistant_migration::HomeAssistantExport;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("Home Assistant dashboard migration failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), DashboardMigrationError> {
+    let mut positional = Vec::new();
+    let mut collected_at_ms = None;
+    let mut timeout_ms = 30_000_u64;
+    let mut dry_run = false;
+    let mut arguments = env::args().skip(1);
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--collected-at-ms" => {
+                let value = arguments.next().ok_or_else(usage)?;
+                collected_at_ms = Some(value.parse::<u64>().map_err(|_| {
+                    DashboardMigrationError::Usage(
+                        "--collected-at-ms must be an unsigned integer".to_string(),
+                    )
+                })?);
+            }
+            "--timeout-ms" => {
+                let value = arguments.next().ok_or_else(usage)?;
+                timeout_ms = value.parse::<u64>().map_err(|_| {
+                    DashboardMigrationError::Usage(
+                        "--timeout-ms must be an unsigned integer".to_string(),
+                    )
+                })?;
+            }
+            "--dry-run" => dry_run = true,
+            _ => positional.push(argument),
+        }
+    }
+    if positional.len() != 3 {
+        return Err(usage());
+    }
+
+    let topology_path = PathBuf::from(&positional[0]);
+    let topology_bytes = fs::read(&topology_path).map_err(|error| DashboardMigrationError::Io {
+        operation: "read topology export",
+        path: topology_path.clone(),
+        message: error.to_string(),
+    })?;
+    let topology: HomeAssistantExport = serde_json::from_slice(&topology_bytes)
+        .map_err(|error| DashboardMigrationError::Decode(error.to_string()))?;
+    let access_token = env::var("HOME_ASSISTANT_TOKEN").map_err(|_| {
+        DashboardMigrationError::Usage("HOME_ASSISTANT_TOKEN must be set".to_string())
+    })?;
+    let config = DashboardCollectorConfig {
+        websocket_url: positional[1].clone(),
+        access_token,
+        source_instance_id: topology.source_instance_id.clone(),
+        collected_at_ms: collected_at_ms.unwrap_or(system_time_ms()?),
+        io_timeout: Duration::from_millis(timeout_ms),
+    };
+    let artifact = migrate_live_dashboards(&topology, &config, dry_run)?;
+    let output_path = PathBuf::from(&positional[2]);
+    write_artifact_atomically(&output_path, &artifact)?;
+    let summary = artifact.plan.summary;
+    println!(
+        "{} Home Assistant dashboards {} with {} views, {}/{} cards, and {} diagnostics",
+        if dry_run { "planned" } else { "migrated" },
+        output_path.display(),
+        summary.views,
+        summary.cards_migrated,
+        summary.cards_discovered,
+        summary.warnings + summary.errors,
+    );
+    Ok(())
+}
+
+fn system_time_ms() -> Result<u64, DashboardMigrationError> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| {
+            DashboardMigrationError::Validation(format!("system clock is before epoch: {error}"))
+        })?;
+    u64::try_from(duration.as_millis()).map_err(|_| {
+        DashboardMigrationError::Validation("system time does not fit u64 milliseconds".to_string())
+    })
+}
+
+fn usage() -> DashboardMigrationError {
+    DashboardMigrationError::Usage(
+        "usage: smart-home-migrate-home-assistant-dashboards <topology-export.json> <ws-url> <dashboard-artifact.json> [--dry-run] [--collected-at-ms <timestamp>] [--timeout-ms <milliseconds>]"
+            .to_string(),
+    )
+}

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/tests/dashboard_migration.rs
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/tests/dashboard_migration.rs
@@ -1,0 +1,307 @@
+use serde_json::{json, Value as JsonValue};
+use smart_home_home_assistant_dashboard_migration::{
+    migrate_live_dashboards, DashboardCollectorConfig, DashboardMigrationArtifact,
+};
+use smart_home_home_assistant_migration::{
+    HomeAssistantEntity, HomeAssistantExport, EXPORT_SCHEMA_VERSION,
+};
+use std::fs;
+use std::net::TcpListener;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+use tungstenite::{accept, Message, WebSocket};
+
+#[test]
+fn live_lovelace_collection_migrates_dashboards_and_resources() {
+    let topology = topology();
+    let (url, server) = fixture_server("dashboard-secret", false, false);
+    let artifact =
+        migrate_live_dashboards(&topology, &config(url), false).expect("migrate live dashboards");
+    server.join().expect("fixture server");
+
+    assert!(!artifact.dry_run);
+    assert!(artifact.receipt.is_some());
+    assert_eq!(artifact.plan.summary.dashboards_discovered, 2);
+    assert_eq!(artifact.plan.summary.dashboards_collected, 2);
+    assert_eq!(artifact.plan.summary.views, 2);
+    assert_eq!(artifact.plan.summary.cards_migrated, 3);
+    assert_eq!(artifact.plan.summary.resources, 1);
+    assert_eq!(artifact.plan.manifest.dashboards[0].url_path, "energy");
+    assert_eq!(artifact.plan.manifest.dashboards[1].url_path, "lovelace");
+    assert!(artifact.plan.diagnostics.iter().any(|item| {
+        item.code == "external_resource_requires_manual_review"
+            && item.message.contains("/local/custom.js")
+    }));
+}
+
+#[test]
+fn repeated_collection_has_stable_source_fingerprint() {
+    let topology = topology();
+    let (first_url, first_server) = fixture_server("dashboard-secret", false, false);
+    let first =
+        migrate_live_dashboards(&topology, &config(first_url), true).expect("first dashboard plan");
+    first_server.join().expect("first fixture server");
+    let (second_url, second_server) = fixture_server("dashboard-secret", false, false);
+    let mut second_config = config(second_url);
+    second_config.collected_at_ms += 10_000;
+    let second =
+        migrate_live_dashboards(&topology, &second_config, true).expect("second dashboard plan");
+    second_server.join().expect("second fixture server");
+
+    assert_eq!(
+        first.plan.source_fingerprint,
+        second.plan.source_fingerprint
+    );
+    assert_eq!(
+        first.plan.manifest.dashboards,
+        second.plan.manifest.dashboards
+    );
+    assert_ne!(first.plan.collected_at_ms, second.plan.collected_at_ms);
+}
+
+#[test]
+fn reviewed_topology_changes_source_fingerprint() {
+    let topology = topology();
+    let (first_url, first_server) = fixture_server("dashboard-secret", false, false);
+    let first =
+        migrate_live_dashboards(&topology, &config(first_url), true).expect("first dashboard plan");
+    first_server.join().expect("first fixture server");
+
+    let mut changed_topology = topology;
+    changed_topology.entities[0].disabled_by = Some("user".to_string());
+    let (second_url, second_server) = fixture_server("dashboard-secret", false, false);
+    let second = migrate_live_dashboards(&changed_topology, &config(second_url), true)
+        .expect("changed topology plan");
+    second_server.join().expect("second fixture server");
+
+    assert_ne!(
+        first.plan.source_fingerprint,
+        second.plan.source_fingerprint
+    );
+    assert!(second.plan.summary.cards_migrated < first.plan.summary.cards_migrated);
+}
+
+#[test]
+fn rejected_authentication_does_not_echo_token() {
+    let topology = topology();
+    let (url, server) = fixture_server("dashboard-secret", true, false);
+    let error = migrate_live_dashboards(&topology, &config(url), true)
+        .expect_err("authentication should fail");
+    server.join().expect("fixture server");
+
+    let message = error.to_string();
+    assert!(message.contains("rejected"));
+    assert!(!message.contains("dashboard-secret"));
+}
+
+#[test]
+fn unavailable_listed_dashboard_is_reviewable_in_dry_run_and_blocks_apply() {
+    let topology = topology();
+    let (dry_url, dry_server) = fixture_server("dashboard-secret", false, true);
+    let dry_run = migrate_live_dashboards(&topology, &config(dry_url), true)
+        .expect("dry run should retain dashboard error");
+    dry_server.join().expect("dry-run fixture server");
+    assert!(dry_run.plan.is_blocked());
+    assert_eq!(dry_run.plan.summary.dashboards_discovered, 2);
+    assert_eq!(dry_run.plan.summary.dashboards_collected, 1);
+    assert!(dry_run
+        .plan
+        .diagnostics
+        .iter()
+        .any(|item| item.code == "dashboard_config_unavailable"));
+
+    let (apply_url, apply_server) = fixture_server("dashboard-secret", false, true);
+    let error = migrate_live_dashboards(&topology, &config(apply_url), false)
+        .expect_err("applied migration should block");
+    apply_server.join().expect("apply fixture server");
+    assert!(error
+        .to_string()
+        .contains("1 collection or validation errors"));
+}
+
+#[test]
+fn cli_writes_applied_artifact_atomically() {
+    let directory = std::env::temp_dir().join(format!(
+        "smart-home-ha-dashboard-cli-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&directory).expect("create test directory");
+    let topology_path = directory.join("topology.json");
+    let output_path = directory.join("dashboard.json");
+    fs::write(
+        &topology_path,
+        serde_json::to_vec_pretty(&topology()).expect("encode topology"),
+    )
+    .expect("write topology");
+    let (url, server) = fixture_server("process-secret", false, false);
+
+    let output = Command::new(env!(
+        "CARGO_BIN_EXE_smart-home-migrate-home-assistant-dashboards"
+    ))
+    .arg(&topology_path)
+    .arg(url)
+    .arg(&output_path)
+    .arg("--timeout-ms")
+    .arg("2000")
+    .arg("--collected-at-ms")
+    .arg("1767312000000")
+    .env("HOME_ASSISTANT_TOKEN", "process-secret")
+    .output()
+    .expect("run dashboard CLI");
+    server.join().expect("fixture server");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("3/3 cards"));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("process-secret"));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("process-secret"));
+    let artifact: DashboardMigrationArtifact =
+        serde_json::from_slice(&fs::read(&output_path).expect("read artifact"))
+            .expect("decode artifact");
+    assert_eq!(artifact.plan.summary.dashboards_collected, 2);
+    assert!(artifact.receipt.is_some());
+    assert!(!directory.join(".dashboard.json.tmp").exists());
+
+    fs::remove_file(topology_path).expect("remove topology");
+    fs::remove_file(output_path).expect("remove output");
+    fs::remove_dir(directory).expect("remove test directory");
+}
+
+fn fixture_server(
+    expected_token: &'static str,
+    reject_auth: bool,
+    fail_energy_config: bool,
+) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fixture");
+    let address = listener.local_addr().expect("fixture address");
+    let handle = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept fixture");
+        let mut socket = accept(stream).expect("upgrade fixture");
+        send(&mut socket, json!({"type": "auth_required"}));
+        let auth = read(&mut socket);
+        assert_eq!(auth["type"], "auth");
+        assert_eq!(auth["access_token"], expected_token);
+        if reject_auth {
+            send(&mut socket, json!({"type": "auth_invalid"}));
+            return;
+        }
+        send(&mut socket, json!({"type": "auth_ok"}));
+
+        let dashboards = read(&mut socket);
+        assert_eq!(dashboards["id"], 1);
+        assert_eq!(dashboards["type"], "lovelace/dashboards/list");
+        send(
+            &mut socket,
+            result(
+                1,
+                json!([
+                    {"id": "overview", "url_path": "lovelace", "title": "Overview", "show_in_sidebar": true},
+                    {"id": "energy", "url_path": "energy", "title": "Energy", "icon": "mdi:flash", "require_admin": true}
+                ]),
+            ),
+        );
+
+        let resources = read(&mut socket);
+        assert_eq!(resources["id"], 2);
+        assert_eq!(resources["type"], "lovelace/resources/list");
+        send(
+            &mut socket,
+            result(
+                2,
+                json!([{"id": "custom", "url": "/local/custom.js", "res_type": "module"}]),
+            ),
+        );
+
+        let energy = read(&mut socket);
+        assert_eq!(energy["id"], 3);
+        assert_eq!(energy["url_path"], "energy");
+        if fail_energy_config {
+            send(
+                &mut socket,
+                json!({"id": 3, "type": "result", "success": false, "error": {"code": "config_not_found", "message": "No config found"}}),
+            );
+        } else {
+            send(
+                &mut socket,
+                result(
+                    3,
+                    json!({"views": [{"title": "Power", "cards": [
+                        {"type": "history-graph", "entities": ["sensor.temperature"]}
+                    ]}]}),
+                ),
+            );
+        }
+
+        let overview = read(&mut socket);
+        assert_eq!(overview["id"], 4);
+        assert_eq!(overview["url_path"], "lovelace");
+        send(
+            &mut socket,
+            result(
+                4,
+                json!({"views": [{"title": "Home", "cards": [
+                    {"type": "entities", "entities": ["light.kitchen", "sensor.temperature"]},
+                    {"type": "light", "entity": "light.kitchen"}
+                ]}]}),
+            ),
+        );
+    });
+    (format!("ws://{address}/api/websocket"), handle)
+}
+
+fn result(id: u64, result: JsonValue) -> JsonValue {
+    json!({"id": id, "type": "result", "success": true, "result": result})
+}
+
+fn send(socket: &mut WebSocket<std::net::TcpStream>, value: JsonValue) {
+    socket
+        .send(Message::Text(value.to_string().into()))
+        .expect("send fixture response");
+}
+
+fn read(socket: &mut WebSocket<std::net::TcpStream>) -> JsonValue {
+    let message = socket.read().expect("read fixture request");
+    serde_json::from_str(message.to_text().expect("text fixture request"))
+        .expect("fixture request JSON")
+}
+
+fn config(websocket_url: String) -> DashboardCollectorConfig {
+    DashboardCollectorConfig {
+        websocket_url,
+        access_token: "dashboard-secret".to_string(),
+        source_instance_id: "home-1".to_string(),
+        collected_at_ms: 1_767_312_000_000,
+        io_timeout: Duration::from_secs(2),
+    }
+}
+
+fn topology() -> HomeAssistantExport {
+    HomeAssistantExport {
+        schema_version: EXPORT_SCHEMA_VERSION,
+        source_instance_id: "home-1".to_string(),
+        exported_at_ms: 1,
+        areas: Vec::new(),
+        devices: Vec::new(),
+        entities: vec![entity("light.kitchen"), entity("sensor.temperature")],
+        states: Vec::new(),
+        scenes: Vec::new(),
+        automations: Vec::new(),
+    }
+}
+
+fn entity(entity_id: &str) -> HomeAssistantEntity {
+    HomeAssistantEntity {
+        entity_id: entity_id.to_string(),
+        device_id: None,
+        area_id: None,
+        platform: "fixture".to_string(),
+        unique_id: entity_id.to_string(),
+        name: None,
+        original_name: None,
+        disabled_by: None,
+    }
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -614,6 +614,28 @@ unsupported Home Assistant behavior:
   authenticated collection, migration compatibility, deterministic reruns,
   partial-definition diagnostics, atomic output, and token redaction.
 
+## Current Home Assistant Dashboard Migration Slice
+
+This slice migrates concrete Lovelace definitions without executing custom
+frontend code or guessing at unsupported behavior:
+
+- `smart-home-home-assistant-dashboard-migration` authenticates to Home
+  Assistant and uses `lovelace/dashboards/list`, `lovelace/config`, and
+  `lovelace/resources/list` over the WebSocket API.
+- Standard entity, light, thermostat, sensor, tile, button, entities, glance,
+  and history cards become a deterministic native dashboard manifest. Layout
+  stacks, grids, and section views are flattened in source order.
+- Entity references are accepted only when they are enabled in the reviewed
+  topology export and use the same `ha:<entity-id>` identifiers as the
+  executable runtime migration.
+- Custom cards and resources, unsupported actions, malformed rows, and unknown
+  entities produce durable review diagnostics instead of approximations. A
+  listed dashboard whose configuration cannot be fetched blocks applied
+  migration while remaining inspectable in dry-run output.
+- Real local WebSocket and CLI process tests prove authenticated multi-dashboard
+  collection, resource capture, deterministic source fingerprints, blocked
+  apply behavior, atomic output, and token redaction.
+
 ## Smart Home Remaining Work
 
 These items move toward retiring an existing Home Assistant install:
@@ -623,8 +645,6 @@ These items move toward retiring an existing Home Assistant install:
   Matter commissioning/secure-session/network host, a Thread border-router
   host, a production Zigbee coordinator/join/security host, and production
   Z-Wave inclusion and S2.
-- Extend the completed Home Assistant topology, current-state, historical-state,
-  scene, and automation migration pipeline with dashboard migration.
 - Provide a dashboard that can inspect devices, rooms, state, health,
   automations, event history, pairing, and command audit.
 


### PR DESCRIPTION
## Summary
- add an authenticated Home Assistant Lovelace collector over `lovelace/dashboards/list`, `lovelace/config`, and `lovelace/resources/list`
- compile supported cards and layout containers into a deterministic repository-owned dashboard manifest using reviewed `ha:<entity-id>` mappings
- preserve unsupported cards, resources, actions, and entity references as durable diagnostics, with dry-run review and blocked applied migration
- update the D18-D23 completion inventory to leave only the live operational dashboard and remaining production integrations

## Validation
- `bash smart-home-home-assistant-dashboard-migration/BUILD` (2 unit + 6 integration/process tests)
- `cargo clippy -p smart-home-home-assistant-dashboard-migration --all-targets -- -D warnings`
- `bash smart-home-home-assistant-migration/BUILD` (7 unit + 1 process test)
- `bash smart-home-home-assistant-definitions/BUILD` (4 integration/process tests)
- `cargo fmt -p smart-home-home-assistant-dashboard-migration -- --check`
- `git diff --check`

Generated `code/packages/rust/Cargo.lock` was removed.