### PR TITLE
feat(venture): wire generated WinUI browser host

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -171,6 +171,7 @@ members = [
     "html-to-paint",
     "venture-browser-core",
     "venture-browser-macos",
+    "venture-browser-windows",
     "html-renderer",
     "intel4004-gatelevel",
     "mos6502-gatelevel",

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -4435,6 +4435,19 @@ version = "1"
                     "{backend:?} project shell must accept the host surface through its MosaicHost contract with {expected:?}:\n{shell}"
                 );
             }
+            match backend {
+                Backend::SwiftUI => assert!(
+                    out.path()
+                        .join("swiftui/Sources/App/MosaicHost.swift")
+                        .exists(),
+                    "Venture must install its package-owned SwiftUI host adapter"
+                ),
+                Backend::Xaml => assert!(
+                    out.path().join("xaml/MosaicHost.cs").exists(),
+                    "Venture must install its package-owned XAML host adapter"
+                ),
+                _ => {}
+            }
         }
     }
 

--- a/code/packages/rust/venture-browser-windows/BUILD
+++ b/code/packages/rust/venture-browser-windows/BUILD
@@ -1,0 +1,2 @@
+cargo test --manifest-path Cargo.toml
+cargo build --manifest-path Cargo.toml

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Add the native Venture session bridge used by the Mosaic-generated WinUI
+  shell, including shared chrome props/events, Direct2D pixel rendering,
+  scrolling, and link activation.

--- a/code/packages/rust/venture-browser-windows/Cargo.toml
+++ b/code/packages/rust/venture-browser-windows/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "venture-browser-windows"
+version = "0.1.0"
+edition = "2021"
+description = "Direct2D content bridge for Venture's Mosaic-generated WinUI host."
+
+[lib]
+crate-type = ["rlib", "cdylib"]
+
+[dependencies]
+html-to-layout = { path = "../html-to-layout" }
+html-to-paint = { path = "../html-to-paint" }
+layout-text-measure-native = { path = "../layout-text-measure-native" }
+text-native = { path = "../text-native" }
+venture-browser-core = { path = "../venture-browser-core" }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+paint-vm-direct2d = { path = "../paint-vm-direct2d" }
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+mosaic-package-artifact-builder = { path = "../mosaic-package-artifact-builder" }

--- a/code/packages/rust/venture-browser-windows/README.md
+++ b/code/packages/rust/venture-browser-windows/README.md
@@ -1,0 +1,28 @@
+# venture-browser-windows
+
+This crate is Venture's native Windows content bridge. It reuses
+`venture-browser-core` for browser sessions, history, loading, chrome state,
+scrolling, and link hit-testing, then renders the current viewport through
+`paint-vm-direct2d` as BGRA8 pixels for WinUI's `WriteableBitmap`.
+
+It does not create browser chrome or a handwritten Win32 window. The shared
+`programs/mosaic/venture-browser` MIL/MLL/MSL package emits the WinUI controls
+and installs its package-owned `host/xaml/MosaicHost.cs` adapter into the
+generated project shell. That adapter calls this crate's C ABI and mounts the
+pixel surface in Mosaic's `content-surface` slot.
+
+```powershell
+cargo build -p venture-browser-windows
+```
+
+The package-level Windows acceptance entry point builds the DLL, copies it
+beside the emitted XAML project, and runs the generated x64 WinUI build:
+
+```powershell
+code\programs\mosaic\venture-browser\scripts\build-all.ps1
+```
+
+The Windows-only integration test compiles the package-owned C# adapter inside
+the generated WinUI project. Cross-platform unit tests exercise the shared
+session and chrome event path without claiming complete browser or HTML
+conformance.

