### PR TITLE
fix(spice): validate MOS instance source perimeter

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS instance `PS` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `PD` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `AS` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2262,6 +2262,13 @@ fn parse_element(
                     ));
                 }
             }
+            if let Some(source_perimeter) = instance_params.get("PS") {
+                if !source_perimeter.is_finite() || *source_perimeter < 0.0 {
+                    return Err(NetlistParseError::new(
+                        "MOSFET PS must be finite and non-negative",
+                    ));
+                }
+            }
             Ok(Element::Mosfet(Mosfet::with_model(
                 name,
                 &fields[1],

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -944,6 +944,22 @@ fn rejects_invalid_mosfet_instance_drain_perimeters() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_instance_source_perimeters() {
+    for source_perimeter in ["-1u", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model nch NMOS\nM1 d g s b nch PS={source_perimeter}"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET PS must be finite and non-negative"));
+    }
+
+    assert!(parse_netlist(".model nch NMOS\nM1 d g s b nch PS=0").is_ok());
+}
+
+#[test]
 fn parses_tf_transfer_function_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS instance drain-perimeter validation.
+1. Rust Berkeley SPICE MOS instance source-perimeter validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite instance `PD` values before lowering MOS
+   - Reject negative and non-finite instance `PS` values before lowering MOS
      elements into engine parameters.
-   - Preserve zero and positive drain perimeters for sidewall-junction behavior.
+   - Preserve zero and positive source perimeters for sidewall-junction behavior.
 
 ## Completed Slices
 
@@ -3904,6 +3904,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite instance `AS` values are rejected before lowering
      MOS elements into engine parameters.
    - Zero and positive source areas remain accepted for bulk-junction behavior.
+
+333. Rust Berkeley SPICE MOS instance drain-perimeter validation.
+   - Status: completed in PR 9448.
+   - Negative and non-finite instance `PD` values are rejected before lowering
+     MOS elements into engine parameters.
+   - Zero and positive drain perimeters remain accepted for sidewall-junction
+     behavior.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS instance `PS` values before lowering
- preserve explicit zero and positive source perimeters
- reconcile the SPICE completion plan after PR #9448

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

Rust-only parser-facade behavior changed; no Python or TypeScript package was touched.