### PR TITLE
test(venture): exercise generated native chrome

### DIFF
--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - optional generated-shell interaction acceptance
+
+Generated SwiftUI applications now call an optional package-host interaction
+hook after their Mosaic root appears. Package owners can exercise the emitted
+native controls and shared dispatch path in direct launch acceptance without
+adding application-specific behavior to the generated shell.
+
 ### Added - Native automation identifiers for authored controls
 
 `HostInput` and `HostButton` now preserve their MLL part names as SwiftUI

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -402,6 +402,9 @@ fn build_app_swift(component_name: &str, slots: &[SlotDecl]) -> String {
     writeln!(out, "  var body: some Scene {{").unwrap();
     writeln!(out, "    WindowGroup(\"{component_name}\") {{").unwrap();
     writeln!(out, "      {root_view}").unwrap();
+    writeln!(out, "      .onAppear {{").unwrap();
+    writeln!(out, "        host.runInteractionAcceptanceIfRequested()").unwrap();
+    writeln!(out, "      }}").unwrap();
     writeln!(out, "    }}").unwrap();
     writeln!(out, "  }}").unwrap();
     writeln!(out, "}}").unwrap();
@@ -461,9 +464,18 @@ fn host_value_for_slot(slot: &SlotDecl, props_expr: &str, host_expr: &str) -> St
 }
 
 fn build_mosaic_host_state(component_name: &str) -> String {
-    format!(
+    let state = format!(
         "private final class MosaicHostState: ObservableObject {{\n  @Published var props: [String: Any] = [:]\n  @Published var lastHostIntent: [String: Any]? = nil\n  private let bridge: MosaicHostBridgeObject?\n\n  init() {{\n    self.bridge = MosaicHostBridge.load()\n    bridge?.setPropsChangedHandler? {{ [weak self] in\n      DispatchQueue.main.async {{\n        self?.refreshProps()\n      }}\n    }}\n    refreshProps()\n  }}\n\n  func node(named name: String) -> AnyView {{\n    guard let object = bridge?.node?(named: name as NSString) else {{\n      return AnyView(EmptyView())\n    }}\n#if os(macOS)\n    guard let view = object as? NSView else {{ return AnyView(EmptyView()) }}\n    return AnyView(MosaicHostPlatformView(view: view))\n#elseif os(iOS)\n    guard let view = object as? UIView else {{ return AnyView(EmptyView()) }}\n    return AnyView(MosaicHostPlatformView(view: view))\n#else\n    return AnyView(EmptyView())\n#endif\n  }}\n\n  func dispatch(_ event: {component_name}Event) {{\n    guard let bridge else {{\n      print(\"Mosaic dispatch: \\(event.mosaicEnvelope)\")\n      return\n    }}\n    applyHostResponse(bridge.handleEvent(event.mosaicEnvelope as NSDictionary, name: event.mosaicName as NSString) as? [String: Any])\n  }}\n\n  private func refreshProps() {{\n    applyHostResponse(bridge?.applyProps() as? [String: Any])\n  }}\n\n  private func applyHostResponse(_ response: [String: Any]?) {{\n    guard let response else {{ return }}\n    if let intent = response[\"hostIntent\"] as? [String: Any] {{\n      self.lastHostIntent = intent\n    }}\n    if let next = response[\"props\"] as? [String: Any] {{\n      self.props = next\n      return\n    }}\n    if response[\"hostIntent\"] != nil || response[\"error\"] != nil {{\n      return\n    }}\n    self.props = response\n  }}\n}}\n\n@objc protocol MosaicHostBridgeObject {{\n  func applyProps() -> NSDictionary?\n  func handleEvent(_ envelope: NSDictionary, name: NSString) -> NSDictionary?\n  @objc optional func node(named name: NSString) -> NSObject?\n  @objc optional func setPropsChangedHandler(_ handler: @escaping () -> Void)\n}}\n\n#if os(macOS)\nprivate struct MosaicHostPlatformView: NSViewRepresentable {{\n  let view: NSView\n  func makeNSView(context: Context) -> NSView {{ view }}\n  func updateNSView(_ nsView: NSView, context: Context) {{}}\n}}\n#elseif os(iOS)\nprivate struct MosaicHostPlatformView: UIViewRepresentable {{\n  let view: UIView\n  func makeUIView(context: Context) -> UIView {{ view }}\n  func updateUIView(_ uiView: UIView, context: Context) {{}}\n}}\n#endif\n\nprivate enum MosaicHostBridge {{\n  static func load() -> MosaicHostBridgeObject? {{\n    for className in [\"App.MosaicHost\", \"MosaicHost\"] {{\n      guard let hostType = NSClassFromString(className) as? NSObject.Type else {{\n        continue\n      }}\n      if let bridge = hostType.init() as? MosaicHostBridgeObject {{\n        return bridge\n      }}\n    }}\n    return nil\n  }}\n}}\n\nprivate enum MosaicHostValue {{\n  static func string(_ props: [String: Any], _ key: String, fallback: String) -> String {{\n    if let value = props[key] as? String {{ return value }}\n    if let value = props[key] {{ return String(describing: value) }}\n    return fallback\n  }}\n\n  static func double(_ props: [String: Any], _ key: String, fallback: Double) -> Double {{\n    if let value = props[key] as? Double {{ return value }}\n    if let value = props[key] as? NSNumber {{ return value.doubleValue }}\n    if let value = props[key] as? String, let parsed = Double(value) {{ return parsed }}\n    return fallback\n  }}\n\n  static func bool(_ props: [String: Any], _ key: String, fallback: Bool) -> Bool {{\n    if let value = props[key] as? Bool {{ return value }}\n    if let value = props[key] as? NSNumber {{ return value.boolValue }}\n    if let value = props[key] as? String, let parsed = Bool(value) {{ return parsed }}\n    return fallback\n  }}\n\n  static func stringList(_ props: [String: Any], _ key: String, fallback: [String]) -> [String] {{\n    if let value = props[key] as? [String] {{ return value }}\n    if let value = props[key] as? [Any] {{ return value.map {{ String(describing: $0) }} }}\n    return fallback\n  }}\n\n  static func doubleList(_ props: [String: Any], _ key: String, fallback: [Double]) -> [Double] {{\n    if let value = props[key] as? [Double] {{ return value }}\n    if let value = props[key] as? [NSNumber] {{ return value.map {{ $0.doubleValue }} }}\n    return fallback\n  }}\n\n  static func boolList(_ props: [String: Any], _ key: String, fallback: [Bool]) -> [Bool] {{\n    if let value = props[key] as? [Bool] {{ return value }}\n    if let value = props[key] as? [NSNumber] {{ return value.map {{ $0.boolValue }} }}\n    return fallback\n  }}\n}}\n"
-    )
+    );
+    state
+        .replace(
+            "  private func refreshProps() {",
+            "  func runInteractionAcceptanceIfRequested() {\n    bridge?.runInteractionAcceptance?()\n  }\n\n  private func refreshProps() {",
+        )
+        .replace(
+            "  @objc optional func setPropsChangedHandler(_ handler: @escaping () -> Void)\n}",
+            "  @objc optional func setPropsChangedHandler(_ handler: @escaping () -> Void)\n  @objc optional func runInteractionAcceptance()\n}",
+        )
 }
 
 fn sample_value_for_slot(slot: &SlotDecl) -> String {
@@ -7489,6 +7501,12 @@ mod tests {
             proj.app_swift.contains("host.dispatch(event)"),
             "App.swift should dispatch the Mosaic wire envelope through the host"
         );
+        assert!(proj
+            .app_swift
+            .contains("host.runInteractionAcceptanceIfRequested()"));
+        assert!(proj
+            .app_swift
+            .contains("@objc optional func runInteractionAcceptance()"));
     }
 
     #[test]

