### PR TITLE
feat(smart-home): add authenticated Reolink CGI integration

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -909,6 +909,7 @@ members = [
     "smart-home-govee-lan-integration",
     "smart-home-lifx-lan-integration",
     "smart-home-kasa-lan-integration",
+    "smart-home-reolink-integration",
     "smart-home-home-assistant-migration",
     "smart-home-home-assistant-export",
     "smart-home-home-assistant-history",

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45121,15 +45121,32 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
             PrimitiveFamily::VaultLease,
             PrimitiveFamily::Supervision,
         ]),
-        camera_entry(
+        base_entry(
             "reolink",
             "Reolink",
-            "Reolink camera, doorbell, siren, and sensor hub integration.",
-            ConnectivityClass::LocalPush,
-            ImplementationStatus::Cataloged,
+            "Authenticated local Reolink camera and NVR device, channel, and motion inspection.",
+            IntegrationCategory::CameraMedia,
+            ConnectivityClass::LocalPolling,
+            ImplementationStatus::FirstPartyRuntime,
             3,
             "reolink",
-        ),
+        )
+        .with_capabilities(&["smart_home.read"])
+        .with_entities(&[EntityKind::Camera, EntityKind::Sensor])
+        .with_discovery(&[DiscoveryMechanism::Manual])
+        .with_auth(&[AuthMode::UsernamePassword])
+        .with_protocols(vec![ProtocolFamily::Vendor("reolink_cgi".to_string())])
+        .with_primitives(&[
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::LocalHttp,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::VaultLease,
+            PrimitiveFamily::Supervision,
+        ])
+        .with_notes(&[
+            "This runtime slice covers authenticated CGI status and motion inspection; media transfer, recording, PTZ, and push events remain separate work.",
+        ]),
         camera_entry(
             "ring",
             "Ring",
@@ -80680,6 +80697,34 @@ mod tests {
             .discovery_mechanisms
             .contains(&DiscoveryMechanism::WsDiscovery));
         assert!(onvif
+            .required_primitives
+            .contains(&PrimitiveFamily::CameraMedia));
+    }
+
+    #[test]
+    fn reolink_entry_exposes_authenticated_cgi_runtime_primitives() {
+        let catalog = first_party_catalog();
+        let reolink = find_entry(&catalog, &IntegrationId::trusted("reolink")).unwrap();
+
+        assert_eq!(
+            reolink.implementation_status,
+            ImplementationStatus::FirstPartyRuntime
+        );
+        assert_eq!(reolink.connectivity, ConnectivityClass::LocalPolling);
+        assert_eq!(
+            reolink.supported_protocols,
+            vec![ProtocolFamily::Vendor("reolink_cgi".to_string())]
+        );
+        assert_eq!(reolink.auth_modes, vec![AuthMode::UsernamePassword]);
+        assert!(reolink.target_entity_kinds.contains(&EntityKind::Camera));
+        assert!(reolink.target_entity_kinds.contains(&EntityKind::Sensor));
+        assert!(reolink
+            .required_primitives
+            .contains(&PrimitiveFamily::LocalHttp));
+        assert!(reolink
+            .required_primitives
+            .contains(&PrimitiveFamily::VaultLease));
+        assert!(!reolink
             .required_primitives
             .contains(&PrimitiveFamily::CameraMedia));
     }

--- a/code/packages/rust/smart-home-reolink-integration/BUILD
+++ b/code/packages/rust/smart-home-reolink-integration/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-reolink-integration -- --nocapture

--- a/code/packages/rust/smart-home-reolink-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-reolink-integration/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Added authenticated Reolink CGI login-token lifecycle, device and channel
+  inspection, optional motion reads, D23 normalization, authorization-before-I/O,
+  and a real loopback HTTP proof.

