### PR TITLE
fix(spice): validate MOS drain resistance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `RD` values before
+  external drain-resistance stamping and noise calculations.
+
 - Reject Level-1 MOS model-card `LD` values that are non-finite, negative, or
   leave a non-positive effective channel length.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -578,6 +578,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET TOX must be finite and positive")
         elif canonical == "U0" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET U0 must be finite and non-negative")
+        elif canonical == "RD" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET RD must be finite and non-negative")
         elif canonical == "KP" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET KP must be finite and positive")
         elif canonical == "W" and (not math.isfinite(value) or value <= 0.0):

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1301,6 +1301,16 @@ def test_mos_model_card_rejects_invalid_lateral_diffusion_length() -> None:
             normalize_model_card("Minvalid", "nmos", parameters)
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_drain_resistance() -> None:
+    for value in (0.0, 10.0, 1.0e6):
+        valid = normalize_model_card("Mvalid", "nmos", {"RD": value})
+        assert valid.parameters["RD"] == pytest.approx(value)
+
+    for invalid_resistance in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET RD must be finite and non-negative"):
+            normalize_model_card("Minvalid", "nmos", {"RD": invalid_resistance})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `RD` values before
+  external drain-resistance stamping and noise calculations.
+
 - Reject Level-1 MOS model-card `LD` values that are non-finite, negative, or
   leave a non-positive effective channel length.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4375,6 +4375,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET U0 must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "RD" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET RD must be finite and non-negative".to_string(),
+                });
             } else if canonical == "KP" && (!raw_value.is_finite() || *raw_value <= 0.0) {
                 return Err(SpiceError::InvalidElement {
                     name: name.clone(),

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1195,6 +1195,22 @@ fn mos_model_card_rejects_invalid_lateral_diffusion_length() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_drain_resistance() {
+    for value in [0.0, 10.0, 1.0e6] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("RD", value)]).unwrap();
+        assert_close(*valid.parameters.get("RD").unwrap(), value);
+    }
+
+    for invalid_resistance in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("RD", invalid_resistance)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET RD must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `RD` values before
+  external drain-resistance stamping and noise calculations.
+
 - Reject Level-1 MOS model-card `LD` values that are non-finite, negative, or
   leave a non-positive effective channel length.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8440,6 +8440,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET TOX must be finite and positive");
     } else if (canonical === "U0" && (!Number.isFinite(value) || value < 0.0)) {
       throw invalidElement(name, "MOSFET U0 must be finite and non-negative");
+    } else if (canonical === "RD" && (!Number.isFinite(value) || value < 0.0)) {
+      throw invalidElement(name, "MOSFET RD must be finite and non-negative");
     } else if (canonical === "KP" && (!Number.isFinite(value) || value <= 0.0)) {
       throw invalidElement(name, "MOSFET KP must be finite and positive");
     } else if (canonical === "W" && (!Number.isFinite(value) || value <= 0.0)) {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1115,6 +1115,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS drain resistance", () => {
+    for (const value of [0.0, 10.0, 1.0e6]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { RD: value });
+      expect(valid.parameters.RD).toBe(value);
+    }
+
+    for (const invalidResistance of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { RD: invalidResistance }),
+      ).toThrow("MOSFET RD must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS lateral-diffusion validation.
+1. Cross-language Level-1 MOS drain-resistance validation.
    - Status: current PR completion candidate.
-   - Reject non-finite or negative model-card `LD` values and values that leave
-     `L - 2*LD <= 0` before device construction.
-   - Preserve valid lateral-diffusion lengths against explicit or default `L`
-     across Rust, Python, and TypeScript.
+   - Reject negative or non-finite model-card `RD` values before external
+     drain-resistance stamping and noise calculations.
+   - Preserve zero and positive drain resistances across Rust, Python, and
+     TypeScript.
 
 ## Completed Slices
 
@@ -3816,6 +3816,13 @@ the Rust, Python, and TypeScript surfaces together.
      comparison and normalization.
    - Finite `LEVEL=1` selectors and the stable unsupported-level diagnostic
      remain aligned across Rust, Python, and TypeScript.
+
+320. Cross-language Level-1 MOS lateral-diffusion validation.
+   - Status: completed in PR 9404.
+   - Non-finite and negative model-card `LD` values and values that leave
+     `L - 2*LD <= 0` are rejected before device construction.
+   - Valid lateral-diffusion lengths against explicit or default `L` remain
+     aligned across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `RD` values during normalization
- preserve zero and positive drain resistances with one stable cross-language diagnostic
- mirror tests and changelogs and advance the SPICE plan after PR #9404

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `.venv/bin/python -m ruff check src tests`
- `.venv/bin/python -m pytest tests/ -q` (701 passed, 88.90% coverage)
- `npm test` (444 passed)
- `npm run build`