### PR TITLE
feat(mosaic): expose native control automation ids

### DIFF
--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - Native automation identifiers for authored controls
+
+`HostInput` and `HostButton` now preserve their MLL part names as SwiftUI
+`accessibilityIdentifier` values. Generated applications can locate the same
+Mosaic-authored control deterministically for accessibility and direct native
+interaction acceptance without adding a parallel AppKit control tree.
+
 ### Added - host-driven prop refresh
 
 Generated SwiftUI project shells now let optional native `MosaicHost` adapters

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -2681,6 +2681,16 @@ fn emit_host_input(node: &LayoutNode, indent: usize) -> Result<String, PipelineE
     // The opening `TextField` expression.
     let mut line = format!("{pad}TextField({placeholder_lit}, text: {text_binding})");
 
+    // Keep the author-owned MLL part identity on the native control. This is
+    // the stable cross-platform handle for accessibility and interaction
+    // acceptance; hosts do not need to invent a parallel AppKit control tree.
+    if let Some(part_name) = &node.part_name {
+        line.push_str(&format!(
+            ".accessibilityIdentifier(\"{}\")",
+            escape_swift_string(part_name)
+        ));
+    }
+
     // Modifier chain. We deliberately keep each modifier on the same
     // line — Swift accepts chained modifiers without line breaks, and
     // the generated source stays compact and grep-friendly.
