### PR TITLE
Add neural network learning labs and training microscope

### DIFF
--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1227 | 1080 | 98 | 58 | 6 | 1065 |
+| 1245 | 1139 | 98 | 59 | 7 | 1081 |
 
 ## Method
 
@@ -24,10 +24,10 @@ mention provides a complete lesson.
 
 | Priority | Dedicated | Related | Index only | Missing |
 | --- | ---: | ---: | ---: | ---: |
-| P0 | 86 | 25 | 5 | 56 |
+| P0 | 86 | 25 | 6 | 55 |
 | P1 | 9 | 22 | 0 | 90 |
 | P2 | 1 | 3 | 1 | 152 |
-| P3 | 2 | 8 | 0 | 767 |
+| P3 | 2 | 9 | 0 | 784 |
 
 ## P0 Backlog
 
@@ -101,8 +101,8 @@ mention provides a complete lesson.
 | `in-memory-data-store-protocol` | 13 | missing |
 | `resp-protocol` | 13 | missing |
 | `http-core` | 12 | missing |
+| `http1` | 12 | missing |
 | `url-parser` | 12 | missing |
-| `http1` | 11 | missing |
 | `type-checker-protocol` | 11 | missing |
 
 ### other
@@ -114,8 +114,8 @@ mention provides a complete lesson.
 | `note-frequency` | 15 | missing |
 | `pixel-container` | 15 | missing |
 | `rng` | 15 | missing |
-| `feature-normalization` | 14 | missing |
-| `trig` | 14 | missing |
+| `trig` | 15 | missing |
+| `feature-normalization` | 14 | index-only |
 | `uuid` | 14 | missing |
 | `in-memory-data-store` | 13 | missing |
 | `in-memory-data-store-engine` | 13 | missing |
@@ -491,6 +491,7 @@ mention provides a complete lesson.
 | `browser-extension-toolkit` | 1 | missing |
 | `forme-doc-page-shell` | 1 | missing |
 | `forme-style-to-terminal` | 1 | missing |
+| `smart-home-shelly-integration` | 1 | missing |
 | `venture-browser-core` | 1 | missing |
 | `venture-browser-macos` | 1 | missing |
 | `mosaic-pkg-card-browser` | 0 | missing |
@@ -606,6 +607,7 @@ mention provides a complete lesson.
 | `paint-vm-vulkan` | 1 | missing |
 | `paint-vm-wgpu` | 1 | missing |
 | `ui-components` | 1 | missing |
+| `venture-browser-windows` | 1 | missing |
 | `window-appkit` | 1 | missing |
 | `window-c` | 1 | missing |
 | `window-canvas` | 1 | missing |
@@ -810,7 +812,6 @@ mention provides a complete lesson.
 | `logic-stdlib` | 1 | missing |
 | `logic-vm` | 1 | missing |
 | `matrix-cuda` | 1 | missing |
-| `matrix-ir` | 1 | missing |
 | `matrix-ir-json` | 1 | missing |
 | `matrix-metal` | 1 | missing |
 | `matrix-profile` | 1 | missing |
@@ -1176,17 +1177,33 @@ mention provides a complete lesson.
 | `sixlowpan` | 1 | missing |
 | `skill-store` | 1 | missing |
 | `smart-home-automation-runtime` | 1 | missing |
+| `smart-home-camera-media` | 1 | missing |
 | `smart-home-capability-cage` | 1 | missing |
 | `smart-home-core` | 1 | missing |
+| `smart-home-dashboard-core` | 1 | missing |
 | `smart-home-discovery` | 1 | missing |
 | `smart-home-discovery-service` | 1 | missing |
 | `smart-home-event-streams` | 1 | missing |
+| `smart-home-govee-lan-integration` | 1 | missing |
+| `smart-home-home-assistant-dashboard-migration` | 1 | missing |
+| `smart-home-home-assistant-definitions` | 1 | missing |
+| `smart-home-home-assistant-export` | 1 | missing |
+| `smart-home-home-assistant-history` | 1 | missing |
+| `smart-home-home-assistant-migration` | 1 | missing |
 | `smart-home-hue-pairing-service` | 1 | missing |
 | `smart-home-integration-catalog` | 1 | missing |
+| `smart-home-kasa-lan-integration` | 1 | missing |
+| `smart-home-lifx-lan-integration` | 1 | missing |
+| `smart-home-matter-integration` | 1 | missing |
+| `smart-home-mqtt-integration` | 1 | missing |
+| `smart-home-onvif-integration` | 1 | missing |
 | `smart-home-registry` | 1 | missing |
 | `smart-home-runtime` | 1 | missing |
 | `smart-home-runtime-store` | 1 | missing |
 | `smart-home-testkit` | 1 | missing |
+| `smart-home-wled-integration` | 1 | missing |
+| `smart-home-zigbee-integration` | 1 | missing |
+| `smart-home-zwave-host` | 1 | missing |
 | `smart-home-zwave-integration` | 1 | missing |
 | `smt-lib-format` | 1 | missing |
 | `sparc-v8-gatelevel` | 1 | missing |

--- a/code/learning/README.md
+++ b/code/learning/README.md
@@ -21,6 +21,7 @@ There are four kinds of material in this directory:
 - [Cryptography](./cryptography/README.md)
 - [Language Tooling](./language-tooling/README.md)
 - [Documents and Media](./documents-media/README.md)
+- [Machine Learning](./machine-learning/README.md)
 - [SQL and Storage](./sql-storage/README.md)
 - [Python Ecosystem](./programming-languages/python-ecosystem.md)
 - [Human Languages](./human-languages/README.md) — personal curriculum, not a package companion
@@ -54,6 +55,7 @@ This table is the current answer to "what learning entry explains this package f
 | Intermediate representations | semantic IR, compiler IR, interpreter IR, lowering, source identity | [Intermediate representations](./language-tooling/intermediate-representations.md) |
 | WebAssembly | binary modules, LEB128, validation, instantiation, stack execution | [WebAssembly from bytes to execution](./language-tooling/webassembly-from-bytes-to-execution.md) |
 | Structured text | JSON, CSV, TOML, XML, lexing, parsing, values, serialization | [Structured text from bytes to values](./language-tooling/structured-text-from-bytes-to-values.md) |
+| Machine learning | `activation-functions`, `loss-functions`, `gradient-descent`, dense networks, autograd, neural graph execution | [Machine learning track](./machine-learning/README.md) |
 | SQL execution | lexing, parsing, logical query order, backends, SQLite | [From SQL text to stored rows](./sql-storage/from-sql-text-to-stored-rows.md) |
 | Barcodes | 1D/2D symbols, finite fields, Reed-Solomon correction, layout | [Barcodes and error correction](./documents-media/barcodes-and-error-correction.md) |
 | Python project conventions | packaging, linting, types, `uv`, `ruff`, `pyproject.toml` | [Modern Python ecosystem](./programming-languages/python-ecosystem.md) |

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -1,0 +1,77 @@
+# Machine Learning
+
+Machine learning is often introduced through a framework call that hides the
+interesting part. This track goes in the other direction: start with arithmetic
+small enough to do on paper, expose every intermediate value, and add
+abstractions only after their purpose is visible.
+
+The track has two equally important outputs:
+
+1. **Understanding:** plain-language lessons and interactive visualizers that
+   explain predictions, losses, gradients, representations, and optimization.
+2. **Portability:** deterministic lab fixtures that the same model can execute
+   in every supported programming language, with an optional Rust backend when
+   performance matters.
+
+## Start Here
+
+Read these in order and reproduce each worked calculation before training a
+larger network:
+
+1. [From Data to One Neuron](./from-data-to-one-neuron.md)
+2. [Backpropagation by Hand](./backpropagation-by-hand.md)
+3. [Matrix Math](../matrix-math.md)
+4. [Loss Functions](../loss-functions.md)
+5. [Gradient Descent](../gradient-descent.md)
+6. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+7. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+8. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+9. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+
+The [full curriculum](./curriculum.md) continues from these foundations through
+convolutional, recurrent, attention-based, generative, graph, and scaled neural
+networks.
+
+## Interactive Lab
+
+The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
+has three complementary views:
+
+- **Training microscope:** pause one update and reveal multiplication, bias,
+  activation, loss, chain-rule gradients, and parameter movement one phase at a
+  time.
+- **Linear lab:** compare 100 datasets, learning rates, loss functions, feature
+  scales, noise levels, and real-data slices.
+- **Hidden-layer lab:** inspect intermediate neuron activations and gradients
+  for XOR-like logic, bends, thresholds, circles, moons, and feature
+  interactions.
+
+## Language-Neutral Corpus
+
+The learning examples are not owned by the visualizer. NN03 stores their data,
+parameters, and golden numerical traces in
+`code/specs/fixtures/neural-learning-v1`. That lets a Rust CLI, a Go package, a
+Python notebook, or a browser visualizer explain the same computation.
+
+Validate the bootstrap corpus with:
+
+```text
+python code/scripts/validate_neural_learning_labs.py
+```
+
+The first four labs cover a weighted forward pass, Celsius regression, a
+sigmoid OR neuron, and the hidden representation used by a solved XOR network.
+
+## How to Study a Model
+
+For every new model family, use the same five passes:
+
+1. **Calculate:** work through one input and one prediction by hand.
+2. **Trace:** print or visualize every intermediate tensor and its shape.
+3. **Differentiate:** check one analytical gradient against finite differences.
+4. **Train:** watch a deterministic loss trajectory on a tiny dataset.
+5. **Scale:** run the identical model through the Rust execution backend and
+   compare results before increasing data or parameter counts.
+
+This discipline keeps larger networks connected to the small arithmetic they
+are built from.

