### PR TITLE
test(venture): launch generated native shells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
             -emit-plan build-plan.json \
             "${shard_flags[@]}"
 
-      - name: Detect Venture Windows acceptance
+      - name: Detect Venture native-shell acceptance
         id: venture-windows
         shell: bash
         run: |
@@ -440,7 +440,7 @@ jobs:
           clang --version | head -1
 
       - name: Set up Rust
-        if: needs.detect.outputs.needs_rust == 'true' || (needs.detect.outputs.needs_venture_windows == 'true' && runner.os == 'Windows')
+        if: needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true'
         # Uses the `stable` channel (matching the rest of this repo's Rust CI).
         # NOTE on the -clippy gate: clippy adds/tightens lints on each stable
         # release, so a new Rust release can surface new lints on `main` — treat
@@ -686,7 +686,7 @@ jobs:
             echo "Node: $(node --version)"
             echo "npm: $(npm --version)"
           fi
-          if [ "${{ needs.detect.outputs.needs_rust }}" = "true" ] || { [ "${{ needs.detect.outputs.needs_venture_windows }}" = "true" ] && [ "$RUNNER_OS" = "Windows" ]; }; then
+          if [ "${{ needs.detect.outputs.needs_rust }}" = "true" ] || [ "${{ needs.detect.outputs.needs_venture_windows }}" = "true" ]; then
             echo "Rust: $(rustc --version)"
             echo "Cargo: $(cargo --version)"
           fi
@@ -783,8 +783,24 @@ jobs:
         if: runner.os == 'Windows' && needs.detect.outputs.needs_venture_windows == 'true'
         shell: pwsh
         run: |
+          $installer = Join-Path $env:RUNNER_TEMP 'WindowsAppRuntimeInstall-x64.exe'
+          Invoke-WebRequest `
+            'https://aka.ms/windowsappsdk/1.7/1.7.250606001/windowsappruntimeinstall-x64.exe' `
+            -OutFile $installer
+          & $installer --quiet
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows App Runtime installer failed with exit code $LASTEXITCODE"
+          }
           Set-Location code/packages/rust
           cargo test -p venture-browser-windows
+
+      - name: Build and test Venture macOS acceptance
+        if: runner.os == 'macOS' && needs.detect.outputs.needs_venture_windows == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd code/packages/rust
+          cargo test -p venture-browser-macos
 
       # ── Run the build ─────────────────────────────────────────
       - name: Build and test affected packages

--- a/code/packages/rust/venture-browser-core/README.md
+++ b/code/packages/rust/venture-browser-core/README.md
@@ -46,8 +46,10 @@ six MIL events to `BrowserNavigation`, synchronizes redirects only after a
 successful load, and projects one coherent `BrowserChromeProps` snapshot for
 the six MIL slots. Generated Mosaic shells now expose the native node seam on
 all registered backends. The first concrete adapter connects this reducer and
-the live Metal page renderer to the generated SwiftUI shell; Windows and the
-remaining native hosts still require equivalent direct acceptance.
+the live Metal page renderer to the generated SwiftUI shell, and the matching
+WinUI adapter mounts Direct2D pixels. Platform-native integration gates now
+build and directly launch both generated projects through those adapters; UI
+interaction acceptance and the remaining native hosts are still incomplete.
 
 ## Development
 

--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -16,6 +16,8 @@
   so the package-owned SwiftUI content surface can drive the same Rust model.
 - Reflow the retained page through the shared Rust pipeline when the generated
   SwiftUI content surface changes logical size.
+- Build and directly launch the Mosaic-emitted SwiftUI app in a platform-native
+  integration gate, requiring a successful Metal host-surface render.
 
 ## 0.1.0
 

--- a/code/packages/rust/venture-browser-macos/Cargo.toml
+++ b/code/packages/rust/venture-browser-macos/Cargo.toml
@@ -19,3 +19,6 @@ window-core = { path = "../window-core" }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc-bridge = { path = "../objc-bridge" }
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+mosaic-package-artifact-builder = { path = "../mosaic-package-artifact-builder" }

