### PR TITLE
fix(camera-media): mediate private endpoint delivery

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -10,16 +10,16 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "1e4956369cb3aeabedf5027c351d1e20a7b8dfac",
+    "revision": "6dbe24e287faac5857f15fd85f398f0e2fb40387",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1207,
-    "implementation_package_slots": 4351,
+    "implementation_identities": 1208,
+    "implementation_package_slots": 4352,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 275,
-    "singleton_packages": 757,
-    "singleton_missing_slots": 10598,
-    "rust_singletons": 562,
+    "singleton_packages": 758,
+    "singleton_missing_slots": 10612,
+    "rust_singletons": 563,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -667,7 +667,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 562, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 563, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -676,7 +676,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30-August 1 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, smart-home-home-assistant-migration, smart-home-home-assistant-export, smart-home-home-assistant-history, smart-home-home-assistant-definitions, smart-home-home-assistant-dashboard-migration, smart-home-dashboard-core, venture-browser-windows, smart-home-camera-media, and smart-home-onvif-integration; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, camera-media broker, ONVIF integration, and Home Assistant packages as native/service/storage boundary cases; venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability; and venture-browser-windows as a mixed boundary whose duplicated session/chrome/status/event bridge belongs in venture-browser-core or a shared portable bridge while WinUI/Direct2D/C-ABI behavior remains native-source. Home Assistant migration, export, history, definitions, and dashboard migration contain deterministic parsing or validation, normalization, planning, diagnostics, identities, fingerprints, projections, and receipts that are portable-core candidates, while WebSocket/TLS collection, runtime application, atomic filesystem writes, CLI behavior, Rust-only runtime dependencies, environment-token intake, clock/console effects, and missing capability manifests require explicit host-boundary review. Smart-home-dashboard-core is already a zero-capability, protocol-neutral deterministic manifest parser, validator, and summarizer, so its fixture and cross-lane expansion has a separate explicit owner. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic through matter-core, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary. Camera-media policy, generation-bound lease state, quotas, and redacted audit are portable candidates, but endpoint use belongs behind an injected trusted host. ONVIF discovery/SOAP/profile parsing, deterministic UsernameToken construction, origin policy, projection, and hostile fixtures are portable candidates, while UDP/DNS/TCP/TLS, trusted time/randomness, Vault leases, process I/O, and endpoint allowlists remain host-owned."
+      "notes": "The July 30-August 1 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, smart-home-home-assistant-migration, smart-home-home-assistant-export, smart-home-home-assistant-history, smart-home-home-assistant-definitions, smart-home-home-assistant-dashboard-migration, smart-home-dashboard-core, venture-browser-windows, smart-home-camera-media, smart-home-onvif-integration, and smart-home-shelly-integration; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, camera-media broker, ONVIF integration, Shelly integration, and Home Assistant packages as native/service/storage boundary cases; venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability; and venture-browser-windows as a mixed boundary whose duplicated session/chrome/status/event bridge belongs in venture-browser-core or a shared portable bridge while WinUI/Direct2D/C-ABI behavior remains native-source. Home Assistant migration, export, history, definitions, and dashboard migration contain deterministic parsing or validation, normalization, planning, diagnostics, identities, fingerprints, projections, and receipts that are portable-core candidates, while WebSocket/TLS collection, runtime application, atomic filesystem writes, CLI behavior, Rust-only runtime dependencies, environment-token intake, clock/console effects, and missing capability manifests require explicit host-boundary review. Smart-home-dashboard-core is already a zero-capability, protocol-neutral deterministic manifest parser, validator, and summarizer, so its fixture and cross-lane expansion has a separate explicit owner. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic through matter-core, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary. Camera-media policy, generation-bound lease state, quotas, and redacted audit are portable candidates, but endpoint use belongs behind an injected trusted host. ONVIF discovery/SOAP/profile parsing, deterministic UsernameToken construction, origin policy, projection, and hostile fixtures are portable candidates, while UDP/DNS/TCP/TLS, trusted time/randomness, Vault leases, process I/O, and endpoint allowlists remain host-owned. Shelly JSON-RPC validation, component projection, stable identities, command planning, and normalized error classes are portable candidates; mDNS, DNS/TCP, plaintext LAN HTTP, trusted clock, console I/O, runtime-effect ordering, future credentials, endpoint policy, and truthful capability profiles remain host-owned."
     },
     {
       "id": "smart-home-camera-media-security-boundary-hardening",
@@ -750,6 +750,43 @@
       "branch": null,
       "pr_number": null,
       "notes": "Extract and fixture correlated discovery and SOAP parsing, deterministic UsernameToken construction with injected nonce/time, origin policy, normalized camera projection, bounds, and hostile inputs. Expand the authority-free core through established lanes while UDP/DNS/TCP/TLS, Vault access, trusted time/randomness, process I/O, and allowlists remain in the native Rust host."
+    },
+    {
+      "id": "smart-home-shelly-host-security-hardening",
+      "title": "Harden Shelly LAN origins, runtime effects, and native-host authority",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 6dbe24e2 inventory after PR #9415 added the Rust-only Shelly Gen2/Gen3 integration. The native host currently accepts caller-supplied principal/time, exposes public arbitrary RPC through ShellyClient::call and client_mut, accepts any DNS host/port for plaintext HTTP, classifies mDNS-derived addresses as verified without retaining an origin binding, publishes optimistic accepted runtime state before the device RPC succeeds, exposes device-controlled RPC error text, bounds total bytes but not component/entity/string counts, and lacks required_capabilities.json despite mDNS, DNS/TCP, clock, environment/arguments, and console authority. Install authenticated session/clock authority once, narrow authorized RPC, add explicit private-origin and DNS-rebinding policy, retain discovery-to-endpoint binding, bound/redact host-controlled data, add validate-and-plan plus commit/compensation semantics for installation and commands, and define truthful runtime/test capability profiles. Keep authentication-enabled devices fail-closed until a separately reviewed Vault-mediated credential flow exists; do not claim Layer 5 approval."
+    },
+    {
+      "id": "smart-home-shelly-capability-layer5-evidence",
+      "title": "Approve the Shelly native-host capability profiles",
+      "status": "pending",
+      "depends_on": ["smart-home-shelly-host-security-hardening"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "After repository-local Shelly hardening establishes the minimum nonempty runtime and test-harness authority profiles, a maintainer must provide hardware-key-backed Layer 5 approval evidence before publication or privileged deployment."
+    },
+    {
+      "id": "smart-home-shelly-portable-core-extraction-and-conformance",
+      "title": "Extract, fixture, and expand the portable Shelly Gen2/Gen3 core",
+      "status": "pending",
+      "depends_on": ["smart-home-shelly-host-security-hardening"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Extract and fixture deterministic Gen2/Gen3 device-info and status parsing, authentication-required classification, component projection, stable identifiers, capability/state normalization, RPC envelope validation, command planning, bounds, and hostile inputs. Expand only this authority-free core through established lanes while mDNS, DNS/TCP, plaintext LAN HTTP, trusted time, console I/O, Vault access, origin allowlists, and SmartHomeRuntime effect application remain in the native Rust host."
+    },
+    {
+      "id": "rust-network-substrate-capability-truthfulness",
+      "title": "Correct Rust network-substrate capability metadata",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the Shelly dependency audit. tcp-client and http1-client declare empty capability profiles despite concrete DNS/TCP calls, while udp-client and smart-home-discovery lack manifests despite socket and discovery authority. Inventory the executable library and harness boundaries, split pure parsers/planners from native I/O where necessary, and add truthful minimum runtime/test profiles without claiming Layer 5 approval. This shared substrate item has leverage across Shelly and other local-network integrations."
     },
     {
       "id": "dart-current-14-of-15-matrix-family",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,18 +8,18 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": 9413,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "c2b5a3d8156e4916fa622a7dcd0df6fc0c206ac3",
+    "revision": "1e4956369cb3aeabedf5027c351d1e20a7b8dfac",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1205,
-    "implementation_package_slots": 4349,
+    "implementation_identities": 1207,
+    "implementation_package_slots": 4351,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 275,
-    "singleton_packages": 755,
-    "singleton_missing_slots": 10570,
-    "rust_singletons": 560,
+    "singleton_packages": 757,
+    "singleton_missing_slots": 10598,
+    "rust_singletons": 562,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -500,11 +500,11 @@
     {
       "id": "phy00-atan-tiny-signed-zero-cross-lane-audit",
       "title": "Audit tiny and signed-zero PHY00 arctangent behavior",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["phy00-small-sqrt-cross-lane-audit"],
       "branch": "codex/phy00-atan-tiny-signed-zero-audit",
       "pr_number": 9413,
-      "notes": "Ready-for-review PR #9413 opened after rebasing onto c2b5a3d8156e4916fa622a7dcd0df6fc0c206ac3. Selected after PR #9400 merged because its only dependency is merged, the shared PHY00 fixture machinery is established, and every existing atan lane had the same signed-zero and subnormal-floor defect. The PR specifies exact binary64 identity for |x| <= 2^-27, binds shared fixtures for negative zero, 2^-30, and signed minimum subnormals, and repairs all 15 established trig lanes plus emerging C/C++. Local validation covered all 17 native trig suites, 15 downstream wave suites, measured production coverage where supported, 14 fixture tests, generated-fixture sync, six real dependency-ordered build-tool lanes, collision-clean 1,205-identity parity inventory, state graph, diff, credential, JSON, Go build-tool test/vet/build, and independent fixture, numerical, security, and inventory audits. Repository-wide BUILD validation has zero delta from the 73 known origin/main failures; the local C build runner also reproduces origin/main's PowerShell 5 UTF-8 parse defect in iso-harness, while direct GCC and Clang trig suites pass."
+      "notes": "Merged PR #9413 at 458405a6e520914edb112f45406e75c1a19899f6 on 2026-08-01 after all 15 checks passed. Selected after PR #9400 merged because its only dependency was merged, the shared PHY00 fixture machinery was established, and every existing atan lane had the same signed-zero and subnormal-floor defect. The PR specifies exact binary64 identity for |x| <= 2^-27, binds shared fixtures for negative zero, 2^-30, and signed minimum subnormals, and repairs all 15 established trig lanes plus emerging C/C++. Local validation covered all 17 native trig suites, 15 downstream wave suites, measured production coverage where supported, 14 fixture tests, generated-fixture sync, six real dependency-ordered build-tool lanes, collision-clean parity inventory, state graph, diff, credential, JSON, Go build-tool test/vet/build, and independent fixture, numerical, security, and inventory audits. Repository-wide BUILD validation had zero delta from the 73 known origin/main failures; the local C build runner also reproduced origin/main's PowerShell 5 UTF-8 parse defect in iso-harness, while direct GCC and Clang trig suites passed."
     },
     {
       "id": "phy01-nonfinite-validation-backfill",
@@ -667,7 +667,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 560, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 562, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -676,7 +676,77 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The July 30-August 1 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, smart-home-home-assistant-migration, smart-home-home-assistant-export, smart-home-home-assistant-history, smart-home-home-assistant-definitions, smart-home-home-assistant-dashboard-migration, smart-home-dashboard-core, and venture-browser-windows; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, and Home Assistant packages as native/service/storage boundary cases; venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability; and venture-browser-windows as a mixed boundary whose duplicated session/chrome/status/event bridge belongs in venture-browser-core or a shared portable bridge while WinUI/Direct2D/C-ABI behavior remains native-source. Home Assistant migration, export, history, definitions, and dashboard migration contain deterministic parsing or validation, normalization, planning, diagnostics, identities, fingerprints, projections, and receipts that are portable-core candidates, while WebSocket/TLS collection, runtime application, atomic filesystem writes, CLI behavior, Rust-only runtime dependencies, environment-token intake, clock/console effects, and missing capability manifests require explicit host-boundary review. Smart-home-dashboard-core is already a zero-capability, protocol-neutral deterministic manifest parser, validator, and summarizer, so its fixture and cross-lane expansion has a separate explicit owner. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic through matter-core, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary."
+      "notes": "The July 30-August 1 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, smart-home-home-assistant-migration, smart-home-home-assistant-export, smart-home-home-assistant-history, smart-home-home-assistant-definitions, smart-home-home-assistant-dashboard-migration, smart-home-dashboard-core, venture-browser-windows, smart-home-camera-media, and smart-home-onvif-integration; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, camera-media broker, ONVIF integration, and Home Assistant packages as native/service/storage boundary cases; venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability; and venture-browser-windows as a mixed boundary whose duplicated session/chrome/status/event bridge belongs in venture-browser-core or a shared portable bridge while WinUI/Direct2D/C-ABI behavior remains native-source. Home Assistant migration, export, history, definitions, and dashboard migration contain deterministic parsing or validation, normalization, planning, diagnostics, identities, fingerprints, projections, and receipts that are portable-core candidates, while WebSocket/TLS collection, runtime application, atomic filesystem writes, CLI behavior, Rust-only runtime dependencies, environment-token intake, clock/console effects, and missing capability manifests require explicit host-boundary review. Smart-home-dashboard-core is already a zero-capability, protocol-neutral deterministic manifest parser, validator, and summarizer, so its fixture and cross-lane expansion has a separate explicit owner. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic through matter-core, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary. Camera-media policy, generation-bound lease state, quotas, and redacted audit are portable candidates, but endpoint use belongs behind an injected trusted host. ONVIF discovery/SOAP/profile parsing, deterministic UsernameToken construction, origin policy, projection, and hostile fixtures are portable candidates, while UDP/DNS/TCP/TLS, trusted time/randomness, Vault leases, process I/O, and endpoint allowlists remain host-owned."
+    },
+    {
+      "id": "smart-home-camera-media-security-boundary-hardening",
+      "title": "Replace camera endpoint redemption with a mediated single-use security boundary",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the post-#9413 audit after PR #9407 added smart-home-camera-media. The current broker returns a replayable secret-bearing snapshot or stream URI, accepts caller-asserted principal and time, does not bind leases to endpoint generations, uses unbounded endpoint and lease maps, and owns OS entropy without capability metadata. Replace raw URI redemption with trusted-host mediation, inject authenticated principal, trusted time, and nonce generation, revalidate active grants at use time, bind leases to endpoint generations, enforce quotas, keep failures redacted, reject credential-bearing or insecure non-loopback endpoints, and add an explicit authority-free manifest for the resulting policy core."
+    },
+    {
+      "id": "smart-home-onvif-origin-credential-transport-hardening",
+      "title": "Bind ONVIF credentials and media endpoints to reviewed secure origins",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the post-#9413 security audit. WS-Discovery and device-supplied XAddr values can currently redirect fresh WS-Security digests to attacker-selected origins, plaintext downgrade is accepted, and discovery is overclassified as verified. Add explicit origin correlation and allowlist policy, secure transport requirements with loopback-only fixture exceptions, redirect and DNS rebinding defenses, bounded SOAP/media parsing, redacted failures, and hostile integration fixtures."
+    },
+    {
+      "id": "smart-home-camera-onvif-capability-profile-and-vault-wiring",
+      "title": "Declare and approve camera/ONVIF host authority with Vault-mediated credentials",
+      "status": "pending",
+      "depends_on": [
+        "smart-home-camera-media-security-boundary-hardening",
+        "smart-home-onvif-origin-credential-transport-hardening"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the post-#9413 governance audit. The ONVIF program owns network, time, entropy, environment, and stdout authority, reads username/password from ambient environment variables, and lacks required_capabilities.json. Narrow the native host after both security boundaries land, replace ambient credentials with one-shot Vault leases, and define truthful runtime and test-harness profiles without claiming Layer 5 approval."
+    },
+    {
+      "id": "smart-home-camera-onvif-capability-layer5-evidence",
+      "title": "Approve the camera and ONVIF native-host capability profiles",
+      "status": "pending",
+      "depends_on": ["smart-home-camera-onvif-capability-profile-and-vault-wiring"],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "Discovered in the post-#9413 governance audit. After repository-local hardening and Vault wiring establish the minimum nonempty authority profiles, a maintainer must provide hardware-key-backed Layer 5 approval evidence before publication or privileged deployment."
+    },
+    {
+      "id": "smart-home-camera-media-portable-core-conformance",
+      "title": "Define fixtures and expand the portable camera-media policy core",
+      "status": "pending",
+      "depends_on": ["smart-home-camera-media-security-boundary-hardening"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Extract and fixture deterministic grant decisions, generation-bound lease state, TTLs, quotas, audit projection, and error classification behind injected authenticated context, time, nonce, and media transport. Expand only this authority-free core through established lanes; keep native media I/O and session hosting outside the denominator."
+    },
+    {
+      "id": "smart-home-onvif-portable-core-conformance",
+      "title": "Define fixtures and expand the portable ONVIF protocol core",
+      "status": "pending",
+      "depends_on": [
+        "smart-home-onvif-origin-credential-transport-hardening",
+        "smart-home-camera-onvif-capability-profile-and-vault-wiring"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Extract and fixture correlated discovery and SOAP parsing, deterministic UsernameToken construction with injected nonce/time, origin policy, normalized camera projection, bounds, and hostile inputs. Expand the authority-free core through established lanes while UDP/DNS/TCP/TLS, Vault access, trusted time/randomness, process I/O, and allowlists remain in the native Rust host."
+    },
+    {
+      "id": "dart-current-14-of-15-matrix-family",
+      "title": "Port the matrix dependency and its immediate ML consumers to Dart",
+      "status": "pending",
+      "depends_on": ["dart-trig-wave", "dart-scaffold-capability-schema"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized from the remaining Dart-only 14-of-15 umbrella during the post-#9413 dependency pass. Deliver matrix first, then loss-functions and feature-normalization in a coherent dependency-shaped slice with shared fixtures, empty capability profiles, package-native tests, coverage, and real downstream builds. Security-critical camera work currently outranks this otherwise highest-leverage portable frontier child."
     },
     {
       "id": "venture-browser-windows-portable-bridge-and-native-host",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,7 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": 9421,
   "last_inventory": {
     "revision": "d5f57bfdbc64ebf44d677f195380714f949b0db6",
     "schema_version": 3,
@@ -681,11 +681,11 @@
     {
       "id": "smart-home-camera-media-security-boundary-hardening",
       "title": "Replace camera endpoint redemption with a mediated single-use security boundary",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["capability-schema-category-action-constraints"],
       "branch": "codex/camera-media-security-boundary",
-      "pr_number": null,
-      "notes": "Selected after the post-#9413 collision-clean inventory and dependency, fixture, and security audits because its only dependency is merged and the current broker's replayable raw-URI redemption is a P0 privacy-boundary defect. The hardening installs authenticated principal, clock, nonce, and executor authority once in a host-owned service; removes bearer IDs from audits; revalidates grants; binds leases to endpoint generations; bounds global/per-principal leases, streams, pending cleanup, endpoints, snapshots, and audit; mints stream IDs outside the executor; owns stream close/expiry; retains and surfaces failed teardown for retry; rejects URL userinfo, fragments, default plaintext, and plaintext query strings; confines secure query tokens to the executor; and schema-validates an explicit authority-free manifest for the policy core. The separately tracked ONVIF origin/credential item remains the owner for discovery correlation, device-origin allowlists, credential transport, and downgrade defenses."
+      "pr_number": 9421,
+      "notes": "Ready-for-review PR #9421. Selected after the post-#9413 collision-clean inventory and dependency, fixture, and security audits because its only dependency is merged and the current broker's replayable raw-URI redemption is a P0 privacy-boundary defect. The hardening installs authenticated principal, clock, nonce, and executor authority once in a host-owned service; removes bearer IDs from audits; revalidates grants; binds leases to endpoint generations; bounds global/per-principal leases, streams, pending cleanup, endpoints, snapshots, and audit; mints stream IDs outside the executor; owns stream close/expiry; retains and surfaces failed teardown for retry; rejects URL userinfo, fragments, default plaintext, and plaintext query strings; confines secure query tokens to the executor; and schema-validates an explicit authority-free manifest for the policy core. Final validation after rebasing onto d5f57bfdb covered 15 camera tests, 4 ONVIF tests, warning-free Clippy/format, 85.87% camera line coverage, 6 capability schema tests, 67 capability-cage tests, a real 21-package build-tool run plus identical post-rebase dry-run closure, zero parity collisions/unknown buckets at 1,209 identities and 4,353 slots, zero dependency vulnerabilities, diff/secret hygiene, and independent contract/fixture/security reviews with no blockers. The separately tracked ONVIF origin/credential item remains the owner for discovery correlation, device-origin allowlists, credential transport, and downgrade defenses."
     },
     {
       "id": "smart-home-onvif-origin-credential-transport-hardening",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -681,11 +681,11 @@
     {
       "id": "smart-home-camera-media-security-boundary-hardening",
       "title": "Replace camera endpoint redemption with a mediated single-use security boundary",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["capability-schema-category-action-constraints"],
-      "branch": null,
+      "branch": "codex/camera-media-security-boundary",
       "pr_number": null,
-      "notes": "Discovered in the post-#9413 audit after PR #9407 added smart-home-camera-media. The current broker returns a replayable secret-bearing snapshot or stream URI, accepts caller-asserted principal and time, does not bind leases to endpoint generations, uses unbounded endpoint and lease maps, and owns OS entropy without capability metadata. Replace raw URI redemption with trusted-host mediation, inject authenticated principal, trusted time, and nonce generation, revalidate active grants at use time, bind leases to endpoint generations, enforce quotas, keep failures redacted, reject credential-bearing or insecure non-loopback endpoints, and add an explicit authority-free manifest for the resulting policy core."
+      "notes": "Selected after the post-#9413 collision-clean inventory and dependency, fixture, and security audits because its only dependency is merged and the current broker's replayable raw-URI redemption is a P0 privacy-boundary defect. The current broker also accepts caller-asserted principal and time, does not bind leases to endpoint generations, uses unbounded endpoint and lease maps, and owns OS entropy without capability metadata. Replace raw URI redemption with trusted-host mediation, inject authenticated principal, trusted time, and nonce generation, revalidate active grants at use time, bind leases to endpoint generations, enforce quotas, keep failures redacted, reject credential-bearing or insecure non-loopback endpoints, and add an explicit authority-free manifest for the resulting policy core."
     },
     {
       "id": "smart-home-onvif-origin-credential-transport-hardening",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -685,7 +685,7 @@
       "depends_on": ["capability-schema-category-action-constraints"],
       "branch": "codex/camera-media-security-boundary",
       "pr_number": null,
-      "notes": "Selected after the post-#9413 collision-clean inventory and dependency, fixture, and security audits because its only dependency is merged and the current broker's replayable raw-URI redemption is a P0 privacy-boundary defect. The current broker also accepts caller-asserted principal and time, does not bind leases to endpoint generations, uses unbounded endpoint and lease maps, and owns OS entropy without capability metadata. Replace raw URI redemption with trusted-host mediation, inject authenticated principal, trusted time, and nonce generation, revalidate active grants at use time, bind leases to endpoint generations, enforce quotas, keep failures redacted, reject credential-bearing or insecure non-loopback endpoints, and add an explicit authority-free manifest for the resulting policy core."
+      "notes": "Selected after the post-#9413 collision-clean inventory and dependency, fixture, and security audits because its only dependency is merged and the current broker's replayable raw-URI redemption is a P0 privacy-boundary defect. The hardening installs authenticated principal, clock, nonce, and executor authority once in a host-owned service; removes bearer IDs from audits; revalidates grants; binds leases to endpoint generations; bounds global/per-principal leases, streams, pending cleanup, endpoints, snapshots, and audit; mints stream IDs outside the executor; owns stream close/expiry; retains and surfaces failed teardown for retry; rejects URL userinfo, fragments, default plaintext, and plaintext query strings; confines secure query tokens to the executor; and schema-validates an explicit authority-free manifest for the policy core. The separately tracked ONVIF origin/credential item remains the owner for discovery correlation, device-origin allowlists, credential transport, and downgrade defenses."
     },
     {
       "id": "smart-home-onvif-origin-credential-transport-hardening",
@@ -695,6 +695,18 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the post-#9413 security audit. WS-Discovery and device-supplied XAddr values can currently redirect fresh WS-Security digests to attacker-selected origins, plaintext downgrade is accepted, and discovery is overclassified as verified. Add explicit origin correlation and allowlist policy, secure transport requirements with loopback-only fixture exceptions, redirect and DNS rebinding defenses, bounded SOAP/media parsing, redacted failures, and hostile integration fixtures."
+    },
+    {
+      "id": "smart-home-onvif-transactional-install",
+      "title": "Make ONVIF runtime and media registration transactional",
+      "status": "pending",
+      "depends_on": [
+        "smart-home-camera-media-security-boundary-hardening",
+        "smart-home-onvif-origin-credential-transport-hardening"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the camera-media hardening security review. install_camera_snapshot mutates bridge and endpoint state before every profile, device, and entity has been validated, so a later URI, quota, or registry failure can leave partial runtime state and rotate existing endpoint generations. Add a validate-and-plan phase, preflight camera-media capacity/origin policy, commit runtime plus endpoint changes atomically or roll them back, and prove failure leaves both stores unchanged."
     },
     {
       "id": "smart-home-camera-onvif-capability-profile-and-vault-wiring",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -10,16 +10,16 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "6dbe24e287faac5857f15fd85f398f0e2fb40387",
+    "revision": "d5f57bfdbc64ebf44d677f195380714f949b0db6",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1208,
-    "implementation_package_slots": 4352,
+    "implementation_identities": 1209,
+    "implementation_package_slots": 4353,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 275,
-    "singleton_packages": 758,
-    "singleton_missing_slots": 10612,
-    "rust_singletons": 563,
+    "singleton_packages": 759,
+    "singleton_missing_slots": 10626,
+    "rust_singletons": 564,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -667,7 +667,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 563, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 564, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -786,7 +786,47 @@
       "depends_on": ["capability-schema-category-action-constraints"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered during the Shelly dependency audit. tcp-client and http1-client declare empty capability profiles despite concrete DNS/TCP calls, while udp-client and smart-home-discovery lack manifests despite socket and discovery authority. Inventory the executable library and harness boundaries, split pure parsers/planners from native I/O where necessary, and add truthful minimum runtime/test profiles without claiming Layer 5 approval. This shared substrate item has leverage across Shelly and other local-network integrations."
+      "notes": "Discovered during the Shelly dependency audit and reconfirmed by the WLED integration. tcp-client and http1-client declare empty capability profiles despite concrete DNS/TCP calls, while udp-client and smart-home-discovery lack manifests despite socket and discovery authority. Inventory the executable library and harness boundaries, split pure parsers/planners from native I/O where necessary, and add truthful minimum runtime/test profiles without claiming Layer 5 approval. This shared substrate item has leverage across Shelly, WLED, and other local-network integrations."
+    },
+    {
+      "id": "smart-home-wled-host-security-hardening",
+      "title": "Harden WLED LAN origins, runtime effects, and native-host authority",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean d5f57bfd inventory after PR #9419 added the Rust-only WLED integration. The native host accepts caller-supplied principal/time, exposes public update_state and mutable transport access, accepts any DNS host/port for plaintext HTTP, marks mDNS-derived addresses verified without a retained origin binding or pairing policy, publishes optimistic runtime acceptance before the device update succeeds, discards the returned device state instead of reconciling it, installs bridge/device/entities incrementally, does not reject duplicate segment IDs or malformed/colliding normalized MAC identities, bounds total bytes but not segments/strings/color arrays/request bodies/entity counts, and lacks required_capabilities.json despite mDNS, DNS/TCP, clock, environment/arguments, and console authority. Install authenticated session/clock authority once, narrow authorized mutations, require reviewed private-origin and discovery binding with DNS-rebinding defenses, bound/redact device data, add validate-and-plan plus commit/compensation/reconciliation semantics, and define truthful runtime/test capability profiles. Coordinate shared network-manifest corrections with rust-network-substrate-capability-truthfulness; do not claim Layer 5 approval."
+    },
+    {
+      "id": "smart-home-wled-capability-layer5-evidence",
+      "title": "Approve the WLED native-host capability profiles",
+      "status": "pending",
+      "depends_on": [
+        "smart-home-wled-host-security-hardening",
+        "rust-network-substrate-capability-truthfulness"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "selection_blocked": true,
+      "notes": "After repository-local WLED hardening and shared network-substrate correction establish the minimum nonempty runtime and test-harness authority profiles, a maintainer must provide hardware-key-backed Layer 5 approval evidence before publication or privileged deployment."
+    },
+    {
+      "id": "smart-home-wled-portable-core-extraction-and-conformance",
+      "title": "Extract, fixture, and expand the portable WLED JSON core",
+      "status": "pending",
+      "depends_on": ["smart-home-wled-host-security-hardening"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Extract and fixture deterministic /json/si DTO validation, master and segment projection, stable identifiers, capability-bit interpretation, state normalization, brightness/RGB/mirek conversion, command planning, bounds, and hostile inputs. Expand only this authority-free core through established lanes while mDNS, DNS/TCP, plaintext LAN HTTP, trusted time, console I/O, origin/pairing policy, and SmartHomeRuntime effect application remain in the native Rust host."
+    },
+    {
+      "id": "smart-home-lan-http-native-executor-consolidation",
+      "title": "Consolidate a bounded native LAN-HTTP executor for smart-home hosts",
+      "status": "pending",
+      "depends_on": ["rust-network-substrate-capability-truthfulness"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the joint Shelly/WLED dependency audit. Both integrations duplicate DNS resolution, connect timeouts, TCP read/write, HTTP/1.1 request encoding, bounded response reads, chunked decoding, and error projection while smart-home-local-http is correctly a pure request planner and http1-client is GET-only. Add a separate native executor with retained origin/address policy, shared byte/time/output ceilings, redacted typed failures, truthful capability profiles, and POST support; migrate Shelly and WLED only after their security owners define pairing, authorization, and transactional semantics."
     },
     {
       "id": "dart-current-14-of-15-matrix-family",

--- a/code/packages/rust/smart-home-camera-media/CHANGELOG.md
+++ b/code/packages/rust/smart-home-camera-media/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.2.0
+
+- Replaced raw endpoint redemption with a host-owned `CameraMediaService` that
+  installs identity, clock, nonce, and executor authority once; operation calls
+  cannot substitute caller-asserted security dependencies.
+- Return bounded zeroizing snapshot bytes and retain executor-owned stream
+  resources behind broker-minted session IDs with explicit close, grant-aware
+  expiry, surfaced teardown failures, and retryable retained cleanup.
+- Removed principal and timestamp fields from untrusted access requests; issue,
+  delivery, expiry sweeps, and audit now use host-supplied identity and time.
+- Recheck active Human Approval grants at delivery and clamp lease expiry to the
+  authorizing grant's expiry.
+- Added endpoint generations, checked expiry arithmetic, collision-failing
+  injected nonce IDs, bounded endpoint/lease state, and closed delivery errors.
+- Removed bearer IDs from audit records; redacted and zeroized public IDs; reject
+  userinfo, fragments, default plaintext, replay, stale generations, oversized
+  snapshots, wrong-kind executor results, and invalid deliveries.
+- Added global, per-principal, stream, endpoint, lease, and audit bounds; expired
+  leases are pruned before quota evaluation.
+- Removed direct OS randomness and declared the resulting in-memory policy core's
+  explicit empty capability profile, with a committed schema-validation gate.
+
 ## 0.1.0
 
 - Added process-local camera endpoint registration with redacted debug output.

--- a/code/packages/rust/smart-home-camera-media/Cargo.toml
+++ b/code/packages/rust/smart-home-camera-media/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "smart-home-camera-media"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Privacy-preserving camera snapshot and stream leases for the smart-home runtime"
 license = "MIT"
 
 [dependencies]
 coding_adventures_zeroize = { path = "../zeroize" }
-rand = "0.8"
 smart-home-core = { path = "../smart-home-core" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 url-parser = { path = "../url-parser" }

--- a/code/packages/rust/smart-home-camera-media/README.md
+++ b/code/packages/rust/smart-home-camera-media/README.md
@@ -2,8 +2,9 @@
 
 `smart-home-camera-media` keeps privacy-sensitive camera endpoints out of the
 durable D23 model. Integrations register snapshot and stream URIs in a
-process-local broker. Authorized principals receive opaque, short-lived,
-single-use leases whose audit records contain no URI or credential material.
+process-local `CameraMediaService`. Authorized principals receive opaque, short-lived,
+single-use leases whose audit records contain no URI, raw bearer ID, or
+credential material.
 
 The broker uses D23 capability grants directly:
 
@@ -11,6 +12,30 @@ The broker uses D23 capability grants directly:
 - `camera.stream` requires a Human Approval grant.
 - entity-scoped, capability-scoped, and all-smart-home grants are supported.
 - expired, pending, revoked, or insufficient-tier grants are rejected.
+- current authorization is checked again immediately before delivery.
+- lease expiry is clamped to the active grant's expiry.
 
 Snapshot and stream URIs are wrapped in the repository's zeroizing secret type
-and are exposed only when a matching lease is redeemed by its principal.
+and are lent only to a trusted `CameraMediaExecutor` during one atomic delivery.
+Snapshot bytes are bounded before release. For streams, the executor returns an
+owned resource, the service mints the public session ID, and the service retains
+the resource until explicit close or trusted-time expiry. The executor cannot
+smuggle an endpoint URI into the public session ID. `reconcile` also closes a
+stream when its current grant is no longer active. Failed native teardown keeps
+broker ownership, is reported, and remains retryable; post-open failures without
+a public session are retained in a bounded cleanup queue.
+
+The security context is installed once in `CameraMediaService` by the native host:
+
+- `CameraMediaClock` provides trusted issue, delivery, expiry, and audit time.
+- `CameraMediaNonceSource` provides collision-resistant 128-bit lease IDs.
+- `CameraMediaPrincipalSource` derives the authenticated `AgentId` from the
+  active host/session, not the untrusted access request or each operation call.
+- `CameraMediaExecutor` owns the actual network/media operation.
+
+The policy core itself performs no filesystem, network, process, environment, FFI,
+clock, standard-I/O, or entropy operation. Endpoint and lease tables are bounded;
+endpoint generations invalidate pre-rotation leases; URL userinfo and fragments
+fail closed. Plaintext endpoints are disabled by default and require an explicit
+loopback-fixture policy opt-in. Query tokens are permitted only on otherwise
+accepted secure endpoints and remain inside the trusted executor boundary.

--- a/code/packages/rust/smart-home-camera-media/required_capabilities.json
+++ b/code/packages/rust/smart-home-camera-media/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/smart-home-camera-media",
+  "capabilities": [],
+  "justification": "Pure in-memory lease policy with host-supplied identity, time, nonce bytes, and media execution; it performs no filesystem, network, process, environment, FFI, clock, or standard-I/O access."
+}

--- a/code/packages/rust/smart-home-camera-media/src/lib.rs
+++ b/code/packages/rust/smart-home-camera-media/src/lib.rs
@@ -1,9 +1,13 @@
 //! Privacy-preserving camera snapshot and stream leases for D23.
+//!
+//! The broker is deliberately an in-memory policy core. A native host supplies
+//! authenticated identity, trusted time, collision-resistant nonce bytes, and
+//! the media executor. The broker never opens a socket and never returns the
+//! camera endpoint URI to the lease holder.
 
 #![forbid(unsafe_code)]
 
 use coding_adventures_zeroize::Zeroizing;
-use rand::{rngs::OsRng, RngCore};
 use smart_home_core::{
     AgentId, CapabilityGrant, CapabilityGrantScope, CapabilityId, CapabilityMode, EntityId,
     PrivilegeTier,
@@ -11,13 +15,20 @@ use smart_home_core::{
 use smart_home_runtime::SmartHomeRuntime;
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use url_parser::Url;
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 pub const SNAPSHOT_CAPABILITY_ID: &str = "camera.snapshot";
 pub const STREAM_CAPABILITY_ID: &str = "camera.stream";
 pub const DEFAULT_MAX_AUDIT_RECORDS: usize = 256;
+pub const DEFAULT_MAX_ENDPOINTS: usize = 128;
+pub const DEFAULT_MAX_ACTIVE_LEASES: usize = 256;
+pub const DEFAULT_MAX_ACTIVE_LEASES_PER_PRINCIPAL: usize = 32;
+pub const DEFAULT_MAX_ACTIVE_STREAMS: usize = 64;
+pub const DEFAULT_MAX_SNAPSHOT_BYTES: usize = 10 * 1024 * 1024;
 
+/// The media action authorized by a lease.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CameraMediaKind {
     Snapshot,
@@ -40,35 +51,85 @@ impl CameraMediaKind {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CameraMediaLeaseId(String);
+/// Opaque bearer identifier for one camera-media authorization.
+///
+/// The ID deliberately has no `Display` implementation, and its `Debug`
+/// representation is redacted. `as_hex` is an explicit boundary operation for
+/// the host protocol. The owned bytes are zeroized when each copy drops.
+pub struct CameraMediaLeaseId(Zeroizing<String>);
 
 impl CameraMediaLeaseId {
-    pub fn as_str(&self) -> &str {
+    pub fn as_hex(&self) -> &str {
         &self.0
+    }
+
+    pub fn from_hex(value: &str) -> Option<Self> {
+        if value.len() != 32
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return None;
+        }
+        Some(Self(Zeroizing::new(value.to_owned())))
+    }
+}
+
+impl Clone for CameraMediaLeaseId {
+    fn clone(&self) -> Self {
+        Self(Zeroizing::new(self.as_hex().to_owned()))
     }
 }
 
 impl fmt::Debug for CameraMediaLeaseId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_tuple("CameraMediaLeaseId")
-            .field(&self.0)
-            .finish()
+        write!(
+            formatter,
+            "CameraMediaLeaseId(<{}-char redacted>)",
+            self.0.len()
+        )
     }
 }
 
-impl fmt::Display for CameraMediaLeaseId {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.0)
+impl Hash for CameraMediaLeaseId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_hex().hash(state);
     }
 }
 
+impl PartialEq for CameraMediaLeaseId {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_hex() == other.as_hex()
+    }
+}
+
+impl Eq for CameraMediaLeaseId {}
+
+impl PartialOrd for CameraMediaLeaseId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CameraMediaLeaseId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_hex().cmp(other.as_hex())
+    }
+}
+
+/// Bounds that keep process-local endpoint and lease state finite.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CameraMediaPolicy {
     pub max_snapshot_ttl_ms: u64,
     pub max_stream_ttl_ms: u64,
     pub max_audit_records: usize,
+    pub max_endpoints: usize,
+    pub max_active_leases: usize,
+    pub max_active_leases_per_principal: usize,
+    pub max_active_streams: usize,
+    pub max_snapshot_bytes: usize,
+    /// Explicit fixture-only escape hatch. Production defaults remain secure.
+    pub allow_plaintext_loopback: bool,
 }
 
 impl Default for CameraMediaPolicy {
@@ -77,6 +138,12 @@ impl Default for CameraMediaPolicy {
             max_snapshot_ttl_ms: 30_000,
             max_stream_ttl_ms: 60_000,
             max_audit_records: DEFAULT_MAX_AUDIT_RECORDS,
+            max_endpoints: DEFAULT_MAX_ENDPOINTS,
+            max_active_leases: DEFAULT_MAX_ACTIVE_LEASES,
+            max_active_leases_per_principal: DEFAULT_MAX_ACTIVE_LEASES_PER_PRINCIPAL,
+            max_active_streams: DEFAULT_MAX_ACTIVE_STREAMS,
+            max_snapshot_bytes: DEFAULT_MAX_SNAPSHOT_BYTES,
+            allow_plaintext_loopback: false,
         }
     }
 }
@@ -90,36 +157,35 @@ impl CameraMediaPolicy {
     }
 }
 
+/// Untrusted camera request fields.
+///
+/// Principal and time are intentionally absent. The native host derives the
+/// authenticated principal and supplies a trusted clock separately.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CameraMediaAccessRequest {
-    pub principal_id: AgentId,
     pub entity_id: EntityId,
     pub kind: CameraMediaKind,
     pub purpose: String,
-    pub requested_at_ms: u64,
     pub ttl_ms: u64,
 }
 
 impl CameraMediaAccessRequest {
     pub fn new(
-        principal_id: AgentId,
         entity_id: EntityId,
         kind: CameraMediaKind,
         purpose: impl Into<String>,
-        requested_at_ms: u64,
         ttl_ms: u64,
     ) -> Self {
         Self {
-            principal_id,
             entity_id,
             kind,
             purpose: purpose.into(),
-            requested_at_ms,
             ttl_ms,
         }
     }
 }
 
+/// Public lease metadata. The endpoint never appears here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CameraMediaLease {
     pub lease_id: CameraMediaLeaseId,
@@ -128,6 +194,7 @@ pub struct CameraMediaLease {
     pub kind: CameraMediaKind,
     pub issued_at_ms: u64,
     pub expires_at_ms: u64,
+    pub endpoint_generation: u64,
 }
 
 impl CameraMediaLease {
@@ -136,13 +203,229 @@ impl CameraMediaLease {
     }
 }
 
+/// Broker-minted stream handle returned after a successful mediated open.
+pub struct CameraMediaStreamSessionId(Zeroizing<String>);
+
+impl CameraMediaStreamSessionId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Clone for CameraMediaStreamSessionId {
+    fn clone(&self) -> Self {
+        Self(Zeroizing::new(self.as_str().to_owned()))
+    }
+}
+
+impl fmt::Debug for CameraMediaStreamSessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "CameraMediaStreamSessionId(<{}-char redacted>)",
+            self.0.len()
+        )
+    }
+}
+
+impl PartialEq for CameraMediaStreamSessionId {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for CameraMediaStreamSessionId {}
+
+impl PartialOrd for CameraMediaStreamSessionId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CameraMediaStreamSessionId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+/// Snapshot bytes retained in zeroizing memory and redacted from diagnostics.
+pub struct CameraMediaSnapshot(Zeroizing<Vec<u8>>);
+
+impl CameraMediaSnapshot {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Clone for CameraMediaSnapshot {
+    fn clone(&self) -> Self {
+        Self(Zeroizing::new(self.as_bytes().to_vec()))
+    }
+}
+
+impl fmt::Debug for CameraMediaSnapshot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "CameraMediaSnapshot(<{} bytes redacted>)",
+            self.0.len()
+        )
+    }
+}
+
+impl PartialEq for CameraMediaSnapshot {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+
+impl Eq for CameraMediaSnapshot {}
+
+/// Non-endpoint result returned by the trusted executor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CameraMediaDelivery {
+    Snapshot {
+        snapshot: CameraMediaSnapshot,
+    },
+    Stream {
+        session_id: CameraMediaStreamSessionId,
+        expires_at_ms: u64,
+    },
+}
+
+impl CameraMediaDelivery {
+    pub fn snapshot_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Snapshot { snapshot } => Some(snapshot.as_bytes()),
+            Self::Stream { .. } => None,
+        }
+    }
+}
+
+/// Executor-owned result. Stream identifiers are deliberately absent: the
+/// service mints those after it has taken ownership of the stream resource.
+pub enum CameraMediaExecutionResult<Stream> {
+    Snapshot(Zeroizing<Vec<u8>>),
+    Stream(Stream),
+}
+
+impl<Stream> CameraMediaExecutionResult<Stream> {
+    pub fn snapshot(bytes: Vec<u8>) -> Self {
+        Self::Snapshot(Zeroizing::new(bytes))
+    }
+
+    pub fn stream(resource: Stream) -> Self {
+        Self::Stream(resource)
+    }
+}
+
+/// Closed, endpoint-free executor failure classes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CameraMediaExecutionError {
+    Unavailable,
+    Rejected,
+    ResourceLimit,
+    Protocol,
+}
+
+impl fmt::Display for CameraMediaExecutionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Unavailable => "media transport unavailable",
+            Self::Rejected => "media transport rejected the request",
+            Self::ResourceLimit => "media transport exceeded a resource limit",
+            Self::Protocol => "media transport protocol failure",
+        })
+    }
+}
+
+/// A borrowed endpoint available only during trusted executor dispatch.
+pub struct CameraMediaExecution<'a> {
+    entity_id: &'a EntityId,
+    kind: CameraMediaKind,
+    endpoint_uri: &'a str,
+    expires_at_ms: u64,
+    max_snapshot_bytes: usize,
+}
+
+impl fmt::Debug for CameraMediaExecution<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CameraMediaExecution")
+            .field("entity_id", self.entity_id)
+            .field("kind", &self.kind)
+            .field("endpoint_uri", &"[REDACTED]")
+            .field("expires_at_ms", &self.expires_at_ms)
+            .field("max_snapshot_bytes", &self.max_snapshot_bytes)
+            .finish()
+    }
+}
+
+impl<'a> CameraMediaExecution<'a> {
+    pub fn entity_id(&self) -> &EntityId {
+        self.entity_id
+    }
+
+    pub fn kind(&self) -> CameraMediaKind {
+        self.kind
+    }
+
+    /// Borrow the endpoint inside the trusted host adapter only.
+    pub fn endpoint_uri(&self) -> &str {
+        self.endpoint_uri
+    }
+
+    pub fn expires_at_ms(&self) -> u64 {
+        self.expires_at_ms
+    }
+
+    pub fn max_snapshot_bytes(&self) -> usize {
+        self.max_snapshot_bytes
+    }
+}
+
+/// Trusted time provider owned by the native host.
+pub trait CameraMediaClock {
+    fn now_ms(&self) -> u64;
+}
+
+/// Endpoint-free failure from a trusted nonce provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CameraMediaNonceError;
+
+/// Collision-resistant nonce provider owned by the native host.
+pub trait CameraMediaNonceSource {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError>;
+}
+
+/// Native media host. The endpoint is lent only for this call.
+pub trait CameraMediaExecutor {
+    type Stream;
+
+    fn deliver(
+        &mut self,
+        execution: CameraMediaExecution<'_>,
+    ) -> Result<CameraMediaExecutionResult<Self::Stream>, CameraMediaExecutionError>;
+
+    /// Close one owned stream. On error the resource remains valid for retry.
+    fn close_stream(&mut self, stream: &mut Self::Stream) -> Result<(), CameraMediaExecutionError>;
+}
+
+/// Authenticated identity source installed once by the native host.
+pub trait CameraMediaPrincipalSource {
+    fn current_principal(&self) -> Option<AgentId>;
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CameraMediaAuditOutcome {
     EndpointRegistered,
+    EndpointRemoved,
     LeaseIssued,
     LeaseDenied,
-    LeaseRedeemed,
+    LeaseDelivered,
     LeaseExpired,
+    LeaseRejected,
+    DeliveryFailed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -151,7 +434,6 @@ pub struct CameraMediaAuditRecord {
     pub principal_id: Option<AgentId>,
     pub entity_id: EntityId,
     pub kind: CameraMediaKind,
-    pub lease_id: Option<CameraMediaLeaseId>,
     pub outcome: CameraMediaAuditOutcome,
     pub reason: Option<String>,
     pub occurred_at_ms: u64,
@@ -161,16 +443,28 @@ pub struct CameraMediaAuditRecord {
 pub struct CameraMediaBrokerSnapshot {
     pub endpoint_count: usize,
     pub active_lease_count: usize,
+    pub active_stream_count: usize,
+    pub pending_stream_cleanup_count: usize,
     pub audit_record_count: usize,
     pub issued_lease_count: u64,
     pub denied_lease_count: u64,
     pub redeemed_lease_count: u64,
+    pub failed_delivery_count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CameraMediaReconcileReport {
+    pub expired_lease_count: usize,
+    pub closed_stream_count: usize,
+    pub failed_stream_close_count: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CameraMediaError {
     InvalidEndpoint(String),
     UnsupportedEndpointScheme(String),
+    EndpointCredentialsForbidden,
+    InsecureEndpoint,
     UnknownEntity(EntityId),
     MissingCapability {
         entity_id: EntityId,
@@ -189,14 +483,37 @@ pub enum CameraMediaError {
         requested_ms: u64,
         maximum_ms: u64,
     },
+    EndpointQuotaExceeded {
+        maximum: usize,
+    },
+    LeaseQuotaExceeded {
+        maximum: usize,
+    },
+    PrincipalLeaseQuotaExceeded {
+        maximum: usize,
+    },
+    StreamQuotaExceeded {
+        maximum: usize,
+    },
+    TimestampOverflow,
+    EndpointGenerationOverflow,
+    NonceUnavailable,
+    DuplicateLeaseId,
+    DuplicateStreamSessionId,
+    Unauthenticated,
     Unauthorized {
         principal_id: AgentId,
         entity_id: EntityId,
         capability_id: CapabilityId,
     },
-    UnknownLease(CameraMediaLeaseId),
-    LeasePrincipalMismatch(CameraMediaLeaseId),
-    ExpiredLease(CameraMediaLeaseId),
+    UnknownLease,
+    LeasePrincipalMismatch,
+    ExpiredLease,
+    EndpointGenerationChanged,
+    Execution(CameraMediaExecutionError),
+    InvalidDelivery,
+    UnknownStreamSession,
+    StreamPrincipalMismatch,
 }
 
 impl fmt::Display for CameraMediaError {
@@ -208,6 +525,12 @@ impl fmt::Display for CameraMediaError {
             Self::UnsupportedEndpointScheme(scheme) => {
                 write!(formatter, "unsupported camera endpoint scheme `{scheme}`")
             }
+            Self::EndpointCredentialsForbidden => {
+                formatter.write_str("camera endpoint must not contain user information")
+            }
+            Self::InsecureEndpoint => formatter.write_str(
+                "plaintext camera endpoints are allowed only for explicit loopback fixtures",
+            ),
             Self::UnknownEntity(entity_id) => {
                 write!(formatter, "unknown camera entity {entity_id}")
             }
@@ -222,13 +545,11 @@ impl fmt::Display for CameraMediaError {
                 formatter,
                 "camera capability {capability_id} on {entity_id} is read-only"
             ),
-            Self::MissingEndpoint { entity_id, kind } => {
-                write!(
-                    formatter,
-                    "camera entity {entity_id} has no {} endpoint",
-                    kind.as_str()
-                )
-            }
+            Self::MissingEndpoint { entity_id, kind } => write!(
+                formatter,
+                "camera entity {entity_id} has no {} endpoint",
+                kind.as_str()
+            ),
             Self::EmptyPurpose => formatter.write_str("camera access purpose must not be empty"),
             Self::InvalidTtl {
                 requested_ms,
@@ -237,6 +558,29 @@ impl fmt::Display for CameraMediaError {
                 formatter,
                 "camera lease TTL {requested_ms}ms exceeds the allowed 1..={maximum_ms}ms range"
             ),
+            Self::EndpointQuotaExceeded { maximum } => {
+                write!(formatter, "camera endpoint quota of {maximum} is exhausted")
+            }
+            Self::LeaseQuotaExceeded { maximum } => {
+                write!(formatter, "camera lease quota of {maximum} is exhausted")
+            }
+            Self::PrincipalLeaseQuotaExceeded { maximum } => write!(
+                formatter,
+                "camera per-principal lease quota of {maximum} is exhausted"
+            ),
+            Self::StreamQuotaExceeded { maximum } => {
+                write!(formatter, "camera stream quota of {maximum} is exhausted")
+            }
+            Self::TimestampOverflow => formatter.write_str("camera lease expiry overflowed"),
+            Self::EndpointGenerationOverflow => {
+                formatter.write_str("camera endpoint generation exhausted")
+            }
+            Self::NonceUnavailable => formatter.write_str("camera lease nonce source unavailable"),
+            Self::DuplicateLeaseId => formatter.write_str("camera lease identifier collision"),
+            Self::DuplicateStreamSessionId => {
+                formatter.write_str("camera stream session identifier collision")
+            }
+            Self::Unauthenticated => formatter.write_str("camera media host is unauthenticated"),
             Self::Unauthorized {
                 principal_id,
                 entity_id,
@@ -245,17 +589,21 @@ impl fmt::Display for CameraMediaError {
                 formatter,
                 "principal {principal_id} is not authorized for {capability_id} on {entity_id}"
             ),
-            Self::UnknownLease(lease_id) => {
-                write!(formatter, "unknown camera media lease {lease_id}")
+            Self::UnknownLease => formatter.write_str("unknown camera media lease"),
+            Self::LeasePrincipalMismatch => {
+                formatter.write_str("camera media lease belongs to another principal")
             }
-            Self::LeasePrincipalMismatch(lease_id) => {
-                write!(
-                    formatter,
-                    "camera media lease {lease_id} belongs to another principal"
-                )
+            Self::ExpiredLease => formatter.write_str("camera media lease expired"),
+            Self::EndpointGenerationChanged => {
+                formatter.write_str("camera media endpoint changed after lease issuance")
             }
-            Self::ExpiredLease(lease_id) => {
-                write!(formatter, "camera media lease {lease_id} expired")
+            Self::Execution(error) => write!(formatter, "{error}"),
+            Self::InvalidDelivery => {
+                formatter.write_str("camera media executor returned an invalid delivery")
+            }
+            Self::UnknownStreamSession => formatter.write_str("unknown camera stream session"),
+            Self::StreamPrincipalMismatch => {
+                formatter.write_str("camera stream session belongs to another principal")
             }
         }
     }
@@ -265,24 +613,365 @@ impl std::error::Error for CameraMediaError {}
 
 struct CameraMediaEndpoint {
     uri: Zeroizing<String>,
+    generation: u64,
 }
 
 impl fmt::Debug for CameraMediaEndpoint {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("CameraMediaEndpoint([REDACTED])")
+        formatter
+            .debug_struct("CameraMediaEndpoint")
+            .field("uri", &"[REDACTED]")
+            .field("generation", &self.generation)
+            .finish()
     }
 }
 
 #[derive(Debug)]
-pub struct CameraMediaBroker {
+struct CameraMediaBroker {
     policy: CameraMediaPolicy,
     endpoints: BTreeMap<(EntityId, CameraMediaKind), CameraMediaEndpoint>,
     leases: BTreeMap<CameraMediaLeaseId, CameraMediaLease>,
     audit: VecDeque<CameraMediaAuditRecord>,
+    next_endpoint_generation: u64,
     next_audit_sequence: u64,
     issued_lease_count: u64,
     denied_lease_count: u64,
     redeemed_lease_count: u64,
+    failed_delivery_count: u64,
+}
+
+struct PendingCameraMediaExecution {
+    lease: CameraMediaLease,
+    endpoint_uri: Zeroizing<String>,
+}
+
+struct ActiveCameraMediaStream<Stream> {
+    principal_id: AgentId,
+    entity_id: EntityId,
+    kind: CameraMediaKind,
+    expires_at_ms: u64,
+    resource: Stream,
+}
+
+/// Host-owned security facade. Identity, time, entropy, and media execution
+/// are installed once and cannot be substituted by an untrusted request.
+pub struct CameraMediaService<Clock, Nonce, Principals, Executor>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor,
+{
+    broker: CameraMediaBroker,
+    clock: Clock,
+    nonce_source: Nonce,
+    principal_source: Principals,
+    executor: Executor,
+    streams: BTreeMap<CameraMediaStreamSessionId, ActiveCameraMediaStream<Executor::Stream>>,
+    pending_stream_cleanup: Vec<Executor::Stream>,
+}
+
+impl<Clock, Nonce, Principals, Executor> CameraMediaService<Clock, Nonce, Principals, Executor>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor,
+{
+    pub fn new(
+        policy: CameraMediaPolicy,
+        clock: Clock,
+        nonce_source: Nonce,
+        principal_source: Principals,
+        executor: Executor,
+    ) -> Self {
+        Self {
+            broker: CameraMediaBroker::new(policy),
+            clock,
+            nonce_source,
+            principal_source,
+            executor,
+            streams: BTreeMap::new(),
+            pending_stream_cleanup: Vec::new(),
+        }
+    }
+
+    pub fn register_endpoint(
+        &mut self,
+        entity_id: EntityId,
+        kind: CameraMediaKind,
+        uri: impl Into<String>,
+    ) -> Result<(), CameraMediaError> {
+        self.broker
+            .register_endpoint_at(self.clock.now_ms(), entity_id, kind, uri)
+    }
+
+    pub fn unregister_endpoint(&mut self, entity_id: &EntityId, kind: CameraMediaKind) -> bool {
+        self.broker
+            .unregister_endpoint_at(self.clock.now_ms(), entity_id, kind)
+    }
+
+    pub fn issue_lease(
+        &mut self,
+        runtime: &SmartHomeRuntime,
+        request: CameraMediaAccessRequest,
+    ) -> Result<CameraMediaLease, CameraMediaError> {
+        let principal_id = self.authenticated_principal()?;
+        self.broker.issue_lease_at(
+            runtime,
+            &principal_id,
+            &mut self.nonce_source,
+            request,
+            self.clock.now_ms(),
+        )
+    }
+
+    pub fn deliver_lease(
+        &mut self,
+        runtime: &SmartHomeRuntime,
+        lease_id: &CameraMediaLeaseId,
+    ) -> Result<CameraMediaDelivery, CameraMediaError> {
+        let principal_id = self.authenticated_principal()?;
+        let now_ms = self.clock.now_ms();
+        let pending = self
+            .broker
+            .prepare_delivery(runtime, &principal_id, lease_id, now_ms)?;
+        if self.pending_stream_cleanup.len() >= self.broker.policy.max_active_streams {
+            return Err(self.broker.record_delivery_failure(
+                &pending.lease,
+                CameraMediaError::StreamQuotaExceeded {
+                    maximum: self.broker.policy.max_active_streams,
+                },
+                now_ms,
+            ));
+        }
+        if pending.lease.kind == CameraMediaKind::Stream
+            && self.streams.len() >= self.broker.policy.max_active_streams
+        {
+            return Err(self.broker.record_delivery_failure(
+                &pending.lease,
+                CameraMediaError::StreamQuotaExceeded {
+                    maximum: self.broker.policy.max_active_streams,
+                },
+                now_ms,
+            ));
+        }
+        let execution = CameraMediaExecution {
+            entity_id: &pending.lease.entity_id,
+            kind: pending.lease.kind,
+            endpoint_uri: pending.endpoint_uri.as_str(),
+            expires_at_ms: pending.lease.expires_at_ms,
+            max_snapshot_bytes: self.broker.policy.max_snapshot_bytes,
+        };
+        let result = match self.executor.deliver(execution) {
+            Ok(result) => result,
+            Err(error) => {
+                return Err(self.broker.record_delivery_failure(
+                    &pending.lease,
+                    CameraMediaError::Execution(error),
+                    now_ms,
+                ));
+            }
+        };
+        match (pending.lease.kind, result) {
+            (CameraMediaKind::Snapshot, CameraMediaExecutionResult::Snapshot(bytes))
+                if bytes.len() <= self.broker.policy.max_snapshot_bytes =>
+            {
+                self.broker.record_delivery_success(&pending.lease, now_ms);
+                Ok(CameraMediaDelivery::Snapshot {
+                    snapshot: CameraMediaSnapshot(bytes),
+                })
+            }
+            (CameraMediaKind::Stream, CameraMediaExecutionResult::Stream(resource)) => {
+                let mut nonce = [0u8; 16];
+                if self.nonce_source.fill_nonce(&mut nonce).is_err() {
+                    let error =
+                        self.close_or_retain_stream(resource, CameraMediaError::NonceUnavailable);
+                    return Err(self
+                        .broker
+                        .record_delivery_failure(&pending.lease, error, now_ms));
+                }
+                let session_id = stream_id_from_nonce(nonce);
+                if self.streams.contains_key(&session_id) {
+                    let error = self.close_or_retain_stream(
+                        resource,
+                        CameraMediaError::DuplicateStreamSessionId,
+                    );
+                    return Err(self
+                        .broker
+                        .record_delivery_failure(&pending.lease, error, now_ms));
+                }
+                let expires_at_ms = pending.lease.expires_at_ms;
+                self.streams.insert(
+                    session_id.clone(),
+                    ActiveCameraMediaStream {
+                        principal_id,
+                        entity_id: pending.lease.entity_id.clone(),
+                        kind: pending.lease.kind,
+                        expires_at_ms,
+                        resource,
+                    },
+                );
+                self.broker.record_delivery_success(&pending.lease, now_ms);
+                Ok(CameraMediaDelivery::Stream {
+                    session_id,
+                    expires_at_ms,
+                })
+            }
+            (_, CameraMediaExecutionResult::Stream(resource)) => {
+                let error =
+                    self.close_or_retain_stream(resource, CameraMediaError::InvalidDelivery);
+                Err(self
+                    .broker
+                    .record_delivery_failure(&pending.lease, error, now_ms))
+            }
+            _ => Err(self.broker.record_delivery_failure(
+                &pending.lease,
+                CameraMediaError::InvalidDelivery,
+                now_ms,
+            )),
+        }
+    }
+
+    pub fn close_stream(
+        &mut self,
+        session_id: &CameraMediaStreamSessionId,
+    ) -> Result<(), CameraMediaError> {
+        let principal_id = self.authenticated_principal()?;
+        let stream = self
+            .streams
+            .get(session_id)
+            .ok_or(CameraMediaError::UnknownStreamSession)?;
+        if stream.principal_id != principal_id {
+            return Err(CameraMediaError::StreamPrincipalMismatch);
+        }
+        let close_result = {
+            let stream = self
+                .streams
+                .get_mut(session_id)
+                .expect("stream was checked above");
+            self.executor.close_stream(&mut stream.resource)
+        };
+        close_result.map_err(CameraMediaError::Execution)?;
+        self.streams.remove(session_id);
+        Ok(())
+    }
+
+    /// Close expired streams and streams whose current grant was revoked.
+    pub fn reconcile(&mut self, runtime: &SmartHomeRuntime) -> CameraMediaReconcileReport {
+        let now_ms = self.clock.now_ms();
+        let expired_leases = self.broker.expire_leases_at(now_ms);
+        let expired_ids = self
+            .streams
+            .iter()
+            .filter_map(|(session_id, stream)| {
+                (now_ms >= stream.expires_at_ms
+                    || authorize_camera_access(
+                        runtime,
+                        &stream.principal_id,
+                        &stream.entity_id,
+                        stream.kind,
+                        now_ms,
+                    )
+                    .is_err())
+                .then_some(session_id.clone())
+            })
+            .collect::<Vec<_>>();
+        let mut closed_stream_count = 0usize;
+        let mut failed_stream_close_count = 0usize;
+        for session_id in &expired_ids {
+            let close_result = self
+                .streams
+                .get_mut(session_id)
+                .map(|stream| self.executor.close_stream(&mut stream.resource));
+            match close_result {
+                Some(Ok(())) => {
+                    self.streams.remove(session_id);
+                    closed_stream_count += 1;
+                }
+                Some(Err(_)) => failed_stream_close_count += 1,
+                None => {}
+            }
+        }
+        let mut cleanup_index = 0usize;
+        while cleanup_index < self.pending_stream_cleanup.len() {
+            match self
+                .executor
+                .close_stream(&mut self.pending_stream_cleanup[cleanup_index])
+            {
+                Ok(()) => {
+                    self.pending_stream_cleanup.remove(cleanup_index);
+                    closed_stream_count += 1;
+                }
+                Err(_) => {
+                    failed_stream_close_count += 1;
+                    cleanup_index += 1;
+                }
+            }
+        }
+        CameraMediaReconcileReport {
+            expired_lease_count: expired_leases,
+            closed_stream_count,
+            failed_stream_close_count,
+        }
+    }
+
+    pub fn audit_records(&self) -> impl Iterator<Item = &CameraMediaAuditRecord> {
+        self.broker.audit_records()
+    }
+
+    pub fn snapshot(&self) -> CameraMediaBrokerSnapshot {
+        self.broker
+            .snapshot(self.streams.len(), self.pending_stream_cleanup.len())
+    }
+
+    fn close_or_retain_stream(
+        &mut self,
+        mut resource: Executor::Stream,
+        operation_error: CameraMediaError,
+    ) -> CameraMediaError {
+        match self.executor.close_stream(&mut resource) {
+            Ok(()) => operation_error,
+            Err(close_error) => {
+                self.pending_stream_cleanup.push(resource);
+                CameraMediaError::Execution(close_error)
+            }
+        }
+    }
+
+    fn authenticated_principal(&self) -> Result<AgentId, CameraMediaError> {
+        self.principal_source
+            .current_principal()
+            .ok_or(CameraMediaError::Unauthenticated)
+    }
+}
+
+/// Minimal endpoint-registration surface used by native camera integrations.
+pub trait CameraMediaEndpointRegistry {
+    fn register_camera_endpoint(
+        &mut self,
+        entity_id: EntityId,
+        kind: CameraMediaKind,
+        uri: &str,
+    ) -> Result<(), CameraMediaError>;
+}
+
+impl<Clock, Nonce, Principals, Executor> CameraMediaEndpointRegistry
+    for CameraMediaService<Clock, Nonce, Principals, Executor>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor,
+{
+    fn register_camera_endpoint(
+        &mut self,
+        entity_id: EntityId,
+        kind: CameraMediaKind,
+        uri: &str,
+    ) -> Result<(), CameraMediaError> {
+        self.register_endpoint(entity_id, kind, uri)
+    }
 }
 
 impl Default for CameraMediaBroker {
@@ -298,180 +987,121 @@ impl CameraMediaBroker {
             endpoints: BTreeMap::new(),
             leases: BTreeMap::new(),
             audit: VecDeque::new(),
+            next_endpoint_generation: 1,
             next_audit_sequence: 1,
             issued_lease_count: 0,
             denied_lease_count: 0,
             redeemed_lease_count: 0,
+            failed_delivery_count: 0,
         }
     }
 
-    pub fn register_endpoint(
+    /// Install or rotate one process-local endpoint.
+    fn register_endpoint_at(
         &mut self,
+        now_ms: u64,
         entity_id: EntityId,
         kind: CameraMediaKind,
         uri: impl Into<String>,
-        registered_at_ms: u64,
     ) -> Result<(), CameraMediaError> {
-        let uri = uri.into();
-        validate_endpoint(&uri, kind)?;
-        self.endpoints.insert(
-            (entity_id.clone(), kind),
-            CameraMediaEndpoint {
-                uri: Zeroizing::new(uri),
-            },
-        );
+        let uri = Zeroizing::new(uri.into());
+        validate_endpoint(uri.as_str(), kind, self.policy.allow_plaintext_loopback)?;
+        let key = (entity_id.clone(), kind);
+        if !self.endpoints.contains_key(&key) && self.endpoints.len() >= self.policy.max_endpoints {
+            return Err(CameraMediaError::EndpointQuotaExceeded {
+                maximum: self.policy.max_endpoints,
+            });
+        }
+        let generation = self.next_endpoint_generation;
+        self.next_endpoint_generation = generation
+            .checked_add(1)
+            .ok_or(CameraMediaError::EndpointGenerationOverflow)?;
+        self.endpoints
+            .insert(key, CameraMediaEndpoint { uri, generation });
         self.push_audit(CameraMediaAuditRecord {
             sequence: 0,
             principal_id: None,
             entity_id,
             kind,
-            lease_id: None,
             outcome: CameraMediaAuditOutcome::EndpointRegistered,
             reason: None,
-            occurred_at_ms: registered_at_ms,
+            occurred_at_ms: now_ms,
         });
         Ok(())
     }
 
-    pub fn issue_lease(
+    /// Remove one endpoint without exposing it. Outstanding leases are left in
+    /// the table so their next use is consumed and audited as a missing endpoint.
+    fn unregister_endpoint_at(
         &mut self,
-        runtime: &SmartHomeRuntime,
-        request: CameraMediaAccessRequest,
-    ) -> Result<CameraMediaLease, CameraMediaError> {
-        let capability_id = request.kind.capability_id();
-        let result = self.validate_request(runtime, &request, &capability_id);
-        if let Err(error) = result {
-            self.denied_lease_count = self.denied_lease_count.saturating_add(1);
-            self.push_audit(CameraMediaAuditRecord {
-                sequence: 0,
-                principal_id: Some(request.principal_id.clone()),
-                entity_id: request.entity_id.clone(),
-                kind: request.kind,
-                lease_id: None,
-                outcome: CameraMediaAuditOutcome::LeaseDenied,
-                reason: Some(error.to_string()),
-                occurred_at_ms: request.requested_at_ms,
-            });
-            return Err(error);
-        }
-
-        let expires_at_ms = request.requested_at_ms.saturating_add(request.ttl_ms);
-        let lease = CameraMediaLease {
-            lease_id: random_lease_id(),
-            principal_id: request.principal_id,
-            entity_id: request.entity_id,
-            kind: request.kind,
-            issued_at_ms: request.requested_at_ms,
-            expires_at_ms,
-        };
-        self.leases.insert(lease.lease_id.clone(), lease.clone());
-        self.issued_lease_count = self.issued_lease_count.saturating_add(1);
-        self.push_audit(CameraMediaAuditRecord {
-            sequence: 0,
-            principal_id: Some(lease.principal_id.clone()),
-            entity_id: lease.entity_id.clone(),
-            kind: lease.kind,
-            lease_id: Some(lease.lease_id.clone()),
-            outcome: CameraMediaAuditOutcome::LeaseIssued,
-            reason: None,
-            occurred_at_ms: lease.issued_at_ms,
-        });
-        Ok(lease)
-    }
-
-    pub fn redeem_lease(
-        &mut self,
-        lease_id: &CameraMediaLeaseId,
-        principal_id: &AgentId,
         now_ms: u64,
-    ) -> Result<Zeroizing<String>, CameraMediaError> {
-        let Some(lease) = self.leases.get(lease_id).cloned() else {
-            return Err(CameraMediaError::UnknownLease(lease_id.clone()));
-        };
-        if lease.principal_id != *principal_id {
-            return Err(CameraMediaError::LeasePrincipalMismatch(lease_id.clone()));
+        entity_id: &EntityId,
+        kind: CameraMediaKind,
+    ) -> bool {
+        if self.endpoints.remove(&(entity_id.clone(), kind)).is_none() {
+            return false;
         }
-        if lease.is_expired_at(now_ms) {
-            self.leases.remove(lease_id);
-            self.push_audit(CameraMediaAuditRecord {
-                sequence: 0,
-                principal_id: Some(principal_id.clone()),
-                entity_id: lease.entity_id,
-                kind: lease.kind,
-                lease_id: Some(lease_id.clone()),
-                outcome: CameraMediaAuditOutcome::LeaseExpired,
-                reason: None,
-                occurred_at_ms: now_ms,
-            });
-            return Err(CameraMediaError::ExpiredLease(lease_id.clone()));
-        }
-        let endpoint = self
-            .endpoints
-            .get(&(lease.entity_id.clone(), lease.kind))
-            .ok_or_else(|| CameraMediaError::MissingEndpoint {
-                entity_id: lease.entity_id.clone(),
-                kind: lease.kind,
-            })?;
-        let secret = Zeroizing::new(endpoint.uri.to_string());
-        self.leases.remove(lease_id);
-        self.redeemed_lease_count = self.redeemed_lease_count.saturating_add(1);
         self.push_audit(CameraMediaAuditRecord {
             sequence: 0,
-            principal_id: Some(principal_id.clone()),
-            entity_id: lease.entity_id,
-            kind: lease.kind,
-            lease_id: Some(lease_id.clone()),
-            outcome: CameraMediaAuditOutcome::LeaseRedeemed,
+            principal_id: None,
+            entity_id: entity_id.clone(),
+            kind,
+            outcome: CameraMediaAuditOutcome::EndpointRemoved,
             reason: None,
             occurred_at_ms: now_ms,
         });
-        Ok(secret)
+        true
     }
 
-    pub fn expire_leases(&mut self, now_ms: u64) -> usize {
-        let expired = self
-            .leases
-            .values()
-            .filter(|lease| lease.is_expired_at(now_ms))
-            .cloned()
-            .collect::<Vec<_>>();
-        for lease in &expired {
-            self.leases.remove(&lease.lease_id);
-            self.push_audit(CameraMediaAuditRecord {
-                sequence: 0,
-                principal_id: Some(lease.principal_id.clone()),
-                entity_id: lease.entity_id.clone(),
-                kind: lease.kind,
-                lease_id: Some(lease.lease_id.clone()),
-                outcome: CameraMediaAuditOutcome::LeaseExpired,
-                reason: None,
-                occurred_at_ms: now_ms,
-            });
-        }
-        expired.len()
-    }
-
-    pub fn audit_records(&self) -> impl Iterator<Item = &CameraMediaAuditRecord> {
-        self.audit.iter()
-    }
-
-    pub fn snapshot(&self) -> CameraMediaBrokerSnapshot {
-        CameraMediaBrokerSnapshot {
-            endpoint_count: self.endpoints.len(),
-            active_lease_count: self.leases.len(),
-            audit_record_count: self.audit.len(),
-            issued_lease_count: self.issued_lease_count,
-            denied_lease_count: self.denied_lease_count,
-            redeemed_lease_count: self.redeemed_lease_count,
-        }
-    }
-
-    fn validate_request(
-        &self,
+    /// Authorize one future media delivery without exposing the endpoint.
+    fn issue_lease_at(
+        &mut self,
         runtime: &SmartHomeRuntime,
+        principal_id: &AgentId,
+        nonce_source: &mut impl CameraMediaNonceSource,
+        request: CameraMediaAccessRequest,
+        now_ms: u64,
+    ) -> Result<CameraMediaLease, CameraMediaError> {
+        self.expire_leases_at(now_ms);
+        let result = self.issue_lease_inner(runtime, principal_id, nonce_source, &request, now_ms);
+        match result {
+            Ok(lease) => {
+                self.issued_lease_count = self.issued_lease_count.saturating_add(1);
+                self.push_audit(CameraMediaAuditRecord {
+                    sequence: 0,
+                    principal_id: Some(principal_id.clone()),
+                    entity_id: lease.entity_id.clone(),
+                    kind: lease.kind,
+                    outcome: CameraMediaAuditOutcome::LeaseIssued,
+                    reason: None,
+                    occurred_at_ms: now_ms,
+                });
+                Ok(lease)
+            }
+            Err(error) => {
+                self.denied_lease_count = self.denied_lease_count.saturating_add(1);
+                self.push_audit(CameraMediaAuditRecord {
+                    sequence: 0,
+                    principal_id: Some(principal_id.clone()),
+                    entity_id: request.entity_id,
+                    kind: request.kind,
+                    outcome: CameraMediaAuditOutcome::LeaseDenied,
+                    reason: Some(error.to_string()),
+                    occurred_at_ms: now_ms,
+                });
+                Err(error)
+            }
+        }
+    }
+
+    fn issue_lease_inner(
+        &mut self,
+        runtime: &SmartHomeRuntime,
+        principal_id: &AgentId,
+        nonce_source: &mut impl CameraMediaNonceSource,
         request: &CameraMediaAccessRequest,
-        capability_id: &CapabilityId,
-    ) -> Result<(), CameraMediaError> {
+        now_ms: u64,
+    ) -> Result<CameraMediaLease, CameraMediaError> {
         if request.purpose.trim().is_empty() {
             return Err(CameraMediaError::EmptyPurpose);
         }
@@ -482,49 +1112,206 @@ impl CameraMediaBroker {
                 maximum_ms,
             });
         }
-        let entity = runtime
-            .registry()
-            .entity(&request.entity_id)
-            .ok_or_else(|| CameraMediaError::UnknownEntity(request.entity_id.clone()))?;
-        let capability = entity
-            .capabilities
-            .iter()
-            .find(|capability| capability.capability_id == *capability_id)
-            .ok_or_else(|| CameraMediaError::MissingCapability {
-                entity_id: request.entity_id.clone(),
-                capability_id: capability_id.clone(),
-            })?;
-        if !matches!(
-            capability.mode,
-            CapabilityMode::Command | CapabilityMode::ObserveAndCommand
-        ) {
-            return Err(CameraMediaError::ReadOnlyCapability {
-                entity_id: request.entity_id.clone(),
-                capability_id: capability_id.clone(),
+        if self.leases.len() >= self.policy.max_active_leases {
+            return Err(CameraMediaError::LeaseQuotaExceeded {
+                maximum: self.policy.max_active_leases,
             });
         }
-        if !self
-            .endpoints
-            .contains_key(&(request.entity_id.clone(), request.kind))
+        if self
+            .leases
+            .values()
+            .filter(|lease| lease.principal_id == *principal_id)
+            .count()
+            >= self.policy.max_active_leases_per_principal
         {
-            return Err(CameraMediaError::MissingEndpoint {
+            return Err(CameraMediaError::PrincipalLeaseQuotaExceeded {
+                maximum: self.policy.max_active_leases_per_principal,
+            });
+        }
+        let grant_expiry = authorize_camera_access(
+            runtime,
+            principal_id,
+            &request.entity_id,
+            request.kind,
+            now_ms,
+        )?;
+        let endpoint_generation = self
+            .endpoints
+            .get(&(request.entity_id.clone(), request.kind))
+            .ok_or_else(|| CameraMediaError::MissingEndpoint {
                 entity_id: request.entity_id.clone(),
                 kind: request.kind,
-            });
+            })?
+            .generation;
+        let requested_expiry = now_ms
+            .checked_add(request.ttl_ms)
+            .ok_or(CameraMediaError::TimestampOverflow)?;
+        let expires_at_ms = grant_expiry.map_or(requested_expiry, |grant_expiry| {
+            requested_expiry.min(grant_expiry)
+        });
+        let mut nonce = [0u8; 16];
+        nonce_source
+            .fill_nonce(&mut nonce)
+            .map_err(|_| CameraMediaError::NonceUnavailable)?;
+        let lease_id = lease_id_from_nonce(nonce);
+        if self.leases.contains_key(&lease_id) {
+            return Err(CameraMediaError::DuplicateLeaseId);
         }
-        let authorized = runtime
-            .registry()
-            .capability_grants_for_principal(&request.principal_id)
-            .into_iter()
-            .any(|grant| grant_covers_camera_access(grant, request, capability_id));
-        if !authorized {
-            return Err(CameraMediaError::Unauthorized {
-                principal_id: request.principal_id.clone(),
-                entity_id: request.entity_id.clone(),
-                capability_id: capability_id.clone(),
-            });
+        let lease = CameraMediaLease {
+            lease_id,
+            principal_id: principal_id.clone(),
+            entity_id: request.entity_id.clone(),
+            kind: request.kind,
+            issued_at_ms: now_ms,
+            expires_at_ms,
+            endpoint_generation,
+        };
+        self.leases.insert(lease.lease_id.clone(), lease.clone());
+        Ok(lease)
+    }
+
+    /// Atomically validate and consume one lease before external execution.
+    fn prepare_delivery(
+        &mut self,
+        runtime: &SmartHomeRuntime,
+        principal_id: &AgentId,
+        lease_id: &CameraMediaLeaseId,
+        now_ms: u64,
+    ) -> Result<PendingCameraMediaExecution, CameraMediaError> {
+        let Some(lease) = self.leases.get(lease_id).cloned() else {
+            return Err(CameraMediaError::UnknownLease);
+        };
+        if lease.principal_id != *principal_id {
+            return Err(CameraMediaError::LeasePrincipalMismatch);
         }
-        Ok(())
+        if lease.is_expired_at(now_ms) {
+            self.leases.remove(lease_id);
+            self.push_lease_audit(&lease, CameraMediaAuditOutcome::LeaseExpired, None, now_ms);
+            return Err(CameraMediaError::ExpiredLease);
+        }
+        if let Err(error) =
+            authorize_camera_access(runtime, principal_id, &lease.entity_id, lease.kind, now_ms)
+        {
+            self.leases.remove(lease_id);
+            self.push_lease_audit(
+                &lease,
+                CameraMediaAuditOutcome::LeaseRejected,
+                Some(error.to_string()),
+                now_ms,
+            );
+            return Err(error);
+        }
+        let endpoint = match self.endpoints.get(&(lease.entity_id.clone(), lease.kind)) {
+            Some(endpoint) => endpoint,
+            None => {
+                self.leases.remove(lease_id);
+                let error = CameraMediaError::MissingEndpoint {
+                    entity_id: lease.entity_id.clone(),
+                    kind: lease.kind,
+                };
+                self.push_lease_audit(
+                    &lease,
+                    CameraMediaAuditOutcome::LeaseRejected,
+                    Some(error.to_string()),
+                    now_ms,
+                );
+                return Err(error);
+            }
+        };
+        if endpoint.generation != lease.endpoint_generation {
+            self.leases.remove(lease_id);
+            self.push_lease_audit(
+                &lease,
+                CameraMediaAuditOutcome::LeaseRejected,
+                Some(CameraMediaError::EndpointGenerationChanged.to_string()),
+                now_ms,
+            );
+            return Err(CameraMediaError::EndpointGenerationChanged);
+        }
+
+        let endpoint_uri = Zeroizing::new(endpoint.uri.as_str().to_owned());
+        // Consume before the external effect. A failing host cannot replay the
+        // same bearer lease and accidentally duplicate media delivery.
+        self.leases.remove(lease_id);
+        Ok(PendingCameraMediaExecution {
+            lease,
+            endpoint_uri,
+        })
+    }
+
+    fn record_delivery_success(&mut self, lease: &CameraMediaLease, now_ms: u64) {
+        self.redeemed_lease_count = self.redeemed_lease_count.saturating_add(1);
+        self.push_lease_audit(lease, CameraMediaAuditOutcome::LeaseDelivered, None, now_ms);
+    }
+
+    fn record_delivery_failure(
+        &mut self,
+        lease: &CameraMediaLease,
+        error: CameraMediaError,
+        now_ms: u64,
+    ) -> CameraMediaError {
+        self.failed_delivery_count = self.failed_delivery_count.saturating_add(1);
+        self.push_lease_audit(
+            lease,
+            CameraMediaAuditOutcome::DeliveryFailed,
+            Some(error.to_string()),
+            now_ms,
+        );
+        error
+    }
+
+    fn expire_leases_at(&mut self, now_ms: u64) -> usize {
+        let expired = self
+            .leases
+            .values()
+            .filter(|lease| lease.is_expired_at(now_ms))
+            .cloned()
+            .collect::<Vec<_>>();
+        for lease in &expired {
+            self.leases.remove(&lease.lease_id);
+            self.push_lease_audit(lease, CameraMediaAuditOutcome::LeaseExpired, None, now_ms);
+        }
+        expired.len()
+    }
+
+    fn audit_records(&self) -> impl Iterator<Item = &CameraMediaAuditRecord> {
+        self.audit.iter()
+    }
+
+    fn snapshot(
+        &self,
+        active_stream_count: usize,
+        pending_stream_cleanup_count: usize,
+    ) -> CameraMediaBrokerSnapshot {
+        CameraMediaBrokerSnapshot {
+            endpoint_count: self.endpoints.len(),
+            active_lease_count: self.leases.len(),
+            active_stream_count,
+            pending_stream_cleanup_count,
+            audit_record_count: self.audit.len(),
+            issued_lease_count: self.issued_lease_count,
+            denied_lease_count: self.denied_lease_count,
+            redeemed_lease_count: self.redeemed_lease_count,
+            failed_delivery_count: self.failed_delivery_count,
+        }
+    }
+
+    fn push_lease_audit(
+        &mut self,
+        lease: &CameraMediaLease,
+        outcome: CameraMediaAuditOutcome,
+        reason: Option<String>,
+        occurred_at_ms: u64,
+    ) {
+        self.push_audit(CameraMediaAuditRecord {
+            sequence: 0,
+            principal_id: Some(lease.principal_id.clone()),
+            entity_id: lease.entity_id.clone(),
+            kind: lease.kind,
+            outcome,
+            reason,
+            occurred_at_ms,
+        });
     }
 
     fn push_audit(&mut self, mut record: CameraMediaAuditRecord) {
@@ -538,222 +1325,178 @@ impl CameraMediaBroker {
     }
 }
 
+fn authorize_camera_access(
+    runtime: &SmartHomeRuntime,
+    principal_id: &AgentId,
+    entity_id: &EntityId,
+    kind: CameraMediaKind,
+    now_ms: u64,
+) -> Result<Option<u64>, CameraMediaError> {
+    let capability_id = kind.capability_id();
+    let entity = runtime
+        .registry()
+        .entity(entity_id)
+        .ok_or_else(|| CameraMediaError::UnknownEntity(entity_id.clone()))?;
+    let capability = entity
+        .capabilities
+        .iter()
+        .find(|capability| capability.capability_id == capability_id)
+        .ok_or_else(|| CameraMediaError::MissingCapability {
+            entity_id: entity_id.clone(),
+            capability_id: capability_id.clone(),
+        })?;
+    if !matches!(
+        capability.mode,
+        CapabilityMode::Command | CapabilityMode::ObserveAndCommand
+    ) {
+        return Err(CameraMediaError::ReadOnlyCapability {
+            entity_id: entity_id.clone(),
+            capability_id,
+        });
+    }
+
+    let mut found = false;
+    let mut latest_expiry = Some(0u64);
+    for grant in runtime
+        .registry()
+        .capability_grants_for_principal(principal_id)
+    {
+        if grant_covers_camera_access(grant, principal_id, entity_id, &capability_id, now_ms) {
+            found = true;
+            match grant.expires_at_ms {
+                None => return Ok(None),
+                Some(expiry) => {
+                    latest_expiry = Some(latest_expiry.unwrap_or_default().max(expiry));
+                }
+            }
+        }
+    }
+    if found {
+        Ok(latest_expiry)
+    } else {
+        Err(CameraMediaError::Unauthorized {
+            principal_id: principal_id.clone(),
+            entity_id: entity_id.clone(),
+            capability_id,
+        })
+    }
+}
+
 fn grant_covers_camera_access(
     grant: &CapabilityGrant,
-    request: &CameraMediaAccessRequest,
+    principal_id: &AgentId,
+    entity_id: &EntityId,
     capability_id: &CapabilityId,
+    now_ms: u64,
 ) -> bool {
-    grant.principal_id == request.principal_id
-        && grant.is_active_at(request.requested_at_ms)
+    grant.principal_id == *principal_id
+        && grant.is_active_at(now_ms)
         && grant.max_tier >= PrivilegeTier::HumanApproval
         && match &grant.scope {
             CapabilityGrantScope::Capability(granted) => granted == capability_id,
             CapabilityGrantScope::EntityCapability {
-                entity_id,
+                entity_id: granted_entity,
                 capability_id: granted,
-            } => entity_id == &request.entity_id && granted == capability_id,
+            } => granted_entity == entity_id && granted == capability_id,
             CapabilityGrantScope::AllSmartHome => true,
             CapabilityGrantScope::Tool(_) => false,
         }
 }
 
-fn validate_endpoint(uri: &str, kind: CameraMediaKind) -> Result<(), CameraMediaError> {
+fn validate_endpoint(
+    uri: &str,
+    kind: CameraMediaKind,
+    allow_plaintext_loopback: bool,
+) -> Result<(), CameraMediaError> {
     let url =
         Url::parse(uri).map_err(|error| CameraMediaError::InvalidEndpoint(error.to_string()))?;
-    let allowed = match kind {
+    if url.userinfo.is_some() {
+        return Err(CameraMediaError::EndpointCredentialsForbidden);
+    }
+    if url.fragment.is_some() {
+        return Err(CameraMediaError::InvalidEndpoint(
+            "fragments are not allowed".to_string(),
+        ));
+    }
+    let host = url
+        .host
+        .as_deref()
+        .filter(|host| !host.is_empty())
+        .ok_or_else(|| CameraMediaError::InvalidEndpoint("missing host".to_string()))?;
+    let scheme_allowed = match kind {
         CameraMediaKind::Snapshot => matches!(url.scheme.as_str(), "http" | "https"),
         CameraMediaKind::Stream => {
             matches!(url.scheme.as_str(), "rtsp" | "rtsps" | "http" | "https")
         }
     };
-    if !allowed {
+    if !scheme_allowed {
         return Err(CameraMediaError::UnsupportedEndpointScheme(url.scheme));
     }
-    if url.host.as_deref().is_none_or(str::is_empty) {
-        return Err(CameraMediaError::InvalidEndpoint(
-            "camera endpoint is missing a host".to_string(),
-        ));
+    let secure = matches!(url.scheme.as_str(), "https" | "rtsps");
+    if !secure && url.query.is_some() {
+        return Err(CameraMediaError::InsecureEndpoint);
+    }
+    if !secure && !(allow_plaintext_loopback && is_loopback_host(host)) {
+        return Err(CameraMediaError::InsecureEndpoint);
     }
     Ok(())
 }
 
-fn random_lease_id() -> CameraMediaLeaseId {
-    let mut bytes = [0u8; 16];
-    OsRng.fill_bytes(&mut bytes);
-    CameraMediaLeaseId(format!(
-        "camera-media:{:016x}{:016x}",
+fn is_loopback_host(host: &str) -> bool {
+    host == "localhost"
+        || host == "[::1]"
+        || host == "127.0.0.1"
+        || host.strip_prefix("127.").is_some_and(|suffix| {
+            let octets = suffix.split('.').collect::<Vec<_>>();
+            octets.len() == 3
+                && octets
+                    .iter()
+                    .all(|octet| !octet.is_empty() && octet.parse::<u8>().is_ok())
+        })
+}
+
+fn lease_id_from_nonce(bytes: [u8; 16]) -> CameraMediaLeaseId {
+    CameraMediaLeaseId(Zeroizing::new(format!(
+        "{:016x}{:016x}",
         u64::from_be_bytes(bytes[..8].try_into().expect("eight bytes")),
         u64::from_be_bytes(bytes[8..].try_into().expect("eight bytes"))
-    ))
+    )))
+}
+
+fn stream_id_from_nonce(bytes: [u8; 16]) -> CameraMediaStreamSessionId {
+    CameraMediaStreamSessionId(Zeroizing::new(format!(
+        "{:016x}{:016x}",
+        u64::from_be_bytes(bytes[..8].try_into().expect("eight bytes")),
+        u64::from_be_bytes(bytes[8..].try_into().expect("eight bytes"))
+    )))
 }
 
 #[cfg(test)]
-mod tests {
+mod unit_tests {
     use super::*;
-    use smart_home_core::{
-        Bridge, BridgeId, BridgeTransport, Capability, CapabilityGrantId, Device, DeviceId, Entity,
-        EntityKind, Health, IntegrationId, Metadata, ProtocolIdentifier, ValueKind,
-    };
-
-    fn fixture_runtime() -> (SmartHomeRuntime, EntityId, AgentId) {
-        let mut runtime = SmartHomeRuntime::default();
-        let bridge_id = BridgeId::trusted("camera-bridge");
-        let device_id = DeviceId::trusted("camera-device");
-        let entity_id = EntityId::trusted("camera-entity");
-        let principal_id = AgentId::trusted("dashboard-user");
-        let mut bridge = Bridge::new(
-            bridge_id.clone(),
-            IntegrationId::trusted("onvif"),
-            BridgeTransport::LanHttp,
-        );
-        bridge.health = Health::Online;
-        runtime.upsert_bridge(bridge).unwrap();
-        runtime
-            .upsert_device(Device {
-                device_id: device_id.clone(),
-                bridge_id,
-                manufacturer: "Fixture".to_string(),
-                model: "Camera".to_string(),
-                name: "Front Door".to_string(),
-                serial: Some("fixture-1".to_string()),
-                firmware_version: None,
-                room_id: None,
-                entity_ids: vec![entity_id.clone()],
-                identifiers: Vec::<ProtocolIdentifier>::new(),
-                health: Health::Online,
-                metadata: Vec::<Metadata>::new(),
-            })
-            .unwrap();
-        runtime
-            .upsert_entity(Entity {
-                entity_id: entity_id.clone(),
-                device_id,
-                kind: EntityKind::Camera,
-                name: "Front Door".to_string(),
-                capabilities: vec![
-                    Capability::new(
-                        CameraMediaKind::Snapshot.capability_id(),
-                        CapabilityMode::Command,
-                        ValueKind::Text,
-                    ),
-                    Capability::new(
-                        CameraMediaKind::Stream.capability_id(),
-                        CapabilityMode::Command,
-                        ValueKind::Text,
-                    ),
-                ],
-                state: None,
-                metadata: Vec::new(),
-            })
-            .unwrap();
-        runtime
-            .registry_mut()
-            .upsert_capability_grant(CapabilityGrant::for_entity_capability(
-                CapabilityGrantId::trusted("camera-snapshot-grant"),
-                principal_id.clone(),
-                entity_id.clone(),
-                CameraMediaKind::Snapshot.capability_id(),
-                PrivilegeTier::HumanApproval,
-                "user",
-                1,
-            ));
-        (runtime, entity_id, principal_id)
-    }
 
     #[test]
-    fn authorized_snapshot_lease_is_short_lived_single_use_and_redacted() {
-        let (runtime, entity_id, principal_id) = fixture_runtime();
-        let mut broker = CameraMediaBroker::default();
-        let secret_uri = "http://camera.local/snapshot.jpg?token=secret";
-        broker
-            .register_endpoint(entity_id.clone(), CameraMediaKind::Snapshot, secret_uri, 10)
-            .unwrap();
-        assert!(!format!("{broker:?}").contains(secret_uri));
-
-        let lease = broker
-            .issue_lease(
-                &runtime,
-                CameraMediaAccessRequest::new(
-                    principal_id.clone(),
-                    entity_id,
-                    CameraMediaKind::Snapshot,
-                    "operator preview",
-                    20,
-                    5_000,
-                ),
-            )
-            .unwrap();
-        let endpoint = broker
-            .redeem_lease(&lease.lease_id, &principal_id, 21)
-            .unwrap();
-        assert_eq!(endpoint.as_str(), secret_uri);
-        assert!(matches!(
-            broker.redeem_lease(&lease.lease_id, &principal_id, 22),
-            Err(CameraMediaError::UnknownLease(_))
-        ));
-        assert_eq!(broker.snapshot().redeemed_lease_count, 1);
-        assert!(broker
-            .audit_records()
-            .all(|record| !format!("{record:?}").contains(secret_uri)));
-    }
-
-    #[test]
-    fn stream_requires_its_own_human_approval_grant() {
-        let (runtime, entity_id, principal_id) = fixture_runtime();
-        let mut broker = CameraMediaBroker::default();
-        broker
-            .register_endpoint(
-                entity_id.clone(),
-                CameraMediaKind::Stream,
-                "rtsp://camera.local/live",
-                10,
-            )
-            .unwrap();
-        let error = broker
-            .issue_lease(
-                &runtime,
-                CameraMediaAccessRequest::new(
-                    principal_id,
-                    entity_id,
-                    CameraMediaKind::Stream,
-                    "live view",
-                    20,
-                    10_000,
-                ),
-            )
-            .unwrap_err();
-        assert!(matches!(error, CameraMediaError::Unauthorized { .. }));
-        assert_eq!(broker.snapshot().denied_lease_count, 1);
-    }
-
-    #[test]
-    fn expired_lease_cannot_reveal_endpoint() {
-        let (runtime, entity_id, principal_id) = fixture_runtime();
-        let mut broker = CameraMediaBroker::default();
-        broker
-            .register_endpoint(
-                entity_id.clone(),
+    fn endpoint_generation_overflow_fails_before_installation() {
+        let mut broker = CameraMediaBroker {
+            next_endpoint_generation: u64::MAX,
+            ..CameraMediaBroker::default()
+        };
+        assert_eq!(
+            broker.register_endpoint_at(
+                7,
+                EntityId::trusted("camera"),
                 CameraMediaKind::Snapshot,
                 "https://camera.local/snapshot.jpg",
-                10,
-            )
-            .unwrap();
-        let lease = broker
-            .issue_lease(
-                &runtime,
-                CameraMediaAccessRequest::new(
-                    principal_id.clone(),
-                    entity_id,
-                    CameraMediaKind::Snapshot,
-                    "preview",
-                    20,
-                    1,
-                ),
-            )
-            .unwrap();
-        assert!(matches!(
-            broker.redeem_lease(&lease.lease_id, &principal_id, 21),
-            Err(CameraMediaError::ExpiredLease(_))
-        ));
+            ),
+            Err(CameraMediaError::EndpointGenerationOverflow)
+        );
+        assert_eq!(broker.snapshot(0, 0).endpoint_count, 0);
+    }
+
+    #[test]
+    fn plaintext_loopback_detection_rejects_hostname_confusion() {
+        assert!(is_loopback_host("127.1.2.3"));
+        assert!(!is_loopback_host("127.evil.local.com"));
+        assert!(!is_loopback_host("127.999.0.1"));
     }
 }

--- a/code/packages/rust/smart-home-camera-media/tests/security_boundary.rs
+++ b/code/packages/rust/smart-home-camera-media/tests/security_boundary.rs
@@ -1,0 +1,918 @@
+use smart_home_camera_media::{
+    CameraMediaAccessRequest, CameraMediaClock, CameraMediaDelivery, CameraMediaError,
+    CameraMediaExecution, CameraMediaExecutionError, CameraMediaExecutionResult,
+    CameraMediaExecutor, CameraMediaKind, CameraMediaNonceError, CameraMediaNonceSource,
+    CameraMediaPolicy, CameraMediaPrincipalSource, CameraMediaService,
+};
+use smart_home_core::{
+    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityGrant, CapabilityGrantId,
+    CapabilityGrantStatus, CapabilityMode, Device, DeviceId, Entity, EntityId, EntityKind, Health,
+    IntegrationId, Metadata, PrivilegeTier, ProtocolIdentifier, ValueKind,
+};
+use smart_home_runtime::SmartHomeRuntime;
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+#[derive(Clone)]
+struct SharedClock(Rc<Cell<u64>>);
+
+impl SharedClock {
+    fn new(now_ms: u64) -> Self {
+        Self(Rc::new(Cell::new(now_ms)))
+    }
+
+    fn set(&self, now_ms: u64) {
+        self.0.set(now_ms);
+    }
+}
+
+impl CameraMediaClock for SharedClock {
+    fn now_ms(&self) -> u64 {
+        self.0.get()
+    }
+}
+
+#[derive(Clone)]
+struct SharedPrincipal(Rc<RefCell<Option<AgentId>>>);
+
+impl SharedPrincipal {
+    fn new(principal_id: AgentId) -> Self {
+        Self(Rc::new(RefCell::new(Some(principal_id))))
+    }
+
+    fn set(&self, principal_id: Option<AgentId>) {
+        *self.0.borrow_mut() = principal_id;
+    }
+}
+
+impl CameraMediaPrincipalSource for SharedPrincipal {
+    fn current_principal(&self) -> Option<AgentId> {
+        self.0.borrow().clone()
+    }
+}
+
+struct TestNonce {
+    next: u8,
+    calls: usize,
+    fail_on_call: Option<usize>,
+    repeat: bool,
+}
+
+impl TestNonce {
+    fn sequence(next: u8) -> Self {
+        Self {
+            next,
+            calls: 0,
+            fail_on_call: None,
+            repeat: false,
+        }
+    }
+
+    fn failing() -> Self {
+        Self {
+            fail_on_call: Some(1),
+            ..Self::sequence(0)
+        }
+    }
+
+    fn repeating(next: u8) -> Self {
+        Self {
+            repeat: true,
+            ..Self::sequence(next)
+        }
+    }
+}
+
+impl CameraMediaNonceSource for TestNonce {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+        self.calls += 1;
+        if self.fail_on_call == Some(self.calls) {
+            return Err(CameraMediaNonceError);
+        }
+        output.fill(self.next);
+        if !self.repeat {
+            self.next = self.next.wrapping_add(1);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ExecutorMode {
+    Snapshot(usize),
+    Stream,
+    Failure(CameraMediaExecutionError),
+    WrongKind,
+}
+
+#[derive(Default)]
+struct ExecutorState {
+    endpoints: Vec<String>,
+    closed_streams: Vec<String>,
+    execution_debug: Vec<String>,
+    fail_close: bool,
+}
+
+struct TestExecutor {
+    mode: ExecutorMode,
+    state: Rc<RefCell<ExecutorState>>,
+}
+
+impl CameraMediaExecutor for TestExecutor {
+    type Stream = String;
+
+    fn deliver(
+        &mut self,
+        execution: CameraMediaExecution<'_>,
+    ) -> Result<CameraMediaExecutionResult<Self::Stream>, CameraMediaExecutionError> {
+        let endpoint = execution.endpoint_uri().to_owned();
+        let debug = format!("{execution:?}");
+        assert!(!debug.contains(&endpoint));
+        let mut state = self.state.borrow_mut();
+        state.endpoints.push(endpoint);
+        state.execution_debug.push(debug);
+        drop(state);
+        match self.mode {
+            ExecutorMode::Snapshot(byte_count) if execution.kind() == CameraMediaKind::Snapshot => {
+                assert!(execution.max_snapshot_bytes() > 0);
+                Ok(CameraMediaExecutionResult::snapshot(vec![0x5a; byte_count]))
+            }
+            ExecutorMode::Stream if execution.kind() == CameraMediaKind::Stream => Ok(
+                CameraMediaExecutionResult::stream("executor-private-resource".to_string()),
+            ),
+            ExecutorMode::Failure(error) => Err(error),
+            ExecutorMode::WrongKind if execution.kind() == CameraMediaKind::Snapshot => Ok(
+                CameraMediaExecutionResult::stream("wrong-kind-resource".to_string()),
+            ),
+            ExecutorMode::WrongKind => Ok(CameraMediaExecutionResult::snapshot(vec![1])),
+            _ => Ok(CameraMediaExecutionResult::snapshot(vec![1])),
+        }
+    }
+
+    fn close_stream(&mut self, stream: &mut Self::Stream) -> Result<(), CameraMediaExecutionError> {
+        let mut state = self.state.borrow_mut();
+        if state.fail_close {
+            return Err(CameraMediaExecutionError::Unavailable);
+        }
+        state.closed_streams.push(stream.clone());
+        Ok(())
+    }
+}
+
+type TestService = CameraMediaService<SharedClock, TestNonce, SharedPrincipal, TestExecutor>;
+
+fn service(
+    clock: &SharedClock,
+    principal: &SharedPrincipal,
+    nonce: TestNonce,
+    mode: ExecutorMode,
+    policy: CameraMediaPolicy,
+) -> (TestService, Rc<RefCell<ExecutorState>>) {
+    let state = Rc::new(RefCell::new(ExecutorState::default()));
+    let executor = TestExecutor {
+        mode,
+        state: Rc::clone(&state),
+    };
+    (
+        CameraMediaService::new(policy, clock.clone(), nonce, principal.clone(), executor),
+        state,
+    )
+}
+
+fn fixture_policy() -> CameraMediaPolicy {
+    CameraMediaPolicy {
+        allow_plaintext_loopback: true,
+        ..CameraMediaPolicy::default()
+    }
+}
+
+fn fixture_runtime(
+    grant_expiry_ms: Option<u64>,
+) -> (SmartHomeRuntime, EntityId, AgentId, CapabilityGrantId) {
+    let mut runtime = SmartHomeRuntime::default();
+    let bridge_id = BridgeId::trusted("camera-bridge");
+    let device_id = DeviceId::trusted("camera-device");
+    let entity_id = EntityId::trusted("camera-entity");
+    let principal_id = AgentId::trusted("dashboard-user");
+    let grant_id = CapabilityGrantId::trusted("camera-snapshot-grant");
+    let mut bridge = Bridge::new(
+        bridge_id.clone(),
+        IntegrationId::trusted("onvif"),
+        BridgeTransport::LanHttp,
+    );
+    bridge.health = Health::Online;
+    runtime.upsert_bridge(bridge).unwrap();
+    runtime
+        .upsert_device(Device {
+            device_id: device_id.clone(),
+            bridge_id,
+            manufacturer: "Fixture".to_string(),
+            model: "Camera".to_string(),
+            name: "Front Door".to_string(),
+            serial: Some("fixture-1".to_string()),
+            firmware_version: None,
+            room_id: None,
+            entity_ids: vec![entity_id.clone()],
+            identifiers: Vec::<ProtocolIdentifier>::new(),
+            health: Health::Online,
+            metadata: Vec::<Metadata>::new(),
+        })
+        .unwrap();
+    runtime
+        .upsert_entity(Entity {
+            entity_id: entity_id.clone(),
+            device_id,
+            kind: EntityKind::Camera,
+            name: "Front Door".to_string(),
+            capabilities: vec![
+                Capability::new(
+                    CameraMediaKind::Snapshot.capability_id(),
+                    CapabilityMode::Command,
+                    ValueKind::Text,
+                ),
+                Capability::new(
+                    CameraMediaKind::Stream.capability_id(),
+                    CapabilityMode::Command,
+                    ValueKind::Text,
+                ),
+            ],
+            state: None,
+            metadata: Vec::new(),
+        })
+        .unwrap();
+    let mut grant = CapabilityGrant::for_entity_capability(
+        grant_id.clone(),
+        principal_id.clone(),
+        entity_id.clone(),
+        CameraMediaKind::Snapshot.capability_id(),
+        PrivilegeTier::HumanApproval,
+        "user",
+        1,
+    );
+    grant.expires_at_ms = grant_expiry_ms;
+    runtime.registry_mut().upsert_capability_grant(grant);
+    (runtime, entity_id, principal_id, grant_id)
+}
+
+fn request(entity_id: EntityId, kind: CameraMediaKind, ttl_ms: u64) -> CameraMediaAccessRequest {
+    CameraMediaAccessRequest::new(entity_id, kind, "operator preview", ttl_ms)
+}
+
+#[test]
+fn delivery_is_host_mediated_single_use_and_audits_never_expose_bearers() {
+    let (runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    let clock = SharedClock::new(10);
+    let principal = SharedPrincipal::new(principal_id);
+    let (mut service, state) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0x11),
+        ExecutorMode::Snapshot(1_024),
+        fixture_policy(),
+    );
+    let secret_uri = "https://camera.local/snapshot.jpg?token=secret";
+    service
+        .register_endpoint(entity_id.clone(), CameraMediaKind::Snapshot, secret_uri)
+        .unwrap();
+    let lease = service
+        .issue_lease(&runtime, request(entity_id, CameraMediaKind::Snapshot, 500))
+        .unwrap();
+    let raw_lease_id = lease.lease_id.as_hex().to_owned();
+    let delivery = service.deliver_lease(&runtime, &lease.lease_id).unwrap();
+    assert_eq!(delivery.snapshot_bytes().unwrap().len(), 1_024);
+    assert!(matches!(
+        service.deliver_lease(&runtime, &lease.lease_id),
+        Err(CameraMediaError::UnknownLease)
+    ));
+    assert_eq!(state.borrow().endpoints, vec![secret_uri]);
+    let public = format!(
+        "{delivery:?}{:?}",
+        service.audit_records().collect::<Vec<_>>()
+    );
+    assert!(!public.contains(secret_uri));
+    assert!(!public.contains(&raw_lease_id));
+}
+
+#[test]
+fn trusted_identity_time_and_current_grant_are_rechecked() {
+    let (mut runtime, entity_id, principal_id, grant_id) = fixture_runtime(Some(120));
+    let clock = SharedClock::new(100);
+    let principal = SharedPrincipal::new(principal_id.clone());
+    let (mut service, _) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0x21),
+        ExecutorMode::Snapshot(2),
+        fixture_policy(),
+    );
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "https://camera.local/snapshot.jpg",
+        )
+        .unwrap();
+    let lease = service
+        .issue_lease(
+            &runtime,
+            request(entity_id.clone(), CameraMediaKind::Snapshot, 1_000),
+        )
+        .unwrap();
+    assert_eq!(lease.expires_at_ms, 120);
+    principal.set(Some(AgentId::trusted("forged-user")));
+    assert!(matches!(
+        service.deliver_lease(&runtime, &lease.lease_id),
+        Err(CameraMediaError::LeasePrincipalMismatch)
+    ));
+    principal.set(Some(principal_id));
+    runtime
+        .registry_mut()
+        .update_capability_grant_status(&grant_id, CapabilityGrantStatus::Revoked)
+        .unwrap();
+    assert!(matches!(
+        service.deliver_lease(&runtime, &lease.lease_id),
+        Err(CameraMediaError::Unauthorized { .. })
+    ));
+    assert_eq!(service.snapshot().active_lease_count, 0);
+}
+
+#[test]
+fn expiry_prunes_before_quota_and_uses_only_the_installed_clock() {
+    let (runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    let clock = SharedClock::new(10);
+    let principal = SharedPrincipal::new(principal_id);
+    let policy = CameraMediaPolicy {
+        max_active_leases: 1,
+        max_active_leases_per_principal: 1,
+        ..fixture_policy()
+    };
+    let (mut service, _) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0x31),
+        ExecutorMode::Snapshot(1),
+        policy,
+    );
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "https://camera.local/snapshot.jpg",
+        )
+        .unwrap();
+    let first = service
+        .issue_lease(
+            &runtime,
+            request(entity_id.clone(), CameraMediaKind::Snapshot, 10),
+        )
+        .unwrap();
+    assert!(matches!(
+        service.issue_lease(
+            &runtime,
+            request(entity_id.clone(), CameraMediaKind::Snapshot, 10)
+        ),
+        Err(CameraMediaError::LeaseQuotaExceeded { maximum: 1 })
+    ));
+    clock.set(first.expires_at_ms);
+    let second = service
+        .issue_lease(&runtime, request(entity_id, CameraMediaKind::Snapshot, 10))
+        .unwrap();
+    assert_ne!(first.lease_id, second.lease_id);
+    assert_eq!(service.snapshot().active_lease_count, 1);
+}
+
+#[test]
+fn endpoint_rotation_and_removal_consume_stale_leases() {
+    let (runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    let clock = SharedClock::new(10);
+    let principal = SharedPrincipal::new(principal_id);
+    let (mut service, state) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0x41),
+        ExecutorMode::Snapshot(1),
+        fixture_policy(),
+    );
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "https://camera.local/old",
+        )
+        .unwrap();
+    let rotated = service
+        .issue_lease(
+            &runtime,
+            request(entity_id.clone(), CameraMediaKind::Snapshot, 100),
+        )
+        .unwrap();
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "https://camera.local/new",
+        )
+        .unwrap();
+    assert!(matches!(
+        service.deliver_lease(&runtime, &rotated.lease_id),
+        Err(CameraMediaError::EndpointGenerationChanged)
+    ));
+    let removed = service
+        .issue_lease(
+            &runtime,
+            request(entity_id.clone(), CameraMediaKind::Snapshot, 100),
+        )
+        .unwrap();
+    assert!(service.unregister_endpoint(&entity_id, CameraMediaKind::Snapshot));
+    assert!(!service.unregister_endpoint(&entity_id, CameraMediaKind::Snapshot));
+    assert!(matches!(
+        service.deliver_lease(&runtime, &removed.lease_id),
+        Err(CameraMediaError::MissingEndpoint { .. })
+    ));
+    assert!(state.borrow().endpoints.is_empty());
+}
+
+#[test]
+fn endpoint_policy_is_secure_by_default_and_fixture_opt_in_is_explicit() {
+    let (_, entity_id, principal_id, _) = fixture_runtime(None);
+    let clock = SharedClock::new(10);
+    let principal = SharedPrincipal::new(principal_id);
+    let (mut secure, _) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0x51),
+        ExecutorMode::Snapshot(1),
+        CameraMediaPolicy::default(),
+    );
+    assert!(matches!(
+        secure.register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "http://127.0.0.1/snapshot"
+        ),
+        Err(CameraMediaError::InsecureEndpoint)
+    ));
+    let (mut fixtures, _) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0x52),
+        ExecutorMode::Snapshot(1),
+        fixture_policy(),
+    );
+    fixtures
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "http://127.2.3.4/snapshot",
+        )
+        .unwrap();
+    assert!(matches!(
+        fixtures.register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "http://127.0.0.1/snapshot?token=plaintext"
+        ),
+        Err(CameraMediaError::InsecureEndpoint)
+    ));
+    for uri in [
+        "http://127.evil.local.com/snapshot",
+        "https://user:password@camera.local/snapshot",
+        "https://camera.local/snapshot#secret",
+        "ftp://camera.local/snapshot",
+    ] {
+        assert!(fixtures
+            .register_endpoint(entity_id.clone(), CameraMediaKind::Snapshot, uri)
+            .is_err());
+    }
+    fixtures
+        .register_endpoint(
+            entity_id,
+            CameraMediaKind::Snapshot,
+            "https://camera.local/snapshot?token=transport-protected",
+        )
+        .unwrap();
+}
+
+#[test]
+fn nonce_failures_and_collisions_fail_closed() {
+    let (runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    let clock = SharedClock::new(10);
+    let principal = SharedPrincipal::new(principal_id);
+    let (mut failing, _) = service(
+        &clock,
+        &principal,
+        TestNonce::failing(),
+        ExecutorMode::Snapshot(1),
+        fixture_policy(),
+    );
+    failing
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "https://camera.local/snapshot",
+        )
+        .unwrap();
+    assert!(matches!(
+        failing.issue_lease(
+            &runtime,
+            request(entity_id.clone(), CameraMediaKind::Snapshot, 10)
+        ),
+        Err(CameraMediaError::NonceUnavailable)
+    ));
+
+    let (mut repeating, _) = service(
+        &clock,
+        &principal,
+        TestNonce::repeating(0x61),
+        ExecutorMode::Snapshot(1),
+        fixture_policy(),
+    );
+    repeating
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "https://camera.local/snapshot",
+        )
+        .unwrap();
+    repeating
+        .issue_lease(
+            &runtime,
+            request(entity_id.clone(), CameraMediaKind::Snapshot, 10),
+        )
+        .unwrap();
+    assert!(matches!(
+        repeating.issue_lease(&runtime, request(entity_id, CameraMediaKind::Snapshot, 10)),
+        Err(CameraMediaError::DuplicateLeaseId)
+    ));
+}
+
+#[test]
+fn executor_failure_oversize_and_wrong_kind_are_consumed_and_closed() {
+    let (runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    for (mode, expected) in [
+        (
+            ExecutorMode::Failure(CameraMediaExecutionError::Protocol),
+            "media transport protocol failure",
+        ),
+        (ExecutorMode::Snapshot(9), "invalid delivery"),
+        (ExecutorMode::WrongKind, "invalid delivery"),
+    ] {
+        let clock = SharedClock::new(10);
+        let principal = SharedPrincipal::new(principal_id.clone());
+        let policy = CameraMediaPolicy {
+            max_snapshot_bytes: 8,
+            ..fixture_policy()
+        };
+        let (mut service, state) =
+            service(&clock, &principal, TestNonce::sequence(0x71), mode, policy);
+        service
+            .register_endpoint(
+                entity_id.clone(),
+                CameraMediaKind::Snapshot,
+                "https://camera.local/snapshot",
+            )
+            .unwrap();
+        let lease = service
+            .issue_lease(
+                &runtime,
+                request(entity_id.clone(), CameraMediaKind::Snapshot, 10),
+            )
+            .unwrap();
+        let error = service
+            .deliver_lease(&runtime, &lease.lease_id)
+            .unwrap_err();
+        assert!(error.to_string().contains(expected));
+        assert!(matches!(
+            service.deliver_lease(&runtime, &lease.lease_id),
+            Err(CameraMediaError::UnknownLease)
+        ));
+        if matches!(mode, ExecutorMode::WrongKind) {
+            assert_eq!(state.borrow().closed_streams, vec!["wrong-kind-resource"]);
+        }
+    }
+}
+
+#[test]
+fn broker_mints_stream_ids_and_owns_close_and_expiry() {
+    let (mut runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    runtime
+        .registry_mut()
+        .upsert_capability_grant(CapabilityGrant::for_entity_capability(
+            CapabilityGrantId::trusted("camera-stream-grant"),
+            principal_id.clone(),
+            entity_id.clone(),
+            CameraMediaKind::Stream.capability_id(),
+            PrivilegeTier::HumanApproval,
+            "user",
+            1,
+        ));
+    let clock = SharedClock::new(20);
+    let principal = SharedPrincipal::new(principal_id.clone());
+    let (mut service, state) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0x81),
+        ExecutorMode::Stream,
+        fixture_policy(),
+    );
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Stream,
+            "rtsps://camera.local/live?token=secret",
+        )
+        .unwrap();
+    let lease = service
+        .issue_lease(&runtime, request(entity_id, CameraMediaKind::Stream, 50))
+        .unwrap();
+    let delivery = service.deliver_lease(&runtime, &lease.lease_id).unwrap();
+    let CameraMediaDelivery::Stream {
+        session_id,
+        expires_at_ms,
+    } = delivery
+    else {
+        panic!("expected stream delivery");
+    };
+    assert_eq!(expires_at_ms, 70);
+    assert_eq!(session_id.as_str().len(), 32);
+    assert!(!session_id.as_str().contains("executor-private-resource"));
+    assert!(!format!("{session_id:?}").contains(session_id.as_str()));
+    principal.set(Some(AgentId::trusted("other-user")));
+    assert!(matches!(
+        service.close_stream(&session_id),
+        Err(CameraMediaError::StreamPrincipalMismatch)
+    ));
+    principal.set(Some(principal_id));
+    service.close_stream(&session_id).unwrap();
+    assert_eq!(
+        state.borrow().closed_streams,
+        vec!["executor-private-resource"]
+    );
+    assert!(matches!(
+        service.close_stream(&session_id),
+        Err(CameraMediaError::UnknownStreamSession)
+    ));
+}
+
+#[test]
+fn failed_stream_teardown_retains_ownership_for_retry() {
+    let (mut runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    runtime
+        .registry_mut()
+        .upsert_capability_grant(CapabilityGrant::for_entity_capability(
+            CapabilityGrantId::trusted("retry-stream-grant"),
+            principal_id.clone(),
+            entity_id.clone(),
+            CameraMediaKind::Stream.capability_id(),
+            PrivilegeTier::HumanApproval,
+            "user",
+            1,
+        ));
+    let clock = SharedClock::new(20);
+    let principal = SharedPrincipal::new(principal_id);
+    let (mut service, state) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0x89),
+        ExecutorMode::Stream,
+        fixture_policy(),
+    );
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Stream,
+            "rtsps://camera.local/live",
+        )
+        .unwrap();
+    let lease = service
+        .issue_lease(
+            &runtime,
+            request(entity_id.clone(), CameraMediaKind::Stream, 10),
+        )
+        .unwrap();
+    let CameraMediaDelivery::Stream { session_id, .. } =
+        service.deliver_lease(&runtime, &lease.lease_id).unwrap()
+    else {
+        panic!("expected stream delivery");
+    };
+    state.borrow_mut().fail_close = true;
+    assert!(matches!(
+        service.close_stream(&session_id),
+        Err(CameraMediaError::Execution(
+            CameraMediaExecutionError::Unavailable
+        ))
+    ));
+    assert_eq!(service.snapshot().active_stream_count, 1);
+    clock.set(30);
+    assert_eq!(
+        service.reconcile(&runtime),
+        smart_home_camera_media::CameraMediaReconcileReport {
+            expired_lease_count: 0,
+            closed_stream_count: 0,
+            failed_stream_close_count: 1,
+        }
+    );
+    assert_eq!(service.snapshot().active_stream_count, 1);
+    state.borrow_mut().fail_close = false;
+    assert_eq!(
+        service.reconcile(&runtime),
+        smart_home_camera_media::CameraMediaReconcileReport {
+            expired_lease_count: 0,
+            closed_stream_count: 1,
+            failed_stream_close_count: 0,
+        }
+    );
+    assert_eq!(service.snapshot().active_stream_count, 0);
+}
+
+#[test]
+fn failed_post_open_cleanup_is_retained_without_a_public_session() {
+    let (mut runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    runtime
+        .registry_mut()
+        .upsert_capability_grant(CapabilityGrant::for_entity_capability(
+            CapabilityGrantId::trusted("cleanup-stream-grant"),
+            principal_id.clone(),
+            entity_id.clone(),
+            CameraMediaKind::Stream.capability_id(),
+            PrivilegeTier::HumanApproval,
+            "user",
+            1,
+        ));
+    let clock = SharedClock::new(20);
+    let principal = SharedPrincipal::new(principal_id);
+    let nonce = TestNonce {
+        fail_on_call: Some(2),
+        ..TestNonce::sequence(0x8d)
+    };
+    let (mut service, state) = service(
+        &clock,
+        &principal,
+        nonce,
+        ExecutorMode::Stream,
+        fixture_policy(),
+    );
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Stream,
+            "rtsps://camera.local/live",
+        )
+        .unwrap();
+    let lease = service
+        .issue_lease(&runtime, request(entity_id, CameraMediaKind::Stream, 10))
+        .unwrap();
+    state.borrow_mut().fail_close = true;
+    assert!(matches!(
+        service.deliver_lease(&runtime, &lease.lease_id),
+        Err(CameraMediaError::Execution(
+            CameraMediaExecutionError::Unavailable
+        ))
+    ));
+    assert_eq!(service.snapshot().active_stream_count, 0);
+    assert_eq!(service.snapshot().pending_stream_cleanup_count, 1);
+    state.borrow_mut().fail_close = false;
+    assert_eq!(
+        service.reconcile(&runtime),
+        smart_home_camera_media::CameraMediaReconcileReport {
+            expired_lease_count: 0,
+            closed_stream_count: 1,
+            failed_stream_close_count: 0,
+        }
+    );
+    assert_eq!(service.snapshot().pending_stream_cleanup_count, 0);
+}
+
+#[test]
+fn stream_quota_and_expiry_cleanup_are_enforced() {
+    let (mut runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    runtime
+        .registry_mut()
+        .upsert_capability_grant(CapabilityGrant::for_entity_capability(
+            CapabilityGrantId::trusted("stream-grant"),
+            principal_id.clone(),
+            entity_id.clone(),
+            CameraMediaKind::Stream.capability_id(),
+            PrivilegeTier::HumanApproval,
+            "user",
+            1,
+        ));
+    let clock = SharedClock::new(10);
+    let principal = SharedPrincipal::new(principal_id);
+    let policy = CameraMediaPolicy {
+        max_active_streams: 1,
+        ..fixture_policy()
+    };
+    let (mut service, state) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0x91),
+        ExecutorMode::Stream,
+        policy,
+    );
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Stream,
+            "rtsps://camera.local/live",
+        )
+        .unwrap();
+    let first = service
+        .issue_lease(
+            &runtime,
+            request(entity_id.clone(), CameraMediaKind::Stream, 20),
+        )
+        .unwrap();
+    service.deliver_lease(&runtime, &first.lease_id).unwrap();
+    let second = service
+        .issue_lease(&runtime, request(entity_id, CameraMediaKind::Stream, 20))
+        .unwrap();
+    assert!(matches!(
+        service.deliver_lease(&runtime, &second.lease_id),
+        Err(CameraMediaError::StreamQuotaExceeded { maximum: 1 })
+    ));
+    clock.set(30);
+    assert_eq!(
+        service.reconcile(&runtime),
+        smart_home_camera_media::CameraMediaReconcileReport {
+            expired_lease_count: 0,
+            closed_stream_count: 1,
+            failed_stream_close_count: 0,
+        }
+    );
+    assert_eq!(service.snapshot().active_stream_count, 0);
+    assert_eq!(state.borrow().closed_streams.len(), 1);
+}
+
+#[test]
+fn unauthenticated_hosts_requests_and_error_text_fail_closed() {
+    let (runtime, entity_id, principal_id, _) = fixture_runtime(None);
+    let clock = SharedClock::new(u64::MAX);
+    let principal = SharedPrincipal::new(principal_id);
+    principal.set(None);
+    let (mut service, _) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0xa1),
+        ExecutorMode::Snapshot(1),
+        fixture_policy(),
+    );
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "https://camera.local/snapshot",
+        )
+        .unwrap();
+    assert!(matches!(
+        service.issue_lease(&runtime, request(entity_id, CameraMediaKind::Snapshot, 1)),
+        Err(CameraMediaError::Unauthenticated)
+    ));
+    for error in [
+        CameraMediaError::PrincipalLeaseQuotaExceeded { maximum: 1 },
+        CameraMediaError::StreamQuotaExceeded { maximum: 1 },
+        CameraMediaError::DuplicateStreamSessionId,
+        CameraMediaError::UnknownStreamSession,
+        CameraMediaError::StreamPrincipalMismatch,
+        CameraMediaError::Unauthenticated,
+    ] {
+        let rendered = error.to_string();
+        assert!(!rendered.contains("camera.local"));
+        assert!(!rendered.is_empty());
+    }
+}
+
+#[test]
+fn bounded_audit_discards_oldest_records() {
+    let (_, entity_id, principal_id, _) = fixture_runtime(None);
+    let clock = SharedClock::new(10);
+    let principal = SharedPrincipal::new(principal_id);
+    let policy = CameraMediaPolicy {
+        max_audit_records: 1,
+        ..fixture_policy()
+    };
+    let (mut service, _) = service(
+        &clock,
+        &principal,
+        TestNonce::sequence(0xb1),
+        ExecutorMode::Snapshot(1),
+        policy,
+    );
+    service
+        .register_endpoint(
+            entity_id.clone(),
+            CameraMediaKind::Snapshot,
+            "https://camera.local/one",
+        )
+        .unwrap();
+    service
+        .register_endpoint(
+            entity_id,
+            CameraMediaKind::Snapshot,
+            "https://camera.local/two",
+        )
+        .unwrap();
+    let records = service.audit_records().collect::<Vec<_>>();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].sequence, 2);
+}