--- a/code/learning/machine-learning/backpropagation-by-hand.md
+++ b/code/learning/machine-learning/backpropagation-by-hand.md
@@ -1,0 +1,145 @@
+# Backpropagation by Hand
+
+Backpropagation is bookkeeping for the chain rule. It starts with a visible
+mistake and walks backward through the operations that produced it.
+
+Use one neuron and one training example:
+
+```text
+x = 2        target = 1
+w = 0.5      b = 0.1
+learning rate = 0.1
+activation = identity
+loss = squared error
+```
+
+## 1. Forward Pass
+
+First calculate the prediction:
+
+```text
+weighted input z_weighted = x * w = 2 * 0.5 = 1
+pre-activation z          = z_weighted + b = 1.1
+prediction                = identity(z) = 1.1
+```
+
+## 2. Measure the Mistake
+
+The error is prediction minus target:
+
+```text
+error = 1.1 - 1 = 0.1
+```
+
+Squared error makes the loss positive and penalizes larger mistakes more:
+
+```text
+loss = error^2 = 0.1^2 = 0.01
+```
+
+The loss is one number. Training must turn that number into a direction for
+every parameter.
+
+## 3. Walk Backward
+
+Start with how loss changes when the prediction changes:
+
+```text
+d_loss/d_prediction = 2 * error = 0.2
+```
+
+The identity activation has derivative `1`:
+
+```text
+d_prediction/d_z = 1
+```
+
+The pre-activation sum contains `x * w + b`, so:
+
+```text
+d_z/d_w = x = 2
+d_z/d_b = 1
+```
+
+Multiply the local derivatives along each path.
+
+For the weight:
+
+```text
+d_loss/d_w
+  = d_loss/d_prediction * d_prediction/d_z * d_z/d_w
+  = 0.2 * 1 * 2
+  = 0.4
+```
+
+For the bias:
+
+```text
+d_loss/d_b
+  = d_loss/d_prediction * d_prediction/d_z * d_z/d_b
+  = 0.2 * 1 * 1
+  = 0.2
+```
+
+Those two numbers are the gradients. Positive gradients say that increasing
+these parameters would increase the loss near the current point.
+
+## 4. Update the Parameters
+
+Gradient descent moves against each gradient:
+
+```text
+new_w = 0.5 - 0.1 * 0.4 = 0.46
+new_b = 0.1 - 0.1 * 0.2 = 0.08
+```
+
+Run the forward pass again:
+
+```text
+new prediction = 2 * 0.46 + 0.08 = 1
+new loss       = (1 - 1)^2 = 0
+```
+
+This example lands exactly on the target because it contains one row and a
+convenient learning rate. Real datasets ask the same parameters to balance many
+rows, so training normally takes repeated smaller steps.
+
+## Where Activations Enter the Chain
+
+If the activation were sigmoid, one additional derivative would scale the
+gradient:
+
+```text
+sigmoid_derivative = prediction * (1 - prediction)
+```
+
+Near prediction `0.5`, that derivative is `0.25`. Near prediction `0` or `1`,
+it becomes small. That is why saturated sigmoid neurons can learn slowly: the
+gradient is multiplied by a small local derivative before reaching earlier
+parameters.
+
+## Hidden Layers Use the Same Rule
+
+For a hidden neuron, the mistake is not compared directly with a target. Its
+signal arrives through every downstream connection:
+
+```text
+hidden_delta = downstream_delta * downstream_weight
+               * hidden_activation_derivative
+```
+
+Then the hidden neuron produces weight and bias gradients exactly as the single
+neuron did. A deeper network contains more paths and tensors, but no new
+calculus principle.
+
+## Check the Gradient Numerically
+
+A finite-difference check nudges one parameter by a tiny value `epsilon`:
+
+```text
+numerical_gradient =
+  (loss(w + epsilon) - loss(w - epsilon)) / (2 * epsilon)
+```
+
+The numerical result should be close to the backpropagated gradient. This is
+one of the most useful tests when implementing a new differentiable operation.

--- a/code/learning/machine-learning/curriculum.md
+++ b/code/learning/machine-learning/curriculum.md
@@ -1,0 +1,114 @@
+# Neural Network Curriculum
+
+This curriculum grows complexity along two dimensions: the mathematical
+capabilities shared by every network and the model families that use those
+capabilities differently.
+
+Do not treat it as a race to transformers. A later stage is useful only when
+you can inspect its tensors, validate its gradients, and explain why the added
+structure helps.
+
+## Shared Foundation
+
+| Stage | Build | Required understanding |
+| --- | --- | --- |
+| F0 | Fixed weighted neuron | Contributions, bias, activation |
+| F1 | Linear and logistic regression | Loss and gradient descent |
+| F2 | Perceptron and softmax classifier | Boundaries and multiclass output |
+| F3 | Two-layer MLP and XOR | Backpropagation through hidden features |
+| F4 | Deep MLP | initialization, normalization, dropout, residual paths |
+| F5 | Tensor/autograd engine | broadcasting, batches, saved values, gradient accumulation |
+| F6 | Compiled training step | NeuralIR, MatrixIR, Rust CPU/GPU execution |
+
+Every model family below starts with the smallest example that needs its new
+idea.
+
+## Spatial Track
+
+```text
+moving 1D filter
+  -> trainable 1D convolution
+  -> tiny image CNN
+  -> pooling and normalization
+  -> residual CNN
+  -> U-Net and vision transformer
+```
+
+The first visualizer should let the learner slide one kernel across one signal
+and inspect every multiply-accumulate before adding channels or batches.
+
+## Sequence Track
+
+```text
+one recurrent state value
+  -> Elman RNN
+  -> gated recurrent unit
+  -> LSTM
+  -> sequence-to-sequence model
+  -> attention and transformer
+```
+
+The first recurrent lab should unroll only three time steps and show how one
+parameter receives gradient contributions from each step.
+
+## Representation and Generation Track
+
+```text
+two-number bottleneck
+  -> tiny autoencoder
+  -> denoising autoencoder
+  -> variational autoencoder
+  -> small GAN
+  -> one-dimensional diffusion process
+  -> image diffusion model
+```
+
+Generation should begin with distributions and noise in one dimension. Images
+come after the learner can visualize what the model is trying to match.
+
+## Structured and Memory Track
+
+```text
+associative memory
+  -> Hopfield network
+  -> radial basis network / self-organizing map
+  -> message passing on a tiny graph
+  -> graph convolution
+  -> graph attention
+```
+
+These labs demonstrate that not every useful neural architecture is a stack of
+dense layers over a rectangular dataset.
+
+## Scaling Track
+
+Scaling is its own curriculum rather than a final switch:
+
+1. Vectorize one scalar loop.
+2. Batch several examples.
+3. Compile a full forward graph.
+4. Compile backward and optimizer graphs.
+5. Keep buffers resident across steps.
+6. Add f16 and bf16 with numerical checks.
+7. Quantize a trained tiny model and measure accuracy change.
+8. Split one model across devices.
+9. Replicate training data and synchronize gradients.
+
+Each step needs a correctness oracle and a benchmark. A GPU label without a
+real-hardware execution test is not evidence of acceleration.
+
+## Corpus Rule
+
+Every new curriculum unit should contribute all of the following:
+
+- a plain-language learning entry;
+- one hand-calculable example;
+- one interactive visualizer or trace view;
+- one deterministic language-neutral fixture;
+- finite-difference gradient checks when training is involved;
+- reference-versus-accelerated backend parity;
+- a small runnable program in at least one language;
+- a coverage entry showing which other language ports exist.
+
+This makes the learning corpus, implementations, and performance substrate grow
+together.