--- a/code/packages/rust/venture-browser-macos/README.md
+++ b/code/packages/rust/venture-browser-macos/README.md
@@ -31,6 +31,15 @@ Exercise the real AppKit + Metal presentation path and close automatically:
 cargo run -p venture-browser-macos -- --smoke-seconds 1 http://info.cern.ch/
 ```
 
+The generated Mosaic SwiftUI shell has a separate direct-launch gate. It emits
+the package, builds the Rust dynamic bridge and SwiftPM app, serves a local
+deterministic page, launches the app, and requires a successful Metal
+content-surface render:
+
+```bash
+cargo test -p venture-browser-macos --test swiftui_project_launch
+```
+
 Mouse-wheel and trackpad input drive the shared clamped viewport and repaint the
 translated scene through Metal. Primary-button input now hit-tests links in
 viewport coordinates, loads the resolved destination through the transactional

--- a/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
+++ b/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
@@ -1,4 +1,4 @@
-#![cfg(target_os = "windows")]
+#![cfg(target_os = "macos")]
 
 use mosaic_package_artifact_builder::{build_package, Backend, BuildOptions};
 use std::fs::{self, File};
@@ -23,7 +23,10 @@ fn temporary_output() -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("system clock after epoch")
         .as_nanos();
-    std::env::temp_dir().join(format!("venture-xaml-{}-{nonce}", std::process::id()))
+    std::env::temp_dir().join(format!(
+        "venture-swiftui-launch-{}-{nonce}",
+        std::process::id()
+    ))
 }
 
 fn build_native_bridge(output: &Path) -> PathBuf {
@@ -32,19 +35,19 @@ fn build_native_bridge(output: &Path) -> PathBuf {
     let build = Command::new(cargo)
         .arg("build")
         .arg("-p")
-        .arg("venture-browser-windows")
+        .arg("venture-browser-macos")
         .arg("--target-dir")
         .arg(&target)
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .output()
-        .expect("build Venture Windows bridge");
+        .expect("build Venture macOS bridge");
     assert!(
         build.status.success(),
-        "Venture Windows bridge failed to build\nstdout:\n{}\nstderr:\n{}",
+        "Venture macOS bridge failed to build\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&build.stdout),
         String::from_utf8_lossy(&build.stderr)
     );
-    target.join("debug/venture_browser_windows.dll")
+    target.join("debug/libventure_browser_macos.dylib")
 }
 
 fn serve_html_once() -> String {
@@ -68,50 +71,39 @@ fn serve_html_once() -> String {
     format!("http://{address}/")
 }
 
-fn find_executable(root: &Path) -> Option<PathBuf> {
-    for entry in fs::read_dir(root).ok()? {
-        let path = entry.ok()?.path();
-        if path.is_dir() {
-            if let Some(found) = find_executable(&path) {
-                return Some(found);
-            }
-        } else if path.file_name().and_then(|name| name.to_str()) == Some("VentureChrome.exe") {
-            return Some(path);
-        }
-    }
-    None
-}
-
 fn wait_for_ready(child: &mut Child, marker: &Path) {
     let deadline = Instant::now() + Duration::from_secs(30);
     while Instant::now() < deadline {
         if marker.exists() {
             return;
         }
-        if let Some(status) = child.try_wait().expect("poll generated WinUI app") {
-            panic!("generated WinUI app exited before rendering: {status}");
+        if let Some(status) = child.try_wait().expect("poll generated SwiftUI app") {
+            panic!("generated SwiftUI app exited before rendering: {status}");
         }
         thread::sleep(Duration::from_millis(100));
     }
     let _ = child.kill();
     let _ = child.wait();
-    panic!("generated WinUI app did not report a rendered Mosaic host surface within 30 seconds");
+    panic!("generated SwiftUI app did not report a rendered Mosaic host surface within 30 seconds");
 }
 
 #[test]
-fn package_owned_xaml_host_compiles_in_generated_winui_project() {
+fn package_owned_swiftui_project_launches_and_renders() {
     let output = temporary_output();
     let result = build_package(&BuildOptions {
         package_root: venture_package_root(),
         output_root: output.clone(),
-        backend: Backend::Xaml,
+        backend: Backend::SwiftUI,
         emit_project: true,
         theme: Some("light".to_string()),
     })
-    .expect("emit Venture XAML package");
-    let project = output.join("xaml");
-    let host = project.join("MosaicHost.cs");
-    assert!(host.exists(), "package-owned XAML host must be installed");
+    .expect("emit Venture SwiftUI package");
+    let project = output.join("swiftui");
+    let host = project.join("Sources/App/MosaicHost.swift");
+    assert!(
+        host.exists(),
+        "package-owned SwiftUI host must be installed"
+    );
     assert!(
         result.artifacts.iter().any(|artifact| artifact == &host),
         "installed host must be a package artifact"
@@ -120,52 +112,48 @@ fn package_owned_xaml_host_compiles_in_generated_winui_project() {
     let library = build_native_bridge(&output);
     assert!(
         library.exists(),
-        "build venture-browser-windows before this launch gate: {}",
+        "build venture-browser-macos before this launch gate: {}",
         library.display()
     );
-    fs::copy(&library, project.join("venture_browser_windows.dll"))
-        .expect("install Venture Windows bridge");
+    fs::copy(&library, project.join("libventure_browser_macos.dylib"))
+        .expect("install Venture macOS bridge");
 
-    let build = Command::new("dotnet")
+    let build = Command::new("swift")
         .arg("build")
-        .arg("VentureChrome.csproj")
-        .arg("-p:Platform=x64")
         .current_dir(&project)
         .output()
-        .expect("run dotnet build for generated WinUI project");
-    if !build.status.success() {
-        panic!(
-            "generated Venture WinUI project failed to build\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&build.stdout),
-            String::from_utf8_lossy(&build.stderr)
-        );
-    }
+        .expect("run swift build");
+    assert!(
+        build.status.success(),
+        "generated Venture SwiftUI project failed to build\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
 
-    let executable = find_executable(&project.join("bin"))
-        .expect("generated WinUI build must produce VentureChrome.exe");
-    let marker = output.join("xaml-ready.json");
-    let app_log = output.join("xaml-app.log");
-    let log = File::create(&app_log).expect("create WinUI app log");
-    let mut child = Command::new(&executable)
-        .current_dir(executable.parent().expect("WinUI executable directory"))
+    let marker = output.join("swiftui-ready.json");
+    let app_log = output.join("swiftui-app.log");
+    let log = File::create(&app_log).expect("create SwiftUI app log");
+    let mut child = Command::new(project.join(".build/debug/App"))
+        .current_dir(&project)
         .env("VENTURE_START_URL", serve_html_once())
+        .env("VENTURE_BROWSER_LIBRARY", &library)
         .env("VENTURE_BROWSER_ACCEPTANCE_PATH", &marker)
-        .stdout(Stdio::from(log.try_clone().expect("clone WinUI app log")))
+        .stdout(Stdio::from(log.try_clone().expect("clone SwiftUI app log")))
         .stderr(Stdio::from(log))
         .spawn()
-        .expect("launch generated Venture WinUI app");
+        .expect("launch generated Venture SwiftUI app");
     wait_for_ready(&mut child, &marker);
+    thread::sleep(Duration::from_millis(500));
     let _ = child.kill();
     let _ = child.wait();
 
-    let readiness = fs::read_to_string(&marker).expect("read WinUI readiness marker");
-    assert!(readiness.contains("\"backend\":\"xaml\""));
+    let readiness = fs::read_to_string(&marker).expect("read SwiftUI readiness marker");
+    assert!(readiness.contains("\"backend\":\"swiftui\""));
     assert!(readiness.contains("\"status\":\"ready\""));
-    let diagnostics = fs::read_to_string(&app_log).expect("read WinUI app log");
+    let diagnostics = fs::read_to_string(&app_log).expect("read SwiftUI app log");
     assert!(
         !diagnostics.contains("assertion failed") && !diagnostics.contains("Assertion failed"),
-        "generated WinUI app reported a native assertion:\n{diagnostics}"
+        "generated SwiftUI app reported a native assertion:\n{diagnostics}"
     );
-
     fs::remove_dir_all(&output).expect("remove clean acceptance output");
 }

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -11,3 +11,5 @@
   WinUI content surface changes logical size.
 - Build and directly launch the Mosaic-emitted WinUI app in a platform-native
   integration gate, requiring a successful Direct2D host-surface render.
+- Copy rendered BGRA pixels through WinRT's supported `IBuffer.AsStream()`
+  projection and retain opt-in launch-phase diagnostics for hosted acceptance.

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -9,3 +9,5 @@
   bridge for package-owned WinUI content-surface input.
 - Reflow the retained page through the shared Rust pipeline when the generated
   WinUI content surface changes logical size.
+- Build and directly launch the Mosaic-emitted WinUI app in a platform-native
+  integration gate, requiring a successful Direct2D host-surface render.

--- a/code/packages/rust/venture-browser-windows/README.md
+++ b/code/packages/rust/venture-browser-windows/README.md
@@ -23,6 +23,12 @@ code\programs\mosaic\venture-browser\scripts\build-all.ps1
 ```
 
 The Windows-only integration test compiles the package-owned C# adapter inside