--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased] — VC2-xaml Grid: WinUI value translation + nested-For + per-column widths
 
+### Added - optional generated-shell interaction acceptance
+
+Generated WinUI applications now invoke an optional package-host interaction
+hook after wiring the Mosaic component's dispatch event. Package owners can
+exercise emitted native controls and shared dispatch in direct launch
+acceptance without adding application-specific behavior to the shell.
+
 ### Added - Native automation identifiers for authored controls
 
 `HostInput` and `HostButton` now preserve their MLL part names as WinUI

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -3953,7 +3953,8 @@ fn emit_main_window_cs(
                              hostStatus = \"Status: sample props loaded\";\n        \
                          }}\n        \
                          this.StatusText.Text = hostStatus;\n        \
-                         this.Component.Dispatch += OnComponentDispatch;\n    \
+                         this.Component.Dispatch += OnComponentDispatch;\n        \
+                         TryRunMosaicHostInteractionAcceptance(this.Component);\n    \
                      }}\n\
                  \n    \
                      /// <summary>\n    \
@@ -3995,6 +3996,24 @@ fn build_optional_host_helpers(name: &str, namespace: &str) -> String {
              catch (System.Exception ex)\n        \
              {{\n            \
                  return $\"Mosaic host failed: {{ex.GetType().Name}}: {{ex.Message}}\";\n        \
+             }}\n    \
+         }}\n\
+         \n    \
+         private void TryRunMosaicHostInteractionAcceptance({name} component)\n    \
+         {{\n        \
+             var method = FindMosaicHostMethod(\n            \
+                 \"RunInteractionAcceptance\",\n            \
+                 typeof(Window),\n            \
+                 typeof({name}));\n        \
+             if (method is null) {{ return; }}\n        \
+             try\n        \
+             {{\n            \
+                 method.Invoke(null, new object[] {{ this, component }});\n        \
+             }}\n        \
+             catch (System.Exception ex)\n        \
+             {{\n            \
+                 System.Diagnostics.Debug.WriteLine(\n                \
+                     $\"Mosaic host interaction acceptance failed: {{ex}}\");\n        \
              }}\n    \
          }}\n\
          \n    \
@@ -9495,6 +9514,10 @@ mod tests {
         // MainWindow.xaml.cs can optionally delegate props/events to an
         // app-provided MosaicHost without requiring one to compile.
         assert!(p.main_window_cs.contains("TryApplyMosaicHostProps"));
+        assert!(p
+            .main_window_cs
+            .contains("TryRunMosaicHostInteractionAcceptance(this.Component)"));
+        assert!(p.main_window_cs.contains("\"RunInteractionAcceptance\""));
         assert!(p.main_window_cs.contains("CoerceMosaicHostResult"));
         assert!(p.main_window_cs.contains("FindMosaicHostMethod"));
         assert!(p

--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -18,6 +18,9 @@
   SwiftUI content surface changes logical size.
 - Build and directly launch the Mosaic-emitted SwiftUI app in a platform-native
   integration gate, requiring a successful Metal host-surface render.
+- Extend the generated-app launch gate through native address editing and Go
+  activation, requiring the shared Rust session to load and title a second
+  deterministic page.
 
 ## 0.1.0
 

--- a/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
+++ b/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
@@ -50,14 +50,14 @@ fn build_native_bridge(output: &Path) -> PathBuf {
     target.join("debug/libventure_browser_macos.dylib")
 }
 
-fn serve_html_once() -> String {
+fn serve_html_once(title: &'static str) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind acceptance server");
     let address = listener.local_addr().expect("read acceptance address");
     thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("accept Venture request");
         let mut request = [0_u8; 1024];
         let _ = stream.read(&mut request);
-        let body = b"<!doctype html><title>Venture launch acceptance</title><main>Ready</main>";
+        let body = format!("<!doctype html><title>{title}</title><main>Ready</main>");
         write!(
             stream,
             "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -65,30 +65,30 @@ fn serve_html_once() -> String {
         )
         .expect("write acceptance response headers");
         stream
-            .write_all(body)
+            .write_all(body.as_bytes())
             .expect("write acceptance response body");
     });
     format!("http://{address}/")
 }
 
-fn wait_for_ready(child: &mut Child, marker: &Path) {
+fn wait_for_marker(child: &mut Child, marker: &Path, description: &str) {
     let deadline = Instant::now() + Duration::from_secs(30);
     while Instant::now() < deadline {
         if marker.exists() {
             return;
         }
         if let Some(status) = child.try_wait().expect("poll generated SwiftUI app") {
-            panic!("generated SwiftUI app exited before rendering: {status}");
+            panic!("generated SwiftUI app exited before {description}: {status}");
         }
         thread::sleep(Duration::from_millis(100));
     }
     let _ = child.kill();
     let _ = child.wait();
-    panic!("generated SwiftUI app did not report a rendered Mosaic host surface within 30 seconds");
+    panic!("generated SwiftUI app did not report {description} within 30 seconds");
 }
 
 #[test]
-fn package_owned_swiftui_project_launches_and_renders() {
+fn package_owned_swiftui_project_launches_renders_and_interacts() {
     let output = temporary_output();
     let result = build_package(&BuildOptions {
         package_root: venture_package_root(),
@@ -131,25 +131,45 @@ fn package_owned_swiftui_project_launches_and_renders() {
     );
 
     let marker = output.join("swiftui-ready.json");
+    let interaction_marker = output.join("swiftui-interaction.json");
+    let start_url = serve_html_once("Venture launch acceptance");
+    let target_url = serve_html_once("Venture interaction acceptance");
     let app_log = output.join("swiftui-app.log");
     let log = File::create(&app_log).expect("create SwiftUI app log");
     let mut child = Command::new(project.join(".build/debug/App"))
         .current_dir(&project)
-        .env("VENTURE_START_URL", serve_html_once())
+        .env("VENTURE_START_URL", start_url)
         .env("VENTURE_BROWSER_LIBRARY", &library)
         .env("VENTURE_BROWSER_ACCEPTANCE_PATH", &marker)
+        .env("VENTURE_BROWSER_INTERACTION_URL", &target_url)
+        .env(
+            "VENTURE_BROWSER_INTERACTION_ACCEPTANCE_PATH",
+            &interaction_marker,
+        )
         .stdout(Stdio::from(log.try_clone().expect("clone SwiftUI app log")))
         .stderr(Stdio::from(log))
         .spawn()
         .expect("launch generated Venture SwiftUI app");
-    wait_for_ready(&mut child, &marker);
-    thread::sleep(Duration::from_millis(500));
+    wait_for_marker(&mut child, &marker, "a rendered Mosaic host surface");
+    wait_for_marker(
+        &mut child,
+        &interaction_marker,
+        "native chrome interaction acceptance",
+    );
     let _ = child.kill();
     let _ = child.wait();
 
     let readiness = fs::read_to_string(&marker).expect("read SwiftUI readiness marker");
     assert!(readiness.contains("\"backend\":\"swiftui\""));
     assert!(readiness.contains("\"status\":\"ready\""));
+    let interaction =
+        fs::read_to_string(&interaction_marker).expect("read SwiftUI interaction marker");
+    assert!(interaction.contains("\"backend\":\"swiftui\""));
+    assert!(interaction.contains("\"status\":\"interacted\""));
+    assert!(
+        interaction.contains(&target_url) || interaction.contains(&target_url.replace('/', "\\/"))
+    );
+    assert!(interaction.contains("Venture interaction acceptance"));
     let diagnostics = fs::read_to_string(&app_log).expect("read SwiftUI app log");
     assert!(
         !diagnostics.contains("assertion failed") && !diagnostics.contains("Assertion failed"),

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -13,6 +13,6 @@
   integration gate, requiring a successful Direct2D host-surface render.
 - Copy rendered BGRA pixels through WinRT's supported `IBuffer.AsStream()`
   projection and retain opt-in launch-phase diagnostics for hosted acceptance.
-- Extend the generated-app launch gate through WinUI value and invoke
-  automation providers, requiring the shared Rust session to load and title a
-  second deterministic page.
+- Extend the generated-app launch gate through the native WinUI address
+  control and button invoke provider, requiring the shared Rust session to
+  load and title a second deterministic page.

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -13,3 +13,6 @@
   integration gate, requiring a successful Direct2D host-surface render.
 - Copy rendered BGRA pixels through WinRT's supported `IBuffer.AsStream()`
   projection and retain opt-in launch-phase diagnostics for hosted acceptance.
+- Extend the generated-app launch gate through WinUI value and invoke
+  automation providers, requiring the shared Rust session to load and title a
+  second deterministic page.

--- a/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
+++ b/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
@@ -229,8 +229,14 @@ fn package_owned_xaml_project_builds_launches_and_interacts() {
     assert!(readiness.contains("\"status\":\"ready\""));
     let interaction =
         fs::read_to_string(&interaction_marker).expect("read WinUI interaction marker");
-    assert!(interaction.contains("\"backend\":\"xaml\""));
-    assert!(interaction.contains("\"status\":\"interacted\""));
+    assert!(
+        interaction.contains("\"backend\":\"xaml\""),
+        "unexpected WinUI interaction marker: {interaction}"
+    );
+    assert!(
+        interaction.contains("\"status\":\"interacted\""),
+        "WinUI interaction failed: {interaction}"
+    );
     assert!(
         interaction.contains(&target_url) || interaction.contains(&target_url.replace('/', "\\/"))
     );

--- a/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
+++ b/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
@@ -47,14 +47,14 @@ fn build_native_bridge(output: &Path) -> PathBuf {
     target.join("debug/venture_browser_windows.dll")
 }
 
-fn serve_html_once() -> String {
+fn serve_html_once(title: &'static str) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind acceptance server");
     let address = listener.local_addr().expect("read acceptance address");
     thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("accept Venture request");
         let mut request = [0_u8; 1024];
         let _ = stream.read(&mut request);
-        let body = b"<!doctype html><title>Venture launch acceptance</title><main>Ready</main>";
+        let body = format!("<!doctype html><title>{title}</title><main>Ready</main>");
         write!(
             stream,
             "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -62,7 +62,7 @@ fn serve_html_once() -> String {
         )
         .expect("write acceptance response headers");
         stream
-            .write_all(body)
+            .write_all(body.as_bytes())
             .expect("write acceptance response body");
     });
     format!("http://{address}/")
@@ -114,7 +114,13 @@ if ($events) {
     }
 }
 
-fn wait_for_ready(child: &mut Child, executable: &Path, marker: &Path, phase_log: &Path) {
+fn wait_for_marker(
+    child: &mut Child,
+    executable: &Path,
+    marker: &Path,
+    phase_log: &Path,
+    description: &str,
+) {
     let deadline = Instant::now() + Duration::from_secs(30);
     while Instant::now() < deadline {
         if marker.exists() {
@@ -124,7 +130,7 @@ fn wait_for_ready(child: &mut Child, executable: &Path, marker: &Path, phase_log
             let phase = fs::read_to_string(phase_log)
                 .unwrap_or_else(|_| "no package-host phase was reported".to_string());
             panic!(
-                "generated WinUI app exited before rendering: {status}\nlast host phase: {phase}\n{}",
+                "generated WinUI app exited before {description}: {status}\nlast host phase: {phase}\n{}",
                 application_failure_diagnostics(executable)
             );
         }
@@ -132,11 +138,11 @@ fn wait_for_ready(child: &mut Child, executable: &Path, marker: &Path, phase_log
     }
     let _ = child.kill();
     let _ = child.wait();
-    panic!("generated WinUI app did not report a rendered Mosaic host surface within 30 seconds");
+    panic!("generated WinUI app did not report {description} within 30 seconds");
 }
 
 #[test]
-fn package_owned_xaml_host_compiles_in_generated_winui_project() {
+fn package_owned_xaml_project_builds_launches_and_interacts() {
     let output = temporary_output();
     let result = build_package(&BuildOptions {
         package_root: venture_package_root(),
@@ -181,25 +187,54 @@ fn package_owned_xaml_host_compiles_in_generated_winui_project() {
     let executable = find_executable(&project.join("bin"))
         .expect("generated WinUI build must produce VentureChrome.exe");
     let marker = output.join("xaml-ready.json");
+    let interaction_marker = output.join("xaml-interaction.json");
     let phase_log = output.join("xaml-phase.json");
+    let start_url = serve_html_once("Venture launch acceptance");
+    let target_url = serve_html_once("Venture interaction acceptance");
     let app_log = output.join("xaml-app.log");
     let log = File::create(&app_log).expect("create WinUI app log");
     let mut child = Command::new(&executable)
         .current_dir(executable.parent().expect("WinUI executable directory"))
-        .env("VENTURE_START_URL", serve_html_once())
+        .env("VENTURE_START_URL", start_url)
         .env("VENTURE_BROWSER_ACCEPTANCE_PATH", &marker)
         .env("VENTURE_BROWSER_ACCEPTANCE_DIAGNOSTIC_PATH", &phase_log)
+        .env("VENTURE_BROWSER_INTERACTION_URL", &target_url)
+        .env(
+            "VENTURE_BROWSER_INTERACTION_ACCEPTANCE_PATH",
+            &interaction_marker,
+        )
         .stdout(Stdio::from(log.try_clone().expect("clone WinUI app log")))
         .stderr(Stdio::from(log))
         .spawn()
         .expect("launch generated Venture WinUI app");
-    wait_for_ready(&mut child, &executable, &marker, &phase_log);
+    wait_for_marker(
+        &mut child,
+        &executable,
+        &marker,
+        &phase_log,
+        "a rendered Mosaic host surface",
+    );
+    wait_for_marker(
+        &mut child,
+        &executable,
+        &interaction_marker,
+        &phase_log,
+        "native chrome interaction acceptance",
+    );
     let _ = child.kill();
     let _ = child.wait();
 
     let readiness = fs::read_to_string(&marker).expect("read WinUI readiness marker");
     assert!(readiness.contains("\"backend\":\"xaml\""));
     assert!(readiness.contains("\"status\":\"ready\""));
+    let interaction =
+        fs::read_to_string(&interaction_marker).expect("read WinUI interaction marker");
+    assert!(interaction.contains("\"backend\":\"xaml\""));
+    assert!(interaction.contains("\"status\":\"interacted\""));
+    assert!(
+        interaction.contains(&target_url) || interaction.contains(&target_url.replace('/', "\\/"))
+    );
+    assert!(interaction.contains("Venture interaction acceptance"));
     let diagnostics = fs::read_to_string(&app_log).expect("read WinUI app log");
     assert!(
         !diagnostics.contains("assertion failed") && !diagnostics.contains("Assertion failed"),

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -40,6 +40,9 @@
 - Direct-launch acceptance for the emitted SwiftUI and WinUI applications,
   requiring each generated shell to load its package-owned Rust bridge and
   render the native content surface against a deterministic local page.
+- Direct interaction acceptance for both emitted applications: the package
+  hosts edit the generated native address control and activate navigation,
+  then require the shared Rust session to load and title a second local page.
 - The XAML host writes rendered BGRA pixels through WinRT's supported
   `IBuffer.AsStream()` projection, avoiding a native COM projection crash in
   the emitted WinUI application.

--- a/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
@@ -98,6 +98,7 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
   private var contentView: VentureContentView?
   private var propsChangedHandler: (() -> Void)?
   private var acceptanceReported = false
+  private var interactionAcceptanceStarted = false
 
   required override init() {
     let native = VentureNativeLibrary()
@@ -140,6 +141,142 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
 
   func setPropsChangedHandler(_ handler: @escaping () -> Void) {
     propsChangedHandler = handler
+  }
+
+  func runInteractionAcceptance() {
+    let environment = ProcessInfo.processInfo.environment
+    guard !interactionAcceptanceStarted,
+      let markerPath = environment["VENTURE_BROWSER_INTERACTION_ACCEPTANCE_PATH"],
+      let targetURL = environment["VENTURE_BROWSER_INTERACTION_URL"]
+    else { return }
+    interactionAcceptanceStarted = true
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+      self?.attemptInteraction(targetURL: targetURL, markerPath: markerPath, remaining: 50)
+    }
+  }
+
+  private func attemptInteraction(targetURL: String, markerPath: String, remaining: Int) {
+    guard !NSApp.windows.isEmpty else {
+      retryInteraction(targetURL: targetURL, markerPath: markerPath, remaining: remaining)
+      return
+    }
+    var visited = Set<ObjectIdentifier>()
+    guard let address = findEditableTextField(in: NSApp, visited: &visited) else {
+      retryInteraction(targetURL: targetURL, markerPath: markerPath, remaining: remaining)
+      return
+    }
+
+    address.selectText(nil)
+    guard let editor = address.currentEditor() as? NSTextView else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error",
+          "error": "address-input native editor unavailable",
+        ],
+        to: markerPath)
+      return
+    }
+    editor.selectAll(nil)
+    editor.insertText(targetURL, replacementRange: editor.selectedRange())
+    if let window = address.window {
+      let addressFrame = address.convert(address.bounds, to: nil)
+      sendPrimaryClick(
+        at: NSPoint(x: addressFrame.maxX + 24, y: addressFrame.midY),
+        to: window)
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+      self?.verifyInteraction(targetURL: targetURL, markerPath: markerPath, remaining: 50)
+    }
+  }
+
+  private func retryInteraction(targetURL: String, markerPath: String, remaining: Int) {
+    guard remaining > 0 else {
+      writeInteractionResult(
+        ["backend": "swiftui", "status": "error", "error": "native controls not found"],
+        to: markerPath)
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+      self?.attemptInteraction(
+        targetURL: targetURL, markerPath: markerPath, remaining: remaining - 1)
+    }
+  }
+
+  private func verifyInteraction(targetURL: String, markerPath: String, remaining: Int) {
+    let response = applyProps()
+    let props = response?["props"] as? NSDictionary
+    let address = props?["address"] as? String ?? ""
+    let pageTitle = props?["page-title"] as? String ?? ""
+    if address == targetURL, pageTitle == "Venture interaction acceptance" {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "interacted", "address": address,
+          "pageTitle": pageTitle,
+        ],
+        to: markerPath)
+      return
+    }
+    guard remaining > 0 else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error", "address": address,
+          "pageTitle": pageTitle, "error": "navigation state did not update",
+        ],
+        to: markerPath)
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+      self?.verifyInteraction(
+        targetURL: targetURL, markerPath: markerPath, remaining: remaining - 1)
+    }
+  }
+
+  private func findEditableTextField(
+    in object: NSObject, visited: inout Set<ObjectIdentifier>
+  ) -> NSTextField? {
+    let objectIdentifier = ObjectIdentifier(object)
+    guard visited.insert(objectIdentifier).inserted else { return nil }
+    if let textField = object as? NSTextField, textField.isEditable { return textField }
+    for child in nativeChildren(of: object) {
+      if let found = findEditableTextField(in: child, visited: &visited) {
+        return found
+      }
+    }
+    return nil
+  }
+
+  private func sendPrimaryClick(at location: NSPoint, to window: NSWindow) {
+    for eventType in [NSEvent.EventType.leftMouseDown, .leftMouseUp] {
+      guard let event = NSEvent.mouseEvent(
+        with: eventType,
+        location: location,
+        modifierFlags: [],
+        timestamp: ProcessInfo.processInfo.systemUptime,
+        windowNumber: window.windowNumber,
+        context: nil,
+        eventNumber: 0,
+        clickCount: 1,
+        pressure: eventType == .leftMouseDown ? 1 : 0)
+      else { continue }
+      NSApp.sendEvent(event)
+    }
+  }
+
+  private func nativeChildren(of object: NSObject) -> [NSObject] {
+    var children: [NSObject] = []
+    if let application = object as? NSApplication {
+      children.append(contentsOf: application.windows)
+    } else if let window = object as? NSWindow, let contentView = window.contentView {
+      children.append(contentView)
+    } else if let view = object as? NSView {
+      children.append(contentsOf: view.subviews)
+    }
+    return children
+  }
+
+  private func writeInteractionResult(_ result: [String: String], to path: String) {
+    guard let data = try? JSONSerialization.data(withJSONObject: result) else { return }
+    try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
   }
 
   fileprivate func render(layer: CAMetalLayer) {

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -98,22 +98,39 @@ public static class MosaicHost
                     return;
                 }
 
-                var valueProvider = new TextBoxAutomationPeer(addressInput)
-                    .GetPattern(PatternInterface.Value) as IValueProvider;
-                var invokeProvider = new ButtonAutomationPeer(goButton)
-                    .GetPattern(PatternInterface.Invoke) as IInvokeProvider;
-                if (valueProvider is null || invokeProvider is null)
+                var invokeProvider = new ButtonAutomationPeer(goButton) as IInvokeProvider;
+                if (invokeProvider is null)
                 {
                     WriteInteractionResult(markerPath, new
                     {
                         backend = "xaml",
                         status = "error",
-                        error = "native automation patterns unavailable",
+                        error = "native button automation provider unavailable",
                     });
                     return;
                 }
 
-                valueProvider.SetValue(targetUrl);
+                _ = addressInput.Focus(FocusState.Programmatic);
+                addressInput.Text = targetUrl;
+                for (var remaining = 20; remaining >= 0; remaining--)
+                {
+                    if (string.Equals(component.Address, targetUrl, StringComparison.Ordinal))
+                    {
+                        break;
+                    }
+                    await System.Threading.Tasks.Task.Delay(50);
+                }
+                if (!string.Equals(component.Address, targetUrl, StringComparison.Ordinal))
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        address = component.Address,
+                        error = "native address edit did not dispatch",
+                    });
+                    return;
+                }
                 invokeProvider.Invoke();
                 for (var remaining = 50; remaining >= 0; remaining--)
                 {

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -1,5 +1,8 @@
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
@@ -27,6 +30,7 @@ public static class MosaicHost
     private static IntPtr browser;
     private static VentureContentSurface? contentSurface;
     private static int acceptanceReported;
+    private static int interactionAcceptanceStarted;
 
     public static string ApplyProps(VentureChrome component)
     {
@@ -62,6 +66,139 @@ public static class MosaicHost
         var status = ApplyResponse(component, response);
         contentSurface?.Refresh();
         return status;
+    }
+
+    public static void RunInteractionAcceptance(Window window, VentureChrome component)
+    {
+        var markerPath = Environment.GetEnvironmentVariable(
+            "VENTURE_BROWSER_INTERACTION_ACCEPTANCE_PATH");
+        var targetUrl = Environment.GetEnvironmentVariable("VENTURE_BROWSER_INTERACTION_URL");
+        if (string.IsNullOrWhiteSpace(markerPath)
+            || string.IsNullOrWhiteSpace(targetUrl)
+            || System.Threading.Interlocked.Exchange(ref interactionAcceptanceStarted, 1) != 0)
+        {
+            return;
+        }
+
+        component.Loaded += async (_, _) =>
+        {
+            try
+            {
+                var addressInput = await FindAutomationElementAsync<TextBox>(
+                    component, "address-input");
+                var goButton = await FindAutomationElementAsync<Button>(component, "go-button");
+                if (addressInput is null || goButton is null)
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native controls not found",
+                    });
+                    return;
+                }
+
+                var valueProvider = new TextBoxAutomationPeer(addressInput)
+                    .GetPattern(PatternInterface.Value) as IValueProvider;
+                var invokeProvider = new ButtonAutomationPeer(goButton)
+                    .GetPattern(PatternInterface.Invoke) as IInvokeProvider;
+                if (valueProvider is null || invokeProvider is null)
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native automation patterns unavailable",
+                    });
+                    return;
+                }
+
+                valueProvider.SetValue(targetUrl);
+                invokeProvider.Invoke();
+                for (var remaining = 50; remaining >= 0; remaining--)
+                {
+                    await System.Threading.Tasks.Task.Delay(100);
+                    _ = ApplyProps(component);
+                    if (string.Equals(component.Address, targetUrl, StringComparison.Ordinal)
+                        && string.Equals(
+                            component.PageTitle,
+                            "Venture interaction acceptance",
+                            StringComparison.Ordinal))
+                    {
+                        WriteInteractionResult(markerPath, new
+                        {
+                            backend = "xaml",
+                            status = "interacted",
+                            address = component.Address,
+                            pageTitle = component.PageTitle,
+                        });
+                        return;
+                    }
+                }
+
+                WriteInteractionResult(markerPath, new
+                {
+                    backend = "xaml",
+                    status = "error",
+                    address = component.Address,
+                    pageTitle = component.PageTitle,
+                    error = "navigation state did not update",
+                });
+            }
+            catch (Exception ex)
+            {
+                WriteInteractionResult(markerPath, new
+                {
+                    backend = "xaml",
+                    status = "error",
+                    error = ex.ToString(),
+                });
+            }
+        };
+    }
+
+    private static async System.Threading.Tasks.Task<T?> FindAutomationElementAsync<T>(
+        DependencyObject root,
+        string automationId)
+        where T : FrameworkElement
+    {
+        for (var remaining = 50; remaining >= 0; remaining--)
+        {
+            if (FindAutomationElement<T>(root, automationId) is { } element)
+            {
+                return element;
+            }
+            await System.Threading.Tasks.Task.Delay(100);
+        }
+        return null;
+    }
+
+    private static T? FindAutomationElement<T>(DependencyObject root, string automationId)
+        where T : FrameworkElement
+    {
+        if (root is T candidate
+            && string.Equals(
+                AutomationProperties.GetAutomationId(candidate),
+                automationId,
+                StringComparison.Ordinal))
+        {
+            return candidate;
+        }
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (var index = 0; index < count; index++)
+        {
+            if (FindAutomationElement<T>(VisualTreeHelper.GetChild(root, index), automationId)
+                is { } found)
+            {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private static void WriteInteractionResult(string path, object result)
+    {
+        File.WriteAllText(path, JsonSerializer.Serialize(result) + "\n");
     }
 
     private static void EnsureBrowser()


### PR DESCRIPTION
## What changed

- add optional interaction-acceptance hooks to generated SwiftUI and WinUI project shells
- implement Venture package-host drivers that edit the emitted native address control and activate navigation
- extend macOS and Windows generated-project launch gates to require a second local page to load through the shared Rust browser session
- keep all browser chrome authored in Venture's shared MIL/MLL/MSL package

## Why

The generated Venture shells already built, launched, and rendered their native content surfaces, and authored controls now expose stable native automation identifiers. The remaining acceptance gap was proving that interacting with those generated native controls reaches Mosaic dispatch and the shared browser session instead of stopping at static shell construction.

This is a bounded browser-wiring and interaction-acceptance slice. It does not claim full browser conformance.

## Validation

- `cargo test -p mosaic-emit-swiftui -p mosaic-emit-xaml -p mosaic-package-artifact-builder -p venture-browser-macos -p venture-browser-windows`
- `cargo clippy -p mosaic-emit-swiftui -p mosaic-emit-xaml -p mosaic-package-artifact-builder -p venture-browser-macos -p venture-browser-windows --all-targets -- -D warnings`
- `cargo test -p venture-browser-macos --test swiftui_project_launch -- --nocapture`
- `scripts/build-all.sh --emit-only` (all 9 Venture backends)
- `cargo test -q -p coding-adventures-html-parser --test html5lib_coverage_audit_test`
- HTML audit ratchets: tree-construction missing `0`; tokenizer missing `0`; normalized tokenizer skipped `0`

The Windows generated-project build/launch/interaction case is `cfg(target_os = "windows")` and runs on the native Windows CI job.
