### PR TITLE
fix(venture): wire native keyboard navigation

### DIFF
--- a/code/packages/rust/venture-browser-core/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add host-neutral keyboard-scroll commands so native SwiftUI and WinUI page
+  surfaces share exact line, page, start, and end scrolling behavior.
+
 ## 0.6.0
 
 - Pin the host-owned `content-surface` node slot used to mount native page

--- a/code/packages/rust/venture-browser-core/src/lib.rs
+++ b/code/packages/rust/venture-browser-core/src/lib.rs
@@ -41,6 +41,53 @@ pub const VENTURE_CHROME_EVENT_NAMES: [&str; 6] = [
     "onNavigate",
 ];
 
+/// Host-neutral keyboard-scroll commands accepted by Venture's native page
+/// surfaces. Platform adapters translate native key codes to these names; the
+/// shared session owns their exact scrolling behavior.
+pub const VENTURE_SCROLL_COMMAND_NAMES: [&str; 6] = [
+    "line-up",
+    "line-down",
+    "page-up",
+    "page-down",
+    "document-start",
+    "document-end",
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BrowserScrollCommand {
+    LineUp,
+    LineDown,
+    PageUp,
+    PageDown,
+    DocumentStart,
+    DocumentEnd,
+}
+
+impl BrowserScrollCommand {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "line-up" => Some(Self::LineUp),
+            "line-down" => Some(Self::LineDown),
+            "page-up" => Some(Self::PageUp),
+            "page-down" => Some(Self::PageDown),
+            "document-start" => Some(Self::DocumentStart),
+            "document-end" => Some(Self::DocumentEnd),
+            _ => None,
+        }
+    }
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::LineUp => "line-up",
+            Self::LineDown => "line-down",
+            Self::PageUp => "page-up",
+            Self::PageDown => "page-down",
+            Self::DocumentStart => "document-start",
+            Self::DocumentEnd => "document-end",
+        }
+    }
+}
+
 /// In-memory browser navigation state.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NavigationHistory {
