### PR TITLE
fix(spice): validate MOS model level

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-finite Level-1 MOS model-card `LEVEL` selectors instead of
+  silently canonicalizing them to `LEVEL=1`.
+
 - Reject non-positive and non-finite Level-1 MOS model-card `L` values before
   channel-current, capacitance, and noise calculations.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -563,7 +563,7 @@ def normalize_model_card(
             continue
         value = float(raw_value)
         if canonical == "LEVEL":
-            if abs(value - 1.0) > 1.0e-12:
+            if not math.isfinite(value) or abs(value - 1.0) > 1.0e-12:
                 raise ValueError(f"{name}: only MOS LEVEL=1 model cards are supported")
             normalized[canonical] = 1.0
         elif canonical == "TPG" and value not in {-1.0, 0.0, 1.0}:

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -3154,9 +3154,13 @@ def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> No
     )
 
 
-def test_non_level_one_mos_model_cards_are_explicitly_rejected() -> None:
-    with pytest.raises(ValueError, match="only MOS LEVEL=1"):
-        normalize_model_card("Mbad", "nmos", {"LEVEL": 2.0})
+def test_non_level_one_or_non_finite_mos_model_cards_are_explicitly_rejected() -> None:
+    valid = normalize_model_card("Mvalid", "nmos", {"LEVEL": 1.0})
+    assert valid.parameters["LEVEL"] == pytest.approx(1.0)
+
+    for invalid_level in (2.0, -math.inf, math.inf, math.nan):
+        with pytest.raises(ValueError, match="only MOS LEVEL=1"):
+            normalize_model_card("Mbad", "nmos", {"LEVEL": invalid_level})
 
 
 def test_custom_model_evaluator_hook_stamps_dc_current() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-finite Level-1 MOS model-card `LEVEL` selectors instead of
+  silently canonicalizing them to `LEVEL=1`.
+
 - Reject non-positive and non-finite Level-1 MOS model-card `L` values before
   channel-current, capacitance, and noise calculations.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4338,7 +4338,7 @@ pub fn normalize_model_card(
         let key = parameter_key(raw_name);
         if let Some(canonical) = model_card_parameter_alias(kind, &key) {
             if canonical == "LEVEL" {
-                if (raw_value - 1.0).abs() > 1.0e-12 {
+                if !raw_value.is_finite() || (raw_value - 1.0).abs() > 1.0e-12 {
                     return Err(SpiceError::InvalidElement {
                         name: name.clone(),
                         reason: "only MOS LEVEL=1 model cards are supported".to_string(),

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1824,11 +1824,16 @@ fn device_model_reference_deck_audit_gate_reports_missing_coverage() {
 }
 
 #[test]
-fn non_level_one_mos_model_cards_are_explicitly_rejected() {
-    let error = normalize_model_card("Mbad", "nmos", &[("LEVEL", 2.0)]).unwrap_err();
-    assert!(error
-        .to_string()
-        .contains("only MOS LEVEL=1 model cards are supported"));
+fn non_level_one_or_non_finite_mos_model_cards_are_explicitly_rejected() {
+    let valid = normalize_model_card("Mvalid", "nmos", &[("LEVEL", 1.0)]).unwrap();
+    assert_close(*valid.parameters.get("LEVEL").unwrap(), 1.0);
+
+    for invalid_level in [2.0, f64::NEG_INFINITY, f64::INFINITY, f64::NAN] {
+        let error = normalize_model_card("Mbad", "nmos", &[("LEVEL", invalid_level)]).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("only MOS LEVEL=1 model cards are supported"));
+    }
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject non-finite Level-1 MOS model-card `LEVEL` selectors instead of
+  silently canonicalizing them to `LEVEL=1`.
+
 - Reject non-positive and non-finite Level-1 MOS model-card `L` values before
   channel-current, capacitance, and noise calculations.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8424,7 +8424,7 @@ export function normalizeModelCard(
     }
     const value = Number(rawValue);
     if (canonical === "LEVEL") {
-      if (Math.abs(value - 1.0) > 1.0e-12) {
+      if (!Number.isFinite(value) || Math.abs(value - 1.0) > 1.0e-12) {
         throw invalidElement(name, "only MOS LEVEL=1 model cards are supported");
       }
       normalized[canonical] = 1.0;

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1542,10 +1542,20 @@ describe("dcOp", () => {
     expect(JSON.parse(formatDeviceModelReferenceDeckAuditGateCoverageDigestJson(report))).toStrictEqual(digestRecords);
   });
 
-  it("rejects non-Level-1 MOS model cards explicitly", () => {
-    expect(() => normalizeModelCard("Mbad", "nmos", { LEVEL: 2.0 })).toThrowError(
-      "only MOS LEVEL=1",
-    );
+  it("rejects non-Level-1 or non-finite MOS model cards explicitly", () => {
+    const valid = normalizeModelCard("Mvalid", "nmos", { LEVEL: 1.0 });
+    expect(valid.parameters.LEVEL).toBe(1.0);
+
+    for (const invalidLevel of [
+      2.0,
+      Number.NEGATIVE_INFINITY,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() => normalizeModelCard("Mbad", "nmos", { LEVEL: invalidLevel })).toThrowError(
+        "only MOS LEVEL=1",
+      );
+    }
   });
 
   it("stamps a custom-model evaluator hook as a DC current", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS length validation.
+1. Cross-language Level-1 MOS model-level validation.
    - Status: current PR completion candidate.
-   - Reject non-positive or non-finite model-card `L` values before
-     channel-current, capacitance, and noise calculations.
-   - Preserve positive model lengths across Rust, Python, and TypeScript.
+   - Reject non-finite model-card `LEVEL` selectors before supported-level
+     comparison and normalization.
+   - Preserve finite `LEVEL=1` selectors and the stable unsupported-level
+     diagnostic across Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3802,6 +3803,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Non-positive and non-finite model-card `W` values are rejected before
      channel-current, capacitance, and noise calculations.
    - Positive model widths remain aligned across Rust, Python, and TypeScript.
+
+318. Cross-language Level-1 MOS length validation.
+   - Status: completed in PR 9397.
+   - Non-positive and non-finite model-card `L` values are rejected before
+     channel-current, capacitance, and noise calculations.
+   - Positive model lengths remain aligned across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-finite MOS `LEVEL` selectors before Level-1 normalization
- preserve finite `LEVEL=1` and the existing unsupported-level diagnostic across Rust, Python, and TypeScript
- record PR #9397 as completed and advance the SPICE implementation plan

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `.venv/bin/python -m ruff check src tests`
- `.venv/bin/python -m pytest tests/ -q` (699 passed, 88.89% coverage)
- `npm test` (442 passed)
- `npm run build`