### PR TITLE
ci(venture): run native Windows acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       needs_kotlin: ${{ steps.toolchains.outputs.needs_kotlin }}
       needs_swift: ${{ steps.toolchains.outputs.needs_swift }}
       needs_cpp: ${{ steps.toolchains.outputs.needs_cpp }}
+      needs_venture_windows: ${{ steps.venture-windows.outputs.required }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
       build_shards: ${{ steps.detect.outputs.build_shards }}
@@ -99,6 +100,7 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_backend_loader.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_capability_broker.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_linux_oci.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_venture_windows_ci_acceptance.py'
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
@@ -168,6 +170,15 @@ jobs:
             -detect-languages \
             -emit-plan build-plan.json \
             "${shard_flags[@]}"
+
+      - name: Detect Venture Windows acceptance
+        id: venture-windows
+        shell: bash
+        run: |
+          python3 code/scripts/venture_windows_ci_acceptance.py \
+            build-plan.json \
+            --repo-root . \
+            --diff-base "${{ steps.diff-base.outputs.base }}" >> "$GITHUB_OUTPUT"
 
       - name: Normalize toolchain requirements
         id: toolchains
@@ -344,8 +355,8 @@ jobs:
       # the C/C++ lane (needs `cl.exe` for the MSVC arm of the pure-ISO check).
       # A single msvc-dev-cmd invocation covers both — invoking the action twice
       # would double-prepend the MSVC environment.
-      - name: Set up MSVC (Lua linker + C/C++ cl.exe)
-        if: (needs.detect.outputs.needs_lua == 'true' || needs.detect.outputs.needs_cpp == 'true') && runner.os == 'Windows'
+      - name: Set up MSVC (Lua linker + C/C++ cl.exe + Venture browser)
+        if: (needs.detect.outputs.needs_lua == 'true' || needs.detect.outputs.needs_cpp == 'true' || needs.detect.outputs.needs_venture_windows == 'true') && runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Set up Lua
@@ -606,7 +617,7 @@ jobs:
           cabal-version: '3.10'
 
       - name: Set up .NET
-        if: needs.detect.outputs.needs_dotnet == 'true'
+        if: needs.detect.outputs.needs_dotnet == 'true' || (needs.detect.outputs.needs_venture_windows == 'true' && runner.os == 'Windows')
         uses: actions/setup-dotnet@v4
         with:
           # .NET 9 is the current LTS release. No platform exclusions needed —
@@ -767,6 +778,13 @@ jobs:
             $shardFlag = @('-shard-index', '${{ matrix.shard_index }}')
           }
           & ./build-tool.exe -root . @planFlag @shardFlag -validate-build-files -language swift
+
+      - name: Build and test Venture Windows acceptance
+        if: runner.os == 'Windows' && needs.detect.outputs.needs_venture_windows == 'true'
+        shell: pwsh
+        run: |
+          Set-Location code/packages/rust
+          cargo test -p venture-browser-windows
 
       # ── Run the build ─────────────────────────────────────────
       - name: Build and test affected packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
           clang --version | head -1
 
       - name: Set up Rust
-        if: needs.detect.outputs.needs_rust == 'true'
+        if: needs.detect.outputs.needs_rust == 'true' || (needs.detect.outputs.needs_venture_windows == 'true' && runner.os == 'Windows')
         # Uses the `stable` channel (matching the rest of this repo's Rust CI).
         # NOTE on the -clippy gate: clippy adds/tightens lints on each stable
         # release, so a new Rust release can surface new lints on `main` — treat
@@ -686,7 +686,7 @@ jobs:
             echo "Node: $(node --version)"
             echo "npm: $(npm --version)"
           fi
-          if [ "${{ needs.detect.outputs.needs_rust }}" = "true" ]; then
+          if [ "${{ needs.detect.outputs.needs_rust }}" = "true" ] || { [ "${{ needs.detect.outputs.needs_venture_windows }}" = "true" ] && [ "$RUNNER_OS" = "Windows" ]; }; then
             echo "Rust: $(rustc --version)"
             echo "Cargo: $(cargo --version)"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed — Venture Windows CI Acceptance
+- The pull-request Windows runner now derives a dedicated Venture acceptance
+  flag from the shared build plan, installs MSVC and .NET only when that slice
+  is affected, and executes the package-owned Rust/WinUI integration test
+  instead of reporting a green job whose general build step was skipped. A
+  focused detector test ratchets force, package, unrelated, and malformed plans.
+
 ### Added — OCaml CI Toolchain Evidence
 - Added OCAML03, a closed evidence manifest, and digest-checked transitive opam
   solver locks plus installed-package receipts for Ubuntu x64, macOS arm64, and