@@ -174,6 +221,18 @@ impl ScrollState {
     pub fn scroll_by(&mut self, delta_y: f64) -> f64 {
         let delta_y = if delta_y.is_finite() { delta_y } else { 0.0 };
         self.set_offset_y(self.offset_y + delta_y)
+    }
+
+    /// Apply one semantic keyboard-scroll command.
+    pub fn apply_command(&mut self, command: BrowserScrollCommand) -> f64 {
+        match command {
+            BrowserScrollCommand::LineUp => self.scroll_by(-40.0),
+            BrowserScrollCommand::LineDown => self.scroll_by(40.0),
+            BrowserScrollCommand::PageUp => self.scroll_by(-self.viewport_height * 0.9),
+            BrowserScrollCommand::PageDown => self.scroll_by(self.viewport_height * 0.9),
+            BrowserScrollCommand::DocumentStart => self.set_offset_y(0.0),
+            BrowserScrollCommand::DocumentEnd => self.set_offset_y(self.max_offset_y()),
+        }
     }
 
     /// Update page or viewport geometry and re-clamp the current offset.
@@ -321,6 +380,10 @@ impl BrowserViewport {
 
     pub fn scroll_by(&mut self, delta_y: f64) -> f64 {
         self.scroll.scroll_by(delta_y)
+    }
+
+    pub fn scroll_command(&mut self, command: BrowserScrollCommand) -> f64 {
+        self.scroll.apply_command(command)
     }
 
     pub fn resize(&mut self, viewport_height: f64) -> f64 {
@@ -1064,6 +1127,44 @@ mod tests {
         assert_eq!(scroll.set_dimensions(f64::NAN, f64::INFINITY), 0.0);
         assert_eq!(scroll.viewport_height(), 0.0);
         assert_eq!(scroll.content_height(), 0.0);
+    }
+
+    #[test]
+    fn semantic_scroll_commands_share_exact_names_and_clamped_behavior() {
+        let commands = [
+            BrowserScrollCommand::LineUp,
+            BrowserScrollCommand::LineDown,
+            BrowserScrollCommand::PageUp,
+            BrowserScrollCommand::PageDown,
+            BrowserScrollCommand::DocumentStart,
+            BrowserScrollCommand::DocumentEnd,
+        ];
+        assert_eq!(
+            commands.map(BrowserScrollCommand::name),
+            VENTURE_SCROLL_COMMAND_NAMES
+        );
+        for command in commands {
+            assert_eq!(
+                BrowserScrollCommand::from_name(command.name()),
+                Some(command)
+            );
+        }
+        assert_eq!(BrowserScrollCommand::from_name("page-sideways"), None);
+
+        let mut scroll = ScrollState::new(100.0, 260.0);
+        assert_eq!(scroll.apply_command(BrowserScrollCommand::LineDown), 40.0);
+        assert_eq!(scroll.apply_command(BrowserScrollCommand::PageDown), 130.0);
+        assert_eq!(
+            scroll.apply_command(BrowserScrollCommand::DocumentEnd),
+            160.0
+        );
+        assert_eq!(scroll.apply_command(BrowserScrollCommand::LineDown), 160.0);
+        assert_eq!(scroll.apply_command(BrowserScrollCommand::PageUp), 70.0);
+        assert_eq!(scroll.apply_command(BrowserScrollCommand::LineUp), 30.0);
+        assert_eq!(
+            scroll.apply_command(BrowserScrollCommand::DocumentStart),
+            0.0
+        );
     }
 
     #[test]

--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Export the concrete dynamic bridge used by Venture's generated SwiftUI
   `MosaicHost`: shared chrome props and events, Metal content rendering, scroll,
   and link activation all stay backed by one Rust browser session.
+- Accept shared semantic keyboard-scroll commands through that dynamic bridge
+  so the package-owned SwiftUI content surface can drive the same Rust model.
 
 ## 0.1.0
 

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -14,7 +14,7 @@ use std::{cell::RefCell, rc::Rc};
 use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 use venture_browser_core::{
     BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
-    BrowserSession,
+    BrowserScrollCommand, BrowserSession,
 };
 use window_core::{ElementState, Key, NamedKey, PointerButton, WindowError, WindowEvent};
 
@@ -312,39 +312,22 @@ pub fn keyboard_scroll_session(session: &mut BrowserSession, event: &WindowEvent
     if modifiers.control || modifiers.alt || modifiers.meta {
         return false;
     }
+    let command = match key {
+        NamedKey::ArrowUp => BrowserScrollCommand::LineUp,
+        NamedKey::ArrowDown => BrowserScrollCommand::LineDown,
+        NamedKey::PageUp => BrowserScrollCommand::PageUp,
+        NamedKey::PageDown => BrowserScrollCommand::PageDown,
+        NamedKey::Space if modifiers.shift => BrowserScrollCommand::PageUp,
+        NamedKey::Space => BrowserScrollCommand::PageDown,
+        NamedKey::Home => BrowserScrollCommand::DocumentStart,
+        NamedKey::End => BrowserScrollCommand::DocumentEnd,
+        _ => return false,
+    };
     let Some(viewport) = session.viewport_mut() else {
         return false;
     };
     let previous_offset = viewport.scroll_state().offset_y();
-    let viewport_height = viewport.scroll_state().viewport_height();
-    match key {
-        NamedKey::ArrowUp => {
-            viewport.scroll_by(-40.0);
-        }
-        NamedKey::ArrowDown => {
-            viewport.scroll_by(40.0);
-        }
-        NamedKey::PageUp => {
-            viewport.scroll_by(-viewport_height * 0.9);
-        }
-        NamedKey::PageDown => {
-            viewport.scroll_by(viewport_height * 0.9);
-        }
-        NamedKey::Space if modifiers.shift => {
-            viewport.scroll_by(-viewport_height * 0.9);
-        }
-        NamedKey::Space => {
-            viewport.scroll_by(viewport_height * 0.9);
-        }
-        NamedKey::Home => {
-            viewport.set_scroll_offset_y(0.0);
-        }
-        NamedKey::End => {
-            let max_offset = viewport.scroll_state().max_offset_y();
-            viewport.set_scroll_offset_y(max_offset);
-        }
-        _ => return false,
-    }
+    viewport.scroll_command(command);
     viewport.scroll_state().offset_y() != previous_offset
 }
 
@@ -490,6 +473,15 @@ impl MacBrowserHost {
         };
         let before = viewport.scroll_state().offset_y();
         viewport.scroll_by(delta_y);
+        viewport.scroll_state().offset_y() != before
+    }
+
+    pub fn scroll_command(&mut self, command: BrowserScrollCommand) -> bool {
+        let Some(viewport) = self.session.viewport_mut() else {
+            return false;
+        };
+        let before = viewport.scroll_state().offset_y();
+        viewport.scroll_command(command);
         viewport.scroll_state().offset_y() != before
     }
 
@@ -646,6 +638,22 @@ mod mosaic_ffi {
     ) -> u8 {
         host.as_mut()
             .map(|host| host.scroll_by(delta_y) as u8)
+            .unwrap_or(0)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_macos_scroll_command(
+        host: *mut MacBrowserHost,
+        name: *const c_char,
+    ) -> u8 {
+        let Some(command) = string_arg(name)
+            .as_deref()
+            .and_then(BrowserScrollCommand::from_name)
+        else {
+            return 0;
+        };
+        host.as_mut()
+            .map(|host| host.scroll_command(command) as u8)
             .unwrap_or(0)
     }
 

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -5,3 +5,5 @@
 - Add the native Venture session bridge used by the Mosaic-generated WinUI
   shell, including shared chrome props/events, Direct2D pixel rendering,
   scrolling, and link activation.
+- Accept the same host-neutral semantic keyboard-scroll commands as the macOS
+  bridge for package-owned WinUI content-surface input.

--- a/code/packages/rust/venture-browser-windows/src/lib.rs
+++ b/code/packages/rust/venture-browser-windows/src/lib.rs
@@ -11,7 +11,7 @@ use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 use venture_browser_core::{
     BrowserChromeController, BrowserChromeEvent, BrowserChromeProps, BrowserFetchResponse,
     BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
-    BrowserSession, HttpBrowserFetcher,
+    BrowserScrollCommand, BrowserSession, HttpBrowserFetcher,
 };
 
 pub const VERSION: &str = "0.1.0";
@@ -163,6 +163,15 @@ impl WindowsBrowserHost {
         };
         let before = viewport.scroll_state().offset_y();
         viewport.scroll_by(delta_y);
+        viewport.scroll_state().offset_y() != before
+    }
+
+    pub fn scroll_command(&mut self, command: BrowserScrollCommand) -> bool {
+        let Some(viewport) = self.session.viewport_mut() else {
+            return false;
+        };
+        let before = viewport.scroll_state().offset_y();
+        viewport.scroll_command(command);
         viewport.scroll_state().offset_y() != before
     }
 
@@ -323,6 +332,22 @@ mod ffi {
     }
 
     #[no_mangle]
+    pub unsafe extern "C" fn venture_browser_windows_scroll_command(
+        host: *mut WindowsBrowserHost,
+        name: *const c_char,
+    ) -> u8 {
+        let Some(command) = string_arg(name)
+            .as_deref()
+            .and_then(BrowserScrollCommand::from_name)
+        else {
+            return 0;
+        };
+        host.as_mut()
+            .map(|host| host.scroll_command(command) as u8)
+            .unwrap_or(0)
+    }
+
+    #[no_mangle]
     pub unsafe extern "C" fn venture_browser_windows_activate_link(
         host: *mut WindowsBrowserHost,
         x: f64,
@@ -422,5 +447,28 @@ mod tests {
         assert_eq!(props.address, "http://example.test/next");
         assert_eq!(props.page_title, "Next");
         assert!(!props.back_disabled);
+    }
+
+    #[test]
+    fn semantic_keyboard_scroll_commands_drive_the_windows_session() {
+        let body = (0..80)
+            .map(|index| format!("<p>Keyboard Venture paragraph {index}</p>"))
+            .collect::<String>();
+        let fetcher = move |url: &str| match url {
+            "http://example.test/" => Ok(page(url, "Keyboard", &body)),
+            _ => Err(format!("unexpected URL {url}")),
+        };
+        let mut host = WindowsBrowserHost::new_with_fetcher(
+            "http://example.test/",
+            320.0,
+            180.0,
+            Box::new(fetcher),
+        )
+        .expect("initial page loads");
+
+        assert!(host.scroll_command(BrowserScrollCommand::LineDown));
+        assert!(host.scroll_command(BrowserScrollCommand::DocumentEnd));
+        assert!(host.scroll_command(BrowserScrollCommand::DocumentStart));
+        assert!(!host.scroll_command(BrowserScrollCommand::DocumentStart));
     }
 }

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -30,3 +30,7 @@
 - SwiftUI host-driven prop refresh after native Metal link activation, keeping
   the Mosaic-authored address, title, and history controls synchronized with
   the shared Rust browser session just like the generated WinUI host.
+- Package-owned SwiftUI and WinUI content surfaces now accept native line,
+  page, start/end, and platform history shortcuts. Both adapters translate key
+  input into shared Rust scroll commands and existing Mosaic Back/Forward
+  events instead of owning navigation or scrolling semantics themselves.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -41,6 +41,11 @@ recreating the surrounding chrome in backend-specific UI code.
   reducer into generated WinUI controls, and mounts Direct2D-rendered pixels
   in the generated `content-surface` `UIElement`. Pointer-wheel scrolling and
   link activation call back into the same Rust browser session.
+- The native content surfaces are keyboard focus targets. Arrow, Page,
+  Space/Shift-Space, Home, and End keys use the exact semantic scroll-command
+  contract owned by `venture-browser-core`; Command-Left/Right on macOS and
+  Alt-Left/Right on Windows reuse the Mosaic `onBack`/`onForward` reducer
+  events and reproject chrome props after navigation.
 
 ## Build every backend
 

--- a/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
@@ -12,6 +12,9 @@ private final class VentureNativeLibrary {
     UnsafeMutableRawPointer?, UnsafePointer<CChar>?, UnsafePointer<CChar>?
   ) -> UnsafeMutablePointer<CChar>?
   typealias Scroll = @convention(c) (UnsafeMutableRawPointer?, Double) -> UInt8
+  typealias ScrollCommand = @convention(c) (
+    UnsafeMutableRawPointer?, UnsafePointer<CChar>?
+  ) -> UInt8
   typealias ActivateLink = @convention(c) (UnsafeMutableRawPointer?, Double, Double) -> UInt8
   typealias Render = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> UInt8
   typealias StringFree = @convention(c) (UnsafeMutablePointer<CChar>?) -> Void
@@ -22,6 +25,7 @@ private final class VentureNativeLibrary {
   let applyProps: ApplyProps
   let handleEvent: HandleEvent
   let scroll: Scroll
+  let scrollCommand: ScrollCommand
   let activateLink: ActivateLink
   let render: Render
   let stringFree: StringFree
@@ -48,6 +52,9 @@ private final class VentureNativeLibrary {
       let applyProps = symbol("venture_browser_macos_apply_props", as: ApplyProps.self),
       let handleEvent = symbol("venture_browser_macos_handle_event", as: HandleEvent.self),
       let scroll = symbol("venture_browser_macos_scroll", as: Scroll.self),
+      let scrollCommand = symbol(
+        "venture_browser_macos_scroll_command", as: ScrollCommand.self
+      ),
       let activateLink = symbol("venture_browser_macos_activate_link", as: ActivateLink.self),
       let render = symbol("venture_browser_macos_render", as: Render.self),
       let stringFree = symbol("venture_browser_string_free", as: StringFree.self)
@@ -62,6 +69,7 @@ private final class VentureNativeLibrary {
     self.applyProps = applyProps
     self.handleEvent = handleEvent
     self.scroll = scroll
+    self.scrollCommand = scrollCommand
     self.activateLink = activateLink
     self.render = render
     self.stringFree = stringFree
@@ -140,6 +148,18 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
     contentView?.renderPage()
   }
 
+  fileprivate func scroll(command: String) {
+    guard let native, let browser else { return }
+    let changed = command.withCString { native.scrollCommand(browser, $0) }
+    guard changed != 0 else { return }
+    contentView?.renderPage()
+  }
+
+  fileprivate func navigateHistory(eventName: String) {
+    _ = handleEvent([:], name: eventName as NSString)
+    propsChangedHandler?()
+  }
+
   fileprivate func activateLink(at point: NSPoint) {
     guard let native, let browser, native.activateLink(browser, point.x, point.y) != 0 else {
       return
@@ -163,6 +183,7 @@ private final class VentureContentView: NSView {
   }
 
   override var isFlipped: Bool { true }
+  override var acceptsFirstResponder: Bool { true }
 
   override func makeBackingLayer() -> CALayer {
     let layer = CAMetalLayer()
@@ -193,8 +214,59 @@ private final class VentureContentView: NSView {
     host?.scroll(by: -event.scrollingDeltaY * scale)
   }
 
+  override func mouseDown(with event: NSEvent) {
+    window?.makeFirstResponder(self)
+    super.mouseDown(with: event)
+  }
+
   override func mouseUp(with event: NSEvent) {
     host?.activateLink(at: convert(event.locationInWindow, from: nil))
+  }
+
+  override func keyDown(with event: NSEvent) {
+    let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+    if modifiers.contains(.command)
+      && modifiers.intersection([.control, .option, .shift]).isEmpty
+    {
+      switch event.keyCode {
+      case 123:
+        host?.navigateHistory(eventName: "onBack")
+        return
+      case 124:
+        host?.navigateHistory(eventName: "onForward")
+        return
+      default:
+        break
+      }
+    }
+    guard modifiers.intersection([.command, .control, .option]).isEmpty else {
+      super.keyDown(with: event)
+      return
+    }
+    let command: String?
+    switch event.keyCode {
+    case 126:
+      command = "line-up"
+    case 125:
+      command = "line-down"
+    case 116:
+      command = "page-up"
+    case 121:
+      command = "page-down"
+    case 49:
+      command = modifiers.contains(.shift) ? "page-up" : "page-down"
+    case 115:
+      command = "document-start"
+    case 119:
+      command = "document-end"
+    default:
+      command = nil
+    }
+    guard let command else {
+      super.keyDown(with: event)
+      return
+    }
+    host?.scroll(command: command)
   }
 
   fileprivate func renderPage() {

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -1,3 +1,4 @@
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -6,6 +7,8 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using Windows.System;
+using Windows.UI.Core;
 
 namespace Mosaic.Generated;
 
@@ -108,7 +111,7 @@ public static class MosaicHost
         }
     }
 
-    private sealed class VentureContentSurface : Grid
+    private sealed class VentureContentSurface : ContentControl
     {
         private readonly VentureChrome component;
         private readonly Image image;
@@ -121,7 +124,12 @@ public static class MosaicHost
             this.component = component;
             Background = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 255, 255, 255));
             image = new Image { Stretch = Stretch.Fill };
-            Children.Add(image);
+            HorizontalContentAlignment = HorizontalAlignment.Stretch;
+            VerticalContentAlignment = VerticalAlignment.Stretch;
+            Content = image;
+            IsTabStop = true;
+            KeyDown += OnKeyDown;
+            PointerPressed += OnPointerPressed;
             PointerWheelChanged += OnPointerWheelChanged;
             PointerReleased += OnPointerReleased;
         }
@@ -164,6 +172,54 @@ public static class MosaicHost
             var delta = e.GetCurrentPoint(this).Properties.MouseWheelDelta;
             if (Native.Scroll(browser, -delta) != 0)
             {
+                Refresh();
+                e.Handled = true;
+            }
+        }
+
+        private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            Focus(FocusState.Pointer);
+        }
+
+        private void OnKeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            if (e.KeyStatus.IsMenuKeyDown)
+            {
+                var historyEvent = e.Key switch
+                {
+                    VirtualKey.Left => "onBack",
+                    VirtualKey.Right => "onForward",
+                    _ => null,
+                };
+                if (historyEvent is not null)
+                {
+                    _ = ApplyResponse(
+                        component,
+                        Native.Decode(Native.HandleEvent(browser, historyEvent, null)));
+                    Refresh();
+                    e.Handled = true;
+                    return;
+                }
+            }
+
+            var shift = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift)
+                & CoreVirtualKeyStates.Down) != 0;
+            var command = e.Key switch
+            {
+                VirtualKey.Up => "line-up",
+                VirtualKey.Down => "line-down",
+                VirtualKey.PageUp => "page-up",
+                VirtualKey.PageDown => "page-down",
+                VirtualKey.Space when shift => "page-up",
+                VirtualKey.Space => "page-down",
+                VirtualKey.Home => "document-start",
+                VirtualKey.End => "document-end",
+                _ => null,
+            };
+            if (command is not null)
+            {
+                _ = Native.ScrollCommand(browser, command);
                 Refresh();
                 e.Handled = true;
             }
