### PR TITLE
feat(spice): validate MOS model width

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-positive and non-finite Level-1 MOS model-card `W` values before
+  channel-current, capacitance, and noise calculations.
+
 - Reject negative and non-finite Level-1 MOS model-card `JS` values before
   bulk-junction leakage-density and temperature preprocessing.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -580,6 +580,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET U0 must be finite and non-negative")
         elif canonical == "KP" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET KP must be finite and positive")
+        elif canonical == "W" and (not math.isfinite(value) or value <= 0.0):
+            raise ValueError(f"{name}: MOSFET W must be finite and positive")
         elif canonical == "VT0" and not math.isfinite(value):
             raise ValueError(f"{name}: MOSFET VT0 must be finite")
         elif canonical == "LAMBDA" and not math.isfinite(value):

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1258,6 +1258,16 @@ def test_mos_model_card_rejects_negative_or_non_finite_saturation_current_densit
             normalize_model_card("Minvalid", "nmos", {"JS": invalid_density})
 
 
+def test_mos_model_card_rejects_non_positive_or_non_finite_width() -> None:
+    for value in (1.0e-9, 2.0e-6, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"W": value})
+        assert valid.parameters["W"] == pytest.approx(value)
+
+    for invalid_width in (-math.inf, -0.1, 0.0, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET W must be finite and positive"):
+            normalize_model_card("Minvalid", "nmos", {"W": invalid_width})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-positive and non-finite Level-1 MOS model-card `W` values before
+  channel-current, capacitance, and noise calculations.
+
 - Reject negative and non-finite Level-1 MOS model-card `JS` values before
   bulk-junction leakage-density and temperature preprocessing.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4380,6 +4380,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET KP must be finite and positive".to_string(),
                 });
+            } else if canonical == "W" && (!raw_value.is_finite() || *raw_value <= 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET W must be finite and positive".to_string(),
+                });
             } else if canonical == "VT0" && !raw_value.is_finite() {
                 return Err(SpiceError::InvalidElement {
                     name: name.clone(),

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1139,6 +1139,22 @@ fn mos_model_card_rejects_negative_or_non_finite_saturation_current_density() {
 }
 
 #[test]
+fn mos_model_card_rejects_non_positive_or_non_finite_width() {
+    for value in [1.0e-9, 2.0e-6, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("W", value)]).unwrap();
+        assert_close(*valid.parameters.get("W").unwrap(), value);
+    }
+
+    for invalid_width in [f64::NEG_INFINITY, -0.1, 0.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("W", invalid_width)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET W must be finite and positive"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-positive and non-finite Level-1 MOS model-card `W` values before
+  channel-current, capacitance, and noise calculations.
+
 - Reject negative and non-finite Level-1 MOS model-card `JS` values before
   bulk-junction leakage-density and temperature preprocessing.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8442,6 +8442,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET U0 must be finite and non-negative");
     } else if (canonical === "KP" && (!Number.isFinite(value) || value <= 0.0)) {
       throw invalidElement(name, "MOSFET KP must be finite and positive");
+    } else if (canonical === "W" && (!Number.isFinite(value) || value <= 0.0)) {
+      throw invalidElement(name, "MOSFET W must be finite and positive");
     } else if (canonical === "VT0" && !Number.isFinite(value)) {
       throw invalidElement(name, "MOSFET VT0 must be finite");
     } else if (canonical === "LAMBDA" && !Number.isFinite(value)) {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1056,6 +1056,25 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects non-positive or non-finite MOS width", () => {
+    for (const value of [1.0e-9, 2.0e-6, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { W: value });
+      expect(valid.parameters.W).toBe(value);
+    }
+
+    for (const invalidWidth of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      0.0,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { W: invalidWidth }),
+      ).toThrow("MOSFET W must be finite and positive");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS saturation-current-density validation.
+1. Cross-language Level-1 MOS width validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `JS` values before bulk-junction
-     leakage-density and temperature preprocessing.
-   - Preserve zero and positive saturation-current densities across Rust,
-     Python, and TypeScript.
+   - Reject non-positive or non-finite model-card `W` values before
+     channel-current, capacitance, and noise calculations.
+   - Preserve positive model widths across Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3790,6 +3789,13 @@ the Rust, Python, and TypeScript surfaces together.
      bulk-junction leakage and temperature preprocessing.
    - Positive saturation currents remain aligned across Rust, Python, and
      TypeScript.
+
+316. Cross-language Level-1 MOS saturation-current-density validation.
+   - Status: completed in PR 9387.
+   - Negative and non-finite model-card `JS` values are rejected before
+     bulk-junction leakage-density and temperature preprocessing.
+   - Zero and positive saturation-current densities remain aligned across
+     Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite Level-1 MOS model-card `W` values with a stable diagnostic
- preserve positive model widths across Rust, Python, and TypeScript
- reconcile the SPICE implementation plan after PR #9387

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `ruff check spice-engine/src spice-engine/tests`
- `pytest spice-engine/tests` (698 passed, 88.89% coverage)
- `npm test` (441 passed)
- `npm run build`