### PR TITLE
feat(venture): wire generated SwiftUI browser host

### DIFF
--- a/code/packages/rust/venture-browser-core/README.md
+++ b/code/packages/rust/venture-browser-core/README.md
@@ -45,9 +45,9 @@ Mosaic `VentureChrome` package. It preserves address edits as a draft, maps the
 six MIL events to `BrowserNavigation`, synchronizes redirects only after a
 successful load, and projects one coherent `BrowserChromeProps` snapshot for
 the six MIL slots. Generated Mosaic shells now expose the native node seam on
-all registered backends, but the concrete adapters that connect this reducer
-and the live Venture page renderer to those shells remain a separate acceptance
-gate.
+all registered backends. The first concrete adapter connects this reducer and
+the live Metal page renderer to the generated SwiftUI shell; Windows and the
+remaining native hosts still require equivalent direct acceptance.
 
 ## Development
 

--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Drive the clamped viewport and Metal repaint path from named navigation keys.
 - Reload Back/Forward history entries from Command-Left/Right shortcuts, then
   update the native title and Metal viewport.
+- Export the concrete dynamic bridge used by Venture's generated SwiftUI
+  `MosaicHost`: shared chrome props and events, Metal content rendering, scroll,
+  and link activation all stay backed by one Rust browser session.
 
 ## 0.1.0
 

--- a/code/packages/rust/venture-browser-macos/Cargo.toml
+++ b/code/packages/rust/venture-browser-macos/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 description = "Runnable AppKit, CoreText, and Metal host for the Venture browser."
 
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 [dependencies]
 html-to-layout = { path = "../html-to-layout" }
 html-to-paint = { path = "../html-to-paint" }

--- a/code/packages/rust/venture-browser-macos/README.md
+++ b/code/packages/rust/venture-browser-macos/README.md
@@ -8,6 +8,11 @@ browser. It composes:
 - AppKit for the native window and `CAMetalLayer`;
 - `paint-metal` for presenting the viewport scene.
 
