### PR TITLE
test(mosaic): add Venture backend build matrix

### DIFF
--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -16,3 +16,6 @@
 - Runnable project-shell acceptance proving each backend can obtain and mount
   that content surface through its optional `MosaicHost` contract; the macOS
   SwiftUI gate builds with a real host-provided `NSView`.
+- POSIX and PowerShell backend-matrix entry points that emit the same Venture
+  package for all nine Mosaic targets and directly invoke each available web,
+  Qt, SwiftUI, XAML, Flutter, or Compose build toolchain.

--- a/code/programs/mosaic/venture-browser/Cargo.toml
+++ b/code/programs/mosaic/venture-browser/Cargo.toml
@@ -12,6 +12,7 @@ mosmodel-compiler = { path = "../../../packages/rust/mosmodel-compiler" }
 moslayout-compiler = { path = "../../../packages/rust/moslayout-compiler" }
 mosstyle-compiler = { path = "../../../packages/rust/mosstyle-compiler" }
 mosaic-package-manifest = { path = "../../../packages/rust/mosaic-package-manifest" }
+mosaic-package-artifact-builder = { path = "../../../packages/rust/mosaic-package-artifact-builder" }
 venture-browser-core = { path = "../../../packages/rust/venture-browser-core" }
 
 [[test]]

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -30,5 +30,29 @@ recreating the surrounding chrome in backend-specific UI code.
   sample placeholder. On macOS, the generated SwiftPM app is compiled with a
   real host-provided `NSView`.
 
+## Build every backend
+
+Venture owns a cross-platform acceptance entry point for the complete Mosaic
+backend matrix. Both scripts compile this exact MIL/MLL/MSL package, emit all
+nine project shells, and then invoke the native build available for each
+backend on the current machine:
+
+```sh
+./scripts/build-all.sh
+```
+
+```powershell
+.\scripts\build-all.ps1
+```
+
+React and Electron run their production builds; HTML and Web Components run
+JavaScript syntax checks; SwiftUI, Qt, XAML, Flutter, and Compose invoke their
+native toolchains. Platform-exclusive builds are explicitly deferred to their
+native host; missing host-applicable toolchains are reported as skips. Pass
+`--strict` on POSIX or `-Strict` on PowerShell to reject those missing
+toolchains in a provisioned macOS, Windows, or Linux build job. `--emit-only` /
+`-EmitOnly` remains useful for inspecting all generated projects without
+claiming that their native builds passed.
+
 This package is a browser-wiring milestone, not a claim of complete Venture or
 HTML conformance.