@@ -219,6 +275,12 @@ public static class MosaicHost
         [DllImport(Library, EntryPoint = "venture_browser_windows_scroll",
             CallingConvention = CallingConvention.Cdecl)]
         internal static extern byte Scroll(IntPtr browser, double deltaY);
+
+        [DllImport(Library, EntryPoint = "venture_browser_windows_scroll_command",
+            CallingConvention = CallingConvention.Cdecl)]
+        internal static extern byte ScrollCommand(
+            IntPtr browser,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string command);
 
         [DllImport(Library, EntryPoint = "venture_browser_windows_activate_link",
             CallingConvention = CallingConvention.Cdecl)]

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -96,7 +96,10 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         "Sources/App/MosaicHost.swift"
     );
     assert_eq!(package.host_assets.files[1].backend, "xaml");
-    assert_eq!(package.host_assets.files[1].source, "host/xaml/MosaicHost.cs");
+    assert_eq!(
+        package.host_assets.files[1].source,
+        "host/xaml/MosaicHost.cs"
+    );
     assert_eq!(package.host_assets.files[1].target, "MosaicHost.cs");
 
     let host = read_package_file("host/swiftui/MosaicHost.swift");
@@ -105,9 +108,12 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         "venture_browser_macos_handle_event",
         "venture_browser_macos_render",
         "venture_browser_macos_scroll",
