### PR TITLE
fix(spice): reject unsupported MOS instance parameters

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject unsupported Level-1 MOS instance parameters instead of silently
+  ignoring misspelled geometry or diffusion fields.
 - Preserve Level-1 MOS model-card `U0` / `UO` and derive `KP` from surface
   mobility and explicit `TOX` when the card omits `KP`.
 - Preserve Level-1 MOS model-card `JS` independently from scalar `IS` so

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2203,6 +2203,16 @@ fn parse_element(
                 }
             };
             let instance_params = parse_element_params(&fields[6..], "MOSFET")?;
+            if let Some(param_name) = instance_params.keys().find(|name| {
+                !matches!(
+                    name.as_str(),
+                    "W" | "L" | "NRD" | "NRS" | "AD" | "AS" | "PD" | "PS"
+                )
+            }) {
+                return Err(NetlistParseError::new(format!(
+                    "unsupported MOSFET parameter {param_name:?}"
+                )));
+            }
             Ok(Element::Mosfet(Mosfet::with_model(
                 name,
                 &fields[1],

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -837,6 +837,13 @@ fn rejects_unsupported_inductor_element_params() {
 }
 
 #[test]
+fn rejects_unsupported_mosfet_element_params() {
+    let error = parse_netlist(".model nch NMOS\nM1 d g s b nch WIDTH=1u").unwrap_err();
+
+    assert!(error.to_string().contains("unsupported MOSFET parameter"));
+}
+
+#[test]
 fn parses_tf_transfer_function_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS flicker-noise exponent validation.
+1. Rust Berkeley SPICE MOS instance-parameter validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `AF` values before flicker-noise
-     calculations.
-   - Preserve zero and positive flicker-noise exponents across Rust, Python, and
-     TypeScript.
+   - Reject unsupported MOS instance parameter names before lowering instead of
+     silently ignoring typos.
+   - Preserve the supported `W`, `L`, `NRD`, `NRS`, `AD`, `AS`, `PD`, and `PS`
+     geometry and diffusion fields.
 
 ## Completed Slices
 
@@ -3850,6 +3850,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `KF` values are rejected before
      flicker-noise calculations.
    - Zero and positive flicker-noise coefficients remain aligned across Rust,
+     Python, and TypeScript.
+
+325. Cross-language Level-1 MOS flicker-noise exponent validation.
+   - Status: completed in PR 9422.
+   - Negative and non-finite model-card `AF` values are rejected before
+     flicker-noise calculations.
+   - Zero and positive flicker-noise exponents remain aligned across Rust,
      Python, and TypeScript.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject unsupported Level-1 MOS instance parameter names before lowering
- preserve the supported W, L, NRD, NRS, AD, AS, PD, and PS fields
- reconcile the SPICE completion plan after AF validation merged in #9422

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `cargo test -p spice-netlist-parser`