@@ -2843,6 +2853,12 @@ fn emit_host_button(
     // Closing brace, then any trailing modifiers on the same line so the
     // generated source stays compact.
     let mut closing = format!("{pad}}}");
+    if let Some(part_name) = &node.part_name {
+        closing.push_str(&format!(
+            ".accessibilityIdentifier(\"{}\")",
+            escape_swift_string(part_name)
+        ));
+    }
     if let Some(slot) = find_slot_ref_prop(node, "disabled") {
         let camel = to_camel_case_first_lower(slot);
         validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
@@ -4959,6 +4975,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn host_input_part_name_becomes_accessibility_identifier() {
+        let input = LayoutNode {
+            tag: "HostInput".to_string(),
+            part_name: Some("address-input".to_string()),
+            props: vec![prop_string("placeholder", "Enter a URL")],
+            children: vec![],
+        };
+        let layout = layout_with("Form", container_node("Box", vec![input]));
+        let out = from_pipeline(
+            &component("Form", vec![], vec![]),
+            &layout,
+            &empty_style("Form"),
+        )
+        .unwrap()
+        .output;
+        assert!(
+            out.contains(".accessibilityIdentifier(\"address-input\")"),
+            "expected the MLL part name on the native TextField, got:\n{out}"
+        );
+    }
+
     // ---------------------------------------------------------------------
     // Test 16b — a `HostInput` with BOTH a `value` slot and an `onChange`
     // handler is EDITABLE: it lowers to a writable `Binding(get:set:)` whose
@@ -5236,6 +5274,28 @@ mod tests {
         assert!(
             out.contains("Text(caption)"),
             "expected label closure with Text(caption), got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn host_button_part_name_becomes_accessibility_identifier() {
+        let button = LayoutNode {
+            tag: "HostButton".to_string(),
+            part_name: Some("go-button".to_string()),
+            props: vec![prop_string("label", "Go")],
+            children: vec![],
+        };
+        let layout = layout_with("Bar", container_node("Box", vec![button]));
+        let out = from_pipeline(
+            &component("Bar", vec![], vec![]),
+            &layout,
+            &empty_style("Bar"),
+        )
+        .unwrap()
+        .output;
+        assert!(
+            out.contains(".accessibilityIdentifier(\"go-button\")"),
+            "expected the MLL part name on the native Button, got:\n{out}"
         );
     }
 

--- a/code/packages/rust/mosaic-emit-swiftui/tests/venture_chrome_compiles_to_swiftui.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/tests/venture_chrome_compiles_to_swiftui.rs
@@ -67,6 +67,14 @@ fn venture_chrome_lowers_to_native_swiftui_controls_and_project_shell() {
             "TextField(\"Enter a URL\", text: Binding(get: { address }, set: { dispatch(.addressChange(value: $0)) }))"
         ));
         assert!(result.output.contains(".onSubmit { dispatch(.navigate) }"));
+        for part in ["back-button", "address-input", "go-button"] {
+            assert!(
+                result
+                    .output
+                    .contains(&format!(".accessibilityIdentifier(\"{part}\")")),
+                "generated SwiftUI chrome omits the native identifier for {part}"
+            );
+        }
         assert!(
             result.output.matches("contentSurface").count() >= 2,
             "the node slot must be declared and mounted in the SwiftUI body"

--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased] — VC2-xaml Grid: WinUI value translation + nested-For + per-column widths
 
+### Added - Native automation identifiers for authored controls
+
+`HostInput` and `HostButton` now preserve their MLL part names as WinUI
+`AutomationProperties.AutomationId` values. Generated applications can locate
+the same Mosaic-authored control deterministically for accessibility and direct
+native interaction acceptance without adding a parallel Win32 control tree.
+
 ### Added - HostSurface native composition
 
 WinUI output now lowers Mosaic `HostSurface ( content: slot: ... )` to a

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -5086,6 +5086,12 @@ fn emit_host_input(
 
     // -- Build the attribute set --
     let mut attrs = String::new();
+    if let Some(part_name) = &node.part_name {
+        attrs.push_str(&format!(
+            " AutomationProperties.AutomationId=\"{}\"",
+            escape_xaml_attr(part_name)
+        ));
+    }
 
     // value: slot/string/expr â†’ Text binding
     match find_prop_value(node, "value") {
@@ -5217,6 +5223,12 @@ fn emit_host_button(
     register_host_visual_states(node, "Button", &x_name, part_styles, ctx);
 
     let mut attrs = String::new();
+    if let Some(part_name) = &node.part_name {
+        attrs.push_str(&format!(
+            " AutomationProperties.AutomationId=\"{}\"",
+            escape_xaml_attr(part_name)
+        ));
+    }
 
     // label: slot/string
     match find_prop_value(node, "label") {
@@ -8311,6 +8323,12 @@ mod tests {
             "got:\n{}",
             r.xaml
         );
+        assert!(
+            r.xaml
+                .contains("AutomationProperties.AutomationId=\"formula-field\""),
+            "got:\n{}",
+            r.xaml
+        );
     }
 
     #[test]
@@ -8495,6 +8513,12 @@ mod tests {
         let r = compile(&c, &l, &empty_style("Foo"));
         assert!(
             r.xaml.contains("<Button x:Name=\"Submit\""),
+            "got:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml
+                .contains("AutomationProperties.AutomationId=\"submit\""),
             "got:\n{}",
             r.xaml
         );
@@ -12292,7 +12316,12 @@ mod tests {
         let r = compile(&c, &l, &s);
         assert!(
             r.xaml
-                .contains("<Button x:Name=\"Button\" Background=\"#202020\""),
+                .contains("<Button x:Name=\"Button\" AutomationProperties.AutomationId=\"button\""),
+            "got:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml.contains("Background=\"#202020\""),
             "got:\n{}",
             r.xaml
         );

--- a/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
@@ -48,15 +48,23 @@ fn venture_chrome_lowers_to_native_xaml_controls_and_project_shell() {
         .expect("emit Venture XAML project");
 
         assert!(result.xaml.contains(
-            "<Button x:Name=\"BackButton\" Content=\"Back\" IsEnabled=\"{x:Bind Not(BackDisabled)}\""
+            "<Button x:Name=\"BackButton\" AutomationProperties.AutomationId=\"back-button\" Content=\"Back\" IsEnabled=\"{x:Bind Not(BackDisabled)}\""
         ));
         assert!(result.xaml.contains(
-            "<TextBox x:Name=\"AddressInput\" Text=\"{x:Bind Address, Mode=TwoWay}\" IsReadOnly=\"{x:Bind NavigationDisabled}\""
+            "<TextBox x:Name=\"AddressInput\" AutomationProperties.AutomationId=\"address-input\" Text=\"{x:Bind Address, Mode=TwoWay}\" IsReadOnly=\"{x:Bind NavigationDisabled}\""
         ));
         assert!(result
             .xaml
             .contains("TextChanged=\"AddressInput_TextChanged\""));
         assert!(result.xaml.contains("KeyDown=\"AddressInput_KeyDown\""));
+        for part in ["back-button", "address-input", "go-button"] {
+            assert!(
+                result
+                    .xaml
+                    .contains(&format!("AutomationProperties.AutomationId=\"{part}\"")),
+                "generated XAML chrome omits the native identifier for {part}"
+            );
+        }
         assert!(result
             .xaml
             .contains("Binding IsPressed, ElementName=GoButton"));

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -43,3 +43,6 @@
 - The XAML host writes rendered BGRA pixels through WinRT's supported
   `IBuffer.AsStream()` projection, avoiding a native COM projection crash in
   the emitted WinUI application.
+- The Mosaic-authored address field and toolbar buttons retain their MLL part
+  names as native SwiftUI and WinUI automation identifiers, establishing one
+  cross-platform identity contract for direct interaction gates.


### PR DESCRIPTION
## Summary

- Preserve Mosaic MLL part names on generated SwiftUI HostInput and HostButton controls as accessibility identifiers.
- Preserve the same part names on generated WinUI controls as automation IDs.
- Prove Venture back, address, and go controls expose the shared identifiers in both native backends.

## Why

Generated native shells could launch and render, but direct interaction gates had no stable cross-platform way to locate Mosaic-authored controls. This establishes one identity contract in the MIL/MLL/MSL pipeline without introducing handwritten AppKit or Win32 browser chrome.

## Validation

- cargo test -p mosaic-emit-swiftui -p mosaic-emit-xaml
- cargo clippy -p mosaic-emit-swiftui -p mosaic-emit-xaml --all-targets -- -D warnings
- cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml
- cargo test -p venture-browser-core -p venture-browser-macos -p venture-browser-windows
- Venture build-all emit-only for all nine backends
- Generated SwiftUI project build, launch, and render acceptance on macOS
- HTML parser coverage audit: tree-construction missing 0; tokenizer missing 0; normalized tokenizer skipped 0

Windows generated WinUI build and interaction acceptance remains covered by the Windows CI runner. This slice does not claim full browser conformance.