### PR TITLE
fix(spice): validate MOS instance drain squares

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS instance `NRD` values before
+  lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS instance `L` values before
   lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS instance `W` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2227,6 +2227,13 @@ fn parse_element(
                     ));
                 }
             }
+            if let Some(drain_squares) = instance_params.get("NRD") {
+                if !drain_squares.is_finite() || *drain_squares < 0.0 {
+                    return Err(NetlistParseError::new(
+                        "MOSFET NRD must be finite and non-negative",
+                    ));
+                }
+            }
             Ok(Element::Mosfet(Mosfet::with_model(
                 name,
                 &fields[1],

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -868,6 +868,22 @@ fn rejects_invalid_mosfet_instance_lengths() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_instance_drain_squares() {
+    for drain_squares in ["-1", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model nch NMOS\nM1 d g s b nch NRD={drain_squares}"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET NRD must be finite and non-negative"));
+    }
+
+    assert!(parse_netlist(".model nch NMOS\nM1 d g s b nch NRD=0").is_ok());
+}
+
+#[test]
 fn parses_tf_transfer_function_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS instance-length validation.
+1. Rust Berkeley SPICE MOS instance drain-squares validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite instance `L` values before lowering
-     MOS elements into engine parameters.
-   - Preserve positive instance lengths and model-card/default length fallback.
+   - Reject negative and non-finite instance `NRD` values before lowering MOS
+     elements into engine parameters.
+   - Preserve zero and positive drain-square counts for `RSH * NRD` resistance.
 
 ## Completed Slices
 
@@ -3870,6 +3870,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Zero, negative, and non-finite instance `W` values are rejected before
      lowering MOS elements into engine parameters.
    - Positive instance widths and model-card/default width fallback remain
+     accepted.
+
+328. Rust Berkeley SPICE MOS instance-length validation.
+   - Status: completed in PR 9432.
+   - Zero, negative, and non-finite instance `L` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Positive instance lengths and model-card/default length fallback remain
      accepted.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS instance `NRD` values before parser lowering
- preserve zero and positive drain-square counts for `RSH * NRD` resistance
- reconcile the SPICE implementation plan after #9432

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`