### PR TITLE
feat(spice): validate MOS model length

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-positive and non-finite Level-1 MOS model-card `L` values before
+  channel-current, capacitance, and noise calculations.
+
 - Reject non-positive and non-finite Level-1 MOS model-card `W` values before
   channel-current, capacitance, and noise calculations.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -582,6 +582,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET KP must be finite and positive")
         elif canonical == "W" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET W must be finite and positive")
+        elif canonical == "L" and (not math.isfinite(value) or value <= 0.0):
+            raise ValueError(f"{name}: MOSFET L must be finite and positive")
         elif canonical == "VT0" and not math.isfinite(value):
             raise ValueError(f"{name}: MOSFET VT0 must be finite")
         elif canonical == "LAMBDA" and not math.isfinite(value):

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1268,6 +1268,16 @@ def test_mos_model_card_rejects_non_positive_or_non_finite_width() -> None:
             normalize_model_card("Minvalid", "nmos", {"W": invalid_width})
 
 
+def test_mos_model_card_rejects_non_positive_or_non_finite_length() -> None:
+    for value in (1.0e-9, 2.0e-6, 1.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"L": value})
+        assert valid.parameters["L"] == pytest.approx(value)
+
+    for invalid_length in (-math.inf, -0.1, 0.0, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET L must be finite and positive"):
+            normalize_model_card("Minvalid", "nmos", {"L": invalid_length})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-positive and non-finite Level-1 MOS model-card `L` values before
+  channel-current, capacitance, and noise calculations.
+
 - Reject non-positive and non-finite Level-1 MOS model-card `W` values before
   channel-current, capacitance, and noise calculations.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4385,6 +4385,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET W must be finite and positive".to_string(),
                 });
+            } else if canonical == "L" && (!raw_value.is_finite() || *raw_value <= 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET L must be finite and positive".to_string(),
+                });
             } else if canonical == "VT0" && !raw_value.is_finite() {
                 return Err(SpiceError::InvalidElement {
                     name: name.clone(),

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1155,6 +1155,22 @@ fn mos_model_card_rejects_non_positive_or_non_finite_width() {
 }
 
 #[test]
+fn mos_model_card_rejects_non_positive_or_non_finite_length() {
+    for value in [1.0e-9, 2.0e-6, 1.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("L", value)]).unwrap();
+        assert_close(*valid.parameters.get("L").unwrap(), value);
+    }
+
+    for invalid_length in [f64::NEG_INFINITY, -0.1, 0.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("L", invalid_length)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET L must be finite and positive"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-positive and non-finite Level-1 MOS model-card `L` values before
+  channel-current, capacitance, and noise calculations.
+
 - Reject non-positive and non-finite Level-1 MOS model-card `W` values before
   channel-current, capacitance, and noise calculations.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8444,6 +8444,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET KP must be finite and positive");
     } else if (canonical === "W" && (!Number.isFinite(value) || value <= 0.0)) {
       throw invalidElement(name, "MOSFET W must be finite and positive");
+    } else if (canonical === "L" && (!Number.isFinite(value) || value <= 0.0)) {
+      throw invalidElement(name, "MOSFET L must be finite and positive");
     } else if (canonical === "VT0" && !Number.isFinite(value)) {
       throw invalidElement(name, "MOSFET VT0 must be finite");
     } else if (canonical === "LAMBDA" && !Number.isFinite(value)) {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1075,6 +1075,25 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects non-positive or non-finite MOS length", () => {
+    for (const value of [1.0e-9, 2.0e-6, 1.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { L: value });
+      expect(valid.parameters.L).toBe(value);
+    }
+
+    for (const invalidLength of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      0.0,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { L: invalidLength }),
+      ).toThrow("MOSFET L must be finite and positive");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS width validation.
+1. Cross-language Level-1 MOS length validation.
    - Status: current PR completion candidate.
-   - Reject non-positive or non-finite model-card `W` values before
+   - Reject non-positive or non-finite model-card `L` values before
      channel-current, capacitance, and noise calculations.
-   - Preserve positive model widths across Rust, Python, and TypeScript.
+   - Preserve positive model lengths across Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3796,6 +3796,12 @@ the Rust, Python, and TypeScript surfaces together.
      bulk-junction leakage-density and temperature preprocessing.
    - Zero and positive saturation-current densities remain aligned across
      Rust, Python, and TypeScript.
+
+317. Cross-language Level-1 MOS width validation.
+   - Status: completed in PR 9392.
+   - Non-positive and non-finite model-card `W` values are rejected before
+     channel-current, capacitance, and noise calculations.
+   - Positive model widths remain aligned across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite Level-1 MOS model-card `L` values during normalization
- preserve positive model lengths with matching Rust, Python, and TypeScript regression coverage
- reconcile the SPICE completion plan after #9392

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine` (including 193 DC tests)
- Python Ruff checks
- Python pytest with coverage: 699 passed, 88.89%
- TypeScript `npm ci`, 442 tests passed, and `npm run build`