-the generated WinUI project. Cross-platform unit tests exercise the shared
-session and chrome event path without claiming complete browser or HTML
-conformance.
+the generated WinUI project, launches its executable against a local
+deterministic page, and requires a successful Direct2D content-surface render:
+
+```powershell
+cargo test -p venture-browser-windows --test xaml_project_build
+```
+
+Cross-platform unit tests exercise the shared session and chrome event path
+without claiming complete browser or HTML conformance.

--- a/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
+++ b/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
@@ -114,15 +114,17 @@ if ($events) {
     }
 }
 
-fn wait_for_ready(child: &mut Child, executable: &Path, marker: &Path) {
+fn wait_for_ready(child: &mut Child, executable: &Path, marker: &Path, phase_log: &Path) {
     let deadline = Instant::now() + Duration::from_secs(30);
     while Instant::now() < deadline {
         if marker.exists() {
             return;
         }
         if let Some(status) = child.try_wait().expect("poll generated WinUI app") {
+            let phase = fs::read_to_string(phase_log)
+                .unwrap_or_else(|_| "no package-host phase was reported".to_string());
             panic!(
-                "generated WinUI app exited before rendering: {status}\n{}",
+                "generated WinUI app exited before rendering: {status}\nlast host phase: {phase}\n{}",
                 application_failure_diagnostics(executable)
             );
         }
@@ -179,17 +181,19 @@ fn package_owned_xaml_host_compiles_in_generated_winui_project() {
     let executable = find_executable(&project.join("bin"))
         .expect("generated WinUI build must produce VentureChrome.exe");
     let marker = output.join("xaml-ready.json");
+    let phase_log = output.join("xaml-phase.json");
     let app_log = output.join("xaml-app.log");
     let log = File::create(&app_log).expect("create WinUI app log");
     let mut child = Command::new(&executable)
         .current_dir(executable.parent().expect("WinUI executable directory"))
         .env("VENTURE_START_URL", serve_html_once())
         .env("VENTURE_BROWSER_ACCEPTANCE_PATH", &marker)
+        .env("VENTURE_BROWSER_ACCEPTANCE_DIAGNOSTIC_PATH", &phase_log)
         .stdout(Stdio::from(log.try_clone().expect("clone WinUI app log")))
         .stderr(Stdio::from(log))
         .spawn()
         .expect("launch generated Venture WinUI app");
-    wait_for_ready(&mut child, &executable, &marker);
+    wait_for_ready(&mut child, &executable, &marker, &phase_log);
     let _ = child.kill();
     let _ = child.wait();
 

--- a/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
+++ b/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
@@ -82,14 +82,49 @@ fn find_executable(root: &Path) -> Option<PathBuf> {
     None
 }
 
-fn wait_for_ready(child: &mut Child, marker: &Path) {
+fn application_failure_diagnostics(executable: &Path) -> String {
+    let executable_name = executable
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("VentureChrome.exe");
+    let script = r#"
+$events = Get-WinEvent -FilterHashtable @{
+    LogName = 'Application'
+    StartTime = (Get-Date).AddMinutes(-5)
+} -ErrorAction SilentlyContinue |
+    Where-Object { $_.Message -like "*$env:VENTURE_ACCEPTANCE_EXE_NAME*" } |
+    Select-Object -First 5 TimeCreated, ProviderName, Id, LevelDisplayName, Message
+if ($events) {
+    $events | Format-List | Out-String -Width 4096
+} else {
+    'No matching Windows Application event was recorded.'
+}
+"#;
+    let output = Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-Command", script])
+        .env("VENTURE_ACCEPTANCE_EXE_NAME", executable_name)
+        .output();
+    match output {
+        Ok(output) => {
+            let mut diagnostics = String::from_utf8_lossy(&output.stdout).into_owned();
+            diagnostics.push_str(&String::from_utf8_lossy(&output.stderr));
+            diagnostics
+        }
+        Err(error) => format!("failed to query Windows Application events: {error}"),
+    }
+}
+
+fn wait_for_ready(child: &mut Child, executable: &Path, marker: &Path) {
     let deadline = Instant::now() + Duration::from_secs(30);
     while Instant::now() < deadline {
         if marker.exists() {
             return;
         }
         if let Some(status) = child.try_wait().expect("poll generated WinUI app") {
-            panic!("generated WinUI app exited before rendering: {status}");
+            panic!(
+                "generated WinUI app exited before rendering: {status}\n{}",
+                application_failure_diagnostics(executable)
+            );
         }
         thread::sleep(Duration::from_millis(100));
     }
@@ -154,7 +189,7 @@ fn package_owned_xaml_host_compiles_in_generated_winui_project() {
         .stderr(Stdio::from(log))
         .spawn()
         .expect("launch generated Venture WinUI app");
-    wait_for_ready(&mut child, &marker);
+    wait_for_ready(&mut child, &executable, &marker);
     let _ = child.kill();
     let _ = child.wait();
 

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -40,3 +40,6 @@
 - Direct-launch acceptance for the emitted SwiftUI and WinUI applications,
   requiring each generated shell to load its package-owned Rust bridge and
   render the native content surface against a deterministic local page.
+- The XAML host writes rendered BGRA pixels through WinRT's supported
+  `IBuffer.AsStream()` projection, avoiding a native COM projection crash in
+  the emitted WinUI application.

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -37,3 +37,6 @@
 - Package-owned SwiftUI and WinUI content surfaces report native logical size
   changes through matching Rust resize ABIs, reflowing the retained document
   and repainting without refetching the page or duplicating chrome.
+- Direct-launch acceptance for the emitted SwiftUI and WinUI applications,
+  requiring each generated shell to load its package-owned Rust bridge and
+  render the native content surface against a deterministic local page.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -50,6 +50,10 @@ recreating the surrounding chrome in backend-specific UI code.
   The shared session recomposes its retained render tree for the new logical
   viewport, preserves and clamps scroll state, updates hit regions, and
   repaints without refetching the HTML document.
+- Platform-native integration gates build and directly launch the emitted
+  SwiftUI and WinUI applications against a local deterministic page. Each app
+  must load its package-owned bridge and render the native `content-surface`
+  before writing its acceptance marker.
 
 ## Build every backend
 
@@ -85,6 +89,21 @@ DLL beside the generated WinUI project, and runs the x64 `dotnet build`. The
 generated project copies that native bridge next to the executable so its
 package-owned `MosaicHost.cs` can load it without a handwritten Win32 chrome
 layer.
+
+The macOS and Windows Rust package tests are the authoritative direct-launch
+gates. Each test builds its platform bridge in an isolated temporary target
+before emitting and launching the generated project:
+
+```sh
+cargo test -p venture-browser-macos
+```
+
+```powershell
+cargo test -p venture-browser-windows
+```
+
+These gates stop after the generated window mounts and renders; they do not yet
+claim direct UI interaction acceptance.
 
 This package is a browser-wiring milestone, not a claim of complete Venture or
 HTML conformance.

--- a/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
@@ -97,6 +97,7 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
   private var browser: UnsafeMutableRawPointer?
   private var contentView: VentureContentView?
   private var propsChangedHandler: (() -> Void)?
+  private var acceptanceReported = false
 
   required override init() {
     let native = VentureNativeLibrary()
@@ -144,7 +145,18 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
   fileprivate func render(layer: CAMetalLayer) {
     guard let native, let browser else { return }
     let rawLayer = Unmanaged.passUnretained(layer).toOpaque()
-    _ = native.render(browser, rawLayer)
+    guard native.render(browser, rawLayer) != 0 else { return }
+    reportAcceptanceIfRequested()
+  }
+
+  private func reportAcceptanceIfRequested() {
+    guard !acceptanceReported else { return }
+    guard let path = ProcessInfo.processInfo.environment["VENTURE_BROWSER_ACCEPTANCE_PATH"]
+    else { return }
+    acceptanceReported = true
+    let result = ["backend": "swiftui", "status": "ready"]
+    guard let data = try? JSONSerialization.data(withJSONObject: result) else { return }
+    try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
   }
 
   fileprivate func scroll(by deltaY: Double) {
@@ -283,6 +295,8 @@ private final class VentureContentView: NSView {
 
   fileprivate func renderPage() {
     guard let layer = layer as? CAMetalLayer else { return }
+    guard bounds.width > 0, bounds.height > 0 else { return }
+    host?.resize(width: bounds.width, height: bounds.height)
     let scale = layer.contentsScale > 0 ? layer.contentsScale : 1
     layer.drawableSize = CGSize(
       width: max(1, bounds.width * scale),

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -5,7 +5,9 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text.Json;
 using Windows.System;
 using Windows.UI.Core;
@@ -171,8 +173,11 @@ public static class MosaicHost
             }
             ReportAcceptancePhase("bitmap-allocated");
 
-            ((IBufferByteAccess)bitmap.PixelBuffer).Buffer(out var destination);
-            Marshal.Copy(pixels, 0, destination, pixels.Length);
+            using (var stream = bitmap.PixelBuffer.AsStream())
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                stream.Write(pixels, 0, pixels.Length);
+            }
             ReportAcceptancePhase("bitmap-copied");
             bitmap.Invalidate();
             ReportAcceptancePhase("bitmap-invalidated");
@@ -290,14 +295,6 @@ public static class MosaicHost
         System.IO.File.WriteAllText(
             path,
             JsonSerializer.Serialize(new { backend = "xaml", phase }) + "\n");
-    }
-
-    [ComImport]
-    [Guid("905a0fe0-bc53-11df-8c49-001e4fc686da")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    private interface IBufferByteAccess
-    {
-        void Buffer(out IntPtr value);
     }
 
     private static class Native

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -28,15 +28,19 @@ public static class MosaicHost
 
     public static string ApplyProps(VentureChrome component)
     {
+        ReportAcceptancePhase("apply-props-entered");
         EnsureBrowser();
         if (browser == IntPtr.Zero)
         {
             return "Status: Venture native bridge is unavailable";
         }
+        ReportAcceptancePhase("browser-created");
 
         contentSurface ??= new VentureContentSurface(component);
         component.ContentSurface = contentSurface;
+        ReportAcceptancePhase("content-surface-mounted");
         var status = ApplyResponse(component, Native.Decode(Native.ApplyProps(browser)));
+        ReportAcceptancePhase("props-applied");
         contentSurface.Refresh();
         return status;
     }
@@ -144,6 +148,7 @@ public static class MosaicHost
             }
 
             var required = Native.RenderBgra(browser, null, 0, out var width, out var height);
+            ReportAcceptancePhase("render-size-read");
             if (required == 0 || width == 0 || height == 0 || required > int.MaxValue)
             {
                 return;
@@ -151,6 +156,7 @@ public static class MosaicHost
 
             var pixels = new byte[(int)required];
             var written = Native.RenderBgra(browser, pixels, pixels.Length, out width, out height);
+            ReportAcceptancePhase("render-pixels-written");
             if (written != required)
             {
                 return;
@@ -163,10 +169,13 @@ public static class MosaicHost
                 pixelWidth = width;
                 pixelHeight = height;
             }
+            ReportAcceptancePhase("bitmap-allocated");
 
             ((IBufferByteAccess)bitmap.PixelBuffer).Buffer(out var destination);
             Marshal.Copy(pixels, 0, destination, pixels.Length);
+            ReportAcceptancePhase("bitmap-copied");
             bitmap.Invalidate();
+            ReportAcceptancePhase("bitmap-invalidated");
             ReportAcceptanceIfRequested();
         }
 
@@ -267,6 +276,20 @@ public static class MosaicHost
         }
 
         System.IO.File.WriteAllText(path, "{\"backend\":\"xaml\",\"status\":\"ready\"}\n");
+    }
+
+    private static void ReportAcceptancePhase(string phase)
+    {
+        var path = Environment.GetEnvironmentVariable(
+            "VENTURE_BROWSER_ACCEPTANCE_DIAGNOSTIC_PATH");
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        System.IO.File.WriteAllText(
+            path,
+            JsonSerializer.Serialize(new { backend = "xaml", phase }) + "\n");
     }
 
     [ComImport]

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -24,6 +24,7 @@ public static class MosaicHost
     private const double ViewportHeight = 640;
     private static IntPtr browser;
     private static VentureContentSurface? contentSurface;
+    private static int acceptanceReported;
 
     public static string ApplyProps(VentureChrome component)
     {
@@ -166,6 +167,7 @@ public static class MosaicHost
             ((IBufferByteAccess)bitmap.PixelBuffer).Buffer(out var destination);
             Marshal.Copy(pixels, 0, destination, pixels.Length);
             bitmap.Invalidate();
+            ReportAcceptanceIfRequested();
         }
 
         private void OnSizeChanged(object sender, SizeChangedEventArgs e)
@@ -253,6 +255,18 @@ public static class MosaicHost
                 e.Handled = true;
             }
         }
+    }
+
+    private static void ReportAcceptanceIfRequested()
+    {
+        var path = Environment.GetEnvironmentVariable("VENTURE_BROWSER_ACCEPTANCE_PATH");
+        if (string.IsNullOrWhiteSpace(path)
+            || System.Threading.Interlocked.Exchange(ref acceptanceReported, 1) != 0)
+        {
+            return;
+        }
+
+        System.IO.File.WriteAllText(path, "{\"backend\":\"xaml\",\"status\":\"ready\"}\n");
     }
 
     [ComImport]

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -116,6 +116,8 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         "host?.resize(width: bounds.width, height: bounds.height)",
         "override func keyDown",
         "navigateHistory(eventName:",
+        "VENTURE_BROWSER_ACCEPTANCE_PATH",
+        "\"backend\": \"swiftui\"",
     ] {
         assert!(host.contains(symbol), "SwiftUI host omits {symbol}");
     }
@@ -136,6 +138,8 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         "private void OnKeyDown",
         "Focus(FocusState.Pointer)",
         "VentureContentSurface : ContentControl",
+        "VENTURE_BROWSER_ACCEPTANCE_PATH",
+        "\\\"backend\\\":\\\"xaml\\\"",
     ] {
         assert!(host.contains(symbol), "XAML host omits {symbol}");
     }

--- a/code/scripts/tests/test_venture_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_venture_windows_ci_acceptance.py
@@ -27,6 +27,13 @@ class VentureWindowsCIAcceptanceTests(unittest.TestCase):
             )
         )
 
