### PR TITLE
fix(spice): validate MOS lateral diffusion

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject Level-1 MOS model-card `LD` values that are non-finite, negative, or
+  leave a non-positive effective channel length.
+
 - Reject non-finite Level-1 MOS model-card `LEVEL` selectors instead of
   silently canonicalizing them to `LEVEL=1`.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -622,6 +622,18 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET JS must be finite and non-negative")
         else:
             normalized[canonical] = value
+    if kind in {"NMOS", "PMOS"}:
+        defaults = Level1Params()
+        length = normalized.get("L", defaults.L)
+        lateral_diffusion_length = normalized.get("LD", defaults.LD)
+        if (
+            not math.isfinite(lateral_diffusion_length)
+            or lateral_diffusion_length < 0.0
+            or length - 2.0 * lateral_diffusion_length <= 0.0
+        ):
+            raise ValueError(
+                f"{name}: MOSFET LD must be finite and non-negative with L - 2*LD > 0"
+            )
     return NormalizedModelCard(
         name=name,
         kind=kind,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1278,6 +1278,29 @@ def test_mos_model_card_rejects_non_positive_or_non_finite_length() -> None:
             normalize_model_card("Minvalid", "nmos", {"L": invalid_length})
 
 
+def test_mos_model_card_rejects_invalid_lateral_diffusion_length() -> None:
+    valid = normalize_model_card("Mvalid", "nmos", {"LD": 0.1e-6, "L": 1.0e-6})
+    assert valid.parameters["LD"] == pytest.approx(0.1e-6)
+
+    default_length = normalize_model_card("Mdefault", "pmos", {"LD": 50.0e-9})
+    assert default_length.parameters["LD"] == pytest.approx(50.0e-9)
+
+    invalid_cards = (
+        {"L": 1.0e-6, "LD": -math.inf},
+        {"L": 1.0e-6, "LD": -0.1e-6},
+        {"L": 1.0e-6, "LD": 0.5e-6},
+        {"L": 1.0e-6, "LD": math.inf},
+        {"L": 1.0e-6, "LD": math.nan},
+        {"LD": 65.0e-9},
+    )
+    for parameters in invalid_cards:
+        with pytest.raises(
+            ValueError,
+            match=r"MOSFET LD must be finite and non-negative with L - 2\*LD > 0",
+        ):
+            normalize_model_card("Minvalid", "nmos", parameters)
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject Level-1 MOS model-card `LD` values that are non-finite, negative, or
+  leave a non-positive effective channel length.
+
 - Reject non-finite Level-1 MOS model-card `LEVEL` selectors instead of
   silently canonicalizing them to `LEVEL=1`.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4484,6 +4484,23 @@ pub fn normalize_model_card(
             unsupported.push(key);
         }
     }
