### PR TITLE
fix(spice): validate MOS instance source area

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS instance `AS` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `AD` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `NRS` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2248,6 +2248,13 @@ fn parse_element(
                     ));
                 }
             }
+            if let Some(source_area) = instance_params.get("AS") {
+                if !source_area.is_finite() || *source_area < 0.0 {
+                    return Err(NetlistParseError::new(
+                        "MOSFET AS must be finite and non-negative",
+                    ));
+                }
+            }
             Ok(Element::Mosfet(Mosfet::with_model(
                 name,
                 &fields[1],

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -914,6 +914,20 @@ fn rejects_invalid_mosfet_instance_drain_areas() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_instance_source_areas() {
+    for source_area in ["-1p", "1e999"] {
+        let error = parse_netlist(&format!(".model nch NMOS\nM1 d g s b nch AS={source_area}"))
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET AS must be finite and non-negative"));
+    }
+
+    assert!(parse_netlist(".model nch NMOS\nM1 d g s b nch AS=0").is_ok());
+}
+
+#[test]
 fn parses_tf_transfer_function_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS instance drain-area validation.
+1. Rust Berkeley SPICE MOS instance source-area validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite instance `AD` values before lowering MOS
+   - Reject negative and non-finite instance `AS` values before lowering MOS
      elements into engine parameters.
-   - Preserve zero and positive drain areas for bulk-junction behavior.
+   - Preserve zero and positive source areas for bulk-junction behavior.
 
 ## Completed Slices
 
@@ -3892,6 +3892,12 @@ the Rust, Python, and TypeScript surfaces together.
      MOS elements into engine parameters.
    - Zero and positive source-square counts remain accepted for `RSH * NRS`
      resistance.
+
+331. Rust Berkeley SPICE MOS instance drain-area validation.
+   - Status: completed in PR 9439.
+   - Negative and non-finite instance `AD` values are rejected before lowering
+     MOS elements into engine parameters.
+   - Zero and positive drain areas remain accepted for bulk-junction behavior.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS instance `AS` values before parser lowering
- preserve zero and positive source areas for bulk-junction behavior
- reconcile the SPICE implementation plan after #9439

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`