--- a/code/packages/rust/smart-home-onvif-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-onvif-integration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.1
+
+- Adapted camera registration and the real loopback integration path to the
+  host-owned camera-media service and its narrow endpoint registry; the loopback
+  transport exception is now an explicit fixture policy rather than a default.
+
 ## 0.1.0
 
 - Added bounded ONVIF WS-Discovery scanning and ProbeMatch normalization.

--- a/code/packages/rust/smart-home-onvif-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-onvif-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-onvif-integration"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Production ONVIF discovery and camera integration for the smart-home runtime"
 license = "MIT"

--- a/code/packages/rust/smart-home-onvif-integration/README.md
+++ b/code/packages/rust/smart-home-onvif-integration/README.md
@@ -9,8 +9,9 @@ This package provides the first production camera integration for D23:
 - device information, media profile, snapshot URI, and RTSP stream URI reads.
 - normalized camera devices/entities with no media URI or credential material in
   runtime state.
-- process-local snapshot and stream registration through
-  `smart-home-camera-media` leases.
+- process-local snapshot and stream registration through the narrow
+  `CameraMediaEndpointRegistry` surface; the host-owned camera-media service
+  never returns a device endpoint URI to the lease holder.
 
 The `smart-home-onvif-integration` binary can run `discover` or inspect one
 device service. Inspection reads `ONVIF_USERNAME` and `ONVIF_PASSWORD` from the