--- a/code/programs/mosaic/venture-browser/scripts/build-all.ps1
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.ps1
@@ -1,0 +1,229 @@
+param(
+    [string]$Output = "target/mosaic-venture-browser",
+    [switch]$Release,
+    [switch]$EmitOnly,
+    [switch]$Strict
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$packageRoot = (Resolve-Path (Join-Path $scriptRoot "..")).Path
+$rustWorkspace = (Resolve-Path (Join-Path $packageRoot "..\..\..\packages\rust")).Path
+$outputRoot = if ([System.IO.Path]::IsPathRooted($Output)) {
+    [System.IO.Path]::GetFullPath($Output)
+} else {
+    [System.IO.Path]::GetFullPath((Join-Path $packageRoot $Output))
+}
+$backends = @("react", "electron", "swiftui", "qt", "webcomponent", "html", "xaml", "flutter", "compose")
+$skipped = [System.Collections.Generic.List[string]]::new()
+$deferred = [System.Collections.Generic.List[string]]::new()
+
+New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)][string]$Command,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Command failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Test-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Skip-Backend {
+    param(
+        [Parameter(Mandatory = $true)][string]$Backend,
+        [Parameter(Mandatory = $true)][string]$Reason
+    )
+
+    Write-Host "==> Skipping ${Backend}: $Reason"
+    $skipped.Add("$Backend ($Reason)")
+}
+
+function Defer-Backend {
+    param(
+        [Parameter(Mandatory = $true)][string]$Backend,
+        [Parameter(Mandatory = $true)][string]$Reason
+    )
+
+    Write-Host "==> Deferring ${Backend}: $Reason"
+    $deferred.Add("$Backend ($Reason)")
+}
+
+foreach ($backend in $backends) {
+    Write-Host "==> Emitting $backend"
+    $cargoArgs = @("run", "-q", "-p", "mosaic-compile")
+    if ($Release) {
+        $cargoArgs += "--release"
+    }
+    $cargoArgs += @(
+        "--",
+        "pkg",
+        $packageRoot,
+        "--backend",
+        $backend,
+        "--output",
+        $outputRoot,
+        "--emit-project",
+        "--theme",
+        "light"
+    )
+    Push-Location $rustWorkspace
+    try {
+        Invoke-Checked -Command "cargo" -Arguments $cargoArgs
+    } finally {
+        Pop-Location
+    }
+}
+
+if ($EmitOnly) {
+    Write-Host "Emitted $($backends.Count) Venture backend projects under $outputRoot"
+    exit 0
+}
+
+foreach ($backend in @("react", "electron")) {
+    if (-not (Test-Command "npm")) {
+        Skip-Backend -Backend $backend -Reason "npm is not installed"
+        continue
+    }
+    Write-Host "==> Building $backend"
+    Push-Location (Join-Path $outputRoot $backend)
+    try {
+        Invoke-Checked -Command "npm" -Arguments @("install", "--ignore-scripts")
+        Invoke-Checked -Command "npm" -Arguments @("run", "build")
+    } finally {
+        Pop-Location
+    }
+}
+
+if (Test-Command "node") {
+    Write-Host "==> Checking html"
+    Push-Location (Join-Path $outputRoot "html")
+    try {
+        Invoke-Checked -Command "node" -Arguments @("--check", "main.js")
+    } finally {
+        Pop-Location
+    }
+
+    Write-Host "==> Checking webcomponent"
+    Push-Location (Join-Path $outputRoot "webcomponent")
+    try {
+        foreach ($source in @("VentureChrome.js", "index.js", "main.js")) {
+            Invoke-Checked -Command "node" -Arguments @("--check", $source)
+        }
+    } finally {
+        Pop-Location
+    }
+} else {
+    Skip-Backend -Backend "html" -Reason "node is not installed"
+    Skip-Backend -Backend "webcomponent" -Reason "node is not installed"
+}
+
+$isWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+$isMacOS = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX)
+$isLinux = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Linux)
+
+if ($isMacOS -and (Test-Command "swift")) {
+    Write-Host "==> Building swiftui"
+    Push-Location (Join-Path $outputRoot "swiftui")
+    try {
+        Invoke-Checked -Command "swift" -Arguments @("build")
+    } finally {
+        Pop-Location
+    }
+} elseif (-not $isMacOS) {
+    Defer-Backend -Backend "swiftui" -Reason "SwiftUI builds require macOS"
+} else {
+    Skip-Backend -Backend "swiftui" -Reason "swift is not installed"
+}
+
+if (Test-Command "cmake") {
+    Write-Host "==> Building qt"
+    Push-Location (Join-Path $outputRoot "qt")
+    try {
+        if (Test-Command "qt-cmake") {
+            Invoke-Checked -Command "qt-cmake" -Arguments @("-S", ".", "-B", "build")
+        } else {
+            Invoke-Checked -Command "cmake" -Arguments @("-S", ".", "-B", "build")
+        }
+        Invoke-Checked -Command "cmake" -Arguments @("--build", "build")
+    } finally {
+        Pop-Location
+    }
+} else {
+    Skip-Backend -Backend "qt" -Reason "cmake is not installed"
+}
+
+if ($isWindows -and (Test-Command "dotnet")) {
+    Write-Host "==> Building xaml"
+    Push-Location (Join-Path $outputRoot "xaml")
+    try {
+        Invoke-Checked -Command "dotnet" -Arguments @("build", "VentureChrome.csproj")
+    } finally {
+        Pop-Location
+    }
+} elseif (-not $isWindows) {
+    Defer-Backend -Backend "xaml" -Reason "WinUI builds require Windows"
+} else {
+    Skip-Backend -Backend "xaml" -Reason "dotnet is not installed"
+}
+
+$flutterPlatform = if ($isMacOS) { "macos" } elseif ($isWindows) { "windows" } elseif ($isLinux) { "linux" } else { $null }
+if ($null -ne $flutterPlatform -and (Test-Command "flutter")) {
+    Write-Host "==> Building flutter ($flutterPlatform)"
+    Push-Location (Join-Path $outputRoot "flutter")
+    try {
+        Invoke-Checked -Command "flutter" -Arguments @("pub", "get")
+        Invoke-Checked -Command "flutter" -Arguments @("analyze", "lib")
+        if (-not (Test-Path -LiteralPath $flutterPlatform)) {
+            Invoke-Checked -Command "flutter" -Arguments @("create", "--platforms=$flutterPlatform", ".")
+        }
+        Invoke-Checked -Command "flutter" -Arguments @("build", $flutterPlatform)
+    } finally {
+        Pop-Location
+    }
+} elseif ($null -eq $flutterPlatform) {
+    Defer-Backend -Backend "flutter" -Reason "unsupported host platform"
+} else {
+    Skip-Backend -Backend "flutter" -Reason "flutter is not installed"
+}
+
+$javaMajor = $null
+if (Test-Command "java") {
+    $javaVersion = (& java -version 2>&1 | Out-String)
+    if ($javaVersion -match 'version "([0-9]+)') {
+        $javaMajor = [int]$Matches[1]
+    }
+}
+if (-not (Test-Command "gradle")) {
+    Skip-Backend -Backend "compose" -Reason "gradle is not installed"
+} elseif ($null -eq $javaMajor -or $javaMajor -lt 21) {
+    Skip-Backend -Backend "compose" -Reason "JDK 21 or newer is not installed"
+} else {
+    Write-Host "==> Building compose"
+    Push-Location (Join-Path $outputRoot "compose")
+    try {
+        Invoke-Checked -Command "gradle" -Arguments @("--no-daemon", "build")
+    } finally {
+        Pop-Location
+    }
+}
+
+Write-Host "Built or checked $($backends.Count - $skipped.Count - $deferred.Count) of $($backends.Count) Venture backend projects."
+if ($deferred.Count -gt 0) {
+    Write-Host "Deferred to native hosts: $($deferred -join ', ')"
+}
+if ($skipped.Count -gt 0) {
+    Write-Host "Skipped: $($skipped -join ', ')"
+    if ($Strict) {
+        throw "Strict mode requires every host-applicable backend gate to run."
+    }
+}