--- a/code/learning/machine-learning/from-data-to-one-neuron.md
+++ b/code/learning/machine-learning/from-data-to-one-neuron.md
@@ -1,0 +1,123 @@
+# From Data to One Neuron
+
+A neuron is not a little mind. It is a short numerical pipeline:
+
+```text
+inputs -> weighted contributions -> sum + bias -> activation -> prediction
+```
+
+Understanding that pipeline removes the first layer of neural-network magic.
+
+## One Input
+
+With one input `x`, weight `w`, and bias `b`, the raw prediction is:
+
+```text
+z = x * w + b
+```
+
+If the activation is the identity function, the final prediction is simply:
+
+```text
+prediction = z
+```
+
+Take this example:
+
+```text
+x = 2
+w = 0.5
+b = 0.1
+```
+
+The neuron performs two visible operations:
+
+```text
+weighted contribution = 2 * 0.5 = 1
+pre-activation sum     = 1 + 0.1 = 1.1
+prediction             = 1.1
+```
+
+The weight controls how strongly the input contributes. The bias moves the
+result even when the input is zero.
+
+## More Than One Input
+
+With two inputs, each input gets its own weight:
+
+```text
+z = x1 * w1 + x2 * w2 + b
+```
+
+The first NN03 fixture uses:
+
+```text
+x1 = 2       w1 = 0.5
+x2 = -1      w2 = -0.25
+b = 0.1
+```
+
+Work through each contribution separately:
+
+```text
+x1 * w1 = 2 * 0.5       = 1
+x2 * w2 = -1 * -0.25    = 0.25
+sum + b = 1 + 0.25 + 0.1 = 1.35
+```
+
+Writing contributions separately matters. Later, a large matrix multiplication
+will calculate thousands of these products at once, but it is still performing
+this same arithmetic.
+
+## Why Add an Activation?
+
+An activation transforms the raw sum:
+
+```text
+prediction = activation(z)
+```
+
+Common choices answer different questions:
+
+| Activation | Useful interpretation |
+| --- | --- |
+| Identity | Any real-valued regression output |
+| Sigmoid | A smooth value between 0 and 1 |
+| Tanh | A smooth value between -1 and 1 |
+| ReLU | Zero for negative evidence, linear for positive evidence |
+
+Without nonlinear activations, stacking dense layers still collapses into one
+linear transformation. Nonlinearity lets hidden layers bend, combine, and
+partition the input space.
+
+## A Batch Is Just Repetition
+
+A dataset contains several input rows. The neuron applies the same parameters
+to every row:
+
+```text
+row 1: prediction1 = x1 * w + b
+row 2: prediction2 = x2 * w + b
+row 3: prediction3 = x3 * w + b
+```
+
+Matrix notation compresses that repetition:
+
+```text
+predictions = XW + b
+```
+
+Here `X` contains the input rows, `W` contains the weights, and the bias is
+added to every row. Matrix notation changes the organization, not the meaning.
+
+## What the Neuron Does Not Do Yet
+
+So far the neuron only predicts. It does not know whether `1.1` is good. To
+learn, it needs:
+
+1. A target value.
+2. A loss that measures the mistake.
+3. Gradients that assign responsibility to each parameter.
+4. An optimizer that moves parameters in a better direction.
+
+That full update is the subject of [Backpropagation by Hand](./backpropagation-by-hand.md).

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,9 +4,26 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-This renderer app started as a tiny linear regression visualizer and is growing
-into a broader ML learning lab. It now includes 100 selectable examples that
-reuse one training shell:
+The app has three workbenches that move from one arithmetic update to small
+hidden-layer networks.
+
+### Training-step microscope
+
+The default view pauses one neuron on one training example and reveals seven
+phases:
+
+```text
+example -> multiply -> add bias -> activate -> loss -> backprop -> update
+```
+
+Future values stay hidden until their phase is selected. The learner can change
+the input, target, weight, bias, activation, and learning rate, inspect the
+chain-rule factors, and apply exactly one proposed update.
+
+### Linear lab
+
+The linear workbench includes 100 selectable examples that reuse one training
+shell:
 
 ```text
 y = weight * x + bias
@@ -15,6 +32,13 @@ y = weight * x + bias
 You can tune the learning rate, initial weight, initial bias, loss function, and
 activation preview, then step through gradient descent while the fitted line,
 prediction points, loss, gradients, and error distances update.
+
+### Hidden-layer lab
+
+The hidden workbench traces XOR-like logic, absolute value, piecewise pricing,
+circle classification, two moons, and feature interactions. It exposes selected
+hidden activations, matrix shapes, gradients, parameter updates, and the shared
+neural graph VM execution path.
 
 ## Lab Families
 
@@ -32,6 +56,11 @@ The browser app should not live-load Hugging Face, Kaggle, or other remote
 datasets. Small teaching datasets can be checked in as local JSON or CSV only
 when their license and source are clear. Dataset notes live in
 `src/data/SOURCES.md`.
+
+The smallest canonical examples also live in the language-neutral NN03 corpus
+under `code/specs/fixtures/neural-learning-v1`. That corpus pins forward values
+and first-step gradients so other language implementations can reproduce the
+same visualized arithmetic.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -3,6 +3,7 @@ import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
+import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import {
   loss,
   meanAbsoluteError,
@@ -166,7 +167,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 }
 
 export function App() {
-  const [workbench, setWorkbench] = useState<"linear" | "hidden">("linear");
+  const [workbench, setWorkbench] = useState<"microscope" | "linear" | "hidden">("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
   const [activationKind, setActivationKind] = useState<ActivationKind>("linear");
@@ -267,11 +268,24 @@ export function App() {
     <div className="app">
       <header className="app-header">
         <div>
-          <p className="eyebrow">{workbench === "linear" ? "100-lab foundation" : "Hidden-layer playground"}</p>
+          <p className="eyebrow">
+            {workbench === "microscope"
+              ? "No hidden magic"
+              : workbench === "linear"
+                ? "100-lab foundation"
+                : "Hidden-layer playground"}
+          </p>
           <h1>ML Learning Lab</h1>
         </div>
         <div className="header-actions">
           <div className="mode-toggle" aria-label="Workbench mode">
+            <button
+              className={workbench === "microscope" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("microscope")}
+            >
+              Microscope
+            </button>
             <button
               className={workbench === "linear" ? "mode-button mode-button--active" : "mode-button"}
               type="button"
@@ -288,7 +302,9 @@ export function App() {
             </button>
           </div>
           <div className="formula">
-            {workbench === "linear" ? (
+            {workbench === "microscope" ? (
+              <>forward {"->"} <strong>loss</strong> {"->"} gradients {"->"} update</>
+            ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
               <>inputs {"->"} <strong>hidden</strong> {"->"} prediction</>
@@ -297,7 +313,9 @@ export function App() {
         </div>
       </header>
 
-      {workbench === "hidden" ? <HiddenLayerWorkbench /> : (
+      {workbench === "microscope" ? (
+        <TrainingStepMicroscope />
+      ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">
           <div className="rail-summary">

--- a/code/programs/typescript/ml-learning-visualizer/src/TrainingStepMicroscope.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/TrainingStepMicroscope.tsx
@@ -1,0 +1,297 @@
+import { useMemo, useState } from "react";
+import {
+  DEFAULT_MICROSCOPE_STATE,
+  traceTrainingStep,
+  type MicroscopeActivation,
+  type MicroscopeState,
+  type MicroscopeTrace,
+} from "./training-microscope.js";
+
+interface PhaseDefinition {
+  id: string;
+  shortLabel: string;
+  title: string;
+  question: string;
+  formula: (trace: MicroscopeTrace) => string;
+  value: (trace: MicroscopeTrace) => string;
+  explanation: (trace: MicroscopeTrace) => string;
+}
+
+function formatNumber(value: number, digits = 5): string {
+  if (!Number.isFinite(value)) {
+    return String(value);
+  }
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  if (Math.abs(value) >= 1000 || (Math.abs(value) > 0 && Math.abs(value) < 0.0001)) {
+    return value.toExponential(3);
+  }
+  return Number(value.toFixed(digits)).toString();
+}
+
+const PHASES: readonly PhaseDefinition[] = [
+  {
+    id: "example",
+    shortLabel: "Example",
+    title: "Choose one training example",
+    question: "What information is the neuron trying to connect?",
+    formula: (trace) => `x = ${formatNumber(trace.input)}, target = ${formatNumber(trace.target)}`,
+    value: (trace) => `x ${formatNumber(trace.input)} / target ${formatNumber(trace.target)}`,
+    explanation: () => "The input is evidence. The target is the answer we want this one neuron to approach.",
+  },
+  {
+    id: "multiply",
+    shortLabel: "Multiply",
+    title: "Scale the input by its weight",
+    question: "How strongly does this input contribute?",
+    formula: (trace) => `${formatNumber(trace.input)} x ${formatNumber(trace.weight)} = ${formatNumber(trace.weightedInput)}`,
+    value: (trace) => formatNumber(trace.weightedInput),
+    explanation: (trace) => `The current weight ${formatNumber(trace.weight)} turns the input into one weighted contribution.`,
+  },
+  {
+    id: "bias",
+    shortLabel: "Add bias",
+    title: "Shift the weighted contribution",
+    question: "What should the neuron predict when its input contribution is zero?",
+    formula: (trace) => `${formatNumber(trace.weightedInput)} + ${formatNumber(trace.bias)} = ${formatNumber(trace.preActivation)}`,
+    value: (trace) => `z = ${formatNumber(trace.preActivation)}`,
+    explanation: (trace) => `The bias ${formatNumber(trace.bias)} shifts the neuron before any activation is applied.`,
+  },
+  {
+    id: "activation",
+    shortLabel: "Activate",
+    title: "Transform the raw sum",
+    question: "What range or shape should the output have?",
+    formula: (trace) => `${trace.activation}(${formatNumber(trace.preActivation)}) = ${formatNumber(trace.prediction)}`,
+    value: (trace) => `prediction ${formatNumber(trace.prediction)}`,
+    explanation: (trace) => `The ${trace.activation} activation transforms z into the value compared with the target.`,
+  },
+  {
+    id: "loss",
+    shortLabel: "Measure loss",
+    title: "Turn the mistake into one score",
+    question: "How wrong is the current prediction?",
+    formula: (trace) => `(${formatNumber(trace.prediction)} - ${formatNumber(trace.target)})^2 = ${formatNumber(trace.loss)}`,
+    value: (trace) => `loss ${formatNumber(trace.loss)}`,
+    explanation: (trace) => `The signed error is ${formatNumber(trace.error)}. Squaring it makes the score positive and magnifies larger mistakes.`,
+  },
+  {
+    id: "backprop",
+    shortLabel: "Backprop",
+    title: "Assign responsibility with the chain rule",
+    question: "How much did each parameter contribute to the loss?",
+    formula: (trace) => `dL/dw = ${formatNumber(trace.lossPredictionDerivative)} x ${formatNumber(trace.activationDerivative)} x ${formatNumber(trace.input)} = ${formatNumber(trace.gradientWeight)}`,
+    value: (trace) => `dw ${formatNumber(trace.gradientWeight)} / db ${formatNumber(trace.gradientBias)}`,
+    explanation: () => "Backpropagation multiplies local derivatives along each path from the loss to a parameter.",
+  },
+  {
+    id: "update",
+    shortLabel: "Update",
+    title: "Move the parameters against the gradient",
+    question: "What small change should reduce the loss?",
+    formula: (trace) => `w' = ${formatNumber(trace.weight)} - ${formatNumber(trace.learningRate)} x ${formatNumber(trace.gradientWeight)} = ${formatNumber(trace.nextWeight)}`,
+    value: (trace) => `w' ${formatNumber(trace.nextWeight)} / b' ${formatNumber(trace.nextBias)}`,
+    explanation: (trace) => `With the proposed parameters, the loss changes from ${formatNumber(trace.loss)} to ${formatNumber(trace.nextLoss)}.`,
+  },
+];
+
+function numberValue(value: string, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function TrainingStepMicroscope() {
+  const [state, setState] = useState<MicroscopeState>(DEFAULT_MICROSCOPE_STATE);
+  const [phaseIndex, setPhaseIndex] = useState(0);
+  const [updateCount, setUpdateCount] = useState(0);
+  const trace = useMemo(() => traceTrainingStep(state), [state]);
+  const phase = PHASES[phaseIndex]!;
+
+  function setNumber(field: keyof Omit<MicroscopeState, "activation">, value: string): void {
+    setState((current) => ({ ...current, [field]: numberValue(value, current[field]) }));
+    setPhaseIndex(0);
+  }
+
+  function setActivation(value: MicroscopeActivation): void {
+    setState((current) => ({ ...current, activation: value }));
+    setPhaseIndex(0);
+  }
+
+  function applyUpdate(): void {
+    setState((current) => {
+      const currentTrace = traceTrainingStep(current);
+      return {
+        ...current,
+        weight: Number(currentTrace.nextWeight.toPrecision(12)),
+        bias: Number(currentTrace.nextBias.toPrecision(12)),
+      };
+    });
+    setUpdateCount((count) => count + 1);
+    setPhaseIndex(0);
+  }
+
+  function reset(): void {
+    setState(DEFAULT_MICROSCOPE_STATE);
+    setPhaseIndex(0);
+    setUpdateCount(0);
+  }
+
+  return (
+    <main className="workspace workspace--microscope">
+      <section className="microscope-stage" aria-label="Training step microscope">
+        <div className="lab-intro">
+          <div>
+            <p className="eyebrow">One neuron / one example / one update</p>
+            <h2>Training-step microscope</h2>
+            <p>Reveal the arithmetic in order. Future phases stay hidden until you reach them.</p>
+          </div>
+          <div className="lab-chip">update {updateCount}</div>
+        </div>
+
+        <ol className="phase-strip" aria-label="Training phases">
+          {PHASES.map((item, index) => (
+            <li key={item.id}>
+              <button
+                className={`phase-button${index === phaseIndex ? " phase-button--active" : ""}${index < phaseIndex ? " phase-button--complete" : ""}`}
+                type="button"
+                onClick={() => setPhaseIndex(index)}
+                aria-current={index === phaseIndex ? "step" : undefined}
+              >
+                <span>{index + 1}</span>
+                {item.shortLabel}
+              </button>
+            </li>
+          ))}
+        </ol>
+
+        <section className="microscope-focus" aria-live="polite">
+          <div>
+            <p className="eyebrow">Phase {phaseIndex + 1} of {PHASES.length}</p>
+            <h2>{phase.title}</h2>
+            <p className="focus-question">{phase.question}</p>
+          </div>
+          <code>{phase.formula(trace)}</code>
+          <p>{phase.explanation(trace)}</p>
+        </section>
+
+        <section className="signal-pipeline" aria-label="Neuron signal pipeline">
+          {PHASES.map((item, index) => (
+            <button
+              key={item.id}
+              className={`signal-node${index === phaseIndex ? " signal-node--active" : ""}${index > phaseIndex ? " signal-node--locked" : ""}`}
+              type="button"
+              onClick={() => setPhaseIndex(index)}
+            >
+              <span>{item.shortLabel}</span>
+              <strong>{index <= phaseIndex ? item.value(trace) : "?"}</strong>
+            </button>
+          ))}
+        </section>
+
+        {phase.id === "backprop" && (
+          <section className="derivative-panel" aria-label="Chain rule factors">
+            <div className="derivative-factor">
+              <span>Loss slope</span>
+              <code>dL/dy = {formatNumber(trace.lossPredictionDerivative)}</code>
+            </div>
+            <div className="derivative-times" aria-hidden="true">x</div>
+            <div className="derivative-factor">
+              <span>Activation slope</span>
+              <code>dy/dz = {formatNumber(trace.activationDerivative)}</code>
+            </div>
+            <div className="derivative-times" aria-hidden="true">x</div>
+            <div className="derivative-factor">
+              <span>Weight path</span>
+              <code>dz/dw = {formatNumber(trace.preActivationWeightDerivative)}</code>
+            </div>
+            <div className="derivative-equals" aria-hidden="true">=</div>
+            <div className="derivative-factor derivative-factor--result">
+              <span>Weight gradient</span>
+              <code>dL/dw = {formatNumber(trace.gradientWeight)}</code>
+            </div>
+          </section>
+        )}
+
+        {phase.id === "update" && (
+          <section className="before-after" aria-label="Parameter update result">
+            <div>
+              <span>Before</span>
+              <strong>w {formatNumber(trace.weight)} / b {formatNumber(trace.bias)}</strong>
+              <small>prediction {formatNumber(trace.prediction)} / loss {formatNumber(trace.loss)}</small>
+            </div>
+            <div className="update-arrow" aria-hidden="true">-&gt;</div>
+            <div>
+              <span>After proposed update</span>
+              <strong>w {formatNumber(trace.nextWeight)} / b {formatNumber(trace.nextBias)}</strong>
+              <small>prediction {formatNumber(trace.nextPrediction)} / loss {formatNumber(trace.nextLoss)}</small>
+            </div>
+          </section>
+        )}
+
+        <div className="microscope-actions">
+          <button type="button" disabled={phaseIndex === 0} onClick={() => setPhaseIndex((index) => Math.max(0, index - 1))}>Previous phase</button>
+          {phaseIndex < PHASES.length - 1 ? (
+            <button className="primary-action" type="button" onClick={() => setPhaseIndex((index) => Math.min(PHASES.length - 1, index + 1))}>Next phase</button>
+          ) : (
+            <button className="primary-action" type="button" onClick={applyUpdate}>Apply this update</button>
+          )}
+          <button type="button" onClick={reset}>Reset example</button>
+        </div>
+      </section>
+
+      <aside className="controls microscope-controls" aria-label="Microscope values">
+        <div className="lesson">
+          <span>Change one thing</span>
+          <p>Adjust a value, then step forward again and watch where its effect first appears.</p>
+        </div>
+
+        <label className="field">
+          <span>Input x</span>
+          <input aria-label="Input x" type="number" step="0.1" value={state.input} onChange={(event) => setNumber("input", event.target.value)} />
+        </label>
+        <label className="field">
+          <span>Target</span>
+          <input aria-label="Target" type="number" step="0.1" value={state.target} onChange={(event) => setNumber("target", event.target.value)} />
+        </label>
+        <div className="field-grid">
+          <label className="field">
+            <span>Weight w</span>
+            <input aria-label="Weight w" type="number" step="0.05" value={state.weight} onChange={(event) => setNumber("weight", event.target.value)} />
+          </label>
+          <label className="field">
+            <span>Bias b</span>
+            <input aria-label="Bias b" type="number" step="0.05" value={state.bias} onChange={(event) => setNumber("bias", event.target.value)} />
+          </label>
+        </div>
+        <label className="field">
+          <span>Activation</span>
+          <select aria-label="Activation" value={state.activation} onChange={(event) => setActivation(event.target.value as MicroscopeActivation)}>
+            <option value="linear">Identity / linear</option>
+            <option value="sigmoid">Sigmoid</option>
+            <option value="tanh">Tanh</option>
+            <option value="relu">ReLU</option>
+          </select>
+        </label>
+        <label className="field">
+          <span>Learning rate</span>
+          <input aria-label="Learning rate" type="number" min="0.0001" step="0.01" value={state.learningRate} onChange={(event) => setNumber("learningRate", event.target.value)} />
+        </label>
+
+        <div className="metric">
+          <span>Current prediction</span>
+          <strong>{formatNumber(trace.prediction)}</strong>
+        </div>
+        <div className="metric">
+          <span>Current loss</span>
+          <strong>{formatNumber(trace.loss)}</strong>
+        </div>
+        <div className="gradients">
+          <span>Proposed gradients</span>
+          <code>dL/dw = {formatNumber(trace.gradientWeight)}</code>
+          <code>dL/db = {formatNumber(trace.gradientBias)}</code>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -136,7 +136,7 @@ h2 {
 
 .mode-toggle {
   display: inline-grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: 4px;
   padding: 4px;
   border: 1px solid $line;
@@ -169,6 +169,235 @@ h2 {
   grid-template-columns: 260px minmax(520px, 1fr) 310px;
   gap: 14px;
   align-items: start;
+}
+
+.workspace--microscope {
+  display: grid;
+  grid-template-columns: minmax(560px, 1fr) 320px;
+  gap: 14px;
+  align-items: start;
+}
+
+.microscope-stage {
+  display: grid;
+  gap: 12px;
+}
+
+.microscope-controls,
+.microscope-focus,
+.derivative-panel,
+.before-after {
+  @include surface;
+}
+
+.phase-strip {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(76px, 1fr));
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.phase-button {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  min-height: 58px;
+  padding: 7px 5px;
+  border-color: $line;
+  color: $muted;
+  font-size: 0.72rem;
+}
+
+.phase-button span {
+  display: block;
+  width: 22px;
+  height: 22px;
+  margin: 0 auto;
+  border-radius: 50%;
+  background: #eef4f0;
+  color: $ink;
+  line-height: 22px;
+}
+
+.phase-button--complete {
+  border-color: rgba(35, 122, 87, 0.42);
+  color: $green;
+}
+
+.phase-button--complete span {
+  background: rgba(35, 122, 87, 0.14);
+  color: $green;
+}
+
+.phase-button--active {
+  border-color: rgba(37, 99, 235, 0.58);
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.phase-button--active span {
+  background: $blue;
+  color: #ffffff;
+}
+
+.microscope-focus {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.8fr) minmax(260px, 1fr);
+  gap: 10px 24px;
+  min-height: 180px;
+  padding: 18px;
+}
+
+.microscope-focus code {
+  align-self: center;
+  min-height: 52px;
+  padding: 14px;
+  background: #edf4ff;
+  color: #173f8a;
+  font-size: 0.94rem;
+}
+
+.microscope-focus p {
+  margin: 0;
+  color: $muted;
+}
+
+.microscope-focus > p {
+  grid-column: 1 / -1;
+}
+
+.focus-question {
+  margin-top: 8px !important;
+  font-weight: 750;
+}
+
+.signal-pipeline {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(94px, 1fr));
+  gap: 8px;
+  overflow-x: auto;
+  padding: 2px 0;
+}
+
+.signal-node {
+  display: grid;
+  align-content: center;
+  gap: 7px;
+  min-height: 92px;
+  padding: 9px;
+  border-color: rgba(35, 122, 87, 0.32);
+  background: #ffffff;
+}
+
+.signal-node span {
+  color: $muted;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+
+.signal-node strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.82rem;
+}
+
+.signal-node--active {
+  border-color: rgba(37, 99, 235, 0.62);
+  background: #edf4ff;
+}
+
+.signal-node--locked {
+  border-style: dashed;
+  background: rgba(255, 255, 255, 0.46);
+  color: $muted;
+}
+
+.derivative-panel {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) auto minmax(120px, 1fr) auto minmax(120px, 1fr) auto minmax(140px, 1fr);
+  align-items: center;
+  gap: 8px;
+  padding: 14px;
+}
+
+.derivative-factor {
+  display: grid;
+  gap: 5px;
+}
+
+.derivative-factor span,
+.before-after span {
+  color: $muted;
+  font-size: 0.7rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.derivative-factor--result code {
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.derivative-times,
+.derivative-equals {
+  color: $muted;
+  font-weight: 850;
+}
+
+.before-after {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 14px;
+  padding: 15px;
+}
+
+.before-after > div:not(.update-arrow) {
+  display: grid;
+  gap: 4px;
+}
+
+.before-after strong,
+.before-after small {
+  display: block;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.before-after small {
+  color: $muted;
+}
+
+.update-arrow {
+  color: $blue;
+  font-size: 1.5rem;
+  font-weight: 850;
+}
+
+.microscope-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.microscope-actions button {
+  padding: 0 14px;
+}
+
+.microscope-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.primary-action {
+  border-color: $green;
+  background: $green;
+  color: #ffffff;
+}
+
+.primary-action:hover {
+  border-color: #195b40;
+  background: #195b40;
 }
 
 .lab-rail,
@@ -680,8 +909,13 @@ code {
     grid-template-columns: 270px minmax(420px, 1fr);
   }
 
-  .metrics {
+  .metrics,
+  .microscope-controls {
     grid-column: 1 / -1;
+  }
+
+  .workspace--microscope {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -703,7 +937,8 @@ code {
   }
 
   .workspace--lab,
-  .workspace--hidden {
+  .workspace--hidden,
+  .workspace--microscope {
     grid-template-columns: 1fr;
   }
 
@@ -717,5 +952,43 @@ code {
 
   .table-row {
     grid-template-columns: 1fr;
+  }
+
+  .mode-toggle {
+    grid-template-columns: 1fr;
+  }
+
+  .phase-strip {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .microscope-focus {
+    grid-template-columns: 1fr;
+  }
+
+  .microscope-focus > p {
+    grid-column: auto;
+  }
+
+  .signal-pipeline {
+    grid-template-columns: repeat(2, minmax(130px, 1fr));
+    overflow: visible;
+  }
+
+  .derivative-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .derivative-times,
+  .derivative-equals {
+    display: none;
+  }
+
+  .before-after {
+    grid-template-columns: 1fr;
+  }
+
+  .update-arrow {
+    transform: rotate(90deg);
   }
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/training-microscope.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training-microscope.ts
@@ -1,0 +1,101 @@
+import { activate, type ActivationKind } from "./activation.js";
+
+export type MicroscopeActivation = Extract<ActivationKind, "linear" | "sigmoid" | "tanh" | "relu">;
+
+export interface MicroscopeState {
+  input: number;
+  target: number;
+  weight: number;
+  bias: number;
+  learningRate: number;
+  activation: MicroscopeActivation;
+}
+
+export interface MicroscopeTrace extends MicroscopeState {
+  weightedInput: number;
+  preActivation: number;
+  prediction: number;
+  error: number;
+  loss: number;
+  lossPredictionDerivative: number;
+  activationDerivative: number;
+  preActivationWeightDerivative: number;
+  preActivationBiasDerivative: number;
+  gradientWeight: number;
+  gradientBias: number;
+  nextWeight: number;
+  nextBias: number;
+  nextPrediction: number;
+  nextLoss: number;
+}
+
+export const DEFAULT_MICROSCOPE_STATE: MicroscopeState = {
+  input: 2,
+  target: 1,
+  weight: 0.5,
+  bias: 0.1,
+  learningRate: 0.1,
+  activation: "linear",
+};
+
+export function activationDerivative(
+  raw: number,
+  output: number,
+  activation: MicroscopeActivation,
+): number {
+  switch (activation) {
+    case "linear":
+      return 1;
+    case "sigmoid":
+      return output * (1 - output);
+    case "tanh":
+      return 1 - output * output;
+    case "relu":
+      return raw > 0 ? 1 : 0;
+  }
+}
+
+export function traceTrainingStep(state: MicroscopeState): MicroscopeTrace {
+  const weightedInput = state.input * state.weight;
+  const preActivation = weightedInput + state.bias;
+  const prediction = activate(preActivation, state.activation);
+  const error = prediction - state.target;
+  const loss = error * error;
+  const lossPredictionDerivative = 2 * error;
+  const localActivationDerivative = activationDerivative(
+    preActivation,
+    prediction,
+    state.activation,
+  );
+  const preActivationWeightDerivative = state.input;
+  const preActivationBiasDerivative = 1;
+  const gradientWeight = lossPredictionDerivative
+    * localActivationDerivative
+    * preActivationWeightDerivative;
+  const gradientBias = lossPredictionDerivative
+    * localActivationDerivative
+    * preActivationBiasDerivative;
+  const nextWeight = state.weight - state.learningRate * gradientWeight;
+  const nextBias = state.bias - state.learningRate * gradientBias;
+  const nextPrediction = activate(state.input * nextWeight + nextBias, state.activation);
+  const nextError = nextPrediction - state.target;
+
+  return {
+    ...state,
+    weightedInput,
+    preActivation,
+    prediction,
+    error,
+    loss,
+    lossPredictionDerivative,
+    activationDerivative: localActivationDerivative,
+    preActivationWeightDerivative,
+    preActivationBiasDerivative,
+    gradientWeight,
+    gradientBias,
+    nextWeight,
+    nextBias,
+    nextPrediction,
+    nextLoss: nextError * nextError,
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -3,6 +3,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { activate } from "./activation.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
+import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import { forwardLayered } from "./layered-network.js";
 import {
   CELSIUS_DATASET,
@@ -22,6 +23,10 @@ import {
 } from "./hidden-layer-examples.js";
 import { predictLayeredWithVm, predictLinearWithVm } from "./neural-vm.js";
 import { renderHiddenNetworkSvg, renderLinearNetworkSvg } from "./NetworkDiagram.js";
+import {
+  DEFAULT_MICROSCOPE_STATE,
+  traceTrainingStep,
+} from "./training-microscope.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -91,6 +96,37 @@ describe("training helpers", () => {
     expect(activate(-2, "leakyRelu")).toBeCloseTo(-0.2);
     expect(activate(0, "sigmoid")).toBeCloseTo(0.5);
     expect(activate(0, "tanh")).toBeCloseTo(0);
+  });
+
+  it("traces the hand-calculated one-neuron training update", () => {
+    const trace = traceTrainingStep(DEFAULT_MICROSCOPE_STATE);
+
+    expect(trace.weightedInput).toBeCloseTo(1);
+    expect(trace.preActivation).toBeCloseTo(1.1);
+    expect(trace.prediction).toBeCloseTo(1.1);
+    expect(trace.loss).toBeCloseTo(0.01);
+    expect(trace.gradientWeight).toBeCloseTo(0.4);
+    expect(trace.gradientBias).toBeCloseTo(0.2);
+    expect(trace.nextWeight).toBeCloseTo(0.46);
+    expect(trace.nextBias).toBeCloseTo(0.08);
+    expect(trace.nextPrediction).toBeCloseTo(1);
+    expect(trace.nextLoss).toBeCloseTo(0);
+  });
+
+  it("reveals and applies one update in the training microscope", () => {
+    render(React.createElement(TrainingStepMicroscope));
+
+    expect(screen.getByRole("heading", { name: "Choose one training example" })).toBeTruthy();
+    for (let phase = 1; phase < 7; phase += 1) {
+      fireEvent.click(screen.getByRole("button", { name: "Next phase" }));
+    }
+    expect(screen.getByRole("heading", { name: "Move the parameters against the gradient" })).toBeTruthy();
+    expect(screen.getByText("After proposed update")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply this update" }));
+    expect(Number((screen.getByLabelText("Weight w") as HTMLInputElement).value)).toBeCloseTo(0.46);
+    expect(Number((screen.getByLabelText("Bias b") as HTMLInputElement).value)).toBeCloseTo(0.08);
+    expect(screen.getByText("update 1")).toBeTruthy();
   });
 
   it("registers the hidden-layer teaching examples without sine yet", () => {

--- a/code/scripts/tests/test_neural_learning_labs.py
+++ b/code/scripts/tests/test_neural_learning_labs.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = ROOT / "code" / "scripts" / "validate_neural_learning_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_neural_learning_labs", SCRIPT_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class NeuralLearningLabTests(unittest.TestCase):
+    def test_checked_in_corpus_is_valid(self) -> None:
+        paths = MODULE.validate_corpus()
+        self.assertEqual(
+            [path.name for path in paths],
+            [
+                "00-weighted-neuron.json",
+                "01-celsius-linear-regression.json",
+                "02-or-sigmoid-neuron.json",
+                "03-xor-hidden-representation.json",
+            ],
+        )
+
+    def test_weighted_neuron_exposes_the_hand_calculated_value(self) -> None:
+        path = MODULE.DEFAULT_FIXTURE_ROOT / "labs" / "00-weighted-neuron.json"
+        lab = MODULE.load_json(path)
+        result = MODULE.forward(lab)
+        self.assertAlmostEqual(result["predictions"][0][0], 1.35)
+
+    def test_training_trace_detects_a_changed_gradient(self) -> None:
+        path = MODULE.DEFAULT_FIXTURE_ROOT / "labs" / "02-or-sigmoid-neuron.json"
+        lab = MODULE.load_json(path)
+        broken = copy.deepcopy(lab)
+        broken["expected"]["first_step"]["gradients"][0]["biases"][0] = 99
+        with self.assertRaisesRegex(MODULE.LabValidationError, "biases"):
+            MODULE.validate_lab(broken, "broken-or")
+
+    def test_shape_validation_rejects_a_ragged_weight_matrix(self) -> None:
+        path = (
+            MODULE.DEFAULT_FIXTURE_ROOT / "labs" / "03-xor-hidden-representation.json"
+        )
+        lab = MODULE.load_json(path)
+        broken = copy.deepcopy(lab)
+        broken["model"]["layers"][0]["weights"][1].pop()
+        with self.assertRaisesRegex(MODULE.LabValidationError, "equal widths"):
+            MODULE.validate_lab(broken, "broken-xor")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/validate_neural_learning_labs.py
+++ b/code/scripts/validate_neural_learning_labs.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN03 neural-learning corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = REPO_ROOT / "code" / "specs" / "fixtures" / "neural-learning-v1"
+ACTIVATIONS = {"identity", "sigmoid", "tanh", "relu"}
+
+
+class LabValidationError(ValueError):
+    """Raised when a learning lab is structurally or numerically invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise LabValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                LabValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise LabValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise LabValidationError(f"{path}: top-level JSON value must be an object")
+    return document
+
+
+def _require_keys(value: dict[str, Any], required: set[str], context: str) -> None:
+    missing = required - value.keys()
+    extra = value.keys() - required
+    if missing:
+        raise LabValidationError(f"{context}: missing keys {sorted(missing)}")
+    if extra:
+        raise LabValidationError(f"{context}: unexpected keys {sorted(extra)}")
+
+
+def _require_number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise LabValidationError(f"{context}: expected a number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise LabValidationError(f"{context}: expected a finite number")
+    return number
+
+
+def _number_vector(value: Any, context: str) -> list[float]:
+    if not isinstance(value, list) or not value:
+        raise LabValidationError(f"{context}: expected a non-empty number vector")
+    return [
+        _require_number(item, f"{context}[{index}]") for index, item in enumerate(value)
+    ]
+
+
+def _number_matrix(value: Any, context: str) -> list[list[float]]:
+    if not isinstance(value, list) or not value:
+        raise LabValidationError(f"{context}: expected a non-empty number matrix")
+    rows = [
+        _number_vector(row, f"{context}[{index}]") for index, row in enumerate(value)
+    ]
+    width = len(rows[0])
+    if any(len(row) != width for row in rows):
+        raise LabValidationError(f"{context}: rows must have equal widths")
+    return rows
+
+
+def _activation(name: str, value: float) -> float:
+    if name == "identity":
+        return value
+    if name == "sigmoid":
+        if value >= 0:
+            return 1.0 / (1.0 + math.exp(-value))
+        exp_value = math.exp(value)
+        return exp_value / (1.0 + exp_value)
+    if name == "tanh":
+        return math.tanh(value)
+    if name == "relu":
+        return max(0.0, value)
+    raise LabValidationError(f"unsupported activation: {name}")
+
+
+def _activation_derivative(name: str, raw: float, output: float) -> float:
+    if name == "identity":
+        return 1.0
+    if name == "sigmoid":
+        return output * (1.0 - output)
+    if name == "tanh":
+        return 1.0 - output * output
+    if name == "relu":
+        return 1.0 if raw > 0 else 0.0
+    raise LabValidationError(f"unsupported activation: {name}")
+
+
+def _matmul(left: list[list[float]], right: list[list[float]]) -> list[list[float]]:
+    if not left or not right or len(left[0]) != len(right):
+        raise LabValidationError("matrix multiplication shape mismatch")
+    return [
+        [
+            sum(row[k] * right[k][column] for k in range(len(right)))
+            for column in range(len(right[0]))
+        ]
+        for row in left
+    ]
+
+
+def _transpose(matrix: list[list[float]]) -> list[list[float]]:
+    return [list(column) for column in zip(*matrix, strict=True)]
+
+
+def validate_structure(lab: dict[str, Any], source: str = "lab") -> None:
+    _require_keys(
+        lab,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "stage",
+            "question",
+            "concepts",
+            "model",
+            "dataset",
+            "training",
+            "expected",
+        },
+        source,
+    )
+    if lab["schema_version"] != 1:
+        raise LabValidationError(f"{source}: schema_version must be 1")
+    if not isinstance(lab["id"], str) or not lab["id"]:
+        raise LabValidationError(f"{source}: id must be a non-empty string")
+    if lab["stage"] not in {"forward", "single-neuron", "hidden-layer"}:
+        raise LabValidationError(f"{source}: invalid stage")
+    if not isinstance(lab["concepts"], list) or not lab["concepts"]:
+        raise LabValidationError(f"{source}: concepts must be a non-empty list")
+
+    model = lab["model"]
+    if not isinstance(model, dict):
+        raise LabValidationError(f"{source}.model: expected an object")
+    _require_keys(model, {"kind", "input_count", "layers"}, f"{source}.model")
+    input_count = model["input_count"]
+    if (
+        not isinstance(input_count, int)
+        or isinstance(input_count, bool)
+        or input_count < 1
+    ):
+        raise LabValidationError(
+            f"{source}.model.input_count: expected a positive integer"
+        )
+    if model["kind"] not in {"single-neuron", "dense-network"}:
+        raise LabValidationError(f"{source}.model.kind: invalid model kind")
+    if not isinstance(model["layers"], list) or not model["layers"]:
+        raise LabValidationError(f"{source}.model.layers: expected a non-empty list")
+
+    previous_width = input_count
+    layer_names: set[str] = set()
+    for index, layer in enumerate(model["layers"]):
+        context = f"{source}.model.layers[{index}]"
+        if not isinstance(layer, dict):
+            raise LabValidationError(f"{context}: expected an object")
+        _require_keys(layer, {"name", "weights", "biases", "activation"}, context)
+        if not isinstance(layer["name"], str) or not layer["name"]:
+            raise LabValidationError(f"{context}.name: expected a non-empty string")
+        if layer["name"] in layer_names:
+            raise LabValidationError(
+                f"{context}.name: duplicate layer name {layer['name']!r}"
+            )
+        layer_names.add(layer["name"])
+        if layer["activation"] not in ACTIVATIONS:
+            raise LabValidationError(f"{context}.activation: unsupported activation")
+        weights = _number_matrix(layer["weights"], f"{context}.weights")
+        biases = _number_vector(layer["biases"], f"{context}.biases")
+        if len(weights) != previous_width:
+            raise LabValidationError(
+                f"{context}.weights: expected {previous_width} input rows, got {len(weights)}"
+            )
+        if len(weights[0]) != len(biases):
+            raise LabValidationError(
+                f"{context}: weight output width must equal bias width"
+            )
+        previous_width = len(biases)
+
+    if model["kind"] == "single-neuron" and (
+        len(model["layers"]) != 1 or previous_width != 1
+    ):
+        raise LabValidationError(
+            f"{source}.model: single-neuron must have one layer and one output"
+        )
+
+    dataset = lab["dataset"]
+    if not isinstance(dataset, dict):
+        raise LabValidationError(f"{source}.dataset: expected an object")
+    _require_keys(
+        dataset, {"input_labels", "target_labels", "rows"}, f"{source}.dataset"
+    )
+    if len(dataset["input_labels"]) != input_count:
+        raise LabValidationError(
+            f"{source}.dataset.input_labels: width must match input_count"
+        )
+    if len(dataset["target_labels"]) != previous_width:
+        raise LabValidationError(
+            f"{source}.dataset.target_labels: width must match model output"
+        )
+    if not isinstance(dataset["rows"], list) or not dataset["rows"]:
+        raise LabValidationError(f"{source}.dataset.rows: expected a non-empty list")
+    labels: set[str] = set()
+    for index, row in enumerate(dataset["rows"]):
+        context = f"{source}.dataset.rows[{index}]"
+        if not isinstance(row, dict):
+            raise LabValidationError(f"{context}: expected an object")
+        _require_keys(row, {"label", "input", "target"}, context)
+        if not isinstance(row["label"], str) or not row["label"]:
+            raise LabValidationError(f"{context}.label: expected a non-empty string")
+        if row["label"] in labels:
+            raise LabValidationError(
+                f"{context}.label: duplicate row label {row['label']!r}"
+            )
+        labels.add(row["label"])
+        if len(_number_vector(row["input"], f"{context}.input")) != input_count:
+            raise LabValidationError(f"{context}.input: width must match input_count")
+        if len(_number_vector(row["target"], f"{context}.target")) != previous_width:
+            raise LabValidationError(f"{context}.target: width must match model output")
+
+    training = lab["training"]
+    expected = lab["expected"]
+    if not isinstance(expected, dict):
+        raise LabValidationError(f"{source}.expected: expected an object")
+    _require_keys(
+        expected, {"absolute_tolerance", "forward", "first_step"}, f"{source}.expected"
+    )
+    tolerance = _require_number(
+        expected["absolute_tolerance"], f"{source}.expected.absolute_tolerance"
+    )
+    if tolerance <= 0:
+        raise LabValidationError(
+            f"{source}.expected.absolute_tolerance: must be positive"
+        )
+    if not isinstance(expected["forward"], list) or len(expected["forward"]) != len(
+        labels
+    ):
+        raise LabValidationError(
+            f"{source}.expected.forward: must cover every dataset row"
+        )
+
+    if training is None:
+        if expected["first_step"] is not None:
+            raise LabValidationError(
+                f"{source}.expected.first_step: must be null without training"
+            )
+    else:
+        if not isinstance(training, dict):
+            raise LabValidationError(f"{source}.training: expected an object or null")
+        _require_keys(training, {"loss", "optimizer", "batch"}, f"{source}.training")
+        if training["loss"] != "mean-squared-error" or training["batch"] != "full":
+            raise LabValidationError(
+                f"{source}.training: V1 requires full-batch mean squared error"
+            )
+        optimizer = training["optimizer"]
+        if not isinstance(optimizer, dict):
+            raise LabValidationError(f"{source}.training.optimizer: expected an object")
+        _require_keys(
+            optimizer, {"kind", "learning_rate"}, f"{source}.training.optimizer"
+        )
+        if (
+            optimizer["kind"] != "sgd"
+            or _require_number(optimizer["learning_rate"], "learning_rate") <= 0
+        ):
+            raise LabValidationError(
+                f"{source}.training.optimizer: V1 requires positive-rate SGD"
+            )
+        if expected["first_step"] is None:
+            raise LabValidationError(
+                f"{source}.expected.first_step: required when training is enabled"
+            )
+
+
+def forward(
+    lab: dict[str, Any], layers: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    active_layers = deepcopy(layers if layers is not None else lab["model"]["layers"])
+    inputs = [
+        [float(value) for value in row["input"]] for row in lab["dataset"]["rows"]
+    ]
+    activations: list[list[list[float]]] = [inputs]
+    raw_by_layer: list[list[list[float]]] = []
+    current = inputs
+    for layer in active_layers:
+        weights = [[float(value) for value in row] for row in layer["weights"]]
+        biases = [float(value) for value in layer["biases"]]
+        raw = _matmul(current, weights)
+        raw = [
+            [value + biases[column] for column, value in enumerate(row)] for row in raw
+        ]
+        current = [
+            [_activation(layer["activation"], value) for value in row] for row in raw
+        ]
+        raw_by_layer.append(raw)
+        activations.append(current)
+    return {"raw": raw_by_layer, "activations": activations, "predictions": current}
+
+
+def train_first_step(lab: dict[str, Any]) -> dict[str, Any]:
+    if lab["training"] is None:
+        raise LabValidationError("cannot train a lab whose training field is null")
+    layers = deepcopy(lab["model"]["layers"])
+    pass_result = forward(lab, layers)
+    predictions = pass_result["predictions"]
+    targets = [
+        [float(value) for value in row["target"]] for row in lab["dataset"]["rows"]
+    ]
+    value_count = len(targets) * len(targets[0])
+    errors = [
+        [
+            prediction - target
+            for prediction, target in zip(prediction_row, target_row, strict=True)
+        ]
+        for prediction_row, target_row in zip(predictions, targets, strict=True)
+    ]
+    loss_before = sum(value * value for row in errors for value in row) / value_count
+    deltas: list[list[list[float]]] = [[] for _ in layers]
+    last = len(layers) - 1
+    deltas[last] = [
+        [
+            (2.0 / value_count)
+            * error
+            * _activation_derivative(
+                layers[last]["activation"],
+                pass_result["raw"][last][row_index][column],
+                predictions[row_index][column],
+            )
+            for column, error in enumerate(error_row)
+        ]
+        for row_index, error_row in enumerate(errors)
+    ]
+
+    for layer_index in range(last - 1, -1, -1):
+        downstream = _matmul(
+            deltas[layer_index + 1], _transpose(layers[layer_index + 1]["weights"])
+        )
+        deltas[layer_index] = [
+            [
+                downstream[row_index][column]
+                * _activation_derivative(
+                    layers[layer_index]["activation"],
+                    pass_result["raw"][layer_index][row_index][column],
+                    pass_result["activations"][layer_index + 1][row_index][column],
+                )
+                for column in range(len(downstream[row_index]))
+            ]
+            for row_index in range(len(downstream))
+        ]
+
+    learning_rate = float(lab["training"]["optimizer"]["learning_rate"])
+    gradients: list[dict[str, Any]] = []
+    next_layers: list[dict[str, Any]] = []
+    for layer_index, layer in enumerate(layers):
+        previous = pass_result["activations"][layer_index]
+        weight_gradient = _matmul(_transpose(previous), deltas[layer_index])
+        bias_gradient = [
+            sum(row[column] for row in deltas[layer_index])
+            for column in range(len(deltas[layer_index][0]))
+        ]
+        gradients.append(
+            {"name": layer["name"], "weights": weight_gradient, "biases": bias_gradient}
+        )
+        next_layers.append(
+            {
+                "name": layer["name"],
+                "weights": [
+                    [
+                        value - learning_rate * weight_gradient[row][column]
+                        for column, value in enumerate(values)
+                    ]
+                    for row, values in enumerate(layer["weights"])
+                ],
+                "biases": [
+                    value - learning_rate * bias_gradient[index]
+                    for index, value in enumerate(layer["biases"])
+                ],
+                "activation": layer["activation"],
+            }
+        )
+
+    next_predictions = forward(lab, next_layers)["predictions"]
+    next_errors = [
+        [
+            prediction - target
+            for prediction, target in zip(prediction_row, target_row, strict=True)
+        ]
+        for prediction_row, target_row in zip(next_predictions, targets, strict=True)
+    ]
+    loss_after = (
+        sum(value * value for row in next_errors for value in row) / value_count
+    )
+    return {
+        "loss_before": loss_before,
+        "gradients": gradients,
+        "parameters_after": next_layers,
+        "loss_after": loss_after,
+    }
+
+
+def _compare_numbers(
+    actual: Any, expected: Any, tolerance: float, context: str
+) -> None:
+    if isinstance(expected, (int, float)) and not isinstance(expected, bool):
+        actual_number = _require_number(actual, context)
+        if abs(actual_number - float(expected)) > tolerance:
+            raise LabValidationError(
+                f"{context}: expected {expected!r}, got {actual_number!r} (tolerance {tolerance})"
+            )
+        return
+    if isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            raise LabValidationError(f"{context}: list shape mismatch")
+        for index, (actual_item, expected_item) in enumerate(
+            zip(actual, expected, strict=True)
+        ):
+            _compare_numbers(
+                actual_item, expected_item, tolerance, f"{context}[{index}]"
+            )
+        return
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict) or actual.keys() != expected.keys():
+            raise LabValidationError(f"{context}: object keys do not match")
+        for key in expected:
+            _compare_numbers(actual[key], expected[key], tolerance, f"{context}.{key}")
+        return
+    if actual != expected:
+        raise LabValidationError(f"{context}: expected {expected!r}, got {actual!r}")
+
+
+def validate_lab(lab: dict[str, Any], source: str = "lab") -> None:
+    validate_structure(lab, source)
+    tolerance = float(lab["expected"]["absolute_tolerance"])
+    result = forward(lab)
+    rows = lab["dataset"]["rows"]
+    expected_by_label = {
+        entry["row"]: entry["prediction"] for entry in lab["expected"]["forward"]
+    }
+    if set(expected_by_label) != {row["label"] for row in rows}:
+        raise LabValidationError(
+            f"{source}.expected.forward: row labels do not match dataset"
+        )
+    for index, row in enumerate(rows):
+        _compare_numbers(
+            result["predictions"][index],
+            expected_by_label[row["label"]],
+            tolerance,
+            f"{source}.expected.forward[{row['label']}]",
+        )
+    if lab["training"] is not None:
+        actual_step = train_first_step(lab)
+        _compare_numbers(
+            actual_step,
+            lab["expected"]["first_step"],
+            tolerance,
+            f"{source}.expected.first_step",
+        )
+
+
+def validate_corpus(fixture_root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    schema = load_json(fixture_root / "schema.json")
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        raise LabValidationError("schema.json: expected JSON Schema Draft 2020-12")
+    lab_paths = sorted((fixture_root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise LabValidationError(f"{fixture_root}: no lab fixtures found")
+    ids: set[str] = set()
+    for path in lab_paths:
+        lab = load_json(path)
+        validate_lab(lab, str(path))
+        if lab["id"] in ids:
+            raise LabValidationError(f"{path}: duplicate lab id {lab['id']!r}")
+        ids.add(lab["id"])
+    return lab_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    try:
+        paths = validate_corpus(args.fixture_root)
+    except LabValidationError as error:
+        parser.exit(1, f"neural learning corpus invalid: {error}\n")
+    print(f"validated {len(paths)} neural learning labs from {args.fixture_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/specs/NN03-neural-learning-labs.md
+++ b/code/specs/NN03-neural-learning-labs.md
@@ -1,0 +1,100 @@
+# NN03: Neural Learning Lab Contract
+
+Status: draft
+
+## Purpose
+
+NN03 defines a small, deterministic corpus for explaining neural networks
+without making one programming language the source of truth. A lab describes
+the model, data, optional training rule, and selected numerical checkpoints as
+plain data. A visualizer, command-line program, or language package can consume
+the same lab and compare its results with the same oracle.
+
+The first version deliberately stops at dense feed-forward networks. It is the
+foundation for later contracts covering convolution, recurrence, attention,
+and generative models.
+
+## Design Rules
+
+1. **Small enough to calculate by hand.** Bootstrap labs contain at most a few
+   rows and neurons.
+2. **Every intermediate value is observable.** Implementations should be able
+   to expose weighted contributions, pre-activation sums, activations, errors,
+   deltas, gradients, and parameter updates.
+3. **Deterministic by construction.** Initial parameters are explicit. There is
+   no implicit random initialization.
+4. **One numerical convention.** Matrices are row-major. A dense layer weight
+   matrix has shape `input_count x output_count`.
+5. **One training convention.** V1 training uses full-batch mean squared error
+   and stochastic gradient descent without momentum.
+6. **Portable precision.** Expected values compare with an absolute tolerance;
+   implementations may use f32 or f64 internally.
+7. **Learning content and runtime stay separate.** The fixture explains what to
+   compute. It does not prescribe a framework API or native backend.
+
+## Forward Semantics
+
+For each dense layer:
+
+```text
+z = previous_activations * weights + biases
+a = activation(z)
+```
+
+V1 activations are `identity`, `sigmoid`, `tanh`, and `relu`.
+
+## Training Semantics
+
+For `N` rows and `O` output values per row:
+
+```text
+loss = sum((prediction - target)^2) / (N * O)
+d_loss/d_prediction = 2 * (prediction - target) / (N * O)
+next_parameter = parameter - learning_rate * gradient
+```
+
+Backpropagation proceeds from the output layer to the first layer. Bias
+gradients are column sums of layer deltas. Weight gradients are the transpose
+of the previous activation matrix multiplied by the layer delta matrix.
+
+## Corpus Layout
+
+The versioned fixtures live under:
+
+```text
+code/specs/fixtures/neural-learning-v1/
+  schema.json
+  labs/*.json
+```
+
+Validate them with:
+
+```text
+python code/scripts/validate_neural_learning_labs.py
+```
+
+## Bootstrap Labs
+
+| Lab | Main question |
+| --- | --- |
+| Weighted neuron | Where does one prediction number come from? |
+| Celsius regression | How do error and input scale produce a gradient? |
+| OR neuron | How does an activation derivative join the chain rule? |
+| Solved XOR | What can hidden neurons represent that one line cannot? |
+
+## Conformance Levels
+
+- **Trace:** reproduce every checked-in forward prediction.
+- **Training:** reproduce the first loss, gradients, updated parameters, and
+  post-update loss for labs with training enabled.
+- **Inspectable:** expose intermediate values for one selected row.
+- **Accelerated:** reproduce the same result through the Rust execution
+  backbone or the browser-native MatrixIR runtime.
+
+Passing a higher level implies every preceding level.
+
+## Later Versions
+
+Future versions may add additional loss functions, optimizers, tensor dtypes,
+convolutions, recurrent state, masks, attention, and separate weight blobs.
+Those additions must not silently change V1 arithmetic.

--- a/code/specs/fixtures/neural-learning-v1/CHANGELOG.md
+++ b/code/specs/fixtures/neural-learning-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0 - 2026-07-31
+
+- Define the dense feed-forward learning-lab envelope.
+- Add weighted-neuron, Celsius regression, OR, and solved-XOR fixtures.
+- Pin forward results and deterministic first-step SGD traces.

--- a/code/specs/fixtures/neural-learning-v1/README.md
+++ b/code/specs/fixtures/neural-learning-v1/README.md
@@ -1,0 +1,29 @@
+# Neural Learning Fixtures v1
+
+This directory is the language-neutral numerical corpus defined by
+`code/specs/NN03-neural-learning-labs.md`.
+
+Each lab contains explicit dense-layer parameters, a tiny dataset, and expected
+forward results. Training labs additionally pin the first full-batch SGD step:
+the loss, gradients, updated parameters, and new loss.
+
+```text
+neural-learning-v1/
+  schema.json
+  CHANGELOG.md
+  labs/
+    00-weighted-neuron.json
+    01-celsius-linear-regression.json
+    02-or-sigmoid-neuron.json
+    03-xor-hidden-representation.json
+```
+
+Validate the corpus:
+
+```text
+python code/scripts/validate_neural_learning_labs.py
+python code/scripts/tests/test_neural_learning_labs.py
+```
+
+The files are intentionally small enough to read beside an implementation.
+They are not performance benchmarks or large-model interchange files.

--- a/code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json
+++ b/code/specs/fixtures/neural-learning-v1/labs/00-weighted-neuron.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "weighted-neuron-forward",
+  "title": "One weighted neuron",
+  "stage": "forward",
+  "question": "Where does one prediction number come from?",
+  "concepts": ["weighted contribution", "bias", "identity activation"],
+  "model": {
+    "kind": "single-neuron",
+    "input_count": 2,
+    "layers": [
+      {
+        "name": "output",
+        "weights": [[0.5], [-0.25]],
+        "biases": [0.1],
+        "activation": "identity"
+      }
+    ]
+  },
+  "dataset": {
+    "input_labels": ["x1", "x2"],
+    "target_labels": ["prediction"],
+    "rows": [
+      { "label": "worked example", "input": [2, -1], "target": [1.35] }
+    ]
+  },
+  "training": null,
+  "expected": {
+    "absolute_tolerance": 0.000001,
+    "forward": [
+      { "row": "worked example", "prediction": [1.35] }
+    ],
+    "first_step": null
+  }
+}

--- a/code/specs/fixtures/neural-learning-v1/labs/01-celsius-linear-regression.json
+++ b/code/specs/fixtures/neural-learning-v1/labs/01-celsius-linear-regression.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "id": "celsius-linear-regression",
+  "title": "Celsius to Fahrenheit regression",
+  "stage": "single-neuron",
+  "question": "How do error and input scale produce a weight gradient?",
+  "concepts": ["linear regression", "mean squared error", "full-batch gradient", "sgd"],
+  "model": {
+    "kind": "single-neuron",
+    "input_count": 1,
+    "layers": [
+      {
+        "name": "output",
+        "weights": [[0.5]],
+        "biases": [0.5],
+        "activation": "identity"
+      }
+    ]
+  },
+  "dataset": {
+    "input_labels": ["celsius"],
+    "target_labels": ["fahrenheit"],
+    "rows": [
+      { "label": "freezing crossover", "input": [-40], "target": [-40] },
+      { "label": "water freezes", "input": [0], "target": [32] },
+      { "label": "hot day", "input": [40], "target": [104] }
+    ]
+  },
+  "training": {
+    "loss": "mean-squared-error",
+    "optimizer": { "kind": "sgd", "learning_rate": 0.0005 },
+    "batch": "full"
+  },
+  "expected": {
+    "absolute_tolerance": 0.000001,
+    "forward": [
+      { "row": "freezing crossover", "prediction": [-19.5] },
+      { "row": "water freezes", "prediction": [0.5] },
+      { "row": "hot day", "prediction": [20.5] }
+    ],
+    "first_step": {
+      "loss_before": 2794.9166666666665,
+      "gradients": [
+        {
+          "name": "output",
+          "weights": [[-2773.333333333333]],
+          "biases": [-63]
+        }
+      ],
+      "parameters_after": [
+        {
+          "name": "output",
+          "weights": [[1.8866666666666665]],
+          "biases": [0.5315],
+          "activation": "identity"
+        }
+      ],
+      "loss_after": 998.278344101852
+    }
+  }
+}

--- a/code/specs/fixtures/neural-learning-v1/labs/02-or-sigmoid-neuron.json
+++ b/code/specs/fixtures/neural-learning-v1/labs/02-or-sigmoid-neuron.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "id": "or-sigmoid-neuron",
+  "title": "OR with one sigmoid neuron",
+  "stage": "single-neuron",
+  "question": "How does an activation derivative join the chain rule?",
+  "concepts": ["binary classification", "sigmoid", "chain rule", "sgd"],
+  "model": {
+    "kind": "single-neuron",
+    "input_count": 2,
+    "layers": [
+      {
+        "name": "output",
+        "weights": [[0], [0]],
+        "biases": [0],
+        "activation": "sigmoid"
+      }
+    ]
+  },
+  "dataset": {
+    "input_labels": ["a", "b"],
+    "target_labels": ["or"],
+    "rows": [
+      { "label": "0 OR 0", "input": [0, 0], "target": [0] },
+      { "label": "0 OR 1", "input": [0, 1], "target": [1] },
+      { "label": "1 OR 0", "input": [1, 0], "target": [1] },
+      { "label": "1 OR 1", "input": [1, 1], "target": [1] }
+    ]
+  },
+  "training": {
+    "loss": "mean-squared-error",
+    "optimizer": { "kind": "sgd", "learning_rate": 1 },
+    "batch": "full"
+  },
+  "expected": {
+    "absolute_tolerance": 0.000001,
+    "forward": [
+      { "row": "0 OR 0", "prediction": [0.5] },
+      { "row": "0 OR 1", "prediction": [0.5] },
+      { "row": "1 OR 0", "prediction": [0.5] },
+      { "row": "1 OR 1", "prediction": [0.5] }
+    ],
+    "first_step": {
+      "loss_before": 0.25,
+      "gradients": [
+        {
+          "name": "output",
+          "weights": [[-0.125], [-0.125]],
+          "biases": [-0.125]
+        }
+      ],
+      "parameters_after": [
+        {
+          "name": "output",
+          "weights": [[0.125], [0.125]],
+          "biases": [0.125],
+          "activation": "sigmoid"
+        }
+      ],
+      "loss_after": 0.20787068247658097
+    }
+  }
+}

--- a/code/specs/fixtures/neural-learning-v1/labs/03-xor-hidden-representation.json
+++ b/code/specs/fixtures/neural-learning-v1/labs/03-xor-hidden-representation.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "id": "xor-hidden-representation",
+  "title": "XOR as two hidden features",
+  "stage": "hidden-layer",
+  "question": "What can hidden neurons represent that one line cannot?",
+  "concepts": ["hidden representation", "non-linearity", "OR feature", "NAND feature", "XOR"],
+  "model": {
+    "kind": "dense-network",
+    "input_count": 2,
+    "layers": [
+      {
+        "name": "hidden",
+        "weights": [[20, -20], [20, -20]],
+        "biases": [-10, 30],
+        "activation": "sigmoid"
+      },
+      {
+        "name": "output",
+        "weights": [[20], [20]],
+        "biases": [-30],
+        "activation": "sigmoid"
+      }
+    ]
+  },
+  "dataset": {
+    "input_labels": ["a", "b"],
+    "target_labels": ["xor"],
+    "rows": [
+      { "label": "0 XOR 0", "input": [0, 0], "target": [0] },
+      { "label": "0 XOR 1", "input": [0, 1], "target": [1] },
+      { "label": "1 XOR 0", "input": [1, 0], "target": [1] },
+      { "label": "1 XOR 1", "input": [1, 1], "target": [0] }
+    ]
+  },
+  "training": null,
+  "expected": {
+    "absolute_tolerance": 0.000001,
+    "forward": [
+      { "row": "0 XOR 0", "prediction": [0.000045439104876545914] },
+      { "row": "0 XOR 1", "prediction": [0.999954519621495] },
+      { "row": "1 XOR 0", "prediction": [0.999954519621495] },
+      { "row": "1 XOR 1", "prediction": [0.000045439104876545914] }
+    ],
+    "first_step": null
+  }
+}

--- a/code/specs/fixtures/neural-learning-v1/schema.json
+++ b/code/specs/fixtures/neural-learning-v1/schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/neural-learning-v1.json",
+  "title": "Neural learning lab v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "stage",
+    "question",
+    "concepts",
+    "model",
+    "dataset",
+    "training",
+    "expected"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "stage": { "enum": ["forward", "single-neuron", "hidden-layer"] },
+    "question": { "type": "string", "minLength": 1 },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "model": { "$ref": "#/$defs/model" },
+    "dataset": { "$ref": "#/$defs/dataset" },
+    "training": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/training" }
+      ]
+    },
+    "expected": { "$ref": "#/$defs/expected" }
+  },
+  "$defs": {
+    "number_vector": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "number" }
+    },
+    "number_matrix": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/number_vector" }
+    },
+    "layer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "weights", "biases", "activation"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "weights": { "$ref": "#/$defs/number_matrix" },
+        "biases": { "$ref": "#/$defs/number_vector" },
+        "activation": { "enum": ["identity", "sigmoid", "tanh", "relu"] }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "input_count", "layers"],
+      "properties": {
+        "kind": { "enum": ["single-neuron", "dense-network"] },
+        "input_count": { "type": "integer", "minimum": 1 },
+        "layers": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/layer" }
+        }
+      }
+    },
+    "row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "input", "target"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "input": { "$ref": "#/$defs/number_vector" },
+        "target": { "$ref": "#/$defs/number_vector" }
+      }
+    },
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_labels", "target_labels", "rows"],
+      "properties": {
+        "input_labels": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "target_labels": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "rows": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/row" }
+        }
+      }
+    },
+    "training": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["loss", "optimizer", "batch"],
+      "properties": {
+        "loss": { "const": "mean-squared-error" },
+        "optimizer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "learning_rate"],
+          "properties": {
+            "kind": { "const": "sgd" },
+            "learning_rate": { "type": "number", "exclusiveMinimum": 0 }
+          }
+        },
+        "batch": { "const": "full" }
+      }
+    },
+    "forward_expectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["row", "prediction"],
+      "properties": {
+        "row": { "type": "string", "minLength": 1 },
+        "prediction": { "$ref": "#/$defs/number_vector" }
+      }
+    },
+    "layer_gradients": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "weights", "biases"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "weights": { "$ref": "#/$defs/number_matrix" },
+        "biases": { "$ref": "#/$defs/number_vector" }
+      }
+    },
+    "first_step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["loss_before", "gradients", "parameters_after", "loss_after"],
+      "properties": {
+        "loss_before": { "type": "number", "minimum": 0 },
+        "gradients": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/layer_gradients" }
+        },
+        "parameters_after": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/layer" }
+        },
+        "loss_after": { "type": "number", "minimum": 0 }
+      }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["absolute_tolerance", "forward", "first_step"],
+      "properties": {
+        "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+        "forward": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/forward_expectation" }
+        },
+        "first_step": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/first_step" }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a Machine Learning learning track that starts with one weighted neuron, works through backpropagation by hand, and maps the path toward larger neural-network families
- define the NN03 deterministic neural-learning contract with four portable JSON fixtures, a standard-library validator, and focused tests
- add a Training Step Microscope to the TypeScript ML Learning Visualizer so multiplication, bias, activation, loss, gradients, and parameter updates can be revealed one phase at a time
- refresh the generated learning coverage inventory

## Why

The repository already contains substantial ML infrastructure, but the beginner path and the mechanics between a prediction and a parameter update were spread across several packages and examples. This creates a small, executable foundation that exposes those mechanics directly and gives future Rust, Python, TypeScript, and other language implementations the same numerical contract.

## Validation

- `python code/scripts/validate_neural_learning_labs.py`
- `python code/scripts/tests/test_neural_learning_labs.py` — 4 tests
- `python code/scripts/tests/test_learning_coverage_report.py` — 5 tests
- `ruff check code/scripts/validate_neural_learning_labs.py code/scripts/tests/test_neural_learning_labs.py`
- `ruff format --check code/scripts/validate_neural_learning_labs.py code/scripts/tests/test_neural_learning_labs.py`
- `npm run build` in `code/programs/typescript/ml-learning-visualizer`
- `npm test` in `code/programs/typescript/ml-learning-visualizer` — 17 tests
- desktop and mobile browser QA, including alternate activations and a clean browser console
- `git diff --check`