--- a/code/packages/rust/smart-home-reolink-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-reolink-integration/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "smart-home-reolink-integration"
+version = "0.1.0"
+edition = "2021"
+description = "Authenticated Reolink camera and NVR CGI integration for the smart-home runtime"
+license = "MIT"
+
+[dependencies]
+coding_adventures_zeroize = { path = "../zeroize" }
+http-core = { path = "../http-core" }
+http1 = { path = "../http1" }
+serde_json = "1"
+smart-home-core = { path = "../smart-home-core" }
+smart-home-discovery = { path = "../smart-home-discovery" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+tls-platform = { path = "../tls-platform" }
+url-parser = { path = "../url-parser" }

--- a/code/packages/rust/smart-home-reolink-integration/README.md
+++ b/code/packages/rust/smart-home-reolink-integration/README.md
@@ -1,0 +1,20 @@
+# smart-home-reolink-integration
+
+This package connects Reolink cameras and NVRs to D23 through the authenticated
+local HTTP/HTTPS CGI API:
+
+- manual fixed-endpoint discovery after authenticated inspection;
+- bounded login-token, device-information, channel-status, motion-state, and
+  logout exchanges;
+- normalized camera-channel and motion-sensor entities; and
+- D23 read authorization before credentials or network I/O are used.
+
+Credentials are zeroized after use and are represented in D23 only by a
+`VaultRef`. Session tokens are redacted and never enter normalized state.
+
+This slice does not claim RTSP media transfer, recording, PTZ control, webhook
+events, or ONVIF PullPoint events. Those remain separate transport/runtime work.
+
+Set `REOLINK_USERNAME`, `REOLINK_PASSWORD`, and `REOLINK_CREDENTIAL_REF`, then
+run `cargo run -p smart-home-reolink-integration -- inspect <base-url>` to emit
+sanitized device and channel state.

--- a/code/packages/rust/smart-home-reolink-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-reolink-integration/src/lib.rs
@@ -1,0 +1,1134 @@
+//! Authenticated Reolink camera and NVR CGI integration for D23.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_zeroize::Zeroizing;
+use http1::{parse_response_head, Http1ParseError};
+use http_core::BodyKind;
+use serde_json::{json, Value as JsonValue};
+use smart_home_core::{
+    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode, Device,
+    DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId, Metadata, ProtocolFamily,
+    ProtocolIdentifier, SmartHomeTool, StateConfidence, StateSnapshot, StateSource, Value,
+    ValueKind, VaultRef,
+};
+use smart_home_discovery::{
+    DiscoveryConfidence, DiscoveryRecord, DiscoverySource, PairingRequirement,
+};
+use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
+use std::fmt;
+use std::io::{self, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+use tls_platform::{default_connector, TlsConfig, TlsConnector};
+use url_parser::{Url, UrlError};
+
+pub const VERSION: &str = "0.1.0";
+pub const INTEGRATION_ID: &str = "reolink";
+pub const PROTOCOL_ID: &str = "reolink_cgi";
+pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Debug)]
+pub enum ReolinkError {
+    Validation(String),
+    Json(serde_json::Error),
+    Url(UrlError),
+    Io(String),
+    Tls(String),
+    Http(String),
+    HttpStatus(u16),
+    ResponseTooLarge {
+        limit: usize,
+    },
+    TruncatedBody {
+        expected: usize,
+        actual: usize,
+    },
+    Api {
+        command: String,
+        code: i64,
+        message: String,
+    },
+    MissingField {
+        command: &'static str,
+        field: &'static str,
+    },
+    NoChannels,
+    Runtime(RuntimeError),
+}
+
+impl fmt::Display for ReolinkError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Validation(message) => write!(formatter, "invalid Reolink input: {message}"),
+            Self::Json(error) => write!(formatter, "invalid Reolink JSON: {error}"),
+            Self::Url(error) => write!(formatter, "invalid Reolink URL: {error}"),
+            Self::Io(message) => write!(formatter, "Reolink LAN I/O failed: {message}"),
+            Self::Tls(message) => write!(formatter, "Reolink TLS failed: {message}"),
+            Self::Http(message) => write!(formatter, "invalid Reolink HTTP response: {message}"),
+            Self::HttpStatus(status) => {
+                write!(formatter, "Reolink endpoint returned HTTP {status}")
+            }
+            Self::ResponseTooLarge { limit } => {
+                write!(formatter, "Reolink response exceeds {limit} bytes")
+            }
+            Self::TruncatedBody { expected, actual } => write!(
+                formatter,
+                "Reolink response body is truncated: expected {expected} bytes, got {actual}"
+            ),
+            Self::Api {
+                command,
+                code,
+                message,
+            } => {
+                write!(
+                    formatter,
+                    "Reolink command {command} failed with code {code}: {message}"
+                )
+            }
+            Self::MissingField { command, field } => {
+                write!(formatter, "Reolink command {command} is missing {field}")
+            }
+            Self::NoChannels => formatter.write_str("Reolink device returned no camera channels"),
+            Self::Runtime(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for ReolinkError {}
+
+impl From<serde_json::Error> for ReolinkError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+impl From<UrlError> for ReolinkError {
+    fn from(error: UrlError) -> Self {
+        Self::Url(error)
+    }
+}
+
+impl From<RuntimeError> for ReolinkError {
+    fn from(error: RuntimeError) -> Self {
+        Self::Runtime(error)
+    }
+}
+
+pub struct ReolinkCredentials {
+    username: Zeroizing<String>,
+    password: Zeroizing<String>,
+}
+
+impl ReolinkCredentials {
+    pub fn new(
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Result<Self, ReolinkError> {
+        let username = username.into();
+        let password = password.into();
+        if username.trim().is_empty() || password.is_empty() {
+            return Err(ReolinkError::Validation(
+                "username and password must not be empty".to_string(),
+            ));
+        }
+        Ok(Self {
+            username: Zeroizing::new(username),
+            password: Zeroizing::new(password),
+        })
+    }
+}
+
+impl fmt::Debug for ReolinkCredentials {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ReolinkCredentials([REDACTED])")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReolinkConfig {
+    pub bridge_id: BridgeId,
+    pub base_url: String,
+    pub credential_ref: VaultRef,
+}
+
+impl ReolinkConfig {
+    pub fn new(
+        bridge_id: BridgeId,
+        base_url: impl Into<String>,
+        credential_ref: VaultRef,
+    ) -> Result<Self, ReolinkError> {
+        let base_url = base_url.into().trim_end_matches('/').to_string();
+        let parsed = Url::parse(&base_url)?;
+        if !matches!(parsed.scheme.as_str(), "http" | "https") {
+            return Err(ReolinkError::Validation(
+                "base URL must use http or https".to_string(),
+            ));
+        }
+        if parsed.host.is_none()
+            || parsed.userinfo.is_some()
+            || parsed.query.is_some()
+            || parsed.fragment.is_some()
+        {
+            return Err(ReolinkError::Validation(
+                "base URL must contain a host and no credentials, query, or fragment".to_string(),
+            ));
+        }
+        Ok(Self {
+            bridge_id,
+            base_url,
+            credential_ref,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReolinkDeviceInformation {
+    pub name: String,
+    pub model: String,
+    pub serial: String,
+    pub firmware_version: Option<String>,
+    pub hardware_version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReolinkChannelStatus {
+    pub channel: u32,
+    pub name: String,
+    pub online: bool,
+    pub sleeping: bool,
+    pub motion: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReolinkSnapshot {
+    pub device: ReolinkDeviceInformation,
+    pub channels: Vec<ReolinkChannelStatus>,
+}
+
+pub trait ReolinkTransport {
+    fn post_json(&mut self, endpoint: &str, body: &[u8]) -> Result<Vec<u8>, ReolinkError>;
+}
+
+pub struct ReolinkLanTransport {
+    connector: Box<dyn TlsConnector>,
+    tls_config: TlsConfig,
+    timeout: Duration,
+    maximum_response_bytes: usize,
+}
+
+impl Default for ReolinkLanTransport {
+    fn default() -> Self {
+        Self::new(default_connector(), TlsConfig::https_default())
+    }
+}
+
+impl ReolinkLanTransport {
+    pub fn new(connector: Box<dyn TlsConnector>, tls_config: TlsConfig) -> Self {
+        Self {
+            connector,
+            tls_config,
+            timeout: Duration::from_secs(5),
+            maximum_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout.max(Duration::from_millis(1));
+        self
+    }
+
+    pub fn with_maximum_response_bytes(mut self, maximum: usize) -> Self {
+        self.maximum_response_bytes = maximum.max(1);
+        self
+    }
+}
+
+impl ReolinkTransport for ReolinkLanTransport {
+    fn post_json(&mut self, endpoint: &str, body: &[u8]) -> Result<Vec<u8>, ReolinkError> {
+        let url = Url::parse(endpoint)?;
+        let host = url
+            .host
+            .as_deref()
+            .ok_or_else(|| ReolinkError::Validation("endpoint is missing a host".to_string()))?;
+        let port = url
+            .effective_port()
+            .ok_or_else(|| ReolinkError::Validation("endpoint is missing a port".to_string()))?;
+        let request = Zeroizing::new(encode_http_request(&url, body)?);
+        let response = match url.scheme.as_str() {
+            "http" => {
+                let mut stream = connect_tcp(host, port, self.timeout)?;
+                write_request(&mut stream, &request)?;
+                read_bounded(&mut stream, self.maximum_response_bytes)?
+            }
+            "https" => {
+                let mut config = self.tls_config.clone();
+                config.connect_timeout = self.timeout;
+                config.read_timeout = Some(self.timeout);
+                config.write_timeout = Some(self.timeout);
+                let mut stream = self
+                    .connector
+                    .connect(host, port, &config)
+                    .map_err(|error| ReolinkError::Tls(error.to_string()))?;
+                write_request(&mut stream, &request)?;
+                let bytes = read_bounded(&mut stream, self.maximum_response_bytes)?;
+                stream
+                    .close_notify()
+                    .map_err(|error| ReolinkError::Tls(error.to_string()))?;
+                bytes
+            }
+            scheme => {
+                return Err(ReolinkError::Validation(format!(
+                    "unsupported Reolink URL scheme `{scheme}`"
+                )))
+            }
+        };
+        decode_http_response(&response, self.maximum_response_bytes)
+    }
+}
+
+struct ReolinkSession {
+    token: Zeroizing<String>,
+    lease_seconds: u64,
+}
+
+impl fmt::Debug for ReolinkSession {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ReolinkSession")
+            .field("token", &"[REDACTED]")
+            .field("lease_seconds", &self.lease_seconds)
+            .finish()
+    }
+}
+
+pub struct ReolinkClient<T> {
+    config: ReolinkConfig,
+    credentials: ReolinkCredentials,
+    transport: T,
+}
+
+impl<T: ReolinkTransport> ReolinkClient<T> {
+    pub fn new(config: ReolinkConfig, credentials: ReolinkCredentials, transport: T) -> Self {
+        Self {
+            config,
+            credentials,
+            transport,
+        }
+    }
+
+    pub fn config(&self) -> &ReolinkConfig {
+        &self.config
+    }
+
+    pub fn transport(&self) -> &T {
+        &self.transport
+    }
+
+    pub fn inspect(&mut self) -> Result<ReolinkSnapshot, ReolinkError> {
+        let session = self.login()?;
+        let result = self.inspect_session(&session);
+        let logout = self.logout(&session);
+        match (result, logout) {
+            (Ok(snapshot), Ok(())) => Ok(snapshot),
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+        }
+    }
+
+    fn inspect_session(
+        &mut self,
+        session: &ReolinkSession,
+    ) -> Result<ReolinkSnapshot, ReolinkError> {
+        let device =
+            parse_device_information(&self.command("GetDevInfo", Some(session), json!({}))?)?;
+        let mut channels =
+            parse_channels(&self.command("GetChannelstatus", Some(session), json!({}))?)?;
+        if channels.is_empty() {
+            return Err(ReolinkError::NoChannels);
+        }
+        for channel in channels
+            .iter_mut()
+            .filter(|channel| channel.online && !channel.sleeping)
+        {
+            let value = self.command(
+                "GetMdState",
+                Some(session),
+                json!({"channel": channel.channel}),
+            );
+            channel.motion = match value {
+                Ok(value) => parse_motion(&value),
+                Err(ReolinkError::Api { .. }) => None,
+                Err(error) => return Err(error),
+            };
+        }
+        Ok(ReolinkSnapshot { device, channels })
+    }
+
+    fn login(&mut self) -> Result<ReolinkSession, ReolinkError> {
+        let value = self.command(
+            "Login",
+            None,
+            json!({
+                "User": {
+                    "userName": self.credentials.username.as_str(),
+                    "password": self.credentials.password.as_str(),
+                }
+            }),
+        )?;
+        let token = value
+            .pointer("/Token/name")
+            .and_then(JsonValue::as_str)
+            .ok_or(ReolinkError::MissingField {
+                command: "Login",
+                field: "value.Token.name",
+            })?;
+        if token.is_empty()
+            || !token
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return Err(ReolinkError::Validation(
+                "login token contains unsafe URL characters".to_string(),
+            ));
+        }
+        Ok(ReolinkSession {
+            token: Zeroizing::new(token.to_string()),
+            lease_seconds: value
+                .pointer("/Token/leaseTime")
+                .and_then(JsonValue::as_u64)
+                .unwrap_or_default(),
+        })
+    }
+
+    fn logout(&mut self, session: &ReolinkSession) -> Result<(), ReolinkError> {
+        self.command("Logout", Some(session), json!({})).map(|_| ())
+    }
+
+    fn command(
+        &mut self,
+        command: &'static str,
+        session: Option<&ReolinkSession>,
+        param: JsonValue,
+    ) -> Result<JsonValue, ReolinkError> {
+        let endpoint = api_endpoint(&self.config.base_url, command, session)?;
+        let body = Zeroizing::new(serde_json::to_vec(&json!([{
+            "cmd": command,
+            "action": 0,
+            "param": param,
+        }]))?);
+        let response = self.transport.post_json(&endpoint, &body)?;
+        parse_command_response(command, &response)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledReolinkDevice {
+    pub bridge_id: BridgeId,
+    pub device_ids: Vec<DeviceId>,
+    pub camera_entity_ids: Vec<EntityId>,
+    pub motion_entity_ids: Vec<EntityId>,
+}
+
+pub struct ReolinkRuntimeIntegration<T> {
+    client: ReolinkClient<T>,
+}
+
+impl<T: ReolinkTransport> ReolinkRuntimeIntegration<T> {
+    pub fn new(client: ReolinkClient<T>) -> Self {
+        Self { client }
+    }
+
+    pub fn client(&self) -> &ReolinkClient<T> {
+        &self.client
+    }
+
+    pub fn inspect_and_install_authorized(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        observed_at_ms: u64,
+    ) -> Result<InstalledReolinkDevice, ReolinkError> {
+        let decision = runtime.authorize_tool_for_principal(
+            principal_id.clone(),
+            SmartHomeTool::GetState,
+            observed_at_ms,
+        );
+        if !decision.missing_capabilities.is_empty() {
+            return Err(ReolinkError::Runtime(RuntimeError::UnauthorizedTool {
+                principal_id,
+                tool: SmartHomeTool::GetState,
+                missing_capabilities: decision.missing_capabilities,
+            }));
+        }
+        let snapshot = self.client.inspect()?;
+        install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)
+    }
+}
+
+pub fn discovery_record(
+    config: &ReolinkConfig,
+    snapshot: &ReolinkSnapshot,
+    discovered_at_ms: u64,
+) -> Result<DiscoveryRecord, ReolinkError> {
+    Ok(DiscoveryRecord::new(
+        IntegrationId::trusted(INTEGRATION_ID),
+        ProtocolFamily::Vendor(PROTOCOL_ID.to_string()),
+        stable_component(&snapshot.device.serial),
+        DiscoverySource::Manual,
+        BridgeTransport::LanHttp,
+        discovered_at_ms,
+    )
+    .map_err(|error| ReolinkError::Validation(error.to_string()))?
+    .with_display_name(snapshot.device.name.clone())
+    .with_address(config.base_url.clone())
+    .with_hardware_model(snapshot.device.model.clone())
+    .with_firmware_version(snapshot.device.firmware_version.clone().unwrap_or_default())
+    .with_confidence(DiscoveryConfidence::Paired)
+    .with_pairing_requirement(PairingRequirement::Credentials)
+    .with_metadata("reolink.protocol", PROTOCOL_ID)
+    .with_metadata("reolink.channel_count", snapshot.channels.len().to_string()))
+}
+
+pub fn install_snapshot(
+    runtime: &mut SmartHomeRuntime,
+    config: &ReolinkConfig,
+    snapshot: &ReolinkSnapshot,
+    observed_at_ms: u64,
+) -> Result<InstalledReolinkDevice, ReolinkError> {
+    let native_id = stable_component(&snapshot.device.serial);
+    if native_id.is_empty() {
+        return Err(ReolinkError::Validation(
+            "device serial is empty".to_string(),
+        ));
+    }
+    let mut bridge = Bridge::new(
+        config.bridge_id.clone(),
+        IntegrationId::trusted(INTEGRATION_ID),
+        BridgeTransport::LanHttp,
+    );
+    bridge.address = Some(config.base_url.clone());
+    bridge.hardware_model = Some(snapshot.device.model.clone());
+    bridge.firmware_version = snapshot.device.firmware_version.clone();
+    bridge.auth_ref = Some(config.credential_ref.clone());
+    bridge.health = Health::Online;
+    bridge.last_seen_at_ms = Some(observed_at_ms);
+    bridge.identifiers = vec![protocol_identifier("serial", &snapshot.device.serial)?];
+    bridge.metadata = vec![
+        Metadata::new("reolink.transport", "authenticated_http_cgi"),
+        Metadata::new("reolink.channel_count", snapshot.channels.len().to_string()),
+    ];
+    runtime.upsert_bridge(bridge)?;
+
+    let mut installed = InstalledReolinkDevice {
+        bridge_id: config.bridge_id.clone(),
+        device_ids: Vec::new(),
+        camera_entity_ids: Vec::new(),
+        motion_entity_ids: Vec::new(),
+    };
+    for channel in &snapshot.channels {
+        let channel_id = format!("{native_id}:ch{}", channel.channel);
+        let device_id = DeviceId::trusted(format!("reolink:{channel_id}"));
+        let camera_id = EntityId::trusted(format!("reolink:{channel_id}:camera"));
+        let motion_id = EntityId::trusted(format!("reolink:{channel_id}:motion"));
+        let mut entity_ids = vec![camera_id.clone()];
+        if channel.motion.is_some() {
+            entity_ids.push(motion_id.clone());
+        }
+        let health = if channel.online {
+            Health::Online
+        } else {
+            Health::Offline
+        };
+        runtime.upsert_device(Device {
+            device_id: device_id.clone(),
+            bridge_id: config.bridge_id.clone(),
+            manufacturer: "Reolink".to_string(),
+            model: snapshot.device.model.clone(),
+            name: channel.name.clone(),
+            serial: Some(format!("{}:ch{}", snapshot.device.serial, channel.channel)),
+            firmware_version: snapshot.device.firmware_version.clone(),
+            room_id: None,
+            entity_ids: entity_ids.clone(),
+            identifiers: vec![protocol_identifier(
+                "channel",
+                &channel.channel.to_string(),
+            )?],
+            health,
+            metadata: vec![Metadata::new("reolink.protocol", PROTOCOL_ID)],
+        })?;
+        runtime.upsert_entity(Entity {
+            entity_id: camera_id.clone(),
+            device_id: device_id.clone(),
+            kind: EntityKind::Camera,
+            name: channel.name.clone(),
+            capabilities: vec![Capability::new(
+                CapabilityId::trusted("camera.channel_status"),
+                CapabilityMode::Observe,
+                ValueKind::Object,
+            )],
+            state: Some(StateSnapshot {
+                entity_id: camera_id.clone(),
+                value: channel_state(channel),
+                source: StateSource::Poll,
+                observed_at_ms,
+                received_at_ms: observed_at_ms,
+                expires_at_ms: None,
+                confidence: StateConfidence::Confirmed,
+            }),
+            metadata: vec![Metadata::new(
+                "reolink.channel",
+                channel.channel.to_string(),
+            )],
+        })?;
+        if let Some(motion) = channel.motion {
+            runtime.upsert_entity(Entity {
+                entity_id: motion_id.clone(),
+                device_id: device_id.clone(),
+                kind: EntityKind::Sensor,
+                name: format!("{} Motion", channel.name),
+                capabilities: vec![Capability::new(
+                    CapabilityId::trusted("sensor.occupancy"),
+                    CapabilityMode::Observe,
+                    ValueKind::Boolean,
+                )],
+                state: Some(StateSnapshot {
+                    entity_id: motion_id.clone(),
+                    value: Value::Bool(motion),
+                    source: StateSource::Poll,
+                    observed_at_ms,
+                    received_at_ms: observed_at_ms,
+                    expires_at_ms: None,
+                    confidence: StateConfidence::Confirmed,
+                }),
+                metadata: vec![Metadata::new(
+                    "reolink.channel",
+                    channel.channel.to_string(),
+                )],
+            })?;
+            installed.motion_entity_ids.push(motion_id);
+        }
+        installed.device_ids.push(device_id);
+        installed.camera_entity_ids.push(camera_id);
+    }
+    Ok(installed)
+}
+
+fn parse_command_response(command: &'static str, bytes: &[u8]) -> Result<JsonValue, ReolinkError> {
+    let response: JsonValue = serde_json::from_slice(bytes)?;
+    let item =
+        response
+            .as_array()
+            .and_then(|items| items.first())
+            .ok_or(ReolinkError::MissingField {
+                command,
+                field: "response[0]",
+            })?;
+    if item.get("cmd").and_then(JsonValue::as_str) != Some(command) {
+        return Err(ReolinkError::Validation(format!(
+            "response command does not match {command}"
+        )));
+    }
+    let code = item.get("code").and_then(JsonValue::as_i64).unwrap_or(-1);
+    if code != 0 {
+        let message = item
+            .pointer("/error/detail")
+            .or_else(|| item.pointer("/error/rspCode"))
+            .and_then(|value| {
+                value
+                    .as_str()
+                    .map(str::to_string)
+                    .or_else(|| Some(value.to_string()))
+            })
+            .unwrap_or_else(|| "device rejected command".to_string());
+        return Err(ReolinkError::Api {
+            command: command.to_string(),
+            code,
+            message,
+        });
+    }
+    item.get("value")
+        .cloned()
+        .ok_or(ReolinkError::MissingField {
+            command,
+            field: "value",
+        })
+}
+
+fn parse_device_information(value: &JsonValue) -> Result<ReolinkDeviceInformation, ReolinkError> {
+    let info = value.get("DevInfo").unwrap_or(value);
+    let model = required_text(info, "GetDevInfo", "model")?;
+    let serial = required_text(info, "GetDevInfo", "serial")?;
+    Ok(ReolinkDeviceInformation {
+        name: text(info, "name").unwrap_or_else(|| model.clone()),
+        model,
+        serial,
+        firmware_version: text(info, "firmVer"),
+        hardware_version: text(info, "hardVer"),
+    })
+}
+
+fn parse_channels(value: &JsonValue) -> Result<Vec<ReolinkChannelStatus>, ReolinkError> {
+    let statuses =
+        value
+            .get("status")
+            .and_then(JsonValue::as_array)
+            .ok_or(ReolinkError::MissingField {
+                command: "GetChannelstatus",
+                field: "value.status",
+            })?;
+    statuses
+        .iter()
+        .map(|status| {
+            let channel = status
+                .get("channel")
+                .and_then(JsonValue::as_u64)
+                .and_then(|value| u32::try_from(value).ok())
+                .ok_or(ReolinkError::MissingField {
+                    command: "GetChannelstatus",
+                    field: "value.status[].channel",
+                })?;
+            Ok(ReolinkChannelStatus {
+                channel,
+                name: text(status, "name").unwrap_or_else(|| format!("Camera {}", channel + 1)),
+                online: boolean(status.get("online")).unwrap_or(false),
+                sleeping: boolean(status.get("sleep")).unwrap_or(false),
+                motion: None,
+            })
+        })
+        .collect()
+}
+
+fn parse_motion(value: &JsonValue) -> Option<bool> {
+    boolean(value.get("state"))
+}
+
+fn boolean(value: Option<&JsonValue>) -> Option<bool> {
+    value.and_then(|value| {
+        value
+            .as_bool()
+            .or_else(|| value.as_i64().map(|number| number != 0))
+    })
+}
+
+fn text(value: &JsonValue, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+}
+
+fn required_text(
+    value: &JsonValue,
+    command: &'static str,
+    field: &'static str,
+) -> Result<String, ReolinkError> {
+    text(value, field)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or(ReolinkError::MissingField { command, field })
+}
+
+fn channel_state(channel: &ReolinkChannelStatus) -> Value {
+    let mut fields = vec![
+        ("online".to_string(), Value::Bool(channel.online)),
+        ("sleeping".to_string(), Value::Bool(channel.sleeping)),
+    ];
+    if let Some(motion) = channel.motion {
+        fields.push(("motion".to_string(), Value::Bool(motion)));
+    }
+    Value::Object(fields)
+}
+
+fn api_endpoint(
+    base_url: &str,
+    command: &str,
+    session: Option<&ReolinkSession>,
+) -> Result<String, ReolinkError> {
+    if !command.bytes().all(|byte| byte.is_ascii_alphanumeric()) {
+        return Err(ReolinkError::Validation(
+            "command contains unsafe URL characters".to_string(),
+        ));
+    }
+    let mut endpoint = format!("{base_url}/api.cgi?cmd={command}");
+    if let Some(session) = session {
+        endpoint.push_str("&token=");
+        endpoint.push_str(&session.token);
+    }
+    Ok(endpoint)
+}
+
+fn protocol_identifier(kind: &str, value: &str) -> Result<ProtocolIdentifier, ReolinkError> {
+    ProtocolIdentifier::new(ProtocolFamily::Vendor(PROTOCOL_ID.to_string()), kind, value)
+        .map_err(|error| ReolinkError::Validation(error.to_string()))
+}
+
+fn stable_component(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn encode_http_request(url: &Url, body: &[u8]) -> Result<Vec<u8>, ReolinkError> {
+    let host = url
+        .host
+        .as_deref()
+        .ok_or_else(|| ReolinkError::Validation("endpoint is missing a host".to_string()))?;
+    let target = match &url.query {
+        Some(query) => format!("{}?{query}", url.path),
+        None => url.path.clone(),
+    };
+    let host_header = match url.port {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    };
+    let mut request = format!(
+        "POST {target} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\nAccept: application/json\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    request.extend_from_slice(body);
+    Ok(request)
+}
+
+fn connect_tcp(host: &str, port: u16, timeout: Duration) -> Result<TcpStream, ReolinkError> {
+    let addresses = (host, port)
+        .to_socket_addrs()
+        .map_err(|error| ReolinkError::Io(error.to_string()))?
+        .collect::<Vec<_>>();
+    let mut last_error = None;
+    for address in addresses {
+        match TcpStream::connect_timeout(&address, timeout) {
+            Ok(stream) => {
+                stream
+                    .set_read_timeout(Some(timeout))
+                    .map_err(|error| ReolinkError::Io(error.to_string()))?;
+                stream
+                    .set_write_timeout(Some(timeout))
+                    .map_err(|error| ReolinkError::Io(error.to_string()))?;
+                return Ok(stream);
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(ReolinkError::Io(
+        last_error
+            .unwrap_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::AddrNotAvailable,
+                    "host resolved to no addresses",
+                )
+            })
+            .to_string(),
+    ))
+}
+
+fn write_request(writer: &mut dyn Write, request: &[u8]) -> Result<(), ReolinkError> {
+    writer
+        .write_all(request)
+        .map_err(|error| ReolinkError::Io(error.to_string()))?;
+    writer
+        .flush()
+        .map_err(|error| ReolinkError::Io(error.to_string()))
+}
+
+fn read_bounded(reader: &mut dyn Read, maximum: usize) -> Result<Vec<u8>, ReolinkError> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| ReolinkError::Io(error.to_string()))?;
+        if read == 0 {
+            break;
+        }
+        if read > maximum.saturating_sub(bytes.len()) {
+            return Err(ReolinkError::ResponseTooLarge { limit: maximum });
+        }
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+    Ok(bytes)
+}
+
+fn decode_http_response(bytes: &[u8], maximum: usize) -> Result<Vec<u8>, ReolinkError> {
+    let parsed = parse_response_head(bytes)
+        .map_err(|error: Http1ParseError| ReolinkError::Http(error.to_string()))?;
+    if !(200..300).contains(&parsed.head.status) {
+        return Err(ReolinkError::HttpStatus(parsed.head.status));
+    }
+    let input = &bytes[parsed.body_offset..];
+    let body = match parsed.body_kind {
+        BodyKind::None => Vec::new(),
+        BodyKind::ContentLength(expected) => {
+            if input.len() < expected {
+                return Err(ReolinkError::TruncatedBody {
+                    expected,
+                    actual: input.len(),
+                });
+            }
+            input[..expected].to_vec()
+        }
+        BodyKind::UntilEof => input.to_vec(),
+        BodyKind::Chunked => decode_chunked(input, maximum)?,
+    };
+    if body.len() > maximum {
+        return Err(ReolinkError::ResponseTooLarge { limit: maximum });
+    }
+    Ok(body)
+}
+
+fn decode_chunked(input: &[u8], maximum: usize) -> Result<Vec<u8>, ReolinkError> {
+    let mut cursor = 0usize;
+    let mut output = Vec::new();
+    loop {
+        let line_offset = input[cursor..]
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .ok_or_else(|| ReolinkError::Http("missing chunk-size terminator".to_string()))?;
+        let line_end = cursor + line_offset;
+        let size_text = std::str::from_utf8(&input[cursor..line_end])
+            .map_err(|_| ReolinkError::Http("chunk size is not ASCII".to_string()))?
+            .split(';')
+            .next()
+            .unwrap_or_default();
+        let size = usize::from_str_radix(size_text.trim(), 16)
+            .map_err(|_| ReolinkError::Http("invalid chunk size".to_string()))?;
+        cursor = line_end + 2;
+        if size == 0 {
+            return Ok(output);
+        }
+        if size > maximum.saturating_sub(output.len()) {
+            return Err(ReolinkError::ResponseTooLarge { limit: maximum });
+        }
+        let end = cursor
+            .checked_add(size)
+            .ok_or_else(|| ReolinkError::Http("chunk size overflow".to_string()))?;
+        if end + 2 > input.len() || &input[end..end + 2] != b"\r\n" {
+            return Err(ReolinkError::Http("truncated chunk payload".to_string()));
+        }
+        output.extend_from_slice(&input[cursor..end]);
+        cursor = end + 2;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    fn response(value: JsonValue) -> Vec<u8> {
+        serde_json::to_vec(&value).unwrap()
+    }
+
+    fn grant(runtime: &mut SmartHomeRuntime, principal: &AgentId) {
+        let _ =
+            runtime
+                .registry_mut()
+                .upsert_capability_grant(CapabilityGrant::for_all_smart_home(
+                    CapabilityGrantId::trusted("grant:reolink-test"),
+                    principal.clone(),
+                    PrivilegeTier::HumanApproval,
+                    "test",
+                    1,
+                ));
+    }
+
+    #[test]
+    fn credentials_and_session_debug_are_redacted() {
+        let credentials = ReolinkCredentials::new("admin", "secret").unwrap();
+        assert_eq!(format!("{credentials:?}"), "ReolinkCredentials([REDACTED])");
+        let session = ReolinkSession {
+            token: Zeroizing::new("session-secret".to_string()),
+            lease_seconds: 3_600,
+        };
+        let rendered = format!("{session:?}");
+        assert!(rendered.contains("[REDACTED]"));
+        assert!(!rendered.contains("session-secret"));
+    }
+
+    #[test]
+    fn api_failures_are_not_accepted_as_state() {
+        let error = parse_command_response(
+            "Login",
+            br#"[{"cmd":"Login","code":1,"error":{"rspCode":-6,"detail":"login failed"}}]"#,
+        )
+        .unwrap_err();
+        assert!(matches!(error, ReolinkError::Api { code: 1, .. }));
+    }
+
+    #[test]
+    fn real_http_login_inspect_motion_logout_and_install() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let server_captured = Arc::clone(&captured);
+        let handle = thread::spawn(move || {
+            let responses = [
+                json!([{"cmd":"Login","code":0,"value":{"Token":{"name":"token123","leaseTime":3600}}}]),
+                json!([{"cmd":"GetDevInfo","code":0,"value":{"DevInfo":{"name":"Front NVR","model":"RLN8-410","serial":"ABC123","firmVer":"v3.5.0","hardVer":"N7MB01"}}}]),
+                json!([{"cmd":"GetChannelstatus","code":0,"value":{"status":[{"channel":0,"name":"Porch","online":1,"sleep":0},{"channel":1,"name":"Garage","online":0,"sleep":0}]}}]),
+                json!([{"cmd":"GetMdState","code":0,"value":{"state":1}}]),
+                json!([{"cmd":"Logout","code":0,"value":{}}]),
+            ];
+            for response_value in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut bytes = Vec::new();
+                let mut buffer = [0u8; 4096];
+                loop {
+                    let read = stream.read(&mut buffer).unwrap();
+                    bytes.extend_from_slice(&buffer[..read]);
+                    if let Some(offset) = bytes.windows(4).position(|window| window == b"\r\n\r\n")
+                    {
+                        let head = String::from_utf8_lossy(&bytes[..offset + 4]);
+                        let length = head
+                            .lines()
+                            .find_map(|line| line.strip_prefix("Content-Length: "))
+                            .and_then(|value| value.parse::<usize>().ok())
+                            .unwrap();
+                        if bytes.len() >= offset + 4 + length {
+                            break;
+                        }
+                    }
+                }
+                server_captured.lock().unwrap().push(bytes);
+                let body = response(response_value);
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                )
+                .unwrap();
+                stream.write_all(&body).unwrap();
+            }
+        });
+
+        let config = ReolinkConfig::new(
+            BridgeId::trusted("reolink.test"),
+            format!("http://{address}"),
+            VaultRef::trusted("vault://reolink/test"),
+        )
+        .unwrap();
+        let transport = ReolinkLanTransport::default().with_timeout(Duration::from_secs(1));
+        let client = ReolinkClient::new(
+            config,
+            ReolinkCredentials::new("admin", "secret").unwrap(),
+            transport,
+        );
+        let mut integration = ReolinkRuntimeIntegration::new(client);
+        let principal = AgentId::trusted("agent:reolink-test");
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        let installed = integration
+            .inspect_and_install_authorized(&mut runtime, principal, 5_000)
+            .unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(installed.device_ids.len(), 2);
+        assert_eq!(installed.camera_entity_ids.len(), 2);
+        assert_eq!(installed.motion_entity_ids.len(), 1);
+        assert_eq!(
+            runtime
+                .registry()
+                .state(&installed.motion_entity_ids[0])
+                .unwrap()
+                .value,
+            Value::Bool(true)
+        );
+        let bridge = runtime.registry().bridge(&installed.bridge_id).unwrap();
+        assert_eq!(
+            bridge.auth_ref.as_ref().unwrap().as_str(),
+            "vault://reolink/test"
+        );
+        let serialized_runtime = format!("{runtime:?}");
+        assert!(!serialized_runtime.contains("secret"));
+        assert!(!serialized_runtime.contains("token123"));
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 5);
+        let request_text = requests
+            .iter()
+            .map(|request| String::from_utf8_lossy(request).to_string())
+            .collect::<Vec<_>>();
+        assert!(request_text[0].contains("cmd=Login"));
+        assert!(request_text[0].contains("\"password\":\"secret\""));
+        assert!(request_text[1].contains("cmd=GetDevInfo&token=token123"));
+        assert!(request_text[3].contains("cmd=GetMdState&token=token123"));
+        assert!(request_text[4].contains("cmd=Logout&token=token123"));
+    }
+
+    #[derive(Debug)]
+    struct CountingTransport {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl ReolinkTransport for CountingTransport {
+        fn post_json(&mut self, _endpoint: &str, _body: &[u8]) -> Result<Vec<u8>, ReolinkError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn denied_read_reaches_no_transport_or_credentials() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let config = ReolinkConfig::new(
+            BridgeId::trusted("reolink.denied"),
+            "http://127.0.0.1",
+            VaultRef::trusted("vault://reolink/denied"),
+        )
+        .unwrap();
+        let client = ReolinkClient::new(
+            config,
+            ReolinkCredentials::new("admin", "secret").unwrap(),
+            CountingTransport {
+                calls: Arc::clone(&calls),
+            },
+        );
+        let mut integration = ReolinkRuntimeIntegration::new(client);
+        let error = integration
+            .inspect_and_install_authorized(
+                &mut SmartHomeRuntime::new(),
+                AgentId::trusted("agent:denied"),
+                5_000,
+            )
+            .unwrap_err();
+        assert!(matches!(error, ReolinkError::Runtime(_)));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn authenticated_snapshot_becomes_paired_manual_discovery() {
+        let config = ReolinkConfig::new(
+            BridgeId::trusted("reolink.discovery"),
+            "https://192.0.2.10",
+            VaultRef::trusted("vault://reolink/discovery"),
+        )
+        .unwrap();
+        let snapshot = ReolinkSnapshot {
+            device: ReolinkDeviceInformation {
+                name: "NVR".to_string(),
+                model: "RLN8-410".to_string(),
+                serial: "ABC123".to_string(),
+                firmware_version: Some("v3".to_string()),
+                hardware_version: None,
+            },
+            channels: vec![ReolinkChannelStatus {
+                channel: 0,
+                name: "Porch".to_string(),
+                online: true,
+                sleeping: false,
+                motion: Some(false),
+            }],
+        };
+        let record = discovery_record(&config, &snapshot, 9_000).unwrap();
+        assert_eq!(record.source, DiscoverySource::Manual);
+        assert_eq!(record.confidence, DiscoveryConfidence::Paired);
+        assert_eq!(record.pairing_requirement, PairingRequirement::Credentials);
+        assert_eq!(record.native_bridge_id, "abc123");
+    }
+}

--- a/code/packages/rust/smart-home-reolink-integration/src/main.rs
+++ b/code/packages/rust/smart-home-reolink-integration/src/main.rs
@@ -1,0 +1,70 @@
+use serde_json::json;
+use smart_home_core::{BridgeId, VaultRef};
+use smart_home_reolink_integration::{
+    discovery_record, ReolinkClient, ReolinkConfig, ReolinkCredentials, ReolinkLanTransport,
+};
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("smart-home-reolink-integration: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let arguments = env::args().skip(1).collect::<Vec<_>>();
+    let [command, base_url] = arguments.as_slice() else {
+        return Err("usage: smart-home-reolink-integration inspect <base-url>".to_string());
+    };
+    if command != "inspect" {
+        return Err("usage: smart-home-reolink-integration inspect <base-url>".to_string());
+    }
+    let username =
+        env::var("REOLINK_USERNAME").map_err(|_| "REOLINK_USERNAME must be set".to_string())?;
+    let password =
+        env::var("REOLINK_PASSWORD").map_err(|_| "REOLINK_PASSWORD must be set".to_string())?;
+    let credential_ref = env::var("REOLINK_CREDENTIAL_REF")
+        .map_err(|_| "REOLINK_CREDENTIAL_REF must be set".to_string())?;
+    let config = ReolinkConfig::new(
+        BridgeId::trusted("reolink.cli"),
+        base_url,
+        VaultRef::new(credential_ref).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    let credentials =
+        ReolinkCredentials::new(username, password).map_err(|error| error.to_string())?;
+    let mut client = ReolinkClient::new(config, credentials, ReolinkLanTransport::default());
+    let snapshot = client.inspect().map_err(|error| error.to_string())?;
+    let record = discovery_record(client.config(), &snapshot, now_ms())
+        .map_err(|error| error.to_string())?;
+    println!(
+        "{}",
+        json!({
+            "id": record.native_bridge_id,
+            "name": record.display_name,
+            "model": record.hardware_model,
+            "firmware_version": record.firmware_version,
+            "address": record.address,
+            "channels": snapshot.channels.iter().map(|channel| json!({
+                "channel": channel.channel,
+                "name": channel.name,
+                "online": channel.online,
+                "sleeping": channel.sleeping,
+                "motion": channel.motion,
+            })).collect::<Vec<_>>(),
+        })
+    );
+    Ok(())
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -800,10 +800,12 @@ plugs, switches, and lights:
 These items move toward retiring an existing Home Assistant install:
 
 - Continue platform integrations beyond Hue, MQTT, ONVIF, Shelly Gen2/Gen3,
-  WLED, Govee LAN, LIFX LAN, Kasa legacy LAN, and the Z-Wave, Zigbee, and Matter
-  runtime adapters: ONVIF PullPoint camera events, RTSP media transfer and
-  recording, vendor-specific camera/NVR integrations, authenticated KLAP/Tapo
-  devices and other broader device families, a production Matter
+  WLED, Govee LAN, LIFX LAN, Kasa legacy LAN, authenticated Reolink CGI
+  device/channel/motion inspection, and the Z-Wave, Zigbee, and Matter runtime
+  adapters: ONVIF PullPoint camera events, RTSP media transfer and recording,
+  Reolink and other vendor-specific camera/NVR media, recording, control, and
+  push-event integrations, authenticated KLAP/Tapo devices and other broader
+  device families, a production Matter
   commissioning/secure-session/network host, a Thread border-router host, a
   production Zigbee coordinator/join/security host, and production Z-Wave
   inclusion and S2.


### PR DESCRIPTION
## Summary
- add a production Reolink HTTP/HTTPS CGI client with redacted, zeroized credentials and bounded login-token lifecycle
- authorize D23 reads before credential or network I/O, then normalize NVR channels and motion state into camera and sensor entities
- add a real loopback HTTP proof, CLI inspection path, precise catalog promotion, and remaining-work inventory update

## Scope boundaries
- does not claim RTSP media transfer, recording, PTZ control, webhook events, or ONVIF PullPoint events
- stores only the credential VaultRef in D23; credentials and session tokens never enter normalized state

## Validation
- `bash smart-home-reolink-integration/BUILD` (5 passed)
- `bash smart-home-integration-catalog/BUILD` (318 passed)
- `cargo clippy -p smart-home-reolink-integration -p smart-home-integration-catalog --all-targets -- -D warnings`
- generated `code/packages/rust/Cargo.lock` removed