### PR TITLE
fix(spice): validate MOS sheet resistance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `RSH` values before
+  drain/source geometry converts sheet resistance into external resistance.
+
 - Reject negative and non-finite Level-1 MOS model-card `RS` values before
   external source-resistance stamping and noise calculations.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -582,6 +582,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET RD must be finite and non-negative")
         elif canonical == "RS" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET RS must be finite and non-negative")
+        elif canonical == "RSH" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET RSH must be finite and non-negative")
         elif canonical == "KP" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET KP must be finite and positive")
         elif canonical == "W" and (not math.isfinite(value) or value <= 0.0):

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1321,6 +1321,16 @@ def test_mos_model_card_rejects_negative_or_non_finite_source_resistance() -> No
             normalize_model_card("Minvalid", "pmos", {"RS": invalid_resistance})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_sheet_resistance() -> None:
+    for value in (0.0, 10.0, 1.0e6):
+        valid = normalize_model_card("Mvalid", "nmos", {"RSH": value})
+        assert valid.parameters["RSH"] == pytest.approx(value)
+
+    for invalid_resistance in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET RSH must be finite and non-negative"):
+            normalize_model_card("Minvalid", "nmos", {"RSH": invalid_resistance})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `RSH` values before
+  drain/source geometry converts sheet resistance into external resistance.
+
 - Reject negative and non-finite Level-1 MOS model-card `RS` values before
   external source-resistance stamping and noise calculations.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4385,6 +4385,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET RS must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "RSH" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET RSH must be finite and non-negative".to_string(),
+                });
             } else if canonical == "KP" && (!raw_value.is_finite() || *raw_value <= 0.0) {
                 return Err(SpiceError::InvalidElement {
                     name: name.clone(),

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1227,6 +1227,22 @@ fn mos_model_card_rejects_negative_or_non_finite_source_resistance() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_sheet_resistance() {
+    for value in [0.0, 10.0, 1.0e6] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("RSH", value)]).unwrap();
+        assert_close(*valid.parameters.get("RSH").unwrap(), value);
+    }
+
+    for invalid_resistance in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("RSH", invalid_resistance)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET RSH must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `RSH` values before
+  drain/source geometry converts sheet resistance into external resistance.
+
 - Reject negative and non-finite Level-1 MOS model-card `RS` values before
   external source-resistance stamping and noise calculations.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8444,6 +8444,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET RD must be finite and non-negative");
     } else if (canonical === "RS" && (!Number.isFinite(value) || value < 0.0)) {
       throw invalidElement(name, "MOSFET RS must be finite and non-negative");
+    } else if (canonical === "RSH" && (!Number.isFinite(value) || value < 0.0)) {
+      throw invalidElement(name, "MOSFET RSH must be finite and non-negative");
     } else if (canonical === "KP" && (!Number.isFinite(value) || value <= 0.0)) {
       throw invalidElement(name, "MOSFET KP must be finite and positive");
     } else if (canonical === "W" && (!Number.isFinite(value) || value <= 0.0)) {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1151,6 +1151,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS sheet resistance", () => {
+    for (const value of [0.0, 10.0, 1.0e6]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { RSH: value });
+      expect(valid.parameters.RSH).toBe(value);
+    }
+
+    for (const invalidResistance of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { RSH: invalidResistance }),
+      ).toThrow("MOSFET RSH must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS source-resistance validation.
+1. Cross-language Level-1 MOS sheet-resistance validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `RS` values before external
-     source-resistance stamping and noise calculations.
-   - Preserve zero and positive source resistances across Rust, Python, and
+   - Reject negative or non-finite model-card `RSH` values before drain/source
+     geometry converts sheet resistance into external resistance.
+   - Preserve zero and positive sheet resistances across Rust, Python, and
      TypeScript.
 
 ## Completed Slices
@@ -3829,6 +3829,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `RD` values are rejected before
      external drain-resistance stamping and noise calculations.
    - Zero and positive drain resistances remain aligned across Rust, Python,
+     and TypeScript.
+
+322. Cross-language Level-1 MOS source-resistance validation.
+   - Status: completed in PR 9411.
+   - Negative and non-finite model-card `RS` values are rejected before
+     external source-resistance stamping and noise calculations.
+   - Zero and positive source resistances remain aligned across Rust, Python,
      and TypeScript.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `RSH` values during normalization
- preserve zero and positive sheet resistance across Rust, Python, and TypeScript
- record the completed `RS` slice and advance the SPICE implementation plan

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `.venv/bin/python -m ruff check src tests`
- `.venv/bin/python -m pytest tests/ -q` (703 passed, 88.90% coverage)
- `npm test` (446 passed)
- `npm run build`