+        "venture_browser_macos_scroll_command",
         "venture_browser_macos_activate_link",
         "setPropsChangedHandler",
         "propsChangedHandler?()",
+        "override func keyDown",
+        "navigateHistory(eventName:",
     ] {
         assert!(host.contains(symbol), "SwiftUI host omits {symbol}");
     }
@@ -118,11 +124,27 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         "venture_browser_windows_handle_event",
         "venture_browser_windows_render_bgra",
         "venture_browser_windows_scroll",
+        "venture_browser_windows_scroll_command",
         "venture_browser_windows_activate_link",
         "WriteableBitmap",
         "component.ContentSurface",
+        "private void OnKeyDown",
+        "Focus(FocusState.Pointer)",
+        "VentureContentSurface : ContentControl",
     ] {
         assert!(host.contains(symbol), "XAML host omits {symbol}");
+    }
+    let swift_host = read_package_file("host/swiftui/MosaicHost.swift");
+    let xaml_host = read_package_file("host/xaml/MosaicHost.cs");
+    for command in venture_browser_core::VENTURE_SCROLL_COMMAND_NAMES {
+        assert!(
+            swift_host.contains(command),
+            "SwiftUI host omits shared scroll command {command}"
+        );
+        assert!(
+            xaml_host.contains(command),
+            "XAML host omits shared scroll command {command}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- add one host-neutral semantic keyboard-scroll contract in `venture-browser-core`
- route package-owned SwiftUI and WinUI content-surface keys through the shared Rust session
- reuse Mosaic `onBack` and `onForward` events for Command-Left/Right and Alt-Left/Right history navigation
- make the native content surfaces focusable without introducing platform-specific browser chrome

## Why

Pointer scrolling and link activation were wired through the generated Venture shells, but keyboard input stopped at the native surface. The standalone macOS host already proved keyboard scrolling and history navigation, while the package-owned SwiftUI and XAML adapters did not expose those interactions. This left the Mosaic-authored proving application with different native behavior on each shell.

## Validation

- `cargo test -p venture-browser-core -p venture-browser-macos -p venture-browser-windows`
- `cargo clippy -p venture-browser-core -p venture-browser-macos -p venture-browser-windows --all-targets -- -D warnings`
- `cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml`
- emitted all nine Venture package backends
- clean `swift build` of the generated SwiftPM shell with the package-owned host adapter
- regenerated XAML shell and byte-compared its copied `MosaicHost.cs` with the package source
- `cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test -- --nocapture` (tree missing 0; tokenizer missing 0; normalized tokenizer skipped 0)

This is a browser-wiring slice, not a claim of complete browser or HTML conformance. The dedicated Windows CI acceptance remains the direct WinUI build gate.
