### PR TITLE
fix(spice): validate MOS instance drain perimeter

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS instance `PD` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `AS` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `AD` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2255,6 +2255,13 @@ fn parse_element(
                     ));
                 }
             }
+            if let Some(drain_perimeter) = instance_params.get("PD") {
+                if !drain_perimeter.is_finite() || *drain_perimeter < 0.0 {
+                    return Err(NetlistParseError::new(
+                        "MOSFET PD must be finite and non-negative",
+                    ));
+                }
+            }
             Ok(Element::Mosfet(Mosfet::with_model(
                 name,
                 &fields[1],

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -928,6 +928,22 @@ fn rejects_invalid_mosfet_instance_source_areas() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_instance_drain_perimeters() {
+    for drain_perimeter in ["-1u", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model nch NMOS\nM1 d g s b nch PD={drain_perimeter}"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET PD must be finite and non-negative"));
+    }
+
+    assert!(parse_netlist(".model nch NMOS\nM1 d g s b nch PD=0").is_ok());
+}
+
+#[test]
 fn parses_tf_transfer_function_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS instance source-area validation.
+1. Rust Berkeley SPICE MOS instance drain-perimeter validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite instance `AS` values before lowering MOS
+   - Reject negative and non-finite instance `PD` values before lowering MOS
      elements into engine parameters.
-   - Preserve zero and positive source areas for bulk-junction behavior.
+   - Preserve zero and positive drain perimeters for sidewall-junction behavior.
 
 ## Completed Slices
 
@@ -3898,6 +3898,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite instance `AD` values are rejected before lowering
      MOS elements into engine parameters.
    - Zero and positive drain areas remain accepted for bulk-junction behavior.
+
+332. Rust Berkeley SPICE MOS instance source-area validation.
+   - Status: completed in PR 9443.
+   - Negative and non-finite instance `AS` values are rejected before lowering
+     MOS elements into engine parameters.
+   - Zero and positive source areas remain accepted for bulk-junction behavior.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS instance `PD` values before parser lowering
- preserve zero and positive drain perimeters for sidewall-junction behavior
- reconcile the SPICE implementation plan after #9443

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`