### PR TITLE
fix(spice): validate MOS flicker noise exponent

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `AF` values before
+  flicker-noise calculations.
+
 - Reject negative and non-finite Level-1 MOS model-card `KF` values before
   flicker-noise calculations.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -586,6 +586,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET RSH must be finite and non-negative")
         elif canonical == "KF" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET KF must be finite and non-negative")
+        elif canonical == "AF" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET AF must be finite and non-negative")
         elif canonical == "KP" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET KP must be finite and positive")
         elif canonical == "W" and (not math.isfinite(value) or value <= 0.0):

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1341,6 +1341,16 @@ def test_mos_model_card_rejects_negative_or_non_finite_flicker_noise_coefficient
             normalize_model_card("Minvalid", "pmos", {"KF": invalid_coefficient})
 
 
+def test_mos_model_card_rejects_negative_or_non_finite_flicker_noise_exponent() -> None:
+    for value in (0.0, 1.0, 2.0):
+        valid = normalize_model_card("Mvalid", "nmos", {"AF": value})
+        assert valid.parameters["AF"] == pytest.approx(value)
+
+    for invalid_exponent in (-math.inf, -0.1, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET AF must be finite and non-negative"):
+            normalize_model_card("Minvalid", "nmos", {"AF": invalid_exponent})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `AF` values before
+  flicker-noise calculations.
+
 - Reject negative and non-finite Level-1 MOS model-card `KF` values before
   flicker-noise calculations.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4395,6 +4395,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET KF must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "AF" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET AF must be finite and non-negative".to_string(),
+                });
             } else if canonical == "KP" && (!raw_value.is_finite() || *raw_value <= 0.0) {
                 return Err(SpiceError::InvalidElement {
                     name: name.clone(),

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1259,6 +1259,22 @@ fn mos_model_card_rejects_negative_or_non_finite_flicker_noise_coefficient() {
 }
 
 #[test]
+fn mos_model_card_rejects_negative_or_non_finite_flicker_noise_exponent() {
+    for value in [0.0, 1.0, 2.0] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[("AF", value)]).unwrap();
+        assert_close(*valid.parameters.get("AF").unwrap(), value);
+    }
+
+    for invalid_exponent in [f64::NEG_INFINITY, -0.1, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("AF", invalid_exponent)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET AF must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Reject negative and non-finite Level-1 MOS model-card `AF` values before
+  flicker-noise calculations.
+
 - Reject negative and non-finite Level-1 MOS model-card `KF` values before
   flicker-noise calculations.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8448,6 +8448,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET RSH must be finite and non-negative");
     } else if (canonical === "KF" && (!Number.isFinite(value) || value < 0.0)) {
       throw invalidElement(name, "MOSFET KF must be finite and non-negative");
+    } else if (canonical === "AF" && (!Number.isFinite(value) || value < 0.0)) {
+      throw invalidElement(name, "MOSFET AF must be finite and non-negative");
     } else if (canonical === "KP" && (!Number.isFinite(value) || value <= 0.0)) {
       throw invalidElement(name, "MOSFET KP must be finite and positive");
     } else if (canonical === "W" && (!Number.isFinite(value) || value <= 0.0)) {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1187,6 +1187,24 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects negative or non-finite MOS flicker-noise exponent", () => {
+    for (const value of [0.0, 1.0, 2.0]) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { AF: value });
+      expect(valid.parameters.AF).toBe(value);
+    }
+
+    for (const invalidExponent of [
+      Number.NEGATIVE_INFINITY,
+      -0.1,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { AF: invalidExponent }),
+      ).toThrow("MOSFET AF must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS flicker-noise coefficient validation.
+1. Cross-language Level-1 MOS flicker-noise exponent validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `KF` values before flicker-noise
+   - Reject negative or non-finite model-card `AF` values before flicker-noise
      calculations.
-   - Preserve zero and positive flicker-noise coefficients across Rust, Python, and
+   - Preserve zero and positive flicker-noise exponents across Rust, Python, and
      TypeScript.
 
 ## Completed Slices
@@ -3844,6 +3844,13 @@ the Rust, Python, and TypeScript surfaces together.
      drain/source geometry converts sheet resistance into external resistance.
    - Zero and positive sheet resistances remain aligned across Rust, Python,
      and TypeScript.
+
+324. Cross-language Level-1 MOS flicker-noise coefficient validation.
+   - Status: completed in PR 9417.
+   - Negative and non-finite model-card `KF` values are rejected before
+     flicker-noise calculations.
+   - Zero and positive flicker-noise coefficients remain aligned across Rust,
+     Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `AF` values during normalization
- preserve zero and positive flicker-noise exponents across Rust, Python, and TypeScript
- record the completed `KF` slice and advance the SPICE implementation plan

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `.venv/bin/python -m ruff check src tests`
- `.venv/bin/python -m pytest tests/ -q` (705 passed, 88.91% coverage)
- `npm test` (448 passed)
- `npm run build`