+The crate also builds as `libventure_browser_macos.dylib`. Venture's generated
+SwiftUI shell loads that library through its package-owned `MosaicHost` adapter,
+so the MIL/MLL/MSL chrome and this Rust navigation/rendering pipeline form one
+native app without handwritten AppKit toolbar controls.
+
 Run the first CERN web page:
 
 ```bash

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -13,8 +13,8 @@ use std::fmt;
 use std::{cell::RefCell, rc::Rc};
 use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 use venture_browser_core::{
-    BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
-    BrowserSession,
+    BrowserChromeController, BrowserChromeEvent, BrowserChromeProps, BrowserLoadError,
+    BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher, BrowserSession,
 };
 use window_core::{ElementState, Key, NamedKey, PointerButton, WindowError, WindowEvent};
 
@@ -394,6 +394,298 @@ where
         &resolver,
     );
     Ok(session.execute(navigation, &pipeline, fetcher)?.is_some())
+}
+
+/// The concrete adapter behind Venture's generated Mosaic SwiftUI shell.
+///
+/// Chrome is still authored by MIL/MLL/MSL and navigation is still reduced by
+/// `venture-browser-core`; this type only joins that shared state to the native
+/// Metal content surface required by the generated `MosaicHost` seam.
+#[cfg(target_vendor = "apple")]
+struct OwnedFetcher(Box<dyn BrowserResourceFetcher>);
+
+#[cfg(target_vendor = "apple")]
+impl BrowserResourceFetcher for OwnedFetcher {
+    fn fetch(&self, url: &str) -> Result<venture_browser_core::BrowserFetchResponse, String> {
+        self.0.fetch(url)
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+pub struct MacBrowserHost {
+    session: BrowserSession,
+    chrome: BrowserChromeController,
+    fetcher: OwnedFetcher,
+    width: f64,
+    height: f64,
+    status_text: String,
+}
+
+#[cfg(target_vendor = "apple")]
+impl MacBrowserHost {
+    pub fn new(start_url: &str, width: f64, height: f64) -> Result<Self, BrowserLoadError> {
+        Self::new_with_fetcher(
+            start_url,
+            width,
+            height,
+            Box::new(HttpBrowserFetcher::default()),
+        )
+    }
+
+    pub fn new_with_fetcher(
+        start_url: &str,
+        width: f64,
+        height: f64,
+        fetcher: Box<dyn BrowserResourceFetcher>,
+    ) -> Result<Self, BrowserLoadError> {
+        let fetcher = OwnedFetcher(fetcher);
+        let session = load_initial_session(start_url, width, height, &fetcher)?;
+        let chrome = BrowserChromeController::new(&session);
+        Ok(Self {
+            session,
+            chrome,
+            fetcher,
+            width,
+            height,
+            status_text: "Ready".to_string(),
+        })
+    }
+
+    pub fn props(&self) -> BrowserChromeProps {
+        self.chrome
+            .props(&self.session, self.status_text.clone(), false)
+    }
+
+    pub fn handle_event(&mut self, event: BrowserChromeEvent) -> Result<bool, BrowserLoadError> {
+        let Some(navigation) = self.chrome.handle_event(event, &self.session, false) else {
+            return Ok(false);
+        };
+        self.status_text = "Loading".to_string();
+        match navigate_session(
+            &mut self.session,
+            navigation,
+            self.width,
+            self.height,
+            &self.fetcher,
+        ) {
+            Ok(changed) => {
+                if changed {
+                    self.chrome.synchronize(&self.session);
+                }
+                self.status_text = "Ready".to_string();
+                Ok(changed)
+            }
+            Err(error) => {
+                self.status_text = format!("Load failed: {error}");
+                Err(error)
+            }
+        }
+    }
+
+    pub fn scroll_by(&mut self, delta_y: f64) -> bool {
+        let Some(viewport) = self.session.viewport_mut() else {
+            return false;
+        };
+        let before = viewport.scroll_state().offset_y();
+        viewport.scroll_by(delta_y);
+        viewport.scroll_state().offset_y() != before
+    }
+
+    pub fn activate_link(&mut self, x: f64, y: f64) -> Result<bool, BrowserLoadError> {
+        let changed = activate_link_at(
+            &mut self.session,
+            x,
+            y,
+            self.width,
+            self.height,
+            &self.fetcher,
+        )?;
+        if changed {
+            self.chrome.synchronize(&self.session);
+            self.status_text = "Ready".to_string();
+        }
+        Ok(changed)
+    }
+
+    pub fn render_to_layer(&self, layer: objc_bridge::Id) -> Result<(), MacBrowserError> {
+        let viewport = self
+            .session
+            .viewport()
+            .ok_or(MacBrowserError::MissingViewport)?;
+        paint_metal::render_to_metal_layer(&viewport.viewport_scene(), layer)
+            .map_err(|error| MacBrowserError::Paint(error.to_string()))
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+mod mosaic_ffi {
+    use super::*;
+    use std::ffi::{c_char, c_void, CStr, CString};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    fn string_arg(value: *const c_char) -> Option<String> {
+        if value.is_null() {
+            return None;
+        }
+        unsafe { CStr::from_ptr(value) }
+            .to_str()
+            .ok()
+            .map(str::to_string)
+    }
+
+    fn json_string(value: &str) -> String {
+        let mut out = String::with_capacity(value.len() + 2);
+        out.push('"');
+        for ch in value.chars() {
+            match ch {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                ch if ch.is_control() => {
+                    use std::fmt::Write;
+                    let _ = write!(out, "\\u{:04x}", ch as u32);
+                }
+                ch => out.push(ch),
+            }
+        }
+        out.push('"');
+        out
+    }
+
+    fn response(host: &MacBrowserHost, error: Option<&str>) -> *mut c_char {
+        let props = host.props();
+        let error = error
+            .map(|message| format!(",\"error\":{}", json_string(message)))
+            .unwrap_or_default();
+        let value = format!(
+            "{{\"props\":{{\"address\":{},\"page-title\":{},\"status-text\":{},\"back-disabled\":{},\"forward-disabled\":{},\"navigation-disabled\":false}}{error}}}",
+            json_string(&props.address),
+            json_string(&props.page_title),
+            json_string(&props.status_text),
+            props.back_disabled,
+            props.forward_disabled,
+        );
+        CString::new(value)
+            .expect("JSON response contains no NUL")
+            .into_raw()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn venture_browser_macos_new(
+        start_url: *const c_char,
+        width: f64,
+        height: f64,
+    ) -> *mut MacBrowserHost {
+        let Some(start_url) = string_arg(start_url) else {
+            return std::ptr::null_mut();
+        };
+        catch_unwind(|| MacBrowserHost::new(&start_url, width, height))
+            .ok()
+            .and_then(Result::ok)
+            .map(Box::new)
+            .map(Box::into_raw)
+            .unwrap_or(std::ptr::null_mut())
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_macos_free(host: *mut MacBrowserHost) {
+        if !host.is_null() {
+            drop(Box::from_raw(host));
+        }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_macos_apply_props(
+        host: *mut MacBrowserHost,
+    ) -> *mut c_char {
+        host.as_ref()
+            .map(|host| response(host, None))
+            .unwrap_or(std::ptr::null_mut())
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_macos_handle_event(
+        host: *mut MacBrowserHost,
+        name: *const c_char,
+        value: *const c_char,
+    ) -> *mut c_char {
+        let Some(host) = host.as_mut() else {
+            return std::ptr::null_mut();
+        };
+        let Some(name) = string_arg(name) else {
+            return response(host, Some("missing Mosaic event name"));
+        };
+        let event = match name.as_str() {
+            "onBack" => Some(BrowserChromeEvent::Back),
+            "onForward" => Some(BrowserChromeEvent::Forward),
+            "onHome" => Some(BrowserChromeEvent::Home),
+            "onReload" => Some(BrowserChromeEvent::Reload),
+            "onNavigate" => Some(BrowserChromeEvent::Navigate),
+            "onAddressChange" => string_arg(value).map(BrowserChromeEvent::AddressChange),
+            _ => None,
+        };
+        let Some(event) = event else {
+            return response(host, Some("unknown or malformed Mosaic event"));
+        };
+        let result = catch_unwind(AssertUnwindSafe(|| host.handle_event(event)));
+        match result {
+            Ok(Ok(_)) => response(host, None),
+            Ok(Err(error)) => response(host, Some(&error.to_string())),
+            Err(_) => response(host, Some("Venture event handler panicked")),
+        }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_macos_scroll(
+        host: *mut MacBrowserHost,
+        delta_y: f64,
+    ) -> u8 {
+        host.as_mut()
+            .map(|host| host.scroll_by(delta_y) as u8)
+            .unwrap_or(0)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_macos_activate_link(
+        host: *mut MacBrowserHost,
+        x: f64,
+        y: f64,
+    ) -> u8 {
+        catch_unwind(AssertUnwindSafe(|| {
+            host.as_mut()
+                .and_then(|host| host.activate_link(x, y).ok())
+                .unwrap_or(false) as u8
+        }))
+        .unwrap_or(0)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_macos_render(
+        host: *mut MacBrowserHost,
+        metal_layer: *mut c_void,
+    ) -> u8 {
+        if metal_layer.is_null() {
+            return 0;
+        }
+        catch_unwind(AssertUnwindSafe(|| {
+            host.as_ref()
+                .map(|host| {
+                    host.render_to_layer(metal_layer.cast::<objc_bridge::Object>())
+                        .is_ok() as u8
+                })
+                .unwrap_or(0)
+        }))
+        .unwrap_or(0)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_string_free(value: *mut c_char) {
+        if !value.is_null() {
+            drop(CString::from_raw(value));
+        }
+    }
 }
 
 /// Track pointer movement and identify a primary-button link activation.
@@ -789,6 +1081,58 @@ mod tests {
                 .and_then(|viewport| viewport.page().document.title.as_deref()),
             Some("Next")
         );
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[test]
+    fn mosaic_host_adapter_drives_shared_chrome_and_metal_page_state() {
+        let fetcher = |url: &str| {
+            let html = match url {
+                "http://example.test/" => "<title>Start</title><p><a href='next.html'>Next</a></p>",
+                "http://example.test/next.html" => {
+                    "<title>Next</title><p>Generated chrome reached Rust</p>"
+                }
+                other => return Err(format!("unexpected URL: {other}")),
+            };
+            Ok(BrowserFetchResponse::new(
+                url,
+                200,
+                Some("text/html; charset=utf-8".into()),
+                html.as_bytes().to_vec(),
+            ))
+        };
+        let mut host = MacBrowserHost::new_with_fetcher(
+            "http://example.test/",
+            320.0,
+            180.0,
+            Box::new(fetcher),
+        )
+        .expect("Mosaic host should load the initial page");
+
+        assert_eq!(host.props().page_title, "Start");
+        host.handle_event(BrowserChromeEvent::AddressChange(
+            "http://example.test/next.html".into(),
+        ))
+        .expect("address edit should update the shared draft");
+        assert_eq!(host.props().address, "http://example.test/next.html");
+        assert!(host
+            .handle_event(BrowserChromeEvent::Navigate)
+            .expect("generated Navigate event should load"));
+
+        let props = host.props();
+        assert_eq!(props.page_title, "Next");
+        assert_eq!(props.status_text, "Ready");
+        assert!(!props.back_disabled);
+        let scene = host
+            .session
+            .viewport()
+            .expect("host should retain a live native viewport")
+            .viewport_scene();
+        let pixels = paint_metal::render(&scene);
+        assert!(pixels
+            .data
+            .chunks_exact(4)
+            .any(|pixel| pixel != [192, 192, 192, 255]));
     }
 
     #[cfg(not(target_vendor = "apple"))]

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -13,13 +13,15 @@ use std::fmt;
 use std::{cell::RefCell, rc::Rc};
 use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 use venture_browser_core::{
-    BrowserChromeController, BrowserChromeEvent, BrowserChromeProps, BrowserLoadError,
-    BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher, BrowserSession,
+    BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
+    BrowserSession,
 };
 use window_core::{ElementState, Key, NamedKey, PointerButton, WindowError, WindowEvent};
 
 #[cfg(target_vendor = "apple")]
-use venture_browser_core::HttpBrowserFetcher;
+use venture_browser_core::{
+    BrowserChromeController, BrowserChromeEvent, BrowserChromeProps, HttpBrowserFetcher,
+};
 
 pub const VERSION: &str = "0.1.0";
 pub const DEFAULT_START_URL: &str = "http://info.cern.ch/";

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -19,3 +19,7 @@
 - POSIX and PowerShell backend-matrix entry points that emit the same Venture
   package for all nine Mosaic targets and directly invoke each available web,
   Qt, SwiftUI, XAML, Flutter, or Compose build toolchain.
+- A package-owned SwiftUI `MosaicHost` adapter that loads Venture's Rust
+  dynamic bridge, hydrates generated chrome from `BrowserChromeController`,
+  dispatches Mosaic events back to it, and mounts the live Metal viewport with
+  native scrolling and link activation.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -29,6 +29,12 @@ recreating the surrounding chrome in backend-specific UI code.
   node through its optional `MosaicHost` seam rather than substituting its
   sample placeholder. On macOS, the generated SwiftPM app is compiled with a
   real host-provided `NSView`.
+- The SwiftUI project receives a package-owned `MosaicHost.swift` adapter. It
+  dynamically loads `libventure_browser_macos.dylib`, projects the shared
+  `BrowserChromeController` props, sends generated Mosaic events back through
+  the shared reducer, and mounts the live Metal page renderer as the
+  `content-surface` `NSView`. Scroll and link activation remain in the same
+  Rust browser session rather than being reimplemented in Swift.
 
 ## Build every backend
 
@@ -53,6 +59,11 @@ native host; missing host-applicable toolchains are reported as skips. Pass
 toolchains in a provisioned macOS, Windows, or Linux build job. `--emit-only` /
 `-EmitOnly` remains useful for inspecting all generated projects without
 claiming that their native builds passed.
+
+On macOS the matrix also builds the Venture Rust dynamic library and places it
+next to the generated SwiftUI project. Run the native shell from that directory
+with `swift run`; set `VENTURE_START_URL` to override the initial page or
+`VENTURE_BROWSER_LIBRARY` to load a bridge from another absolute path.
 
 This package is a browser-wiring milestone, not a claim of complete Venture or
 HTML conformance.

--- a/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
@@ -1,0 +1,202 @@
+import AppKit
+import Darwin
+import Foundation
+import Metal
+import QuartzCore
+
+private final class VentureNativeLibrary {
+  typealias New = @convention(c) (UnsafePointer<CChar>?, Double, Double) -> UnsafeMutableRawPointer?
+  typealias Free = @convention(c) (UnsafeMutableRawPointer?) -> Void
+  typealias ApplyProps = @convention(c) (UnsafeMutableRawPointer?) -> UnsafeMutablePointer<CChar>?
+  typealias HandleEvent = @convention(c) (
+    UnsafeMutableRawPointer?, UnsafePointer<CChar>?, UnsafePointer<CChar>?
+  ) -> UnsafeMutablePointer<CChar>?
+  typealias Scroll = @convention(c) (UnsafeMutableRawPointer?, Double) -> UInt8
+  typealias ActivateLink = @convention(c) (UnsafeMutableRawPointer?, Double, Double) -> UInt8
+  typealias Render = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> UInt8
+  typealias StringFree = @convention(c) (UnsafeMutablePointer<CChar>?) -> Void
+
+  let library: UnsafeMutableRawPointer
+  let new: New
+  let free: Free
+  let applyProps: ApplyProps
+  let handleEvent: HandleEvent
+  let scroll: Scroll
+  let activateLink: ActivateLink
+  let render: Render
+  let stringFree: StringFree
+
+  init?() {
+    let environment = ProcessInfo.processInfo.environment["VENTURE_BROWSER_LIBRARY"]
+    let current = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+      .appendingPathComponent("libventure_browser_macos.dylib").path
+    let executable = Bundle.main.executableURL?.deletingLastPathComponent()
+      .appendingPathComponent("libventure_browser_macos.dylib").path
+    let candidates = [environment, current, executable].compactMap { $0 }
+    guard let library = candidates.lazy.compactMap({ dlopen($0, RTLD_NOW | RTLD_LOCAL) }).first else {
+      return nil
+    }
+
+    func symbol<T>(_ name: String, as type: T.Type) -> T? {
+      guard let raw = dlsym(library, name) else { return nil }
+      return unsafeBitCast(raw, to: type)
+    }
+
+    guard
+      let new = symbol("venture_browser_macos_new", as: New.self),
+      let free = symbol("venture_browser_macos_free", as: Free.self),
+      let applyProps = symbol("venture_browser_macos_apply_props", as: ApplyProps.self),
+      let handleEvent = symbol("venture_browser_macos_handle_event", as: HandleEvent.self),
+      let scroll = symbol("venture_browser_macos_scroll", as: Scroll.self),
+      let activateLink = symbol("venture_browser_macos_activate_link", as: ActivateLink.self),
+      let render = symbol("venture_browser_macos_render", as: Render.self),
+      let stringFree = symbol("venture_browser_string_free", as: StringFree.self)
+    else {
+      dlclose(library)
+      return nil
+    }
+
+    self.library = library
+    self.new = new
+    self.free = free
+    self.applyProps = applyProps
+    self.handleEvent = handleEvent
+    self.scroll = scroll
+    self.activateLink = activateLink
+    self.render = render
+    self.stringFree = stringFree
+  }
+
+  deinit {
+    dlclose(library)
+  }
+
+  func decode(_ value: UnsafeMutablePointer<CChar>?) -> NSDictionary? {
+    guard let value else { return nil }
+    defer { stringFree(value) }
+    let data = Data(bytes: value, count: strlen(value))
+    return try? JSONSerialization.jsonObject(with: data) as? NSDictionary
+  }
+}
+
+@objc(MosaicHost)
+final class MosaicHost: NSObject, MosaicHostBridgeObject {
+  private let native: VentureNativeLibrary?
+  private var browser: UnsafeMutableRawPointer?
+  private var contentView: VentureContentView?
+
+  required override init() {
+    let native = VentureNativeLibrary()
+    self.native = native
+    let startURL = ProcessInfo.processInfo.environment["VENTURE_START_URL"]
+      ?? "http://info.cern.ch/"
+    self.browser = startURL.withCString { native?.new($0, 1024, 640) }
+    super.init()
+  }
+
+  deinit {
+    native?.free(browser)
+  }
+
+  func applyProps() -> NSDictionary? {
+    native?.decode(native?.applyProps(browser))
+      ?? ["error": "Venture native bridge is unavailable"]
+  }
+
+  func handleEvent(_ envelope: NSDictionary, name: NSString) -> NSDictionary? {
+    guard let native, let browser else { return applyProps() }
+    let value = envelope["value"] as? String
+    let response = name.utf8String.flatMap { eventName in
+      if let value {
+        return value.withCString { native.handleEvent(browser, eventName, $0) }
+      }
+      return native.handleEvent(browser, eventName, nil)
+    }
+    contentView?.renderPage()
+    return native.decode(response)
+  }
+
+  func node(named name: NSString) -> NSObject? {
+    guard name == "content-surface", native != nil, browser != nil else { return nil }
+    if contentView == nil {
+      contentView = VentureContentView(host: self)
+    }
+    return contentView
+  }
+
+  fileprivate func render(layer: CAMetalLayer) {
+    guard let native, let browser else { return }
+    let rawLayer = Unmanaged.passUnretained(layer).toOpaque()
+    _ = native.render(browser, rawLayer)
+  }
+
+  fileprivate func scroll(by deltaY: Double) {
+    guard let native, let browser, native.scroll(browser, deltaY) != 0 else { return }
+    contentView?.renderPage()
+  }
+
+  fileprivate func activateLink(at point: NSPoint) {
+    guard let native, let browser, native.activateLink(browser, point.x, point.y) != 0 else {
+      return
+    }
+    contentView?.renderPage()
+  }
+}
+
+private final class VentureContentView: NSView {
+  private weak var host: MosaicHost?
+
+  init(host: MosaicHost) {
+    self.host = host
+    super.init(frame: NSRect(x: 0, y: 0, width: 1024, height: 640))
+    wantsLayer = true
+  }
+
+  required init?(coder: NSCoder) {
+    nil
+  }
+
+  override var isFlipped: Bool { true }
+
+  override func makeBackingLayer() -> CALayer {
+    let layer = CAMetalLayer()
+    layer.device = MTLCreateSystemDefaultDevice()
+    layer.pixelFormat = .bgra8Unorm
+    layer.drawableSize = CGSize(width: 1024, height: 640)
+    return layer
+  }
+
+  override func layout() {
+    super.layout()
+    guard let layer = layer as? CAMetalLayer else { return }
+    layer.contentsScale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1
+    layer.drawableSize = CGSize(
+      width: max(1024, bounds.width * layer.contentsScale),
+      height: max(640, bounds.height * layer.contentsScale)
+    )
+    renderPage()
+  }
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    renderPage()
+  }
+
+  override func scrollWheel(with event: NSEvent) {
+    let scale = event.hasPreciseScrollingDeltas ? 1.0 : 40.0
+    host?.scroll(by: -event.scrollingDeltaY * scale)
+  }
+
+  override func mouseUp(with event: NSEvent) {
+    host?.activateLink(at: convert(event.locationInWindow, from: nil))
+  }
+
+  fileprivate func renderPage() {
+    guard let layer = layer as? CAMetalLayer else { return }
+    layer.drawableSize = CGSize(
+      width: max(1024, layer.drawableSize.width),
+      height: max(640, layer.drawableSize.height)
+    )
+    host?.render(layer: layer)
+  }
+}

--- a/code/programs/mosaic/venture-browser/mosaic-package.toml
+++ b/code/programs/mosaic/venture-browser/mosaic-package.toml
@@ -7,5 +7,10 @@ license = "MIT OR Apache-2.0"
 [components]
 exports = ["VentureChrome"]
 
+[host_assets]
+files = [
+  { backend = "swiftui", source = "host/swiftui/MosaicHost.swift", target = "Sources/App/MosaicHost.swift" },
+]
+
 [kernel]
 version = "1"

--- a/code/programs/mosaic/venture-browser/scripts/build-all.ps1
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.ps1
@@ -132,6 +132,22 @@ $isMacOS = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([Sy
 $isLinux = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Linux)
 
 if ($isMacOS -and (Test-Command "swift")) {
+    Write-Host "==> Building Venture macOS native bridge"
+    $bridgeArgs = @("build", "-p", "venture-browser-macos")
+    $bridgeProfile = "debug"
+    if ($Release) {
+        $bridgeArgs += "--release"
+        $bridgeProfile = "release"
+    }
+    Push-Location $rustWorkspace
+    try {
+        Invoke-Checked -Command "cargo" -Arguments $bridgeArgs
+    } finally {
+        Pop-Location
+    }
+    Copy-Item -Force `
+        (Join-Path $rustWorkspace "target/$bridgeProfile/libventure_browser_macos.dylib") `
+        (Join-Path $outputRoot "swiftui/libventure_browser_macos.dylib")
     Write-Host "==> Building swiftui"
     Push-Location (Join-Path $outputRoot "swiftui")
     try {

--- a/code/programs/mosaic/venture-browser/scripts/build-all.sh
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.sh
@@ -138,6 +138,16 @@ fi
 host_os="$(uname -s)"
 
 if [[ "$host_os" == Darwin ]] && has_command swift; then
+  echo "==> Building Venture macOS native bridge"
+  bridge_args=(build -p venture-browser-macos)
+  bridge_profile=debug
+  if ((release)); then
+    bridge_args+=(--release)
+    bridge_profile=release
+  fi
+  (cd "$rust_workspace" && cargo "${bridge_args[@]}")
+  cp "$rust_workspace/target/$bridge_profile/libventure_browser_macos.dylib" \
+    "$output_root/swiftui/libventure_browser_macos.dylib"
   echo "==> Building swiftui"
   (cd "$output_root/swiftui" && swift build)
 elif [[ "$host_os" != Darwin ]]; then

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -89,6 +89,23 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     let package = mosaic_package_manifest::parse(&manifest).expect("parse manifest");
     assert_eq!(package.package.name, "venture-browser");
     assert_eq!(package.components.exports, ["VentureChrome"]);
+    assert_eq!(package.host_assets.files.len(), 1);
+    assert_eq!(package.host_assets.files[0].backend, "swiftui");
+    assert_eq!(
+        package.host_assets.files[0].target,
+        "Sources/App/MosaicHost.swift"
+    );
+
+    let host = read_package_file("host/swiftui/MosaicHost.swift");
+    for symbol in [
+        "venture_browser_macos_apply_props",
+        "venture_browser_macos_handle_event",
+        "venture_browser_macos_render",
+        "venture_browser_macos_scroll",
+        "venture_browser_macos_activate_link",
+    ] {
+        assert!(host.contains(symbol), "SwiftUI host omits {symbol}");
+    }
 }
 
 #[test]
@@ -125,6 +142,8 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "npm run build",
         "node --check",
         "swift build",
+        "cargo \"${bridge_args[@]}\"",
+        "libventure_browser_macos.dylib",
         "cmake --build",
         "dotnet build",
         "flutter build",
@@ -138,6 +157,8 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "npm",
         "node",
         "swift",
+        "venture-browser-macos",
+        "libventure_browser_macos.dylib",
         "cmake",
         "dotnet",
         "flutter",

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -93,12 +93,14 @@ now use top-left viewport coordinates to activate links through transactional
 page loads, update the title, and repaint across repeated navigation. Named
 AppKit navigation keys now drive clamped viewport scrolling and Metal repaint.
 Command-Left/Right now reload Back/Forward history entries through the shared
-transactional session, update the native title, and repaint. Implementing the
-concrete `MosaicHost` adapters that join the generated chrome,
-`BrowserChromeController`, and live Venture page renderer remains before the
-shell is runnable end to end. Resize/reflow, richer pointer behavior, and direct
-macOS and Windows build/interaction acceptance also remain before the browser
-shell is complete.
+transactional session, update the native title, and repaint. The first concrete
+`MosaicHost` adapter now joins the generated SwiftUI chrome,
+`BrowserChromeController`, and live Metal Venture page renderer through a thin
+dynamic Rust bridge. It carries address and navigation events, native scrolling,
+and link activation through one browser session without handwritten AppKit
+chrome. Direct launch/interaction acceptance, resize/reflow, the equivalent
+Windows adapter, and the remaining platform hosts still remain before the
+browser shell is complete.
 
 ## Where It Fits
 


### PR DESCRIPTION
## Summary
- install a package-owned SwiftUI `MosaicHost` into Venture's generated project shell
- expose a thin Rust dynamic bridge that keeps Mosaic events, `BrowserChromeController`, navigation, scrolling, link activation, and Metal page rendering in one browser session
- build/copy the bridge in the cross-platform backend matrix and document the remaining Windows/direct interaction work

## Validation
- `cargo clippy -p venture-browser-macos --all-targets -- -D warnings`
- `cargo test -p venture-browser-core -- --nocapture`
- `cargo test -p venture-browser-macos -- --nocapture`
- `cargo test` in `code/programs/mosaic/venture-browser`
- exhaustive `Backend::ALL` Venture artifact-builder acceptance
- all nine Venture projects emitted; generated SwiftPM app built and launched with `libventure_browser_macos.dylib`
- Qt QML validated with `qmllint` (CMake unavailable on this host; direct Qt build remains covered by #9394)
- live WPT/html5lib audit: tree-construction missing 0; tokenizer missing 0; normalized skipped 0

This is a bounded browser-wiring milestone, not a claim of full browser or HTML conformance. Windows and the remaining native host adapters still follow.