--- a/code/scripts/tests/test_venture_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_venture_windows_ci_acceptance.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "venture_windows_ci_acceptance.py"
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci.yml"
+SPEC = importlib.util.spec_from_file_location("venture_windows_ci_acceptance", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VentureWindowsCIAcceptanceTests(unittest.TestCase):
+    def test_force_plan_requires_acceptance(self) -> None:
+        self.assertTrue(MODULE.requires_venture_windows({"affected_packages": None}))
+
+    def test_windows_bridge_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_venture_windows(
+                {"affected_packages": ["rust/venture-browser-windows"]}
+            )
+        )
+
+    def test_mosaic_package_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_venture_windows(
+                {"affected_packages": ["unknown/programs/venture-browser"]}
+            )
+        )
+
+    def test_unrelated_plan_skips_acceptance(self) -> None:
+        self.assertFalse(
+            MODULE.requires_venture_windows(
+                {"affected_packages": ["rust/venture-browser-core"]}
+            )
+        )
+
+    def test_workflow_change_self_tests_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_venture_windows(
+                {"affected_packages": []}, workflow_changed=True
+            )
+        )
+
+    def test_invalid_affected_packages_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "array or null"):
+            MODULE.requires_venture_windows({"affected_packages": "all"})
+
+    def test_cli_emits_github_output_value(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plan = Path(directory) / "build-plan.json"
+            plan.write_text(
+                '{"affected_packages":["rust/venture-browser-windows"]}',
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), str(plan)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.stdout, "required=true\n")
+
+    def test_workflow_routes_required_toolchains_and_acceptance(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "needs_venture_windows: ${{ steps.venture-windows.outputs.required }}",
+            workflow,
+        )
+        self.assertIn(
+            "python3 code/scripts/venture_windows_ci_acceptance.py",
+            workflow,
+        )
+        self.assertIn(
+            '--diff-base "${{ steps.diff-base.outputs.base }}"',
+            workflow,
+        )
+        self.assertIn(
+            "needs.detect.outputs.needs_venture_windows == 'true') "
+            "&& runner.os == 'Windows'",
+            workflow,
+        )
+        self.assertIn(
+            "needs.detect.outputs.needs_venture_windows == 'true' "
+            "&& runner.os == 'Windows')",
+            workflow,
+        )
+        self.assertIn("cargo test -p venture-browser-windows", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_venture_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_venture_windows_ci_acceptance.py
@@ -91,6 +91,12 @@ class VentureWindowsCIAcceptanceTests(unittest.TestCase):
             "&& runner.os == 'Windows')",
             workflow,
         )
+        self.assertIn(
+            "needs.detect.outputs.needs_rust == 'true' || "
+            "(needs.detect.outputs.needs_venture_windows == 'true' "
+            "&& runner.os == 'Windows')",
+            workflow,
+        )
         self.assertIn("cargo test -p venture-browser-windows", workflow)
 
 

--- a/code/scripts/venture_windows_ci_acceptance.py
+++ b/code/scripts/venture_windows_ci_acceptance.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Derive the Venture native-Windows acceptance flag from a build plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+ACCEPTANCE_PACKAGES = frozenset(
+    {
+        "rust/venture-browser-windows",
+        "unknown/programs/venture-browser",
+    }
+)
+
+
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+
+
+def requires_venture_windows(
+    plan: dict[str, Any], *, workflow_changed: bool = False
+) -> bool:
+    """Return whether this plan must exercise Venture's native Windows gate."""
+
+    if workflow_changed:
+        return True
+    affected = plan.get("affected_packages")
+    if affected is None:
+        return True
+    if not isinstance(affected, list):
+        raise ValueError("affected_packages must be an array or null")
+    return bool(ACCEPTANCE_PACKAGES.intersection(affected))
+
+
+def workflow_changed(repo_root: Path, diff_base: str) -> bool:
+    """Return whether the main CI workflow differs from the selected base."""
+
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--quiet",
+            f"{diff_base}...HEAD",
+            "--",
+            CI_WORKFLOW_PATH,
+        ],
+        cwd=repo_root,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f"git diff exited with status {result.returncode}")
+    return result.returncode == 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("--repo-root", type=Path)
+    parser.add_argument("--diff-base")
+    args = parser.parse_args()
+
+    if (args.repo_root is None) != (args.diff_base is None):
+        parser.error("--repo-root and --diff-base must be provided together")
+
+    with args.plan.open(encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not isinstance(plan, dict):
+        raise ValueError("build plan root must be an object")
+
+    changed = False
+    if args.repo_root is not None and args.diff_base is not None:
+        changed = workflow_changed(args.repo_root, args.diff_base)
+
+    required = requires_venture_windows(plan, workflow_changed=changed)
+    print(f"required={'true' if required else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- derive a dedicated Venture Windows acceptance flag from the shared build plan
- self-test the native Windows lane when the CI workflow itself changes
- install MSVC and .NET only for affected Venture Windows work
- run `cargo test -p venture-browser-windows` on `windows-latest`, which compiles the Rust Direct2D bridge and builds the generated WinUI project
- add focused plan-detector and workflow-wiring regression tests

## Why

PR #9405 added the package-owned XAML host and Windows bridge, but the repository's general affected-package step is intentionally disabled on Windows. The Windows job therefore passed while skipping the new native acceptance test. This routes only the Venture Windows slice into a real native gate without enabling every Rust package on Windows.

## Validation

- `python3 -m unittest discover -s code/scripts/tests -p 'test_venture_windows_ci_acceptance.py'`
- parsed `.github/workflows/ci.yml` with Ruby Psych
- `go test ./...` in `code/programs/go/build-tool`
- `cargo test -p venture-browser-windows`
- `cargo check -p venture-browser-windows --target x86_64-pc-windows-msvc --all-targets`
- `cargo clippy -p venture-browser-windows --target x86_64-pc-windows-msvc --all-targets --no-deps -- -D warnings`
- `cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test -- --nocapture`
- real post-commit build-plan simulation: `affected_packages=[]`, `required=true`

This is a bounded CI acceptance repair. It does not claim full browser conformance.