+    def test_macos_bridge_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_venture_windows(
+                {"affected_packages": ["rust/venture-browser-macos"]}
+            )
+        )
+
     def test_mosaic_package_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_venture_windows(
@@ -93,11 +100,11 @@ class VentureWindowsCIAcceptanceTests(unittest.TestCase):
         )
         self.assertIn(
             "needs.detect.outputs.needs_rust == 'true' || "
-            "(needs.detect.outputs.needs_venture_windows == 'true' "
-            "&& runner.os == 'Windows')",
+            "needs.detect.outputs.needs_venture_windows == 'true'",
             workflow,
         )
         self.assertIn("cargo test -p venture-browser-windows", workflow)
+        self.assertIn("cargo test -p venture-browser-macos", workflow)
 
 
 if __name__ == "__main__":

--- a/code/scripts/venture_windows_ci_acceptance.py
+++ b/code/scripts/venture_windows_ci_acceptance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Derive the Venture native-Windows acceptance flag from a build plan."""
+"""Derive the Venture native-shell acceptance flag from a build plan."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from typing import Any
 
 ACCEPTANCE_PACKAGES = frozenset(
     {
+        "rust/venture-browser-macos",
         "rust/venture-browser-windows",
         "unknown/programs/venture-browser",
     }

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -100,9 +100,11 @@ through thin dynamic Rust bridges. They carry address and navigation events,
 native scrolling, link activation, keyboard navigation, and logical surface
 resize through one browser session without handwritten platform chrome. Resize
 reflows the retained render tree, image placement, link regions, and scroll
-bounds without refetching the HTML document. Direct launch and interaction
-acceptance plus the remaining platform hosts still remain before the browser
-shell is complete.
+bounds without refetching the HTML document. Direct launch acceptance now
+builds and starts the emitted SwiftUI and WinUI applications, loads each
+package-owned native bridge, and requires a rendered host-surface readiness
+signal. Direct UI interaction acceptance plus the remaining platform hosts
+still remain before the browser shell is complete.
 
 ## Where It Fits
 


### PR DESCRIPTION
## Summary

- add macOS and Windows integration gates that emit, build, and directly launch Venture’s Mosaic-generated SwiftUI and WinUI applications
- require each package-owned host adapter to load its Rust bridge and report readiness only after the native content surface renders
- keep SwiftUI reflow synchronized with the mounted view bounds, rejecting the Metal out-of-bounds diagnostic exposed by the new launch gate
- route affected macOS, Windows, and shared Venture package changes through both native CI lanes

## Why

The generated native projects were build-checked but never started, leaving bridge loading, project entry points, and first native render outside acceptance. These gates use a deterministic in-process HTTP page and isolated native bridge build so they do not depend on external networking or stale workspace artifacts.

## Validation

- clean-target `cargo test -p venture-browser-macos --test swiftui_project_launch -- --nocapture`
- `cargo test -p venture-browser-macos`
- `cargo test -p venture-browser-windows` (cross-platform unit coverage locally; native WinUI launch runs on Windows CI)
- `cargo clippy -p venture-browser-macos -p venture-browser-windows --all-targets -- -D warnings`
- Venture Mosaic package tests
- all nine Mosaic backends emitted with `build-all.sh --emit-only`
- CI routing unit tests
- HTML parser coverage audit: tree missing 0, tokenizer missing 0, normalized tokenizer skipped 0

This closes direct generated-shell launch acceptance only. Direct UI interaction acceptance and remaining platform hosts are still incomplete, so this does not claim complete Venture or HTML conformance.