--- a/code/programs/mosaic/venture-browser/scripts/build-all.sh
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+package_root="$(cd "$script_root/.." && pwd)"
+rust_workspace="$(cd "$package_root/../../../packages/rust" && pwd)"
+output="target/mosaic-venture-browser"
+release=0
+emit_only=0
+strict=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-all.sh [--output PATH] [--release] [--emit-only] [--strict]
+
+Emits Venture's shared Mosaic package for every supported backend, then builds
+each project whose native toolchain is available on the current host.
+
+  --output PATH  Generated project root (default: target/mosaic-venture-browser)
+  --release      Build mosaic-compile in release mode
+  --emit-only    Emit all project shells without invoking backend toolchains
+  --strict       Fail when a host-applicable backend toolchain is missing
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --output)
+      [[ $# -ge 2 ]] || { echo "--output requires a path" >&2; exit 2; }
+      output="$2"
+      shift 2
+      ;;
+    --release)
+      release=1
+      shift
+      ;;
+    --emit-only)
+      emit_only=1
+      shift
+      ;;
+    --strict)
+      strict=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$output" == /* ]]; then
+  output_path="$output"
+else
+  output_path="$package_root/$output"
+fi
+mkdir -p "$output_path"
+output_root="$(cd "$output_path" && pwd)"
+backends=(react electron swiftui qt webcomponent html xaml flutter compose)
+cargo_args=(run -q -p mosaic-compile)
+if ((release)); then
+  cargo_args+=(--release)
+fi
+cargo_args+=(-- pkg "$package_root")
+
+for backend in "${backends[@]}"; do
+  echo "==> Emitting $backend"
+  (
+    cd "$rust_workspace"
+    cargo "${cargo_args[@]}" \
+      --backend "$backend" \
+      --output "$output_root" \
+      --emit-project \
+      --theme light
+  )
+done
+
+if ((emit_only)); then
+  echo "Emitted ${#backends[@]} Venture backend projects under $output_root"
+  exit 0
+fi
+
+skipped=()
+deferred=()
+
+skip_backend() {
+  local backend="$1"
+  local reason="$2"
+  echo "==> Skipping $backend: $reason"
+  skipped+=("$backend ($reason)")
+}
+
+defer_backend() {
+  local backend="$1"
+  local reason="$2"
+  echo "==> Deferring $backend: $reason"
+  deferred+=("$backend ($reason)")
+}
+
+has_command() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+build_node_project() {
+  local backend="$1"
+  if ! has_command npm; then
+    skip_backend "$backend" "npm is not installed"
+    return
+  fi
+  echo "==> Building $backend"
+  (cd "$output_root/$backend" && npm install --ignore-scripts && npm run build)
+}
+
+build_node_project react
+build_node_project electron
+
+if has_command node; then
+  echo "==> Checking html"
+  (cd "$output_root/html" && node --check main.js)
+  echo "==> Checking webcomponent"
+  (
+    cd "$output_root/webcomponent"
+    node --check VentureChrome.js
+    node --check index.js
+    node --check main.js
+  )
+else
+  skip_backend html "node is not installed"
+  skip_backend webcomponent "node is not installed"
+fi
+
+host_os="$(uname -s)"
+
+if [[ "$host_os" == Darwin ]] && has_command swift; then
+  echo "==> Building swiftui"
+  (cd "$output_root/swiftui" && swift build)
+elif [[ "$host_os" != Darwin ]]; then
+  defer_backend swiftui "SwiftUI builds require macOS"
+else
+  skip_backend swiftui "swift is not installed"
+fi
+
+if has_command cmake; then
+  echo "==> Building qt"
+  if has_command qt-cmake; then
+    (cd "$output_root/qt" && qt-cmake -S . -B build && cmake --build build)
+  else
+    (cd "$output_root/qt" && cmake -S . -B build && cmake --build build)
+  fi
+else
+  skip_backend qt "cmake is not installed"
+fi
+
+case "$host_os" in
+  MINGW*|MSYS*|CYGWIN*)
+    if has_command dotnet; then
+      echo "==> Building xaml"
+      (cd "$output_root/xaml" && dotnet build VentureChrome.csproj)
+    else
+      skip_backend xaml "dotnet is not installed"
+    fi
+    ;;
+  *)
+    defer_backend xaml "WinUI builds require Windows"
+    ;;
+esac
+
+flutter_platform=""
+case "$host_os" in
+  Darwin) flutter_platform=macos ;;
+  Linux) flutter_platform=linux ;;
+  MINGW*|MSYS*|CYGWIN*) flutter_platform=windows ;;
+esac
+
+if [[ -n "$flutter_platform" ]] && has_command flutter; then
+  echo "==> Building flutter ($flutter_platform)"
+  (
+    cd "$output_root/flutter"
+    flutter pub get
+    flutter analyze lib
+    if [[ ! -d "$flutter_platform" ]]; then
+      flutter create "--platforms=$flutter_platform" .
+    fi
+    flutter build "$flutter_platform"
+  )
+elif [[ -z "$flutter_platform" ]]; then
+  defer_backend flutter "unsupported host platform"
+else
+  skip_backend flutter "flutter is not installed"
+fi
+
+java_major=""
+if has_command java; then
+  java_version="$(java -version 2>&1 || true)"
+  java_major="$(printf '%s\n' "$java_version" | sed -nE 's/.*version "([0-9]+).*/\1/p' | head -1)"
+fi
+if ! has_command gradle; then
+  skip_backend compose "gradle is not installed"
+elif [[ -z "$java_major" || "$java_major" -lt 21 ]]; then
+  skip_backend compose "JDK 21 or newer is not installed"
+else
+  echo "==> Building compose"
+  (cd "$output_root/compose" && gradle --no-daemon build)
+fi
+
+echo "Built or checked $((${#backends[@]} - ${#skipped[@]} - ${#deferred[@]})) of ${#backends[@]} Venture backend projects."
+if ((${#deferred[@]})); then
+  printf 'Deferred to native hosts: %s\n' "${deferred[*]}"
+fi
+if ((${#skipped[@]})); then
+  printf 'Skipped: %s\n' "${skipped[*]}"
+  if ((strict)); then
+    echo "Strict mode requires every host-applicable backend gate to run." >&2
+    exit 1
+  fi
+fi

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -9,25 +9,26 @@ fn read(name: &str) -> String {
     fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
 }
 
+fn read_package_file(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(name);
+    fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
 #[test]
 fn venture_chrome_sources_compile_with_matching_theme_topology() {
     let interface =
         mosmodel_compiler::compile(&read("VentureChrome.mil")).expect("compile interface");
-    let layout = moslayout_compiler::compile(
-        &read("VentureChrome.mll"),
-        Some(&interface.descriptor_json),
-    )
-    .expect("compile layout");
+    let layout =
+        moslayout_compiler::compile(&read("VentureChrome.mll"), Some(&interface.descriptor_json))
+            .expect("compile layout");
     let light = mosstyle_compiler::compile(
         &read("VentureChrome.light.msl"),
         Some(&layout.part_map_json),
     )
     .expect("compile light theme");
-    let dark = mosstyle_compiler::compile(
-        &read("VentureChrome.dark.msl"),
-        Some(&layout.part_map_json),
-    )
-    .expect("compile dark theme");
+    let dark =
+        mosstyle_compiler::compile(&read("VentureChrome.dark.msl"), Some(&layout.part_map_json))
+            .expect("compile dark theme");
 
     assert_eq!(interface.component.component, "VentureChrome");
     assert_eq!(layout.def.component_name, "VentureChrome");
@@ -80,16 +81,72 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         .iter()
         .map(|event| event.name.as_str())
         .collect();
-    assert_eq!(
-        events,
-        venture_browser_core::VENTURE_CHROME_EVENT_NAMES
-    );
+    assert_eq!(events, venture_browser_core::VENTURE_CHROME_EVENT_NAMES);
 
-    let manifest = fs::read_to_string(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("mosaic-package.toml"),
-    )
-    .expect("read manifest");
+    let manifest =
+        fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("mosaic-package.toml"))
+            .expect("read manifest");
     let package = mosaic_package_manifest::parse(&manifest).expect("parse manifest");
     assert_eq!(package.package.name, "venture-browser");
     assert_eq!(package.components.exports, ["VentureChrome"]);
+}
+
+#[test]
+fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
+    let shell = read_package_file("scripts/build-all.sh");
+    let powershell = read_package_file("scripts/build-all.ps1");
+    let backends = [
+        "react",
+        "electron",
+        "swiftui",
+        "qt",
+        "webcomponent",
+        "html",
+        "xaml",
+        "flutter",
+        "compose",
+    ];
+    assert_eq!(
+        backends.len(),
+        mosaic_package_artifact_builder::Backend::ALL.len(),
+        "the Venture build matrix must track Mosaic's exhaustive backend list"
+    );
+
+    for backend in backends {
+        assert!(shell.contains(backend), "POSIX build omits {backend}");
+        assert!(
+            powershell.contains(backend),
+            "PowerShell build omits {backend}"
+        );
+    }
+
+    for required in [
+        "--emit-project",
+        "npm run build",
+        "node --check",
+        "swift build",
+        "cmake --build",
+        "dotnet build",
+        "flutter build",
+        "gradle --no-daemon build",
+        "--strict",
+    ] {
+        assert!(shell.contains(required), "POSIX build omits {required}");
+    }
+    for required in [
+        "--emit-project",
+        "npm",
+        "node",
+        "swift",
+        "cmake",
+        "dotnet",
+        "flutter",
+        "gradle",
+        "$Strict",
+    ] {
+        assert!(
+            powershell.contains(required),
+            "PowerShell build omits {required}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- add POSIX and PowerShell entry points that emit Venture's shared MIL/MLL/MSL package for all nine Mosaic backends
- invoke real backend gates for React, Electron, HTML, Web Components, SwiftUI, Qt, XAML, Flutter, and Compose when their host toolchains are available
- distinguish native-OS deferrals from missing prerequisites, with strict mode for provisioned platform jobs
- ratchet the script matrix against `mosaic_package_artifact_builder::Backend::ALL`

This is a backend-build acceptance slice. It does not claim complete Venture, browser-wiring, or HTML conformance.

## Validation

- `cargo test` in `code/programs/mosaic/venture-browser`
- `cargo test -p mosaic-package-artifact-builder venture_browser_builds_and_mounts_host_surface_on_every_backend`
- `cargo test -p venture-browser-core`
- `cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test` (tree-construction missing: 0; tokenizer missing: 0)
- `bash -n scripts/build-all.sh`
- full POSIX matrix run: all nine projects emitted; React, Electron, HTML, Web Components, SwiftUI, and Flutter macOS gates passed
- generated Qt 6 project configured and linked successfully with CMake
- generated Compose Desktop project built successfully with JDK 21

The XAML project is emitted on macOS but its direct WinUI build remains intentionally deferred to the Windows path in `build-all.ps1`.
