### PR TITLE
fix(spice): validate MOS instance length

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS instance `L` values before
+  lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS instance `W` values before
   lowering netlist elements into the engine.
 - Reject unsupported Level-1 MOS instance parameters instead of silently

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2220,6 +2220,13 @@ fn parse_element(
                     ));
                 }
             }
+            if let Some(length) = instance_params.get("L") {
+                if !length.is_finite() || *length <= 0.0 {
+                    return Err(NetlistParseError::new(
+                        "MOSFET L must be finite and positive",
+                    ));
+                }
+            }
             Ok(Element::Mosfet(Mosfet::with_model(
                 name,
                 &fields[1],

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -856,6 +856,18 @@ fn rejects_invalid_mosfet_instance_widths() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_instance_lengths() {
+    for length in ["0", "-1u", "1e999"] {
+        let error =
+            parse_netlist(&format!(".model nch NMOS\nM1 d g s b nch L={length}")).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET L must be finite and positive"));
+    }
+}
+
+#[test]
 fn parses_tf_transfer_function_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS instance-width validation.
+1. Rust Berkeley SPICE MOS instance-length validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite instance `W` values before lowering
+   - Reject zero, negative, and non-finite instance `L` values before lowering
      MOS elements into engine parameters.
-   - Preserve positive instance widths and model-card/default width fallback.
+   - Preserve positive instance lengths and model-card/default length fallback.
 
 ## Completed Slices
 
@@ -3864,6 +3864,13 @@ the Rust, Python, and TypeScript surfaces together.
      instead of silently ignoring typos.
    - Supported `W`, `L`, `NRD`, `NRS`, `AD`, `AS`, `PD`, and `PS` geometry and
      diffusion fields remain accepted.
+
+327. Rust Berkeley SPICE MOS instance-width validation.
+   - Status: completed in PR 9429.
+   - Zero, negative, and non-finite instance `W` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Positive instance widths and model-card/default width fallback remain
+     accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite MOS instance `L` values before parser lowering
- preserve positive instance lengths and model/default length fallback
- reconcile the SPICE implementation plan after #9429

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`