--- a/code/packages/rust/smart-home-onvif-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-onvif-integration/src/lib.rs
@@ -11,7 +11,7 @@ use http1::{parse_response_head, Http1ParseError};
 use http_core::BodyKind;
 use rand::{rngs::OsRng, RngCore};
 use smart_home_camera_media::{
-    CameraMediaBroker, CameraMediaKind, SNAPSHOT_CAPABILITY_ID, STREAM_CAPABILITY_ID,
+    CameraMediaEndpointRegistry, CameraMediaKind, SNAPSHOT_CAPABILITY_ID, STREAM_CAPABILITY_ID,
 };
 use smart_home_core::{
     Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode, Device, DeviceId,
@@ -31,7 +31,7 @@ use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use udp_client::{send_to_and_collect, UdpError, UdpOptions};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.1.1";
 pub const INTEGRATION_ID: &str = "onvif";
 pub const WS_DISCOVERY_PORT: u16 = 3702;
 pub const WS_DISCOVERY_IPV4: Ipv4Addr = Ipv4Addr::new(239, 255, 255, 250);
@@ -706,7 +706,7 @@ pub struct InstalledOnvifCamera {
 
 pub fn install_camera_snapshot(
     runtime: &mut SmartHomeRuntime,
-    media_broker: &mut CameraMediaBroker,
+    media_registry: &mut impl CameraMediaEndpointRegistry,
     config: &OnvifCameraConfig,
     snapshot: &OnvifCameraSnapshot,
     observed_at_ms: u64,
@@ -805,24 +805,14 @@ pub fn install_camera_snapshot(
             metadata,
         });
         if let Some(uri) = profile.snapshot_uri() {
-            media_broker
-                .register_endpoint(
-                    entity_id.clone(),
-                    CameraMediaKind::Snapshot,
-                    uri,
-                    observed_at_ms,
-                )
+            media_registry
+                .register_camera_endpoint(entity_id.clone(), CameraMediaKind::Snapshot, uri)
                 .map_err(|error| OnvifError::CameraMedia(error.to_string()))?;
             snapshot_endpoint_count += 1;
         }
         if let Some(uri) = profile.stream_uri() {
-            media_broker
-                .register_endpoint(
-                    entity_id.clone(),
-                    CameraMediaKind::Stream,
-                    uri,
-                    observed_at_ms,
-                )
+            media_registry
+                .register_camera_endpoint(entity_id.clone(), CameraMediaKind::Stream, uri)
                 .map_err(|error| OnvifError::CameraMedia(error.to_string()))?;
             stream_endpoint_count += 1;
         }
@@ -1167,15 +1157,72 @@ fn has_unsafe_http_text(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use smart_home_camera_media::{CameraMediaAccessRequest, CameraMediaError};
+    use smart_home_camera_media::{
+        CameraMediaAccessRequest, CameraMediaClock, CameraMediaError, CameraMediaExecution,
+        CameraMediaExecutionError, CameraMediaExecutionResult, CameraMediaExecutor,
+        CameraMediaNonceError, CameraMediaNonceSource, CameraMediaPolicy,
+        CameraMediaPrincipalSource, CameraMediaService,
+    };
     use smart_home_core::{AgentId, CapabilityGrant, CapabilityGrantId, PrivilegeTier};
+    use std::cell::Cell;
     use std::io::{BufRead, BufReader};
     use std::net::{TcpListener, UdpSocket};
+    use std::rc::Rc;
     use std::sync::{Arc, Mutex};
     use std::thread;
 
     const USERNAME: &str = "operator";
     const PASSWORD: &str = "fixture-password";
+
+    struct FixedNonce([u8; 16]);
+
+    impl CameraMediaNonceSource for FixedNonce {
+        fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+            output.copy_from_slice(&self.0);
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestClock(Rc<Cell<u64>>);
+
+    impl CameraMediaClock for TestClock {
+        fn now_ms(&self) -> u64 {
+            self.0.get()
+        }
+    }
+
+    struct FixedPrincipal(AgentId);
+
+    impl CameraMediaPrincipalSource for FixedPrincipal {
+        fn current_principal(&self) -> Option<AgentId> {
+            Some(self.0.clone())
+        }
+    }
+
+    struct SnapshotDeliveryHost {
+        saw_snapshot_endpoint: Rc<Cell<bool>>,
+    }
+
+    impl CameraMediaExecutor for SnapshotDeliveryHost {
+        type Stream = ();
+
+        fn deliver(
+            &mut self,
+            execution: CameraMediaExecution<'_>,
+        ) -> Result<CameraMediaExecutionResult<Self::Stream>, CameraMediaExecutionError> {
+            self.saw_snapshot_endpoint
+                .set(execution.endpoint_uri().contains("snapshot.jpg"));
+            Ok(CameraMediaExecutionResult::snapshot(vec![0x5a; 128]))
+        }
+
+        fn close_stream(
+            &mut self,
+            _stream: &mut Self::Stream,
+        ) -> Result<(), CameraMediaExecutionError> {
+            Ok(())
+        }
+    }
 
     fn soap(body: &str) -> String {
         format!(
@@ -1281,7 +1328,7 @@ mod tests {
                 } else if body.contains("GetProfiles") {
                     soap("<trt:GetProfilesResponse><trt:Profiles token=\"profile-main\"><tt:Name>Main Stream</tt:Name><tt:VideoEncoderConfiguration><tt:Encoding>H264</tt:Encoding><tt:Resolution><tt:Width>1920</tt:Width><tt:Height>1080</tt:Height></tt:Resolution><tt:RateControl><tt:FrameRateLimit>30</tt:FrameRateLimit></tt:RateControl></tt:VideoEncoderConfiguration></trt:Profiles></trt:GetProfilesResponse>")
                 } else if body.contains("GetSnapshotUri") {
-                    soap(&format!("<trt:GetSnapshotUriResponse><trt:MediaUri><tt:Uri>{server_base}/snapshot.jpg?token=private</tt:Uri></trt:MediaUri></trt:GetSnapshotUriResponse>"))
+                    soap(&format!("<trt:GetSnapshotUriResponse><trt:MediaUri><tt:Uri>{server_base}/snapshot.jpg</tt:Uri></trt:MediaUri></trt:GetSnapshotUriResponse>"))
                 } else {
                     soap("<trt:GetStreamUriResponse><trt:MediaUri><tt:Uri>rtsp://127.0.0.1/private-stream</tt:Uri></trt:MediaUri></trt:GetStreamUriResponse>")
                 };
@@ -1315,10 +1362,24 @@ mod tests {
         drop(captured);
 
         let mut runtime = SmartHomeRuntime::default();
-        let mut broker = CameraMediaBroker::default();
+        let principal = AgentId::trusted("dashboard-user");
+        let clock_value = Rc::new(Cell::new(1_000));
+        let saw_snapshot_endpoint = Rc::new(Cell::new(false));
+        let mut media = CameraMediaService::new(
+            CameraMediaPolicy {
+                allow_plaintext_loopback: true,
+                ..CameraMediaPolicy::default()
+            },
+            TestClock(Rc::clone(&clock_value)),
+            FixedNonce([0x44; 16]),
+            FixedPrincipal(principal.clone()),
+            SnapshotDeliveryHost {
+                saw_snapshot_endpoint: Rc::clone(&saw_snapshot_endpoint),
+            },
+        );
         let installed = install_camera_snapshot(
             &mut runtime,
-            &mut broker,
+            &mut media,
             &OnvifCameraConfig {
                 bridge_id: BridgeId::trusted("onvif-loopback"),
                 endpoint_reference: "urn:uuid:loopback-camera".to_string(),
@@ -1342,7 +1403,6 @@ mod tests {
             EntityKind::Camera
         );
 
-        let principal = AgentId::trusted("dashboard-user");
         runtime
             .registry_mut()
             .upsert_capability_grant(CapabilityGrant::for_entity_capability(
@@ -1354,28 +1414,30 @@ mod tests {
                 "operator",
                 1_000,
             ));
-        let lease = broker
+        clock_value.set(1_001);
+        let lease = media
             .issue_lease(
                 &runtime,
                 CameraMediaAccessRequest::new(
-                    principal.clone(),
                     installed.entity_ids[0].clone(),
                     CameraMediaKind::Snapshot,
                     "door preview",
-                    1_001,
                     5_000,
                 ),
             )
             .unwrap();
-        let uri = broker
-            .redeem_lease(&lease.lease_id, &principal, 1_002)
-            .unwrap();
-        assert!(uri.contains("snapshot.jpg"));
+        clock_value.set(1_002);
+        let delivery = media.deliver_lease(&runtime, &lease.lease_id).unwrap();
+        assert_eq!(delivery.snapshot_bytes().unwrap().len(), 128);
+        assert!(saw_snapshot_endpoint.get());
         assert!(!format!("{:?}", runtime.durable_snapshot()).contains("snapshot.jpg"));
-        assert!(!format!("{broker:?}").contains("private-stream"));
+        assert!(
+            !format!("{:?}", media.audit_records().collect::<Vec<_>>()).contains("private-stream")
+        );
+        clock_value.set(1_003);
         assert!(matches!(
-            broker.redeem_lease(&lease.lease_id, &principal, 1_003),
-            Err(CameraMediaError::UnknownLease(_))
+            media.deliver_lease(&runtime, &lease.lease_id),
+            Err(CameraMediaError::UnknownLease)
         ));
     }
 }

--- a/code/scripts/tests/test_capability_taxonomy.py
+++ b/code/scripts/tests/test_capability_taxonomy.py
@@ -134,6 +134,20 @@ class CapabilityTaxonomyTest(unittest.TestCase):
                 ):
                     self.assertIn(pair, allowed)
 
+    def test_camera_media_authority_free_manifest_is_schema_valid(self) -> None:
+        manifest_path = (
+            REPO_ROOT
+            / "code/packages/rust/smart-home-camera-media/required_capabilities.json"
+        )
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        validator = jsonschema.Draft202012Validator(
+            self.manifest_schemas["required"]
+        )
+        validator.validate(manifest)
+        self.assertEqual("rust/smart-home-camera-media", manifest["package"])
+        self.assertEqual([], manifest["capabilities"])
+        self.assertTrue(manifest["justification"].strip())
+
     @staticmethod
     def manifest(schema_name: str, category: str, action: str) -> dict[str, Any]:
         capability = {

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -726,15 +726,19 @@ The camera-media broker is a portable policy boundary, not a transport host:
   transport execution.
 - Redemption rechecks the current D23 Human Approval grant at trusted current
   time, atomically consumes the lease, and lends the endpoint only to a trusted
-  media executor. The public result is snapshot bytes/metadata or an opaque
-  host-owned stream-session handle, never a URI or embedded credential.
-- Endpoint and active-lease tables are bounded by policy. Credential-bearing
-  URLs and plaintext non-loopback snapshot/stream schemes fail closed. Audit,
-  debug, and transport errors remain typed and endpoint-free.
-- Clock, authenticated identity, nonce generation, and media I/O are injected
-  authority owned by the native host. The deterministic broker therefore declares
-  an explicit empty package capability profile; the later native ONVIF host owns
-  and must obtain approval for its nonempty authority.
+  media executor. Snapshot bytes are bounded before release. The executor yields
+  an owned stream resource; the service mints the public session ID and retains
+  the resource through explicit close or trusted-time expiry. Failed teardown
+  remains owned, reported, and retryable rather than disappearing from state.
+- Endpoint, active-lease, per-principal lease, stream, and audit tables are bounded
+  by policy. URL userinfo and fragments fail closed. Plaintext schemes are denied
+  by default and require an explicit loopback-fixture opt-in; secure query tokens
+  remain confined to the trusted executor. Audit rows contain no bearer ID.
+- Clock, authenticated identity, nonce generation, and media I/O are installed
+  once in the host-owned service and cannot be substituted per request. The
+  deterministic policy core therefore declares an explicit empty package
+  capability profile; the later native ONVIF host owns and must obtain approval
+  for its nonempty authority.
 
 ## Smart Home Remaining Work
 

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -669,9 +669,10 @@ privacy-sensitive media endpoints in durable D23 state:
 - ONVIF cameras project to first-class normalized `Camera` entities and the
   `Onvif` protocol family. Runtime state contains profile metadata but no media
   URI, password, nonce, or credential material.
-- `smart-home-camera-media` keeps endpoints process-local and reveals them only
-  through short-lived, principal-bound, single-use leases backed by active
-  Human Approval capability grants for `camera.snapshot` or `camera.stream`.
+- `smart-home-camera-media` keeps endpoints process-local. Short-lived,
+  principal-bound, single-use leases backed by active Human Approval grants for
+  `camera.snapshot` or `camera.stream` authorize one trusted-host delivery; the
+  lease holder never receives the snapshot or stream endpoint URI.
 - Real loopback UDP and TCP tests prove discovery, five authenticated SOAP
   exchanges, runtime installation, capability authorization, media redemption,
   and redaction boundaries over actual host transports.
@@ -711,6 +712,29 @@ controllers:
 - Real loopback TCP tests prove inspection, runtime installation, authorization,
   and command transfer over the production transport. This first host uses
   polling and does not claim WebSocket push support.
+
+## Current Camera Media Security Hardening Slice
+
+The camera-media broker is a portable policy boundary, not a transport host:
+
+- An access request carries target, media kind, purpose, and bounded TTL only.
+  The trusted host supplies the authenticated principal, monotonic current time,
+  and collision-resistant nonce source; callers cannot backdate or impersonate
+  those fields through the request DTO.
+- A lease records the endpoint generation it authorized. Registering or rotating
+  an endpoint advances that generation, invalidating every older lease before
+  transport execution.
+- Redemption rechecks the current D23 Human Approval grant at trusted current
+  time, atomically consumes the lease, and lends the endpoint only to a trusted
+  media executor. The public result is snapshot bytes/metadata or an opaque
+  host-owned stream-session handle, never a URI or embedded credential.
+- Endpoint and active-lease tables are bounded by policy. Credential-bearing
+  URLs and plaintext non-loopback snapshot/stream schemes fail closed. Audit,
+  debug, and transport errors remain typed and endpoint-free.
+- Clock, authenticated identity, nonce generation, and media I/O are injected
+  authority owned by the native host. The deterministic broker therefore declares
+  an explicit empty package capability profile; the later native ONVIF host owns
+  and must obtain approval for its nonempty authority.
 
 ## Smart Home Remaining Work
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,9 +106,9 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on August 1, 2026 at `1e4956369` after merged PR
-#9413 and the addition of the Rust camera-media and ONVIF integration packages.
-It contains 1,207 normalized implementation identities across 4,351 established-lane package
+inventory was regenerated on August 1, 2026 at `6dbe24e28` after merged PR
+#9415 and the addition of the Rust Shelly Gen2/Gen3 integration package.
+It contains 1,208 normalized implementation identities across 4,352 established-lane package
 slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -116,23 +116,27 @@ slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 275 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 757 | 10,598 |
+| Present in one language | 758 | 10,612 |
 
-The loop must not start by attempting 10,598 singleton ports. It should finish
+The loop must not start by attempting 10,612 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current inventory at
-`1e4956369cb3aeabedf5027c351d1e20a7b8dfac` is collision-clean at 1,207
-normalized implementation identities, 4,351 implementation slots, 172
-high-consensus packages, 275 high-consensus missing slots, 757 singletons, 562
+`6dbe24e287faac5857f15fd85f398f0e2fb40387` is collision-clean at 1,208
+normalized implementation identities, 4,352 implementation slots, 172
+high-consensus packages, 275 high-consensus missing slots, 758 singletons, 563
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The two newest identities are Rust-only `smart-home-camera-media` and
-`smart-home-onvif-integration`. Both are mixed splits rather than blind parity
-ports: camera grant policy, generation-bound lease state, quotas, and redacted
-audit are portable, while authenticated host context and media delivery remain
-native mediation; ONVIF discovery/SOAP parsing, deterministic UsernameToken
-construction, origin policy, and projection are portable, while sockets, TLS,
-trusted time/randomness, Vault access, process I/O, and allowlists remain native.
+The three newest identities are Rust-only `smart-home-camera-media`,
+`smart-home-onvif-integration`, and `smart-home-shelly-integration`. All are
+mixed splits rather than blind parity ports: camera grant policy,
+generation-bound lease state, quotas, and redacted audit are portable, while
+authenticated host context and media delivery remain native mediation; ONVIF
+discovery/SOAP parsing, deterministic UsernameToken construction, origin policy,
+and projection are portable, while sockets, TLS, trusted time/randomness, Vault
+access, process I/O, and allowlists remain native; Shelly JSON/RPC normalization,
+projection, stable identities, and command planning are portable, while mDNS,
+DNS/TCP, plaintext LAN HTTP, trusted time, console I/O, endpoint policy, effect
+ordering, future credentials, and capability profiles remain native.
 The security review found urgent repository-local hardening owners for raw media
 URI redemption and attacker-controlled ONVIF origins before either portable core
 is expanded.
@@ -153,7 +157,7 @@ The August 1 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 972 | 0 | 100% |
+| Rust | 973 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -947,10 +951,10 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 562 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 563 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30-August 1 inventories added twenty-two Rust singleton identities that now
+The July 30-August 1 inventories added twenty-three Rust singleton identities that now
 have explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
@@ -1006,6 +1010,25 @@ every profile, device, and entity has passed validation. A separate dependency-
 ordered item adds validate-and-plan preflight plus atomic commit or rollback so a
 late URI, quota, or registry failure cannot leave partial runtime state or rotate
 previously valid endpoint generations.
+
+The twenty-third identity, `smart-home-shelly-integration`, is another mixed
+split. Gen2/Gen3 device-info and status parsing, authentication-required
+classification, component projection, stable identifiers, capability/state
+normalization, RPC envelope validation, and command planning are deterministic
+portable-core candidates. mDNS, DNS/TCP, plaintext LAN HTTP, trusted time,
+console I/O, origin allowlists, runtime effect application, and future Vault
+credential delivery remain in the native Rust host. Before cross-lane expansion,
+the host must install authenticated session/clock authority once, narrow public
+arbitrary RPC access, bind discovery to reviewed private origins, defend DNS
+rebinding, redact and bound device-controlled data, make installation and
+command effects transactional or compensating, and declare truthful nonempty
+runtime/test capability profiles. Authentication-enabled devices remain
+fail-closed until a reviewed Vault-mediated flow exists; Layer 5 approval stays
+a separate external gate. The same dependency audit found capability drift in
+the shared Rust network substrates: `tcp-client` and `http1-client` claim empty
+profiles despite concrete network calls, while `udp-client` and
+`smart-home-discovery` lack manifests. A separate high-leverage owner corrects
+those native boundaries before downstream approval.
 
 The fourteenth identity, `smart-home-home-assistant-migration`, is a mixed
 boundary rather than an automatic fifteen-lane port. Its deterministic export

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -266,6 +266,9 @@ Their first security audit found that camera-media redemption returns a durable,
 replayable endpoint URI and that ONVIF can relay fresh credential digests to a
 device- or discovery-controlled origin. Those P0 boundaries outrank the ordinary
 Dart frontier while remaining split into serial, reviewable hardening tranches.
+The serial loop selected `smart-home-camera-media-security-boundary-hardening`
+first because it is dependency-ready and closes the endpoint-disclosure boundary
+without coupling that focused repair to ONVIF origin/Vault work.
 The remaining Dart ML dependency child is now explicit rather than hidden in an
 umbrella: `matrix`, then `loss-functions` and `feature-normalization`.
 The build-tool execution critical path remains blocked on external

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,10 +106,9 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on August 1, 2026 at `c2b5a3d81` after the merged
-cross-lane PHY01 wave repair, Rust `smart-home-dashboard-core`, and the
-Windows-native `venture-browser-windows` host. It contains 1,205 normalized
-implementation identities across 4,349 established-lane package
+inventory was regenerated on August 1, 2026 at `1e4956369` after merged PR
+#9413 and the addition of the Rust camera-media and ONVIF integration packages.
+It contains 1,207 normalized implementation identities across 4,351 established-lane package
 slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -117,24 +116,26 @@ slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 275 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 755 | 10,570 |
+| Present in one language | 757 | 10,598 |
 
-The loop must not start by attempting 10,570 singleton ports. It should finish
+The loop must not start by attempting 10,598 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current inventory at
-`c2b5a3d8156e4916fa622a7dcd0df6fc0c206ac3` is collision-clean at 1,205
-normalized implementation identities, 4,349 implementation slots, 172
-high-consensus packages, 275 high-consensus missing slots, 755 singletons, 560
+`1e4956369cb3aeabedf5027c351d1e20a7b8dfac` is collision-clean at 1,207
+normalized implementation identities, 4,351 implementation slots, 172
+high-consensus packages, 275 high-consensus missing slots, 757 singletons, 562
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The two recent identities are Rust-only `smart-home-dashboard-core` and
-`venture-browser-windows`. Dashboard core is a zero-capability, protocol-neutral
-deterministic manifest parser, validator, and summarizer, so its shared fixture
-contract and cross-lane expansion have an explicit owner. The Windows package is
-a mixed split: deterministic session/chrome/status and event-bridge logic belongs
-in `venture-browser-core` or a shared portable bridge, while WinUI, Direct2D, the
-C ABI, and native text shaping remain `native-source`. Its focused owner covers
-that extraction, missing capability metadata, and native host validation.
+The two newest identities are Rust-only `smart-home-camera-media` and
+`smart-home-onvif-integration`. Both are mixed splits rather than blind parity
+ports: camera grant policy, generation-bound lease state, quotas, and redacted
+audit are portable, while authenticated host context and media delivery remain
+native mediation; ONVIF discovery/SOAP parsing, deterministic UsernameToken
+construction, origin policy, and projection are portable, while sockets, TLS,
+trusted time/randomness, Vault access, process I/O, and allowlists remain native.
+The security review found urgent repository-local hardening owners for raw media
+URI redemption and attacker-controlled ONVIF origins before either portable core
+is expanded.
 
 The August 1 lane audit is:
 
@@ -152,7 +153,7 @@ The August 1 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 970 | 0 | 100% |
+| Rust | 972 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -259,6 +260,14 @@ square-root numerical audit had discovered that separate
 underflows at the subnormal floor and loses the sign of negative zero, so that
 work remained tracked behind the merged square-root and wave slices rather
 than expanding either delivery.
+PR #9413 merged that repair at `458405a6e` after all 15 checks passed. The
+collision-clean `1e4956369` refresh added the two Rust-only camera identities.
+Their first security audit found that camera-media redemption returns a durable,
+replayable endpoint URI and that ONVIF can relay fresh credential digests to a
+device- or discovery-controlled origin. Those P0 boundaries outrank the ordinary
+Dart frontier while remaining split into serial, reviewable hardening tranches.
+The remaining Dart ML dependency child is now explicit rather than hidden in an
+umbrella: `matrix`, then `loss-functions` and `feature-normalization`.
 The build-tool execution critical path remains blocked on external
 immutable-runner and attester provisioning.
 
@@ -935,10 +944,10 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 560 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 562 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30-August 1 inventories added twenty Rust singleton identities that now
+The July 30-August 1 inventories added twenty-two Rust singleton identities that now
 have explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
@@ -966,6 +975,26 @@ DLL, WinUI adapter, Direct2D BGRA rendering, native text shaping, and C ABI rema
 native-source. The same owner adds the missing capability profile and Windows
 ABI, generated-project, pointer-lifetime, panic-containment, and pixel-buffer
 validation; other lanes must not duplicate the native shell.
+
+The twenty-first identity, `smart-home-camera-media`, currently mixes a portable
+authorization and lease-policy core with host authority. Its first implementation
+returns the secret snapshot/stream URI to the lease holder, accepts caller-asserted
+identity and time, does not bind a lease to an endpoint generation, owns OS entropy,
+and leaves endpoint/lease maps unbounded. The hardening owner replaces redemption
+with trusted-host delivery of snapshot bytes or an opaque stream-session handle,
+injects identity/time/nonce, revalidates current grants, rejects credential-bearing
+and insecure non-loopback endpoints, binds leases to generations, and imposes
+quotas. A later fixture owner expands only the resulting authority-free policy core.
+
+The twenty-second identity, `smart-home-onvif-integration`, is also a mixed split.
+Correlated discovery and SOAP parsing, deterministic UsernameToken construction,
+origin policy, profile projection, and hostile input handling form a portable core.
+UDP/DNS/TCP/TLS, trusted time and randomness, Vault credential leases, process I/O,
+and reviewed endpoint allowlists remain native. Before extraction, the host must
+stop following discovery- or device-controlled XAddr values across origins with a
+fresh credential digest, fail closed on insecure non-loopback transport, and replace
+ambient username/password environment variables with Vault-mediated credentials.
+The nonempty native profiles then require separately tracked Layer 5 evidence.
 
 The fourteenth identity, `smart-home-home-assistant-migration`, is a mixed
 boundary rather than an automatic fifteen-lane port. Its deterministic export

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,9 +106,9 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on August 1, 2026 at `6dbe24e28` after merged PR
-#9415 and the addition of the Rust Shelly Gen2/Gen3 integration package.
-It contains 1,208 normalized implementation identities across 4,352 established-lane package
+inventory was regenerated on August 1, 2026 at `d5f57bfdb` after merged PR
+#9419 and the addition of the Rust WLED integration package.
+It contains 1,209 normalized implementation identities across 4,353 established-lane package
 slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -116,18 +116,19 @@ slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 275 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 758 | 10,612 |
+| Present in one language | 759 | 10,626 |
 
-The loop must not start by attempting 10,612 singleton ports. It should finish
+The loop must not start by attempting 10,626 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current inventory at
-`6dbe24e287faac5857f15fd85f398f0e2fb40387` is collision-clean at 1,208
-normalized implementation identities, 4,352 implementation slots, 172
-high-consensus packages, 275 high-consensus missing slots, 758 singletons, 563
+`d5f57bfdbc64ebf44d677f195380714f949b0db6` is collision-clean at 1,209
+normalized implementation identities, 4,353 implementation slots, 172
+high-consensus packages, 275 high-consensus missing slots, 759 singletons, 564
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The three newest identities are Rust-only `smart-home-camera-media`,
-`smart-home-onvif-integration`, and `smart-home-shelly-integration`. All are
+The four newest identities are Rust-only `smart-home-camera-media`,
+`smart-home-onvif-integration`, `smart-home-shelly-integration`, and
+`smart-home-wled-integration`. All are
 mixed splits rather than blind parity ports: camera grant policy,
 generation-bound lease state, quotas, and redacted audit are portable, while
 authenticated host context and media delivery remain native mediation; ONVIF
@@ -137,6 +138,10 @@ access, process I/O, and allowlists remain native; Shelly JSON/RPC normalization
 projection, stable identities, and command planning are portable, while mDNS,
 DNS/TCP, plaintext LAN HTTP, trusted time, console I/O, endpoint policy, effect
 ordering, future credentials, and capability profiles remain native.
+WLED DTO validation, master/segment projection, capability-bit interpretation,
+state normalization, and command planning are portable, while mDNS, DNS/TCP,
+plaintext LAN HTTP, trusted time, console I/O, pairing/origin policy, runtime
+effects, and capability profiles remain native.
 The security review found urgent repository-local hardening owners for raw media
 URI redemption and attacker-controlled ONVIF origins before either portable core
 is expanded.
@@ -157,7 +162,7 @@ The August 1 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 973 | 0 | 100% |
+| Rust | 974 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -951,10 +956,10 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 563 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 564 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30-August 1 inventories added twenty-three Rust singleton identities that now
+The July 30-August 1 inventories added twenty-four Rust singleton identities that now
 have explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
@@ -1029,6 +1034,21 @@ the shared Rust network substrates: `tcp-client` and `http1-client` claim empty
 profiles despite concrete network calls, while `udp-client` and
 `smart-home-discovery` lack manifests. A separate high-leverage owner corrects
 those native boundaries before downstream approval.
+
+The twenty-fourth identity, `smart-home-wled-integration`, follows the same
+mixed pattern. `/json/si` DTO validation, master and segment projection, stable
+identifiers, capability-bit interpretation, state normalization, brightness,
+RGB and mirek conversion, and JSON command planning form the portable candidate.
+mDNS, DNS/TCP, plaintext LAN HTTP, trusted time, console I/O, pairing/origin
+policy, and runtime effects remain native. Before extraction, the host must stop
+accepting caller-asserted identity/time and arbitrary public state updates, bind
+discovery to reviewed private origins, defend DNS rebinding, bound/redact device
+data, reject identity/segment collisions, reconcile returned device state, and
+make runtime/device effects transactional or compensating. Truthful nonempty
+host profiles and external Layer 5 evidence remain separate owners. A shared
+follow-up consolidates the duplicated Shelly/WLED DNS, TCP, request encoding,
+bounded response, chunked decoding, and error projection behind a native LAN-
+HTTP executor while keeping `smart-home-local-http` a pure request planner.
 
 The fourteenth identity, `smart-home-home-assistant-migration`, is a mixed
 boundary rather than an automatic fifteen-lane port. Its deterministic export

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -984,10 +984,13 @@ authorization and lease-policy core with host authority. Its first implementatio
 returns the secret snapshot/stream URI to the lease holder, accepts caller-asserted
 identity and time, does not bind a lease to an endpoint generation, owns OS entropy,
 and leaves endpoint/lease maps unbounded. The hardening owner replaces redemption
-with trusted-host delivery of snapshot bytes or an opaque stream-session handle,
-injects identity/time/nonce, revalidates current grants, rejects credential-bearing
-and insecure non-loopback endpoints, binds leases to generations, and imposes
-quotas. A later fixture owner expands only the resulting authority-free policy core.
+with a host-owned service that installs identity/time/nonce/executor authority once,
+revalidates current grants, bounds snapshot bytes, owns broker-minted stream sessions,
+retains failed teardown for reported retry, rejects URL userinfo and default plaintext,
+binds leases to generations, and imposes global and per-principal quotas. An explicit
+policy opt-in exists only for loopback fixtures, where query strings remain forbidden;
+secure query tokens remain confined to the executor. A later fixture owner expands
+only the resulting authority-free policy core.
 
 The twenty-second identity, `smart-home-onvif-integration`, is also a mixed split.
 Correlated discovery and SOAP parsing, deterministic UsernameToken construction,
@@ -998,6 +1001,11 @@ stop following discovery- or device-controlled XAddr values across origins with 
 fresh credential digest, fail closed on insecure non-loopback transport, and replace
 ambient username/password environment variables with Vault-mediated credentials.
 The nonempty native profiles then require separately tracked Layer 5 evidence.
+Its current installation path also mutates bridge and camera endpoint state before
+every profile, device, and entity has passed validation. A separate dependency-
+ordered item adds validate-and-plan preflight plus atomic commit or rollback so a
+late URI, quota, or registry failure cannot leave partial runtime state or rotate
+previously valid endpoint generations.
 
 The fourteenth identity, `smart-home-home-assistant-migration`, is a mixed
 boundary rather than an automatic fifteen-lane port. Its deterministic export


### PR DESCRIPTION
## Summary

- replace raw camera endpoint redemption with a host-owned, authenticated, single-use media service
- bind leases to endpoint generations, recheck grants at trusted current time, mint stream identities outside executors, and retain failed teardown for bounded retry
- keep endpoint URLs and bearer lease IDs out of public results, audit/debug/error surfaces, and default-deny plaintext or credential-bearing endpoints
- adapt ONVIF integration to the mediated registry/service boundary and preserve real loopback transport coverage through an explicit plaintext-fixture policy
- refresh the collision-checked parity inventory through merged Shelly and WLED packages, classify both mixed native/portable boundaries, and assign every newly discovered hardening/conformance owner

## Root cause

The original broker returned durable snapshot/stream URIs to callers and accepted caller-supplied principal, current time, nonce/executor authority, leaving replay, impersonation, endpoint-rotation, credential-disclosure, unbounded-state, and teardown-ownership gaps at a privacy-critical boundary.

## Validation

- `cargo test -p smart-home-camera-media -p smart-home-onvif-integration` — 15 camera-media tests and 4 ONVIF tests pass after the final rebase
- `cargo clippy -p smart-home-camera-media -p smart-home-onvif-integration --all-targets -- -D warnings` — clean
- package `cargo fmt -- --check` — clean
- camera-media LLVM coverage — 85.87% lines, 84.92% regions, 82.35% functions
- capability taxonomy schema tests — 6 pass; `capability-cage` — 67 pass
- `cargo build -p smart-home-camera-media -p smart-home-onvif-integration` — pass
- repository Go build tool — 907 Rust packages discovered; 2 changed / 21 affected; the real run built all 21 successfully, and a post-WLED dry-run reproduced the identical 21-package closure
- parity reporter schema v3 at `d5f57bfdb` — 1,209 identities, 4,353 slots, 759 singletons, 564 Rust singletons, zero canonical collisions, zero unknown buckets
- state graph — 99 unique items, valid dependencies/statuses, zero active parity PRs before publication
- `cargo audit --file code/packages/rust/Cargo.lock` — zero vulnerabilities; two acknowledged unmaintained advisories (`bare-metal` and `paste`)
- dependency/source audit — no `rand`/`getrandom` or direct ambient authority in camera-media; empty policy-core capability manifest schema-validates
- `git diff --check` and high-confidence secret scan — clean
- independent contract, fixture/schema, and security reviews — no release blockers

## Follow-ups recorded

- ONVIF origin/credential transport hardening, transactional installation, Vault/capability wiring, and Layer 5 evidence
- camera-media and ONVIF portable-core fixture/conformance waves
- Shelly and WLED host hardening, portable-core extraction, and externally approved capability profiles
- truthful Rust network-substrate metadata and a shared bounded native LAN-HTTP executor