+    if matches!(kind, ModelCardKind::Nmos | ModelCardKind::Pmos) {
+        let defaults = MosfetLevel1Params::default();
+        let length = normalized.get("L").copied().unwrap_or(defaults.l);
+        let lateral_diffusion_length = normalized
+            .get("LD")
+            .copied()
+            .unwrap_or(defaults.lateral_diffusion_length);
+        if !lateral_diffusion_length.is_finite()
+            || lateral_diffusion_length < 0.0
+            || length - 2.0 * lateral_diffusion_length <= 0.0
+        {
+            return Err(SpiceError::InvalidElement {
+                name,
+                reason: "MOSFET LD must be finite and non-negative with L - 2*LD > 0".to_string(),
+            });
+        }
+    }
     Ok(NormalizedModelCard {
         name,
         kind,

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1171,6 +1171,30 @@ fn mos_model_card_rejects_non_positive_or_non_finite_length() {
 }
 
 #[test]
+fn mos_model_card_rejects_invalid_lateral_diffusion_length() {
+    let valid = normalize_model_card("Mvalid", "nmos", &[("LD", 0.1e-6), ("L", 1.0e-6)]).unwrap();
+    assert_close(*valid.parameters.get("LD").unwrap(), 0.1e-6);
+
+    let default_length = normalize_model_card("Mdefault", "pmos", &[("LD", 50.0e-9)]).unwrap();
+    assert_close(*default_length.parameters.get("LD").unwrap(), 50.0e-9);
+
+    for parameters in [
+        vec![("L", 1.0e-6), ("LD", f64::NEG_INFINITY)],
+        vec![("L", 1.0e-6), ("LD", -0.1e-6)],
+        vec![("L", 1.0e-6), ("LD", 0.5e-6)],
+        vec![("L", 1.0e-6), ("LD", f64::INFINITY)],
+        vec![("L", 1.0e-6), ("LD", f64::NAN)],
+        vec![("LD", 65.0e-9)],
+    ] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &parameters),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET LD must be finite and non-negative with L - 2*LD > 0"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject Level-1 MOS model-card `LD` values that are non-finite, negative, or
+  leave a non-positive effective channel length.
+
 - Reject non-finite Level-1 MOS model-card `LEVEL` selectors instead of
   silently canonicalizing them to `LEVEL=1`.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8529,6 +8529,21 @@ export function normalizeModelCard(
       normalized[canonical] = value;
     }
   }
+  if (kind === "NMOS" || kind === "PMOS") {
+    const defaults = defaultMosfetLevel1Params();
+    const length = normalized.L ?? defaults.L;
+    const lateralDiffusionLength = normalized.LD ?? defaults.LD;
+    if (
+      !Number.isFinite(lateralDiffusionLength) ||
+      lateralDiffusionLength < 0.0 ||
+      length - 2.0 * lateralDiffusionLength <= 0.0
+    ) {
+      throw invalidElement(
+        name,
+        "MOSFET LD must be finite and non-negative with L - 2*LD > 0",
+      );
+    }
+  }
   return { name, kind, parameters: normalized, unsupportedParameters: unsupported };
 }
 

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1094,6 +1094,27 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects invalid MOS lateral diffusion length", () => {
+    const valid = normalizeModelCard("Mvalid", "nmos", { LD: 0.1e-6, L: 1.0e-6 });
+    expect(valid.parameters.LD).toBe(0.1e-6);
+
+    const defaultLength = normalizeModelCard("Mdefault", "pmos", { LD: 50.0e-9 });
+    expect(defaultLength.parameters.LD).toBe(50.0e-9);
+
+    for (const parameters of [
+      { L: 1.0e-6, LD: Number.NEGATIVE_INFINITY },
+      { L: 1.0e-6, LD: -0.1e-6 },
+      { L: 1.0e-6, LD: 0.5e-6 },
+      { L: 1.0e-6, LD: Number.POSITIVE_INFINITY },
+      { L: 1.0e-6, LD: Number.NaN },
+      { LD: 65.0e-9 },
+    ]) {
+      expect(() => normalizeModelCard("Minvalid", "nmos", parameters)).toThrow(
+        "MOSFET LD must be finite and non-negative with L - 2*LD > 0",
+      );
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS model-level validation.
+1. Cross-language Level-1 MOS lateral-diffusion validation.
    - Status: current PR completion candidate.
-   - Reject non-finite model-card `LEVEL` selectors before supported-level
-     comparison and normalization.
-   - Preserve finite `LEVEL=1` selectors and the stable unsupported-level
-     diagnostic across Rust, Python, and TypeScript.
+   - Reject non-finite or negative model-card `LD` values and values that leave
+     `L - 2*LD <= 0` before device construction.
+   - Preserve valid lateral-diffusion lengths against explicit or default `L`
+     across Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3809,6 +3809,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Non-positive and non-finite model-card `L` values are rejected before
      channel-current, capacitance, and noise calculations.
    - Positive model lengths remain aligned across Rust, Python, and TypeScript.
+
+319. Cross-language Level-1 MOS model-level validation.
+   - Status: completed in PR 9402.
+   - Non-finite model-card `LEVEL` selectors are rejected before supported-level
+     comparison and normalization.
+   - Finite `LEVEL=1` selectors and the stable unsupported-level diagnostic
+     remain aligned across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-finite and negative MOS model-card `LD` values during normalization
- reject `LD` values that leave `L - 2*LD <= 0`, using explicit or default Level-1 length
- mirror behavior, diagnostics, tests, changelogs, and plan state across Rust, Python, and TypeScript

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `.venv/bin/python -m ruff check src tests`
- `.venv/bin/python -m pytest tests/ -q` (700 passed, 88.90% coverage)
- `npm test` (443 passed)
- `npm run build`