### PR TITLE
fix(trig): normalize sqrt across language lanes

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,18 +8,18 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": 9390,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "5b5cb01273be03cdd018eed9786f2d62c14e1225",
+    "revision": "41622fa7896a45b6001ea3cf1e7f5da5c86be161",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1201,
-    "implementation_package_slots": 4345,
+    "implementation_identities": 1202,
+    "implementation_package_slots": 4346,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 275,
-    "singleton_packages": 751,
-    "singleton_missing_slots": 10514,
-    "rust_singletons": 556,
+    "singleton_packages": 752,
+    "singleton_missing_slots": 10528,
+    "rust_singletons": 557,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -316,6 +316,9 @@
       "status": "pending",
       "depends_on": [
         "build-tool-pure-domain-corpus",
+        "build-tool-cli-parser-corpus",
+        "build-tool-starlark-metering-corpus",
+        "build-tool-validation-oracle-corpus",
         "build-tool-execution-semantics-corpus"
       ],
       "branch": null,
@@ -392,13 +395,22 @@
       "notes": "Discovered during the post-#9323 security audit after PR #9324 added argument_verify_e2e.rs. Audit the package's pre-existing filesystem, environment, process, and stdout use; isolate test-harness authority from the publishable runtime profile; add truthful manifests; and obtain Layer-5 approval for every nonempty profile."
     },
     {
+      "id": "ocaml-build-substrate-process-free-core",
+      "title": "Integrate OCaml discovery, resolution, hashing, and validation into the process-free Go substrate",
+      "status": "pending",
+      "depends_on": ["ocaml-infrastructure", "ocaml-ci-toolchain", "build-tool-pure-domain-corpus"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the 41622fa7 post-merge security and leverage audit. Deliver the repository-owned, process-free OCaml build substrate now: language detection, package discovery, opam/Dune dependency resolution, source hashing, validator support, shard cost, affected-node behavior, and CI workflow markers. Do not claim execution conformance, opam-switch serialization, or promotion; those remain gated on the canonical Go oracle and execution contract."
+    },
+    {
       "id": "ocaml-build-substrate",
       "title": "Integrate OCaml into the canonical Go build substrate",
       "status": "pending",
-      "depends_on": ["ocaml-infrastructure", "ocaml-ci-toolchain", "build-tool-go-oracle"],
+      "depends_on": ["ocaml-build-substrate-process-free-core", "build-tool-go-oracle"],
       "branch": null,
       "pr_number": null,
-      "notes": "Add discovery, opam/Dune dependency resolution, source hashing, opam-switch serialization, language detection, validator support, shard cost, affected-node behavior, and CI workflow markers."
+      "notes": "Complete the execution-coupled OCaml build substrate after the process-free core lands: opam-switch serialization, canonical execution fixtures, and final Go-oracle conformance."
     },
     {
       "id": "ocaml-representative-core",
@@ -470,20 +482,29 @@
     {
       "id": "phy00-phy01-language-neutral-fixtures",
       "title": "Define shared language-neutral PHY00 trig and PHY01 wave fixtures",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["dart-trig-wave"],
       "branch": "codex/phy00-phy01-conformance-fixtures",
       "pr_number": 9390,
-      "notes": "Ready-for-review PR #9390. Selected after #9383 merged because the shared corpus is a repository-owned dependency for both tracked PHY00/PHY01 cross-lane hardening items. Defines a closed 53-case Draft 2020-12 oracle, strict JSON and binary64 semantics, operation-specific outcomes, exact corpus membership, an authority-free generated Dart mirror, and an always-on consumer CI reverse edge. Validation: 14 Python oracle tests; Dart format/analyze and 41 trig plus 37 wave tests; 100% production line coverage in both packages; real incremental build-tool execution for exactly trig and wave; full build-tool conformance groups; Go test/vet/build; collision-clean 1,201-identity parity report; zero-delta BUILD validation against main; state, YAML/JSON, generated-sync, diff, dependency, and security checks; and independent contract, fixture, and security re-audits."
+      "notes": "Merged PR #9390 at 41622fa7896a45b6001ea3cf1e7f5da5c86be161 on 2026-07-31 after all fixture-consumer, Linux, macOS, Windows, detect, and CodeQL checks passed. Selected after #9383 merged because the shared corpus is a repository-owned dependency for both tracked PHY00/PHY01 cross-lane hardening items. Defines a closed 53-case Draft 2020-12 oracle, strict JSON and binary64 semantics, operation-specific outcomes, exact corpus membership, an authority-free generated Dart mirror, and an always-on consumer CI reverse edge. Validation: 14 Python oracle tests; Dart format/analyze and 41 trig plus 37 wave tests; 100% production line coverage in both packages; real incremental build-tool execution for exactly trig and wave; full build-tool conformance groups; Go test/vet/build; collision-clean 1,201-identity parity report; zero-delta BUILD validation against main; state, YAML/JSON, generated-sync, diff, dependency, and security checks; and independent contract, fixture, and security re-audits."
     },
     {
       "id": "phy00-small-sqrt-cross-lane-audit",
       "title": "Audit and backfill the full-range PHY00 square-root contract",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["dart-trig-wave", "phy00-phy01-language-neutral-fixtures"],
+      "branch": "codex/phy00-sqrt-cross-lane-audit",
+      "pr_number": null,
+      "notes": "Selected after merged PR #9390 and the collision-clean 41622fa7 inventory because PHY00 is the foundational numeric dependency beneath PHY01 and the shared corpus now makes the known tiny/subnormal defect testable across all 15 established lanes plus emerging C/C++. Implemented the shared full-range binary64 contract in C, C++, C#, Elixir, F#, Go, Haskell, Java, Kotlin, Lua, Perl, Python, Ruby, Rust, Swift, and TypeScript; Dart already conformed. The implementation uses power-of-four normalization, relative Newton convergence, infinity handling where the runtime represents infinity, signed-zero preservation, NaN propagation where representable, and lane-native negative-input errors without delegating to host square-root functions. Shared boundary tests cover sqrt(2), 1e-100, the minimum subnormal, the maximum finite value, negative zero, positive infinity, NaN, and negative inputs, with an explicit BEAM applicability exception. Local validation covers all 17 lane test suites, measured production coverage in C, C++, C#, Dart, Elixir, F#, Haskell, Java, Kotlin, Lua, Python, Ruby, Swift, and TypeScript, plus Go coverage; Rust coverage instrumentation passed all 49 tests but Windows rejected the generated llvm-cov command because the monorepo workspace exclusion expression exceeded the command-line limit. Lint, vet, strict native compilation, package builds, build-file detection, fixture validation, parity collision checks, diff checks, and source security scans also pass, apart from the already-tracked 73 repository-wide standalone BUILD_windows integrity failures outside trig and pre-existing platform formatter/harness limitations."
+    },
+    {
+      "id": "phy00-atan-tiny-signed-zero-cross-lane-audit",
+      "title": "Audit tiny and signed-zero PHY00 arctangent behavior",
+      "status": "pending",
+      "depends_on": ["phy00-small-sqrt-cross-lane-audit"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered by security review of the Dart port. Existing lanes commonly start Newton iteration at 1.0 for values below one, which can exhaust a fixed iteration budget before converging for tiny normal or subnormal inputs. Audit every lane and backfill power-of-four normalization, infinity handling, signed-zero preservation, and shared boundary vectors without delegating to opaque standard-library square root implementations."
+      "notes": "Discovered during the full-range square-root security audit. Every existing atan lane returns a literal positive zero for negative-zero input, and half-angle reduction underflows at the binary64 subnormal floor. Add shared fixture cases and a small-argument identity fast path that returns the input before half-angle reduction; retain reciprocal reduction for large and infinite inputs."
     },
     {
       "id": "phy01-nonfinite-validation-backfill",
@@ -646,7 +667,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 556, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 557, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -655,7 +676,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30-31 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, smart-home-home-assistant-migration, smart-home-home-assistant-export, and smart-home-home-assistant-history; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, and Home Assistant packages as native/service/storage boundary cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. Home Assistant migration, export, and history contain deterministic parsing or validation, normalization, planning, diagnostics, identities, fingerprints, projections, and receipts that are portable-core candidates, while WebSocket/TLS collection, runtime application, atomic filesystem writes, CLI behavior, Rust-only runtime dependencies, environment-token intake, clock/console effects, and missing capability manifests require explicit host-boundary review. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic into the Matter contract, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary."
+      "notes": "The July 30-August 1 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, smart-home-home-assistant-migration, smart-home-home-assistant-export, smart-home-home-assistant-history, and smart-home-home-assistant-definitions; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, and Home Assistant packages as native/service/storage boundary cases; and venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability rather than a blind 14-lane port. Home Assistant migration, export, history, and definitions contain deterministic parsing or validation, normalization, planning, diagnostics, identities, fingerprints, projections, and receipts that are portable-core candidates, while WebSocket/TLS collection, runtime application, atomic filesystem writes, CLI behavior, Rust-only runtime dependencies, environment-token intake, clock/console effects, and missing capability manifests require explicit host-boundary review. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic into the Matter contract, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary."
     },
     {
       "id": "matter-portable-core-extraction-and-conformance",
@@ -680,12 +701,22 @@
     },
     {
       "id": "smart-home-mqtt-integration-security-hardening",
-      "title": "Declare MQTT host capabilities and replace ambient credentials with Vault leases",
+      "title": "Harden MQTT transport, credentials, limits, and redaction",
       "status": "pending",
-      "depends_on": ["rust-singletons-20260730-classification"],
+      "depends_on": ["capability-schema-category-action-constraints"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered in the 3b025282e post-merge singleton audit. The Rust MQTT integration owns live network, environment, clock, console, credential, and runtime-mutation behavior but has no required_capabilities.json, and its CLI reads MQTT username/password directly from ambient environment variables despite D23's Vault-lease rule. Add truthful reviewed capability metadata, Vault-mediated credential delivery, redacted error paths, and focused integration tests before treating the native-source classification as complete."
+      "notes": "Discovered in the 3b025282e post-merge singleton audit and decoupled from broad classification during the 41622fa7 security audit. The Rust MQTT integration owns live network, environment, clock, console, credential, and runtime-mutation behavior, and its CLI reads MQTT username/password directly from ambient environment variables despite D23's Vault-lease rule. Deliver repository-local Vault-mediated credential delivery, secure transport, bounded resources, redacted error paths, and focused integration tests without claiming Layer 5 capability approval."
+    },
+    {
+      "id": "smart-home-mqtt-integration-capability-layer5-evidence",
+      "title": "Approve the MQTT integration's truthful nonempty capability profile",
+      "status": "pending",
+      "depends_on": ["smart-home-mqtt-integration-security-hardening"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered during the 41622fa7 security audit. After repository-local hardening defines the narrow runtime and test-harness authorities, a maintainer must provide hardware-key-backed Layer 5 approval evidence for the resulting nonempty capability profiles before publication or privileged deployment."
     },
     {
       "id": "home-assistant-history-portable-core-extraction-and-conformance",
@@ -698,12 +729,22 @@
     },
     {
       "id": "home-assistant-history-host-security-hardening",
-      "title": "Immediately harden Home Assistant history authority and transport",
+      "title": "Immediately harden Home Assistant history transport and host boundary",
       "status": "pending",
       "depends_on": ["capability-schema-category-action-constraints"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered in the c6457e908 post-merge security audit and made independent of portable-core extraction during the fixture-slice re-audit. Add separate truthful runtime and test-harness capability profiles with Layer 5 approval; replace ambient HOME_ASSISTANT_TOKEN intake with Vault-mediated leases; require wss except explicitly authorized loopback fixtures; impose connection, byte, entity, state, attribute, artifact, and time-window ceilings; centrally redact every host error; and use exclusive no-follow temporary creation plus platform-correct durable atomic replacement."
+      "notes": "Discovered in the c6457e908 post-merge security audit and made independent of portable-core extraction during the fixture-slice re-audit. Deliver the repository-local hardening: replace ambient HOME_ASSISTANT_TOKEN intake with Vault-mediated leases; require wss except explicitly authorized loopback fixtures; impose connection, byte, entity, state, attribute, artifact, and time-window ceilings; centrally redact every host error; and use exclusive no-follow temporary creation plus platform-correct durable atomic replacement. Do not claim Layer 5 approval; the separate evidence item owns that external gate."
+    },
+    {
+      "id": "home-assistant-history-capability-layer5-evidence",
+      "title": "Approve Home Assistant history runtime and test-harness capability profiles",
+      "status": "pending",
+      "depends_on": ["home-assistant-history-host-security-hardening"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered during the 41622fa7 security audit. Once repository-local hardening establishes the narrow runtime and test-harness authorities, a maintainer must provide hardware-key-backed Layer 5 approval evidence for every nonempty profile before publication or privileged deployment."
     },
     {
       "id": "home-assistant-history-host-refactoring",
@@ -716,6 +757,46 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered during the c6457e908 fixture-slice security re-audit. After the urgent authority boundary is hardened and the deterministic core is extracted, narrow the Rust host to WebSocket collection, runtime application, artifact I/O, clock/reporting effects, and CLI orchestration without delaying the security remediation on the larger refactor."
+    },
+    {
+      "id": "home-assistant-definitions-portable-core-extraction-and-conformance",
+      "title": "Extract and fixture the portable Home Assistant definitions core",
+      "status": "pending",
+      "depends_on": ["rust-singletons-20260730-classification"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the 41622fa7 inventory after PR #9386 added the Rust-only definitions collector. Separate deterministic safe-subset validation and normalization, state and time-pattern triggers, conditions, scene/action mapping, ordering, uniqueness, fingerprints, reports, and diagnostics from WebSocket/HTTP/TLS collection, credentials, artifact I/O, clock, and CLI orchestration; define language-neutral fixtures before expanding the portable core across lanes."
+    },
+    {
+      "id": "home-assistant-definitions-host-security-hardening",
+      "title": "Immediately harden Home Assistant definitions transport and host boundary",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the 41622fa7 security audit and intentionally independent of broad singleton classification. Replace ambient administrator-token intake with Vault-mediated leases; reject plaintext HTTP and WebSocket transports except explicit loopback fixtures; bound requests, definitions, diagnostics, artifacts, and timeouts; centrally redact server-provided error text; and replace predictable link-following temporary output with exclusive no-follow creation plus platform-correct durable atomic replacement. Do not claim Layer 5 capability approval."
+    },
+    {
+      "id": "home-assistant-definitions-capability-layer5-evidence",
+      "title": "Approve Home Assistant definitions runtime and test-harness capability profiles",
+      "status": "pending",
+      "depends_on": ["home-assistant-definitions-host-security-hardening"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered during the 41622fa7 security audit. The new collector currently lacks required_capabilities.json despite environment, filesystem, network, time, and stdout authority. After repository-local hardening narrows runtime and test-harness authority, a maintainer must provide hardware-key-backed Layer 5 approval evidence for every nonempty profile."
+    },
+    {
+      "id": "home-assistant-definitions-host-refactoring",
+      "title": "Refactor the hardened Home Assistant definitions host around the portable core",
+      "status": "pending",
+      "depends_on": [
+        "home-assistant-definitions-portable-core-extraction-and-conformance",
+        "home-assistant-definitions-host-security-hardening"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "After the urgent host boundary is hardened and the deterministic core is extracted, narrow the Rust host to WebSocket/HTTP/TLS collection, Vault leases, artifact I/O, clock/reporting effects, and CLI orchestration without delaying security remediation on the larger refactor."
     },
     {
       "id": "c-cpp-graduation",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,7 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": 9395,
   "last_inventory": {
     "revision": "41622fa7896a45b6001ea3cf1e7f5da5c86be161",
     "schema_version": 3,
@@ -491,11 +491,11 @@
     {
       "id": "phy00-small-sqrt-cross-lane-audit",
       "title": "Audit and backfill the full-range PHY00 square-root contract",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["dart-trig-wave", "phy00-phy01-language-neutral-fixtures"],
       "branch": "codex/phy00-sqrt-cross-lane-audit",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9390 and the collision-clean 41622fa7 inventory because PHY00 is the foundational numeric dependency beneath PHY01 and the shared corpus now makes the known tiny/subnormal defect testable across all 15 established lanes plus emerging C/C++. Implemented the shared full-range binary64 contract in C, C++, C#, Elixir, F#, Go, Haskell, Java, Kotlin, Lua, Perl, Python, Ruby, Rust, Swift, and TypeScript; Dart already conformed. The implementation uses power-of-four normalization, relative Newton convergence, infinity handling where the runtime represents infinity, signed-zero preservation, NaN propagation where representable, and lane-native negative-input errors without delegating to host square-root functions. Shared boundary tests cover sqrt(2), 1e-100, the minimum subnormal, the maximum finite value, negative zero, positive infinity, NaN, and negative inputs, with an explicit BEAM applicability exception. Local validation covers all 17 lane test suites, measured production coverage in C, C++, C#, Dart, Elixir, F#, Haskell, Java, Kotlin, Lua, Python, Ruby, Swift, and TypeScript, plus Go coverage; Rust coverage instrumentation passed all 49 tests but Windows rejected the generated llvm-cov command because the monorepo workspace exclusion expression exceeded the command-line limit. Lint, vet, strict native compilation, package builds, build-file detection, fixture validation, parity collision checks, diff checks, and source security scans also pass, apart from the already-tracked 73 repository-wide standalone BUILD_windows integrity failures outside trig and pre-existing platform formatter/harness limitations."
+      "pr_number": 9395,
+      "notes": "Ready-for-review PR #9395. Selected after merged PR #9390 and the collision-clean 41622fa7 inventory because PHY00 is the foundational numeric dependency beneath PHY01 and the shared corpus now makes the known tiny/subnormal defect testable across all 15 established lanes plus emerging C/C++. Implemented the shared full-range binary64 contract in C, C++, C#, Elixir, F#, Go, Haskell, Java, Kotlin, Lua, Perl, Python, Ruby, Rust, Swift, and TypeScript; Dart already conformed. The implementation uses power-of-four normalization, relative Newton convergence, infinity handling where the runtime represents infinity, signed-zero preservation, NaN propagation where representable, and lane-native negative-input errors without delegating to host square-root functions. Shared boundary tests cover sqrt(2), 1e-100, the minimum subnormal, the maximum finite value, negative zero, positive infinity, NaN, and negative inputs, with an explicit BEAM applicability exception. Local validation covers all 17 lane test suites, measured production coverage in C, C++, C#, Dart, Elixir, F#, Haskell, Java, Kotlin, Lua, Python, Ruby, Swift, and TypeScript, plus Go coverage; Rust coverage instrumentation passed all 49 tests but Windows rejected the generated llvm-cov command because the monorepo workspace exclusion expression exceeded the command-line limit. Lint, vet, strict native compilation, package builds, build-file detection, fixture validation, parity collision checks, diff checks, and source security scans also pass, apart from the already-tracked 73 repository-wide standalone BUILD_windows integrity failures outside trig and pre-existing platform formatter/harness limitations."
     },
     {
       "id": "phy00-atan-tiny-signed-zero-cross-lane-audit",

--- a/code/packages/c/trig/CHANGELOG.md
+++ b/code/packages/c/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 All notable changes to the C `trig` package are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

--- a/code/packages/c/trig/README.md
+++ b/code/packages/c/trig/README.md
@@ -1,5 +1,14 @@
 # trig (C)
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions **from first principles**, in pure ISO C17 — a faithful
 port of the Rust `trig` crate. No `<math.h>`, no libm: every value is computed
 from `+ - * /` and comparisons.

--- a/code/packages/c/trig/src/trig.c
+++ b/code/packages/c/trig/src/trig.c
@@ -7,6 +7,7 @@
  * comparisons. See trig.h for the mathematical background of each function.
  */
 #include "trig.h"
+#include <float.h>
 
 /* 2*PI — a full revolution; pre-computed to save a multiply in range reduction. */
 #define TRIG_TWO_PI (2.0 * TRIG_PI)
@@ -48,22 +49,33 @@ static double d_fmod(double x, double m) { return x - m * d_trunc(x / m); }
  * See trig_sqrt for the documented public entry point. */
 static double sqrt_unchecked(double x) {
     if (x == 0.0) {
-        return 0.0;
+        return x;
     }
-    /* Start high enough to converge quickly: x for x >= 1, else 1.0 so the
-     * first step does not divide by a tiny number. */
-    double guess = x >= 1.0 ? x : 1.0;
+    if (x > DBL_MAX) {
+        return x;
+    }
+    double scaled = x;
+    double result_scale = 1.0;
+    while (scaled < 0.25) {
+        scaled *= 4.0;
+        result_scale *= 0.5;
+    }
+    while (scaled >= 4.0) {
+        scaled *= 0.25;
+        result_scale *= 2.0;
+    }
+    double guess = scaled >= 1.0 ? scaled : 1.0;
     int i;
     for (i = 0; i < 60; i++) {
-        double next = (guess + x / guess) / 2.0;
+        double next = (guess + scaled / guess) / 2.0;
         /* Stop when the improvement is negligible. The relative term handles
          * large values; the 1e-300 floor keeps subnormal inputs safe. */
         if (d_abs(next - guess) < 1e-15 * guess + 1e-300) {
-            return next;
+            return next * result_scale;
         }
         guess = next;
     }
-    return guess;
+    return guess * result_scale;
 }
 
 /* Reduce `x` into [-PI, PI], preserving the value of any 2*PI-periodic

--- a/code/packages/c/trig/tests/trig_test.c
+++ b/code/packages/c/trig/tests/trig_test.c
@@ -5,6 +5,9 @@
  */
 #include "iso_test.h"
 
+#include <float.h>
+#include <math.h>
+
 #include "trig.h"
 
 int main(void) {
@@ -59,6 +62,22 @@ int main(void) {
         ISO_CHECK_EQ_DBL(r, 0.0, eps);
         ISO_CHECK(trig_sqrt(1e12, &r) == TRIG_OK);
         ISO_CHECK_EQ_DBL(r, 1000000.0, 1e-4);
+        ISO_CHECK(trig_sqrt(1e-100, &r) == TRIG_OK);
+        ISO_CHECK_EQ_DBL((r - 1e-50) / 1e-50, 0.0, 1e-12);
+        ISO_CHECK(trig_sqrt(0x0.0000000000001p-1022, &r) == TRIG_OK);
+        ISO_CHECK_EQ_DBL((r - 2.2227587494850775e-162) /
+                             2.2227587494850775e-162,
+                         0.0, 1e-12);
+        ISO_CHECK(trig_sqrt(DBL_MAX, &r) == TRIG_OK);
+        ISO_CHECK_EQ_DBL((r - 1.3407807929942596e154) /
+                             1.3407807929942596e154,
+                         0.0, 1e-12);
+        ISO_CHECK(trig_sqrt(-0.0, &r) == TRIG_OK);
+        ISO_CHECK(r == 0.0 && signbit(r));
+        ISO_CHECK(trig_sqrt(INFINITY, &r) == TRIG_OK);
+        ISO_CHECK(isinf(r) && r > 0.0);
+        ISO_CHECK(trig_sqrt(NAN, &r) == TRIG_OK);
+        ISO_CHECK(isnan(r));
         /* Negative input is a domain error and leaves *out untouched. */
         r = -999.0;
         ISO_CHECK(trig_sqrt(-1.0, &r) == TRIG_ERR_DOMAIN);

--- a/code/packages/cpp/trig/CHANGELOG.md
+++ b/code/packages/cpp/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 All notable changes to the C++ `trig` package are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

--- a/code/packages/cpp/trig/README.md
+++ b/code/packages/cpp/trig/README.md
@@ -1,5 +1,14 @@
 # trig (C++)
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions **from first principles**, header-only in pure ISO
 C++17 (namespace `ca::trig`) — a faithful port of the Rust `trig` crate. No
 `<cmath>`, no libm: every value is computed from `+ - * /` and comparisons.

--- a/code/packages/cpp/trig/include/trig.hpp
+++ b/code/packages/cpp/trig/include/trig.hpp
@@ -24,6 +24,7 @@
 #define CA_TRIG_HPP
 
 #include <stdexcept>
+#include <limits>
 
 namespace ca {
 namespace trig {
@@ -59,14 +60,27 @@ inline double d_fmod(double x, double m) { return x - m * d_trunc(x / m); }
 
 // Square root via Newton's method, no domain check (callers guarantee x >= 0).
 inline double sqrt_unchecked(double x) {
-    if (x == 0.0) return 0.0;
-    double guess = x >= 1.0 ? x : 1.0;
+    if (x == 0.0) return x;
+    if (x > std::numeric_limits<double>::max()) return x;
+    double scaled = x;
+    double result_scale = 1.0;
+    while (scaled < 0.25) {
+        scaled *= 4.0;
+        result_scale *= 0.5;
+    }
+    while (scaled >= 4.0) {
+        scaled *= 0.25;
+        result_scale *= 2.0;
+    }
+    double guess = scaled >= 1.0 ? scaled : 1.0;
     for (int i = 0; i < 60; i++) {
-        double next = (guess + x / guess) / 2.0;
-        if (d_abs(next - guess) < 1e-15 * guess + 1e-300) return next;
+        double next = (guess + scaled / guess) / 2.0;
+        if (d_abs(next - guess) < 1e-15 * guess + 1e-300) {
+            return next * result_scale;
+        }
         guess = next;
     }
-    return guess;
+    return guess * result_scale;
 }
 
 // Reduce x into [-PI, PI], preserving any 2*PI-periodic function's value.

--- a/code/packages/cpp/trig/tests/trig_test.cpp
+++ b/code/packages/cpp/trig/tests/trig_test.cpp
@@ -3,6 +3,8 @@
 // tolerance — our from-scratch series should match the real functions.
 #include "iso_test.h"
 
+#include <cmath>
+#include <limits>
 #include <stdexcept>
 
 #include "trig.hpp"
@@ -50,6 +52,20 @@ int main() {
     ISO_CHECK_EQ_DBL(t::sqrt(2.0), 1.4142135623730951, eps);
     ISO_CHECK_EQ_DBL(t::sqrt(0.0), 0.0, eps);
     ISO_CHECK_EQ_DBL(t::sqrt(1e12), 1000000.0, 1e-4);
+    ISO_CHECK_EQ_DBL((t::sqrt(1e-100) - 1e-50) / 1e-50, 0.0, 1e-12);
+    ISO_CHECK_EQ_DBL(
+        (t::sqrt(std::numeric_limits<double>::denorm_min()) -
+         2.2227587494850775e-162) /
+            2.2227587494850775e-162,
+        0.0, 1e-12);
+    ISO_CHECK_EQ_DBL(
+        (t::sqrt(std::numeric_limits<double>::max()) -
+         1.3407807929942596e154) /
+            1.3407807929942596e154,
+        0.0, 1e-12);
+    ISO_CHECK(std::signbit(t::sqrt(-0.0)));
+    ISO_CHECK(std::isinf(t::sqrt(std::numeric_limits<double>::infinity())));
+    ISO_CHECK(std::isnan(t::sqrt(std::numeric_limits<double>::quiet_NaN())));
     {
         bool threw = false;
         try {

--- a/code/packages/csharp/trig/CHANGELOG.md
+++ b/code/packages/csharp/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 All notable changes to this package will be documented in this file.
 
 ## [0.1.0] - 2026-04-15

--- a/code/packages/csharp/trig/README.md
+++ b/code/packages/csharp/trig/README.md
@@ -1,5 +1,14 @@
 # trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 C# implementation of the `trig` foundation package.
 
 This package computes `sin`, `cos`, `tan`, `sqrt`, `atan`, and `atan2`

--- a/code/packages/csharp/trig/Trig.cs
+++ b/code/packages/csharp/trig/Trig.cs
@@ -97,22 +97,40 @@ public static class Trig
 
         if (x == 0.0)
         {
-            return 0.0;
+            return x;
         }
 
-        var guess = x >= 1.0 ? x : 1.0;
+        if (double.IsPositiveInfinity(x))
+        {
+            return x;
+        }
+
+        var scaled = x;
+        var resultScale = 1.0;
+        while (scaled < 0.25)
+        {
+            scaled *= 4.0;
+            resultScale *= 0.5;
+        }
+        while (scaled >= 4.0)
+        {
+            scaled *= 0.25;
+            resultScale *= 2.0;
+        }
+
+        var guess = scaled >= 1.0 ? scaled : 1.0;
         for (var i = 0; i < 60; i++)
         {
-            var next = (guess + x / guess) / 2.0;
+            var next = (guess + scaled / guess) / 2.0;
             if (Math.Abs(next - guess) < 1e-15 * guess + 1e-300)
             {
-                return next;
+                return next * resultScale;
             }
 
             guess = next;
         }
 
-        return guess;
+        return guess * resultScale;
     }
 
     /// <summary>

--- a/code/packages/csharp/trig/tests/CodingAdventures.Trig.Tests/TrigTests.cs
+++ b/code/packages/csharp/trig/tests/CodingAdventures.Trig.Tests/TrigTests.cs
@@ -69,6 +69,9 @@ public sealed class TrigTests
     [Fact]
     public void SqrtMatchesKnownValues()
     {
+        static bool Relative(double actual, double expected) =>
+            Math.Abs(actual - expected) / Math.Abs(expected) <= 1e-12;
+
         Assert.Equal(0.0, Trig.Sqrt(0.0));
         Assert.True(ApproxEqual(Trig.Sqrt(1.0), 1.0));
         Assert.True(ApproxEqual(Trig.Sqrt(4.0), 2.0));
@@ -76,6 +79,12 @@ public sealed class TrigTests
         Assert.True(ApproxEqual(Trig.Sqrt(2.0), 1.41421356237));
         Assert.True(ApproxEqual(Trig.Sqrt(0.25), 0.5));
         Assert.True(Math.Abs(Trig.Sqrt(1e10) - 1e5) < 1e-4);
+        Assert.True(Relative(Trig.Sqrt(1e-100), 1e-50));
+        Assert.True(Relative(Trig.Sqrt(double.Epsilon), 2.2227587494850775e-162));
+        Assert.True(Relative(Trig.Sqrt(double.MaxValue), 1.3407807929942596e154));
+        Assert.True(BitConverter.DoubleToInt64Bits(Trig.Sqrt(-0.0)) < 0);
+        Assert.True(double.IsPositiveInfinity(Trig.Sqrt(double.PositiveInfinity)));
+        Assert.True(double.IsNaN(Trig.Sqrt(double.NaN)));
     }
 
     [Fact]

--- a/code/packages/elixir/trig/CHANGELOG.md
+++ b/code/packages/elixir/trig/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize finite square-root inputs by powers of four before Newton iteration
+  so the complete BEAM binary64 exponent range converges.
+- Record IEEE-754 NaN and infinity fixture cases as not applicable because
+  Erlang/OTP does not expose them as ordinary BEAM floats.
+
+### Tests
+
+- Cover tiny, minimum-subnormal, maximum-finite, signed-zero, and negative-input
+  behavior from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 ## [0.2.0] - 2026-04-03
 
 ### Added

--- a/code/packages/elixir/trig/README.md
+++ b/code/packages/elixir/trig/README.md
@@ -1,5 +1,14 @@
 # Trig
 
+## Full-range square root
+
+`Trig.sqrt/1` normalizes finite binary64 values by powers of four into
+`[0.25, 4)` before at most 60 Newton steps, preserves negative zero, and rejects
+negative inputs with `ArithmeticError`. Erlang/OTP does not expose IEEE-754 NaN
+or infinity as ordinary BEAM floats, so those two shared fixture cases are
+explicitly not applicable in this lane. Finite boundary behavior is checked
+against [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions implemented from first principles using Maclaurin (Taylor) series. No external dependencies, no `:math` module — just basic arithmetic building up to `sin`, `cos`, and angle conversions.
 
 ## Layer

--- a/code/packages/elixir/trig/lib/trig.ex
+++ b/code/packages/elixir/trig/lib/trig.ex
@@ -323,19 +323,28 @@ defmodule Trig do
   end
 
   def sqrt(x) when is_number(x) do
-    x = x / 1.0  # ensure float
+    # ensure float
+    x = x / 1.0
 
     # sqrt(0) is exactly 0.
     if x == 0.0 do
-      0.0
+      x
     else
-      # Initial guess: x itself for x >= 1, else 1.0.
-      guess = if x >= 1.0, do: x, else: 1.0
+      {scaled, result_scale} = normalize_sqrt(x, 1.0)
+      guess = if scaled >= 1.0, do: scaled, else: 1.0
 
       # Iterate up to 60 times — quadratic convergence means ~15 in practice.
-      sqrt_iterate(x, guess, 0)
+      sqrt_iterate(scaled, guess, 0) * result_scale
     end
   end
+
+  defp normalize_sqrt(x, scale) when x < 0.25,
+    do: normalize_sqrt(x * 4.0, scale * 0.5)
+
+  defp normalize_sqrt(x, scale) when x >= 4.0,
+    do: normalize_sqrt(x * 0.25, scale * 2.0)
+
+  defp normalize_sqrt(x, scale), do: {x, scale}
 
   # Private recursive helper for sqrt Newton iterations.
   defp sqrt_iterate(_x, guess, 60), do: guess

--- a/code/packages/elixir/trig/test/trig_test.exs
+++ b/code/packages/elixir/trig/test/trig_test.exs
@@ -238,6 +238,22 @@ defmodule TrigTest do
       assert_in_delta Trig.sqrt(1.0e10), 1.0e5, 1.0e-4
     end
 
+    test "covers the finite binary64 exponent range and signed zero" do
+      tiny = Trig.sqrt(1.0e-100)
+      assert abs(tiny - 1.0e-50) / 1.0e-50 <= 1.0e-12
+
+      subnormal = Trig.sqrt(5.0e-324)
+      expected_subnormal = 2.2227587494850775e-162
+      assert abs(subnormal - expected_subnormal) / expected_subnormal <= 1.0e-12
+
+      largest = Trig.sqrt(1.7976931348623157e308)
+      expected_largest = 1.3407807929942596e154
+      assert abs(largest - expected_largest) / expected_largest <= 1.0e-12
+
+      <<sign::1, _::63>> = <<Trig.sqrt(-0.0)::float-64>>
+      assert sign == 1
+    end
+
     test "sqrt(2) * sqrt(2) ≈ 2.0 (roundtrip)" do
       s = Trig.sqrt(2)
       assert_in_delta s * s, 2.0, @tolerance

--- a/code/packages/fsharp/trig/CHANGELOG.md
+++ b/code/packages/fsharp/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 All notable changes to this package will be documented in this file.
 
 ## [0.1.0] - 2026-04-15

--- a/code/packages/fsharp/trig/README.md
+++ b/code/packages/fsharp/trig/README.md
@@ -1,5 +1,14 @@
 # trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 F# implementation of the `trig` foundation package.
 
 This package computes trigonometric functions from arithmetic building blocks

--- a/code/packages/fsharp/trig/Trig.fs
+++ b/code/packages/fsharp/trig/Trig.fs
@@ -60,19 +60,32 @@ module Trig =
             raise (ArgumentOutOfRangeException("x", x, "sqrt: domain error -- input is negative"))
 
         elif x = 0.0 then
-            0.0
+            x
+
+        elif Double.IsPositiveInfinity x then
+            x
 
         else
-            let mutable guess = if x >= 1.0 then x else 1.0
+            let mutable scaled = x
+            let mutable resultScale = 1.0
+            while scaled < 0.25 do
+                scaled <- scaled * 4.0
+                resultScale <- resultScale * 0.5
+            while scaled >= 4.0 do
+                scaled <- scaled * 0.25
+                resultScale <- resultScale * 2.0
+
+            let mutable guess = if scaled >= 1.0 then scaled else 1.0
+            let mutable converged = false
 
             for _ in 0 .. 59 do
-                let next = (guess + x / guess) / 2.0
-                if abs (next - guess) < 1e-15 * guess + 1e-300 then
-                    guess <- next
-                else
+                if not converged then
+                    let next = (guess + scaled / guess) / 2.0
+                    if abs (next - guess) < 1e-15 * guess + 1e-300 then
+                        converged <- true
                     guess <- next
 
-            guess
+            guess * resultScale
 
     let tan (x: float) =
         let sine = sin x

--- a/code/packages/fsharp/trig/tests/CodingAdventures.Trig.Tests/TrigTests.fs
+++ b/code/packages/fsharp/trig/tests/CodingAdventures.Trig.Tests/TrigTests.fs
@@ -45,6 +45,7 @@ type TrigTests() =
     [<Fact>]
     member _.``Square root matches reference values``() =
         let approxEqual left right = abs (left - right) < 1e-10
+        let relative actual expected = abs (actual - expected) / abs expected <= 1e-12
 
         Assert.Equal(0.0, Trig.sqrt 0.0)
         Assert.True(approxEqual (Trig.sqrt 1.0) 1.0)
@@ -53,6 +54,12 @@ type TrigTests() =
         Assert.True(approxEqual (Trig.sqrt 2.0) 1.41421356237)
         Assert.True(approxEqual (Trig.sqrt 0.25) 0.5)
         Assert.True(abs (Trig.sqrt 1e10 - 1e5) < 1e-4)
+        Assert.True(relative (Trig.sqrt 1e-100) 1e-50)
+        Assert.True(relative (Trig.sqrt System.Double.Epsilon) 2.2227587494850775e-162)
+        Assert.True(relative (Trig.sqrt System.Double.MaxValue) 1.3407807929942596e154)
+        Assert.True(System.BitConverter.DoubleToInt64Bits(Trig.sqrt -0.0) < 0L)
+        Assert.True(System.Double.IsPositiveInfinity(Trig.sqrt System.Double.PositiveInfinity))
+        Assert.True(System.Double.IsNaN(Trig.sqrt System.Double.NaN))
         Assert.Throws<System.ArgumentOutOfRangeException>(fun () -> Trig.sqrt -1.0 |> ignore) |> ignore
 
     [<Fact>]

--- a/code/packages/go/trig/CHANGELOG.md
+++ b/code/packages/go/trig/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+- Move negative-input rejection outside the operation callback so `Sqrt`
+  propagates its documented panic instead of returning the operation fallback.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 ## [0.3.0] - 2026-04-03
 
 ### Added

--- a/code/packages/go/trig/README.md
+++ b/code/packages/go/trig/README.md
@@ -1,5 +1,14 @@
 # trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions built from first principles using Taylor/Maclaurin series.
 
 ## Layer

--- a/code/packages/go/trig/trig.go
+++ b/code/packages/go/trig/trig.go
@@ -346,31 +346,43 @@ const halfPI = PI / 2.0
 //
 // Typically converges in 10–15 iterations for any normal float64 input.
 func Sqrt(x float64) float64 {
+	if x < 0 {
+		panic("trig.Sqrt: domain error — input is negative")
+	}
 	result, _ := StartNew[float64]("trig.Sqrt", 0,
 		func(op *Operation[float64], rf *ResultFactory[float64]) *OperationResult[float64] {
 			op.AddProperty("x", x)
 
-			// Negative inputs are outside the domain of real square roots.
-			if x < 0 {
-				panic("trig.Sqrt: domain error — input is negative")
-			}
-
 			// sqrt(0) = 0 exactly.
 			if x == 0.0 {
-				return rf.Generate(true, false, 0.0)
+				return rf.Generate(true, false, x)
+			}
+			if x > 1.7976931348623157e308 {
+				return rf.Generate(true, false, x)
+			}
+
+			scaled := x
+			resultScale := 1.0
+			for scaled < 0.25 {
+				scaled *= 4.0
+				resultScale *= 0.5
+			}
+			for scaled >= 4.0 {
+				scaled *= 0.25
+				resultScale *= 2.0
 			}
 
 			// Initial guess: x itself for large values (saves a few iterations),
 			// 1.0 for values in (0, 1) (avoids an expensive first step).
-			guess := x
-			if x < 1.0 {
+			guess := scaled
+			if scaled < 1.0 {
 				guess = 1.0
 			}
 
 			// Iterate until convergence. The safety cap of 60 is extreme;
 			// quadratic convergence means real-world termination in ~15 steps.
 			for i := 0; i < 60; i++ {
-				next := (guess + x/guess) / 2.0
+				next := (guess + scaled/guess) / 2.0
 
 				// Stop when improvement is below the precision floor.
 				// 1e-15*guess handles relative precision for large values.
@@ -380,13 +392,13 @@ func Sqrt(x float64) float64 {
 					improvement = -improvement
 				}
 				if improvement < 1e-15*guess+1e-300 {
-					return rf.Generate(true, false, next)
+					return rf.Generate(true, false, next*resultScale)
 				}
 
 				guess = next
 			}
 
-			return rf.Generate(true, false, guess)
+			return rf.Generate(true, false, guess*resultScale)
 		}).GetResult()
 	return result
 }

--- a/code/packages/go/trig/trig_test.go
+++ b/code/packages/go/trig/trig_test.go
@@ -273,6 +273,35 @@ func TestSqrtLarge(t *testing.T) {
 	}
 }
 
+func TestSqrtFullBinary64Range(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected float64
+	}{
+		{"tiny normal", 1e-100, 1e-50},
+		{"minimum subnormal", math.SmallestNonzeroFloat64, 2.2227587494850775e-162},
+		{"maximum finite", math.MaxFloat64, 1.3407807929942596e154},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := Sqrt(test.input)
+			if math.Abs(actual-test.expected)/math.Abs(test.expected) > 1e-12 {
+				t.Fatalf("Sqrt(%v) = %v, want %v", test.input, actual, test.expected)
+			}
+		})
+	}
+	if !math.Signbit(Sqrt(math.Copysign(0.0, -1.0))) {
+		t.Fatal("Sqrt(-0.0) did not preserve the sign bit")
+	}
+	if !math.IsInf(Sqrt(math.Inf(1)), 1) {
+		t.Fatal("Sqrt(+Inf) did not return +Inf")
+	}
+	if !math.IsNaN(Sqrt(math.NaN())) {
+		t.Fatal("Sqrt(NaN) did not return NaN")
+	}
+}
+
 func TestSqrtRoundtrip(t *testing.T) {
 	// sqrt(2) * sqrt(2) ≈ 2.0
 	s := Sqrt(2.0)
@@ -281,16 +310,13 @@ func TestSqrtRoundtrip(t *testing.T) {
 	}
 }
 
-// TestSqrtNegativeHandled verifies that Sqrt(-1) does not produce a meaningful
-// result. The Go Operation framework catches panics from the callback and returns
-// the fallback value (0.0) rather than propagating. This is acceptable — callers
-// should never pass negative inputs to Sqrt. We simply verify the call completes
-// without crashing the test binary and returns the zero fallback.
-func TestSqrtNegativeHandled(t *testing.T) {
-	result := Sqrt(-1.0)
-	// The operation catches the panic and returns 0.0 (fallback).
-	// Any value is acceptable here since the input is invalid.
-	_ = result // no assertion needed — the test just verifies no crash
+func TestSqrtNegativePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Sqrt(-1) did not panic")
+		}
+	}()
+	Sqrt(-1.0)
 }
 
 // ============================================================================

--- a/code/packages/haskell/trig/CHANGELOG.md
+++ b/code/packages/haskell/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 ## 0.1.0 - 2026-07-18
 
 - Add first-principles sine and cosine using range-reduced Maclaurin series.

--- a/code/packages/haskell/trig/README.md
+++ b/code/packages/haskell/trig/README.md
@@ -1,5 +1,14 @@
 # trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions implemented from first principles with basic
 arithmetic.
 

--- a/code/packages/haskell/trig/src/Trig.hs
+++ b/code/packages/haskell/trig/src/Trig.hs
@@ -102,16 +102,22 @@ rangeReduce angle
 
 sqrtNonnegative :: Double -> Double
 sqrtNonnegative value
-    | value == 0.0 = 0.0
-    | otherwise = iterateNewton 60 initial
+    | value == 0.0 = value
+    | isInfinite value = value
+    | otherwise = resultScale * iterateNewton 60 initial
   where
-    initial = if value >= 1.0 then value else 1.0
+    (scaled, resultScale) = normalize value 1.0
+    normalize current scale
+        | current < 0.25 = normalize (current * 4.0) (scale * 0.5)
+        | current >= 4.0 = normalize (current * 0.25) (scale * 2.0)
+        | otherwise = (current, scale)
+    initial = if scaled >= 1.0 then scaled else 1.0
     iterateNewton remaining guess
         | remaining == (0 :: Int) = guess
         | abs (next - guess) < 1e-15 * guess + 1e-300 = next
         | otherwise = iterateNewton (remaining - 1) next
       where
-        next = (guess + value / guess) / 2.0
+        next = (guess + scaled / guess) / 2.0
 
 atanCore :: Double -> Double
 atanCore value = 2.0 * snd (foldl' step (reduced, reduced) [1 .. 30])

--- a/code/packages/haskell/trig/test/TrigSpec.hs
+++ b/code/packages/haskell/trig/test/TrigSpec.hs
@@ -93,6 +93,20 @@ spec = do
             mapM_ checkSquareRoot cases
         it "rejects negative input" $
             sqrt (-1.0) `shouldSatisfy` isLeft
+        it "covers the full binary64 range and special values" $ do
+            let relative actual expected = abs (actual - expected) / abs expected <= 1e-12
+            tiny <- rightValue $ sqrt 1e-100
+            tiny `shouldSatisfy` (`relative` 1e-50)
+            subnormal <- rightValue $ sqrt (encodeFloat 1 (-1074))
+            subnormal `shouldSatisfy` (`relative` 2.2227587494850775e-162)
+            largest <- rightValue $ sqrt (encodeFloat (2 ^ (53 :: Int) - 1) (1023 - 52))
+            largest `shouldSatisfy` (`relative` 1.3407807929942596e154)
+            negativeZero <- rightValue $ sqrt (-0.0)
+            negativeZero `shouldSatisfy` isNegativeZero
+            positiveInfinity <- rightValue $ sqrt (1.0 / 0.0)
+            positiveInfinity `shouldSatisfy` isInfinite
+            notANumber <- rightValue $ sqrt (0.0 / 0.0)
+            notANumber `shouldSatisfy` isNaN
 
     describe "tan" $ do
         it "matches reference values" $ do

--- a/code/packages/java/trig/CHANGELOG.md
+++ b/code/packages/java/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — trig (Java)
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 ## [0.1.0] — 2026-04-25
 
 ### Added

--- a/code/packages/java/trig/README.md
+++ b/code/packages/java/trig/README.md
@@ -1,5 +1,14 @@
 # trig — Java
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions built from first principles using Maclaurin series.
 No `Math.sin`, `Math.cos`, or any other standard library math functions are
 used internally — every result is derived from addition, multiplication, and

--- a/code/packages/java/trig/src/main/java/com/codingadventures/trig/Trig.java
+++ b/code/packages/java/trig/src/main/java/com/codingadventures/trig/Trig.java
@@ -288,29 +288,44 @@ public final class Trig {
 
         // sqrt(0) is exactly 0.
         if (x == 0.0) {
-            return 0.0;
+            return x;
+        }
+
+        if (x == Double.POSITIVE_INFINITY) {
+            return x;
+        }
+
+        double scaled = x;
+        double resultScale = 1.0;
+        while (scaled < 0.25) {
+            scaled *= 4.0;
+            resultScale *= 0.5;
+        }
+        while (scaled >= 4.0) {
+            scaled *= 0.25;
+            resultScale *= 2.0;
         }
 
         // Initial guess: x itself for x >= 1 (good for large numbers),
         // 1.0 for x < 1 (avoids dividing by a tiny number in the first step).
-        double guess = x >= 1.0 ? x : 1.0;
+        double guess = scaled >= 1.0 ? scaled : 1.0;
 
         // Iterate up to 60 times. Quadratic convergence means 60 is an extreme
         // safety margin; typical convergence happens in 15 or fewer iterations.
         for (int i = 0; i < 60; i++) {
-            double next = (guess + x / guess) / 2.0;
+            double next = (guess + scaled / guess) / 2.0;
 
             // Convergence criterion: stop when improvement is negligible.
             // 1e-15 * guess handles relative precision near large values.
             // 1e-300 is a floor to handle subnormal (near-zero) inputs safely.
             if (Math.abs(next - guess) < 1e-15 * guess + 1e-300) {
-                return next;
+                return next * resultScale;
             }
 
             guess = next;
         }
 
-        return guess;
+        return guess * resultScale;
     }
 
     // =========================================================================

--- a/code/packages/java/trig/src/test/java/com/codingadventures/trig/TrigTest.java
+++ b/code/packages/java/trig/src/test/java/com/codingadventures/trig/TrigTest.java
@@ -231,6 +231,16 @@ class TrigTest {
     }
 
     @Test
+    void sqrtCoversFullBinary64Range() {
+        assertEquals(1e-50, Trig.sqrt(1e-100), 1e-62);
+        assertEquals(2.2227587494850775e-162, Trig.sqrt(Double.MIN_VALUE), 2.3e-174);
+        assertEquals(1.3407807929942596e154, Trig.sqrt(Double.MAX_VALUE), 1.4e142);
+        assertEquals(Long.MIN_VALUE, Double.doubleToRawLongBits(Trig.sqrt(-0.0)));
+        assertEquals(Double.POSITIVE_INFINITY, Trig.sqrt(Double.POSITIVE_INFINITY));
+        assertTrue(Double.isNaN(Trig.sqrt(Double.NaN)));
+    }
+
+    @Test
     void sqrtRoundtrip() {
         // sqrt(2) * sqrt(2) should recover 2.0
         double s = Trig.sqrt(2.0);

--- a/code/packages/kotlin/trig/CHANGELOG.md
+++ b/code/packages/kotlin/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — trig (Kotlin)
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 ## [0.1.0] — 2026-04-25
 
 ### Added

--- a/code/packages/kotlin/trig/README.md
+++ b/code/packages/kotlin/trig/README.md
@@ -1,5 +1,14 @@
 # trig — Kotlin
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions built from first principles using Maclaurin series.
 No `kotlin.math.sin`, `kotlin.math.cos`, or any other standard library math
 functions are used internally — every result is derived from addition,

--- a/code/packages/kotlin/trig/src/main/kotlin/com/codingadventures/trig/Trig.kt
+++ b/code/packages/kotlin/trig/src/main/kotlin/com/codingadventures/trig/Trig.kt
@@ -239,21 +239,33 @@ object Trig {
         if (x < 0.0) throw ArithmeticException(
             "sqrt: domain error — input $x is negative")
 
-        if (x == 0.0) return 0.0
+        if (x == 0.0) return x
+        if (x == Double.POSITIVE_INFINITY) return x
+
+        var scaled = x
+        var resultScale = 1.0
+        while (scaled < 0.25) {
+            scaled *= 4.0
+            resultScale *= 0.5
+        }
+        while (scaled >= 4.0) {
+            scaled *= 0.25
+            resultScale *= 2.0
+        }
 
         // Initial guess: x itself for x >= 1, 1.0 for x < 1.
-        var guess = if (x >= 1.0) x else 1.0
+        var guess = if (scaled >= 1.0) scaled else 1.0
 
         repeat(60) {
-            val next = (guess + x / guess) / 2.0
+            val next = (guess + scaled / guess) / 2.0
             if (Math.abs(next - guess) < 1e-15 * guess + 1e-300) {
                 guess = next
-                return guess
+                return guess * resultScale
             }
             guess = next
         }
 
-        return guess
+        return guess * resultScale
     }
 
     // =========================================================================

--- a/code/packages/kotlin/trig/src/test/kotlin/com/codingadventures/trig/TrigTest.kt
+++ b/code/packages/kotlin/trig/src/test/kotlin/com/codingadventures/trig/TrigTest.kt
@@ -187,6 +187,16 @@ class TrigTest {
     }
 
     @Test
+    fun sqrtCoversFullBinary64Range() {
+        assertEquals(1e-50, Trig.sqrt(1e-100), 1e-62)
+        assertEquals(2.2227587494850775e-162, Trig.sqrt(Double.MIN_VALUE), 2.3e-174)
+        assertEquals(1.3407807929942596e154, Trig.sqrt(Double.MAX_VALUE), 1.4e142)
+        assertEquals(Long.MIN_VALUE, Trig.sqrt(-0.0).toRawBits())
+        assertEquals(Double.POSITIVE_INFINITY, Trig.sqrt(Double.POSITIVE_INFINITY))
+        assertTrue(Trig.sqrt(Double.NaN).isNaN())
+    }
+
+    @Test
     fun sqrtRoundtrip() {
         val s = Trig.sqrt(2.0)
         assertEquals(2.0, s * s, TOL)

--- a/code/packages/lua/trig/CHANGELOG.md
+++ b/code/packages/lua/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 All notable changes to this package will be documented in this file.
 
 ## [0.2.0] - 2026-04-03

--- a/code/packages/lua/trig/README.md
+++ b/code/packages/lua/trig/README.md
@@ -1,5 +1,14 @@
 # trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions computed from first principles using Maclaurin series. No standard-library trig functions are used in the implementation -- the goal is to understand *how* sine, cosine, and tangent work at the mathematical level.
 
 This is a Lua 5.4 port of the Go implementation at `code/packages/go/trig/`.

--- a/code/packages/lua/trig/src/coding_adventures/trig/init.lua
+++ b/code/packages/lua/trig/src/coding_adventures/trig/init.lua
@@ -391,26 +391,38 @@ function trig.sqrt(x)
     end
 
     -- sqrt(0) is exactly 0.
-    if x == 0.0 then return 0.0 end
+    if x == 0.0 then return x end
+    if x == math.huge then return x end
+
+    local scaled = x
+    local result_scale = 1.0
+    while scaled < 0.25 do
+        scaled = scaled * 4.0
+        result_scale = result_scale * 0.5
+    end
+    while scaled >= 4.0 do
+        scaled = scaled * 0.25
+        result_scale = result_scale * 2.0
+    end
 
     -- Initial guess: x itself for x >= 1 (better for large values),
     -- 1.0 for x in (0, 1) (avoids dividing by a tiny number).
-    local guess = (x >= 1.0) and x or 1.0
+    local guess = (scaled >= 1.0) and scaled or 1.0
 
     -- Iterate up to 60 times. Quadratic convergence means ~15 in practice.
     for _ = 1, 60 do
-        local next_guess = (guess + x / guess) / 2.0
+        local next_guess = (guess + scaled / guess) / 2.0
 
         -- Stop when improvement is below the precision floor.
         -- 1e-15 * guess is relative precision; 1e-300 is a subnormal floor.
         if math.abs(next_guess - guess) < 1e-15 * guess + 1e-300 then
-            return next_guess
+            return next_guess * result_scale
         end
 
         guess = next_guess
     end
 
-    return guess
+    return guess * result_scale
 end
 
 -- ============================================================================

--- a/code/packages/lua/trig/tests/test_trig.lua
+++ b/code/packages/lua/trig/tests/test_trig.lua
@@ -588,6 +588,19 @@ describe("sqrt", function()
         assert.is_true(approx_equal(trig.sqrt(1e10), 1e5, 1e-4))
     end)
 
+    it("covers the full binary64 range and special values", function()
+        local function relative(actual, expected)
+            return math.abs(actual - expected) / math.abs(expected) <= 1e-12
+        end
+        assert.is_true(relative(trig.sqrt(1e-100), 1e-50))
+        assert.is_true(relative(trig.sqrt(5e-324), 2.2227587494850775e-162))
+        assert.is_true(relative(trig.sqrt(1.7976931348623157e308), 1.3407807929942596e154))
+        assert.are.equal(1 / trig.sqrt(-0.0), -math.huge)
+        assert.are.equal(trig.sqrt(math.huge), math.huge)
+        local nan = trig.sqrt(0 / 0)
+        assert.is_true(nan ~= nan)
+    end)
+
     it("sqrt(2)^2 ≈ 2.0 (roundtrip)", function()
         local s = trig.sqrt(2)
         assert.is_true(approx_equal(s * s, 2.0))

--- a/code/packages/perl/trig/CHANGELOG.md
+++ b/code/packages/perl/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 All notable changes to this package will be documented in this file.
 
 ## [0.2.0] - 2026-04-03

--- a/code/packages/perl/trig/README.md
+++ b/code/packages/perl/trig/README.md
@@ -1,5 +1,14 @@
 # trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Pure-Perl trig implementation
 
 ## Development

--- a/code/packages/perl/trig/lib/CodingAdventures/Trig.pm
+++ b/code/packages/perl/trig/lib/CodingAdventures/Trig.pm
@@ -328,27 +328,39 @@ sub sqrt_approx {
     die "sqrt_approx: domain error — input $x is negative\n" if $x < 0;
 
     # sqrt(0) = 0 exactly.
-    return 0.0 if $x == 0.0;
+    return $x if $x == 0.0;
+    return $x if $x > 1.7976931348623157e308;
+
+    my $scaled = $x;
+    my $result_scale = 1.0;
+    while ( $scaled < 0.25 ) {
+        $scaled *= 4.0;
+        $result_scale *= 0.5;
+    }
+    while ( $scaled >= 4.0 ) {
+        $scaled *= 0.25;
+        $result_scale *= 2.0;
+    }
 
     # Initial guess: x itself for x >= 1, else 1.0.
     # For large x, starting at x converges faster than starting at 1.
     # For x in (0, 1), starting at 1.0 avoids dividing by a tiny number.
-    my $guess = ( $x >= 1.0 ) ? $x : 1.0;
+    my $guess = ( $scaled >= 1.0 ) ? $scaled : 1.0;
 
     # Iterate to convergence (up to 60 steps as a safety cap).
     for my $i ( 1 .. 60 ) {
-        my $next = ( $guess + $x / $guess ) / 2.0;
+        my $next = ( $guess + $scaled / $guess ) / 2.0;
 
         # Stop when improvement is negligibly small.
         # 1e-15 * $guess handles relative precision for large values.
         # 1e-300 is an absolute floor for subnormal inputs.
         my $improvement = abs( $next - $guess );
-        return $next if $improvement < 1e-15 * $guess + 1e-300;
+        return $next * $result_scale if $improvement < 1e-15 * $guess + 1e-300;
 
         $guess = $next;
     }
 
-    return $guess;
+    return $guess * $result_scale;
 }
 
 # ============================================================================

--- a/code/packages/perl/trig/t/01-basic.t
+++ b/code/packages/perl/trig/t/01-basic.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test2::V0;
+use POSIX qw(HUGE_VAL);
 
 # ---------------------------------------------------------------------------
 # Load the module under test.
@@ -168,13 +169,26 @@ ok( near( sqrt_approx(9),    3.0 ),          'sqrt(9) = 3' );
 ok( near( sqrt_approx(2),    1.41421356237, 1e-9 ), 'sqrt(2) ≈ 1.41421356237' );
 ok( near( sqrt_approx(0.25), 0.5 ),          'sqrt(0.25) = 0.5' );
 ok( near( sqrt_approx(1e10), 1e5,  1e-4 ),  'sqrt(1e10) ≈ 1e5' );
+ok( abs( sqrt_approx(1e-100) - 1e-50 ) / 1e-50 <= 1e-12,
+    'sqrt(1e-100) uses relative precision' );
+ok( abs( sqrt_approx(5e-324) - 2.2227587494850775e-162 ) /
+        2.2227587494850775e-162 <= 1e-12,
+    'sqrt(min subnormal) covers the binary64 floor' );
+ok( abs( sqrt_approx(1.7976931348623157e308) - 1.3407807929942596e154 ) /
+        1.3407807929942596e154 <= 1e-12,
+    'sqrt(max finite) covers the binary64 ceiling' );
+is( unpack('Q>', pack('d>', sqrt_approx(-0.0))) >> 63, 1,
+    'sqrt(-0.0) preserves the sign bit' );
+is( sqrt_approx(HUGE_VAL), HUGE_VAL, 'sqrt(+Inf) is +Inf' );
+my $nan = sqrt_approx(HUGE_VAL - HUGE_VAL);
+ok( $nan != $nan, 'sqrt(NaN) is NaN' );
 
 # Roundtrip: sqrt(2)^2 ≈ 2
 my $sq2 = sqrt_approx(2);
 ok( near( $sq2 * $sq2, 2.0 ), 'sqrt(2)^2 ≈ 2.0' );
 
 # Negative input should die
-ok( eval { sqrt_approx(-1); 0 } || 1, 'sqrt(-1) dies' );
+ok( !eval { sqrt_approx(-1); 1 }, 'sqrt(-1) dies' );
 
 # ===========================================================================
 # 12. atan_approx

--- a/code/packages/python/trig/CHANGELOG.md
+++ b/code/packages/python/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 ## [0.2.0] - 2026-04-03
 
 ### Added

--- a/code/packages/python/trig/README.md
+++ b/code/packages/python/trig/README.md
@@ -1,5 +1,14 @@
 # trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions implemented from first principles using Taylor (Maclaurin) series. No math library is used — everything is built from basic arithmetic.
 
 ## Layer

--- a/code/packages/python/trig/src/trig/trig.py
+++ b/code/packages/python/trig/src/trig/trig.py
@@ -288,24 +288,35 @@ def sqrt(x: float) -> float:
 
     # sqrt(0) is exactly 0.
     if x == 0.0:
-        return 0.0
+        return x
+    if x == float("inf"):
+        return x
+
+    scaled = x
+    result_scale = 1.0
+    while scaled < 0.25:
+        scaled *= 4.0
+        result_scale *= 0.5
+    while scaled >= 4.0:
+        scaled *= 0.25
+        result_scale *= 2.0
 
     # Initial guess: x itself for x >= 1 (good for large numbers),
     # 1.0 for x < 1 (avoids dividing by a tiny number in the first step).
-    guess: float = x if x >= 1.0 else 1.0
+    guess: float = max(scaled, 1.0)
 
     # Iterate until convergence or safety limit.
     for _ in range(60):
-        next_guess = (guess + x / guess) / 2.0
+        next_guess = (guess + scaled / guess) / 2.0
 
         # Stop when improvement is below the precision floor.
         # 1e-15 * guess is relative precision; 1e-300 handles subnormals.
         if abs(next_guess - guess) < 1e-15 * guess + 1e-300:
-            return next_guess
+            return next_guess * result_scale
 
         guess = next_guess
 
-    return guess
+    return guess * result_scale
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/trig/tests/test_trig.py
+++ b/code/packages/python/trig/tests/test_trig.py
@@ -6,10 +6,12 @@ cos against known mathematical identities and special values.  We use
 pytest.approx with an absolute tolerance of 1e-10 throughout.
 """
 
+import math
+import sys
+
 import pytest
 
-from trig import PI, sin, cos, tan, atan, atan2, sqrt, radians, degrees
-
+from trig import PI, atan, atan2, cos, degrees, radians, sin, sqrt, tan
 
 # ---------------------------------------------------------------------------
 # Tolerance used for all approximate comparisons
@@ -262,6 +264,19 @@ class TestSqrt:
     def test_sqrt_large(self) -> None:
         """sqrt(1e10) ≈ 1e5."""
         assert sqrt(1e10) == pytest.approx(1e5, rel=1e-9)
+
+    def test_sqrt_full_binary64_range(self) -> None:
+        """Shared PHY00 boundary cases use relative precision."""
+        assert sqrt(1e-100) == pytest.approx(1e-50, rel=1e-12)
+        assert sqrt(float.fromhex("0x0.0000000000001p-1022")) == pytest.approx(
+            2.2227587494850775e-162, rel=1e-12
+        )
+        assert sqrt(sys.float_info.max) == pytest.approx(
+            1.3407807929942596e154, rel=1e-12
+        )
+        assert math.copysign(1.0, sqrt(-0.0)) == -1.0
+        assert sqrt(float("inf")) == float("inf")
+        assert math.isnan(sqrt(float("nan")))
 
     def test_sqrt_roundtrip(self) -> None:
         """sqrt(2) * sqrt(2) ≈ 2.0."""

--- a/code/packages/ruby/trig/CHANGELOG.md
+++ b/code/packages/ruby/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 ## [0.2.0] - 2026-04-03
 
 ### Added

--- a/code/packages/ruby/trig/README.md
+++ b/code/packages/ruby/trig/README.md
@@ -1,5 +1,14 @@
 # Trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions implemented from first principles using Maclaurin (Taylor) series. No standard library math functions are used — everything is built from basic arithmetic.
 
 **Layer:** PHY00 (leaf package, no dependencies)

--- a/code/packages/ruby/trig/lib/trig.rb
+++ b/code/packages/ruby/trig/lib/trig.rb
@@ -274,24 +274,38 @@ module Trig
     raise ArgumentError, "sqrt: domain error — input #{x} is negative" if x < 0
 
     # sqrt(0) is exactly 0.
-    return 0.0 if x == 0.0
+    return x if x == 0.0
+    return x if x.infinite? == 1
+
+    scaled = x
+    result_scale = 1.0
+    while scaled < 0.25
+      scaled *= 4.0
+      result_scale *= 0.5
+    end
+    while scaled >= 4.0
+      scaled *= 0.25
+      result_scale *= 2.0
+    end
 
     # Initial guess: x itself works for x >= 1 (large values converge faster
     # from x than from 1). For x < 1, start at 1.0 to avoid tiny denominators.
-    guess = x >= 1.0 ? x : 1.0
+    guess = scaled >= 1.0 ? scaled : 1.0
 
     # Iterate to convergence (or up to 60 steps as a safety cap).
     60.times do
-      next_guess = (guess + x / guess) / 2.0
+      next_guess = (guess + scaled / guess) / 2.0
 
       # Stop when improvement is below the precision floor.
       # 1e-15 * guess is relative precision; 1e-300 handles subnormals.
-      return next_guess if (next_guess - guess).abs < 1e-15 * guess + 1e-300
+      if (next_guess - guess).abs < 1e-15 * guess + 1e-300
+        return next_guess * result_scale
+      end
 
       guess = next_guess
     end
 
-    guess
+    guess * result_scale
   end
 
   # ---------------------------------------------------------------------------

--- a/code/packages/ruby/trig/test/test_trig.rb
+++ b/code/packages/ruby/trig/test/test_trig.rb
@@ -278,6 +278,19 @@ class TestTrig < Minitest::Test
     assert_in_delta 1e5, Trig.sqrt(1e10), 1e-4
   end
 
+  def test_sqrt_full_binary64_range
+    assert_operator((Trig.sqrt(1e-100) - 1e-50).abs / 1e-50, :<=, 1e-12)
+    expected_subnormal = 2.2227587494850775e-162
+    assert_operator((Trig.sqrt(2.0**-1074) - expected_subnormal).abs / expected_subnormal,
+                    :<=, 1e-12)
+    expected_largest = 1.3407807929942596e154
+    assert_operator((Trig.sqrt(Float::MAX) - expected_largest).abs / expected_largest,
+                    :<=, 1e-12)
+    assert_equal(-Float::INFINITY, 1.0 / Trig.sqrt(-0.0))
+    assert_equal Float::INFINITY, Trig.sqrt(Float::INFINITY)
+    assert_predicate Trig.sqrt(Float::NAN), :nan?
+  end
+
   def test_sqrt_roundtrip
     s = Trig.sqrt(2)
     assert_in_delta 2.0, s * s, DELTA

--- a/code/packages/rust/trig/CHANGELOG.md
+++ b/code/packages/rust/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 ## [0.2.0] - 2026-04-03
 
 ### Added

--- a/code/packages/rust/trig/README.md
+++ b/code/packages/rust/trig/README.md
@@ -1,5 +1,14 @@
 # trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions computed from first principles using Maclaurin (Taylor) series. No standard-library trig functions are used — every value is built up from basic arithmetic.
 
 ## Layer

--- a/code/packages/rust/trig/src/lib.rs
+++ b/code/packages/rust/trig/src/lib.rs
@@ -292,29 +292,43 @@ pub fn sqrt(x: f64) -> f64 {
 
     // sqrt(0) is exactly 0.
     if x == 0.0 {
-        return 0.0;
+        return x;
+    }
+    if x.is_infinite() {
+        return x;
+    }
+
+    let mut scaled = x;
+    let mut result_scale = 1.0;
+    while scaled < 0.25 {
+        scaled *= 4.0;
+        result_scale *= 0.5;
+    }
+    while scaled >= 4.0 {
+        scaled *= 0.25;
+        result_scale *= 2.0;
     }
 
     // Initial guess: x itself for x >= 1 (avoids a slow start for large values),
     // 1.0 for x < 1 (avoids the first step dividing by a tiny number).
-    let mut guess = if x >= 1.0 { x } else { 1.0 };
+    let mut guess = if scaled >= 1.0 { scaled } else { 1.0 };
 
     // Iterate up to 60 times. Quadratic convergence means 60 is an extreme
     // safety margin; typical convergence happens in 15 or fewer iterations.
     for _ in 0..60 {
-        let next = (guess + x / guess) / 2.0;
+        let next = (guess + scaled / guess) / 2.0;
 
         // Convergence criterion: stop when improvement is negligible.
         // 1e-15 * guess handles relative precision near large values.
         // 1e-300 is a floor to handle subnormal (near-zero) inputs safely.
         if (next - guess).abs() < 1e-15 * guess + 1e-300 {
-            return next;
+            return next * result_scale;
         }
 
         guess = next;
     }
 
-    guess
+    guess * result_scale
 }
 
 // ============================================================================

--- a/code/packages/rust/trig/tests/trig_tests.rs
+++ b/code/packages/rust/trig/tests/trig_tests.rs
@@ -242,6 +242,19 @@ fn sqrt_large() {
 }
 
 #[test]
+fn sqrt_covers_full_binary64_range() {
+    fn relative(actual: f64, expected: f64) -> bool {
+        (actual - expected).abs() / expected.abs() <= 1e-12
+    }
+    assert!(relative(sqrt(1e-100), 1e-50));
+    assert!(relative(sqrt(f64::from_bits(1)), 2.2227587494850775e-162));
+    assert!(relative(sqrt(f64::MAX), 1.3407807929942596e154));
+    assert!(sqrt(-0.0).is_sign_negative());
+    assert_eq!(sqrt(f64::INFINITY), f64::INFINITY);
+    assert!(sqrt(f64::NAN).is_nan());
+}
+
+#[test]
 fn sqrt_roundtrip() {
     // sqrt(2) * sqrt(2) should equal 2.0
     let s = sqrt(2.0);

--- a/code/packages/swift/trig/CHANGELOG.md
+++ b/code/packages/swift/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — trig (Swift)
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 

--- a/code/packages/swift/trig/README.md
+++ b/code/packages/swift/trig/README.md
@@ -1,5 +1,14 @@
 # trig — Trigonometric Functions from First Principles (Swift)
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 A Swift implementation of trigonometric functions built entirely from scratch using mathematical series and Newton's method. No Foundation, no Darwin, no standard-library math functions — everything is computed from basic arithmetic.
 
 ## What It Does

--- a/code/packages/swift/trig/Sources/Trig/Trig.swift
+++ b/code/packages/swift/trig/Sources/Trig/Trig.swift
@@ -196,30 +196,44 @@ public struct Trig {
     /// - Returns: √x to full Double precision
     /// - Precondition: x ≥ 0. A negative input triggers a `fatalError`.
     public static func sqrt(_ x: Double) -> Double {
-        precondition(x >= 0, "Trig.sqrt: domain error — input \(x) is negative")
+        if x < 0 {
+            preconditionFailure("Trig.sqrt: domain error — input \(x) is negative")
+        }
 
         // sqrt(0) = 0 exactly.
-        if x == 0.0 { return 0.0 }
+        if x == 0.0 { return x }
+        if x.isInfinite { return x }
+
+        var scaled = x
+        var resultScale = 1.0
+        while scaled < 0.25 {
+            scaled *= 4.0
+            resultScale *= 0.5
+        }
+        while scaled >= 4.0 {
+            scaled *= 0.25
+            resultScale *= 2.0
+        }
 
         // Initial guess: x itself for x ≥ 1 (saves iterations for large values),
         // 1.0 for x in (0, 1) (avoids dividing by a tiny number on the first step).
-        var guess = x >= 1.0 ? x : 1.0
+        var guess = scaled >= 1.0 ? scaled : 1.0
 
         // Iterate up to 60 times. Quadratic convergence means ~15 in practice.
         for _ in 0..<60 {
-            let next = (guess + x / guess) / 2.0
+            let next = (guess + scaled / guess) / 2.0
 
             // Convergence criterion: stop when improvement is negligibly small.
             // 1e-15 * guess handles relative precision for large values.
             // 1e-300 is an absolute floor for subnormal (near-zero) inputs.
             if Swift.abs(next - guess) < 1e-15 * guess + 1e-300 {
-                return next
+                return next * resultScale
             }
 
             guess = next
         }
 
-        return guess
+        return guess * resultScale
     }
 
     // =========================================================================

--- a/code/packages/swift/trig/Tests/TrigTests/TrigTests.swift
+++ b/code/packages/swift/trig/Tests/TrigTests/TrigTests.swift
@@ -144,6 +144,24 @@ final class TrigTests: XCTestCase {
         XCTAssertEqual(Trig.sqrt(1e10), 1e5, accuracy: 1e-4)
     }
 
+    func testSqrtFullBinary64Range() {
+        func relative(_ actual: Double, _ expected: Double) -> Bool {
+            Swift.abs(actual - expected) / Swift.abs(expected) <= 1e-12
+        }
+        XCTAssertTrue(relative(Trig.sqrt(1e-100), 1e-50))
+        XCTAssertTrue(relative(
+            Trig.sqrt(Double.leastNonzeroMagnitude),
+            2.2227587494850775e-162
+        ))
+        XCTAssertTrue(relative(
+            Trig.sqrt(Double.greatestFiniteMagnitude),
+            1.3407807929942596e154
+        ))
+        XCTAssertEqual(Trig.sqrt(-0.0).sign, .minus)
+        XCTAssertEqual(Trig.sqrt(Double.infinity), Double.infinity)
+        XCTAssertTrue(Trig.sqrt(Double.nan).isNaN)
+    }
+
     func testSqrtRoundtrip() {
         // sqrt(2) * sqrt(2) should recover 2.0
         let s = Trig.sqrt(2.0)

--- a/code/packages/typescript/trig/CHANGELOG.md
+++ b/code/packages/typescript/trig/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Normalize square-root inputs by powers of four before Newton iteration so the
+  complete binary64 exponent range converges without host square-root calls.
+
+### Fixed
+
+- Preserve negative zero, return positive infinity, propagate NaN, and retain
+  the lane-native negative-input error.
+
+### Tests
+
+- Cover the shared PHY00 square-root boundaries from
+  [`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json) with
+  relative-error assertions for finite nonzero results.
+
 ## [0.2.0] - 2026-04-03
 
 ### Added

--- a/code/packages/typescript/trig/README.md
+++ b/code/packages/typescript/trig/README.md
@@ -1,5 +1,14 @@
 # trig
 
+## Full-range square root
+
+The square-root API follows PHY00 across the full binary64 range. It preserves
+negative zero, returns positive infinity and NaN unchanged, rejects negative
+inputs with the lane-native error, normalizes by powers of four into `[0.25, 4)`,
+and then applies at most 60 Newton steps without calling the host square-root
+routine. Boundary behavior is checked against
+[`trig.json`](../../../specs/fixtures/phy00-phy01-v1/cases/trig.json).
+
 Trigonometric functions computed from first principles using Taylor (Maclaurin) series. No `Math.sin` or `Math.cos` — just arithmetic.
 
 ## Layer

--- a/code/packages/typescript/trig/src/trig.ts
+++ b/code/packages/typescript/trig/src/trig.ts
@@ -193,31 +193,43 @@ export function sqrt(x: number): number {
   }
 
   // sqrt(0) is exactly 0 by definition.
-  if (x === 0.0) return 0.0;
+  if (x === 0.0) return x;
+  if (x === Infinity) return x;
+
+  let scaled = x;
+  let resultScale = 1.0;
+  while (scaled < 0.25) {
+    scaled *= 4.0;
+    resultScale *= 0.5;
+  }
+  while (scaled >= 4.0) {
+    scaled *= 0.25;
+    resultScale *= 2.0;
+  }
 
   // Initial guess: use x itself for x >= 1 (decent for large numbers),
   // and 1.0 for x < 1 (avoids dividing by a very small number early on).
   // Both converge correctly; this just saves a few iterations.
-  let guess = x >= 1.0 ? x : 1.0;
+  let guess = scaled >= 1.0 ? scaled : 1.0;
 
   // Iterate up to 60 times. In practice the loop exits in ~15 iterations
   // due to quadratic convergence. The cap prevents infinite loops on
   // edge cases near floating-point subnormals.
   for (let i = 0; i < 60; i++) {
-    const next = (guess + x / guess) / 2.0;
+    const next = (guess + scaled / guess) / 2.0;
 
     // Convergence check: stop when the improvement is smaller than the
     // best precision we can hope for at this magnitude.
     // The 1e-15 * guess term accounts for relative precision near large values.
     // The 1e-300 absolute floor handles subnormals safely.
     if (Math.abs(next - guess) < 1e-15 * guess + 1e-300) {
-      return next;
+      return next * resultScale;
     }
 
     guess = next;
   }
 
-  return guess;
+  return guess * resultScale;
 }
 
 // ----------------------------------------------------------------------------

--- a/code/packages/typescript/trig/tests/trig.test.ts
+++ b/code/packages/typescript/trig/tests/trig.test.ts
@@ -223,6 +223,17 @@ describe("Trigonometric Functions", () => {
       expect(sqrt(1e10)).toBeCloseTo(1e5, 5);
     });
 
+    it("covers the full binary64 range and special values", () => {
+      const relative = (actual: number, expected: number): boolean =>
+        Math.abs(actual - expected) / Math.abs(expected) <= 1e-12;
+      expect(relative(sqrt(1e-100), 1e-50)).toBe(true);
+      expect(relative(sqrt(Number.MIN_VALUE), 2.2227587494850775e-162)).toBe(true);
+      expect(relative(sqrt(Number.MAX_VALUE), 1.3407807929942596e154)).toBe(true);
+      expect(Object.is(sqrt(-0.0), -0.0)).toBe(true);
+      expect(sqrt(Infinity)).toBe(Infinity);
+      expect(Number.isNaN(sqrt(NaN))).toBe(true);
+    });
+
     it("sqrt(x)^2 ≈ x (roundtrip)", () => {
       const s = sqrt(2);
       expect(s * s).toBeCloseTo(2.0, 10);

--- a/code/packages/typescript/trig/tsconfig.json
+++ b/code/packages/typescript/trig/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
   "include": ["src/**/*.ts"]
 }

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,10 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 31, 2026 at `5b5cb0127` after merged Dart
-`trig` and `wave`, Rust `smart-home-home-assistant-history`, Mosaic browser
-host, Spice validation, and Algol closure work. It contains 1,201 normalized
-implementation identities across 4,345 established-lane package
+inventory was regenerated on July 31, 2026 at `41622fa78` after merged Dart
+`trig` and `wave`, the PHY00/PHY01 shared fixture corpus, Rust
+`smart-home-home-assistant-definitions`, Mosaic browser host, Spice validation,
+and Algol closure work. It contains 1,202 normalized implementation identities
+across 4,346 established-lane package
 slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -117,18 +118,20 @@ slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 275 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 751 | 10,514 |
+| Present in one language | 752 | 10,528 |
 
 The loop must not start by attempting 10,514 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
-The post-#9383 inventory at
-`5b5cb01273be03cdd018eed9786f2d62c14e1225` is collision-clean at 1,201
-normalized implementation identities, 4,345 implementation slots, 172
-high-consensus packages, 275 high-consensus missing slots, 751 singletons, and
-zero unknown language buckets. The newly discovered Rust-only Home Assistant
-history package is now explicitly owned by the singleton classification,
-portable-core extraction, and native-host security backlog.
+The post-#9390 inventory at
+`41622fa7896a45b6001ea3cf1e7f5da5c86be161` is collision-clean at 1,202
+normalized implementation identities, 4,346 implementation slots, 172
+high-consensus packages, 275 high-consensus missing slots, 752 singletons, 557
+Rust singletons, zero canonical collisions, and zero unknown language buckets.
+The sole new identity since the previous inventory is Rust-only
+`smart-home-home-assistant-definitions`; its portable-core extraction,
+repository-local host hardening, externally approved capability profile, and
+post-extraction host refactor now have explicit owners.
 
 The July 31 lane audit is:
 
@@ -146,7 +149,7 @@ The July 31 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 966 | 0 | 100% |
+| Rust | 967 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -232,17 +235,22 @@ reconciliation. The pure `dart-trig-wave` child neither executes nor publishes
 the generator and introduces only empty capability profiles.
 
 The child review also exposed three separately owned follow-ups rather than
-silently widening this serial delivery slice: PHY00/PHY01 lack a machine-
-readable language-neutral fixture corpus; existing PHY00 lanes need a full-
-range tiny/subnormal square-root audit; and existing PHY01 lanes need finite-
-input and overflow-safe evaluation reconciliation. The backlog now records
-these as `phy00-phy01-language-neutral-fixtures`,
-`phy00-small-sqrt-cross-lane-audit`, and
-`phy01-nonfinite-validation-backfill`, with the shared corpus preceding the
-cross-lane remediations. After #9383 merged, dependency/leverage review selected
-the shared fixture corpus as the one active slice because it is repository-owned
-and immediately unlocks both cross-lane hardening items; the build-tool critical
-path remains blocked on external immutable-runner and attester provisioning.
+silently widening that delivery slice: a machine-readable language-neutral
+PHY00/PHY01 fixture corpus, a full-range tiny/subnormal PHY00 square-root audit,
+and finite-input and overflow-safe PHY01 evaluation reconciliation. Merged PR
+#9390 delivered the closed 53-case shared corpus and its first always-on Dart
+consumer. The collision-clean post-merge inventory and parallel dependency,
+fixture, and security audits then selected
+`phy00-small-sqrt-cross-lane-audit` as the one active slice because PHY00 is the
+foundational numeric dependency beneath PHY01 and the shared oracle now makes
+the known boundary defect testable across all 15 established lanes plus the
+emerging C and C++ implementations. `phy01-nonfinite-validation-backfill`
+follows it. The square-root numerical audit also discovered a separate
+`phy00-atan-tiny-signed-zero-cross-lane-audit`: current half-angle reduction
+underflows at the subnormal floor and loses the sign of negative zero, so that
+work is now tracked behind the square-root slice rather than expanding it.
+The build-tool execution critical path remains blocked on external
+immutable-runner and attester provisioning.
 
 Port dependency families together when doing so avoids temporary broken package
 graphs. Grammar-generated lexer/parser pairs should be generated from the shared
@@ -250,7 +258,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 277
+The 172 packages present in at least ten implementation languages need 275
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -917,10 +925,10 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 556 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 557 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30-31 inventories added sixteen Rust singleton identities that now
+The July 30-August 1 inventories added seventeen Rust singleton identities that now
 have explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
@@ -965,6 +973,21 @@ The urgent capability, Vault, transport, limit, redaction, and write hardening
 depends only on the merged capability-taxonomy contract; it must not wait for
 portable-core extraction. A later host refactor can depend on both the hardened
 boundary and the extracted core.
+
+The seventeenth identity, `smart-home-home-assistant-definitions`, is the same
+kind of deliberate split rather than a blind fourteen-lane port. Its safe-
+subset validation and normalization, state and time-pattern triggers,
+conditions, scene/action mapping, ordering, uniqueness, fingerprints, reports,
+and diagnostics are fixture-driven portable-core candidates. WebSocket and
+HTTP/TLS collection, administrator credentials, artifact I/O, wall clock,
+console output, and CLI orchestration stay in the Rust native host. The current
+host lacks `required_capabilities.json`, accepts plaintext transports, reads an
+ambient administrator token, persists server-provided error text, and creates
+a predictable link-following temporary output. Repository-local transport,
+Vault, limit, redaction, and durable no-follow write hardening must land without
+claiming capability approval; a separately blocked Layer 5 item owns the
+hardware-key-backed approval evidence, and the later host refactor depends on
+both the portable core and hardened boundary.
 
 The new `smart-home-matter-integration` is also a mixed split candidate rather
 than a native-source exception: endpoint projection, report normalization, and
@@ -1184,18 +1207,21 @@ macOS, Windows, and CodeQL checks. The collision-checked post-merge inventory
 found thirteen Dart-only 14-of-15 gaps. The serial loop selected
 `dart-trig-wave` because PHY00 `trig` is a dependency-free numeric leaf and
 PHY01 `wave` is its direct consumer. PR #9383 merged that pair with green Linux,
-macOS, Windows, and CodeQL checks. The refreshed collision-clean inventory has
-11 remaining Dart-only frontier gaps and one newly owned Rust history singleton.
-The next build-tool successor remains `build-tool-bootstrap-execution-fixture`,
-which is still blocked on the Linux OCI enforcement chain.
+macOS, Windows, and CodeQL checks, and PR #9390 then merged the closed shared
+PHY00/PHY01 oracle plus its always-on Dart consumer. The refreshed
+collision-clean inventory has 11 remaining Dart-only frontier gaps and one
+newly owned Rust Home Assistant definitions singleton. The next build-tool
+execution successor remains `build-tool-bootstrap-execution-fixture`, which is
+still blocked on the Linux OCI enforcement chain.
 
 Final Dart review hardened the selected implementation for subnormal square
 roots, infinity and signed zero, non-finite wave parameters and time, angular-
 frequency overflow, zero-amplitude evaluation, and extreme finite products.
-The equivalent existing-lane audits and the missing shared PHY00/PHY01 fixture
-corpus remain explicit dependent backlog items rather than unowned gaps. The
-serial loop selected the shared language-neutral corpus next because it unlocks
-both existing-lane audits without claiming their remediation in advance.
+The shared PHY00/PHY01 corpus is now merged. The serial loop selected the
+existing-lane PHY00 square-root audit next because it is the foundational
+dependency and its tiny-normal, minimum-subnormal, maximum-finite, infinity,
+NaN, and signed-zero cases are now normative; the PHY01 audit remains the
+explicit successor.
 
 The post-#9368 dependency audit also found that trusted authority requires one
 held case and one selected in-image adapter even though both checked-in
@@ -1227,6 +1253,16 @@ land before final adapter parity:
 - model deterministic inline inputs and semantic oracles for dependency,
   standalone-prerequisite, Starlark-declaration, identity, toolchain, and path
   validation checks before admitting them to the closed v1 schema.
+
+The 41622fa7 dependency audit made those three gates direct prerequisites of
+`build-tool-go-oracle`; the merged pure-domain umbrella alone cannot make the
+oracle ready while its CLI, Starlark-metering, and validation-oracle children
+remain pending. The same audit split `ocaml-build-substrate-process-free-core`
+from the execution-coupled OCaml substrate. Repository-owned OCaml discovery,
+opam/Dune resolution, hashing, validation, shard cost, affected-node behavior,
+and workflow markers can now land before external execution infrastructure,
+while opam-switch serialization, canonical execution conformance, and OCaml
+promotion remain gated on the Go oracle and trusted-execution contract.
 
 The Linux OCI review discovered eight additional dependency gates:
 


### PR DESCRIPTION
## Summary

- make PHY00 square root cover the complete binary64 range in C, C++, C#, Elixir, F#, Go, Haskell, Java, Kotlin, Lua, Perl, Python, Ruby, Rust, Swift, and TypeScript; Dart already conformed
- preserve signed zero, positive infinity, and NaN where the runtime represents them; reject negative inputs with lane-native errors
- normalize by powers of four before relative-convergence Newton iteration, without calling host square-root routines
- add the shared boundary vectors and document the BEAM nonfinite applicability exception
- refresh the post-#9390 collision-clean parity inventory, split newly discovered dependency/security work, and record the adjacent atan signed-zero/subnormal follow-up

## Validation

### Package and coverage

- C: 62 checks; Clang C17 strict build; 98.53% lines, 90.32% branches, 100% functions
- C++: 51 checks; Clang C++17 strict build; 100% lines, 90.32% branches, 100% functions
- C#: 11 tests; dotnet format clean; 95.23% lines, 87.5% branches, 100% methods
- F#: 5 tests; 96.51% lines, 87.93% branches, 100% methods
- Go: go test ./... -cover, go vet, go build, gofmt; 85.2% statements
- Haskell: 18 examples, cabal check; 100% functions/alternatives and 99% expressions
- Java: Gradle/JDK 21 tests and JaCoCo; 100% lines, 91% branches
- Kotlin: Gradle/JDK 21 tests and JaCoCo; 100% lines, 89% branches
- Elixir: 65 tests; 93.75% coverage
- Lua: 90 Busted tests; 98.84% production lines
- Perl: 100 TAP assertions and syntax check
- Python: 65 tests; Ruff, Bandit, compileall; 97.83% lines
- Ruby: 66 runs / 101 assertions; syntax check; 97.75% lines, 88.89% branches
- Rust: 49 integration tests plus 8 doc tests; clippy -D warnings, rustfmt, cargo build. Coverage instrumentation reran all 49 tests successfully; Windows could not emit the percentage because cargo-llvm-cov's monorepo exclusion argument exceeded the OS command-line limit.
- Swift: 48 tests; 95.33% lines, 89.33% regions
- TypeScript: 62 Jest tests; npm build; 96.66% lines, 88.63% branches, 100% functions
- Dart reference: 41 tests, dart analyze, generated fixture sync; 100% lines

### Repository gates

- 14 language-neutral fixture schema/oracle tests
- package parity schema 3: 1,202 implementation identities, 4,346 package slots, zero canonical collisions, zero unknown language buckets
- state dependency/status validation: 77 items, exactly one in-progress item before publication, no missing dependency IDs
- real Go build-tool detect/validate/dry-run: no trig failures; only the already-tracked 73 unrelated repository-wide standalone BUILD_windows integrity failures
- no host-library square-root calls in changed production files
- git diff --check

### Platform-local notes

- the shared C Windows PowerShell 5 runner still hits its pre-existing UTF-8 mojibake parse problem; direct strict Clang compilation and coverage validate this package
- Elixir's formatter reports pre-existing unrelated formatting in the same files; changed blocks were manually checked