### PR TITLE
fix(spice): validate MOS instance drain area

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS instance `AD` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `NRS` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `NRD` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2241,6 +2241,13 @@ fn parse_element(
                     ));
                 }
             }
+            if let Some(drain_area) = instance_params.get("AD") {
+                if !drain_area.is_finite() || *drain_area < 0.0 {
+                    return Err(NetlistParseError::new(
+                        "MOSFET AD must be finite and non-negative",
+                    ));
+                }
+            }
             Ok(Element::Mosfet(Mosfet::with_model(
                 name,
                 &fields[1],

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -900,6 +900,20 @@ fn rejects_invalid_mosfet_instance_source_squares() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_instance_drain_areas() {
+    for drain_area in ["-1p", "1e999"] {
+        let error =
+            parse_netlist(&format!(".model nch NMOS\nM1 d g s b nch AD={drain_area}")).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET AD must be finite and non-negative"));
+    }
+
+    assert!(parse_netlist(".model nch NMOS\nM1 d g s b nch AD=0").is_ok());
+}
+
+#[test]
 fn parses_tf_transfer_function_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS instance source-squares validation.
+1. Rust Berkeley SPICE MOS instance drain-area validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite instance `NRS` values before lowering MOS
+   - Reject negative and non-finite instance `AD` values before lowering MOS
      elements into engine parameters.
-   - Preserve zero and positive source-square counts for `RSH * NRS` resistance.
+   - Preserve zero and positive drain areas for bulk-junction behavior.
 
 ## Completed Slices
 
@@ -3884,6 +3884,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite instance `NRD` values are rejected before lowering
      MOS elements into engine parameters.
    - Zero and positive drain-square counts remain accepted for `RSH * NRD`
+     resistance.
+
+330. Rust Berkeley SPICE MOS instance source-squares validation.
+   - Status: completed in PR 9437.
+   - Negative and non-finite instance `NRS` values are rejected before lowering
+     MOS elements into engine parameters.
+   - Zero and positive source-square counts remain accepted for `RSH * NRS`
      resistance.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS instance `AD` values before parser lowering
- preserve zero and positive drain areas for bulk-junction behavior
- reconcile the SPICE implementation plan after #9437

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`