### PR TITLE
fix(spice): validate MOS instance source squares

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS instance `NRS` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `NRD` values before
   lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS instance `L` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2234,6 +2234,13 @@ fn parse_element(
                     ));
                 }
             }
+            if let Some(source_squares) = instance_params.get("NRS") {
+                if !source_squares.is_finite() || *source_squares < 0.0 {
+                    return Err(NetlistParseError::new(
+                        "MOSFET NRS must be finite and non-negative",
+                    ));
+                }
+            }
             Ok(Element::Mosfet(Mosfet::with_model(
                 name,
                 &fields[1],

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -884,6 +884,22 @@ fn rejects_invalid_mosfet_instance_drain_squares() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_instance_source_squares() {
+    for source_squares in ["-1", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model nch NMOS\nM1 d g s b nch NRS={source_squares}"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET NRS must be finite and non-negative"));
+    }
+
+    assert!(parse_netlist(".model nch NMOS\nM1 d g s b nch NRS=0").is_ok());
+}
+
+#[test]
 fn parses_tf_transfer_function_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS instance drain-squares validation.
+1. Rust Berkeley SPICE MOS instance source-squares validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite instance `NRD` values before lowering MOS
+   - Reject negative and non-finite instance `NRS` values before lowering MOS
      elements into engine parameters.
-   - Preserve zero and positive drain-square counts for `RSH * NRD` resistance.
+   - Preserve zero and positive source-square counts for `RSH * NRS` resistance.
 
 ## Completed Slices
 
@@ -3878,6 +3878,13 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Positive instance lengths and model-card/default length fallback remain
      accepted.
+
+329. Rust Berkeley SPICE MOS instance drain-squares validation.
+   - Status: completed in PR 9436.
+   - Negative and non-finite instance `NRD` values are rejected before lowering
+     MOS elements into engine parameters.
+   - Zero and positive drain-square counts remain accepted for `RSH * NRD`
+     resistance.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS instance `NRS` values before parser lowering
- preserve zero and positive source-square counts for `RSH * NRS` resistance
- reconcile the SPICE implementation plan after #9436

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`