### PR TITLE
fix(spice): validate MOS instance width

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS instance `W` values before
+  lowering netlist elements into the engine.
 - Reject unsupported Level-1 MOS instance parameters instead of silently
   ignoring misspelled geometry or diffusion fields.
 - Preserve Level-1 MOS model-card `U0` / `UO` and derive `KP` from surface

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2213,6 +2213,13 @@ fn parse_element(
                     "unsupported MOSFET parameter {param_name:?}"
                 )));
             }
+            if let Some(width) = instance_params.get("W") {
+                if !width.is_finite() || *width <= 0.0 {
+                    return Err(NetlistParseError::new(
+                        "MOSFET W must be finite and positive",
+                    ));
+                }
+            }
             Ok(Element::Mosfet(Mosfet::with_model(
                 name,
                 &fields[1],

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -844,6 +844,18 @@ fn rejects_unsupported_mosfet_element_params() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_instance_widths() {
+    for width in ["0", "-1u", "1e999"] {
+        let error =
+            parse_netlist(&format!(".model nch NMOS\nM1 d g s b nch W={width}")).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET W must be finite and positive"));
+    }
+}
+
+#[test]
 fn parses_tf_transfer_function_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS instance-parameter validation.
+1. Rust Berkeley SPICE MOS instance-width validation.
    - Status: current PR completion candidate.
-   - Reject unsupported MOS instance parameter names before lowering instead of
-     silently ignoring typos.
-   - Preserve the supported `W`, `L`, `NRD`, `NRS`, `AD`, `AS`, `PD`, and `PS`
-     geometry and diffusion fields.
+   - Reject zero, negative, and non-finite instance `W` values before lowering
+     MOS elements into engine parameters.
+   - Preserve positive instance widths and model-card/default width fallback.
 
 ## Completed Slices
 
@@ -3858,6 +3857,13 @@ the Rust, Python, and TypeScript surfaces together.
      flicker-noise calculations.
    - Zero and positive flicker-noise exponents remain aligned across Rust,
      Python, and TypeScript.
+
+326. Rust Berkeley SPICE MOS instance-parameter validation.
+   - Status: completed in PR 9427.
+   - Unsupported MOS instance parameter names are rejected before lowering
+     instead of silently ignoring typos.
+   - Supported `W`, `L`, `NRD`, `NRS`, `AD`, `AS`, `PD`, and `PS` geometry and
+     diffusion fields remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite MOS instance `W` values before parser lowering
- preserve positive instance widths and model/default width fallback
- reconcile the SPICE implementation plan after #9427

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`