### PR TITLE
feat(smart-home): add operational dashboard

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -887,6 +887,7 @@ members = [
     "md5-native-jni",
     "irc-server-capi",
     "smart-home-core",
+    "smart-home-dashboard-core",
     "smart-home-capability-cage",
     "smart-home-discovery",
     "smart-home-discovery-service",

--- a/code/packages/rust/smart-home-dashboard-core/BUILD
+++ b/code/packages/rust/smart-home-dashboard-core/BUILD
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+cargo test -p smart-home-dashboard-core
+cargo clippy -p smart-home-dashboard-core --all-targets -- -D warnings

--- a/code/packages/rust/smart-home-dashboard-core/BUILD
+++ b/code/packages/rust/smart-home-dashboard-core/BUILD
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-cd "$(dirname "$0")/.."
-cargo test -p smart-home-dashboard-core
-cargo clippy -p smart-home-dashboard-core --all-targets -- -D warnings
+cargo test -p smart-home-dashboard-core -- --nocapture

--- a/code/packages/rust/smart-home-dashboard-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-dashboard-core/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add versioned native dashboard, view, card, and source-resource contracts.
+- Parse raw manifests and applied Home Assistant dashboard migration artifacts.
+- Validate identifiers and summarize dashboard content.

--- a/code/packages/rust/smart-home-dashboard-core/Cargo.toml
+++ b/code/packages/rust/smart-home-dashboard-core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "smart-home-dashboard-core"
+version = "0.1.0"
+edition = "2021"
+description = "Protocol-neutral native dashboard manifest contracts for the smart-home platform"
+license = "MIT"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/code/packages/rust/smart-home-dashboard-core/README.md
+++ b/code/packages/rust/smart-home-dashboard-core/README.md
@@ -1,0 +1,14 @@
+# smart-home-dashboard-core
+
+Shared native smart-home dashboard manifest contracts.
+
+The package owns the versioned manifest shape used by Home Assistant dashboard
+migration and the operational local controller. It accepts either an applied
+migration artifact or a raw native manifest, rejects dry-run artifacts, and
+validates identifiers before the dashboard is served.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/smart-home-dashboard-core/src/lib.rs
+++ b/code/packages/rust/smart-home-dashboard-core/src/lib.rs
@@ -1,0 +1,301 @@
+//! Native dashboard manifest contracts shared by migration and runtime clients.
+
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fmt;
+
+pub const DASHBOARD_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeDashboardCardKind {
+    EntityControl,
+    EntityList,
+    History,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeDashboardCard {
+    pub card_id: String,
+    pub kind: NativeDashboardCardKind,
+    pub source_type: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    pub entity_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeDashboardView {
+    pub view_id: String,
+    pub title: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub icon: Option<String>,
+    pub cards: Vec<NativeDashboardCard>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeDashboard {
+    pub dashboard_id: String,
+    pub url_path: String,
+    pub title: String,
+    #[serde(default)]
+    pub icon: Option<String>,
+    pub require_admin: bool,
+    pub show_in_sidebar: bool,
+    pub views: Vec<NativeDashboardView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HomeAssistantDashboardResource {
+    pub resource_id: String,
+    pub url: String,
+    pub resource_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NativeDashboardManifest {
+    pub schema_version: u32,
+    pub source_instance_id: String,
+    pub generated_at_ms: u64,
+    pub dashboards: Vec<NativeDashboard>,
+    pub source_resources: Vec<HomeAssistantDashboardResource>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct NativeDashboardManifestSummary {
+    pub dashboards: usize,
+    pub views: usize,
+    pub cards: usize,
+    pub entity_references: usize,
+    pub source_resources: usize,
+}
+
+impl NativeDashboardManifest {
+    pub fn validate(&self) -> Result<(), DashboardManifestError> {
+        if self.schema_version != DASHBOARD_MANIFEST_SCHEMA_VERSION {
+            return Err(DashboardManifestError::Validation(format!(
+                "unsupported dashboard manifest schema version {}",
+                self.schema_version
+            )));
+        }
+        require_non_empty("source_instance_id", &self.source_instance_id)?;
+
+        let mut dashboard_ids = BTreeSet::new();
+        let mut view_ids = BTreeSet::new();
+        let mut card_ids = BTreeSet::new();
+        for dashboard in &self.dashboards {
+            require_non_empty("dashboard_id", &dashboard.dashboard_id)?;
+            require_non_empty("dashboard title", &dashboard.title)?;
+            require_non_empty("dashboard url_path", &dashboard.url_path)?;
+            if !dashboard_ids.insert(dashboard.dashboard_id.as_str()) {
+                return Err(DashboardManifestError::Validation(format!(
+                    "duplicate dashboard_id `{}`",
+                    dashboard.dashboard_id
+                )));
+            }
+            for view in &dashboard.views {
+                require_non_empty("view_id", &view.view_id)?;
+                require_non_empty("view title", &view.title)?;
+                if !view_ids.insert((dashboard.dashboard_id.as_str(), view.view_id.as_str())) {
+                    return Err(DashboardManifestError::Validation(format!(
+                        "duplicate view_id `{}` in dashboard `{}`",
+                        view.view_id, dashboard.dashboard_id
+                    )));
+                }
+                for card in &view.cards {
+                    require_non_empty("card_id", &card.card_id)?;
+                    require_non_empty("card source_type", &card.source_type)?;
+                    if !card_ids.insert((
+                        dashboard.dashboard_id.as_str(),
+                        view.view_id.as_str(),
+                        card.card_id.as_str(),
+                    )) {
+                        return Err(DashboardManifestError::Validation(format!(
+                            "duplicate card_id `{}` in view `{}`",
+                            card.card_id, view.view_id
+                        )));
+                    }
+                    if card
+                        .entity_ids
+                        .iter()
+                        .any(|entity_id| entity_id.trim().is_empty())
+                    {
+                        return Err(DashboardManifestError::Validation(format!(
+                            "card `{}` contains an empty entity id",
+                            card.card_id
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn summary(&self) -> NativeDashboardManifestSummary {
+        let mut summary = NativeDashboardManifestSummary {
+            dashboards: self.dashboards.len(),
+            source_resources: self.source_resources.len(),
+            ..NativeDashboardManifestSummary::default()
+        };
+        for dashboard in &self.dashboards {
+            summary.views += dashboard.views.len();
+            for view in &dashboard.views {
+                summary.cards += view.cards.len();
+                summary.entity_references += view
+                    .cards
+                    .iter()
+                    .map(|card| card.entity_ids.len())
+                    .sum::<usize>();
+            }
+        }
+        summary
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum DashboardManifestDocument {
+    Manifest(NativeDashboardManifest),
+    MigrationArtifact {
+        dry_run: bool,
+        plan: DashboardManifestPlan,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct DashboardManifestPlan {
+    manifest: NativeDashboardManifest,
+}
+
+pub fn parse_dashboard_manifest(
+    bytes: &[u8],
+) -> Result<NativeDashboardManifest, DashboardManifestError> {
+    let document: DashboardManifestDocument = serde_json::from_slice(bytes)
+        .map_err(|error| DashboardManifestError::Decode(error.to_string()))?;
+    let manifest = match document {
+        DashboardManifestDocument::Manifest(manifest) => manifest,
+        DashboardManifestDocument::MigrationArtifact { dry_run, plan } => {
+            if dry_run {
+                return Err(DashboardManifestError::Validation(
+                    "dry-run dashboard migration artifacts cannot be served".to_string(),
+                ));
+            }
+            plan.manifest
+        }
+    };
+    manifest.validate()?;
+    Ok(manifest)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DashboardManifestError {
+    Decode(String),
+    Validation(String),
+}
+
+impl fmt::Display for DashboardManifestError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decode(message) => {
+                write!(formatter, "dashboard manifest decode failed: {message}")
+            }
+            Self::Validation(message) => write!(formatter, "invalid dashboard manifest: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for DashboardManifestError {}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), DashboardManifestError> {
+    if value.trim().is_empty() {
+        Err(DashboardManifestError::Validation(format!(
+            "{field} must not be empty"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest() -> NativeDashboardManifest {
+        NativeDashboardManifest {
+            schema_version: DASHBOARD_MANIFEST_SCHEMA_VERSION,
+            source_instance_id: "home".to_string(),
+            generated_at_ms: 42,
+            dashboards: vec![NativeDashboard {
+                dashboard_id: "overview".to_string(),
+                url_path: "lovelace".to_string(),
+                title: "Overview".to_string(),
+                icon: None,
+                require_admin: false,
+                show_in_sidebar: true,
+                views: vec![NativeDashboardView {
+                    view_id: "home".to_string(),
+                    title: "Home".to_string(),
+                    path: None,
+                    icon: None,
+                    cards: vec![NativeDashboardCard {
+                        card_id: "lights".to_string(),
+                        kind: NativeDashboardCardKind::EntityList,
+                        source_type: "entities".to_string(),
+                        title: Some("Lights".to_string()),
+                        entity_ids: vec!["ha:light.kitchen".to_string()],
+                    }],
+                }],
+            }],
+            source_resources: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn parses_raw_and_applied_migration_documents() {
+        let expected = manifest();
+        let raw = serde_json::to_vec(&expected).unwrap();
+        assert_eq!(parse_dashboard_manifest(&raw).unwrap(), expected);
+
+        let artifact = serde_json::json!({
+            "schema_version": 1,
+            "dry_run": false,
+            "plan": {"manifest": expected},
+            "receipt": {"migration_id": "migration-1"}
+        });
+        assert_eq!(
+            parse_dashboard_manifest(&serde_json::to_vec(&artifact).unwrap()).unwrap(),
+            manifest()
+        );
+    }
+
+    #[test]
+    fn rejects_dry_runs_and_duplicate_ids() {
+        let dry_run = serde_json::json!({
+            "dry_run": true,
+            "plan": {"manifest": manifest()}
+        });
+        assert!(parse_dashboard_manifest(&serde_json::to_vec(&dry_run).unwrap()).is_err());
+
+        let mut duplicate = manifest();
+        duplicate.dashboards.push(duplicate.dashboards[0].clone());
+        assert!(duplicate.validate().is_err());
+    }
+
+    #[test]
+    fn summarizes_manifest_content() {
+        assert_eq!(
+            manifest().summary(),
+            NativeDashboardManifestSummary {
+                dashboards: 1,
+                views: 1,
+                cards: 1,
+                entity_references: 1,
+                source_resources: 0,
+            }
+        );
+    }
+}

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1.0
 
+- Share the native manifest contract with the operational dashboard through
+  `smart-home-dashboard-core`.
 - Add authenticated collection of Lovelace dashboard metadata, configurations,
   and frontend resources through Home Assistant's WebSocket API.
 - Add deterministic compilation of standard entity, control, and history cards

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/Cargo.toml
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 coding_adventures_sha256 = { path = "../sha256" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+smart-home-dashboard-core = { path = "../smart-home-dashboard-core" }
 smart-home-home-assistant-migration = { path = "../smart-home-home-assistant-migration" }
 tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/README.md
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/README.md
@@ -6,6 +6,9 @@ repository-owned dashboard manifest. It uses the concrete
 `lovelace/dashboards/list`, `lovelace/config`, and
 `lovelace/resources/list` WebSocket commands.
 
+The manifest contract is owned by `smart-home-dashboard-core`, so migration
+output and the operational local dashboard share one validated schema.
+
 Standard entity, light, thermostat, sensor, tile, button, entities, glance,
 and history-graph cards are compiled to native entity-control, entity-list,
 and history widgets. Vertical stacks, horizontal stacks, grids, and section

--- a/code/packages/rust/smart-home-home-assistant-dashboard-migration/src/lib.rs
+++ b/code/packages/rust/smart-home-home-assistant-dashboard-migration/src/lib.rs
@@ -5,6 +5,10 @@
 use coding_adventures_sha256::sha256_hex;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
+pub use smart_home_dashboard_core::{
+    HomeAssistantDashboardResource, NativeDashboard, NativeDashboardCard, NativeDashboardCardKind,
+    NativeDashboardManifest, NativeDashboardView,
+};
 use smart_home_home_assistant_migration::{HomeAssistantExport, EXPORT_SCHEMA_VERSION};
 use std::collections::BTreeSet;
 use std::fmt;
@@ -16,7 +20,8 @@ use std::time::Duration;
 use tungstenite::stream::MaybeTlsStream;
 use tungstenite::{connect, Message, WebSocket};
 
-pub const DASHBOARD_MIGRATION_SCHEMA_VERSION: u32 = 1;
+pub const DASHBOARD_MIGRATION_SCHEMA_VERSION: u32 =
+    smart_home_dashboard_core::DASHBOARD_MANIFEST_SCHEMA_VERSION;
 const MAX_UNMATCHED_MESSAGES: usize = 64;
 
 type HomeAssistantSocket = WebSocket<MaybeTlsStream<TcpStream>>;
@@ -70,63 +75,6 @@ pub struct DashboardDiagnostic {
     pub source_id: String,
     pub code: String,
     pub message: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum NativeDashboardCardKind {
-    EntityControl,
-    EntityList,
-    History,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NativeDashboardCard {
-    pub card_id: String,
-    pub kind: NativeDashboardCardKind,
-    pub source_type: String,
-    #[serde(default)]
-    pub title: Option<String>,
-    pub entity_ids: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NativeDashboardView {
-    pub view_id: String,
-    pub title: String,
-    #[serde(default)]
-    pub path: Option<String>,
-    #[serde(default)]
-    pub icon: Option<String>,
-    pub cards: Vec<NativeDashboardCard>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NativeDashboard {
-    pub dashboard_id: String,
-    pub url_path: String,
-    pub title: String,
-    #[serde(default)]
-    pub icon: Option<String>,
-    pub require_admin: bool,
-    pub show_in_sidebar: bool,
-    pub views: Vec<NativeDashboardView>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct HomeAssistantDashboardResource {
-    pub resource_id: String,
-    pub url: String,
-    pub resource_type: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NativeDashboardManifest {
-    pub schema_version: u32,
-    pub source_instance_id: String,
-    pub generated_at_ms: u64,
-    pub dashboards: Vec<NativeDashboard>,
-    pub source_resources: Vec<HomeAssistantDashboardResource>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Added an operational browser dashboard for native migrated views, runtime
+  inventory and health, automation definitions and audit, pairing sessions,
+  state history, and command/authorization audit. The durable controller can
+  load validated raw or applied dashboard manifests before binding.
+- Added native dashboard-manifest and pairing-session list/detail routes.
 - Added a restart-safe automation runtime to the production controller, a local
   schedule worker, and native definition, evaluation, dry-run, and audit API
   routes with atomic persistence rollback.

--- a/code/packages/rust/smart-home-platform-http/Cargo.toml
+++ b/code/packages/rust/smart-home-platform-http/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smart-home-automation-runtime = { path = "../smart-home-automation-runtime" }
 smart-home-core = { path = "../smart-home-core" }
+smart-home-dashboard-core = { path = "../smart-home-dashboard-core" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 smart-home-runtime-store = { path = "../smart-home-runtime-store" }
 storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -25,6 +25,7 @@ stable local API responses for:
 - `/api/smart_home/readiness`
 - `/api/smart_home/controller_handoff`
 - `/api/smart_home/dashboard`
+- `/api/smart_home/dashboard_manifest`
 - `/api/smart_home/bootstrap`
 - `/api/smart_home/smoke`
 - `/api/smart_home/smoke_script`
@@ -40,6 +41,8 @@ stable local API responses for:
 - `/api/smart_home/devices/:device_id`
 - `/api/smart_home/bridges`
 - `/api/smart_home/bridges/:bridge_id`
+- `/api/smart_home/pairing_sessions`
+- `/api/smart_home/pairing_sessions/:session_id`
 - `/api/smart_home/rooms`
 - `/api/smart_home/rooms/:room_id`
 - `/api/smart_home/scenes`
@@ -61,6 +64,8 @@ stable local API responses for:
 - `DELETE /api/smart_home/desired_states/:entity_id`
 - `/api/smart_home/state_history`
 - `/api/smart_home/state_history/:event_id`
+- `/api/smart_home/automations`
+- `/api/smart_home/automation_audit`
 
 `POST /api/services/:domain/:service` accepts Home Assistant-style JSON targets
 and dispatches through `SmartHomeRuntime::execute_command_tool`, so runtime
@@ -122,10 +127,12 @@ to use for fixture-controller verification without scraping launch text.
 `sh` script using `curl`; set `SMART_HOME_BASE_URL` or `CURL` to override the
 defaults when the fixture controller runs on a custom address.
 
-The browser routes serve an embedded local dashboard shell over the same
-`web-core::WebApp`. The shell loads bootstrap, readiness, state, scene,
+The browser routes serve an embedded operational dashboard over the same
+`web-core::WebApp`. The shell loads bootstrap, readiness, native dashboard
+manifests, state, scene,
 desired-state, room, device, bridge, state-history, command-result audit,
-runtime event-log, authorization audit, capability-grant inventory, service
+runtime event-log, automation definitions and audit, pairing sessions,
+authorization audit, capability-grant inventory, service
 catalog, capability catalog, API catalog, and audit summary data from the
 native API routes and sends light on/off, light brightness, scene, and
 desired-state set/clear actions through the existing Home
@@ -178,6 +185,7 @@ reopen bounded replay slices without fetching the full audit tail.
 ## Dependencies
 
 - embeddable-http-server
+- smart-home-dashboard-core
 - smart-home-core
 - smart-home-runtime
 - smart-home-runtime-store
@@ -198,10 +206,14 @@ Run the production local controller against a durable runtime folder:
 ```bash
 cargo run -p smart-home-platform-http --bin smart-home-local-controller -- \
   --data-dir "$HOME/.coding-adventures/smart-home" \
+  --dashboard-manifest "$HOME/.coding-adventures/smart-home/dashboards.json" \
   --bind 127.0.0.1:8123
 ```
 
 `SMART_HOME_DATA_DIR` supplies the data folder when `--data-dir` is omitted.
+`SMART_HOME_DASHBOARD_MANIFEST` supplies the applied migration artifact or raw
+native manifest when `--dashboard-manifest` is omitted. Invalid and dry-run
+artifacts are rejected before the controller binds.
 The controller loads the latest `smart-home-runtime-store` snapshot before it
 binds, restores automation definitions, consumed trigger occurrences, and
 automation audit, uses wall-clock request timestamps, and saves the local API
@@ -258,6 +270,7 @@ curl http://127.0.0.1:8123/api/smart_home/health
 curl http://127.0.0.1:8123/api/smart_home/readiness
 curl http://127.0.0.1:8123/api/smart_home/controller_handoff
 curl http://127.0.0.1:8123/api/smart_home/dashboard
+curl http://127.0.0.1:8123/api/smart_home/dashboard_manifest
 curl http://127.0.0.1:8123/api/smart_home/bootstrap
 curl http://127.0.0.1:8123/api/smart_home/smoke
 curl http://127.0.0.1:8123/api/smart_home/smoke_script
@@ -276,6 +289,7 @@ curl 'http://127.0.0.1:8123/api/smart_home/entities?room_id=kitchen'
 curl 'http://127.0.0.1:8123/api/smart_home/capabilities?domain=light&commandable=true'
 curl 'http://127.0.0.1:8123/api/smart_home/devices?room_id=kitchen&health=online'
 curl 'http://127.0.0.1:8123/api/smart_home/bridges?integration_id=hue&transport=lan_http'
+curl 'http://127.0.0.1:8123/api/smart_home/pairing_sessions?status=pending_user_presence'
 curl 'http://127.0.0.1:8123/api/smart_home/rooms?sort=scene_count&state_gaps_only=true'
 curl 'http://127.0.0.1:8123/api/smart_home/rooms/kitchen'
 curl 'http://127.0.0.1:8123/api/smart_home/scenes?room_id=kitchen&scope=room'

--- a/code/packages/rust/smart-home-platform-http/examples/hue_fixture_controller.rs
+++ b/code/packages/rust/smart-home-platform-http/examples/hue_fixture_controller.rs
@@ -1,13 +1,22 @@
 use embeddable_http_server::HttpServerOptions;
+use smart_home_automation_runtime::{
+    AutomationAction, AutomationDefinition, AutomationTrigger, SmartHomeAutomationRuntime,
+};
+use smart_home_core::{AgentId, CommandType, EntityId, Value};
+use smart_home_dashboard_core::{
+    NativeDashboard, NativeDashboardCard, NativeDashboardCardKind, NativeDashboardManifest,
+    NativeDashboardView, DASHBOARD_MANIFEST_SCHEMA_VERSION,
+};
 use smart_home_platform_http::{
     home_assistant_runtime_web_app, SmartHomePlatformHttpConfig, SmartHomePlatformHttpRuntime,
 };
+use smart_home_runtime::{RuntimePairingSession, RuntimePairingSessionId};
 use smart_home_testkit::hue_lighting_runtime;
 use std::env;
 use std::error::Error;
 use std::io;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use web_core::WebServer;
 
 const DEFAULT_BIND_ADDR: &str = "127.0.0.1:8123";
@@ -19,11 +28,46 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("{USAGE}");
         return Ok(());
     };
+    let mut fixture = hue_lighting_runtime();
+    let bridge = fixture
+        .registry()
+        .bridges()
+        .next()
+        .cloned()
+        .ok_or_else(|| io::Error::other("fixture has no bridge"))?;
+    fixture.start_pairing_session(RuntimePairingSession::pending(
+        RuntimePairingSessionId::trusted("pairing-fixture-1"),
+        &bridge,
+        AgentId::trusted("agent:fixture-operator"),
+        4_000,
+        15_000,
+        Vec::new(),
+    ))?;
+
+    let mut automations = SmartHomeAutomationRuntime::new();
+    automations.upsert_definition(AutomationDefinition {
+        automation_id: "fixture-nightly-off".to_string(),
+        enabled: true,
+        trigger: AutomationTrigger::Schedule {
+            every_ms: 86_400_000,
+            offset_ms: 0,
+        },
+        conditions: Vec::new(),
+        actions: vec![AutomationAction::Command {
+            entity_id: EntityId::trusted("entity-light-1"),
+            command_type: CommandType::TurnOff,
+            arguments: Value::Bool(false),
+            timeout_ms: None,
+        }],
+    })?;
+
     let runtime = SmartHomePlatformHttpRuntime::new(
-        hue_lighting_runtime(),
+        fixture,
         SmartHomePlatformHttpConfig::new("Codex Home").with_time_zone("America/Los_Angeles"),
     )
     .with_now_ms(5_000)
+    .with_automation_runtime(Arc::new(Mutex::new(automations)))
+    .with_dashboard_manifest(fixture_dashboard_manifest())
     .grant_local_full_access("hue-fixture-controller", 1_000);
     let app = Arc::new(home_assistant_runtime_web_app(runtime));
     let options = dashboard_server_options();
@@ -46,6 +90,36 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("{}", launch_guide(server.local_addr()));
     server.serve()?;
     Ok(())
+}
+
+fn fixture_dashboard_manifest() -> NativeDashboardManifest {
+    NativeDashboardManifest {
+        schema_version: DASHBOARD_MANIFEST_SCHEMA_VERSION,
+        source_instance_id: "fixture-home-assistant".to_string(),
+        generated_at_ms: 5_000,
+        dashboards: vec![NativeDashboard {
+            dashboard_id: "fixture-overview".to_string(),
+            url_path: "lovelace".to_string(),
+            title: "Fixture Overview".to_string(),
+            icon: None,
+            require_admin: false,
+            show_in_sidebar: true,
+            views: vec![NativeDashboardView {
+                view_id: "living-room".to_string(),
+                title: "Living Room".to_string(),
+                path: Some("living-room".to_string()),
+                icon: None,
+                cards: vec![NativeDashboardCard {
+                    card_id: "living-room-light".to_string(),
+                    kind: NativeDashboardCardKind::EntityControl,
+                    source_type: "light".to_string(),
+                    title: Some("Living Room Light".to_string()),
+                    entity_ids: vec!["entity-light-1".to_string()],
+                }],
+            }],
+        }],
+        source_resources: Vec::new(),
+    }
 }
 
 fn dashboard_server_options() -> HttpServerOptions {

--- a/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
+++ b/code/packages/rust/smart-home-platform-http/src/bin/smart-home-local-controller.rs
@@ -1,5 +1,6 @@
 use embeddable_http_server::HttpServerOptions;
 use smart_home_automation_runtime::{AutomationTriggerInput, SmartHomeAutomationRuntime};
+use smart_home_dashboard_core::parse_dashboard_manifest;
 use smart_home_platform_http::{
     home_assistant_runtime_web_app, SmartHomePlatformHttpConfig, SmartHomePlatformHttpRuntime,
 };
@@ -7,6 +8,7 @@ use smart_home_runtime::SmartHomeRuntime;
 use smart_home_runtime_store::SmartHomeRuntimeStore;
 use std::env;
 use std::error::Error;
+use std::fs;
 use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -19,21 +21,28 @@ use web_core::WebServer;
 const DEFAULT_BIND_ADDR: &str = "127.0.0.1:8123";
 const DEFAULT_DATA_DIR: &str = ".smart-home";
 const DASHBOARD_PENDING_WRITE_BYTES: usize = 256 * 1024;
-const USAGE: &str = "Usage: smart-home-local-controller [--bind ADDRESS] [--data-dir PATH]\n\
+const USAGE: &str = "Usage: smart-home-local-controller [--bind ADDRESS] [--data-dir PATH] [--dashboard-manifest PATH]\n\
                        \n\
                        Options:\n\
                          --bind ADDRESS   Local listen address (default: 127.0.0.1:8123)\n\
                          --data-dir PATH  Durable runtime folder (default: SMART_HOME_DATA_DIR or .smart-home)\n\
+                         --dashboard-manifest PATH  Applied native dashboard manifest (default: SMART_HOME_DASHBOARD_MANIFEST)\n\
                          -h, --help       Show this help";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ControllerConfig {
     bind_addr: String,
     data_dir: PathBuf,
+    dashboard_manifest: Option<PathBuf>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let Some(config) = config_from_args(env::args().skip(1), default_data_dir())? else {
+    let Some(config) = config_from_args(
+        env::args().skip(1),
+        default_data_dir(),
+        env::var_os("SMART_HOME_DASHBOARD_MANIFEST").map(PathBuf::from),
+    )?
+    else {
         println!("{USAGE}");
         return Ok(());
     };
@@ -60,7 +69,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let persistence_store = Arc::clone(&store);
     let persistence_automations = Arc::clone(&automation_runtime);
     let automation_persistence_store = Arc::clone(&store);
-    let runtime = SmartHomePlatformHttpRuntime::from_shared_runtime(
+    let mut runtime = SmartHomePlatformHttpRuntime::from_shared_runtime(
         Arc::clone(&shared_runtime),
         SmartHomePlatformHttpConfig::new("Codex Home"),
     )
@@ -94,6 +103,20 @@ fn main() -> Result<(), Box<dyn Error>> {
             .map_err(|error| error.to_string())
     })
     .grant_local_full_access("smart-home-local-controller", unix_time_ms());
+
+    if let Some(path) = config.dashboard_manifest.as_ref() {
+        let bytes = fs::read(path).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!(
+                    "could not read dashboard manifest {}: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+        let manifest = parse_dashboard_manifest(&bytes).map_err(io::Error::other)?;
+        runtime = runtime.with_dashboard_manifest(manifest);
+    }
 
     {
         let runtime = shared_runtime.lock().map_err(|_| {
@@ -165,9 +188,11 @@ fn default_data_dir() -> PathBuf {
 fn config_from_args(
     args: impl IntoIterator<Item = String>,
     default_data_dir: PathBuf,
+    default_dashboard_manifest: Option<PathBuf>,
 ) -> Result<Option<ControllerConfig>, io::Error> {
     let mut bind_addr = DEFAULT_BIND_ADDR.to_string();
     let mut data_dir = default_data_dir;
+    let mut dashboard_manifest = default_dashboard_manifest;
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -178,12 +203,24 @@ fn config_from_args(
             "--data-dir" => {
                 data_dir = PathBuf::from(required_value(&mut args, "--data-dir")?);
             }
+            "--dashboard-manifest" => {
+                dashboard_manifest = Some(PathBuf::from(required_value(
+                    &mut args,
+                    "--dashboard-manifest",
+                )?));
+            }
             _ if arg.starts_with("--bind=") => {
                 bind_addr = non_empty_value(&arg["--bind=".len()..], "--bind")?.to_string();
             }
             _ if arg.starts_with("--data-dir=") => {
                 data_dir =
                     PathBuf::from(non_empty_value(&arg["--data-dir=".len()..], "--data-dir")?);
+            }
+            _ if arg.starts_with("--dashboard-manifest=") => {
+                dashboard_manifest = Some(PathBuf::from(non_empty_value(
+                    &arg["--dashboard-manifest=".len()..],
+                    "--dashboard-manifest",
+                )?));
             }
             _ => return Err(invalid_input(format!("unknown argument `{arg}`"))),
         }
@@ -194,6 +231,7 @@ fn config_from_args(
     Ok(Some(ControllerConfig {
         bind_addr,
         data_dir,
+        dashboard_manifest,
     }))
 }
 
@@ -263,10 +301,12 @@ mod tests {
     #[test]
     fn config_defaults_to_loopback_and_supplied_data_dir() {
         assert_eq!(
-            config_from_args(Vec::<String>::new(), test_default_dir()).expect("default config"),
+            config_from_args(Vec::<String>::new(), test_default_dir(), None)
+                .expect("default config"),
             Some(ControllerConfig {
                 bind_addr: DEFAULT_BIND_ADDR.to_string(),
                 data_dir: test_default_dir(),
+                dashboard_manifest: None,
             })
         );
     }
@@ -281,24 +321,58 @@ mod tests {
                     "/tmp/codex-home".to_string(),
                 ],
                 test_default_dir(),
+                None,
             )
             .expect("explicit config"),
             Some(ControllerConfig {
                 bind_addr: "127.0.0.1:9123".to_string(),
                 data_dir: PathBuf::from("/tmp/codex-home"),
+                dashboard_manifest: None,
             })
+        );
+    }
+
+    #[test]
+    fn config_accepts_dashboard_manifest_argument_and_default() {
+        assert_eq!(
+            config_from_args(
+                ["--dashboard-manifest=/tmp/dashboard.json".to_string()],
+                test_default_dir(),
+                None,
+            )
+            .expect("manifest config")
+            .unwrap()
+            .dashboard_manifest,
+            Some(PathBuf::from("/tmp/dashboard.json"))
+        );
+        assert_eq!(
+            config_from_args(
+                Vec::<String>::new(),
+                test_default_dir(),
+                Some(PathBuf::from("/tmp/default-dashboard.json")),
+            )
+            .expect("default manifest config")
+            .unwrap()
+            .dashboard_manifest,
+            Some(PathBuf::from("/tmp/default-dashboard.json"))
         );
     }
 
     #[test]
     fn config_handles_help_and_rejects_invalid_options() {
         assert_eq!(
-            config_from_args(["--help".to_string()], test_default_dir()).expect("help"),
+            config_from_args(["--help".to_string()], test_default_dir(), None).expect("help"),
             None
         );
-        assert!(config_from_args(["--bind".to_string()], test_default_dir()).is_err());
-        assert!(config_from_args(["--data-dir=".to_string()], test_default_dir()).is_err());
-        assert!(config_from_args(["--unknown".to_string()], test_default_dir()).is_err());
+        assert!(config_from_args(["--bind".to_string()], test_default_dir(), None).is_err());
+        assert!(config_from_args(["--data-dir=".to_string()], test_default_dir(), None).is_err());
+        assert!(config_from_args(
+            ["--dashboard-manifest=".to_string()],
+            test_default_dir(),
+            None,
+        )
+        .is_err());
+        assert!(config_from_args(["--unknown".to_string()], test_default_dir(), None).is_err());
     }
 
     #[test]

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -19,18 +19,21 @@ use smart_home_core::{
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
     CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device,
     DeviceCommand, DeviceEvent, DeviceEventType, Entity, EntityId, EntityKind, EventId, Health,
-    PrivilegeTier, Scene, SceneScope, SmartHomeTool, StateConfidence, StateDelta, StateSource,
-    Value, ValueKind,
+    IntegrationId, PrivilegeTier, Scene, SceneScope, SmartHomeTool, StateConfidence, StateDelta,
+    StateSource, Value, ValueKind,
 };
+use smart_home_dashboard_core::NativeDashboardManifest;
 use smart_home_runtime::{
-    DesiredEntityState, DesiredStateQuery, RuntimeAuthorizationDecisionQuery,
+    DesiredEntityState, DesiredStateQuery, PairingSessionStatus, RuntimeAuthorizationDecisionQuery,
     RuntimeAuthorizationDecisionSort, RuntimeCapabilityGrantQuery, RuntimeCapabilityGrantScopeKind,
     RuntimeCapabilityGrantSort, RuntimeClearDesiredStateToolOutput,
     RuntimeClearDesiredStateToolRequest, RuntimeCommandResultQuery, RuntimeCommandResultRecord,
     RuntimeCommandResultSort, RuntimeCommandToolRequest, RuntimeError, RuntimeEvent,
     RuntimeEventCheckpoint, RuntimeEventFilter, RuntimeEventLogEntry, RuntimeEventQuery,
-    RuntimeEventSort, RuntimeReadSnapshot, RuntimeRoomQuery, RuntimeRoomSort, RuntimeRoomSummary,
-    RuntimeSetDesiredStateToolOutput, RuntimeSetDesiredStateToolRequest, SmartHomeRuntime,
+    RuntimeEventSort, RuntimePairingSession, RuntimePairingSessionId, RuntimePairingSessionQuery,
+    RuntimePairingSessionSort, RuntimeReadSnapshot, RuntimeRoomQuery, RuntimeRoomSort,
+    RuntimeRoomSummary, RuntimeSetDesiredStateToolOutput, RuntimeSetDesiredStateToolRequest,
+    SmartHomeRuntime,
 };
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
@@ -89,6 +92,29 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       background: #f9fbfa;
     }
 
+    .section-tabs {
+      display: flex;
+      gap: 4px;
+      overflow-x: auto;
+      padding: 8px 16px;
+      border-bottom: 1px solid var(--line);
+      background: #ffffff;
+    }
+
+    .section-tabs a {
+      flex: 0 0 auto;
+      padding: 7px 10px;
+      color: var(--ink);
+      text-decoration: none;
+      border-bottom: 2px solid transparent;
+      font-weight: 700;
+    }
+
+    .section-tabs a:hover,
+    .section-tabs a:focus-visible {
+      border-bottom-color: var(--teal);
+    }
+
     h1, h2, h3, p {
       margin: 0;
     }
@@ -119,13 +145,20 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       display: grid;
       gap: 12px;
       align-content: start;
+      min-width: 0;
     }
 
     .panel {
+      min-width: 0;
+      overflow-x: auto;
       background: var(--panel);
       border: 1px solid var(--line);
       border-radius: 8px;
       padding: 14px;
+    }
+
+    .panel > * {
+      min-width: 0;
     }
 
     .toolbar, .row, .metric-grid {
@@ -133,6 +166,19 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       gap: 8px;
       align-items: center;
       flex-wrap: wrap;
+    }
+
+    .row > div {
+      min-width: 0;
+    }
+
+    #checks .row > div {
+      flex: 1 1 180px;
+      min-width: 0;
+    }
+
+    h3, p, td {
+      overflow-wrap: anywhere;
     }
 
     .metric-grid {
@@ -267,6 +313,25 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       background: #fbfcfb;
     }
 
+    .manifest-dashboard + .manifest-dashboard {
+      margin-top: 14px;
+      padding-top: 14px;
+      border-top: 1px solid var(--line);
+    }
+
+    .manifest-view {
+      display: grid;
+      grid-template-columns: minmax(140px, 1fr) minmax(0, 3fr) auto;
+      gap: 10px;
+      align-items: center;
+      padding: 9px 0;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .manifest-view:last-child {
+      border-bottom: 0;
+    }
+
     .entity-card .actions {
       margin-top: 10px;
     }
@@ -321,6 +386,10 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       main {
         grid-template-columns: 1fr;
       }
+
+      .manifest-view {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 </head>
@@ -335,6 +404,17 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       <button id="refresh" class="primary" type="button">Refresh</button>
     </div>
   </header>
+  <nav class="section-tabs" aria-label="Dashboard sections">
+    <a href="#overview-panel">Overview</a>
+    <a href="#dashboards-panel">Dashboards</a>
+    <a href="#rooms-panel">Rooms</a>
+    <a href="#devices-panel">Devices</a>
+    <a href="#entities-panel">State</a>
+    <a href="#automations-panel">Automations</a>
+    <a href="#pairing-panel">Pairing</a>
+    <a href="#history-panel">History</a>
+    <a href="#commands-panel">Audit</a>
+  </nav>
   <main>
     <aside>
       <section class="panel">
@@ -355,11 +435,21 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       </section>
     </aside>
     <section>
-      <div class="panel">
+      <div id="overview-panel" class="panel">
         <h2>Home</h2>
         <div id="summary" class="metric-grid"></div>
       </div>
-      <div class="panel">
+      <div id="dashboards-panel" class="panel">
+        <div class="row" style="justify-content: space-between;">
+          <div>
+            <h2>Native Dashboards</h2>
+            <span id="dashboard-manifest-summary" class="muted"></span>
+          </div>
+          <button id="dashboard-view-all" type="button">All entities</button>
+        </div>
+        <div id="dashboard-manifests"></div>
+      </div>
+      <div id="filters-panel" class="panel">
         <div class="row" style="justify-content: space-between;">
           <h2>Filters</h2>
           <button id="reset-filters" type="button">Reset</button>
@@ -625,14 +715,14 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           </label>
         </div>
       </div>
-      <div class="panel">
+      <div id="rooms-panel" class="panel">
         <div class="row">
           <h2>Rooms</h2>
           <span class="muted">Topology and coverage</span>
         </div>
         <div id="rooms" class="cards"></div>
       </div>
-      <div class="panel">
+      <div id="devices-panel" class="panel">
         <div class="row">
           <h2>Devices</h2>
           <span class="muted">Bridge inventory</span>
@@ -653,7 +743,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
         </div>
         <div id="scenes" class="cards"></div>
       </div>
-      <div class="panel">
+      <div id="entities-panel" class="panel">
         <div class="row">
           <h2>Entities</h2>
           <span id="state-count" class="muted"></span>
@@ -685,7 +775,38 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           <tbody id="gaps"></tbody>
         </table>
       </div>
-      <div class="panel">
+      <div id="automations-panel" class="panel">
+        <div class="row">
+          <h2>Automations</h2>
+          <span id="automation-count" class="muted"></span>
+        </div>
+        <table>
+          <thead>
+            <tr><th>Automation</th><th>Trigger</th><th>Actions</th><th>Status</th><th></th></tr>
+          </thead>
+          <tbody id="automations"></tbody>
+        </table>
+        <h3 style="margin-top: 14px;">Automation Audit</h3>
+        <table>
+          <thead>
+            <tr><th>Automation</th><th>Outcome</th><th>Occurrence</th><th>Time</th></tr>
+          </thead>
+          <tbody id="automation-audit"></tbody>
+        </table>
+      </div>
+      <div id="pairing-panel" class="panel">
+        <div class="row">
+          <h2>Pairing</h2>
+          <span id="pairing-count" class="muted"></span>
+        </div>
+        <table>
+          <thead>
+            <tr><th>Session</th><th>Bridge</th><th>Status</th><th>Expires</th><th></th></tr>
+          </thead>
+          <tbody id="pairing-sessions"></tbody>
+        </table>
+      </div>
+      <div id="history-panel" class="panel">
         <h2>History</h2>
         <table>
           <thead>
@@ -703,7 +824,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           <tbody id="events"></tbody>
         </table>
       </div>
-      <div class="panel">
+      <div id="commands-panel" class="panel">
         <h2>Commands</h2>
         <table>
           <thead>
@@ -749,6 +870,9 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
   <script>
     const els = {
       activity: document.querySelector("#activity"),
+      automationAudit: document.querySelector("#automation-audit"),
+      automationCount: document.querySelector("#automation-count"),
+      automations: document.querySelector("#automations"),
       authorizationDecisions: document.querySelector("#authorization-decisions"),
       bridges: document.querySelector("#bridges"),
       capabilities: document.querySelector("#capabilities"),
@@ -762,6 +886,9 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       detailTitle: document.querySelector("#detail-title"),
       desired: document.querySelector("#desired"),
       devices: document.querySelector("#devices"),
+      dashboardManifestSummary: document.querySelector("#dashboard-manifest-summary"),
+      dashboardManifests: document.querySelector("#dashboard-manifests"),
+      dashboardViewAll: document.querySelector("#dashboard-view-all"),
       entities: document.querySelector("#entities"),
       events: document.querySelector("#events"),
       filterActivityEntity: document.querySelector("#filter-activity-entity"),
@@ -816,6 +943,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       history: document.querySelector("#history"),
       location: document.querySelector("#location"),
       log: document.querySelector("#log"),
+      pairingCount: document.querySelector("#pairing-count"),
+      pairingSessions: document.querySelector("#pairing-sessions"),
       refresh: document.querySelector("#refresh"),
       resetFilters: document.querySelector("#reset-filters"),
       routes: document.querySelector("#routes"),
@@ -886,6 +1015,9 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       ["grant_scope", els.filterGrantScope],
       ["grant_principal", els.filterGrantPrincipal]
     ];
+
+    let selectedManifestView = new URLSearchParams(window.location.search).get("dashboard_view") || "";
+    let selectedManifestEntityIds = new Set();
 
     const ensureSelectOption = (control, value) => {
       if (!value || control.tagName !== "SELECT") {
@@ -992,6 +1124,12 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
     const roomMatchesFilters = (filters, room) => !filters.room || room.room_id === filters.room;
     const isCommandable = (entity) => (entity.capabilities || []).some((item) => item.commandable);
     const entityMatchesFilters = (filters, entity) => {
+      if (selectedManifestEntityIds.size > 0) {
+        const ids = [entity.entity_id, entity.home_assistant_entity_id].filter(Boolean);
+        if (!ids.some((id) => selectedManifestEntityIds.has(id))) {
+          return false;
+        }
+      }
       if (!matchesSearch(filters, entity)) {
         return false;
       }
@@ -1008,6 +1146,13 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
 
     const metric = (label, value) =>
       `<div class="metric"><strong>${value}</strong><span class="muted">${label}</span></div>`;
+
+    const escapeText = (value) => String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
 
     const statusClass = (status) => `status ${String(status || "ok").toLowerCase()}`;
     const valueText = (value) => value === null || value === undefined ? "null" : JSON.stringify(value);
@@ -1278,6 +1423,102 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           </span>
         </div>
       `).join("") || `<p class="muted">No routes</p>`;
+    };
+
+    const activateManifestView = (manifestData) => {
+      selectedManifestEntityIds.clear();
+      if (!selectedManifestView || !manifestData.manifest) {
+        return;
+      }
+      for (const dashboard of manifestData.manifest.dashboards || []) {
+        for (const view of dashboard.views || []) {
+          if (`${dashboard.dashboard_id}/${view.view_id}` !== selectedManifestView) {
+            continue;
+          }
+          for (const card of view.cards || []) {
+            for (const entityId of card.entity_ids || []) {
+              selectedManifestEntityIds.add(entityId);
+            }
+          }
+        }
+      }
+    };
+
+    const renderDashboardManifests = (manifestData) => {
+      const summary = manifestData.summary || {};
+      els.dashboardManifestSummary.textContent = manifestData.configured
+        ? `${summary.dashboards || 0} dashboards, ${summary.views || 0} views, ${summary.cards || 0} cards`
+        : "No migrated manifest configured";
+      els.dashboardViewAll.disabled = !selectedManifestView;
+      const manifest = manifestData.manifest;
+      if (!manifest) {
+        els.dashboardManifests.innerHTML = `<p class="muted">The controller is using the native operational overview.</p>`;
+        return;
+      }
+      els.dashboardManifests.innerHTML = (manifest.dashboards || []).map((dashboard) => `
+        <div class="manifest-dashboard">
+          <div class="row" style="justify-content: space-between;">
+            <h3>${escapeText(dashboard.title)}</h3>
+            <span class="muted">${escapeText(dashboard.url_path)}</span>
+          </div>
+          ${(dashboard.views || []).map((view) => {
+            const viewKey = `${dashboard.dashboard_id}/${view.view_id}`;
+            const cards = view.cards || [];
+            const entityCount = new Set(cards.flatMap((card) => card.entity_ids || [])).size;
+            return `
+              <div class="manifest-view">
+                <strong>${escapeText(view.title)}</strong>
+                <span class="muted">${cards.length} cards, ${entityCount} entities</span>
+                <button type="button" data-manifest-view="${escapeText(viewKey)}"${selectedManifestView === viewKey ? " disabled" : ""}>${selectedManifestView === viewKey ? "Active" : "Open"}</button>
+              </div>
+            `;
+          }).join("") || `<p class="muted">No migrated views</p>`}
+        </div>
+      `).join("") || `<p class="muted">No migrated dashboards</p>`;
+    };
+
+    const renderAutomations = (automationData, auditData) => {
+      const definitions = automationData.definitions || [];
+      els.automationCount.textContent = `${definitions.length} definitions`;
+      els.automations.innerHTML = definitions.map((definition) => {
+        const trigger = definition.trigger || {};
+        const triggerText = trigger.kind === "schedule"
+          ? `Every ${trigger.every_ms} ms`
+          : `${trigger.event_type || "event"}${trigger.entity_id ? ` / ${trigger.entity_id}` : ""}`;
+        return `
+          <tr>
+            <td>${escapeText(definition.automation_id)}</td>
+            <td>${escapeText(triggerText)}</td>
+            <td>${(definition.actions || []).length}</td>
+            <td><span class="${statusClass(definition.enabled ? "ready" : "attention")}">${definition.enabled ? "enabled" : "disabled"}</span></td>
+            <td>${inspectButton("/api/smart_home/automations", "automation definitions")}</td>
+          </tr>
+        `;
+      }).join("") || `<tr><td colspan="5" class="muted">No automation definitions</td></tr>`;
+
+      const records = [...(auditData.records || [])].reverse().slice(0, 12);
+      els.automationAudit.innerHTML = records.map((record) => `
+        <tr>
+          <td>${escapeText(record.automation_id)}</td>
+          <td><span class="${statusClass(record.outcome)}">${escapeText(record.outcome)}</span></td>
+          <td>${escapeText(record.trigger_key)}</td>
+          <td>${escapeText(observedText(record.evaluated_at_ms))}</td>
+        </tr>
+      `).join("") || `<tr><td colspan="4" class="muted">No automation audit records</td></tr>`;
+    };
+
+    const renderPairingSessions = (pairingData) => {
+      const sessions = pairingData.sessions || [];
+      els.pairingCount.textContent = `${pairingData.summary?.total_sessions || 0} sessions`;
+      els.pairingSessions.innerHTML = sessions.map((session) => `
+        <tr>
+          <td>${escapeText(session.session_id)}<br><span class="muted">${escapeText(session.requested_by)}</span></td>
+          <td>${escapeText(session.bridge_id)}<br><span class="muted">${escapeText(session.integration_id)}</span></td>
+          <td><span class="${statusClass(session.status === "completed" ? "ready" : session.status === "pending_user_presence" ? "attention" : session.status)}">${escapeText(session.status)}</span></td>
+          <td>${escapeText(observedText(session.expires_at_ms))}</td>
+          <td>${inspectButton(`/api/smart_home/pairing_sessions/${encodeURIComponent(session.session_id)}`, "pairing session")}</td>
+        </tr>
+      `).join("") || `<tr><td colspan="5" class="muted">No pairing sessions</td></tr>`;
     };
 
     const renderRoomOptions = (inventory, selectedRoom) => {
@@ -1580,7 +1821,11 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           events,
           commandResults,
           authorizationDecisions,
-          capabilityGrants
+          capabilityGrants,
+          dashboardManifest,
+          automations,
+          automationAudit,
+          pairingSessions
         ] = await Promise.all([
           json("/api/smart_home/bootstrap"),
           json("/api/smart_home/readiness"),
@@ -1674,7 +1919,11 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
             status: filters.grantStatus,
             scope: filters.grantScope,
             sort: "principal_id"
-          }))
+          })),
+          json("/api/smart_home/dashboard_manifest"),
+          json("/api/smart_home/automations"),
+          json("/api/smart_home/automation_audit"),
+          json("/api/smart_home/pairing_sessions?limit=12&sort=status_then_expires_at")
         ]);
         const summary = bootstrap.dashboard.summary;
         els.location.textContent = bootstrap.dashboard.config.location_name;
@@ -1685,6 +1934,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           metric("Devices", summary.device_count),
           metric("Rooms", summary.room_count),
           metric("Scenes", summary.scene_count),
+          metric("Automations", automations.summary.definition_count),
+          metric("Pairing", pairingSessions.summary.total_sessions),
           metric("Active grants", capabilityGrants.summary.active_grants)
         ].join("");
         els.activity.innerHTML = [
@@ -1695,6 +1946,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           metric("State gaps", bootstrap.state_gaps.summary.total_entities)
         ].join("");
         renderChecks(readiness);
+        activateManifestView(dashboardManifest);
+        renderDashboardManifests(dashboardManifest);
         renderServices(services);
         renderRoutes(routes);
         renderRoomOptions(rooms, filters.room);
@@ -1711,6 +1964,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
         renderCommandResults(commandResults, filters);
         renderAuthorizationDecisions(authorizationDecisions, filters);
         renderCapabilityGrants(capabilityGrants, filters);
+        renderAutomations(automations, automationAudit);
+        renderPairingSessions(pairingSessions);
         log("Dashboard refreshed");
       } catch (error) {
         els.status.className = statusClass("blocked");
@@ -1748,8 +2003,23 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       const clearDesiredButton = event.target.closest("button[data-clear-desired]");
       const desiredButton = event.target.closest("button[data-desired-action]");
       const inspectDetailButton = event.target.closest("button[data-inspect-url]");
-      const button = serviceButton || sceneButton || clearDesiredButton || desiredButton || inspectDetailButton;
+      const manifestViewButton = event.target.closest("button[data-manifest-view]");
+      const manifestAllButton = event.target.closest("#dashboard-view-all");
+      const button = serviceButton || sceneButton || clearDesiredButton || desiredButton || inspectDetailButton || manifestViewButton || manifestAllButton;
       if (!button) {
+        return;
+      }
+      if (manifestViewButton || manifestAllButton) {
+        selectedManifestView = manifestViewButton?.dataset.manifestView || "";
+        const params = new URLSearchParams(window.location.search);
+        if (selectedManifestView) {
+          params.set("dashboard_view", selectedManifestView);
+        } else {
+          params.delete("dashboard_view");
+        }
+        const query = params.toString();
+        window.history.replaceState(null, "", `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`);
+        await render();
         return;
       }
       button.disabled = true;
@@ -1959,6 +2229,7 @@ pub struct SmartHomePlatformService {
 pub struct SmartHomePlatformHttpRuntime {
     runtime: Arc<Mutex<SmartHomeRuntime>>,
     automation_runtime: Option<Arc<Mutex<SmartHomeAutomationRuntime>>>,
+    dashboard_manifest: Option<Arc<NativeDashboardManifest>>,
     config: SmartHomePlatformHttpConfig,
     event_types: Vec<String>,
     principal_id: AgentId,
@@ -1979,6 +2250,7 @@ impl SmartHomePlatformHttpRuntime {
         Self {
             runtime,
             automation_runtime: None,
+            dashboard_manifest: None,
             config,
             event_types: default_event_types(),
             principal_id: AgentId::trusted("agent:home-assistant-local-api"),
@@ -2029,6 +2301,11 @@ impl SmartHomePlatformHttpRuntime {
         automation_runtime: Arc<Mutex<SmartHomeAutomationRuntime>>,
     ) -> Self {
         self.automation_runtime = Some(automation_runtime);
+        self
+    }
+
+    pub fn with_dashboard_manifest(mut self, manifest: NativeDashboardManifest) -> Self {
+        self.dashboard_manifest = Some(Arc::new(manifest));
         self
     }
 
@@ -2365,6 +2642,13 @@ pub fn home_assistant_runtime_web_app(runtime: SmartHomePlatformHttpRuntime) -> 
 
     {
         let runtime = runtime.clone();
+        app.get("/api/smart_home/dashboard_manifest", move |_| {
+            dashboard_manifest_response(&runtime)
+        });
+    }
+
+    {
+        let runtime = runtime.clone();
         app.get("/api/smart_home/bootstrap", move |_| {
             runtime_bootstrap_response(&runtime)
         });
@@ -2477,6 +2761,21 @@ pub fn home_assistant_runtime_web_app(runtime: SmartHomePlatformHttpRuntime) -> 
         app.get("/api/smart_home/bridges/:bridge_id", move |request| {
             runtime_bridge_response(&runtime, request)
         });
+    }
+
+    {
+        let runtime = runtime.clone();
+        app.get("/api/smart_home/pairing_sessions", move |request| {
+            runtime_pairing_sessions_response(&runtime, request)
+        });
+    }
+
+    {
+        let runtime = runtime.clone();
+        app.get(
+            "/api/smart_home/pairing_sessions/:session_id",
+            move |request| runtime_pairing_session_response(&runtime, request),
+        );
     }
 
     {
@@ -3242,6 +3541,15 @@ const API_ROUTE_CATALOG: &[ApiRouteDescriptor] = &[
     },
     ApiRouteDescriptor {
         method: "GET",
+        path: "/api/smart_home/dashboard_manifest",
+        category: "dashboard",
+        surface: "smart_home",
+        mutates_runtime: false,
+        runtime_authorized: false,
+        query_params: &[],
+    },
+    ApiRouteDescriptor {
+        method: "GET",
         path: "/api/smart_home/bootstrap",
         category: "dashboard",
         surface: "smart_home",
@@ -3426,6 +3734,34 @@ const API_ROUTE_CATALOG: &[ApiRouteDescriptor] = &[
         method: "GET",
         path: "/api/smart_home/bridges/:bridge_id",
         category: "bridges",
+        surface: "smart_home",
+        mutates_runtime: false,
+        runtime_authorized: false,
+        query_params: &[],
+    },
+    ApiRouteDescriptor {
+        method: "GET",
+        path: "/api/smart_home/pairing_sessions",
+        category: "pairing",
+        surface: "smart_home",
+        mutates_runtime: false,
+        runtime_authorized: false,
+        query_params: &[
+            "bridge_id",
+            "expires_before_ms",
+            "expiring_at_ms",
+            "integration_id",
+            "limit",
+            "requested_by",
+            "session_id",
+            "sort",
+            "status",
+        ],
+    },
+    ApiRouteDescriptor {
+        method: "GET",
+        path: "/api/smart_home/pairing_sessions/:session_id",
+        category: "pairing",
         surface: "smart_home",
         mutates_runtime: false,
         runtime_authorized: false,
@@ -3794,6 +4130,27 @@ fn runtime_dashboard_response(runtime: &SmartHomePlatformHttpRuntime) -> WebResp
     WebResponse::json(runtime_dashboard_json(runtime, &runtime_guard).into_bytes())
 }
 
+fn dashboard_manifest_response(runtime: &SmartHomePlatformHttpRuntime) -> WebResponse {
+    match runtime.dashboard_manifest.as_deref() {
+        Some(manifest) => serialized_json_response(&serde_json::json!({
+            "configured": true,
+            "summary": manifest.summary(),
+            "manifest": manifest,
+        })),
+        None => serialized_json_response(&serde_json::json!({
+            "configured": false,
+            "summary": {
+                "dashboards": 0,
+                "views": 0,
+                "cards": 0,
+                "entity_references": 0,
+                "source_resources": 0,
+            },
+            "manifest": null,
+        })),
+    }
+}
+
 fn runtime_bootstrap_response(runtime: &SmartHomePlatformHttpRuntime) -> WebResponse {
     let runtime_guard = runtime
         .runtime
@@ -4082,6 +4439,72 @@ fn runtime_bridge_response(
         }
     };
     WebResponse::json(bridge_registry_json(bridge, &runtime_guard, runtime.now_ms()).into_bytes())
+}
+
+fn runtime_pairing_sessions_response(
+    runtime: &SmartHomePlatformHttpRuntime,
+    request: &WebRequest,
+) -> WebResponse {
+    let query = match runtime_pairing_session_query(request) {
+        Ok(query) => query,
+        Err(error) => return api_error_response(error),
+    };
+    let runtime_guard = runtime
+        .runtime
+        .lock()
+        .expect("smart-home runtime mutex should not be poisoned");
+    let sessions = runtime_guard.query_pairing_sessions(&query);
+    let summary = runtime_guard.pairing_session_inventory_summary_at(&query, runtime.now_ms());
+    serialized_json_response(&serde_json::json!({
+        "generated_at_ms": runtime.now_ms(),
+        "summary": {
+            "total_sessions": summary.total_sessions,
+            "pending_user_presence_sessions": summary.pending_user_presence_sessions,
+            "completed_sessions": summary.completed_sessions,
+            "expired_sessions": summary.expired_sessions,
+            "cancelled_sessions": summary.cancelled_sessions,
+            "expiring_sessions": summary.expiring_sessions,
+            "sessions_with_vault_ref": summary.sessions_with_vault_ref,
+        },
+        "sessions": sessions
+            .iter()
+            .map(|session| pairing_session_json(session))
+            .collect::<Vec<_>>(),
+    }))
+}
+
+fn runtime_pairing_session_response(
+    runtime: &SmartHomePlatformHttpRuntime,
+    request: &WebRequest,
+) -> WebResponse {
+    let Some(session_id) = request.route_params.get("session_id") else {
+        return api_error_response(ApiError::bad_request("missing session_id"));
+    };
+    let runtime_guard = runtime
+        .runtime
+        .lock()
+        .expect("smart-home runtime mutex should not be poisoned");
+    let session_id = RuntimePairingSessionId::trusted(session_id);
+    let Some(session) = runtime_guard.pairing_session(&session_id) else {
+        return api_error_response(ApiError::not_found(format!(
+            "pairing session `{session_id}` not found"
+        )));
+    };
+    serialized_json_response(&pairing_session_json(session))
+}
+
+fn pairing_session_json(session: &RuntimePairingSession) -> JsonValue {
+    serde_json::json!({
+        "session_id": session.session_id,
+        "bridge_id": session.bridge_id,
+        "integration_id": session.integration_id,
+        "requested_by": session.requested_by,
+        "started_at_ms": session.started_at_ms,
+        "expires_at_ms": session.expires_at_ms,
+        "status": pairing_session_status_label(session.status),
+        "vault_ref": session.vault_ref,
+        "metadata": session.metadata,
+    })
 }
 
 fn runtime_rooms_response(
@@ -7809,6 +8232,39 @@ fn runtime_command_result_query(
     Ok(query)
 }
 
+fn runtime_pairing_session_query(
+    request: &WebRequest,
+) -> Result<RuntimePairingSessionQuery, ApiError> {
+    let mut query = RuntimePairingSessionQuery::new()
+        .with_limit(query_limit(request, 50, 500)?)
+        .sorted_by(RuntimePairingSessionSort::StatusThenExpiresAt);
+    if let Some(session_id) = query_string(request, "session_id") {
+        query = query.for_session(RuntimePairingSessionId::trusted(session_id));
+    }
+    if let Some(bridge_id) = query_string(request, "bridge_id") {
+        query = query.for_bridge(BridgeId::trusted(bridge_id));
+    }
+    if let Some(integration_id) = query_string(request, "integration_id") {
+        query = query.for_integration(IntegrationId::trusted(integration_id));
+    }
+    if let Some(requested_by) = query_string(request, "requested_by") {
+        query = query.requested_by(AgentId::trusted(requested_by));
+    }
+    if let Some(status) = query_string(request, "status") {
+        query = query.with_status(pairing_session_status_from_label(status)?);
+    }
+    if let Some(expires_before_ms) = query_u64(request, "expires_before_ms")? {
+        query = query.expires_before(expires_before_ms);
+    }
+    if let Some(expiring_at_ms) = query_u64(request, "expiring_at_ms")? {
+        query = query.expiring_at(expiring_at_ms);
+    }
+    if let Some(sort) = query_string(request, "sort") {
+        query = query.sorted_by(pairing_session_sort_from_label(sort)?);
+    }
+    Ok(query)
+}
+
 fn runtime_authorization_decision_query(
     request: &WebRequest,
 ) -> Result<RuntimeAuthorizationDecisionQuery, ApiError> {
@@ -9638,6 +10094,39 @@ fn query_limit(request: &WebRequest, default: usize, max: usize) -> Result<usize
     Ok(limit.min(max))
 }
 
+fn pairing_session_status_from_label(label: &str) -> Result<PairingSessionStatus, ApiError> {
+    match label {
+        "pending_user_presence" | "pending" => Ok(PairingSessionStatus::PendingUserPresence),
+        "completed" => Ok(PairingSessionStatus::Completed),
+        "expired" => Ok(PairingSessionStatus::Expired),
+        "cancelled" => Ok(PairingSessionStatus::Cancelled),
+        other => Err(ApiError::bad_request(format!(
+            "unsupported pairing session status `{other}`"
+        ))),
+    }
+}
+
+fn pairing_session_status_label(status: PairingSessionStatus) -> &'static str {
+    match status {
+        PairingSessionStatus::PendingUserPresence => "pending_user_presence",
+        PairingSessionStatus::Completed => "completed",
+        PairingSessionStatus::Expired => "expired",
+        PairingSessionStatus::Cancelled => "cancelled",
+    }
+}
+
+fn pairing_session_sort_from_label(label: &str) -> Result<RuntimePairingSessionSort, ApiError> {
+    match label {
+        "session_id" => Ok(RuntimePairingSessionSort::SessionId),
+        "expires_at" => Ok(RuntimePairingSessionSort::ExpiresAt),
+        "started_at_desc" => Ok(RuntimePairingSessionSort::StartedAtDesc),
+        "status_then_expires_at" => Ok(RuntimePairingSessionSort::StatusThenExpiresAt),
+        other => Err(ApiError::bad_request(format!(
+            "unsupported pairing session sort `{other}`"
+        ))),
+    }
+}
+
 fn command_status_label(status: CommandStatus) -> &'static str {
     match status {
         CommandStatus::Accepted => "accepted",
@@ -10278,6 +10767,10 @@ mod tests {
     use http_core::{Header, HttpVersion, RequestHead};
     use smart_home_automation_runtime::{AutomationAction, AutomationTrigger};
     use smart_home_core::{BridgeId, DeviceId, EventId};
+    use smart_home_dashboard_core::{
+        NativeDashboard, NativeDashboardCard, NativeDashboardCardKind, NativeDashboardView,
+        DASHBOARD_MANIFEST_SCHEMA_VERSION,
+    };
     use smart_home_runtime_store::SmartHomeRuntimeStore;
     use smart_home_testkit::hue_lighting_runtime;
     use std::fs;
@@ -10464,6 +10957,36 @@ mod tests {
         }
     }
 
+    fn fixture_dashboard_manifest() -> NativeDashboardManifest {
+        NativeDashboardManifest {
+            schema_version: DASHBOARD_MANIFEST_SCHEMA_VERSION,
+            source_instance_id: "fixture-home-assistant".to_string(),
+            generated_at_ms: 5_000,
+            dashboards: vec![NativeDashboard {
+                dashboard_id: "overview".to_string(),
+                url_path: "lovelace".to_string(),
+                title: "Overview".to_string(),
+                icon: None,
+                require_admin: false,
+                show_in_sidebar: true,
+                views: vec![NativeDashboardView {
+                    view_id: "living-room".to_string(),
+                    title: "Living Room".to_string(),
+                    path: Some("living-room".to_string()),
+                    icon: None,
+                    cards: vec![NativeDashboardCard {
+                        card_id: "living-room-light".to_string(),
+                        kind: NativeDashboardCardKind::EntityControl,
+                        source_type: "light".to_string(),
+                        title: Some("Living Room Light".to_string()),
+                        entity_ids: vec!["entity-light-1".to_string()],
+                    }],
+                }],
+            }],
+            source_resources: Vec::new(),
+        }
+    }
+
     fn fixture_runtime_with_desired_state() -> SmartHomePlatformHttpRuntime {
         let mut runtime = hue_lighting_runtime();
         runtime
@@ -10545,6 +11068,12 @@ mod tests {
             assert!(body.contains("<title>Codex Home</title>"));
             assert!(body.contains("json(\"/api/smart_home/bootstrap\")"));
             assert!(body.contains("json(\"/api/smart_home/readiness\")"));
+            assert!(body.contains("json(\"/api/smart_home/dashboard_manifest\")"));
+            assert!(body.contains("json(\"/api/smart_home/automations\")"));
+            assert!(body.contains("/api/smart_home/pairing_sessions?limit=12"));
+            assert!(body.contains("id=\"dashboards-panel\""));
+            assert!(body.contains("id=\"automations-panel\""));
+            assert!(body.contains("id=\"pairing-panel\""));
             assert!(body.contains("data-dashboard-filter=\"search\""));
             assert!(body.contains("data-dashboard-filter=\"room\""));
             assert!(body.contains("data-dashboard-filter=\"domain\""));
@@ -10749,6 +11278,69 @@ mod tests {
             assert!(body.contains("clear desired state response"));
             assert!(body.contains("desired ${desiredButton.dataset.desiredAction} response"));
         }
+    }
+
+    #[test]
+    fn runtime_web_app_serves_native_manifest_and_pairing_inventory() {
+        let mut d23 = hue_lighting_runtime();
+        let bridge = d23.registry().bridges().next().cloned().unwrap();
+        d23.start_pairing_session(smart_home_runtime::RuntimePairingSession::pending(
+            RuntimePairingSessionId::trusted("pairing-dashboard-1"),
+            &bridge,
+            AgentId::trusted("agent:operator"),
+            4_000,
+            8_000,
+            Vec::new(),
+        ))
+        .unwrap();
+        let runtime =
+            SmartHomePlatformHttpRuntime::new(d23, SmartHomePlatformHttpConfig::new("Codex Home"))
+                .with_now_ms(5_000)
+                .with_dashboard_manifest(fixture_dashboard_manifest());
+        let app = home_assistant_runtime_web_app(runtime);
+
+        let manifest: serde_json::Value = serde_json::from_str(&response_body(
+            app.handle(request("GET", "/api/smart_home/dashboard_manifest"))
+                .into(),
+        ))
+        .unwrap();
+        assert_eq!(manifest["configured"], true);
+        assert_eq!(manifest["summary"]["dashboards"], 1);
+        assert_eq!(manifest["summary"]["entity_references"], 1);
+        assert_eq!(
+            manifest["manifest"]["dashboards"][0]["views"][0]["title"],
+            "Living Room"
+        );
+
+        let pairing: serde_json::Value = serde_json::from_str(&response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/pairing_sessions?status=pending&sort=expires_at",
+            ))
+            .into(),
+        ))
+        .unwrap();
+        assert_eq!(pairing["summary"]["total_sessions"], 1);
+        assert_eq!(pairing["sessions"][0]["session_id"], "pairing-dashboard-1");
+        assert_eq!(pairing["sessions"][0]["status"], "pending_user_presence");
+
+        let detail: serde_json::Value = serde_json::from_str(&response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/pairing_sessions/pairing-dashboard-1",
+            ))
+            .into(),
+        ))
+        .unwrap();
+        assert_eq!(detail["bridge_id"], bridge.bridge_id.as_str());
+
+        let invalid: web_core::WebResponse = app
+            .handle(request(
+                "GET",
+                "/api/smart_home/pairing_sessions?status=unknown",
+            ))
+            .into();
+        assert_eq!(invalid.status, 400);
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -636,6 +636,25 @@ frontend code or guessing at unsupported behavior:
   collection, resource capture, deterministic source fingerprints, blocked
   apply behavior, atomic output, and token redaction.
 
+## Current Operational Dashboard Slice
+
+This slice turns the durable local API and migrated dashboard artifacts into a
+complete browser-operated control surface:
+
+- `smart-home-dashboard-core` owns and validates the native dashboard manifest
+  shared by Home Assistant migration and the local controller.
+- The durable controller loads a raw manifest or applied migration artifact
+  before binding and exposes it through
+  `/api/smart_home/dashboard_manifest`.
+- The embedded dashboard consumes native manifest views to scope entities and
+  provides direct sections for health, rooms, devices, current state,
+  automations and audit, pairing sessions, state history, runtime events,
+  command results, authorization decisions, and capability grants.
+- Pairing list/detail routes expose session state and opaque vault references
+  without disclosing credential material.
+- Rust route tests plus desktop and mobile browser verification prove the
+  manifest, automation, pairing, and audit workflows over the fixture runtime.
+
 ## Smart Home Remaining Work
 
 These items move toward retiring an existing Home Assistant install:
@@ -645,8 +664,6 @@ These items move toward retiring an existing Home Assistant install:
   Matter commissioning/secure-session/network host, a Thread border-router
   host, a production Zigbee coordinator/join/security host, and production
   Z-Wave inclusion and S2.
-- Provide a dashboard that can inspect devices, rooms, state, health,
-  automations, event history, pairing, and command audit.
 
 ## End-To-End Definition
 


### PR DESCRIPTION
## Summary
- add a shared validated native dashboard manifest contract and load applied Home Assistant dashboard migrations in the durable controller
- expose native dashboard-manifest and pairing-session APIs, then surface migrated views, automations, pairing, history, and command/authorization audit in the embedded dashboard
- complete the operational-dashboard inventory slice with responsive desktop/mobile verification

## Validation
- cargo test -p smart-home-dashboard-core -p smart-home-home-assistant-dashboard-migration -p smart-home-platform-http
- cargo clippy -p smart-home-dashboard-core -p smart-home-home-assistant-dashboard-migration -p smart-home-platform-http --all-targets -- -D warnings
- bash smart-home-dashboard-core/BUILD
- bash smart-home-home-assistant-dashboard-migration/BUILD
- bash smart-home-platform-http/BUILD
- browser verification at 1440x1000 and 390x844 with migrated-view scoping and a clean console