--- a/code/packages/rust/venture-browser-windows/src/lib.rs
+++ b/code/packages/rust/venture-browser-windows/src/lib.rs
@@ -1,0 +1,426 @@
+//! Native page-content bridge for Venture's Mosaic-generated WinUI shell.
+//!
+//! Mosaic remains the sole owner of browser chrome. This crate joins the
+//! host-neutral Venture session and chrome reducer to a Direct2D pixel surface
+//! that the package-owned XAML adapter mounts in the generated `HostSurface`.
+
+use html_to_layout::mosaic_html_theme;
+use html_to_paint::HtmlPaintViewport;
+use layout_text_measure_native::NativeMeasurer;
+use text_native::{NativeMetrics, NativeResolver, NativeShaper};
+use venture_browser_core::{
+    BrowserChromeController, BrowserChromeEvent, BrowserChromeProps, BrowserFetchResponse,
+    BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
+    BrowserSession, HttpBrowserFetcher,
+};
+
+pub const VERSION: &str = "0.1.0";
+pub const DEFAULT_START_URL: &str = "http://info.cern.ch/";
+pub const DEFAULT_VIEWPORT_WIDTH: f64 = 1024.0;
+pub const DEFAULT_VIEWPORT_HEIGHT: f64 = 640.0;
+
+fn execute_navigation<F>(
+    session: &mut BrowserSession,
+    navigation: BrowserNavigation,
+    width: f64,
+    height: f64,
+    fetcher: &F,
+) -> Result<bool, BrowserLoadError>
+where
+    F: BrowserResourceFetcher,
+{
+    let theme = mosaic_html_theme();
+    let measurer = NativeMeasurer::new();
+    let shaper = NativeShaper::new();
+    let metrics = NativeMetrics::new();
+    let resolver = NativeResolver::new();
+    let pipeline = BrowserPagePipeline::new(
+        &theme,
+        HtmlPaintViewport::new(width, height, 1.0),
+        &measurer,
+        &shaper,
+        &metrics,
+        &resolver,
+    );
+    Ok(session.execute(navigation, &pipeline, fetcher)?.is_some())
+}
+
+fn activate_link<F>(
+    session: &mut BrowserSession,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    fetcher: &F,
+) -> Result<bool, BrowserLoadError>
+where
+    F: BrowserResourceFetcher,
+{
+    let theme = mosaic_html_theme();
+    let measurer = NativeMeasurer::new();
+    let shaper = NativeShaper::new();
+    let metrics = NativeMetrics::new();
+    let resolver = NativeResolver::new();
+    let pipeline = BrowserPagePipeline::new(
+        &theme,
+        HtmlPaintViewport::new(width, height, 1.0),
+        &measurer,
+        &shaper,
+        &metrics,
+        &resolver,
+    );
+    Ok(session.activate_link(x, y, &pipeline, fetcher)?.is_some())
+}
+
+struct OwnedFetcher(Box<dyn BrowserResourceFetcher>);
+
+impl BrowserResourceFetcher for OwnedFetcher {
+    fn fetch(&self, url: &str) -> Result<BrowserFetchResponse, String> {
+        self.0.fetch(url)
+    }
+}
+
+/// One browser session shared by generated chrome and the Direct2D surface.
+pub struct WindowsBrowserHost {
+    session: BrowserSession,
+    chrome: BrowserChromeController,
+    fetcher: OwnedFetcher,
+    width: f64,
+    height: f64,
+    status_text: String,
+}
+
+impl WindowsBrowserHost {
+    pub fn new(start_url: &str, width: f64, height: f64) -> Result<Self, BrowserLoadError> {
+        Self::new_with_fetcher(
+            start_url,
+            width,
+            height,
+            Box::new(HttpBrowserFetcher::default()),
+        )
+    }
+
+    pub fn new_with_fetcher(
+        start_url: &str,
+        width: f64,
+        height: f64,
+        fetcher: Box<dyn BrowserResourceFetcher>,
+    ) -> Result<Self, BrowserLoadError> {
+        let fetcher = OwnedFetcher(fetcher);
+        let mut session = BrowserSession::new(start_url, height);
+        execute_navigation(
+            &mut session,
+            BrowserNavigation::Navigate(start_url.to_string()),
+            width,
+            height,
+            &fetcher,
+        )?;
+        let chrome = BrowserChromeController::new(&session);
+        Ok(Self {
+            session,
+            chrome,
+            fetcher,
+            width,
+            height,
+            status_text: "Ready".to_string(),
+        })
+    }
+
+    pub fn props(&self) -> BrowserChromeProps {
+        self.chrome
+            .props(&self.session, self.status_text.clone(), false)
+    }
+
+    pub fn handle_event(&mut self, event: BrowserChromeEvent) -> Result<bool, BrowserLoadError> {
+        let Some(navigation) = self.chrome.handle_event(event, &self.session, false) else {
+            return Ok(false);
+        };
+        self.status_text = "Loading".to_string();
+        match execute_navigation(
+            &mut self.session,
+            navigation,
+            self.width,
+            self.height,
+            &self.fetcher,
+        ) {
+            Ok(changed) => {
+                if changed {
+                    self.chrome.synchronize(&self.session);
+                }
+                self.status_text = "Ready".to_string();
+                Ok(changed)
+            }
+            Err(error) => {
+                self.status_text = format!("Load failed: {error}");
+                Err(error)
+            }
+        }
+    }
+
+    pub fn scroll_by(&mut self, delta_y: f64) -> bool {
+        let Some(viewport) = self.session.viewport_mut() else {
+            return false;
+        };
+        let before = viewport.scroll_state().offset_y();
+        viewport.scroll_by(delta_y);
+        viewport.scroll_state().offset_y() != before
+    }
+
+    pub fn activate_link(&mut self, x: f64, y: f64) -> Result<bool, BrowserLoadError> {
+        let changed = activate_link(
+            &mut self.session,
+            x,
+            y,
+            self.width,
+            self.height,
+            &self.fetcher,
+        )?;
+        if changed {
+            self.chrome.synchronize(&self.session);
+            self.status_text = "Ready".to_string();
+        }
+        Ok(changed)
+    }
+
+    #[cfg(target_os = "windows")]
+    fn render_bgra(&self) -> Option<(u32, u32, Vec<u8>)> {
+        let scene = self.session.viewport()?.viewport_scene();
+        let mut pixels = paint_vm_direct2d::render(&scene);
+        for pixel in pixels.data.chunks_exact_mut(4) {
+            pixel.swap(0, 2);
+        }
+        Some((pixels.width, pixels.height, pixels.data))
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod ffi {
+    use super::*;
+    use std::ffi::{c_char, CStr, CString};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    fn string_arg(value: *const c_char) -> Option<String> {
+        if value.is_null() {
+            return None;
+        }
+        unsafe { CStr::from_ptr(value) }
+            .to_str()
+            .ok()
+            .map(str::to_string)
+    }
+
+    fn json_string(value: &str) -> String {
+        let mut out = String::with_capacity(value.len() + 2);
+        out.push('"');
+        for ch in value.chars() {
+            match ch {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                ch if ch.is_control() => {
+                    use std::fmt::Write;
+                    let _ = write!(out, "\\u{:04x}", ch as u32);
+                }
+                ch => out.push(ch),
+            }
+        }
+        out.push('"');
+        out
+    }
+
+    fn response(host: &WindowsBrowserHost, error: Option<&str>) -> *mut c_char {
+        let props = host.props();
+        let error = error
+            .map(|message| format!(",\"error\":{}", json_string(message)))
+            .unwrap_or_default();
+        let value = format!(
+            "{{\"props\":{{\"address\":{},\"page-title\":{},\"status-text\":{},\"back-disabled\":{},\"forward-disabled\":{},\"navigation-disabled\":false}}{error}}}",
+            json_string(&props.address),
+            json_string(&props.page_title),
+            json_string(&props.status_text),
+            props.back_disabled,
+            props.forward_disabled,
+        );
+        CString::new(value)
+            .expect("JSON response contains no NUL")
+            .into_raw()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn venture_browser_windows_new(
+        start_url: *const c_char,
+        width: f64,
+        height: f64,
+    ) -> *mut WindowsBrowserHost {
+        let Some(start_url) = string_arg(start_url) else {
+            return std::ptr::null_mut();
+        };
+        catch_unwind(|| WindowsBrowserHost::new(&start_url, width, height))
+            .ok()
+            .and_then(Result::ok)
+            .map(Box::new)
+            .map(Box::into_raw)
+            .unwrap_or(std::ptr::null_mut())
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_windows_free(host: *mut WindowsBrowserHost) {
+        if !host.is_null() {
+            drop(Box::from_raw(host));
+        }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_windows_apply_props(
+        host: *mut WindowsBrowserHost,
+    ) -> *mut c_char {
+        host.as_ref()
+            .map(|host| response(host, None))
+            .unwrap_or(std::ptr::null_mut())
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_windows_handle_event(
+        host: *mut WindowsBrowserHost,
+        name: *const c_char,
+        value: *const c_char,
+    ) -> *mut c_char {
+        let Some(host) = host.as_mut() else {
+            return std::ptr::null_mut();
+        };
+        let Some(name) = string_arg(name) else {
+            return response(host, Some("missing Mosaic event name"));
+        };
+        let event = match name.as_str() {
+            "onBack" => Some(BrowserChromeEvent::Back),
+            "onForward" => Some(BrowserChromeEvent::Forward),
+            "onHome" => Some(BrowserChromeEvent::Home),
+            "onReload" => Some(BrowserChromeEvent::Reload),
+            "onNavigate" => Some(BrowserChromeEvent::Navigate),
+            "onAddressChange" => string_arg(value).map(BrowserChromeEvent::AddressChange),
+            _ => None,
+        };
+        let Some(event) = event else {
+            return response(host, Some("unknown or malformed Mosaic event"));
+        };
+        match catch_unwind(AssertUnwindSafe(|| host.handle_event(event))) {
+            Ok(Ok(_)) => response(host, None),
+            Ok(Err(error)) => response(host, Some(&error.to_string())),
+            Err(_) => response(host, Some("Venture event handler panicked")),
+        }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_windows_scroll(
+        host: *mut WindowsBrowserHost,
+        delta_y: f64,
+    ) -> u8 {
+        host.as_mut()
+            .map(|host| host.scroll_by(delta_y) as u8)
+            .unwrap_or(0)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_windows_activate_link(
+        host: *mut WindowsBrowserHost,
+        x: f64,
+        y: f64,
+    ) -> u8 {
+        catch_unwind(AssertUnwindSafe(|| {
+            host.as_mut()
+                .and_then(|host| host.activate_link(x, y).ok())
+                .unwrap_or(false) as u8
+        }))
+        .unwrap_or(0)
+    }
+
+    /// Render BGRA8 pixels for WinUI's `WriteableBitmap`.
+    ///
+    /// The required byte count is returned for both probe and copy calls. A
+    /// null or undersized output buffer is never written.
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_windows_render_bgra(
+        host: *mut WindowsBrowserHost,
+        output: *mut u8,
+        capacity: usize,
+        width: *mut u32,
+        height: *mut u32,
+    ) -> usize {
+        catch_unwind(AssertUnwindSafe(|| {
+            let Some(host) = host.as_ref() else {
+                return 0;
+            };
+            let Some((pixel_width, pixel_height, pixels)) = host.render_bgra() else {
+                return 0;
+            };
+            if !width.is_null() {
+                *width = pixel_width;
+            }
+            if !height.is_null() {
+                *height = pixel_height;
+            }
+            if !output.is_null() && capacity >= pixels.len() {
+                std::ptr::copy_nonoverlapping(pixels.as_ptr(), output, pixels.len());
+            }
+            pixels.len()
+        }))
+        .unwrap_or(0)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_windows_string_free(value: *mut c_char) {
+        if !value.is_null() {
+            drop(CString::from_raw(value));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn page(url: &str, title: &str, body: &str) -> BrowserFetchResponse {
+        BrowserFetchResponse::new(
+            url,
+            200,
+            Some("text/html; charset=utf-8".to_string()),
+            format!("<html><head><title>{title}</title></head><body>{body}</body></html>")
+                .into_bytes(),
+        )
+    }
+
+    #[test]
+    fn generated_chrome_and_content_share_one_browser_session() {
+        let fetcher = |url: &str| match url {
+            "http://example.test/" => Ok(page(
+                url,
+                "Home",
+                "<a href='http://example.test/next'>Next</a>",
+            )),
+            "http://example.test/next" => Ok(page(url, "Next", "done")),
+            _ => Err(format!("unexpected URL {url}")),
+        };
+        let mut host = WindowsBrowserHost::new_with_fetcher(
+            "http://example.test/",
+            320.0,
+            180.0,
+            Box::new(fetcher),
+        )
+        .expect("initial page loads");
+
+        assert_eq!(host.props().page_title, "Home");
+        host.handle_event(BrowserChromeEvent::AddressChange(
+            "http://example.test/next".to_string(),
+        ))
+        .expect("address draft updates");
+        assert!(host
+            .handle_event(BrowserChromeEvent::Navigate)
+            .expect("navigation succeeds"));
+        let props = host.props();
+        assert_eq!(props.address, "http://example.test/next");
+        assert_eq!(props.page_title, "Next");
+        assert!(!props.back_disabled);
+    }
+}

--- a/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
+++ b/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
@@ -1,0 +1,61 @@
+#![cfg(target_os = "windows")]
+
+use mosaic_package_artifact_builder::{build_package, Backend, BuildOptions};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn venture_package_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(|code| code.join("programs").join("mosaic").join("venture-browser"))
+        .expect("derive Venture package root")
+}
+
+fn temporary_output() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("venture-xaml-{}-{nonce}", std::process::id()))
+}
+
+#[test]
+fn package_owned_xaml_host_compiles_in_generated_winui_project() {
+    let output = temporary_output();
+    let result = build_package(&BuildOptions {
+        package_root: venture_package_root(),
+        output_root: output.clone(),
+        backend: Backend::Xaml,
+        emit_project: true,
+        theme: Some("light".to_string()),
+    })
+    .expect("emit Venture XAML package");
+    let project = output.join("xaml");
+    let host = project.join("MosaicHost.cs");
+    assert!(host.exists(), "package-owned XAML host must be installed");
+    assert!(
+        result.artifacts.iter().any(|artifact| artifact == &host),
+        "installed host must be a package artifact"
+    );
+
+    let build = Command::new("dotnet")
+        .arg("build")
+        .arg("VentureChrome.csproj")
+        .arg("-p:Platform=x64")
+        .current_dir(&project)
+        .output()
+        .expect("run dotnet build for generated WinUI project");
+    if !build.status.success() {
+        panic!(
+            "generated Venture WinUI project failed to build\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    }
+
+    fs::remove_dir_all(&output).expect("remove clean acceptance output");
+}

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -23,3 +23,7 @@
   dynamic bridge, hydrates generated chrome from `BrowserChromeController`,
   dispatches Mosaic events back to it, and mounts the live Metal viewport with
   native scrolling and link activation.
+- A package-owned XAML `MosaicHost` adapter and `venture-browser-windows`
+  Direct2D bridge that hydrate the same generated chrome contract, mount the
+  live browser viewport as a WinUI `UIElement`, and keep scrolling and link
+  activation in the shared Rust session.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -35,6 +35,11 @@ recreating the surrounding chrome in backend-specific UI code.
   the shared reducer, and mounts the live Metal page renderer as the
   `content-surface` `NSView`. Scroll and link activation remain in the same
   Rust browser session rather than being reimplemented in Swift.
+- The XAML project receives the matching package-owned `MosaicHost.cs`
+  adapter. It loads `venture_browser_windows.dll`, projects that same shared
+  reducer into generated WinUI controls, and mounts Direct2D-rendered pixels
+  in the generated `content-surface` `UIElement`. Pointer-wheel scrolling and
+  link activation call back into the same Rust browser session.
 
 ## Build every backend
 
@@ -64,6 +69,12 @@ On macOS the matrix also builds the Venture Rust dynamic library and places it
 next to the generated SwiftUI project. Run the native shell from that directory
 with `swift run`; set `VENTURE_START_URL` to override the initial page or
 `VENTURE_BROWSER_LIBRARY` to load a bridge from another absolute path.
+
+On Windows the PowerShell matrix builds `venture-browser-windows`, copies its
+DLL beside the generated WinUI project, and runs the x64 `dotnet build`. The
+generated project copies that native bridge next to the executable so its
+package-owned `MosaicHost.cs` can load it without a handwritten Win32 chrome
+layer.
 
 This package is a browser-wiring milestone, not a claim of complete Venture or
 HTML conformance.

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -1,0 +1,290 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+using System;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace Mosaic.Generated;
+
+/// <summary>
+/// Venture's package-owned adapter for the XAML project shell emitted by
+/// Mosaic. Browser chrome remains generated from MIL/MLL/MSL; this adapter only
+/// projects the shared Rust session and mounts its Direct2D pixels in the
+/// generated content-surface slot.
+/// </summary>
+public static class MosaicHost
+{
+    private const double ViewportWidth = 1024;
+    private const double ViewportHeight = 640;
+    private static IntPtr browser;
+    private static VentureContentSurface? contentSurface;
+
+    public static string ApplyProps(VentureChrome component)
+    {
+        EnsureBrowser();
+        if (browser == IntPtr.Zero)
+        {
+            return "Status: Venture native bridge is unavailable";
+        }
+
+        contentSurface ??= new VentureContentSurface(component);
+        component.ContentSurface = contentSurface;
+        var status = ApplyResponse(component, Native.Decode(Native.ApplyProps(browser)));
+        contentSurface.Refresh();
+        return status;
+    }
+
+    public static string HandleEvent(VentureChrome component, VentureChromeEvent ev)
+    {
+        EnsureBrowser();
+        if (browser == IntPtr.Zero)
+        {
+            return "Status: Venture native bridge is unavailable";
+        }
+
+        string? value = ev is VentureChromeEvent.AddressChange addressChange
+            ? addressChange.Value
+            : null;
+        var response = Native.Decode(Native.HandleEvent(browser, ev.MosaicName, value));
+        var status = ApplyResponse(component, response);
+        contentSurface?.Refresh();
+        return status;
+    }
+
+    private static void EnsureBrowser()
+    {
+        if (browser != IntPtr.Zero)
+        {
+            return;
+        }
+
+        var startUrl = Environment.GetEnvironmentVariable("VENTURE_START_URL")
+            ?? "http://info.cern.ch/";
+        browser = Native.New(startUrl, ViewportWidth, ViewportHeight);
+    }
+
+    private static string ApplyResponse(VentureChrome component, JsonDocument? response)
+    {
+        using (response)
+        {
+            if (response is null)
+            {
+                return "Status: Venture native bridge returned no state";
+            }
+
+            var root = response.RootElement;
+            if (!root.TryGetProperty("props", out var props))
+            {
+                return "Status: Venture native bridge returned malformed state";
+            }
+
+            SetIfChanged(component.Address, props.GetProperty("address").GetString(),
+                value => component.Address = value);
+            SetIfChanged(component.PageTitle, props.GetProperty("page-title").GetString(),
+                value => component.PageTitle = value);
+            SetIfChanged(component.StatusText, props.GetProperty("status-text").GetString(),
+                value => component.StatusText = value);
+            component.BackDisabled = props.GetProperty("back-disabled").GetBoolean();
+            component.ForwardDisabled = props.GetProperty("forward-disabled").GetBoolean();
+            component.NavigationDisabled = props.GetProperty("navigation-disabled").GetBoolean();
+
+            if (root.TryGetProperty("error", out var error))
+            {
+                return $"Status: {error.GetString()}";
+            }
+            return $"Status: {component.StatusText}";
+        }
+    }
+
+    private static void SetIfChanged(string current, string? next, Action<string> set)
+    {
+        next ??= string.Empty;
+        if (!string.Equals(current, next, StringComparison.Ordinal))
+        {
+            set(next);
+        }
+    }
+
+    private sealed class VentureContentSurface : Grid
+    {
+        private readonly VentureChrome component;
+        private readonly Image image;
+        private WriteableBitmap? bitmap;
+        private uint pixelWidth;
+        private uint pixelHeight;
+
+        internal VentureContentSurface(VentureChrome component)
+        {
+            this.component = component;
+            Background = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 255, 255, 255));
+            image = new Image { Stretch = Stretch.Fill };
+            Children.Add(image);
+            PointerWheelChanged += OnPointerWheelChanged;
+            PointerReleased += OnPointerReleased;
+        }
+
+        internal void Refresh()
+        {
+            if (browser == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var required = Native.RenderBgra(browser, null, 0, out var width, out var height);
+            if (required == 0 || width == 0 || height == 0 || required > int.MaxValue)
+            {
+                return;
+            }
+
+            var pixels = new byte[(int)required];
+            var written = Native.RenderBgra(browser, pixels, pixels.Length, out width, out height);
+            if (written != required)
+            {
+                return;
+            }
+
+            if (bitmap is null || pixelWidth != width || pixelHeight != height)
+            {
+                bitmap = new WriteableBitmap((int)width, (int)height);
+                image.Source = bitmap;
+                pixelWidth = width;
+                pixelHeight = height;
+            }
+
+            ((IBufferByteAccess)bitmap.PixelBuffer).Buffer(out var destination);
+            Marshal.Copy(pixels, 0, destination, pixels.Length);
+            bitmap.Invalidate();
+        }
+
+        private void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
+        {
+            var delta = e.GetCurrentPoint(this).Properties.MouseWheelDelta;
+            if (Native.Scroll(browser, -delta) != 0)
+            {
+                Refresh();
+                e.Handled = true;
+            }
+        }
+
+        private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
+        {
+            if (pixelWidth == 0 || pixelHeight == 0 || ActualWidth <= 0 || ActualHeight <= 0)
+            {
+                return;
+            }
+            var point = e.GetCurrentPoint(image).Position;
+            var x = point.X * pixelWidth / ActualWidth;
+            var y = point.Y * pixelHeight / ActualHeight;
+            if (Native.ActivateLink(browser, x, y) != 0)
+            {
+                _ = ApplyProps(component);
+                e.Handled = true;
+            }
+        }
+    }
+
+    [ComImport]
+    [Guid("905a0fe0-bc53-11df-8c49-001e4fc686da")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IBufferByteAccess
+    {
+        void Buffer(out IntPtr value);
+    }
+
+    private static class Native
+    {
+        private const string Library = "venture_browser_windows";
+
+        [DllImport(Library, EntryPoint = "venture_browser_windows_new",
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr New(
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string startUrl,
+            double width,
+            double height);
+
+        [DllImport(Library, EntryPoint = "venture_browser_windows_apply_props",
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr ApplyProps(IntPtr browser);
+
+        [DllImport(Library, EntryPoint = "venture_browser_windows_handle_event",
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr HandleEvent(
+            IntPtr browser,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string? value);
+
+        [DllImport(Library, EntryPoint = "venture_browser_windows_scroll",
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte Scroll(IntPtr browser, double deltaY);
+
+        [DllImport(Library, EntryPoint = "venture_browser_windows_activate_link",
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte ActivateLink(IntPtr browser, double x, double y);
+
+        [DllImport(Library, EntryPoint = "venture_browser_windows_render_bgra",
+            CallingConvention = CallingConvention.Cdecl)]
+        private static extern UIntPtr RenderBgraRaw(
+            IntPtr browser,
+            IntPtr output,
+            UIntPtr capacity,
+            out uint width,
+            out uint height);
+
+        [DllImport(Library, EntryPoint = "venture_browser_windows_string_free",
+            CallingConvention = CallingConvention.Cdecl)]
+        private static extern void StringFree(IntPtr value);
+
+        internal static ulong RenderBgra(
+            IntPtr browser,
+            byte[]? output,
+            int capacity,
+            out uint width,
+            out uint height)
+        {
+            if (output is null || output.Length == 0)
+            {
+                return RenderBgraRaw(
+                    browser,
+                    IntPtr.Zero,
+                    UIntPtr.Zero,
+                    out width,
+                    out height).ToUInt64();
+            }
+
+            var handle = GCHandle.Alloc(output, GCHandleType.Pinned);
+            try
+            {
+                return RenderBgraRaw(
+                    browser,
+                    handle.AddrOfPinnedObject(),
+                    (UIntPtr)(uint)Math.Max(0, capacity),
+                    out width,
+                    out height).ToUInt64();
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        internal static JsonDocument? Decode(IntPtr value)
+        {
+            if (value == IntPtr.Zero)
+            {
+                return null;
+            }
+            try
+            {
+                var json = Marshal.PtrToStringUTF8(value);
+                return json is null ? null : JsonDocument.Parse(json);
+            }
+            finally
+            {
+                StringFree(value);
+            }
+        }
+    }
+}

--- a/code/programs/mosaic/venture-browser/mosaic-package.toml
+++ b/code/programs/mosaic/venture-browser/mosaic-package.toml
@@ -10,6 +10,7 @@ exports = ["VentureChrome"]
 [host_assets]
 files = [
   { backend = "swiftui", source = "host/swiftui/MosaicHost.swift", target = "Sources/App/MosaicHost.swift" },
+  { backend = "xaml", source = "host/xaml/MosaicHost.cs", target = "MosaicHost.cs" },
 ]
 
 [kernel]

--- a/code/programs/mosaic/venture-browser/scripts/build-all.ps1
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.ps1
@@ -179,10 +179,26 @@ if (Test-Command "cmake") {
 }
 
 if ($isWindows -and (Test-Command "dotnet")) {
+    Write-Host "==> Building Venture Windows native bridge"
+    $bridgeArgs = @("build", "-p", "venture-browser-windows")
+    $bridgeProfile = "debug"
+    if ($Release) {
+        $bridgeArgs += "--release"
+        $bridgeProfile = "release"
+    }
+    Push-Location $rustWorkspace
+    try {
+        Invoke-Checked -Command "cargo" -Arguments $bridgeArgs
+    } finally {
+        Pop-Location
+    }
+    Copy-Item -Force `
+        (Join-Path $rustWorkspace "target/$bridgeProfile/venture_browser_windows.dll") `
+        (Join-Path $outputRoot "xaml/venture_browser_windows.dll")
     Write-Host "==> Building xaml"
     Push-Location (Join-Path $outputRoot "xaml")
     try {
-        Invoke-Checked -Command "dotnet" -Arguments @("build", "VentureChrome.csproj")
+        Invoke-Checked -Command "dotnet" -Arguments @("build", "VentureChrome.csproj", "-p:Platform=x64")
     } finally {
         Pop-Location
     }

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -89,12 +89,15 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     let package = mosaic_package_manifest::parse(&manifest).expect("parse manifest");
     assert_eq!(package.package.name, "venture-browser");
     assert_eq!(package.components.exports, ["VentureChrome"]);
-    assert_eq!(package.host_assets.files.len(), 1);
+    assert_eq!(package.host_assets.files.len(), 2);
     assert_eq!(package.host_assets.files[0].backend, "swiftui");
     assert_eq!(
         package.host_assets.files[0].target,
         "Sources/App/MosaicHost.swift"
     );
+    assert_eq!(package.host_assets.files[1].backend, "xaml");
+    assert_eq!(package.host_assets.files[1].source, "host/xaml/MosaicHost.cs");
+    assert_eq!(package.host_assets.files[1].target, "MosaicHost.cs");
 
     let host = read_package_file("host/swiftui/MosaicHost.swift");
     for symbol in [
@@ -105,6 +108,19 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         "venture_browser_macos_activate_link",
     ] {
         assert!(host.contains(symbol), "SwiftUI host omits {symbol}");
+    }
+
+    let host = read_package_file("host/xaml/MosaicHost.cs");
+    for symbol in [
+        "venture_browser_windows_apply_props",
+        "venture_browser_windows_handle_event",
+        "venture_browser_windows_render_bgra",
+        "venture_browser_windows_scroll",
+        "venture_browser_windows_activate_link",
+        "WriteableBitmap",
+        "component.ContentSurface",
+    ] {
+        assert!(host.contains(symbol), "XAML host omits {symbol}");
     }
 }
 
@@ -159,6 +175,9 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "swift",
         "venture-browser-macos",
         "libventure_browser_macos.dylib",
+        "venture-browser-windows",
+        "venture_browser_windows.dll",
+        "-p:Platform=x64",
         "cmake",
         "dotnet",
         "flutter",


### PR DESCRIPTION
## Summary

- add `venture-browser-windows`, a Direct2D pixel bridge backed by the shared `BrowserSession` and `BrowserChromeController`
- install a package-owned XAML `MosaicHost.cs` through Venture's Mosaic manifest so generated WinUI chrome mounts the live Rust viewport in `content-surface`
- keep wheel scrolling, link activation, and generated Mosaic events in the same Rust session
- build and copy the native DLL before the generated x64 WinUI project, with a Windows-only `dotnet build` acceptance test

## Why

The generated XAML shell already emitted native WinUI chrome, but Venture only supplied a concrete SwiftUI host adapter. Windows therefore stopped at the generated sample host instead of wiring the Mosaic-authored chrome to Venture's browser session and page renderer.

## Validation

- `cargo test -p venture-browser-windows`
- Windows-target `cargo check -p venture-browser-windows --target x86_64-pc-windows-msvc --all-targets`
- `cargo test -p mosaic-package-artifact-builder venture_browser_builds_and_mounts_host_surface_on_every_backend -- --nocapture`
- `cargo test -p mosaic-emit-xaml`
- Venture Mosaic package tests
- Rust HTML parser coverage audit: tree-construction missing 0, tokenizer missing 0

This is a bounded Windows browser-wiring milestone, not a claim of complete Venture or HTML conformance.