### PR TITLE
Build the neural network learning roadmap

### DIFF
--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1150 | 98 | 60 | 7 | 1082 |
+| 1247 | 1151 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1153 | 98 | 60 | 7 | 1082 |
+| 1247 | 1154 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1145 | 98 | 60 | 7 | 1082 |
+| 1247 | 1146 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1144 | 98 | 60 | 7 | 1082 |
+| 1247 | 1145 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1148 | 98 | 60 | 7 | 1082 |
+| 1247 | 1149 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1147 | 98 | 60 | 7 | 1082 |
+| 1247 | 1148 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1158 | 98 | 60 | 7 | 1082 |
+| 1247 | 1159 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1246 | 1141 | 98 | 59 | 7 | 1082 |
+| 1246 | 1142 | 98 | 60 | 7 | 1081 |
 
 ## Method
 
@@ -27,7 +27,7 @@ mention provides a complete lesson.
 | P0 | 86 | 25 | 6 | 55 |
 | P1 | 9 | 22 | 0 | 90 |
 | P2 | 1 | 3 | 1 | 152 |
-| P3 | 2 | 9 | 0 | 785 |
+| P3 | 2 | 10 | 0 | 784 |
 
 ## P0 Backlog
 
@@ -966,7 +966,6 @@ mention provides a complete lesson.
 | `dom-core` | 1 | missing |
 | `double-ratchet` | 1 | missing |
 | `dsp-complex` | 1 | missing |
-| `dsp-conv` | 1 | missing |
 | `dsp-dct` | 1 | missing |
 | `dsp-fft` | 1 | missing |
 | `dsp-filters` | 1 | missing |

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1156 | 98 | 60 | 7 | 1082 |
+| 1247 | 1157 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1143 | 98 | 60 | 7 | 1082 |
+| 1247 | 1144 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1155 | 98 | 60 | 7 | 1082 |
+| 1247 | 1156 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1149 | 98 | 60 | 7 | 1082 |
+| 1247 | 1150 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1159 | 98 | 60 | 7 | 1082 |
+| 1247 | 1160 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1146 | 98 | 60 | 7 | 1082 |
+| 1247 | 1147 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1245 | 1139 | 98 | 59 | 7 | 1081 |
+| 1246 | 1141 | 98 | 59 | 7 | 1082 |
 
 ## Method
 
@@ -27,7 +27,7 @@ mention provides a complete lesson.
 | P0 | 86 | 25 | 6 | 55 |
 | P1 | 9 | 22 | 0 | 90 |
 | P2 | 1 | 3 | 1 | 152 |
-| P3 | 2 | 9 | 0 | 784 |
+| P3 | 2 | 9 | 0 | 785 |
 
 ## P0 Backlog
 
@@ -1198,6 +1198,7 @@ mention provides a complete lesson.
 | `smart-home-mqtt-integration` | 1 | missing |
 | `smart-home-onvif-integration` | 1 | missing |
 | `smart-home-registry` | 1 | missing |
+| `smart-home-reolink-integration` | 1 | missing |
 | `smart-home-runtime` | 1 | missing |
 | `smart-home-runtime-store` | 1 | missing |
 | `smart-home-testkit` | 1 | missing |

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1151 | 98 | 60 | 7 | 1082 |
+| 1247 | 1152 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1161 | 98 | 60 | 7 | 1082 |
+| 1247 | 1162 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1154 | 98 | 60 | 7 | 1082 |
+| 1247 | 1155 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1157 | 98 | 60 | 7 | 1082 |
+| 1247 | 1158 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1246 | 1142 | 98 | 60 | 7 | 1081 |
+| 1247 | 1143 | 98 | 60 | 7 | 1082 |
 
 ## Method
 
@@ -27,7 +27,7 @@ mention provides a complete lesson.
 | P0 | 86 | 25 | 6 | 55 |
 | P1 | 9 | 22 | 0 | 90 |
 | P2 | 1 | 3 | 1 | 152 |
-| P3 | 2 | 10 | 0 | 784 |
+| P3 | 2 | 10 | 0 | 785 |
 
 ## P0 Backlog
 
@@ -1198,6 +1198,7 @@ mention provides a complete lesson.
 | `smart-home-onvif-integration` | 1 | missing |
 | `smart-home-registry` | 1 | missing |
 | `smart-home-reolink-integration` | 1 | missing |
+| `smart-home-roku-ecp-integration` | 1 | missing |
 | `smart-home-runtime` | 1 | missing |
 | `smart-home-runtime-store` | 1 | missing |
 | `smart-home-testkit` | 1 | missing |

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1160 | 98 | 60 | 7 | 1082 |
+| 1247 | 1161 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1247 | 1152 | 98 | 60 | 7 | 1082 |
+| 1247 | 1153 | 98 | 60 | 7 | 1082 |
 
 ## Method
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -39,13 +39,14 @@ larger network:
 19. [Hopfield Associative Memory, by Hand](./hopfield-associative-memory-by-hand.md)
 20. [Tiny Graph Message Passing, by Hand](./tiny-graph-message-passing-by-hand.md)
 21. [Graph Convolution and Attention, by Hand](./graph-convolution-and-attention-by-hand.md)
-22. [Matrix Math](../matrix-math.md)
-23. [Loss Functions](../loss-functions.md)
-24. [Gradient Descent](../gradient-descent.md)
-25. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-26. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-27. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-28. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+22. [Initialization and Activation Distributions, by Hand](./initialization-and-activation-distributions-by-hand.md)
+23. [Matrix Math](../matrix-math.md)
+24. [Loss Functions](../loss-functions.md)
+25. [Gradient Descent](../gradient-descent.md)
+26. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+27. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+28. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+29. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -55,7 +56,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has eleven complementary views:
+has twelve complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -113,6 +114,10 @@ has eleven complementary views:
   sum its neighbors, and expose the shared synchronous affine-plus-ReLU update.
   Finish by comparing degree-normalized graph convolution with stable-softmax
   graph attention on the same self-looped neighborhoods.
+- **Deep-training lab:** hold a three-layer sign template fixed while switching
+  between tiny, Xavier, He, and deliberately large weight scales. Compare tanh
+  saturation with ReLU zeros, open one multiply-sum-activation calculation,
+  and watch population standard deviation change across layers.
 
 ## Language-Neutral Corpus
 
@@ -204,6 +209,11 @@ NN22 adds `code/specs/fixtures/graph-convolution-attention-v1`, including
 self-looped neighborhoods, endpoint-degree GCN coefficients, stable GAT
 softmax rows, every weighted contribution, and both output vectors.
 
+NN23 adds `code/specs/fixtures/initialization-activation-distribution-v1`,
+including fixed input and sign matrices, tiny/Xavier/He/large scales, canonical
+preactivations and activations, population standard deviations, exact-zero
+fractions, and tanh saturation fractions.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -227,6 +237,7 @@ python code/scripts/validate_one_dimensional_diffusion_labs.py
 python code/scripts/validate_hopfield_associative_memory_labs.py
 python code/scripts/validate_tiny_message_passing_labs.py
 python code/scripts/validate_graph_convolution_attention_labs.py
+python code/scripts/validate_initialization_activation_distribution_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -38,13 +38,14 @@ larger network:
 18. [One-Dimensional Diffusion, by Hand](./one-dimensional-diffusion-by-hand.md)
 19. [Hopfield Associative Memory, by Hand](./hopfield-associative-memory-by-hand.md)
 20. [Tiny Graph Message Passing, by Hand](./tiny-graph-message-passing-by-hand.md)
-21. [Matrix Math](../matrix-math.md)
-22. [Loss Functions](../loss-functions.md)
-23. [Gradient Descent](../gradient-descent.md)
-24. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-25. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-26. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-27. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+21. [Graph Convolution and Attention, by Hand](./graph-convolution-and-attention-by-hand.md)
+22. [Matrix Math](../matrix-math.md)
+23. [Loss Functions](../loss-functions.md)
+24. [Gradient Descent](../gradient-descent.md)
+25. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+26. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+27. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+28. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -110,6 +111,8 @@ has eleven complementary views:
   recovered fixed point.
   Then expand a three-node path into directed messages, select any node's inbox,
   sum its neighbors, and expose the shared synchronous affine-plus-ReLU update.
+  Finish by comparing degree-normalized graph convolution with stable-softmax
+  graph attention on the same self-looped neighborhoods.
 
 ## Language-Neutral Corpus
 
@@ -197,6 +200,10 @@ NN21 adds `code/specs/fixtures/tiny-message-passing-v1`, including undirected-
 edge expansion, every directed source-weighted message, per-node sum inboxes,
 shared self and bias routes, ReLU inputs, and all synchronous output features.
 
+NN22 adds `code/specs/fixtures/graph-convolution-attention-v1`, including
+self-looped neighborhoods, endpoint-degree GCN coefficients, stable GAT
+softmax rows, every weighted contribution, and both output vectors.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -219,6 +226,7 @@ python code/scripts/validate_one_dimensional_gan_labs.py
 python code/scripts/validate_one_dimensional_diffusion_labs.py
 python code/scripts/validate_hopfield_associative_memory_labs.py
 python code/scripts/validate_tiny_message_passing_labs.py
+python code/scripts/validate_graph_convolution_attention_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -30,13 +30,14 @@ larger network:
 10. [GRU and LSTM Gates, by Hand](./gru-and-lstm-gates-by-hand.md)
 11. [Query, Key, and Value Scores by Hand](./attention-qkv-by-hand.md)
 12. [Softmax Attention and Causal Masking, by Hand](./softmax-attention-and-causal-masking-by-hand.md)
-13. [Matrix Math](../matrix-math.md)
-14. [Loss Functions](../loss-functions.md)
-15. [Gradient Descent](../gradient-descent.md)
-16. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-17. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-18. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-19. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+13. [Multi-Head Attention, Add, and Norm, by Hand](./multi-head-attention-add-and-norm-by-hand.md)
+14. [Matrix Math](../matrix-math.md)
+15. [Loss Functions](../loss-functions.md)
+16. [Gradient Descent](../gradient-descent.md)
+17. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+18. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+19. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+20. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -80,7 +81,9 @@ has nine complementary views:
   without pretending that softmax or value mixing has happened yet. Then open
   the causal-softmax view to select a whole query row, expose stable
   normalization, block future keys, and follow every weight into its value
-  contribution and output context.
+  contribution and output context. Finally, compare two independently
+  projected causal heads and trace their concatenation, output projection,
+  residual addition, and per-token layer normalization.
 
 ## Language-Neutral Corpus
 
@@ -127,6 +130,11 @@ NN13 adds `code/specs/fixtures/attention-softmax-v1`, including masked and
 unmasked stable-softmax traces, row maxima, exponentials, denominators,
 attention weights, weighted value contributions, and output contexts.
 
+NN14 adds `code/specs/fixtures/multi-head-attention-v1`, including two scalar
+heads with different projections, complete per-head causal-softmax traces,
+context concatenation, output-projection products, residual coordinates, and
+layer-normalization statistics.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -141,6 +149,7 @@ python code/scripts/validate_recurrent_bptt_labs.py
 python code/scripts/validate_gated_recurrent_labs.py
 python code/scripts/validate_attention_qkv_labs.py
 python code/scripts/validate_attention_softmax_labs.py
+python code/scripts/validate_multi_head_attention_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -165,6 +174,9 @@ The first NN12 lab gives three tokens separate asking, matching, and payload
 roles, then expands all nine query-key scores before softmax or value mixing.
 The first NN13 lab masks the future before normalization, proves that every
 allowed row sums to one, and carries those weights into an explicit value mix.
+The first NN14 lab gives two heads different coordinate views, rejoins their
+contexts at model width, adds the original token, and exposes every population-
+variance layer-normalization term.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -22,13 +22,14 @@ larger network:
 2. [Backpropagation by Hand](./backpropagation-by-hand.md)
 3. [Optimization Under the Microscope](./optimization-under-the-microscope.md)
 4. [Convolution, Window by Window](./convolution-window-by-window.md)
-5. [Matrix Math](../matrix-math.md)
-6. [Loss Functions](../loss-functions.md)
-7. [Gradient Descent](../gradient-descent.md)
-8. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-9. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-10. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-11. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+5. [Training a Convolution Kernel by Hand](./training-a-convolution-kernel-by-hand.md)
+6. [Matrix Math](../matrix-math.md)
+7. [Loss Functions](../loss-functions.md)
+8. [Gradient Descent](../gradient-descent.md)
+9. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+10. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+11. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+12. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -52,7 +53,8 @@ has five complementary views:
   for XOR-like logic, bends, thresholds, circles, moons, and feature
   interactions.
 - **Spatial lab:** slide one shared 1D kernel across a signal and inspect every
-  window, product, running accumulator, and feature-map output.
+  window, product, running accumulator, feature-map output, per-position
+  gradient contribution, shared-weight reduction, and proposed update.
 
 ## Language-Neutral Corpus
 
@@ -65,12 +67,17 @@ cross-correlation and complete multiply-accumulate traces in
 package, a Python notebook, or a browser visualizer explain the same
 computation.
 
+NN06 adds a trainable shared-kernel trace in
+`code/specs/fixtures/convolution-training-v1`, including a central finite-
+difference check and one complete gradient-descent update.
+
 Validate the bootstrap corpus with:
 
 ```text
 python code/scripts/validate_neural_learning_labs.py
 python code/scripts/validate_optimization_learning_labs.py
 python code/scripts/validate_convolution_learning_labs.py
+python code/scripts/validate_convolution_training_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -78,7 +85,8 @@ sigmoid OR neuron, and the hidden representation used by a solved XOR network.
 The first NN04 lab covers a linear loss landscape, an independent gradient
 check, and stochastic, mini-batch, and full-batch trajectories. The first NN05
 lab covers an asymmetric shared kernel and every intermediate produced as it
-slides over a signal.
+slides over a signal. The first NN06 lab shows how every output contributes to
+the shared kernel gradient and verifies one loss-reducing update.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -26,13 +26,14 @@ larger network:
 6. [A Tiny Image CNN, Completely by Hand](./tiny-image-cnn-by-hand.md)
 7. [Residual Paths and Receptive Fields by Hand](./residual-paths-and-receptive-fields-by-hand.md)
 8. [One Recurrent State, Unrolled by Hand](./recurrent-state-unrolled-by-hand.md)
-9. [Matrix Math](../matrix-math.md)
-10. [Loss Functions](../loss-functions.md)
-11. [Gradient Descent](../gradient-descent.md)
-12. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-13. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-14. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-15. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+9. [Backpropagation Through Time, by Hand](./backpropagation-through-time-by-hand.md)
+10. [Matrix Math](../matrix-math.md)
+11. [Loss Functions](../loss-functions.md)
+12. [Gradient Descent](../gradient-descent.md)
+13. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+14. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+15. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+16. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -66,7 +67,9 @@ has eight complementary views:
   boundary-clipped receptive fields.
 - **Recurrent lab:** unroll one shared scalar cell for three time steps, inspect
   every input and carried-state term, and cut the recurrent link to isolate
-  what memory contributes.
+  what memory contributes. Then reverse the unroll, select any BPTT step, add
+  shared-parameter gradient contributions, audit them with finite differences,
+  and preview one loss-reducing update.
 
 ## Language-Neutral Corpus
 
@@ -96,6 +99,11 @@ NN09 adds a three-step scalar recurrent chain in
 `code/specs/fixtures/recurrent-unroll-v1`, including its explicit initial
 state, shared parameters, every forward term, and a no-memory ablation.
 
+NN10 adds the reverse pass in `code/specs/fixtures/recurrent-bptt-v1`, including
+direct and future state gradients, every time-step contribution to shared
+parameters, their accumulated totals, a central finite-difference audit, the
+initial-state gradient, and one complete update.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -106,6 +114,7 @@ python code/scripts/validate_convolution_training_labs.py
 python code/scripts/validate_tiny_image_cnn_labs.py
 python code/scripts/validate_residual_receptive_labs.py
 python code/scripts/validate_recurrent_unroll_labs.py
+python code/scripts/validate_recurrent_bptt_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -121,6 +130,9 @@ max pooling. The first NN08 lab expands a two-layer residual block into its
 deep and identity routes, then counts every path from one output back to the
 original input. The first NN09 lab passes one hidden-state value through three
 executions of the same cell and compares it with the recurrent link removed.
+The first NN10 lab reverses that chain, proves how later loss reaches earlier
+states, accumulates all three executions into one shared gradient set, and
+checks the result independently before applying an update.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -20,26 +20,31 @@ larger network:
 
 1. [From Data to One Neuron](./from-data-to-one-neuron.md)
 2. [Backpropagation by Hand](./backpropagation-by-hand.md)
-3. [Matrix Math](../matrix-math.md)
-4. [Loss Functions](../loss-functions.md)
-5. [Gradient Descent](../gradient-descent.md)
-6. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-7. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-8. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-9. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+3. [Optimization Under the Microscope](./optimization-under-the-microscope.md)
+4. [Matrix Math](../matrix-math.md)
+5. [Loss Functions](../loss-functions.md)
+6. [Gradient Descent](../gradient-descent.md)
+7. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+8. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+9. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+10. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
-The [full curriculum](./curriculum.md) continues from these foundations through
+The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
+[full curriculum](./curriculum.md) continues from these foundations through
 convolutional, recurrent, attention-based, generative, graph, and scaled neural
 networks.
 
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has three complementary views:
+has four complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
   time.
+- **Optimization microscope:** inspect a loss landscape, check backpropagation
+  against finite differences, and compare stochastic, mini-batch, and
+  full-batch updates.
 - **Linear lab:** compare 100 datasets, learning rates, loss functions, feature
   scales, noise levels, and real-data slices.
 - **Hidden-layer lab:** inspect intermediate neuron activations and gradients
@@ -48,19 +53,24 @@ has three complementary views:
 
 ## Language-Neutral Corpus
 
-The learning examples are not owned by the visualizer. NN03 stores their data,
-parameters, and golden numerical traces in
-`code/specs/fixtures/neural-learning-v1`. That lets a Rust CLI, a Go package, a
-Python notebook, or a browser visualizer explain the same computation.
+The learning examples are not owned by the visualizer. NN03 stores forward and
+first-step traces in `code/specs/fixtures/neural-learning-v1`. NN04 stores
+finite-difference checks and deterministic batch-strategy traces in
+`code/specs/fixtures/optimization-learning-v1`. That lets a Rust CLI, a Go
+package, a Python notebook, or a browser visualizer explain the same
+computation.
 
 Validate the bootstrap corpus with:
 
 ```text
 python code/scripts/validate_neural_learning_labs.py
+python code/scripts/validate_optimization_learning_labs.py
 ```
 
-The first four labs cover a weighted forward pass, Celsius regression, a
+The first NN03 labs cover a weighted forward pass, Celsius regression, a
 sigmoid OR neuron, and the hidden representation used by a solved XOR network.
+The first NN04 lab covers a linear loss landscape, an independent gradient
+check, and stochastic, mini-batch, and full-batch trajectories.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -21,13 +21,14 @@ larger network:
 1. [From Data to One Neuron](./from-data-to-one-neuron.md)
 2. [Backpropagation by Hand](./backpropagation-by-hand.md)
 3. [Optimization Under the Microscope](./optimization-under-the-microscope.md)
-4. [Matrix Math](../matrix-math.md)
-5. [Loss Functions](../loss-functions.md)
-6. [Gradient Descent](../gradient-descent.md)
-7. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-8. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-9. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-10. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+4. [Convolution, Window by Window](./convolution-window-by-window.md)
+5. [Matrix Math](../matrix-math.md)
+6. [Loss Functions](../loss-functions.md)
+7. [Gradient Descent](../gradient-descent.md)
+8. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+9. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+10. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+11. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -37,7 +38,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has four complementary views:
+has five complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -50,13 +51,17 @@ has four complementary views:
 - **Hidden-layer lab:** inspect intermediate neuron activations and gradients
   for XOR-like logic, bends, thresholds, circles, moons, and feature
   interactions.
+- **Spatial lab:** slide one shared 1D kernel across a signal and inspect every
+  window, product, running accumulator, and feature-map output.
 
 ## Language-Neutral Corpus
 
 The learning examples are not owned by the visualizer. NN03 stores forward and
 first-step traces in `code/specs/fixtures/neural-learning-v1`. NN04 stores
 finite-difference checks and deterministic batch-strategy traces in
-`code/specs/fixtures/optimization-learning-v1`. That lets a Rust CLI, a Go
+`code/specs/fixtures/optimization-learning-v1`. NN05 stores valid 1D
+cross-correlation and complete multiply-accumulate traces in
+`code/specs/fixtures/convolution-learning-v1`. That lets a Rust CLI, a Go
 package, a Python notebook, or a browser visualizer explain the same
 computation.
 
@@ -65,12 +70,15 @@ Validate the bootstrap corpus with:
 ```text
 python code/scripts/validate_neural_learning_labs.py
 python code/scripts/validate_optimization_learning_labs.py
+python code/scripts/validate_convolution_learning_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
 sigmoid OR neuron, and the hidden representation used by a solved XOR network.
 The first NN04 lab covers a linear loss landscape, an independent gradient
-check, and stochastic, mini-batch, and full-batch trajectories.
+check, and stochastic, mini-batch, and full-batch trajectories. The first NN05
+lab covers an asymmetric shared kernel and every intermediate produced as it
+slides over a signal.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -24,13 +24,14 @@ larger network:
 4. [Convolution, Window by Window](./convolution-window-by-window.md)
 5. [Training a Convolution Kernel by Hand](./training-a-convolution-kernel-by-hand.md)
 6. [A Tiny Image CNN, Completely by Hand](./tiny-image-cnn-by-hand.md)
-7. [Matrix Math](../matrix-math.md)
-8. [Loss Functions](../loss-functions.md)
-9. [Gradient Descent](../gradient-descent.md)
-10. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-11. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-12. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-13. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+7. [Residual Paths and Receptive Fields by Hand](./residual-paths-and-receptive-fields-by-hand.md)
+8. [Matrix Math](../matrix-math.md)
+9. [Loss Functions](../loss-functions.md)
+10. [Gradient Descent](../gradient-descent.md)
+11. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+12. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+13. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+14. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -40,7 +41,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has six complementary views:
+has seven complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -59,6 +60,9 @@ has six complementary views:
 - **Image CNN lab:** follow two `3 x 3` input channels through per-channel
   kernels, channel reduction, spatial normalization, ReLU, and max pooling,
   with every selected window and winner exposed.
+- **Residual lab:** compare a two-layer local path with an identity shortcut,
+  toggle the shortcut, and expand any output into exact input-path counts and
+  boundary-clipped receptive fields.
 
 ## Language-Neutral Corpus
 
@@ -79,6 +83,11 @@ NN07 adds a two-channel tiny image pipeline in
 `code/specs/fixtures/tiny-image-cnn-v1`, including every channel contribution,
 normalization statistic, ReLU output, pooled value, and argmax coordinate.
 
+NN08 adds a two-layer residual block in
+`code/specs/fixtures/residual-receptive-v1`, including the deep and identity
+paths, every expanded input dependency, path multiplicities, and clipped
+boundary receptive fields.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -87,6 +96,7 @@ python code/scripts/validate_optimization_learning_labs.py
 python code/scripts/validate_convolution_learning_labs.py
 python code/scripts/validate_convolution_training_labs.py
 python code/scripts/validate_tiny_image_cnn_labs.py
+python code/scripts/validate_residual_receptive_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -98,7 +108,9 @@ slides over a signal. The first NN06 lab shows how every output contributes to
 the shared kernel gradient and verifies one loss-reducing update. The first
 NN07 lab shows how input channels accumulate into output feature maps, which
 spatial values share normalization statistics, and which locations survive
-max pooling.
+max pooling. The first NN08 lab expands a two-layer residual block into its
+deep and identity routes, then counts every path from one output back to the
+original input.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -23,13 +23,14 @@ larger network:
 3. [Optimization Under the Microscope](./optimization-under-the-microscope.md)
 4. [Convolution, Window by Window](./convolution-window-by-window.md)
 5. [Training a Convolution Kernel by Hand](./training-a-convolution-kernel-by-hand.md)
-6. [Matrix Math](../matrix-math.md)
-7. [Loss Functions](../loss-functions.md)
-8. [Gradient Descent](../gradient-descent.md)
-9. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-10. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-11. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-12. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+6. [A Tiny Image CNN, Completely by Hand](./tiny-image-cnn-by-hand.md)
+7. [Matrix Math](../matrix-math.md)
+8. [Loss Functions](../loss-functions.md)
+9. [Gradient Descent](../gradient-descent.md)
+10. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+11. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+12. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+13. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -39,7 +40,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has five complementary views:
+has six complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -55,6 +56,9 @@ has five complementary views:
 - **Spatial lab:** slide one shared 1D kernel across a signal and inspect every
   window, product, running accumulator, feature-map output, per-position
   gradient contribution, shared-weight reduction, and proposed update.
+- **Image CNN lab:** follow two `3 x 3` input channels through per-channel
+  kernels, channel reduction, spatial normalization, ReLU, and max pooling,
+  with every selected window and winner exposed.
 
 ## Language-Neutral Corpus
 
@@ -71,6 +75,10 @@ NN06 adds a trainable shared-kernel trace in
 `code/specs/fixtures/convolution-training-v1`, including a central finite-
 difference check and one complete gradient-descent update.
 
+NN07 adds a two-channel tiny image pipeline in
+`code/specs/fixtures/tiny-image-cnn-v1`, including every channel contribution,
+normalization statistic, ReLU output, pooled value, and argmax coordinate.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -78,6 +86,7 @@ python code/scripts/validate_neural_learning_labs.py
 python code/scripts/validate_optimization_learning_labs.py
 python code/scripts/validate_convolution_learning_labs.py
 python code/scripts/validate_convolution_training_labs.py
+python code/scripts/validate_tiny_image_cnn_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -86,7 +95,10 @@ The first NN04 lab covers a linear loss landscape, an independent gradient
 check, and stochastic, mini-batch, and full-batch trajectories. The first NN05
 lab covers an asymmetric shared kernel and every intermediate produced as it
 slides over a signal. The first NN06 lab shows how every output contributes to
-the shared kernel gradient and verifies one loss-reducing update.
+the shared kernel gradient and verifies one loss-reducing update. The first
+NN07 lab shows how input channels accumulate into output feature maps, which
+spatial values share normalization statistics, and which locations survive
+max pooling.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -31,13 +31,14 @@ larger network:
 11. [Query, Key, and Value Scores by Hand](./attention-qkv-by-hand.md)
 12. [Softmax Attention and Causal Masking, by Hand](./softmax-attention-and-causal-masking-by-hand.md)
 13. [Multi-Head Attention, Add, and Norm, by Hand](./multi-head-attention-add-and-norm-by-hand.md)
-14. [Matrix Math](../matrix-math.md)
-15. [Loss Functions](../loss-functions.md)
-16. [Gradient Descent](../gradient-descent.md)
-17. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-18. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-19. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-20. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+14. [A Tiny Decoder-Only Language Model Training Step, by Hand](./tiny-decoder-language-model-training-by-hand.md)
+15. [Matrix Math](../matrix-math.md)
+16. [Loss Functions](../loss-functions.md)
+17. [Gradient Descent](../gradient-descent.md)
+18. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+19. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+20. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+21. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -83,7 +84,10 @@ has nine complementary views:
   normalization, block future keys, and follow every weight into its value
   contribution and output context. Finally, compare two independently
   projected causal heads and trace their concatenation, output projection,
-  residual addition, and per-token layer normalization.
+  residual addition, and per-token layer normalization. Continue into the tiny
+  decoder trace to shift a sequence into next-token targets, inspect logits,
+  stable softmax, cross-entropy, shared-head gradients, and one loss-reducing
+  SGD update.
 
 ## Language-Neutral Corpus
 
@@ -135,6 +139,11 @@ heads with different projections, complete per-head causal-softmax traces,
 context concatenation, output-projection products, residual coordinates, and
 layer-normalization statistics.
 
+NN15 adds `code/specs/fixtures/tiny-decoder-training-v1`, including the causal
+next-token shift, saved decoder states, every unembedding product, stable
+softmax and cross-entropy trace, state and shared-head gradients, a central
+finite-difference audit, one SGD update, and the resulting lower mean loss.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -150,6 +159,7 @@ python code/scripts/validate_gated_recurrent_labs.py
 python code/scripts/validate_attention_qkv_labs.py
 python code/scripts/validate_attention_softmax_labs.py
 python code/scripts/validate_multi_head_attention_labs.py
+python code/scripts/validate_tiny_decoder_training_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -177,6 +187,10 @@ allowed row sums to one, and carries those weights into an explicit value mix.
 The first NN14 lab gives two heads different coordinate views, rejoins their
 contexts at model width, adds the original token, and exposes every population-
 variance layer-normalization term.
+The first NN15 lab shifts `red blue purple` into two causal next-token
+predictions, updates their shared vocabulary head, preserves the gradient
+entering the frozen decoder states, and verifies that one SGD step lowers mean
+cross-entropy.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -32,13 +32,14 @@ larger network:
 12. [Softmax Attention and Causal Masking, by Hand](./softmax-attention-and-causal-masking-by-hand.md)
 13. [Multi-Head Attention, Add, and Norm, by Hand](./multi-head-attention-add-and-norm-by-hand.md)
 14. [A Tiny Decoder-Only Language Model Training Step, by Hand](./tiny-decoder-language-model-training-by-hand.md)
-15. [Matrix Math](../matrix-math.md)
-16. [Loss Functions](../loss-functions.md)
-17. [Gradient Descent](../gradient-descent.md)
-18. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-19. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-20. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-21. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+15. [A Two-Number Autoencoder Bottleneck, by Hand](./two-number-autoencoder-bottleneck-by-hand.md)
+16. [Matrix Math](../matrix-math.md)
+17. [Loss Functions](../loss-functions.md)
+18. [Gradient Descent](../gradient-descent.md)
+19. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+20. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+21. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+22. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -48,7 +49,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has nine complementary views:
+has ten complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -88,6 +89,10 @@ has nine complementary views:
   decoder trace to shift a sequence into next-token targets, inspect logits,
   stable softmax, cross-entropy, shared-head gradients, and one loss-reducing
   SGD update.
+- **Representation lab:** compress two coordinates through one scalar, inspect
+  each decoder branch and reconstruction error, add both routes into the
+  bottleneck gradient, audit all seven parameters, and compare the full model
+  before and after one loss-reducing update.
 
 ## Language-Neutral Corpus
 
@@ -144,6 +149,11 @@ next-token shift, saved decoder states, every unembedding product, stable
 softmax and cross-entropy trace, state and shared-head gradients, a central
 finite-difference audit, one SGD update, and the resulting lower mean loss.
 
+NN16 adds `code/specs/fixtures/two-number-autoencoder-v1`, including both
+encoder products, a one-scalar bottleneck, two decoder branches,
+reconstruction errors, complete backward gradients, a seven-parameter central
+finite-difference audit, and one loss-reducing update.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -160,6 +170,7 @@ python code/scripts/validate_attention_qkv_labs.py
 python code/scripts/validate_attention_softmax_labs.py
 python code/scripts/validate_multi_head_attention_labs.py
 python code/scripts/validate_tiny_decoder_training_labs.py
+python code/scripts/validate_two_number_autoencoder_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -191,6 +202,9 @@ The first NN15 lab shifts `red blue purple` into two causal next-token
 predictions, updates their shared vocabulary head, preserves the gradient
 entering the frozen decoder states, and verifies that one SGD step lowers mean
 cross-entropy.
+The first NN16 lab forces `[2,-1]` through one scalar, adds both reconstruction
+errors at that bottleneck, audits all seven trainable gradients, and reruns the
+entire encoder and decoder after one loss-reducing step.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -29,13 +29,14 @@ larger network:
 9. [Backpropagation Through Time, by Hand](./backpropagation-through-time-by-hand.md)
 10. [GRU and LSTM Gates, by Hand](./gru-and-lstm-gates-by-hand.md)
 11. [Query, Key, and Value Scores by Hand](./attention-qkv-by-hand.md)
-12. [Matrix Math](../matrix-math.md)
-13. [Loss Functions](../loss-functions.md)
-14. [Gradient Descent](../gradient-descent.md)
-15. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-16. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-17. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-18. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+12. [Softmax Attention and Causal Masking, by Hand](./softmax-attention-and-causal-masking-by-hand.md)
+13. [Matrix Math](../matrix-math.md)
+14. [Loss Functions](../loss-functions.md)
+15. [Gradient Descent](../gradient-descent.md)
+16. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+17. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+18. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+19. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -76,7 +77,10 @@ has nine complementary views:
 - **Attention lab:** project three tokens into aligned query, key, and value
   rows; open any cell in the `3 x 3` query-key score matrix; inspect its two
   coordinate products; and switch between raw and dimension-scaled scores
-  without pretending that softmax or value mixing has happened yet.
+  without pretending that softmax or value mixing has happened yet. Then open
+  the causal-softmax view to select a whole query row, expose stable
+  normalization, block future keys, and follow every weight into its value
+  contribution and output context.
 
 ## Language-Neutral Corpus
 
@@ -119,6 +123,10 @@ NN12 adds `code/specs/fixtures/attention-qkv-v1`, including all three shared
 projection matrices, every token's query/key/value vectors, all nine
 coordinate-level dot products, and the raw and scaled score matrices.
 
+NN13 adds `code/specs/fixtures/attention-softmax-v1`, including masked and
+unmasked stable-softmax traces, row maxima, exponentials, denominators,
+attention weights, weighted value contributions, and output contexts.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -132,6 +140,7 @@ python code/scripts/validate_recurrent_unroll_labs.py
 python code/scripts/validate_recurrent_bptt_labs.py
 python code/scripts/validate_gated_recurrent_labs.py
 python code/scripts/validate_attention_qkv_labs.py
+python code/scripts/validate_attention_softmax_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -154,6 +163,8 @@ The first NN11 lab routes the same old memory and candidate through a GRU and
 an LSTM, then closes or opens one gate at a time to isolate its responsibility.
 The first NN12 lab gives three tokens separate asking, matching, and payload
 roles, then expands all nine query-key scores before softmax or value mixing.
+The first NN13 lab masks the future before normalization, proves that every
+allowed row sums to one, and carries those weights into an explicit value mix.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -27,13 +27,14 @@ larger network:
 7. [Residual Paths and Receptive Fields by Hand](./residual-paths-and-receptive-fields-by-hand.md)
 8. [One Recurrent State, Unrolled by Hand](./recurrent-state-unrolled-by-hand.md)
 9. [Backpropagation Through Time, by Hand](./backpropagation-through-time-by-hand.md)
-10. [Matrix Math](../matrix-math.md)
-11. [Loss Functions](../loss-functions.md)
-12. [Gradient Descent](../gradient-descent.md)
-13. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-14. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-15. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-16. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+10. [GRU and LSTM Gates, by Hand](./gru-and-lstm-gates-by-hand.md)
+11. [Matrix Math](../matrix-math.md)
+12. [Loss Functions](../loss-functions.md)
+13. [Gradient Descent](../gradient-descent.md)
+14. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+15. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+16. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+17. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -69,7 +70,8 @@ has eight complementary views:
   every input and carried-state term, and cut the recurrent link to isolate
   what memory contributes. Then reverse the unroll, select any BPTT step, add
   shared-parameter gradient contributions, audit them with finite differences,
-  and preview one loss-reducing update.
+  and preview one loss-reducing update. Finally, compare aligned GRU and LSTM
+  memory lanes and intervene on one gate without changing the other signals.
 
 ## Language-Neutral Corpus
 
@@ -104,6 +106,10 @@ direct and future state gradients, every time-step contribution to shared
 parameters, their accumulated totals, a central finite-difference audit, the
 initial-state gradient, and one complete update.
 
+NN11 adds `code/specs/fixtures/gated-recurrent-v1`, including scalar GRU and
+LSTM gate preactivations, every state contribution, explicit LSTM cell/hidden
+outputs, and seven one-gate counterfactuals.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -115,6 +121,7 @@ python code/scripts/validate_tiny_image_cnn_labs.py
 python code/scripts/validate_residual_receptive_labs.py
 python code/scripts/validate_recurrent_unroll_labs.py
 python code/scripts/validate_recurrent_bptt_labs.py
+python code/scripts/validate_gated_recurrent_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -133,6 +140,8 @@ executions of the same cell and compares it with the recurrent link removed.
 The first NN10 lab reverses that chain, proves how later loss reaches earlier
 states, accumulates all three executions into one shared gradient set, and
 checks the result independently before applying an update.
+The first NN11 lab routes the same old memory and candidate through a GRU and
+an LSTM, then closes or opens one gate at a time to isolate its responsibility.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -33,13 +33,14 @@ larger network:
 13. [Multi-Head Attention, Add, and Norm, by Hand](./multi-head-attention-add-and-norm-by-hand.md)
 14. [A Tiny Decoder-Only Language Model Training Step, by Hand](./tiny-decoder-language-model-training-by-hand.md)
 15. [A Two-Number Autoencoder Bottleneck, by Hand](./two-number-autoencoder-bottleneck-by-hand.md)
-16. [Matrix Math](../matrix-math.md)
-17. [Loss Functions](../loss-functions.md)
-18. [Gradient Descent](../gradient-descent.md)
-19. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-20. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-21. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-22. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+16. [Variational Sampling and the KL Tradeoff, by Hand](./variational-sampling-and-kl-tradeoff-by-hand.md)
+17. [Matrix Math](../matrix-math.md)
+18. [Loss Functions](../loss-functions.md)
+19. [Gradient Descent](../gradient-descent.md)
+20. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+21. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+22. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+23. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -91,8 +92,9 @@ has ten complementary views:
   SGD update.
 - **Representation lab:** compress two coordinates through one scalar, inspect
   each decoder branch and reconstruction error, add both routes into the
-  bottleneck gradient, audit all seven parameters, and compare the full model
-  before and after one loss-reducing update.
+  bottleneck gradient, then switch to a scalar variational autoencoder to expose
+  Gaussian parameters, saved-noise reparameterization, reconstruction versus
+  beta-weighted KL gradients, six finite differences, and a full-model update.
 
 ## Language-Neutral Corpus
 
@@ -154,6 +156,11 @@ encoder products, a one-scalar bottleneck, two decoder branches,
 reconstruction errors, complete backward gradients, a seven-parameter central
 finite-difference audit, and one loss-reducing update.
 
+NN17 adds `code/specs/fixtures/variational-autoencoder-v1`, including a scalar
+Gaussian mean and log-variance, saved epsilon, reparameterized latent sample,
+half-squared reconstruction loss, beta-weighted KL divergence, separate
+gradient routes, six central finite differences, and one lower-total-loss step.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -171,6 +178,7 @@ python code/scripts/validate_attention_softmax_labs.py
 python code/scripts/validate_multi_head_attention_labs.py
 python code/scripts/validate_tiny_decoder_training_labs.py
 python code/scripts/validate_two_number_autoencoder_labs.py
+python code/scripts/validate_variational_autoencoder_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -205,6 +213,9 @@ cross-entropy.
 The first NN16 lab forces `[2,-1]` through one scalar, adds both reconstruction
 errors at that bottleneck, audits all seven trainable gradients, and reruns the
 entire encoder and decoder after one loss-reducing step.
+The first NN17 lab holds one Gaussian noise sample fixed, exposes how
+reconstruction and beta-weighted KL signals meet at the mean and log-variance,
+audits all six trainable gradients, and reruns the complete stochastic path.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -37,13 +37,14 @@ larger network:
 17. [A One-Dimensional GAN Game, by Hand](./one-dimensional-gan-game-by-hand.md)
 18. [One-Dimensional Diffusion, by Hand](./one-dimensional-diffusion-by-hand.md)
 19. [Hopfield Associative Memory, by Hand](./hopfield-associative-memory-by-hand.md)
-20. [Matrix Math](../matrix-math.md)
-21. [Loss Functions](../loss-functions.md)
-22. [Gradient Descent](../gradient-descent.md)
-23. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-24. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-25. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-26. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+20. [Tiny Graph Message Passing, by Hand](./tiny-graph-message-passing-by-hand.md)
+21. [Matrix Math](../matrix-math.md)
+22. [Loss Functions](../loss-functions.md)
+23. [Gradient Descent](../gradient-descent.md)
+24. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+25. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+26. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+27. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -107,6 +108,8 @@ has eleven complementary views:
   symmetric zero-diagonal weight matrix, damage one bit, expose every incoming
   vote in an asynchronous sweep, and watch energy descend as overlap reaches a
   recovered fixed point.
+  Then expand a three-node path into directed messages, select any node's inbox,
+  sum its neighbors, and expose the shared synchronous affine-plus-ReLU update.
 
 ## Language-Neutral Corpus
 
@@ -190,6 +193,10 @@ normalized Hebbian outer product, symmetric zero-diagonal weights, one damaged
 bipolar cue, every asynchronous incoming vote and state transition, Hopfield
 energy, normalized overlap, and the recovered fixed point.
 
+NN21 adds `code/specs/fixtures/tiny-message-passing-v1`, including undirected-
+edge expansion, every directed source-weighted message, per-node sum inboxes,
+shared self and bias routes, ReLU inputs, and all synchronous output features.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -211,6 +218,7 @@ python code/scripts/validate_variational_autoencoder_labs.py
 python code/scripts/validate_one_dimensional_gan_labs.py
 python code/scripts/validate_one_dimensional_diffusion_labs.py
 python code/scripts/validate_hopfield_associative_memory_labs.py
+python code/scripts/validate_tiny_message_passing_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -25,13 +25,14 @@ larger network:
 5. [Training a Convolution Kernel by Hand](./training-a-convolution-kernel-by-hand.md)
 6. [A Tiny Image CNN, Completely by Hand](./tiny-image-cnn-by-hand.md)
 7. [Residual Paths and Receptive Fields by Hand](./residual-paths-and-receptive-fields-by-hand.md)
-8. [Matrix Math](../matrix-math.md)
-9. [Loss Functions](../loss-functions.md)
-10. [Gradient Descent](../gradient-descent.md)
-11. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-12. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-13. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-14. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+8. [One Recurrent State, Unrolled by Hand](./recurrent-state-unrolled-by-hand.md)
+9. [Matrix Math](../matrix-math.md)
+10. [Loss Functions](../loss-functions.md)
+11. [Gradient Descent](../gradient-descent.md)
+12. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+13. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+14. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+15. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -41,7 +42,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has seven complementary views:
+has eight complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -63,6 +64,9 @@ has seven complementary views:
 - **Residual lab:** compare a two-layer local path with an identity shortcut,
   toggle the shortcut, and expand any output into exact input-path counts and
   boundary-clipped receptive fields.
+- **Recurrent lab:** unroll one shared scalar cell for three time steps, inspect
+  every input and carried-state term, and cut the recurrent link to isolate
+  what memory contributes.
 
 ## Language-Neutral Corpus
 
@@ -88,6 +92,10 @@ NN08 adds a two-layer residual block in
 paths, every expanded input dependency, path multiplicities, and clipped
 boundary receptive fields.
 
+NN09 adds a three-step scalar recurrent chain in
+`code/specs/fixtures/recurrent-unroll-v1`, including its explicit initial
+state, shared parameters, every forward term, and a no-memory ablation.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -97,6 +105,7 @@ python code/scripts/validate_convolution_learning_labs.py
 python code/scripts/validate_convolution_training_labs.py
 python code/scripts/validate_tiny_image_cnn_labs.py
 python code/scripts/validate_residual_receptive_labs.py
+python code/scripts/validate_recurrent_unroll_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -110,7 +119,8 @@ NN07 lab shows how input channels accumulate into output feature maps, which
 spatial values share normalization statistics, and which locations survive
 max pooling. The first NN08 lab expands a two-layer residual block into its
 deep and identity routes, then counts every path from one output back to the
-original input.
+original input. The first NN09 lab passes one hidden-state value through three
+executions of the same cell and compares it with the recurrent link removed.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -28,13 +28,14 @@ larger network:
 8. [One Recurrent State, Unrolled by Hand](./recurrent-state-unrolled-by-hand.md)
 9. [Backpropagation Through Time, by Hand](./backpropagation-through-time-by-hand.md)
 10. [GRU and LSTM Gates, by Hand](./gru-and-lstm-gates-by-hand.md)
-11. [Matrix Math](../matrix-math.md)
-12. [Loss Functions](../loss-functions.md)
-13. [Gradient Descent](../gradient-descent.md)
-14. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-15. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-16. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-17. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+11. [Query, Key, and Value Scores by Hand](./attention-qkv-by-hand.md)
+12. [Matrix Math](../matrix-math.md)
+13. [Loss Functions](../loss-functions.md)
+14. [Gradient Descent](../gradient-descent.md)
+15. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+16. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+17. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+18. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -44,7 +45,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has eight complementary views:
+has nine complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -72,6 +73,10 @@ has eight complementary views:
   shared-parameter gradient contributions, audit them with finite differences,
   and preview one loss-reducing update. Finally, compare aligned GRU and LSTM
   memory lanes and intervene on one gate without changing the other signals.
+- **Attention lab:** project three tokens into aligned query, key, and value
+  rows; open any cell in the `3 x 3` query-key score matrix; inspect its two
+  coordinate products; and switch between raw and dimension-scaled scores
+  without pretending that softmax or value mixing has happened yet.
 
 ## Language-Neutral Corpus
 
@@ -110,6 +115,10 @@ NN11 adds `code/specs/fixtures/gated-recurrent-v1`, including scalar GRU and
 LSTM gate preactivations, every state contribution, explicit LSTM cell/hidden
 outputs, and seven one-gate counterfactuals.
 
+NN12 adds `code/specs/fixtures/attention-qkv-v1`, including all three shared
+projection matrices, every token's query/key/value vectors, all nine
+coordinate-level dot products, and the raw and scaled score matrices.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -122,6 +131,7 @@ python code/scripts/validate_residual_receptive_labs.py
 python code/scripts/validate_recurrent_unroll_labs.py
 python code/scripts/validate_recurrent_bptt_labs.py
 python code/scripts/validate_gated_recurrent_labs.py
+python code/scripts/validate_attention_qkv_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -142,6 +152,8 @@ states, accumulates all three executions into one shared gradient set, and
 checks the result independently before applying an update.
 The first NN11 lab routes the same old memory and candidate through a GRU and
 an LSTM, then closes or opens one gate at a time to isolate its responsibility.
+The first NN12 lab gives three tokens separate asking, matching, and payload
+roles, then expands all nine query-key scores before softmax or value mixing.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -35,13 +35,14 @@ larger network:
 15. [A Two-Number Autoencoder Bottleneck, by Hand](./two-number-autoencoder-bottleneck-by-hand.md)
 16. [Variational Sampling and the KL Tradeoff, by Hand](./variational-sampling-and-kl-tradeoff-by-hand.md)
 17. [A One-Dimensional GAN Game, by Hand](./one-dimensional-gan-game-by-hand.md)
-18. [Matrix Math](../matrix-math.md)
-19. [Loss Functions](../loss-functions.md)
-20. [Gradient Descent](../gradient-descent.md)
-21. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-22. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-23. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-24. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+18. [One-Dimensional Diffusion, by Hand](./one-dimensional-diffusion-by-hand.md)
+19. [Matrix Math](../matrix-math.md)
+20. [Loss Functions](../loss-functions.md)
+21. [Gradient Descent](../gradient-descent.md)
+22. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+23. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+24. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+25. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -98,7 +99,9 @@ has ten complementary views:
   beta-weighted KL gradients, six finite differences, and a full-model update.
   Continue into a one-dimensional adversarial game to alternate a detached
   discriminator move and a frozen-discriminator generator response on one
-  visible number line.
+  visible number line. Then follow one clean scalar through two diffusion noise
+  levels, train a timestep-aware noise predictor, and replay two deterministic
+  reverse means.
 
 ## Language-Neutral Corpus
 
@@ -171,6 +174,12 @@ discriminator gradients, a frozen-discriminator generator counter-move, two
 objective-specific central finite-difference audits, and all three loss
 snapshots.
 
+NN19 adds `code/specs/fixtures/one-dimensional-diffusion-v1`, including a
+two-level cumulative-alpha schedule, saved-noise forward mixtures, timestep-
+conditioned predictions, per-level and reduced gradients, a three-parameter
+central finite-difference audit, one loss-reducing update, and a deterministic
+two-step reverse mean.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -190,6 +199,7 @@ python code/scripts/validate_tiny_decoder_training_labs.py
 python code/scripts/validate_two_number_autoencoder_labs.py
 python code/scripts/validate_variational_autoencoder_labs.py
 python code/scripts/validate_one_dimensional_gan_labs.py
+python code/scripts/validate_one_dimensional_diffusion_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -230,6 +240,9 @@ audits all six trainable gradients, and reruns the complete stochastic path.
 The first NN18 lab alternates a detached discriminator update and a generator
 counter-move through a frozen discriminator, audits each player's own
 objective, and makes the resulting pushback between losses explicit.
+The first NN19 lab trades clean signal for saved noise at two cumulative levels,
+teaches one timestep-aware denoiser from both rows, audits its three shared
+gradients, and iterates the learned reverse mean back near the clean sample.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -34,13 +34,14 @@ larger network:
 14. [A Tiny Decoder-Only Language Model Training Step, by Hand](./tiny-decoder-language-model-training-by-hand.md)
 15. [A Two-Number Autoencoder Bottleneck, by Hand](./two-number-autoencoder-bottleneck-by-hand.md)
 16. [Variational Sampling and the KL Tradeoff, by Hand](./variational-sampling-and-kl-tradeoff-by-hand.md)
-17. [Matrix Math](../matrix-math.md)
-18. [Loss Functions](../loss-functions.md)
-19. [Gradient Descent](../gradient-descent.md)
-20. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-21. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-22. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-23. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+17. [A One-Dimensional GAN Game, by Hand](./one-dimensional-gan-game-by-hand.md)
+18. [Matrix Math](../matrix-math.md)
+19. [Loss Functions](../loss-functions.md)
+20. [Gradient Descent](../gradient-descent.md)
+21. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+22. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+23. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+24. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -95,6 +96,9 @@ has ten complementary views:
   bottleneck gradient, then switch to a scalar variational autoencoder to expose
   Gaussian parameters, saved-noise reparameterization, reconstruction versus
   beta-weighted KL gradients, six finite differences, and a full-model update.
+  Continue into a one-dimensional adversarial game to alternate a detached
+  discriminator move and a frozen-discriminator generator response on one
+  visible number line.
 
 ## Language-Neutral Corpus
 
@@ -161,6 +165,12 @@ Gaussian mean and log-variance, saved epsilon, reparameterized latent sample,
 half-squared reconstruction loss, beta-weighted KL divergence, separate
 gradient routes, six central finite differences, and one lower-total-loss step.
 
+NN18 adds `code/specs/fixtures/one-dimensional-gan-v1`, including one saved
+noise value, a real and fake scalar, sigmoid discriminator scores, detached
+discriminator gradients, a frozen-discriminator generator counter-move, two
+objective-specific central finite-difference audits, and all three loss
+snapshots.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -179,6 +189,7 @@ python code/scripts/validate_multi_head_attention_labs.py
 python code/scripts/validate_tiny_decoder_training_labs.py
 python code/scripts/validate_two_number_autoencoder_labs.py
 python code/scripts/validate_variational_autoencoder_labs.py
+python code/scripts/validate_one_dimensional_gan_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -216,6 +227,9 @@ entire encoder and decoder after one loss-reducing step.
 The first NN17 lab holds one Gaussian noise sample fixed, exposes how
 reconstruction and beta-weighted KL signals meet at the mean and log-variance,
 audits all six trainable gradients, and reruns the complete stochastic path.
+The first NN18 lab alternates a detached discriminator update and a generator
+counter-move through a frozen discriminator, audits each player's own
+objective, and makes the resulting pushback between losses explicit.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -36,13 +36,14 @@ larger network:
 16. [Variational Sampling and the KL Tradeoff, by Hand](./variational-sampling-and-kl-tradeoff-by-hand.md)
 17. [A One-Dimensional GAN Game, by Hand](./one-dimensional-gan-game-by-hand.md)
 18. [One-Dimensional Diffusion, by Hand](./one-dimensional-diffusion-by-hand.md)
-19. [Matrix Math](../matrix-math.md)
-20. [Loss Functions](../loss-functions.md)
-21. [Gradient Descent](../gradient-descent.md)
-22. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-23. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-24. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-25. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+19. [Hopfield Associative Memory, by Hand](./hopfield-associative-memory-by-hand.md)
+20. [Matrix Math](../matrix-math.md)
+21. [Loss Functions](../loss-functions.md)
+22. [Gradient Descent](../gradient-descent.md)
+23. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+24. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+25. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+26. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -52,7 +53,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has ten complementary views:
+has eleven complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -102,6 +103,10 @@ has ten complementary views:
   visible number line. Then follow one clean scalar through two diffusion noise
   levels, train a timestep-aware noise predictor, and replay two deterministic
   reverse means.
+- **Structured and memory lab:** store one four-neuron bipolar pattern in a
+  symmetric zero-diagonal weight matrix, damage one bit, expose every incoming
+  vote in an asynchronous sweep, and watch energy descend as overlap reaches a
+  recovered fixed point.
 
 ## Language-Neutral Corpus
 
@@ -180,6 +185,11 @@ conditioned predictions, per-level and reduced gradients, a three-parameter
 central finite-difference audit, one loss-reducing update, and a deterministic
 two-step reverse mean.
 
+NN20 adds `code/specs/fixtures/hopfield-associative-memory-v1`, including a
+normalized Hebbian outer product, symmetric zero-diagonal weights, one damaged
+bipolar cue, every asynchronous incoming vote and state transition, Hopfield
+energy, normalized overlap, and the recovered fixed point.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -200,6 +210,7 @@ python code/scripts/validate_two_number_autoencoder_labs.py
 python code/scripts/validate_variational_autoencoder_labs.py
 python code/scripts/validate_one_dimensional_gan_labs.py
 python code/scripts/validate_one_dimensional_diffusion_labs.py
+python code/scripts/validate_hopfield_associative_memory_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -41,13 +41,14 @@ larger network:
 21. [Graph Convolution and Attention, by Hand](./graph-convolution-and-attention-by-hand.md)
 22. [Initialization and Activation Distributions, by Hand](./initialization-and-activation-distributions-by-hand.md)
 23. [Vanishing and Exploding Gradients, by Hand](./vanishing-and-exploding-gradients-by-hand.md)
-24. [Matrix Math](../matrix-math.md)
-25. [Loss Functions](../loss-functions.md)
-26. [Gradient Descent](../gradient-descent.md)
-27. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-28. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-29. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-30. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+24. [Normalization, Dropout, and Residual Paths, by Hand](./normalization-dropout-and-residual-paths-by-hand.md)
+25. [Matrix Math](../matrix-math.md)
+26. [Loss Functions](../loss-functions.md)
+27. [Gradient Descent](../gradient-descent.md)
+28. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+29. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+30. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+31. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -121,7 +122,11 @@ has twelve complementary views:
   and watch population standard deviation change across layers. Then reverse a
   four-layer scalar chain, select any chain-rule step, compare small-weight and
   saturated vanishing paths with stable and exploding ReLU controls, and audit
-  the input gradient with finite differences.
+  the input gradient with finite differences. Finish by routing one fixed
+  four-coordinate branch through plain, population-normalized, deterministic
+  inverted-dropout, and identity-residual paths. Compare their outputs,
+  vector-Jacobian products, input and weight gradients, dropout expectation,
+  and twenty independent finite differences.
 
 ## Language-Neutral Corpus
 
@@ -222,6 +227,11 @@ NN24 adds `code/specs/fixtures/gradient-flow-v1`, including four scalar forward
 chains, activation derivatives, local Jacobians, every reverse-mode gradient,
 the total chain product, flow classification, and input finite differences.
 
+NN25 adds `code/specs/fixtures/training-stabilizers-v1`, including one shared
+four-coordinate branch, population layer-normalization statistics, a pinned
+inverted-dropout mask and expectation, an identity residual, every input and
+branch-weight gradient, and central finite differences.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -247,6 +257,7 @@ python code/scripts/validate_tiny_message_passing_labs.py
 python code/scripts/validate_graph_convolution_attention_labs.py
 python code/scripts/validate_initialization_activation_distribution_labs.py
 python code/scripts/validate_gradient_flow_labs.py
+python code/scripts/validate_training_stabilizer_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -40,13 +40,14 @@ larger network:
 20. [Tiny Graph Message Passing, by Hand](./tiny-graph-message-passing-by-hand.md)
 21. [Graph Convolution and Attention, by Hand](./graph-convolution-and-attention-by-hand.md)
 22. [Initialization and Activation Distributions, by Hand](./initialization-and-activation-distributions-by-hand.md)
-23. [Matrix Math](../matrix-math.md)
-24. [Loss Functions](../loss-functions.md)
-25. [Gradient Descent](../gradient-descent.md)
-26. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-27. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-28. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-29. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+23. [Vanishing and Exploding Gradients, by Hand](./vanishing-and-exploding-gradients-by-hand.md)
+24. [Matrix Math](../matrix-math.md)
+25. [Loss Functions](../loss-functions.md)
+26. [Gradient Descent](../gradient-descent.md)
+27. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+28. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+29. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+30. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -117,7 +118,10 @@ has twelve complementary views:
 - **Deep-training lab:** hold a three-layer sign template fixed while switching
   between tiny, Xavier, He, and deliberately large weight scales. Compare tanh
   saturation with ReLU zeros, open one multiply-sum-activation calculation,
-  and watch population standard deviation change across layers.
+  and watch population standard deviation change across layers. Then reverse a
+  four-layer scalar chain, select any chain-rule step, compare small-weight and
+  saturated vanishing paths with stable and exploding ReLU controls, and audit
+  the input gradient with finite differences.
 
 ## Language-Neutral Corpus
 
@@ -214,6 +218,10 @@ including fixed input and sign matrices, tiny/Xavier/He/large scales, canonical
 preactivations and activations, population standard deviations, exact-zero
 fractions, and tanh saturation fractions.
 
+NN24 adds `code/specs/fixtures/gradient-flow-v1`, including four scalar forward
+chains, activation derivatives, local Jacobians, every reverse-mode gradient,
+the total chain product, flow classification, and input finite differences.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -238,6 +246,7 @@ python code/scripts/validate_hopfield_associative_memory_labs.py
 python code/scripts/validate_tiny_message_passing_labs.py
 python code/scripts/validate_graph_convolution_attention_labs.py
 python code/scripts/validate_initialization_activation_distribution_labs.py
+python code/scripts/validate_gradient_flow_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -51,7 +51,7 @@ trace, and tests.
 
 - [ ] Deep-training mechanics
   - [x] Initialization and activation-distribution explorer.
-  - [ ] Vanishing and exploding gradient trace.
+  - [x] Vanishing and exploding gradient trace.
   - [ ] Normalization, dropout, and residual comparisons.
 - [ ] Tensor and autograd bridge
   - [ ] Shape and broadcasting visualizer.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -39,7 +39,7 @@ trace, and tests.
   - [x] Tiny decoder-only language model training trace.
 - [ ] Representation and generation
   - [x] Two-number autoencoder bottleneck.
-  - [ ] Variational sampling and KL tradeoff.
+  - [x] Variational sampling and KL tradeoff.
   - [ ] One-dimensional GAN game.
   - [ ] One-dimensional diffusion forward and denoising steps.
 - [ ] Structured and memory networks

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -37,11 +37,11 @@ trace, and tests.
   - [x] Softmax attention weights and causal masking.
   - [x] Multi-head attention, residual paths, and normalization.
   - [x] Tiny decoder-only language model training trace.
-- [ ] Representation and generation
+- [x] Representation and generation
   - [x] Two-number autoencoder bottleneck.
   - [x] Variational sampling and KL tradeoff.
   - [x] One-dimensional GAN game.
-  - [ ] One-dimensional diffusion forward and denoising steps.
+  - [x] One-dimensional diffusion forward and denoising steps.
 - [ ] Structured and memory networks
   - [ ] Hopfield associative memory.
   - [ ] Message passing on a tiny graph.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -40,7 +40,7 @@ trace, and tests.
 - [ ] Representation and generation
   - [x] Two-number autoencoder bottleneck.
   - [x] Variational sampling and KL tradeoff.
-  - [ ] One-dimensional GAN game.
+  - [x] One-dimensional GAN game.
   - [ ] One-dimensional diffusion forward and denoising steps.
 - [ ] Structured and memory networks
   - [ ] Hopfield associative memory.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -28,10 +28,10 @@ trace, and tests.
   - [x] Trainable one-dimensional convolution and gradient trace.
   - [x] Tiny image CNN, channels, pooling, and normalization.
   - [x] Residual path and receptive-field explorer.
-- [ ] Sequence networks
+- [x] Sequence networks
   - [x] One recurrent state unrolled for three steps.
   - [x] Backpropagation through time and gradient accumulation.
-  - [ ] GRU and LSTM gate comparison.
+  - [x] GRU and LSTM gate comparison.
 - [ ] Attention and transformers
   - [ ] Query/key/value dot products for three tokens.
   - [ ] Softmax attention weights and causal masking.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -33,7 +33,7 @@ trace, and tests.
   - [x] Backpropagation through time and gradient accumulation.
   - [x] GRU and LSTM gate comparison.
 - [ ] Attention and transformers
-  - [ ] Query/key/value dot products for three tokens.
+  - [x] Query/key/value dot products for three tokens.
   - [ ] Softmax attention weights and causal masking.
   - [ ] Multi-head attention, residual paths, and normalization.
   - [ ] Tiny decoder-only language model training trace.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -49,10 +49,10 @@ trace, and tests.
 
 ## Depth and Scaling Tranches
 
-- [ ] Deep-training mechanics
+- [x] Deep-training mechanics
   - [x] Initialization and activation-distribution explorer.
   - [x] Vanishing and exploding gradient trace.
-  - [ ] Normalization, dropout, and residual comparisons.
+  - [x] Normalization, dropout, and residual comparisons.
 - [ ] Tensor and autograd bridge
   - [ ] Shape and broadcasting visualizer.
   - [ ] Dynamic computation graph and saved-value trace.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -1,0 +1,79 @@
+# Neural Learning Delivery Roadmap
+
+This roadmap drives the long-lived neural-learning pull request. Each tranche
+should land as one reviewable commit and must include the smallest complete
+learning loop: explanation, hand calculation, deterministic oracle, interactive
+trace, and tests.
+
+## Delivered Foundation
+
+- [x] One-neuron forward pass and training-step microscope.
+- [x] Backpropagation worked by hand.
+- [x] Deterministic NN03 forward and first-step fixtures.
+- [x] Linear and hidden-layer example workbenches.
+
+## Active Tranche
+
+- [ ] Optimization fundamentals
+  - [x] Loss-landscape view.
+  - [x] Analytical-versus-finite-difference gradient check.
+  - [x] Deterministic stochastic, mini-batch, and full-batch comparison.
+  - [x] Plain-language optimization lesson.
+  - [x] Language-neutral NN04 optimization fixture and validator.
+
+## Architecture Tranches
+
+- [ ] Spatial networks
+  - [ ] Sliding one-dimensional kernel with every multiply-accumulate exposed.
+  - [ ] Trainable one-dimensional convolution and gradient trace.
+  - [ ] Tiny image CNN, channels, pooling, and normalization.
+  - [ ] Residual path and receptive-field explorer.
+- [ ] Sequence networks
+  - [ ] One recurrent state unrolled for three steps.
+  - [ ] Backpropagation through time and gradient accumulation.
+  - [ ] GRU and LSTM gate comparison.
+- [ ] Attention and transformers
+  - [ ] Query/key/value dot products for three tokens.
+  - [ ] Softmax attention weights and causal masking.
+  - [ ] Multi-head attention, residual paths, and normalization.
+  - [ ] Tiny decoder-only language model training trace.
+- [ ] Representation and generation
+  - [ ] Two-number autoencoder bottleneck.
+  - [ ] Variational sampling and KL tradeoff.
+  - [ ] One-dimensional GAN game.
+  - [ ] One-dimensional diffusion forward and denoising steps.
+- [ ] Structured and memory networks
+  - [ ] Hopfield associative memory.
+  - [ ] Message passing on a tiny graph.
+  - [ ] Graph convolution and graph attention.
+
+## Depth and Scaling Tranches
+
+- [ ] Deep-training mechanics
+  - [ ] Initialization and activation-distribution explorer.
+  - [ ] Vanishing and exploding gradient trace.
+  - [ ] Normalization, dropout, and residual comparisons.
+- [ ] Tensor and autograd bridge
+  - [ ] Shape and broadcasting visualizer.
+  - [ ] Dynamic computation graph and saved-value trace.
+  - [ ] Gradient accumulation and zeroing behavior.
+- [ ] Compilation and performance bridge
+  - [ ] Forward graph lowering to NeuralIR and MatrixIR.
+  - [ ] Backward and optimizer graph lowering.
+  - [ ] CPU, Rust core, and accelerated-backend parity.
+  - [ ] Precision, quantization, and buffer-residency experiments.
+- [ ] Cross-language consumers
+  - [ ] Validate every fixture with the reference implementation.
+  - [ ] Add thin consumers in representative language families.
+  - [ ] Define a stable Rust C ABI for high-performance execution.
+  - [ ] Track native implementation versus Rust-core binding coverage.
+
+## Loop Rules
+
+1. Keep at most one neural-learning pull request open.
+2. Inspect current PR checks before starting the next tranche.
+3. Work on the same branch and push only validated commits.
+4. Update this roadmap in each commit.
+5. Do not mark a tranche complete without direct numerical and interaction
+   evidence.
+6. Do not merge autonomously.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -50,7 +50,7 @@ trace, and tests.
 ## Depth and Scaling Tranches
 
 - [ ] Deep-training mechanics
-  - [ ] Initialization and activation-distribution explorer.
+  - [x] Initialization and activation-distribution explorer.
   - [ ] Vanishing and exploding gradient trace.
   - [ ] Normalization, dropout, and residual comparisons.
 - [ ] Tensor and autograd bridge

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -35,7 +35,7 @@ trace, and tests.
 - [ ] Attention and transformers
   - [x] Query/key/value dot products for three tokens.
   - [x] Softmax attention weights and causal masking.
-  - [ ] Multi-head attention, residual paths, and normalization.
+  - [x] Multi-head attention, residual paths, and normalization.
   - [ ] Tiny decoder-only language model training trace.
 - [ ] Representation and generation
   - [ ] Two-number autoencoder bottleneck.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -38,7 +38,7 @@ trace, and tests.
   - [x] Multi-head attention, residual paths, and normalization.
   - [x] Tiny decoder-only language model training trace.
 - [ ] Representation and generation
-  - [ ] Two-number autoencoder bottleneck.
+  - [x] Two-number autoencoder bottleneck.
   - [ ] Variational sampling and KL tradeoff.
   - [ ] One-dimensional GAN game.
   - [ ] One-dimensional diffusion forward and denoising steps.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -23,11 +23,11 @@ trace, and tests.
 
 ## Architecture Tranches
 
-- [ ] Spatial networks
+- [x] Spatial networks
   - [x] Sliding one-dimensional kernel with every multiply-accumulate exposed.
   - [x] Trainable one-dimensional convolution and gradient trace.
   - [x] Tiny image CNN, channels, pooling, and normalization.
-  - [ ] Residual path and receptive-field explorer.
+  - [x] Residual path and receptive-field explorer.
 - [ ] Sequence networks
   - [ ] One recurrent state unrolled for three steps.
   - [ ] Backpropagation through time and gradient accumulation.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -26,7 +26,7 @@ trace, and tests.
 - [ ] Spatial networks
   - [x] Sliding one-dimensional kernel with every multiply-accumulate exposed.
   - [x] Trainable one-dimensional convolution and gradient trace.
-  - [ ] Tiny image CNN, channels, pooling, and normalization.
+  - [x] Tiny image CNN, channels, pooling, and normalization.
   - [ ] Residual path and receptive-field explorer.
 - [ ] Sequence networks
   - [ ] One recurrent state unrolled for three steps.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -32,11 +32,11 @@ trace, and tests.
   - [x] One recurrent state unrolled for three steps.
   - [x] Backpropagation through time and gradient accumulation.
   - [x] GRU and LSTM gate comparison.
-- [ ] Attention and transformers
+- [x] Attention and transformers
   - [x] Query/key/value dot products for three tokens.
   - [x] Softmax attention weights and causal masking.
   - [x] Multi-head attention, residual paths, and normalization.
-  - [ ] Tiny decoder-only language model training trace.
+  - [x] Tiny decoder-only language model training trace.
 - [ ] Representation and generation
   - [ ] Two-number autoencoder bottleneck.
   - [ ] Variational sampling and KL tradeoff.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -34,7 +34,7 @@ trace, and tests.
   - [x] GRU and LSTM gate comparison.
 - [ ] Attention and transformers
   - [x] Query/key/value dot products for three tokens.
-  - [ ] Softmax attention weights and causal masking.
+  - [x] Softmax attention weights and causal masking.
   - [ ] Multi-head attention, residual paths, and normalization.
   - [ ] Tiny decoder-only language model training trace.
 - [ ] Representation and generation

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -42,10 +42,10 @@ trace, and tests.
   - [x] Variational sampling and KL tradeoff.
   - [x] One-dimensional GAN game.
   - [x] One-dimensional diffusion forward and denoising steps.
-- [ ] Structured and memory networks
+- [x] Structured and memory networks
   - [x] Hopfield associative memory.
   - [x] Message passing on a tiny graph.
-  - [ ] Graph convolution and graph attention.
+  - [x] Graph convolution and graph attention.
 
 ## Depth and Scaling Tranches
 

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -43,7 +43,7 @@ trace, and tests.
   - [x] One-dimensional GAN game.
   - [x] One-dimensional diffusion forward and denoising steps.
 - [ ] Structured and memory networks
-  - [ ] Hopfield associative memory.
+  - [x] Hopfield associative memory.
   - [ ] Message passing on a tiny graph.
   - [ ] Graph convolution and graph attention.
 

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -14,7 +14,7 @@ trace, and tests.
 
 ## Active Tranche
 
-- [ ] Optimization fundamentals
+- [x] Optimization fundamentals
   - [x] Loss-landscape view.
   - [x] Analytical-versus-finite-difference gradient check.
   - [x] Deterministic stochastic, mini-batch, and full-batch comparison.
@@ -24,7 +24,7 @@ trace, and tests.
 ## Architecture Tranches
 
 - [ ] Spatial networks
-  - [ ] Sliding one-dimensional kernel with every multiply-accumulate exposed.
+  - [x] Sliding one-dimensional kernel with every multiply-accumulate exposed.
   - [ ] Trainable one-dimensional convolution and gradient trace.
   - [ ] Tiny image CNN, channels, pooling, and normalization.
   - [ ] Residual path and receptive-field explorer.

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -25,7 +25,7 @@ trace, and tests.
 
 - [ ] Spatial networks
   - [x] Sliding one-dimensional kernel with every multiply-accumulate exposed.
-  - [ ] Trainable one-dimensional convolution and gradient trace.
+  - [x] Trainable one-dimensional convolution and gradient trace.
   - [ ] Tiny image CNN, channels, pooling, and normalization.
   - [ ] Residual path and receptive-field explorer.
 - [ ] Sequence networks

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -29,7 +29,7 @@ trace, and tests.
   - [x] Tiny image CNN, channels, pooling, and normalization.
   - [x] Residual path and receptive-field explorer.
 - [ ] Sequence networks
-  - [ ] One recurrent state unrolled for three steps.
+  - [x] One recurrent state unrolled for three steps.
   - [ ] Backpropagation through time and gradient accumulation.
   - [ ] GRU and LSTM gate comparison.
 - [ ] Attention and transformers

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -44,7 +44,7 @@ trace, and tests.
   - [x] One-dimensional diffusion forward and denoising steps.
 - [ ] Structured and memory networks
   - [x] Hopfield associative memory.
-  - [ ] Message passing on a tiny graph.
+  - [x] Message passing on a tiny graph.
   - [ ] Graph convolution and graph attention.
 
 ## Depth and Scaling Tranches

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -30,7 +30,7 @@ trace, and tests.
   - [x] Residual path and receptive-field explorer.
 - [ ] Sequence networks
   - [x] One recurrent state unrolled for three steps.
-  - [ ] Backpropagation through time and gradient accumulation.
+  - [x] Backpropagation through time and gradient accumulation.
   - [ ] GRU and LSTM gate comparison.
 - [ ] Attention and transformers
   - [ ] Query/key/value dot products for three tokens.

--- a/code/learning/machine-learning/attention-qkv-by-hand.md
+++ b/code/learning/machine-learning/attention-qkv-by-hand.md
@@ -1,0 +1,175 @@
+# Query, Key, and Value Dot Products, by Hand
+
+Attention starts by giving every token three different jobs:
+
+- a **query** asks what this token is looking for;
+- a **key** describes what this token can match; and
+- a **value** carries the information that may be retrieved later.
+
+This lesson projects three tiny token embeddings and computes all nine
+query-key comparisons. It stops before softmax, masking, or value mixing. The
+language-neutral oracle is
+[`00-three-token-qkv.json`](../../specs/fixtures/attention-qkv-v1/labs/00-three-token-qkv.json),
+and the contract is
+[`NN12-attention-qkv-labs.md`](../../specs/NN12-attention-qkv-labs.md).
+
+## Three two-number tokens
+
+Use embeddings that are easy to picture:
+
+```text
+red    = [1, 0]
+blue   = [0, 1]
+purple = [1, 1]
+```
+
+Stacking them produces a `3 x 2` matrix `X`: three token rows and two features.
+
+## One embedding, three projections
+
+Each role has its own learned matrix:
+
+```text
+W_q = [[ 1, 0],    W_k = [[ 1, 1],    W_v = [[2, 0],
+       [ 0, 1]]           [-1, 1]]           [0, 1]]
+```
+
+The row-vector convention is:
+
+```text
+Q = X W_q
+K = X W_k
+V = X W_v
+```
+
+For example, blue `[0,1]` becomes:
+
+```text
+blue query
+  [0,1] W_q = [0*1 + 1*0, 0*0 + 1*1] = [0,1]
+
+blue key
+  [0,1] W_k = [0*1 + 1*(-1), 0*1 + 1*1] = [-1,1]
+
+blue value
+  [0,1] W_v = [0*2 + 1*0, 0*0 + 1*1] = [0,1]
+```
+
+All projected rows are:
+
+| token | query `Q` | key `K` | value `V` |
+| --- | --- | --- | --- |
+| red | `[1,0]` | `[1,1]` | `[2,0]` |
+| blue | `[0,1]` | `[-1,1]` | `[0,1]` |
+| purple | `[1,1]` | `[0,2]` | `[2,1]` |
+
+The original embedding is the same, but three parameter matrices give it three
+different roles.
+
+## A query compares with every key
+
+Select the blue query `q_blue = [0,1]`. Dot it with each key:
+
+```text
+blue query · red key
+  [0,1] · [1,1] = 0*1 + 1*1 = 1
+
+blue query · blue key
+  [0,1] · [-1,1] = 0*(-1) + 1*1 = 1
+
+blue query · purple key
+  [0,1] · [0,2] = 0*0 + 1*2 = 2
+```
+
+The blue query has raw scores `[1,1,2]`. A larger score means stronger
+query-key alignment at this stage. It is not a probability.
+
+Repeat that calculation for every query:
+
+```text
+                      key
+              red  blue  purple
+query red       1    -1       0
+      blue      1     1       2
+      purple    2     0       2
+```
+
+Rows answer “what does this query match?” Columns answer “which queries match
+this key?” Swapping those axes changes the meaning.
+
+## Why divide by the square root of the key size?
+
+Transformer attention normally scales each raw score:
+
+```text
+scaled score = raw score / sqrt(d_k)
+```
+
+Here `d_k = 2`, so the blue row becomes:
+
+```text
+[1,1,2] / sqrt(2)
+= [0.707106781187, 0.707106781187, 1.414213562373]
+```
+
+As vector dimensions grow, unscaled dot products can grow in magnitude. The
+square-root factor keeps the next softmax stage from becoming unnecessarily
+sharp. NN12 records both forms but applies neither softmax nor masking.
+
+## Where values fit—and where they do not
+
+Values are not used to calculate query-key scores:
+
+```text
+score = query dot key
+```
+
+The next attention stage will normalize scores and use them to mix value rows.
+Keeping `V` out of the current arithmetic makes the role separation testable:
+queries ask, keys match, values carry.
+
+## Inspect one score cell
+
+Every matrix cell retains its element-wise products. The purple-query,
+blue-key score is:
+
+```text
+q_purple = [1,1]
+k_blue   = [-1,1]
+
+products = [1*(-1), 1*1] = [-1,1]
+raw score = -1 + 1 = 0
+```
+
+The zero came from cancellation, not from two zero vectors. A trace that stores
+only the final score would hide that distinction.
+
+## Common implementation bugs
+
+- Multiplying matrices in the wrong row/column orientation.
+- Comparing queries with values instead of keys.
+- Transposing the score matrix and silently swapping query and key identities.
+- Dividing by `d_k` instead of `sqrt(d_k)`.
+- Applying softmax too early and losing access to raw score arithmetic.
+- Fusing Q/K/V projections without preserving their logical identities in
+  traces and checkpoints.
+- Treating a raw or scaled score as an attention probability.
+
+## Try the score microscope
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+keeps the three projection rows aligned with a `3 x 3` score matrix. Select any
+query row and key column to open its two products. Toggle square-root scaling to
+see exactly which operation changes while values remain payload-only.
+
+## Cross-language checkpoint
+
+An NN12 consumer is conformant when it reproduces all Q/K/V rows, nine product
+pairs, the raw score matrix, and the scaled score matrix.
+
+Implement the scalar loops directly in every language first. A Rust core can
+later lower `XW` and `QK^T` to matrix kernels, but a stable C ABI should keep
+shapes, strides, row identities, projection ownership, and optional trace
+buffers explicit. Fused storage is an optimization, not a reason to make Q, K,
+and V indistinguishable outside Rust.

--- a/code/learning/machine-learning/backpropagation-through-time-by-hand.md
+++ b/code/learning/machine-learning/backpropagation-through-time-by-hand.md
@@ -1,0 +1,205 @@
+# Backpropagation Through Time, by Hand
+
+The recurrent cell in the previous lesson reused one set of parameters at
+three time steps. Training reverses that unrolled chain. A gradient can travel
+from a later state into an earlier state, and every execution contributes to
+the gradients of the shared parameters.
+
+This reverse walk is **backpropagation through time**, or BPTT. The complete
+language-neutral oracle is
+[`00-final-state-loss.json`](../../specs/fixtures/recurrent-bptt-v1/labs/00-final-state-loss.json).
+The formulas and conformance rules are in
+[`NN10-recurrent-bptt-labs.md`](../../specs/NN10-recurrent-bptt-labs.md).
+
+## Reuse the three-step forward pass
+
+Use the same scalar ReLU cell and numbers:
+
+```text
+a[t] = W_x * x[t] + W_h * h[t - 1] + b
+h[t] = ReLU(a[t])
+
+x                  = [1, 2, 0]
+h[-1]              = 0
+W_x, W_h, b        = 2, 0.5, -1
+a[0], a[1], a[2]  = 1, 3.5, 0.75
+h[0], h[1], h[2]  = 1, 3.5, 0.75
+```
+
+Only the final state is compared with target `y = 0`. Half-squared error keeps
+the derivative small enough to see:
+
+```text
+L = 0.5 * (h[2] - y)^2
+  = 0.5 * (0.75 - 0)^2
+  = 0.28125
+
+dL/dh[2] = h[2] - y = 0.75
+```
+
+Save each input, previous state, preactivation, and state during the forward
+pass. The backward pass needs those values.
+
+## Two ways a state can receive gradient
+
+At a time step, the state gradient has two possible sources:
+
+```text
+dL/dh[t] = direct gradient from a loss at t
+         + gradient carried backward from t + 1
+```
+
+This example has a loss only at the final step, so the direct gradient is
+`0.75` at `t = 2` and zero earlier. Earlier steps still receive gradient
+through the recurrent links.
+
+Every preactivation is positive, so every ReLU derivative is `1`:
+
+```text
+dL/da[t] = dL/dh[t] * ReLU'(a[t])
+```
+
+## Reverse step 2
+
+Start at the loss and walk from right to left:
+
+```text
+direct dL/dh[2] = 0.75
+future gradient = 0
+dL/dh[2]        = 0.75 + 0 = 0.75
+dL/da[2]        = 0.75 * 1 = 0.75
+```
+
+This execution used `x[2] = 0` and `h[1] = 3.5`, so its local parameter
+contributions are:
+
+```text
+dL/dW_x at t=2 = 0.75 * x[2] = 0
+dL/dW_h at t=2 = 0.75 * h[1] = 2.625
+dL/db   at t=2 = 0.75
+```
+
+The gradient crossing the recurrent edge into the previous state is:
+
+```text
+dL/dh[1] from the future = 0.75 * W_h = 0.375
+```
+
+## Reverse step 1
+
+There is no direct loss at step 1, but `0.375` arrived from step 2:
+
+```text
+direct dL/dh[1] = 0
+future gradient = 0.375
+dL/dh[1]        = 0 + 0.375 = 0.375
+dL/da[1]        = 0.375 * 1 = 0.375
+
+dL/dW_x at t=1 = 0.375 * x[1] = 0.75
+dL/dW_h at t=1 = 0.375 * h[0] = 0.375
+dL/db   at t=1 = 0.375
+
+dL/dh[0] from the future = 0.375 * 0.5 = 0.1875
+```
+
+## Reverse step 0
+
+The same pattern reaches the first execution:
+
+```text
+direct dL/dh[0] = 0
+future gradient = 0.1875
+dL/dh[0]        = 0 + 0.1875 = 0.1875
+dL/da[0]        = 0.1875 * 1 = 0.1875
+
+dL/dW_x at t=0 = 0.1875 * x[0]  = 0.1875
+dL/dW_h at t=0 = 0.1875 * h[-1] = 0
+dL/db   at t=0 = 0.1875
+
+dL/dh[-1] = 0.1875 * 0.5 = 0.09375
+```
+
+`dL/dh[-1]` matters when an initial state is trainable or came from an earlier
+sequence chunk. Even when the initial state is fixed at zero, its gradient
+should be an explicit result rather than silently discarded inside the loop.
+
+## Add contributions into shared gradients
+
+There is one `W_x`, one `W_h`, and one `b`—not a separate parameter set at each
+time. Their gradients are sums:
+
+| parameter | step 2 | step 1 | step 0 | total |
+| --- | ---: | ---: | ---: | ---: |
+| `W_x` | 0 | 0.75 | 0.1875 | **0.9375** |
+| `W_h` | 2.625 | 0.375 | 0 | **3** |
+| `b` | 0.75 | 0.375 | 0.1875 | **1.3125** |
+
+This is gradient accumulation: use `+=` for each shared parameter contribution.
+Replacing a gradient at every step would keep only one execution's evidence.
+
+## Audit the backward pass independently
+
+Central finite differences perturb one parameter without using the BPTT code:
+
+```text
+numerical gradient = (L(parameter + 0.000001)
+                    - L(parameter - 0.000001)) / 0.000002
+```
+
+| parameter | BPTT | finite difference | absolute error |
+| --- | ---: | ---: | ---: |
+| `W_x` | 0.9375 | 0.937500000131 | 0.000000000131 |
+| `W_h` | 3 | 3.000000000086 | 0.000000000086 |
+| `b` | 1.3125 | 1.312500000045 | 0.000000000045 |
+
+The largest disagreement is about `1.31e-10`. That is floating-point rounding,
+not evidence that the two methods disagree.
+
+## Take one update
+
+With learning rate `0.1`, subtract each total gradient:
+
+```text
+W_x = 2   - 0.1 * 0.9375 = 1.90625
+W_h = 0.5 - 0.1 * 3      = 0.2
+b   = -1  - 0.1 * 1.3125 = -1.13125
+```
+
+The updated preactivations are `[0.775, 2.83625, -0.564]`, so the states are
+`[0.775, 2.83625, 0]`. The final prediction now equals the target, and this
+single-example loss falls from `0.28125` to `0`.
+
+## Common implementation bugs
+
+- Walking forward during the backward pass uses gradients before they exist.
+- Assigning a shared gradient instead of adding contributions loses time steps.
+- Skipping `ReLU'(a[t])` lets gradient cross an inactive cell incorrectly.
+- Recomputing with updated parameters mixes two different model states.
+- Hiding the initial-state gradient breaks chunked-sequence training.
+- Forgetting to zero parameter-gradient buffers between optimizer steps makes
+  separate batches accumulate accidentally.
+
+Longer sequences add practical choices such as truncated BPTT, saved-state
+buffers, and recomputation. Those choices change memory and compute costs, not
+the local arithmetic shown here.
+
+## Try the backward microscope
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+places the forward states above a right-to-left backward lane. Select a reverse
+step to see its direct and future gradients combine, then inspect one reduction
+table for all shared-parameter contributions, the finite-difference audit, and
+the proposed update.
+
+## Cross-language checkpoint
+
+An NN10 implementation is ready to scale when it reproduces the fixture's
+reverse step order, all local contributions, shared-gradient totals,
+initial-state gradient, finite-difference check, and updated forward pass.
+
+A Rust core can implement V1 as a reverse loop over saved scalar states or as
+a static unrolled graph. A future C ABI should keep forward-state storage,
+gradient buffers, accumulation-versus-zeroing policy, and initial-state
+gradient ownership explicit. Other languages can either implement the same
+fixture directly or consume that core without making BPTT a Rust-only concept.

--- a/code/learning/machine-learning/convolution-window-by-window.md
+++ b/code/learning/machine-learning/convolution-window-by-window.md
@@ -1,0 +1,113 @@
+# Convolution, Window by Window
+
+A dense neuron looks at every input. A convolutional neuron starts smaller: it
+looks at one local window, then reuses the same weights at the next position.
+That repeated little calculation is the foundation of convolutional networks.
+
+## The Smallest Example
+
+Use this six-value signal and three-value kernel:
+
+```text
+signal = [2,  1, 3, 0, 4, 2]
+kernel = [1, -1, 2]
+```
+
+Start with the kernel over the first three signal values:
+
+```text
+window   = [2,  1, 3]
+kernel   = [1, -1, 2]
+products = [2, -1, 6]
+
+accumulator: 0 -> 2 -> 1 -> 7
+```
+
+So the first output is `7`. Move the same kernel one position right and repeat:
+
+| Output | Signal window | Products | Running sum | Result |
+| --- | --- | --- | --- | ---: |
+| `y[0]` | `[2, 1, 3]` | `[2, -1, 6]` | `0 -> 2 -> 1 -> 7` | 7 |
+| `y[1]` | `[1, 3, 0]` | `[1, -3, 0]` | `0 -> 1 -> -2 -> -2` | -2 |
+| `y[2]` | `[3, 0, 4]` | `[3, 0, 8]` | `0 -> 3 -> 3 -> 11` | 11 |
+| `y[3]` | `[0, 4, 2]` | `[0, -4, 4]` | `0 -> 0 -> -4 -> 0` | 0 |
+
+The feature map is therefore:
+
+```text
+[7, -2, 11, 0]
+```
+
+For signal length `N` and kernel length `K`, valid stride-one mode produces
+`N - K + 1` outputs. Here that is `6 - 3 + 1 = 4`.
+
+## What the Kernel Means
+
+The three kernel numbers are a tiny feature detector. Positive weights reward
+values in particular positions; negative weights subtract evidence. The
+important architectural idea is **weight sharing**: all four outputs use the
+same `[1, -1, 2]`. A dense layer would need separate weights for each position.
+
+Sharing gives the model a useful bias: if a pattern matters at the left of a
+signal, a similar pattern can matter at the right. It also reduces the number
+of trainable parameters.
+
+Each output sees only three values. That local window is its **receptive
+field**. Later layers combine neighboring features, so their effective
+receptive fields become larger.
+
+## “Convolution” Without a Kernel Flip
+
+Mathematical convolution reverses the kernel before sliding it. Most neural
+network libraries do not; they compute cross-correlation but conventionally
+call the operation convolution.
+
+NN05 follows the neural convention:
+
+```text
+y[i] = sum(signal[i + j] * kernel[j])
+```
+
+The asymmetric kernel makes the convention visible. Reversing it to
+`[2, -1, 1]` would produce `[6, -1, 10, -2]`, not the canonical
+`[7, -2, 11, 0]`.
+
+## From One Dimension to an Image
+
+Nothing mysterious changes for an image. The kernel gains a height as well as
+a width, so it slides across rows and columns. Color images add an input-channel
+loop. Multiple learned detectors add an output-channel loop. Batches add one
+more outer loop.
+
+Before adding those axes, be able to point to every value in this 1D trace and
+answer:
+
+1. Which signal values were visible to this output?
+2. Which shared weight multiplied each value?
+3. What were the products and partial sums?
+4. Why are there four outputs instead of six?
+
+The interactive **Spatial** view in the
+[ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
+lets you slide the kernel, edit both arrays, and inspect those answers.
+
+## Portable and Fast Implementations
+
+The language-neutral fixture at
+`code/specs/fixtures/convolution-learning-v1` pins the signal, kernel,
+convention, complete trace, and tolerance. Any language can implement the
+small loop directly and validate it with:
+
+```text
+python code/scripts/validate_convolution_learning_labs.py
+```
+
+Performance-oriented consumers can later call a Rust core through a stable C
+ABI. The existing Rust `dsp-conv` package performs centered mathematical
+convolution, so an adapter must reverse the neural kernel and select only the
+valid outputs implied by its centering convention. A native cross-correlation
+kernel is also reasonable. In either case, the NN05 fixture remains the oracle:
+acceleration is correct only when its outputs match the simple loop.
+
+The next tranche makes the kernel trainable and traces how every shared weight
+receives gradient contributions from all output positions.

--- a/code/learning/machine-learning/curriculum.md
+++ b/code/learning/machine-learning/curriculum.md
@@ -20,6 +20,9 @@ structure helps.
 | F5 | Tensor/autograd engine | broadcasting, batches, saved values, gradient accumulation |
 | F6 | Compiled training step | NeuralIR, MatrixIR, Rust CPU/GPU execution |
 
+Implementation progress and the commit-sized delivery queue live in the
+[neural learning delivery roadmap](./ROADMAP.md).
+
 Every model family below starts with the smallest example that needs its new
 idea.
 

--- a/code/learning/machine-learning/graph-convolution-and-attention-by-hand.md
+++ b/code/learning/machine-learning/graph-convolution-and-attention-by-hand.md
@@ -1,0 +1,134 @@
+# Graph Convolution and Attention, by Hand
+
+NN21 separated graph computation into message, aggregate, and update. This
+lesson compares two rules for weighting the same inbox: graph convolution uses
+the graph's degrees, while graph attention uses the current features.
+
+The language-neutral contract is
+[NN22](../../specs/NN22-graph-convolution-attention-labs.md), with the canonical
+fixture in
+[`00-three-node-gcn-gat.json`](../../specs/fixtures/graph-convolution-attention-v1/labs/00-three-node-gcn-gat.json).
+
+## 1. Reuse the three-node path
+
+```text
+node 0 ----- node 1 ----- node 2
+  1            2           -1
+```
+
+Add one self-loop to every node. The neighborhoods become:
+
+```text
+N(0) = [0, 1]       degree 2
+N(1) = [0, 1, 2]    degree 3
+N(2) = [1, 2]       degree 2
+```
+
+A self-loop lets each node retain its own feature inside the same aggregation
+used for neighbors.
+
+## 2. Graph convolution: weight by structure
+
+For source `j` entering target `i`, use symmetric degree normalization:
+
+```text
+coefficient(j -> i) = 1 / sqrt(degree_i * degree_j)
+```
+
+For middle target `1`:
+
+```text
+source 0: 1/sqrt(3*2) *  1 =  0.408248
+source 1: 1/sqrt(3*3) *  2 =  0.666667
+source 2: 1/sqrt(3*2) * -1 = -0.408248
+                                      --------
+sum                                   0.666667
+ReLU                                  0.666667
+```
+
+The positive and negative outside neighbors cancel because their degree
+coefficients are equal. All outputs are:
+
+```text
+GCN -> [1.316497, 0.666667, 0.316497]
+```
+
+The word **convolution** here means applying one shared local mixing rule across
+the graph. Unlike an image grid, each node can have a different neighbor count,
+so degrees normalize the mixing.
+
+## 3. Graph attention: weight by features
+
+Keep the same neighborhood but score each source by its scalar feature:
+
+```text
+scores for target 1 = [1, 2, -1]
+```
+
+Use stable softmax. Subtract the row maximum `2` before exponentiating:
+
+```text
+shifted scores = [-1, 0, -3]
+exponentials   = [0.367879, 1, 0.049787]
+denominator    = 1.417667
+weights        = [0.259496, 0.705385, 0.035119]
+```
+
+The weights sum to one. Mix source features with those weights:
+
+```text
+0.259496*1 + 0.705385*2 + 0.035119*(-1)
+= 0.259496 + 1.410769 - 0.035119
+= 1.635146
+```
+
+All outputs are:
+
+```text
+GAT -> [1.731059, 1.635146, 1.857722]
+```
+
+Attention gives the high-feature node `1` most of the weight. The graph did not
+change; the data-dependent weighting rule did.
+
+## 4. What the comparison teaches
+
+| Property | GCN | GAT |
+| --- | --- | --- |
+| Neighborhood | self plus graph neighbors | self plus graph neighbors |
+| Weight source | endpoint degrees | learned/data-dependent scores |
+| Normalization | square-root degree factors | softmax inside each inbox |
+| Sum-to-one | not required | yes |
+| Changes when features change | contributions only | weights and contributions |
+
+Our GAT score is intentionally simple. Real graph-attention layers first
+transform features and learn a scoring function involving source and target.
+The stable-softmax and weighted-sum mechanics remain the same.
+
+## 5. Validate the deterministic corpus
+
+```text
+python code/scripts/validate_graph_convolution_attention_labs.py
+```
+
+The validator rejects unknown or duplicate keys, non-finite features,
+neighborhoods without self-loops, asymmetry, invalid indices, trace mismatches,
+and attention rows that do not sum to one.
+
+## 6. Cross-language and Rust-core path
+
+Implement these three scalar neighborhoods directly in every host language.
+The fixture aligns every degree coefficient, softmax intermediate, weight, and
+contribution.
+
+A Rust core can traverse CSR neighborhoods, cache degree factors, run segmented
+stable softmax, and fuse reductions. A C ABI and WASM layer can expose the same
+buffers to other languages. Trace mode should remain available even when the
+production path fuses edge scoring and aggregation.
+
+## 7. Next experiment
+
+Change node `2` from `-1` to `3`. GCN coefficients stay fixed because degrees
+do not change. GAT weights shift immediately because the scores changed. That
+counterfactual isolates the central difference between structural and
+feature-dependent weighting.

--- a/code/learning/machine-learning/gru-and-lstm-gates-by-hand.md
+++ b/code/learning/machine-learning/gru-and-lstm-gates-by-hand.md
@@ -1,0 +1,231 @@
+# GRU and LSTM Gates, by Hand
+
+A plain recurrent cell always mixes its new input and previous hidden state in
+the same way. A gated cell learns numbers between `0` and `1` that control how
+much information is kept, written, forgotten, or exposed.
+
+This lesson sends the same scalar memory through a GRU and an LSTM. The
+language-neutral oracle is
+[`00-gru-lstm-gates.json`](../../specs/fixtures/gated-recurrent-v1/labs/00-gru-lstm-gates.json).
+The complete contract is
+[`NN11-gated-recurrent-labs.md`](../../specs/NN11-gated-recurrent-labs.md).
+
+## What a gate is
+
+A gate is normally produced by a learned affine calculation followed by a
+sigmoid:
+
+```text
+gate = sigmoid(weighted inputs + bias)
+```
+
+Sigmoid maps every finite number between `0` and `1`. Multiplying a signal by
+the gate makes it a soft valve:
+
+```text
+gate = 0     blocks the signal
+gate = 0.25  passes one quarter
+gate = 1     passes all of it
+```
+
+The cells below use preactivations chosen to produce simple gate values:
+
+```text
+sigmoid(0)       = 0.5
+sigmoid(-ln(3))  = 0.25
+sigmoid( ln(3))  = 0.75
+tanh(atanh(0.6)) = 0.6
+```
+
+The same input arrives at both cells:
+
+```text
+x                 = 1
+previous hidden h = 0.8
+previous cell c   = 0.8  (LSTM only)
+candidate         = 0.6
+```
+
+## GRU: reset, then mix one state
+
+A gated recurrent unit keeps one state, `h`. This lesson uses `z` as the share
+of the new candidate:
+
+```text
+r = reset gate
+z = update gate
+n = candidate
+
+n = tanh(input product + U * (r * h_previous) + bias)
+h = (1 - z) * h_previous + z * n
+```
+
+Some libraries name `z` in the opposite direction. Always inspect the equation,
+not only the gate name.
+
+### Reset gate constructs the candidate
+
+Use reset gate `r = 0.5`:
+
+```text
+reset previous state = 0.5 * 0.8
+                     = 0.4
+
+candidate preactivation = 0 + 1 * 0.4 + 0.29314718056
+                        = 0.69314718056
+
+n = tanh(0.69314718056)
+  = 0.6
+```
+
+The reset gate changes what old information is available while constructing
+the candidate. It does not directly choose the final mixture.
+
+### Update gate mixes old and new
+
+Use update gate `z = 0.25`:
+
+```text
+retained old state = (1 - 0.25) * 0.8
+                   = 0.75 * 0.8
+                   = 0.6
+
+candidate write = 0.25 * 0.6
+                = 0.15
+
+next hidden state = 0.6 + 0.15
+                  = 0.75
+```
+
+The GRU exposes the same number it stores: `h_next = 0.75`.
+
+## LSTM: maintain a cell, then choose what to expose
+
+A long short-term memory cell has two state values:
+
+- `c`, the cell state carried along the memory path; and
+- `h`, the hidden state exposed to the rest of the network.
+
+Its scalar equations are:
+
+```text
+f = forget gate
+i = input gate
+o = output gate
+g = candidate
+
+c_next = f * c_previous + i * g
+h_next = o * tanh(c_next)
+```
+
+Use `f = 0.5`, `i = 0.25`, `o = 0.75`, and `g = 0.6`.
+
+### Forget and input gates update the private cell
+
+```text
+retained cell = 0.5 * 0.8
+              = 0.4
+
+candidate write = 0.25 * 0.6
+                = 0.15
+
+next cell state = 0.4 + 0.15
+                = 0.55
+```
+
+Notice that this update has the same two numerical contributions as the GRU
+example. The architectural difference appears next.
+
+### Output gate controls the public hidden state
+
+```text
+squashed cell = tanh(0.55)
+              = 0.50052021119
+
+next hidden state = 0.75 * 0.50052021119
+                  = 0.375390158393
+```
+
+The LSTM remembers `c_next = 0.55` internally while exposing
+`h_next = 0.375390158393`. Hiding part of the cell does not erase it.
+
+## The comparison in one table
+
+| question | GRU | LSTM |
+| --- | --- | --- |
+| Stored state | one hidden state | cell state plus hidden state |
+| Candidate control | reset gate | candidate has its own tanh path |
+| Old-memory control | update mixture | forget gate |
+| New-write control | update mixture | input gate |
+| Exposure control | no separate gate | output gate |
+| Canonical result | `h = 0.75` | `c = 0.55`, `h = 0.375390158393` |
+
+Neither cell is automatically better. A GRU has fewer gates and state buffers;
+an LSTM separates long-lived cell memory from what is exposed at each step.
+Data, sequence length, compute constraints, and training behavior decide which
+tradeoff matters.
+
+## Change one gate at a time
+
+Counterfactuals make each responsibility visible.
+
+### GRU update extremes
+
+```text
+z = 0: h_next = 1 * 0.8 + 0 * 0.6 = 0.8  (preserve old)
+z = 1: h_next = 0 * 0.8 + 1 * 0.6 = 0.6  (replace with candidate)
+```
+
+### GRU reset off
+
+With `r = 0`, the candidate cannot see the previous hidden state:
+
+```text
+n = tanh(0 + 0 + 0.29314718056)
+  = 0.285028898194
+
+h_next = 0.75 * 0.8 + 0.25 * 0.285028898194
+       = 0.671257224548
+```
+
+### LSTM forget, input, and output off
+
+```text
+f = 0: c_next = 0 + 0.15 = 0.15
+i = 0: c_next = 0.4 + 0 = 0.4
+o = 0: c_next stays 0.55, but h_next = 0
+```
+
+Turning the output gate back to `1` exposes `tanh(0.55) = 0.50052021119`
+without changing the stored cell.
+
+## Common implementation bugs
+
+- Mixing two opposite GRU update-gate conventions without an adapter.
+- Applying the GRU reset gate after candidate construction instead of inside it.
+- Treating the LSTM cell state and hidden state as one buffer.
+- Multiplying the output gate into `c_next` and thereby erasing private memory.
+- Forgetting the candidate's tanh or the final `tanh(c_next)` in the LSTM.
+- Reusing one gate's parameters for another gate accidentally when packing
+  matrices for a fast kernel.
+- Hiding recurrent state inside a runtime object, which breaks chunked and
+  cross-language execution.
+
+## Try the gate comparator
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+aligns the GRU and LSTM memory lanes. Select a gate to see its canonical value
+and its zero-or-one counterfactual without changing the other signals. The LSTM
+lane keeps cell and hidden state visibly separate.
+
+## Cross-language checkpoint
+
+An NN11 consumer is conformant when it reproduces every gate from its
+preactivation, both canonical cells, and all seven one-gate counterfactuals.
+
+Implement the scalar fixture directly in every language first. A future Rust
+core can fuse vector gate projections for performance, but its trace mode and C
+ABI should expose gate buffers and caller-owned recurrent state. GRU needs one
+state buffer; LSTM needs an explicit `(hidden, cell)` pair. That distinction
+must survive every binding rather than becoming Rust-only knowledge.

--- a/code/learning/machine-learning/hopfield-associative-memory-by-hand.md
+++ b/code/learning/machine-learning/hopfield-associative-memory-by-hand.md
@@ -1,0 +1,256 @@
+# Hopfield Associative Memory, by Hand
+
+A usual neural network sends information forward through layers. A Hopfield
+network does something different: every neuron reads the current pattern and
+the network repeatedly cleans that pattern up. A stored memory is not a row in
+a database. It is a state that the dynamics prefer to settle into.
+
+This lesson stores one four-bit memory, flips one bit, and restores it using
+arithmetic small enough to check with a pencil. The matching language-neutral
+contract is [NN20](../../specs/NN20-hopfield-associative-memory-labs.md), and
+the canonical fixture is
+[`00-one-bit-recall.json`](../../specs/fixtures/hopfield-associative-memory-v1/labs/00-one-bit-recall.json).
+
+## 1. Replace bits with bipolar states
+
+Hopfield networks traditionally use **bipolar** values: every neuron is either
+`+1` or `-1`. Bipolar means “having two poles.” Here the two poles are the two
+allowed states.
+
+Save this pattern:
+
+```text
+p = [+1, -1, +1, -1]
+```
+
+You can imagine `+1` as a bright square and `-1` as a dark square. With only
+four positions, the pattern is tiny, but the storage rule is the same one used
+for longer patterns.
+
+## 2. Store the pattern in connections
+
+The Hebbian idea is often summarized as “units that are active together wire
+together.” Donald Hebb proposed the underlying learning principle in 1949.
+For bipolar values, equal signs produce a positive connection and opposite
+signs produce a negative connection.
+
+For four neurons, divide each outer-product entry by `4`:
+
+```text
+w_ij = p_i * p_j / 4   when i != j
+w_ii = 0
+```
+
+An **outer product** pairs every entry of one vector with every entry of the
+other. We use the saved pattern twice, so every neuron is paired with every
+neuron.
+
+The first row is:
+
+```text
+to neuron 0 from neuron 0: 0
+to neuron 0 from neuron 1: (+1 * -1) / 4 = -0.25
+to neuron 0 from neuron 2: (+1 * +1) / 4 = +0.25
+to neuron 0 from neuron 3: (+1 * -1) / 4 = -0.25
+```
+
+The complete matrix is:
+
+```text
+W = [
+  [ 0,    -0.25,  0.25, -0.25],
+  [-0.25,  0,    -0.25,  0.25],
+  [ 0.25, -0.25,  0,    -0.25],
+  [-0.25,  0.25, -0.25,  0   ]
+]
+```
+
+Two properties matter:
+
+- The diagonal is zero, so a neuron does not vote for itself.
+- The matrix is symmetric: `w_ij = w_ji`.
+
+Symmetry will let us define one energy score for the whole network.
+
+## 3. Damage one bit
+
+Flip the first saved bit:
+
+```text
+saved p = [+1, -1, +1, -1]
+cue   s = [-1, -1, +1, -1]
+```
+
+The Hamming distance is `1` because one position differs. Richard Hamming
+developed the distance while studying error-correcting codes: it simply counts
+positions that disagree.
+
+We can also measure normalized overlap:
+
+```text
+overlap = sum_i(p_i * s_i) / 4
+        = ((+1 * -1) + (-1 * -1) + (+1 * +1) + (-1 * -1)) / 4
+        = (-1 + 1 + 1 + 1) / 4
+        = 0.5
+```
+
+An overlap of `1` is a perfect match. The damaged cue starts halfway between a
+perfect match and complete disagreement.
+
+## 4. Give each neighbor one vote
+
+Recall is asynchronous: update one neuron and immediately use its new state for
+the next neuron. The fixture fixes the order as `0, 1, 2, 3` so every language
+produces the same trace.
+
+For neuron `0`, multiply its weight row by the damaged state:
+
+```text
+from 0:  0    * -1 = 0
+from 1: -0.25 * -1 = +0.25
+from 2: +0.25 * +1 = +0.25
+from 3: -0.25 * -1 = +0.25
+                          ------
+local field                 +0.75
+```
+
+The **local field** is the total weighted vote arriving at one neuron. Apply a
+sign activation:
+
+```text
+positive field -> +1
+negative field -> -1
+zero field     -> preserve the previous state
+```
+
+The field is positive, so neuron `0` changes from `-1` to `+1`:
+
+```text
+[-1, -1, +1, -1] -> [+1, -1, +1, -1]
+```
+
+The memory has already been restored.
+
+The explicit zero-field rule matters. Some libraries define `sign(0)` as `0`,
+but zero is not a valid bipolar neuron state. Preserving the previous state
+keeps the model deterministic and bipolar.
+
+## 5. Watch energy move downhill
+
+The Hopfield energy is:
+
+```text
+E(s) = -1/2 * sum_i sum_j(w_ij * s_i * s_j)
+```
+
+The double sum counts every connection twice, once in each direction. The
+factor `1/2` removes that double counting. The leading minus sign makes aligned
+weighted relationships low energy.
+
+For the damaged cue, the three pairs involving the flipped bit contribute
+`-0.25` while the other three pairs contribute `+0.25`. They cancel:
+
+```text
+E(damaged cue) = 0
+```
+
+For the restored memory, all six unordered pairs contribute `+0.25`:
+
+```text
+directed sum = 2 * (6 * 0.25) = 3
+E(memory)    = -1/2 * 3 = -1.5
+```
+
+The first update therefore changes energy from `0` to `-1.5`. Lower is better
+in this energy landscape.
+
+## 6. Finish the sweep
+
+The remaining neurons see the restored state.
+
+Neuron `1`:
+
+```text
+-0.25*(+1) + 0*(-1) + -0.25*(+1) + 0.25*(-1)
+= -0.75 -> -1
+```
+
+Neuron `2`:
+
+```text
+0.25*(+1) + -0.25*(-1) + 0*(+1) + -0.25*(-1)
+= +0.75 -> +1
+```
+
+Neuron `3`:
+
+```text
+-0.25*(+1) + 0.25*(-1) + -0.25*(+1) + 0*(-1)
+= -0.75 -> -1
+```
+
+None changes. The completed trace is:
+
+| Moment | State | Energy | Overlap |
+| --- | --- | ---: | ---: |
+| damaged cue | `[-1, -1, +1, -1]` | `0` | `0.5` |
+| update neuron 0 | `[+1, -1, +1, -1]` | `-1.5` | `1` |
+| update neuron 1 | `[+1, -1, +1, -1]` | `-1.5` | `1` |
+| update neuron 2 | `[+1, -1, +1, -1]` | `-1.5` | `1` |
+| update neuron 3 | `[+1, -1, +1, -1]` | `-1.5` | `1` |
+
+The stored pattern is a **fixed point**: applying the update rule leaves it
+unchanged. It is also an **attractor** for this damaged cue because the dynamics
+move the cue into that fixed point.
+
+## 7. What is guaranteed, and what is not
+
+With symmetric weights, a zero diagonal, and asynchronous updates, Hopfield
+energy cannot increase. The network eventually reaches a fixed point because a
+finite bipolar network has only finitely many states.
+
+That does not mean every fixed point is a memory you intended to store. Larger
+Hopfield networks can have spurious attractors, and storing too many patterns
+causes interference. This first lab deliberately stores one pattern so the
+mechanism is visible before capacity questions arrive.
+
+Parallel updates are also different. If all neurons compute from the same old
+state and change together, the simple energy-descent story can break or enter a
+two-state oscillation. NN20 therefore requires asynchronous in-place updates.
+
+## 8. Run the deterministic corpus
+
+From the repository root:
+
+```text
+python code/scripts/validate_hopfield_associative_memory_labs.py
+```
+
+The validator rejects unknown or duplicate keys, non-finite values,
+non-bipolar states, malformed update orders, trace mismatches, energy increases,
+and failure to recover the saved pattern.
+
+## 9. Cross-language and Rust-core path
+
+Implement this four-neuron loop directly in every host language first. The
+fixture gives each implementation a shared oracle for:
+
+- the learned weight matrix;
+- every incoming weighted vote;
+- each asynchronous state transition;
+- energy and normalized overlap;
+- the final fixed point.
+
+A performant Rust core can later batch outer products and recall sweeps. Keep
+the boundary simple: flat bipolar state buffers, flat row-major weights, and an
+explicit integer update-order buffer. A stable C ABI can serve C-family and FFI
+consumers; WASM can serve browsers; higher-level languages can add idiomatic
+wrappers. Optimized calls may return only the fixed point, but a trace mode must
+remain available so speed never puts the “magic” back into the lesson.
+
+## 10. Next experiment
+
+Store a second pattern and inspect where its outer product reinforces or
+cancels the first. Then corrupt two bits and test whether the same update order
+still reaches the intended memory. Those experiments introduce capacity,
+interference, and spurious attractors without changing the underlying rules.

--- a/code/learning/machine-learning/initialization-and-activation-distributions-by-hand.md
+++ b/code/learning/machine-learning/initialization-and-activation-distributions-by-hand.md
@@ -1,0 +1,165 @@
+# Initialization and Activation Distributions, by Hand
+
+A deep network repeats the same two operations many times:
+
+```text
+inputs x weights -> preactivation -> activation
+```
+
+If the first weights are too small, signals can fade toward zero. If they are
+too large, ReLU values can grow rapidly while bounded activations such as
+`tanh` can become pinned near their limits. **Initialization** is the choice of
+the network's starting parameter values, before any training step occurs.
+
+The language-neutral contract is
+[NN23](../../specs/NN23-initialization-activation-distribution-labs.md), with
+the canonical fixture in
+[`00-three-layer-scale-comparison.json`](../../specs/fixtures/initialization-activation-distribution-v1/labs/00-three-layer-scale-comparison.json).
+
+## 1. Keep the experiment tiny and controlled
+
+Use four two-number inputs:
+
+```text
+[ 1,  0]
+[ 0,  1]
+[-1,  0]
+[ 0, -1]
+```
+
+Every layer has two inputs and two outputs. Reuse this sign template three
+times:
+
+```text
+base weights = [[1, -1],
+                [1,  1]]
+```
+
+Real initializers sample random weights. This lesson fixes the signs so that
+only scale changes and every language sees exactly the same arithmetic.
+
+## 2. Four scaling rules
+
+The **fan-in** is the number of values entering one neuron. Here it is `2` in
+every layer.
+
+| Initializer | Scale | With fan-in 2 |
+| --- | ---: | ---: |
+| Tiny control | `0.1` | `0.1` |
+| Xavier | `sqrt(1 / fan_in)` | `0.707107` |
+| He | `sqrt(2 / fan_in)` | `1` |
+| Large control | `2` | `2` |
+
+Xavier scaling is a common match for symmetric activations such as `tanh`. He
+scaling allows more spread before ReLU discards negative values. The tiny and
+large controls intentionally demonstrate failure directions.
+
+## 3. One Xavier calculation by hand
+
+Scale the template by `1 / sqrt(2)`:
+
+```text
+W = [[ 0.707107, -0.707107],
+     [ 0.707107,  0.707107]]
+```
+
+Open sample `[1, 0]` and the first neuron:
+
+```text
+z_0 = 1 * 0.707107 + 0 * 0.707107
+    = 0.707107
+
+tanh(z_0) = 0.608859
+```
+
+The second neuron receives:
+
+```text
+z_1 = 1 * -0.707107 + 0 * 0.707107
+    = -0.707107
+
+tanh(z_1) = -0.608859
+```
+
+Across all four samples, the eight first-layer activations are four positive
+and four negative copies of `0.608859`.
+
+## 4. Summarize a distribution
+
+A **distribution** here means the collection of all eight activation values in
+one layer. Use population statistics because these eight values are the whole
+toy batch, not a sample estimating a larger batch:
+
+```text
+mean     = sum(values) / 8
+variance = sum((value - mean)^2) / 8
+std dev  = sqrt(variance)
+```
+
+For Xavier plus `tanh`, layer 1 has mean `0` and standard deviation
+`0.608859`. Continue the same matrix multiplication through all three layers:
+
+```text
+layer standard deviations = [0.608859, 0.492713, 0.456367]
+```
+
+The signal narrows gently rather than collapsing immediately.
+
+## 5. See four different outcomes
+
+With ReLU, the scale differences accumulate visibly:
+
+| Initializer | Layer 1 std | Layer 2 std | Layer 3 std |
+| --- | ---: | ---: | ---: |
+| Tiny | `0.05` | `0.006960` | `0.000857` |
+| Xavier | `0.353553` | `0.347985` | `0.302980` |
+| He | `0.5` | `0.695971` | `0.856957` |
+| Large | `1` | `2.783882` | `6.855655` |
+
+The tiny signal nearly disappears. The deliberately large signal grows by
+almost seven times the original input standard deviation.
+
+ReLU also turns negative preactivations into exact zeros. The zero fraction in
+this fixed experiment is `50%`, `50%`, then `62.5%`.
+
+With large weights and `tanh`, `100%` of layer 1 values, `50%` of layer 2, and
+`100%` of layer 3 have absolute magnitude at least `0.95`. Those values are
+called **saturated** here: changing the preactivation has little effect on the
+bounded output.
+
+## 6. What initialization does and does not do
+
+A useful initializer keeps forward signals informative long enough for
+training to begin. It does not guarantee learning, and the best rule depends
+on the activation, width, architecture, normalization, and optimizer.
+
+This forward experiment also does not yet trace gradients. The next lesson
+will reverse a similar network and show why repeated small or large derivative
+factors produce vanishing or exploding gradients.
+
+## 7. Validate the deterministic corpus
+
+```text
+python code/scripts/validate_initialization_activation_distribution_labs.py
+```
+
+The validator rejects unknown or duplicate keys, non-finite or ragged
+matrices, incompatible layer shapes, changed conventions, and any activation or
+summary that drifts beyond the fixture tolerance.
+
+## 8. Cross-language and Rust-core path
+
+Implement the fixed sign templates first. That separates matrix and statistics
+parity from pseudorandom-generator parity.
+
+A Rust core can accept row-major input and template buffers, derive each layer's
+scale, fuse matrix multiplication with the activation, and reduce population
+statistics with SIMD. C ABI and WASM bindings can expose the same buffers to
+other languages. An explain mode should retain preactivation and activation
+buffers even when the fast path fuses those operations.
+
+## 9. Next experiment
+
+Change the layer width while keeping the raw sign pattern. Xavier and He scales
+change automatically because fan-in changes; the fixed `0.1` and `2` controls
+do not. That experiment shows why useful initializers depend on network shape.

--- a/code/learning/machine-learning/multi-head-attention-add-and-norm-by-hand.md
+++ b/code/learning/machine-learning/multi-head-attention-add-and-norm-by-hand.md
@@ -1,0 +1,207 @@
+# Multi-Head Attention, Add, and Norm, by Hand
+
+One attention head gives every token one way to ask what matters. A transformer
+usually runs several heads in parallel so different learned projections can
+look for different relationships. The results still have to rejoin one model
+stream, preserve the original token, and keep feature scales controlled.
+
+This lesson builds the smallest complete version: two tokens-wide features,
+two scalar heads, a causal mask, an output projection, a residual addition, and
+layer normalization. The language-neutral oracle is
+[`00-two-head-causal-add-norm.json`](../../specs/fixtures/multi-head-attention-v1/labs/00-two-head-causal-add-norm.json),
+and the contract is
+[`NN14-multi-head-add-norm-labs.md`](../../specs/NN14-multi-head-add-norm-labs.md).
+
+## Keep the same three tokens
+
+The token embeddings are the value vectors from the previous attention lesson:
+
+```text
+x_red    = [2,0]
+x_blue   = [0,1]
+x_purple = [2,1]
+```
+
+The model width is two. Split that width across two heads, so each head produces
+one scalar context:
+
+```text
+head count = 2
+head width = model width / head count = 2 / 2 = 1
+```
+
+This is intentionally tiny. Real models use many coordinates per head, but the
+control flow is the same.
+
+## Give the heads different views
+
+The horizontal head projects query and key with `[0.5,0]` and value with
+`[1,0]`. It sees only the first coordinate. The vertical head uses `[0,1]` for
+all three projections and sees only the second coordinate.
+
+For the blue query:
+
+```text
+horizontal query = [0,1] dot [0.5,0] = 0
+horizontal keys  = [1,0,1]
+horizontal values = [2,0,2]
+
+vertical query = [0,1] dot [0,1] = 1
+vertical keys  = [0,1,1]
+vertical values = [0,1,1]
+```
+
+The head width is one, so dividing scores by `sqrt(head width)` divides by one.
+The scale step is still explicit because it stops being trivial as head width
+grows.
+
+## Work both blue-query heads
+
+Blue may read red and itself, but not future purple.
+
+The horizontal query is zero, so both allowed scores are zero:
+
+```text
+scores       = [0 * 1, 0 * 0, blocked]
+             = [0, 0, blocked]
+exponentials = [1, 1, 0]
+weights      = [0.5, 0.5, 0]
+context      = 0.5 * 2 + 0.5 * 0 + 0 * 2
+             = 1
+```
+
+The vertical head finds a stronger match with blue itself:
+
+```text
+scores        = [1 * 0, 1 * 1, blocked]
+              = [0, 1, blocked]
+shifted       = [-1, 0, blocked]
+exponentials  = [exp(-1), 1, 0]
+denominator   = 0.367879 + 1 = 1.367879
+weights       = [0.268941, 0.731059, 0]
+context       = 0.268941 * 0 + 0.731059 * 1 + 0 * 1
+              = 0.731059
+```
+
+The heads used the same token row and causal boundary, yet learned projections
+made them attend differently. That is the reason to have multiple heads.
+
+## Concatenate, then project
+
+Put the head contexts beside each other in head order:
+
+```text
+concatenated blue context = [1, 0.731059]
+```
+
+Concatenation restores the model width. A learned output matrix can now mix
+information across heads. This first lab uses the identity matrix so every
+multiply remains easy to audit:
+
+```text
+W_output = [[1,0],
+            [0,1]]
+
+projected attention = [1 * 1 + 0.731059 * 0,
+                       1 * 0 + 0.731059 * 1]
+                    = [1, 0.731059]
+```
+
+Do not omit the output projection from an implementation just because the toy
+matrix is the identity. The fixture records all four products.
+
+## Add the residual path
+
+The attention path should not replace the original token. Add the input back:
+
+```text
+attention path = [1, 0.731059]
+identity path  = [0, 1]
+residual sum   = [1 + 0, 0.731059 + 1]
+               = [1, 1.731059]
+```
+
+The short route helps information and gradients cross a deep stack even when
+the learned attention path is temporarily unhelpful.
+
+## Normalize the two features
+
+This lab uses post-attention layer normalization: attention, add residual, then
+normalize. Statistics belong to one token row and span its feature coordinates.
+They do not mix tokens.
+
+```text
+mean = (1 + 1.731059) / 2
+     = 1.365529
+
+centered = [1 - 1.365529, 1.731059 - 1.365529]
+         = [-0.365529, 0.365529]
+
+population variance
+  = ((-0.365529)^2 + 0.365529^2) / 2
+  = 0.133612
+
+denominator = sqrt(variance + 0.00001)
+            = 0.365543
+
+normalized = centered / denominator
+           = [-0.999963, 0.999963]
+```
+
+With `gamma = [1,1]` and `beta = [0,0]`, the affine step leaves those two
+normalized coordinates unchanged. Gamma and beta are learned in a real block.
+
+## Follow the complete block
+
+For one token, the post-norm block is:
+
+```text
+embedding
+  -> two independent causal attention heads
+  -> concatenate head contexts
+  -> output projection
+  -> add the original embedding
+  -> layer normalization
+```
+
+Some modern decoder stacks use pre-normalization, placing layer normalization
+before attention. That is a different block order, not a different definition
+of multi-head attention. NN14 pins post-normalization so every consumer checks
+the same graph.
+
+## Common implementation bugs
+
+- Sharing one softmax denominator across heads instead of normalizing each head
+  independently.
+- Applying one set of query, key, and value projections to every head, which
+  makes the heads identical by construction.
+- Concatenating in a different order than the output projection expects.
+- Adding the residual before restoring the model width.
+- Normalizing across tokens instead of across one token's feature coordinates.
+- Using sample variance and dividing by `width - 1`; layer normalization here
+  uses population variance and divides by `width`.
+- Adding epsilon after the square root rather than inside it.
+- Forgetting the learned gamma and beta affine step.
+
+## Try the complete attention block
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+keeps both heads visible at once, aligns their three weights and scalar value
+contributions, then follows the concatenated result through projection,
+residual addition, and normalization. Select another token or remove the
+residual and normalization stages to see which part of the block caused each
+number.
+
+## Cross-language checkpoint
+
+An NN14 consumer is conformant when it reproduces every scalar projection
+product, per-head score, mask, stable-softmax intermediate, value contribution,
+context, output-projection product, residual coordinate, normalization
+statistic, affine product, and final output.
+
+Implement the scalar loops directly in each language first. A Rust core may
+later fuse projection, masked softmax, value reduction, residual addition, and
+normalization for performance. Its stable C ABI should expose dimensions,
+strides, masks, epsilon, caller-owned buffers, and optional trace buffers. The
+fast path and the teaching path should share one numerical contract.

--- a/code/learning/machine-learning/normalization-dropout-and-residual-paths-by-hand.md
+++ b/code/learning/machine-learning/normalization-dropout-and-residual-paths-by-hand.md
@@ -1,0 +1,274 @@
+# Normalization, Dropout, and Residual Paths, by Hand
+
+NN23 showed how initialization shapes forward signals. NN24 followed gradients
+backward. This lesson keeps one learned branch fixed and changes only the route
+around it, so three often-mixed-up tools have visibly different jobs:
+
+- **normalization** makes coordinates share scale information;
+- **dropout** samples a smaller training-time subnetwork;
+- a **residual path** adds a short identity route.
+
+The language-neutral contract is
+[NN25](../../specs/NN25-normalization-dropout-residual-labs.md), with the
+canonical fixture in
+[`00-four-route-comparison.json`](../../specs/fixtures/training-stabilizers-v1/labs/00-four-route-comparison.json).
+
+## 1. One shared branch
+
+Use a four-coordinate input and one scalar branch weight:
+
+```text
+input x       = [1, 1, 3, 3]
+branch weight = 0.5
+h             = weight * x
+              = [0.5, 0.5, 1.5, 1.5]
+```
+
+Instead of hiding the reverse pass inside a large loss, seed it with one
+visible upstream vector:
+
+```text
+g = dS/doutput = [1, 0, 0, -1]
+S = dot(g, output)
+```
+
+`S` is a scalar score. Its gradient is a vector-Jacobian product: it asks how
+the chosen weighted combination of outputs changes when an input or the branch
+weight changes.
+
+## 2. The plain route is the control
+
+The plain route returns the branch unchanged:
+
+```text
+output = h = [0.5, 0.5, 1.5, 1.5]
+S = 1 * 0.5 + 0 * 0.5 + 0 * 1.5 - 1 * 1.5
+  = -1
+```
+
+The gradient entering `h` is just `g`. The branch multiplies every input by
+`0.5`, so the reverse pass multiplies by the same local derivative:
+
+```text
+dS/dx = 0.5 * g
+      = [0.5, 0, 0, -0.5]
+```
+
+The shared branch-weight gradient adds all four coordinate contributions:
+
+```text
+dS/dweight = dot(dS/dh, x)
+            = 1*1 + 0*1 + 0*3 - 1*3
+            = -2
+```
+
+## 3. Layer normalization shares statistics
+
+Normalize the four values of `h` together. NN25 uses population variance and
+omits the tiny numerical epsilon so every number can be calculated by hand.
+The fixture has nonzero variance, so division remains safe.
+
+First find the mean:
+
+```text
+mean = (0.5 + 0.5 + 1.5 + 1.5) / 4 = 1
+```
+
+Center the coordinates and find their population variance:
+
+```text
+centered = [-0.5, -0.5, 0.5, 0.5]
+variance = (0.25 + 0.25 + 0.25 + 0.25) / 4 = 0.25
+standard deviation = sqrt(0.25) = 0.5
+```
+
+Divide every centered coordinate by that shared standard deviation:
+
+```text
+normalized output = [-1, -1, 1, 1]
+S = 1*(-1) + 0*(-1) + 0*1 - 1*1 = -2
+```
+
+The reverse pass is coupled: one output gradient can affect other input
+coordinates because mean and variance used all four values. For `N = 4`:
+
+```text
+dS/dh[i] =
+  (N*g[i] - sum(g) - normalized[i]*sum(g*normalized))
+  / (N*standard_deviation)
+```
+
+The two shared sums are:
+
+```text
+sum(g) = 0
+sum(g * normalized) = -2
+```
+
+For coordinate 1:
+
+```text
+dS/dh[1] = (4*1 - 0 - (-1)*(-2)) / (4*0.5)
+          = (4 - 2) / 2
+          = 1
+```
+
+For coordinate 2, the direct upstream gradient is zero, but shared statistics
+still produce a gradient:
+
+```text
+dS/dh[2] = (4*0 - 0 - (-1)*(-2)) / 2 = -1
+```
+
+The complete reverse vectors are:
+
+```text
+dS/dh = [1, -1, 1, -1]
+dS/dx = 0.5 * dS/dh
+      = [0.5, -0.5, 0.5, -0.5]
+```
+
+The shared scalar weight gradient is zero:
+
+```text
+1*1 - 1*1 + 1*3 - 1*3 = 0
+```
+
+That is not a failed gradient. With zero epsilon and a positive scalar weight,
+layer normalization removes that common scale, so changing only the scale does
+not change this normalized output.
+
+Real implementations add a small positive epsilon inside the square root and
+usually learn per-coordinate `gamma` and `beta`. NN25 isolates the core
+centering and scaling calculation.
+
+## 4. Inverted dropout samples a route
+
+Use keep probability `0.5` and pin one training mask:
+
+```text
+mask = [1, 0, 1, 0]
+mask / keep_probability = [2, 0, 2, 0]
+```
+
+Inverted dropout rescales kept values during training:
+
+```text
+training output = h * mask / 0.5
+                = [1, 0, 3, 0]
+S = 1
+```
+
+At evaluation time dropout is off:
+
+```text
+evaluation output = h = [0.5, 0.5, 1.5, 1.5]
+```
+
+For a Bernoulli mask, `E[mask] = keep_probability`, so each expected scaled
+mask coordinate is one:
+
+```text
+E[mask / keep_probability] = 1
+E[training output] = h
+```
+
+That equality is an expectation over many masks, not a promise that this one
+training pass equals evaluation.
+
+The same scaled mask appears in the reverse pass:
+
+```text
+dS/dh = g * mask / 0.5
+      = [2, 0, 0, 0]
+dS/dx = 0.5 * dS/dh
+      = [1, 0, 0, 0]
+dS/dweight = dot(dS/dh, x) = 2
+```
+
+The fourth upstream coordinate was `-1`, but its mask was zero, so this sampled
+subnetwork sends no gradient through that coordinate.
+
+## 5. A residual path adds an identity route
+
+The residual route adds the original input to the learned branch:
+
+```text
+output = x + h
+       = [1.5, 1.5, 4.5, 4.5]
+S = 1.5 - 4.5 = -3
+```
+
+The upstream gradient splits. One copy crosses the learned branch and is
+multiplied by `0.5`; another crosses the identity skip with derivative `1`:
+
+```text
+branch contribution = 0.5 * g = [0.5, 0, 0, -0.5]
+skip contribution   = 1.0 * g = [1, 0, 0, -1]
+total dS/dx          = [1.5, 0, 0, -1.5]
+```
+
+The skip does not replace the learned branch. It gives the forward signal and
+the reverse gradient a shorter additional route. Shapes must still match, or a
+projection must make them compatible before addition.
+
+## 6. Put the four routes side by side
+
+| Route | Output | `dS/dx` | `dS/dweight` |
+| --- | --- | --- | ---: |
+| Plain | `[0.5, 0.5, 1.5, 1.5]` | `[0.5, 0, 0, -0.5]` | `-2` |
+| Layer normalization | `[-1, -1, 1, 1]` | `[0.5, -0.5, 0.5, -0.5]` | `0` |
+| Inverted dropout | `[1, 0, 3, 0]` | `[1, 0, 0, 0]` | `2` |
+| Identity residual | `[1.5, 1.5, 4.5, 4.5]` | `[1.5, 0, 0, -1.5]` | `-2` |
+
+Normalization couples coordinates. Dropout changes the sampled training graph.
+Residual addition creates a second path. They can coexist in one architecture,
+but they are not interchangeable remedies.
+
+## 7. Check every gradient independently
+
+For each input coordinate, perturb only that coordinate:
+
+```text
+dS/dx[i] ~= (S(x[i] + epsilon) - S(x[i] - epsilon)) / (2 * epsilon)
+```
+
+Perturb the scalar branch weight the same way. NN25 uses epsilon `0.000001` and
+checks four input gradients plus one weight gradient for each route. All twenty
+analytical values agree with their central finite differences within `1e-8`.
+
+The dropout mask stays fixed during this audit. Changing the mask between the
+positive and negative evaluations would compare two different sampled
+functions instead of checking one derivative.
+
+## 8. Practical boundaries
+
+- Normalization requires an explicit axis, epsilon, and learned-affine policy.
+- Dropout requires a training/evaluation mode and reproducible random-state or
+  caller-supplied mask for tests.
+- Residual addition requires compatible shapes and clear aliasing rules.
+- None guarantees a deep model will train; inspect activations, gradients,
+  updates, and data together.
+
+## 9. Validate the deterministic corpus
+
+```text
+python code/scripts/validate_training_stabilizer_labs.py
+```
+
+The validator rejects unknown or duplicate keys, non-finite vectors, malformed
+masks, changed conventions, route reordering, trace drift, and failed input or
+weight finite differences.
+
+## 10. Cross-language and Rust-core path
+
+Implement the four vector routes directly in each host language first. That
+pins population statistics, inverted-mask scaling, residual gradient splitting,
+and vector-Jacobian-product order before tensor broadcasting enters the design.
+
+A Rust core can later fuse normalization, dropout, residual addition, and their
+backward kernels over contiguous buffers. A stable C ABI or WASM surface should
+accept dimensions, normalization axes and epsilon, training mode, a seed or
+caller-provided mask, and residual buffers. An optional trace mode should expose
+the saved statistics and split gradients so every language can still unpack
+the optimized result.

--- a/code/learning/machine-learning/one-dimensional-diffusion-by-hand.md
+++ b/code/learning/machine-learning/one-dimensional-diffusion-by-hand.md
@@ -1,0 +1,363 @@
+# One-Dimensional Diffusion, by Hand
+
+A diffusion model learns generation by practicing a reversible-looking task:
+
+1. mix clean data with a known amount of noise;
+2. train a neural network to predict the noise that was mixed in;
+3. subtract predicted noise a little at a time.
+
+Large diffusion models do this with images, thousands of dimensions, and many
+timesteps. This lesson uses one clean number, one saved noise value, two noise
+levels, and a three-parameter denoiser. Every coefficient and update fits on
+paper.
+
+The deterministic oracle is
+[`00-two-level-forward-and-reverse.json`](../../specs/fixtures/one-dimensional-diffusion-v1/labs/00-two-level-forward-and-reverse.json),
+and the language-neutral contract is
+[`NN19-one-dimensional-diffusion-labs.md`](../../specs/NN19-one-dimensional-diffusion-labs.md).
+
+## Start with one clean sample and one saved noise value
+
+Use:
+
+```text
+x0 = 1
+epsilon = -0.5
+```
+
+In real training, `epsilon` is usually drawn from a standard normal
+distribution. Saving one already-drawn value makes this trace reproducible and
+lets every language audit identical arithmetic.
+
+## Turn beta into signal and noise scales
+
+Each timestep has a noise rate `beta_t` and retained-signal rate:
+
+```text
+alpha_t = 1 - beta_t
+```
+
+The cumulative retained signal through timestep `t` is:
+
+```text
+alpha_bar_t = alpha_1 * alpha_2 * ... * alpha_t
+```
+
+Use this two-step schedule:
+
+| timestep | beta | alpha | alpha_bar |
+| ---: | ---: | ---: | ---: |
+| `1` | `0.36` | `0.64` | `0.64` |
+| `2` | `0.4375` | `0.5625` | `0.36` |
+
+The closed-form forward sample is:
+
+```text
+x_t
+  = sqrt(alpha_bar_t) * x0
+  + sqrt(1 - alpha_bar_t) * epsilon
+```
+
+The first square root scales clean signal. The second scales noise. Their
+squared coefficients add to `1`, so the mixture shifts smoothly rather than
+growing without bound.
+
+## Forward level 1
+
+At `t = 1`:
+
+```text
+signal scale = sqrt(0.64) = 0.8
+noise scale = sqrt(1 - 0.64) = sqrt(0.36) = 0.6
+
+signal contribution = 0.8 * 1 = 0.8
+noise contribution = 0.6 * (-0.5) = -0.3
+
+x1 = 0.8 + (-0.3)
+   = 0.5
+```
+
+The clean value has moved from `1` to `0.5`, but its signal coefficient is
+still larger than its noise coefficient.
+
+## Forward level 2
+
+At `t = 2`:
+
+```text
+signal scale = sqrt(0.36) = 0.6
+noise scale = sqrt(1 - 0.36) = sqrt(0.64) = 0.8
+
+signal contribution = 0.6 * 1 = 0.6
+noise contribution = 0.8 * (-0.5) = -0.4
+
+x2 = 0.6 + (-0.4)
+   = 0.2
+```
+
+Now noise has the larger coefficient. Both levels reused the same saved
+`epsilon` so the changing coefficients are easy to compare. They are direct
+closed-form samples from `x0`, not consecutive draws from one Markov forward
+trajectory. A production trainer may sample an arbitrary timestep directly in
+exactly this way.
+
+## Ask the model to predict noise
+
+The denoiser must know both the noisy value and how far along the schedule it
+is. Give it normalized times `0.5` and `1`:
+
+```text
+epsilon_hat
+  = sample_weight * x_t
+  + timestep_weight * normalized_t
+  + bias
+```
+
+Start all three parameters at zero. The prediction at both timesteps is zero:
+
+```text
+epsilon_hat_1 = 0
+epsilon_hat_2 = 0
+```
+
+The target is the saved noise `-0.5`. Use half-squared error per row:
+
+```text
+error = predicted_noise - target_noise
+      = 0 - (-0.5)
+      = 0.5
+
+row_loss = 0.5 * error^2
+         = 0.5 * 0.25
+         = 0.125
+```
+
+Both row losses are `0.125`, so their mean is also `0.125`.
+
+Predicting noise may look indirect. Its advantage is that training always has a
+known target: the program just generated `epsilon`. Once the model estimates
+that corruption, the reverse formula converts the estimate into a cleaner
+sample.
+
+## Backpropagate both timesteps
+
+The objective is the mean of two half-squared errors. Therefore each row's
+prediction gradient includes a factor of `1 / 2`:
+
+```text
+d mean_loss / d predicted_noise
+  = error / 2
+  = 0.5 / 2
+  = 0.25
+```
+
+At level 1, `x1 = 0.5` and normalized time is `0.5`:
+
+```text
+sample-weight contribution = 0.25 * 0.5 = 0.125
+time-weight contribution = 0.25 * 0.5 = 0.125
+bias contribution = 0.25
+```
+
+At level 2, `x2 = 0.2` and normalized time is `1`:
+
+```text
+sample-weight contribution = 0.25 * 0.2 = 0.05
+time-weight contribution = 0.25 * 1 = 0.25
+bias contribution = 0.25
+```
+
+Add contributions because both rows used the same denoiser parameters:
+
+```text
+sample_weight gradient = 0.125 + 0.05 = 0.175
+timestep_weight gradient = 0.125 + 0.25 = 0.375
+bias gradient = 0.25 + 0.25 = 0.5
+```
+
+The timestep feature matters. The same network must interpret a moderately
+noisy value differently from a heavily noisy one.
+
+## Audit the three gradients
+
+For each parameter, perturb the initial value with
+`audit_epsilon = 0.000001` and recompute the mean loss:
+
+```text
+numerical gradient
+  = (loss(parameter + audit_epsilon)
+     - loss(parameter - audit_epsilon))
+    / (2 * audit_epsilon)
+```
+
+The numerical gradients are:
+
+```text
+[0.174999999998, 0.374999999997, 0.499999999994]
+```
+
+The largest analytical-versus-numerical difference is about `6.44e-12`, which
+is floating-point rounding.
+
+## Apply one SGD step
+
+Use learning rate `0.5`:
+
+```text
+new sample_weight = 0 - 0.5 * 0.175
+                  = -0.0875
+
+new timestep_weight = 0 - 0.5 * 0.375
+                    = -0.1875
+
+new bias = 0 - 0.5 * 0.5
+         = -0.25
+```
+
+Rerun both saved-noise examples.
+
+At level 1:
+
+```text
+epsilon_hat_1
+  = -0.0875 * 0.5 + -0.1875 * 0.5 + -0.25
+  = -0.3875
+
+loss_1 = 0.5 * (-0.3875 - -0.5)^2
+       = 0.006328125
+```
+
+At level 2:
+
+```text
+epsilon_hat_2
+  = -0.0875 * 0.2 + -0.1875 * 1 + -0.25
+  = -0.455
+
+loss_2 = 0.5 * (-0.455 - -0.5)^2
+       = 0.0010125
+```
+
+The new mean loss is:
+
+```text
+(0.006328125 + 0.0010125) / 2
+  = 0.0036703125
+```
+
+One step lowered the objective from `0.125` to `0.0036703125`.
+
+## Reverse from level 2 to level 1
+
+For this deterministic audit, use the DDPM reverse mean without adding fresh
+reverse noise:
+
+```text
+noise_coefficient_t
+  = beta_t / sqrt(1 - alpha_bar_t)
+
+previous_mean
+  = (current_sample
+     - noise_coefficient_t * predicted_noise)
+    / sqrt(alpha_t)
+```
+
+At `t = 2`:
+
+```text
+noise coefficient = 0.4375 / 0.8
+                  = 0.546875
+
+scaled noise correction = 0.546875 * (-0.455)
+                        = -0.248828125
+
+corrected sample = 0.2 - (-0.248828125)
+                 = 0.448828125
+
+mean1 = 0.448828125 / sqrt(0.5625)
+      = 0.448828125 / 0.75
+      = 0.5984375
+```
+
+This generated `mean1` becomes the next denoiser input. Do not replace it with
+the saved forward value `x1 = 0.5`; reverse generation must follow its own path.
+
+## Reverse from level 1 to clean data
+
+Predict noise again using the generated mean and normalized time `0.5`:
+
+```text
+epsilon_hat
+  = -0.0875 * 0.5984375 + -0.1875 * 0.5 + -0.25
+  = -0.39611328125
+```
+
+Apply the `t = 1` reverse mean:
+
+```text
+noise coefficient = 0.36 / 0.6 = 0.6
+
+scaled noise correction = 0.6 * (-0.39611328125)
+                        = -0.23766796875
+
+corrected sample = 0.5984375 - (-0.23766796875)
+                 = 0.83610546875
+
+mean0 = 0.83610546875 / sqrt(0.64)
+      = 0.83610546875 / 0.8
+      = 1.0451318359375
+```
+
+The noisiest input `0.2` was `0.8` away from the clean value. The final reverse
+mean is only `0.0451318359375` away. It is not exact because the tiny denoiser
+still predicts imperfect noise.
+
+## What this trace leaves out
+
+- Production schedules use many more, usually much smaller, beta values.
+- A real denoiser consumes tensors and a learned timestep embedding.
+- Training samples many clean examples, timesteps, and fresh noise values.
+- A stochastic sampler may add controlled reverse variance at intermediate
+  steps; this fixture follows the mean only.
+- Better noise-prediction loss often helps generation, but sample quality and
+  diversity still need direct evaluation.
+- Other parameterizations predict clean data, velocity, or score rather than
+  raw noise.
+
+## Common implementation bugs
+
+- Using `alpha_t` where the closed-form forward equation needs cumulative
+  `alpha_bar_t`.
+- Scaling noise by `sqrt(beta_t)` in the direct-from-`x0` formula instead of
+  `sqrt(1 - alpha_bar_t)`.
+- Forgetting timestep conditioning.
+- Drawing unrelated noise for the analytical and finite-difference passes.
+- Forgetting the mean-reduction factor when accumulating shared gradients.
+- Feeding the saved forward `x1` into the second reverse step instead of the
+  generated `mean1`.
+- Subtracting `predicted_noise` directly without the schedule coefficient.
+- Adding random reverse noise during a fixture that specifies the deterministic
+  mean path.
+
+## Explore the round trip
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+keeps the clean value, both forward mixtures, denoiser objective, per-timestep
+gradient contributions, audited update, and both reverse means in one view.
+Advance the six phases to see which value becomes the next input and when the
+initial denoiser switches to its trained parameters.
+
+## Cross-language checkpoint
+
+An NN19 consumer is conformant when it reproduces both forward noise levels,
+the initial and updated predictions, mean losses, per-row and reduced gradients,
+three numerical slopes, updated parameters, both reverse means, and final
+reconstruction error.
+
+Implement this scalar loop directly in every host language first. A Rust core
+can later vectorize coefficient generation, noise mixing, denoiser kernels,
+loss reductions, backward passes, and samplers behind a stable C ABI. Keep beta
+schedules, timestep encoding, random-number ownership, reduction rules, reverse
+variance policy, and optional trace buffers explicit so performance does not
+hide the forward/reverse contract.

--- a/code/learning/machine-learning/one-dimensional-gan-game-by-hand.md
+++ b/code/learning/machine-learning/one-dimensional-gan-game-by-hand.md
@@ -1,0 +1,299 @@
+# A One-Dimensional GAN Game, by Hand
+
+A generative adversarial network is not one model minimizing one loss. It is a
+game between two models:
+
+- a **generator** turns noise into a fake sample;
+- a **discriminator** estimates whether a sample came from real data.
+
+The discriminator first gets better at spotting the fake. Then the generator
+uses the discriminator's slope to make a more convincing fake. That alternating
+schedule is the important idea; larger images and deeper networks only replace
+the scalar arithmetic.
+
+This lesson uses one real number, one saved noise value, two scalar affine
+models, and one sigmoid. The deterministic oracle is
+[`00-discriminator-generator-round.json`](../../specs/fixtures/one-dimensional-gan-v1/labs/00-discriminator-generator-round.json),
+and the language-neutral contract is
+[`NN18-one-dimensional-gan-labs.md`](../../specs/NN18-one-dimensional-gan-labs.md).
+
+## Put both models on one number line
+
+Use one real sample and one already-drawn noise value:
+
+```text
+real = 1
+noise = 1
+```
+
+The generator starts with weight `0.2` and bias `0`:
+
+```text
+fake = generator_weight * noise + generator_bias
+     = 0.2 * 1 + 0
+     = 0.2
+```
+
+The discriminator starts with weight `1` and bias `0`. It turns its affine
+logit into a probability with the sigmoid function:
+
+```text
+discriminator_probability(x)
+  = sigmoid(discriminator_weight * x + discriminator_bias)
+
+real logit = 1 * 1 + 0 = 1
+D(real) = sigmoid(1) = 0.7310585786
+
+fake logit = 1 * 0.2 + 0 = 0.2
+D(fake) = sigmoid(0.2) = 0.5498339973
+```
+
+These values are scores under the current discriminator, not objective facts
+about authenticity. An untrained discriminator happens to call both points
+more real than fake.
+
+## Give the players different jobs
+
+The discriminator uses mean binary cross-entropy. The real point has target
+`1`; the fake point has target `0`:
+
+```text
+discriminator_loss
+  = -0.5 * (log D(real) + log(1 - D(fake)))
+  = -0.5 * (log 0.7310585786 + log(1 - 0.5498339973))
+  = 0.5557002784
+```
+
+The generator uses the non-saturating objective. It asks for its fake to receive
+the real label:
+
+```text
+generator_loss = -log D(fake)
+               = -log 0.5498339973
+               = 0.5981388694
+```
+
+These losses disagree on purpose. The discriminator wants `D(fake)` lower; the
+generator wants it higher. Do not add them and run one joint update.
+
+## Turn one: train the discriminator
+
+During the discriminator turn, treat the generated value `0.2` as fixed. This
+operation is often called **detach** or **stop gradient**. The discriminator may
+change, but the generator may not.
+
+For sigmoid plus binary cross-entropy, each logit gradient is prediction minus
+target. The mean over two examples adds a factor of `0.5`:
+
+```text
+real logit gradient
+  = 0.5 * (D(real) - 1)
+  = 0.5 * (0.7310585786 - 1)
+  = -0.1344707107
+
+fake logit gradient
+  = 0.5 * (D(fake) - 0)
+  = 0.5 * 0.5498339973
+  = 0.2749169987
+```
+
+Both examples use the same discriminator weight and bias, so add their
+contributions:
+
+```text
+discriminator weight gradient
+  = real_logit_gradient * real
+    + fake_logit_gradient * fake
+  = -0.1344707107 * 1 + 0.2749169987 * 0.2
+  = -0.0794873110
+
+discriminator bias gradient
+  = real_logit_gradient + fake_logit_gradient
+  = -0.1344707107 + 0.2749169987
+  = 0.1404462880
+```
+
+There is no generator gradient in this turn:
+
+```text
+gradient into fake sample = 0
+generator gradients = 0
+```
+
+Apply discriminator learning rate `0.5`:
+
+```text
+new discriminator weight
+  = 1 - 0.5 * (-0.0794873110)
+  = 1.0397436555
+
+new discriminator bias
+  = 0 - 0.5 * 0.1404462880
+  = -0.0702231440
+```
+
+The generator remains unchanged, so the fake is still `0.2`. Rerun the updated
+discriminator:
+
+```text
+new D(real) = 0.7250239152
+new D(fake) = 0.5343770743
+
+discriminator loss: 0.5557002784 -> 0.5429648914
+generator loss:     0.5981388694 -> 0.6266535576
+```
+
+The discriminator improved its own loss. The generator's loss worsened because
+the judge just became harder to fool.
+
+## Turn two: train the generator
+
+Now freeze the updated discriminator parameters. Freezing does **not** mean
+cutting the entire graph at the discriminator. Its input slope still tells the
+generator which direction makes the fake look more real.
+
+For the non-saturating generator loss, the fake-logit gradient is:
+
+```text
+fake logit gradient
+  = D(fake) - 1
+  = 0.5343770743 - 1
+  = -0.4656229257
+```
+
+Carry that signal through the updated discriminator weight:
+
+```text
+fake sample gradient
+  = fake_logit_gradient * updated_discriminator_weight
+  = -0.4656229257 * 1.0397436555
+  = -0.4841284829
+```
+
+Then carry it through the generator. Because the saved noise is `1`:
+
+```text
+generator weight gradient
+  = fake_sample_gradient * noise
+  = -0.4841284829 * 1
+  = -0.4841284829
+
+generator bias gradient = -0.4841284829
+```
+
+The discriminator parameter gradients are not accumulated or applied in this
+turn. Apply generator learning rate `0.25`:
+
+```text
+new generator weight
+  = 0.2 - 0.25 * (-0.4841284829)
+  = 0.3210321207
+
+new generator bias
+  = 0 - 0.25 * (-0.4841284829)
+  = 0.1210321207
+```
+
+Reuse the saved noise to generate the counter-move:
+
+```text
+new fake
+  = 0.3210321207 * 1 + 0.1210321207
+  = 0.4420642414
+
+frozen updated D(new fake) = 0.5961407441
+
+generator loss:     0.6266535576 -> 0.5172784919
+discriminator loss: 0.5429648914 -> 0.6141197382
+```
+
+The generator moved its point from `0.2` toward the real point at `1` and
+lowered its own loss. The discriminator loss rose. That is not a failed update;
+it is evidence that the opponent made a successful move.
+
+## Audit two different objectives
+
+A normal supervised model has one objective for a gradient check. This GAN
+round requires two checks because the player and the frozen values change.
+
+For each parameter, use centered finite differences with
+`epsilon = 0.000001`:
+
+```text
+numerical gradient
+  = (loss(parameter + epsilon) - loss(parameter - epsilon))
+    / (2 * epsilon)
+```
+
+The discriminator audit perturbs its initial weight and bias while holding the
+initial fake `0.2` detached. Its numerical gradients are:
+
+```text
+[-0.0794873109, 0.1404462880]
+```
+
+The largest analytical-versus-numerical difference is about `5.38e-11`.
+
+The generator audit perturbs its initial weight and bias while holding the
+**updated** discriminator and saved noise fixed. Its numerical gradients are:
+
+```text
+[-0.4841284829, -0.4841284829]
+```
+
+The largest difference is about `3.34e-12`. A joint finite-difference check over
+all four parameters would describe neither turn in the schedule.
+
+## What changes in a real GAN
+
+This scalar trace preserves the training topology, but not the scale:
+
+- real training uses batches and many fresh noise samples;
+- generator and discriminator are usually deep networks;
+- their learning rates and update counts may differ;
+- losses can oscillate because the target keeps changing;
+- a low loss does not by itself prove diverse, high-quality generation;
+- mode collapse can let a generator fool the critic with too little variety.
+
+The one real point also cannot teach a distribution. It exists so every route
+and freeze boundary fits on paper.
+
+## Common implementation bugs
+
+- Updating generator parameters during the discriminator turn.
+- Detaching the fake during the generator turn, which removes its learning
+  signal.
+- Updating discriminator parameters during the generator turn instead of only
+  using its input gradient.
+- Reusing stale fake probabilities after either model changes.
+- Minimizing `log(1 - D(fake))` for the generator without recognizing its weak
+  early gradient; this fixture specifies the non-saturating `-log D(fake)`
+  objective.
+- Treating `D(x)` as a calibrated probability of authenticity outside the
+  current game.
+- Declaring training broken whenever the opponent's loss rises.
+- Drawing different noise for the plus and minus gradient-audit evaluations.
+
+## Play the round
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+places the real and fake samples on one number line. Advance from the initial
+forward pass to the discriminator move and generator response. The active
+gradient route, detached or frozen boundary, both objectives, audited updates,
+and counter-push in the opponent's loss remain visible together.
+
+## Cross-language checkpoint
+
+An NN18 consumer is conformant when it reproduces the initial fake and both
+scores, the detached discriminator backward pass and update, the frozen-
+discriminator generator backward pass and update, both numerical audits, and
+all three objective snapshots.
+
+Implement this scalar schedule directly in every host language first. A Rust
+core can later batch stable sigmoid/BCE kernels, generator and discriminator
+forwards, backward passes, and optimizer steps behind a stable C ABI. The ABI
+must name the active player, frozen parameter buffers, update order, reduction
+rule, and saved-noise ownership explicitly. Optional trace buffers should keep
+detach boundaries, discriminator input gradients, and per-player losses
+inspectable instead of trading understanding for speed.

--- a/code/learning/machine-learning/optimization-under-the-microscope.md
+++ b/code/learning/machine-learning/optimization-under-the-microscope.md
@@ -1,0 +1,130 @@
+# Optimization Under the Microscope
+
+A gradient is not a command from a framework. It is a local description of a
+loss surface: if a parameter moves a tiny distance, the gradient predicts how
+the loss will change.
+
+This lesson makes that description visible and checks it without trusting
+backpropagation.
+
+## A Four-Point Problem
+
+Use one linear neuron:
+
+```text
+prediction = weight * x + bias
+```
+
+and four examples that sit exactly on `y = 2x + 1`:
+
+| x | target |
+| ---: | ---: |
+| -1 | -1 |
+| 0 | 1 |
+| 1 | 3 |
+| 2 | 5 |
+
+Start at `weight = -0.5` and `bias = 0`. The predictions are `0.5`, `0`,
+`-0.5`, and `-1`. Their mean squared error is:
+
+```text
+((1.5)^2 + (-1)^2 + (-3.5)^2 + (-6)^2) / 4 = 12.875
+```
+
+Every possible `(weight, bias)` pair is a location on the loss landscape. The
+lowest point is `(2, 1)`, where all four errors are zero.
+
+## The Analytical Gradient
+
+For mean squared error over `n` examples:
+
+```text
+dL/dweight = (2/n) * sum((prediction - target) * x)
+dL/dbias   = (2/n) * sum(prediction - target)
+```
+
+At the starting point:
+
+```text
+dL/dweight = -8.5
+dL/dbias   = -4.5
+```
+
+Both values are negative. Increasing either parameter should reduce the loss.
+With learning rate `0.05`, one full-batch update is:
+
+```text
+weight' = -0.5 - 0.05 * (-8.5) = -0.075
+bias'   =  0.0 - 0.05 * (-4.5) =  0.225
+```
+
+The full-dataset loss falls from `12.875` to `8.6671875`.
+
+## Check Backpropagation Independently
+
+Backpropagation is fast, but an implementation can silently contain a wrong
+sign, missing factor, or shape error. A finite-difference check estimates the
+same slope using only forward evaluations.
+
+For one parameter `p` and a small `epsilon`:
+
+```text
+numerical gradient = (loss(p + epsilon) - loss(p - epsilon)) / (2 * epsilon)
+```
+
+This is a central difference. It asks whether nudging the parameter left and
+right produces the change predicted by backpropagation.
+
+Use an epsilon such as `1e-5` for this small double-precision example. An
+epsilon that is too large measures the curve across too wide a region. An
+epsilon that is too small loses the difference to floating-point rounding.
+
+A gradient check is a debugging oracle, not a training algorithm: it needs two
+extra forward evaluations per checked parameter, so large networks usually
+sample only a few parameters.
+
+## One Gradient, Three Batch Strategies
+
+The loss definition may cover the entire dataset, while an optimizer can
+estimate its gradient from different subsets:
+
+| Strategy | Rows per update | What the path looks like |
+| --- | ---: | --- |
+| Stochastic gradient descent | 1 | Noisy and frequently corrected |
+| Mini-batch gradient descent | 2 in this lab | Less noisy while still updating often |
+| Full-batch gradient descent | 4 | Smooth and deterministic |
+
+The optimization lab cycles through rows deterministically so that every
+language produces the same trace. Real training usually shuffles examples with
+a seeded random-number generator.
+
+Noise is not automatically bad. A noisy gradient is cheaper to compute and can
+help a model move through complicated landscapes. The important questions are
+how much the estimate varies, whether the learning rate is stable, and whether
+the full-dataset objective improves over time.
+
+## Learning-Rate Failure Modes
+
+The update is `parameter - learning_rate * gradient`.
+
+- A tiny rate moves in the right direction but wastes steps.
+- A useful rate makes visible progress without repeatedly crossing the valley.
+- A large rate overshoots the valley and can oscillate or diverge.
+
+Change the rate in the visualizer while keeping the starting model fixed. The
+three batch strategies respond differently because they see different gradient
+estimates, even though they optimize the same full-dataset loss.
+
+## What to Verify Before Scaling
+
+Before training a deeper network:
+
+1. Check analytical gradients against finite differences.
+2. Confirm the update moves against the gradient.
+3. Plot the loss before and after each update.
+4. Make batch selection deterministic in tests.
+5. Deliberately try a learning rate that diverges.
+6. Compare the exact trace across language implementations.
+
+These checks turn optimization from hidden framework behavior into observable,
+testable arithmetic.

--- a/code/learning/machine-learning/recurrent-state-unrolled-by-hand.md
+++ b/code/learning/machine-learning/recurrent-state-unrolled-by-hand.md
@@ -1,0 +1,185 @@
+# One Recurrent State, Unrolled by Hand
+
+A feed-forward network receives an input, produces an output, and finishes. A
+sequence network needs a way for an earlier input to affect a later step. The
+smallest possible memory is one number called the **hidden state**.
+
+This lesson runs one recurrent cell for only three time steps. The complete
+language-neutral oracle is
+[`00-three-step-relu-state.json`](../../specs/fixtures/recurrent-unroll-v1/labs/00-three-step-relu-state.json).
+The formulas and conformance rules are in
+[`NN09-recurrent-unroll-labs.md`](../../specs/NN09-recurrent-unroll-labs.md).
+
+## One cell, used repeatedly
+
+At every time step, the cell receives two values:
+
+1. the new sequence value `x[t]`; and
+2. the previous hidden state `h[t - 1]`.
+
+It combines them with one shared parameter set:
+
+```text
+input contribution  = W_x * x[t]
+memory contribution = W_h * h[t - 1]
+a[t]                = input contribution + memory contribution + b
+h[t]                = ReLU(a[t])
+```
+
+`a[t]` is the value before activation. ReLU keeps positive values and replaces
+negative values with zero.
+
+Use these tiny numbers:
+
+```text
+sequence x         = [1, 2, 0]
+initial state h[-1] = 0
+input weight W_x    = 2
+memory weight W_h   = 0.5
+bias b              = -1
+```
+
+The initial state is explicit. A production model might receive it from a
+previous sequence chunk, initialize it to zeros, or let a caller supply it. It
+must not appear from hidden runtime state.
+
+## Time step 0
+
+The first step sees `x[0] = 1` and the initial state `h[-1] = 0`:
+
+```text
+input contribution  = 2 * 1   = 2
+memory contribution = 0.5 * 0 = 0
+a[0]                = 2 + 0 - 1
+                    = 1
+h[0]                = ReLU(1)
+                    = 1
+```
+
+The new state `1` is both this step's result and part of the next step's input.
+
+## Time step 1
+
+The second step sees new input `2` and carried state `1`:
+
+```text
+input contribution  = 2 * 2   = 4
+memory contribution = 0.5 * 1 = 0.5
+a[1]                = 4 + 0.5 - 1
+                    = 3.5
+h[1]                = ReLU(3.5)
+                    = 3.5
+```
+
+Nothing new was learned between time steps. `W_x`, `W_h`, and `b` have exactly
+the same values as they had at step 0. Reusing them is what makes this one
+recurrent layer rather than three unrelated layers.
+
+## Time step 2: no new signal, but memory remains
+
+The final sequence input is zero:
+
+```text
+input contribution  = 2 * 0     = 0
+memory contribution = 0.5 * 3.5 = 1.75
+a[2]                = 0 + 1.75 - 1
+                    = 0.75
+h[2]                = ReLU(0.75)
+                    = 0.75
+```
+
+The final output is positive even though the new input is zero. Earlier inputs
+changed `h[1]`, and `h[1]` crossed the recurrent link into the final step. That
+is the entire memory mechanism in this tiny network.
+
+The complete state sequence is:
+
+```text
+initial -> step 0 -> step 1 -> step 2
+   0         1        3.5       0.75
+```
+
+## What “unrolling” means
+
+The implementation can be a loop containing one cell:
+
+```text
+state = initial_state
+for input in sequence:
+    state = ReLU(W_x * input + W_h * state + b)
+```
+
+To inspect dependencies, draw one copy of that cell for each time step:
+
+```text
+h[-1] -> [cell t=0] -> h[0] -> [cell t=1] -> h[1] -> [cell t=2] -> h[2]
+             ^                       ^                       ^
+            x[0]                    x[1]                    x[2]
+```
+
+This drawing is the **unrolled graph**. The boxes are executions at different
+times, not independently parameterized cells. Every box points back to the
+same `W_x`, `W_h`, and `b`.
+
+Unrolling turns a cycle described over time into an acyclic chain for one
+finite sequence. The next lesson can walk backward through that chain and show
+how shared parameters collect gradient contributions from several steps.
+
+## Break the recurrent link
+
+To isolate memory, keep all inputs and parameters fixed but replace every
+memory contribution with zero:
+
+```text
+time:                 0    1    2
+state with memory:    1   3.5  0.75
+state without memory: 1   3    0
+difference:           0   0.5  0.75
+```
+
+Without recurrence, each step becomes an independent calculation:
+
+```text
+h[t] = ReLU(2 * x[t] - 1)
+```
+
+The zero final input then produces `ReLU(-1) = 0`. This counterfactual does not
+claim the recurrent state stores every detail forever. It proves which part of
+this result came through the memory path.
+
+## What this model can and cannot remember
+
+One scalar state compresses all earlier inputs into one number. It cannot
+recover the original sequence `[1, 2]` from `3.5`; different histories could
+produce the same state. Larger RNNs use vectors, but the compression problem
+remains.
+
+ReLU also changes the memory behavior. A negative preactivation resets this
+cell to zero, while a large positive recurrent weight could make states grow.
+Later lessons will expose the resulting vanishing and exploding gradients, and
+then compare gated cells such as GRUs and LSTMs.
+
+## Try the interactive unroll
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+draws all three executions on one time axis. Select a step to inspect its input
+term, carried-state term, bias, preactivation, and ReLU result. Toggle the
+recurrent link to compare the same sequence with no memory.
+
+## Cross-language checkpoint
+
+An implementation is ready for the next sequence lesson when it can load the
+same JSON fixture and reproduce:
+
+- every input and recurrent product;
+- all three preactivations and states;
+- the explicit initial-to-final state chain;
+- one parameter set shared across every time step; and
+- the no-recurrence states and per-step differences.
+
+Rust can execute V1 with a scalar loop or an explicitly unrolled acyclic neural
+graph. Other languages can implement the same loop directly or call a future
+Rust sequence core through a stable C ABI. In either case, initial-state input,
+final-state output, parameter ownership, and optional trace buffers must remain
+explicit so “memory” never means invisible process state.

--- a/code/learning/machine-learning/residual-paths-and-receptive-fields-by-hand.md
+++ b/code/learning/machine-learning/residual-paths-and-receptive-fields-by-hand.md
@@ -1,0 +1,205 @@
+# Residual Paths and Receptive Fields, by Hand
+
+A deep spatial network is still made from local arithmetic, but two things
+become harder to see as layers accumulate:
+
+1. **How much of the original input can one output see?**
+2. **Is there a short route through the network as well as the deep route?**
+
+The first question is about the **receptive field**. The second is why residual
+networks add **skip connections**.
+
+This lesson uses five values and two three-tap layers. The complete
+language-neutral oracle is
+[`00-two-layer-residual.json`](../../specs/fixtures/residual-receptive-v1/labs/00-two-layer-residual.json).
+The formulas and conformance rules are in
+[`NN08-residual-receptive-labs.md`](../../specs/NN08-residual-receptive-labs.md).
+
+## The tiny residual block
+
+Start with:
+
+```text
+index:  0  1  2  3  4
+input:  1  0  2  0  1
+```
+
+Both convolution layers use kernel `[1, 1, 1]`, stride one, and same zero
+padding. At each position, add the left neighbor, the position itself, and the
+right neighbor. Values outside the signal are zero.
+
+The block has two routes:
+
+```text
+main path: input -> convolution 1 -> convolution 2 -> + -> ReLU
+skip path: input -------------------------------------> +
+```
+
+The skip is the identity: it copies `input[i]` directly to the addition at the
+same index.
+
+## First local layer
+
+At the center, index `2`:
+
+```text
+hidden[2] = input[1] + input[2] + input[3]
+          = 0 + 2 + 0
+          = 2
+```
+
+Doing the same operation at every position gives:
+
+```text
+hidden: 1  3  2  3  1
+```
+
+The boundary calculation includes padding. For example:
+
+```text
+hidden[0] = padding[-1] + input[0] + input[1]
+          = 0 + 1 + 0
+          = 1
+```
+
+Same padding preserves five positions; it does not invent five real input
+values at the edge.
+
+## Second local layer
+
+The second layer performs the same operation on `hidden`:
+
+```text
+main[2] = hidden[1] + hidden[2] + hidden[3]
+        = 3 + 2 + 3
+        = 8
+```
+
+Across all positions:
+
+```text
+main: 4  6  8  6  4
+```
+
+The center output only reads three values from the immediately previous layer,
+but those three hidden values were each made from three input values. We need
+to expand the graph one more step to see the true receptive field.
+
+## Open the center output all the way back to the input
+
+The three hidden dependencies expand as:
+
+```text
+hidden[1] = input[0] + input[1] + input[2] = 1 + 0 + 2 = 3
+hidden[2] = input[1] + input[2] + input[3] = 0 + 2 + 0 = 2
+hidden[3] = input[2] + input[3] + input[4] = 2 + 0 + 1 = 3
+```
+
+Now count how many computational paths connect each input to `main[2]`:
+
+```text
+input index:       0  1  2  3  4
+path count:        1  2  3  2  1
+input value:       1  0  2  0  1
+value x paths:     1  0  6  0  1
+```
+
+The expanded contributions still sum to the same main-path value:
+
+```text
+1 + 0 + 6 + 0 + 1 = 8
+```
+
+Two zeros make no numerical contribution, but they remain inside the
+**structural receptive field**. If training or a new example changes them,
+`main[2]` can change. A receptive field describes possible dependency, not only
+the nonzero arithmetic in one example.
+
+For `L` stride-one layers with odd kernel width `K`, no dilation, and the same
+spatial resolution, an interior receptive-field width grows as:
+
+```text
+width = 1 + L * (K - 1)
+```
+
+Here `1 + 2 * (3 - 1) = 5`.
+
+## Add the identity skip
+
+The skip path does not use either convolution. At center index `2`, it copies:
+
+```text
+skip[2] = input[2] = 2
+```
+
+The residual addition combines the deep and short routes:
+
+```text
+preactivation[2] = main[2] + skip[2]
+                 = 8 + 2
+                 = 10
+```
+
+ReLU keeps `10` because it is positive. The whole block produces:
+
+```text
+main:          4  6   8  6  4
+identity skip: 1  0   2  0  1
+               ----------------
+residual sum:  5  6  10  6  5
+after ReLU:    5  6  10  6  5
+```
+
+Toggling the skip off does not change the main path or its receptive field. It
+only removes the direct contribution, so the center falls from `10` back to
+`8`.
+
+## Why a short path helps deep networks
+
+The identity route lets information and gradients travel through one addition
+instead of relying entirely on every transformation in the main path. The main
+path can learn a useful **residual change** while the skip preserves a simple
+baseline.
+
+This example does not prove that every residual network trains well. It exposes
+the mechanism a larger network repeats:
+
+```text
+output = activation(transform(input) + compatible_skip(input))
+```
+
+If shapes differ, the skip cannot be a raw identity; it needs a projection or
+resampling step. Shape compatibility is part of the residual contract, not a
+minor implementation detail.
+
+## What happens at the boundary?
+
+Select output `0`. Layer two reads only `hidden[0]` and `hidden[1]`; its left
+neighbor is padding. Those hidden positions reach actual input indices
+`[0, 1, 2]`. The in-range receptive field is three positions rather than the
+center's five.
+
+The visualizer in
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+lets you select all five outputs. It keeps three facts separate:
+
+- the immediate hidden positions read by layer two;
+- the union of original input positions they can reach; and
+- the direct identity value added by the skip.
+
+## Cross-language checkpoint
+
+An implementation is ready for the next architecture when it can load the same
+JSON fixture and reproduce:
+
+- both same-padded convolution outputs;
+- every identity contribution, residual sum, and ReLU output;
+- each output's hidden dependencies;
+- each input's path multiplicity and numerical contribution; and
+- the clipped receptive-field indices at both boundaries.
+
+The Rust `dsp-conv` package can reproduce these two main-path layers directly
+with zero boundaries because `[1, 1, 1]` is symmetric. Native language loops
+and Rust-backed consumers must agree with the fixture before the block is fused
+or accelerated. A debug path should remain available after fusion so “residual
+block” never becomes another name for hidden arithmetic.

--- a/code/learning/machine-learning/softmax-attention-and-causal-masking-by-hand.md
+++ b/code/learning/machine-learning/softmax-attention-and-causal-masking-by-hand.md
@@ -1,0 +1,177 @@
+# Softmax Attention and Causal Masking, by Hand
+
+The previous lesson produced one row of match scores for every query. Those
+numbers can be negative, positive, or larger than one. They are not yet
+fractions and they do not yet mix any information.
+
+This lesson turns each score row into attention weights, prevents left-to-right
+language models from looking ahead, and finally uses the weights to blend value
+vectors. The language-neutral oracle is
+[`00-three-token-causal-softmax.json`](../../specs/fixtures/attention-softmax-v1/labs/00-three-token-causal-softmax.json),
+and the contract is
+[`NN13-attention-softmax-labs.md`](../../specs/NN13-attention-softmax-labs.md).
+
+## Start with scaled scores and values
+
+NN12 gave the tokens `red`, `blue`, and `purple` these scaled query-key scores:
+
+```text
+                         key
+                 red       blue     purple
+query red     0.707107  -0.707107   0
+      blue    0.707107   0.707107   1.414214
+      purple  1.414214   0          1.414214
+```
+
+The value payloads are:
+
+```text
+v_red    = [2,0]
+v_blue   = [0,1]
+v_purple = [2,1]
+```
+
+Softmax operates across one query row. It never mixes rows together.
+
+## Why a causal mask comes before softmax
+
+Imagine generating the sequence from left to right. When the model is working
+on `blue`, `purple` is still in the future. Letting blue read purple would leak
+the answer during training.
+
+For query position `i` and key position `j`, the causal rule is:
+
+```text
+allowed when j <= i
+```
+
+That makes the three allowed-key rows:
+
+```text
+red query:     [yes, no,  no ]
+blue query:    [yes, yes, no ]
+purple query:  [yes, yes, yes]
+```
+
+Mathematically, implementations add negative infinity to blocked scores before
+softmax. JSON cannot safely store infinity, so the NN13 trace records blocked
+scores as `null`, then records their exponentials and weights as zero.
+
+## Work the blue row by hand
+
+The scaled blue-query row is:
+
+```text
+[0.707107, 0.707107, 1.414214]
+```
+
+First block the future purple key:
+
+```text
+[0.707107, 0.707107, blocked]
+```
+
+Softmax uses exponentials, but exponentiating very large scores directly can
+overflow. Subtract the largest allowed score first. Both allowed scores are
+equal, so:
+
+```text
+row maximum      = 0.707107
+shifted scores   = [0, 0, blocked]
+exponentials     = [exp(0), exp(0), 0]
+                 = [1, 1, 0]
+denominator      = 1 + 1 + 0 = 2
+attention weight = [1/2, 1/2, 0/2]
+                 = [0.5, 0.5, 0]
+```
+
+The weights are non-negative and sum to one. The future position receives
+exactly zero.
+
+## Use the weights to mix values
+
+Multiply each key's value by its blue-query weight:
+
+```text
+red contribution    = 0.5 * [2,0] = [1,0]
+blue contribution   = 0.5 * [0,1] = [0,0.5]
+purple contribution = 0.0 * [2,1] = [0,0]
+```
+
+Add the three contribution rows:
+
+```text
+blue context = [1,0] + [0,0.5] + [0,0]
+             = [1,0.5]
+```
+
+The blue output now contains a weighted blend of information it was allowed to
+read. This is where the value vectors, deliberately unused in NN12's score
+calculation, finally enter the computation.
+
+## Compare with the mask removed
+
+Without a causal mask, the blue query can read purple. Stable softmax gives:
+
+```text
+unmasked blue weights
+  = [0.248255, 0.248255, 0.503490]
+
+unmasked blue context
+  = [1.503490, 0.751745]
+```
+
+The largest score sends slightly more than half the weight to the future purple
+value. The arithmetic is valid for an encoder that may read the whole input,
+but it violates autoregressive generation. The mask changes the model's
+information boundary, not merely its presentation.
+
+## Read the full causal matrix
+
+The causal weight matrix is approximately:
+
+```text
+                         key
+                 red       blue     purple
+query red     1.000000   0          0
+      blue    0.500000   0.500000   0
+      purple  0.445808   0.108383   0.445808
+```
+
+Each row sums to one over allowed keys. The upper-right triangle is zero because
+those keys are in the future. The last row matches its unmasked version because
+no key lies to the right of the final token.
+
+## Common implementation bugs
+
+- Applying softmax before the mask, then setting blocked weights to zero without
+  renormalizing the remaining positions.
+- Masking the lower-left triangle and allowing tokens to read the future.
+- Using one maximum or denominator for the entire matrix instead of one per
+  query row.
+- Exponentiating large raw scores without subtracting the allowed row maximum.
+- Treating a blocked score as numeric zero; `exp(0) = 1`, so it would still
+  receive weight.
+- Letting a masked position contribute a value because its displayed weight
+  looks close to zero instead of being exactly zero.
+- Multiplying weights by keys rather than by values.
+
+## Try the causal-softmax mixer
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+keeps the triangular weight matrix, selected row normalization, and weighted
+value contributions aligned. Select any query and switch the causal mask off to
+see exactly which weights and context coordinates change.
+
+## Cross-language checkpoint
+
+An NN13 consumer is conformant when it reproduces every allowed position, row
+maximum, shifted score, exponential, denominator, weight, value contribution,
+and context for both masked and unmasked modes.
+
+Implement stable softmax and the weighted sum directly in each language first.
+A Rust core may later fuse these kernels for performance, but a stable C ABI
+should keep shapes, strides, masks, input buffers, caller-owned outputs, and
+optional trace buffers explicit. Fusing work must not make the independently
+checkable attention weights disappear.

--- a/code/learning/machine-learning/tiny-decoder-language-model-training-by-hand.md
+++ b/code/learning/machine-learning/tiny-decoder-language-model-training-by-hand.md
@@ -1,0 +1,268 @@
+# A Tiny Decoder-Only Language Model Training Step, by Hand
+
+A decoder-only language model learns one deceptively simple task: given every
+token it is allowed to see so far, predict the token that comes next. The
+attention block from the previous lessons builds a context-aware state. A
+shared vocabulary head turns that state into guesses, cross-entropy measures
+the surprise, and gradients make the next guess a little less surprising.
+
+This lesson traces that full boundary with two positions and three vocabulary
+items. The deterministic oracle is
+[`00-two-position-next-token-step.json`](../../specs/fixtures/tiny-decoder-training-v1/labs/00-two-position-next-token-step.json),
+and the language-neutral contract is
+[`NN15-tiny-decoder-training-labs.md`](../../specs/NN15-tiny-decoder-training-labs.md).
+
+## Shift one sequence into training examples
+
+Start with a three-token sequence:
+
+```text
+red blue purple
+```
+
+A decoder does not copy the token at its current target position into its
+input. Shift the same sequence by one:
+
+```text
+position 0: input prefix [red]       -> target blue
+position 1: input prefix [red, blue] -> target purple
+```
+
+The second position may use red and blue, but never future purple. That causal
+boundary is what makes training match left-to-right generation.
+
+## Start at a visible decoder boundary
+
+Suppose a tiny causal decoder block has already produced these saved states:
+
+```text
+h_red  = [1,0]
+h_blue = [0,1]
+```
+
+They are deliberately simple so the vocabulary-head arithmetic fits on paper.
+NN15 freezes the decoder body for one step, updates only the head, and records
+the gradient flowing into each saved state. Later, automatic differentiation
+can continue that gradient through layer normalization, residual paths,
+attention, and embeddings.
+
+## Turn a state into vocabulary logits
+
+The vocabulary order is `[red, blue, purple]`. Use one shared unembedding
+matrix and one shared bias at both positions:
+
+```text
+                 red  blue  purple
+unembedding = [[  1,    0,    -1],   <- state coordinate 0
+               [  0,    1,    -1]]   <- state coordinate 1
+
+bias = [0,0,0]
+```
+
+For the first state `[1,0]`, compute one dot product per vocabulary item:
+
+```text
+red logit    = 1 * 1  + 0 * 0  + 0 =  1
+blue logit   = 1 * 0  + 0 * 1  + 0 =  0
+purple logit = 1 * -1 + 0 * -1 + 0 = -1
+
+logits = [1,0,-1]
+```
+
+A logit is an unnormalized preference. It is not yet a probability.
+
+## Apply stable softmax
+
+Subtract the largest logit before exponentiating:
+
+```text
+row maximum = 1
+shifted     = [0,-1,-2]
+exp         = [1,0.367879,0.135335]
+denominator = 1.503215
+
+probabilities = [0.665241,0.244728,0.090031]
+```
+
+The target is blue, so this position assigned its correct answer probability
+`0.244728`.
+
+At the second position, state `[0,1]` produces logits `[0,1,-1]` and
+probabilities:
+
+```text
+[0.244728,0.665241,0.090031]
+```
+
+That distribution prefers blue, but the target is purple. The model is quite
+confident in the wrong direction.
+
+## Convert target probability into loss
+
+Cross-entropy for one one-hot target is just negative log target probability:
+
+```text
+loss at red  = -ln(P(blue))   = -ln(0.244728) = 1.407606
+loss at blue = -ln(P(purple)) = -ln(0.090031) = 2.407606
+
+mean loss = (1.407606 + 2.407606) / 2
+          = 1.907606
+```
+
+The second prediction contributes more loss because it gave the correct token
+less probability. Cross-entropy is a smooth measure of surprise.
+
+## Differentiate logits without magic
+
+Softmax plus cross-entropy has a compact derivative. For a mean over two
+positions:
+
+```text
+d mean loss / d logit
+  = (probability - one_hot_target) / 2
+```
+
+For the first target, blue:
+
+```text
+one-hot target = [0,1,0]
+logit gradient = ([0.665241,0.244728,0.090031] - [0,1,0]) / 2
+               = [0.332620,-0.377636,0.045015]
+```
+
+The blue coordinate is negative. SGD subtracts the gradient, so the blue logit
+will rise. Positive non-target gradients make those logits fall.
+
+For the second target, purple:
+
+```text
+logit gradient = [0.122364,0.332620,-0.454985]
+```
+
+Every row sums to zero. Softmax redistributes probability; increasing one share
+requires decreasing others.
+
+## Send error into the decoder state
+
+Multiply the logit gradients by the transpose of the original unembedding:
+
+```text
+d loss / d h_red  = [ 0.287605,-0.422651]
+d loss / d h_blue = [ 0.577349, 0.787605]
+```
+
+NN15 stops parameter updates at this boundary but does not hide these values.
+They are the exact signals a full decoder backward pass would continue through
+the causal block.
+
+## Reduce gradients into shared parameters
+
+The same unembedding and bias served both positions. Each position contributes
+an outer product of its state and its logit gradient. Add those contributions:
+
+```text
+unembedding gradient =
+  [[ 0.332620,-0.377636, 0.045015],
+   [ 0.122364, 0.332620,-0.454985]]
+
+bias gradient =
+  [0.454985,-0.045015,-0.409969]
+```
+
+Do not average these values a second time. The factor `1/2` is already inside
+each logit gradient because the objective is the mean loss.
+
+## Audit the gradient independently
+
+Backpropagation and a numerical gradient should reach the same answer by
+different routes. Perturb each trainable scalar by `epsilon = 0.000001`, rerun
+the mean loss on both sides, and measure the centered slope:
+
+```text
+numerical gradient
+  = (loss(parameter + epsilon) - loss(parameter - epsilon))
+    / (2 * epsilon)
+```
+
+Across all nine unembedding and bias parameters, the largest absolute
+difference from the analytical gradients is about `1.98e-10`. That tiny error
+is expected floating-point rounding and gives us an independent reason to
+trust the backward trace before changing parameters.
+
+## Apply one SGD update
+
+With learning rate `0.5`:
+
+```text
+parameter_after = parameter_before - 0.5 * gradient
+```
+
+The updated bias is:
+
+```text
+[-0.227492,0.022508,0.204985]
+```
+
+Rerun both forward passes with the updated head:
+
+```text
+P(blue | red)        0.244728 -> 0.351913
+P(purple | red blue) 0.090031 -> 0.154460
+
+mean loss            1.907606 -> 1.456094
+```
+
+Both correct-token probabilities rose, and the objective fell. That is one
+complete language-model training step.
+
+## What this tiny model leaves out
+
+The arithmetic is real, but the scope is controlled:
+
+- The vocabulary contains three items rather than tens of thousands.
+- There are two training positions rather than a packed batch of sequences.
+- Decoder states have width two and are saved rather than recomputed here.
+- The output head is trained while the decoder body is frozen for this step.
+- SGD has no momentum, adaptive moments, weight decay, or gradient clipping.
+
+Each later feature scales one boundary without changing the basic loop:
+
+```text
+causal prefixes -> decoder states -> logits -> probabilities -> loss
+                <- state gradient <- logit gradient <- target
+```
+
+## Common implementation bugs
+
+- Pairing each input token with itself instead of the next token.
+- Letting the second training position see future purple.
+- Applying softmax across positions instead of across vocabulary items.
+- Computing `log(softmax)` from unstable raw exponentials.
+- Using the largest probability rather than the target probability in the loss.
+- Forgetting the `1 / position_count` factor for a mean objective.
+- Averaging shared gradients again after the mean factor is already applied.
+- Trusting a hand-derived gradient without an independent numerical audit.
+- Updating each position's private copy instead of one shared unembedding.
+- Recomputing state gradients with the updated weights instead of the weights
+  used in the saved forward pass.
+
+## Explore the training trace
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+keeps the two shifted positions aligned, lets you select either prediction, and
+follows its state through logits, stable probabilities, target surprise, and
+the compact logit gradient. Switch to the post-update view to see both target
+probabilities rise and the mean loss fall while the causal prefixes stay fixed.
+
+## Cross-language checkpoint
+
+An NN15 consumer is conformant when it reproduces the sequence shift, causal
+prefixes, every unembedding product, stable-softmax intermediate, target
+probability, position and mean losses, state gradients, per-position and
+reduced parameter gradients, updated parameters, and post-update loss.
+
+Implement those scalar loops in every host language first. A Rust core may
+later fuse matrix multiplication and softmax cross-entropy or update batched
+buffers through a C ABI. Its optimized path must retain an optional trace mode
+so language bindings and teaching tools can explain the same step they execute.

--- a/code/learning/machine-learning/tiny-graph-message-passing-by-hand.md
+++ b/code/learning/machine-learning/tiny-graph-message-passing-by-hand.md
@@ -1,0 +1,168 @@
+# Tiny Graph Message Passing, by Hand
+
+Images live on grids and sentences live in sequences. Some data instead lives
+on a **graph**: a collection of nodes connected by edges. A node might be a
+person, atom, road intersection, or web page. An edge says which nodes can
+exchange information.
+
+This lesson performs one complete message-passing round on three nodes. The
+matching language-neutral contract is
+[NN21](../../specs/NN21-tiny-message-passing-labs.md), with its canonical
+fixture in
+[`00-three-node-path.json`](../../specs/fixtures/tiny-message-passing-v1/labs/00-three-node-path.json).
+
+## 1. Start with a path
+
+Use three nodes and two undirected edges:
+
+```text
+node 0 ----- node 1 ----- node 2
+  1            2           -1
+```
+
+The number under each node is its scalar feature. “Scalar” means one number.
+An undirected edge has no arrow, so information may travel both ways.
+
+## 2. Expand edges into directed messages
+
+For computation, expand each undirected edge into two directions:
+
+```text
+0 -> 1
+1 -> 0
+1 -> 2
+2 -> 1
+```
+
+Use one shared message rule:
+
+```text
+message(source -> target) = 0.5 * old_feature[source]
+```
+
+The messages are:
+
+```text
+1 -> 0: 0.5 *  2 =  1
+0 -> 1: 0.5 *  1 =  0.5
+2 -> 1: 0.5 * -1 = -0.5
+1 -> 2: 0.5 *  2 =  1
+```
+
+The same weight applies everywhere. This sharing lets the rule work on graphs
+with different node counts and layouts.
+
+## 3. Aggregate each inbox
+
+**Aggregate** comes from Latin roots meaning “bring into a flock.” In a graph
+network it means combining all messages that arrive at one node. Use a sum:
+
+```text
+node 0 inbox: 1                 -> aggregate 1
+node 1 inbox: 0.5 + (-0.5)      -> aggregate 0
+node 2 inbox: 1                 -> aggregate 1
+```
+
+The middle node has two neighbors. Their messages cancel exactly. A sum is
+permutation invariant: swapping the arrival order does not change the result.
+That matters because a graph has no natural “first neighbor.”
+
+## 4. Keep a self route
+
+A node should not lose its own old feature while listening to neighbors. Give
+the old feature a shared weight `0.25`, then add the inbox and bias `-0.5`:
+
+```text
+preactivation = 0.25 * old_feature + aggregate - 0.5
+new_feature   = ReLU(preactivation)
+```
+
+ReLU keeps positive values and replaces negative values with zero.
+
+Node 0:
+
+```text
+self route = 0.25 * 1 = 0.25
+neighbor   = 1
+bias       = -0.5
+preact     = 0.25 + 1 - 0.5 = 0.75
+output     = ReLU(0.75) = 0.75
+```
+
+Node 1:
+
+```text
+self route = 0.25 * 2 = 0.5
+neighbor   = 0.5 + (-0.5) = 0
+bias       = -0.5
+preact     = 0.5 + 0 - 0.5 = 0
+output     = ReLU(0) = 0
+```
+
+Node 2:
+
+```text
+self route = 0.25 * -1 = -0.25
+neighbor   = 1
+bias       = -0.5
+preact     = -0.25 + 1 - 0.5 = 0.25
+output     = ReLU(0.25) = 0.25
+```
+
+One round transforms:
+
+```text
+[1, 2, -1] -> [0.75, 0, 0.25]
+```
+
+## 5. Why the round is synchronous
+
+All four messages use the original snapshot `[1, 2, -1]`. Node 0's new `0.75`
+does not replace its old `1` while node 1 is still computing. The outputs become
+the next round's inputs only after every node finishes.
+
+This is **synchronous** computation: everyone reads the same old clock tick and
+writes the same new clock tick. It differs deliberately from NN20's
+asynchronous Hopfield sweep, where later updates read earlier changes.
+
+## 6. The general message-passing shape
+
+More expressive graph networks keep the same three stages:
+
+1. **Message:** transform a source node, target node, and possibly edge data.
+2. **Aggregate:** combine all messages arriving at each target.
+3. **Update:** mix the aggregate with the target's previous state.
+
+Our example uses one scalar, a source-only linear message, sum aggregation, and
+a shared affine-plus-ReLU update. Later graph convolution and attention labs can
+change those functions without hiding this skeleton.
+
+## 7. Validate the corpus
+
+From the repository root:
+
+```text
+python code/scripts/validate_tiny_message_passing_labs.py
+```
+
+The validator rejects duplicate or unknown keys, non-finite features, invalid
+or repeated edges, self edges, isolated nodes, and any mismatch in messages,
+inboxes, affine terms, or outputs.
+
+## 8. Cross-language and Rust-core path
+
+Implement this three-node round directly in every host language first. Each
+consumer can compare every directed message and node update with the same JSON
+oracle.
+
+A Rust core can later consume COO or CSR edge-index buffers plus dense feature
+buffers, perform deterministic segmented reductions, and fuse shared updates.
+A stable C ABI can serve native FFI consumers and WASM can serve browsers. Even
+when an optimized kernel fuses message, aggregate, and update, trace mode should
+retain source and target identities so learners can still unpack the round.
+
+## 9. Next experiment
+
+Replace the fixed message weight with degree normalization, then let each target
+assign different weights to its neighbors. Those two changes lead directly to
+graph convolution and graph attention.

--- a/code/learning/machine-learning/tiny-image-cnn-by-hand.md
+++ b/code/learning/machine-learning/tiny-image-cnn-by-hand.md
@@ -1,0 +1,218 @@
+# A Tiny Image CNN, Completely by Hand
+
+A convolutional neural network does not receive a picture as a special object.
+It receives stacks of number grids. A color image often has red, green, and
+blue grids. This lab uses two simpler channels:
+
+- **vertical position** says how far down a pixel is; and
+- **horizontal position** says how far right a pixel is.
+
+```text
+vertical-position        horizontal-position
+
+0  0  0                  0  1  2
+1  1  1                  0  1  2
+2  2  2                  0  1  2
+```
+
+The complete language-neutral oracle is
+[`00-two-channel-image.json`](../../specs/fixtures/tiny-image-cnn-v1/labs/00-two-channel-image.json).
+The formulas and conformance rules are in
+[`NN07-tiny-image-cnn-labs.md`](../../specs/NN07-tiny-image-cnn-labs.md).
+
+## What changes when a signal becomes an image?
+
+The one-dimensional lab slid left to right. An image kernel slides across rows
+*and* columns. There is one more important loop: a filter has one small kernel
+for every input channel.
+
+At one output location, the network:
+
+1. takes a `2 x 2` window from input channel 0;
+2. multiplies it by filter 0's channel-0 kernel and adds the products;
+3. repeats that for input channel 1;
+4. adds the two channel sums and one filter bias.
+
+That final number belongs to one **output channel**, also called a feature map.
+Using two filters gives us two output channels.
+
+## Filter 0: larger toward the bottom-right
+
+Filter 0 has these channel-specific kernels and bias `0`:
+
+```text
+vertical kernel          horizontal kernel
+
+4  0                     2  0
+0  0                     0  0
+```
+
+Select output row `1`, column `1`. Its two input windows are:
+
+```text
+vertical window          horizontal window
+
+1  1                     1  2
+2  2                     1  2
+```
+
+The channel calculations are:
+
+```text
+vertical:   1x4 + 1x0 + 2x0 + 2x0 = 4
+horizontal: 1x2 + 2x0 + 1x0 + 2x0 = 2
+bias:                                            0
+                                                --
+output[0, 1, 1] = 4 + 2 + 0 =                  6
+```
+
+Repeating the same weights at all four valid positions gives:
+
+```text
+vertical contribution    horizontal contribution    convolution
+
+0  0                     0  2                       0  2
+4  4                     0  2                       4  6
+```
+
+This is the essential channel rule: **correlate each input channel, then add
+the matching spatial positions**. Channels do not make separate final images
+unless separate filters learn to preserve them.
+
+## Filter 1: larger toward the top-left
+
+Filter 1 reverses the signs and adds bias `6`:
+
+```text
+vertical kernel          horizontal kernel
+
+-4  0                    -2  0
+ 0  0                     0  0
+```
+
+At row `1`, column `1`:
+
+```text
+vertical:   1x-4 + 1x0 + 2x0 + 2x0 = -4
+horizontal: 1x-2 + 2x0 + 1x0 + 2x0 = -2
+bias:                                             +6
+                                                   --
+output[1, 1, 1] = -4 + -2 + 6 =                    0
+```
+
+Its complete feature map points in the opposite direction:
+
+```text
+6  4
+2  0
+```
+
+## Why normalize a feature map?
+
+The two filters use different weights and biases, yet both maps have mean `3`.
+For filter 0:
+
+```text
+mean = (0 + 2 + 4 + 6) / 4 = 3
+```
+
+Population variance measures the average squared distance from that mean:
+
+```text
+variance = ((0-3)^2 + (2-3)^2 + (4-3)^2 + (6-3)^2) / 4
+         = (9 + 1 + 1 + 9) / 4
+         = 5
+```
+
+Normalization divides by `sqrt(variance + epsilon)`. This teaching fixture
+uses `epsilon = 4`, so the denominator is exactly:
+
+```text
+sqrt(5 + 4) = 3
+```
+
+With scale `gamma = 1` and shift `beta = 0`, filter 0 becomes:
+
+```text
+(value - 3) / 3
+
+-1    -1/3
+ 1/3   1
+```
+
+Filter 1 contains the same values in reverse order, so it has the same mean,
+variance, and denominator:
+
+```text
+ 1     1/3
+-1/3  -1
+```
+
+The large epsilon is chosen only to keep this first example exact on paper. In
+real networks epsilon is usually much smaller. The key idea is unchanged: a
+normalization layer defines a group of values that share statistics, then
+recenters and rescales that group. Batch, instance, and layer normalization
+differ mainly in which axes belong to the group.
+
+## ReLU keeps positive evidence
+
+ReLU replaces every negative number with zero:
+
+```text
+filter 0 after ReLU       filter 1 after ReLU
+
+0    0                   1    1/3
+1/3  1                   0    0
+```
+
+The two channels now say where each learned pattern has positive evidence.
+
+## Max pooling keeps the strongest location
+
+A `2 x 2` max pool covers each entire activated feature map:
+
+```text
+filter 0: max(0, 0, 1/3, 1) = 1 at row 1, column 1
+filter 1: max(1, 1/3, 0, 0) = 1 at row 0, column 0
+```
+
+Pooling throws away detail on purpose. It retains a strong response while
+making the next representation smaller. The argmax location matters during
+backpropagation because only the winning input receives the gradient through a
+max-pool operation.
+
+## The whole pipeline
+
+```text
+two 3x3 channels
+  -> two filters, each with two 2x2 kernels
+  -> two 2x2 convolution maps
+  -> normalize each output channel over four positions
+  -> ReLU
+  -> one max-pooled value per output channel
+```
+
+The visualizer in
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+lets you select a filter, spatial output, input channel, and pipeline stage. Use
+it to answer three questions without trusting a tensor library:
+
+1. Which exact input values and kernel values made this output?
+2. Which values shared normalization statistics?
+3. Which location survived pooling, and which locations were discarded?
+
+## Cross-language checkpoint
+
+An implementation is ready for the next lesson when it can load the same JSON
+fixture and reproduce:
+
+- every per-input-channel contribution map;
+- both biased convolution maps;
+- both means, variances, denominators, and normalized maps;
+- the ReLU maps; and
+- pooled values plus row-major argmax coordinates.
+
+Native loops are enough for this tiny oracle. A performant language binding can
+later pass contiguous image, kernel, bias, and output buffers to a Rust core
+through a stable C ABI. Either route must keep an inspectable mode so fusion and
+acceleration never put the arithmetic back behind “magic.”

--- a/code/learning/machine-learning/training-a-convolution-kernel-by-hand.md
+++ b/code/learning/machine-learning/training-a-convolution-kernel-by-hand.md
@@ -1,0 +1,162 @@
+# Training a Convolution Kernel by Hand
+
+The previous lesson slid one fixed kernel across a signal. Training changes the
+kernel so its feature map moves toward desired targets.
+
+The surprising part is not the derivative itself. It is that one kernel weight
+was reused at several positions, so its gradient must collect evidence from
+every position where it appeared.
+
+## Start with the NN05 Forward Pass
+
+Reuse the same signal and asymmetric kernel:
+
+```text
+signal  = [2,  1, 3, 0, 4, 2]
+kernel  = [1, -1, 2]
+targets = [6, -2, 10, 0]
+```
+
+Valid stride-one cross-correlation produces:
+
+```text
+outputs = [7, -2, 11, 0]
+errors  = [1,  0,  1, 0]
+```
+
+Only `y[0]` and `y[2]` are wrong. With mean squared error over four outputs:
+
+```text
+loss = (1^2 + 0^2 + 1^2 + 0^2) / 4 = 0.5
+```
+
+## Differentiate the Loss First
+
+For each output:
+
+```text
+dLoss/dOutput[i] = 2 * error[i] / 4
+```
+
+| Output | Error | `dLoss/dOutput` |
+| --- | ---: | ---: |
+| `y[0]` | 1 | 0.5 |
+| `y[1]` | 0 | 0 |
+| `y[2]` | 1 | 0.5 |
+| `y[3]` | 0 | 0 |
+
+An output that already matches its target sends zero gradient backward.
+
+## Follow One Output into the Kernel
+
+The first output used window `[2, 1, 3]`:
+
+```text
+y[0] = 2*k[0] + 1*k[1] + 3*k[2]
+```
+
+Its output gradient is `0.5`, so its contributions are:
+
+```text
+toward k[0]: 0.5 * 2 = 1
+toward k[1]: 0.5 * 1 = 0.5
+toward k[2]: 0.5 * 3 = 1.5
+```
+
+The third output, `y[2]`, used window `[3, 0, 4]` and sends:
+
+```text
+[0.5 * 3, 0.5 * 0, 0.5 * 4] = [1.5, 0, 2]
+```
+
+## Add Contributions for Shared Weights
+
+Every column belongs to one shared parameter. Add down each column:
+
+| Kernel gradient | From `y[0]` | From `y[1]` | From `y[2]` | From `y[3]` | Sum |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `dL/dk[0]` | 1 | 0 | 1.5 | 0 | 2.5 |
+| `dL/dk[1]` | 0.5 | 0 | 0 | 0 | 0.5 |
+| `dL/dk[2]` | 1.5 | 0 | 2 | 0 | 3.5 |
+
+Therefore:
+
+```text
+dLoss/dKernel = [2.5, 0.5, 3.5]
+```
+
+This reduction is the heart of convolutional backpropagation. The kernel has
+only three parameters, but each parameter can influence several outputs.
+
+## Check the Gradient Independently
+
+Before trusting the backward pass, perturb one weight at a time. For `k[j]`
+and `epsilon = 0.000001`:
+
+```text
+numeric[j] = (loss(k[j] + epsilon) - loss(k[j] - epsilon))
+             / (2 * epsilon)
+```
+
+Binary64 arithmetic produces approximately:
+
+```text
+[2.4999999999, 0.5000000001, 3.5000000003]
+```
+
+That matches `[2.5, 0.5, 3.5]` within `1e-9`. The numerical calculation uses
+only forward loss evaluations, so it can catch mistakes in the analytical
+gradient.
+
+## Take One Learning Step
+
+Use learning rate `0.02` and update all weights simultaneously:
+
+```text
+k[0] =  1 - 0.02 * 2.5 =  0.95
+k[1] = -1 - 0.02 * 0.5 = -1.01
+k[2] =  2 - 0.02 * 3.5 =  1.93
+```
+
+The new kernel produces:
+
+```text
+next outputs = [6.68, -2.08, 10.57, -0.18]
+next loss    = 0.206525
+```
+
+One step lowered loss from `0.5` to `0.206525`. This does not prove every
+learning rate will work; it proves this gradient points downhill locally.
+
+## Inspect It Interactively
+
+Open the **Spatial** view in the
+[ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md).
+Selecting a feature-map output now synchronizes two paths:
+
+1. the forward window and multiply-accumulate that produced `y[i]`;
+2. the backward contributions that `y[i]` sends to every shared kernel weight.
+
+The contribution table adds across all positions, compares the analytical sum
+with a finite difference, and previews the next kernel and loss. Apply one step
+to watch the detector and its next gradient change together.
+
+## Portable and Fast Implementations
+
+NN06 stores this entire trace in
+`code/specs/fixtures/convolution-training-v1`. Any implementation can validate
+against it with:
+
+```text
+python code/scripts/validate_convolution_training_labs.py
+```
+
+A language-native implementation needs only nested loops and arrays. A
+performance-oriented binding can pass contiguous signal, kernel, and
+output-gradient buffers to a Rust forward/backward core through a stable C ABI.
+The existing Rust `dsp-conv` package can support an adapted forward path, but a
+neural backward kernel still needs to be defined. Both paths should reproduce
+the NN06 fixture before larger tensors, channels, or accelerators are added.
+
+The next spatial tranche adds the axes hidden by this example: image height and
+width, input and output channels, pooling, and normalization.

--- a/code/learning/machine-learning/two-number-autoencoder-bottleneck-by-hand.md
+++ b/code/learning/machine-learning/two-number-autoencoder-bottleneck-by-hand.md
@@ -1,0 +1,272 @@
+# A Two-Number Autoencoder Bottleneck, by Hand
+
+An autoencoder tries to reproduce its input after forcing the information
+through a constrained middle representation. The encoder compresses. The
+decoder reconstructs. Reconstruction error teaches both sides what the middle
+number must preserve.
+
+This lesson uses the smallest undercomplete autoencoder: two input coordinates,
+one scalar bottleneck, and two reconstructed coordinates. The deterministic
+oracle is
+[`00-linear-bottleneck-step.json`](../../specs/fixtures/two-number-autoencoder-v1/labs/00-linear-bottleneck-step.json),
+and the language-neutral contract is
+[`NN16-two-number-autoencoder-labs.md`](../../specs/NN16-two-number-autoencoder-labs.md).
+
+## What the bottleneck changes
+
+A two-number identity function could copy each input directly to its matching
+output. That would teach us nothing. Instead, require this shape:
+
+```text
+[x0, x1] -> one number z -> [x_hat0, x_hat1]
+```
+
+Both original coordinates must influence `z`, and both reconstructions must be
+created from that same `z`. The model cannot send two independent values across
+the middle boundary.
+
+For this first trace, the input is:
+
+```text
+x = [2,-1]
+```
+
+The hats in `x_hat` mean reconstructed estimates, not new target labels. In an
+autoencoder, the input is also the target.
+
+## Encode two values into one
+
+Use a linear encoder with weights `[0.5,-0.25]` and bias `0`:
+
+```text
+z = x0 * encoder_weight0
+  + x1 * encoder_weight1
+  + encoder_bias
+
+  = 2 * 0.5 + (-1) * (-0.25) + 0
+  = 1 + 0.25
+  = 1.25
+```
+
+The negative second input and negative second weight make a positive
+contribution. The bottleneck is now one scalar, `1.25`.
+
+This does not mean `1.25` has a universal human label. A learned representation
+is useful because of how the encoder places examples and how the decoder uses
+those positions, not because every coordinate has a name.
+
+## Decode the same scalar along two branches
+
+Use decoder weights `[1.2,-0.8]` and biases `[0.1,-0.2]`:
+
+```text
+x_hat0 = 1.25 * 1.2 + 0.1
+       = 1.5 + 0.1
+       = 1.6
+
+x_hat1 = 1.25 * (-0.8) + (-0.2)
+       = -1 - 0.2
+       = -1.2
+```
+
+The reconstruction is:
+
+```text
+x_hat = [1.6,-1.2]
+```
+
+Both output branches received exactly the same bottleneck value. Their separate
+weights and biases interpret it differently.
+
+## Measure what compression failed to preserve
+
+Define error as reconstruction minus input:
+
+```text
+error = x_hat - x
+      = [1.6 - 2, -1.2 - (-1)]
+      = [-0.4,-0.2]
+```
+
+Use mean squared error across the two coordinates:
+
+```text
+squared errors = [(-0.4)^2, (-0.2)^2]
+               = [0.16,0.04]
+
+loss = (0.16 + 0.04) / 2
+     = 0.1
+```
+
+The model missed the first coordinate by `0.4` and the second by `0.2`. Squaring
+makes both misses positive and penalizes the larger miss more strongly.
+
+## Start backward at both reconstructions
+
+For mean squared error over two outputs:
+
+```text
+d loss / d x_hat[j]
+  = 2 * error[j] / 2
+  = error[j]
+```
+
+Therefore:
+
+```text
+reconstruction gradients = [-0.4,-0.2]
+```
+
+Each decoder weight multiplied the bottleneck, so:
+
+```text
+d loss / d decoder_weight0 = -0.4 * 1.25 = -0.5
+d loss / d decoder_weight1 = -0.2 * 1.25 = -0.25
+
+d loss / d decoder_bias = [-0.4,-0.2]
+```
+
+Negative gradients mean that subtracting the gradient will increase these
+parameters.
+
+## Make both errors meet at the bottleneck
+
+The scalar `z` fed both decoder branches. Its gradient must add both routes:
+
+```text
+from x_hat0: -0.4 * 1.2  = -0.48
+from x_hat1: -0.2 * -0.8 =  0.16
+
+d loss / d z = -0.48 + 0.16
+             = -0.32
+```
+
+The two contributions partially cancel. This is ordinary gradient accumulation:
+one saved value influenced several downstream calculations, so its derivative
+is the sum of every route back from the loss.
+
+## Continue through the encoder
+
+The encoder used each input as a multiplier:
+
+```text
+d loss / d encoder_weight0 = -0.32 * 2    = -0.64
+d loss / d encoder_weight1 = -0.32 * (-1) =  0.32
+d loss / d encoder_bias                  = -0.32
+```
+
+The same bottleneck gradient reaches both encoder weights, scaled by the input
+coordinate each weight saw during the forward pass.
+
+## Audit all seven trainable scalars
+
+The model has seven parameters:
+
+```text
+2 encoder weights + 1 encoder bias
++ 2 decoder weights + 2 decoder biases
+= 7
+```
+
+For each parameter, perturb it by `epsilon = 0.000001`, rerun the complete
+forward loss on both sides, and estimate a centered numerical slope:
+
+```text
+numerical gradient
+  = (loss(parameter + epsilon) - loss(parameter - epsilon))
+    / (2 * epsilon)
+```
+
+The largest absolute difference between backpropagation and the seven numerical
+gradients is about `2.03e-11`. That tiny gap is floating-point rounding. The
+independent calculation gives us evidence that the encoder and decoder gradient
+routes were assembled correctly.
+
+## Apply one SGD step
+
+Use learning rate `0.1`:
+
+```text
+parameter_after = parameter_before - 0.1 * gradient
+```
+
+The updated parameters are:
+
+```text
+encoder weights = [0.564,-0.282]
+encoder bias    = 0.032
+
+decoder weights = [1.25,-0.775]
+decoder biases  = [0.14,-0.18]
+```
+
+Rerun the entire autoencoder:
+
+```text
+z_after = 2 * 0.564 + (-1) * (-0.282) + 0.032
+        = 1.442
+
+x_hat_after = [1.442 * 1.25 + 0.14,
+               1.442 * -0.775 - 0.18]
+            = [1.9425,-1.29755]
+```
+
+The new errors and loss are:
+
+```text
+errors = [-0.0575,-0.29755]
+
+loss = ((-0.0575)^2 + (-0.29755)^2) / 2
+     = 0.04592112625
+```
+
+One coordinate became much more accurate while the other became less accurate,
+yet their mean squared error fell from `0.1` to `0.04592112625`. A shared
+bottleneck couples the reconstruction tradeoff.
+
+## What this one-example model does not prove
+
+This arithmetic is a real autoencoder step, but one example is not enough to
+learn a generally useful representation. With a dataset, the same small
+bottleneck must preserve regularities shared across many inputs rather than
+memorize one pair of numbers.
+
+A linear `2 -> 1 -> 2` autoencoder trained across centered data learns a
+one-dimensional direction closely related to principal component analysis.
+Nonlinear layers can learn curved representations, but only after we understand
+this shared compression boundary.
+
+## Common implementation bugs
+
+- Giving the decoder the original input as well as the bottleneck, which lets it
+  bypass compression.
+- Training against a separate label instead of using the input as the target.
+- Summing squared errors while using gradients for a mean reduction, or the
+  reverse.
+- Sending only one output's gradient into the bottleneck instead of adding both.
+- Reusing decoder weights when computing encoder products.
+- Applying an update before finishing every gradient from the saved forward pass.
+- Trusting the analytical gradient without the independent numerical audit.
+- Assuming a lower single-example loss proves a useful dataset-level embedding.
+
+## Explore the bottleneck
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+shows both input coordinates converging into one scalar and the same scalar
+branching into two reconstructions. Select either output to isolate its decoder
+arithmetic and its contribution to the bottleneck gradient. Toggle the updated
+parameters to see the coupled reconstruction tradeoff and the lower total loss.
+
+## Cross-language checkpoint
+
+An NN16 consumer is conformant when it reproduces encoder products, bottleneck,
+decoder products, reconstructions, coordinate errors, mean loss, all decoder and
+encoder gradients, the two bottleneck-gradient contributions, seven numerical
+gradients, updated parameters, and the post-update forward trace.
+
+Implement the scalar operations in every host language first. A Rust core may
+later batch and fuse dense layers, reconstruction loss, backward reductions,
+and optimizer updates behind a C ABI. Its fast path should retain optional trace
+buffers so every binding and learning tool can explain the representation it
+executes.

--- a/code/learning/machine-learning/vanishing-and-exploding-gradients-by-hand.md
+++ b/code/learning/machine-learning/vanishing-and-exploding-gradients-by-hand.md
@@ -1,0 +1,197 @@
+# Vanishing and Exploding Gradients, by Hand
+
+NN23 followed activation values forward. Training must also send information in
+the opposite direction: a loss gradient travels backward through every layer.
+At each step the chain rule multiplies by another local slope.
+
+If those factors are repeatedly smaller than one, the gradient can
+**vanish**. If they are repeatedly larger than one, it can **explode**.
+
+The language-neutral contract is
+[NN24](../../specs/NN24-gradient-flow-labs.md), with the canonical fixture in
+[`00-four-layer-gradient-flow.json`](../../specs/fixtures/gradient-flow-v1/labs/00-four-layer-gradient-flow.json).
+
+## 1. One scalar layer
+
+Use a bias-free scalar layer:
+
+```text
+z = weight * input
+a = activation(z)
+```
+
+The slope from the layer's output back to its input is its **local Jacobian**:
+
+```text
+da/dinput = weight * activation'(z)
+```
+
+For a chain of four layers, the output-to-input slope is the product of four
+local Jacobians:
+
+```text
+da4/da0 = J1 * J2 * J3 * J4
+```
+
+## 2. An exploding ReLU chain
+
+Start with input `1`, use four weights equal to `2`, and apply ReLU after each
+multiply. Every preactivation is positive, so every ReLU derivative is `1`.
+
+The forward pass is exact:
+
+| Layer | Input | Weight | Activation |
+| ---: | ---: | ---: | ---: |
+| 1 | `1` | `2` | `2` |
+| 2 | `2` | `2` | `4` |
+| 3 | `4` | `2` | `8` |
+| 4 | `8` | `2` | `16` |
+
+Use target `0` and half squared error:
+
+```text
+L = 0.5 * (16 - 0)^2 = 128
+dL/da4 = 16
+```
+
+Each local Jacobian is:
+
+```text
+weight * ReLU'(z) = 2 * 1 = 2
+```
+
+So the chain product is:
+
+```text
+da4/da0 = 2 * 2 * 2 * 2 = 16
+```
+
+Multiply the loss's output gradient by that path:
+
+```text
+dL/da0 = dL/da4 * da4/da0
+        = 16 * 16
+        = 256
+```
+
+The reverse values grow as they move toward the first layer:
+
+```text
+16 -> 32 -> 64 -> 128 -> 256
+```
+
+That is an exploding gradient in miniature.
+
+## 3. Open one reverse step
+
+At layer 3, the upstream gradient is `32`, the ReLU derivative is `1`, the
+weight is `2`, and the saved forward input is `4`:
+
+```text
+dL/dz3     = 32 * 1 = 32
+dL/dinput3 = 32 * 2 = 64
+dL/dweight3 = 32 * 4 = 128
+```
+
+The saved forward value matters for the parameter gradient. Reverse-mode
+automatic differentiation stores or recomputes such values for exactly this
+reason.
+
+## 4. A small-weight tanh chain vanishes
+
+Now use four weights equal to `0.5` and `tanh`. The four local Jacobians are:
+
+```text
+[0.393224, 0.474228, 0.493612, 0.498406]
+```
+
+Their product is only:
+
+```text
+0.393224 * 0.474228 * 0.493612 * 0.498406
+= 0.045877
+```
+
+The output error is `0.056456`, so the gradient reaching the input is:
+
+```text
+0.056456 * 0.045877 = 0.002590
+```
+
+Early layers receive a much quieter learning signal than the output layer.
+
+## 5. Large weights can still vanish
+
+Four `tanh` weights equal to `3` produce activations near `0.995`. Near the
+flat ends of `tanh`, its derivative is only about `0.01`.
+
+The first local Jacobian is therefore:
+
+```text
+3 * 0.009866 = 0.029598
+```
+
+All four local Jacobians are close to `0.03`, so their product is only:
+
+```text
+0.000000840045
+```
+
+This is **saturation**: large weights did not create a useful large gradient.
+They pushed `tanh` into a flat region whose derivative overwhelms the weight.
+
+## 6. A stable control
+
+With positive ReLU activations and four weights equal to `1`, every local
+Jacobian equals `1`:
+
+```text
+1 * 1 * 1 * 1 = 1
+```
+
+The input gradient stays equal to the output gradient. Real networks do not
+stay this perfectly balanced, but the control makes the comparison concrete.
+
+## 7. Check reverse mode independently
+
+Use a central finite difference on the input:
+
+```text
+dL/dinput ~= (L(input + epsilon) - L(input - epsilon)) / (2 * epsilon)
+epsilon = 0.000001
+```
+
+All four NN24 traces compare this numerical slope with the analytical reverse
+pass. The absolute errors stay below `1e-8`.
+
+## 8. Practical responses
+
+Initialization matched to the activation helps at the first step. Residual
+paths create shorter gradient routes. Normalization can keep internal scales
+manageable, and gradient clipping can cap an exploding update. None is a magic
+replacement for inspecting the actual signals.
+
+The next lesson will place normalization, dropout, and a residual route beside
+the same tiny network so their different jobs remain visible.
+
+## 9. Validate the deterministic corpus
+
+```text
+python code/scripts/validate_gradient_flow_labs.py
+```
+
+The validator rejects unknown or duplicate keys, non-finite scenarios,
+unsupported activations, changed conventions, trace drift, and failed input
+finite differences.
+
+## 10. Cross-language and Rust-core path
+
+Implement the four scalar chains directly in each host language first. They
+pin the order and meaning of every reverse-mode value without tensor-layout
+questions.
+
+A Rust core can later store activations and derivative masks in a contiguous
+tape, traverse it backward, and fuse vector-Jacobian products with parameter-
+gradient reductions. A C ABI or WASM layer can return the final gradient
+buffers for speed and optionally expose the unfused tape for teaching and
+debugging.

--- a/code/learning/machine-learning/variational-sampling-and-kl-tradeoff-by-hand.md
+++ b/code/learning/machine-learning/variational-sampling-and-kl-tradeoff-by-hand.md
@@ -1,0 +1,379 @@
+# Variational Sampling and the KL Tradeoff, by Hand
+
+A regular autoencoder turns an input into one fixed bottleneck value. A
+variational autoencoder turns the input into a *distribution* of possible
+bottleneck values. The encoder describes that distribution, we draw a sample,
+and the decoder reconstructs from the sample.
+
+Why add uncertainty? We want nearby, sampleable regions in latent space rather
+than an arbitrary collection of isolated codes. That requires two learning
+pressures:
+
+- reconstruction keeps information about the input;
+- KL divergence keeps the encoded distribution near a simple prior that we can
+  sample without already having an input.
+
+This lesson uses one input, one Gaussian latent variable, one saved noise value,
+and one output. The deterministic oracle is
+[`00-saved-noise-kl-step.json`](../../specs/fixtures/variational-autoencoder-v1/labs/00-saved-noise-kl-step.json),
+and the language-neutral contract is
+[`NN17-variational-autoencoder-labs.md`](../../specs/NN17-variational-autoencoder-labs.md).
+
+## Encode a distribution, not a point
+
+The input is:
+
+```text
+x = 1
+```
+
+The encoder has two scalar heads. One produces the Gaussian mean. The other
+produces the log of its variance:
+
+```text
+mean = x * mean_weight + mean_bias
+     = 1 * 0.4 + 0
+     = 0.4
+
+log_variance
+  = x * log_variance_weight + log_variance_bias
+  = 1 * 0 + 0
+  = 0
+```
+
+Networks usually predict log-variance because any real log-variance becomes a
+positive variance after exponentiation:
+
+```text
+variance = exp(log_variance)
+         = exp(0)
+         = 1
+
+standard_deviation = exp(0.5 * log_variance)
+                   = exp(0)
+                   = 1
+```
+
+The encoded distribution is therefore `Normal(mean=0.4, variance=1)`.
+
+## Save the noise and reparameterize
+
+A direct random draw looks like a dead end for backpropagation: how do we
+differentiate through an instruction that says "pick a random value"?
+
+The reparameterization trick moves randomness into a separate input:
+
+```text
+epsilon ~ Normal(0, 1)
+z = mean + standard_deviation * epsilon
+```
+
+For this trace, save one already-drawn noise value:
+
+```text
+epsilon = 0.5
+
+noise contribution = 1 * 0.5
+                   = 0.5
+
+z = 0.4 + 0.5
+  = 0.9
+```
+
+Now every operation after `epsilon` is ordinary differentiable arithmetic.
+Training still uses fresh noise samples in general, but a fixture holds one
+sample fixed so every language can replay and audit the same step.
+
+## Reconstruct from the sampled value
+
+Use decoder weight `1` and bias `0`:
+
+```text
+x_hat = z * decoder_weight + decoder_bias
+      = 0.9 * 1 + 0
+      = 0.9
+```
+
+Use half squared reconstruction error:
+
+```text
+error = x_hat - x
+      = 0.9 - 1
+      = -0.1
+
+reconstruction_loss = 0.5 * error^2
+                    = 0.5 * 0.01
+                    = 0.005
+```
+
+The factor `0.5` makes the derivative with respect to the reconstruction equal
+to the error.
+
+## Measure distance from the prior
+
+We want the encoded Gaussian to stay near the standard normal prior
+`Normal(0, 1)`. For one scalar Gaussian, the KL divergence is:
+
+```text
+KL = 0.5 * (mean^2 + variance - 1 - log_variance)
+```
+
+Substitute this trace:
+
+```text
+KL = 0.5 * (0.4^2 + 1 - 1 - 0)
+   = 0.5 * 0.16
+   = 0.08
+```
+
+The variance already matches the prior variance of `1`, but the mean is shifted
+away from the prior mean of `0`. That is why the KL value is positive.
+
+## Use beta to expose the tradeoff
+
+The complete objective is:
+
+```text
+total_loss = reconstruction_loss + beta * KL
+```
+
+Use `beta = 0.1`:
+
+```text
+weighted_KL = 0.1 * 0.08
+            = 0.008
+
+total_loss = 0.005 + 0.008
+           = 0.013
+```
+
+Beta is not a probability. It is a knob controlling how loudly prior matching
+speaks relative to reconstruction:
+
+| beta | weighted objective before the update | meaning in this trace |
+| ---: | ---: | --- |
+| `0` | `0.005` | reconstruction speaks alone |
+| `0.1` | `0.013` | gentle pull toward the prior |
+| `0.25` | `0.025` | the two mean-gradient routes exactly cancel |
+| `1` | `0.085` | prior matching dominates the mean direction |
+
+These values compare objectives with different definitions, so do not rank
+models by the raw totals across beta settings. Inspect how beta changes the
+gradient directions and the eventual reconstruction-versus-regularity balance.
+
+## Backpropagate through reconstruction
+
+Start at the output:
+
+```text
+d reconstruction_loss / d x_hat = error = -0.1
+
+d loss / d decoder_weight = -0.1 * z
+                            = -0.09
+d loss / d decoder_bias = -0.1
+
+d loss / d z = -0.1 * decoder_weight
+             = -0.1
+```
+
+The sample equation was:
+
+```text
+z = mean + standard_deviation * epsilon
+```
+
+So the reconstruction route into the mean is direct:
+
+```text
+reconstruction mean gradient = -0.1
+```
+
+For log-variance:
+
+```text
+d standard_deviation / d log_variance
+  = 0.5 * standard_deviation
+
+reconstruction log-variance gradient
+  = d loss/dz * 0.5 * standard_deviation * epsilon
+  = -0.1 * 0.5 * 1 * 0.5
+  = -0.025
+```
+
+This is the key payoff of reparameterization: the decoder's reconstruction
+signal reaches both distribution parameters through normal calculus.
+
+## Backpropagate through KL independently
+
+Differentiate the scalar KL formula:
+
+```text
+d KL / d mean = mean
+              = 0.4
+
+d KL / d log_variance = 0.5 * (variance - 1)
+                       = 0.5 * (1 - 1)
+                       = 0
+```
+
+Scale those routes by beta `0.1`:
+
+```text
+weighted KL mean gradient = 0.1 * 0.4 = 0.04
+weighted KL log-variance gradient = 0.1 * 0 = 0
+```
+
+The KL variance gradient is zero here because the encoded variance already
+equals the prior variance. The mean still needs to move toward zero.
+
+## Add both objectives at the encoder
+
+The encoder outputs influenced both reconstruction and KL, so add the routes:
+
+```text
+total mean gradient = -0.1 + 0.04
+                    = -0.06
+
+total log-variance gradient = -0.025 + 0
+                            = -0.025
+```
+
+Because `x = 1`, each encoder weight gradient equals its output gradient:
+
+```text
+mean weight gradient = -0.06 * 1 = -0.06
+mean bias gradient = -0.06
+
+log-variance weight gradient = -0.025 * 1 = -0.025
+log-variance bias gradient = -0.025
+```
+
+Notice the mean conflict. Reconstruction contributes `-0.1`, asking the sample
+to move upward toward the input. KL contributes `+0.04`, asking the mean to move
+down toward zero. Beta controls the result after those signals meet.
+
+## Audit all six trainable scalars
+
+The model has six parameters:
+
+```text
+2 mean-head parameters
++ 2 log-variance-head parameters
++ 2 decoder parameters
+= 6
+```
+
+Perturb each parameter by `epsilon = 0.000001`, keep the *sampling noise* fixed
+at `0.5`, and rerun the whole total loss:
+
+```text
+numerical gradient
+  = (loss(parameter + epsilon) - loss(parameter - epsilon))
+    / (2 * epsilon)
+```
+
+Holding sampling noise fixed matters. If the plus and minus evaluations used
+different random draws, noise could overwhelm the tiny slope we are trying to
+measure. The largest analytical-versus-numerical difference is about
+`7.66e-12`, which is floating-point rounding.
+
+## Apply one SGD step
+
+Use learning rate `0.1`:
+
+```text
+parameter_after = parameter_before - 0.1 * gradient
+```
+
+The updated parameters are:
+
+```text
+mean weight = 0.406
+mean bias = 0.006
+
+log-variance weight = 0.0025
+log-variance bias = 0.0025
+
+decoder weight = 1.009
+decoder bias = 0.01
+```
+
+Rerun the same saved-noise trace:
+
+```text
+mean_after = 1 * 0.406 + 0.006
+           = 0.412
+
+log_variance_after = 1 * 0.0025 + 0.0025
+                   = 0.005
+
+standard_deviation_after = exp(0.5 * 0.005)
+                         = 1.0025031276
+
+z_after = 0.412 + 1.0025031276 * 0.5
+        = 0.9132515638
+
+x_hat_after = 0.9132515638 * 1.009 + 0.01
+            = 0.9314708279
+```
+
+The post-update terms are:
+
+```text
+reconstruction_loss_after = 0.0023481237
+KL_after = 0.0848782604
+weighted_KL_after = 0.0084878260
+total_loss_after = 0.0108359498
+```
+
+Reconstruction improved while KL increased slightly. The weighted sum still
+fell from `0.013` to `0.0108359498`. A VAE step optimizes the combined objective,
+not either term in isolation.
+
+## What this one-sample trace does not prove
+
+This fixture explains one pathwise gradient. A useful VAE requires a dataset,
+many latent dimensions, many noise samples over training, and careful evaluation
+of both reconstruction and generated samples.
+
+The saved `epsilon = 0.5` is an audit tool, not a recommendation to reuse one
+noise value forever. Production training should draw fresh standard-normal
+noise while reproducible runs control the generator seed or supply explicit
+noise buffers.
+
+## Common implementation bugs
+
+- Predicting variance directly and allowing it to become negative.
+- Using `exp(log_variance)` where the standard deviation requires
+  `exp(0.5 * log_variance)`.
+- Drawing unrelated noise for the plus and minus finite-difference evaluations.
+- Stopping the gradient at the sampled latent value.
+- Forgetting to multiply KL gradients by beta.
+- Minimizing KL alone and losing input-specific information.
+- Comparing raw total losses across different beta values as if the objective
+  had not changed.
+- Updating parameters before both reconstruction and KL routes are accumulated.
+
+## Explore the tradeoff
+
+The
+[`ml-learning-visualizer`](../../programs/typescript/ml-learning-visualizer/README.md)
+shows the two encoder heads, saved noise, reparameterized sample, decoder, split
+objective, and both gradient routes. Change beta to watch the mean direction
+move from reconstruction toward the prior; beta `0.25` makes those mean routes
+cancel exactly in this hand-sized example. Toggle the update to rerun the full
+distribution and objective.
+
+## Cross-language checkpoint
+
+An NN17 consumer is conformant when it reproduces the Gaussian parameters,
+saved-noise sample, reconstruction, KL and beta-weighted objective, separate
+gradient routes, six numerical gradients, updated parameters, and post-update
+trace.
+
+Implement the scalar exponential and reparameterization directly in every host
+language first. A Rust core may later batch the encoder heads, accept explicit
+epsilon buffers or a documented generator, fuse decoder and loss kernels, and
+return optional trace buffers through a stable C ABI. Random-number ownership
+must stay explicit so performance never makes cross-language reproducibility or
+the sampling boundary mysterious.

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
   finite-difference verification, and an apply-one-step interaction.
 - Add the NN07 tiny-image CNN workbench with channel-specific correlation,
   spatial normalization, ReLU, max pooling, and synchronized path selection.
+- Add the NN08 residual-path and receptive-field workbench with an identity
+  toggle, exact dependency expansion, and boundary-field exploration.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - Add the NN05 spatial workbench with editable 1D valid cross-correlation and
   complete multiply-accumulate traces.
+- Extend the spatial workbench with NN06 shared-kernel gradient accumulation,
+  finite-difference verification, and an apply-one-step interaction.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Add the NN05 spatial workbench with editable 1D valid cross-correlation and
+  complete multiply-accumulate traces.
+
 ### Changed
 
 - Routed linear and hidden-layer visualizer predictions through the shared

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this package will be documented in this file.
   toggle, exact dependency expansion, and boundary-field exploration.
 - Add the NN09 three-step recurrent-state unroller with shared parameters,
   selectable cell arithmetic, and a no-memory ablation.
+- Extend the recurrent workbench with the NN10 BPTT microscope, including
+  selectable reverse steps, shared-gradient accumulation, finite-difference
+  verification, and one update preview.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to this package will be documented in this file.
 - Extend the attention workbench with the NN15 two-position decoder training
   trace, including causal next-token shift, cross-entropy gradients, shared-head
   SGD, and a before/after loss comparison.
+- Add the NN16 representation workbench with a `2 -> 1 -> 2` autoencoder,
+  selectable decoder branches, bottleneck-gradient accumulation, seven central
+  finite differences, and one full-model SGD update.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
   complete multiply-accumulate traces.
 - Extend the spatial workbench with NN06 shared-kernel gradient accumulation,
   finite-difference verification, and an apply-one-step interaction.
+- Add the NN07 tiny-image CNN workbench with channel-specific correlation,
+  spatial normalization, ReLU, max pooling, and synchronized path selection.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -34,6 +34,9 @@ All notable changes to this package will be documented in this file.
 - Add the NN16 representation workbench with a `2 -> 1 -> 2` autoencoder,
   selectable decoder branches, bottleneck-gradient accumulation, seven central
   finite differences, and one full-model SGD update.
+- Extend the representation workbench with the NN17 scalar variational
+  autoencoder, saved-noise reparameterization, interactive beta/KL tradeoff,
+  six central finite differences, and one complete stochastic-path update.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this package will be documented in this file.
 - Extend the recurrent workbench with the NN10 BPTT microscope, including
   selectable reverse steps, shared-gradient accumulation, finite-difference
   verification, and one update preview.
+- Extend the recurrent workbench with the NN11 aligned GRU/LSTM gate comparator
+  and zero/canonical/one interventions for every gate family.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this package will be documented in this file.
   before softmax and value mixing.
 - Extend the attention workbench with the NN13 causal-softmax mixer, including
   stable row normalization, future-key masking, and weighted value traces.
+- Extend the attention workbench with the NN14 two-head comparator and the full
+  concatenate, output-project, residual-add, and layer-normalize path.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this package will be documented in this file.
   spatial normalization, ReLU, max pooling, and synchronized path selection.
 - Add the NN08 residual-path and receptive-field workbench with an identity
   toggle, exact dependency expansion, and boundary-field exploration.
+- Add the NN09 three-step recurrent-state unroller with shared parameters,
+  selectable cell arithmetic, and a no-memory ablation.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this package will be documented in this file.
 - Add the NN12 query-key score microscope with aligned token projections, all
   nine selectable dot products, square-root scaling, and an explicit boundary
   before softmax and value mixing.
+- Extend the attention workbench with the NN13 causal-softmax mixer, including
+  stable row normalization, future-key masking, and weighted value traces.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this package will be documented in this file.
   stable row normalization, future-key masking, and weighted value traces.
 - Extend the attention workbench with the NN14 two-head comparator and the full
   concatenate, output-project, residual-add, and layer-normalize path.
+- Extend the attention workbench with the NN15 two-position decoder training
+  trace, including causal next-token shift, cross-entropy gradients, shared-head
+  SGD, and a before/after loss comparison.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this package will be documented in this file.
   verification, and one update preview.
 - Extend the recurrent workbench with the NN11 aligned GRU/LSTM gate comparator
   and zero/canonical/one interventions for every gate family.
+- Add the NN12 query-key score microscope with aligned token projections, all
+  nine selectable dot products, square-root scaling, and an explicit boundary
+  before softmax and value mixing.
 
 ### Changed
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,8 +4,8 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has four workbenches that move from one arithmetic update to small
-hidden-layer networks.
+The app has five workbenches that move from one arithmetic update to small
+spatial and hidden-layer networks.
 
 ### Training-step microscope
 
@@ -48,6 +48,14 @@ circle classification, two moons, and feature interactions. It exposes selected
 hidden activations, matrix shapes, gradients, parameter updates, and the shared
 neural graph VM execution path.
 
+### Spatial lab
+
+The spatial workbench slides an editable one-dimensional kernel over an
+editable signal in valid, stride-one mode. Select any feature-map output to see
+its receptive-field window, element-wise products, and running accumulator. An
+asymmetric default kernel makes the neural cross-correlation convention
+visible instead of silently flipping weights.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -70,6 +78,9 @@ under `code/specs/fixtures/neural-learning-v1` pins forward values and first-ste
 gradients. NN04 under `code/specs/fixtures/optimization-learning-v1` pins
 finite-difference checks and batch-strategy trajectories so other language
 implementations can reproduce the same visualized arithmetic.
+
+NN05 under `code/specs/fixtures/convolution-learning-v1` pins the first
+sliding-kernel trace, including every window, product, accumulator, and output.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has six workbenches that move from one arithmetic update to small
+The app has seven workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -67,6 +67,15 @@ channel-specific kernels, products, partial sums, bias, and final feature-map
 value. Step forward to see which four values share normalization statistics,
 how ReLU changes them, and which row-major location wins `2 x 2` max pooling.
 
+### Residual and receptive-field lab
+
+The residual workbench sends a five-value signal through two same-padded local
+layers and an identity shortcut. Select any output to expose both routes at the
+addition, expand the local route through its hidden values, and count every
+path back to the original inputs. Boundary selections make receptive-field
+clipping visible, while the shortcut toggle separates what depth changes from
+what the identity path preserves.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -99,6 +108,10 @@ step.
 NN07 under `code/specs/fixtures/tiny-image-cnn-v1` pins two-channel 2D
 cross-correlation, output-channel normalization statistics, ReLU maps, and
 max-pool values and winner coordinates.
+
+NN08 under `code/specs/fixtures/residual-receptive-v1` pins two same-padded
+local layers, the identity addition, all hidden-to-input expansions, input
+path counts, and boundary-clipped receptive fields.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -188,6 +188,14 @@ to expand `dL/da`, `da/dz`, `dL/dz`, the input gradient, and the weight gradient
 The complete chain product and an independent input finite difference remain
 visible beside all four scenarios.
 
+Switch to stabilizers to hold one four-coordinate learned branch fixed while
+comparing a plain control, population layer normalization, deterministic
+inverted dropout, and an identity residual. Open any coordinate to see the
+selected vector-Jacobian-product arithmetic, shared normalization sums,
+dropout mask scaling, residual branch/skip split, input gradient, branch-weight
+gradient, and matching central finite differences. Dropout's evaluation output
+and exact training-mask expectation remain visible beside its sampled output.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -298,6 +306,11 @@ NN24 under `code/specs/fixtures/gradient-flow-v1` pins four scalar chains,
 every activation derivative and local Jacobian, all reverse-mode input and
 weight gradients, vanishing/stable/exploding classifications, and input finite-
 difference checks.
+
+NN25 under `code/specs/fixtures/training-stabilizers-v1` pins the shared branch,
+population layer-normalization statistics, deterministic inverted dropout and
+its expectation, an identity residual, all vector-Jacobian products, and input
+plus branch-weight finite-difference checks.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -91,6 +91,11 @@ parameter contributions, and see all three executions reduce into one shared
 gradient set. A central finite-difference table audits BPTT independently, and
 an update preview reruns the forward pass with the proposed parameters.
 
+Continue to the gate comparator to align a scalar GRU and LSTM on the same
+inputs. Select reset, update, forget, input, or output; then use its canonical
+value or force it to zero or one. The two lanes remain visible together, and
+the LSTM keeps its private cell state separate from its exposed hidden state.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -135,6 +140,10 @@ counterfactual trace with its recurrent contribution removed.
 NN10 under `code/specs/fixtures/recurrent-bptt-v1` pins the reverse-time state
 gradients, local and accumulated shared-parameter gradients, initial-state
 gradient, central finite-difference oracle, and one loss-reducing update.
+
+NN11 under `code/specs/fixtures/gated-recurrent-v1` pins scalar GRU and LSTM
+gate activations, candidate and memory contributions, explicit recurrent
+states, and reset/update/forget/input/output counterfactuals.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -141,6 +141,13 @@ sample, and decode it. Beta controls how reconstruction and KL-to-prior gradient
 routes combine. The balance point at beta `0.25`, a six-parameter numerical
 audit, and the complete post-update distribution remain directly inspectable.
 
+Continue into the adversarial view to place one real point and one generated
+point on the same number line. Advance a deterministic round from the initial
+scores through a detached discriminator update and a generator response against
+the frozen updated discriminator. Each player's objective, active gradient
+route, two-parameter numerical audit, and the opponent's counter-push stay
+visible at every phase.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -217,6 +224,11 @@ NN17 under `code/specs/fixtures/variational-autoencoder-v1` pins a scalar
 Gaussian encoder, saved epsilon, reparameterized sample, half-squared
 reconstruction error, beta-weighted KL divergence, both encoder gradient routes,
 six central finite differences, updated parameters, and lower total objective.
+
+NN18 under `code/specs/fixtures/one-dimensional-gan-v1` pins one complete
+scalar adversarial round: saved noise, real and fake scores, a detached
+discriminator update, a frozen-discriminator generator response, both players'
+loss snapshots, and two objective-specific finite-difference audits.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has eight workbenches that move from one arithmetic update to small
+The app has nine workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -96,6 +96,15 @@ inputs. Select reset, update, forget, input, or output; then use its canonical
 value or force it to zero or one. The two lanes remain visible together, and
 the LSTM keeps its private cell state separate from its exposed hidden state.
 
+### Attention score lab
+
+The attention workbench projects `red`, `blue`, and `purple` into query, key,
+and value vectors with three shared matrices. Open any cell in the aligned
+`3 x 3` score matrix to see its coordinate products and dot-product sum. A
+single control applies the standard square-root dimension scaling while
+keeping the raw score visible in the arithmetic. Values remain explicitly
+downstream: this lab stops before softmax, masking, or weighted value mixing.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -144,6 +153,10 @@ gradient, central finite-difference oracle, and one loss-reducing update.
 NN11 under `code/specs/fixtures/gated-recurrent-v1` pins scalar GRU and LSTM
 gate activations, candidate and memory contributions, explicit recurrent
 states, and reset/update/forget/input/output counterfactuals.
+
+NN12 under `code/specs/fixtures/attention-qkv-v1` pins three token embeddings,
+the shared query/key/value projection matrices, every coordinate product in
+all nine query-key dot products, and the raw and scaled score matrices.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has ten workbenches that move from one arithmetic update to small
+The app has eleven workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -154,6 +154,14 @@ timestep-aware noise predictor, audits all three parameter gradients, and feeds
 two deterministic reverse means into each other. The final reconstruction keeps
 its small residual error visible rather than implying a perfect toy denoiser.
 
+### Structured and memory lab
+
+The structured workbench begins with a four-neuron Hopfield memory. It turns one
+bipolar pattern into a symmetric zero-diagonal Hebbian weight matrix, presents a
+cue with one flipped bit, and advances a saved asynchronous update order. Every
+incoming weighted vote, local field, state change, energy value, and normalized
+overlap stays visible through the recovered fixed point.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -240,6 +248,11 @@ NN19 under `code/specs/fixtures/one-dimensional-diffusion-v1` pins two scalar
 forward noise levels, cumulative schedule coefficients, saved-noise targets, a
 shared timestep-conditioned denoiser update, a three-parameter numerical audit,
 and the complete deterministic reverse-mean path.
+
+NN20 under `code/specs/fixtures/hopfield-associative-memory-v1` pins one
+four-neuron bipolar memory, normalized Hebbian weights, a one-bit-damaged cue,
+all in-place asynchronous updates, energy descent, overlap improvement, and the
+recovered fixed point.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -118,6 +118,14 @@ through concatenation, an explicit output projection, residual addition, and
 per-token layer normalization. Residual and normalization toggles act as
 controlled ablations without changing either head.
 
+Continue into the tiny decoder training trace to shift `red blue purple` into
+two causal next-token examples. Select either position to follow its saved
+decoder state through shared unembedding logits, stable softmax, target
+cross-entropy, logit gradients, and the gradient entering the decoder body.
+An independent finite-difference audit checks the shared-head gradients. The
+before/after toggle reruns both positions with one SGD update and checks the
+resulting lower mean loss.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -179,6 +187,11 @@ NN14 under `code/specs/fixtures/multi-head-attention-v1` pins two independently
 projected scalar heads, every causal-softmax intermediate, head concatenation,
 output projection, residual addition, and population-variance layer
 normalization.
+
+NN15 under `code/specs/fixtures/tiny-decoder-training-v1` pins a causal
+next-token sequence shift, saved decoder states, unembedding logits, stable
+softmax, mean cross-entropy, state and shared-head gradients, central finite
+differences, one SGD update, and its post-update probabilities and loss.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -135,6 +135,12 @@ the accumulated bottleneck gradient. The same view exposes all encoder and
 decoder gradients, a seven-parameter central finite-difference audit, and the
 full-model loss before and after one SGD step.
 
+Switch to the variational view to encode one input as a Gaussian mean and
+log-variance, transform a saved standard-normal noise value into a latent
+sample, and decode it. Beta controls how reconstruction and KL-to-prior gradient
+routes combine. The balance point at beta `0.25`, a six-parameter numerical
+audit, and the complete post-update distribution remain directly inspectable.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -206,6 +212,11 @@ NN16 under `code/specs/fixtures/two-number-autoencoder-v1` pins a two-number
 input, one-scalar encoding, two reconstructed outputs, mean squared error,
 complete decoder and encoder gradients, all seven central finite differences,
 updated parameters, and the lower post-update reconstruction loss.
+
+NN17 under `code/specs/fixtures/variational-autoencoder-v1` pins a scalar
+Gaussian encoder, saved epsilon, reparameterized sample, half-squared
+reconstruction error, beta-weighted KL divergence, both encoder gradient routes,
+six central finite differences, updated parameters, and lower total objective.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has three workbenches that move from one arithmetic update to small
+The app has four workbenches that move from one arithmetic update to small
 hidden-layer networks.
 
 ### Training-step microscope
@@ -19,6 +19,14 @@ example -> multiply -> add bias -> activate -> loss -> backprop -> update
 Future values stay hidden until their phase is selected. The learner can change
 the input, target, weight, bias, activation, and learning rate, inspect the
 chain-rule factors, and apply exactly one proposed update.
+
+### Optimization microscope
+
+The optimization workbench plots the mean-squared-error surface for a
+four-point linear problem. It shows the current parameters, the known minimum,
+and one full-batch gradient step on the same surface. An independent central
+finite-difference estimate checks the analytical gradient, while synchronized
+loss curves compare stochastic, mini-batch, and full-batch row selection.
 
 ### Linear lab
 
@@ -57,10 +65,11 @@ datasets. Small teaching datasets can be checked in as local JSON or CSV only
 when their license and source are clear. Dataset notes live in
 `src/data/SOURCES.md`.
 
-The smallest canonical examples also live in the language-neutral NN03 corpus
-under `code/specs/fixtures/neural-learning-v1`. That corpus pins forward values
-and first-step gradients so other language implementations can reproduce the
-same visualized arithmetic.
+The smallest canonical examples also live in language-neutral corpora. NN03
+under `code/specs/fixtures/neural-learning-v1` pins forward values and first-step
+gradients. NN04 under `code/specs/fixtures/optimization-learning-v1` pins
+finite-difference checks and batch-strategy trajectories so other language
+implementations can reproduce the same visualized arithmetic.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -103,7 +103,13 @@ and value vectors with three shared matrices. Open any cell in the aligned
 `3 x 3` score matrix to see its coordinate products and dot-product sum. A
 single control applies the standard square-root dimension scaling while
 keeping the raw score visible in the arithmetic. Values remain explicitly
-downstream: this lab stops before softmax, masking, or weighted value mixing.
+downstream in this first view.
+
+Continue into the causal-softmax mixer to select a whole query row. It shows
+the future-key mask, stable maximum subtraction, exponentials, denominator,
+and normalized weights as one connected flow. The triangular weight matrix and
+three value-contribution lanes update together, while a mask toggle provides an
+unmasked comparison without changing scores or values.
 
 ## Lab Families
 
@@ -157,6 +163,10 @@ states, and reset/update/forget/input/output counterfactuals.
 NN12 under `code/specs/fixtures/attention-qkv-v1` pins three token embeddings,
 the shared query/key/value projection matrices, every coordinate product in
 all nine query-key dot products, and the raw and scaled score matrices.
+
+NN13 under `code/specs/fixtures/attention-softmax-v1` pins both masked and
+unmasked stable-softmax rows, including allowed positions, shifts,
+exponentials, denominators, weights, value contributions, and contexts.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has five workbenches that move from one arithmetic update to small
+The app has six workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -59,6 +59,14 @@ its loss derivative and contribution to each shared kernel weight. A reduction
 table checks the analytical gradient against central finite differences and
 previews or applies one loss-reducing update.
 
+### Image CNN lab
+
+The image workbench opens a complete two-channel image pipeline. Select either
+filter and any `2 x 2` output position to inspect its two input windows,
+channel-specific kernels, products, partial sums, bias, and final feature-map
+value. Step forward to see which four values share normalization statistics,
+how ReLU changes them, and which row-major location wins `2 x 2` max pooling.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -87,6 +95,10 @@ sliding-kernel trace, including every window, product, accumulator, and output.
 NN06 under `code/specs/fixtures/convolution-training-v1` pins every shared-
 weight gradient contribution, the finite-difference oracle, and one optimizer
 step.
+
+NN07 under `code/specs/fixtures/tiny-image-cnn-v1` pins two-channel 2D
+cross-correlation, output-channel normalization statistics, ReLU maps, and
+max-pool values and winner coordinates.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has seven workbenches that move from one arithmetic update to small
+The app has eight workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -76,6 +76,15 @@ path back to the original inputs. Boundary selections make receptive-field
 clipping visible, while the shortcut toggle separates what depth changes from
 what the identity path preserves.
 
+### Recurrent-state lab
+
+The recurrent workbench unrolls one scalar ReLU cell across three time steps.
+Select any execution to separate its new-input product, previous-state product,
+bias, preactivation, and next state. The same parameter strip stays above all
+three cells to make sharing explicit. A memory toggle removes only the
+recurrent contribution and exposes why the final zero input still produces a
+positive state when earlier context is carried forward.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -112,6 +121,10 @@ max-pool values and winner coordinates.
 NN08 under `code/specs/fixtures/residual-receptive-v1` pins two same-padded
 local layers, the identity addition, all hidden-to-input expansions, input
 path counts, and boundary-clipped receptive fields.
+
+NN09 under `code/specs/fixtures/recurrent-unroll-v1` pins an explicit initial
+state, three shared-parameter recurrent steps, all scalar arithmetic, and the
+counterfactual trace with its recurrent contribution removed.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has eleven workbenches that move from one arithmetic update to small
+The app has twelve workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -172,6 +172,15 @@ self-looped neighborhood, inspect every square-root degree coefficient, then
 switch to stable neighborhood softmax and audit scores, exponentials, attention
 weights, contributions, and both output vectors.
 
+### Deep-training lab
+
+The deep-training workbench sends four fixed two-value samples through three
+layers with one shared sign template. Switch between tiny, Xavier, He, and
+deliberately large scales, then compare `tanh` and ReLU. Every layer exposes its
+eight activation values, population variance and standard deviation, exact-zero
+or saturation fraction, and one selected neuron's full arithmetic. A comparison
+panel keeps all four initializer trajectories visible at once.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -272,6 +281,11 @@ NN22 under `code/specs/fixtures/graph-convolution-attention-v1` pins the same
 three self-looped neighborhoods under symmetric-normalized GCN and stable-
 softmax GAT, including every coefficient, score, weight, contribution, and
 output.
+
+NN23 under `code/specs/fixtures/initialization-activation-distribution-v1`
+pins three bias-free layers under four scales and two activations, including a
+canonical Xavier-plus-tanh trace and cross-mode standard-deviation, zero, and
+saturation summaries.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -148,6 +148,12 @@ the frozen updated discriminator. Each player's objective, active gradient
 route, two-parameter numerical audit, and the opponent's counter-push stay
 visible at every phase.
 
+Finish the representation sequence with the diffusion view. It mixes one clean
+scalar with a saved noise value at two cumulative-alpha levels, trains a shared
+timestep-aware noise predictor, audits all three parameter gradients, and feeds
+two deterministic reverse means into each other. The final reconstruction keeps
+its small residual error visible rather than implying a perfect toy denoiser.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -229,6 +235,11 @@ NN18 under `code/specs/fixtures/one-dimensional-gan-v1` pins one complete
 scalar adversarial round: saved noise, real and fake scores, a detached
 discriminator update, a frozen-discriminator generator response, both players'
 loss snapshots, and two objective-specific finite-difference audits.
+
+NN19 under `code/specs/fixtures/one-dimensional-diffusion-v1` pins two scalar
+forward noise levels, cumulative schedule coefficients, saved-noise targets, a
+shared timestep-conditioned denoiser update, a three-parameter numerical audit,
+and the complete deterministic reverse-mean path.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -111,6 +111,13 @@ and normalized weights as one connected flow. The triangular weight matrix and
 three value-contribution lanes update together, while a mask toggle provides an
 unmasked comparison without changing scores or values.
 
+Continue once more into the two-head add-and-norm block. The horizontal and
+vertical scalar heads stay aligned so their different score rows, weights,
+value contributions, and contexts can be compared. Their contexts then move
+through concatenation, an explicit output projection, residual addition, and
+per-token layer normalization. Residual and normalization toggles act as
+controlled ablations without changing either head.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -167,6 +174,11 @@ all nine query-key dot products, and the raw and scaled score matrices.
 NN13 under `code/specs/fixtures/attention-softmax-v1` pins both masked and
 unmasked stable-softmax rows, including allowed positions, shifts,
 exponentials, denominators, weights, value contributions, and contexts.
+
+NN14 under `code/specs/fixtures/multi-head-attention-v1` pins two independently
+projected scalar heads, every causal-softmax intermediate, head concatenation,
+output projection, residual addition, and population-variance layer
+normalization.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -54,7 +54,10 @@ The spatial workbench slides an editable one-dimensional kernel over an
 editable signal in valid, stride-one mode. Select any feature-map output to see
 its receptive-field window, element-wise products, and running accumulator. An
 asymmetric default kernel makes the neural cross-correlation convention
-visible instead of silently flipping weights.
+visible instead of silently flipping weights. The same selected output exposes
+its loss derivative and contribution to each shared kernel weight. A reduction
+table checks the analytical gradient against central finite differences and
+previews or applies one loss-reducing update.
 
 ## Lab Families
 
@@ -81,6 +84,9 @@ implementations can reproduce the same visualized arithmetic.
 
 NN05 under `code/specs/fixtures/convolution-learning-v1` pins the first
 sliding-kernel trace, including every window, product, accumulator, and output.
+NN06 under `code/specs/fixtures/convolution-training-v1` pins every shared-
+weight gradient contribution, the finite-difference oracle, and one optimizer
+step.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -162,6 +162,11 @@ cue with one flipped bit, and advances a saved asynchronous update order. Every
 incoming weighted vote, local field, state change, energy value, and normalized
 overlap stays visible through the recovered fixed point.
 
+Switch to message passing to open a three-node path. The view expands two
+undirected edges into four directed messages, highlights the selected node's
+inbox, sums its messages, and combines that aggregate with a shared self route,
+bias, and ReLU. All nodes read the same original feature snapshot.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -253,6 +258,10 @@ NN20 under `code/specs/fixtures/hopfield-associative-memory-v1` pins one
 four-neuron bipolar memory, normalized Hebbian weights, a one-bit-damaged cue,
 all in-place asynchronous updates, energy descent, overlap improvement, and the
 recovered fixed point.
+
+NN21 under `code/specs/fixtures/tiny-message-passing-v1` pins one synchronous
+three-node graph round, including every directed message, target inbox,
+aggregate, self contribution, affine preactivation, ReLU, and output feature.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -85,6 +85,12 @@ three cells to make sharing explicit. A memory toggle removes only the
 recurrent contribution and exposes why the final zero input still produces a
 positive state when earlier context is carried forward.
 
+Switch to the backward microscope to reverse the same saved states. Select a
+time step to combine direct and future state gradients, inspect its local
+parameter contributions, and see all three executions reduce into one shared
+gradient set. A central finite-difference table audits BPTT independently, and
+an update preview reruns the forward pass with the proposed parameters.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -125,6 +131,10 @@ path counts, and boundary-clipped receptive fields.
 NN09 under `code/specs/fixtures/recurrent-unroll-v1` pins an explicit initial
 state, three shared-parameter recurrent steps, all scalar arithmetic, and the
 counterfactual trace with its recurrent contribution removed.
+
+NN10 under `code/specs/fixtures/recurrent-bptt-v1` pins the reverse-time state
+gradients, local and accumulated shared-parameter gradients, initial-state
+gradient, central finite-difference oracle, and one loss-reducing update.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -181,6 +181,13 @@ eight activation values, population variance and standard deviation, exact-zero
 or saturation fraction, and one selected neuron's full arithmetic. A comparison
 panel keeps all four initializer trajectories visible at once.
 
+Switch to gradient flow to reverse four scalar layers. Small-weight and
+saturated `tanh` chains show two ways a gradient can vanish, unit ReLU provides
+a stable control, and large ReLU doubles every local Jacobian. Select any layer
+to expand `dL/da`, `da/dz`, `dL/dz`, the input gradient, and the weight gradient.
+The complete chain product and an independent input finite difference remain
+visible beside all four scenarios.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -286,6 +293,11 @@ NN23 under `code/specs/fixtures/initialization-activation-distribution-v1`
 pins three bias-free layers under four scales and two activations, including a
 canonical Xavier-plus-tanh trace and cross-mode standard-deviation, zero, and
 saturation summaries.
+
+NN24 under `code/specs/fixtures/gradient-flow-v1` pins four scalar chains,
+every activation derivative and local Jacobian, all reverse-mode input and
+weight gradients, vanishing/stable/exploding classifications, and input finite-
+difference checks.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has nine workbenches that move from one arithmetic update to small
+The app has ten workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -126,6 +126,15 @@ An independent finite-difference audit checks the shared-head gradients. The
 before/after toggle reruns both positions with one SGD update and checks the
 resulting lower mean loss.
 
+### Representation lab
+
+The representation workbench compresses `[2,-1]` through a one-scalar linear
+bottleneck and reconstructs both coordinates from that shared value. Select
+either output to isolate its decoder formula, coordinate error, and route into
+the accumulated bottleneck gradient. The same view exposes all encoder and
+decoder gradients, a seven-parameter central finite-difference audit, and the
+full-model loss before and after one SGD step.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -192,6 +201,11 @@ NN15 under `code/specs/fixtures/tiny-decoder-training-v1` pins a causal
 next-token sequence shift, saved decoder states, unembedding logits, stable
 softmax, mean cross-entropy, state and shared-head gradients, central finite
 differences, one SGD update, and its post-update probabilities and loss.
+
+NN16 under `code/specs/fixtures/two-number-autoencoder-v1` pins a two-number
+input, one-scalar encoding, two reconstructed outputs, mean squared error,
+complete decoder and encoder gradients, all seven central finite differences,
+updated parameters, and the lower post-update reconstruction loss.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -167,6 +167,11 @@ undirected edges into four directed messages, highlights the selected node's
 inbox, sums its messages, and combines that aggregate with a shared self route,
 bias, and ReLU. All nodes read the same original feature snapshot.
 
+Finish the structured sequence with the GCN-versus-GAT comparison. Select any
+self-looped neighborhood, inspect every square-root degree coefficient, then
+switch to stable neighborhood softmax and audit scores, exponentials, attention
+weights, contributions, and both output vectors.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -262,6 +267,11 @@ recovered fixed point.
 NN21 under `code/specs/fixtures/tiny-message-passing-v1` pins one synchronous
 three-node graph round, including every directed message, target inbox,
 aggregate, self contribution, affine preactivation, ReLU, and output feature.
+
+NN22 under `code/specs/fixtures/graph-convolution-attention-v1` pins the same
+three self-looped neighborhoods under symmetric-normalized GCN and stable-
+softmax GAT, including every coefficient, score, weight, contribution, and
+output.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -2,9 +2,9 @@ import { useEffect, useMemo, useState } from "react";
 import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./activation.js";
 import { AttentionWorkbench } from "./AttentionWorkbench.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
+import { DeepTrainingWorkbench } from "./DeepTrainingWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
-import { InitializationWorkbench } from "./InitializationWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
@@ -299,7 +299,7 @@ export function App() {
               : workbench === "structured"
                 ? "Structure shapes computation"
               : workbench === "deep"
-                ? "Scale shapes every layer"
+                ? "Scale shapes forward and backward signals"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -413,7 +413,7 @@ export function App() {
             ) : workbench === "structured" ? (
               <>connections {"->"} <strong>shared rule</strong> {"->"} updated state</>
             ) : workbench === "deep" ? (
-              <>initializer {"->"} <strong>activation spread</strong> {"->"} deeper signal</>
+              <>initialize {"->"} <strong>activation spread</strong> {"->"} gradient flow</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -442,7 +442,7 @@ export function App() {
       ) : workbench === "structured" ? (
         <StructuredWorkbench />
       ) : workbench === "deep" ? (
-        <InitializationWorkbench />
+        <DeepTrainingWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./activation.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
+import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
@@ -170,7 +171,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -279,6 +280,8 @@ export function App() {
                 ? "Trust, then independently verify"
               : workbench === "convolution"
                 ? "One detector, every position"
+              : workbench === "image-cnn"
+                ? "Channels become features"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -322,6 +325,13 @@ export function App() {
             >
               Spatial
             </button>
+            <button
+              className={workbench === "image-cnn" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("image-cnn")}
+            >
+              Image CNN
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -330,6 +340,8 @@ export function App() {
               <>loss surface {"->"} <strong>gradient check</strong> {"->"} batch strategy</>
             ) : workbench === "convolution" ? (
               <>window × <strong>shared kernel</strong> {"->"} feature</>
+            ) : workbench === "image-cnn" ? (
+              <>channels {"->"} <strong>normalize + ReLU</strong> {"->"} pool</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -345,6 +357,8 @@ export function App() {
         <OptimizationWorkbench />
       ) : workbench === "convolution" ? (
         <ConvolutionWorkbench />
+      ) : workbench === "image-cnn" ? (
+        <ImageCnnWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -6,6 +6,7 @@ import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
+import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import {
@@ -172,7 +173,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -285,6 +286,8 @@ export function App() {
                 ? "Channels become features"
               : workbench === "residual"
                 ? "Deep route, short route"
+              : workbench === "recurrent"
+                ? "Memory becomes an input"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -342,6 +345,13 @@ export function App() {
             >
               Residual
             </button>
+            <button
+              className={workbench === "recurrent" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("recurrent")}
+            >
+              Recurrent
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -354,6 +364,8 @@ export function App() {
               <>channels {"->"} <strong>normalize + ReLU</strong> {"->"} pool</>
             ) : workbench === "residual" ? (
               <>local layers + <strong>identity skip</strong> {"->"} wider field</>
+            ) : workbench === "recurrent" ? (
+              <>input + <strong>previous state</strong> {"->"} next state</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -373,6 +385,8 @@ export function App() {
         <ImageCnnWorkbench />
       ) : workbench === "residual" ? (
         <ResidualWorkbench />
+      ) : workbench === "recurrent" ? (
+        <RecurrentWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./activation.js";
+import { AttentionWorkbench } from "./AttentionWorkbench.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
@@ -173,7 +174,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -288,6 +289,8 @@ export function App() {
                 ? "Deep route, short route"
               : workbench === "recurrent"
                 ? "Memory becomes an input"
+              : workbench === "attention"
+                ? "Every token asks and matches"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -352,6 +355,13 @@ export function App() {
             >
               Recurrent
             </button>
+            <button
+              className={workbench === "attention" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("attention")}
+            >
+              Attention
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -366,6 +376,8 @@ export function App() {
               <>local layers + <strong>identity skip</strong> {"->"} wider field</>
             ) : workbench === "recurrent" ? (
               <>input + <strong>previous state</strong> {"->"} next state</>
+            ) : workbench === "attention" ? (
+              <>QK^T / sqrt(d_k) {"->"} <strong>scores</strong></>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -387,6 +399,8 @@ export function App() {
         <ResidualWorkbench />
       ) : workbench === "recurrent" ? (
         <RecurrentWorkbench />
+      ) : workbench === "attention" ? (
+        <AttentionWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -377,7 +377,7 @@ export function App() {
             ) : workbench === "recurrent" ? (
               <>input + <strong>previous state</strong> {"->"} next state</>
             ) : workbench === "attention" ? (
-              <>QK^T {"->"} mask {"->"} <strong>softmax</strong> {"->"} values</>
+              <>2 heads {"->"} <strong>join</strong> {"->"} add + norm</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -4,6 +4,7 @@ import { AttentionWorkbench } from "./AttentionWorkbench.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
+import { InitializationWorkbench } from "./InitializationWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
@@ -176,7 +177,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation" | "structured"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation" | "structured" | "deep"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -297,6 +298,8 @@ export function App() {
                 ? "Compress, then reconstruct"
               : workbench === "structured"
                 ? "Structure shapes computation"
+              : workbench === "deep"
+                ? "Scale shapes every layer"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -382,6 +385,13 @@ export function App() {
             >
               Structured
             </button>
+            <button
+              className={workbench === "deep" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("deep")}
+            >
+              Deep Training
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -402,6 +412,8 @@ export function App() {
               <>encode {"->"} <strong>constrained latent</strong> {"->"} reconstruct</>
             ) : workbench === "structured" ? (
               <>connections {"->"} <strong>shared rule</strong> {"->"} updated state</>
+            ) : workbench === "deep" ? (
+              <>initializer {"->"} <strong>activation spread</strong> {"->"} deeper signal</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -429,6 +441,8 @@ export function App() {
         <RepresentationWorkbench />
       ) : workbench === "structured" ? (
         <StructuredWorkbench />
+      ) : workbench === "deep" ? (
+        <InitializationWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -377,7 +377,7 @@ export function App() {
             ) : workbench === "recurrent" ? (
               <>input + <strong>previous state</strong> {"->"} next state</>
             ) : workbench === "attention" ? (
-              <>QK^T / sqrt(d_k) {"->"} <strong>scores</strong></>
+              <>QK^T {"->"} mask {"->"} <strong>softmax</strong> {"->"} values</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -413,7 +413,7 @@ export function App() {
             ) : workbench === "structured" ? (
               <>connections {"->"} <strong>shared rule</strong> {"->"} updated state</>
             ) : workbench === "deep" ? (
-              <>initialize {"->"} <strong>activation spread</strong> {"->"} gradient flow</>
+              <>initialize {"->"} <strong>gradient flow</strong> {"->"} stabilize</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -3,6 +3,7 @@ import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
+import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import {
   loss,
@@ -167,7 +168,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 }
 
 export function App() {
-  const [workbench, setWorkbench] = useState<"microscope" | "linear" | "hidden">("microscope");
+  const [workbench, setWorkbench] = useState<"microscope" | "optimization" | "linear" | "hidden">("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
   const [activationKind, setActivationKind] = useState<ActivationKind>("linear");
@@ -271,6 +272,8 @@ export function App() {
           <p className="eyebrow">
             {workbench === "microscope"
               ? "No hidden magic"
+              : workbench === "optimization"
+                ? "Trust, then independently verify"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -285,6 +288,13 @@ export function App() {
               onClick={() => setWorkbench("microscope")}
             >
               Microscope
+            </button>
+            <button
+              className={workbench === "optimization" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("optimization")}
+            >
+              Optimization
             </button>
             <button
               className={workbench === "linear" ? "mode-button mode-button--active" : "mode-button"}
@@ -304,6 +314,8 @@ export function App() {
           <div className="formula">
             {workbench === "microscope" ? (
               <>forward {"->"} <strong>loss</strong> {"->"} gradients {"->"} update</>
+            ) : workbench === "optimization" ? (
+              <>loss surface {"->"} <strong>gradient check</strong> {"->"} batch strategy</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -315,6 +327,8 @@ export function App() {
 
       {workbench === "microscope" ? (
         <TrainingStepMicroscope />
+      ) : workbench === "optimization" ? (
+        <OptimizationWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -296,7 +296,7 @@ export function App() {
               : workbench === "representation"
                 ? "Compress, then reconstruct"
               : workbench === "structured"
-                ? "A pattern becomes an attractor"
+                ? "Structure shapes computation"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -401,7 +401,7 @@ export function App() {
             ) : workbench === "representation" ? (
               <>encode {"->"} <strong>constrained latent</strong> {"->"} reconstruct</>
             ) : workbench === "structured" ? (
-              <>damaged cue {"->"} <strong>energy descent</strong> {"->"} recalled memory</>
+              <>connections {"->"} <strong>shared rule</strong> {"->"} updated state</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -6,6 +6,7 @@ import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
+import { ResidualWorkbench } from "./ResidualWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import {
   loss,
@@ -171,7 +172,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -282,6 +283,8 @@ export function App() {
                 ? "One detector, every position"
               : workbench === "image-cnn"
                 ? "Channels become features"
+              : workbench === "residual"
+                ? "Deep route, short route"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -332,6 +335,13 @@ export function App() {
             >
               Image CNN
             </button>
+            <button
+              className={workbench === "residual" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("residual")}
+            >
+              Residual
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -342,6 +352,8 @@ export function App() {
               <>window × <strong>shared kernel</strong> {"->"} feature</>
             ) : workbench === "image-cnn" ? (
               <>channels {"->"} <strong>normalize + ReLU</strong> {"->"} pool</>
+            ) : workbench === "residual" ? (
+              <>local layers + <strong>identity skip</strong> {"->"} wider field</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -359,6 +371,8 @@ export function App() {
         <ConvolutionWorkbench />
       ) : workbench === "image-cnn" ? (
         <ImageCnnWorkbench />
+      ) : workbench === "residual" ? (
+        <ResidualWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -10,6 +10,7 @@ import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
 import { RepresentationWorkbench } from "./RepresentationWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
+import { StructuredWorkbench } from "./StructuredWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import {
   loss,
@@ -175,7 +176,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation" | "structured"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -294,6 +295,8 @@ export function App() {
                 ? "Every token asks and matches"
               : workbench === "representation"
                 ? "Compress, then reconstruct"
+              : workbench === "structured"
+                ? "A pattern becomes an attractor"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -372,6 +375,13 @@ export function App() {
             >
               Representation
             </button>
+            <button
+              className={workbench === "structured" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("structured")}
+            >
+              Structured
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -390,6 +400,8 @@ export function App() {
               <>2 heads {"->"} <strong>join</strong> {"->"} add + norm</>
             ) : workbench === "representation" ? (
               <>encode {"->"} <strong>constrained latent</strong> {"->"} reconstruct</>
+            ) : workbench === "structured" ? (
+              <>damaged cue {"->"} <strong>energy descent</strong> {"->"} recalled memory</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -415,6 +427,8 @@ export function App() {
         <AttentionWorkbench />
       ) : workbench === "representation" ? (
         <RepresentationWorkbench />
+      ) : workbench === "structured" ? (
+        <StructuredWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./activation.js";
 import { AttentionWorkbench } from "./AttentionWorkbench.js";
+import { AutoencoderWorkbench } from "./AutoencoderWorkbench.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
@@ -174,7 +175,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -291,6 +292,8 @@ export function App() {
                 ? "Memory becomes an input"
               : workbench === "attention"
                 ? "Every token asks and matches"
+              : workbench === "representation"
+                ? "Compress, then reconstruct"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -362,6 +365,13 @@ export function App() {
             >
               Attention
             </button>
+            <button
+              className={workbench === "representation" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("representation")}
+            >
+              Representation
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -378,6 +388,8 @@ export function App() {
               <>input + <strong>previous state</strong> {"->"} next state</>
             ) : workbench === "attention" ? (
               <>2 heads {"->"} <strong>join</strong> {"->"} add + norm</>
+            ) : workbench === "representation" ? (
+              <>2 values {"->"} <strong>1 bottleneck</strong> {"->"} reconstruct 2</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -401,6 +413,8 @@ export function App() {
         <RecurrentWorkbench />
       ) : workbench === "attention" ? (
         <AttentionWorkbench />
+      ) : workbench === "representation" ? (
+        <AutoencoderWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./activation.js";
+import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
@@ -168,7 +169,9 @@ function groupColor(group: string | undefined, groups: string[]): string {
 }
 
 export function App() {
-  const [workbench, setWorkbench] = useState<"microscope" | "optimization" | "linear" | "hidden">("microscope");
+  const [workbench, setWorkbench] = useState<
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution"
+  >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
   const [activationKind, setActivationKind] = useState<ActivationKind>("linear");
@@ -274,6 +277,8 @@ export function App() {
               ? "No hidden magic"
               : workbench === "optimization"
                 ? "Trust, then independently verify"
+              : workbench === "convolution"
+                ? "One detector, every position"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -310,12 +315,21 @@ export function App() {
             >
               Hidden Layer
             </button>
+            <button
+              className={workbench === "convolution" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("convolution")}
+            >
+              Spatial
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
               <>forward {"->"} <strong>loss</strong> {"->"} gradients {"->"} update</>
             ) : workbench === "optimization" ? (
               <>loss surface {"->"} <strong>gradient check</strong> {"->"} batch strategy</>
+            ) : workbench === "convolution" ? (
+              <>window × <strong>shared kernel</strong> {"->"} feature</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -329,6 +343,8 @@ export function App() {
         <TrainingStepMicroscope />
       ) : workbench === "optimization" ? (
         <OptimizationWorkbench />
+      ) : workbench === "convolution" ? (
+        <ConvolutionWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./activation.js";
 import { AttentionWorkbench } from "./AttentionWorkbench.js";
-import { AutoencoderWorkbench } from "./AutoencoderWorkbench.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
@@ -9,6 +8,7 @@ import { LAB_CATEGORIES, LABS, type LabDefinition } from "./labs.js";
 import { LinearNetworkDiagram } from "./NetworkDiagram.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
+import { RepresentationWorkbench } from "./RepresentationWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import {
@@ -389,7 +389,7 @@ export function App() {
             ) : workbench === "attention" ? (
               <>2 heads {"->"} <strong>join</strong> {"->"} add + norm</>
             ) : workbench === "representation" ? (
-              <>2 values {"->"} <strong>1 bottleneck</strong> {"->"} reconstruct 2</>
+              <>encode {"->"} <strong>constrained latent</strong> {"->"} reconstruct</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -414,7 +414,7 @@ export function App() {
       ) : workbench === "attention" ? (
         <AttentionWorkbench />
       ) : workbench === "representation" ? (
-        <AutoencoderWorkbench />
+        <RepresentationWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/AttentionWeightsWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/AttentionWeightsWorkbench.tsx
@@ -1,0 +1,225 @@
+import { useMemo, useState } from "react";
+import {
+  attentionSoftmaxRow,
+  traceAttentionSoftmax,
+} from "./attention-softmax-lab.js";
+import type { AttentionTokenId } from "./attention-qkv-lab.js";
+
+interface AttentionWeightsWorkbenchProps {
+  onShowScores: () => void;
+}
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(6)).toString();
+}
+
+function formatVector(values: readonly number[]): string {
+  return `[${values.map(formatNumber).join(", ")}]`;
+}
+
+function formatNullableVector(values: ReadonlyArray<number | null>): string {
+  return `[${values.map((value) => value === null ? "blocked" : formatNumber(value)).join(", ")}]`;
+}
+
+export function AttentionWeightsWorkbench({ onShowScores }: AttentionWeightsWorkbenchProps) {
+  const [causal, setCausal] = useState(true);
+  const [queryId, setQueryId] = useState<AttentionTokenId>("blue");
+  const trace = useMemo(() => traceAttentionSoftmax(causal), [causal]);
+  const selected = attentionSoftmaxRow(trace, queryId);
+
+  return (
+    <main className="workspace workspace--attention-softmax">
+      <section className="attention-softmax-stage" aria-label="Causal attention weight trace">
+        <div className="attention-softmax-intro">
+          <div>
+            <p className="eyebrow">NN13 · normalize without looking ahead</p>
+            <h2>Causal-softmax mixer</h2>
+            <p>
+              Mask future keys, normalize one query row into weights, then
+              follow each weight into the value vector it scales.
+            </p>
+          </div>
+          <div className="attention-softmax-chip">{causal ? "causal decoder" : "full context"}</div>
+        </div>
+
+        <section className="attention-weight-panel" aria-label="Attention weight matrix">
+          <div className="attention-softmax-heading">
+            <div>
+              <p className="eyebrow">Rows normalize independently</p>
+              <h2>{causal ? "Causal" : "Unmasked"} attention weights</h2>
+            </div>
+            <code>each row sums to 1</code>
+          </div>
+
+          <div
+            className="attention-weight-grid"
+            role="grid"
+            aria-label={`${causal ? "Causal" : "Unmasked"} attention weight matrix`}
+          >
+            <span className="attention-grid-corner">q \ k</span>
+            {trace.tokenIds.map((tokenId) => (
+              <span className="attention-grid-label" key={`weight-key-${tokenId}`}>{tokenId} k</span>
+            ))}
+            {trace.rows.flatMap((row) => [
+              <button
+                aria-label={`Select ${row.queryId} query row`}
+                aria-pressed={queryId === row.queryId}
+                className={queryId === row.queryId
+                  ? "attention-weight-row-button attention-weight-row-button--active"
+                  : "attention-weight-row-button"}
+                key={`weight-query-${row.queryId}`}
+                type="button"
+                onClick={() => setQueryId(row.queryId)}
+              >
+                {row.queryId} q
+              </button>,
+              ...row.weights.map((weight, keyIndex) => {
+                const blocked = !row.allowed[keyIndex];
+                return (
+                  <div
+                    aria-label={`${row.queryId} query to ${trace.tokenIds[keyIndex]} key: ${blocked ? "blocked" : formatNumber(weight)}`}
+                    className={blocked
+                      ? "attention-weight-cell attention-weight-cell--blocked"
+                      : queryId === row.queryId
+                        ? "attention-weight-cell attention-weight-cell--selected-row"
+                        : "attention-weight-cell"}
+                    key={`${row.queryId}-${trace.tokenIds[keyIndex]}`}
+                    role="gridcell"
+                  >
+                    <strong>{blocked ? "blocked" : formatNumber(weight)}</strong>
+                    <span aria-hidden="true" style={{ width: `${Math.max(weight * 100, 0)}%` }} />
+                  </div>
+                );
+              }),
+            ])}
+          </div>
+        </section>
+
+        <section className="attention-normalize-panel" aria-label="Selected softmax row trace">
+          <div className="attention-softmax-heading">
+            <div>
+              <p className="eyebrow">Selected · {selected.queryId} query</p>
+              <h2>Score → mask → stable exponentials → weights</h2>
+            </div>
+            <code>max = {formatNumber(selected.rowMax)}</code>
+          </div>
+
+          <div className="attention-normalize-flow">
+            <div>
+              <small>scaled scores</small>
+              <code>{formatVector(selected.scaledScores)}</code>
+            </div>
+            <span aria-hidden="true">→</span>
+            <div>
+              <small>after mask</small>
+              <code>{formatNullableVector(selected.maskedScores)}</code>
+            </div>
+            <span aria-hidden="true">→</span>
+            <div>
+              <small>subtract max, exp</small>
+              <code>{formatVector(selected.exponentials)}</code>
+            </div>
+            <span aria-hidden="true">→</span>
+            <div className="attention-normalize-flow__result">
+              <small>divide by {formatNumber(selected.denominator)}</small>
+              <code>{formatVector(selected.weights)}</code>
+            </div>
+          </div>
+        </section>
+
+        <section className="attention-value-mix-panel" aria-label="Selected weighted value mix">
+          <div className="attention-softmax-heading">
+            <div>
+              <p className="eyebrow">Weights finally meet values</p>
+              <h2>Build the {selected.queryId} context</h2>
+            </div>
+            <div className="attention-context-result">
+              <small>context</small>
+              <strong>{formatVector(selected.context)}</strong>
+            </div>
+          </div>
+
+          <div className="attention-value-lanes">
+            {trace.tokenIds.map((tokenId, keyIndex) => (
+              <div
+                className={selected.allowed[keyIndex]
+                  ? "attention-value-lane"
+                  : "attention-value-lane attention-value-lane--blocked"}
+                key={tokenId}
+              >
+                <span><i className={`attention-token-dot attention-token-dot--${tokenId}`} />{tokenId} value</span>
+                <code>
+                  {formatNumber(selected.weights[keyIndex]!)} × {formatVector(selected.values[keyIndex]!)}
+                </code>
+                <strong>= {formatVector(selected.valueContributions[keyIndex]!)}</strong>
+              </div>
+            ))}
+          </div>
+        </section>
+      </section>
+
+      <aside className="attention-softmax-controls" aria-label="Causal attention controls">
+        <p className="eyebrow">One information boundary</p>
+        <h2>Mask controls</h2>
+        <p>
+          Select a whole query row. Softmax belongs to that row, not to one
+          score cell.
+        </p>
+
+        <button className="attention-back-button" type="button" onClick={onShowScores}>
+          Return to Q/K/V scores
+        </button>
+
+        <label className="attention-scale-control">
+          <input
+            type="checkbox"
+            checked={causal}
+            onChange={(event) => setCausal(event.target.checked)}
+          />
+          <span>
+            <strong>Block future keys</strong>
+            <small>Allow column j only when j ≤ query row i.</small>
+          </span>
+        </label>
+
+        <div className="attention-query-buttons" aria-label="Query row selection">
+          {trace.tokenIds.map((tokenId) => (
+            <button
+              aria-pressed={queryId === tokenId}
+              key={tokenId}
+              type="button"
+              onClick={() => setQueryId(tokenId)}
+            >
+              {tokenId}
+            </button>
+          ))}
+        </div>
+
+        <div className="attention-selected-summary">
+          <small>selected context</small>
+          <strong>{formatVector(selected.context)}</strong>
+          <span>{selected.queryId} reads {selected.allowed.filter(Boolean).length} value{selected.allowed.filter(Boolean).length === 1 ? "" : "s"}.</span>
+        </div>
+
+        <div className="attention-value-boundary">
+          <span>Why subtract the maximum?</span>
+          <p>
+            It keeps exponentials finite without changing their normalized
+            proportions. The maximum shifted score is always zero.
+          </p>
+        </div>
+
+        <div className="attention-next-note">
+          <span>What scales next?</span>
+          <p>
+            Multiple heads repeat this calculation with different projections,
+            then concatenate their context vectors.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/AttentionWeightsWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/AttentionWeightsWorkbench.tsx
@@ -6,6 +6,7 @@ import {
 import type { AttentionTokenId } from "./attention-qkv-lab.js";
 
 interface AttentionWeightsWorkbenchProps {
+  onShowMultiHead: () => void;
   onShowScores: () => void;
 }
 
@@ -24,7 +25,10 @@ function formatNullableVector(values: ReadonlyArray<number | null>): string {
   return `[${values.map((value) => value === null ? "blocked" : formatNumber(value)).join(", ")}]`;
 }
 
-export function AttentionWeightsWorkbench({ onShowScores }: AttentionWeightsWorkbenchProps) {
+export function AttentionWeightsWorkbench({
+  onShowMultiHead,
+  onShowScores,
+}: AttentionWeightsWorkbenchProps) {
   const [causal, setCausal] = useState(true);
   const [queryId, setQueryId] = useState<AttentionTokenId>("blue");
   const trace = useMemo(() => traceAttentionSoftmax(causal), [causal]);
@@ -171,6 +175,10 @@ export function AttentionWeightsWorkbench({ onShowScores }: AttentionWeightsWork
 
         <button className="attention-back-button" type="button" onClick={onShowScores}>
           Return to Q/K/V scores
+        </button>
+
+        <button className="attention-back-button" type="button" onClick={onShowMultiHead}>
+          Open multi-head add and norm
         </button>
 
         <label className="attention-scale-control">

--- a/code/programs/typescript/ml-learning-visualizer/src/AttentionWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/AttentionWorkbench.tsx
@@ -5,6 +5,7 @@ import {
   type AttentionTokenId,
 } from "./attention-qkv-lab.js";
 import { AttentionWeightsWorkbench } from "./AttentionWeightsWorkbench.js";
+import { DecoderTrainingWorkbench } from "./DecoderTrainingWorkbench.js";
 import { MultiHeadAttentionWorkbench } from "./MultiHeadAttentionWorkbench.js";
 
 function formatNumber(value: number): string {
@@ -188,7 +189,7 @@ function AttentionScoreWorkbench({ onShowWeights }: AttentionScoreWorkbenchProps
 }
 
 export function AttentionWorkbench() {
-  const [view, setView] = useState<"scores" | "weights" | "multi-head">("scores");
+  const [view, setView] = useState<"scores" | "weights" | "multi-head" | "decoder">("scores");
 
   if (view === "weights") {
     return (
@@ -199,7 +200,15 @@ export function AttentionWorkbench() {
     );
   }
   if (view === "multi-head") {
-    return <MultiHeadAttentionWorkbench onShowWeights={() => setView("weights")} />;
+    return (
+      <MultiHeadAttentionWorkbench
+        onShowDecoder={() => setView("decoder")}
+        onShowWeights={() => setView("weights")}
+      />
+    );
+  }
+  if (view === "decoder") {
+    return <DecoderTrainingWorkbench onShowMultiHead={() => setView("multi-head")} />;
   }
   return <AttentionScoreWorkbench onShowWeights={() => setView("weights")} />;
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/AttentionWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/AttentionWorkbench.tsx
@@ -5,6 +5,7 @@ import {
   type AttentionTokenId,
 } from "./attention-qkv-lab.js";
 import { AttentionWeightsWorkbench } from "./AttentionWeightsWorkbench.js";
+import { MultiHeadAttentionWorkbench } from "./MultiHeadAttentionWorkbench.js";
 
 function formatNumber(value: number): string {
   if (Math.abs(value) < 1e-12) {
@@ -187,10 +188,18 @@ function AttentionScoreWorkbench({ onShowWeights }: AttentionScoreWorkbenchProps
 }
 
 export function AttentionWorkbench() {
-  const [view, setView] = useState<"scores" | "weights">("scores");
+  const [view, setView] = useState<"scores" | "weights" | "multi-head">("scores");
 
   if (view === "weights") {
-    return <AttentionWeightsWorkbench onShowScores={() => setView("scores")} />;
+    return (
+      <AttentionWeightsWorkbench
+        onShowMultiHead={() => setView("multi-head")}
+        onShowScores={() => setView("scores")}
+      />
+    );
+  }
+  if (view === "multi-head") {
+    return <MultiHeadAttentionWorkbench onShowWeights={() => setView("weights")} />;
   }
   return <AttentionScoreWorkbench onShowWeights={() => setView("weights")} />;
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/AttentionWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/AttentionWorkbench.tsx
@@ -4,6 +4,7 @@ import {
   traceAttentionQkv,
   type AttentionTokenId,
 } from "./attention-qkv-lab.js";
+import { AttentionWeightsWorkbench } from "./AttentionWeightsWorkbench.js";
 
 function formatNumber(value: number): string {
   if (Math.abs(value) < 1e-12) {
@@ -16,7 +17,11 @@ function formatVector(values: readonly number[]): string {
   return `[${values.map(formatNumber).join(", ")}]`;
 }
 
-export function AttentionWorkbench() {
+interface AttentionScoreWorkbenchProps {
+  onShowWeights: () => void;
+}
+
+function AttentionScoreWorkbench({ onShowWeights }: AttentionScoreWorkbenchProps) {
   const trace = useMemo(() => traceAttentionQkv(), []);
   const [queryId, setQueryId] = useState<AttentionTokenId>("blue");
   const [keyId, setKeyId] = useState<AttentionTokenId>("purple");
@@ -141,6 +146,10 @@ export function AttentionWorkbench() {
           say how much of a value to blend.
         </p>
 
+        <button className="attention-back-button" type="button" onClick={onShowWeights}>
+          Apply softmax and causal mask
+        </button>
+
         <label className="attention-scale-control">
           <input
             type="checkbox"
@@ -168,11 +177,20 @@ export function AttentionWorkbench() {
         <div className="attention-next-note">
           <span>What comes next?</span>
           <p>
-            Softmax turns each score row into weights. A later lab will use
+            Open the next view to turn each score row into weights and use
             those weights to blend the value vectors.
           </p>
         </div>
       </aside>
     </main>
   );
+}
+
+export function AttentionWorkbench() {
+  const [view, setView] = useState<"scores" | "weights">("scores");
+
+  if (view === "weights") {
+    return <AttentionWeightsWorkbench onShowScores={() => setView("scores")} />;
+  }
+  return <AttentionScoreWorkbench onShowWeights={() => setView("weights")} />;
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/AttentionWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/AttentionWorkbench.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from "react";
+import {
+  attentionCell,
+  traceAttentionQkv,
+  type AttentionTokenId,
+} from "./attention-qkv-lab.js";
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(6)).toString();
+}
+
+function formatVector(values: readonly number[]): string {
+  return `[${values.map(formatNumber).join(", ")}]`;
+}
+
+export function AttentionWorkbench() {
+  const trace = useMemo(() => traceAttentionQkv(), []);
+  const [queryId, setQueryId] = useState<AttentionTokenId>("blue");
+  const [keyId, setKeyId] = useState<AttentionTokenId>("purple");
+  const [scaled, setScaled] = useState(false);
+  const selected = attentionCell(trace, queryId, keyId);
+  const query = trace.projections.find((item) => item.id === queryId)!;
+  const key = trace.projections.find((item) => item.id === keyId)!;
+  const scoreMatrix = scaled ? trace.scaledScoreMatrix : trace.rawScoreMatrix;
+
+  return (
+    <main className="workspace workspace--attention">
+      <section className="attention-stage" aria-label="Three-token attention score trace">
+        <div className="attention-intro">
+          <div>
+            <p className="eyebrow">NN12 · attention foundations</p>
+            <h2>Query-key score microscope</h2>
+            <p>
+              Give every token three jobs, then open any score cell to see the
+              two multiplications and one addition behind its match strength.
+            </p>
+          </div>
+          <div className="attention-sequence-chip">red · blue · purple</div>
+        </div>
+
+        <section className="attention-projection-panel" aria-label="Token projections">
+          <div className="attention-panel-heading">
+            <div>
+              <p className="eyebrow">One token · three projections</p>
+              <h2>Ask, advertise, carry</h2>
+            </div>
+            <p>Each row uses the same three learned matrices.</p>
+          </div>
+          <div className="attention-projection-table">
+            <div className="attention-projection-head" aria-hidden="true">
+              <span>token x</span><span>query q</span><span>key k</span><span>value v</span>
+            </div>
+            {trace.projections.map((projection) => (
+              <div className="attention-projection-row" key={projection.id}>
+                <div>
+                  <i className={`attention-token-dot attention-token-dot--${projection.id}`} />
+                  <strong>{projection.label}</strong>
+                  <code>{formatVector(projection.embedding)}</code>
+                </div>
+                <div><small>asks with</small><code>{formatVector(projection.query)}</code></div>
+                <div><small>matches with</small><code>{formatVector(projection.key)}</code></div>
+                <div><small>carries</small><code>{formatVector(projection.value)}</code></div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="attention-score-panel" aria-label="Query-key score matrix">
+          <div className="attention-panel-heading">
+            <div>
+              <p className="eyebrow">Rows ask · columns match</p>
+              <h2>{scaled ? "Scaled" : "Raw"} query-key scores</h2>
+            </div>
+            <code>{scaled ? "QK^T / sqrt(2)" : "QK^T"}</code>
+          </div>
+
+          <div className="attention-score-layout">
+            <div className="attention-score-grid" role="grid" aria-label={`${scaled ? "Scaled" : "Raw"} attention scores`}>
+              <span className="attention-grid-corner">q \ k</span>
+              {trace.projections.map((projection) => (
+                <span className="attention-grid-label" key={`key-${projection.id}`}>{projection.label} k</span>
+              ))}
+              {trace.projections.flatMap((queryProjection, row) => [
+                <span className="attention-grid-label" key={`query-${queryProjection.id}`}>{queryProjection.label} q</span>,
+                ...trace.projections.map((keyProjection, column) => {
+                  const active = queryId === queryProjection.id && keyId === keyProjection.id;
+                  return (
+                    <button
+                      aria-label={`Select ${queryProjection.label} query and ${keyProjection.label} key`}
+                      aria-selected={active}
+                      className={active ? "attention-score-cell attention-score-cell--active" : "attention-score-cell"}
+                      key={`${queryProjection.id}-${keyProjection.id}`}
+                      role="gridcell"
+                      type="button"
+                      onClick={() => {
+                        setQueryId(queryProjection.id);
+                        setKeyId(keyProjection.id);
+                      }}
+                    >
+                      {formatNumber(scoreMatrix[row]![column]!)}
+                    </button>
+                  );
+                }),
+              ])}
+            </div>
+
+            <div className="attention-cell-trace" aria-label="Selected dot-product arithmetic">
+              <div>
+                <p className="eyebrow">Selected cell</p>
+                <h3>{query.label} asks · {key.label} matches</h3>
+              </div>
+              <div className="attention-vector-pair">
+                <span><small>query</small><code>q_{query.id} = {formatVector(query.query)}</code></span>
+                <span><small>key</small><code>k_{key.id} = {formatVector(key.key)}</code></span>
+              </div>
+              <div className="attention-dot-equation">
+                <code>{`${formatNumber(query.query[0]!)} × ${formatNumber(key.key[0]!)} + ${formatNumber(query.query[1]!)} × ${formatNumber(key.key[1]!)}`}</code>
+                <strong>= {formatNumber(selected.rawScore)}</strong>
+              </div>
+              <div className="attention-products">
+                coordinate products {formatVector(selected.products)}
+              </div>
+              {scaled ? (
+                <div className="attention-scale-equation">
+                  {formatNumber(selected.rawScore)} / sqrt(2) = <strong>{formatNumber(selected.scaledScore)}</strong>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <aside className="attention-controls" aria-label="Attention score controls">
+        <p className="eyebrow">Keep the boundary honest</p>
+        <h2>Score controls</h2>
+        <p>
+          A score says how strongly one query matches one key. It does not yet
+          say how much of a value to blend.
+        </p>
+
+        <label className="attention-scale-control">
+          <input
+            type="checkbox"
+            checked={scaled}
+            onChange={(event) => setScaled(event.target.checked)}
+          />
+          <span>
+            <strong>Scale by sqrt(key dimension)</strong>
+            <small>Divide every raw score by sqrt(2).</small>
+          </span>
+        </label>
+
+        <div className="attention-selected-summary">
+          <small>selected score</small>
+          <strong>{formatNumber(scaled ? selected.scaledScore : selected.rawScore)}</strong>
+          <span>{query.label} query → {key.label} key</span>
+        </div>
+
+        <div className="attention-value-boundary">
+          <span>Value waiting downstream</span>
+          <code>v_{key.id} = {formatVector(key.value)}</code>
+          <p>This payload does not enter the score calculation.</p>
+        </div>
+
+        <div className="attention-next-note">
+          <span>What comes next?</span>
+          <p>
+            Softmax turns each score row into weights. A later lab will use
+            those weights to blend the value vectors.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/AutoencoderWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/AutoencoderWorkbench.tsx
@@ -1,0 +1,305 @@
+import { useMemo, useState } from "react";
+import { traceTwoNumberAutoencoder } from "./autoencoder-lab.js";
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(8)).toString();
+}
+
+function formatVector(values: readonly number[]): string {
+  return `[${values.map(formatNumber).join(", ")}]`;
+}
+
+export function AutoencoderWorkbench() {
+  const trace = useMemo(() => traceTwoNumberAutoencoder(), []);
+  const [selectedOutput, setSelectedOutput] = useState(0);
+  const [showUpdated, setShowUpdated] = useState(false);
+  const currentForward = showUpdated ? trace.postUpdate : trace.forward;
+  const currentParameters = showUpdated
+    ? trace.updatedParameters
+    : trace.parameters;
+
+  return (
+    <main className="workspace workspace--autoencoder">
+      <section className="autoencoder-stage" aria-label="Two-number autoencoder bottleneck trace">
+        <div className="autoencoder-intro">
+          <div>
+            <p className="eyebrow">NN16 - representation through constraint</p>
+            <h2>Two numbers through one bottleneck</h2>
+            <p>
+              Compress a two-coordinate input into one scalar, reconstruct both
+              coordinates from that shared value, and follow both errors back
+              through one audited SGD step.
+            </p>
+          </div>
+          <div className="autoencoder-chip">2 -&gt; 1 -&gt; 2</div>
+        </div>
+
+        <section className="autoencoder-network-panel" aria-label="Autoencoder encode and decode path">
+          <div className="autoencoder-heading">
+            <div>
+              <p className="eyebrow">The decoder never sees the original pair</p>
+              <h2>One scalar must serve two reconstructions</h2>
+            </div>
+            <code>{showUpdated ? "after one SGD step" : "saved forward pass"}</code>
+          </div>
+
+          <div className="autoencoder-network">
+            <div className="autoencoder-input-stack">
+              <small>input is also target</small>
+              {trace.input.map((value, index) => (
+                <div key={index}>
+                  <span>x{index}</span>
+                  <strong>{formatNumber(value)}</strong>
+                </div>
+              ))}
+            </div>
+
+            <span className="autoencoder-arrow" aria-hidden="true">-&gt;</span>
+
+            <div className="autoencoder-encoder-stack">
+              <small>encoder products</small>
+              {currentForward.encoderProducts.map((product, index) => (
+                <code key={index}>
+                  {formatNumber(trace.input[index]!)} x {formatNumber(currentParameters.encoder.weights[index]!)} = {formatNumber(product)}
+                </code>
+              ))}
+              <code>+ bias {formatNumber(currentParameters.encoder.bias)}</code>
+            </div>
+
+            <span className="autoencoder-arrow" aria-hidden="true">-&gt;</span>
+
+            <div className="autoencoder-bottleneck">
+              <small>bottleneck z</small>
+              <strong>{formatNumber(currentForward.bottleneck)}</strong>
+              <span>one saved number</span>
+            </div>
+
+            <span className="autoencoder-arrow" aria-hidden="true">-&gt;</span>
+
+            <div className="autoencoder-output-stack">
+              <small>decoder reconstructions</small>
+              {currentForward.reconstruction.map((value, index) => (
+                <button
+                  aria-label={`Select reconstruction ${index}`}
+                  aria-pressed={selectedOutput === index}
+                  key={index}
+                  type="button"
+                  onClick={() => setSelectedOutput(index)}
+                >
+                  <span>x_hat{index}</span>
+                  <strong>{formatNumber(value)}</strong>
+                  <small>target {formatNumber(trace.input[index]!)}</small>
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="autoencoder-reconstruction-panel" aria-label={`Selected autoencoder reconstruction ${selectedOutput}`}>
+          <div className="autoencoder-heading">
+            <div>
+              <p className="eyebrow">Selected - reconstruction {selectedOutput}</p>
+              <h2>Decode and measure one coordinate</h2>
+            </div>
+            <div className="autoencoder-loss-badge">
+              <small>total mean loss</small>
+              <strong>{formatNumber(currentForward.loss)}</strong>
+            </div>
+          </div>
+
+          <div className="autoencoder-reconstruction-flow">
+            <div>
+              <small>shared bottleneck</small>
+              <code>z = {formatNumber(currentForward.bottleneck)}</code>
+            </div>
+            <span aria-hidden="true">x</span>
+            <div>
+              <small>decoder weight {selectedOutput}</small>
+              <code>{formatNumber(currentParameters.decoder.weights[selectedOutput]!)}</code>
+            </div>
+            <span aria-hidden="true">+</span>
+            <div>
+              <small>decoder bias {selectedOutput}</small>
+              <code>{formatNumber(currentParameters.decoder.bias[selectedOutput]!)}</code>
+            </div>
+            <span aria-hidden="true">=</span>
+            <div className="autoencoder-reconstruction-result">
+              <small>reconstruction</small>
+              <strong>{formatNumber(currentForward.reconstruction[selectedOutput]!)}</strong>
+            </div>
+            <span aria-hidden="true">-</span>
+            <div>
+              <small>input target</small>
+              <code>{formatNumber(trace.input[selectedOutput]!)}</code>
+            </div>
+            <span aria-hidden="true">=</span>
+            <div className="autoencoder-error-result">
+              <small>error / loss gradient</small>
+              <strong>{formatNumber(currentForward.errors[selectedOutput]!)}</strong>
+              <code>squared {formatNumber(currentForward.squaredErrors[selectedOutput]!)}</code>
+            </div>
+          </div>
+        </section>
+
+        <section className="autoencoder-backward-panel" aria-label="Autoencoder bottleneck gradient trace">
+          <div className="autoencoder-heading">
+            <div>
+              <p className="eyebrow">Two decoder branches meet at z</p>
+              <h2>Reconstruction error flows back through compression</h2>
+            </div>
+            <code>dL/dz = sum of both routes</code>
+          </div>
+
+          <div className="autoencoder-branch-gradients">
+            {trace.backward.bottleneckGradientContributions.map((contribution, index) => (
+              <button
+                aria-label={`Select reconstruction gradient ${index}`}
+                aria-pressed={selectedOutput === index}
+                key={index}
+                type="button"
+                onClick={() => setSelectedOutput(index)}
+              >
+                <small>output {index} route</small>
+                <code>
+                  {formatNumber(trace.backward.reconstructionGradients[index]!)} x {formatNumber(trace.parameters.decoder.weights[index]!)}
+                </code>
+                <strong>{formatNumber(contribution)}</strong>
+              </button>
+            ))}
+            <span aria-hidden="true">sum</span>
+            <div className="autoencoder-bottleneck-gradient">
+              <small>bottleneck gradient</small>
+              <strong>{formatNumber(trace.backward.bottleneckGradient)}</strong>
+            </div>
+          </div>
+
+          <div className="autoencoder-gradient-grid">
+            <div>
+              <small>decoder weight gradients</small>
+              <code>{formatVector(trace.backward.decoderWeightGradients)}</code>
+            </div>
+            <div>
+              <small>decoder bias gradients</small>
+              <code>{formatVector(trace.backward.decoderBiasGradients)}</code>
+            </div>
+            <div>
+              <small>encoder weight gradients</small>
+              <code>{formatVector(trace.backward.encoderWeightGradients)}</code>
+            </div>
+            <div>
+              <small>encoder bias gradient</small>
+              <code>{formatNumber(trace.backward.encoderBiasGradient)}</code>
+            </div>
+          </div>
+        </section>
+
+        <section className="autoencoder-update-panel" aria-label="Autoencoder SGD update and gradient audit">
+          <div className="autoencoder-heading">
+            <div>
+              <p className="eyebrow">All seven parameters move together</p>
+              <h2>Audit, update, rerun</h2>
+            </div>
+            <code>parameter - {trace.learningRate} x gradient</code>
+          </div>
+
+          <div className="autoencoder-parameter-grid">
+            <div>
+              <small>encoder before</small>
+              <code>w {formatVector(trace.parameters.encoder.weights)}</code>
+              <code>b {formatNumber(trace.parameters.encoder.bias)}</code>
+            </div>
+            <div>
+              <small>encoder after</small>
+              <code>w {formatVector(trace.updatedParameters.encoder.weights)}</code>
+              <code>b {formatNumber(trace.updatedParameters.encoder.bias)}</code>
+            </div>
+            <div>
+              <small>decoder before</small>
+              <code>w {formatVector(trace.parameters.decoder.weights)}</code>
+              <code>b {formatVector(trace.parameters.decoder.bias)}</code>
+            </div>
+            <div>
+              <small>decoder after</small>
+              <code>w {formatVector(trace.updatedParameters.decoder.weights)}</code>
+              <code>b {formatVector(trace.updatedParameters.decoder.bias)}</code>
+            </div>
+          </div>
+
+          <div className="autoencoder-gradient-audit">
+            <span>Central finite differences - 7 parameters</span>
+            <code>epsilon = {trace.gradientCheck.epsilon}</code>
+            <strong>max error {trace.gradientCheck.maxAbsoluteError.toExponential(3)}</strong>
+          </div>
+
+          <div className="autoencoder-loss-drop">
+            <div><small>loss before</small><strong>{formatNumber(trace.forward.loss)}</strong></div>
+            <span aria-hidden="true">-&gt;</span>
+            <div><small>loss after</small><strong>{formatNumber(trace.postUpdate.loss)}</strong></div>
+            <p>One reconstruction improves sharply; the shared mean objective falls.</p>
+          </div>
+        </section>
+      </section>
+
+      <aside className="autoencoder-controls" aria-label="Autoencoder trace controls">
+        <p className="eyebrow">Open one decoder branch</p>
+        <h2>Bottleneck controls</h2>
+        <p>
+          Both outputs stay visible. Selection follows one reconstruction's
+          arithmetic and gradient route without disconnecting the shared scalar.
+        </p>
+
+        <div className="attention-query-buttons" aria-label="Autoencoder reconstruction selection">
+          {[0, 1].map((index) => (
+            <button
+              aria-pressed={selectedOutput === index}
+              key={index}
+              type="button"
+              onClick={() => setSelectedOutput(index)}
+            >
+              output {index}
+            </button>
+          ))}
+        </div>
+
+        <label className="attention-scale-control">
+          <input
+            type="checkbox"
+            checked={showUpdated}
+            onChange={(event) => setShowUpdated(event.target.checked)}
+          />
+          <span>
+            <strong>Use updated parameters</strong>
+            <small>Rerun encode, decode, and loss after one SGD step.</small>
+          </span>
+        </label>
+
+        <div className="attention-selected-summary">
+          <small>selected reconstruction</small>
+          <strong>x_hat{selectedOutput}</strong>
+          <span>
+            {formatNumber(currentForward.reconstruction[selectedOutput]!)} versus target {formatNumber(trace.input[selectedOutput]!)}
+          </span>
+        </div>
+
+        <div className="attention-value-boundary">
+          <span>What is actually compressed?</span>
+          <p>
+            The decoder receives z only. It cannot inspect either original
+            coordinate while rebuilding the pair.
+          </p>
+        </div>
+
+        <div className="attention-next-note">
+          <span>Keep the claim small</span>
+          <p>
+            One example explains the mechanics. A useful representation needs
+            many examples to reveal a shared lower-dimensional pattern.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/BpttWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/BpttWorkbench.tsx
@@ -6,6 +6,7 @@ import {
 
 interface BpttWorkbenchProps {
   onShowForward: () => void;
+  onShowGates: () => void;
 }
 
 function formatNumber(value: number): string {
@@ -18,7 +19,7 @@ function formatNumber(value: number): string {
   return Number(value.toFixed(6)).toString();
 }
 
-export function BpttWorkbench({ onShowForward }: BpttWorkbenchProps) {
+export function BpttWorkbench({ onShowForward, onShowGates }: BpttWorkbenchProps) {
   const trace = useMemo(() => traceRecurrentBptt(), []);
   const [selectedTime, setSelectedTime] = useState(2);
   const selected = trace.backwardSteps.find((step) => step.time === selectedTime)!;
@@ -191,6 +192,9 @@ export function BpttWorkbench({ onShowForward }: BpttWorkbenchProps) {
         </p>
         <button className="bptt-view-button" type="button" onClick={onShowForward}>
           Show forward unroll
+        </button>
+        <button className="bptt-view-button" type="button" onClick={onShowGates}>
+          Compare GRU and LSTM gates
         </button>
         <div className="recurrent-selected-summary">
           <small>selected reverse step</small>

--- a/code/programs/typescript/ml-learning-visualizer/src/BpttWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/BpttWorkbench.tsx
@@ -1,0 +1,212 @@
+import { useMemo, useState } from "react";
+import {
+  DEFAULT_RECURRENT_PARAMETERS,
+  traceRecurrentBptt,
+} from "./recurrent-unroll-lab.js";
+
+interface BpttWorkbenchProps {
+  onShowForward: () => void;
+}
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  if (Math.abs(value) < 1e-6) {
+    return value.toExponential(2);
+  }
+  return Number(value.toFixed(6)).toString();
+}
+
+export function BpttWorkbench({ onShowForward }: BpttWorkbenchProps) {
+  const trace = useMemo(() => traceRecurrentBptt(), []);
+  const [selectedTime, setSelectedTime] = useState(2);
+  const selected = trace.backwardSteps.find((step) => step.time === selectedTime)!;
+  const chronologicalSteps = [...trace.backwardSteps].reverse();
+
+  return (
+    <main className="workspace workspace--bptt">
+      <section className="bptt-stage" aria-label="Backpropagation through time trace">
+        <div className="bptt-intro">
+          <div>
+            <p className="eyebrow">NN10 · sequence gradients</p>
+            <h2>Backpropagation-through-time microscope</h2>
+            <p>
+              Keep the three saved forward states, then reverse every arrow.
+              Watch later evidence reach earlier cells and add into one shared gradient.
+            </p>
+          </div>
+          <div className="bptt-loss-chip">
+            <small>final-state loss</small>
+            <strong>{formatNumber(trace.loss)}</strong>
+          </div>
+        </div>
+
+        <section className="bptt-panel" aria-label="Forward states and backward gradient lane">
+          <div className="bptt-panel-heading">
+            <div>
+              <p className="eyebrow">Forward saved · backward reversed</p>
+              <h2>One chain, two directions</h2>
+            </div>
+            <code>target = {formatNumber(trace.target)}</code>
+          </div>
+
+          <div className="bptt-forward-lane" aria-label="Saved forward states">
+            <div><small>initial</small><strong>h[-1] = 0</strong></div>
+            {trace.forward.steps.map((step) => (
+              <div key={step.time}>
+                <small>a[{step.time}] = {formatNumber(step.preactivation)}</small>
+                <strong>h[{step.time}] = {formatNumber(step.state)}</strong>
+              </div>
+            ))}
+            <div className="bptt-forward-lane__loss">
+              <small>half-squared</small>
+              <strong>L = {formatNumber(trace.loss)}</strong>
+            </div>
+          </div>
+
+          <div className="bptt-direction-label">
+            <span aria-hidden="true">←</span>
+            backward pass runs from t = 2 to t = 0
+          </div>
+          <div className="bptt-backward-lane" aria-label="Reverse-time gradient steps">
+            {trace.backwardSteps.map((step) => (
+              <button
+                aria-label={`Select backward step ${step.time}`}
+                aria-pressed={selectedTime === step.time}
+                className={selectedTime === step.time
+                  ? "bptt-step bptt-step--active"
+                  : "bptt-step"}
+                key={step.time}
+                type="button"
+                onClick={() => setSelectedTime(step.time)}
+              >
+                <small>reverse t = {step.time}</small>
+                <strong>dL/dh = {formatNumber(step.stateGradient)}</strong>
+                <span>dL/da = {formatNumber(step.preactivationGradient)}</span>
+              </button>
+            ))}
+          </div>
+
+          <div className="bptt-arithmetic" aria-label="Selected backward arithmetic">
+            <div className="bptt-arithmetic-heading">
+              <div>
+                <p className="eyebrow">Selected · reverse step {selectedTime}</p>
+                <h3>Combine incoming gradient before differentiating</h3>
+              </div>
+              <code>ReLU&apos; = {formatNumber(selected.reluDerivative)}</code>
+            </div>
+            <div className="bptt-equation">
+              <div><small>direct loss</small><strong>{formatNumber(selected.directStateGradient)}</strong></div>
+              <span>+</span>
+              <div><small>from future</small><strong>{formatNumber(selected.futureStateGradient)}</strong></div>
+              <span>=</span>
+              <div><small>dL/dh[{selectedTime}]</small><strong>{formatNumber(selected.stateGradient)}</strong></div>
+              <span>×</span>
+              <div><small>ReLU derivative</small><strong>{formatNumber(selected.reluDerivative)}</strong></div>
+              <span>=</span>
+              <div className="bptt-equation__result"><small>dL/da[{selectedTime}]</small><strong>{formatNumber(selected.preactivationGradient)}</strong></div>
+            </div>
+            <div className="bptt-local-gradients">
+              <code>ΔW_x = {formatNumber(selected.parameterContributions.inputWeight)}</code>
+              <code>ΔW_h = {formatNumber(selected.parameterContributions.recurrentWeight)}</code>
+              <code>Δb = {formatNumber(selected.parameterContributions.bias)}</code>
+              <code>to h[{selectedTime - 1}] = {formatNumber(selected.previousStateGradient)}</code>
+            </div>
+          </div>
+        </section>
+
+        <section className="bptt-panel" aria-label="Shared gradient reduction">
+          <div className="bptt-panel-heading">
+            <div>
+              <p className="eyebrow">Three executions · one parameter set</p>
+              <h2>Shared gradients add; they do not overwrite</h2>
+            </div>
+            <strong className="bptt-pass">ACCUMULATE</strong>
+          </div>
+          <div className="bptt-table-wrap">
+            <table className="bptt-table">
+              <caption>Per-time-step parameter contributions and their totals</caption>
+              <thead><tr><th scope="col">gradient</th>{chronologicalSteps.map((step) => <th scope="col" key={step.time}>t = {step.time}</th>)}<th scope="col">total</th></tr></thead>
+              <tbody>
+                <tr><th scope="row">dL/dW_x</th>{chronologicalSteps.map((step) => <td key={step.time}>{formatNumber(step.parameterContributions.inputWeight)}</td>)}<td><strong>{formatNumber(trace.gradientTotals.inputWeight)}</strong></td></tr>
+                <tr><th scope="row">dL/dW_h</th>{chronologicalSteps.map((step) => <td key={step.time}>{formatNumber(step.parameterContributions.recurrentWeight)}</td>)}<td><strong>{formatNumber(trace.gradientTotals.recurrentWeight)}</strong></td></tr>
+                <tr><th scope="row">dL/db</th>{chronologicalSteps.map((step) => <td key={step.time}>{formatNumber(step.parameterContributions.bias)}</td>)}<td><strong>{formatNumber(trace.gradientTotals.bias)}</strong></td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="bptt-initial-gradient">
+            The reverse chain continues into the explicit initial state:
+            <strong> dL/dh[-1] = {formatNumber(trace.gradientTotals.initialState)}</strong>
+          </p>
+        </section>
+
+        <section className="bptt-audit-grid" aria-label="Gradient audit and update preview">
+          <div className="bptt-panel">
+            <div className="bptt-panel-heading">
+              <div><p className="eyebrow">Independent oracle</p><h2>Finite-difference gradient check</h2></div>
+              <strong className="bptt-pass">PASS</strong>
+            </div>
+            <div className="bptt-table-wrap">
+              <table className="bptt-table">
+                <caption>Analytical and numerical gradient agreement</caption>
+                <thead><tr><th scope="col">parameter</th><th scope="col">BPTT</th><th scope="col">numerical</th><th scope="col">error</th></tr></thead>
+                <tbody>
+                  {(["inputWeight", "recurrentWeight", "bias"] as const).map((parameter) => (
+                    <tr key={parameter}>
+                      <th scope="row">{parameter === "inputWeight" ? "W_x" : parameter === "recurrentWeight" ? "W_h" : "b"}</th>
+                      <td>{formatNumber(trace.gradientTotals[parameter])}</td>
+                      <td>{formatNumber(trace.numericalGradients[parameter])}</td>
+                      <td>{formatNumber(trace.gradientErrors[parameter])}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div className="bptt-panel bptt-update-panel">
+            <p className="eyebrow">One step · learning rate 0.1</p>
+            <h2>Move against the accumulated gradient</h2>
+            <div className="bptt-loss-change">
+              <div><small>before loss</small><strong>{formatNumber(trace.loss)}</strong></div>
+              <span aria-hidden="true">→</span>
+              <div><small>after loss</small><strong>{formatNumber(trace.update.loss)}</strong></div>
+            </div>
+            <div className="bptt-parameter-update">
+              <code>W_x: {formatNumber(DEFAULT_RECURRENT_PARAMETERS.inputWeight)} → {formatNumber(trace.update.parameters.inputWeight)}</code>
+              <code>W_h: {formatNumber(DEFAULT_RECURRENT_PARAMETERS.recurrentWeight)} → {formatNumber(trace.update.parameters.recurrentWeight)}</code>
+              <code>b: {formatNumber(DEFAULT_RECURRENT_PARAMETERS.bias)} → {formatNumber(trace.update.parameters.bias)}</code>
+            </div>
+            <p>Updated states = [{trace.update.states.map(formatNumber).join(", ")}]</p>
+          </div>
+        </section>
+      </section>
+
+      <aside className="recurrent-controls bptt-controls" aria-label="BPTT microscope controls">
+        <p className="eyebrow">Forward and backward belong together</p>
+        <h2>Reverse the unroll</h2>
+        <p>
+          Select a reverse-time cell. Its future gradient was produced by the
+          cell immediately to its right in the forward graph.
+        </p>
+        <button className="bptt-view-button" type="button" onClick={onShowForward}>
+          Show forward unroll
+        </button>
+        <div className="recurrent-selected-summary">
+          <small>selected reverse step</small>
+          <strong>t = {selectedTime}</strong>
+          <span>
+            {formatNumber(selected.directStateGradient)} direct + {formatNumber(selected.futureStateGradient)} from the future.
+          </span>
+        </div>
+        <div className="recurrent-note">
+          <span>What scales next?</span>
+          <p>
+            Vectors use the same reverse walk with matrix products. GRUs and
+            LSTMs add gates, while truncated BPTT limits how far this lane runs.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/ConvolutionWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/ConvolutionWorkbench.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  DEFAULT_CONVOLUTION_KERNEL,
+  DEFAULT_CONVOLUTION_SIGNAL,
+  parseNumberList,
+  traceValidCorrelation,
+} from "./convolution-lab.js";
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(4)).toString();
+}
+
+function listText(values: readonly number[]): string {
+  return values.join(", ");
+}
+
+export function ConvolutionWorkbench() {
+  const [signalText, setSignalText] = useState(listText(DEFAULT_CONVOLUTION_SIGNAL));
+  const [kernelText, setKernelText] = useState(listText(DEFAULT_CONVOLUTION_KERNEL));
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const signal = useMemo(() => parseNumberList(signalText), [signalText]);
+  const kernel = useMemo(() => parseNumberList(kernelText), [kernelText]);
+  const error = signal === null || kernel === null
+    ? "Use comma-separated finite numbers."
+    : kernel.length > signal.length
+      ? "The kernel must fit entirely inside the signal in valid mode."
+      : null;
+  const traces = useMemo(
+    () => error === null ? traceValidCorrelation(signal!, kernel!) : [],
+    [error, kernel, signal],
+  );
+
+  useEffect(() => {
+    setSelectedIndex((current) => Math.min(current, Math.max(traces.length - 1, 0)));
+  }, [traces.length]);
+
+  const trace = traces[selectedIndex];
+  const activeEnd = trace === undefined ? -1 : trace.startIndex + trace.window.length;
+
+  function reset(): void {
+    setSignalText(listText(DEFAULT_CONVOLUTION_SIGNAL));
+    setKernelText(listText(DEFAULT_CONVOLUTION_KERNEL));
+    setSelectedIndex(0);
+  }
+
+  return (
+    <main className="workspace workspace--convolution">
+      <section className="convolution-stage" aria-label="Sliding kernel trace">
+        <div className="convolution-intro">
+          <div>
+            <p className="eyebrow">NN05 · spatial networks</p>
+            <h2>Sliding-kernel microscope</h2>
+            <p>
+              One small detector reuses the same weights at every position. Select an
+              output to expose the exact window, products, and running sum that made it.
+            </p>
+          </div>
+          <div className="convolution-mode-chip">valid · stride 1 · no flip</div>
+        </div>
+
+        {trace === undefined || signal === null || kernel === null ? (
+          <div className="convolution-error" role="alert">{error}</div>
+        ) : (
+          <>
+            <section className="kernel-slide" aria-label="Kernel over signal">
+              <div className="array-label">
+                <span>signal</span>
+                <code>{signal.length} values</code>
+              </div>
+              <div
+                className="signal-array"
+                style={{ gridTemplateColumns: `repeat(${signal.length}, minmax(48px, 1fr))` }}
+              >
+                {signal.map((value, index) => (
+                  <div
+                    className={index >= trace.startIndex && index < activeEnd
+                      ? "signal-cell signal-cell--active"
+                      : "signal-cell"}
+                    key={`${index}-${value}`}
+                  >
+                    <small>x[{index}]</small>
+                    <strong>{formatNumber(value)}</strong>
+                  </div>
+                ))}
+              </div>
+
+              <div className="array-label array-label--kernel">
+                <span>shared kernel</span>
+                <code>starts at x[{trace.startIndex}]</code>
+              </div>
+              <div
+                className="kernel-track"
+                style={{ gridTemplateColumns: `repeat(${signal.length}, minmax(48px, 1fr))` }}
+              >
+                <div
+                  className="kernel-window"
+                  style={{
+                    gridColumn: `${trace.startIndex + 1} / span ${kernel.length}`,
+                    gridTemplateColumns: `repeat(${kernel.length}, minmax(48px, 1fr))`,
+                  }}
+                >
+                  {kernel.map((value, index) => (
+                    <div className="kernel-cell" key={`${index}-${value}`}>
+                      <small>k[{index}]</small>
+                      <strong>{formatNumber(value)}</strong>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <section className="mac-panel" aria-label="Multiply accumulate trace">
+              <div className="mac-heading">
+                <div>
+                  <p className="eyebrow">Output y[{trace.outputIndex}]</p>
+                  <h2>Multiply, then accumulate</h2>
+                </div>
+                <strong className="mac-result">{formatNumber(trace.output)}</strong>
+              </div>
+              <div className="product-grid">
+                {trace.products.map((product, index) => (
+                  <div className="product-card" key={index}>
+                    <small>term {index + 1}</small>
+                    <code>
+                      {formatNumber(trace.window[index]!)} × {formatNumber(kernel[index]!)}
+                    </code>
+                    <strong>{formatNumber(product)}</strong>
+                  </div>
+                ))}
+              </div>
+              <div className="accumulator-strip" aria-label="Running accumulator">
+                {trace.accumulator.map((value, index) => (
+                  <div className="accumulator-step" key={index}>
+                    <small>{index === 0 ? "start" : `after term ${index}`}</small>
+                    <strong>{formatNumber(value)}</strong>
+                  </div>
+                ))}
+              </div>
+              <code className="expanded-equation">
+                {trace.window.map((value, index) => (
+                  `${formatNumber(value)}×${formatNumber(kernel[index]!)}`
+                )).join(" + ")} = {formatNumber(trace.output)}
+              </code>
+            </section>
+
+            <section className="output-strip" aria-label="Feature map outputs">
+              <div className="array-label">
+                <span>feature map</span>
+                <code>{signal.length} - {kernel.length} + 1 = {traces.length}</code>
+              </div>
+              <div className="output-buttons">
+                {traces.map((position) => (
+                  <button
+                    aria-label={`Select output ${position.outputIndex}`}
+                    className={position.outputIndex === selectedIndex
+                      ? "output-button output-button--active"
+                      : "output-button"}
+                    key={position.outputIndex}
+                    type="button"
+                    onClick={() => setSelectedIndex(position.outputIndex)}
+                  >
+                    <small>y[{position.outputIndex}]</small>
+                    <strong>{formatNumber(position.output)}</strong>
+                  </button>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
+      </section>
+
+      <aside className="convolution-controls" aria-label="Convolution controls">
+        <div>
+          <p className="eyebrow">Change the arithmetic</p>
+          <h2>Signal and detector</h2>
+          <p>Use an asymmetric kernel: reversing it should change the outputs.</p>
+        </div>
+        <label className="field">
+          <span>Input signal</span>
+          <input
+            aria-label="Input signal"
+            value={signalText}
+            onChange={(event) => setSignalText(event.target.value)}
+          />
+        </label>
+        <label className="field">
+          <span>Kernel weights</span>
+          <input
+            aria-label="Kernel weights"
+            value={kernelText}
+            onChange={(event) => setKernelText(event.target.value)}
+          />
+        </label>
+        <div className="button-grid">
+          <button
+            type="button"
+            disabled={selectedIndex === 0}
+            onClick={() => setSelectedIndex((index) => Math.max(index - 1, 0))}
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            disabled={selectedIndex >= traces.length - 1}
+            onClick={() => setSelectedIndex((index) => Math.min(index + 1, traces.length - 1))}
+          >
+            Next
+          </button>
+          <button type="button" onClick={reset}>Reset fixture</button>
+        </div>
+        <div className="convolution-note">
+          <span>Why “no flip”?</span>
+          <p>
+            Neural libraries usually say convolution while computing
+            cross-correlation. Kernel k[0] multiplies the leftmost value in every
+            window. The NN05 fixture makes this convention testable across languages.
+          </p>
+        </div>
+        <div className="convolution-note">
+          <span>What scales next?</span>
+          <p>
+            A trainable kernel learns these shared weights. Images add a second spatial
+            direction; channels and batches add more indexed loops, not new magic.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/ConvolutionWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/ConvolutionWorkbench.tsx
@@ -1,8 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   DEFAULT_CONVOLUTION_KERNEL,
+  DEFAULT_CONVOLUTION_LEARNING_RATE,
   DEFAULT_CONVOLUTION_SIGNAL,
+  DEFAULT_CONVOLUTION_TARGETS,
+  numericalKernelGradient,
   parseNumberList,
+  proposeConvolutionStep,
+  traceConvolutionTraining,
   traceValidCorrelation,
 } from "./convolution-lab.js";
 
@@ -20,9 +25,13 @@ function listText(values: readonly number[]): string {
 export function ConvolutionWorkbench() {
   const [signalText, setSignalText] = useState(listText(DEFAULT_CONVOLUTION_SIGNAL));
   const [kernelText, setKernelText] = useState(listText(DEFAULT_CONVOLUTION_KERNEL));
+  const [targetText, setTargetText] = useState(listText(DEFAULT_CONVOLUTION_TARGETS));
+  const [learningRate, setLearningRate] = useState(DEFAULT_CONVOLUTION_LEARNING_RATE);
+  const [trainingStep, setTrainingStep] = useState(0);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const signal = useMemo(() => parseNumberList(signalText), [signalText]);
   const kernel = useMemo(() => parseNumberList(kernelText), [kernelText]);
+  const targets = useMemo(() => parseNumberList(targetText), [targetText]);
   const error = signal === null || kernel === null
     ? "Use comma-separated finite numbers."
     : kernel.length > signal.length
@@ -32,18 +41,61 @@ export function ConvolutionWorkbench() {
     () => error === null ? traceValidCorrelation(signal!, kernel!) : [],
     [error, kernel, signal],
   );
+  const trainingError = error !== null
+    ? error
+    : targets === null
+      ? "Use comma-separated finite training targets."
+      : targets.length !== traces.length
+        ? `Valid mode produces ${traces.length} outputs, so enter ${traces.length} targets.`
+        : !Number.isFinite(learningRate) || learningRate <= 0
+          ? "The learning rate must be a positive number."
+          : null;
+  const trainingTrace = useMemo(
+    () => trainingError === null
+      ? traceConvolutionTraining(signal!, kernel!, targets!)
+      : null,
+    [kernel, signal, targets, trainingError],
+  );
+  const numericalGradient = useMemo(
+    () => trainingError === null
+      ? numericalKernelGradient(signal!, kernel!, targets!)
+      : [],
+    [kernel, signal, targets, trainingError],
+  );
+  const proposal = useMemo(
+    () => trainingError === null
+      ? proposeConvolutionStep(signal!, kernel!, targets!, learningRate)
+      : null,
+    [kernel, learningRate, signal, targets, trainingError],
+  );
+  const gradientCheckPasses = trainingTrace !== null
+    && trainingTrace.kernelGradient.every(
+      (gradient, index) => Math.abs(gradient - numericalGradient[index]!) <= 1e-7,
+    );
 
   useEffect(() => {
     setSelectedIndex((current) => Math.min(current, Math.max(traces.length - 1, 0)));
   }, [traces.length]);
 
   const trace = traces[selectedIndex];
+  const selectedContribution = trainingTrace?.contributions[selectedIndex];
   const activeEnd = trace === undefined ? -1 : trace.startIndex + trace.window.length;
 
   function reset(): void {
     setSignalText(listText(DEFAULT_CONVOLUTION_SIGNAL));
     setKernelText(listText(DEFAULT_CONVOLUTION_KERNEL));
+    setTargetText(listText(DEFAULT_CONVOLUTION_TARGETS));
+    setLearningRate(DEFAULT_CONVOLUTION_LEARNING_RATE);
+    setTrainingStep(0);
     setSelectedIndex(0);
+  }
+
+  function applyGradientStep(): void {
+    if (proposal === null) {
+      return;
+    }
+    setKernelText(listText(proposal.nextKernel));
+    setTrainingStep((step) => step + 1);
   }
 
   return (
@@ -168,6 +220,114 @@ export function ConvolutionWorkbench() {
                 ))}
               </div>
             </section>
+
+            <section className="training-panel" aria-label="Shared kernel gradient trace">
+              <div className="training-heading">
+                <div>
+                  <p className="eyebrow">NN06 · backward pass</p>
+                  <h2>Shared weights collect gradients</h2>
+                  <p>
+                    Every output sends a contribution back to each kernel weight.
+                    Columns add because the same weight was reused in every window.
+                  </p>
+                </div>
+                <div className={gradientCheckPasses
+                  ? "gradient-check-badge gradient-check-badge--pass"
+                  : "gradient-check-badge"}
+                >
+                  <small>finite difference</small>
+                  <strong>{gradientCheckPasses ? "PASS" : "CHECK"}</strong>
+                </div>
+              </div>
+
+              {trainingTrace === null || proposal === null || selectedContribution === undefined ? (
+                <div className="convolution-error" role="alert">{trainingError}</div>
+              ) : (
+                <>
+                  <div className="loss-flow" aria-label="Loss before and after proposed step">
+                    <div>
+                      <small>current MSE</small>
+                      <strong>{formatNumber(trainingTrace.loss)}</strong>
+                    </div>
+                    <span aria-hidden="true">− η∇</span>
+                    <div>
+                      <small>after proposed step</small>
+                      <strong>{formatNumber(proposal.nextLoss)}</strong>
+                    </div>
+                  </div>
+
+                  <section className="selected-gradient-path" aria-label="Selected output gradient path">
+                    <div className="mac-heading">
+                      <div>
+                        <p className="eyebrow">Selected path · y[{selectedIndex}]</p>
+                        <h3>One output sends three contributions</h3>
+                      </div>
+                      <code>
+                        dL/dy = 2/{trainingTrace.outputs.length} × {formatNumber(trainingTrace.errors[selectedIndex]!)}
+                        {" = "}{formatNumber(selectedContribution.outputGradient)}
+                      </code>
+                    </div>
+                    <div className="product-grid">
+                      {selectedContribution.kernelGradient.map((gradient, kernelIndex) => (
+                        <div className="product-card" key={kernelIndex}>
+                          <small>toward k[{kernelIndex}]</small>
+                          <code>
+                            {formatNumber(selectedContribution.outputGradient)} × {formatNumber(selectedContribution.window[kernelIndex]!)}
+                          </code>
+                          <strong>{formatNumber(gradient)}</strong>
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+
+                  <div className="gradient-table-wrap">
+                    <table className="gradient-table">
+                      <caption>Gradient contributions from every reused position</caption>
+                      <thead>
+                        <tr>
+                          <th scope="col">weight</th>
+                          {trainingTrace.contributions.map((contribution) => (
+                            <th scope="col" key={contribution.outputIndex}>
+                              y[{contribution.outputIndex}]
+                            </th>
+                          ))}
+                          <th scope="col">sum</th>
+                          <th scope="col">numeric</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {kernel.map((_, kernelIndex) => (
+                          <tr key={kernelIndex}>
+                            <th scope="row">dL/dk[{kernelIndex}]</th>
+                            {trainingTrace.contributions.map((contribution) => (
+                              <td key={contribution.outputIndex}>
+                                {formatNumber(contribution.kernelGradient[kernelIndex]!)}
+                              </td>
+                            ))}
+                            <td className="gradient-sum">
+                              {formatNumber(trainingTrace.kernelGradient[kernelIndex]!)}
+                            </td>
+                            <td>{formatNumber(numericalGradient[kernelIndex]!)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  <div className="kernel-update-grid" aria-label="Proposed kernel update">
+                    {kernel.map((value, kernelIndex) => (
+                      <div className="kernel-update" key={kernelIndex}>
+                        <small>update k[{kernelIndex}]</small>
+                        <code>
+                          {formatNumber(value)} − {formatNumber(learningRate)} × {formatNumber(trainingTrace.kernelGradient[kernelIndex]!)}
+                        </code>
+                        <strong>{formatNumber(proposal.nextKernel[kernelIndex]!)}</strong>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+            </section>
           </>
         )}
       </section>
@@ -194,6 +354,39 @@ export function ConvolutionWorkbench() {
             onChange={(event) => setKernelText(event.target.value)}
           />
         </label>
+        <div className="convolution-training-controls">
+          <div className="history__topline">
+            <span>Train shared weights</span>
+            <strong>step {trainingStep}</strong>
+          </div>
+          <label className="field">
+            <span>Training targets</span>
+            <input
+              aria-label="Training targets"
+              value={targetText}
+              onChange={(event) => setTargetText(event.target.value)}
+            />
+          </label>
+          <label className="field">
+            <span>Learning rate</span>
+            <input
+              aria-label="Convolution learning rate"
+              min="0.0001"
+              step="0.001"
+              type="number"
+              value={learningRate}
+              onChange={(event) => setLearningRate(Number(event.target.value))}
+            />
+          </label>
+          <button
+            className="training-step-button"
+            disabled={proposal === null}
+            type="button"
+            onClick={applyGradientStep}
+          >
+            Apply gradient step
+          </button>
+        </div>
         <div className="button-grid">
           <button
             type="button"
@@ -222,8 +415,9 @@ export function ConvolutionWorkbench() {
         <div className="convolution-note">
           <span>What scales next?</span>
           <p>
-            A trainable kernel learns these shared weights. Images add a second spatial
-            direction; channels and batches add more indexed loops, not new magic.
+            Images add a second spatial direction; channels and batches add more
+            indexed loops. The same shared-gradient reduction still happens for every
+            trainable filter.
           </p>
         </div>
       </aside>

--- a/code/programs/typescript/ml-learning-visualizer/src/DecoderTrainingWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/DecoderTrainingWorkbench.tsx
@@ -1,0 +1,292 @@
+import { useMemo, useState } from "react";
+import {
+  DEFAULT_DECODER_BIAS,
+  DEFAULT_DECODER_UNEMBEDDING,
+  decoderTrainingRow,
+  traceTinyDecoderTraining,
+} from "./decoder-language-model-lab.js";
+
+interface DecoderTrainingWorkbenchProps {
+  onShowMultiHead: () => void;
+}
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(6)).toString();
+}
+
+function formatVector(values: readonly number[]): string {
+  return `[${values.map(formatNumber).join(", ")}]`;
+}
+
+function formatMatrix(values: readonly (readonly number[])[]): string {
+  return values.map(formatVector).join("  ");
+}
+
+export function DecoderTrainingWorkbench({
+  onShowMultiHead,
+}: DecoderTrainingWorkbenchProps) {
+  const trace = useMemo(() => traceTinyDecoderTraining(), []);
+  const [position, setPosition] = useState(1);
+  const [showUpdated, setShowUpdated] = useState(false);
+  const selected = decoderTrainingRow(trace, position);
+  const current = showUpdated ? trace.postUpdateRows[position]! : selected;
+
+  return (
+    <main className="workspace workspace--decoder">
+      <section className="decoder-stage" aria-label="Tiny decoder language model training trace">
+        <div className="decoder-intro">
+          <div>
+            <p className="eyebrow">NN15 - a complete next-token learning step</p>
+            <h2>Tiny decoder training trace</h2>
+            <p>
+              Shift one sequence into two causal predictions, turn saved decoder
+              states into vocabulary probabilities, then follow the shared error
+              through cross-entropy and one loss-reducing SGD update.
+            </p>
+          </div>
+          <div className="decoder-chip">3-token vocabulary - 2 positions</div>
+        </div>
+
+        <section className="decoder-shift-panel" aria-label="Causal next-token sequence shift">
+          <div className="decoder-heading">
+            <div>
+              <p className="eyebrow">One sequence - shifted by one</p>
+              <h2>Prefixes predict what comes next</h2>
+            </div>
+            <code>red blue purple</code>
+          </div>
+          <div className="decoder-position-lanes">
+            {trace.rows.map((row) => (
+              <button
+                aria-label={`Select position ${row.position}: ${row.causalPrefix.join(" ")} predicts ${row.targetToken}`}
+                aria-pressed={position === row.position}
+                className="decoder-position-button"
+                key={row.position}
+                type="button"
+                onClick={() => setPosition(row.position)}
+              >
+                <span>position {row.position}</span>
+                <strong>{row.causalPrefix.join(" ")}</strong>
+                <i aria-hidden="true">-&gt;</i>
+                <strong>{row.targetToken}</strong>
+                <small>future target stays outside the prefix</small>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="decoder-prediction-panel" aria-label={`Selected decoder prediction at position ${position}`}>
+          <div className="decoder-heading">
+            <div>
+              <p className="eyebrow">Selected - position {position}</p>
+              <h2>{showUpdated ? "Rerun the updated head" : "State to target surprise"}</h2>
+            </div>
+            <div className="decoder-loss-badge">
+              <small>position loss</small>
+              <strong>{formatNumber(current.loss)}</strong>
+            </div>
+          </div>
+
+          <div className="decoder-forward-flow">
+            <div className="decoder-state-node">
+              <small>saved causal state</small>
+              <strong>h_{selected.inputToken}</strong>
+              <code>{formatVector(selected.decoderState)}</code>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div className="decoder-logit-node">
+              <small>{showUpdated ? "updated logits" : "shared head logits"}</small>
+              <code>{formatVector(current.logits)}</code>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div className="decoder-probability-node">
+              <small>stable softmax</small>
+              <code>{formatVector(current.probabilities)}</code>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div className="decoder-target-node">
+              <small>target probability</small>
+              <strong>P({selected.targetToken}) = {formatNumber(current.targetProbability)}</strong>
+              <code>-ln(P) = {formatNumber(current.loss)}</code>
+            </div>
+          </div>
+
+          <div className="decoder-vocabulary-grid" role="list" aria-label="Vocabulary probability distribution">
+            {trace.vocabulary.map((token, vocabularyIndex) => {
+              const probability = current.probabilities[vocabularyIndex]!;
+              const isTarget = vocabularyIndex === selected.targetIndex;
+              return (
+                <div
+                  className={isTarget ? "decoder-vocabulary-row decoder-vocabulary-row--target" : "decoder-vocabulary-row"}
+                  key={token}
+                  role="listitem"
+                >
+                  <div>
+                    <span>{token}{isTarget ? " - target" : ""}</span>
+                    <strong>{formatNumber(probability)}</strong>
+                  </div>
+                  <i aria-hidden="true" style={{ width: `${probability * 100}%` }} />
+                  {!showUpdated ? (
+                    <code>
+                      {formatNumber(selected.logitProducts[vocabularyIndex]![0]!)} + {formatNumber(selected.logitProducts[vocabularyIndex]![1]!)} + bias = {formatNumber(selected.logits[vocabularyIndex]!)}
+                    </code>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+
+          {!showUpdated ? (
+            <div className="decoder-softmax-trace" aria-label="Stable softmax arithmetic">
+              <div><small>row max</small><code>{formatNumber(selected.rowMax)}</code></div>
+              <div><small>shift logits</small><code>{formatVector(selected.shiftedLogits)}</code></div>
+              <div><small>exponentials</small><code>{formatVector(selected.exponentials)}</code></div>
+              <div><small>denominator</small><code>{formatNumber(selected.denominator)}</code></div>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="decoder-gradient-panel" aria-label="Decoder loss gradient trace">
+          <div className="decoder-heading">
+            <div>
+              <p className="eyebrow">Probability minus target - divided by two</p>
+              <h2>Error flows back through the shared head</h2>
+            </div>
+            <code>(p - one_hot) / positions</code>
+          </div>
+          <div className="decoder-gradient-flow">
+            <div>
+              <small>logit gradient</small>
+              <code>{formatVector(selected.logitGradients)}</code>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div>
+              <small>this position's unembedding contribution</small>
+              <code>{formatMatrix(selected.unembeddingGradientContribution)}</code>
+            </div>
+            <span aria-hidden="true">+</span>
+            <div>
+              <small>bias contribution</small>
+              <code>{formatVector(selected.biasGradientContribution)}</code>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div className="decoder-state-gradient">
+              <small>gradient entering decoder body</small>
+              <code>{formatVector(selected.stateGradient)}</code>
+            </div>
+          </div>
+        </section>
+
+        <section className="decoder-update-panel" aria-label="Shared decoder head SGD update">
+          <div className="decoder-heading">
+            <div>
+              <p className="eyebrow">Both positions reduce into one update</p>
+              <h2>Shared-head SGD checkpoint</h2>
+            </div>
+            <code>parameter - {trace.learningRate} x gradient</code>
+          </div>
+          <div className="decoder-update-grid">
+            <div>
+              <small>unembedding before</small>
+              <code>{formatMatrix(DEFAULT_DECODER_UNEMBEDDING)}</code>
+            </div>
+            <div>
+              <small>reduced gradient</small>
+              <code>{formatMatrix(trace.unembeddingGradient)}</code>
+            </div>
+            <div>
+              <small>unembedding after</small>
+              <code>{formatMatrix(trace.updatedUnembedding)}</code>
+            </div>
+            <div>
+              <small>bias before</small>
+              <code>{formatVector(DEFAULT_DECODER_BIAS)}</code>
+            </div>
+            <div>
+              <small>bias gradient</small>
+              <code>{formatVector(trace.biasGradient)}</code>
+            </div>
+            <div>
+              <small>bias after</small>
+              <code>{formatVector(trace.updatedBias)}</code>
+            </div>
+          </div>
+          <div className="decoder-gradient-audit">
+            <span>Central finite-difference audit</span>
+            <code>epsilon = {trace.gradientCheck.epsilon}</code>
+            <strong>max error {trace.gradientCheck.maxAbsoluteError.toExponential(3)}</strong>
+          </div>
+          <div className="decoder-loss-drop">
+            <div><small>mean loss before</small><strong>{formatNumber(trace.meanLoss)}</strong></div>
+            <span aria-hidden="true">-&gt;</span>
+            <div><small>mean loss after one step</small><strong>{formatNumber(trace.postUpdateMeanLoss)}</strong></div>
+            <p>Both target probabilities rise; the deterministic objective falls.</p>
+          </div>
+        </section>
+      </section>
+
+      <aside className="decoder-controls" aria-label="Tiny decoder training controls">
+        <p className="eyebrow">Inspect one prediction</p>
+        <h2>Training controls</h2>
+        <p>
+          The causal prefixes and saved states do not change. The toggle swaps
+          only the shared vocabulary head before and after its one SGD step.
+        </p>
+
+        <button className="attention-back-button" type="button" onClick={onShowMultiHead}>
+          Return to multi-head block
+        </button>
+
+        <div className="attention-query-buttons" aria-label="Decoder position selection">
+          {trace.rows.map((row) => (
+            <button
+              aria-pressed={position === row.position}
+              key={row.position}
+              type="button"
+              onClick={() => setPosition(row.position)}
+            >
+              position {row.position}
+            </button>
+          ))}
+        </div>
+
+        <label className="attention-scale-control">
+          <input
+            type="checkbox"
+            checked={showUpdated}
+            onChange={(event) => setShowUpdated(event.target.checked)}
+          />
+          <span>
+            <strong>Use updated vocabulary head</strong>
+            <small>Rerun logits and loss after one SGD step.</small>
+          </span>
+        </label>
+
+        <div className="attention-selected-summary">
+          <small>selected target</small>
+          <strong>{selected.targetToken}</strong>
+          <span>{selected.causalPrefix.join(" ")} -&gt; {selected.targetToken}</span>
+        </div>
+
+        <div className="attention-value-boundary">
+          <span>Frozen on purpose</span>
+          <p>
+            This first trace updates unembedding and bias. The state gradient is
+            preserved for a later full-decoder autograd pass.
+          </p>
+        </div>
+
+        <div className="attention-next-note">
+          <span>What scales next?</span>
+          <p>
+            Add token sampling and a generation trace, then continue the saved
+            state gradients through every decoder-block parameter.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/DeepTrainingWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/DeepTrainingWorkbench.tsx
@@ -1,0 +1,16 @@
+import { useState } from "react";
+import { GradientFlowWorkbench } from "./GradientFlowWorkbench.js";
+import { InitializationWorkbench } from "./InitializationWorkbench.js";
+
+export function DeepTrainingWorkbench() {
+  const [lab, setLab] = useState<"initialization" | "gradient-flow">("initialization");
+  return (
+    <div className="deep-training-workbench">
+      <nav className="deep-training-switch" aria-label="Deep training learning lab">
+        <button aria-pressed={lab === "initialization"} type="button" onClick={() => setLab("initialization")}>Initialization</button>
+        <button aria-pressed={lab === "gradient-flow"} type="button" onClick={() => setLab("gradient-flow")}>Gradient flow</button>
+      </nav>
+      {lab === "initialization" ? <InitializationWorkbench /> : <GradientFlowWorkbench />}
+    </div>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/DeepTrainingWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/DeepTrainingWorkbench.tsx
@@ -1,16 +1,22 @@
 import { useState } from "react";
 import { GradientFlowWorkbench } from "./GradientFlowWorkbench.js";
 import { InitializationWorkbench } from "./InitializationWorkbench.js";
+import { TrainingStabilizersWorkbench } from "./TrainingStabilizersWorkbench.js";
 
 export function DeepTrainingWorkbench() {
-  const [lab, setLab] = useState<"initialization" | "gradient-flow">("initialization");
+  const [lab, setLab] = useState<"initialization" | "gradient-flow" | "stabilizers">("initialization");
   return (
     <div className="deep-training-workbench">
       <nav className="deep-training-switch" aria-label="Deep training learning lab">
         <button aria-pressed={lab === "initialization"} type="button" onClick={() => setLab("initialization")}>Initialization</button>
         <button aria-pressed={lab === "gradient-flow"} type="button" onClick={() => setLab("gradient-flow")}>Gradient flow</button>
+        <button aria-pressed={lab === "stabilizers"} type="button" onClick={() => setLab("stabilizers")}>Stabilizers</button>
       </nav>
-      {lab === "initialization" ? <InitializationWorkbench /> : <GradientFlowWorkbench />}
+      {lab === "initialization"
+        ? <InitializationWorkbench />
+        : lab === "gradient-flow"
+          ? <GradientFlowWorkbench />
+          : <TrainingStabilizersWorkbench />}
     </div>
   );
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/DiffusionWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/DiffusionWorkbench.tsx
@@ -1,0 +1,263 @@
+import { useMemo, useState } from "react";
+import { traceOneDimensionalDiffusion } from "./diffusion-lab.js";
+
+type DiffusionPhase =
+  | "clean"
+  | "forward1"
+  | "forward2"
+  | "learn"
+  | "reverse2"
+  | "reverse1";
+
+const PHASES: Array<{
+  value: DiffusionPhase;
+  shortLabel: string;
+  label: string;
+}> = [
+  { value: "clean", shortLabel: "0. Data", label: "Clean sample" },
+  { value: "forward1", shortLabel: "1. Forward", label: "Noise level 1" },
+  { value: "forward2", shortLabel: "2. Forward", label: "Noise level 2" },
+  { value: "learn", shortLabel: "3. Learn", label: "Predict saved noise" },
+  { value: "reverse2", shortLabel: "4. Reverse", label: "Denoise step 2" },
+  { value: "reverse1", shortLabel: "5. Reverse", label: "Denoise step 1" },
+];
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(8)).toString();
+}
+
+export function DiffusionWorkbench() {
+  const [phase, setPhase] = useState<DiffusionPhase>("clean");
+  const trace = useMemo(() => traceOneDimensionalDiffusion(), []);
+  const phaseIndex = PHASES.findIndex((candidate) => candidate.value === phase);
+  const showLearned = phaseIndex >= 3;
+  const predictionRows = showLearned
+    ? trace.postUpdateDenoising
+    : trace.initialDenoising;
+  const predictionLoss = showLearned
+    ? trace.postUpdateMeanLoss
+    : trace.initialMeanLoss;
+  const parameters = showLearned ? trace.updatedDenoiser : trace.denoiser;
+  const reverseTwoVisible = phaseIndex >= 4;
+  const reverseOneVisible = phaseIndex >= 5;
+  const selectedValue = phase === "clean"
+    ? trace.cleanSample
+    : phase === "forward1"
+      ? trace.forwardSteps[0]!.noisySample
+      : phase === "reverse2"
+        ? trace.reverseSteps[0]!.outputMean
+        : phase === "reverse1"
+          ? trace.finalReconstruction
+          : trace.forwardSteps[1]!.noisySample;
+
+  return (
+    <main className="workspace workspace--diffusion">
+      <section className="diffusion-stage" aria-label="One-dimensional diffusion trace">
+        <div className="diffusion-intro">
+          <div>
+            <p className="eyebrow">NN19 - add known noise, then learn to remove it</p>
+            <h2>One clean number through a diffusion round trip</h2>
+            <p>
+              Trade signal for one saved noise value at two known levels,
+              train a timestep-aware predictor, and follow its deterministic
+              reverse mean back toward the data.
+            </p>
+          </div>
+          <div className="diffusion-chip">x0 -&gt; x1 -&gt; x2 -&gt; mean1 -&gt; mean0</div>
+        </div>
+
+        <section className="diffusion-forward-panel" aria-label="Diffusion forward noise schedule">
+          <div className="diffusion-heading">
+            <div>
+              <p className="eyebrow">One epsilon, two comparable noise levels</p>
+              <h2>Signal shrinks while noise grows</h2>
+            </div>
+            <code>saved epsilon = {formatNumber(trace.savedNoise)}</code>
+          </div>
+          <div className="diffusion-forward-lane">
+            <div className={phase === "clean" ? "diffusion-state diffusion-state--active" : "diffusion-state"}>
+              <small>clean data</small>
+              <strong>x0 = {formatNumber(trace.cleanSample)}</strong>
+              <span>100% signal</span>
+            </div>
+            {trace.forwardSteps.map((step, index) => (
+              <div className="diffusion-forward-hop" key={step.t}>
+                <span aria-hidden="true">+ noise</span>
+                <div className={phase === `forward${step.t}` ? "diffusion-state diffusion-state--active diffusion-state--noisy" : "diffusion-state diffusion-state--noisy"}>
+                  <small>noise level {step.t}</small>
+                  <code>
+                    {formatNumber(step.signalScale)} x {formatNumber(trace.cleanSample)} + {formatNumber(step.noiseScale)} x ({formatNumber(trace.savedNoise)})
+                  </code>
+                  <strong>x{step.t} = {formatNumber(step.noisySample)}</strong>
+                  <span>alpha_bar = {formatNumber(step.alphaBar)}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="diffusion-coefficient-grid">
+            {trace.forwardSteps.map((step) => (
+              <div key={step.t}>
+                <small>level {step.t} contributions</small>
+                <code>signal {formatNumber(step.signalContribution)}</code>
+                <code>noise {formatNumber(step.noiseContribution)}</code>
+                <strong>{formatNumber(step.signalContribution)} + {formatNumber(step.noiseContribution)} = {formatNumber(step.noisySample)}</strong>
+              </div>
+            ))}
+          </div>
+          <p className="diffusion-forward-note">
+            Each row samples directly from x0 with the same saved epsilon. That
+            makes coefficient changes comparable; it is not one Markov noise path.
+          </p>
+        </section>
+
+        <section className="diffusion-predict-panel" aria-label="Diffusion noise prediction objective">
+          <div className="diffusion-heading">
+            <div>
+              <p className="eyebrow">The model predicts corruption, not x0 directly</p>
+              <h2>Condition the denoiser on sample and timestep</h2>
+            </div>
+            <div className="diffusion-loss-badge">
+              <small>{showLearned ? "mean loss after SGD" : "initial mean loss"}</small>
+              <strong>{formatNumber(predictionLoss)}</strong>
+            </div>
+          </div>
+          <div className="diffusion-equation">
+            <code>
+              epsilon_hat = {formatNumber(parameters.sampleWeight)} x x_t + {formatNumber(parameters.timestepWeight)} x normalized_t + {formatNumber(parameters.bias)}
+            </code>
+          </div>
+          <div className="diffusion-prediction-grid">
+            {predictionRows.map((row) => (
+              <div key={row.t}>
+                <small>level {row.t}, normalized t = {formatNumber(row.normalizedT)}</small>
+                <code>input x{row.t} = {formatNumber(row.noisySample)}</code>
+                <strong>predicted {formatNumber(row.predictedNoise)}</strong>
+                <span>target {formatNumber(row.targetNoise)}</span>
+                <span>half-squared loss {formatNumber(row.loss)}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="diffusion-gradient-panel" aria-label="Diffusion denoiser gradient and update">
+          <div className="diffusion-heading">
+            <div>
+              <p className="eyebrow">Both timesteps train one shared denoiser</p>
+              <h2>Add row contributions, audit, then update</h2>
+            </div>
+            <code>parameter - {formatNumber(trace.learningRate)} x gradient</code>
+          </div>
+          <div className="diffusion-gradient-rows">
+            {trace.backward.perStep.map((row) => (
+              <div key={row.t}>
+                <small>level {row.t}</small>
+                <code>dL / d prediction = {formatNumber(row.predictionGradient)}</code>
+                <span>sample-w route {formatNumber(row.sampleWeightContribution)}</span>
+                <span>time-w route {formatNumber(row.timestepWeightContribution)}</span>
+                <span>bias route {formatNumber(row.biasContribution)}</span>
+              </div>
+            ))}
+          </div>
+          <div className="diffusion-gradient-sum">
+            <div><small>sample weight gradient</small><strong>{formatNumber(trace.backward.sampleWeightGradient)}</strong></div>
+            <div><small>timestep weight gradient</small><strong>{formatNumber(trace.backward.timestepWeightGradient)}</strong></div>
+            <div><small>bias gradient</small><strong>{formatNumber(trace.backward.biasGradient)}</strong></div>
+          </div>
+          <div className="diffusion-update-row">
+            <div>
+              <small>parameters before -&gt; after</small>
+              <code>sample w {formatNumber(trace.denoiser.sampleWeight)} -&gt; {formatNumber(trace.updatedDenoiser.sampleWeight)}</code>
+              <code>time w {formatNumber(trace.denoiser.timestepWeight)} -&gt; {formatNumber(trace.updatedDenoiser.timestepWeight)}</code>
+              <code>bias {formatNumber(trace.denoiser.bias)} -&gt; {formatNumber(trace.updatedDenoiser.bias)}</code>
+            </div>
+            <div>
+              <small>central finite-difference audit</small>
+              <strong>3 parameters</strong>
+              <code>max error {trace.gradientCheck.maxAbsoluteError.toExponential(3)}</code>
+            </div>
+            <div className="diffusion-loss-drop">
+              <small>same two rows rerun</small>
+              <strong>{formatNumber(trace.initialMeanLoss)} -&gt; {formatNumber(trace.postUpdateMeanLoss)}</strong>
+              <span>noise prediction improves</span>
+            </div>
+          </div>
+        </section>
+
+        <section className="diffusion-reverse-panel" aria-label="Diffusion deterministic reverse mean path">
+          <div className="diffusion-heading">
+            <div>
+              <p className="eyebrow">Subtract predicted noise one level at a time</p>
+              <h2>Run the updated model backward</h2>
+            </div>
+            <code>no fresh reverse noise in this audit</code>
+          </div>
+          <div className="diffusion-reverse-lane">
+            <div className="diffusion-state diffusion-state--noisy">
+              <small>start at noisiest sample</small>
+              <strong>x2 = {formatNumber(trace.forwardSteps[1]!.noisySample)}</strong>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div className={phase === "reverse2" ? "diffusion-reverse-step diffusion-reverse-step--active" : "diffusion-reverse-step"}>
+              <small>reverse t = 2</small>
+              {reverseTwoVisible ? (
+                <>
+                  <code>{formatNumber(trace.reverseSteps[0]!.inputSample)} - ({formatNumber(trace.reverseSteps[0]!.scaledNoiseCorrection)})</code>
+                  <strong>mean1 = {formatNumber(trace.reverseSteps[0]!.outputMean)}</strong>
+                  <span>predicted noise {formatNumber(trace.reverseSteps[0]!.predictedNoise)}</span>
+                </>
+              ) : <strong>?</strong>}
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div className={phase === "reverse1" ? "diffusion-reverse-step diffusion-reverse-step--active" : "diffusion-reverse-step"}>
+              <small>reverse t = 1</small>
+              {reverseOneVisible ? (
+                <>
+                  <code>{formatNumber(trace.reverseSteps[1]!.inputSample)} - ({formatNumber(trace.reverseSteps[1]!.scaledNoiseCorrection)})</code>
+                  <strong>mean0 = {formatNumber(trace.finalReconstruction)}</strong>
+                  <span>predicted noise {formatNumber(trace.reverseSteps[1]!.predictedNoise)}</span>
+                </>
+              ) : <strong>?</strong>}
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div className="diffusion-final-state">
+              <small>reconstructed clean sample</small>
+              <strong>{reverseOneVisible ? formatNumber(trace.finalReconstruction) : "?"}</strong>
+              <span>{reverseOneVisible ? `absolute error ${formatNumber(trace.finalAbsoluteError)}` : "finish both reverse means"}</span>
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <aside className="diffusion-controls" aria-label="Diffusion phase controls">
+        <p className="eyebrow">Round-trip schedule</p>
+        <h2>Advance the process</h2>
+        <p>
+          Forward levels share saved noise. Reverse levels reuse the learned
+          denoiser but feed each generated mean into the next step.
+        </p>
+        <div className="diffusion-phase-buttons">
+          {PHASES.map((candidate) => (
+            <button
+              key={candidate.value}
+              type="button"
+              aria-pressed={phase === candidate.value}
+              onClick={() => setPhase(candidate.value)}
+            >
+              <span>{candidate.shortLabel}</span>
+              <strong>{candidate.label}</strong>
+            </button>
+          ))}
+        </div>
+        <div className="diffusion-selected-summary">
+          <small>selected state</small>
+          <strong>{PHASES[phaseIndex]!.label}</strong>
+          <span>visible scalar = {formatNumber(selectedValue)}</span>
+          <span>{showLearned ? "updated denoiser" : "initial denoiser"}</span>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/GanWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/GanWorkbench.tsx
@@ -1,0 +1,275 @@
+import { useMemo, useState } from "react";
+import {
+  traceOneDimensionalGan,
+  type GanState,
+} from "./gan-lab.js";
+
+type GanPhase = "initial" | "discriminator" | "generator";
+
+const PHASES: Array<{ value: GanPhase; label: string; shortLabel: string }> = [
+  { value: "initial", label: "Before training", shortLabel: "0. Forward" },
+  {
+    value: "discriminator",
+    label: "Discriminator moves",
+    shortLabel: "1. Critic",
+  },
+  {
+    value: "generator",
+    label: "Generator responds",
+    shortLabel: "2. Maker",
+  },
+];
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(8)).toString();
+}
+
+function phaseDescription(phase: GanPhase): string {
+  if (phase === "discriminator") {
+    return "The fake sample is detached. Only the discriminator can move.";
+  }
+  if (phase === "generator") {
+    return "The updated discriminator is frozen. Its input gradient teaches the generator.";
+  }
+  return "Both players make predictions, but neither has moved yet.";
+}
+
+function SampleNumberLine({ state, realSample }: { state: GanState; realSample: number }) {
+  const position = (value: number) => `${Math.max(3, Math.min(97, value * 72 + 12))}%`;
+  return (
+    <div className="gan-number-line" aria-label="GAN sample number line">
+      <div className="gan-number-line__axis" aria-hidden="true">
+        <span>0</span><span>0.5</span><span>1</span>
+      </div>
+      <div
+        className="gan-number-line__marker gan-number-line__marker--fake"
+        style={{ left: position(state.fakeSample) }}
+      >
+        <strong>fake {formatNumber(state.fakeSample)}</strong>
+        <small>G(noise)</small>
+      </div>
+      <div
+        className="gan-number-line__marker gan-number-line__marker--real"
+        style={{ left: position(realSample) }}
+      >
+        <strong>real {formatNumber(realSample)}</strong>
+        <small>data</small>
+      </div>
+    </div>
+  );
+}
+
+export function GanWorkbench() {
+  const [phase, setPhase] = useState<GanPhase>("initial");
+  const trace = useMemo(() => traceOneDimensionalGan(), []);
+  const state = phase === "initial"
+    ? trace.initial
+    : phase === "discriminator"
+      ? trace.discriminatorStep.state
+      : trace.generatorStep.state;
+  const discriminator = phase === "initial"
+    ? trace.parameters.discriminator
+    : trace.discriminatorStep.updatedParameters;
+  const generator = phase === "generator"
+    ? trace.generatorStep.updatedParameters
+    : trace.parameters.generator;
+
+  return (
+    <main className="workspace workspace--gan">
+      <section className="gan-stage" aria-label="One-dimensional GAN game trace">
+        <div className="gan-intro">
+          <div>
+            <p className="eyebrow">NN18 - two losses, two turns, one game</p>
+            <h2>A generator and discriminator on one number line</h2>
+            <p>
+              The critic learns to separate one real point from one generated
+              point. Then the maker follows the frozen critic&apos;s slope toward a
+              more convincing sample.
+            </p>
+          </div>
+          <div className="gan-chip">D moves -&gt; freeze D -&gt; G moves</div>
+        </div>
+
+        <section className="gan-sample-panel" aria-label="GAN samples and discriminator probabilities">
+          <div className="gan-heading">
+            <div>
+              <p className="eyebrow">Same saved noise through every phase</p>
+              <h2>Watch the fake sample move toward the data</h2>
+            </div>
+            <code>{phaseDescription(phase)}</code>
+          </div>
+          <SampleNumberLine state={state} realSample={trace.realSample} />
+          <div className="gan-probability-grid">
+            <div>
+              <small>critic on real</small>
+              <code>sigmoid({formatNumber(state.realLogit)})</code>
+              <strong>{formatNumber(state.realProbability)}</strong>
+            </div>
+            <div>
+              <small>critic on fake</small>
+              <code>sigmoid({formatNumber(state.fakeLogit)})</code>
+              <strong>{formatNumber(state.fakeProbability)}</strong>
+            </div>
+            <div>
+              <small>generator equation</small>
+              <code>
+                {formatNumber(trace.savedNoise)} x {formatNumber(generator.weight)} + {formatNumber(generator.bias)}
+              </code>
+              <strong>{formatNumber(state.fakeSample)}</strong>
+            </div>
+          </div>
+        </section>
+
+        <section className="gan-objective-panel" aria-label="GAN competing objectives">
+          <div className="gan-heading">
+            <div>
+              <p className="eyebrow">The players do not minimize one shared loss</p>
+              <h2>Judge correctly; fool the judge</h2>
+            </div>
+            <code>non-saturating generator objective</code>
+          </div>
+          <div className="gan-objectives">
+            <div className={phase === "discriminator" ? "gan-player gan-player--active" : "gan-player"}>
+              <small>discriminator minimizes</small>
+              <code>-0.5 x [log D(real) + log(1 - D(fake))]</code>
+              <strong>D loss {formatNumber(state.discriminatorLoss)}</strong>
+              <span>real label 1, fake label 0</span>
+            </div>
+            <div className="gan-versus" aria-hidden="true">vs</div>
+            <div className={phase === "generator" ? "gan-player gan-player--active gan-player--generator" : "gan-player gan-player--generator"}>
+              <small>generator minimizes</small>
+              <code>-log D(G(noise))</code>
+              <strong>G loss {formatNumber(state.generatorLoss)}</strong>
+              <span>make the fake receive label 1</span>
+            </div>
+          </div>
+        </section>
+
+        <section className="gan-gradient-panel" aria-label="GAN active gradient route">
+          <div className="gan-heading">
+            <div>
+              <p className="eyebrow">Only one parameter set moves per turn</p>
+              <h2>{phase === "generator" ? "The critic becomes a teaching signal" : phase === "discriminator" ? "The generated value is detached" : "Choose a move to reveal its gradient"}</h2>
+            </div>
+            <code>{phase === "initial" ? "forward pass only" : "active route highlighted"}</code>
+          </div>
+          {phase === "initial" ? (
+            <div className="gan-gradient-placeholder">
+              Start with two sigmoid scores. The turn buttons expose which
+              edges carry gradients and which parameter set stays frozen.
+            </div>
+          ) : phase === "discriminator" ? (
+            <div className="gan-gradient-route">
+              <div>
+                <small>real-logit route</small>
+                <code>0.5 x (D(real) - 1)</code>
+                <strong>{formatNumber(trace.discriminatorStep.backward.realLogitGradient)}</strong>
+              </div>
+              <span aria-hidden="true">+</span>
+              <div>
+                <small>fake-logit route</small>
+                <code>0.5 x D(fake)</code>
+                <strong>{formatNumber(trace.discriminatorStep.backward.fakeLogitGradient)}</strong>
+              </div>
+              <span aria-hidden="true">-&gt;</span>
+              <div className="gan-gradient-route__result">
+                <small>D weight / bias gradient</small>
+                <strong>
+                  {formatNumber(trace.discriminatorStep.backward.weightGradient)} / {formatNumber(trace.discriminatorStep.backward.biasGradient)}
+                </strong>
+                <span>gradient into fake = 0 (detached)</span>
+              </div>
+            </div>
+          ) : (
+            <div className="gan-gradient-route">
+              <div>
+                <small>G loss to fake logit</small>
+                <code>D(fake) - 1</code>
+                <strong>{formatNumber(trace.generatorStep.backward.fakeLogitGradient)}</strong>
+              </div>
+              <span aria-hidden="true">x</span>
+              <div>
+                <small>frozen D input slope</small>
+                <code>D weight = {formatNumber(discriminator.weight)}</code>
+                <strong>{formatNumber(trace.generatorStep.backward.fakeSampleGradient)}</strong>
+              </div>
+              <span aria-hidden="true">-&gt;</span>
+              <div className="gan-gradient-route__result gan-gradient-route__result--generator">
+                <small>G weight / bias gradient</small>
+                <strong>
+                  {formatNumber(trace.generatorStep.backward.weightGradient)} / {formatNumber(trace.generatorStep.backward.biasGradient)}
+                </strong>
+                <span>D parameters stay frozen</span>
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="gan-update-panel" aria-label="GAN alternating updates and gradient audits">
+          <div className="gan-heading">
+            <div>
+              <p className="eyebrow">Audit each player against its own objective</p>
+              <h2>The losses push back after alternating moves</h2>
+            </div>
+            <code>central difference epsilon = 1e-6</code>
+          </div>
+          <div className="gan-update-grid">
+            <div>
+              <small>discriminator update</small>
+              <code>w {formatNumber(trace.parameters.discriminator.weight)} -&gt; {formatNumber(trace.discriminatorStep.updatedParameters.weight)}</code>
+              <code>b {formatNumber(trace.parameters.discriminator.bias)} -&gt; {formatNumber(trace.discriminatorStep.updatedParameters.bias)}</code>
+              <strong>D loss {formatNumber(trace.initial.discriminatorLoss)} -&gt; {formatNumber(trace.discriminatorStep.state.discriminatorLoss)}</strong>
+              <span>max audit error {trace.discriminatorStep.gradientCheck.maxAbsoluteError.toExponential(3)}</span>
+            </div>
+            <div>
+              <small>generator counter-move</small>
+              <code>w {formatNumber(trace.parameters.generator.weight)} -&gt; {formatNumber(trace.generatorStep.updatedParameters.weight)}</code>
+              <code>b {formatNumber(trace.parameters.generator.bias)} -&gt; {formatNumber(trace.generatorStep.updatedParameters.bias)}</code>
+              <strong>G loss {formatNumber(trace.discriminatorStep.state.generatorLoss)} -&gt; {formatNumber(trace.generatorStep.state.generatorLoss)}</strong>
+              <span>max audit error {trace.generatorStep.gradientCheck.maxAbsoluteError.toExponential(3)}</span>
+            </div>
+          </div>
+          <div className="gan-counterpush">
+            <strong>After G moves, D loss rises to {formatNumber(trace.generatorStep.state.discriminatorLoss)}.</strong>
+            <p>That is the game working: the newly improved fake is harder for the frozen critic.</p>
+          </div>
+        </section>
+      </section>
+
+      <aside className="gan-controls" aria-label="GAN game phase controls">
+        <p className="eyebrow">Alternating schedule</p>
+        <h2>Advance one turn</h2>
+        <p>
+          These are snapshots of one deterministic round, not three independent
+          experiments.
+        </p>
+        <div className="gan-phase-buttons">
+          {PHASES.map((candidate) => (
+            <button
+              key={candidate.value}
+              type="button"
+              aria-pressed={phase === candidate.value}
+              onClick={() => setPhase(candidate.value)}
+            >
+              <span>{candidate.shortLabel}</span>
+              <strong>{candidate.label}</strong>
+            </button>
+          ))}
+        </div>
+        <div className="gan-selected-summary">
+          <small>current snapshot</small>
+          <strong>{PHASES.find((candidate) => candidate.value === phase)!.label}</strong>
+          <span>fake = {formatNumber(state.fakeSample)}</span>
+          <span>D(fake) = {formatNumber(state.fakeProbability)}</span>
+        </div>
+        <div className="gan-freeze-key">
+          <small>freeze contract</small>
+          <code>{phase === "discriminator" ? "grad(G) = 0" : phase === "generator" ? "grad(D params) = 0" : "no backward pass"}</code>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/GateComparisonWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/GateComparisonWorkbench.tsx
@@ -1,0 +1,275 @@
+import { useMemo, useState } from "react";
+import {
+  type GatedCellGate,
+  type GatedModel,
+  traceGateCounterfactual,
+  traceGatedRecurrent,
+} from "./gated-recurrent-lab.js";
+
+interface GateComparisonWorkbenchProps {
+  onShowBackward: () => void;
+}
+
+type Intervention = "canonical" | 0 | 1;
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(6)).toString();
+}
+
+function canonicalGateValue(model: GatedModel, selectedGate: GatedCellGate): number {
+  if (model === "gru") {
+    return selectedGate === "reset" ? 0.5 : 0.25;
+  }
+  if (selectedGate === "forget") {
+    return 0.5;
+  }
+  return selectedGate === "input" ? 0.25 : 0.75;
+}
+
+export function GateComparisonWorkbench({
+  onShowBackward,
+}: GateComparisonWorkbenchProps) {
+  const trace = useMemo(() => traceGatedRecurrent(), []);
+  const [model, setModel] = useState<GatedModel>("gru");
+  const [selectedGate, setSelectedGate] = useState<GatedCellGate>("update");
+  const [intervention, setIntervention] = useState<Intervention>("canonical");
+  const gateValue = intervention === "canonical"
+    ? canonicalGateValue(model, selectedGate)
+    : intervention;
+  const counterfactual = traceGateCounterfactual(
+    model,
+    selectedGate,
+    gateValue,
+    trace,
+  );
+
+  const selectGate = (nextModel: GatedModel, gate: GatedCellGate) => {
+    setModel(nextModel);
+    setSelectedGate(gate);
+    setIntervention("canonical");
+  };
+
+  const gruReset = model === "gru" && selectedGate === "reset"
+    ? gateValue
+    : trace.gru.resetGate.value;
+  const gruUpdate = model === "gru" && selectedGate === "update"
+    ? gateValue
+    : trace.gru.updateGate.value;
+  const gruCandidate = model === "gru" ? counterfactual.candidate : trace.gru.candidate.value;
+  const gruRetained = (1 - gruUpdate) * trace.previousHidden;
+  const gruWrite = gruUpdate * gruCandidate;
+  const gruHidden = gruRetained + gruWrite;
+
+  const lstmForget = model === "lstm" && selectedGate === "forget"
+    ? gateValue
+    : trace.lstm.forgetGate.value;
+  const lstmInput = model === "lstm" && selectedGate === "input"
+    ? gateValue
+    : trace.lstm.inputGate.value;
+  const lstmOutput = model === "lstm" && selectedGate === "output"
+    ? gateValue
+    : trace.lstm.outputGate.value;
+  const lstmRetained = lstmForget * trace.previousCell;
+  const lstmWrite = lstmInput * trace.lstm.candidate.value;
+  const lstmCell = lstmRetained + lstmWrite;
+  const lstmHidden = lstmOutput * Math.tanh(lstmCell);
+
+  return (
+    <main className="workspace workspace--gates">
+      <section className="gate-stage" aria-label="GRU and LSTM gate comparison">
+        <div className="gate-intro">
+          <div>
+            <p className="eyebrow">NN11 · gated sequence memory</p>
+            <h2>GRU and LSTM gate comparator</h2>
+            <p>
+              Route the same previous memory and candidate through both cells.
+              Change one gate while every other signal stays fixed.
+            </p>
+          </div>
+          <div className="gate-input-chip">
+            <small>shared input</small>
+            <strong>x = 1 · h = 0.8</strong>
+          </div>
+        </div>
+
+        <section className="gate-comparison-panel" aria-label="Aligned gated memory lanes">
+          <div className="gate-panel-heading">
+            <div>
+              <p className="eyebrow">Same evidence · different state design</p>
+              <h2>Follow what each gate lets through</h2>
+            </div>
+            <code>candidate = 0.6</code>
+          </div>
+
+          <article className="gate-model-lane gate-model-lane--gru" aria-label="GRU memory lane">
+            <div className="gate-model-label">
+              <span>GRU</span>
+              <strong>one stored and exposed state</strong>
+            </div>
+            <div className="gate-flow">
+              <div className="gate-state-node">
+                <small>previous state</small>
+                <strong>h = {formatNumber(trace.previousHidden)}</strong>
+              </div>
+              <button
+                aria-label="Select GRU reset gate"
+                aria-pressed={model === "gru" && selectedGate === "reset"}
+                className={model === "gru" && selectedGate === "reset"
+                  ? "gate-node gate-node--active"
+                  : "gate-node"}
+                type="button"
+                onClick={() => selectGate("gru", "reset")}
+              >
+                <small>reset r</small>
+                <strong>{formatNumber(gruReset)}</strong>
+                <span>candidate sees {formatNumber(gruReset * trace.previousHidden)}</span>
+              </button>
+              <div className="gate-candidate-node">
+                <small>candidate n</small>
+                <strong>{formatNumber(gruCandidate)}</strong>
+              </div>
+              <button
+                aria-label="Select GRU update gate"
+                aria-pressed={model === "gru" && selectedGate === "update"}
+                className={model === "gru" && selectedGate === "update"
+                  ? "gate-node gate-node--active"
+                  : "gate-node"}
+                type="button"
+                onClick={() => selectGate("gru", "update")}
+              >
+                <small>update z</small>
+                <strong>{formatNumber(gruUpdate)}</strong>
+                <span>new share</span>
+              </button>
+              <div className="gate-result-node">
+                <small>next hidden</small>
+                <strong>h = {formatNumber(gruHidden)}</strong>
+                <span>{formatNumber(gruRetained)} old + {formatNumber(gruWrite)} new</span>
+              </div>
+            </div>
+          </article>
+
+          <article className="gate-model-lane gate-model-lane--lstm" aria-label="LSTM memory lane">
+            <div className="gate-model-label">
+              <span>LSTM</span>
+              <strong>private cell plus exposed hidden state</strong>
+            </div>
+            <div className="gate-flow gate-flow--lstm">
+              <div className="gate-state-node">
+                <small>previous cell</small>
+                <strong>c = {formatNumber(trace.previousCell)}</strong>
+              </div>
+              <button
+                aria-label="Select LSTM forget gate"
+                aria-pressed={model === "lstm" && selectedGate === "forget"}
+                className={model === "lstm" && selectedGate === "forget"
+                  ? "gate-node gate-node--active"
+                  : "gate-node"}
+                type="button"
+                onClick={() => selectGate("lstm", "forget")}
+              >
+                <small>forget f</small>
+                <strong>{formatNumber(lstmForget)}</strong>
+                <span>old share</span>
+              </button>
+              <button
+                aria-label="Select LSTM input gate"
+                aria-pressed={model === "lstm" && selectedGate === "input"}
+                className={model === "lstm" && selectedGate === "input"
+                  ? "gate-node gate-node--active"
+                  : "gate-node"}
+                type="button"
+                onClick={() => selectGate("lstm", "input")}
+              >
+                <small>input i</small>
+                <strong>{formatNumber(lstmInput)}</strong>
+                <span>candidate share</span>
+              </button>
+              <div className="gate-cell-node">
+                <small>private cell</small>
+                <strong>c = {formatNumber(lstmCell)}</strong>
+                <span>{formatNumber(lstmRetained)} old + {formatNumber(lstmWrite)} new</span>
+              </div>
+              <button
+                aria-label="Select LSTM output gate"
+                aria-pressed={model === "lstm" && selectedGate === "output"}
+                className={model === "lstm" && selectedGate === "output"
+                  ? "gate-node gate-node--active"
+                  : "gate-node"}
+                type="button"
+                onClick={() => selectGate("lstm", "output")}
+              >
+                <small>output o</small>
+                <strong>{formatNumber(lstmOutput)}</strong>
+                <span>visible share</span>
+              </button>
+              <div className="gate-result-node">
+                <small>next hidden</small>
+                <strong>h = {formatNumber(lstmHidden)}</strong>
+                <span>o × tanh(c)</span>
+              </div>
+            </div>
+          </article>
+        </section>
+
+        <section className="gate-comparison-panel" aria-label="Gate responsibility comparison">
+          <div className="gate-panel-heading">
+            <div>
+              <p className="eyebrow">Architecture, not acronym memorization</p>
+              <h2>Which signal does each gate control?</h2>
+            </div>
+          </div>
+          <div className="gate-table-wrap">
+            <table className="gate-table">
+              <caption>GRU and LSTM state-routing responsibilities</caption>
+              <thead><tr><th scope="col">Responsibility</th><th scope="col">GRU</th><th scope="col">LSTM</th></tr></thead>
+              <tbody>
+                <tr><th scope="row">Build candidate</th><td>reset gate</td><td>candidate tanh path</td></tr>
+                <tr><th scope="row">Retain old memory</th><td rowSpan={2}>update gate mixes both</td><td>forget gate</td></tr>
+                <tr><th scope="row">Write new memory</th><td>input gate</td></tr>
+                <tr><th scope="row">Expose memory</th><td>same hidden state</td><td>output gate</td></tr>
+                <tr><th scope="row">State buffers</th><td>h = {formatNumber(gruHidden)}</td><td>c = {formatNumber(lstmCell)}, h = {formatNumber(lstmHidden)}</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </section>
+
+      <aside className="gate-controls" aria-label="Gate intervention controls">
+        <p className="eyebrow">One controlled intervention</p>
+        <h2>{model.toUpperCase()} {selectedGate} gate</h2>
+        <p>
+          Keep every other gate fixed. Use the learned canonical value or force
+          this one valve fully closed or open.
+        </p>
+        <div className="gate-intervention-buttons" aria-label="Selected gate value">
+          <button aria-pressed={intervention === "canonical"} type="button" onClick={() => setIntervention("canonical")}>Canonical</button>
+          <button aria-pressed={intervention === 0} type="button" onClick={() => setIntervention(0)}>Force 0</button>
+          <button aria-pressed={intervention === 1} type="button" onClick={() => setIntervention(1)}>Force 1</button>
+        </div>
+        <div className="gate-selected-summary" aria-label="Selected gate effect">
+          <small>selected value</small>
+          <strong>{formatNumber(gateValue)}</strong>
+          <span>
+            {model === "gru"
+              ? `candidate ${formatNumber(gruCandidate)} · next h ${formatNumber(gruHidden)}`
+              : `next c ${formatNumber(lstmCell)} · visible h ${formatNumber(lstmHidden)}`}
+          </span>
+        </div>
+        <button className="bptt-view-button" type="button" onClick={onShowBackward}>
+          Return to BPTT gradients
+        </button>
+        <div className="recurrent-note">
+          <span>What scales next?</span>
+          <p>
+            Vector cells pack each gate&apos;s affine projection into matrices.
+            The scalar routing stays identical at every coordinate.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/GradientFlowWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/GradientFlowWorkbench.tsx
@@ -1,0 +1,174 @@
+import { useMemo, useState } from "react";
+import { GRADIENT_SCENARIOS, traceGradientFlow } from "./gradient-flow-lab.js";
+
+function formatNumber(value: number, digits = 6): string {
+  if (Math.abs(value) < 1e-12) return "0";
+  if (Math.abs(value) < 0.0001 || Math.abs(value) >= 1000) return value.toExponential(3);
+  return Number(value.toFixed(digits)).toString();
+}
+
+export function GradientFlowWorkbench() {
+  const [scenarioId, setScenarioId] = useState("small-tanh");
+  const [selectedLayer, setSelectedLayer] = useState(3);
+  const trace = useMemo(() => traceGradientFlow(scenarioId), [scenarioId]);
+  const comparison = useMemo(
+    () => GRADIENT_SCENARIOS.map((scenario) => traceGradientFlow(scenario.id)),
+    [],
+  );
+  const layer = trace.layers[selectedLayer]!;
+  const maxLogGradient = Math.max(
+    ...comparison.map((item) => Math.log10(1 + Math.abs(item.inputGradient))),
+    1e-12,
+  );
+
+  return (
+    <main className="workspace workspace--gradient-flow">
+      <section className="gradient-flow-stage" aria-label="Vanishing and exploding gradient explorer">
+        <div className="gradient-flow-intro">
+          <div>
+            <p className="eyebrow">NN24 / reverse one scalar chain</p>
+            <h2>Vanishing and exploding gradients</h2>
+            <p>Multiply four local Jacobians and watch one loss gradient travel from the output back to the input.</p>
+          </div>
+          <div className={`gradient-flow-chip gradient-flow-chip--${trace.classification}`}>{trace.classification}</div>
+        </div>
+
+        <section className="gradient-forward-panel" aria-label="Gradient flow forward pass">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Forward / save every value</p>
+              <h2>Input to loss</h2>
+            </div>
+            <span>half squared error target {formatNumber(trace.scenario.target)}</span>
+          </div>
+          <div className="gradient-forward-lane">
+            <div><span>input</span><strong>{formatNumber(trace.scenario.input)}</strong></div>
+            {trace.layers.map((item) => (
+              <div key={item.layer}>
+                <span>layer {item.layer}</span>
+                <code>{formatNumber(item.input)} x {formatNumber(item.weight)}</code>
+                <strong>{trace.scenario.activation} = {formatNumber(item.activation)}</strong>
+              </div>
+            ))}
+            <div className="gradient-loss-node"><span>loss</span><strong>{formatNumber(trace.loss)}</strong></div>
+          </div>
+        </section>
+
+        <section className="gradient-backward-panel" aria-label="Gradient flow backward pass">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Backward / multiply local slopes</p>
+              <h2>Loss to input</h2>
+            </div>
+            <span>start dL/da4 = {formatNumber(trace.outputError)}</span>
+          </div>
+          <div className="gradient-backward-lane">
+            {[...trace.layers].reverse().map((item) => (
+              <button
+                aria-pressed={selectedLayer === item.layer - 1}
+                key={item.layer}
+                type="button"
+                onClick={() => setSelectedLayer(item.layer - 1)}
+              >
+                <span>layer {item.layer}</span>
+                <small>upstream {formatNumber(item.upstreamGradient)}</small>
+                <strong>local x {formatNumber(item.localJacobian)}</strong>
+                <code>to input {formatNumber(item.inputGradient)}</code>
+              </button>
+            ))}
+            <div className="gradient-input-node">
+              <span>input gradient</span>
+              <strong>{formatNumber(trace.inputGradient)}</strong>
+            </div>
+          </div>
+        </section>
+
+        <section className="gradient-arithmetic-panel" aria-label="Selected gradient calculation">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Open layer {layer.layer}</p>
+              <h2>One chain-rule step</h2>
+            </div>
+            <span>saved input {formatNumber(layer.input)}</span>
+          </div>
+          <div className="gradient-equation-grid">
+            <code>{formatNumber(layer.upstreamGradient)} x {formatNumber(layer.activationDerivative)} = {formatNumber(layer.preactivationGradient)}</code>
+            <span>dL/da x da/dz = dL/dz</span>
+            <code>{formatNumber(layer.preactivationGradient)} x {formatNumber(layer.weight)} = {formatNumber(layer.inputGradient)}</code>
+            <span>dL/dz x dz/dinput</span>
+            <code>{formatNumber(layer.preactivationGradient)} x {formatNumber(layer.input)} = {formatNumber(layer.weightGradient)}</code>
+            <span>dL/dz x saved input = dL/dw</span>
+          </div>
+        </section>
+
+        <section className="gradient-chain-panel" aria-label="Gradient chain product">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Separate the path from the loss</p>
+              <h2>Total local Jacobian product</h2>
+            </div>
+            <strong>{formatNumber(trace.chainJacobian)}</strong>
+          </div>
+          <div className="gradient-chain-equation">
+            {trace.layers.map((item) => <code key={item.layer}>{formatNumber(item.localJacobian)}</code>)}
+            <span>=</span>
+            <strong>{formatNumber(trace.chainJacobian)}</strong>
+          </div>
+          <p>{formatNumber(trace.outputError)} output error x {formatNumber(trace.chainJacobian)} chain = <strong>{formatNumber(trace.inputGradient)}</strong> input gradient.</p>
+          <div className="gradient-audit">
+            <span>central finite difference</span>
+            <code>{formatNumber(trace.finiteDifferenceInputGradient)}</code>
+            <span>absolute error</span>
+            <code>{formatNumber(trace.finiteDifferenceError)}</code>
+          </div>
+        </section>
+
+        <section className="gradient-comparison-panel" aria-label="Gradient scenario comparison">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Four mechanisms side by side</p>
+              <h2>Compare input-gradient magnitude</h2>
+            </div>
+            <span>bar uses log10(1 + |gradient|)</span>
+          </div>
+          <div className="gradient-comparison-grid">
+            {comparison.map((item) => (
+              <article className={item.scenario.id === scenarioId ? "is-selected" : ""} key={item.scenario.id}>
+                <strong>{item.scenario.label}</strong>
+                <span>{item.classification}</span>
+                <i style={{ width: `${(Math.log10(1 + Math.abs(item.inputGradient)) / maxLogGradient) * 100}%` }} />
+                <code>dL/dinput {formatNumber(item.inputGradient)}</code>
+                <small>chain {formatNumber(item.chainJacobian)}</small>
+              </article>
+            ))}
+          </div>
+        </section>
+      </section>
+
+      <aside className="controls gradient-flow-controls">
+        <p className="eyebrow">Gradient mechanism</p>
+        <h2>Choose a chain</h2>
+        <p>Each scenario keeps four scalar layers and target zero.</p>
+        <div className="gradient-scenario-buttons">
+          {GRADIENT_SCENARIOS.map((scenario) => (
+            <button
+              aria-pressed={scenario.id === scenarioId}
+              key={scenario.id}
+              type="button"
+              onClick={() => setScenarioId(scenario.id)}
+            >
+              <strong>{scenario.label}</strong>
+              <span>{scenario.summary}</span>
+              <code>{scenario.weights.join(" x ")} / {scenario.activation}</code>
+            </button>
+          ))}
+        </div>
+        <div className="gradient-flow-reading">
+          <p className="eyebrow">What to notice</p>
+          <h2>{trace.classification === "vanishing" ? "Early layers hear a whisper" : trace.classification === "exploding" ? "Early layers receive a blast" : "The gradient keeps its scale"}</h2>
+          <p>Changing a weight changes both the forward activation and the local factor used on the reverse path.</p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/GraphNeighborhoodWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/GraphNeighborhoodWorkbench.tsx
@@ -1,0 +1,49 @@
+import { useMemo, useState } from "react";
+import { traceGraphNeighborhoodComparison } from "./graph-neighborhood-lab.js";
+
+function fmt(value: number): string {
+  if (Math.abs(value) < 1e-12) return "0";
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(6).replace(/0+$/, "");
+}
+
+export function GraphNeighborhoodWorkbench() {
+  const trace = useMemo(() => traceGraphNeighborhoodComparison(), []);
+  const [model, setModel] = useState<"gcn" | "gat">("gcn");
+  const [target, setTarget] = useState(1);
+  const gcn = trace.gcn[target]!;
+  const gat = trace.gat[target]!;
+
+  return (
+    <main className="workspace workspace--graph-neighborhood">
+      <section className="graph-neighborhood-stage" aria-label="Graph convolution and attention trace">
+        <div className="graph-neighborhood-intro"><div><p className="eyebrow">NN22 - same neighborhood, two weighting rules</p><h2>Compare graph convolution with graph attention</h2><p>Add self-loops to one three-node path, then inspect fixed degree normalization beside learned softmax attention.</p></div><div className="graph-neighborhood-chip">GCN vs GAT</div></div>
+
+        <section className="graph-neighborhood-map" aria-label="Graph neighborhood selector">
+          <div className="graph-neighborhood-heading"><div><p>Original scalar features</p><h2>Select a target neighborhood</h2></div><code>0(1) &lt;-&gt; 1(2) &lt;-&gt; 2(-1), plus self-loops</code></div>
+          <div className="graph-targets">{trace.features.map((feature, node) => <button aria-pressed={target === node} type="button" onClick={() => setTarget(node)} key={node}><small>node {node}</small><strong>{fmt(feature)}</strong><span>degree {trace.degrees[node]}</span></button>)}</div>
+          <p>Target {target} reads sources [{trace.neighborhoods[target]!.join(", ")}]. Both models use exactly this same inbox.</p>
+        </section>
+
+        {model === "gcn" ? (
+          <section className="graph-model-panel" aria-label="Graph convolution calculation">
+            <div className="graph-neighborhood-heading"><div><p>Fixed structural weights</p><h2>Normalize by both endpoint degrees</h2></div><code>coefficient = 1 / sqrt(d_target x d_source)</code></div>
+            <div className="graph-row-grid">{gcn.rows.map((row) => <div key={row.source}><small>source {row.source}</small><code>1 / sqrt({row.targetDegree} x {row.sourceDegree})</code><strong>{fmt(row.coefficient)}</strong><span>x feature {fmt(row.sourceFeature)}</span><b>= {fmt(row.contribution)}</b></div>)}</div>
+            <div className="graph-result"><span>sum contributions</span><strong>{gcn.rows.map((row) => fmt(row.contribution)).join(" + ")} = {fmt(gcn.preactivation)}</strong><b>ReLU -&gt; {fmt(gcn.output)}</b></div>
+          </section>
+        ) : (
+          <section className="graph-model-panel" aria-label="Graph attention calculation">
+            <div className="graph-neighborhood-heading"><div><p>Data-dependent weights</p><h2>Softmax the source scores inside this inbox</h2></div><code>score = source feature; alpha = stable softmax(score)</code></div>
+            <div className="graph-softmax-summary"><span>row max = {fmt(gat.maximumScore)}</span><span>denominator = {fmt(gat.denominator)}</span><strong>weights sum = {fmt(gat.rows.reduce((sum, row) => sum + row.attentionWeight, 0))}</strong></div>
+            <div className="graph-row-grid">{gat.rows.map((row) => <div key={row.source}><small>source {row.source}</small><code>score {fmt(row.score)} - max {fmt(gat.maximumScore)} = {fmt(row.shiftedScore)}</code><span>exp = {fmt(row.exponential)}</span><strong>alpha = {fmt(row.attentionWeight)}</strong><b>x {fmt(row.sourceFeature)} = {fmt(row.contribution)}</b></div>)}</div>
+            <div className="graph-result"><span>weighted sum</span><strong>{gat.rows.map((row) => fmt(row.contribution)).join(" + ")} = {fmt(gat.preactivation)}</strong><b>ReLU -&gt; {fmt(gat.output)}</b></div>
+          </section>
+        )}
+
+        <section className="graph-output-panel" aria-label="Graph model output comparison"><div><small>GCN outputs</small><strong>[{trace.gcnOutputs.map(fmt).join(", ")}]</strong></div><div><small>GAT outputs</small><strong>[{trace.gatOutputs.map(fmt).join(", ")}]</strong></div><p>GCN weights depend only on graph degrees. GAT weights change with the node features, even though the edges are unchanged.</p></section>
+      </section>
+
+      <aside className="graph-neighborhood-controls" aria-label="Graph model controls"><p>Neighborhood model</p><h2>Switch the weighting rule</h2><p>Keep the target and graph fixed while changing how its inbox is weighted.</p><button aria-pressed={model === "gcn"} type="button" onClick={() => setModel("gcn")}><span>Degree rule</span><strong>Graph convolution</strong></button><button aria-pressed={model === "gat"} type="button" onClick={() => setModel("gat")}><span>Softmax rule</span><strong>Graph attention</strong></button><div><small>selected target</small><strong>{target}</strong><span>{model === "gcn" ? "structural coefficients" : "feature-dependent attention"}</span></div></aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/HopfieldWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/HopfieldWorkbench.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from "react";
+import { traceHopfieldRecall, type BipolarState } from "./hopfield-memory.js";
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function patternText(state: readonly BipolarState[]): string {
+  return `[${state.map((value) => value > 0 ? "+1" : "-1").join(", ")}]`;
+}
+
+const PHASES = [
+  { eyebrow: "0. Store", title: "Hebbian weights" },
+  { eyebrow: "1. Cue", title: "One flipped bit" },
+  { eyebrow: "2. Recall", title: "Update neuron 0" },
+  { eyebrow: "3. Recall", title: "Update neuron 1" },
+  { eyebrow: "4. Recall", title: "Update neuron 2" },
+  { eyebrow: "5. Recall", title: "Update neuron 3" },
+] as const;
+
+export function HopfieldWorkbench() {
+  const trace = useMemo(() => traceHopfieldRecall(), []);
+  const [phase, setPhase] = useState(0);
+  const visibleUpdateCount = Math.max(phase - 1, 0);
+  const activeUpdate = visibleUpdateCount > 0 ? trace.updates[visibleUpdateCount - 1] : null;
+  const visibleState = phase === 0
+    ? trace.storedPattern
+    : activeUpdate?.stateAfter ?? trace.corruptedState;
+  const visibleEnergy = phase === 0
+    ? trace.finalEnergy
+    : activeUpdate?.energyAfter ?? trace.initialEnergy;
+  const visibleOverlap = phase === 0
+    ? 1
+    : activeUpdate?.overlapAfter ?? trace.initialOverlap;
+
+  return (
+    <main className="workspace workspace--hopfield">
+      <section className="hopfield-stage" aria-label="Hopfield associative memory trace">
+        <div className="hopfield-intro">
+          <div>
+            <p className="eyebrow">NN20 - a remembered pattern becomes an attractor</p>
+            <h2>Restore one flipped bit with four connected neurons</h2>
+            <p>
+              Store a bipolar pattern in symmetric weights, present a damaged cue,
+              and audit every asynchronous update as energy moves downhill.
+            </p>
+          </div>
+          <div className="hopfield-chip">4 neurons - 1 memory</div>
+        </div>
+
+        <section className="hopfield-store-panel" aria-label="Hopfield Hebbian storage rule">
+          <div className="hopfield-heading">
+            <div>
+              <p>Outer product, then erase self-connections</p>
+              <h2>Turn the saved pattern into weights</h2>
+            </div>
+            <code>w_ij = p_i p_j / 4, w_ii = 0</code>
+          </div>
+          <div className="hopfield-pattern-row">
+            <div>
+              <small>stored pattern p</small>
+              <strong>{patternText(trace.storedPattern)}</strong>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div>
+              <small>normalization</small>
+              <strong>divide by {trace.normalization}</strong>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div>
+              <small>diagonal</small>
+              <strong>set to 0</strong>
+            </div>
+          </div>
+          <div className="hopfield-matrix" role="table" aria-label="Hopfield learned weight matrix">
+            <div className="hopfield-matrix__corner" />
+            {trace.storedPattern.map((_, column) => <b key={`column-${column}`}>from {column}</b>)}
+            {trace.weights.map((row, rowIndex) => (
+              <div className="hopfield-matrix__row" role="row" key={`row-${rowIndex}`}>
+                <b>to {rowIndex}</b>
+                {row.map((weight, columnIndex) => (
+                  <code className={rowIndex === columnIndex ? "hopfield-weight hopfield-weight--diagonal" : "hopfield-weight"} key={`${rowIndex}-${columnIndex}`}>
+                    {formatNumber(weight)}
+                  </code>
+                ))}
+              </div>
+            ))}
+          </div>
+          <p className="hopfield-note">
+            Symmetry makes the energy score valid. A zero diagonal keeps each neuron
+            from voting for itself.
+          </p>
+        </section>
+
+        <section className="hopfield-recall-panel" aria-label="Hopfield asynchronous recall trace">
+          <div className="hopfield-heading">
+            <div>
+              <p>Use the newest state immediately</p>
+              <h2>Recall one neuron at a time</h2>
+            </div>
+            <code>state_i = sign(sum_j w_ij state_j)</code>
+          </div>
+          <div className="hopfield-recall-lane">
+            <div className="hopfield-state">
+              <small>damaged cue</small>
+              <strong>{patternText(trace.corruptedState)}</strong>
+              <span>distance {trace.initialHammingDistance}</span>
+            </div>
+            {trace.updates.map((update, index) => (
+              <div className={visibleUpdateCount > index ? "hopfield-update hopfield-update--visible" : "hopfield-update"} key={update.step}>
+                <small>update {update.neuronIndex}</small>
+                <strong>{visibleUpdateCount > index ? patternText(update.stateAfter) : "?"}</strong>
+                <span>{visibleUpdateCount > index ? `field ${formatNumber(update.localField)}` : "advance to reveal"}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="hopfield-audit-grid">
+            <div>
+              <small>visible state</small>
+              <strong>{patternText(visibleState)}</strong>
+            </div>
+            <div>
+              <small>normalized overlap</small>
+              <strong>{formatNumber(visibleOverlap)}</strong>
+            </div>
+            <div>
+              <small>Hopfield energy</small>
+              <strong>{formatNumber(visibleEnergy)}</strong>
+            </div>
+          </div>
+
+          {activeUpdate === null ? (
+            <div className="hopfield-contribution-panel">
+              <p>{phase === 0 ? "The stored pattern is already a low-energy fixed point." : "The cue matches three of four saved bits. Update neuron 0 first."}</p>
+            </div>
+          ) : (
+            <div className="hopfield-contribution-panel" aria-label="Hopfield active neuron calculation">
+              <div>
+                <small>active neuron</small>
+                <strong>{activeUpdate.neuronIndex}</strong>
+              </div>
+              <div className="hopfield-contributions">
+                {activeUpdate.incoming.map((row) => (
+                  <code key={row.sourceIndex}>
+                    {formatNumber(row.weight)} x {row.sourceState > 0 ? "+1" : "-1"} = {formatNumber(row.contribution)}
+                  </code>
+                ))}
+              </div>
+              <div>
+                <small>local field -&gt; next state</small>
+                <strong>{formatNumber(activeUpdate.localField)} -&gt; {activeUpdate.nextState > 0 ? "+1" : "-1"}</strong>
+              </div>
+              <div>
+                <small>energy before -&gt; after</small>
+                <strong>{formatNumber(activeUpdate.energyBefore)} -&gt; {formatNumber(activeUpdate.energyAfter)}</strong>
+              </div>
+              <div>
+                <small>overlap before -&gt; after</small>
+                <strong>{formatNumber(activeUpdate.overlapBefore)} -&gt; {formatNumber(activeUpdate.overlapAfter)}</strong>
+              </div>
+            </div>
+          )}
+        </section>
+      </section>
+
+      <aside className="hopfield-controls" aria-label="Hopfield phase controls">
+        <p>Associative recall</p>
+        <h2>Advance the memory</h2>
+        <p>
+          The first recall step repairs the flipped bit. The other steps prove the
+          recovered pattern is stable under a complete deterministic sweep.
+        </p>
+        <div className="hopfield-phase-buttons">
+          {PHASES.map((item, index) => (
+            <button aria-pressed={phase === index} type="button" onClick={() => setPhase(index)} key={item.title}>
+              <span>{item.eyebrow}</span>
+              <strong>{item.title}</strong>
+            </button>
+          ))}
+        </div>
+        <div className="hopfield-selected-summary">
+          <small>selected state</small>
+          <strong>{PHASES[phase]!.title}</strong>
+          <span>energy = {formatNumber(visibleEnergy)}</span>
+          <span>overlap = {formatNumber(visibleOverlap)}</span>
+          {phase === PHASES.length - 1 ? <b>fixed point recovered</b> : null}
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/ImageCnnWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/ImageCnnWorkbench.tsx
@@ -1,0 +1,411 @@
+import { useMemo, useState } from "react";
+import {
+  DEFAULT_IMAGE_BETA,
+  DEFAULT_IMAGE_CHANNELS,
+  DEFAULT_IMAGE_EPSILON,
+  DEFAULT_IMAGE_FILTERS,
+  DEFAULT_IMAGE_GAMMA,
+  traceTinyImageCnn,
+  type NumberMatrix,
+} from "./image-cnn-lab.js";
+
+const PIPELINE_STAGES = [
+  { id: "channels", label: "Channels" },
+  { id: "convolve", label: "Convolve" },
+  { id: "normalize", label: "Normalize" },
+  { id: "relu", label: "ReLU" },
+  { id: "pool", label: "Pool" },
+] as const;
+
+type PipelineStage = typeof PIPELINE_STAGES[number]["id"];
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(4)).toString();
+}
+
+function MatrixGrid({
+  values,
+  label,
+  selected,
+  winner,
+}: {
+  values: NumberMatrix;
+  label: string;
+  selected?: readonly [number, number];
+  winner?: readonly [number, number];
+}) {
+  return (
+    <div className="image-matrix-block">
+      <span>{label}</span>
+      <div
+        className="image-matrix"
+        style={{ gridTemplateColumns: `repeat(${values[0]!.length}, minmax(44px, 1fr))` }}
+        aria-label={label}
+      >
+        {values.flatMap((row, rowIndex) => row.map((value, columnIndex) => {
+          const isSelected = selected?.[0] === rowIndex && selected[1] === columnIndex;
+          const isWinner = winner?.[0] === rowIndex && winner[1] === columnIndex;
+          const className = isWinner
+            ? "image-matrix-cell image-matrix-cell--winner"
+            : isSelected
+              ? "image-matrix-cell image-matrix-cell--selected"
+              : "image-matrix-cell";
+          return (
+            <div className={className} key={`${rowIndex}-${columnIndex}`}>
+              <small>[{rowIndex},{columnIndex}]</small>
+              <strong>{formatNumber(value)}</strong>
+            </div>
+          );
+        }))}
+      </div>
+    </div>
+  );
+}
+
+export function ImageCnnWorkbench() {
+  const [stage, setStage] = useState<PipelineStage>("channels");
+  const [selectedFilter, setSelectedFilter] = useState(0);
+  const [selectedPosition, setSelectedPosition] = useState(3);
+  const trace = useMemo(() => traceTinyImageCnn(), []);
+  const stageIndex = PIPELINE_STAGES.findIndex((item) => item.id === stage);
+  const row = Math.floor(selectedPosition / 2);
+  const column = selectedPosition % 2;
+  const filter = DEFAULT_IMAGE_FILTERS[selectedFilter]!;
+  const position = trace.positions[selectedFilter]![row]![column]!;
+  const selectedCoordinate = [row, column] as const;
+
+  function moveStage(offset: number): void {
+    const nextIndex = Math.min(
+      Math.max(stageIndex + offset, 0),
+      PIPELINE_STAGES.length - 1,
+    );
+    setStage(PIPELINE_STAGES[nextIndex]!.id);
+  }
+
+  function reset(): void {
+    setStage("channels");
+    setSelectedFilter(0);
+    setSelectedPosition(3);
+  }
+
+  return (
+    <main className="workspace workspace--image-cnn">
+      <section className="image-cnn-stage" aria-label="Tiny image CNN trace">
+        <div className="image-cnn-intro">
+          <div>
+            <p className="eyebrow">NN07 · tiny image CNN</p>
+            <h2>Open the image pipeline</h2>
+            <p>
+              Follow two image channels through shared spatial windows, channel
+              reduction, normalization, ReLU, and max pooling.
+            </p>
+          </div>
+          <div className="image-shape-chip">2 × 3 × 3 → 2 × 2 × 2 → 2</div>
+        </div>
+
+        <nav className="image-pipeline" aria-label="Image CNN pipeline stages">
+          {PIPELINE_STAGES.map((item, index) => (
+            <button
+              aria-label={`Show ${item.label} stage`}
+              className={item.id === stage
+                ? "image-stage-button image-stage-button--active"
+                : index < stageIndex
+                  ? "image-stage-button image-stage-button--visited"
+                  : "image-stage-button"}
+              key={item.id}
+              type="button"
+              onClick={() => setStage(item.id)}
+            >
+              <small>{index + 1}</small>
+              <strong>{item.label}</strong>
+            </button>
+          ))}
+        </nav>
+
+        {stage === "channels" ? (
+          <section className="image-stage-panel" aria-label="Input image channels">
+            <div className="image-stage-heading">
+              <div>
+                <p className="eyebrow">Stage 1 · input tensor</p>
+                <h2>One image can have several number grids</h2>
+              </div>
+              <code>shape [channels, rows, columns] = [2, 3, 3]</code>
+            </div>
+            <div className="image-channel-grid">
+              {DEFAULT_IMAGE_CHANNELS.map((channel, channelIndex) => (
+                <article className="image-channel-card" key={channel.name}>
+                  <div>
+                    <small>input channel {channelIndex}</small>
+                    <strong>{channel.name}</strong>
+                  </div>
+                  <MatrixGrid values={channel.values} label={`${channel.name} values`} />
+                </article>
+              ))}
+            </div>
+            <p className="image-stage-note">
+              A filter owns one kernel per input channel. Their spatial results
+              meet only after each channel has produced its own partial sum.
+            </p>
+          </section>
+        ) : null}
+
+        {stage === "convolve" ? (
+          <section className="image-stage-panel" aria-label="Channel accumulation trace">
+            <div className="image-stage-heading">
+              <div>
+                <p className="eyebrow">
+                  Stage 2 · filter {selectedFilter} · output [{row},{column}]
+                </p>
+                <h2>Correlate each channel, then add</h2>
+              </div>
+              <strong className="image-output-value">{formatNumber(position.output)}</strong>
+            </div>
+
+            <div className="channel-math-grid">
+              {DEFAULT_IMAGE_CHANNELS.map((channel, channelIndex) => (
+                <article className="channel-math-card" key={channel.name}>
+                  <div className="channel-math-title">
+                    <div>
+                      <small>channel {channelIndex}</small>
+                      <strong>{channel.name}</strong>
+                    </div>
+                    <strong>{formatNumber(position.channelSums[channelIndex]!)}</strong>
+                  </div>
+                  <div className="window-kernel-pair">
+                    <MatrixGrid
+                      values={position.windows[channelIndex]!}
+                      label="selected window"
+                    />
+                    <span aria-hidden="true">×</span>
+                    <MatrixGrid
+                      values={filter.kernels[channelIndex]!}
+                      label="channel kernel"
+                    />
+                  </div>
+                  <div className="image-product-list">
+                    {position.products[channelIndex]!.flatMap((productRow, kernelRow) => (
+                      productRow.map((product, kernelColumn) => (
+                        <code key={`${kernelRow}-${kernelColumn}`}>
+                          {formatNumber(position.windows[channelIndex]![kernelRow]![kernelColumn]!)}
+                          ×{formatNumber(filter.kernels[channelIndex]![kernelRow]![kernelColumn]!)}
+                          ={formatNumber(product)}
+                        </code>
+                      ))
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+
+            <div className="channel-reduction" aria-label="Channel reduction equation">
+              <div>
+                <small>channel 0</small>
+                <strong>{formatNumber(position.channelSums[0]!)}</strong>
+              </div>
+              <span>+</span>
+              <div>
+                <small>channel 1</small>
+                <strong>{formatNumber(position.channelSums[1]!)}</strong>
+              </div>
+              <span>+</span>
+              <div>
+                <small>bias</small>
+                <strong>{formatNumber(filter.bias)}</strong>
+              </div>
+              <span>=</span>
+              <div className="channel-reduction__result">
+                <small>output</small>
+                <strong>{formatNumber(position.output)}</strong>
+              </div>
+            </div>
+
+            <div className="image-map-pair">
+              {trace.convolution.map((featureMap, filterIndex) => (
+                <MatrixGrid
+                  key={filterIndex}
+                  values={featureMap}
+                  label={`filter ${filterIndex} convolution map`}
+                  selected={filterIndex === selectedFilter ? selectedCoordinate : undefined}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {stage === "normalize" ? (
+          <section className="image-stage-panel" aria-label="Spatial normalization trace">
+            <div className="image-stage-heading">
+              <div>
+                <p className="eyebrow">Stage 3 · output channel {selectedFilter}</p>
+                <h2>Four spatial values share statistics</h2>
+              </div>
+              <code>(x − μ) / √(variance + ε)</code>
+            </div>
+            <div className="normalization-flow">
+              <MatrixGrid
+                values={trace.convolution[selectedFilter]!}
+                label="convolution map"
+                selected={selectedCoordinate}
+              />
+              <div className="normalization-stats">
+                <div><small>mean μ</small><strong>{formatNumber(trace.normalization.means[selectedFilter]!)}</strong></div>
+                <div><small>variance</small><strong>{formatNumber(trace.normalization.variances[selectedFilter]!)}</strong></div>
+                <div><small>epsilon ε</small><strong>{formatNumber(DEFAULT_IMAGE_EPSILON)}</strong></div>
+                <div><small>denominator</small><strong>{formatNumber(trace.normalization.denominators[selectedFilter]!)}</strong></div>
+              </div>
+              <MatrixGrid
+                values={trace.normalization.maps[selectedFilter]!}
+                label="normalized map"
+                selected={selectedCoordinate}
+              />
+            </div>
+            <code className="normalization-equation">
+              ({formatNumber(position.output)} − {formatNumber(trace.normalization.means[selectedFilter]!)})
+              {' '}/ {formatNumber(trace.normalization.denominators[selectedFilter]!)}
+              {' '}× γ {formatNumber(DEFAULT_IMAGE_GAMMA[selectedFilter]!)}
+              {' '}+ β {formatNumber(DEFAULT_IMAGE_BETA[selectedFilter]!)}
+              {' '}= {formatNumber(trace.normalization.maps[selectedFilter]![row]![column]!)}
+            </code>
+          </section>
+        ) : null}
+
+        {stage === "relu" ? (
+          <section className="image-stage-panel" aria-label="ReLU activation trace">
+            <div className="image-stage-heading">
+              <div>
+                <p className="eyebrow">Stage 4 · output channel {selectedFilter}</p>
+                <h2>Keep positive evidence</h2>
+              </div>
+              <code>ReLU(x) = max(0, x)</code>
+            </div>
+            <div className="activation-flow">
+              <MatrixGrid
+                values={trace.normalization.maps[selectedFilter]!}
+                label="normalized values"
+                selected={selectedCoordinate}
+              />
+              <span aria-hidden="true">→</span>
+              <MatrixGrid
+                values={trace.activation[selectedFilter]!}
+                label="after ReLU"
+                selected={selectedCoordinate}
+              />
+            </div>
+            <code className="normalization-equation">
+              max(0, {formatNumber(trace.normalization.maps[selectedFilter]![row]![column]!)})
+              {' '}= {formatNumber(trace.activation[selectedFilter]![row]![column]!)}
+            </code>
+          </section>
+        ) : null}
+
+        {stage === "pool" ? (
+          <section className="image-stage-panel" aria-label="Max pooling trace">
+            <div className="image-stage-heading">
+              <div>
+                <p className="eyebrow">Stage 5 · shrink the maps</p>
+                <h2>Keep each channel's strongest location</h2>
+              </div>
+              <code>2 × 2 max pool · stride 2</code>
+            </div>
+            <div className="pooling-grid">
+              {trace.activation.map((featureMap, filterIndex) => (
+                <article className="pooling-card" key={filterIndex}>
+                  <MatrixGrid
+                    values={featureMap}
+                    label={`filter ${filterIndex} activated map`}
+                    winner={trace.pooling.argmax[filterIndex]!}
+                  />
+                  <span aria-hidden="true">→</span>
+                  <div className="pooled-value">
+                    <small>pooled[{filterIndex}]</small>
+                    <strong>{formatNumber(trace.pooling.values[filterIndex]!)}</strong>
+                    <code>
+                      from [{trace.pooling.argmax[filterIndex]![0]},
+                      {trace.pooling.argmax[filterIndex]![1]}]
+                    </code>
+                  </div>
+                </article>
+              ))}
+            </div>
+            <p className="image-stage-note">
+              Only the highlighted winner receives gradient through max pooling.
+              The other three values were useful for comparison, but are discarded.
+            </p>
+          </section>
+        ) : null}
+      </section>
+
+      <aside className="image-cnn-controls" aria-label="Image CNN trace controls">
+        <p className="eyebrow">Choose one path</p>
+        <h2>Filter and output</h2>
+        <p>Selections stay synchronized as you move through the pipeline.</p>
+
+        <div className="image-control-group">
+          <span>Output filter</span>
+          <div className="image-filter-buttons">
+            {DEFAULT_IMAGE_FILTERS.map((item, index) => (
+              <button
+                aria-label={`Select filter ${index} ${item.name}`}
+                className={index === selectedFilter ? "image-choice image-choice--active" : "image-choice"}
+                key={item.name}
+                type="button"
+                onClick={() => setSelectedFilter(index)}
+              >
+                <small>filter {index}</small>
+                <strong>{item.name}</strong>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="image-control-group">
+          <span>Spatial output</span>
+          <div className="image-position-buttons">
+            {[0, 1, 2, 3].map((index) => {
+              const outputRow = Math.floor(index / 2);
+              const outputColumn = index % 2;
+              return (
+                <button
+                  aria-label={`Select image output row ${outputRow} column ${outputColumn}`}
+                  className={index === selectedPosition ? "image-choice image-choice--active" : "image-choice"}
+                  key={index}
+                  type="button"
+                  onClick={() => setSelectedPosition(index)}
+                >
+                  <small>[{outputRow},{outputColumn}]</small>
+                  <strong>{formatNumber(trace.convolution[selectedFilter]![outputRow]![outputColumn]!)}</strong>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="button-grid image-stage-controls">
+          <button type="button" disabled={stageIndex === 0} onClick={() => moveStage(-1)}>
+            Previous stage
+          </button>
+          <button
+            type="button"
+            disabled={stageIndex === PIPELINE_STAGES.length - 1}
+            onClick={() => moveStage(1)}
+          >
+            Next stage
+          </button>
+          <button type="button" onClick={reset}>Reset trace</button>
+        </div>
+
+        <div className="image-cnn-note">
+          <span>What scales next?</span>
+          <p>
+            Larger CNNs repeat these same loops over batches, many channels,
+            many filters, and deeper feature maps. Accelerators change the
+            schedule, not the arithmetic contract.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/InitializationWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/InitializationWorkbench.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useState } from "react";
+import {
+  INITIALIZATION_KINDS,
+  traceInitializationDistributions,
+  type DistributionActivation,
+  type InitializationKind,
+} from "./initialization-distribution-lab.js";
+
+const INITIALIZERS: readonly { kind: InitializationKind; label: string; summary: string }[] = [
+  { kind: "tiny", label: "Tiny", summary: "fixed scale 0.1" },
+  { kind: "xavier", label: "Xavier", summary: "sqrt(1 / fan-in)" },
+  { kind: "he", label: "He", summary: "sqrt(2 / fan-in)" },
+  { kind: "large", label: "Large", summary: "fixed scale 2" },
+];
+
+function formatNumber(value: number, digits = 6): string {
+  if (Math.abs(value) < 1e-12) return "0";
+  if (Math.abs(value) < 0.0001 || Math.abs(value) >= 1000) return value.toExponential(3);
+  return Number(value.toFixed(digits)).toString();
+}
+
+function distributionPosition(value: number, minimum: number, maximum: number): string {
+  const span = Math.max(maximum - minimum, 1e-12);
+  return `${((value - minimum) / span) * 100}%`;
+}
+
+export function InitializationWorkbench() {
+  const [initializer, setInitializer] = useState<InitializationKind>("xavier");
+  const [activation, setActivation] = useState<DistributionActivation>("tanh");
+  const [selectedLayer, setSelectedLayer] = useState(0);
+  const trace = useMemo(
+    () => traceInitializationDistributions(initializer, activation),
+    [activation, initializer],
+  );
+  const comparison = useMemo(
+    () => INITIALIZATION_KINDS.map((kind) => traceInitializationDistributions(kind, activation)),
+    [activation],
+  );
+  const layer = trace.layers[selectedLayer]!;
+  const sampleInput = layer.inputs[0]!;
+  const terms = sampleInput.map((value, index) => value * layer.weights[index]![0]!);
+  const range = Math.max(
+    ...trace.layers.flatMap((item) => item.activations.flat().map(Math.abs)),
+    1,
+  );
+  const comparisonMax = Math.max(
+    ...comparison.flatMap((item) => item.layers.map((entry) => entry.summary.standardDeviation)),
+    1e-12,
+  );
+
+  return (
+    <main className="workspace workspace--initialization">
+      <section className="initialization-stage" aria-label="Initialization distribution explorer">
+        <div className="lab-intro initialization-intro">
+          <div>
+            <p className="eyebrow">NN23 / same signs, different scale</p>
+            <h2>Initialization and activation distributions</h2>
+            <p>Follow four tiny inputs through three layers and see when signals shrink, spread, saturate, or explode.</p>
+          </div>
+          <div className="initialization-chip">{initializer} + {activation}</div>
+        </div>
+
+        <section className="initialization-flow" aria-label="Layer activation distributions">
+          <div className="distribution-card distribution-card--input">
+            <p className="eyebrow">Input batch</p>
+            <strong>4 rows x 2 values</strong>
+            <code>std {formatNumber(trace.inputSummary.standardDeviation)}</code>
+          </div>
+          {trace.layers.map((item, index) => {
+            const values = item.activations.flat();
+            return (
+              <button
+                aria-pressed={selectedLayer === index}
+                className="distribution-card"
+                key={item.layer}
+                type="button"
+                onClick={() => setSelectedLayer(index)}
+              >
+                <span className="eyebrow">Layer {item.layer}</span>
+                <strong>std {formatNumber(item.summary.standardDeviation)}</strong>
+                <span className="distribution-dot-plot" aria-hidden="true">
+                  {values.map((value, valueIndex) => (
+                    <i
+                      key={valueIndex}
+                      style={{ left: distributionPosition(value, -range, range) }}
+                    />
+                  ))}
+                </span>
+                <span>{formatNumber(item.summary.minimum)} to {formatNumber(item.summary.maximum)}</span>
+              </button>
+            );
+          })}
+        </section>
+
+        <section className="distribution-summary-panel" aria-label="Selected activation distribution">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">All eight activations</p>
+              <h2>Layer {layer.layer} distribution</h2>
+            </div>
+            <span>scale {formatNumber(layer.scale)}</span>
+          </div>
+          <div className="distribution-stat-grid">
+            <div><span>mean</span><strong>{formatNumber(layer.summary.mean)}</strong></div>
+            <div><span>variance</span><strong>{formatNumber(layer.summary.variance)}</strong></div>
+            <div><span>standard deviation</span><strong>{formatNumber(layer.summary.standardDeviation)}</strong></div>
+            <div><span>{activation === "tanh" ? "saturated" : "exact zeros"}</span><strong>{formatNumber((activation === "tanh" ? layer.summary.saturatedFraction : layer.summary.zeroFraction) * 100, 3)}%</strong></div>
+          </div>
+          <div className="activation-value-grid">
+            {layer.activations.flat().map((value, index) => (
+              <code key={index}>{formatNumber(value)}</code>
+            ))}
+          </div>
+        </section>
+
+        <section className="initialization-arithmetic" aria-label="Selected layer hand calculation">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Sample 0 / neuron 0</p>
+              <h2>Open one activation</h2>
+            </div>
+            <span>no bias in this controlled experiment</span>
+          </div>
+          <div className="initialization-equation">
+            {terms.map((term, index) => (
+              <code key={index}>{formatNumber(sampleInput[index]!)} x {formatNumber(layer.weights[index]![0]!)} = {formatNumber(term)}</code>
+            ))}
+            <strong>sum = {formatNumber(layer.preactivations[0]![0]!)}</strong>
+            <strong>{activation} = {formatNumber(layer.activations[0]![0]!)}</strong>
+          </div>
+        </section>
+
+        <section className="initializer-comparison" aria-label="Initializer comparison">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Same inputs / same signs / same activation</p>
+              <h2>Compare signal spread</h2>
+            </div>
+            <span>bar length = layer standard deviation</span>
+          </div>
+          <div className="initializer-comparison-grid">
+            {comparison.map((item) => (
+              <article className={item.initializer === initializer ? "is-selected" : ""} key={item.initializer}>
+                <strong>{item.initializer}</strong>
+                {item.layers.map((entry) => (
+                  <div className="spread-row" key={entry.layer}>
+                    <span>L{entry.layer}</span>
+                    <i style={{ width: `${(entry.summary.standardDeviation / comparisonMax) * 100}%` }} />
+                    <code>{formatNumber(entry.summary.standardDeviation)}</code>
+                  </div>
+                ))}
+              </article>
+            ))}
+          </div>
+        </section>
+      </section>
+
+      <aside className="controls initialization-controls">
+        <section>
+          <p className="eyebrow">Weight scale</p>
+          <h2>Choose an initializer</h2>
+          <p>The sign template stays fixed so only the scaling rule changes.</p>
+          <div className="initializer-buttons">
+            {INITIALIZERS.map((item) => (
+              <button
+                aria-pressed={initializer === item.kind}
+                key={item.kind}
+                type="button"
+                onClick={() => setInitializer(item.kind)}
+              >
+                <span>{item.label}</span>
+                <small>{item.summary}</small>
+              </button>
+            ))}
+          </div>
+        </section>
+        <section>
+          <p className="eyebrow">Nonlinearity</p>
+          <h2>Switch the activation</h2>
+          <div className="activation-choice-grid">
+            {(["tanh", "relu"] as const).map((kind) => (
+              <button
+                aria-pressed={activation === kind}
+                key={kind}
+                type="button"
+                onClick={() => setActivation(kind)}
+              >
+                {kind === "tanh" ? "tanh" : "ReLU"}
+              </button>
+            ))}
+          </div>
+        </section>
+        <section className="initialization-reading">
+          <p className="eyebrow">What to notice</p>
+          <h2>{initializer === "tiny" ? "Signal is fading" : initializer === "large" ? (activation === "tanh" ? "tanh is pinned near its limits" : "Signal is growing") : "Scale and activation cooperate"}</h2>
+          <p>Real initializers draw random weights. NN23 fixes the signs so every language can reproduce the arithmetic exactly.</p>
+        </section>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/MessagePassingWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/MessagePassingWorkbench.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from "react";
+import { traceTinyMessagePassing } from "./message-passing-lab.js";
+
+function format(value: number): string {
+  if (Math.abs(value) < 1e-12) return "0";
+  return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+const PHASES = ["Graph", "Messages", "Aggregate", "Update"] as const;
+
+export function MessagePassingWorkbench() {
+  const trace = useMemo(() => traceTinyMessagePassing(), []);
+  const [phase, setPhase] = useState<(typeof PHASES)[number]>("Graph");
+  const [selectedNode, setSelectedNode] = useState(1);
+  const update = trace.nodeUpdates[selectedNode]!;
+  const showMessages = phase !== "Graph";
+  const showAggregate = phase === "Aggregate" || phase === "Update";
+  const showOutput = phase === "Update";
+
+  return (
+    <main className="workspace workspace--message-passing">
+      <section className="message-stage" aria-label="Tiny graph message-passing trace">
+        <div className="message-intro">
+          <div>
+            <p className="eyebrow">NN21 - neighbors send, nodes collect, one round updates</p>
+            <h2>Pass scalar messages across a three-node path</h2>
+            <p>Expand two undirected edges into four directed messages, sum each inbox, and update all nodes from the same saved feature snapshot.</p>
+          </div>
+          <div className="message-chip">3 nodes - 2 edges</div>
+        </div>
+
+        <section className="message-graph-panel" aria-label="Tiny graph and directed messages">
+          <div className="message-heading">
+            <div><p>Synchronous round</p><h2>Original features stay fixed while messages travel</h2></div>
+            <code>m(source -&gt; target) = 0.5 x source</code>
+          </div>
+          <div className="message-graph">
+            {trace.nodeFeatures.map((feature, node) => (
+              <button className={selectedNode === node ? "message-node message-node--selected" : "message-node"} type="button" onClick={() => setSelectedNode(node)} key={node}>
+                <small>node {node}</small><strong>{showOutput ? format(trace.outputFeatures[node]!) : format(feature)}</strong>
+                <span>{showOutput ? "new feature" : "old feature"}</span>
+              </button>
+            ))}
+            <div className="message-edge message-edge--left">0 &lt;-&gt; 1</div>
+            <div className="message-edge message-edge--right">1 &lt;-&gt; 2</div>
+          </div>
+          <div className="message-ledger">
+            {trace.directedMessages.map((row) => (
+              <div className={showMessages && row.target === selectedNode ? "message-card message-card--active" : "message-card"} key={`${row.source}-${row.target}`}>
+                <small>{row.source} -&gt; {row.target}</small>
+                <code>0.5 x {format(row.sourceFeature)}</code>
+                <strong>{showMessages ? format(row.message) : "?"}</strong>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="message-update-panel" aria-label="Selected graph node update">
+          <div className="message-heading">
+            <div><p>Selected node {selectedNode}</p><h2>Open its inbox and update equation</h2></div>
+            <code>ReLU(0.25 x self + sum(messages) - 0.5)</code>
+          </div>
+          <div className="message-inbox">
+            <div><small>incoming messages</small><strong>{showMessages ? update.incoming.map((row) => format(row.message)).join(" + ") : "hidden"}</strong></div>
+            <span>=</span>
+            <div><small>sum aggregate</small><strong>{showAggregate ? format(update.aggregate) : "?"}</strong></div>
+          </div>
+          <div className="message-equation">
+            <div><small>self route</small><code>0.25 x {format(update.oldFeature)}</code><strong>{showAggregate ? format(update.selfContribution) : "?"}</strong></div>
+            <span>+</span>
+            <div><small>neighbor route</small><code>sum inbox</code><strong>{showAggregate ? format(update.aggregate) : "?"}</strong></div>
+            <span>+</span>
+            <div><small>bias</small><code>-0.5</code><strong>{showAggregate ? "-0.5" : "?"}</strong></div>
+            <span>=</span>
+            <div><small>preactivation</small><code>before ReLU</code><strong>{showAggregate ? format(update.preactivation) : "?"}</strong></div>
+            <span>-&gt;</span>
+            <div className="message-output"><small>new feature</small><code>ReLU</code><strong>{showOutput ? format(update.outputFeature) : "?"}</strong></div>
+          </div>
+          <p className="message-sync-note">All four messages use the original features `[1, 2, -1]`. No node reads another node's new output during this round.</p>
+        </section>
+      </section>
+
+      <aside className="message-controls" aria-label="Message-passing phase controls">
+        <p>One graph round</p><h2>Reveal the pipeline</h2>
+        <p>Select any node, then expose directed messages, its order-invariant sum, and the shared update rule.</p>
+        <div className="message-phase-buttons">
+          {PHASES.map((item, index) => <button aria-pressed={phase === item} type="button" onClick={() => setPhase(item)} key={item}><span>{index}. Phase</span><strong>{item}</strong></button>)}
+        </div>
+        <div className="message-selected-summary"><small>selected node</small><strong>{selectedNode}</strong><span>neighbors = {update.incoming.map((row) => row.source).join(", ")}</span><span>output = {showOutput ? format(update.outputFeature) : "?"}</span>{showOutput ? <b>round complete</b> : null}</div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/MultiHeadAttentionWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/MultiHeadAttentionWorkbench.tsx
@@ -1,0 +1,259 @@
+import { useMemo, useState } from "react";
+import type { AttentionTokenId } from "./attention-qkv-lab.js";
+import {
+  multiHeadAttentionRow,
+  traceMultiHeadAttention,
+} from "./multi-head-attention-lab.js";
+
+interface MultiHeadAttentionWorkbenchProps {
+  onShowWeights: () => void;
+}
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(6)).toString();
+}
+
+function formatVector(values: readonly number[]): string {
+  return `[${values.map(formatNumber).join(", ")}]`;
+}
+
+function headLabel(id: string): string {
+  return id === "horizontal" ? "Head A - horizontal" : "Head B - vertical";
+}
+
+export function MultiHeadAttentionWorkbench({
+  onShowWeights,
+}: MultiHeadAttentionWorkbenchProps) {
+  const [tokenId, setTokenId] = useState<AttentionTokenId>("blue");
+  const [includeResidual, setIncludeResidual] = useState(true);
+  const [applyLayerNorm, setApplyLayerNorm] = useState(true);
+  const trace = useMemo(
+    () => traceMultiHeadAttention(includeResidual, applyLayerNorm),
+    [applyLayerNorm, includeResidual],
+  );
+  const selected = multiHeadAttentionRow(trace, tokenId);
+
+  return (
+    <main className="workspace workspace--multi-head">
+      <section className="multi-head-stage" aria-label="Multi-head attention block trace">
+        <div className="multi-head-intro">
+          <div>
+            <p className="eyebrow">NN14 - parallel views rejoin one stream</p>
+            <h2>Multi-head add-and-norm block</h2>
+            <p>
+              Run two causal heads on the same token, keep their weights
+              separate, then follow concatenation, projection, residual, and
+              layer normalization without skipping a boundary.
+            </p>
+          </div>
+          <div className="multi-head-chip">2 heads x 1 feature</div>
+        </div>
+
+        <section className="multi-head-panel" aria-label={`Two attention heads for ${tokenId}`}>
+          <div className="multi-head-heading">
+            <div>
+              <p className="eyebrow">Selected - {tokenId} query</p>
+              <h2>Same token, different learned views</h2>
+            </div>
+            <code>each head softmaxes alone</code>
+          </div>
+
+          <div className="multi-head-lanes">
+            {selected.heads.map((head) => (
+              <article className={`multi-head-lane multi-head-lane--${head.id}`} key={head.id}>
+                <div className="multi-head-lane__heading">
+                  <div>
+                    <small>{headLabel(head.id)}</small>
+                    <strong>q = {formatNumber(head.query)}</strong>
+                  </div>
+                  <code>context {formatNumber(head.context)}</code>
+                </div>
+
+                <div className="multi-head-score-row">
+                  <span>scores</span>
+                  <code>{formatVector(head.scaledScores)}</code>
+                </div>
+
+                <div className="multi-head-weight-row" role="list" aria-label={`${head.id} weights`}>
+                  {trace.tokenIds.map((keyId, keyIndex) => (
+                    <div
+                      className={head.allowed[keyIndex]
+                        ? "multi-head-weight"
+                        : "multi-head-weight multi-head-weight--blocked"}
+                      key={keyId}
+                      role="listitem"
+                    >
+                      <span>{keyId}</span>
+                      <strong>{head.allowed[keyIndex] ? formatNumber(head.weights[keyIndex]!) : "blocked"}</strong>
+                      <i aria-hidden="true" style={{ width: `${head.weights[keyIndex]! * 100}%` }} />
+                    </div>
+                  ))}
+                </div>
+
+                <div className="multi-head-value-row">
+                  {trace.tokenIds.map((keyId, keyIndex) => (
+                    <code key={keyId}>
+                      {formatNumber(head.weights[keyIndex]!)} x {formatNumber(head.values[keyIndex]!)} = {formatNumber(head.valueContributions[keyIndex]!)}
+                    </code>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="multi-head-join-panel" aria-label="Concatenate project and add residual trace">
+          <div className="multi-head-heading">
+            <div>
+              <p className="eyebrow">Heads rejoin before the shortcut</p>
+              <h2>Concatenate - project - add</h2>
+            </div>
+            <code>model width = 2</code>
+          </div>
+
+          <div className="multi-head-join-flow">
+            <div>
+              <small>head contexts</small>
+              <code>{formatVector(selected.heads.map((head) => head.context))}</code>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div>
+              <small>concatenate</small>
+              <code>{formatVector(selected.concatenated)}</code>
+            </div>
+            <span aria-hidden="true">-&gt;</span>
+            <div>
+              <small>identity W_o</small>
+              <code>{formatVector(selected.projectedAttention)}</code>
+            </div>
+            <span aria-hidden="true">+</span>
+            <div className={includeResidual ? "multi-head-residual" : "multi-head-residual multi-head-residual--off"}>
+              <small>{includeResidual ? `${tokenId} residual` : "residual removed"}</small>
+              <code>{formatVector(includeResidual ? selected.input : [0, 0])}</code>
+            </div>
+            <span aria-hidden="true">=</span>
+            <div className="multi-head-join-result">
+              <small>add result</small>
+              <code>{formatVector(selected.residualSum)}</code>
+            </div>
+          </div>
+        </section>
+
+        <section className="multi-head-norm-panel" aria-label="Layer normalization arithmetic">
+          <div className="multi-head-heading">
+            <div>
+              <p className="eyebrow">One token - normalize across features</p>
+              <h2>{applyLayerNorm ? "Layer normalization" : "Layer normalization bypassed"}</h2>
+            </div>
+            <div className="multi-head-output">
+              <small>block output</small>
+              <strong>{formatVector(selected.output)}</strong>
+            </div>
+          </div>
+
+          <div className={applyLayerNorm ? "multi-head-norm-flow" : "multi-head-norm-flow multi-head-norm-flow--off"}>
+            <div>
+              <small>mean</small>
+              <code>{formatNumber(selected.layerNorm.mean)}</code>
+            </div>
+            <div>
+              <small>centered</small>
+              <code>{formatVector(selected.layerNorm.centered)}</code>
+            </div>
+            <div>
+              <small>squared deviations</small>
+              <code>{formatVector(selected.layerNorm.squaredDeviations)}</code>
+            </div>
+            <div>
+              <small>variance</small>
+              <code>{formatNumber(selected.layerNorm.variance)}</code>
+            </div>
+            <div>
+              <small>sqrt(var + 0.00001)</small>
+              <code>{formatNumber(selected.layerNorm.denominator)}</code>
+            </div>
+            <div className="multi-head-norm-result">
+              <small>gamma x normalized + beta</small>
+              <code>{formatVector(selected.layerNorm.output)}</code>
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <aside className="multi-head-controls" aria-label="Multi-head attention controls">
+        <p className="eyebrow">Inspect one token row</p>
+        <h2>Block controls</h2>
+        <p>
+          Both heads stay visible so their different scores and value mixes can
+          be compared on the same causal boundary.
+        </p>
+
+        <button className="attention-back-button" type="button" onClick={onShowWeights}>
+          Return to single-head weights
+        </button>
+
+        <div className="attention-query-buttons" aria-label="Multi-head token selection">
+          {trace.tokenIds.map((id) => (
+            <button
+              aria-pressed={tokenId === id}
+              key={id}
+              type="button"
+              onClick={() => setTokenId(id)}
+            >
+              {id}
+            </button>
+          ))}
+        </div>
+
+        <label className="attention-scale-control">
+          <input
+            type="checkbox"
+            checked={includeResidual}
+            onChange={(event) => setIncludeResidual(event.target.checked)}
+          />
+          <span>
+            <strong>Add residual token</strong>
+            <small>Keep the original embedding on a short route.</small>
+          </span>
+        </label>
+
+        <label className="attention-scale-control">
+          <input
+            type="checkbox"
+            checked={applyLayerNorm}
+            onChange={(event) => setApplyLayerNorm(event.target.checked)}
+          />
+          <span>
+            <strong>Apply layer normalization</strong>
+            <small>Use population variance across this token's features.</small>
+          </span>
+        </label>
+
+        <div className="attention-selected-summary">
+          <small>selected block output</small>
+          <strong>{formatVector(selected.output)}</strong>
+          <span>{tokenId} after both head paths rejoin.</span>
+        </div>
+
+        <div className="attention-value-boundary">
+          <span>Why keep the heads separate?</span>
+          <p>
+            A softmax row belongs to one head. Concatenation happens only after
+            each head has produced its own context.
+          </p>
+        </div>
+
+        <div className="attention-next-note">
+          <span>What scales next?</span>
+          <p>
+            A decoder repeats this block across tokens and layers, then adds
+            embeddings, a feed-forward path, logits, loss, and an optimizer.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/MultiHeadAttentionWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/MultiHeadAttentionWorkbench.tsx
@@ -6,6 +6,7 @@ import {
 } from "./multi-head-attention-lab.js";
 
 interface MultiHeadAttentionWorkbenchProps {
+  onShowDecoder: () => void;
   onShowWeights: () => void;
 }
 
@@ -25,6 +26,7 @@ function headLabel(id: string): string {
 }
 
 export function MultiHeadAttentionWorkbench({
+  onShowDecoder,
   onShowWeights,
 }: MultiHeadAttentionWorkbenchProps) {
   const [tokenId, setTokenId] = useState<AttentionTokenId>("blue");
@@ -193,6 +195,10 @@ export function MultiHeadAttentionWorkbench({
 
         <button className="attention-back-button" type="button" onClick={onShowWeights}>
           Return to single-head weights
+        </button>
+
+        <button className="attention-back-button" type="button" onClick={onShowDecoder}>
+          Open tiny decoder training
         </button>
 
         <div className="attention-query-buttons" aria-label="Multi-head token selection">

--- a/code/programs/typescript/ml-learning-visualizer/src/OptimizationWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/OptimizationWorkbench.tsx
@@ -1,0 +1,299 @@
+import { useMemo, useState } from "react";
+import {
+  DEFAULT_OPTIMIZATION_STATE,
+  OPTIMIZATION_DATASET,
+  OPTIMUM_PARAMETERS,
+  checkGradient,
+  meanSquaredError,
+  optimizationStep,
+  runOptimization,
+  sampleLossLandscape,
+  type BatchStrategy,
+  type OptimizationState,
+  type OptimizationTracePoint,
+} from "./optimization-lab.js";
+
+const STRATEGIES: readonly { kind: BatchStrategy; label: string; summary: string }[] = [
+  { kind: "stochastic", label: "SGD / 1 row", summary: "Noisy, frequent updates" },
+  { kind: "mini-batch", label: "Mini-batch / 2 rows", summary: "A compromise between noise and stability" },
+  { kind: "full-batch", label: "Full batch / 4 rows", summary: "Stable average gradient" },
+];
+
+const LANDSCAPE = {
+  width: 720,
+  height: 430,
+  left: 68,
+  right: 28,
+  top: 24,
+  bottom: 58,
+  weightRange: [-1, 3.5] as const,
+  biasRange: [-1, 3] as const,
+  resolution: 25,
+};
+
+function formatNumber(value: number, digits = 5): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  if (Math.abs(value) >= 1000 || Math.abs(value) < 0.0001) {
+    return value.toExponential(3);
+  }
+  return Number(value.toFixed(digits)).toString();
+}
+
+function scaleX(weight: number): number {
+  const innerWidth = LANDSCAPE.width - LANDSCAPE.left - LANDSCAPE.right;
+  return LANDSCAPE.left
+    + ((weight - LANDSCAPE.weightRange[0])
+      / (LANDSCAPE.weightRange[1] - LANDSCAPE.weightRange[0])) * innerWidth;
+}
+
+function scaleY(bias: number): number {
+  const innerHeight = LANDSCAPE.height - LANDSCAPE.top - LANDSCAPE.bottom;
+  return LANDSCAPE.top
+    + (1 - (bias - LANDSCAPE.biasRange[0])
+      / (LANDSCAPE.biasRange[1] - LANDSCAPE.biasRange[0])) * innerHeight;
+}
+
+function tracePath(trace: readonly OptimizationTracePoint[], maxLogLoss: number): string {
+  if (trace.length === 0) {
+    return "";
+  }
+  const width = 590;
+  const height = 138;
+  const stepSpan = Math.max(trace.length - 1, 1);
+  return trace.map((point, index) => {
+    const x = (index / stepSpan) * width;
+    const y = height - (Math.log1p(point.loss) / maxLogLoss) * height;
+    return `${index === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`;
+  }).join(" ");
+}
+
+function numberValue(value: string, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function OptimizationWorkbench() {
+  const [state, setState] = useState<OptimizationState>(DEFAULT_OPTIMIZATION_STATE);
+  const [epsilon, setEpsilon] = useState(0.00001);
+  const [learningRate, setLearningRate] = useState(0.05);
+  const [stepCount, setStepCount] = useState(20);
+  const gradientCheck = useMemo(
+    () => checkGradient(OPTIMIZATION_DATASET, state, epsilon),
+    [epsilon, state],
+  );
+  const landscape = useMemo(
+    () => sampleLossLandscape(
+      OPTIMIZATION_DATASET,
+      LANDSCAPE.weightRange,
+      LANDSCAPE.biasRange,
+      LANDSCAPE.resolution,
+    ),
+    [],
+  );
+  const maxLogLandscapeLoss = useMemo(
+    () => Math.max(...landscape.map((point) => Math.log1p(point.loss)), 1),
+    [landscape],
+  );
+  const trajectories = useMemo(
+    () => STRATEGIES.map((strategy) => ({
+      ...strategy,
+      trace: runOptimization(strategy.kind, stepCount, learningRate, state),
+    })),
+    [learningRate, state, stepCount],
+  );
+  const maxLogTraceLoss = Math.max(
+    ...trajectories.flatMap((trajectory) => trajectory.trace.map((point) => Math.log1p(point.loss))),
+    1,
+  );
+  const oneStep = optimizationStep(OPTIMIZATION_DATASET, state, learningRate, "full-batch");
+  const cellWidth = (LANDSCAPE.width - LANDSCAPE.left - LANDSCAPE.right) / LANDSCAPE.resolution;
+  const cellHeight = (LANDSCAPE.height - LANDSCAPE.top - LANDSCAPE.bottom) / LANDSCAPE.resolution;
+
+  function updateState(field: "weight" | "bias", value: string): void {
+    setState((current) => ({ ...current, [field]: numberValue(value, current[field]), step: 0 }));
+  }
+
+  function reset(): void {
+    setState(DEFAULT_OPTIMIZATION_STATE);
+    setEpsilon(0.00001);
+    setLearningRate(0.05);
+    setStepCount(20);
+  }
+
+  return (
+    <main className="workspace workspace--optimization">
+      <section className="optimization-stage" aria-label="Optimization microscope">
+        <div className="lab-intro">
+          <div>
+            <p className="eyebrow">Slope / check / step size / batch noise</p>
+            <h2>Optimization microscope</h2>
+            <p>See the loss surface, verify the gradient independently, and compare three ways to choose training rows.</p>
+          </div>
+          <div className="lab-chip">MSE {formatNumber(meanSquaredError(OPTIMIZATION_DATASET, state), 4)}</div>
+        </div>
+
+        <section className="landscape-panel" aria-label="Loss landscape">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Every location is one model</p>
+              <h2>Loss landscape</h2>
+            </div>
+            <span>Darker = larger loss</span>
+          </div>
+          <svg
+            className="landscape-chart"
+            viewBox={`0 0 ${LANDSCAPE.width} ${LANDSCAPE.height}`}
+            role="img"
+            aria-label={`Mean squared error by weight and bias. Current weight ${formatNumber(state.weight)} and bias ${formatNumber(state.bias)}.`}
+          >
+            <title>Loss landscape for a four-point linear regression problem</title>
+            {landscape.map((point) => (
+              <rect
+                className="landscape-cell"
+                key={`${point.row}-${point.column}`}
+                x={LANDSCAPE.left + point.column * cellWidth}
+                y={LANDSCAPE.top + (LANDSCAPE.resolution - 1 - point.row) * cellHeight}
+                width={cellWidth + 0.4}
+                height={cellHeight + 0.4}
+                style={{ opacity: 0.08 + 0.78 * (Math.log1p(point.loss) / maxLogLandscapeLoss) }}
+              />
+            ))}
+            <line
+              className="gradient-arrow"
+              x1={scaleX(state.weight)}
+              y1={scaleY(state.bias)}
+              x2={scaleX(oneStep.weight)}
+              y2={scaleY(oneStep.bias)}
+              markerEnd="url(#gradient-arrow-head)"
+            />
+            <defs>
+              <marker id="gradient-arrow-head" markerWidth="8" markerHeight="8" refX="5" refY="3" orient="auto">
+                <path d="M 0 0 L 6 3 L 0 6 z" className="gradient-arrow-head" />
+              </marker>
+            </defs>
+            <circle className="optimum-point" cx={scaleX(OPTIMUM_PARAMETERS.weight)} cy={scaleY(OPTIMUM_PARAMETERS.bias)} r="8" />
+            <text className="landscape-label" x={scaleX(OPTIMUM_PARAMETERS.weight) + 12} y={scaleY(OPTIMUM_PARAMETERS.bias) - 10}>minimum (2, 1)</text>
+            <circle className="current-parameter-point" cx={scaleX(state.weight)} cy={scaleY(state.bias)} r="9" />
+            <text className="landscape-label" x={scaleX(state.weight) + 12} y={scaleY(state.bias) + 22}>current model</text>
+            <text className="axis-title" x={LANDSCAPE.width / 2} y={LANDSCAPE.height - 10}>weight w</text>
+            <text className="axis-title axis-title--optimization-y" x="18" y={LANDSCAPE.height / 2}>bias b</text>
+          </svg>
+          <div className="landscape-equation">
+            <code>w' = {formatNumber(state.weight)} - {formatNumber(learningRate)} x ({formatNumber(gradientCheck.analytical.weight)}) = {formatNumber(oneStep.weight)}</code>
+            <code>b' = {formatNumber(state.bias)} - {formatNumber(learningRate)} x ({formatNumber(gradientCheck.analytical.bias)}) = {formatNumber(oneStep.bias)}</code>
+          </div>
+        </section>
+
+        <section className="gradient-check-panel" aria-label="Finite-difference gradient check">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Backpropagation gets an independent audit</p>
+              <h2>Finite-difference gradient check</h2>
+            </div>
+            <span className={gradientCheck.passes ? "check-status check-status--pass" : "check-status check-status--fail"}>
+              {gradientCheck.passes ? "PASS" : "CHECK EPSILON"}
+            </span>
+          </div>
+          <div className="gradient-check-grid" role="table" aria-label="Gradient comparison">
+            <span role="columnheader">Parameter</span>
+            <span role="columnheader">Backprop</span>
+            <span role="columnheader">Finite difference</span>
+            <span role="columnheader">Absolute error</span>
+            <strong role="cell">weight</strong>
+            <code role="cell">{formatNumber(gradientCheck.analytical.weight)}</code>
+            <code role="cell">{formatNumber(gradientCheck.numerical.weight)}</code>
+            <code role="cell">{formatNumber(gradientCheck.absoluteError.weight)}</code>
+            <strong role="cell">bias</strong>
+            <code role="cell">{formatNumber(gradientCheck.analytical.bias)}</code>
+            <code role="cell">{formatNumber(gradientCheck.numerical.bias)}</code>
+            <code role="cell">{formatNumber(gradientCheck.absoluteError.bias)}</code>
+          </div>
+          <p>Finite differences nudge one parameter by +/- epsilon and estimate the slope without using backpropagation.</p>
+        </section>
+
+        <section className="batch-comparison-panel" aria-label="Batch strategy comparison">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Same model / same data / different row selection</p>
+              <h2>Batch versus stochastic updates</h2>
+            </div>
+            <span>{stepCount} updates</span>
+          </div>
+          <svg className="batch-chart" viewBox="0 0 650 175" role="img" aria-label="Loss trajectories for stochastic, mini-batch, and full-batch gradient descent">
+            <line className="batch-grid" x1="42" x2="632" y1="148" y2="148" />
+            <line className="batch-grid" x1="42" x2="42" y1="10" y2="148" />
+            <g transform="translate(42 10)">
+              {trajectories.map((trajectory) => (
+                <path
+                  key={trajectory.kind}
+                  className={`batch-line batch-line--${trajectory.kind}`}
+                  d={tracePath(trajectory.trace, maxLogTraceLoss)}
+                />
+              ))}
+            </g>
+            <text className="batch-axis-label" x="337" y="172">update</text>
+            <text className="batch-axis-label batch-axis-label--y" x="12" y="82">log loss</text>
+          </svg>
+          <div className="strategy-grid">
+            {trajectories.map((trajectory) => {
+              const final = trajectory.trace[trajectory.trace.length - 1]!;
+              return (
+                <div className={`strategy-summary strategy-summary--${trajectory.kind}`} key={trajectory.kind}>
+                  <strong>{trajectory.label}</strong>
+                  <span>{trajectory.summary}</span>
+                  <code>loss {formatNumber(final.loss, 4)}</code>
+                  <small>w {formatNumber(final.weight, 3)} / b {formatNumber(final.bias, 3)}</small>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </section>
+
+      <aside className="controls optimization-controls" aria-label="Optimization controls">
+        <div className="lesson">
+          <span>Try this</span>
+          <p>Move the model away from the minimum, then increase the learning rate until one or more trajectories overshoot.</p>
+        </div>
+        <div className="field-grid">
+          <label className="field">
+            <span>Weight w</span>
+            <input aria-label="Optimization weight" type="number" step="0.1" value={state.weight} onChange={(event) => updateState("weight", event.target.value)} />
+          </label>
+          <label className="field">
+            <span>Bias b</span>
+            <input aria-label="Optimization bias" type="number" step="0.1" value={state.bias} onChange={(event) => updateState("bias", event.target.value)} />
+          </label>
+        </div>
+        <label className="field">
+          <span>Learning rate</span>
+          <input aria-label="Optimization learning rate" type="range" min="0.005" max="0.3" step="0.005" value={learningRate} onChange={(event) => setLearningRate(Number(event.target.value))} />
+          <input type="number" min="0.005" max="0.3" step="0.005" value={learningRate} onChange={(event) => setLearningRate(numberValue(event.target.value, learningRate))} />
+        </label>
+        <label className="field">
+          <span>Comparison updates</span>
+          <input aria-label="Comparison updates" type="range" min="1" max="80" step="1" value={stepCount} onChange={(event) => setStepCount(Number(event.target.value))} />
+          <strong>{stepCount}</strong>
+        </label>
+        <label className="field">
+          <span>Finite-difference epsilon</span>
+          <select aria-label="Finite-difference epsilon" value={epsilon} onChange={(event) => setEpsilon(Number(event.target.value))}>
+            <option value="0.01">1e-2</option>
+            <option value="0.001">1e-3</option>
+            <option value="0.0001">1e-4</option>
+            <option value="0.00001">1e-5</option>
+            <option value="0.000001">1e-6</option>
+            <option value="1e-8">1e-8</option>
+          </select>
+        </label>
+        <div className="metric">
+          <span>Maximum relative gradient error</span>
+          <strong>{formatNumber(gradientCheck.maximumRelativeError)}</strong>
+        </div>
+        <button type="button" onClick={reset}>Reset optimization lab</button>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/RecurrentWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/RecurrentWorkbench.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useMemo, useState } from "react";
 import { BpttWorkbench } from "./BpttWorkbench.js";
+import { GateComparisonWorkbench } from "./GateComparisonWorkbench.js";
 import {
   DEFAULT_RECURRENT_INITIAL_STATE,
   DEFAULT_RECURRENT_INPUTS,
@@ -228,10 +229,18 @@ function RecurrentForwardWorkbench({ onShowBackward }: RecurrentForwardWorkbench
 }
 
 export function RecurrentWorkbench() {
-  const [view, setView] = useState<"forward" | "backward">("forward");
+  const [view, setView] = useState<"forward" | "backward" | "gates">("forward");
 
   if (view === "backward") {
-    return <BpttWorkbench onShowForward={() => setView("forward")} />;
+    return (
+      <BpttWorkbench
+        onShowForward={() => setView("forward")}
+        onShowGates={() => setView("gates")}
+      />
+    );
+  }
+  if (view === "gates") {
+    return <GateComparisonWorkbench onShowBackward={() => setView("backward")} />;
   }
   return <RecurrentForwardWorkbench onShowBackward={() => setView("backward")} />;
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/RecurrentWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/RecurrentWorkbench.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useMemo, useState } from "react";
+import { BpttWorkbench } from "./BpttWorkbench.js";
 import {
   DEFAULT_RECURRENT_INITIAL_STATE,
   DEFAULT_RECURRENT_INPUTS,
@@ -13,7 +14,11 @@ function formatNumber(value: number): string {
   return Number(value.toFixed(4)).toString();
 }
 
-export function RecurrentWorkbench() {
+interface RecurrentForwardWorkbenchProps {
+  onShowBackward: () => void;
+}
+
+function RecurrentForwardWorkbench({ onShowBackward }: RecurrentForwardWorkbenchProps) {
   const [selectedTime, setSelectedTime] = useState(0);
   const [memoryEnabled, setMemoryEnabled] = useState(true);
   const withMemory = useMemo(() => traceRecurrentUnroll(), []);
@@ -183,6 +188,10 @@ export function RecurrentWorkbench() {
           its inputs, weights, or bias.
         </p>
 
+        <button className="bptt-view-button" type="button" onClick={onShowBackward}>
+          Trace backward gradients
+        </button>
+
         <label className="recurrent-memory-control">
           <input
             type="checkbox"
@@ -216,4 +225,13 @@ export function RecurrentWorkbench() {
       </aside>
     </main>
   );
+}
+
+export function RecurrentWorkbench() {
+  const [view, setView] = useState<"forward" | "backward">("forward");
+
+  if (view === "backward") {
+    return <BpttWorkbench onShowForward={() => setView("forward")} />;
+  }
+  return <RecurrentForwardWorkbench onShowBackward={() => setView("backward")} />;
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/RecurrentWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/RecurrentWorkbench.tsx
@@ -1,0 +1,219 @@
+import { Fragment, useMemo, useState } from "react";
+import {
+  DEFAULT_RECURRENT_INITIAL_STATE,
+  DEFAULT_RECURRENT_INPUTS,
+  DEFAULT_RECURRENT_PARAMETERS,
+  traceRecurrentUnroll,
+} from "./recurrent-unroll-lab.js";
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(4)).toString();
+}
+
+export function RecurrentWorkbench() {
+  const [selectedTime, setSelectedTime] = useState(0);
+  const [memoryEnabled, setMemoryEnabled] = useState(true);
+  const withMemory = useMemo(() => traceRecurrentUnroll(), []);
+  const withoutMemory = useMemo(
+    () => traceRecurrentUnroll(
+      DEFAULT_RECURRENT_INPUTS,
+      DEFAULT_RECURRENT_INITIAL_STATE,
+      DEFAULT_RECURRENT_PARAMETERS,
+      false,
+    ),
+    [],
+  );
+  const displayed = memoryEnabled ? withMemory : withoutMemory;
+  const selected = displayed.steps[selectedTime]!;
+
+  return (
+    <main className="workspace workspace--recurrent">
+      <section className="recurrent-stage" aria-label="Three-step recurrent state trace">
+        <div className="recurrent-intro">
+          <div>
+            <p className="eyebrow">NN09 · sequence networks</p>
+            <h2>Recurrent-state unroller</h2>
+            <p>
+              Run one scalar cell three times. Each result becomes part of the
+              next input while one parameter set stays shared across time.
+            </p>
+          </div>
+          <div className="recurrent-sequence-chip">x = [1, 2, 0]</div>
+        </div>
+
+        <section className="recurrent-unroll-panel" aria-label="Recurrent cell unroll">
+          <div className="recurrent-panel-heading">
+            <div>
+              <p className="eyebrow">One cell · three executions</p>
+              <h2>Follow the state from left to right</h2>
+            </div>
+            <div className="recurrent-final-state">
+              <small>final state</small>
+              <strong>{formatNumber(displayed.finalState)}</strong>
+            </div>
+          </div>
+
+          <div className="shared-parameter-strip" aria-label="Parameters shared by every time step">
+            <span>shared at t=0, 1, 2</span>
+            <code>Wₓ = {formatNumber(DEFAULT_RECURRENT_PARAMETERS.inputWeight)}</code>
+            <code>Wₕ = {formatNumber(DEFAULT_RECURRENT_PARAMETERS.recurrentWeight)}</code>
+            <code>b = {formatNumber(DEFAULT_RECURRENT_PARAMETERS.bias)}</code>
+          </div>
+
+          <div className="recurrent-chain" aria-label="Unrolled recurrent state chain">
+            <div className="recurrent-initial-node">
+              <small>initial</small>
+              <strong>h[-1]</strong>
+              <code>{formatNumber(DEFAULT_RECURRENT_INITIAL_STATE)}</code>
+            </div>
+            {displayed.steps.map((step) => (
+              <Fragment key={step.time}>
+                <div className={memoryEnabled
+                  ? "recurrent-connector"
+                  : "recurrent-connector recurrent-connector--disabled"}
+                >
+                  <small>{memoryEnabled ? "carry h" : "cut"}</small>
+                  <span aria-hidden="true">→</span>
+                </div>
+                <button
+                  aria-label={`Select recurrent step ${step.time}`}
+                  aria-pressed={selectedTime === step.time}
+                  className={selectedTime === step.time
+                    ? "recurrent-cell recurrent-cell--active"
+                    : "recurrent-cell"}
+                  type="button"
+                  onClick={() => setSelectedTime(step.time)}
+                >
+                  <small>time {step.time}</small>
+                  <span>x[{step.time}] = {formatNumber(step.input)}</span>
+                  <strong>h[{step.time}] = {formatNumber(step.state)}</strong>
+                </button>
+              </Fragment>
+            ))}
+          </div>
+
+          <div className="recurrent-arithmetic" aria-label="Selected recurrent arithmetic">
+            <div className="recurrent-arithmetic-heading">
+              <div>
+                <p className="eyebrow">Selected · time {selectedTime}</p>
+                <h3>Open this cell</h3>
+              </div>
+              <code>h[{selectedTime - 1}] → h[{selectedTime}]</code>
+            </div>
+            <div className="recurrent-equation">
+              <div>
+                <small>new input</small>
+                <strong>
+                  2 × {formatNumber(selected.input)} = {formatNumber(selected.inputProduct)}
+                </strong>
+              </div>
+              <span>+</span>
+              <div className={memoryEnabled ? "" : "equation-term--disabled"}>
+                <small>carried state</small>
+                <strong>
+                  0.5 × {formatNumber(selected.previousState)} = {formatNumber(selected.recurrentProduct)}
+                </strong>
+              </div>
+              <span>+</span>
+              <div>
+                <small>bias</small>
+                <strong>{formatNumber(selected.bias)}</strong>
+              </div>
+              <span>=</span>
+              <div>
+                <small>preactivation</small>
+                <strong>{formatNumber(selected.preactivation)}</strong>
+              </div>
+              <span>→</span>
+              <div className="recurrent-equation__state">
+                <small>ReLU state</small>
+                <strong>{formatNumber(selected.state)}</strong>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="memory-ablation-panel" aria-label="Recurrent memory ablation">
+          <div className="recurrent-panel-heading">
+            <div>
+              <p className="eyebrow">Same inputs · memory removed</p>
+              <h2>What came through the recurrent link?</h2>
+            </div>
+            <p>The final zero input remembers earlier steps only when the link is present.</p>
+          </div>
+          <div className="recurrent-table-wrap">
+            <table className="recurrent-table">
+              <caption>State comparison with and without recurrence</caption>
+              <thead>
+                <tr>
+                  <th scope="col">time</th>
+                  <th scope="col">input</th>
+                  <th scope="col">with memory</th>
+                  <th scope="col">without memory</th>
+                  <th scope="col">difference</th>
+                </tr>
+              </thead>
+              <tbody>
+                {withMemory.steps.map((step, time) => {
+                  const ablatedState = withoutMemory.states[time]!;
+                  return (
+                    <tr className={selectedTime === time ? "recurrent-table-row--active" : ""} key={time}>
+                      <th scope="row">{time}</th>
+                      <td>{formatNumber(step.input)}</td>
+                      <td>{formatNumber(step.state)}</td>
+                      <td>{formatNumber(ablatedState)}</td>
+                      <td>{formatNumber(step.state - ablatedState)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </section>
+
+      <aside className="recurrent-controls" aria-label="Recurrent unroll controls">
+        <p className="eyebrow">One honest experiment</p>
+        <h2>Memory control</h2>
+        <p>
+          Select a time-step cell, then cut the recurrent link without changing
+          its inputs, weights, or bias.
+        </p>
+
+        <label className="recurrent-memory-control">
+          <input
+            type="checkbox"
+            checked={memoryEnabled}
+            onChange={(event) => setMemoryEnabled(event.target.checked)}
+          />
+          <span>
+            <strong>Carry the previous state</strong>
+            <small>Use Wₕ × h[t - 1] at every step.</small>
+          </span>
+        </label>
+
+        <div className="recurrent-selected-summary">
+          <small>selected time</small>
+          <strong>t = {selectedTime}</strong>
+          <span>
+            {memoryEnabled
+              ? `${formatNumber(selected.recurrentProduct)} enters through memory.`
+              : "The recurrent contribution is forced to zero."}
+          </span>
+        </div>
+
+        <div className="recurrent-note">
+          <span>What scales next?</span>
+          <p>
+            Vector states repeat this same pattern across several coordinates.
+            Backpropagation will reverse the unrolled arrows and add gradient
+            contributions into the shared parameters.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/RepresentationWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/RepresentationWorkbench.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
 import { AutoencoderWorkbench } from "./AutoencoderWorkbench.js";
+import { DiffusionWorkbench } from "./DiffusionWorkbench.js";
 import { GanWorkbench } from "./GanWorkbench.js";
 import { VariationalWorkbench } from "./VariationalWorkbench.js";
 
 export function RepresentationWorkbench() {
-  const [lab, setLab] = useState<"autoencoder" | "variational" | "gan">("autoencoder");
+  const [lab, setLab] = useState<
+    "autoencoder" | "variational" | "gan" | "diffusion"
+  >("autoencoder");
 
   return (
     <div className="representation-workbench">
@@ -30,13 +33,22 @@ export function RepresentationWorkbench() {
         >
           Adversarial game
         </button>
+        <button
+          aria-pressed={lab === "diffusion"}
+          type="button"
+          onClick={() => setLab("diffusion")}
+        >
+          Diffusion path
+        </button>
       </nav>
       {lab === "autoencoder" ? (
         <AutoencoderWorkbench />
       ) : lab === "variational" ? (
         <VariationalWorkbench />
-      ) : (
+      ) : lab === "gan" ? (
         <GanWorkbench />
+      ) : (
+        <DiffusionWorkbench />
       )}
     </div>
   );

--- a/code/programs/typescript/ml-learning-visualizer/src/RepresentationWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/RepresentationWorkbench.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { AutoencoderWorkbench } from "./AutoencoderWorkbench.js";
+import { GanWorkbench } from "./GanWorkbench.js";
 import { VariationalWorkbench } from "./VariationalWorkbench.js";
 
 export function RepresentationWorkbench() {
-  const [lab, setLab] = useState<"autoencoder" | "variational">("autoencoder");
+  const [lab, setLab] = useState<"autoencoder" | "variational" | "gan">("autoencoder");
 
   return (
     <div className="representation-workbench">
@@ -22,8 +23,21 @@ export function RepresentationWorkbench() {
         >
           Variational sample
         </button>
+        <button
+          aria-pressed={lab === "gan"}
+          type="button"
+          onClick={() => setLab("gan")}
+        >
+          Adversarial game
+        </button>
       </nav>
-      {lab === "autoencoder" ? <AutoencoderWorkbench /> : <VariationalWorkbench />}
+      {lab === "autoencoder" ? (
+        <AutoencoderWorkbench />
+      ) : lab === "variational" ? (
+        <VariationalWorkbench />
+      ) : (
+        <GanWorkbench />
+      )}
     </div>
   );
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/RepresentationWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/RepresentationWorkbench.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { AutoencoderWorkbench } from "./AutoencoderWorkbench.js";
+import { VariationalWorkbench } from "./VariationalWorkbench.js";
+
+export function RepresentationWorkbench() {
+  const [lab, setLab] = useState<"autoencoder" | "variational">("autoencoder");
+
+  return (
+    <div className="representation-workbench">
+      <nav className="representation-lab-switch" aria-label="Representation learning lab">
+        <button
+          aria-pressed={lab === "autoencoder"}
+          type="button"
+          onClick={() => setLab("autoencoder")}
+        >
+          Deterministic bottleneck
+        </button>
+        <button
+          aria-pressed={lab === "variational"}
+          type="button"
+          onClick={() => setLab("variational")}
+        >
+          Variational sample
+        </button>
+      </nav>
+      {lab === "autoencoder" ? <AutoencoderWorkbench /> : <VariationalWorkbench />}
+    </div>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/ResidualWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/ResidualWorkbench.tsx
@@ -1,0 +1,288 @@
+import { useMemo, useState } from "react";
+import {
+  DEFAULT_RESIDUAL_INPUT,
+  traceResidualBlock,
+} from "./residual-field-lab.js";
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(4)).toString();
+}
+
+function SignalRow({
+  label,
+  values,
+  selectedIndex,
+  activeIndices = [],
+  annotation,
+}: {
+  label: string;
+  values: readonly number[];
+  selectedIndex?: number;
+  activeIndices?: readonly number[];
+  annotation?: string;
+}) {
+  return (
+    <div className="residual-signal-block">
+      <div className="residual-row-label">
+        <span>{label}</span>
+        {annotation === undefined ? null : <code>{annotation}</code>}
+      </div>
+      <div
+        className="residual-signal-row"
+        style={{ gridTemplateColumns: `repeat(${values.length}, minmax(52px, 1fr))` }}
+        aria-label={label}
+      >
+        {values.map((value, index) => {
+          const className = index === selectedIndex
+            ? "residual-cell residual-cell--selected"
+            : activeIndices.includes(index)
+              ? "residual-cell residual-cell--active"
+              : "residual-cell";
+          return (
+            <div className={className} key={index}>
+              <small>[{index}]</small>
+              <strong>{formatNumber(value)}</strong>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function ResidualWorkbench() {
+  const [selectedIndex, setSelectedIndex] = useState(2);
+  const [includeSkip, setIncludeSkip] = useState(true);
+  const block = useMemo(() => traceResidualBlock(), []);
+  const trace = block.traces[selectedIndex]!;
+  const displayedSum = trace.mainOutput + (includeSkip ? trace.skipContribution : 0);
+  const displayedOutput = Math.max(0, displayedSum);
+  const displayedOutputs = block.main.map((mainValue, index) => (
+    Math.max(0, mainValue + (includeSkip ? block.skip[index]! : 0))
+  ));
+
+  function reset(): void {
+    setSelectedIndex(2);
+    setIncludeSkip(true);
+  }
+
+  return (
+    <main className="workspace workspace--residual">
+      <section className="residual-stage" aria-label="Residual path and receptive field trace">
+        <div className="residual-intro">
+          <div>
+            <p className="eyebrow">NN08 · spatial networks</p>
+            <h2>Residual-path microscope</h2>
+            <p>
+              Open one output into its deep local path and short identity path,
+              then trace every dependency back to the original input.
+            </p>
+          </div>
+          <div className="residual-shape-chip">5 → 5 → 5 + identity</div>
+        </div>
+
+        <section className="residual-block-panel" aria-label="Residual block forward trace">
+          <div className="residual-panel-heading">
+            <div>
+              <p className="eyebrow">Selected output · y[{selectedIndex}]</p>
+              <h2>Two routes meet at one addition</h2>
+            </div>
+            <strong className="residual-result">{formatNumber(displayedOutput)}</strong>
+          </div>
+
+          <div className="residual-main-path">
+            <span className="residual-lane-label">main path · two local layers</span>
+            <SignalRow
+              label="input x"
+              values={DEFAULT_RESIDUAL_INPUT}
+              selectedIndex={includeSkip ? selectedIndex : undefined}
+              activeIndices={trace.receptiveFieldIndices}
+              annotation="receptive field highlighted"
+            />
+            <span className="residual-down-arrow" aria-hidden="true">↓ [1, 1, 1] · same zero pad</span>
+            <SignalRow
+              label="hidden h"
+              values={block.hidden}
+              activeIndices={trace.hiddenIndices}
+              annotation={`${trace.hiddenIndices.length} values feed main[${selectedIndex}]`}
+            />
+            <span className="residual-down-arrow" aria-hidden="true">↓ [1, 1, 1] · same zero pad</span>
+            <SignalRow
+              label="main transform F(x)"
+              values={block.main}
+              selectedIndex={selectedIndex}
+              annotation={`main[${selectedIndex}] = ${formatNumber(trace.mainOutput)}`}
+            />
+          </div>
+
+          <div className={includeSkip ? "residual-skip-lane" : "residual-skip-lane residual-skip-lane--disabled"}>
+            <div>
+              <small>identity skip</small>
+              <strong>x[{selectedIndex}] = {formatNumber(trace.skipContribution)}</strong>
+            </div>
+            <span aria-hidden="true">────────────→</span>
+            <code>{includeSkip ? "included" : "disabled"}</code>
+          </div>
+
+          <div className="residual-addition" aria-label="Selected residual addition">
+            <div>
+              <small>main path</small>
+              <strong>{formatNumber(trace.mainOutput)}</strong>
+            </div>
+            <span>+</span>
+            <div>
+              <small>skip path</small>
+              <strong>{includeSkip ? formatNumber(trace.skipContribution) : "0"}</strong>
+            </div>
+            <span>=</span>
+            <div>
+              <small>before ReLU</small>
+              <strong>{formatNumber(displayedSum)}</strong>
+            </div>
+            <span>→</span>
+            <div className="residual-addition__output">
+              <small>output</small>
+              <strong>{formatNumber(displayedOutput)}</strong>
+            </div>
+          </div>
+
+          <SignalRow
+            label={includeSkip ? "block output ReLU(F(x) + x)" : "block output ReLU(F(x))"}
+            values={displayedOutputs}
+            selectedIndex={selectedIndex}
+          />
+        </section>
+
+        <section className="receptive-panel" aria-label="Receptive field explorer">
+          <div className="residual-panel-heading">
+            <div>
+              <p className="eyebrow">Receptive field · output {selectedIndex}</p>
+              <h2>One output, every path back</h2>
+            </div>
+            <div className="field-width-badge">
+              <small>in-range width</small>
+              <strong>{trace.receptiveFieldIndices.length}</strong>
+            </div>
+          </div>
+
+          <div className="hidden-path-grid">
+            {trace.hiddenPaths.map((path) => (
+              <article className="hidden-path-card" key={path.hiddenIndex}>
+                <div>
+                  <small>layer 2 reads</small>
+                  <strong>h[{path.hiddenIndex}] = {formatNumber(path.subtotal)}</strong>
+                </div>
+                <code>
+                  {path.inputIndices.map((inputIndex) => `x[${inputIndex}]`).join(" + ")}
+                </code>
+                <span>
+                  {path.inputValues.map(formatNumber).join(" + ")} = {formatNumber(path.subtotal)}
+                </span>
+              </article>
+            ))}
+          </div>
+
+          <div className="path-count-table-wrap">
+            <table className="path-count-table">
+              <caption>Original inputs after expanding both layers</caption>
+              <thead>
+                <tr>
+                  <th scope="col">input</th>
+                  {DEFAULT_RESIDUAL_INPUT.map((_, index) => <th scope="col" key={index}>x[{index}]</th>)}
+                  <th scope="col">sum</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row">paths</th>
+                  {trace.inputPathCounts.map((count, index) => <td key={index}>{count}</td>)}
+                  <td>—</td>
+                </tr>
+                <tr>
+                  <th scope="row">value × paths</th>
+                  {trace.inputContributions.map((value, index) => <td key={index}>{formatNumber(value)}</td>)}
+                  <td className="path-count-total">{formatNumber(trace.mainOutput)}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div className="receptive-summary">
+            <code>
+              receptive input indices = [{trace.receptiveFieldIndices.join(", ")}]
+            </code>
+            <span>
+              Zero-valued inputs still belong to the structural field: changing
+              them can change this output.
+            </span>
+          </div>
+        </section>
+      </section>
+
+      <aside className="residual-controls" aria-label="Residual explorer controls">
+        <p className="eyebrow">Choose one output</p>
+        <h2>Trace controls</h2>
+        <p>Move from a clipped boundary field to the five-position center field.</p>
+
+        <div className="residual-output-buttons">
+          {block.output.map((value, index) => (
+            <button
+              aria-label={`Select residual output ${index}`}
+              className={index === selectedIndex
+                ? "residual-output-button residual-output-button--active"
+                : "residual-output-button"}
+              key={index}
+              type="button"
+              onClick={() => setSelectedIndex(index)}
+            >
+              <small>y[{index}]</small>
+              <strong>{formatNumber(value)}</strong>
+            </button>
+          ))}
+        </div>
+
+        <label className="residual-skip-control">
+          <input
+            type="checkbox"
+            checked={includeSkip}
+            onChange={(event) => setIncludeSkip(event.target.checked)}
+          />
+          <span>
+            <strong>Include identity skip</strong>
+            <small>Add x[i] directly to the main path.</small>
+          </span>
+        </label>
+
+        <div className="button-grid">
+          <button
+            type="button"
+            disabled={selectedIndex === 0}
+            onClick={() => setSelectedIndex((index) => Math.max(0, index - 1))}
+          >
+            Previous output
+          </button>
+          <button
+            type="button"
+            disabled={selectedIndex === block.output.length - 1}
+            onClick={() => setSelectedIndex((index) => Math.min(block.output.length - 1, index + 1))}
+          >
+            Next output
+          </button>
+          <button type="button" onClick={reset}>Reset trace</button>
+        </div>
+
+        <div className="residual-note">
+          <span>What scales next?</span>
+          <p>
+            More layers widen the main path's field. Projection skips handle
+            shape changes, but must still land on a tensor compatible with the
+            addition.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/StructuredWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/StructuredWorkbench.tsx
@@ -1,16 +1,18 @@
 import { useState } from "react";
 import { HopfieldWorkbench } from "./HopfieldWorkbench.js";
 import { MessagePassingWorkbench } from "./MessagePassingWorkbench.js";
+import { GraphNeighborhoodWorkbench } from "./GraphNeighborhoodWorkbench.js";
 
 export function StructuredWorkbench() {
-  const [lab, setLab] = useState<"hopfield" | "message">("hopfield");
+  const [lab, setLab] = useState<"hopfield" | "message" | "graph-models">("hopfield");
   return (
     <div className="structured-workbench">
       <nav className="structured-lab-switch" aria-label="Structured and memory learning lab">
         <button aria-pressed={lab === "hopfield"} type="button" onClick={() => setLab("hopfield")}>Hopfield memory</button>
         <button aria-pressed={lab === "message"} type="button" onClick={() => setLab("message")}>Message passing</button>
+        <button aria-pressed={lab === "graph-models"} type="button" onClick={() => setLab("graph-models")}>GCN vs GAT</button>
       </nav>
-      {lab === "hopfield" ? <HopfieldWorkbench /> : <MessagePassingWorkbench />}
+      {lab === "hopfield" ? <HopfieldWorkbench /> : lab === "message" ? <MessagePassingWorkbench /> : <GraphNeighborhoodWorkbench />}
     </div>
   );
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/StructuredWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/StructuredWorkbench.tsx
@@ -1,0 +1,12 @@
+import { HopfieldWorkbench } from "./HopfieldWorkbench.js";
+
+export function StructuredWorkbench() {
+  return (
+    <div className="structured-workbench">
+      <nav className="structured-lab-switch" aria-label="Structured and memory learning lab">
+        <button aria-pressed="true" type="button">Hopfield memory</button>
+      </nav>
+      <HopfieldWorkbench />
+    </div>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/StructuredWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/StructuredWorkbench.tsx
@@ -1,12 +1,16 @@
+import { useState } from "react";
 import { HopfieldWorkbench } from "./HopfieldWorkbench.js";
+import { MessagePassingWorkbench } from "./MessagePassingWorkbench.js";
 
 export function StructuredWorkbench() {
+  const [lab, setLab] = useState<"hopfield" | "message">("hopfield");
   return (
     <div className="structured-workbench">
       <nav className="structured-lab-switch" aria-label="Structured and memory learning lab">
-        <button aria-pressed="true" type="button">Hopfield memory</button>
+        <button aria-pressed={lab === "hopfield"} type="button" onClick={() => setLab("hopfield")}>Hopfield memory</button>
+        <button aria-pressed={lab === "message"} type="button" onClick={() => setLab("message")}>Message passing</button>
       </nav>
-      <HopfieldWorkbench />
+      {lab === "hopfield" ? <HopfieldWorkbench /> : <MessagePassingWorkbench />}
     </div>
   );
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/TrainingStabilizersWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/TrainingStabilizersWorkbench.tsx
@@ -1,0 +1,267 @@
+import { useMemo, useState } from "react";
+import {
+  TRAINING_STABILIZER_ROUTES,
+  traceTrainingStabilizers,
+  type TrainingStabilizerRouteId,
+} from "./training-stabilizers-lab.js";
+
+function formatNumber(value: number, digits = 6): string {
+  if (Math.abs(value) < 1e-12) return "0";
+  if (Math.abs(value) < 0.0001 || Math.abs(value) >= 1000) return value.toExponential(3);
+  return Number(value.toFixed(digits)).toString();
+}
+
+function formatVector(values: readonly number[]): string {
+  return `[${values.map((value) => formatNumber(value)).join(", ")}]`;
+}
+
+function VectorStrip({
+  label,
+  values,
+  selectedCoordinate,
+  tone = "blue",
+}: {
+  label: string;
+  values: readonly number[];
+  selectedCoordinate: number;
+  tone?: "blue" | "green" | "purple" | "red";
+}) {
+  return (
+    <div className={`stabilizer-vector stabilizer-vector--${tone}`}>
+      <span>{label}</span>
+      <div>
+        {values.map((value, index) => (
+          <code className={selectedCoordinate === index ? "is-selected" : ""} key={`${label}-${index}`}>
+            <small>{index + 1}</small>
+            {formatNumber(value)}
+          </code>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function TrainingStabilizersWorkbench() {
+  const [routeId, setRouteId] = useState<TrainingStabilizerRouteId>("plain");
+  const [selectedCoordinate, setSelectedCoordinate] = useState(0);
+  const trace = useMemo(() => traceTrainingStabilizers(), []);
+  const route = trace.routes.find((item) => item.id === routeId)!;
+  const definition = TRAINING_STABILIZER_ROUTES.find((item) => item.id === routeId)!;
+  const coordinate = selectedCoordinate;
+  const maxInputError = Math.max(...route.inputGradientAbsoluteError);
+
+  return (
+    <main className="workspace workspace--stabilizers">
+      <section className="stabilizer-stage" aria-label="Normalization dropout and residual comparison">
+        <div className="stabilizer-intro">
+          <div>
+            <p className="eyebrow">NN25 / one branch, four routes</p>
+            <h2>Normalization, dropout, and residual paths</h2>
+            <p>Hold one learned branch fixed, then watch each training mechanism change its forward values and reverse gradient.</p>
+          </div>
+          <div className="stabilizer-chip">4 coordinates</div>
+        </div>
+
+        <section className="stabilizer-common-panel" aria-label="Shared stabilizer branch">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Shared setup</p>
+              <h2>Everything starts from the same branch</h2>
+            </div>
+            <span>score = upstream · output</span>
+          </div>
+          <div className="stabilizer-common-flow">
+            <VectorStrip label="input x" values={trace.input} selectedCoordinate={coordinate} />
+            <div className="stabilizer-flow-arrow">× {formatNumber(trace.branchWeight)}</div>
+            <VectorStrip label="learned branch h" values={trace.branch} selectedCoordinate={coordinate} tone="purple" />
+            <VectorStrip label="upstream dS/doutput" values={trace.upstreamGradient} selectedCoordinate={coordinate} tone="red" />
+          </div>
+        </section>
+
+        <section className="stabilizer-comparison-panel" aria-label="Training stabilizer route comparison">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Same numbers, different jobs</p>
+              <h2>Compare all four routes</h2>
+            </div>
+            <span>select a route to unpack it</span>
+          </div>
+          <div className="stabilizer-comparison-grid">
+            {trace.routes.map((item) => {
+              const itemDefinition = TRAINING_STABILIZER_ROUTES.find((candidate) => candidate.id === item.id)!;
+              return (
+                <button
+                  aria-pressed={item.id === routeId}
+                  key={item.id}
+                  type="button"
+                  onClick={() => setRouteId(item.id)}
+                >
+                  <strong>{itemDefinition.label}</strong>
+                  <span>{itemDefinition.summary}</span>
+                  <code>output {formatVector(item.output)}</code>
+                  <code>dS/dx {formatVector(item.inputGradient)}</code>
+                  <small>score {formatNumber(item.score)}</small>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="stabilizer-forward-panel" aria-label="Selected stabilizer forward trace">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Forward / {definition.label}</p>
+              <h2>What changes on this route?</h2>
+            </div>
+            <strong>score {formatNumber(route.score)}</strong>
+          </div>
+          {routeId === "normalization" ? (
+            <div className="stabilizer-mechanism-trace">
+              <div className="stabilizer-stat-grid">
+                <div><small>mean</small><strong>{formatNumber(trace.normalization.mean)}</strong></div>
+                <div><small>variance / population</small><strong>{formatNumber(trace.normalization.variance)}</strong></div>
+                <div><small>standard deviation</small><strong>{formatNumber(trace.normalization.standardDeviation)}</strong></div>
+                <div><small>epsilon / hand fixture</small><strong>0</strong></div>
+              </div>
+              <VectorStrip label="centered h - mean" values={trace.normalization.centered} selectedCoordinate={coordinate} tone="purple" />
+              <VectorStrip label="normalized output" values={route.output} selectedCoordinate={coordinate} tone="green" />
+              <code className="stabilizer-formula">normalized[i] = (h[i] - mean) / standard deviation</code>
+            </div>
+          ) : routeId === "dropout" ? (
+            <div className="stabilizer-mechanism-trace">
+              <VectorStrip label="binary mask" values={trace.dropoutMask} selectedCoordinate={coordinate} tone="red" />
+              <VectorStrip label="mask / keep probability" values={trace.dropout.scaledMask} selectedCoordinate={coordinate} tone="purple" />
+              <VectorStrip label="training output" values={route.output} selectedCoordinate={coordinate} tone="green" />
+              <div className="stabilizer-dropout-compare">
+                <div><small>evaluation / dropout off</small><code>{formatVector(trace.dropout.evaluationOutput)}</code></div>
+                <div><small>expectation over training masks</small><code>{formatVector(trace.dropout.trainingExpectation)}</code></div>
+              </div>
+              <code className="stabilizer-formula">training output[i] = h[i] × mask[i] / {formatNumber(trace.keepProbability)}</code>
+            </div>
+          ) : routeId === "residual" ? (
+            <div className="stabilizer-mechanism-trace">
+              <VectorStrip label="identity skip x" values={trace.input} selectedCoordinate={coordinate} />
+              <div className="stabilizer-plus">+</div>
+              <VectorStrip label="learned branch h" values={trace.branch} selectedCoordinate={coordinate} tone="purple" />
+              <div className="stabilizer-plus">=</div>
+              <VectorStrip label="residual output" values={route.output} selectedCoordinate={coordinate} tone="green" />
+              <code className="stabilizer-formula">output[i] = input[i] + branch[i]</code>
+            </div>
+          ) : (
+            <div className="stabilizer-mechanism-trace">
+              <VectorStrip label="plain output = h" values={route.output} selectedCoordinate={coordinate} tone="green" />
+              <code className="stabilizer-formula">No extra route: output[i] = {formatNumber(trace.branchWeight)} × input[i]</code>
+            </div>
+          )}
+        </section>
+
+        <section className="stabilizer-backward-panel" aria-label="Selected stabilizer backward trace">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Backward / vector-Jacobian product</p>
+              <h2>Where does the score gradient travel?</h2>
+            </div>
+            <span>dS/dweight {formatNumber(route.weightGradient)}</span>
+          </div>
+          <div className="stabilizer-gradient-flow">
+            <VectorStrip label="upstream" values={trace.upstreamGradient} selectedCoordinate={coordinate} tone="red" />
+            <VectorStrip label="into learned branch" values={route.branchGradient} selectedCoordinate={coordinate} tone="purple" />
+            {routeId === "residual" ? (
+              <VectorStrip label="through identity skip" values={route.skipGradient} selectedCoordinate={coordinate} />
+            ) : null}
+            <VectorStrip label="total dS/dinput" values={route.inputGradient} selectedCoordinate={coordinate} tone="green" />
+          </div>
+        </section>
+
+        <section className="stabilizer-arithmetic-panel" aria-label="Selected stabilizer coordinate calculation">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Open coordinate {coordinate + 1}</p>
+              <h2>One reverse calculation</h2>
+            </div>
+            <span>input {formatNumber(trace.input[coordinate]!)}</span>
+          </div>
+          <div className="stabilizer-equations">
+            {routeId === "normalization" ? (
+              <>
+                <code>(4 × {formatNumber(trace.upstreamGradient[coordinate]!)} - {formatNumber(trace.normalization.upstreamSum)} - {formatNumber(trace.normalization.normalized[coordinate]!)} × {formatNumber(trace.normalization.upstreamDotNormalized)}) / (4 × {formatNumber(trace.normalization.standardDeviation)}) = {formatNumber(route.branchGradient[coordinate]!)}</code>
+                <span>layer norm couples this coordinate to both vector-wide sums</span>
+              </>
+            ) : routeId === "dropout" ? (
+              <>
+                <code>{formatNumber(trace.upstreamGradient[coordinate]!)} × {formatNumber(trace.dropoutMask[coordinate]!)} / {formatNumber(trace.keepProbability)} = {formatNumber(route.branchGradient[coordinate]!)}</code>
+                <span>a dropped coordinate receives zero branch gradient</span>
+              </>
+            ) : (
+              <>
+                <code>dS/dh[{coordinate + 1}] = {formatNumber(route.branchGradient[coordinate]!)}</code>
+                <span>{routeId === "residual" ? "the branch and skip both receive the upstream gradient" : "the plain branch passes the upstream gradient unchanged"}</span>
+              </>
+            )}
+            <code>{formatNumber(trace.branchWeight)} × {formatNumber(route.branchGradient[coordinate]!)} + {formatNumber(route.skipGradient[coordinate]!)} = {formatNumber(route.inputGradient[coordinate]!)}</code>
+            <span>branch contribution + identity-skip contribution</span>
+            <code>Σ dS/dh[i] × input[i] = {formatNumber(route.weightGradient)}</code>
+            <span>the shared scalar branch-weight gradient</span>
+          </div>
+        </section>
+
+        <section className="stabilizer-audit-panel" aria-label="Training stabilizer finite difference audit">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">Independent numerical audit</p>
+              <h2>Analytical gradients match score slopes</h2>
+            </div>
+            <span>epsilon 1e-6</span>
+          </div>
+          <div className="stabilizer-audit-grid">
+            <div><small>selected analytical dS/dx</small><code>{formatNumber(route.inputGradient[coordinate]!)}</code></div>
+            <div><small>selected finite difference</small><code>{formatNumber(route.finiteDifferenceInputGradient[coordinate]!)}</code></div>
+            <div><small>maximum input error</small><code>{formatNumber(maxInputError)}</code></div>
+            <div><small>analytical dS/dweight</small><code>{formatNumber(route.weightGradient)}</code></div>
+            <div><small>weight finite difference</small><code>{formatNumber(route.finiteDifferenceWeightGradient)}</code></div>
+            <div><small>weight error</small><code>{formatNumber(route.weightGradientAbsoluteError)}</code></div>
+          </div>
+        </section>
+      </section>
+
+      <aside className="controls stabilizer-controls" aria-label="Training stabilizer controls">
+        <p className="eyebrow">Training mechanism</p>
+        <h2>Choose a route</h2>
+        <p>The learned branch, input, and upstream vector stay fixed.</p>
+        <div className="stabilizer-route-buttons">
+          {TRAINING_STABILIZER_ROUTES.map((item) => (
+            <button
+              aria-pressed={item.id === routeId}
+              key={item.id}
+              type="button"
+              onClick={() => setRouteId(item.id)}
+            >
+              <strong>{item.label}</strong>
+              <span>{item.summary}</span>
+            </button>
+          ))}
+        </div>
+        <p className="eyebrow">Coordinate microscope</p>
+        <div className="stabilizer-coordinate-buttons">
+          {trace.input.map((value, index) => (
+            <button
+              aria-label={`Open stabilizer coordinate ${index + 1}`}
+              aria-pressed={coordinate === index}
+              key={index}
+              type="button"
+              onClick={() => setSelectedCoordinate(index)}
+            >
+              <span>{index + 1}</span>
+              <code>x = {formatNumber(value)}</code>
+            </button>
+          ))}
+        </div>
+        <div className="stabilizer-reading">
+          <p className="eyebrow">Different jobs</p>
+          <h2>{routeId === "normalization" ? "Coordinates share context" : routeId === "dropout" ? "Training samples a subnetwork" : routeId === "residual" ? "The skip keeps a short route" : "The control exposes the branch"}</h2>
+          <p>These mechanisms can coexist, but they are not interchangeable fixes for depth.</p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/VariationalWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/VariationalWorkbench.tsx
@@ -1,0 +1,307 @@
+import { useMemo, useState } from "react";
+import { traceScalarVariationalAutoencoder } from "./variational-lab.js";
+
+const BETA_OPTIONS = [0, 0.1, 0.25, 1];
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) {
+    return "0";
+  }
+  return Number(value.toFixed(8)).toString();
+}
+
+export function VariationalWorkbench() {
+  const [beta, setBeta] = useState(0.1);
+  const [gradientTarget, setGradientTarget] = useState<"mean" | "logVariance">("mean");
+  const [showUpdated, setShowUpdated] = useState(false);
+  const trace = useMemo(
+    () => traceScalarVariationalAutoencoder(beta),
+    [beta],
+  );
+  const currentForward = showUpdated ? trace.postUpdate : trace.forward;
+  const currentParameters = showUpdated
+    ? trace.updatedParameters
+    : trace.parameters;
+  const reconstructionRoute = gradientTarget === "mean"
+    ? trace.backward.reconstructionMeanGradient
+    : trace.backward.reconstructionLogVarianceGradient;
+  const klRoute = gradientTarget === "mean"
+    ? trace.backward.weightedKlMeanGradient
+    : trace.backward.weightedKlLogVarianceGradient;
+  const combinedRoute = gradientTarget === "mean"
+    ? trace.backward.meanGradient
+    : trace.backward.logVarianceGradient;
+  const gradientTargetLabel = gradientTarget === "mean"
+    ? "mean"
+    : "log-variance";
+
+  return (
+    <main className="workspace workspace--variational">
+      <section className="variational-stage" aria-label="Scalar variational autoencoder trace">
+        <div className="variational-intro">
+          <div>
+            <p className="eyebrow">NN17 - uncertainty without hidden randomness</p>
+            <h2>One Gaussian latent sample, fully unpacked</h2>
+            <p>
+              Encode a mean and log-variance, transform one saved noise value,
+              then watch reconstruction and prior matching negotiate one update.
+            </p>
+          </div>
+          <div className="variational-chip">mean + sigma x epsilon</div>
+        </div>
+
+        <section className="variational-flow-panel" aria-label="Variational encode sample and decode path">
+          <div className="variational-heading">
+            <div>
+              <p className="eyebrow">The sample is random; the path is differentiable</p>
+              <h2>Move noise outside the network</h2>
+            </div>
+            <code>{showUpdated ? "after one SGD step" : "saved epsilon = 0.5"}</code>
+          </div>
+
+          <div className="variational-flow">
+            <div className="variational-scalar-node">
+              <small>input is target</small>
+              <strong>x = {formatNumber(trace.input)}</strong>
+            </div>
+            <span className="variational-arrow" aria-hidden="true">-&gt;</span>
+            <div className="variational-distribution-node">
+              <small>encoder distribution</small>
+              <code>
+                mean = {formatNumber(currentForward.meanProduct)} + {formatNumber(currentParameters.encoder.mean.bias)} = {formatNumber(currentForward.mean)}
+              </code>
+              <code>
+                log var = {formatNumber(currentForward.logVarianceProduct)} + {formatNumber(currentParameters.encoder.logVariance.bias)} = {formatNumber(currentForward.logVariance)}
+              </code>
+              <code>sigma = {formatNumber(currentForward.standardDeviation)}</code>
+            </div>
+            <span className="variational-arrow" aria-hidden="true">-&gt;</span>
+            <div className="variational-sample-node">
+              <small>reparameterized sample</small>
+              <code>
+                {formatNumber(currentForward.mean)} + {formatNumber(currentForward.standardDeviation)} x {formatNumber(currentForward.epsilon)}
+              </code>
+              <strong>z = {formatNumber(currentForward.latent)}</strong>
+              <span>epsilon stays fixed for this audit</span>
+            </div>
+            <span className="variational-arrow" aria-hidden="true">-&gt;</span>
+            <div className="variational-scalar-node variational-scalar-node--output">
+              <small>decoder reconstruction</small>
+              <code>
+                {formatNumber(currentForward.latent)} x {formatNumber(currentParameters.decoder.weight)} + {formatNumber(currentParameters.decoder.bias)}
+              </code>
+              <strong>x_hat = {formatNumber(currentForward.reconstruction)}</strong>
+            </div>
+          </div>
+        </section>
+
+        <section className="variational-objective-panel" aria-label="Variational reconstruction and KL objective">
+          <div className="variational-heading">
+            <div>
+              <p className="eyebrow">Two pressures, one weighted objective</p>
+              <h2>Reconstruct here; stay sampleable everywhere</h2>
+            </div>
+            <div className="variational-loss-badge">
+              <small>total loss</small>
+              <strong>{formatNumber(currentForward.totalLoss)}</strong>
+            </div>
+          </div>
+
+          <div className="variational-objective-equation">
+            <div>
+              <small>reconstruction</small>
+              <code>0.5 x ({formatNumber(currentForward.error)})^2</code>
+              <strong>{formatNumber(currentForward.reconstructionLoss)}</strong>
+              <span>preserve this input</span>
+            </div>
+            <span aria-hidden="true">+</span>
+            <div>
+              <small>KL to Normal(0, 1)</small>
+              <code>
+                0.5 x ({formatNumber(currentForward.meanSquared)} + {formatNumber(currentForward.variance)} - 1 - {formatNumber(currentForward.logVariance)})
+              </code>
+              <strong>{formatNumber(currentForward.kl)}</strong>
+              <span>keep latent space sampleable</span>
+            </div>
+            <span aria-hidden="true">x</span>
+            <div className="variational-beta-node">
+              <small>beta</small>
+              <strong>{formatNumber(beta)}</strong>
+            </div>
+            <span aria-hidden="true">=</span>
+            <div className="variational-total-node">
+              <small>weighted total</small>
+              <code>
+                {formatNumber(currentForward.reconstructionLoss)} + {formatNumber(currentForward.weightedKl)}
+              </code>
+              <strong>{formatNumber(currentForward.totalLoss)}</strong>
+            </div>
+          </div>
+        </section>
+
+        <section className="variational-gradient-panel" aria-label={`Variational ${gradientTargetLabel} gradient tradeoff`}>
+          <div className="variational-heading">
+            <div>
+              <p className="eyebrow">Both objectives meet at the encoder</p>
+              <h2>Beta can reinforce, soften, or reverse a direction</h2>
+            </div>
+            <code>saved forward pass gradients</code>
+          </div>
+
+          <div className="variational-gradient-targets" aria-label="Variational gradient target">
+            <button
+              aria-pressed={gradientTarget === "mean"}
+              type="button"
+              onClick={() => setGradientTarget("mean")}
+            >
+              mean output
+            </button>
+            <button
+              aria-pressed={gradientTarget === "logVariance"}
+              type="button"
+              onClick={() => setGradientTarget("logVariance")}
+            >
+              log-variance output
+            </button>
+          </div>
+
+          <div className="variational-gradient-routes">
+            <div>
+              <small>reconstruction route</small>
+              <strong>{formatNumber(reconstructionRoute)}</strong>
+              <span>sample should rebuild x</span>
+            </div>
+            <span aria-hidden="true">+</span>
+            <div>
+              <small>beta x KL route</small>
+              <code>
+                {formatNumber(beta)} x {formatNumber(gradientTarget === "mean" ? trace.backward.klMeanGradient : trace.backward.klLogVarianceGradient)}
+              </code>
+              <strong>{formatNumber(klRoute)}</strong>
+              <span>distribution should match prior</span>
+            </div>
+            <span aria-hidden="true">=</span>
+            <div className="variational-combined-gradient">
+              <small>combined {gradientTargetLabel} gradient</small>
+              <strong>{formatNumber(combinedRoute)}</strong>
+              <span>
+                {combinedRoute === 0 ? "the routes cancel exactly" : "this is the encoder's update direction"}
+              </span>
+            </div>
+          </div>
+
+          <div className="variational-gradient-grid">
+            <div><small>decoder weight</small><code>{formatNumber(trace.backward.decoderWeightGradient)}</code></div>
+            <div><small>decoder bias</small><code>{formatNumber(trace.backward.decoderBiasGradient)}</code></div>
+            <div><small>mean weight / bias</small><code>{formatNumber(trace.backward.meanWeightGradient)} / {formatNumber(trace.backward.meanBiasGradient)}</code></div>
+            <div><small>log-var weight / bias</small><code>{formatNumber(trace.backward.logVarianceWeightGradient)} / {formatNumber(trace.backward.logVarianceBiasGradient)}</code></div>
+          </div>
+        </section>
+
+        <section className="variational-update-panel" aria-label="Variational SGD update and gradient audit">
+          <div className="variational-heading">
+            <div>
+              <p className="eyebrow">Same epsilon for analytical and numerical slopes</p>
+              <h2>Audit six parameters, then rerun everything</h2>
+            </div>
+            <code>parameter - {trace.learningRate} x gradient</code>
+          </div>
+
+          <div className="variational-parameter-grid">
+            <div>
+              <small>mean head before -&gt; after</small>
+              <code>w {formatNumber(trace.parameters.encoder.mean.weight)} -&gt; {formatNumber(trace.updatedParameters.encoder.mean.weight)}</code>
+              <code>b {formatNumber(trace.parameters.encoder.mean.bias)} -&gt; {formatNumber(trace.updatedParameters.encoder.mean.bias)}</code>
+            </div>
+            <div>
+              <small>log-var head before -&gt; after</small>
+              <code>w {formatNumber(trace.parameters.encoder.logVariance.weight)} -&gt; {formatNumber(trace.updatedParameters.encoder.logVariance.weight)}</code>
+              <code>b {formatNumber(trace.parameters.encoder.logVariance.bias)} -&gt; {formatNumber(trace.updatedParameters.encoder.logVariance.bias)}</code>
+            </div>
+            <div>
+              <small>decoder before -&gt; after</small>
+              <code>w {formatNumber(trace.parameters.decoder.weight)} -&gt; {formatNumber(trace.updatedParameters.decoder.weight)}</code>
+              <code>b {formatNumber(trace.parameters.decoder.bias)} -&gt; {formatNumber(trace.updatedParameters.decoder.bias)}</code>
+            </div>
+          </div>
+
+          <div className="variational-audit-row">
+            <span>Central finite differences - 6 parameters</span>
+            <code>epsilon = {trace.gradientCheck.epsilon}</code>
+            <strong>max error {trace.gradientCheck.maxAbsoluteError.toExponential(3)}</strong>
+          </div>
+
+          <div className="variational-loss-drop">
+            <div><small>total before</small><strong>{formatNumber(trace.forward.totalLoss)}</strong></div>
+            <span aria-hidden="true">-&gt;</span>
+            <div><small>total after</small><strong>{formatNumber(trace.postUpdate.totalLoss)}</strong></div>
+            <p>
+              Reconstruction falls from {formatNumber(trace.forward.reconstructionLoss)} to {formatNumber(trace.postUpdate.reconstructionLoss)}; KL may move differently while the selected weighted objective falls.
+            </p>
+          </div>
+        </section>
+      </section>
+
+      <aside className="variational-controls" aria-label="Variational trace controls">
+        <p className="eyebrow">Turn the prior pressure</p>
+        <h2>KL tradeoff controls</h2>
+        <p>
+          Epsilon stays fixed at 0.5. Changing beta therefore changes the
+          objective and gradient, not the sampled noise.
+        </p>
+
+        <div className="variational-beta-buttons" aria-label="Variational beta selection">
+          {BETA_OPTIONS.map((option) => (
+            <button
+              aria-pressed={beta === option}
+              key={option}
+              type="button"
+              onClick={() => {
+                setBeta(option);
+                setShowUpdated(false);
+              }}
+            >
+              beta {option}
+            </button>
+          ))}
+        </div>
+
+        <label className="attention-scale-control">
+          <input
+            type="checkbox"
+            checked={showUpdated}
+            onChange={(event) => setShowUpdated(event.target.checked)}
+          />
+          <span>
+            <strong>Use updated parameters</strong>
+            <small>Rerun distribution, sample, decoder, and both losses.</small>
+          </span>
+        </label>
+
+        <div className="variational-selected-summary">
+          <small>selected beta</small>
+          <strong>{formatNumber(beta)}</strong>
+          <span>
+            mean gradient {formatNumber(trace.backward.meanGradient)}; total {formatNumber(trace.forward.totalLoss)}
+          </span>
+        </div>
+
+        <div className="attention-value-boundary">
+          <span>Why save epsilon?</span>
+          <p>
+            The trace remains stochastic in meaning but reproducible in
+            execution. Finite differences compare the same noise on both sides.
+          </p>
+        </div>
+
+        <div className="attention-next-note">
+          <span>Do not optimize one term alone</span>
+          <p>
+            A useful VAE needs reconstruction and a navigable latent prior.
+            Their weighted sum, not either isolated term, defines this step.
+          </p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/attention-qkv-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/attention-qkv-lab.ts
@@ -1,0 +1,141 @@
+export type AttentionTokenId = "red" | "blue" | "purple";
+
+export interface AttentionToken {
+  id: AttentionTokenId;
+  label: string;
+  embedding: readonly number[];
+}
+
+export interface AttentionProjection {
+  id: AttentionTokenId;
+  label: string;
+  embedding: number[];
+  query: number[];
+  key: number[];
+  value: number[];
+}
+
+export interface AttentionDotProduct {
+  queryId: AttentionTokenId;
+  keyId: AttentionTokenId;
+  products: number[];
+  rawScore: number;
+  scaledScore: number;
+}
+
+export interface AttentionQkvTrace {
+  projections: AttentionProjection[];
+  dotProducts: AttentionDotProduct[];
+  rawScoreMatrix: number[][];
+  scaledScoreMatrix: number[][];
+  scaleDivisor: number;
+}
+
+export const DEFAULT_ATTENTION_TOKENS: readonly AttentionToken[] = [
+  { id: "red", label: "red", embedding: [1, 0] },
+  { id: "blue", label: "blue", embedding: [0, 1] },
+  { id: "purple", label: "purple", embedding: [1, 1] },
+];
+
+export const DEFAULT_QUERY_MATRIX: readonly (readonly number[])[] = [
+  [1, 0],
+  [0, 1],
+];
+
+export const DEFAULT_KEY_MATRIX: readonly (readonly number[])[] = [
+  [1, 1],
+  [-1, 1],
+];
+
+export const DEFAULT_VALUE_MATRIX: readonly (readonly number[])[] = [
+  [2, 0],
+  [0, 1],
+];
+
+function cleanZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+function project(
+  row: readonly number[],
+  matrix: readonly (readonly number[])[],
+): number[] {
+  if (
+    row.length === 0
+    || matrix.length !== row.length
+    || matrix.some((matrixRow) => matrixRow.length !== matrix[0]!.length)
+    || ![...row, ...matrix.flat()].every(Number.isFinite)
+  ) {
+    throw new Error("NN12 V1 needs finite row vectors and compatible rectangular matrices.");
+  }
+
+  return matrix[0]!.map((_, column) => cleanZero(
+    row.reduce((sum, value, index) => sum + value * matrix[index]![column]!, 0),
+  ));
+}
+
+export function traceAttentionQkv(
+  tokens: readonly AttentionToken[] = DEFAULT_ATTENTION_TOKENS,
+  queryMatrix: readonly (readonly number[])[] = DEFAULT_QUERY_MATRIX,
+  keyMatrix: readonly (readonly number[])[] = DEFAULT_KEY_MATRIX,
+  valueMatrix: readonly (readonly number[])[] = DEFAULT_VALUE_MATRIX,
+): AttentionQkvTrace {
+  if (
+    tokens.length !== 3
+    || new Set(tokens.map((token) => token.id)).size !== tokens.length
+    || tokens.some((token) => token.label.length === 0 || token.embedding.length !== 2)
+    || [queryMatrix, keyMatrix, valueMatrix].some(
+      (matrix) => matrix.length !== 2 || matrix.some((row) => row.length !== 2),
+    )
+  ) {
+    throw new Error("NN12 V1 needs three unique two-number tokens and three 2 x 2 matrices.");
+  }
+
+  const projections = tokens.map((token): AttentionProjection => ({
+    id: token.id,
+    label: token.label,
+    embedding: [...token.embedding],
+    query: project(token.embedding, queryMatrix),
+    key: project(token.embedding, keyMatrix),
+    value: project(token.embedding, valueMatrix),
+  }));
+  const keyDimension = projections[0]!.key.length;
+  const scaleDivisor = Math.sqrt(keyDimension);
+  const dotProducts = projections.flatMap((query) => projections.map((key) => {
+    const products = query.query.map((value, index) => cleanZero(value * key.key[index]!));
+    const rawScore = cleanZero(products.reduce((sum, value) => sum + value, 0));
+    return {
+      queryId: query.id,
+      keyId: key.id,
+      products,
+      rawScore,
+      scaledScore: cleanZero(rawScore / scaleDivisor),
+    };
+  }));
+
+  return {
+    projections,
+    dotProducts,
+    rawScoreMatrix: projections.map((query) => projections.map((key) => (
+      dotProducts.find((item) => item.queryId === query.id && item.keyId === key.id)!.rawScore
+    ))),
+    scaledScoreMatrix: projections.map((query) => projections.map((key) => (
+      dotProducts.find((item) => item.queryId === query.id && item.keyId === key.id)!.scaledScore
+    ))),
+    scaleDivisor,
+  };
+}
+
+export function attentionCell(
+  trace: AttentionQkvTrace,
+  queryId: AttentionTokenId,
+  keyId: AttentionTokenId,
+): AttentionDotProduct {
+  const cell = trace.dotProducts.find(
+    (item) => item.queryId === queryId && item.keyId === keyId,
+  );
+  if (cell === undefined) {
+    throw new Error(`Unknown attention cell ${queryId} -> ${keyId}.`);
+  }
+  return cell;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/attention-softmax-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/attention-softmax-lab.ts
@@ -1,0 +1,140 @@
+import {
+  traceAttentionQkv,
+  type AttentionTokenId,
+} from "./attention-qkv-lab.js";
+
+export interface AttentionSoftmaxRow {
+  queryId: AttentionTokenId;
+  allowed: boolean[];
+  scaledScores: number[];
+  maskedScores: Array<number | null>;
+  rowMax: number;
+  shiftedScores: Array<number | null>;
+  exponentials: number[];
+  denominator: number;
+  weights: number[];
+  values: number[][];
+  valueContributions: number[][];
+  context: number[];
+}
+
+export interface AttentionSoftmaxTrace {
+  causal: boolean;
+  tokenIds: AttentionTokenId[];
+  rows: AttentionSoftmaxRow[];
+  weightMatrix: number[][];
+  contextMatrix: number[][];
+}
+
+const qkvTrace = traceAttentionQkv();
+
+export const DEFAULT_ATTENTION_TOKEN_IDS = qkvTrace.projections.map(
+  (projection) => projection.id,
+);
+export const DEFAULT_SCALED_SCORE_MATRIX = qkvTrace.scaledScoreMatrix;
+export const DEFAULT_ATTENTION_VALUES = qkvTrace.projections.map(
+  (projection) => projection.value,
+);
+
+function cleanZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+function validMatrix(
+  matrix: readonly (readonly number[])[],
+  rows: number,
+  columns: number,
+): boolean {
+  return matrix.length === rows
+    && matrix.every(
+      (row) => row.length === columns && row.every(Number.isFinite),
+    );
+}
+
+export function traceAttentionSoftmax(
+  causal = true,
+  scaledScoreMatrix: readonly (readonly number[])[] = DEFAULT_SCALED_SCORE_MATRIX,
+  values: readonly (readonly number[])[] = DEFAULT_ATTENTION_VALUES,
+  tokenIds: readonly AttentionTokenId[] = DEFAULT_ATTENTION_TOKEN_IDS,
+): AttentionSoftmaxTrace {
+  if (
+    tokenIds.length !== 3
+    || new Set(tokenIds).size !== tokenIds.length
+    || !validMatrix(scaledScoreMatrix, 3, 3)
+    || !validMatrix(values, 3, 2)
+  ) {
+    throw new Error(
+      "NN13 V1 needs three token IDs, a finite 3 x 3 score matrix, and finite 3 x 2 values.",
+    );
+  }
+
+  const rows = scaledScoreMatrix.map(
+    (scoreRow, queryIndex): AttentionSoftmaxRow => {
+      const allowed = scoreRow.map(
+        (_, keyIndex) => !causal || keyIndex <= queryIndex,
+      );
+      const maskedScores = scoreRow.map((score, keyIndex) => (
+        allowed[keyIndex] ? score : null
+      ));
+      const rowMax = Math.max(
+        ...maskedScores.filter((score): score is number => score !== null),
+      );
+      const shiftedScores = maskedScores.map((score) => (
+        score === null ? null : cleanZero(score - rowMax)
+      ));
+      const exponentials = shiftedScores.map((score) => (
+        score === null ? 0 : Math.exp(score)
+      ));
+      const denominator = exponentials.reduce(
+        (sum, exponential) => sum + exponential,
+        0,
+      );
+      const weights = exponentials.map(
+        (exponential) => cleanZero(exponential / denominator),
+      );
+      const valueContributions = values.map((value, keyIndex) => (
+        value.map((coordinate) => cleanZero(weights[keyIndex]! * coordinate))
+      ));
+      const context = values[0]!.map((_, coordinate) => cleanZero(
+        valueContributions.reduce(
+          (sum, contribution) => sum + contribution[coordinate]!,
+          0,
+        ),
+      ));
+
+      return {
+        queryId: tokenIds[queryIndex]!,
+        allowed,
+        scaledScores: [...scoreRow],
+        maskedScores,
+        rowMax,
+        shiftedScores,
+        exponentials,
+        denominator,
+        weights,
+        values: values.map((value) => [...value]),
+        valueContributions,
+        context,
+      };
+    },
+  );
+
+  return {
+    causal,
+    tokenIds: [...tokenIds],
+    rows,
+    weightMatrix: rows.map((row) => row.weights),
+    contextMatrix: rows.map((row) => row.context),
+  };
+}
+
+export function attentionSoftmaxRow(
+  trace: AttentionSoftmaxTrace,
+  queryId: AttentionTokenId,
+): AttentionSoftmaxRow {
+  const row = trace.rows.find((item) => item.queryId === queryId);
+  if (row === undefined) {
+    throw new Error(`Unknown attention softmax query ${queryId}.`);
+  }
+  return row;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/autoencoder-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/autoencoder-lab.ts
@@ -1,0 +1,250 @@
+export interface AutoencoderParameters {
+  encoder: {
+    weights: number[];
+    bias: number;
+  };
+  decoder: {
+    weights: number[];
+    bias: number[];
+  };
+}
+
+export interface AutoencoderForwardTrace {
+  encoderProducts: number[];
+  bottleneck: number;
+  decoderProducts: number[];
+  reconstruction: number[];
+  errors: number[];
+  squaredErrors: number[];
+  loss: number;
+}
+
+export interface AutoencoderBackwardTrace {
+  reconstructionGradients: number[];
+  decoderWeightGradients: number[];
+  decoderBiasGradients: number[];
+  bottleneckGradientContributions: number[];
+  bottleneckGradient: number;
+  encoderWeightGradients: number[];
+  encoderBiasGradient: number;
+}
+
+export interface AutoencoderTrace {
+  input: number[];
+  learningRate: number;
+  parameters: AutoencoderParameters;
+  forward: AutoencoderForwardTrace;
+  backward: AutoencoderBackwardTrace;
+  gradientCheck: {
+    epsilon: number;
+    parameterOrder: string[];
+    analytical: number[];
+    numerical: number[];
+    maxAbsoluteError: number;
+  };
+  updatedParameters: AutoencoderParameters;
+  postUpdate: AutoencoderForwardTrace;
+}
+
+export const DEFAULT_AUTOENCODER_INPUT = [2, -1];
+export const DEFAULT_AUTOENCODER_PARAMETERS: AutoencoderParameters = {
+  encoder: {
+    weights: [0.5, -0.25],
+    bias: 0,
+  },
+  decoder: {
+    weights: [1.2, -0.8],
+    bias: [0.1, -0.2],
+  },
+};
+export const DEFAULT_AUTOENCODER_LEARNING_RATE = 0.1;
+export const AUTOENCODER_PARAMETER_ORDER = [
+  "encoder.weights[0]",
+  "encoder.weights[1]",
+  "encoder.bias",
+  "decoder.weights[0]",
+  "decoder.weights[1]",
+  "decoder.bias[0]",
+  "decoder.bias[1]",
+];
+
+function cleanZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+function validVector(values: readonly number[], length: number): boolean {
+  return values.length === length && values.every(Number.isFinite);
+}
+
+function copyParameters(parameters: AutoencoderParameters): AutoencoderParameters {
+  return {
+    encoder: {
+      weights: [...parameters.encoder.weights],
+      bias: parameters.encoder.bias,
+    },
+    decoder: {
+      weights: [...parameters.decoder.weights],
+      bias: [...parameters.decoder.bias],
+    },
+  };
+}
+
+function forwardAutoencoder(
+  input: readonly number[],
+  parameters: AutoencoderParameters,
+): AutoencoderForwardTrace {
+  const encoderProducts = input.map((value, index) => cleanZero(
+    value * parameters.encoder.weights[index]!,
+  ));
+  const bottleneck = cleanZero(
+    encoderProducts.reduce((sum, value) => sum + value, 0)
+    + parameters.encoder.bias,
+  );
+  const decoderProducts = parameters.decoder.weights.map((weight) => (
+    cleanZero(bottleneck * weight)
+  ));
+  const reconstruction = decoderProducts.map((product, index) => cleanZero(
+    product + parameters.decoder.bias[index]!,
+  ));
+  const errors = reconstruction.map((value, index) => cleanZero(
+    value - input[index]!,
+  ));
+  const squaredErrors = errors.map((value) => value * value);
+  return {
+    encoderProducts,
+    bottleneck,
+    decoderProducts,
+    reconstruction,
+    errors,
+    squaredErrors,
+    loss: squaredErrors.reduce((sum, value) => sum + value, 0) / 2,
+  };
+}
+
+function flattenParameters(parameters: AutoencoderParameters): number[] {
+  return [
+    ...parameters.encoder.weights,
+    parameters.encoder.bias,
+    ...parameters.decoder.weights,
+    ...parameters.decoder.bias,
+  ];
+}
+
+function parametersFromFlat(values: readonly number[]): AutoencoderParameters {
+  return {
+    encoder: {
+      weights: values.slice(0, 2),
+      bias: values[2]!,
+    },
+    decoder: {
+      weights: values.slice(3, 5),
+      bias: values.slice(5, 7),
+    },
+  };
+}
+
+export function traceTwoNumberAutoencoder(
+  learningRate = DEFAULT_AUTOENCODER_LEARNING_RATE,
+  input: readonly number[] = DEFAULT_AUTOENCODER_INPUT,
+  parameters: AutoencoderParameters = DEFAULT_AUTOENCODER_PARAMETERS,
+): AutoencoderTrace {
+  if (
+    !Number.isFinite(learningRate)
+    || learningRate <= 0
+    || !validVector(input, 2)
+    || !validVector(parameters.encoder.weights, 2)
+    || !Number.isFinite(parameters.encoder.bias)
+    || !validVector(parameters.decoder.weights, 2)
+    || !validVector(parameters.decoder.bias, 2)
+  ) {
+    throw new Error(
+      "NN16 V1 needs a two-number input, 2 -> 1 -> 2 finite parameters, and a positive learning rate.",
+    );
+  }
+
+  const parameterCopy = copyParameters(parameters);
+  const forward = forwardAutoencoder(input, parameterCopy);
+  const reconstructionGradients = [...forward.errors];
+  const decoderWeightGradients = reconstructionGradients.map((gradient) => (
+    cleanZero(gradient * forward.bottleneck)
+  ));
+  const decoderBiasGradients = [...reconstructionGradients];
+  const bottleneckGradientContributions = reconstructionGradients.map(
+    (gradient, index) => cleanZero(
+      gradient * parameterCopy.decoder.weights[index]!,
+    ),
+  );
+  const bottleneckGradient = cleanZero(
+    bottleneckGradientContributions.reduce((sum, value) => sum + value, 0),
+  );
+  const encoderWeightGradients = input.map((value) => cleanZero(
+    bottleneckGradient * value,
+  ));
+  const encoderBiasGradient = bottleneckGradient;
+  const backward: AutoencoderBackwardTrace = {
+    reconstructionGradients,
+    decoderWeightGradients,
+    decoderBiasGradients,
+    bottleneckGradientContributions,
+    bottleneckGradient,
+    encoderWeightGradients,
+    encoderBiasGradient,
+  };
+
+  const analytical = [
+    ...encoderWeightGradients,
+    encoderBiasGradient,
+    ...decoderWeightGradients,
+    ...decoderBiasGradients,
+  ];
+  const flatParameters = flattenParameters(parameterCopy);
+  const epsilon = 1e-6;
+  const numerical = flatParameters.map((_, parameterIndex) => {
+    const plus = [...flatParameters];
+    const minus = [...flatParameters];
+    plus[parameterIndex]! += epsilon;
+    minus[parameterIndex]! -= epsilon;
+    return (
+      forwardAutoencoder(input, parametersFromFlat(plus)).loss
+      - forwardAutoencoder(input, parametersFromFlat(minus)).loss
+    ) / (2 * epsilon);
+  });
+  const maxAbsoluteError = Math.max(...analytical.map((value, index) => (
+    Math.abs(value - numerical[index]!)
+  )));
+
+  const updatedParameters: AutoencoderParameters = {
+    encoder: {
+      weights: parameterCopy.encoder.weights.map((value, index) => (
+        value - learningRate * encoderWeightGradients[index]!
+      )),
+      bias: parameterCopy.encoder.bias - learningRate * encoderBiasGradient,
+    },
+    decoder: {
+      weights: parameterCopy.decoder.weights.map((value, index) => (
+        value - learningRate * decoderWeightGradients[index]!
+      )),
+      bias: parameterCopy.decoder.bias.map((value, index) => (
+        value - learningRate * decoderBiasGradients[index]!
+      )),
+    },
+  };
+  const postUpdate = forwardAutoencoder(input, updatedParameters);
+
+  return {
+    input: [...input],
+    learningRate,
+    parameters: parameterCopy,
+    forward,
+    backward,
+    gradientCheck: {
+      epsilon,
+      parameterOrder: [...AUTOENCODER_PARAMETER_ORDER],
+      analytical,
+      numerical,
+      maxAbsoluteError,
+    },
+    updatedParameters,
+    postUpdate,
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/convolution-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/convolution-lab.ts
@@ -1,0 +1,55 @@
+export interface ConvolutionPositionTrace {
+  outputIndex: number;
+  startIndex: number;
+  window: number[];
+  products: number[];
+  accumulator: number[];
+  output: number;
+}
+
+export const DEFAULT_CONVOLUTION_SIGNAL = [2, 1, 3, 0, 4, 2] as const;
+export const DEFAULT_CONVOLUTION_KERNEL = [1, -1, 2] as const;
+
+export function traceValidCorrelation(
+  signal: readonly number[],
+  kernel: readonly number[],
+): ConvolutionPositionTrace[] {
+  if (signal.length === 0 || kernel.length === 0) {
+    throw new Error("Signal and kernel must contain at least one number.");
+  }
+  if (kernel.length > signal.length) {
+    throw new Error("The kernel cannot be longer than the signal in valid mode.");
+  }
+  if (![...signal, ...kernel].every(Number.isFinite)) {
+    throw new Error("Signal and kernel values must be finite numbers.");
+  }
+
+  return Array.from({ length: signal.length - kernel.length + 1 }, (_, startIndex) => {
+    const window = signal.slice(startIndex, startIndex + kernel.length);
+    const products = window.map((value, index) => {
+      const product = value * kernel[index]!;
+      return product === 0 ? 0 : product;
+    });
+    const accumulator = products.reduce<number[]>(
+      (values, product) => [...values, values[values.length - 1]! + product],
+      [0],
+    );
+    return {
+      outputIndex: startIndex,
+      startIndex,
+      window,
+      products,
+      accumulator,
+      output: accumulator[accumulator.length - 1]!,
+    };
+  });
+}
+
+export function parseNumberList(text: string): number[] | null {
+  const pieces = text.split(",").map((piece) => piece.trim());
+  if (pieces.length === 0 || pieces.some((piece) => piece === "")) {
+    return null;
+  }
+  const values = pieces.map(Number);
+  return values.every(Number.isFinite) ? values : null;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/convolution-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/convolution-lab.ts
@@ -7,8 +7,37 @@ export interface ConvolutionPositionTrace {
   output: number;
 }
 
+export interface ConvolutionGradientContribution {
+  outputIndex: number;
+  window: number[];
+  outputGradient: number;
+  kernelGradient: number[];
+}
+
+export interface ConvolutionTrainingTrace {
+  outputs: number[];
+  errors: number[];
+  loss: number;
+  outputGradients: number[];
+  contributions: ConvolutionGradientContribution[];
+  kernelGradient: number[];
+}
+
+export interface ConvolutionStepProposal {
+  nextKernel: number[];
+  nextOutputs: number[];
+  nextLoss: number;
+}
+
 export const DEFAULT_CONVOLUTION_SIGNAL = [2, 1, 3, 0, 4, 2] as const;
 export const DEFAULT_CONVOLUTION_KERNEL = [1, -1, 2] as const;
+export const DEFAULT_CONVOLUTION_TARGETS = [6, -2, 10, 0] as const;
+export const DEFAULT_CONVOLUTION_LEARNING_RATE = 0.02;
+export const DEFAULT_CONVOLUTION_EPSILON = 0.000001;
+
+function cleanZero(value: number): number {
+  return value === 0 ? 0 : value;
+}
 
 export function traceValidCorrelation(
   signal: readonly number[],
@@ -28,7 +57,7 @@ export function traceValidCorrelation(
     const window = signal.slice(startIndex, startIndex + kernel.length);
     const products = window.map((value, index) => {
       const product = value * kernel[index]!;
-      return product === 0 ? 0 : product;
+      return cleanZero(product);
     });
     const accumulator = products.reduce<number[]>(
       (values, product) => [...values, values[values.length - 1]! + product],
@@ -43,6 +72,101 @@ export function traceValidCorrelation(
       output: accumulator[accumulator.length - 1]!,
     };
   });
+}
+
+export function meanSquaredError(
+  outputs: readonly number[],
+  targets: readonly number[],
+): number {
+  if (outputs.length === 0 || outputs.length !== targets.length) {
+    throw new Error("Outputs and targets must have the same non-zero length.");
+  }
+  return outputs.reduce(
+    (total, output, index) => total + (output - targets[index]!) ** 2,
+    0,
+  ) / outputs.length;
+}
+
+export function traceConvolutionTraining(
+  signal: readonly number[],
+  kernel: readonly number[],
+  targets: readonly number[],
+): ConvolutionTrainingTrace {
+  const positionTraces = traceValidCorrelation(signal, kernel);
+  const outputs = positionTraces.map((position) => position.output);
+  if (targets.length !== outputs.length || !targets.every(Number.isFinite)) {
+    throw new Error(`Expected ${outputs.length} finite target values.`);
+  }
+  const errors = outputs.map((output, index) => cleanZero(output - targets[index]!));
+  const outputGradients = errors.map((error) => cleanZero((2 * error) / errors.length));
+  const kernelGradient = kernel.map(() => 0);
+  const contributions = positionTraces.map((position, outputIndex) => {
+    const outputGradient = outputGradients[outputIndex]!;
+    const contribution = position.window.map((value, kernelIndex) => {
+      const gradient = cleanZero(outputGradient * value);
+      kernelGradient[kernelIndex] = cleanZero(kernelGradient[kernelIndex]! + gradient);
+      return gradient;
+    });
+    return {
+      outputIndex,
+      window: position.window,
+      outputGradient,
+      kernelGradient: contribution,
+    };
+  });
+  return {
+    outputs,
+    errors,
+    loss: meanSquaredError(outputs, targets),
+    outputGradients,
+    contributions,
+    kernelGradient,
+  };
+}
+
+export function numericalKernelGradient(
+  signal: readonly number[],
+  kernel: readonly number[],
+  targets: readonly number[],
+  epsilon = DEFAULT_CONVOLUTION_EPSILON,
+): number[] {
+  if (!Number.isFinite(epsilon) || epsilon <= 0) {
+    throw new Error("Finite-difference epsilon must be positive.");
+  }
+  return kernel.map((_, index) => {
+    const plus = [...kernel];
+    const minus = [...kernel];
+    plus[index] += epsilon;
+    minus[index] -= epsilon;
+    const plusOutputs = traceValidCorrelation(signal, plus).map((position) => position.output);
+    const minusOutputs = traceValidCorrelation(signal, minus).map((position) => position.output);
+    return (
+      meanSquaredError(plusOutputs, targets) - meanSquaredError(minusOutputs, targets)
+    ) / (2 * epsilon);
+  });
+}
+
+export function proposeConvolutionStep(
+  signal: readonly number[],
+  kernel: readonly number[],
+  targets: readonly number[],
+  learningRate: number,
+): ConvolutionStepProposal {
+  if (!Number.isFinite(learningRate) || learningRate <= 0) {
+    throw new Error("Learning rate must be positive.");
+  }
+  const training = traceConvolutionTraining(signal, kernel, targets);
+  const nextKernel = kernel.map(
+    (value, index) => cleanZero(value - learningRate * training.kernelGradient[index]!),
+  );
+  const nextOutputs = traceValidCorrelation(signal, nextKernel).map(
+    (position) => position.output,
+  );
+  return {
+    nextKernel,
+    nextOutputs,
+    nextLoss: meanSquaredError(nextOutputs, targets),
+  };
 }
 
 export function parseNumberList(text: string): number[] | null {

--- a/code/programs/typescript/ml-learning-visualizer/src/decoder-language-model-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/decoder-language-model-lab.ts
@@ -1,0 +1,292 @@
+export type DecoderTokenId = "red" | "blue" | "purple";
+
+export interface DecoderTrainingRow {
+  position: number;
+  inputToken: DecoderTokenId;
+  targetToken: DecoderTokenId;
+  targetIndex: number;
+  causalPrefix: DecoderTokenId[];
+  decoderState: number[];
+  logitProducts: number[][];
+  logits: number[];
+  rowMax: number;
+  shiftedLogits: number[];
+  exponentials: number[];
+  denominator: number;
+  probabilities: number[];
+  targetProbability: number;
+  loss: number;
+  logitGradients: number[];
+  unembeddingGradientContribution: number[][];
+  biasGradientContribution: number[];
+  stateGradient: number[];
+}
+
+export interface DecoderPostUpdateRow {
+  position: number;
+  logits: number[];
+  probabilities: number[];
+  targetProbability: number;
+  loss: number;
+}
+
+export interface DecoderTrainingTrace {
+  vocabulary: DecoderTokenId[];
+  sequence: DecoderTokenId[];
+  learningRate: number;
+  rows: DecoderTrainingRow[];
+  meanLoss: number;
+  unembeddingGradient: number[][];
+  biasGradient: number[];
+  gradientCheck: {
+    epsilon: number;
+    numericalUnembeddingGradient: number[][];
+    numericalBiasGradient: number[];
+    maxAbsoluteError: number;
+  };
+  updatedUnembedding: number[][];
+  updatedBias: number[];
+  postUpdateRows: DecoderPostUpdateRow[];
+  postUpdateMeanLoss: number;
+}
+
+export const DEFAULT_DECODER_VOCABULARY: DecoderTokenId[] = [
+  "red",
+  "blue",
+  "purple",
+];
+export const DEFAULT_DECODER_SEQUENCE: DecoderTokenId[] = [
+  "red",
+  "blue",
+  "purple",
+];
+export const DEFAULT_DECODER_STATES = [[1, 0], [0, 1]];
+export const DEFAULT_DECODER_UNEMBEDDING = [[1, 0, -1], [0, 1, -1]];
+export const DEFAULT_DECODER_BIAS = [0, 0, 0];
+export const DEFAULT_DECODER_LEARNING_RATE = 0.5;
+
+function cleanZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+function validMatrix(
+  matrix: readonly (readonly number[])[],
+  rows: number,
+  columns: number,
+): boolean {
+  return matrix.length === rows
+    && matrix.every((row) => (
+      row.length === columns && row.every(Number.isFinite)
+    ));
+}
+
+function forwardRow(
+  state: readonly number[],
+  targetIndex: number,
+  unembedding: readonly (readonly number[])[],
+  bias: readonly number[],
+) {
+  const logitProducts = DEFAULT_DECODER_VOCABULARY.map((_, vocabularyIndex) => (
+    state.map((value, dimension) => cleanZero(
+      value * unembedding[dimension]![vocabularyIndex]!,
+    ))
+  ));
+  const logits = logitProducts.map((products, vocabularyIndex) => cleanZero(
+    products.reduce((sum, value) => sum + value, 0) + bias[vocabularyIndex]!,
+  ));
+  const rowMax = Math.max(...logits);
+  const shiftedLogits = logits.map((logit) => cleanZero(logit - rowMax));
+  const exponentials = shiftedLogits.map(Math.exp);
+  const denominator = exponentials.reduce((sum, value) => sum + value, 0);
+  const probabilities = exponentials.map((value) => value / denominator);
+  const targetProbability = probabilities[targetIndex]!;
+  return {
+    logitProducts,
+    logits,
+    rowMax,
+    shiftedLogits,
+    exponentials,
+    denominator,
+    probabilities,
+    targetProbability,
+    loss: -Math.log(targetProbability),
+  };
+}
+
+function meanLoss(
+  states: readonly (readonly number[])[],
+  targetIndices: readonly number[],
+  unembedding: readonly (readonly number[])[],
+  bias: readonly number[],
+): number {
+  return states.reduce((sum, state, position) => (
+    sum + forwardRow(
+      state,
+      targetIndices[position]!,
+      unembedding,
+      bias,
+    ).loss
+  ), 0) / states.length;
+}
+
+export function traceTinyDecoderTraining(
+  learningRate = DEFAULT_DECODER_LEARNING_RATE,
+  states: readonly (readonly number[])[] = DEFAULT_DECODER_STATES,
+  unembedding: readonly (readonly number[])[] = DEFAULT_DECODER_UNEMBEDDING,
+  bias: readonly number[] = DEFAULT_DECODER_BIAS,
+): DecoderTrainingTrace {
+  if (
+    !Number.isFinite(learningRate)
+    || learningRate <= 0
+    || !validMatrix(states, 2, 2)
+    || !validMatrix(unembedding, 2, 3)
+    || bias.length !== 3
+    || !bias.every(Number.isFinite)
+  ) {
+    throw new Error(
+      "NN15 V1 needs two 2D decoder states, a 2 x 3 unembedding, three finite biases, and a positive learning rate.",
+    );
+  }
+
+  const inputTokens = DEFAULT_DECODER_SEQUENCE.slice(0, -1);
+  const targetTokens = DEFAULT_DECODER_SEQUENCE.slice(1);
+  const unembeddingGradient = Array.from({ length: 2 }, () => [0, 0, 0]);
+  const biasGradient = [0, 0, 0];
+  const rows = states.map((state, position): DecoderTrainingRow => {
+    const inputToken = inputTokens[position]!;
+    const targetToken = targetTokens[position]!;
+    const targetIndex = DEFAULT_DECODER_VOCABULARY.indexOf(targetToken);
+    const forward = forwardRow(state, targetIndex, unembedding, bias);
+    const logitGradients = forward.probabilities.map((probability, index) => (
+      (probability - (index === targetIndex ? 1 : 0)) / states.length
+    ));
+    const unembeddingGradientContribution = state.map((value) => (
+      logitGradients.map((gradient) => cleanZero(value * gradient))
+    ));
+    for (let dimension = 0; dimension < 2; dimension += 1) {
+      for (let vocabularyIndex = 0; vocabularyIndex < 3; vocabularyIndex += 1) {
+        unembeddingGradient[dimension]![vocabularyIndex]! += (
+          unembeddingGradientContribution[dimension]![vocabularyIndex]!
+        );
+      }
+    }
+    for (let vocabularyIndex = 0; vocabularyIndex < 3; vocabularyIndex += 1) {
+      biasGradient[vocabularyIndex]! += logitGradients[vocabularyIndex]!;
+    }
+    const stateGradient = state.map((_, dimension) => cleanZero(
+      logitGradients.reduce((sum, gradient, vocabularyIndex) => (
+        sum + gradient * unembedding[dimension]![vocabularyIndex]!
+      ), 0),
+    ));
+
+    return {
+      position,
+      inputToken,
+      targetToken,
+      targetIndex,
+      causalPrefix: DEFAULT_DECODER_SEQUENCE.slice(0, position + 1),
+      decoderState: [...state],
+      ...forward,
+      logitGradients,
+      unembeddingGradientContribution,
+      biasGradientContribution: [...logitGradients],
+      stateGradient,
+    };
+  });
+
+  const updatedUnembedding = unembedding.map((row, dimension) => (
+    row.map((value, vocabularyIndex) => (
+      value - learningRate * unembeddingGradient[dimension]![vocabularyIndex]!
+    ))
+  ));
+  const updatedBias = bias.map((value, vocabularyIndex) => (
+    value - learningRate * biasGradient[vocabularyIndex]!
+  ));
+  const gradientEpsilon = 1e-6;
+  const targetIndices = rows.map((row) => row.targetIndex);
+  const numericalUnembeddingGradient = Array.from(
+    { length: 2 },
+    () => [0, 0, 0],
+  );
+  for (let dimension = 0; dimension < 2; dimension += 1) {
+    for (let vocabularyIndex = 0; vocabularyIndex < 3; vocabularyIndex += 1) {
+      const plus = unembedding.map((row) => [...row]);
+      const minus = unembedding.map((row) => [...row]);
+      plus[dimension]![vocabularyIndex]! += gradientEpsilon;
+      minus[dimension]![vocabularyIndex]! -= gradientEpsilon;
+      numericalUnembeddingGradient[dimension]![vocabularyIndex] = (
+        meanLoss(states, targetIndices, plus, bias)
+        - meanLoss(states, targetIndices, minus, bias)
+      ) / (2 * gradientEpsilon);
+    }
+  }
+  const numericalBiasGradient = bias.map((_, vocabularyIndex) => {
+    const plus = [...bias];
+    const minus = [...bias];
+    plus[vocabularyIndex]! += gradientEpsilon;
+    minus[vocabularyIndex]! -= gradientEpsilon;
+    return (
+      meanLoss(states, targetIndices, unembedding, plus)
+      - meanLoss(states, targetIndices, unembedding, minus)
+    ) / (2 * gradientEpsilon);
+  });
+  const gradientErrors = [
+    ...unembeddingGradient.flatMap((row, dimension) => (
+      row.map((value, vocabularyIndex) => Math.abs(
+        value - numericalUnembeddingGradient[dimension]![vocabularyIndex]!,
+      ))
+    )),
+    ...biasGradient.map((value, index) => Math.abs(
+      value - numericalBiasGradient[index]!,
+    )),
+  ];
+  const postUpdateRows = rows.map((row): DecoderPostUpdateRow => {
+    const forward = forwardRow(
+      row.decoderState,
+      row.targetIndex,
+      updatedUnembedding,
+      updatedBias,
+    );
+    return {
+      position: row.position,
+      logits: forward.logits,
+      probabilities: forward.probabilities,
+      targetProbability: forward.targetProbability,
+      loss: forward.loss,
+    };
+  });
+
+  return {
+    vocabulary: [...DEFAULT_DECODER_VOCABULARY],
+    sequence: [...DEFAULT_DECODER_SEQUENCE],
+    learningRate,
+    rows,
+    meanLoss: rows.reduce((sum, row) => sum + row.loss, 0) / rows.length,
+    unembeddingGradient,
+    biasGradient,
+    gradientCheck: {
+      epsilon: gradientEpsilon,
+      numericalUnembeddingGradient,
+      numericalBiasGradient,
+      maxAbsoluteError: Math.max(...gradientErrors),
+    },
+    updatedUnembedding,
+    updatedBias,
+    postUpdateRows,
+    postUpdateMeanLoss: postUpdateRows.reduce(
+      (sum, row) => sum + row.loss,
+      0,
+    ) / postUpdateRows.length,
+  };
+}
+
+export function decoderTrainingRow(
+  trace: DecoderTrainingTrace,
+  position: number,
+): DecoderTrainingRow {
+  const row = trace.rows[position];
+  if (row === undefined) {
+    throw new Error(`Unknown decoder training position ${position}.`);
+  }
+  return row;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/diffusion-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/diffusion-lab.ts
@@ -1,0 +1,329 @@
+export interface DiffusionScheduleStep {
+  t: number;
+  beta: number;
+  normalizedT: number;
+}
+
+export interface DiffusionDenoiserParameters {
+  sampleWeight: number;
+  timestepWeight: number;
+  bias: number;
+}
+
+export interface DiffusionForwardStep extends DiffusionScheduleStep {
+  alpha: number;
+  alphaBar: number;
+  signalScale: number;
+  noiseScale: number;
+  signalContribution: number;
+  noiseContribution: number;
+  noisySample: number;
+}
+
+export interface DiffusionPredictionStep {
+  t: number;
+  noisySample: number;
+  normalizedT: number;
+  predictedNoise: number;
+  targetNoise: number;
+  error: number;
+  loss: number;
+}
+
+export interface DiffusionReverseStep {
+  t: number;
+  inputSample: number;
+  normalizedT: number;
+  predictedNoise: number;
+  noiseCoefficient: number;
+  scaledNoiseCorrection: number;
+  correctedSample: number;
+  alphaScale: number;
+  outputMean: number;
+}
+
+export interface OneDimensionalDiffusionTrace {
+  cleanSample: number;
+  savedNoise: number;
+  learningRate: number;
+  schedule: DiffusionScheduleStep[];
+  denoiser: DiffusionDenoiserParameters;
+  forwardSteps: DiffusionForwardStep[];
+  initialDenoising: DiffusionPredictionStep[];
+  initialMeanLoss: number;
+  backward: {
+    perStep: Array<{
+      t: number;
+      predictionGradient: number;
+      sampleWeightContribution: number;
+      timestepWeightContribution: number;
+      biasContribution: number;
+    }>;
+    sampleWeightGradient: number;
+    timestepWeightGradient: number;
+    biasGradient: number;
+  };
+  gradientCheck: {
+    epsilon: number;
+    parameterOrder: string[];
+    analytical: number[];
+    numerical: number[];
+    maxAbsoluteError: number;
+  };
+  updatedDenoiser: DiffusionDenoiserParameters;
+  postUpdateDenoising: DiffusionPredictionStep[];
+  postUpdateMeanLoss: number;
+  reverseSteps: DiffusionReverseStep[];
+  finalReconstruction: number;
+  finalAbsoluteError: number;
+}
+
+export const DEFAULT_DIFFUSION_CLEAN_SAMPLE = 1;
+export const DEFAULT_DIFFUSION_SAVED_NOISE = -0.5;
+export const DEFAULT_DIFFUSION_SCHEDULE: DiffusionScheduleStep[] = [
+  { t: 1, beta: 0.36, normalizedT: 0.5 },
+  { t: 2, beta: 0.4375, normalizedT: 1 },
+];
+export const DEFAULT_DIFFUSION_DENOISER: DiffusionDenoiserParameters = {
+  sampleWeight: 0,
+  timestepWeight: 0,
+  bias: 0,
+};
+export const DEFAULT_DIFFUSION_LEARNING_RATE = 0.5;
+export const DIFFUSION_PARAMETER_ORDER = [
+  "denoiser.sample_weight",
+  "denoiser.timestep_weight",
+  "denoiser.bias",
+];
+
+function copyDenoiser(
+  parameters: DiffusionDenoiserParameters,
+): DiffusionDenoiserParameters {
+  return { ...parameters };
+}
+
+function forwardDiffusion(
+  cleanSample: number,
+  savedNoise: number,
+  schedule: readonly DiffusionScheduleStep[],
+): DiffusionForwardStep[] {
+  let alphaBar = 1;
+  return schedule.map((step) => {
+    const alpha = 1 - step.beta;
+    alphaBar *= alpha;
+    const signalScale = Math.sqrt(alphaBar);
+    const noiseScale = Math.sqrt(1 - alphaBar);
+    const signalContribution = signalScale * cleanSample;
+    const noiseContribution = noiseScale * savedNoise;
+    return {
+      ...step,
+      alpha,
+      alphaBar,
+      signalScale,
+      noiseScale,
+      signalContribution,
+      noiseContribution,
+      noisySample: signalContribution + noiseContribution,
+    };
+  });
+}
+
+function predictNoise(
+  forwardSteps: readonly DiffusionForwardStep[],
+  savedNoise: number,
+  denoiser: DiffusionDenoiserParameters,
+): { rows: DiffusionPredictionStep[]; meanLoss: number } {
+  const rows = forwardSteps.map((step) => {
+    const predictedNoise = denoiser.sampleWeight * step.noisySample
+      + denoiser.timestepWeight * step.normalizedT
+      + denoiser.bias;
+    const error = predictedNoise - savedNoise;
+    return {
+      t: step.t,
+      noisySample: step.noisySample,
+      normalizedT: step.normalizedT,
+      predictedNoise,
+      targetNoise: savedNoise,
+      error,
+      loss: 0.5 * error * error,
+    };
+  });
+  return {
+    rows,
+    meanLoss: rows.reduce((sum, row) => sum + row.loss, 0) / rows.length,
+  };
+}
+
+function reverseDiffusion(
+  forwardSteps: readonly DiffusionForwardStep[],
+  denoiser: DiffusionDenoiserParameters,
+): DiffusionReverseStep[] {
+  let currentSample = forwardSteps[forwardSteps.length - 1]!.noisySample;
+  return [...forwardSteps].reverse().map((step) => {
+    const predictedNoise = denoiser.sampleWeight * currentSample
+      + denoiser.timestepWeight * step.normalizedT
+      + denoiser.bias;
+    const noiseCoefficient = step.beta / step.noiseScale;
+    const scaledNoiseCorrection = noiseCoefficient * predictedNoise;
+    const correctedSample = currentSample - scaledNoiseCorrection;
+    const alphaScale = Math.sqrt(step.alpha);
+    const outputMean = correctedSample / alphaScale;
+    const trace = {
+      t: step.t,
+      inputSample: currentSample,
+      normalizedT: step.normalizedT,
+      predictedNoise,
+      noiseCoefficient,
+      scaledNoiseCorrection,
+      correctedSample,
+      alphaScale,
+      outputMean,
+    };
+    currentSample = outputMean;
+    return trace;
+  });
+}
+
+export function traceOneDimensionalDiffusion(
+  cleanSample = DEFAULT_DIFFUSION_CLEAN_SAMPLE,
+  savedNoise = DEFAULT_DIFFUSION_SAVED_NOISE,
+  learningRate = DEFAULT_DIFFUSION_LEARNING_RATE,
+  denoiser: DiffusionDenoiserParameters = DEFAULT_DIFFUSION_DENOISER,
+  schedule: readonly DiffusionScheduleStep[] = DEFAULT_DIFFUSION_SCHEDULE,
+): OneDimensionalDiffusionTrace {
+  const scalarInputs = [
+    cleanSample,
+    savedNoise,
+    learningRate,
+    denoiser.sampleWeight,
+    denoiser.timestepWeight,
+    denoiser.bias,
+    ...schedule.flatMap((step) => [step.t, step.beta, step.normalizedT]),
+  ];
+  if (
+    !scalarInputs.every(Number.isFinite)
+    || learningRate <= 0
+    || schedule.length < 2
+    || schedule.some((step, index) => (
+      !Number.isInteger(step.t)
+      || step.t !== index + 1
+      || step.beta <= 0
+      || step.beta >= 1
+      || step.normalizedT <= (schedule[index - 1]?.normalizedT ?? 0)
+      || step.normalizedT > 1
+    ))
+    || Math.abs(schedule[schedule.length - 1]!.normalizedT - 1) > 1e-12
+  ) {
+    throw new Error(
+      "NN19 V1 needs finite scalars, a positive learning rate, and consecutive increasing diffusion steps ending at normalized time 1.",
+    );
+  }
+
+  const parameterCopy = copyDenoiser(denoiser);
+  const scheduleCopy = schedule.map((step) => ({ ...step }));
+  const forwardSteps = forwardDiffusion(
+    cleanSample,
+    savedNoise,
+    scheduleCopy,
+  );
+  const initial = predictNoise(forwardSteps, savedNoise, parameterCopy);
+  const count = initial.rows.length;
+  const perStep = initial.rows.map((row) => {
+    const predictionGradient = row.error / count;
+    return {
+      t: row.t,
+      predictionGradient,
+      sampleWeightContribution: predictionGradient * row.noisySample,
+      timestepWeightContribution: predictionGradient * row.normalizedT,
+      biasContribution: predictionGradient,
+    };
+  });
+  const sampleWeightGradient = perStep.reduce(
+    (sum, row) => sum + row.sampleWeightContribution,
+    0,
+  );
+  const timestepWeightGradient = perStep.reduce(
+    (sum, row) => sum + row.timestepWeightContribution,
+    0,
+  );
+  const biasGradient = perStep.reduce(
+    (sum, row) => sum + row.biasContribution,
+    0,
+  );
+  const analytical = [
+    sampleWeightGradient,
+    timestepWeightGradient,
+    biasGradient,
+  ];
+  const initialParameters = [
+    parameterCopy.sampleWeight,
+    parameterCopy.timestepWeight,
+    parameterCopy.bias,
+  ];
+  const auditEpsilon = 1e-6;
+  const numerical = initialParameters.map((_, parameterIndex) => {
+    const plus = [...initialParameters];
+    const minus = [...initialParameters];
+    plus[parameterIndex]! += auditEpsilon;
+    minus[parameterIndex]! -= auditEpsilon;
+    const lossFor = (values: readonly number[]) => predictNoise(
+      forwardSteps,
+      savedNoise,
+      {
+        sampleWeight: values[0]!,
+        timestepWeight: values[1]!,
+        bias: values[2]!,
+      },
+    ).meanLoss;
+    return (lossFor(plus) - lossFor(minus)) / (2 * auditEpsilon);
+  });
+  const maxAbsoluteError = Math.max(
+    ...analytical.map((value, index) => (
+      Math.abs(value - numerical[index]!)
+    )),
+  );
+  const updatedDenoiser = {
+    sampleWeight: parameterCopy.sampleWeight
+      - learningRate * sampleWeightGradient,
+    timestepWeight: parameterCopy.timestepWeight
+      - learningRate * timestepWeightGradient,
+    bias: parameterCopy.bias - learningRate * biasGradient,
+  };
+  const postUpdate = predictNoise(
+    forwardSteps,
+    savedNoise,
+    updatedDenoiser,
+  );
+  const reverseSteps = reverseDiffusion(forwardSteps, updatedDenoiser);
+  const finalReconstruction = reverseSteps[reverseSteps.length - 1]!.outputMean;
+
+  return {
+    cleanSample,
+    savedNoise,
+    learningRate,
+    schedule: scheduleCopy,
+    denoiser: parameterCopy,
+    forwardSteps,
+    initialDenoising: initial.rows,
+    initialMeanLoss: initial.meanLoss,
+    backward: {
+      perStep,
+      sampleWeightGradient,
+      timestepWeightGradient,
+      biasGradient,
+    },
+    gradientCheck: {
+      epsilon: auditEpsilon,
+      parameterOrder: [...DIFFUSION_PARAMETER_ORDER],
+      analytical,
+      numerical,
+      maxAbsoluteError,
+    },
+    updatedDenoiser,
+    postUpdateDenoising: postUpdate.rows,
+    postUpdateMeanLoss: postUpdate.meanLoss,
+    reverseSteps,
+    finalReconstruction,
+    finalAbsoluteError: Math.abs(finalReconstruction - cleanSample),
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/gan-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/gan-lab.ts
@@ -1,0 +1,303 @@
+export interface ScalarAffineParameters {
+  weight: number;
+  bias: number;
+}
+
+export interface GanParameters {
+  generator: ScalarAffineParameters;
+  discriminator: ScalarAffineParameters;
+}
+
+export interface GanState {
+  generatorProduct: number;
+  fakeSample: number;
+  realLogit: number;
+  realProbability: number;
+  fakeLogit: number;
+  fakeProbability: number;
+  discriminatorLoss: number;
+  generatorLoss: number;
+}
+
+export interface GradientAudit {
+  epsilon: number;
+  parameterOrder: string[];
+  analytical: number[];
+  numerical: number[];
+  maxAbsoluteError: number;
+}
+
+export interface OneDimensionalGanTrace {
+  realSample: number;
+  savedNoise: number;
+  discriminatorLearningRate: number;
+  generatorLearningRate: number;
+  parameters: GanParameters;
+  initial: GanState;
+  discriminatorStep: {
+    backward: {
+      realLogitGradient: number;
+      fakeLogitGradient: number;
+      weightGradient: number;
+      biasGradient: number;
+      fakeSampleGradient: number;
+    };
+    updatedParameters: ScalarAffineParameters;
+    state: GanState;
+    gradientCheck: GradientAudit;
+  };
+  generatorStep: {
+    backward: {
+      fakeLogitGradient: number;
+      fakeSampleGradient: number;
+      weightGradient: number;
+      biasGradient: number;
+    };
+    updatedParameters: ScalarAffineParameters;
+    state: GanState;
+    gradientCheck: GradientAudit;
+  };
+}
+
+export const DEFAULT_GAN_PARAMETERS: GanParameters = {
+  generator: { weight: 0.2, bias: 0 },
+  discriminator: { weight: 1, bias: 0 },
+};
+export const DEFAULT_GAN_REAL_SAMPLE = 1;
+export const DEFAULT_GAN_SAVED_NOISE = 1;
+export const DEFAULT_DISCRIMINATOR_LEARNING_RATE = 0.5;
+export const DEFAULT_GENERATOR_LEARNING_RATE = 0.25;
+
+function cleanZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+function sigmoid(value: number): number {
+  if (value >= 0) {
+    return 1 / (1 + Math.exp(-value));
+  }
+  const exponential = Math.exp(value);
+  return exponential / (1 + exponential);
+}
+
+function forwardGan(
+  realSample: number,
+  savedNoise: number,
+  parameters: GanParameters,
+): GanState {
+  const generatorProduct = cleanZero(
+    savedNoise * parameters.generator.weight,
+  );
+  const fakeSample = cleanZero(
+    generatorProduct + parameters.generator.bias,
+  );
+  const realLogit = cleanZero(
+    realSample * parameters.discriminator.weight
+      + parameters.discriminator.bias,
+  );
+  const fakeLogit = cleanZero(
+    fakeSample * parameters.discriminator.weight
+      + parameters.discriminator.bias,
+  );
+  const realProbability = sigmoid(realLogit);
+  const fakeProbability = sigmoid(fakeLogit);
+  const discriminatorLoss = -0.5 * (
+    Math.log(realProbability) + Math.log(1 - fakeProbability)
+  );
+  const generatorLoss = -Math.log(fakeProbability);
+  return {
+    generatorProduct,
+    fakeSample,
+    realLogit,
+    realProbability,
+    fakeLogit,
+    fakeProbability,
+    discriminatorLoss,
+    generatorLoss,
+  };
+}
+
+function finiteDifference(
+  values: readonly number[],
+  lossFunction: (candidate: readonly number[]) => number,
+): Omit<GradientAudit, "parameterOrder" | "analytical"> {
+  const epsilon = 1e-6;
+  const numerical = values.map((_, parameterIndex) => {
+    const plus = [...values];
+    const minus = [...values];
+    plus[parameterIndex]! += epsilon;
+    minus[parameterIndex]! -= epsilon;
+    return (lossFunction(plus) - lossFunction(minus)) / (2 * epsilon);
+  });
+  return { epsilon, numerical, maxAbsoluteError: 0 };
+}
+
+function maxAbsoluteError(
+  analytical: readonly number[],
+  numerical: readonly number[],
+): number {
+  return Math.max(
+    ...analytical.map((value, index) => (
+      Math.abs(value - numerical[index]!)
+    )),
+  );
+}
+
+export function traceOneDimensionalGan(
+  realSample = DEFAULT_GAN_REAL_SAMPLE,
+  savedNoise = DEFAULT_GAN_SAVED_NOISE,
+  discriminatorLearningRate = DEFAULT_DISCRIMINATOR_LEARNING_RATE,
+  generatorLearningRate = DEFAULT_GENERATOR_LEARNING_RATE,
+  parameters: GanParameters = DEFAULT_GAN_PARAMETERS,
+): OneDimensionalGanTrace {
+  const scalarInputs = [
+    realSample,
+    savedNoise,
+    discriminatorLearningRate,
+    generatorLearningRate,
+    parameters.generator.weight,
+    parameters.generator.bias,
+    parameters.discriminator.weight,
+    parameters.discriminator.bias,
+  ];
+  if (
+    !scalarInputs.every(Number.isFinite)
+    || discriminatorLearningRate <= 0
+    || generatorLearningRate <= 0
+  ) {
+    throw new Error(
+      "NN18 V1 needs finite scalar samples and parameters, plus positive learning rates.",
+    );
+  }
+
+  const parameterCopy: GanParameters = {
+    generator: { ...parameters.generator },
+    discriminator: { ...parameters.discriminator },
+  };
+  const initial = forwardGan(realSample, savedNoise, parameterCopy);
+
+  const realLogitGradient = 0.5 * (initial.realProbability - 1);
+  const fakeLogitGradient = 0.5 * initial.fakeProbability;
+  const discriminatorWeightGradient = cleanZero(
+    realLogitGradient * realSample
+      + fakeLogitGradient * initial.fakeSample,
+  );
+  const discriminatorBiasGradient = cleanZero(
+    realLogitGradient + fakeLogitGradient,
+  );
+  const discriminatorAnalytical = [
+    discriminatorWeightGradient,
+    discriminatorBiasGradient,
+  ];
+  const discriminatorNumerical = finiteDifference(
+    [parameterCopy.discriminator.weight, parameterCopy.discriminator.bias],
+    ([weight, bias]) => {
+      const realProbability = sigmoid(realSample * weight! + bias!);
+      const fakeProbability = sigmoid(initial.fakeSample * weight! + bias!);
+      return -0.5 * (
+        Math.log(realProbability) + Math.log(1 - fakeProbability)
+      );
+    },
+  );
+  const updatedDiscriminator = {
+    weight: cleanZero(
+      parameterCopy.discriminator.weight
+        - discriminatorLearningRate * discriminatorWeightGradient,
+    ),
+    bias: cleanZero(
+      parameterCopy.discriminator.bias
+        - discriminatorLearningRate * discriminatorBiasGradient,
+    ),
+  };
+  const afterDiscriminator = forwardGan(realSample, savedNoise, {
+    generator: parameterCopy.generator,
+    discriminator: updatedDiscriminator,
+  });
+
+  const generatorFakeLogitGradient = afterDiscriminator.fakeProbability - 1;
+  const generatorFakeSampleGradient = cleanZero(
+    generatorFakeLogitGradient * updatedDiscriminator.weight,
+  );
+  const generatorWeightGradient = cleanZero(
+    generatorFakeSampleGradient * savedNoise,
+  );
+  const generatorBiasGradient = generatorFakeSampleGradient;
+  const generatorAnalytical = [
+    generatorWeightGradient,
+    generatorBiasGradient,
+  ];
+  const generatorNumerical = finiteDifference(
+    [parameterCopy.generator.weight, parameterCopy.generator.bias],
+    ([weight, bias]) => {
+      const fakeSample = savedNoise * weight! + bias!;
+      const fakeProbability = sigmoid(
+        fakeSample * updatedDiscriminator.weight + updatedDiscriminator.bias,
+      );
+      return -Math.log(fakeProbability);
+    },
+  );
+  const updatedGenerator = {
+    weight: cleanZero(
+      parameterCopy.generator.weight
+        - generatorLearningRate * generatorWeightGradient,
+    ),
+    bias: cleanZero(
+      parameterCopy.generator.bias
+        - generatorLearningRate * generatorBiasGradient,
+    ),
+  };
+  const afterGenerator = forwardGan(realSample, savedNoise, {
+    generator: updatedGenerator,
+    discriminator: updatedDiscriminator,
+  });
+
+  return {
+    realSample,
+    savedNoise,
+    discriminatorLearningRate,
+    generatorLearningRate,
+    parameters: parameterCopy,
+    initial,
+    discriminatorStep: {
+      backward: {
+        realLogitGradient,
+        fakeLogitGradient,
+        weightGradient: discriminatorWeightGradient,
+        biasGradient: discriminatorBiasGradient,
+        fakeSampleGradient: 0,
+      },
+      updatedParameters: updatedDiscriminator,
+      state: afterDiscriminator,
+      gradientCheck: {
+        epsilon: discriminatorNumerical.epsilon,
+        parameterOrder: ["discriminator.weight", "discriminator.bias"],
+        analytical: discriminatorAnalytical,
+        numerical: discriminatorNumerical.numerical,
+        maxAbsoluteError: maxAbsoluteError(
+          discriminatorAnalytical,
+          discriminatorNumerical.numerical,
+        ),
+      },
+    },
+    generatorStep: {
+      backward: {
+        fakeLogitGradient: generatorFakeLogitGradient,
+        fakeSampleGradient: generatorFakeSampleGradient,
+        weightGradient: generatorWeightGradient,
+        biasGradient: generatorBiasGradient,
+      },
+      updatedParameters: updatedGenerator,
+      state: afterGenerator,
+      gradientCheck: {
+        epsilon: generatorNumerical.epsilon,
+        parameterOrder: ["generator.weight", "generator.bias"],
+        analytical: generatorAnalytical,
+        numerical: generatorNumerical.numerical,
+        maxAbsoluteError: maxAbsoluteError(
+          generatorAnalytical,
+          generatorNumerical.numerical,
+        ),
+      },
+    },
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/gated-recurrent-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/gated-recurrent-lab.ts
@@ -1,0 +1,196 @@
+export type GatedModel = "gru" | "lstm";
+export type GruGate = "reset" | "update";
+export type LstmGate = "forget" | "input" | "output";
+export type GatedCellGate = GruGate | LstmGate;
+
+export interface GateTrace {
+  preactivation: number;
+  value: number;
+}
+
+export interface GruGateTrace {
+  resetGate: GateTrace;
+  updateGate: GateTrace;
+  candidate: {
+    inputProduct: number;
+    resetState: number;
+    recurrentProduct: number;
+    bias: number;
+    preactivation: number;
+    value: number;
+  };
+  retainedState: number;
+  candidateWrite: number;
+  hiddenState: number;
+}
+
+export interface LstmGateTrace {
+  forgetGate: GateTrace;
+  inputGate: GateTrace;
+  outputGate: GateTrace;
+  candidate: GateTrace;
+  retainedCell: number;
+  candidateWrite: number;
+  cellState: number;
+  exposedCell: number;
+  hiddenState: number;
+}
+
+export interface GatedRecurrentTrace {
+  input: number;
+  previousHidden: number;
+  previousCell: number;
+  gru: GruGateTrace;
+  lstm: LstmGateTrace;
+}
+
+export interface GateCounterfactual {
+  model: GatedModel;
+  gate: GatedCellGate;
+  gateValue: number;
+  candidate: number;
+  cellState: number | null;
+  hiddenState: number;
+}
+
+export const DEFAULT_GATED_INPUT = 1;
+export const DEFAULT_GATED_PREVIOUS_HIDDEN = 0.8;
+export const DEFAULT_GATED_PREVIOUS_CELL = 0.8;
+export const DEFAULT_GATE_VALUES = {
+  reset: 0.5,
+  update: 0.25,
+  forget: 0.5,
+  input: 0.25,
+  output: 0.75,
+} as const;
+
+const LOG_THREE = Math.log(3);
+const CANDIDATE_PREACTIVATION = Math.atanh(0.6);
+const GRU_CANDIDATE_BIAS = CANDIDATE_PREACTIVATION - 0.4;
+
+function sigmoid(value: number): number {
+  if (value >= 0) {
+    const factor = Math.exp(-value);
+    return 1 / (1 + factor);
+  }
+  const factor = Math.exp(value);
+  return factor / (1 + factor);
+}
+
+function gate(preactivation: number): GateTrace {
+  return { preactivation, value: sigmoid(preactivation) };
+}
+
+export function traceGatedRecurrent(
+  input = DEFAULT_GATED_INPUT,
+  previousHidden = DEFAULT_GATED_PREVIOUS_HIDDEN,
+  previousCell = DEFAULT_GATED_PREVIOUS_CELL,
+): GatedRecurrentTrace {
+  if (![input, previousHidden, previousCell].every(Number.isFinite)) {
+    throw new Error("NN11 V1 needs finite scalar input and recurrent states.");
+  }
+
+  const resetGate = gate(0);
+  const updateGate = gate(-LOG_THREE);
+  const resetState = resetGate.value * previousHidden;
+  const inputProduct = 0 * input;
+  const recurrentProduct = resetState;
+  const gruCandidatePreactivation = inputProduct
+    + recurrentProduct
+    + GRU_CANDIDATE_BIAS;
+  const gruCandidateValue = Math.tanh(gruCandidatePreactivation);
+  const retainedState = (1 - updateGate.value) * previousHidden;
+  const gruCandidateWrite = updateGate.value * gruCandidateValue;
+
+  const forgetGate = gate(0);
+  const inputGate = gate(-LOG_THREE);
+  const outputGate = gate(LOG_THREE);
+  const lstmCandidate = {
+    preactivation: CANDIDATE_PREACTIVATION,
+    value: Math.tanh(CANDIDATE_PREACTIVATION),
+  };
+  const retainedCell = forgetGate.value * previousCell;
+  const lstmCandidateWrite = inputGate.value * lstmCandidate.value;
+  const cellState = retainedCell + lstmCandidateWrite;
+  const exposedCell = Math.tanh(cellState);
+
+  return {
+    input,
+    previousHidden,
+    previousCell,
+    gru: {
+      resetGate,
+      updateGate,
+      candidate: {
+        inputProduct,
+        resetState,
+        recurrentProduct,
+        bias: GRU_CANDIDATE_BIAS,
+        preactivation: gruCandidatePreactivation,
+        value: gruCandidateValue,
+      },
+      retainedState,
+      candidateWrite: gruCandidateWrite,
+      hiddenState: retainedState + gruCandidateWrite,
+    },
+    lstm: {
+      forgetGate,
+      inputGate,
+      outputGate,
+      candidate: lstmCandidate,
+      retainedCell,
+      candidateWrite: lstmCandidateWrite,
+      cellState,
+      exposedCell,
+      hiddenState: outputGate.value * exposedCell,
+    },
+  };
+}
+
+export function traceGateCounterfactual(
+  model: GatedModel,
+  selectedGate: GatedCellGate,
+  gateValue: number,
+  trace: GatedRecurrentTrace = traceGatedRecurrent(),
+): GateCounterfactual {
+  if (!Number.isFinite(gateValue) || gateValue < 0 || gateValue > 1) {
+    throw new Error("NN11 gate interventions must be between zero and one.");
+  }
+
+  if (model === "gru") {
+    if (selectedGate !== "reset" && selectedGate !== "update") {
+      throw new Error(`Gate ${selectedGate} does not belong to the GRU.`);
+    }
+    const reset = selectedGate === "reset" ? gateValue : trace.gru.resetGate.value;
+    const update = selectedGate === "update" ? gateValue : trace.gru.updateGate.value;
+    const candidate = Math.tanh(
+      trace.gru.candidate.inputProduct
+      + reset * trace.previousHidden
+      + trace.gru.candidate.bias,
+    );
+    return {
+      model,
+      gate: selectedGate,
+      gateValue,
+      candidate,
+      cellState: null,
+      hiddenState: (1 - update) * trace.previousHidden + update * candidate,
+    };
+  }
+
+  if (!["forget", "input", "output"].includes(selectedGate)) {
+    throw new Error(`Gate ${selectedGate} does not belong to the LSTM.`);
+  }
+  const forget = selectedGate === "forget" ? gateValue : trace.lstm.forgetGate.value;
+  const inputGate = selectedGate === "input" ? gateValue : trace.lstm.inputGate.value;
+  const output = selectedGate === "output" ? gateValue : trace.lstm.outputGate.value;
+  const cellState = forget * trace.previousCell + inputGate * trace.lstm.candidate.value;
+  return {
+    model,
+    gate: selectedGate,
+    gateValue,
+    candidate: trace.lstm.candidate.value,
+    cellState,
+    hiddenState: output * Math.tanh(cellState),
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/gradient-flow-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/gradient-flow-lab.ts
@@ -1,0 +1,179 @@
+export type GradientActivation = "tanh" | "relu";
+export type GradientFlowClassification = "vanishing" | "stable" | "exploding";
+
+export interface GradientScenario {
+  id: string;
+  label: string;
+  summary: string;
+  input: number;
+  weights: number[];
+  activation: GradientActivation;
+  target: number;
+}
+
+export interface GradientLayerTrace {
+  layer: number;
+  input: number;
+  weight: number;
+  preactivation: number;
+  activation: number;
+  activationDerivative: number;
+  localJacobian: number;
+  upstreamGradient: number;
+  preactivationGradient: number;
+  weightGradient: number;
+  inputGradient: number;
+}
+
+export interface GradientFlowTrace {
+  scenario: GradientScenario;
+  output: number;
+  outputError: number;
+  loss: number;
+  chainJacobian: number;
+  inputGradient: number;
+  finiteDifferenceInputGradient: number;
+  finiteDifferenceError: number;
+  classification: GradientFlowClassification;
+  layers: GradientLayerTrace[];
+}
+
+export const GRADIENT_SCENARIOS: readonly GradientScenario[] = [
+  {
+    id: "small-tanh",
+    label: "Small tanh",
+    summary: "Weights and tanh derivatives shrink the chain",
+    input: 1,
+    weights: [0.5, 0.5, 0.5, 0.5],
+    activation: "tanh",
+    target: 0,
+  },
+  {
+    id: "saturated-tanh",
+    label: "Saturated tanh",
+    summary: "Large preactivations make tanh derivatives tiny",
+    input: 1,
+    weights: [3, 3, 3, 3],
+    activation: "tanh",
+    target: 0,
+  },
+  {
+    id: "unit-relu",
+    label: "Unit ReLU",
+    summary: "Local Jacobians stay at one",
+    input: 1,
+    weights: [1, 1, 1, 1],
+    activation: "relu",
+    target: 0,
+  },
+  {
+    id: "large-relu",
+    label: "Large ReLU",
+    summary: "Every layer doubles the forward and backward signal",
+    input: 1,
+    weights: [2, 2, 2, 2],
+    activation: "relu",
+    target: 0,
+  },
+];
+
+function scenarioById(id: string): GradientScenario {
+  const scenario = GRADIENT_SCENARIOS.find((item) => item.id === id);
+  if (!scenario) throw new Error(`NN24 unknown gradient scenario: ${id}`);
+  return scenario;
+}
+
+function activate(value: number, kind: GradientActivation): number {
+  return kind === "tanh" ? Math.tanh(value) : Math.max(0, value);
+}
+
+function derivative(preactivation: number, activation: number, kind: GradientActivation): number {
+  return kind === "tanh" ? 1 - activation ** 2 : preactivation > 0 ? 1 : 0;
+}
+
+function lossAtInput(scenario: GradientScenario, input: number): number {
+  const output = scenario.weights.reduce(
+    (value, weight) => activate(weight * value, scenario.activation),
+    input,
+  );
+  return 0.5 * (output - scenario.target) ** 2;
+}
+
+export function traceGradientFlow(
+  scenarioId = "small-tanh",
+  finiteDifferenceEpsilon = 1e-6,
+): GradientFlowTrace {
+  const scenario = scenarioById(scenarioId);
+  if (!Number.isFinite(finiteDifferenceEpsilon) || finiteDifferenceEpsilon <= 0) {
+    throw new Error("NN24 finite-difference epsilon must be positive and finite.");
+  }
+  if (
+    !Number.isFinite(scenario.input)
+    || !Number.isFinite(scenario.target)
+    || scenario.weights.length < 2
+    || !scenario.weights.every(Number.isFinite)
+  ) {
+    throw new Error("NN24 scenarios need finite values and at least two weights.");
+  }
+
+  let current = scenario.input;
+  const layers: GradientLayerTrace[] = scenario.weights.map((weight, index) => {
+    const preactivation = weight * current;
+    const activation = activate(preactivation, scenario.activation);
+    const activationDerivative = derivative(preactivation, activation, scenario.activation);
+    const layer: GradientLayerTrace = {
+      layer: index + 1,
+      input: current,
+      weight,
+      preactivation,
+      activation,
+      activationDerivative,
+      localJacobian: weight * activationDerivative,
+      upstreamGradient: 0,
+      preactivationGradient: 0,
+      weightGradient: 0,
+      inputGradient: 0,
+    };
+    current = activation;
+    return layer;
+  });
+
+  const output = current;
+  const outputError = output - scenario.target;
+  const loss = 0.5 * outputError ** 2;
+  let upstreamGradient = outputError;
+  for (let index = layers.length - 1; index >= 0; index -= 1) {
+    const layer = layers[index]!;
+    const preactivationGradient = upstreamGradient * layer.activationDerivative;
+    layer.upstreamGradient = upstreamGradient;
+    layer.preactivationGradient = preactivationGradient;
+    layer.weightGradient = preactivationGradient * layer.input;
+    layer.inputGradient = preactivationGradient * layer.weight;
+    upstreamGradient = layer.inputGradient;
+  }
+
+  const chainJacobian = layers.reduce((product, layer) => product * layer.localJacobian, 1);
+  const finiteDifferenceInputGradient = (
+    lossAtInput(scenario, scenario.input + finiteDifferenceEpsilon)
+    - lossAtInput(scenario, scenario.input - finiteDifferenceEpsilon)
+  ) / (2 * finiteDifferenceEpsilon);
+  const magnitude = Math.abs(chainJacobian);
+  const classification: GradientFlowClassification = magnitude < 0.1
+    ? "vanishing"
+    : magnitude > 10
+      ? "exploding"
+      : "stable";
+
+  return {
+    scenario: { ...scenario, weights: [...scenario.weights] },
+    output,
+    outputError,
+    loss,
+    chainJacobian,
+    inputGradient: upstreamGradient,
+    finiteDifferenceInputGradient,
+    finiteDifferenceError: Math.abs(upstreamGradient - finiteDifferenceInputGradient),
+    classification,
+    layers,
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/graph-neighborhood-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/graph-neighborhood-lab.ts
@@ -1,0 +1,70 @@
+export interface NeighborhoodRow {
+  source: number;
+  sourceFeature: number;
+  sourceDegree: number;
+  targetDegree: number;
+  coefficient: number;
+  contribution: number;
+}
+export interface AttentionRow {
+  source: number;
+  sourceFeature: number;
+  score: number;
+  shiftedScore: number;
+  exponential: number;
+  attentionWeight: number;
+  contribution: number;
+}
+export interface GraphNeighborhoodTrace {
+  features: number[];
+  neighborhoods: number[][];
+  degrees: number[];
+  gcn: Array<{ target: number; rows: NeighborhoodRow[]; preactivation: number; output: number }>;
+  gat: Array<{ target: number; rows: AttentionRow[]; maximumScore: number; denominator: number; preactivation: number; output: number }>;
+  gcnOutputs: number[];
+  gatOutputs: number[];
+}
+
+export const DEFAULT_GRAPH_NEIGHBORHOODS = [[0, 1], [0, 1, 2], [1, 2]];
+export const DEFAULT_GRAPH_ATTENTION_FEATURES = [1, 2, -1];
+
+export function traceGraphNeighborhoodComparison(
+  features: readonly number[] = DEFAULT_GRAPH_ATTENTION_FEATURES,
+  neighborhoods: readonly (readonly number[])[] = DEFAULT_GRAPH_NEIGHBORHOODS,
+): GraphNeighborhoodTrace {
+  if (features.length < 2 || !features.every(Number.isFinite) || neighborhoods.length !== features.length) {
+    throw new Error("NN22 V1 needs finite features and one neighborhood per node.");
+  }
+  neighborhoods.forEach((sources, target) => {
+    if (sources.length < 1 || new Set(sources).size !== sources.length || !sources.includes(target) || sources.some((source) => !Number.isInteger(source) || source < 0 || source >= features.length)) {
+      throw new Error("NN22 V1 neighborhoods must be unique valid indices and include self-loops.");
+    }
+  });
+  for (let target = 0; target < neighborhoods.length; target += 1) {
+    for (const source of neighborhoods[target]!) {
+      if (!neighborhoods[source]!.includes(target)) throw new Error("NN22 V1 neighborhoods must be symmetric.");
+    }
+  }
+  const degrees = neighborhoods.map((sources) => sources.length);
+  const gcn = neighborhoods.map((sources, target) => {
+    const rows = sources.map((source) => {
+      const coefficient = 1 / Math.sqrt(degrees[target]! * degrees[source]!);
+      return { source, sourceFeature: features[source]!, sourceDegree: degrees[source]!, targetDegree: degrees[target]!, coefficient, contribution: coefficient * features[source]! };
+    });
+    const preactivation = rows.reduce((sum, row) => sum + row.contribution, 0);
+    return { target, rows, preactivation, output: Math.max(0, preactivation) };
+  });
+  const gat = neighborhoods.map((sources, target) => {
+    const scores = sources.map((source) => features[source]!);
+    const maximumScore = Math.max(...scores);
+    const exponentials = scores.map((score) => Math.exp(score - maximumScore));
+    const denominator = exponentials.reduce((sum, value) => sum + value, 0);
+    const rows = sources.map((source, index) => {
+      const attentionWeight = exponentials[index]! / denominator;
+      return { source, sourceFeature: features[source]!, score: scores[index]!, shiftedScore: scores[index]! - maximumScore, exponential: exponentials[index]!, attentionWeight, contribution: attentionWeight * features[source]! };
+    });
+    const preactivation = rows.reduce((sum, row) => sum + row.contribution, 0);
+    return { target, rows, maximumScore, denominator, preactivation, output: Math.max(0, preactivation) };
+  });
+  return { features: [...features], neighborhoods: neighborhoods.map((row) => [...row]), degrees, gcn, gat, gcnOutputs: gcn.map((row) => row.output), gatOutputs: gat.map((row) => row.output) };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/hopfield-memory.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/hopfield-memory.ts
@@ -1,0 +1,175 @@
+export type BipolarState = -1 | 1;
+
+export interface HopfieldContribution {
+  sourceIndex: number;
+  weight: number;
+  sourceState: BipolarState;
+  contribution: number;
+}
+
+export interface HopfieldUpdateStep {
+  step: number;
+  neuronIndex: number;
+  stateBefore: BipolarState[];
+  incoming: HopfieldContribution[];
+  localField: number;
+  previousState: BipolarState;
+  nextState: BipolarState;
+  changed: boolean;
+  stateAfter: BipolarState[];
+  energyBefore: number;
+  energyAfter: number;
+  overlapBefore: number;
+  overlapAfter: number;
+}
+
+export interface HopfieldMemoryTrace {
+  storedPattern: BipolarState[];
+  normalization: number;
+  weights: number[][];
+  corruptedState: BipolarState[];
+  updateOrder: number[];
+  initialEnergy: number;
+  initialOverlap: number;
+  initialHammingDistance: number;
+  updates: HopfieldUpdateStep[];
+  finalState: BipolarState[];
+  finalEnergy: number;
+  finalOverlap: number;
+  finalHammingDistance: number;
+  converged: boolean;
+}
+
+export const DEFAULT_HOPFIELD_PATTERN: BipolarState[] = [1, -1, 1, -1];
+export const DEFAULT_HOPFIELD_CORRUPTED_STATE: BipolarState[] = [-1, -1, 1, -1];
+export const DEFAULT_HOPFIELD_UPDATE_ORDER = [0, 1, 2, 3];
+
+function normalizeZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+function assertBipolar(values: readonly number[], name: string): asserts values is readonly BipolarState[] {
+  if (values.length < 2 || values.some((value) => value !== -1 && value !== 1)) {
+    throw new Error(`${name} must contain at least two bipolar values (-1 or +1).`);
+  }
+}
+
+export function hopfieldWeights(pattern: readonly BipolarState[]): number[][] {
+  const normalization = pattern.length;
+  return pattern.map((target, row) => pattern.map((source, column) => (
+    row === column ? 0 : (target * source) / normalization
+  )));
+}
+
+export function hopfieldEnergy(
+  state: readonly BipolarState[],
+  weights: readonly (readonly number[])[],
+): number {
+  let directedSum = 0;
+  for (let row = 0; row < state.length; row += 1) {
+    for (let column = 0; column < state.length; column += 1) {
+      directedSum += weights[row]![column]! * state[row]! * state[column]!;
+    }
+  }
+  return normalizeZero(-0.5 * directedSum);
+}
+
+export function normalizedOverlap(
+  pattern: readonly BipolarState[],
+  state: readonly BipolarState[],
+): number {
+  return pattern.reduce((sum, value, index) => sum + value * state[index]!, 0)
+    / pattern.length;
+}
+
+export function hammingDistance(
+  pattern: readonly BipolarState[],
+  state: readonly BipolarState[],
+): number {
+  return pattern.filter((value, index) => value !== state[index]).length;
+}
+
+export function traceHopfieldRecall(
+  storedPattern: readonly number[] = DEFAULT_HOPFIELD_PATTERN,
+  corruptedState: readonly number[] = DEFAULT_HOPFIELD_CORRUPTED_STATE,
+  updateOrder: readonly number[] = DEFAULT_HOPFIELD_UPDATE_ORDER,
+): HopfieldMemoryTrace {
+  assertBipolar(storedPattern, "storedPattern");
+  assertBipolar(corruptedState, "corruptedState");
+  if (
+    storedPattern.length !== corruptedState.length
+    || updateOrder.length !== storedPattern.length
+    || new Set(updateOrder).size !== updateOrder.length
+    || updateOrder.some((index) => !Number.isInteger(index) || index < 0 || index >= storedPattern.length)
+  ) {
+    throw new Error("NN20 V1 needs equal-sized states and one permutation of every neuron index.");
+  }
+
+  const pattern = [...storedPattern];
+  const initialState = [...corruptedState];
+  const weights = hopfieldWeights(pattern);
+  const initialEnergy = hopfieldEnergy(initialState, weights);
+  const initialOverlap = normalizedOverlap(pattern, initialState);
+  const updates: HopfieldUpdateStep[] = [];
+  let state = [...initialState];
+
+  updateOrder.forEach((neuronIndex, step) => {
+    const stateBefore = [...state];
+    const incoming = stateBefore.map((sourceState, sourceIndex) => {
+      const weight = weights[neuronIndex]![sourceIndex]!;
+      return {
+        sourceIndex,
+        weight,
+        sourceState,
+        contribution: normalizeZero(weight * sourceState),
+      };
+    });
+    const localField = normalizeZero(
+      incoming.reduce((sum, row) => sum + row.contribution, 0),
+    );
+    const previousState = stateBefore[neuronIndex]!;
+    const nextState: BipolarState = localField > 0
+      ? 1
+      : localField < 0
+        ? -1
+        : previousState;
+    state = [...stateBefore];
+    state[neuronIndex] = nextState;
+    updates.push({
+      step,
+      neuronIndex,
+      stateBefore,
+      incoming,
+      localField,
+      previousState,
+      nextState,
+      changed: nextState !== previousState,
+      stateAfter: [...state],
+      energyBefore: hopfieldEnergy(stateBefore, weights),
+      energyAfter: hopfieldEnergy(state, weights),
+      overlapBefore: normalizedOverlap(pattern, stateBefore),
+      overlapAfter: normalizedOverlap(pattern, state),
+    });
+  });
+
+  const finalEnergy = hopfieldEnergy(state, weights);
+  const finalOverlap = normalizedOverlap(pattern, state);
+  const finalHammingDistance = hammingDistance(pattern, state);
+  return {
+    storedPattern: pattern,
+    normalization: pattern.length,
+    weights,
+    corruptedState: initialState,
+    updateOrder: [...updateOrder],
+    initialEnergy,
+    initialOverlap,
+    initialHammingDistance: hammingDistance(pattern, initialState),
+    updates,
+    finalState: [...state],
+    finalEnergy,
+    finalOverlap,
+    finalHammingDistance,
+    converged: finalHammingDistance === 0
+      && updates.every((row) => row.energyAfter <= row.energyBefore + 1e-12),
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/image-cnn-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/image-cnn-lab.ts
@@ -1,0 +1,248 @@
+export type NumberMatrix = number[][];
+
+export interface ImageInputChannel {
+  name: string;
+  values: NumberMatrix;
+}
+
+export interface ImageFilter {
+  name: string;
+  kernels: NumberMatrix[];
+  bias: number;
+}
+
+export interface ImagePositionTrace {
+  filterIndex: number;
+  row: number;
+  column: number;
+  windows: NumberMatrix[];
+  products: NumberMatrix[];
+  channelSums: number[];
+  preBiasSum: number;
+  output: number;
+}
+
+export interface ImageNormalizationTrace {
+  means: number[];
+  variances: number[];
+  denominators: number[];
+  maps: NumberMatrix[];
+}
+
+export interface ImagePoolingTrace {
+  values: number[];
+  argmax: [number, number][];
+}
+
+export interface TinyImageCnnTrace {
+  positions: ImagePositionTrace[][][];
+  channelContributions: NumberMatrix[][];
+  convolution: NumberMatrix[];
+  normalization: ImageNormalizationTrace;
+  activation: NumberMatrix[];
+  pooling: ImagePoolingTrace;
+}
+
+export const DEFAULT_IMAGE_CHANNELS: ImageInputChannel[] = [
+  {
+    name: "vertical-position",
+    values: [[0, 0, 0], [1, 1, 1], [2, 2, 2]],
+  },
+  {
+    name: "horizontal-position",
+    values: [[0, 1, 2], [0, 1, 2], [0, 1, 2]],
+  },
+];
+
+export const DEFAULT_IMAGE_FILTERS: ImageFilter[] = [
+  {
+    name: "toward-bottom-right",
+    kernels: [
+      [[4, 0], [0, 0]],
+      [[2, 0], [0, 0]],
+    ],
+    bias: 0,
+  },
+  {
+    name: "toward-top-left",
+    kernels: [
+      [[-4, 0], [0, 0]],
+      [[-2, 0], [0, 0]],
+    ],
+    bias: 6,
+  },
+];
+
+export const DEFAULT_IMAGE_EPSILON = 4;
+export const DEFAULT_IMAGE_GAMMA = [1, 1] as const;
+export const DEFAULT_IMAGE_BETA = [0, 0] as const;
+
+function cleanZero(value: number): number {
+  return value === 0 ? 0 : value;
+}
+
+function matrixShape(matrix: readonly (readonly number[])[]): [number, number] {
+  if (matrix.length === 0 || matrix[0]!.length === 0) {
+    throw new Error("Matrices must contain at least one value.");
+  }
+  const width = matrix[0]!.length;
+  if (matrix.some((row) => row.length !== width || !row.every(Number.isFinite))) {
+    throw new Error("Matrices must be rectangular and contain finite numbers.");
+  }
+  return [matrix.length, width];
+}
+
+function spatialNormalize(
+  maps: readonly NumberMatrix[],
+  epsilon: number,
+  gamma: readonly number[],
+  beta: readonly number[],
+): ImageNormalizationTrace {
+  if (!Number.isFinite(epsilon) || epsilon <= 0) {
+    throw new Error("Normalization epsilon must be positive.");
+  }
+  if (gamma.length !== maps.length || beta.length !== maps.length) {
+    throw new Error("Gamma and beta must match the output channel count.");
+  }
+  const means: number[] = [];
+  const variances: number[] = [];
+  const denominators: number[] = [];
+  const normalizedMaps = maps.map((featureMap, filterIndex) => {
+    const values = featureMap.flat();
+    const mean = values.reduce((total, value) => total + value, 0) / values.length;
+    const variance = values.reduce(
+      (total, value) => total + (value - mean) ** 2,
+      0,
+    ) / values.length;
+    const denominator = Math.sqrt(variance + epsilon);
+    means.push(mean);
+    variances.push(variance);
+    denominators.push(denominator);
+    return featureMap.map((row) => row.map((value) => cleanZero(
+      gamma[filterIndex]! * (value - mean) / denominator + beta[filterIndex]!,
+    )));
+  });
+  return { means, variances, denominators, maps: normalizedMaps };
+}
+
+function maxPoolEntireMaps(maps: readonly NumberMatrix[]): ImagePoolingTrace {
+  const values: number[] = [];
+  const argmax: [number, number][] = [];
+  for (const featureMap of maps) {
+    let bestValue = Number.NEGATIVE_INFINITY;
+    let bestPosition: [number, number] = [0, 0];
+    for (const [rowIndex, row] of featureMap.entries()) {
+      for (const [columnIndex, value] of row.entries()) {
+        if (value > bestValue) {
+          bestValue = value;
+          bestPosition = [rowIndex, columnIndex];
+        }
+      }
+    }
+    values.push(bestValue);
+    argmax.push(bestPosition);
+  }
+  return { values, argmax };
+}
+
+export function traceTinyImageCnn(
+  channels: readonly ImageInputChannel[] = DEFAULT_IMAGE_CHANNELS,
+  filters: readonly ImageFilter[] = DEFAULT_IMAGE_FILTERS,
+  epsilon = DEFAULT_IMAGE_EPSILON,
+  gamma: readonly number[] = DEFAULT_IMAGE_GAMMA,
+  beta: readonly number[] = DEFAULT_IMAGE_BETA,
+): TinyImageCnnTrace {
+  if (channels.length === 0 || filters.length === 0) {
+    throw new Error("The image and filter bank must be non-empty.");
+  }
+  const [inputHeight, inputWidth] = matrixShape(channels[0]!.values);
+  if (channels.some((channel) => {
+    const shape = matrixShape(channel.values);
+    return shape[0] !== inputHeight || shape[1] !== inputWidth;
+  })) {
+    throw new Error("Every input channel must have the same image shape.");
+  }
+
+  const positions: ImagePositionTrace[][][] = [];
+  const channelContributions: NumberMatrix[][] = [];
+  const convolution: NumberMatrix[] = [];
+  for (const [filterIndex, filter] of filters.entries()) {
+    if (!Number.isFinite(filter.bias) || filter.kernels.length !== channels.length) {
+      throw new Error("Every filter needs a finite bias and one kernel per input channel.");
+    }
+    const [kernelHeight, kernelWidth] = matrixShape(filter.kernels[0]!);
+    if (filter.kernels.some((kernel) => {
+      const shape = matrixShape(kernel);
+      return shape[0] !== kernelHeight || shape[1] !== kernelWidth;
+    })) {
+      throw new Error("Every kernel in one filter must have the same shape.");
+    }
+    if (kernelHeight > inputHeight || kernelWidth > inputWidth) {
+      throw new Error("Kernels must fit inside the image in valid mode.");
+    }
+    const outputHeight = inputHeight - kernelHeight + 1;
+    const outputWidth = inputWidth - kernelWidth + 1;
+    const filterContributions = channels.map(
+      () => Array.from({ length: outputHeight }, () => Array(outputWidth).fill(0) as number[]),
+    );
+    const filterPositions: ImagePositionTrace[][] = [];
+    const outputMap: NumberMatrix = [];
+    for (let row = 0; row < outputHeight; row += 1) {
+      const positionRow: ImagePositionTrace[] = [];
+      const outputRow: number[] = [];
+      for (let column = 0; column < outputWidth; column += 1) {
+        const windows = channels.map((channel) => (
+          Array.from({ length: kernelHeight }, (_, kernelRow) => (
+            channel.values[row + kernelRow]!.slice(column, column + kernelWidth)
+          ))
+        ));
+        const products = windows.map((window, channelIndex) => (
+          window.map((windowRow, kernelRow) => (
+            windowRow.map((value, kernelColumn) => cleanZero(
+              value * filter.kernels[channelIndex]![kernelRow]![kernelColumn]!,
+            ))
+          ))
+        ));
+        const channelSums = products.map((product) => cleanZero(
+          product.flat().reduce((total, value) => total + value, 0),
+        ));
+        const preBiasSum = cleanZero(
+          channelSums.reduce((total, value) => total + value, 0),
+        );
+        const output = cleanZero(preBiasSum + filter.bias);
+        channelSums.forEach((sum, channelIndex) => {
+          filterContributions[channelIndex]![row]![column] = sum;
+        });
+        positionRow.push({
+          filterIndex,
+          row,
+          column,
+          windows,
+          products,
+          channelSums,
+          preBiasSum,
+          output,
+        });
+        outputRow.push(output);
+      }
+      filterPositions.push(positionRow);
+      outputMap.push(outputRow);
+    }
+    positions.push(filterPositions);
+    channelContributions.push(filterContributions);
+    convolution.push(outputMap);
+  }
+
+  const normalization = spatialNormalize(convolution, epsilon, gamma, beta);
+  const activation = normalization.maps.map((featureMap) => (
+    featureMap.map((row) => row.map((value) => Math.max(0, value)))
+  ));
+  return {
+    positions,
+    channelContributions,
+    convolution,
+    normalization,
+    activation,
+    pooling: maxPoolEntireMaps(activation),
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/initialization-distribution-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/initialization-distribution-lab.ts
@@ -1,0 +1,150 @@
+export type InitializationKind = "tiny" | "xavier" | "he" | "large";
+export type DistributionActivation = "tanh" | "relu";
+
+export interface DistributionSummary {
+  mean: number;
+  variance: number;
+  standardDeviation: number;
+  minimum: number;
+  maximum: number;
+  zeroFraction: number;
+  saturatedFraction: number;
+}
+
+export interface InitializationLayerTrace {
+  layer: number;
+  fanIn: number;
+  scale: number;
+  weights: number[][];
+  inputs: number[][];
+  preactivations: number[][];
+  activations: number[][];
+  summary: DistributionSummary;
+}
+
+export interface InitializationDistributionTrace {
+  initializer: InitializationKind;
+  activation: DistributionActivation;
+  inputSummary: DistributionSummary;
+  layers: InitializationLayerTrace[];
+}
+
+export const INITIALIZATION_KINDS: readonly InitializationKind[] = [
+  "tiny",
+  "xavier",
+  "he",
+  "large",
+];
+
+export const DEFAULT_DISTRIBUTION_INPUTS = [
+  [1, 0],
+  [0, 1],
+  [-1, 0],
+  [0, -1],
+];
+
+export const DEFAULT_WEIGHT_TEMPLATES = [
+  [[1, -1], [1, 1]],
+  [[1, -1], [1, 1]],
+  [[1, -1], [1, 1]],
+];
+
+export function initializerScale(kind: InitializationKind, fanIn: number): number {
+  if (!Number.isInteger(fanIn) || fanIn < 1) {
+    throw new Error("NN23 fan-in must be a positive integer.");
+  }
+  if (kind === "tiny") return 0.1;
+  if (kind === "xavier") return Math.sqrt(1 / fanIn);
+  if (kind === "he") return Math.sqrt(2 / fanIn);
+  return 2;
+}
+
+export function summarizeDistribution(
+  matrix: readonly (readonly number[])[],
+  activation: DistributionActivation,
+): DistributionSummary {
+  const values = matrix.flat();
+  if (values.length === 0 || !values.every(Number.isFinite)) {
+    throw new Error("NN23 distributions need at least one finite value.");
+  }
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance = values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / values.length;
+  return {
+    mean,
+    variance,
+    standardDeviation: Math.sqrt(variance),
+    minimum: Math.min(...values),
+    maximum: Math.max(...values),
+    zeroFraction: values.filter((value) => Math.abs(value) < 1e-12).length / values.length,
+    saturatedFraction: activation === "tanh"
+      ? values.filter((value) => Math.abs(value) >= 0.95).length / values.length
+      : 0,
+  };
+}
+
+function activate(value: number, kind: DistributionActivation): number {
+  return kind === "tanh" ? Math.tanh(value) : Math.max(0, value);
+}
+
+export function traceInitializationDistributions(
+  initializer: InitializationKind = "xavier",
+  activation: DistributionActivation = "tanh",
+  inputs: readonly (readonly number[])[] = DEFAULT_DISTRIBUTION_INPUTS,
+  templates: readonly (readonly (readonly number[])[])[] = DEFAULT_WEIGHT_TEMPLATES,
+): InitializationDistributionTrace {
+  if (!INITIALIZATION_KINDS.includes(initializer)) {
+    throw new Error("NN23 initializer is not supported.");
+  }
+  if (activation !== "tanh" && activation !== "relu") {
+    throw new Error("NN23 activation must be tanh or ReLU.");
+  }
+  if (inputs.length < 2 || inputs[0]!.length < 1) {
+    throw new Error("NN23 needs at least two non-empty input rows.");
+  }
+  const inputWidth = inputs[0]!.length;
+  if (inputs.some((row) => row.length !== inputWidth || !row.every(Number.isFinite))) {
+    throw new Error("NN23 inputs must be a finite rectangular matrix.");
+  }
+  if (templates.length < 1) {
+    throw new Error("NN23 needs at least one weight template.");
+  }
+
+  let current = inputs.map((row) => [...row]);
+  const layers = templates.map((template, layerIndex) => {
+    const fanIn = current[0]!.length;
+    if (template.length !== fanIn || template.length === 0) {
+      throw new Error(`NN23 layer ${layerIndex + 1} template must match fan-in.`);
+    }
+    const width = template[0]!.length;
+    if (width < 1 || template.some((row) => row.length !== width || !row.every(Number.isFinite))) {
+      throw new Error(`NN23 layer ${layerIndex + 1} template must be finite and rectangular.`);
+    }
+    const scale = initializerScale(initializer, fanIn);
+    const weights = template.map((row) => row.map((value) => value * scale));
+    const preactivations = current.map((row) => (
+      Array.from({ length: width }, (_, output) => (
+        row.reduce((sum, value, input) => sum + value * weights[input]![output]!, 0)
+      ))
+    ));
+    const activations = preactivations.map((row) => row.map((value) => activate(value, activation)));
+    const trace: InitializationLayerTrace = {
+      layer: layerIndex + 1,
+      fanIn,
+      scale,
+      weights,
+      inputs: current,
+      preactivations,
+      activations,
+      summary: summarizeDistribution(activations, activation),
+    };
+    current = activations;
+    return trace;
+  });
+
+  return {
+    initializer,
+    activation,
+    inputSummary: summarizeDistribution(inputs, activation),
+    layers,
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/message-passing-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/message-passing-lab.ts
@@ -1,0 +1,103 @@
+export interface GraphEdge { source: number; target: number }
+export interface MessageParameters { messageWeight: number; selfWeight: number; bias: number }
+export interface DirectedMessage {
+  source: number;
+  target: number;
+  sourceFeature: number;
+  messageWeight: number;
+  message: number;
+}
+export interface NodeMessageUpdate {
+  node: number;
+  oldFeature: number;
+  incoming: DirectedMessage[];
+  aggregate: number;
+  selfContribution: number;
+  bias: number;
+  preactivation: number;
+  outputFeature: number;
+}
+export interface MessagePassingTrace {
+  nodeFeatures: number[];
+  edges: GraphEdge[];
+  parameters: MessageParameters;
+  directedMessages: DirectedMessage[];
+  nodeUpdates: NodeMessageUpdate[];
+  outputFeatures: number[];
+}
+
+export const DEFAULT_GRAPH_FEATURES = [1, 2, -1];
+export const DEFAULT_GRAPH_EDGES: GraphEdge[] = [{ source: 0, target: 1 }, { source: 1, target: 2 }];
+export const DEFAULT_MESSAGE_PARAMETERS: MessageParameters = { messageWeight: 0.5, selfWeight: 0.25, bias: -0.5 };
+
+function normalizeZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+export function traceTinyMessagePassing(
+  nodeFeatures: readonly number[] = DEFAULT_GRAPH_FEATURES,
+  edges: readonly GraphEdge[] = DEFAULT_GRAPH_EDGES,
+  parameters: MessageParameters = DEFAULT_MESSAGE_PARAMETERS,
+): MessagePassingTrace {
+  const scalars = [...nodeFeatures, parameters.messageWeight, parameters.selfWeight, parameters.bias];
+  if (
+    nodeFeatures.length < 2
+    || !scalars.every(Number.isFinite)
+    || edges.length < 1
+    || edges.some((edge) => (
+      !Number.isInteger(edge.source)
+      || !Number.isInteger(edge.target)
+      || edge.source < 0
+      || edge.target < 0
+      || edge.source >= nodeFeatures.length
+      || edge.target >= nodeFeatures.length
+      || edge.source === edge.target
+    ))
+  ) {
+    throw new Error("NN21 V1 needs finite node features and valid non-self undirected edges.");
+  }
+  const edgeKeys = edges.map((edge) => `${Math.min(edge.source, edge.target)}-${Math.max(edge.source, edge.target)}`);
+  if (new Set(edgeKeys).size !== edgeKeys.length) {
+    throw new Error("NN21 V1 needs unique undirected edges.");
+  }
+
+  const directedMessages = edges.flatMap((edge) => ([
+    { source: edge.source, target: edge.target },
+    { source: edge.target, target: edge.source },
+  ])).map(({ source, target }) => {
+    const sourceFeature = nodeFeatures[source]!;
+    return {
+      source,
+      target,
+      sourceFeature,
+      messageWeight: parameters.messageWeight,
+      message: normalizeZero(parameters.messageWeight * sourceFeature),
+    };
+  }).sort((left, right) => left.target - right.target || left.source - right.source);
+
+  const nodeUpdates = nodeFeatures.map((oldFeature, node) => {
+    const incoming = directedMessages.filter((message) => message.target === node);
+    const aggregate = normalizeZero(incoming.reduce((sum, row) => sum + row.message, 0));
+    const selfContribution = normalizeZero(parameters.selfWeight * oldFeature);
+    const preactivation = normalizeZero(selfContribution + aggregate + parameters.bias);
+    return {
+      node,
+      oldFeature,
+      incoming,
+      aggregate,
+      selfContribution,
+      bias: parameters.bias,
+      preactivation,
+      outputFeature: Math.max(0, preactivation),
+    };
+  });
+
+  return {
+    nodeFeatures: [...nodeFeatures],
+    edges: edges.map((edge) => ({ ...edge })),
+    parameters: { ...parameters },
+    directedMessages,
+    nodeUpdates,
+    outputFeatures: nodeUpdates.map((row) => row.outputFeature),
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/multi-head-attention-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/multi-head-attention-lab.ts
@@ -1,0 +1,292 @@
+import type { AttentionTokenId } from "./attention-qkv-lab.js";
+
+export type AttentionHeadId = "horizontal" | "vertical";
+
+export interface AttentionHeadParameters {
+  id: AttentionHeadId;
+  queryProjection: number[];
+  keyProjection: number[];
+  valueProjection: number[];
+}
+
+export interface MultiHeadTrace {
+  id: AttentionHeadId;
+  queryProducts: number[];
+  query: number;
+  keyProducts: number[][];
+  keys: number[];
+  valueProducts: number[][];
+  values: number[];
+  scaleDivisor: number;
+  scaledScores: number[];
+  allowed: boolean[];
+  maskedScores: Array<number | null>;
+  rowMax: number;
+  shiftedScores: Array<number | null>;
+  exponentials: number[];
+  denominator: number;
+  weights: number[];
+  valueContributions: number[];
+  context: number;
+}
+
+export interface LayerNormTrace {
+  mean: number;
+  centered: number[];
+  squaredDeviations: number[];
+  variance: number;
+  denominator: number;
+  normalized: number[];
+  affineProducts: number[];
+  output: number[];
+}
+
+export interface MultiHeadAttentionRow {
+  tokenId: AttentionTokenId;
+  input: number[];
+  heads: MultiHeadTrace[];
+  concatenated: number[];
+  outputProjectionProducts: number[][];
+  projectedAttention: number[];
+  residualSum: number[];
+  layerNorm: LayerNormTrace;
+  output: number[];
+}
+
+export interface MultiHeadAttentionTrace {
+  includeResidual: boolean;
+  applyLayerNorm: boolean;
+  tokenIds: AttentionTokenId[];
+  rows: MultiHeadAttentionRow[];
+}
+
+export const DEFAULT_MULTI_HEAD_TOKEN_IDS: AttentionTokenId[] = [
+  "red",
+  "blue",
+  "purple",
+];
+
+export const DEFAULT_MULTI_HEAD_EMBEDDINGS = [
+  [2, 0],
+  [0, 1],
+  [2, 1],
+];
+
+export const DEFAULT_ATTENTION_HEADS: AttentionHeadParameters[] = [
+  {
+    id: "horizontal",
+    queryProjection: [0.5, 0],
+    keyProjection: [0.5, 0],
+    valueProjection: [1, 0],
+  },
+  {
+    id: "vertical",
+    queryProjection: [0, 1],
+    keyProjection: [0, 1],
+    valueProjection: [0, 1],
+  },
+];
+
+export const DEFAULT_OUTPUT_PROJECTION = [
+  [1, 0],
+  [0, 1],
+];
+
+export const DEFAULT_LAYER_NORM = {
+  epsilon: 0.00001,
+  gamma: [1, 1],
+  beta: [0, 0],
+};
+
+function cleanZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+function validMatrix(
+  matrix: readonly (readonly number[])[],
+  rows: number,
+  columns: number,
+): boolean {
+  return matrix.length === rows
+    && matrix.every(
+      (row) => row.length === columns && row.every(Number.isFinite),
+    );
+}
+
+function products(
+  vector: readonly number[],
+  projection: readonly number[],
+): number[] {
+  return vector.map((value, index) => cleanZero(value * projection[index]!));
+}
+
+function executeHead(
+  embeddings: readonly (readonly number[])[],
+  queryIndex: number,
+  parameters: AttentionHeadParameters,
+): MultiHeadTrace {
+  const queryProducts = products(
+    embeddings[queryIndex]!,
+    parameters.queryProjection,
+  );
+  const query = cleanZero(queryProducts.reduce((sum, value) => sum + value, 0));
+  const keyProducts = embeddings.map((embedding) => (
+    products(embedding, parameters.keyProjection)
+  ));
+  const keys = keyProducts.map((items) => cleanZero(
+    items.reduce((sum, value) => sum + value, 0),
+  ));
+  const valueProducts = embeddings.map((embedding) => (
+    products(embedding, parameters.valueProjection)
+  ));
+  const values = valueProducts.map((items) => cleanZero(
+    items.reduce((sum, value) => sum + value, 0),
+  ));
+  const scaleDivisor = 1;
+  const scaledScores = keys.map((key) => cleanZero(query * key / scaleDivisor));
+  const allowed = scaledScores.map((_, keyIndex) => keyIndex <= queryIndex);
+  const maskedScores = scaledScores.map((score, keyIndex) => (
+    allowed[keyIndex] ? score : null
+  ));
+  const rowMax = Math.max(
+    ...maskedScores.filter((score): score is number => score !== null),
+  );
+  const shiftedScores = maskedScores.map((score) => (
+    score === null ? null : cleanZero(score - rowMax)
+  ));
+  const exponentials = shiftedScores.map((score) => (
+    score === null ? 0 : Math.exp(score)
+  ));
+  const denominator = exponentials.reduce((sum, value) => sum + value, 0);
+  const weights = exponentials.map((value) => cleanZero(value / denominator));
+  const valueContributions = weights.map((weight, index) => (
+    cleanZero(weight * values[index]!)
+  ));
+
+  return {
+    id: parameters.id,
+    queryProducts,
+    query,
+    keyProducts,
+    keys,
+    valueProducts,
+    values,
+    scaleDivisor,
+    scaledScores,
+    allowed,
+    maskedScores,
+    rowMax,
+    shiftedScores,
+    exponentials,
+    denominator,
+    weights,
+    valueContributions,
+    context: cleanZero(valueContributions.reduce((sum, value) => sum + value, 0)),
+  };
+}
+
+export function traceMultiHeadAttention(
+  includeResidual = true,
+  applyLayerNorm = true,
+  embeddings: readonly (readonly number[])[] = DEFAULT_MULTI_HEAD_EMBEDDINGS,
+  tokenIds: readonly AttentionTokenId[] = DEFAULT_MULTI_HEAD_TOKEN_IDS,
+  heads: readonly AttentionHeadParameters[] = DEFAULT_ATTENTION_HEADS,
+  outputProjection: readonly (readonly number[])[] = DEFAULT_OUTPUT_PROJECTION,
+  epsilon = DEFAULT_LAYER_NORM.epsilon,
+  gamma: readonly number[] = DEFAULT_LAYER_NORM.gamma,
+  beta: readonly number[] = DEFAULT_LAYER_NORM.beta,
+): MultiHeadAttentionTrace {
+  if (
+    tokenIds.length !== 3
+    || new Set(tokenIds).size !== 3
+    || !validMatrix(embeddings, 3, 2)
+    || heads.length !== 2
+    || new Set(heads.map((head) => head.id)).size !== 2
+    || heads.some((head) => (
+      !validMatrix([
+        head.queryProjection,
+        head.keyProjection,
+        head.valueProjection,
+      ], 3, 2)
+    ))
+    || !validMatrix(outputProjection, 2, 2)
+    || !Number.isFinite(epsilon)
+    || epsilon <= 0
+    || !validMatrix([gamma, beta], 2, 2)
+  ) {
+    throw new Error(
+      "NN14 V1 needs three 2D tokens, two scalar heads, a 2 x 2 output projection, and finite layer-norm parameters.",
+    );
+  }
+
+  const rows = embeddings.map((embedding, queryIndex): MultiHeadAttentionRow => {
+    const headTraces = heads.map((head) => executeHead(
+      embeddings,
+      queryIndex,
+      head,
+    ));
+    const concatenated = headTraces.map((head) => head.context);
+    const outputProjectionProducts = outputProjection[0]!.map(
+      (_, outputIndex) => concatenated.map((context, headIndex) => (
+        cleanZero(context * outputProjection[headIndex]![outputIndex]!)
+      )),
+    );
+    const projectedAttention = outputProjectionProducts.map((items) => (
+      cleanZero(items.reduce((sum, value) => sum + value, 0))
+    ));
+    const residualSum = projectedAttention.map((value, index) => cleanZero(
+      value + (includeResidual ? embedding[index]! : 0),
+    ));
+    const mean = residualSum.reduce((sum, value) => sum + value, 0) / 2;
+    const centered = residualSum.map((value) => cleanZero(value - mean));
+    const squaredDeviations = centered.map((value) => value * value);
+    const variance = squaredDeviations.reduce((sum, value) => sum + value, 0) / 2;
+    const denominator = Math.sqrt(variance + epsilon);
+    const normalized = centered.map((value) => cleanZero(value / denominator));
+    const affineProducts = normalized.map((value, index) => (
+      cleanZero(value * gamma[index]!)
+    ));
+    const normalizedOutput = affineProducts.map((value, index) => (
+      cleanZero(value + beta[index]!)
+    ));
+
+    return {
+      tokenId: tokenIds[queryIndex]!,
+      input: [...embedding],
+      heads: headTraces,
+      concatenated,
+      outputProjectionProducts,
+      projectedAttention,
+      residualSum,
+      layerNorm: {
+        mean,
+        centered,
+        squaredDeviations,
+        variance,
+        denominator,
+        normalized,
+        affineProducts,
+        output: normalizedOutput,
+      },
+      output: applyLayerNorm ? normalizedOutput : residualSum,
+    };
+  });
+
+  return {
+    includeResidual,
+    applyLayerNorm,
+    tokenIds: [...tokenIds],
+    rows,
+  };
+}
+
+export function multiHeadAttentionRow(
+  trace: MultiHeadAttentionTrace,
+  tokenId: AttentionTokenId,
+): MultiHeadAttentionRow {
+  const row = trace.rows.find((item) => item.tokenId === tokenId);
+  if (row === undefined) {
+    throw new Error(`Unknown multi-head attention token ${tokenId}.`);
+  }
+  return row;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/optimization-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/optimization-lab.ts
@@ -1,0 +1,238 @@
+export type BatchStrategy = "stochastic" | "mini-batch" | "full-batch";
+
+export interface OptimizationPoint {
+  x: number;
+  y: number;
+}
+
+export interface OptimizationState {
+  weight: number;
+  bias: number;
+  step: number;
+}
+
+export interface GradientVector {
+  weight: number;
+  bias: number;
+}
+
+export interface GradientCheck {
+  analytical: GradientVector;
+  numerical: GradientVector;
+  absoluteError: GradientVector;
+  maximumRelativeError: number;
+  passes: boolean;
+}
+
+export interface OptimizationTracePoint extends OptimizationState {
+  loss: number;
+  batchIndices: number[];
+}
+
+export interface LandscapePoint {
+  weight: number;
+  bias: number;
+  loss: number;
+  column: number;
+  row: number;
+}
+
+export const OPTIMIZATION_DATASET: readonly OptimizationPoint[] = [
+  { x: -1, y: -1 },
+  { x: 0, y: 1 },
+  { x: 1, y: 3 },
+  { x: 2, y: 5 },
+];
+
+export const DEFAULT_OPTIMIZATION_STATE: OptimizationState = {
+  weight: -0.5,
+  bias: 0,
+  step: 0,
+};
+
+export const OPTIMUM_PARAMETERS = { weight: 2, bias: 1 };
+
+export function predictPoint(point: OptimizationPoint, state: OptimizationState): number {
+  return state.weight * point.x + state.bias;
+}
+
+export function meanSquaredError(
+  points: readonly OptimizationPoint[],
+  state: OptimizationState,
+): number {
+  if (points.length === 0) {
+    throw new Error("meanSquaredError requires at least one point");
+  }
+
+  return points.reduce((sum, point) => {
+    const error = predictPoint(point, state) - point.y;
+    return sum + error * error;
+  }, 0) / points.length;
+}
+
+export function analyticalGradient(
+  points: readonly OptimizationPoint[],
+  state: OptimizationState,
+): GradientVector {
+  if (points.length === 0) {
+    throw new Error("analyticalGradient requires at least one point");
+  }
+
+  const scale = 2 / points.length;
+  return points.reduce(
+    (gradient, point) => {
+      const error = predictPoint(point, state) - point.y;
+      return {
+        weight: gradient.weight + scale * error * point.x,
+        bias: gradient.bias + scale * error,
+      };
+    },
+    { weight: 0, bias: 0 },
+  );
+}
+
+export function numericalGradient(
+  points: readonly OptimizationPoint[],
+  state: OptimizationState,
+  epsilon: number,
+): GradientVector {
+  if (!(epsilon > 0) || !Number.isFinite(epsilon)) {
+    throw new Error("epsilon must be a positive finite number");
+  }
+
+  function centralDifference(field: "weight" | "bias"): number {
+    const plus = { ...state, [field]: state[field] + epsilon };
+    const minus = { ...state, [field]: state[field] - epsilon };
+    return (meanSquaredError(points, plus) - meanSquaredError(points, minus)) / (2 * epsilon);
+  }
+
+  return {
+    weight: centralDifference("weight"),
+    bias: centralDifference("bias"),
+  };
+}
+
+export function checkGradient(
+  points: readonly OptimizationPoint[],
+  state: OptimizationState,
+  epsilon: number,
+  tolerance = 1e-6,
+): GradientCheck {
+  const analytical = analyticalGradient(points, state);
+  const numerical = numericalGradient(points, state, epsilon);
+  const absoluteError = {
+    weight: Math.abs(analytical.weight - numerical.weight),
+    bias: Math.abs(analytical.bias - numerical.bias),
+  };
+  const relativeErrors = (["weight", "bias"] as const).map((field) => {
+    const scale = Math.max(1, Math.abs(analytical[field]), Math.abs(numerical[field]));
+    return absoluteError[field] / scale;
+  });
+  const maximumRelativeError = Math.max(...relativeErrors);
+
+  return {
+    analytical,
+    numerical,
+    absoluteError,
+    maximumRelativeError,
+    passes: maximumRelativeError <= tolerance,
+  };
+}
+
+export function batchIndices(
+  strategy: BatchStrategy,
+  step: number,
+  pointCount: number,
+): number[] {
+  if (!Number.isInteger(pointCount) || pointCount < 1) {
+    throw new Error("pointCount must be a positive integer");
+  }
+
+  if (strategy === "full-batch") {
+    return Array.from({ length: pointCount }, (_, index) => index);
+  }
+  if (strategy === "stochastic") {
+    return [step % pointCount];
+  }
+
+  const start = (step * 2) % pointCount;
+  return [start, (start + 1) % pointCount];
+}
+
+export function optimizationStep(
+  points: readonly OptimizationPoint[],
+  state: OptimizationState,
+  learningRate: number,
+  strategy: BatchStrategy,
+): OptimizationTracePoint {
+  if (!(learningRate > 0) || !Number.isFinite(learningRate)) {
+    throw new Error("learningRate must be a positive finite number");
+  }
+
+  const indices = batchIndices(strategy, state.step, points.length);
+  const batch = indices.map((index) => points[index]!);
+  const gradient = analyticalGradient(batch, state);
+  const next = {
+    weight: state.weight - learningRate * gradient.weight,
+    bias: state.bias - learningRate * gradient.bias,
+    step: state.step + 1,
+  };
+
+  return {
+    ...next,
+    loss: meanSquaredError(points, next),
+    batchIndices: indices,
+  };
+}
+
+export function runOptimization(
+  strategy: BatchStrategy,
+  steps: number,
+  learningRate: number,
+  initialState: OptimizationState = DEFAULT_OPTIMIZATION_STATE,
+  points: readonly OptimizationPoint[] = OPTIMIZATION_DATASET,
+): OptimizationTracePoint[] {
+  if (!Number.isInteger(steps) || steps < 0) {
+    throw new Error("steps must be a non-negative integer");
+  }
+
+  const trace: OptimizationTracePoint[] = [{
+    ...initialState,
+    loss: meanSquaredError(points, initialState),
+    batchIndices: [],
+  }];
+  let current = initialState;
+  for (let index = 0; index < steps; index += 1) {
+    const next = optimizationStep(points, current, learningRate, strategy);
+    trace.push(next);
+    current = next;
+  }
+  return trace;
+}
+
+export function sampleLossLandscape(
+  points: readonly OptimizationPoint[],
+  weightRange: readonly [number, number],
+  biasRange: readonly [number, number],
+  resolution: number,
+): LandscapePoint[] {
+  if (!Number.isInteger(resolution) || resolution < 2) {
+    throw new Error("resolution must be an integer of at least two");
+  }
+
+  const samples: LandscapePoint[] = [];
+  for (let row = 0; row < resolution; row += 1) {
+    const bias = biasRange[0] + (biasRange[1] - biasRange[0]) * (row / (resolution - 1));
+    for (let column = 0; column < resolution; column += 1) {
+      const weight = weightRange[0] + (weightRange[1] - weightRange[0]) * (column / (resolution - 1));
+      samples.push({
+        weight,
+        bias,
+        loss: meanSquaredError(points, { weight, bias, step: 0 }),
+        column,
+        row,
+      });
+    }
+  }
+  return samples;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/recurrent-unroll-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/recurrent-unroll-lab.ts
@@ -21,6 +21,41 @@ export interface RecurrentUnrollTrace {
   finalState: number;
 }
 
+export interface ParameterGradients {
+  inputWeight: number;
+  recurrentWeight: number;
+  bias: number;
+}
+
+export interface BpttBackwardStep {
+  time: number;
+  directStateGradient: number;
+  futureStateGradient: number;
+  stateGradient: number;
+  reluDerivative: number;
+  preactivationGradient: number;
+  parameterContributions: ParameterGradients;
+  previousStateGradient: number;
+}
+
+export interface RecurrentBpttTrace {
+  forward: RecurrentUnrollTrace;
+  target: number;
+  loss: number;
+  backwardSteps: BpttBackwardStep[];
+  gradientTotals: ParameterGradients & { initialState: number };
+  numericalGradients: ParameterGradients;
+  gradientErrors: ParameterGradients;
+  maxGradientError: number;
+  update: {
+    learningRate: number;
+    parameters: RecurrentParameters;
+    preactivations: number[];
+    states: number[];
+    loss: number;
+  };
+}
+
 export const DEFAULT_RECURRENT_INPUTS = [1, 2, 0] as const;
 export const DEFAULT_RECURRENT_INITIAL_STATE = 0;
 export const DEFAULT_RECURRENT_PARAMETERS: Readonly<RecurrentParameters> = {
@@ -28,6 +63,9 @@ export const DEFAULT_RECURRENT_PARAMETERS: Readonly<RecurrentParameters> = {
   recurrentWeight: 0.5,
   bias: -1,
 };
+export const DEFAULT_RECURRENT_TARGET = 0;
+export const DEFAULT_RECURRENT_LEARNING_RATE = 0.1;
+export const DEFAULT_RECURRENT_FINITE_DIFFERENCE_EPSILON = 1e-6;
 
 function cleanZero(value: number): number {
   return Math.abs(value) < 1e-12 ? 0 : value;
@@ -80,5 +118,138 @@ export function traceRecurrentUnroll(
     steps,
     states: steps.map((step) => step.state),
     finalState: steps[steps.length - 1]!.state,
+  };
+}
+
+function finalStateLoss(
+  inputs: readonly number[],
+  initialState: number,
+  parameters: Readonly<RecurrentParameters>,
+  target: number,
+): number {
+  const prediction = traceRecurrentUnroll(inputs, initialState, parameters).finalState;
+  return 0.5 * (prediction - target) ** 2;
+}
+
+function numericalParameterGradient(
+  parameter: keyof RecurrentParameters,
+  inputs: readonly number[],
+  initialState: number,
+  parameters: Readonly<RecurrentParameters>,
+  target: number,
+  epsilon: number,
+): number {
+  const plus = { ...parameters, [parameter]: parameters[parameter] + epsilon };
+  const minus = { ...parameters, [parameter]: parameters[parameter] - epsilon };
+  return (
+    finalStateLoss(inputs, initialState, plus, target)
+    - finalStateLoss(inputs, initialState, minus, target)
+  ) / (2 * epsilon);
+}
+
+export function traceRecurrentBptt(
+  inputs: readonly number[] = DEFAULT_RECURRENT_INPUTS,
+  initialState = DEFAULT_RECURRENT_INITIAL_STATE,
+  parameters: Readonly<RecurrentParameters> = DEFAULT_RECURRENT_PARAMETERS,
+  target = DEFAULT_RECURRENT_TARGET,
+  learningRate = DEFAULT_RECURRENT_LEARNING_RATE,
+  epsilon = DEFAULT_RECURRENT_FINITE_DIFFERENCE_EPSILON,
+): RecurrentBpttTrace {
+  if (![target, learningRate, epsilon].every(Number.isFinite) || epsilon <= 0) {
+    throw new Error("NN10 V1 needs a finite target and learning rate, plus a positive epsilon.");
+  }
+
+  const forward = traceRecurrentUnroll(inputs, initialState, parameters);
+  const loss = 0.5 * (forward.finalState - target) ** 2;
+  let futureStateGradient = 0;
+  const backwardSteps: BpttBackwardStep[] = [];
+
+  for (let time = forward.steps.length - 1; time >= 0; time -= 1) {
+    const forwardStep = forward.steps[time]!;
+    const directStateGradient = time === forward.steps.length - 1
+      ? forward.finalState - target
+      : 0;
+    const stateGradient = cleanZero(directStateGradient + futureStateGradient);
+    const reluDerivative = forwardStep.preactivation > 0 ? 1 : 0;
+    const preactivationGradient = cleanZero(stateGradient * reluDerivative);
+    const parameterContributions = {
+      inputWeight: cleanZero(preactivationGradient * forwardStep.input),
+      recurrentWeight: cleanZero(preactivationGradient * forwardStep.previousState),
+      bias: preactivationGradient,
+    };
+    const previousStateGradient = cleanZero(
+      preactivationGradient * parameters.recurrentWeight,
+    );
+
+    backwardSteps.push({
+      time,
+      directStateGradient,
+      futureStateGradient,
+      stateGradient,
+      reluDerivative,
+      preactivationGradient,
+      parameterContributions,
+      previousStateGradient,
+    });
+    futureStateGradient = previousStateGradient;
+  }
+
+  const gradientTotals = backwardSteps.reduce(
+    (total, step) => ({
+      inputWeight: cleanZero(total.inputWeight + step.parameterContributions.inputWeight),
+      recurrentWeight: cleanZero(
+        total.recurrentWeight + step.parameterContributions.recurrentWeight,
+      ),
+      bias: cleanZero(total.bias + step.parameterContributions.bias),
+      initialState: step.time === 0 ? step.previousStateGradient : total.initialState,
+    }),
+    { inputWeight: 0, recurrentWeight: 0, bias: 0, initialState: 0 },
+  );
+
+  const numericalGradients = {
+    inputWeight: numericalParameterGradient(
+      "inputWeight", inputs, initialState, parameters, target, epsilon,
+    ),
+    recurrentWeight: numericalParameterGradient(
+      "recurrentWeight", inputs, initialState, parameters, target, epsilon,
+    ),
+    bias: numericalParameterGradient(
+      "bias", inputs, initialState, parameters, target, epsilon,
+    ),
+  };
+  const gradientErrors = {
+    inputWeight: Math.abs(gradientTotals.inputWeight - numericalGradients.inputWeight),
+    recurrentWeight: Math.abs(
+      gradientTotals.recurrentWeight - numericalGradients.recurrentWeight,
+    ),
+    bias: Math.abs(gradientTotals.bias - numericalGradients.bias),
+  };
+  const updatedParameters = {
+    inputWeight: cleanZero(
+      parameters.inputWeight - learningRate * gradientTotals.inputWeight,
+    ),
+    recurrentWeight: cleanZero(
+      parameters.recurrentWeight - learningRate * gradientTotals.recurrentWeight,
+    ),
+    bias: cleanZero(parameters.bias - learningRate * gradientTotals.bias),
+  };
+  const updatedForward = traceRecurrentUnroll(inputs, initialState, updatedParameters);
+
+  return {
+    forward,
+    target,
+    loss,
+    backwardSteps,
+    gradientTotals,
+    numericalGradients,
+    gradientErrors,
+    maxGradientError: Math.max(...Object.values(gradientErrors)),
+    update: {
+      learningRate,
+      parameters: updatedParameters,
+      preactivations: updatedForward.steps.map((step) => step.preactivation),
+      states: updatedForward.states,
+      loss: 0.5 * (updatedForward.finalState - target) ** 2,
+    },
   };
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/recurrent-unroll-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/recurrent-unroll-lab.ts
@@ -1,0 +1,84 @@
+export interface RecurrentParameters {
+  inputWeight: number;
+  recurrentWeight: number;
+  bias: number;
+}
+
+export interface RecurrentStepTrace {
+  time: number;
+  input: number;
+  previousState: number;
+  inputProduct: number;
+  recurrentProduct: number;
+  bias: number;
+  preactivation: number;
+  state: number;
+}
+
+export interface RecurrentUnrollTrace {
+  steps: RecurrentStepTrace[];
+  states: number[];
+  finalState: number;
+}
+
+export const DEFAULT_RECURRENT_INPUTS = [1, 2, 0] as const;
+export const DEFAULT_RECURRENT_INITIAL_STATE = 0;
+export const DEFAULT_RECURRENT_PARAMETERS: Readonly<RecurrentParameters> = {
+  inputWeight: 2,
+  recurrentWeight: 0.5,
+  bias: -1,
+};
+
+function cleanZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+export function traceRecurrentUnroll(
+  inputs: readonly number[] = DEFAULT_RECURRENT_INPUTS,
+  initialState = DEFAULT_RECURRENT_INITIAL_STATE,
+  parameters: Readonly<RecurrentParameters> = DEFAULT_RECURRENT_PARAMETERS,
+  recurrentEnabled = true,
+): RecurrentUnrollTrace {
+  if (
+    inputs.length !== 3
+    || ![
+      ...inputs,
+      initialState,
+      parameters.inputWeight,
+      parameters.recurrentWeight,
+      parameters.bias,
+    ].every(Number.isFinite)
+  ) {
+    throw new Error("NN09 V1 needs three finite inputs, state, and parameters.");
+  }
+
+  let previousState = initialState;
+  const steps = inputs.map((input, time): RecurrentStepTrace => {
+    const inputProduct = cleanZero(parameters.inputWeight * input);
+    const recurrentProduct = recurrentEnabled
+      ? cleanZero(parameters.recurrentWeight * previousState)
+      : 0;
+    const preactivation = cleanZero(
+      inputProduct + recurrentProduct + parameters.bias,
+    );
+    const state = cleanZero(Math.max(0, preactivation));
+    const step = {
+      time,
+      input,
+      previousState,
+      inputProduct,
+      recurrentProduct,
+      bias: parameters.bias,
+      preactivation,
+      state,
+    };
+    previousState = state;
+    return step;
+  });
+
+  return {
+    steps,
+    states: steps.map((step) => step.state),
+    finalState: steps[steps.length - 1]!.state,
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/residual-field-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/residual-field-lab.ts
@@ -1,0 +1,119 @@
+export interface HiddenPathTrace {
+  hiddenIndex: number;
+  inputIndices: number[];
+  inputValues: number[];
+  subtotal: number;
+}
+
+export interface ResidualOutputTrace {
+  outputIndex: number;
+  hiddenIndices: number[];
+  hiddenValues: number[];
+  hiddenPaths: HiddenPathTrace[];
+  inputPathCounts: number[];
+  inputContributions: number[];
+  receptiveFieldIndices: number[];
+  mainOutput: number;
+  skipContribution: number;
+  residualSum: number;
+  output: number;
+}
+
+export interface ResidualBlockTrace {
+  hidden: number[];
+  main: number[];
+  skip: number[];
+  residualSum: number[];
+  output: number[];
+  traces: ResidualOutputTrace[];
+}
+
+export const DEFAULT_RESIDUAL_INPUT = [1, 0, 2, 0, 1] as const;
+export const DEFAULT_RESIDUAL_KERNELS = [
+  [1, 1, 1],
+  [1, 1, 1],
+] as const;
+
+function cleanZero(value: number): number {
+  return value === 0 ? 0 : value;
+}
+
+export function sameCorrelation(
+  signal: readonly number[],
+  kernel: readonly number[],
+): number[] {
+  if (
+    signal.length === 0
+    || kernel.length === 0
+    || kernel.length % 2 === 0
+    || ![...signal, ...kernel].every(Number.isFinite)
+  ) {
+    throw new Error("Same correlation needs a finite signal and an odd kernel.");
+  }
+  const radius = Math.floor(kernel.length / 2);
+  return signal.map((_, index) => cleanZero(
+    kernel.reduce((total, weight, kernelIndex) => {
+      const signalIndex = index + kernelIndex - radius;
+      const signalValue = signalIndex >= 0 && signalIndex < signal.length
+        ? signal[signalIndex]!
+        : 0;
+      return total + signalValue * weight;
+    }, 0),
+  ));
+}
+
+export function traceResidualBlock(
+  input: readonly number[] = DEFAULT_RESIDUAL_INPUT,
+  kernels: readonly (readonly number[])[] = DEFAULT_RESIDUAL_KERNELS,
+): ResidualBlockTrace {
+  if (
+    kernels.length !== 2
+    || kernels.some((kernel) => (
+      kernel.length !== 3 || kernel.some((value) => value !== 1)
+    ))
+  ) {
+    throw new Error("NN08 V1 uses two [1, 1, 1] kernels.");
+  }
+  const hidden = sameCorrelation(input, kernels[0]!);
+  const main = sameCorrelation(hidden, kernels[1]!);
+  const skip = [...input];
+  const residualSum = main.map((value, index) => cleanZero(value + skip[index]!));
+  const output = residualSum.map((value) => Math.max(0, value));
+  const traces = input.map((_, outputIndex): ResidualOutputTrace => {
+    const hiddenIndices = [outputIndex - 1, outputIndex, outputIndex + 1]
+      .filter((index) => index >= 0 && index < input.length);
+    const inputPathCounts = input.map(() => 0);
+    const hiddenPaths = hiddenIndices.map((hiddenIndex): HiddenPathTrace => {
+      const inputIndices = [hiddenIndex - 1, hiddenIndex, hiddenIndex + 1]
+        .filter((index) => index >= 0 && index < input.length);
+      inputIndices.forEach((inputIndex) => {
+        inputPathCounts[inputIndex] = inputPathCounts[inputIndex]! + 1;
+      });
+      return {
+        hiddenIndex,
+        inputIndices,
+        inputValues: inputIndices.map((inputIndex) => input[inputIndex]!),
+        subtotal: hidden[hiddenIndex]!,
+      };
+    });
+    return {
+      outputIndex,
+      hiddenIndices,
+      hiddenValues: hiddenIndices.map((hiddenIndex) => hidden[hiddenIndex]!),
+      hiddenPaths,
+      inputPathCounts,
+      inputContributions: input.map(
+        (value, inputIndex) => cleanZero(value * inputPathCounts[inputIndex]!),
+      ),
+      receptiveFieldIndices: inputPathCounts
+        .map((count, inputIndex) => ({ count, inputIndex }))
+        .filter(({ count }) => count > 0)
+        .map(({ inputIndex }) => inputIndex),
+      mainOutput: main[outputIndex]!,
+      skipContribution: skip[outputIndex]!,
+      residualSum: residualSum[outputIndex]!,
+      output: output[outputIndex]!,
+    };
+  });
+  return { hidden, main, skip, residualSum, output, traces };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -136,7 +136,7 @@ h2 {
 
 .mode-toggle {
   display: inline-grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: 4px;
   padding: 4px;
   border: 1px solid $line;
@@ -1513,6 +1513,410 @@ code {
   font-weight: 750;
 }
 
+.workspace--image-cnn {
+  display: grid;
+  grid-template-columns: minmax(660px, 1fr) 320px;
+  gap: 14px;
+  align-items: start;
+}
+
+.image-cnn-stage,
+.image-cnn-controls,
+.image-stage-panel {
+  @include surface;
+}
+
+.image-cnn-stage {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.image-cnn-intro,
+.image-stage-heading,
+.channel-math-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.image-cnn-intro p:not(.eyebrow),
+.image-cnn-controls > p,
+.image-cnn-note p {
+  margin: 5px 0 0;
+  color: $muted;
+}
+
+.image-shape-chip {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: #173f8a;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.75rem;
+  font-weight: 850;
+}
+
+.image-pipeline {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(92px, 1fr));
+  gap: 6px;
+}
+
+.image-stage-button {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 7px;
+  min-height: 48px;
+  padding: 6px 9px;
+  color: $muted;
+  text-align: left;
+}
+
+.image-stage-button small {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: rgba(23, 32, 28, 0.07);
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.image-stage-button--visited {
+  border-color: rgba(35, 122, 87, 0.34);
+  color: $green;
+}
+
+.image-stage-button--active {
+  border-color: rgba(37, 99, 235, 0.52);
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.image-stage-button--active small {
+  background: #173f8a;
+  color: #ffffff;
+}
+
+.image-stage-panel {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.image-stage-heading > code {
+  min-height: 0;
+  padding: 6px 9px;
+  white-space: nowrap;
+}
+
+.image-channel-grid,
+.channel-math-grid,
+.image-map-pair,
+.pooling-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.image-channel-card,
+.channel-math-card,
+.pooling-card {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 11px;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.image-channel-card > div:first-child,
+.channel-math-title > div {
+  display: grid;
+}
+
+.image-channel-card small,
+.channel-math-card small,
+.image-matrix-block > span,
+.normalization-stats small,
+.pooled-value small,
+.image-control-group > span {
+  color: $muted;
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.image-matrix-block {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.image-matrix {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.image-matrix-cell {
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  min-height: 58px;
+  padding: 5px;
+  border: 1px solid $line;
+  border-radius: 7px;
+  background: #f9faf7;
+}
+
+.image-matrix-cell small {
+  color: $muted;
+  font-size: 0.62rem;
+}
+
+.image-matrix-cell strong,
+.channel-math-title > strong,
+.normalization-stats strong,
+.pooled-value strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.image-matrix-cell--selected {
+  border-color: rgba(37, 99, 235, 0.62);
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.image-matrix-cell--winner {
+  border-color: rgba(35, 122, 87, 0.62);
+  background: #eaf7ef;
+  color: #17603f;
+}
+
+.image-stage-note {
+  margin: 0;
+  padding: 10px;
+  border-left: 3px solid rgba(35, 122, 87, 0.42);
+  background: #f6fbf8;
+  color: $muted;
+}
+
+.image-output-value {
+  min-width: 68px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(35, 122, 87, 0.13);
+  color: $green;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.35rem;
+  text-align: center;
+}
+
+.window-kernel-pair {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 7px;
+}
+
+.window-kernel-pair > span,
+.activation-flow > span,
+.pooling-card > span {
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 850;
+}
+
+.channel-math-card .image-matrix-cell {
+  min-height: 48px;
+}
+
+.image-product-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 5px;
+}
+
+.image-product-list code {
+  min-height: 0;
+  padding: 4px;
+  font-size: 0.72rem;
+  text-align: center;
+}
+
+.channel-reduction {
+  display: grid;
+  grid-template-columns: repeat(7, auto);
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 11px;
+  border-block: 1px solid $line;
+}
+
+.channel-reduction > div {
+  display: grid;
+  min-width: 72px;
+  text-align: center;
+}
+
+.channel-reduction small {
+  color: $muted;
+  font-size: 0.66rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.channel-reduction strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.channel-reduction__result {
+  padding: 6px;
+  border-radius: 7px;
+  background: #eaf7ef;
+  color: $green;
+}
+
+.normalization-flow {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(170px, 0.8fr) minmax(160px, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+
+.normalization-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.normalization-stats > div {
+  display: grid;
+  padding: 8px;
+  border: 1px solid $line;
+  border-radius: 7px;
+  background: #ffffff;
+}
+
+.normalization-equation {
+  min-height: 0;
+  padding: 10px;
+  overflow-x: auto;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.activation-flow {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) auto minmax(180px, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+
+.pooling-card {
+  grid-template-columns: minmax(160px, 1fr) auto minmax(92px, 0.45fr);
+  align-items: center;
+}
+
+.pooled-value {
+  display: grid;
+  place-items: center;
+  min-height: 100px;
+  padding: 8px;
+  border: 1px solid rgba(35, 122, 87, 0.32);
+  border-radius: 8px;
+  background: #eaf7ef;
+  color: $green;
+  text-align: center;
+}
+
+.pooled-value strong {
+  font-size: 1.35rem;
+}
+
+.pooled-value code {
+  min-height: 0;
+  padding: 2px 4px;
+  font-size: 0.68rem;
+}
+
+.image-cnn-controls {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+}
+
+.image-control-group {
+  display: grid;
+  gap: 7px;
+  padding-block: 11px;
+  border-top: 1px solid $line;
+}
+
+.image-filter-buttons,
+.image-position-buttons {
+  display: grid;
+  gap: 7px;
+}
+
+.image-position-buttons {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.image-choice {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  min-height: 54px;
+  padding: 7px;
+  text-align: left;
+}
+
+.image-choice small {
+  color: $muted;
+  font-size: 0.68rem;
+}
+
+.image-choice strong {
+  overflow-wrap: anywhere;
+}
+
+.image-choice--active {
+  border-color: rgba(37, 99, 235, 0.52);
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.image-stage-controls button:last-child {
+  grid-column: 1 / -1;
+}
+
+.image-stage-controls button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.image-cnn-note {
+  padding-top: 12px;
+  border-top: 1px solid $line;
+}
+
+.image-cnn-note span {
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
 @media (max-width: 1180px) {
   .workspace--lab,
   .workspace--hidden {
@@ -1526,9 +1930,14 @@ code {
     grid-column: 1 / -1;
   }
 
+  .image-cnn-controls {
+    grid-column: 1 / -1;
+  }
+
   .workspace--microscope,
   .workspace--optimization,
-  .workspace--convolution {
+  .workspace--convolution,
+  .workspace--image-cnn {
     grid-template-columns: 1fr;
   }
 }
@@ -1554,13 +1963,16 @@ code {
   .workspace--hidden,
   .workspace--microscope,
   .workspace--optimization,
-  .workspace--convolution {
+    .workspace--convolution,
+    .workspace--image-cnn {
     grid-template-columns: 1fr;
   }
 
   .convolution-intro,
   .mac-heading,
-  .training-heading {
+  .training-heading,
+  .image-cnn-intro,
+  .image-stage-heading {
     display: grid;
     align-items: start;
   }
@@ -1598,7 +2010,43 @@ code {
   }
 
   .mode-button:last-child {
+    grid-column: auto;
+  }
+
+  .image-pipeline {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .image-stage-button:last-child {
     grid-column: 1 / -1;
+  }
+
+  .image-channel-grid,
+  .channel-math-grid,
+  .image-map-pair,
+  .pooling-grid,
+  .normalization-flow,
+  .activation-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .activation-flow > span,
+  .pooling-card > span {
+    transform: rotate(90deg);
+    justify-self: center;
+  }
+
+  .pooling-card {
+    grid-template-columns: 1fr;
+  }
+
+  .channel-reduction {
+    grid-template-columns: repeat(3, auto);
+  }
+
+  .channel-reduction > span:nth-of-type(3),
+  .channel-reduction__result {
+    grid-column: auto;
   }
 
   .phase-strip {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -7960,3 +7960,421 @@ code {
     justify-self: center;
   }
 }
+
+.workspace--stabilizers {
+  grid-template-columns: minmax(0, 1fr) 300px;
+  align-items: start;
+  gap: 18px;
+}
+
+.stabilizer-stage {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.stabilizer-intro,
+.stabilizer-common-panel,
+.stabilizer-comparison-panel,
+.stabilizer-forward-panel,
+.stabilizer-backward-panel,
+.stabilizer-arithmetic-panel,
+.stabilizer-audit-panel,
+.stabilizer-controls {
+  @include surface;
+}
+
+.stabilizer-intro,
+.stabilizer-common-panel,
+.stabilizer-comparison-panel,
+.stabilizer-forward-panel,
+.stabilizer-backward-panel,
+.stabilizer-arithmetic-panel,
+.stabilizer-audit-panel {
+  padding: 18px;
+}
+
+.stabilizer-intro {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.stabilizer-intro h2,
+.stabilizer-controls h2 {
+  margin: 0;
+}
+
+.stabilizer-intro p:not(.eyebrow),
+.stabilizer-controls > p {
+  color: $muted;
+  line-height: 1.55;
+}
+
+.stabilizer-chip {
+  flex: 0 0 auto;
+  border: 1px solid rgba(35, 122, 87, 0.4);
+  border-radius: 999px;
+  background: rgba(35, 122, 87, 0.08);
+  color: #1d6849;
+  padding: 8px 12px;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.stabilizer-common-panel,
+.stabilizer-comparison-panel,
+.stabilizer-forward-panel,
+.stabilizer-backward-panel,
+.stabilizer-arithmetic-panel,
+.stabilizer-audit-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.stabilizer-common-flow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) minmax(0, 1fr);
+  align-items: end;
+  gap: 9px;
+}
+
+.stabilizer-flow-arrow,
+.stabilizer-plus {
+  align-self: center;
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 850;
+  text-align: center;
+}
+
+.stabilizer-vector {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.stabilizer-vector > span {
+  color: $muted;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.stabilizer-vector > div {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 5px;
+}
+
+.stabilizer-vector code {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: 8px;
+  background: rgba(37, 99, 235, 0.055);
+  color: #234c9f;
+  padding: 9px 5px;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  text-align: center;
+}
+
+.stabilizer-vector code small {
+  color: $muted;
+  font-size: 0.6rem;
+}
+
+.stabilizer-vector code.is-selected {
+  border-color: rgba(194, 65, 59, 0.58);
+  box-shadow: inset 0 -3px rgba(194, 65, 59, 0.13);
+}
+
+.stabilizer-vector--purple code {
+  border-color: rgba(109, 91, 208, 0.2);
+  background: rgba(109, 91, 208, 0.06);
+  color: #4b3e9d;
+}
+
+.stabilizer-vector--green code {
+  border-color: rgba(35, 122, 87, 0.22);
+  background: rgba(35, 122, 87, 0.065);
+  color: #1d6849;
+}
+
+.stabilizer-vector--red code {
+  border-color: rgba(194, 65, 59, 0.2);
+  background: rgba(194, 65, 59, 0.055);
+  color: #9b3131;
+}
+
+.stabilizer-comparison-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.stabilizer-comparison-grid button {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  border: 1px solid $line;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.78);
+  color: $ink;
+  padding: 11px;
+  text-align: left;
+}
+
+.stabilizer-comparison-grid button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.5);
+  background: rgba(109, 91, 208, 0.08);
+}
+
+.stabilizer-comparison-grid span,
+.stabilizer-comparison-grid small {
+  color: $muted;
+  font-size: 0.7rem;
+}
+
+.stabilizer-comparison-grid code,
+.stabilizer-comparison-grid small {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.stabilizer-comparison-grid code {
+  overflow-wrap: anywhere;
+  color: #4b3e9d;
+  font-size: 0.67rem;
+}
+
+.stabilizer-mechanism-trace,
+.stabilizer-gradient-flow {
+  display: grid;
+  gap: 12px;
+}
+
+.stabilizer-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.stabilizer-stat-grid > div,
+.stabilizer-dropout-compare > div {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: rgba(37, 99, 235, 0.045);
+  padding: 10px;
+}
+
+.stabilizer-stat-grid small,
+.stabilizer-dropout-compare small,
+.stabilizer-audit-grid small {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.stabilizer-stat-grid strong,
+.stabilizer-dropout-compare code,
+.stabilizer-audit-grid code,
+.stabilizer-formula,
+.stabilizer-equations code {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.stabilizer-dropout-compare {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.stabilizer-dropout-compare code {
+  color: #1d6849;
+  overflow-wrap: anywhere;
+}
+
+.stabilizer-formula {
+  border-radius: 8px;
+  background: rgba(109, 91, 208, 0.07);
+  color: #4b3e9d;
+  padding: 11px;
+  overflow-wrap: anywhere;
+}
+
+.stabilizer-gradient-flow {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.stabilizer-equations {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(190px, 0.6fr);
+  align-items: center;
+  gap: 8px;
+}
+
+.stabilizer-equations code,
+.stabilizer-equations span {
+  min-width: 0;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.stabilizer-equations code {
+  background: rgba(37, 99, 235, 0.07);
+  color: #234c9f;
+  overflow-wrap: anywhere;
+}
+
+.stabilizer-equations span {
+  color: $muted;
+  font-size: 0.75rem;
+}
+
+.stabilizer-audit-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.stabilizer-audit-grid > div {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  border: 1px solid $line;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.stabilizer-audit-grid code {
+  color: #1d6849;
+}
+
+.stabilizer-controls {
+  position: sticky;
+  top: 18px;
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+}
+
+.stabilizer-route-buttons {
+  display: grid;
+  gap: 7px;
+}
+
+.stabilizer-route-buttons button {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  border: 1px solid $line;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.85);
+  color: $ink;
+  padding: 10px;
+  text-align: left;
+}
+
+.stabilizer-route-buttons button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.48);
+  background: rgba(109, 91, 208, 0.1);
+  color: #4b3e9d;
+}
+
+.stabilizer-route-buttons span {
+  color: $muted;
+  font-size: 0.7rem;
+}
+
+.stabilizer-coordinate-buttons {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.stabilizer-coordinate-buttons button {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.85);
+  color: $ink;
+  padding: 7px 4px;
+}
+
+.stabilizer-coordinate-buttons button[aria-pressed="true"] {
+  border-color: rgba(194, 65, 59, 0.5);
+  background: rgba(194, 65, 59, 0.075);
+}
+
+.stabilizer-coordinate-buttons code {
+  color: $muted;
+  font-size: 0.62rem;
+}
+
+.stabilizer-reading {
+  display: grid;
+  gap: 7px;
+  margin-top: 6px;
+  border-radius: 9px;
+  background: rgba(35, 122, 87, 0.065);
+  padding: 11px;
+}
+
+.stabilizer-reading h2,
+.stabilizer-reading p {
+  margin: 0;
+}
+
+@media (max-width: 1180px) {
+  .workspace--stabilizers {
+    grid-template-columns: 1fr;
+  }
+
+  .stabilizer-controls {
+    position: static;
+  }
+
+  .stabilizer-route-buttons {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .stabilizer-intro,
+  .stabilizer-common-panel .panel-heading,
+  .stabilizer-comparison-panel .panel-heading,
+  .stabilizer-forward-panel .panel-heading,
+  .stabilizer-backward-panel .panel-heading,
+  .stabilizer-arithmetic-panel .panel-heading,
+  .stabilizer-audit-panel .panel-heading {
+    display: grid;
+  }
+
+  .stabilizer-chip {
+    justify-self: start;
+  }
+
+  .stabilizer-common-flow,
+  .stabilizer-comparison-grid,
+  .stabilizer-stat-grid,
+  .stabilizer-dropout-compare,
+  .stabilizer-gradient-flow,
+  .stabilizer-equations,
+  .stabilizer-audit-grid,
+  .stabilizer-route-buttons {
+    grid-template-columns: 1fr;
+  }
+
+  .stabilizer-flow-arrow {
+    transform: rotate(90deg);
+  }
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -136,7 +136,7 @@ h2 {
 
 .mode-toggle {
   display: inline-grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(7, 1fr);
   gap: 4px;
   padding: 4px;
   border: 1px solid $line;
@@ -1917,6 +1917,397 @@ code {
   text-transform: uppercase;
 }
 
+.workspace--residual {
+  display: grid;
+  grid-template-columns: minmax(660px, 1fr) 320px;
+  gap: 14px;
+  align-items: start;
+}
+
+.residual-stage,
+.residual-controls,
+.residual-block-panel,
+.receptive-panel {
+  @include surface;
+}
+
+.residual-stage {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.residual-intro,
+.residual-panel-heading,
+.residual-row-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.residual-intro p:not(.eyebrow),
+.residual-controls > p,
+.residual-note p {
+  margin: 5px 0 0;
+  color: $muted;
+}
+
+.residual-shape-chip {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(109, 91, 208, 0.11);
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.75rem;
+  font-weight: 850;
+}
+
+.residual-block-panel,
+.receptive-panel {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.residual-result {
+  min-width: 70px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(35, 122, 87, 0.13);
+  color: $green;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.35rem;
+  text-align: center;
+}
+
+.residual-main-path {
+  display: grid;
+  gap: 8px;
+  padding: 11px;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  border-radius: 8px;
+  background: rgba(37, 99, 235, 0.035);
+}
+
+.residual-lane-label,
+.residual-row-label > span {
+  color: $muted;
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.residual-signal-block {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.residual-row-label code {
+  min-height: 0;
+  padding: 3px 6px;
+  font-size: 0.7rem;
+}
+
+.residual-signal-row {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.residual-cell {
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  min-height: 58px;
+  padding: 5px;
+  border: 1px solid $line;
+  border-radius: 7px;
+  background: #ffffff;
+}
+
+.residual-cell small {
+  color: $muted;
+  font-size: 0.64rem;
+}
+
+.residual-cell strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.residual-cell--active {
+  border-color: rgba(109, 91, 208, 0.46);
+  background: rgba(109, 91, 208, 0.08);
+  color: #4f3da9;
+}
+
+.residual-cell--selected {
+  border-color: rgba(37, 99, 235, 0.62);
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.residual-down-arrow {
+  justify-self: center;
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.75rem;
+}
+
+.residual-skip-lane {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 10px;
+  border: 1px solid rgba(109, 91, 208, 0.3);
+  border-radius: 8px;
+  background: rgba(109, 91, 208, 0.07);
+  color: #4f3da9;
+}
+
+.residual-skip-lane > div {
+  display: grid;
+}
+
+.residual-skip-lane small,
+.residual-addition small,
+.field-width-badge small,
+.hidden-path-card small {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.residual-skip-lane code {
+  min-height: 0;
+  padding: 3px 7px;
+}
+
+.residual-skip-lane--disabled {
+  filter: grayscale(1);
+  opacity: 0.55;
+}
+
+.residual-addition {
+  display: grid;
+  grid-template-columns: repeat(7, auto);
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 11px;
+  border-block: 1px solid $line;
+}
+
+.residual-addition > div {
+  display: grid;
+  min-width: 80px;
+  text-align: center;
+}
+
+.residual-addition strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.residual-addition__output {
+  padding: 6px;
+  border-radius: 7px;
+  background: #eaf7ef;
+  color: $green;
+}
+
+.field-width-badge {
+  display: grid;
+  min-width: 100px;
+  padding: 7px;
+  border: 1px solid rgba(35, 122, 87, 0.3);
+  border-radius: 8px;
+  background: #eaf7ef;
+  color: $green;
+  text-align: center;
+}
+
+.field-width-badge strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.2rem;
+}
+
+.hidden-path-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 8px;
+}
+
+.hidden-path-card {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.hidden-path-card > div {
+  display: grid;
+}
+
+.hidden-path-card code {
+  min-height: 0;
+  padding: 4px 6px;
+}
+
+.hidden-path-card > span {
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+}
+
+.path-count-table-wrap {
+  overflow-x: auto;
+  border-block: 1px solid $line;
+}
+
+.path-count-table {
+  width: 100%;
+  min-width: 600px;
+  border-collapse: collapse;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  text-align: right;
+}
+
+.path-count-table caption {
+  padding: 9px 0 5px;
+  color: $muted;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-weight: 800;
+  text-align: left;
+}
+
+.path-count-table th,
+.path-count-table td {
+  padding: 8px;
+  border-bottom: 1px solid $line;
+}
+
+.path-count-table th:first-child {
+  color: $muted;
+  text-align: left;
+}
+
+.path-count-total {
+  background: #eaf7ef;
+  color: $green;
+  font-weight: 850;
+}
+
+.receptive-summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.receptive-summary code {
+  min-height: 0;
+  padding: 7px;
+  white-space: nowrap;
+}
+
+.receptive-summary span {
+  color: $muted;
+}
+
+.residual-controls {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+}
+
+.residual-output-buttons {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+  padding-block: 11px;
+  border-block: 1px solid $line;
+}
+
+.residual-output-button {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  min-height: 58px;
+  padding: 6px;
+}
+
+.residual-output-button small {
+  color: $muted;
+  font-size: 0.66rem;
+}
+
+.residual-output-button strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.residual-output-button--active {
+  border-color: rgba(37, 99, 235, 0.52);
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.residual-skip-control {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid rgba(109, 91, 208, 0.3);
+  border-radius: 8px;
+  background: rgba(109, 91, 208, 0.07);
+  cursor: pointer;
+}
+
+.residual-skip-control input {
+  width: 20px;
+  min-height: 20px;
+  accent-color: $violet;
+}
+
+.residual-skip-control span {
+  display: grid;
+}
+
+.residual-skip-control small {
+  color: $muted;
+}
+
+.residual-controls .button-grid button:last-child {
+  grid-column: 1 / -1;
+}
+
+.residual-controls button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.residual-note {
+  padding-top: 12px;
+  border-top: 1px solid $line;
+}
+
+.residual-note span {
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
 @media (max-width: 1180px) {
   .workspace--lab,
   .workspace--hidden {
@@ -1934,10 +2325,15 @@ code {
     grid-column: 1 / -1;
   }
 
+  .residual-controls {
+    grid-column: 1 / -1;
+  }
+
   .workspace--microscope,
   .workspace--optimization,
   .workspace--convolution,
-  .workspace--image-cnn {
+  .workspace--image-cnn,
+  .workspace--residual {
     grid-template-columns: 1fr;
   }
 }
@@ -1964,7 +2360,8 @@ code {
   .workspace--microscope,
   .workspace--optimization,
     .workspace--convolution,
-    .workspace--image-cnn {
+    .workspace--image-cnn,
+    .workspace--residual {
     grid-template-columns: 1fr;
   }
 
@@ -1972,7 +2369,9 @@ code {
   .mac-heading,
   .training-heading,
   .image-cnn-intro,
-  .image-stage-heading {
+  .image-stage-heading,
+  .residual-intro,
+  .residual-panel-heading {
     display: grid;
     align-items: start;
   }
@@ -2010,7 +2409,7 @@ code {
   }
 
   .mode-button:last-child {
-    grid-column: auto;
+    grid-column: 1 / -1;
   }
 
   .image-pipeline {
@@ -2047,6 +2446,25 @@ code {
   .channel-reduction > span:nth-of-type(3),
   .channel-reduction__result {
     grid-column: auto;
+  }
+
+  .residual-skip-lane {
+    display: grid;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .residual-addition {
+    grid-template-columns: repeat(3, auto);
+  }
+
+  .receptive-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .receptive-summary code {
+    overflow-x: auto;
+    white-space: nowrap;
   }
 
   .phase-strip {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -16,6 +16,357 @@ $violet: #6d5bd0;
   box-shadow: 0 18px 50px rgba(29, 45, 39, 0.08);
 }
 
+.workspace--initialization {
+  grid-template-columns: minmax(0, 1fr) 300px;
+  align-items: start;
+  gap: 18px;
+}
+
+.initialization-stage {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.initialization-intro,
+.distribution-summary-panel,
+.initialization-arithmetic,
+.initializer-comparison,
+.initialization-controls {
+  @include surface;
+}
+
+.initialization-intro,
+.distribution-summary-panel,
+.initialization-arithmetic,
+.initializer-comparison {
+  padding: 18px;
+}
+
+.initialization-intro {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.initialization-intro h2,
+.initialization-controls h2 {
+  margin: 0;
+}
+
+.initialization-intro p:not(.eyebrow),
+.initialization-controls p,
+.initializer-comparison .panel-heading > span {
+  color: $muted;
+  line-height: 1.55;
+}
+
+.initialization-chip {
+  flex: 0 0 auto;
+  border: 1px solid rgba(109, 91, 208, 0.3);
+  border-radius: 999px;
+  background: rgba(109, 91, 208, 0.1);
+  color: #4b3e9d;
+  padding: 8px 12px;
+  font-weight: 850;
+  text-transform: capitalize;
+}
+
+.initialization-flow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.distribution-card {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  min-height: 132px;
+  border: 1px solid $line;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.86);
+  color: $ink;
+  padding: 12px;
+  text-align: left;
+}
+
+button.distribution-card:hover,
+button.distribution-card[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.5);
+  background: rgba(109, 91, 208, 0.09);
+}
+
+.distribution-card--input {
+  align-content: start;
+  border-color: rgba(35, 122, 87, 0.25);
+  background: rgba(35, 122, 87, 0.055);
+}
+
+.distribution-card strong,
+.distribution-card code,
+.distribution-stat-grid strong,
+.spread-row code,
+.initialization-equation {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.distribution-card > span:last-child {
+  color: $muted;
+  font-size: 0.72rem;
+}
+
+.distribution-dot-plot {
+  position: relative;
+  display: block;
+  height: 30px;
+  border-radius: 6px;
+  background:
+    linear-gradient(90deg, transparent 49.5%, rgba(23, 32, 28, 0.14) 49.5%, rgba(23, 32, 28, 0.14) 50.5%, transparent 50.5%),
+    rgba(37, 99, 235, 0.055);
+  overflow: hidden;
+}
+
+.distribution-dot-plot i {
+  position: absolute;
+  top: 8px;
+  width: 9px;
+  height: 9px;
+  margin-left: -4px;
+  border: 2px solid white;
+  border-radius: 50%;
+  background: $blue;
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.28);
+}
+
+.distribution-summary-panel,
+.initialization-arithmetic,
+.initializer-comparison {
+  display: grid;
+  gap: 14px;
+}
+
+.distribution-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.distribution-stat-grid > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  border-radius: 8px;
+  background: rgba(35, 122, 87, 0.065);
+  padding: 10px;
+}
+
+.distribution-stat-grid span {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.activation-value-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.activation-value-grid code {
+  min-width: 0;
+  overflow: hidden;
+  padding: 7px 3px;
+  border-radius: 6px;
+  background: rgba(37, 99, 235, 0.07);
+  color: #234c9f;
+  font-size: 0.7rem;
+  text-align: center;
+  text-overflow: ellipsis;
+}
+
+.initialization-equation {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.initialization-equation code,
+.initialization-equation strong {
+  min-width: 0;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.initialization-equation code {
+  background: rgba(37, 99, 235, 0.065);
+  color: #234c9f;
+}
+
+.initialization-equation strong {
+  background: rgba(109, 91, 208, 0.1);
+  color: #4b3e9d;
+}
+
+.initializer-comparison-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.initializer-comparison-grid article {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  border: 1px solid $line;
+  border-radius: 9px;
+  padding: 11px;
+}
+
+.initializer-comparison-grid article.is-selected {
+  border-color: rgba(109, 91, 208, 0.45);
+  background: rgba(109, 91, 208, 0.055);
+}
+
+.spread-row {
+  display: grid;
+  grid-template-columns: 20px minmax(30px, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.spread-row span,
+.spread-row code {
+  color: $muted;
+  font-size: 0.68rem;
+}
+
+.spread-row i {
+  display: block;
+  min-width: 2px;
+  height: 7px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, $green, $blue);
+}
+
+.initialization-controls {
+  position: sticky;
+  top: 18px;
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+}
+
+.initialization-controls section {
+  display: grid;
+  gap: 9px;
+}
+
+.initialization-controls section + section {
+  padding-top: 14px;
+  border-top: 1px solid $line;
+}
+
+.initializer-buttons,
+.activation-choice-grid {
+  display: grid;
+  gap: 7px;
+}
+
+.initializer-buttons button,
+.activation-choice-grid button {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.85);
+  color: $ink;
+  padding: 10px;
+  text-align: left;
+}
+
+.initializer-buttons button[aria-pressed="true"],
+.activation-choice-grid button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.48);
+  background: rgba(109, 91, 208, 0.1);
+  color: #4b3e9d;
+}
+
+.initializer-buttons small {
+  color: $muted;
+}
+
+.activation-choice-grid {
+  grid-template-columns: 1fr 1fr;
+}
+
+.activation-choice-grid button {
+  text-align: center;
+}
+
+.initialization-reading {
+  border-radius: 9px;
+  background: rgba(35, 122, 87, 0.065);
+  padding: 11px;
+}
+
+@media (max-width: 1180px) {
+  .workspace--initialization {
+    grid-template-columns: 1fr;
+  }
+
+  .initialization-controls {
+    position: static;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .initialization-controls section + section {
+    padding-top: 0;
+    padding-left: 14px;
+    border-top: 0;
+    border-left: 1px solid $line;
+  }
+}
+
+@media (max-width: 820px) {
+  .initialization-intro,
+  .distribution-summary-panel .panel-heading,
+  .initialization-arithmetic .panel-heading,
+  .initializer-comparison .panel-heading {
+    display: grid;
+  }
+
+  .initialization-chip {
+    justify-self: start;
+  }
+
+  .initialization-flow,
+  .distribution-stat-grid,
+  .initializer-comparison-grid,
+  .initialization-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .activation-value-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .initialization-equation {
+    grid-template-columns: 1fr;
+  }
+
+  .initialization-controls section + section {
+    padding-top: 14px;
+    padding-left: 0;
+    border-top: 1px solid $line;
+    border-left: 0;
+  }
+}
+
 .structured-workbench {
   display: grid;
   gap: 14px;

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -7555,3 +7555,408 @@ code {
     transform: rotate(90deg);
   }
 }
+
+.deep-training-workbench {
+  display: grid;
+  gap: 14px;
+}
+
+.deep-training-switch {
+  display: flex;
+  gap: 8px;
+  padding: 0 24px;
+}
+
+.deep-training-switch button {
+  border: 1px solid $line;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.72);
+  color: $ink;
+  padding: 10px 16px;
+  font: inherit;
+  font-weight: 750;
+}
+
+.deep-training-switch button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.42);
+  background: rgba(109, 91, 208, 0.1);
+  color: #4b3e9d;
+}
+
+.workspace--gradient-flow {
+  grid-template-columns: minmax(0, 1fr) 300px;
+  align-items: start;
+  gap: 18px;
+}
+
+.gradient-flow-stage {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.gradient-flow-intro,
+.gradient-forward-panel,
+.gradient-backward-panel,
+.gradient-arithmetic-panel,
+.gradient-chain-panel,
+.gradient-comparison-panel,
+.gradient-flow-controls {
+  @include surface;
+}
+
+.gradient-flow-intro,
+.gradient-forward-panel,
+.gradient-backward-panel,
+.gradient-arithmetic-panel,
+.gradient-chain-panel,
+.gradient-comparison-panel {
+  padding: 18px;
+}
+
+.gradient-flow-intro {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.gradient-flow-intro h2,
+.gradient-flow-controls h2 {
+  margin: 0;
+}
+
+.gradient-flow-intro p:not(.eyebrow),
+.gradient-flow-controls > p,
+.gradient-chain-panel > p {
+  color: $muted;
+  line-height: 1.55;
+}
+
+.gradient-flow-chip {
+  flex: 0 0 auto;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.gradient-flow-chip--vanishing {
+  background: rgba(37, 99, 235, 0.08);
+  color: #234c9f;
+}
+
+.gradient-flow-chip--stable {
+  background: rgba(35, 122, 87, 0.08);
+  color: #1d6849;
+}
+
+.gradient-flow-chip--exploding {
+  background: rgba(194, 65, 59, 0.08);
+  color: #9b3131;
+}
+
+.gradient-forward-panel,
+.gradient-backward-panel,
+.gradient-arithmetic-panel,
+.gradient-chain-panel,
+.gradient-comparison-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.gradient-forward-lane {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.gradient-forward-lane > div {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-width: 0;
+  min-height: 92px;
+  border: 1px solid $line;
+  border-radius: 9px;
+  background: rgba(37, 99, 235, 0.055);
+  padding: 10px;
+  text-align: center;
+}
+
+.gradient-forward-lane span,
+.gradient-backward-lane span,
+.gradient-backward-lane small,
+.gradient-input-node span {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.gradient-forward-lane code,
+.gradient-forward-lane strong,
+.gradient-backward-lane strong,
+.gradient-backward-lane code,
+.gradient-input-node strong,
+.gradient-chain-panel strong,
+.gradient-chain-panel code,
+.gradient-audit code,
+.gradient-comparison-grid code {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.gradient-forward-lane code {
+  color: #234c9f;
+  font-size: 0.7rem;
+}
+
+.gradient-forward-lane .gradient-loss-node {
+  border-color: rgba(194, 65, 59, 0.22);
+  background: rgba(194, 65, 59, 0.07);
+}
+
+.gradient-backward-lane {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.gradient-backward-lane button,
+.gradient-input-node {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  border: 1px solid rgba(109, 91, 208, 0.22);
+  border-radius: 9px;
+  background: rgba(109, 91, 208, 0.055);
+  color: $ink;
+  padding: 10px;
+  text-align: left;
+}
+
+.gradient-backward-lane button:hover,
+.gradient-backward-lane button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.55);
+  background: rgba(109, 91, 208, 0.13);
+}
+
+.gradient-backward-lane code {
+  color: #4b3e9d;
+  font-size: 0.72rem;
+}
+
+.gradient-input-node {
+  align-content: center;
+  border-color: rgba(35, 122, 87, 0.28);
+  background: rgba(35, 122, 87, 0.075);
+}
+
+.gradient-equation-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(190px, 0.65fr);
+  gap: 8px;
+  align-items: center;
+}
+
+.gradient-equation-grid code,
+.gradient-equation-grid span {
+  min-width: 0;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.gradient-equation-grid code {
+  background: rgba(37, 99, 235, 0.07);
+  color: #234c9f;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.gradient-equation-grid span {
+  color: $muted;
+  font-size: 0.75rem;
+}
+
+.gradient-chain-equation {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr)) auto minmax(90px, 1fr);
+  align-items: center;
+  gap: 7px;
+}
+
+.gradient-chain-equation code,
+.gradient-chain-equation strong {
+  border-radius: 8px;
+  padding: 10px;
+  text-align: center;
+}
+
+.gradient-chain-equation code {
+  background: rgba(109, 91, 208, 0.08);
+  color: #4b3e9d;
+}
+
+.gradient-chain-equation span {
+  color: $muted;
+  font-weight: 850;
+}
+
+.gradient-chain-equation strong {
+  background: rgba(35, 122, 87, 0.08);
+  color: #1d6849;
+}
+
+.gradient-audit {
+  display: grid;
+  grid-template-columns: auto minmax(90px, 1fr) auto minmax(90px, 1fr);
+  align-items: center;
+  gap: 8px;
+  border-top: 1px solid $line;
+  padding-top: 12px;
+}
+
+.gradient-audit span {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.gradient-audit code {
+  border-radius: 7px;
+  background: rgba(35, 122, 87, 0.075);
+  padding: 8px;
+}
+
+.gradient-comparison-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.gradient-comparison-grid article {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  border: 1px solid $line;
+  border-radius: 9px;
+  padding: 11px;
+}
+
+.gradient-comparison-grid article.is-selected {
+  border-color: rgba(109, 91, 208, 0.45);
+  background: rgba(109, 91, 208, 0.055);
+}
+
+.gradient-comparison-grid article > span,
+.gradient-comparison-grid small {
+  color: $muted;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.gradient-comparison-grid i {
+  display: block;
+  min-width: 2px;
+  height: 8px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, $blue, $red);
+}
+
+.gradient-flow-controls {
+  position: sticky;
+  top: 18px;
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+}
+
+.gradient-scenario-buttons {
+  display: grid;
+  gap: 7px;
+}
+
+.gradient-scenario-buttons button {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  border: 1px solid $line;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.85);
+  color: $ink;
+  padding: 10px;
+  text-align: left;
+}
+
+.gradient-scenario-buttons button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.48);
+  background: rgba(109, 91, 208, 0.1);
+  color: #4b3e9d;
+}
+
+.gradient-scenario-buttons span,
+.gradient-scenario-buttons code {
+  color: $muted;
+  font-size: 0.7rem;
+}
+
+.gradient-flow-reading {
+  display: grid;
+  gap: 7px;
+  margin-top: 6px;
+  border-radius: 9px;
+  background: rgba(35, 122, 87, 0.065);
+  padding: 11px;
+}
+
+.gradient-flow-reading h2,
+.gradient-flow-reading p {
+  margin: 0;
+}
+
+@media (max-width: 1180px) {
+  .workspace--gradient-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .gradient-flow-controls {
+    position: static;
+  }
+
+  .gradient-scenario-buttons {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .deep-training-switch,
+  .gradient-flow-intro,
+  .gradient-forward-panel .panel-heading,
+  .gradient-backward-panel .panel-heading,
+  .gradient-arithmetic-panel .panel-heading,
+  .gradient-chain-panel .panel-heading,
+  .gradient-comparison-panel .panel-heading {
+    display: grid;
+  }
+
+  .gradient-flow-chip {
+    justify-self: start;
+  }
+
+  .deep-training-switch,
+  .gradient-forward-lane,
+  .gradient-backward-lane,
+  .gradient-equation-grid,
+  .gradient-chain-equation,
+  .gradient-audit,
+  .gradient-comparison-grid,
+  .gradient-scenario-buttons {
+    grid-template-columns: 1fr;
+  }
+
+  .gradient-chain-equation span {
+    justify-self: center;
+  }
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -1132,7 +1132,8 @@ code {
 .convolution-controls,
 .kernel-slide,
 .mac-panel,
-.output-strip {
+.output-strip,
+.training-panel {
   @include surface;
 }
 
@@ -1153,7 +1154,8 @@ code {
 
 .convolution-intro p:not(.eyebrow),
 .convolution-controls p,
-.convolution-note p {
+.convolution-note p,
+.training-heading p {
   margin: 5px 0 0;
   color: $muted;
 }
@@ -1319,10 +1321,172 @@ code {
   color: #17603f;
 }
 
+.training-panel {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+  overflow: hidden;
+}
+
+.training-heading,
+.loss-flow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.gradient-check-badge {
+  display: grid;
+  flex: 0 0 auto;
+  min-width: 112px;
+  padding: 8px 10px;
+  border: 1px solid rgba(194, 65, 59, 0.3);
+  border-radius: 8px;
+  background: #fff5f4;
+  color: $red;
+  text-align: center;
+}
+
+.gradient-check-badge small,
+.loss-flow small,
+.kernel-update small {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.gradient-check-badge--pass {
+  border-color: rgba(35, 122, 87, 0.3);
+  background: #eaf7ef;
+  color: $green;
+}
+
+.loss-flow {
+  justify-content: center;
+  padding: 10px;
+  border-block: 1px solid $line;
+}
+
+.loss-flow > div {
+  display: grid;
+  min-width: 140px;
+  text-align: center;
+}
+
+.loss-flow strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.15rem;
+}
+
+.loss-flow span {
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.selected-gradient-path {
+  display: grid;
+  gap: 10px;
+}
+
+.selected-gradient-path h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.selected-gradient-path .mac-heading > code {
+  min-height: 0;
+  white-space: nowrap;
+}
+
+.gradient-table-wrap {
+  overflow-x: auto;
+  border-block: 1px solid $line;
+}
+
+.gradient-table {
+  width: 100%;
+  min-width: 650px;
+  border-collapse: collapse;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  text-align: right;
+}
+
+.gradient-table caption {
+  padding: 10px 0 6px;
+  color: $muted;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-weight: 800;
+  text-align: left;
+}
+
+.gradient-table th,
+.gradient-table td {
+  padding: 8px;
+  border-bottom: 1px solid $line;
+}
+
+.gradient-table thead th,
+.gradient-table tbody th {
+  color: $muted;
+  font-weight: 800;
+}
+
+.gradient-table thead th:first-child,
+.gradient-table tbody th {
+  text-align: left;
+}
+
+.gradient-sum {
+  background: #f0f8f4;
+  color: $green;
+  font-weight: 850;
+}
+
+.kernel-update-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+}
+
+.kernel-update {
+  display: grid;
+  gap: 5px;
+  padding: 9px;
+  border: 1px solid rgba(109, 91, 208, 0.22);
+  border-radius: 8px;
+  background: rgba(109, 91, 208, 0.06);
+}
+
+.kernel-update code {
+  min-height: 0;
+  padding: 3px 6px;
+}
+
+.kernel-update strong {
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
 .convolution-controls {
   display: grid;
   gap: 14px;
   padding: 14px;
+}
+
+.convolution-training-controls {
+  display: grid;
+  gap: 10px;
+  padding-block: 12px;
+  border-block: 1px solid $line;
+}
+
+.training-step-button {
+  border-color: rgba(109, 91, 208, 0.38);
+  background: #f1efff;
+  color: #4f3da9;
 }
 
 .convolution-controls .button-grid button:last-child {
@@ -1395,9 +1559,22 @@ code {
   }
 
   .convolution-intro,
-  .mac-heading {
+  .mac-heading,
+  .training-heading {
     display: grid;
     align-items: start;
+  }
+
+  .gradient-check-badge {
+    justify-self: start;
+  }
+
+  .loss-flow {
+    align-items: stretch;
+  }
+
+  .loss-flow > div {
+    min-width: 0;
   }
 
   .convolution-mode-chip {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -2964,6 +2964,265 @@ code {
   grid-template-columns: 1fr;
 }
 
+.workspace--gates {
+  display: grid;
+  grid-template-columns: minmax(780px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.gate-stage,
+.gate-controls,
+.gate-comparison-panel {
+  @include surface;
+}
+
+.gate-stage {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.gate-intro,
+.gate-panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.gate-intro p:not(.eyebrow),
+.gate-controls > p {
+  margin: 5px 0 0;
+  color: $muted;
+}
+
+.gate-input-chip {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 3px;
+  min-width: 150px;
+  padding: 9px 12px;
+  border-radius: 8px;
+  background: rgba(35, 122, 87, 0.1);
+  color: $green;
+  text-align: center;
+}
+
+.gate-input-chip small,
+.gate-state-node small,
+.gate-node small,
+.gate-candidate-node small,
+.gate-cell-node small,
+.gate-result-node small,
+.gate-selected-summary small {
+  color: $muted;
+  font-size: 0.67rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.gate-input-chip strong,
+.gate-flow strong,
+.gate-selected-summary strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.gate-comparison-panel {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.gate-panel-heading code {
+  min-height: 0;
+  padding: 4px 7px;
+}
+
+.gate-model-lane {
+  display: grid;
+  grid-template-columns: 132px minmax(0, 1fr);
+  align-items: stretch;
+  gap: 10px;
+  padding-block: 12px;
+  border-block: 1px solid $line;
+}
+
+.gate-model-lane + .gate-model-lane {
+  border-top: 0;
+}
+
+.gate-model-label {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  padding-right: 10px;
+  border-right: 2px solid rgba(109, 91, 208, 0.25);
+}
+
+.gate-model-label span {
+  color: #4f3da9;
+  font-size: 1.2rem;
+  font-weight: 900;
+}
+
+.gate-model-label strong {
+  color: $muted;
+  font-size: 0.72rem;
+}
+
+.gate-flow {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(110px, 1fr));
+  align-items: stretch;
+  gap: 7px;
+  min-width: 0;
+}
+
+.gate-flow--lstm {
+  grid-template-columns: repeat(6, minmax(96px, 1fr));
+}
+
+.gate-state-node,
+.gate-candidate-node,
+.gate-cell-node,
+.gate-result-node,
+.gate-node {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-width: 0;
+  min-height: 96px;
+  padding: 9px;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: rgba(35, 122, 87, 0.04);
+  color: $ink;
+  text-align: left;
+}
+
+.gate-node {
+  background: rgba(109, 91, 208, 0.055);
+}
+
+.gate-node:hover,
+.gate-node--active {
+  border-color: rgba(109, 91, 208, 0.62);
+  background: rgba(109, 91, 208, 0.14);
+}
+
+.gate-node--active {
+  box-shadow: inset 0 0 0 1px rgba(109, 91, 208, 0.12);
+}
+
+.gate-node span,
+.gate-state-node span,
+.gate-candidate-node span,
+.gate-cell-node span,
+.gate-result-node span {
+  color: $muted;
+  font-size: 0.7rem;
+}
+
+.gate-candidate-node {
+  background: rgba(37, 99, 235, 0.06);
+}
+
+.gate-cell-node {
+  background: rgba(205, 146, 38, 0.1);
+}
+
+.gate-result-node {
+  background: rgba(35, 122, 87, 0.1);
+  color: $green;
+}
+
+.gate-table-wrap {
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.gate-table {
+  width: 100%;
+  min-width: 620px;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.gate-table caption {
+  padding-bottom: 7px;
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-align: left;
+}
+
+.gate-table th,
+.gate-table td {
+  padding: 9px;
+  border-bottom: 1px solid $line;
+  text-align: left;
+}
+
+.gate-table thead th {
+  color: $muted;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.gate-table tbody th {
+  width: 30%;
+}
+
+.gate-controls {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+}
+
+.gate-intervention-buttons {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+}
+
+.gate-intervention-buttons button {
+  min-height: 39px;
+  padding: 7px;
+  border: 1px solid $line;
+  border-radius: 7px;
+  background: #ffffff;
+  color: $ink;
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+.gate-intervention-buttons button:hover,
+.gate-intervention-buttons button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.62);
+  background: rgba(109, 91, 208, 0.13);
+  color: #4f3da9;
+}
+
+.gate-selected-summary {
+  display: grid;
+  gap: 4px;
+  padding: 11px;
+  border-left: 3px solid rgba(109, 91, 208, 0.45);
+  background: rgba(109, 91, 208, 0.045);
+}
+
+.gate-selected-summary strong {
+  color: #4f3da9;
+  font-size: 1.35rem;
+}
+
+.gate-selected-summary span {
+  color: $muted;
+}
+
 @media (max-width: 1180px) {
   .workspace--lab,
   .workspace--hidden {
@@ -2995,8 +3254,13 @@ code {
   .workspace--image-cnn,
   .workspace--residual,
   .workspace--recurrent,
-  .workspace--bptt {
+  .workspace--bptt,
+  .workspace--gates {
     grid-template-columns: 1fr;
+  }
+
+  .gate-controls {
+    grid-column: 1 / -1;
   }
 }
 
@@ -3025,7 +3289,8 @@ code {
   .workspace--image-cnn,
   .workspace--residual,
   .workspace--recurrent,
-  .workspace--bptt {
+  .workspace--bptt,
+  .workspace--gates {
     grid-template-columns: 1fr;
   }
 
@@ -3041,7 +3306,9 @@ code {
   .recurrent-arithmetic-heading,
   .bptt-intro,
   .bptt-panel-heading,
-  .bptt-arithmetic-heading {
+  .bptt-arithmetic-heading,
+  .gate-intro,
+  .gate-panel-heading {
     display: grid;
     align-items: start;
   }
@@ -3180,6 +3447,26 @@ code {
 
   .bptt-equation > span {
     justify-self: center;
+  }
+
+  .gate-model-lane,
+  .gate-flow,
+  .gate-flow--lstm {
+    grid-template-columns: 1fr;
+  }
+
+  .gate-model-label {
+    padding: 0 0 9px;
+    border-right: 0;
+    border-bottom: 2px solid rgba(109, 91, 208, 0.25);
+  }
+
+  .gate-state-node,
+  .gate-candidate-node,
+  .gate-cell-node,
+  .gate-result-node,
+  .gate-node {
+    min-height: 0;
   }
 
   .phase-strip {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -3782,6 +3782,292 @@ code {
   color: #4f3da9;
 }
 
+.workspace--multi-head {
+  display: grid;
+  grid-template-columns: minmax(700px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.multi-head-stage,
+.multi-head-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.multi-head-intro,
+.multi-head-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.multi-head-intro,
+.multi-head-panel,
+.multi-head-join-panel,
+.multi-head-norm-panel,
+.multi-head-controls {
+  @include surface;
+  padding: 16px;
+}
+
+.multi-head-intro p:last-child,
+.multi-head-heading p,
+.multi-head-controls > p {
+  margin: 7px 0 0;
+  color: $muted;
+}
+
+.multi-head-chip {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border: 1px solid rgba(109, 91, 208, 0.28);
+  border-radius: 999px;
+  background: rgba(109, 91, 208, 0.08);
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 750;
+}
+
+.multi-head-panel,
+.multi-head-join-panel,
+.multi-head-norm-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.multi-head-heading > code {
+  flex: 0 0 auto;
+  padding: 6px 9px;
+  border-radius: 6px;
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.multi-head-lanes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.multi-head-lane {
+  display: grid;
+  gap: 11px;
+  min-width: 0;
+  padding: 13px;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  border-top: 4px solid rgba(37, 99, 235, 0.46);
+  border-radius: 7px;
+  background: rgba(37, 99, 235, 0.035);
+}
+
+.multi-head-lane--vertical {
+  border-color: rgba(109, 91, 208, 0.2);
+  border-top-color: rgba(109, 91, 208, 0.5);
+  background: rgba(109, 91, 208, 0.035);
+}
+
+.multi-head-lane__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.multi-head-lane__heading > div {
+  display: grid;
+  gap: 3px;
+}
+
+.multi-head-lane__heading small,
+.multi-head-score-row span,
+.multi-head-join-flow small,
+.multi-head-norm-flow small,
+.multi-head-output small {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.multi-head-lane__heading > code {
+  color: #173f8a;
+  font-weight: 800;
+}
+
+.multi-head-score-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding-top: 9px;
+  border-top: 1px solid $line;
+}
+
+.multi-head-score-row code {
+  overflow-wrap: anywhere;
+  color: #173f8a;
+}
+
+.multi-head-weight-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.multi-head-weight {
+  position: relative;
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  min-height: 68px;
+  overflow: hidden;
+  padding: 8px;
+  border: 1px solid rgba(37, 99, 235, 0.17);
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.multi-head-weight span {
+  color: $muted;
+  font-size: 0.72rem;
+}
+
+.multi-head-weight strong {
+  position: relative;
+  z-index: 1;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.multi-head-weight i {
+  position: absolute;
+  inset: auto auto 0 0;
+  height: 6px;
+  background: rgba(37, 99, 235, 0.34);
+}
+
+.multi-head-lane--vertical .multi-head-weight i {
+  background: rgba(109, 91, 208, 0.38);
+}
+
+.multi-head-weight--blocked {
+  opacity: 0.58;
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(194, 65, 59, 0.025),
+      rgba(194, 65, 59, 0.025) 7px,
+      rgba(194, 65, 59, 0.075) 7px,
+      rgba(194, 65, 59, 0.075) 8px
+    );
+}
+
+.multi-head-value-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 5px;
+}
+
+.multi-head-value-row code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: $muted;
+  font-size: 0.74rem;
+}
+
+.multi-head-join-flow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr) auto) minmax(0, 1fr);
+  gap: 7px;
+  align-items: center;
+}
+
+.multi-head-join-flow > div,
+.multi-head-norm-flow > div {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  min-height: 72px;
+  align-content: center;
+  padding: 9px;
+  border: 1px solid $line;
+  border-radius: 7px;
+  background: #fbfcfa;
+}
+
+.multi-head-join-flow > span {
+  color: $muted;
+  font-weight: 850;
+}
+
+.multi-head-join-flow code,
+.multi-head-norm-flow code {
+  overflow-wrap: anywhere;
+  color: #173f8a;
+  font-size: 0.78rem;
+  white-space: normal;
+}
+
+.multi-head-residual {
+  border-color: rgba(20, 122, 83, 0.32) !important;
+  background: rgba(20, 122, 83, 0.05) !important;
+}
+
+.multi-head-residual--off,
+.multi-head-norm-flow--off {
+  opacity: 0.5;
+}
+
+.multi-head-join-result,
+.multi-head-norm-result {
+  border-color: rgba(109, 91, 208, 0.42) !important;
+  background: rgba(109, 91, 208, 0.07) !important;
+}
+
+.multi-head-join-result code,
+.multi-head-norm-result code {
+  color: #4f3da9;
+  font-weight: 850;
+}
+
+.multi-head-norm-flow {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.multi-head-output {
+  display: grid;
+  gap: 2px;
+  min-width: 170px;
+  padding: 8px 10px;
+  border-left: 3px solid rgba(109, 91, 208, 0.5);
+  background: rgba(109, 91, 208, 0.05);
+}
+
+.multi-head-output strong {
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.18rem;
+}
+
+.multi-head-controls {
+  position: sticky;
+  top: 14px;
+}
+
+@media (max-width: 1360px) {
+  .app-header,
+  .header-actions {
+    display: grid;
+    align-items: start;
+  }
+
+  .formula {
+    min-width: 0;
+    text-align: left;
+  }
+}
+
 @media (max-width: 1180px) {
   .workspace--lab,
   .workspace--hidden {
@@ -3814,9 +4100,10 @@ code {
   .workspace--residual,
   .workspace--recurrent,
   .workspace--bptt,
-  .workspace--gates,
-  .workspace--attention,
-  .workspace--attention-softmax {
+    .workspace--gates,
+    .workspace--attention,
+    .workspace--attention-softmax,
+    .workspace--multi-head {
     grid-template-columns: 1fr;
   }
 
@@ -3826,6 +4113,11 @@ code {
   }
 
   .attention-softmax-controls {
+    position: static;
+    grid-column: 1 / -1;
+  }
+
+  .multi-head-controls {
     position: static;
     grid-column: 1 / -1;
   }
@@ -3861,9 +4153,10 @@ code {
   .workspace--residual,
   .workspace--recurrent,
   .workspace--bptt,
-  .workspace--gates,
-  .workspace--attention,
-  .workspace--attention-softmax {
+    .workspace--gates,
+    .workspace--attention,
+    .workspace--attention-softmax,
+    .workspace--multi-head {
     grid-template-columns: 1fr;
   }
 
@@ -3883,9 +4176,11 @@ code {
   .gate-intro,
   .gate-panel-heading,
   .attention-intro,
-  .attention-panel-heading,
-  .attention-softmax-intro,
-  .attention-softmax-heading {
+    .attention-panel-heading,
+    .attention-softmax-intro,
+    .attention-softmax-heading,
+    .multi-head-intro,
+    .multi-head-heading {
     display: grid;
     align-items: start;
   }
@@ -4080,6 +4375,21 @@ code {
   .attention-normalize-flow > span {
     justify-self: center;
     transform: rotate(90deg);
+  }
+
+  .multi-head-lanes,
+  .multi-head-join-flow,
+  .multi-head-norm-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .multi-head-join-flow > span {
+    justify-self: center;
+    transform: rotate(90deg);
+  }
+
+  .multi-head-value-row {
+    grid-template-columns: 1fr;
   }
 
   .gate-model-label {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -4055,6 +4055,300 @@ code {
   top: 14px;
 }
 
+.workspace--decoder {
+  display: grid;
+  grid-template-columns: minmax(700px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.decoder-stage,
+.decoder-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.decoder-intro,
+.decoder-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.decoder-intro,
+.decoder-shift-panel,
+.decoder-prediction-panel,
+.decoder-gradient-panel,
+.decoder-update-panel,
+.decoder-controls {
+  @include surface;
+  padding: 16px;
+}
+
+.decoder-intro p:last-child,
+.decoder-heading p,
+.decoder-controls > p {
+  margin: 7px 0 0;
+  color: $muted;
+}
+
+.decoder-chip {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border: 1px solid rgba(35, 122, 87, 0.28);
+  border-radius: 999px;
+  background: rgba(35, 122, 87, 0.08);
+  color: #185a40;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 750;
+}
+
+.decoder-shift-panel,
+.decoder-prediction-panel,
+.decoder-gradient-panel,
+.decoder-update-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.decoder-heading > code {
+  flex: 0 0 auto;
+  padding: 6px 9px;
+  border-radius: 6px;
+  background: #e9f7f0;
+  color: #185a40;
+}
+
+.decoder-position-lanes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.decoder-position-button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 6px 10px;
+  align-items: center;
+  min-width: 0;
+  padding: 11px;
+  border: 1px solid rgba(35, 122, 87, 0.2);
+  border-radius: 7px;
+  background: rgba(35, 122, 87, 0.035);
+  text-align: left;
+}
+
+.decoder-position-button:hover,
+.decoder-position-button[aria-pressed="true"] {
+  border-color: rgba(35, 122, 87, 0.55);
+  background: rgba(35, 122, 87, 0.09);
+}
+
+.decoder-position-button span,
+.decoder-position-button small {
+  color: $muted;
+  font-size: 0.72rem;
+}
+
+.decoder-position-button span,
+.decoder-position-button small {
+  grid-column: 1 / -1;
+}
+
+.decoder-position-button strong {
+  overflow-wrap: anywhere;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.decoder-loss-badge {
+  display: grid;
+  gap: 2px;
+  min-width: 150px;
+  padding: 8px 10px;
+  border-left: 3px solid rgba(194, 65, 59, 0.5);
+  background: rgba(194, 65, 59, 0.05);
+}
+
+.decoder-loss-badge small,
+.decoder-forward-flow small,
+.decoder-softmax-trace small,
+.decoder-gradient-flow small,
+.decoder-update-grid small,
+.decoder-loss-drop small {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.decoder-loss-badge strong {
+  color: #9f342f;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.18rem;
+}
+
+.decoder-forward-flow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1.2fr);
+  align-items: stretch;
+  gap: 7px;
+}
+
+.decoder-forward-flow > div,
+.decoder-gradient-flow > div,
+.decoder-softmax-trace > div,
+.decoder-update-grid > div {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: $paper;
+}
+
+.decoder-forward-flow > span,
+.decoder-gradient-flow > span {
+  align-self: center;
+  color: $muted;
+  font-weight: 850;
+}
+
+.decoder-forward-flow code,
+.decoder-gradient-flow code,
+.decoder-softmax-trace code,
+.decoder-update-grid code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.decoder-target-node {
+  border-color: rgba(35, 122, 87, 0.3) !important;
+  background: rgba(35, 122, 87, 0.055) !important;
+}
+
+.decoder-vocabulary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.decoder-vocabulary-row {
+  position: relative;
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.decoder-vocabulary-row > div {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.decoder-vocabulary-row > i {
+  height: 6px;
+  background: rgba(37, 99, 235, 0.35);
+}
+
+.decoder-vocabulary-row--target {
+  border-color: rgba(35, 122, 87, 0.42);
+  background: rgba(35, 122, 87, 0.045);
+}
+
+.decoder-vocabulary-row--target > i {
+  background: rgba(35, 122, 87, 0.48);
+}
+
+.decoder-vocabulary-row code {
+  overflow-wrap: anywhere;
+  color: $muted;
+  font-size: 0.72rem;
+  white-space: normal;
+}
+
+.decoder-softmax-trace {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.decoder-gradient-flow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1.3fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: stretch;
+  gap: 7px;
+}
+
+.decoder-state-gradient {
+  border-color: rgba(109, 91, 208, 0.28) !important;
+  background: rgba(109, 91, 208, 0.05) !important;
+}
+
+.decoder-update-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.decoder-loss-drop {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px;
+  border-left: 4px solid rgba(35, 122, 87, 0.52);
+  background: rgba(35, 122, 87, 0.055);
+}
+
+.decoder-gradient-audit {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 11px;
+  border: 1px solid rgba(109, 91, 208, 0.24);
+  border-radius: 6px;
+  background: rgba(109, 91, 208, 0.045);
+}
+
+.decoder-gradient-audit code {
+  color: $muted;
+}
+
+.decoder-gradient-audit strong {
+  margin-left: auto;
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.decoder-loss-drop > div {
+  display: grid;
+  gap: 2px;
+}
+
+.decoder-loss-drop strong {
+  color: #185a40;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.12rem;
+}
+
+.decoder-loss-drop p {
+  margin: 0 0 0 auto;
+  color: $muted;
+}
+
+.decoder-controls {
+  position: sticky;
+  top: 14px;
+}
+
 @media (max-width: 1360px) {
   .app-header,
   .header-actions {
@@ -4103,7 +4397,8 @@ code {
     .workspace--gates,
     .workspace--attention,
     .workspace--attention-softmax,
-    .workspace--multi-head {
+    .workspace--multi-head,
+    .workspace--decoder {
     grid-template-columns: 1fr;
   }
 
@@ -4118,6 +4413,11 @@ code {
   }
 
   .multi-head-controls {
+    position: static;
+    grid-column: 1 / -1;
+  }
+
+  .decoder-controls {
     position: static;
     grid-column: 1 / -1;
   }
@@ -4156,7 +4456,8 @@ code {
     .workspace--gates,
     .workspace--attention,
     .workspace--attention-softmax,
-    .workspace--multi-head {
+    .workspace--multi-head,
+    .workspace--decoder {
     grid-template-columns: 1fr;
   }
 
@@ -4180,7 +4481,9 @@ code {
     .attention-softmax-intro,
     .attention-softmax-heading,
     .multi-head-intro,
-    .multi-head-heading {
+    .multi-head-heading,
+    .decoder-intro,
+    .decoder-heading {
     display: grid;
     align-items: start;
   }
@@ -4390,6 +4693,52 @@ code {
 
   .multi-head-value-row {
     grid-template-columns: 1fr;
+  }
+
+  .decoder-position-lanes,
+  .decoder-vocabulary-grid,
+  .decoder-softmax-trace,
+  .decoder-forward-flow,
+  .decoder-gradient-flow,
+  .decoder-update-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .decoder-position-button {
+    grid-template-columns: 1fr;
+  }
+
+  .decoder-position-button > i {
+    justify-self: center;
+    transform: rotate(90deg);
+  }
+
+  .decoder-chip {
+    justify-self: start;
+  }
+
+  .decoder-forward-flow > span,
+  .decoder-gradient-flow > span {
+    justify-self: center;
+    transform: rotate(90deg);
+  }
+
+  .decoder-loss-drop {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .decoder-gradient-audit {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .decoder-gradient-audit strong {
+    margin-left: 0;
+  }
+
+  .decoder-loss-drop p {
+    margin-left: 0;
   }
 
   .gate-model-label {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -136,7 +136,7 @@ h2 {
 
 .mode-toggle {
   display: inline-grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: 4px;
   padding: 4px;
   border: 1px solid $line;
@@ -1121,6 +1121,234 @@ code {
   margin-top: 4px;
 }
 
+.workspace--convolution {
+  display: grid;
+  grid-template-columns: minmax(620px, 1fr) 320px;
+  gap: 14px;
+  align-items: start;
+}
+
+.convolution-stage,
+.convolution-controls,
+.kernel-slide,
+.mac-panel,
+.output-strip {
+  @include surface;
+}
+
+.convolution-stage {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+}
+
+.convolution-intro,
+.mac-heading,
+.array-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.convolution-intro p:not(.eyebrow),
+.convolution-controls p,
+.convolution-note p {
+  margin: 5px 0 0;
+  color: $muted;
+}
+
+.convolution-mode-chip {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(109, 91, 208, 0.11);
+  color: #4f3da9;
+  font-size: 0.75rem;
+  font-weight: 850;
+}
+
+.kernel-slide,
+.mac-panel,
+.output-strip {
+  padding: 14px;
+  overflow-x: auto;
+}
+
+.array-label {
+  min-width: 420px;
+  margin-bottom: 7px;
+  color: $muted;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.array-label code {
+  min-height: 0;
+  padding: 3px 7px;
+  text-transform: none;
+}
+
+.array-label--kernel {
+  margin-top: 14px;
+}
+
+.signal-array,
+.kernel-track {
+  display: grid;
+  min-width: 420px;
+  gap: 6px;
+}
+
+.signal-cell,
+.kernel-cell {
+  display: grid;
+  place-items: center;
+  min-height: 70px;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: #ffffff;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.signal-cell small,
+.kernel-cell small,
+.product-card small,
+.accumulator-step small,
+.output-button small {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.signal-cell strong,
+.kernel-cell strong,
+.product-card strong,
+.accumulator-step strong,
+.output-button strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.signal-cell--active {
+  border-color: rgba(37, 99, 235, 0.58);
+  background: #edf4ff;
+}
+
+.kernel-window {
+  display: grid;
+  gap: 6px;
+  padding: 5px;
+  border: 2px solid rgba(109, 91, 208, 0.55);
+  border-radius: 10px;
+  background: rgba(109, 91, 208, 0.07);
+}
+
+.kernel-cell {
+  min-height: 58px;
+  border-color: rgba(109, 91, 208, 0.26);
+}
+
+.mac-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.mac-result {
+  min-width: 72px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(35, 122, 87, 0.13);
+  color: $green;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.35rem;
+  text-align: center;
+}
+
+.product-grid,
+.accumulator-strip,
+.output-buttons {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(105px, 1fr));
+  gap: 8px;
+}
+
+.product-card,
+.accumulator-step {
+  display: grid;
+  gap: 5px;
+  padding: 9px;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.product-card code {
+  min-height: 0;
+  padding: 3px 6px;
+}
+
+.accumulator-step {
+  border-color: rgba(35, 122, 87, 0.22);
+  background: #f6fbf8;
+}
+
+.expanded-equation {
+  min-height: 0;
+  padding: 10px;
+  overflow-x: auto;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.output-strip {
+  display: grid;
+  gap: 7px;
+}
+
+.output-button {
+  display: grid;
+  gap: 2px;
+  min-height: 60px;
+}
+
+.output-button--active {
+  border-color: rgba(35, 122, 87, 0.62);
+  background: #eaf7ef;
+  color: #17603f;
+}
+
+.convolution-controls {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+}
+
+.convolution-controls .button-grid button:last-child {
+  grid-column: 1 / -1;
+}
+
+.convolution-note {
+  padding-top: 12px;
+  border-top: 1px solid $line;
+}
+
+.convolution-note span {
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.convolution-error {
+  padding: 20px;
+  border: 1px solid rgba(194, 65, 59, 0.28);
+  border-radius: 8px;
+  background: #fff5f4;
+  color: $red;
+  font-weight: 750;
+}
+
 @media (max-width: 1180px) {
   .workspace--lab,
   .workspace--hidden {
@@ -1129,12 +1357,14 @@ code {
 
   .metrics,
   .microscope-controls,
-  .optimization-controls {
+  .optimization-controls,
+  .convolution-controls {
     grid-column: 1 / -1;
   }
 
   .workspace--microscope,
-  .workspace--optimization {
+  .workspace--optimization,
+  .workspace--convolution {
     grid-template-columns: 1fr;
   }
 }
@@ -1159,8 +1389,19 @@ code {
   .workspace--lab,
   .workspace--hidden,
   .workspace--microscope,
-  .workspace--optimization {
+  .workspace--optimization,
+  .workspace--convolution {
     grid-template-columns: 1fr;
+  }
+
+  .convolution-intro,
+  .mac-heading {
+    display: grid;
+    align-items: start;
+  }
+
+  .convolution-mode-chip {
+    justify-self: start;
   }
 
   .lab-rail {
@@ -1176,7 +1417,11 @@ code {
   }
 
   .mode-toggle {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .mode-button:last-child {
+    grid-column: 1 / -1;
   }
 
   .phase-strip {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -4349,6 +4349,326 @@ code {
   top: 14px;
 }
 
+.workspace--autoencoder {
+  display: grid;
+  grid-template-columns: minmax(700px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.autoencoder-stage,
+.autoencoder-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.autoencoder-intro,
+.autoencoder-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.autoencoder-intro,
+.autoencoder-network-panel,
+.autoencoder-reconstruction-panel,
+.autoencoder-backward-panel,
+.autoencoder-update-panel,
+.autoencoder-controls {
+  @include surface;
+  padding: 16px;
+}
+
+.autoencoder-intro p:last-child,
+.autoencoder-heading p,
+.autoencoder-controls > p {
+  margin: 7px 0 0;
+  color: $muted;
+}
+
+.autoencoder-chip {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border: 1px solid rgba(183, 121, 31, 0.3);
+  border-radius: 999px;
+  background: rgba(183, 121, 31, 0.09);
+  color: #81520d;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 750;
+}
+
+.autoencoder-network-panel,
+.autoencoder-reconstruction-panel,
+.autoencoder-backward-panel,
+.autoencoder-update-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.autoencoder-heading > code {
+  flex: 0 0 auto;
+  padding: 6px 9px;
+  border-radius: 6px;
+  background: rgba(183, 121, 31, 0.1);
+  color: #81520d;
+}
+
+.autoencoder-network {
+  display: grid;
+  grid-template-columns: minmax(100px, 0.8fr) auto minmax(160px, 1fr) auto minmax(110px, 0.8fr) auto minmax(160px, 1fr);
+  gap: 8px;
+  align-items: center;
+}
+
+.autoencoder-input-stack,
+.autoencoder-encoder-stack,
+.autoencoder-output-stack {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.autoencoder-input-stack > small,
+.autoencoder-encoder-stack > small,
+.autoencoder-output-stack > small,
+.autoencoder-bottleneck small,
+.autoencoder-reconstruction-flow small,
+.autoencoder-loss-badge small,
+.autoencoder-branch-gradients small,
+.autoencoder-gradient-grid small,
+.autoencoder-parameter-grid small,
+.autoencoder-loss-drop small {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.autoencoder-input-stack > div,
+.autoencoder-encoder-stack,
+.autoencoder-output-stack > button {
+  min-width: 0;
+  padding: 9px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: $paper;
+}
+
+.autoencoder-input-stack > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.autoencoder-encoder-stack code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.autoencoder-bottleneck {
+  display: grid;
+  place-items: center;
+  gap: 3px;
+  min-height: 130px;
+  padding: 13px;
+  border: 3px solid rgba(183, 121, 31, 0.38);
+  border-radius: 50%;
+  background: rgba(183, 121, 31, 0.08);
+  text-align: center;
+}
+
+.autoencoder-bottleneck strong {
+  color: #81520d;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.45rem;
+}
+
+.autoencoder-bottleneck span {
+  color: $muted;
+  font-size: 0.72rem;
+}
+
+.autoencoder-output-stack > button {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2px 8px;
+  text-align: left;
+}
+
+.autoencoder-output-stack > button small {
+  grid-column: 1 / -1;
+  color: $muted;
+}
+
+.autoencoder-output-stack > button[aria-pressed="true"] {
+  border-color: rgba(183, 121, 31, 0.55);
+  background: rgba(183, 121, 31, 0.1);
+  color: #674108;
+}
+
+.autoencoder-arrow {
+  color: $muted;
+  font-weight: 850;
+}
+
+.autoencoder-loss-badge {
+  display: grid;
+  gap: 2px;
+  min-width: 150px;
+  padding: 8px 10px;
+  border-left: 3px solid rgba(194, 65, 59, 0.5);
+  background: rgba(194, 65, 59, 0.05);
+}
+
+.autoencoder-loss-badge strong {
+  color: #9f342f;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.18rem;
+}
+
+.autoencoder-reconstruction-flow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr) auto) minmax(0, 1fr) auto minmax(0, 1.15fr);
+  gap: 7px;
+  align-items: stretch;
+}
+
+.autoencoder-reconstruction-flow > div,
+.autoencoder-gradient-grid > div,
+.autoencoder-parameter-grid > div {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: $paper;
+}
+
+.autoencoder-reconstruction-flow > span {
+  align-self: center;
+  color: $muted;
+  font-weight: 850;
+}
+
+.autoencoder-reconstruction-flow code,
+.autoencoder-gradient-grid code,
+.autoencoder-parameter-grid code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.autoencoder-reconstruction-result {
+  border-color: rgba(35, 122, 87, 0.3) !important;
+  background: rgba(35, 122, 87, 0.055) !important;
+}
+
+.autoencoder-error-result {
+  border-color: rgba(194, 65, 59, 0.28) !important;
+  background: rgba(194, 65, 59, 0.045) !important;
+}
+
+.autoencoder-branch-gradients {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto minmax(130px, 0.8fr);
+  gap: 8px;
+  align-items: stretch;
+}
+
+.autoencoder-branch-gradients > button,
+.autoencoder-bottleneck-gradient {
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(109, 91, 208, 0.2);
+  border-radius: 6px;
+  background: rgba(109, 91, 208, 0.035);
+  text-align: left;
+}
+
+.autoencoder-branch-gradients > button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.55);
+  background: rgba(109, 91, 208, 0.1);
+  color: #4f3da9;
+}
+
+.autoencoder-branch-gradients > span {
+  align-self: center;
+  color: $muted;
+  font-weight: 850;
+}
+
+.autoencoder-bottleneck-gradient {
+  border-color: rgba(183, 121, 31, 0.36);
+  background: rgba(183, 121, 31, 0.07);
+}
+
+.autoencoder-bottleneck-gradient strong {
+  color: #81520d;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.14rem;
+}
+
+.autoencoder-gradient-grid,
+.autoencoder-parameter-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.autoencoder-gradient-audit {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 11px;
+  border: 1px solid rgba(109, 91, 208, 0.24);
+  border-radius: 6px;
+  background: rgba(109, 91, 208, 0.045);
+}
+
+.autoencoder-gradient-audit code {
+  color: $muted;
+}
+
+.autoencoder-gradient-audit strong {
+  margin-left: auto;
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.autoencoder-loss-drop {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px;
+  border-left: 4px solid rgba(35, 122, 87, 0.52);
+  background: rgba(35, 122, 87, 0.055);
+}
+
+.autoencoder-loss-drop > div {
+  display: grid;
+  gap: 2px;
+}
+
+.autoencoder-loss-drop strong {
+  color: #185a40;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.12rem;
+}
+
+.autoencoder-loss-drop p {
+  margin: 0 0 0 auto;
+  color: $muted;
+}
+
+.autoencoder-controls {
+  position: sticky;
+  top: 14px;
+}
+
 @media (max-width: 1360px) {
   .app-header,
   .header-actions {
@@ -4398,7 +4718,8 @@ code {
     .workspace--attention,
     .workspace--attention-softmax,
     .workspace--multi-head,
-    .workspace--decoder {
+    .workspace--decoder,
+    .workspace--autoencoder {
     grid-template-columns: 1fr;
   }
 
@@ -4418,6 +4739,11 @@ code {
   }
 
   .decoder-controls {
+    position: static;
+    grid-column: 1 / -1;
+  }
+
+  .autoencoder-controls {
     position: static;
     grid-column: 1 / -1;
   }
@@ -4457,7 +4783,8 @@ code {
     .workspace--attention,
     .workspace--attention-softmax,
     .workspace--multi-head,
-    .workspace--decoder {
+    .workspace--decoder,
+    .workspace--autoencoder {
     grid-template-columns: 1fr;
   }
 
@@ -4483,7 +4810,9 @@ code {
     .multi-head-intro,
     .multi-head-heading,
     .decoder-intro,
-    .decoder-heading {
+    .decoder-heading,
+    .autoencoder-intro,
+    .autoencoder-heading {
     display: grid;
     align-items: start;
   }
@@ -4738,6 +5067,44 @@ code {
   }
 
   .decoder-loss-drop p {
+    margin-left: 0;
+  }
+
+  .autoencoder-network,
+  .autoencoder-reconstruction-flow,
+  .autoencoder-branch-gradients,
+  .autoencoder-gradient-grid,
+  .autoencoder-parameter-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .autoencoder-arrow,
+  .autoencoder-reconstruction-flow > span {
+    justify-self: center;
+    transform: rotate(90deg);
+  }
+
+  .autoencoder-branch-gradients > span {
+    justify-self: center;
+  }
+
+  .autoencoder-bottleneck {
+    justify-self: center;
+    min-width: 140px;
+  }
+
+  .autoencoder-chip {
+    justify-self: start;
+  }
+
+  .autoencoder-gradient-audit,
+  .autoencoder-loss-drop {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .autoencoder-gradient-audit strong,
+  .autoencoder-loss-drop p {
     margin-left: 0;
   }
 

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -16,6 +16,370 @@ $violet: #6d5bd0;
   box-shadow: 0 18px 50px rgba(29, 45, 39, 0.08);
 }
 
+.structured-workbench {
+  display: grid;
+  gap: 14px;
+}
+
+.structured-lab-switch {
+  display: flex;
+  gap: 8px;
+  padding: 0 24px;
+}
+
+.structured-lab-switch button {
+  border: 1px solid $line;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.72);
+  color: $ink;
+  padding: 10px 16px;
+  font: inherit;
+  font-weight: 700;
+}
+
+.structured-lab-switch button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.38);
+  background: rgba(109, 91, 208, 0.1);
+  color: #4b3e9d;
+}
+
+.workspace--hopfield {
+  grid-template-columns: minmax(0, 1fr) 286px;
+  align-items: start;
+  gap: 18px;
+}
+
+.hopfield-stage {
+  min-width: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.hopfield-intro,
+.hopfield-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.hopfield-intro h2,
+.hopfield-heading h2,
+.hopfield-controls h2 {
+  margin: 0;
+}
+
+.hopfield-intro > div:first-child > p:last-child,
+.hopfield-heading p,
+.hopfield-controls > p {
+  color: $muted;
+  line-height: 1.55;
+}
+
+.hopfield-chip {
+  flex: 0 0 auto;
+  border: 1px solid rgba(35, 122, 87, 0.25);
+  border-radius: 999px;
+  background: rgba(35, 122, 87, 0.08);
+  color: #1d6849;
+  padding: 8px 12px;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.hopfield-store-panel,
+.hopfield-recall-panel,
+.hopfield-controls {
+  border: 1px solid $line;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 50px rgba(29, 45, 39, 0.08);
+}
+
+.hopfield-store-panel,
+.hopfield-recall-panel {
+  padding: 18px;
+}
+
+.hopfield-heading > code {
+  flex: 0 0 auto;
+  border-radius: 8px;
+  background: rgba(38, 99, 235, 0.08);
+  color: #234c9f;
+  padding: 8px 10px;
+  font-size: 0.78rem;
+}
+
+.hopfield-pattern-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  margin: 16px 0;
+}
+
+.hopfield-pattern-row > div,
+.hopfield-state,
+.hopfield-update,
+.hopfield-audit-grid > div,
+.hopfield-contribution-panel > div {
+  display: grid;
+  gap: 5px;
+  border: 1px solid rgba(45, 55, 72, 0.12);
+  border-radius: 10px;
+  background: rgba(248, 249, 246, 0.86);
+  padding: 11px;
+}
+
+.hopfield-pattern-row small,
+.hopfield-state small,
+.hopfield-update small,
+.hopfield-audit-grid small,
+.hopfield-contribution-panel small,
+.hopfield-selected-summary small {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.hopfield-pattern-row strong,
+.hopfield-state strong,
+.hopfield-update strong,
+.hopfield-audit-grid strong,
+.hopfield-contribution-panel strong,
+.hopfield-selected-summary strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.hopfield-matrix {
+  display: grid;
+  grid-template-columns: 72px repeat(4, minmax(70px, 1fr));
+  gap: 5px;
+  align-items: center;
+}
+
+.hopfield-matrix > b {
+  color: $muted;
+  font-size: 0.7rem;
+  text-align: center;
+}
+
+.hopfield-matrix__row {
+  display: contents;
+}
+
+.hopfield-matrix__row > b {
+  color: $muted;
+  font-size: 0.7rem;
+}
+
+.hopfield-weight {
+  border: 1px solid rgba(38, 99, 235, 0.16);
+  border-radius: 8px;
+  background: rgba(38, 99, 235, 0.08);
+  padding: 9px 6px;
+  text-align: center;
+}
+
+.hopfield-weight--diagonal {
+  border-color: rgba(183, 121, 31, 0.2);
+  background: rgba(183, 121, 31, 0.09);
+  color: #8a5a17;
+}
+
+.hopfield-note {
+  margin: 14px 0 0;
+  color: $muted;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.hopfield-recall-lane {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  margin: 16px 0;
+}
+
+.hopfield-state {
+  border-color: rgba(194, 65, 59, 0.24);
+  background: rgba(194, 65, 59, 0.07);
+}
+
+.hopfield-update {
+  opacity: 0.48;
+}
+
+.hopfield-update--visible {
+  border-color: rgba(35, 122, 87, 0.28);
+  background: rgba(35, 122, 87, 0.08);
+  opacity: 1;
+}
+
+.hopfield-state span,
+.hopfield-update span {
+  color: $muted;
+  font-size: 0.72rem;
+}
+
+.hopfield-audit-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.hopfield-contribution-panel {
+  display: grid;
+  grid-template-columns: 0.65fr 2.3fr 1.2fr 1.2fr 1.2fr;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.hopfield-contribution-panel > p {
+  grid-column: 1 / -1;
+  margin: 0;
+  border-radius: 10px;
+  background: rgba(109, 91, 208, 0.08);
+  color: #50469a;
+  padding: 12px;
+  line-height: 1.5;
+}
+
+.hopfield-contributions {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.hopfield-contributions code {
+  border-radius: 6px;
+  background: rgba(38, 99, 235, 0.07);
+  padding: 4px 6px;
+  font-size: 0.7rem;
+}
+
+.hopfield-controls {
+  position: sticky;
+  top: 18px;
+  padding: 16px;
+}
+
+.hopfield-controls > p:first-child {
+  margin: 0 0 4px;
+  color: #237a57;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hopfield-phase-buttons {
+  display: grid;
+  gap: 7px;
+  margin-top: 14px;
+}
+
+.hopfield-phase-buttons button {
+  display: grid;
+  gap: 2px;
+  border: 1px solid $line;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.8);
+  color: $ink;
+  padding: 9px 10px;
+  text-align: left;
+}
+
+.hopfield-phase-buttons button span {
+  color: $muted;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.hopfield-phase-buttons button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.42);
+  background: rgba(109, 91, 208, 0.11);
+  color: #4b3e9d;
+}
+
+.hopfield-selected-summary {
+  display: grid;
+  gap: 5px;
+  margin-top: 12px;
+  border-radius: 10px;
+  background: rgba(35, 122, 87, 0.08);
+  padding: 12px;
+}
+
+.hopfield-selected-summary span,
+.hopfield-selected-summary b {
+  color: $muted;
+  font-size: 0.75rem;
+}
+
+.hopfield-selected-summary b {
+  color: #1d6849;
+}
+
+@media (max-width: 1180px) {
+  .workspace--hopfield {
+    grid-template-columns: 1fr;
+  }
+
+  .hopfield-controls {
+    position: static;
+  }
+
+  .hopfield-phase-buttons {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .structured-lab-switch {
+    padding: 0 12px;
+  }
+
+  .structured-lab-switch button {
+    width: 100%;
+  }
+
+  .hopfield-intro,
+  .hopfield-heading {
+    display: grid;
+  }
+
+  .hopfield-chip,
+  .hopfield-heading > code {
+    justify-self: start;
+  }
+
+  .hopfield-pattern-row,
+  .hopfield-recall-lane,
+  .hopfield-audit-grid,
+  .hopfield-contribution-panel,
+  .hopfield-contributions,
+  .hopfield-phase-buttons {
+    grid-template-columns: 1fr;
+  }
+
+  .hopfield-pattern-row > span {
+    justify-self: center;
+  }
+
+  .hopfield-matrix {
+    grid-template-columns: 54px repeat(4, minmax(0, 1fr));
+  }
+
+  .hopfield-weight {
+    padding: 8px 2px;
+    font-size: 0.7rem;
+  }
+}
+
 :root {
   color-scheme: light;
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -136,7 +136,7 @@ h2 {
 
 .mode-toggle {
   display: inline-grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(4, 1fr);
   gap: 4px;
   padding: 4px;
   border: 1px solid $line;
@@ -174,6 +174,13 @@ h2 {
 .workspace--microscope {
   display: grid;
   grid-template-columns: minmax(560px, 1fr) 320px;
+  gap: 14px;
+  align-items: start;
+}
+
+.workspace--optimization {
+  display: grid;
+  grid-template-columns: minmax(620px, 1fr) 320px;
   gap: 14px;
   align-items: start;
 }
@@ -387,6 +394,217 @@ h2 {
 .microscope-actions button:disabled {
   cursor: not-allowed;
   opacity: 0.45;
+}
+
+.optimization-stage {
+  display: grid;
+  gap: 12px;
+}
+
+.landscape-panel,
+.gradient-check-panel,
+.batch-comparison-panel,
+.optimization-controls {
+  @include surface;
+}
+
+.landscape-panel,
+.gradient-check-panel,
+.batch-comparison-panel {
+  padding: 14px;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
+.panel-heading > span {
+  color: $muted;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.landscape-chart {
+  display: block;
+  width: 100%;
+  aspect-ratio: 720 / 430;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.landscape-cell {
+  fill: $blue;
+}
+
+.gradient-arrow {
+  stroke: $red;
+  stroke-width: 4;
+}
+
+.gradient-arrow-head {
+  fill: $red;
+}
+
+.current-parameter-point {
+  fill: $red;
+  stroke: #ffffff;
+  stroke-width: 3;
+}
+
+.optimum-point {
+  fill: $green;
+  stroke: #ffffff;
+  stroke-width: 3;
+}
+
+.landscape-label {
+  fill: $ink;
+  font-size: 13px;
+  font-weight: 850;
+  paint-order: stroke;
+  stroke: rgba(255, 255, 255, 0.86);
+  stroke-width: 4px;
+}
+
+.axis-title--optimization-y {
+  transform: rotate(-90deg);
+  transform-origin: 18px 215px;
+}
+
+.landscape-equation {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.gradient-check-panel > p {
+  margin: 10px 0 0;
+  color: $muted;
+}
+
+.check-status {
+  padding: 5px 9px;
+  border-radius: 999px;
+  letter-spacing: 0.06em;
+}
+
+.check-status--pass {
+  background: rgba(35, 122, 87, 0.12);
+  color: $green !important;
+}
+
+.check-status--fail {
+  background: rgba(194, 65, 59, 0.12);
+  color: $red !important;
+}
+
+.gradient-check-grid {
+  display: grid;
+  grid-template-columns: minmax(92px, 0.7fr) repeat(3, minmax(130px, 1fr));
+  align-items: center;
+  gap: 1px;
+  overflow-x: auto;
+}
+
+.gradient-check-grid > * {
+  min-width: 0;
+  min-height: 38px;
+  padding: 8px;
+  border-bottom: 1px solid $line;
+}
+
+.gradient-check-grid > span {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.gradient-check-grid code {
+  border-radius: 0;
+  background: transparent;
+}
+
+.batch-chart {
+  display: block;
+  width: 100%;
+  max-height: 210px;
+  background: #ffffff;
+}
+
+.batch-grid {
+  stroke: rgba(23, 32, 28, 0.16);
+  stroke-width: 1;
+}
+
+.batch-line {
+  fill: none;
+  stroke-width: 3;
+}
+
+.batch-line--stochastic {
+  stroke: $red;
+}
+
+.batch-line--mini-batch {
+  stroke: $gold;
+}
+
+.batch-line--full-batch {
+  stroke: $green;
+}
+
+.batch-axis-label {
+  fill: $muted;
+  font-size: 12px;
+  font-weight: 800;
+  text-anchor: middle;
+}
+
+.batch-axis-label--y {
+  transform: rotate(-90deg);
+  transform-origin: 12px 82px;
+}
+
+.strategy-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 9px;
+  margin-top: 8px;
+}
+
+.strategy-summary {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  border-left: 4px solid;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.strategy-summary--stochastic {
+  border-color: $red;
+}
+
+.strategy-summary--mini-batch {
+  border-color: $gold;
+}
+
+.strategy-summary--full-batch {
+  border-color: $green;
+}
+
+.strategy-summary span,
+.strategy-summary small {
+  color: $muted;
+}
+
+.strategy-summary code {
+  margin-top: 4px;
 }
 
 .primary-action {
@@ -910,11 +1128,13 @@ code {
   }
 
   .metrics,
-  .microscope-controls {
+  .microscope-controls,
+  .optimization-controls {
     grid-column: 1 / -1;
   }
 
-  .workspace--microscope {
+  .workspace--microscope,
+  .workspace--optimization {
     grid-template-columns: 1fr;
   }
 }
@@ -938,7 +1158,8 @@ code {
 
   .workspace--lab,
   .workspace--hidden,
-  .workspace--microscope {
+  .workspace--microscope,
+  .workspace--optimization {
     grid-template-columns: 1fr;
   }
 
@@ -986,6 +1207,21 @@ code {
 
   .before-after {
     grid-template-columns: 1fr;
+  }
+
+  .landscape-equation,
+  .strategy-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gradient-check-grid {
+    grid-template-columns: 72px repeat(3, minmax(0, 1fr));
+    min-width: 0;
+  }
+
+  .gradient-check-grid > * {
+    padding: 6px 3px;
+    font-size: 0.68rem;
   }
 
   .update-arrow {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -709,6 +709,255 @@ $violet: #6d5bd0;
   }
 }
 
+.workspace--graph-neighborhood {
+  grid-template-columns: minmax(0, 1fr) 286px;
+  align-items: start;
+  gap: 18px;
+}
+
+.graph-neighborhood-stage {
+  min-width: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.graph-neighborhood-intro,
+.graph-neighborhood-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.graph-neighborhood-intro h2,
+.graph-neighborhood-heading h2,
+.graph-neighborhood-controls h2 {
+  margin: 0;
+}
+
+.graph-neighborhood-intro p,
+.graph-neighborhood-heading p,
+.graph-neighborhood-map > p,
+.graph-output-panel p,
+.graph-neighborhood-controls > p {
+  color: $muted;
+  line-height: 1.55;
+}
+
+.graph-neighborhood-chip {
+  flex: 0 0 auto;
+  border: 1px solid rgba(109, 91, 208, 0.3);
+  border-radius: 999px;
+  background: rgba(109, 91, 208, 0.1);
+  color: #4b3e9d;
+  padding: 8px 12px;
+  font-weight: 800;
+}
+
+.graph-neighborhood-map,
+.graph-model-panel,
+.graph-output-panel,
+.graph-neighborhood-controls {
+  border: 1px solid $line;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 50px rgba(29, 45, 39, 0.08);
+}
+
+.graph-neighborhood-map,
+.graph-model-panel,
+.graph-output-panel {
+  padding: 18px;
+}
+
+.graph-neighborhood-heading > code {
+  flex: 0 0 auto;
+  border-radius: 8px;
+  background: rgba(37, 99, 235, 0.08);
+  color: #234c9f;
+  padding: 8px 10px;
+  font-size: 0.76rem;
+}
+
+.graph-targets,
+.graph-row-grid,
+.graph-output-panel {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.graph-targets {
+  margin-top: 16px;
+}
+
+.graph-targets button,
+.graph-row-grid > div,
+.graph-output-panel > div {
+  display: grid;
+  gap: 5px;
+  border: 1px solid rgba(45, 55, 72, 0.13);
+  border-radius: 10px;
+  background: rgba(248, 249, 246, 0.86);
+  padding: 11px;
+}
+
+.graph-targets button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.5);
+  background: rgba(109, 91, 208, 0.11);
+  color: #4b3e9d;
+}
+
+.graph-targets small,
+.graph-row-grid small,
+.graph-output-panel small,
+.graph-neighborhood-controls small {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.graph-targets strong,
+.graph-row-grid strong,
+.graph-output-panel strong,
+.graph-result strong,
+.graph-neighborhood-controls strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.graph-targets span,
+.graph-row-grid span,
+.graph-softmax-summary span,
+.graph-neighborhood-controls span {
+  color: $muted;
+  font-size: 0.74rem;
+}
+
+.graph-row-grid {
+  margin-top: 16px;
+}
+
+.graph-row-grid code {
+  color: #234c9f;
+  font-size: 0.72rem;
+}
+
+.graph-row-grid b {
+  color: #237a57;
+  font-size: 0.78rem;
+}
+
+.graph-result,
+.graph-softmax-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 12px;
+  border-radius: 10px;
+  background: rgba(35, 122, 87, 0.08);
+  padding: 12px;
+}
+
+.graph-result b {
+  color: #1d6849;
+}
+
+.graph-output-panel {
+  grid-template-columns: 1fr 1fr;
+}
+
+.graph-output-panel p {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.graph-neighborhood-controls {
+  position: sticky;
+  top: 18px;
+  display: grid;
+  gap: 9px;
+  padding: 16px;
+}
+
+.graph-neighborhood-controls > p:first-child {
+  margin: 0;
+  color: #237a57;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.graph-neighborhood-controls button,
+.graph-neighborhood-controls > div {
+  display: grid;
+  gap: 3px;
+  border: 1px solid $line;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.82);
+  color: $ink;
+  padding: 10px;
+  text-align: left;
+}
+
+.graph-neighborhood-controls button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.45);
+  background: rgba(109, 91, 208, 0.11);
+  color: #4b3e9d;
+}
+
+.graph-neighborhood-controls > div {
+  margin-top: 5px;
+  background: rgba(35, 122, 87, 0.08);
+}
+
+@media (max-width: 1180px) {
+  .workspace--graph-neighborhood {
+    grid-template-columns: 1fr;
+  }
+
+  .graph-neighborhood-controls {
+    position: static;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .graph-neighborhood-controls > p,
+  .graph-neighborhood-controls > h2,
+  .graph-neighborhood-controls > div {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 820px) {
+  .graph-neighborhood-intro,
+  .graph-neighborhood-heading,
+  .graph-result,
+  .graph-softmax-summary {
+    display: grid;
+  }
+
+  .graph-neighborhood-chip,
+  .graph-neighborhood-heading > code {
+    justify-self: start;
+  }
+
+  .graph-targets,
+  .graph-row-grid,
+  .graph-output-panel,
+  .graph-neighborhood-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .graph-neighborhood-controls > p,
+  .graph-neighborhood-controls > h2,
+  .graph-neighborhood-controls > div {
+    grid-column: auto;
+  }
+}
+
 :root {
   color-scheme: light;
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -2646,6 +2646,324 @@ code {
   text-transform: uppercase;
 }
 
+.bptt-view-button {
+  min-height: 42px;
+  padding: 9px 12px;
+  border: 1px solid rgba(109, 91, 208, 0.35);
+  border-radius: 8px;
+  background: rgba(109, 91, 208, 0.09);
+  color: #4f3da9;
+  font-weight: 850;
+}
+
+.bptt-view-button:hover {
+  border-color: $violet;
+  background: rgba(109, 91, 208, 0.15);
+}
+
+.workspace--bptt {
+  display: grid;
+  grid-template-columns: minmax(760px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.bptt-stage,
+.bptt-panel {
+  @include surface;
+}
+
+.bptt-stage {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.bptt-panel {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.bptt-intro,
+.bptt-panel-heading,
+.bptt-arithmetic-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.bptt-intro p:not(.eyebrow),
+.bptt-controls > p,
+.bptt-update-panel > p {
+  margin: 5px 0 0;
+  color: $muted;
+}
+
+.bptt-loss-chip {
+  display: grid;
+  flex: 0 0 auto;
+  min-width: 120px;
+  padding: 9px 12px;
+  border-radius: 8px;
+  background: rgba(191, 64, 64, 0.1);
+  color: #9b3131;
+  text-align: center;
+}
+
+.bptt-loss-chip small,
+.bptt-forward-lane small,
+.bptt-step small,
+.bptt-equation small,
+.bptt-loss-change small {
+  color: $muted;
+  font-size: 0.67rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.bptt-loss-chip strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.25rem;
+}
+
+.bptt-panel-heading code {
+  min-height: 0;
+  padding: 4px 7px;
+}
+
+.bptt-forward-lane {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(118px, 1fr));
+  gap: 8px;
+}
+
+.bptt-forward-lane > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 7px;
+  background: rgba(35, 122, 87, 0.055);
+}
+
+.bptt-forward-lane strong,
+.bptt-step strong,
+.bptt-step span {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.bptt-forward-lane .bptt-forward-lane__loss {
+  border-color: rgba(191, 64, 64, 0.2);
+  background: rgba(191, 64, 64, 0.07);
+}
+
+.bptt-direction-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #4f3da9;
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.bptt-direction-label span {
+  font-size: 1.2rem;
+}
+
+.bptt-backward-lane {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(150px, 1fr));
+  gap: 9px;
+}
+
+.bptt-step {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 11px;
+  border: 1px solid rgba(109, 91, 208, 0.22);
+  border-radius: 8px;
+  background: rgba(109, 91, 208, 0.055);
+  color: $ink;
+  text-align: left;
+}
+
+.bptt-step:hover,
+.bptt-step--active {
+  border-color: rgba(109, 91, 208, 0.62);
+  background: rgba(109, 91, 208, 0.13);
+}
+
+.bptt-step--active {
+  box-shadow: inset 0 0 0 1px rgba(109, 91, 208, 0.12);
+}
+
+.bptt-step span {
+  color: $muted;
+  font-size: 0.75rem;
+}
+
+.bptt-arithmetic {
+  display: grid;
+  gap: 12px;
+  padding-top: 13px;
+  border-top: 1px solid $line;
+}
+
+.bptt-arithmetic-heading code {
+  min-height: 0;
+  padding: 4px 7px;
+}
+
+.bptt-equation {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(85px, 1fr) auto) minmax(100px, 1fr);
+  align-items: center;
+  gap: 7px;
+}
+
+.bptt-equation > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 9px;
+  border-radius: 7px;
+  background: rgba(37, 99, 235, 0.055);
+  text-align: center;
+}
+
+.bptt-equation > span {
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 850;
+}
+
+.bptt-equation strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.bptt-equation .bptt-equation__result {
+  background: rgba(109, 91, 208, 0.13);
+  color: #4f3da9;
+}
+
+.bptt-local-gradients,
+.bptt-parameter-update {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.bptt-local-gradients code,
+.bptt-parameter-update code {
+  min-height: 0;
+  padding: 6px 7px;
+  white-space: normal;
+}
+
+.bptt-table-wrap {
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.bptt-table {
+  width: 100%;
+  min-width: 570px;
+  border-collapse: collapse;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+}
+
+.bptt-table caption {
+  padding-bottom: 7px;
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-align: left;
+}
+
+.bptt-table th,
+.bptt-table td {
+  padding: 9px;
+  border-bottom: 1px solid $line;
+  text-align: right;
+}
+
+.bptt-table th:first-child {
+  text-align: left;
+}
+
+.bptt-table thead th {
+  color: $muted;
+  font-size: 0.69rem;
+  text-transform: uppercase;
+}
+
+.bptt-table td:last-child {
+  color: #4f3da9;
+  background: rgba(109, 91, 208, 0.055);
+}
+
+.bptt-pass {
+  color: $green;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+}
+
+.bptt-initial-gradient {
+  margin: 0;
+  padding: 8px 10px;
+  border-left: 3px solid rgba(109, 91, 208, 0.45);
+  background: rgba(109, 91, 208, 0.04);
+}
+
+.bptt-audit-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(270px, 0.65fr);
+  gap: 12px;
+  min-width: 0;
+}
+
+.bptt-update-panel {
+  align-content: start;
+}
+
+.bptt-loss-change {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 8px;
+}
+
+.bptt-loss-change > div {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  border-radius: 7px;
+  background: rgba(191, 64, 64, 0.07);
+  text-align: center;
+}
+
+.bptt-loss-change > div:last-child {
+  background: rgba(35, 122, 87, 0.1);
+  color: $green;
+}
+
+.bptt-loss-change strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.05rem;
+}
+
+.bptt-parameter-update {
+  grid-template-columns: 1fr;
+}
+
 @media (max-width: 1180px) {
   .workspace--lab,
   .workspace--hidden {
@@ -2676,7 +2994,8 @@ code {
   .workspace--convolution,
   .workspace--image-cnn,
   .workspace--residual,
-  .workspace--recurrent {
+  .workspace--recurrent,
+  .workspace--bptt {
     grid-template-columns: 1fr;
   }
 }
@@ -2705,7 +3024,8 @@ code {
   .workspace--convolution,
   .workspace--image-cnn,
   .workspace--residual,
-  .workspace--recurrent {
+  .workspace--recurrent,
+  .workspace--bptt {
     grid-template-columns: 1fr;
   }
 
@@ -2718,7 +3038,10 @@ code {
   .residual-panel-heading,
   .recurrent-intro,
   .recurrent-panel-heading,
-  .recurrent-arithmetic-heading {
+  .recurrent-arithmetic-heading,
+  .bptt-intro,
+  .bptt-panel-heading,
+  .bptt-arithmetic-heading {
     display: grid;
     align-items: start;
   }
@@ -2842,6 +3165,21 @@ code {
 
   .recurrent-equation > span:last-of-type {
     transform: rotate(90deg);
+  }
+
+  .bptt-forward-lane,
+  .bptt-backward-lane,
+  .bptt-audit-grid,
+  .bptt-local-gradients {
+    grid-template-columns: 1fr;
+  }
+
+  .bptt-equation {
+    grid-template-columns: 1fr;
+  }
+
+  .bptt-equation > span {
+    justify-self: center;
   }
 
   .phase-strip {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -3524,6 +3524,264 @@ code {
   color: #173f8a;
 }
 
+.attention-back-button {
+  border-color: rgba(109, 91, 208, 0.42);
+  background: rgba(109, 91, 208, 0.08);
+  color: #4f3da9;
+}
+
+.attention-back-button:hover {
+  border-color: rgba(109, 91, 208, 0.68);
+  background: rgba(109, 91, 208, 0.14);
+}
+
+.workspace--attention-softmax {
+  display: grid;
+  grid-template-columns: minmax(700px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.attention-softmax-stage,
+.attention-softmax-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.attention-softmax-intro,
+.attention-softmax-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.attention-softmax-intro,
+.attention-weight-panel,
+.attention-normalize-panel,
+.attention-value-mix-panel,
+.attention-softmax-controls {
+  @include surface;
+  padding: 16px;
+}
+
+.attention-softmax-intro p:last-child,
+.attention-softmax-heading p,
+.attention-softmax-controls > p {
+  margin: 7px 0 0;
+  color: $muted;
+}
+
+.attention-softmax-chip {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border: 1px solid rgba(109, 91, 208, 0.28);
+  border-radius: 999px;
+  background: rgba(109, 91, 208, 0.08);
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 750;
+}
+
+.attention-softmax-heading > code {
+  flex: 0 0 auto;
+  padding: 6px 9px;
+  border-radius: 6px;
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.attention-weight-grid {
+  display: grid;
+  grid-template-columns: minmax(78px, 0.7fr) repeat(3, minmax(105px, 1fr));
+  gap: 6px;
+  margin-top: 14px;
+}
+
+.attention-weight-row-button {
+  min-width: 0;
+  min-height: 68px;
+  border-color: transparent;
+  background: transparent;
+  color: $muted;
+}
+
+.attention-weight-row-button:hover,
+.attention-weight-row-button--active {
+  border-color: rgba(109, 91, 208, 0.4);
+  background: rgba(109, 91, 208, 0.08);
+  color: #4f3da9;
+}
+
+.attention-weight-cell {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  min-height: 68px;
+  overflow: hidden;
+  border: 1px solid rgba(37, 99, 235, 0.17);
+  border-radius: 7px;
+  background: rgba(37, 99, 235, 0.035);
+  color: #173f8a;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.attention-weight-cell span {
+  position: absolute;
+  inset: auto auto 0 0;
+  height: 6px;
+  background: rgba(37, 99, 235, 0.3);
+}
+
+.attention-weight-cell strong {
+  position: relative;
+  z-index: 1;
+}
+
+.attention-weight-cell--selected-row {
+  border-color: rgba(109, 91, 208, 0.5);
+  background: rgba(109, 91, 208, 0.08);
+  color: #4f3da9;
+}
+
+.attention-weight-cell--selected-row span {
+  background: rgba(109, 91, 208, 0.38);
+}
+
+.attention-weight-cell--blocked {
+  border-color: rgba(194, 65, 59, 0.16);
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(194, 65, 59, 0.025),
+      rgba(194, 65, 59, 0.025) 7px,
+      rgba(194, 65, 59, 0.075) 7px,
+      rgba(194, 65, 59, 0.075) 8px
+    );
+  color: #8f342f;
+  font-family: inherit;
+  font-size: 0.76rem;
+}
+
+.attention-normalize-panel,
+.attention-value-mix-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.attention-normalize-flow {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr) auto) minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+}
+
+.attention-normalize-flow > div {
+  display: grid;
+  gap: 4px;
+  min-height: 76px;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 7px;
+  background: #fbfcfa;
+}
+
+.attention-normalize-flow small,
+.attention-context-result small {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.attention-normalize-flow code {
+  color: #173f8a;
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.attention-normalize-flow > span {
+  color: $muted;
+  font-weight: 850;
+}
+
+.attention-normalize-flow__result {
+  border-color: rgba(109, 91, 208, 0.42) !important;
+  background: rgba(109, 91, 208, 0.07) !important;
+}
+
+.attention-normalize-flow__result code {
+  color: #4f3da9;
+  font-weight: 850;
+}
+
+.attention-context-result {
+  display: grid;
+  gap: 2px;
+  min-width: 150px;
+  padding: 8px 10px;
+  border-left: 3px solid rgba(109, 91, 208, 0.5);
+  background: rgba(109, 91, 208, 0.05);
+}
+
+.attention-context-result strong {
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.25rem;
+}
+
+.attention-value-lanes {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.attention-value-lane {
+  display: grid;
+  gap: 7px;
+  padding: 11px;
+  border: 1px solid rgba(37, 99, 235, 0.19);
+  border-radius: 7px;
+  background: rgba(37, 99, 235, 0.035);
+}
+
+.attention-value-lane > span {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-weight: 800;
+}
+
+.attention-value-lane code {
+  overflow-x: auto;
+  color: #173f8a;
+  white-space: nowrap;
+}
+
+.attention-value-lane--blocked {
+  opacity: 0.58;
+  border-color: $line;
+  background: #fbfcfa;
+}
+
+.attention-softmax-controls {
+  position: sticky;
+  top: 14px;
+}
+
+.attention-query-buttons {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.attention-query-buttons button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.62);
+  background: rgba(109, 91, 208, 0.13);
+  color: #4f3da9;
+}
+
 @media (max-width: 1180px) {
   .workspace--lab,
   .workspace--hidden {
@@ -3557,11 +3815,17 @@ code {
   .workspace--recurrent,
   .workspace--bptt,
   .workspace--gates,
-  .workspace--attention {
+  .workspace--attention,
+  .workspace--attention-softmax {
     grid-template-columns: 1fr;
   }
 
   .attention-controls {
+    position: static;
+    grid-column: 1 / -1;
+  }
+
+  .attention-softmax-controls {
     position: static;
     grid-column: 1 / -1;
   }
@@ -3598,7 +3862,8 @@ code {
   .workspace--recurrent,
   .workspace--bptt,
   .workspace--gates,
-  .workspace--attention {
+  .workspace--attention,
+  .workspace--attention-softmax {
     grid-template-columns: 1fr;
   }
 
@@ -3618,7 +3883,9 @@ code {
   .gate-intro,
   .gate-panel-heading,
   .attention-intro,
-  .attention-panel-heading {
+  .attention-panel-heading,
+  .attention-softmax-intro,
+  .attention-softmax-heading {
     display: grid;
     align-items: start;
   }
@@ -3792,6 +4059,27 @@ code {
   .attention-dot-equation {
     align-items: start;
     flex-direction: column;
+  }
+
+  .attention-weight-grid {
+    grid-template-columns: minmax(58px, 0.7fr) repeat(3, minmax(62px, 1fr));
+  }
+
+  .attention-weight-row-button,
+  .attention-weight-cell {
+    min-height: 58px;
+    padding: 4px;
+    font-size: 0.76rem;
+  }
+
+  .attention-normalize-flow,
+  .attention-value-lanes {
+    grid-template-columns: 1fr;
+  }
+
+  .attention-normalize-flow > span {
+    justify-self: center;
+    transform: rotate(90deg);
   }
 
   .gate-model-label {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -5006,6 +5006,337 @@ code {
   font-size: 1.7rem;
 }
 
+.workspace--gan {
+  display: grid;
+  grid-template-columns: minmax(700px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.gan-stage,
+.gan-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.gan-intro,
+.gan-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.gan-intro,
+.gan-sample-panel,
+.gan-objective-panel,
+.gan-gradient-panel,
+.gan-update-panel,
+.gan-controls {
+  @include surface;
+  padding: 16px;
+}
+
+.gan-intro p:last-child,
+.gan-heading p,
+.gan-controls > p {
+  margin: 7px 0 0;
+  color: $muted;
+}
+
+.gan-chip {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border: 1px solid rgba(35, 122, 87, 0.3);
+  border-radius: 999px;
+  background: rgba(35, 122, 87, 0.08);
+  color: #185a40;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 750;
+}
+
+.gan-sample-panel,
+.gan-objective-panel,
+.gan-gradient-panel,
+.gan-update-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.gan-heading > code {
+  flex: 0 1 390px;
+  padding: 6px 9px;
+  border-radius: 6px;
+  background: rgba(35, 122, 87, 0.07);
+  color: #185a40;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.gan-number-line {
+  position: relative;
+  min-height: 135px;
+  margin: 10px 22px 0;
+  border-bottom: 3px solid #334155;
+}
+
+.gan-number-line__axis {
+  position: absolute;
+  inset: auto 0 -25px;
+  display: flex;
+  justify-content: space-between;
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+}
+
+.gan-number-line__marker {
+  position: absolute;
+  bottom: 10px;
+  display: grid;
+  gap: 2px;
+  min-width: 95px;
+  padding: 8px;
+  border-radius: 6px;
+  transform: translateX(-50%);
+  text-align: center;
+}
+
+.gan-number-line__marker::after {
+  position: absolute;
+  bottom: -13px;
+  left: calc(50% - 5px);
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.gan-number-line__marker small {
+  color: $muted;
+}
+
+.gan-number-line__marker--fake {
+  bottom: 10px;
+  background: rgba(109, 91, 208, 0.09);
+  color: #4f3da9;
+}
+
+.gan-number-line__marker--real {
+  bottom: 70px;
+  background: rgba(35, 122, 87, 0.09);
+  color: #185a40;
+}
+
+.gan-number-line__marker--real::after {
+  bottom: -73px;
+  height: 70px;
+  border-radius: 0;
+  background: linear-gradient(currentColor, currentColor 2px, transparent 2px);
+}
+
+.gan-probability-grid,
+.gan-update-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.gan-probability-grid > div,
+.gan-player,
+.gan-gradient-route > div,
+.gan-update-grid > div,
+.gan-freeze-key {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: $paper;
+}
+
+.gan-probability-grid small,
+.gan-player small,
+.gan-gradient-route small,
+.gan-update-grid small,
+.gan-freeze-key small {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.gan-probability-grid code,
+.gan-player code,
+.gan-gradient-route code,
+.gan-update-grid code,
+.gan-freeze-key code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.gan-probability-grid strong,
+.gan-player strong,
+.gan-gradient-route strong,
+.gan-update-grid strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.gan-probability-grid strong {
+  color: #185a40;
+  font-size: 1.18rem;
+}
+
+.gan-objectives {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: stretch;
+}
+
+.gan-player {
+  border-left: 4px solid rgba(35, 122, 87, 0.38);
+}
+
+.gan-player--generator {
+  border-left-color: rgba(109, 91, 208, 0.42);
+}
+
+.gan-player--active {
+  border-color: rgba(35, 122, 87, 0.56);
+  background: rgba(35, 122, 87, 0.07);
+}
+
+.gan-player--active.gan-player--generator {
+  border-color: rgba(109, 91, 208, 0.56);
+  background: rgba(109, 91, 208, 0.08);
+}
+
+.gan-player span,
+.gan-gradient-route span,
+.gan-update-grid span,
+.gan-selected-summary span {
+  color: $muted;
+  font-size: 0.73rem;
+}
+
+.gan-versus,
+.gan-gradient-route > span {
+  align-self: center;
+  color: $muted;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.gan-gradient-placeholder {
+  padding: 18px;
+  border: 1px dashed rgba(109, 91, 208, 0.35);
+  border-radius: 6px;
+  background: rgba(109, 91, 208, 0.035);
+  color: $muted;
+  text-align: center;
+}
+
+.gan-gradient-route {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1.2fr);
+  gap: 8px;
+  align-items: stretch;
+}
+
+.gan-gradient-route__result {
+  border-color: rgba(35, 122, 87, 0.38) !important;
+  background: rgba(35, 122, 87, 0.06) !important;
+}
+
+.gan-gradient-route__result--generator {
+  border-color: rgba(109, 91, 208, 0.42) !important;
+  background: rgba(109, 91, 208, 0.07) !important;
+}
+
+.gan-update-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.gan-update-grid > div:first-child {
+  border-left: 4px solid rgba(35, 122, 87, 0.42);
+}
+
+.gan-update-grid > div:last-child {
+  border-left: 4px solid rgba(109, 91, 208, 0.45);
+}
+
+.gan-counterpush {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px;
+  border-left: 4px solid rgba(183, 121, 31, 0.5);
+  background: rgba(183, 121, 31, 0.07);
+}
+
+.gan-counterpush strong {
+  color: #81520d;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.gan-counterpush p {
+  margin: 0 0 0 auto;
+  color: $muted;
+}
+
+.gan-controls {
+  position: sticky;
+  top: 14px;
+}
+
+.gan-phase-buttons {
+  display: grid;
+  gap: 8px;
+}
+
+.gan-phase-buttons button {
+  display: grid;
+  gap: 2px;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.72);
+  text-align: left;
+}
+
+.gan-phase-buttons button span {
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+}
+
+.gan-phase-buttons button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.55);
+  background: rgba(109, 91, 208, 0.1);
+  color: #4f3da9;
+}
+
+.gan-selected-summary {
+  display: grid;
+  gap: 4px;
+  padding: 11px;
+  border-left: 3px solid rgba(109, 91, 208, 0.45);
+  background: rgba(109, 91, 208, 0.045);
+}
+
+.gan-selected-summary small {
+  color: $muted;
+}
+
+.gan-selected-summary strong {
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.15rem;
+}
+
 @media (max-width: 1360px) {
   .app-header,
   .header-actions {
@@ -5057,7 +5388,8 @@ code {
     .workspace--multi-head,
     .workspace--decoder,
     .workspace--autoencoder,
-    .workspace--variational {
+    .workspace--variational,
+    .workspace--gan {
     grid-template-columns: 1fr;
   }
 
@@ -5087,6 +5419,11 @@ code {
   }
 
   .variational-controls {
+    position: static;
+    grid-column: 1 / -1;
+  }
+
+  .gan-controls {
     position: static;
     grid-column: 1 / -1;
   }
@@ -5128,7 +5465,8 @@ code {
     .workspace--multi-head,
     .workspace--decoder,
     .workspace--autoencoder,
-    .workspace--variational {
+    .workspace--variational,
+    .workspace--gan {
     grid-template-columns: 1fr;
   }
 
@@ -5158,7 +5496,9 @@ code {
     .autoencoder-intro,
     .autoencoder-heading,
     .variational-intro,
-    .variational-heading {
+    .variational-heading,
+    .gan-intro,
+    .gan-heading {
     display: grid;
     align-items: start;
   }
@@ -5489,6 +5829,31 @@ code {
 
   .variational-audit-row strong,
   .variational-loss-drop p {
+    margin-left: 0;
+  }
+
+  .gan-chip {
+    justify-self: start;
+  }
+
+  .gan-probability-grid,
+  .gan-objectives,
+  .gan-gradient-route,
+  .gan-update-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gan-versus,
+  .gan-gradient-route > span {
+    justify-self: center;
+  }
+
+  .gan-counterpush {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .gan-counterpush p {
     margin-left: 0;
   }
 

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -4669,6 +4669,343 @@ code {
   top: 14px;
 }
 
+.representation-workbench {
+  display: grid;
+  gap: 12px;
+}
+
+.representation-lab-switch {
+  @include surface;
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+}
+
+.representation-lab-switch button,
+.variational-gradient-targets button,
+.variational-beta-buttons button {
+  padding: 8px 11px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.72);
+  font-weight: 800;
+}
+
+.representation-lab-switch button[aria-pressed="true"],
+.variational-gradient-targets button[aria-pressed="true"],
+.variational-beta-buttons button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.55);
+  background: rgba(109, 91, 208, 0.1);
+  color: #4f3da9;
+}
+
+.workspace--variational {
+  display: grid;
+  grid-template-columns: minmax(700px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.variational-stage,
+.variational-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.variational-intro,
+.variational-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.variational-intro,
+.variational-flow-panel,
+.variational-objective-panel,
+.variational-gradient-panel,
+.variational-update-panel,
+.variational-controls {
+  @include surface;
+  padding: 16px;
+}
+
+.variational-intro p:last-child,
+.variational-heading p,
+.variational-controls > p {
+  margin: 7px 0 0;
+  color: $muted;
+}
+
+.variational-chip {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border: 1px solid rgba(109, 91, 208, 0.3);
+  border-radius: 999px;
+  background: rgba(109, 91, 208, 0.09);
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 750;
+}
+
+.variational-flow-panel,
+.variational-objective-panel,
+.variational-gradient-panel,
+.variational-update-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.variational-heading > code {
+  flex: 0 0 auto;
+  padding: 6px 9px;
+  border-radius: 6px;
+  background: rgba(109, 91, 208, 0.09);
+  color: #4f3da9;
+}
+
+.variational-flow {
+  display: grid;
+  grid-template-columns: minmax(95px, 0.6fr) auto minmax(210px, 1.35fr) auto minmax(170px, 1fr) auto minmax(180px, 1fr);
+  gap: 8px;
+  align-items: stretch;
+}
+
+.variational-scalar-node,
+.variational-distribution-node,
+.variational-sample-node,
+.variational-objective-equation > div,
+.variational-gradient-routes > div,
+.variational-gradient-grid > div,
+.variational-parameter-grid > div {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: $paper;
+}
+
+.variational-scalar-node small,
+.variational-distribution-node small,
+.variational-sample-node small,
+.variational-objective-equation small,
+.variational-loss-badge small,
+.variational-gradient-routes small,
+.variational-gradient-grid small,
+.variational-parameter-grid small,
+.variational-loss-drop small {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.variational-scalar-node code,
+.variational-distribution-node code,
+.variational-sample-node code,
+.variational-objective-equation code,
+.variational-gradient-routes code,
+.variational-gradient-grid code,
+.variational-parameter-grid code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.variational-sample-node {
+  border-color: rgba(109, 91, 208, 0.34);
+  background: rgba(109, 91, 208, 0.055);
+}
+
+.variational-sample-node strong {
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.25rem;
+}
+
+.variational-sample-node span,
+.variational-objective-equation span,
+.variational-gradient-routes span {
+  color: $muted;
+  font-size: 0.73rem;
+}
+
+.variational-scalar-node--output {
+  border-color: rgba(35, 122, 87, 0.3);
+  background: rgba(35, 122, 87, 0.055);
+}
+
+.variational-scalar-node--output strong {
+  color: #185a40;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.variational-arrow {
+  align-self: center;
+  color: $muted;
+  font-weight: 850;
+}
+
+.variational-loss-badge {
+  display: grid;
+  gap: 2px;
+  min-width: 135px;
+  padding: 8px 10px;
+  border-left: 3px solid rgba(194, 65, 59, 0.5);
+  background: rgba(194, 65, 59, 0.05);
+}
+
+.variational-loss-badge strong {
+  color: #9f342f;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.18rem;
+}
+
+.variational-objective-equation {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) auto minmax(210px, 1.35fr) auto minmax(70px, 0.45fr) auto minmax(150px, 1fr);
+  gap: 8px;
+  align-items: stretch;
+}
+
+.variational-objective-equation > span,
+.variational-gradient-routes > span {
+  align-self: center;
+  color: $muted;
+  font-weight: 850;
+}
+
+.variational-objective-equation strong,
+.variational-gradient-routes strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.16rem;
+}
+
+.variational-beta-node {
+  place-items: center;
+  border-color: rgba(183, 121, 31, 0.32) !important;
+  background: rgba(183, 121, 31, 0.07) !important;
+  text-align: center;
+}
+
+.variational-beta-node strong {
+  color: #81520d;
+}
+
+.variational-total-node {
+  border-color: rgba(194, 65, 59, 0.28) !important;
+  background: rgba(194, 65, 59, 0.045) !important;
+}
+
+.variational-total-node strong {
+  color: #9f342f;
+}
+
+.variational-gradient-targets,
+.variational-beta-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.variational-gradient-routes {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) auto minmax(170px, 1fr) auto minmax(180px, 1.1fr);
+  gap: 8px;
+  align-items: stretch;
+}
+
+.variational-combined-gradient {
+  border-color: rgba(109, 91, 208, 0.38) !important;
+  background: rgba(109, 91, 208, 0.07) !important;
+}
+
+.variational-combined-gradient strong {
+  color: #4f3da9;
+}
+
+.variational-gradient-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.variational-parameter-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.variational-audit-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 11px;
+  border: 1px solid rgba(109, 91, 208, 0.24);
+  border-radius: 6px;
+  background: rgba(109, 91, 208, 0.045);
+}
+
+.variational-audit-row code {
+  color: $muted;
+}
+
+.variational-audit-row strong {
+  margin-left: auto;
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.variational-loss-drop {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px;
+  border-left: 4px solid rgba(35, 122, 87, 0.52);
+  background: rgba(35, 122, 87, 0.055);
+}
+
+.variational-loss-drop > div {
+  display: grid;
+  gap: 2px;
+}
+
+.variational-loss-drop strong {
+  color: #185a40;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.12rem;
+}
+
+.variational-loss-drop p {
+  margin: 0 0 0 auto;
+  color: $muted;
+}
+
+.variational-controls {
+  position: sticky;
+  top: 14px;
+}
+
+.variational-selected-summary {
+  display: grid;
+  gap: 4px;
+  padding: 11px;
+  border-left: 3px solid rgba(109, 91, 208, 0.45);
+  background: rgba(109, 91, 208, 0.045);
+}
+
+.variational-selected-summary small,
+.variational-selected-summary span {
+  color: $muted;
+}
+
+.variational-selected-summary strong {
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.7rem;
+}
+
 @media (max-width: 1360px) {
   .app-header,
   .header-actions {
@@ -4719,7 +5056,8 @@ code {
     .workspace--attention-softmax,
     .workspace--multi-head,
     .workspace--decoder,
-    .workspace--autoencoder {
+    .workspace--autoencoder,
+    .workspace--variational {
     grid-template-columns: 1fr;
   }
 
@@ -4744,6 +5082,11 @@ code {
   }
 
   .autoencoder-controls {
+    position: static;
+    grid-column: 1 / -1;
+  }
+
+  .variational-controls {
     position: static;
     grid-column: 1 / -1;
   }
@@ -4784,7 +5127,8 @@ code {
     .workspace--attention-softmax,
     .workspace--multi-head,
     .workspace--decoder,
-    .workspace--autoencoder {
+    .workspace--autoencoder,
+    .workspace--variational {
     grid-template-columns: 1fr;
   }
 
@@ -4812,7 +5156,9 @@ code {
     .decoder-intro,
     .decoder-heading,
     .autoencoder-intro,
-    .autoencoder-heading {
+    .autoencoder-heading,
+    .variational-intro,
+    .variational-heading {
     display: grid;
     align-items: start;
   }
@@ -5105,6 +5451,44 @@ code {
 
   .autoencoder-gradient-audit strong,
   .autoencoder-loss-drop p {
+    margin-left: 0;
+  }
+
+  .representation-lab-switch {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .variational-flow,
+  .variational-objective-equation,
+  .variational-gradient-routes,
+  .variational-gradient-grid,
+  .variational-parameter-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .variational-arrow {
+    justify-self: center;
+    transform: rotate(90deg);
+  }
+
+  .variational-objective-equation > span,
+  .variational-gradient-routes > span {
+    justify-self: center;
+  }
+
+  .variational-chip {
+    justify-self: start;
+  }
+
+  .variational-audit-row,
+  .variational-loss-drop {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .variational-audit-row strong,
+  .variational-loss-drop p {
     margin-left: 0;
   }
 

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -136,7 +136,7 @@ h2 {
 
 .mode-toggle {
   display: inline-grid;
-  grid-template-columns: repeat(8, 1fr);
+  grid-template-columns: repeat(9, 1fr);
   gap: 4px;
   padding: 4px;
   border: 1px solid $line;
@@ -3223,6 +3223,307 @@ code {
   color: $muted;
 }
 
+.workspace--attention {
+  display: grid;
+  grid-template-columns: minmax(700px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.attention-stage,
+.attention-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.attention-intro,
+.attention-panel-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.attention-intro {
+  @include surface;
+  padding: 18px;
+}
+
+.attention-intro p:last-child,
+.attention-panel-heading p,
+.attention-controls > p,
+.attention-value-boundary p,
+.attention-next-note p {
+  margin: 7px 0 0;
+  color: $muted;
+}
+
+.attention-sequence-chip {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border: 1px solid rgba(109, 91, 208, 0.28);
+  border-radius: 999px;
+  background: rgba(109, 91, 208, 0.08);
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 750;
+}
+
+.attention-projection-panel,
+.attention-score-panel,
+.attention-controls {
+  @include surface;
+  padding: 16px;
+}
+
+.attention-projection-table {
+  display: grid;
+  gap: 6px;
+  margin-top: 14px;
+}
+
+.attention-projection-head,
+.attention-projection-row {
+  display: grid;
+  grid-template-columns: 1.05fr repeat(3, 1fr);
+  gap: 7px;
+  align-items: stretch;
+}
+
+.attention-projection-head span {
+  padding: 0 10px;
+  color: $muted;
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.attention-projection-row > div {
+  display: grid;
+  align-content: center;
+  gap: 2px;
+  min-width: 0;
+  min-height: 70px;
+  padding: 9px 10px;
+  border: 1px solid $line;
+  border-radius: 7px;
+  background: #fbfcfa;
+}
+
+.attention-projection-row > div:first-child {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+}
+
+.attention-projection-row > div:first-child code {
+  grid-column: 2;
+}
+
+.attention-projection-row small,
+.attention-cell-trace small,
+.attention-selected-summary small {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.attention-projection-row code {
+  overflow-x: auto;
+  color: #173f8a;
+  white-space: nowrap;
+}
+
+.attention-token-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.attention-token-dot--red { background: $red; }
+.attention-token-dot--blue { background: $blue; }
+.attention-token-dot--purple { background: $violet; }
+
+.attention-score-panel {
+  display: grid;
+  gap: 15px;
+}
+
+.attention-panel-heading > code {
+  flex: 0 0 auto;
+  padding: 6px 9px;
+  border-radius: 6px;
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.attention-score-layout {
+  display: grid;
+  grid-template-columns: minmax(330px, 0.9fr) minmax(330px, 1.1fr);
+  gap: 14px;
+  align-items: stretch;
+}
+
+.attention-score-grid {
+  display: grid;
+  grid-template-columns: minmax(68px, 0.72fr) repeat(3, minmax(72px, 1fr));
+  gap: 5px;
+}
+
+.attention-grid-label,
+.attention-grid-corner {
+  display: grid;
+  place-items: center;
+  min-height: 38px;
+  color: $muted;
+  font-size: 0.76rem;
+  font-weight: 850;
+}
+
+.attention-grid-corner {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.attention-score-cell {
+  min-width: 0;
+  min-height: 70px;
+  border-color: rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.04);
+  color: #173f8a;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.2rem;
+}
+
+.attention-score-cell:hover,
+.attention-score-cell--active {
+  border-color: rgba(109, 91, 208, 0.68);
+  background: rgba(109, 91, 208, 0.13);
+  color: #4f3da9;
+}
+
+.attention-score-cell--active {
+  box-shadow: inset 0 0 0 2px rgba(109, 91, 208, 0.22);
+}
+
+.attention-cell-trace {
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  padding: 14px;
+  border-left: 4px solid rgba(109, 91, 208, 0.5);
+  border-radius: 6px;
+  background: rgba(109, 91, 208, 0.045);
+}
+
+.attention-cell-trace h3 {
+  margin: 0;
+}
+
+.attention-vector-pair {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.attention-vector-pair span {
+  display: grid;
+  gap: 2px;
+  padding: 8px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.attention-dot-equation {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 7px;
+  background: #17201c;
+  color: #ffffff;
+}
+
+.attention-dot-equation strong {
+  color: #b9e7cf;
+  font-size: 1.25rem;
+}
+
+.attention-products,
+.attention-scale-equation {
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.83rem;
+}
+
+.attention-scale-equation strong {
+  color: #4f3da9;
+}
+
+.attention-controls {
+  position: sticky;
+  top: 14px;
+}
+
+.attention-scale-control {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 11px;
+  border: 1px solid $line;
+  border-radius: 7px;
+  background: #fbfcfa;
+}
+
+.attention-scale-control input {
+  width: auto;
+  min-height: 0;
+  margin-top: 4px;
+  accent-color: $violet;
+}
+
+.attention-scale-control span,
+.attention-selected-summary,
+.attention-value-boundary,
+.attention-next-note {
+  display: grid;
+  gap: 4px;
+}
+
+.attention-scale-control small,
+.attention-selected-summary span {
+  color: $muted;
+}
+
+.attention-selected-summary {
+  padding: 12px;
+  border-left: 3px solid rgba(109, 91, 208, 0.5);
+  background: rgba(109, 91, 208, 0.05);
+}
+
+.attention-selected-summary strong {
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.7rem;
+}
+
+.attention-value-boundary,
+.attention-next-note {
+  padding-top: 12px;
+  border-top: 1px solid $line;
+}
+
+.attention-value-boundary > span,
+.attention-next-note > span {
+  font-weight: 850;
+}
+
+.attention-value-boundary code {
+  color: #173f8a;
+}
+
 @media (max-width: 1180px) {
   .workspace--lab,
   .workspace--hidden {
@@ -3255,8 +3556,14 @@ code {
   .workspace--residual,
   .workspace--recurrent,
   .workspace--bptt,
-  .workspace--gates {
+  .workspace--gates,
+  .workspace--attention {
     grid-template-columns: 1fr;
+  }
+
+  .attention-controls {
+    position: static;
+    grid-column: 1 / -1;
   }
 
   .gate-controls {
@@ -3290,7 +3597,8 @@ code {
   .workspace--residual,
   .workspace--recurrent,
   .workspace--bptt,
-  .workspace--gates {
+  .workspace--gates,
+  .workspace--attention {
     grid-template-columns: 1fr;
   }
 
@@ -3308,7 +3616,9 @@ code {
   .bptt-panel-heading,
   .bptt-arithmetic-heading,
   .gate-intro,
-  .gate-panel-heading {
+  .gate-panel-heading,
+  .attention-intro,
+  .attention-panel-heading {
     display: grid;
     align-items: start;
   }
@@ -3453,6 +3763,35 @@ code {
   .gate-flow,
   .gate-flow--lstm {
     grid-template-columns: 1fr;
+  }
+
+  .attention-projection-head {
+    display: none;
+  }
+
+  .attention-projection-row,
+  .attention-score-layout,
+  .attention-vector-pair {
+    grid-template-columns: 1fr;
+  }
+
+  .attention-projection-row > div:first-child {
+    grid-template-columns: auto 1fr;
+  }
+
+  .attention-score-grid {
+    grid-template-columns: minmax(54px, 0.7fr) repeat(3, minmax(60px, 1fr));
+  }
+
+  .attention-score-cell {
+    min-height: 58px;
+    padding: 4px;
+    font-size: 0.98rem;
+  }
+
+  .attention-dot-equation {
+    align-items: start;
+    flex-direction: column;
   }
 
   .gate-model-label {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -5337,6 +5337,319 @@ code {
   font-size: 1.15rem;
 }
 
+.workspace--diffusion {
+  display: grid;
+  grid-template-columns: minmax(700px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.diffusion-stage,
+.diffusion-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.diffusion-intro,
+.diffusion-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.diffusion-intro,
+.diffusion-forward-panel,
+.diffusion-predict-panel,
+.diffusion-gradient-panel,
+.diffusion-reverse-panel,
+.diffusion-controls {
+  @include surface;
+  padding: 16px;
+}
+
+.diffusion-intro p:last-child,
+.diffusion-heading p,
+.diffusion-controls > p {
+  margin: 7px 0 0;
+  color: $muted;
+}
+
+.diffusion-chip {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border: 1px solid rgba(43, 108, 176, 0.3);
+  border-radius: 999px;
+  background: rgba(43, 108, 176, 0.08);
+  color: #235d98;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 750;
+}
+
+.diffusion-forward-panel,
+.diffusion-predict-panel,
+.diffusion-gradient-panel,
+.diffusion-reverse-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.diffusion-heading > code {
+  flex: 0 1 350px;
+  padding: 6px 9px;
+  border-radius: 6px;
+  background: rgba(43, 108, 176, 0.07);
+  color: #235d98;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.diffusion-forward-lane {
+  display: grid;
+  grid-template-columns: minmax(130px, 0.7fr) repeat(2, minmax(230px, 1fr));
+  gap: 9px;
+  align-items: stretch;
+}
+
+.diffusion-forward-hop {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  align-items: stretch;
+}
+
+.diffusion-forward-hop > span,
+.diffusion-reverse-lane > span {
+  align-self: center;
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.diffusion-state,
+.diffusion-prediction-grid > div,
+.diffusion-gradient-rows > div,
+.diffusion-gradient-sum > div,
+.diffusion-update-row > div,
+.diffusion-reverse-step,
+.diffusion-final-state,
+.diffusion-coefficient-grid > div {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: $paper;
+}
+
+.diffusion-state small,
+.diffusion-prediction-grid small,
+.diffusion-gradient-rows small,
+.diffusion-gradient-sum small,
+.diffusion-update-row small,
+.diffusion-reverse-step small,
+.diffusion-final-state small,
+.diffusion-coefficient-grid small,
+.diffusion-loss-badge small {
+  color: $muted;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.diffusion-state code,
+.diffusion-prediction-grid code,
+.diffusion-gradient-rows code,
+.diffusion-update-row code,
+.diffusion-reverse-step code,
+.diffusion-coefficient-grid code,
+.diffusion-equation code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.diffusion-state strong,
+.diffusion-prediction-grid strong,
+.diffusion-gradient-sum strong,
+.diffusion-update-row strong,
+.diffusion-reverse-step strong,
+.diffusion-final-state strong,
+.diffusion-coefficient-grid strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.diffusion-state span,
+.diffusion-prediction-grid span,
+.diffusion-gradient-rows span,
+.diffusion-update-row span,
+.diffusion-reverse-step span,
+.diffusion-final-state span {
+  color: $muted;
+  font-size: 0.73rem;
+}
+
+.diffusion-state--noisy {
+  border-color: rgba(43, 108, 176, 0.26);
+  background: rgba(43, 108, 176, 0.045);
+}
+
+.diffusion-state--active,
+.diffusion-reverse-step--active {
+  border-color: rgba(43, 108, 176, 0.62);
+  box-shadow: inset 0 0 0 2px rgba(43, 108, 176, 0.09);
+  background: rgba(43, 108, 176, 0.09);
+}
+
+.diffusion-state--active strong,
+.diffusion-reverse-step--active strong {
+  color: #235d98;
+}
+
+.diffusion-coefficient-grid,
+.diffusion-prediction-grid,
+.diffusion-gradient-rows {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.diffusion-forward-note {
+  margin: 0;
+  padding: 9px 11px;
+  border-left: 3px solid rgba(183, 121, 31, 0.45);
+  background: rgba(183, 121, 31, 0.055);
+  color: $muted;
+}
+
+.diffusion-loss-badge {
+  display: grid;
+  gap: 2px;
+  min-width: 150px;
+  padding: 8px 10px;
+  border-left: 3px solid rgba(194, 65, 59, 0.5);
+  background: rgba(194, 65, 59, 0.05);
+}
+
+.diffusion-loss-badge strong {
+  color: #9f342f;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.18rem;
+}
+
+.diffusion-equation {
+  padding: 10px;
+  border: 1px dashed rgba(43, 108, 176, 0.35);
+  border-radius: 6px;
+  background: rgba(43, 108, 176, 0.035);
+  text-align: center;
+}
+
+.diffusion-prediction-grid > div {
+  border-left: 4px solid rgba(43, 108, 176, 0.38);
+}
+
+.diffusion-gradient-sum {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.diffusion-gradient-sum strong {
+  color: #4f3da9;
+  font-size: 1.15rem;
+}
+
+.diffusion-update-row {
+  display: grid;
+  grid-template-columns: 1.3fr 0.8fr 1fr;
+  gap: 8px;
+}
+
+.diffusion-loss-drop {
+  border-color: rgba(35, 122, 87, 0.35) !important;
+  background: rgba(35, 122, 87, 0.06) !important;
+}
+
+.diffusion-loss-drop strong {
+  color: #185a40;
+  font-size: 1.12rem;
+}
+
+.diffusion-reverse-lane {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.7fr) auto minmax(150px, 1fr) auto minmax(150px, 1fr) auto minmax(140px, 0.9fr);
+  gap: 8px;
+  align-items: stretch;
+}
+
+.diffusion-reverse-step {
+  border-color: rgba(109, 91, 208, 0.3);
+  background: rgba(109, 91, 208, 0.045);
+}
+
+.diffusion-final-state {
+  border-color: rgba(35, 122, 87, 0.38);
+  background: rgba(35, 122, 87, 0.06);
+}
+
+.diffusion-final-state strong {
+  color: #185a40;
+  font-size: 1.2rem;
+}
+
+.diffusion-controls {
+  position: sticky;
+  top: 14px;
+}
+
+.diffusion-phase-buttons {
+  display: grid;
+  gap: 7px;
+}
+
+.diffusion-phase-buttons button {
+  display: grid;
+  gap: 2px;
+  padding: 9px 10px;
+  border: 1px solid $line;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.72);
+  text-align: left;
+}
+
+.diffusion-phase-buttons button span {
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+}
+
+.diffusion-phase-buttons button[aria-pressed="true"] {
+  border-color: rgba(43, 108, 176, 0.58);
+  background: rgba(43, 108, 176, 0.1);
+  color: #235d98;
+}
+
+.diffusion-selected-summary {
+  display: grid;
+  gap: 4px;
+  padding: 11px;
+  border-left: 3px solid rgba(43, 108, 176, 0.48);
+  background: rgba(43, 108, 176, 0.05);
+}
+
+.diffusion-selected-summary small,
+.diffusion-selected-summary span {
+  color: $muted;
+}
+
+.diffusion-selected-summary strong {
+  color: #235d98;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.15rem;
+}
+
 @media (max-width: 1360px) {
   .app-header,
   .header-actions {
@@ -5389,7 +5702,8 @@ code {
     .workspace--decoder,
     .workspace--autoencoder,
     .workspace--variational,
-    .workspace--gan {
+    .workspace--gan,
+    .workspace--diffusion {
     grid-template-columns: 1fr;
   }
 
@@ -5424,6 +5738,11 @@ code {
   }
 
   .gan-controls {
+    position: static;
+    grid-column: 1 / -1;
+  }
+
+  .diffusion-controls {
     position: static;
     grid-column: 1 / -1;
   }
@@ -5466,7 +5785,8 @@ code {
     .workspace--decoder,
     .workspace--autoencoder,
     .workspace--variational,
-    .workspace--gan {
+    .workspace--gan,
+    .workspace--diffusion {
     grid-template-columns: 1fr;
   }
 
@@ -5498,7 +5818,9 @@ code {
     .variational-intro,
     .variational-heading,
     .gan-intro,
-    .gan-heading {
+    .gan-heading,
+    .diffusion-intro,
+    .diffusion-heading {
     display: grid;
     align-items: start;
   }
@@ -5855,6 +6177,26 @@ code {
 
   .gan-counterpush p {
     margin-left: 0;
+  }
+
+  .diffusion-chip {
+    justify-self: start;
+  }
+
+  .diffusion-forward-lane,
+  .diffusion-forward-hop,
+  .diffusion-coefficient-grid,
+  .diffusion-prediction-grid,
+  .diffusion-gradient-rows,
+  .diffusion-gradient-sum,
+  .diffusion-update-row,
+  .diffusion-reverse-lane {
+    grid-template-columns: 1fr;
+  }
+
+  .diffusion-forward-hop > span,
+  .diffusion-reverse-lane > span {
+    justify-self: center;
   }
 
   .gate-model-label {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -136,7 +136,7 @@ h2 {
 
 .mode-toggle {
   display: inline-grid;
-  grid-template-columns: repeat(7, 1fr);
+  grid-template-columns: repeat(8, 1fr);
   gap: 4px;
   padding: 4px;
   border: 1px solid $line;
@@ -2308,6 +2308,344 @@ code {
   text-transform: uppercase;
 }
 
+.workspace--recurrent {
+  display: grid;
+  grid-template-columns: minmax(760px, 1fr) 300px;
+  gap: 14px;
+  align-items: start;
+}
+
+.recurrent-stage,
+.recurrent-controls,
+.recurrent-unroll-panel,
+.memory-ablation-panel {
+  @include surface;
+}
+
+.recurrent-stage {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.recurrent-intro,
+.recurrent-panel-heading,
+.recurrent-arithmetic-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.recurrent-intro p:not(.eyebrow),
+.recurrent-controls > p,
+.recurrent-panel-heading > p,
+.recurrent-note p {
+  margin: 5px 0 0;
+  color: $muted;
+}
+
+.recurrent-sequence-chip {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(109, 91, 208, 0.11);
+  color: #4f3da9;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  font-weight: 850;
+}
+
+.recurrent-unroll-panel,
+.memory-ablation-panel {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.recurrent-final-state {
+  display: grid;
+  min-width: 90px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(35, 122, 87, 0.13);
+  color: $green;
+  text-align: center;
+}
+
+.recurrent-final-state small,
+.recurrent-initial-node small,
+.recurrent-cell small,
+.recurrent-equation small,
+.recurrent-selected-summary small {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.recurrent-final-state strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.35rem;
+}
+
+.shared-parameter-strip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  padding: 9px;
+  border: 1px solid rgba(109, 91, 208, 0.22);
+  border-radius: 8px;
+  background: rgba(109, 91, 208, 0.055);
+}
+
+.shared-parameter-strip span {
+  color: #4f3da9;
+  font-size: 0.7rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.shared-parameter-strip code {
+  min-height: 0;
+  padding: 4px 7px;
+}
+
+.recurrent-chain {
+  display: grid;
+  grid-template-columns: 94px 42px repeat(2, minmax(150px, 1fr) 42px) minmax(150px, 1fr);
+  align-items: center;
+  min-width: 0;
+}
+
+.recurrent-initial-node {
+  display: grid;
+  gap: 3px;
+  place-items: center;
+  min-height: 96px;
+  padding: 9px;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: rgba(35, 122, 87, 0.055);
+}
+
+.recurrent-initial-node code {
+  min-height: 0;
+  padding: 3px 8px;
+}
+
+.recurrent-connector {
+  display: grid;
+  place-items: center;
+  color: #4f3da9;
+}
+
+.recurrent-connector small {
+  color: $muted;
+  font-size: 0.62rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.recurrent-connector span {
+  font-size: 1.25rem;
+}
+
+.recurrent-connector--disabled {
+  filter: grayscale(1);
+  opacity: 0.42;
+}
+
+.recurrent-cell {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  min-height: 112px;
+  padding: 12px;
+  border: 1px solid $line;
+  border-radius: 8px;
+  background: #ffffff;
+  color: $ink;
+  text-align: left;
+}
+
+.recurrent-cell:hover {
+  border-color: rgba(37, 99, 235, 0.38);
+  background: #f7faff;
+}
+
+.recurrent-cell span {
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.76rem;
+}
+
+.recurrent-cell strong {
+  color: #173f8a;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1rem;
+}
+
+.recurrent-cell--active {
+  border-color: rgba(37, 99, 235, 0.62);
+  background: #edf4ff;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.14);
+}
+
+.recurrent-arithmetic {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border-block: 1px solid $line;
+}
+
+.recurrent-arithmetic-heading code {
+  min-height: 0;
+  padding: 4px 7px;
+}
+
+.recurrent-equation {
+  display: grid;
+  grid-template-columns: minmax(115px, 1fr) auto minmax(145px, 1.2fr) auto minmax(70px, 0.6fr) auto minmax(95px, 0.8fr) auto minmax(90px, 0.7fr);
+  align-items: center;
+  gap: 8px;
+}
+
+.recurrent-equation > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 9px;
+  border-radius: 7px;
+  background: rgba(109, 91, 208, 0.055);
+  text-align: center;
+}
+
+.recurrent-equation strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+}
+
+.recurrent-equation > span {
+  color: $muted;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 850;
+}
+
+.recurrent-equation .equation-term--disabled {
+  filter: grayscale(1);
+  opacity: 0.5;
+}
+
+.recurrent-equation .recurrent-equation__state {
+  background: #eaf7ef;
+  color: $green;
+}
+
+.recurrent-table-wrap {
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.recurrent-table {
+  width: 100%;
+  min-width: 580px;
+  border-collapse: collapse;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+}
+
+.recurrent-table caption {
+  padding-bottom: 7px;
+  color: $muted;
+  font-family: inherit;
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-align: left;
+}
+
+.recurrent-table th,
+.recurrent-table td {
+  padding: 9px;
+  border-bottom: 1px solid $line;
+  text-align: right;
+}
+
+.recurrent-table th:first-child {
+  text-align: left;
+}
+
+.recurrent-table thead th {
+  color: $muted;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.recurrent-table-row--active {
+  background: #edf4ff;
+  color: #173f8a;
+}
+
+.recurrent-controls {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+}
+
+.recurrent-memory-control {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  padding: 11px;
+  border: 1px solid rgba(109, 91, 208, 0.2);
+  border-radius: 8px;
+  background: rgba(109, 91, 208, 0.07);
+  cursor: pointer;
+}
+
+.recurrent-memory-control input {
+  width: 20px;
+  min-height: 20px;
+  accent-color: $violet;
+}
+
+.recurrent-memory-control span,
+.recurrent-selected-summary {
+  display: grid;
+  gap: 3px;
+}
+
+.recurrent-memory-control small,
+.recurrent-selected-summary span {
+  color: $muted;
+}
+
+.recurrent-selected-summary {
+  padding: 11px;
+  border-left: 3px solid rgba(37, 99, 235, 0.45);
+  background: rgba(37, 99, 235, 0.045);
+}
+
+.recurrent-selected-summary strong {
+  color: #173f8a;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.recurrent-note {
+  padding-top: 12px;
+  border-top: 1px solid $line;
+}
+
+.recurrent-note span {
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
 @media (max-width: 1180px) {
   .workspace--lab,
   .workspace--hidden {
@@ -2329,11 +2667,16 @@ code {
     grid-column: 1 / -1;
   }
 
+  .recurrent-controls {
+    grid-column: 1 / -1;
+  }
+
   .workspace--microscope,
   .workspace--optimization,
   .workspace--convolution,
   .workspace--image-cnn,
-  .workspace--residual {
+  .workspace--residual,
+  .workspace--recurrent {
     grid-template-columns: 1fr;
   }
 }
@@ -2359,9 +2702,10 @@ code {
   .workspace--hidden,
   .workspace--microscope,
   .workspace--optimization,
-    .workspace--convolution,
-    .workspace--image-cnn,
-    .workspace--residual {
+  .workspace--convolution,
+  .workspace--image-cnn,
+  .workspace--residual,
+  .workspace--recurrent {
     grid-template-columns: 1fr;
   }
 
@@ -2371,7 +2715,10 @@ code {
   .image-cnn-intro,
   .image-stage-heading,
   .residual-intro,
-  .residual-panel-heading {
+  .residual-panel-heading,
+  .recurrent-intro,
+  .recurrent-panel-heading,
+  .recurrent-arithmetic-heading {
     display: grid;
     align-items: start;
   }
@@ -2406,10 +2753,6 @@ code {
 
   .mode-toggle {
     grid-template-columns: repeat(2, 1fr);
-  }
-
-  .mode-button:last-child {
-    grid-column: 1 / -1;
   }
 
   .image-pipeline {
@@ -2465,6 +2808,40 @@ code {
   .receptive-summary code {
     overflow-x: auto;
     white-space: nowrap;
+  }
+
+  .shared-parameter-strip {
+    flex-wrap: wrap;
+  }
+
+  .recurrent-chain {
+    grid-template-columns: 1fr;
+    justify-items: stretch;
+  }
+
+  .recurrent-initial-node,
+  .recurrent-cell {
+    min-height: 0;
+  }
+
+  .recurrent-connector {
+    min-height: 38px;
+  }
+
+  .recurrent-connector span {
+    transform: rotate(90deg);
+  }
+
+  .recurrent-equation {
+    grid-template-columns: 1fr;
+  }
+
+  .recurrent-equation > span {
+    justify-self: center;
+  }
+
+  .recurrent-equation > span:last-of-type {
+    transform: rotate(90deg);
   }
 
   .phase-strip {

--- a/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
+++ b/code/programs/typescript/ml-learning-visualizer/src/styles/app.lattice
@@ -380,6 +380,335 @@ $violet: #6d5bd0;
   }
 }
 
+.workspace--message-passing {
+  grid-template-columns: minmax(0, 1fr) 286px;
+  align-items: start;
+  gap: 18px;
+}
+
+.message-stage {
+  min-width: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.message-intro,
+.message-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.message-intro h2,
+.message-heading h2,
+.message-controls h2 {
+  margin: 0;
+}
+
+.message-intro > div:first-child > p:last-child,
+.message-heading p,
+.message-controls > p,
+.message-sync-note {
+  color: $muted;
+  line-height: 1.55;
+}
+
+.message-chip {
+  flex: 0 0 auto;
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.08);
+  color: #234c9f;
+  padding: 8px 12px;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.message-graph-panel,
+.message-update-panel,
+.message-controls {
+  border: 1px solid $line;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 50px rgba(29, 45, 39, 0.08);
+}
+
+.message-graph-panel,
+.message-update-panel {
+  padding: 18px;
+}
+
+.message-heading > code {
+  flex: 0 0 auto;
+  border-radius: 8px;
+  background: rgba(37, 99, 235, 0.08);
+  color: #234c9f;
+  padding: 8px 10px;
+  font-size: 0.78rem;
+}
+
+.message-graph {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1fr;
+  align-items: center;
+  gap: 10px;
+  margin: 18px 0;
+}
+
+.message-node {
+  display: grid;
+  gap: 4px;
+  min-height: 104px;
+  border-radius: 50%;
+  background: rgba(35, 122, 87, 0.07);
+}
+
+.message-node small,
+.message-card small,
+.message-inbox small,
+.message-equation small,
+.message-selected-summary small {
+  color: $muted;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.message-node strong,
+.message-card strong,
+.message-inbox strong,
+.message-equation strong,
+.message-selected-summary strong {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 1.05rem;
+}
+
+.message-node span {
+  color: $muted;
+  font-size: 0.68rem;
+}
+
+.message-node--selected {
+  border-color: rgba(109, 91, 208, 0.55);
+  background: rgba(109, 91, 208, 0.11);
+  color: #4b3e9d;
+}
+
+.message-node:nth-child(1) {
+  grid-column: 1;
+}
+
+.message-node:nth-child(2) {
+  grid-column: 3;
+}
+
+.message-node:nth-child(3) {
+  grid-column: 5;
+}
+
+.message-edge {
+  color: #2563eb;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.message-edge--left {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.message-edge--right {
+  grid-column: 4;
+  grid-row: 1;
+}
+
+.message-ledger {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.message-card,
+.message-inbox > div,
+.message-equation > div {
+  display: grid;
+  gap: 5px;
+  border: 1px solid rgba(45, 55, 72, 0.12);
+  border-radius: 10px;
+  background: rgba(248, 249, 246, 0.86);
+  padding: 11px;
+}
+
+.message-card {
+  opacity: 0.55;
+}
+
+.message-card--active {
+  border-color: rgba(37, 99, 235, 0.34);
+  background: rgba(37, 99, 235, 0.08);
+  opacity: 1;
+}
+
+.message-card code,
+.message-equation code {
+  color: $muted;
+  font-size: 0.72rem;
+}
+
+.message-inbox {
+  display: grid;
+  grid-template-columns: 2fr auto 1fr;
+  align-items: center;
+  gap: 10px;
+  margin: 16px 0 10px;
+}
+
+.message-equation {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr) auto) minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: stretch;
+  gap: 7px;
+}
+
+.message-equation > span,
+.message-inbox > span {
+  align-self: center;
+  color: $muted;
+  font-weight: 800;
+}
+
+.message-output {
+  border-color: rgba(35, 122, 87, 0.28) !important;
+  background: rgba(35, 122, 87, 0.08) !important;
+}
+
+.message-sync-note {
+  margin: 12px 0 0;
+  border-radius: 9px;
+  background: rgba(183, 121, 31, 0.08);
+  padding: 10px;
+  font-size: 0.8rem;
+}
+
+.message-controls {
+  position: sticky;
+  top: 18px;
+  padding: 16px;
+}
+
+.message-controls > p:first-child {
+  margin: 0 0 4px;
+  color: #237a57;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.message-phase-buttons {
+  display: grid;
+  gap: 7px;
+  margin-top: 14px;
+}
+
+.message-phase-buttons button {
+  display: grid;
+  gap: 2px;
+  border: 1px solid $line;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.8);
+  color: $ink;
+  padding: 9px 10px;
+  text-align: left;
+}
+
+.message-phase-buttons button span {
+  color: $muted;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.message-phase-buttons button[aria-pressed="true"] {
+  border-color: rgba(109, 91, 208, 0.42);
+  background: rgba(109, 91, 208, 0.11);
+  color: #4b3e9d;
+}
+
+.message-selected-summary {
+  display: grid;
+  gap: 5px;
+  margin-top: 12px;
+  border-radius: 10px;
+  background: rgba(35, 122, 87, 0.08);
+  padding: 12px;
+}
+
+.message-selected-summary span,
+.message-selected-summary b {
+  color: $muted;
+  font-size: 0.75rem;
+}
+
+.message-selected-summary b {
+  color: #1d6849;
+}
+
+@media (max-width: 1180px) {
+  .workspace--message-passing {
+    grid-template-columns: 1fr;
+  }
+
+  .message-controls {
+    position: static;
+  }
+
+  .message-phase-buttons {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .message-intro,
+  .message-heading {
+    display: grid;
+  }
+
+  .message-chip,
+  .message-heading > code {
+    justify-self: start;
+  }
+
+  .message-graph,
+  .message-ledger,
+  .message-inbox,
+  .message-equation,
+  .message-phase-buttons {
+    grid-template-columns: 1fr;
+  }
+
+  .message-node {
+    grid-column: 1 !important;
+    min-height: 76px;
+    border-radius: 12px;
+  }
+
+  .message-edge,
+  .message-equation > span,
+  .message-inbox > span {
+    justify-self: center;
+  }
+
+  .message-edge {
+    grid-column: 1;
+    grid-row: auto;
+  }
+}
+
 :root {
   color-scheme: light;
 }

--- a/code/programs/typescript/ml-learning-visualizer/src/training-stabilizers-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training-stabilizers-lab.ts
@@ -1,0 +1,276 @@
+export type TrainingStabilizerRouteId = "plain" | "normalization" | "dropout" | "residual";
+
+export interface TrainingStabilizerRouteDefinition {
+  id: TrainingStabilizerRouteId;
+  label: string;
+  summary: string;
+}
+
+export interface TrainingNormalizationTrace {
+  mean: number;
+  centered: number[];
+  variance: number;
+  standardDeviation: number;
+  normalized: number[];
+  upstreamSum: number;
+  upstreamDotNormalized: number;
+}
+
+export interface TrainingDropoutTrace {
+  scaledMask: number[];
+  evaluationOutput: number[];
+  trainingExpectation: number[];
+}
+
+export interface TrainingStabilizerRouteTrace {
+  id: TrainingStabilizerRouteId;
+  output: number[];
+  score: number;
+  branchGradient: number[];
+  skipGradient: number[];
+  inputGradient: number[];
+  weightGradient: number;
+  finiteDifferenceInputGradient: number[];
+  finiteDifferenceWeightGradient: number;
+  inputGradientAbsoluteError: number[];
+  weightGradientAbsoluteError: number;
+}
+
+export interface TrainingStabilizerTrace {
+  input: number[];
+  branchWeight: number;
+  upstreamGradient: number[];
+  dropoutMask: number[];
+  keepProbability: number;
+  branch: number[];
+  normalization: TrainingNormalizationTrace;
+  dropout: TrainingDropoutTrace;
+  routes: TrainingStabilizerRouteTrace[];
+}
+
+export const TRAINING_STABILIZER_ROUTES: readonly TrainingStabilizerRouteDefinition[] = [
+  { id: "plain", label: "Plain branch", summary: "The learned branch is the control" },
+  { id: "normalization", label: "Layer normalization", summary: "Coordinates share mean and variance" },
+  { id: "dropout", label: "Inverted dropout", summary: "A pinned training mask drops and rescales" },
+  { id: "residual", label: "Identity residual", summary: "A short skip bypasses the learned branch" },
+];
+
+export const DEFAULT_STABILIZER_INPUT = [1, 1, 3, 3] as const;
+export const DEFAULT_STABILIZER_UPSTREAM = [1, 0, 0, -1] as const;
+export const DEFAULT_STABILIZER_DROPOUT_MASK = [1, 0, 1, 0] as const;
+
+function cleanZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+function dot(left: readonly number[], right: readonly number[]): number {
+  return cleanZero(left.reduce((sum, value, index) => sum + value * right[index]!, 0));
+}
+
+function normalize(
+  values: readonly number[],
+  upstream: readonly number[],
+  epsilon: number,
+): TrainingNormalizationTrace {
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const centered = values.map((value) => cleanZero(value - mean));
+  const variance = centered.reduce((sum, value) => sum + value ** 2, 0) / values.length;
+  const standardDeviation = Math.sqrt(variance + epsilon);
+  if (standardDeviation === 0) {
+    throw new Error("NN25 normalization variance must be positive.");
+  }
+  const normalized = centered.map((value) => cleanZero(value / standardDeviation));
+  return {
+    mean,
+    centered,
+    variance,
+    standardDeviation,
+    normalized,
+    upstreamSum: cleanZero(upstream.reduce((sum, value) => sum + value, 0)),
+    upstreamDotNormalized: dot(upstream, normalized),
+  };
+}
+
+function routeOutput(
+  routeId: TrainingStabilizerRouteId,
+  input: readonly number[],
+  branchWeight: number,
+  dropoutMask: readonly number[],
+  keepProbability: number,
+  normalizationEpsilon: number,
+): number[] {
+  const branch = input.map((value) => cleanZero(branchWeight * value));
+  if (routeId === "plain") return branch;
+  if (routeId === "normalization") {
+    return normalize(branch, [0, 0, 0, 0], normalizationEpsilon).normalized;
+  }
+  if (routeId === "dropout") {
+    return branch.map((value, index) => cleanZero(
+      value * dropoutMask[index]! / keepProbability,
+    ));
+  }
+  return branch.map((value, index) => cleanZero(value + input[index]!));
+}
+
+function traceRoute(
+  routeId: TrainingStabilizerRouteId,
+  input: readonly number[],
+  branchWeight: number,
+  upstream: readonly number[],
+  dropoutMask: readonly number[],
+  keepProbability: number,
+  normalizationEpsilon: number,
+  finiteDifferenceEpsilon: number,
+  normalization: TrainingNormalizationTrace,
+): TrainingStabilizerRouteTrace {
+  const output = routeOutput(
+    routeId,
+    input,
+    branchWeight,
+    dropoutMask,
+    keepProbability,
+    normalizationEpsilon,
+  );
+  let branchGradient: number[];
+  if (routeId === "normalization") {
+    const count = input.length;
+    const denominator = count * normalization.standardDeviation;
+    branchGradient = upstream.map((value, index) => cleanZero((
+      count * value
+      - normalization.upstreamSum
+      - normalization.normalized[index]! * normalization.upstreamDotNormalized
+    ) / denominator));
+  } else if (routeId === "dropout") {
+    branchGradient = upstream.map((value, index) => cleanZero(
+      value * dropoutMask[index]! / keepProbability,
+    ));
+  } else {
+    branchGradient = [...upstream];
+  }
+  const skipGradient = routeId === "residual" ? [...upstream] : input.map(() => 0);
+  const inputGradient = branchGradient.map((value, index) => cleanZero(
+    branchWeight * value + skipGradient[index]!,
+  ));
+  const weightGradient = dot(branchGradient, input);
+  const score = dot(upstream, output);
+  const finiteDifferenceInputGradient = input.map((_, coordinate) => {
+    const positive = [...input];
+    const negative = [...input];
+    positive[coordinate] = positive[coordinate]! + finiteDifferenceEpsilon;
+    negative[coordinate] = negative[coordinate]! - finiteDifferenceEpsilon;
+    const positiveScore = dot(upstream, routeOutput(
+      routeId,
+      positive,
+      branchWeight,
+      dropoutMask,
+      keepProbability,
+      normalizationEpsilon,
+    ));
+    const negativeScore = dot(upstream, routeOutput(
+      routeId,
+      negative,
+      branchWeight,
+      dropoutMask,
+      keepProbability,
+      normalizationEpsilon,
+    ));
+    return (positiveScore - negativeScore) / (2 * finiteDifferenceEpsilon);
+  });
+  const positiveWeightScore = dot(upstream, routeOutput(
+    routeId,
+    input,
+    branchWeight + finiteDifferenceEpsilon,
+    dropoutMask,
+    keepProbability,
+    normalizationEpsilon,
+  ));
+  const negativeWeightScore = dot(upstream, routeOutput(
+    routeId,
+    input,
+    branchWeight - finiteDifferenceEpsilon,
+    dropoutMask,
+    keepProbability,
+    normalizationEpsilon,
+  ));
+  const finiteDifferenceWeightGradient = (
+    positiveWeightScore - negativeWeightScore
+  ) / (2 * finiteDifferenceEpsilon);
+  return {
+    id: routeId,
+    output,
+    score,
+    branchGradient,
+    skipGradient,
+    inputGradient,
+    weightGradient,
+    finiteDifferenceInputGradient,
+    finiteDifferenceWeightGradient,
+    inputGradientAbsoluteError: inputGradient.map((value, index) => (
+      Math.abs(value - finiteDifferenceInputGradient[index]!)
+    )),
+    weightGradientAbsoluteError: Math.abs(
+      weightGradient - finiteDifferenceWeightGradient,
+    ),
+  };
+}
+
+export function traceTrainingStabilizers(
+  input: readonly number[] = DEFAULT_STABILIZER_INPUT,
+  branchWeight = 0.5,
+  upstreamGradient: readonly number[] = DEFAULT_STABILIZER_UPSTREAM,
+  dropoutMask: readonly number[] = DEFAULT_STABILIZER_DROPOUT_MASK,
+  keepProbability = 0.5,
+  normalizationEpsilon = 0,
+  finiteDifferenceEpsilon = 1e-6,
+): TrainingStabilizerTrace {
+  if (
+    input.length !== 4
+    || upstreamGradient.length !== 4
+    || dropoutMask.length !== 4
+    || !input.every(Number.isFinite)
+    || !upstreamGradient.every(Number.isFinite)
+    || !dropoutMask.every((value) => value === 0 || value === 1)
+    || !Number.isFinite(branchWeight)
+    || !Number.isFinite(keepProbability)
+    || keepProbability <= 0
+    || keepProbability > 1
+    || !Number.isFinite(normalizationEpsilon)
+    || normalizationEpsilon < 0
+    || !Number.isFinite(finiteDifferenceEpsilon)
+    || finiteDifferenceEpsilon <= 0
+  ) {
+    throw new Error(
+      "NN25 needs four finite coordinates, a binary mask, valid probability, and valid epsilon values.",
+    );
+  }
+  const branch = input.map((value) => cleanZero(branchWeight * value));
+  const normalization = normalize(branch, upstreamGradient, normalizationEpsilon);
+  const scaledMask = dropoutMask.map((value) => cleanZero(value / keepProbability));
+  const dropout: TrainingDropoutTrace = {
+    scaledMask,
+    evaluationOutput: [...branch],
+    trainingExpectation: [...branch],
+  };
+  const routes = TRAINING_STABILIZER_ROUTES.map((route) => traceRoute(
+    route.id,
+    input,
+    branchWeight,
+    upstreamGradient,
+    dropoutMask,
+    keepProbability,
+    normalizationEpsilon,
+    finiteDifferenceEpsilon,
+    normalization,
+  ));
+  return {
+    input: [...input],
+    branchWeight,
+    upstreamGradient: [...upstreamGradient],
+    dropoutMask: [...dropoutMask],
+    keepProbability,
+    branch,
+    normalization,
+    dropout,
+    routes,
+  };
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -4,6 +4,8 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { transpileLatticeInBrowser } from "@coding-adventures/lattice-transpiler/src/browser.js";
 import { activate } from "./activation.js";
 import { AttentionWorkbench } from "./AttentionWorkbench.js";
+import { AutoencoderWorkbench } from "./AutoencoderWorkbench.js";
+import { traceTwoNumberAutoencoder } from "./autoencoder-lab.js";
 import {
   decoderTrainingRow,
   traceTinyDecoderTraining,
@@ -925,5 +927,74 @@ describe("tiny decoder-only language model training lab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Return to multi-head block" }));
     expect(screen.getByRole("heading", { name: "Multi-head add-and-norm block" })).toBeTruthy();
+  });
+});
+
+describe("two-number autoencoder bottleneck lab", () => {
+  it("keeps the autoencoder workbench in the generated production stylesheet", () => {
+    const css = transpileLatticeInBrowser(latticeSource);
+
+    expect(css).toContain(".workspace--autoencoder");
+    expect(css).toContain(".autoencoder-bottleneck");
+  });
+
+  it("compresses two values and reconstructs both from one scalar", () => {
+    const trace = traceTwoNumberAutoencoder();
+
+    expect(trace.forward.encoderProducts).toEqual([1, 0.25]);
+    expect(trace.forward.bottleneck).toBe(1.25);
+    expect(trace.forward.decoderProducts).toEqual([1.5, -1]);
+    expect(trace.forward.reconstruction).toEqual([1.6, -1.2]);
+    expect(trace.forward.loss).toBeCloseTo(0.1);
+  });
+
+  it("adds both decoder routes into the bottleneck gradient", () => {
+    const trace = traceTwoNumberAutoencoder();
+
+    expect(trace.backward.bottleneckGradientContributions).toEqual([
+      -0.47999999999999987,
+      0.15999999999999998,
+    ]);
+    expect(trace.backward.bottleneckGradient).toBeCloseTo(-0.32);
+    expect(trace.backward.encoderWeightGradients).toEqual([
+      -0.6399999999999998,
+      0.3199999999999999,
+    ]);
+  });
+
+  it("audits every parameter and lowers reconstruction loss", () => {
+    const trace = traceTwoNumberAutoencoder();
+
+    expect(trace.gradientCheck.parameterOrder).toHaveLength(7);
+    expect(trace.gradientCheck.maxAbsoluteError).toBeLessThan(1e-8);
+    expect(trace.updatedParameters.encoder.weights).toEqual([0.564, -0.282]);
+    expect(trace.postUpdate.bottleneck).toBeCloseTo(1.442);
+    expect(trace.postUpdate.reconstruction).toEqual([1.9425, -1.29755]);
+    expect(trace.postUpdate.loss).toBeCloseTo(0.04592112625);
+    expect(trace.postUpdate.loss).toBeLessThan(trace.forward.loss);
+  });
+
+  it("selects either decoder branch and reruns the updated model", () => {
+    render(React.createElement(AutoencoderWorkbench));
+
+    expect(screen.getByRole("heading", { name: "Two numbers through one bottleneck" })).toBeTruthy();
+    expect(screen.getByLabelText("Autoencoder encode and decode path").textContent)
+      .toMatch(/x02.*x1-1.*-1 x -0\.25 = 0\.25.*bottleneck z1\.25.*x_hat01\.6.*x_hat1-1\.2/s);
+    expect(screen.getByLabelText("Selected autoencoder reconstruction 0").textContent)
+      .toMatch(/1\.25.*1\.2.*0\.1.*1\.6.*2.*-0\.4.*squared 0\.16/s);
+    expect(screen.getByLabelText("Autoencoder bottleneck gradient trace").textContent)
+      .toMatch(/-0\.4 x 1\.2.*-0\.48.*-0\.2 x -0\.8.*0\.16.*bottleneck gradient-0\.32/s);
+    expect(screen.getByLabelText("Autoencoder SGD update and gradient audit").textContent)
+      .toMatch(/7 parameters.*max error 2\.032e-11.*loss before0\.1.*loss after0\.04592113/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "output 1" }));
+    expect(screen.getByLabelText("Selected autoencoder reconstruction 1").textContent)
+      .toContain("error / loss gradient-0.2");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Use updated parameters/ }));
+    expect(screen.getByLabelText("Autoencoder encode and decode path").textContent)
+      .toMatch(/after one SGD step.*bottleneck z1\.442.*x_hat01\.9425.*x_hat1-1\.29755/s);
+    expect(screen.getByLabelText("Selected autoencoder reconstruction 1").textContent)
+      .toContain("error / loss gradient-0.29755");
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -14,6 +14,8 @@ import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { traceOneDimensionalDiffusion } from "./diffusion-lab.js";
 import { traceOneDimensionalGan } from "./gan-lab.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
+import { GraphNeighborhoodWorkbench } from "./GraphNeighborhoodWorkbench.js";
+import { traceGraphNeighborhoodComparison } from "./graph-neighborhood-lab.js";
 import { HopfieldWorkbench } from "./HopfieldWorkbench.js";
 import { traceHopfieldRecall } from "./hopfield-memory.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
@@ -1411,5 +1413,43 @@ describe("tiny graph message passing", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /node 2 0\.25 new feature/ }));
     expect(screen.getByLabelText("Selected graph node update").textContent).toMatch(/Selected node 2.*incoming messages1.*sum aggregate1.*self route0\.25 x -1.*-0\.25.*preactivation.*0\.25.*new feature.*0\.25/s);
+  });
+});
+
+describe("graph convolution and attention", () => {
+  it("keeps the graph comparison in the production stylesheet", () => {
+    expect(productionCss).toContain(".workspace--graph-neighborhood");
+    expect(productionCss).toContain(".graph-softmax-summary");
+  });
+
+  it("computes degree-normalized GCN contributions", () => {
+    const trace = traceGraphNeighborhoodComparison();
+    expect(trace.degrees).toEqual([2, 3, 2]);
+    expect(trace.gcn[1]!.rows.map((row) => row.coefficient)).toEqual([1 / Math.sqrt(6), 1 / 3, 1 / Math.sqrt(6)]);
+    expect(trace.gcnOutputs[0]).toBeCloseTo(1.3164965809277263);
+    expect(trace.gcnOutputs[1]).toBeCloseTo(2 / 3);
+    expect(trace.gcnOutputs[2]).toBeCloseTo(0.31649658092772615);
+  });
+
+  it("computes stable normalized graph attention", () => {
+    const trace = traceGraphNeighborhoodComparison();
+    expect(trace.gat[1]!.rows.map((row) => row.shiftedScore)).toEqual([-1, 0, -3]);
+    expect(trace.gat[1]!.rows.reduce((sum, row) => sum + row.attentionWeight, 0)).toBeCloseTo(1);
+    expect(trace.gatOutputs).toEqual([1.7310585786300048, 1.6351464587795619, 1.8577223804673]);
+  });
+
+  it("rejects neighborhoods without self-loops or symmetry", () => {
+    expect(() => traceGraphNeighborhoodComparison([1, 2], [[1], [0, 1]])).toThrow(/self-loops/);
+    expect(() => traceGraphNeighborhoodComparison([1, 2], [[0], [0, 1]])).toThrow(/symmetric/);
+  });
+
+  it("switches targets and weighting rules without changing the graph", () => {
+    render(React.createElement(GraphNeighborhoodWorkbench));
+    expect(screen.getByRole("heading", { name: "Compare graph convolution with graph attention" })).toBeTruthy();
+    expect(screen.getByLabelText("Graph convolution calculation").textContent).toMatch(/source 0.*1 \/ sqrt\(3 x 2\).*0\.408248.*source 1.*0\.333333.*source 2.*-0\.408248.*ReLU -> 0\.666667/s);
+    fireEvent.click(screen.getByRole("button", { name: /Graph attention/ }));
+    expect(screen.getByLabelText("Graph attention calculation").textContent).toMatch(/row max = 2.*denominator = 1\.417667.*weights sum = 1.*score 1 - max 2 = -1.*alpha = 0\.259496.*score -1 - max 2 = -3.*alpha = 0\.035119.*ReLU -> 1\.635146/s);
+    fireEvent.click(screen.getByRole("button", { name: /node 2.*degree 2/ }));
+    expect(screen.getByLabelText("Graph attention calculation").textContent).toMatch(/denominator = 1\.049787.*alpha = 0\.952574.*alpha = 0\.047426.*ReLU -> 1\.857722/s);
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -40,8 +40,13 @@ import {
 } from "./training-microscope.js";
 import {
   DEFAULT_CONVOLUTION_KERNEL,
+  DEFAULT_CONVOLUTION_LEARNING_RATE,
   DEFAULT_CONVOLUTION_SIGNAL,
+  DEFAULT_CONVOLUTION_TARGETS,
+  numericalKernelGradient,
   parseNumberList,
+  proposeConvolutionStep,
+  traceConvolutionTraining,
   traceValidCorrelation,
 } from "./convolution-lab.js";
 
@@ -219,6 +224,63 @@ describe("training helpers", () => {
       target: { value: "2, -1, 1" },
     });
     expect(screen.getByRole("button", { name: "Select output 1" }).textContent).toContain("-1");
+  });
+
+  it("accumulates a shared kernel gradient from every output window", () => {
+    const trace = traceConvolutionTraining(
+      DEFAULT_CONVOLUTION_SIGNAL,
+      DEFAULT_CONVOLUTION_KERNEL,
+      DEFAULT_CONVOLUTION_TARGETS,
+    );
+
+    expect(trace.loss).toBeCloseTo(0.5);
+    expect(trace.errors).toEqual([1, 0, 1, 0]);
+    expect(trace.outputGradients).toEqual([0.5, 0, 0.5, 0]);
+    expect(trace.contributions[0]!.kernelGradient).toEqual([1, 0.5, 1.5]);
+    expect(trace.contributions[2]!.kernelGradient).toEqual([1.5, 0, 2]);
+    expect(trace.kernelGradient).toEqual([2.5, 0.5, 3.5]);
+  });
+
+  it("matches the convolution backward pass with finite differences", () => {
+    const trace = traceConvolutionTraining(
+      DEFAULT_CONVOLUTION_SIGNAL,
+      DEFAULT_CONVOLUTION_KERNEL,
+      DEFAULT_CONVOLUTION_TARGETS,
+    );
+    const numerical = numericalKernelGradient(
+      DEFAULT_CONVOLUTION_SIGNAL,
+      DEFAULT_CONVOLUTION_KERNEL,
+      DEFAULT_CONVOLUTION_TARGETS,
+    );
+
+    for (const [index, gradient] of trace.kernelGradient.entries()) {
+      expect(numerical[index]).toBeCloseTo(gradient, 8);
+    }
+  });
+
+  it("proposes a kernel update that lowers convolution loss", () => {
+    const proposal = proposeConvolutionStep(
+      DEFAULT_CONVOLUTION_SIGNAL,
+      DEFAULT_CONVOLUTION_KERNEL,
+      DEFAULT_CONVOLUTION_TARGETS,
+      DEFAULT_CONVOLUTION_LEARNING_RATE,
+    );
+
+    expect(proposal.nextKernel).toEqual([0.95, -1.01, 1.93]);
+    expect(proposal.nextOutputs).toEqual([6.68, -2.08, 10.57, -0.18000000000000016]);
+    expect(proposal.nextLoss).toBeCloseTo(0.206525);
+  });
+
+  it("applies one shared-kernel gradient step in the workbench", () => {
+    render(React.createElement(ConvolutionWorkbench));
+
+    expect(screen.getByRole("heading", { name: "Shared weights collect gradients" })).toBeTruthy();
+    expect(screen.getByText("PASS")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Apply gradient step" }));
+
+    expect((screen.getByLabelText("Kernel weights") as HTMLInputElement).value)
+      .toBe("0.95, -1.01, 1.93");
+    expect(screen.getByText("step 1")).toBeTruthy();
   });
 
   it("registers the hidden-layer teaching examples without sine yet", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -3,6 +3,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { activate } from "./activation.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
+import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import { forwardLayered } from "./layered-network.js";
 import {
@@ -23,6 +24,15 @@ import {
 } from "./hidden-layer-examples.js";
 import { predictLayeredWithVm, predictLinearWithVm } from "./neural-vm.js";
 import { renderHiddenNetworkSvg, renderLinearNetworkSvg } from "./NetworkDiagram.js";
+import {
+  DEFAULT_OPTIMIZATION_STATE,
+  OPTIMIZATION_DATASET,
+  analyticalGradient,
+  batchIndices,
+  checkGradient,
+  meanSquaredError,
+  runOptimization,
+} from "./optimization-lab.js";
 import {
   DEFAULT_MICROSCOPE_STATE,
   traceTrainingStep,
@@ -129,6 +139,45 @@ describe("training helpers", () => {
     expect(screen.getByText("update 1")).toBeTruthy();
   });
 
+  it("matches backpropagation with a central finite-difference gradient", () => {
+    const check = checkGradient(OPTIMIZATION_DATASET, DEFAULT_OPTIMIZATION_STATE, 1e-5);
+
+    expect(check.analytical.weight).toBeCloseTo(-8.5);
+    expect(check.analytical.bias).toBeCloseTo(-4.5);
+    expect(check.numerical.weight).toBeCloseTo(check.analytical.weight, 8);
+    expect(check.numerical.bias).toBeCloseTo(check.analytical.bias, 8);
+    expect(check.passes).toBe(true);
+  });
+
+  it("selects deterministic rows for stochastic, mini-batch, and full-batch training", () => {
+    expect(batchIndices("stochastic", 5, 4)).toEqual([1]);
+    expect(batchIndices("mini-batch", 0, 4)).toEqual([0, 1]);
+    expect(batchIndices("mini-batch", 1, 4)).toEqual([2, 3]);
+    expect(batchIndices("full-batch", 99, 4)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("reduces full-dataset loss with every deterministic batch strategy", () => {
+    const before = meanSquaredError(OPTIMIZATION_DATASET, DEFAULT_OPTIMIZATION_STATE);
+
+    for (const strategy of ["stochastic", "mini-batch", "full-batch"] as const) {
+      const trace = runOptimization(strategy, 20, 0.05);
+      expect(trace[trace.length - 1]!.loss).toBeLessThan(before);
+    }
+  });
+
+  it("renders the optimization microscope and its independent gradient audit", () => {
+    render(React.createElement(OptimizationWorkbench));
+
+    expect(screen.getByRole("heading", { name: "Optimization microscope" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Loss landscape" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Finite-difference gradient check" })).toBeTruthy();
+    expect(screen.getByText("PASS")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Optimization weight"), { target: { value: "1" } });
+    const gradient = analyticalGradient(OPTIMIZATION_DATASET, { weight: 1, bias: 0, step: 0 });
+    expect(screen.getAllByText(formatTestNumber(gradient.weight)).length).toBeGreaterThan(0);
+  });
+
   it("registers the hidden-layer teaching examples without sine yet", () => {
     expect(HIDDEN_LAYER_EXAMPLES.map((example) => example.id)).toEqual([
       "xnor",
@@ -231,3 +280,7 @@ describe("training helpers", () => {
     }
   });
 });
+
+function formatTestNumber(value: number): string {
+  return Number(value.toFixed(5)).toString();
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -6,6 +6,7 @@ import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
+import { ResidualWorkbench } from "./ResidualWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import { forwardLayered } from "./layered-network.js";
 import {
@@ -55,6 +56,11 @@ import {
   DEFAULT_IMAGE_FILTERS,
   traceTinyImageCnn,
 } from "./image-cnn-lab.js";
+import {
+  DEFAULT_RESIDUAL_INPUT,
+  sameCorrelation,
+  traceResidualBlock,
+} from "./residual-field-lab.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -343,6 +349,45 @@ describe("training helpers", () => {
       "from [1,1]",
       "from [0,0]",
     ]);
+  });
+
+  it("runs the two local layers and identity path by hand", () => {
+    const block = traceResidualBlock();
+
+    expect(sameCorrelation(DEFAULT_RESIDUAL_INPUT, [1, 1, 1])).toEqual([1, 3, 2, 3, 1]);
+    expect(block.main).toEqual([4, 6, 8, 6, 4]);
+    expect(block.skip).toEqual([1, 0, 2, 0, 1]);
+    expect(block.output).toEqual([5, 6, 10, 6, 5]);
+  });
+
+  it("expands center and boundary receptive fields into exact input paths", () => {
+    const block = traceResidualBlock();
+    const center = block.traces[2]!;
+
+    expect(center.hiddenIndices).toEqual([1, 2, 3]);
+    expect(center.inputPathCounts).toEqual([1, 2, 3, 2, 1]);
+    expect(center.inputContributions).toEqual([1, 0, 6, 0, 1]);
+    expect(center.receptiveFieldIndices).toEqual([0, 1, 2, 3, 4]);
+    expect(block.traces[0]!.receptiveFieldIndices).toEqual([0, 1, 2]);
+    expect(block.traces[4]!.receptiveFieldIndices).toEqual([2, 3, 4]);
+  });
+
+  it("opens residual and receptive-field paths interactively", () => {
+    render(React.createElement(ResidualWorkbench));
+
+    expect(screen.getByRole("heading", { name: "Residual-path microscope" })).toBeTruthy();
+    expect(screen.getByLabelText("Selected residual addition").textContent)
+      .toMatch(/8.*\+.*2.*=.*10.*10/s);
+    expect(screen.getByLabelText("Receptive field explorer").textContent)
+      .toContain("receptive input indices = [0, 1, 2, 3, 4]");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Include identity skip/ }));
+    expect(screen.getByLabelText("Selected residual addition").textContent)
+      .toMatch(/8.*\+.*0.*=.*8.*8/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select residual output 0" }));
+    expect(screen.getByLabelText("Receptive field explorer").textContent)
+      .toContain("receptive input indices = [0, 1, 2]");
   });
 
   it("registers the hidden-layer teaching examples without sine yet", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -11,6 +11,7 @@ import {
   traceTinyDecoderTraining,
 } from "./decoder-language-model-lab.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
+import { traceOneDimensionalGan } from "./gan-lab.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
@@ -1078,5 +1079,96 @@ describe("scalar variational autoencoder lab", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /Use updated parameters/ }));
     expect(screen.getByLabelText("Variational encode sample and decode path").textContent)
       .toMatch(/after one SGD step.*mean = 0\.4 \+ 0 = 0\.4.*log var = 0\.0025 \+ 0\.0025 = 0\.005.*z = 0\.90125156.*x_hat = 0\.91936283/s);
+  });
+});
+
+describe("one-dimensional GAN game", () => {
+  it("keeps the adversarial workbench in the generated production stylesheet", () => {
+    const css = transpileLatticeInBrowser(latticeSource);
+
+    expect(css).toContain(".workspace--gan");
+    expect(css).toContain(".gan-number-line__marker--fake");
+  });
+
+  it("scores one real and one generated point before either player moves", () => {
+    const trace = traceOneDimensionalGan();
+
+    expect(trace.initial.fakeSample).toBeCloseTo(0.2);
+    expect(trace.initial.realProbability).toBeCloseTo(0.7310585786300049);
+    expect(trace.initial.fakeProbability).toBeCloseTo(0.549833997312478);
+    expect(trace.initial.discriminatorLoss).toBeCloseTo(0.5557002784499074);
+    expect(trace.initial.generatorLoss).toBeCloseTo(0.5981388693815918);
+  });
+
+  it("detaches the fake and lowers only the discriminator objective", () => {
+    const trace = traceOneDimensionalGan();
+
+    expect(trace.discriminatorStep.backward.fakeSampleGradient).toBe(0);
+    expect(trace.discriminatorStep.backward.weightGradient)
+      .toBeCloseTo(-0.07948731095374975);
+    expect(trace.discriminatorStep.backward.biasGradient)
+      .toBeCloseTo(0.14044628797124142);
+    expect(trace.discriminatorStep.updatedParameters.weight)
+      .toBeCloseTo(1.0397436554768749);
+    expect(trace.discriminatorStep.updatedParameters.bias)
+      .toBeCloseTo(-0.07022314398562071);
+    expect(trace.discriminatorStep.state.discriminatorLoss)
+      .toBeLessThan(trace.initial.discriminatorLoss);
+  });
+
+  it("freezes the updated critic and sends its input slope into the generator", () => {
+    const trace = traceOneDimensionalGan();
+
+    expect(trace.generatorStep.backward.fakeSampleGradient)
+      .toBeCloseTo(-0.48412848285494775);
+    expect(trace.generatorStep.updatedParameters.weight)
+      .toBeCloseTo(0.32103212071373693);
+    expect(trace.generatorStep.updatedParameters.bias)
+      .toBeCloseTo(0.12103212071373694);
+    expect(trace.generatorStep.state.fakeSample).toBeCloseTo(0.44206424142747386);
+    expect(trace.generatorStep.state.generatorLoss)
+      .toBeLessThan(trace.discriminatorStep.state.generatorLoss);
+    expect(trace.generatorStep.state.discriminatorLoss)
+      .toBeGreaterThan(trace.discriminatorStep.state.discriminatorLoss);
+  });
+
+  it("audits each player against its own fixed-opponent objective", () => {
+    const trace = traceOneDimensionalGan();
+
+    expect(trace.discriminatorStep.gradientCheck.parameterOrder)
+      .toEqual(["discriminator.weight", "discriminator.bias"]);
+    expect(trace.generatorStep.gradientCheck.parameterOrder)
+      .toEqual(["generator.weight", "generator.bias"]);
+    expect(trace.discriminatorStep.gradientCheck.maxAbsoluteError)
+      .toBeLessThan(1e-8);
+    expect(trace.generatorStep.gradientCheck.maxAbsoluteError)
+      .toBeLessThan(1e-8);
+  });
+
+  it("switches from the forward pass through both alternating moves", () => {
+    render(React.createElement(RepresentationWorkbench));
+    fireEvent.click(screen.getByRole("button", { name: "Adversarial game" }));
+
+    expect(screen.getByRole("heading", {
+      name: "A generator and discriminator on one number line",
+    })).toBeTruthy();
+    expect(screen.getByLabelText("GAN samples and discriminator probabilities").textContent)
+      .toMatch(/neither has moved.*fake 0\.2.*real 1.*0\.73105858.*0\.549834/s);
+    expect(screen.getByLabelText("GAN competing objectives").textContent)
+      .toMatch(/D loss 0\.55570028.*G loss 0\.59813887/s);
+
+    fireEvent.click(screen.getByRole("button", { name: /Discriminator moves/ }));
+    expect(screen.getByLabelText("GAN active gradient route").textContent)
+      .toMatch(/generated value is detached.*-0\.13447071.*0\.274917.*-0\.07948731 \/ 0\.14044629.*gradient into fake = 0/s);
+    expect(screen.getByLabelText("GAN competing objectives").textContent)
+      .toContain("D loss 0.54296489");
+
+    fireEvent.click(screen.getByRole("button", { name: /Generator responds/ }));
+    expect(screen.getByLabelText("GAN samples and discriminator probabilities").textContent)
+      .toMatch(/updated discriminator is frozen.*fake 0\.44206424.*0\.59614074/s);
+    expect(screen.getByLabelText("GAN active gradient route").textContent)
+      .toMatch(/critic becomes a teaching signal.*-0\.46562293.*-0\.48412848.*D parameters stay frozen/s);
+    expect(screen.getByLabelText("GAN competing objectives").textContent)
+      .toMatch(/D loss 0\.61411974.*G loss 0\.51727849/s);
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -17,6 +17,8 @@ import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { HopfieldWorkbench } from "./HopfieldWorkbench.js";
 import { traceHopfieldRecall } from "./hopfield-memory.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
+import { MessagePassingWorkbench } from "./MessagePassingWorkbench.js";
+import { traceTinyMessagePassing } from "./message-passing-lab.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
 import { RepresentationWorkbench } from "./RepresentationWorkbench.js";
@@ -1367,5 +1369,47 @@ describe("Hopfield associative memory", () => {
       .toMatch(/update 0\[\+1, -1, \+1, -1\].*update 3\[\+1, -1, \+1, -1\].*Hopfield energy-1\.5/s);
     expect(screen.getByLabelText("Hopfield phase controls").textContent)
       .toMatch(/fixed point recovered/);
+  });
+});
+
+describe("tiny graph message passing", () => {
+  it("keeps the message-passing workbench in the production stylesheet", () => {
+    expect(productionCss).toContain(".workspace--message-passing");
+    expect(productionCss).toContain(".message-ledger");
+  });
+
+  it("expands two undirected edges into four sorted directed messages", () => {
+    const trace = traceTinyMessagePassing();
+    expect(trace.directedMessages.map((row) => [row.source, row.target])).toEqual([[1, 0], [0, 1], [2, 1], [1, 2]]);
+    expect(trace.directedMessages.map((row) => row.message)).toEqual([1, 0.5, -0.5, 1]);
+  });
+
+  it("sums each inbox and applies one shared update", () => {
+    const trace = traceTinyMessagePassing();
+    expect(trace.nodeUpdates.map((row) => row.aggregate)).toEqual([1, 0, 1]);
+    expect(trace.nodeUpdates.map((row) => row.selfContribution)).toEqual([0.25, 0.5, -0.25]);
+    expect(trace.nodeUpdates.map((row) => row.preactivation)).toEqual([0.75, 0, 0.25]);
+    expect(trace.outputFeatures).toEqual([0.75, 0, 0.25]);
+  });
+
+  it("rejects invalid and duplicate undirected edges", () => {
+    expect(() => traceTinyMessagePassing([1, 2], [{ source: 0, target: 0 }])).toThrow(/non-self/);
+    expect(() => traceTinyMessagePassing([1, 2], [{ source: 0, target: 1 }, { source: 1, target: 0 }])).toThrow(/unique/);
+  });
+
+  it("reveals messages, the selected inbox, and final outputs", () => {
+    render(React.createElement(MessagePassingWorkbench));
+    expect(screen.getByRole("heading", { name: "Pass scalar messages across a three-node path" })).toBeTruthy();
+    expect(screen.getByLabelText("Tiny graph and directed messages").textContent).toMatch(/old feature.*1 -> 0.*0 -> 1.*2 -> 1.*1 -> 2/s);
+
+    fireEvent.click(screen.getByRole("button", { name: /Messages/ }));
+    expect(screen.getByLabelText("Tiny graph and directed messages").textContent).toMatch(/1 -> 0.*0\.5 x 2.*1.*0 -> 1.*0\.5/s);
+    fireEvent.click(screen.getByRole("button", { name: /Aggregate/ }));
+    expect(screen.getByLabelText("Selected graph node update").textContent).toMatch(/Selected node 1.*0\.5 \+ -0\.5.*sum aggregate0.*self route0\.25 x 2.*0\.5.*preactivation.*0/s);
+    fireEvent.click(screen.getByRole("button", { name: /Update/ }));
+    expect(screen.getByLabelText("Selected graph node update").textContent).toMatch(/new feature.*0.*original features.*\[1, 2, -1\]/s);
+
+    fireEvent.click(screen.getByRole("button", { name: /node 2 0\.25 new feature/ }));
+    expect(screen.getByLabelText("Selected graph node update").textContent).toMatch(/Selected node 2.*incoming messages1.*sum aggregate1.*self route0\.25 x -1.*-0\.25.*preactivation.*0\.25.*new feature.*0\.25/s);
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -78,6 +78,10 @@ import {
   attentionCell,
   traceAttentionQkv,
 } from "./attention-qkv-lab.js";
+import {
+  attentionSoftmaxRow,
+  traceAttentionSoftmax,
+} from "./attention-softmax-lab.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -705,5 +709,70 @@ describe("attention query-key-value lab", () => {
     expect(screen.getByLabelText("Selected dot-product arithmetic").textContent)
       .toMatch(/2 \/ sqrt\(2\) = 1\.414214/s);
     expect(screen.getByLabelText("Scaled attention scores").textContent).toContain("1.414214");
+  });
+});
+
+describe("attention softmax and causal mask lab", () => {
+  it("normalizes every causal row while zeroing future keys", () => {
+    const trace = traceAttentionSoftmax(true);
+
+    expect(trace.weightMatrix[0]).toEqual([1, 0, 0]);
+    expect(trace.weightMatrix[1]).toEqual([0.5, 0.5, 0]);
+    expect(trace.rows[0]!.maskedScores).toEqual([
+      1 / Math.sqrt(2),
+      null,
+      null,
+    ]);
+    for (const row of trace.rows) {
+      expect(row.weights.reduce((sum, weight) => sum + weight, 0)).toBeCloseTo(1);
+    }
+  });
+
+  it("mixes values into the expected causal contexts", () => {
+    const trace = traceAttentionSoftmax(true);
+
+    expect(attentionSoftmaxRow(trace, "red").context).toEqual([2, 0]);
+    expect(attentionSoftmaxRow(trace, "blue").valueContributions).toEqual([
+      [1, 0],
+      [0, 0.5],
+      [0, 0],
+    ]);
+    expect(attentionSoftmaxRow(trace, "blue").context).toEqual([1, 0.5]);
+    expect(attentionSoftmaxRow(trace, "purple").context[0]).toBeCloseTo(1.7832330964304126);
+  });
+
+  it("subtracts the row maximum before exponentiating large scores", () => {
+    const trace = traceAttentionSoftmax(
+      false,
+      [[1000, 999, 998], [0, 0, 0], [0, 0, 0]],
+    );
+    const row = trace.rows[0]!;
+
+    expect(row.shiftedScores).toEqual([0, -1, -2]);
+    expect(row.exponentials.every(Number.isFinite)).toBe(true);
+    expect(row.weights.reduce((sum, weight) => sum + weight, 0)).toBeCloseTo(1);
+  });
+
+  it("switches between causal and full-context value mixing interactively", () => {
+    render(React.createElement(AttentionWorkbench));
+    fireEvent.click(screen.getByRole("button", { name: "Apply softmax and causal mask" }));
+
+    expect(screen.getByRole("heading", { name: "Causal-softmax mixer" })).toBeTruthy();
+    expect(screen.getByLabelText("Causal attention weight matrix").textContent)
+      .toMatch(/red q.*1.*blocked.*blocked.*blue q.*0\.5.*0\.5.*blocked/s);
+    expect(screen.getByLabelText("Selected softmax row trace").textContent)
+      .toMatch(/0\.707107.*0\.707107.*1\.414214.*0\.707107.*0\.707107.*blocked.*\[1, 1, 0\].*\[0\.5, 0\.5, 0\]/s);
+    expect(screen.getByLabelText("Selected weighted value mix").textContent)
+      .toMatch(/0\.5 × \[2, 0\].*= \[1, 0\].*0\.5 × \[0, 1\].*= \[0, 0\.5\].*0 × \[2, 1\].*= \[0, 0\]/s);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Block future keys/ }));
+    expect(screen.getByRole("heading", { name: "Unmasked attention weights" })).toBeTruthy();
+    expect(screen.getByLabelText("Selected softmax row trace").textContent)
+      .toContain("[0.248255, 0.248255, 0.50349]");
+    expect(screen.getByLabelText("Selected weighted value mix").textContent)
+      .toContain("[1.50349, 0.751745]");
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to Q/K/V scores" }));
+    expect(screen.getByRole("heading", { name: "Query-key score microscope" })).toBeTruthy();
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { activate } from "./activation.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
+import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import { forwardLayered } from "./layered-network.js";
@@ -49,6 +50,11 @@ import {
   traceConvolutionTraining,
   traceValidCorrelation,
 } from "./convolution-lab.js";
+import {
+  DEFAULT_IMAGE_CHANNELS,
+  DEFAULT_IMAGE_FILTERS,
+  traceTinyImageCnn,
+} from "./image-cnn-lab.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -281,6 +287,62 @@ describe("training helpers", () => {
     expect((screen.getByLabelText("Kernel weights") as HTMLInputElement).value)
       .toBe("0.95, -1.01, 1.93");
     expect(screen.getByText("step 1")).toBeTruthy();
+  });
+
+  it("reduces two image channels into two convolution maps", () => {
+    const trace = traceTinyImageCnn(DEFAULT_IMAGE_CHANNELS, DEFAULT_IMAGE_FILTERS);
+
+    expect(trace.channelContributions[0]).toEqual([
+      [[0, 0], [4, 4]],
+      [[0, 2], [0, 2]],
+    ]);
+    expect(trace.convolution).toEqual([
+      [[0, 2], [4, 6]],
+      [[6, 4], [2, 0]],
+    ]);
+    expect(trace.positions[0]![1]![1]!.channelSums).toEqual([4, 2]);
+  });
+
+  it("normalizes each CNN output channel over its spatial map", () => {
+    const trace = traceTinyImageCnn();
+
+    expect(trace.normalization.means).toEqual([3, 3]);
+    expect(trace.normalization.variances).toEqual([5, 5]);
+    expect(trace.normalization.denominators).toEqual([3, 3]);
+    expect(trace.normalization.maps[0]![0]![1]).toBeCloseTo(-1 / 3);
+    expect(trace.normalization.maps[1]![1]![0]).toBeCloseTo(-1 / 3);
+  });
+
+  it("tracks ReLU and max-pool winners for each feature channel", () => {
+    const trace = traceTinyImageCnn();
+
+    expect(trace.activation).toEqual([
+      [[0, 0], [1 / 3, 1]],
+      [[1, 1 / 3], [0, 0]],
+    ]);
+    expect(trace.pooling).toEqual({ values: [1, 1], argmax: [[1, 1], [0, 0]] });
+  });
+
+  it("steps through an inspectable tiny image CNN pipeline", () => {
+    render(React.createElement(ImageCnnWorkbench));
+
+    expect(screen.getByRole("heading", { name: "Open the image pipeline" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "One image can have several number grids" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show Convolve stage" }));
+    expect(screen.getByRole("heading", { name: "Correlate each channel, then add" })).toBeTruthy();
+    expect(screen.getByLabelText("Channel reduction equation").textContent)
+      .toMatch(/channel 0.*4.*channel 1.*2.*bias.*0.*output.*6/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show Normalize stage" }));
+    expect(screen.getByText("mean μ").parentElement?.textContent).toContain("3");
+    expect(screen.getByText("denominator").parentElement?.textContent).toContain("3");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show Pool stage" }));
+    expect(screen.getAllByText(/from \[/).map((item) => item.textContent)).toEqual([
+      "from [1,1]",
+      "from [0,0]",
+    ]);
   });
 
   it("registers the hidden-layer teaching examples without sine yet", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -14,6 +14,8 @@ import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { traceOneDimensionalDiffusion } from "./diffusion-lab.js";
 import { traceOneDimensionalGan } from "./gan-lab.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
+import { HopfieldWorkbench } from "./HopfieldWorkbench.js";
+import { traceHopfieldRecall } from "./hopfield-memory.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
@@ -1277,5 +1279,93 @@ describe("one-dimensional diffusion round trip", () => {
     fireEvent.click(screen.getByRole("button", { name: /Denoise step 1/ }));
     expect(screen.getByLabelText("Diffusion deterministic reverse mean path").textContent)
       .toMatch(/reverse t = 2.*mean1 = 0\.5984375.*reverse t = 1.*mean0 = 1\.04513184.*absolute error 0\.04513184/s);
+  });
+});
+
+describe("Hopfield associative memory", () => {
+  it("keeps the Hopfield workbench in the generated production stylesheet", () => {
+    const css = productionCss;
+
+    expect(css).toContain(".workspace--hopfield");
+    expect(css).toContain(".hopfield-recall-lane");
+  });
+
+  it("stores one bipolar pattern in symmetric zero-diagonal weights", () => {
+    const trace = traceHopfieldRecall();
+
+    expect(trace.weights).toEqual([
+      [0, -0.25, 0.25, -0.25],
+      [-0.25, 0, -0.25, 0.25],
+      [0.25, -0.25, 0, -0.25],
+      [-0.25, 0.25, -0.25, 0],
+    ]);
+    expect(trace.normalization).toBe(4);
+  });
+
+  it("starts one bit away at half overlap and zero energy", () => {
+    const trace = traceHopfieldRecall();
+
+    expect(trace.initialHammingDistance).toBe(1);
+    expect(trace.initialOverlap).toBeCloseTo(0.5);
+    expect(trace.initialEnergy).toBeCloseTo(0);
+  });
+
+  it("repairs the flipped bit with three positive incoming votes", () => {
+    const first = traceHopfieldRecall().updates[0]!;
+
+    expect(first.incoming.map((row) => row.contribution)).toEqual([0, 0.25, 0.25, 0.25]);
+    expect(first.localField).toBeCloseTo(0.75);
+    expect(first.previousState).toBe(-1);
+    expect(first.nextState).toBe(1);
+    expect(first.stateAfter).toEqual([1, -1, 1, -1]);
+  });
+
+  it("descends in energy and finishes at the saved fixed point", () => {
+    const trace = traceHopfieldRecall();
+
+    expect(trace.updates.map((row) => [row.energyBefore, row.energyAfter])).toEqual([
+      [0, -1.5],
+      [-1.5, -1.5],
+      [-1.5, -1.5],
+      [-1.5, -1.5],
+    ]);
+    expect(trace.updates.map((row) => row.changed)).toEqual([true, false, false, false]);
+    expect(trace.finalState).toEqual([1, -1, 1, -1]);
+    expect(trace.finalOverlap).toBeCloseTo(1);
+    expect(trace.finalHammingDistance).toBe(0);
+    expect(trace.converged).toBe(true);
+  });
+
+  it("rejects non-bipolar states and malformed update orders", () => {
+    expect(() => traceHopfieldRecall([1, 0, 1, -1])).toThrow(/bipolar/);
+    expect(() => traceHopfieldRecall(
+      [1, -1, 1, -1],
+      [-1, -1, 1, -1],
+      [0, 1, 1, 3],
+    )).toThrow(/permutation/);
+  });
+
+  it("walks through storage, cue repair, and the stable sweep", () => {
+    render(React.createElement(HopfieldWorkbench));
+
+    expect(screen.getByRole("heading", {
+      name: "Restore one flipped bit with four connected neurons",
+    })).toBeTruthy();
+    expect(screen.getByLabelText("Hopfield Hebbian storage rule").textContent)
+      .toMatch(/\[\+1, -1, \+1, -1\].*divide by 4.*from 0.*-0\.25.*0\.25/s);
+
+    fireEvent.click(screen.getByRole("button", { name: /One flipped bit/ }));
+    expect(screen.getByLabelText("Hopfield asynchronous recall trace").textContent)
+      .toMatch(/damaged cue\[-1, -1, \+1, -1\].*distance 1.*normalized overlap0\.5.*Hopfield energy0/s);
+
+    fireEvent.click(screen.getByRole("button", { name: /Update neuron 0/ }));
+    expect(screen.getByLabelText("Hopfield active neuron calculation").textContent)
+      .toMatch(/active neuron0.*-0\.25 x -1 = 0\.25.*local field -> next state0\.75 -> \+1.*energy before -> after0 -> -1\.5.*overlap before -> after0\.5 -> 1/s);
+
+    fireEvent.click(screen.getByRole("button", { name: /Update neuron 3/ }));
+    expect(screen.getByLabelText("Hopfield asynchronous recall trace").textContent)
+      .toMatch(/update 0\[\+1, -1, \+1, -1\].*update 3\[\+1, -1, \+1, -1\].*Hopfield energy-1\.5/s);
+    expect(screen.getByLabelText("Hopfield phase controls").textContent)
+      .toMatch(/fixed point recovered/);
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { transpileLatticeInBrowser } from "@coding-adventures/lattice-transpiler/src/browser.js";
 import { activate } from "./activation.js";
 import { AttentionWorkbench } from "./AttentionWorkbench.js";
@@ -31,6 +31,8 @@ import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
 import { RepresentationWorkbench } from "./RepresentationWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
+import { TrainingStabilizersWorkbench } from "./TrainingStabilizersWorkbench.js";
+import { traceTrainingStabilizers } from "./training-stabilizers-lab.js";
 import latticeSource from "./styles/app.lattice?raw";
 import { forwardLayered } from "./layered-network.js";
 import {
@@ -1570,5 +1572,76 @@ describe("vanishing and exploding gradients", () => {
     render(React.createElement(GradientFlowWorkbench));
     fireEvent.click(screen.getByRole("button", { name: /layer 1.*upstream 0\.006587/ }));
     expect(screen.getByLabelText("Selected gradient calculation").textContent).toMatch(/0\.006587 x 0\.786448 = 0\.00518.*0\.00518 x 0\.5 = 0\.00259/s);
+  });
+});
+
+describe("normalization dropout and residual comparisons", () => {
+  it("keeps the stabilizer comparison in the production stylesheet", () => {
+    expect(productionCss).toContain(".workspace--stabilizers");
+    expect(productionCss).toContain(".stabilizer-equations");
+  });
+
+  it("pins the shared branch and exact layer-normalization statistics", () => {
+    const trace = traceTrainingStabilizers();
+    expect(trace.branch).toEqual([0.5, 0.5, 1.5, 1.5]);
+    expect(trace.normalization.mean).toBe(1);
+    expect(trace.normalization.variance).toBe(0.25);
+    expect(trace.normalization.standardDeviation).toBe(0.5);
+    expect(trace.normalization.normalized).toEqual([-1, -1, 1, 1]);
+    expect(trace.normalization.upstreamDotNormalized).toBe(-2);
+  });
+
+  it("separates the four mechanisms in forward and reverse mode", () => {
+    const routes = Object.fromEntries(
+      traceTrainingStabilizers().routes.map((route) => [route.id, route]),
+    );
+    expect(routes.plain!.inputGradient).toEqual([0.5, 0, 0, -0.5]);
+    expect(routes.normalization!.branchGradient).toEqual([1, -1, 1, -1]);
+    expect(routes.normalization!.weightGradient).toBe(0);
+    expect(routes.dropout!.output).toEqual([1, 0, 3, 0]);
+    expect(routes.dropout!.inputGradient).toEqual([1, 0, 0, 0]);
+    expect(routes.residual!.skipGradient).toEqual([1, 0, 0, -1]);
+    expect(routes.residual!.inputGradient).toEqual([1.5, 0, 0, -1.5]);
+  });
+
+  it("keeps inverted-dropout expectation equal to evaluation output", () => {
+    const dropout = traceTrainingStabilizers().dropout;
+    expect(dropout.scaledMask).toEqual([2, 0, 2, 0]);
+    expect(dropout.evaluationOutput).toEqual([0.5, 0.5, 1.5, 1.5]);
+    expect(dropout.trainingExpectation).toEqual(dropout.evaluationOutput);
+  });
+
+  it("checks every analytical input and weight gradient numerically", () => {
+    traceTrainingStabilizers().routes.forEach((route) => {
+      expect(Math.max(...route.inputGradientAbsoluteError)).toBeLessThan(1e-8);
+      expect(route.weightGradientAbsoluteError).toBeLessThan(1e-8);
+    });
+  });
+
+  it("rejects malformed vectors masks probabilities and zero variance", () => {
+    expect(() => traceTrainingStabilizers([1, 2])).toThrow(/four finite/);
+    expect(() => traceTrainingStabilizers([1, 1, 3, 3], 0.5, [1, 0, 0, -1], [1, 2, 1, 0])).toThrow(/binary mask/);
+    expect(() => traceTrainingStabilizers([1, 1, 3, 3], 0.5, [1, 0, 0, -1], [1, 0, 1, 0], 0)).toThrow(/probability/);
+    expect(() => traceTrainingStabilizers([1, 1, 1, 1])).toThrow(/variance/);
+  });
+
+  it("switches deep-training routes and opens coupled coordinate arithmetic", () => {
+    render(React.createElement(DeepTrainingWorkbench));
+    fireEvent.click(screen.getByRole("button", { name: "Stabilizers" }));
+    expect(screen.getByRole("heading", { name: "Normalization, dropout, and residual paths" })).toBeTruthy();
+    const comparison = screen.getByLabelText("Training stabilizer route comparison");
+    fireEvent.click(within(comparison).getByRole("button", { name: /Layer normalization/ }));
+    expect(screen.getByLabelText("Selected stabilizer forward trace").textContent).toMatch(/mean1.*variance.*0\.25.*standard deviation0\.5.*normalized output.*-1.*-1.*1.*1/s);
+    fireEvent.click(screen.getByRole("button", { name: "Open stabilizer coordinate 2" }));
+    expect(screen.getByLabelText("Selected stabilizer coordinate calculation").textContent).toMatch(/4 × 0 - 0 - -1 × -2.*= -1.*0\.5 × -1 \+ 0 = -0\.5/s);
+    fireEvent.click(within(comparison).getByRole("button", { name: /Inverted dropout/ }));
+    expect(screen.getByLabelText("Selected stabilizer forward trace").textContent).toMatch(/binary mask.*1.*0.*1.*0.*evaluation.*0\.5.*0\.5.*1\.5.*1\.5.*expectation/s);
+    fireEvent.click(within(comparison).getByRole("button", { name: /Identity residual/ }));
+    expect(screen.getByLabelText("Selected stabilizer backward trace").textContent).toMatch(/through identity skip.*1.*0.*0.*-1.*total dS\/dinput.*1\.5.*0.*0.*-1\.5/s);
+  });
+
+  it("renders the stabilizer workbench directly", () => {
+    render(React.createElement(TrainingStabilizersWorkbench));
+    expect(screen.getByLabelText("Training stabilizer finite difference audit").textContent).toMatch(/0\.5.*0\.5.*6\.989e-11.*-2.*-2.*5\.351e-11/s);
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -98,6 +98,8 @@ import {
   traceMultiHeadAttention,
 } from "./multi-head-attention-lab.js";
 
+const productionCss = transpileLatticeInBrowser(latticeSource);
+
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
     const initial: ModelState = { weight: 0.5, bias: 0.5, epoch: 0 };
@@ -856,7 +858,7 @@ describe("multi-head attention add-and-norm lab", () => {
 
 describe("tiny decoder-only language model training lab", () => {
   it("keeps the decoder workbench in the generated production stylesheet", () => {
-    const css = transpileLatticeInBrowser(latticeSource);
+    const css = productionCss;
 
     expect(css).toContain(".workspace--decoder");
     expect(css).toContain(".decoder-forward-flow");
@@ -935,7 +937,7 @@ describe("tiny decoder-only language model training lab", () => {
 
 describe("two-number autoencoder bottleneck lab", () => {
   it("keeps the autoencoder workbench in the generated production stylesheet", () => {
-    const css = transpileLatticeInBrowser(latticeSource);
+    const css = productionCss;
 
     expect(css).toContain(".workspace--autoencoder");
     expect(css).toContain(".autoencoder-bottleneck");
@@ -1004,7 +1006,7 @@ describe("two-number autoencoder bottleneck lab", () => {
 
 describe("scalar variational autoencoder lab", () => {
   it("keeps the variational workbench in the generated production stylesheet", () => {
-    const css = transpileLatticeInBrowser(latticeSource);
+    const css = productionCss;
 
     expect(css).toContain(".workspace--variational");
     expect(css).toContain(".variational-sample-node");
@@ -1084,7 +1086,7 @@ describe("scalar variational autoencoder lab", () => {
 
 describe("one-dimensional GAN game", () => {
   it("keeps the adversarial workbench in the generated production stylesheet", () => {
-    const css = transpileLatticeInBrowser(latticeSource);
+    const css = productionCss;
 
     expect(css).toContain(".workspace--gan");
     expect(css).toContain(".gan-number-line__marker--fake");

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -19,6 +19,8 @@ import { traceGraphNeighborhoodComparison } from "./graph-neighborhood-lab.js";
 import { HopfieldWorkbench } from "./HopfieldWorkbench.js";
 import { traceHopfieldRecall } from "./hopfield-memory.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
+import { InitializationWorkbench } from "./InitializationWorkbench.js";
+import { initializerScale, traceInitializationDistributions } from "./initialization-distribution-lab.js";
 import { MessagePassingWorkbench } from "./MessagePassingWorkbench.js";
 import { traceTinyMessagePassing } from "./message-passing-lab.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
@@ -1451,5 +1453,67 @@ describe("graph convolution and attention", () => {
     expect(screen.getByLabelText("Graph attention calculation").textContent).toMatch(/row max = 2.*denominator = 1\.417667.*weights sum = 1.*score 1 - max 2 = -1.*alpha = 0\.259496.*score -1 - max 2 = -3.*alpha = 0\.035119.*ReLU -> 1\.635146/s);
     fireEvent.click(screen.getByRole("button", { name: /node 2.*degree 2/ }));
     expect(screen.getByLabelText("Graph attention calculation").textContent).toMatch(/denominator = 1\.049787.*alpha = 0\.952574.*alpha = 0\.047426.*ReLU -> 1\.857722/s);
+  });
+});
+
+describe("initialization and activation distributions", () => {
+  it("keeps the deep-training explorer in the production stylesheet", () => {
+    expect(productionCss).toContain(".workspace--initialization");
+    expect(productionCss).toContain(".distribution-dot-plot");
+  });
+
+  it("derives Xavier and He scales from fan-in", () => {
+    expect(initializerScale("xavier", 2)).toBeCloseTo(1 / Math.sqrt(2));
+    expect(initializerScale("he", 2)).toBe(1);
+  });
+
+  it("traces the canonical Xavier tanh distribution", () => {
+    const trace = traceInitializationDistributions("xavier", "tanh");
+    expect(trace.layers[0]!.activations[0]).toEqual([Math.tanh(1 / Math.sqrt(2)), Math.tanh(-1 / Math.sqrt(2))]);
+    const expectedStandardDeviations = [
+      0.6088593650139138,
+      0.49271338636057294,
+      0.4563673571184874,
+    ];
+    trace.layers.forEach((layer, index) => {
+      expect(layer.summary.standardDeviation).toBeCloseTo(expectedStandardDeviations[index]!, 14);
+    });
+  });
+
+  it("makes shrinking and exploding ReLU signals visible", () => {
+    const tiny = traceInitializationDistributions("tiny", "relu");
+    const large = traceInitializationDistributions("large", "relu");
+    const expectedTiny = [
+      0.05,
+      0.006959705453537528,
+      0.0008569568250501307,
+    ];
+    const expectedLarge = [
+      1,
+      2.7838821814150108,
+      6.855654600401044,
+    ];
+    tiny.layers.forEach((layer, index) => {
+      expect(layer.summary.standardDeviation).toBeCloseTo(expectedTiny[index]!, 14);
+    });
+    large.layers.forEach((layer, index) => {
+      expect(layer.summary.standardDeviation).toBeCloseTo(expectedLarge[index]!, 14);
+    });
+  });
+
+  it("rejects malformed matrices", () => {
+    expect(() => traceInitializationDistributions("xavier", "tanh", [[1], [1, 2]])).toThrow(/rectangular/);
+    expect(() => traceInitializationDistributions("xavier", "tanh", [[1], [-1]], [[[1, 2]], [[1]]])).toThrow(/fan-in/);
+  });
+
+  it("switches initializer, activation, and layer in the explorer", () => {
+    render(React.createElement(InitializationWorkbench));
+    expect(screen.getByRole("heading", { name: "Initialization and activation distributions" })).toBeTruthy();
+    expect(screen.getByLabelText("Selected layer hand calculation").textContent).toMatch(/0\.707107.*tanh = 0\.608859/s);
+    fireEvent.click(screen.getByRole("button", { name: /Large.*fixed scale 2/ }));
+    expect(screen.getByLabelText("Layer activation distributions").textContent).toMatch(/std 0\.964028.*std 0\.706474.*std 0\.963901/s);
+    fireEvent.click(screen.getByRole("button", { name: "ReLU" }));
+    fireEvent.click(screen.getByRole("button", { name: /Layer 3.*std 6\.855655/ }));
+    expect(screen.getByLabelText("Selected activation distribution").textContent).toMatch(/standard deviation6\.855655.*exact zeros62\.5%/s);
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { activate } from "./activation.js";
+import { AttentionWorkbench } from "./AttentionWorkbench.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
@@ -73,6 +74,10 @@ import {
   traceGateCounterfactual,
   traceGatedRecurrent,
 } from "./gated-recurrent-lab.js";
+import {
+  attentionCell,
+  traceAttentionQkv,
+} from "./attention-qkv-lab.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -651,3 +656,54 @@ describe("training helpers", () => {
 function formatTestNumber(value: number): string {
   return Number(value.toFixed(5)).toString();
 }
+
+describe("attention query-key-value lab", () => {
+  it("projects three tokens and reproduces the canonical score matrices", () => {
+    const trace = traceAttentionQkv();
+
+    expect(trace.projections.map(({ query, key, value }) => ({ query, key, value }))).toEqual([
+      { query: [1, 0], key: [1, 1], value: [2, 0] },
+      { query: [0, 1], key: [-1, 1], value: [0, 1] },
+      { query: [1, 1], key: [0, 2], value: [2, 1] },
+    ]);
+    expect(trace.rawScoreMatrix).toEqual([
+      [1, -1, 0],
+      [1, 1, 2],
+      [2, 0, 2],
+    ]);
+    expect(trace.scaledScoreMatrix[1]![2]).toBeCloseTo(Math.SQRT2);
+  });
+
+  it("keeps the coordinate products behind every dot product", () => {
+    const bluePurple = attentionCell(traceAttentionQkv(), "blue", "purple");
+    const purpleBlue = attentionCell(traceAttentionQkv(), "purple", "blue");
+
+    expect(bluePurple.products).toEqual([0, 2]);
+    expect(bluePurple.rawScore).toBe(2);
+    expect(purpleBlue.products).toEqual([-1, 1]);
+    expect(purpleBlue.rawScore).toBe(0);
+  });
+
+  it("rejects inputs that leave the fixed V1 shapes", () => {
+    expect(() => traceAttentionQkv(undefined, [[1]])).toThrow(/three 2 x 2 matrices/);
+  });
+
+  it("opens raw, cancelling, and scaled score arithmetic interactively", () => {
+    render(React.createElement(AttentionWorkbench));
+
+    expect(screen.getByRole("heading", { name: "Query-key score microscope" })).toBeTruthy();
+    expect(screen.getByLabelText("Selected dot-product arithmetic").textContent)
+      .toMatch(/blue asks.*purple matches.*0 × 0 \+ 1 × 2.*= 2.*coordinate products \[0, 2\]/s);
+    expect(screen.getByText("v_purple = [2, 1]")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("gridcell", { name: "Select purple query and blue key" }));
+    expect(screen.getByLabelText("Selected dot-product arithmetic").textContent)
+      .toMatch(/purple asks.*blue matches.*1 × -1 \+ 1 × 1.*= 0.*coordinate products \[-1, 1\]/s);
+
+    fireEvent.click(screen.getByRole("gridcell", { name: "Select blue query and purple key" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /Scale by sqrt/ }));
+    expect(screen.getByLabelText("Selected dot-product arithmetic").textContent)
+      .toMatch(/2 \/ sqrt\(2\) = 1\.414214/s);
+    expect(screen.getByLabelText("Scaled attention scores").textContent).toContain("1.414214");
+  });
+});

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { activate } from "./activation.js";
+import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
@@ -37,6 +38,12 @@ import {
   DEFAULT_MICROSCOPE_STATE,
   traceTrainingStep,
 } from "./training-microscope.js";
+import {
+  DEFAULT_CONVOLUTION_KERNEL,
+  DEFAULT_CONVOLUTION_SIGNAL,
+  parseNumberList,
+  traceValidCorrelation,
+} from "./convolution-lab.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -176,6 +183,42 @@ describe("training helpers", () => {
     fireEvent.change(screen.getByLabelText("Optimization weight"), { target: { value: "1" } });
     const gradient = analyticalGradient(OPTIMIZATION_DATASET, { weight: 1, bias: 0, step: 0 });
     expect(screen.getAllByText(formatTestNumber(gradient.weight)).length).toBeGreaterThan(0);
+  });
+
+  it("traces every multiply-accumulate for an asymmetric sliding kernel", () => {
+    const traces = traceValidCorrelation(
+      DEFAULT_CONVOLUTION_SIGNAL,
+      DEFAULT_CONVOLUTION_KERNEL,
+    );
+
+    expect(traces.map((trace) => trace.output)).toEqual([7, -2, 11, 0]);
+    expect(traces[2]!.window).toEqual([3, 0, 4]);
+    expect(traces[2]!.products).toEqual([3, 0, 8]);
+    expect(traces[2]!.accumulator).toEqual([0, 3, 3, 11]);
+  });
+
+  it("does not reverse the neural convolution kernel", () => {
+    const reversed = traceValidCorrelation(
+      DEFAULT_CONVOLUTION_SIGNAL,
+      [...DEFAULT_CONVOLUTION_KERNEL].reverse(),
+    );
+
+    expect(reversed.map((trace) => trace.output)).toEqual([6, -1, 10, -2]);
+    expect(parseNumberList("2, -1, 1")).toEqual([2, -1, 1]);
+    expect(parseNumberList("2, nope, 1")).toBeNull();
+  });
+
+  it("lets the sliding-kernel microscope inspect and edit outputs", () => {
+    render(React.createElement(ConvolutionWorkbench));
+
+    expect(screen.getByRole("heading", { name: "Sliding-kernel microscope" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Output y[1]")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Kernel weights"), {
+      target: { value: "2, -1, 1" },
+    });
+    expect(screen.getByRole("button", { name: "Select output 1" }).textContent).toContain("-1");
   });
 
   it("registers the hidden-layer teaching examples without sine yet", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -11,6 +11,7 @@ import {
   traceTinyDecoderTraining,
 } from "./decoder-language-model-lab.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
+import { traceOneDimensionalDiffusion } from "./diffusion-lab.js";
 import { traceOneDimensionalGan } from "./gan-lab.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
@@ -1172,5 +1173,109 @@ describe("one-dimensional GAN game", () => {
       .toMatch(/critic becomes a teaching signal.*-0\.46562293.*-0\.48412848.*D parameters stay frozen/s);
     expect(screen.getByLabelText("GAN competing objectives").textContent)
       .toMatch(/D loss 0\.61411974.*G loss 0\.51727849/s);
+  });
+});
+
+describe("one-dimensional diffusion round trip", () => {
+  it("keeps the diffusion workbench in the generated production stylesheet", () => {
+    const css = productionCss;
+
+    expect(css).toContain(".workspace--diffusion");
+    expect(css).toContain(".diffusion-reverse-lane");
+  });
+
+  it("mixes one clean sample with saved noise at two levels", () => {
+    const trace = traceOneDimensionalDiffusion();
+
+    expect(trace.forwardSteps.map((row) => row.alphaBar))
+      .toEqual([0.64, 0.36]);
+    expect(trace.forwardSteps.map((row) => row.signalScale))
+      .toEqual([0.8, 0.6]);
+    expect(trace.forwardSteps.map((row) => row.noiseScale))
+      .toEqual([0.6, 0.8]);
+    expect(trace.forwardSteps.map((row) => row.noisySample))
+      .toEqual([0.5, 0.19999999999999996]);
+  });
+
+  it("reduces both timestep examples into shared denoiser gradients", () => {
+    const trace = traceOneDimensionalDiffusion();
+
+    expect(trace.initialMeanLoss).toBeCloseTo(0.125);
+    expect(trace.backward.perStep.map((row) => row.predictionGradient))
+      .toEqual([0.25, 0.25]);
+    expect(trace.backward.sampleWeightGradient).toBeCloseTo(0.175);
+    expect(trace.backward.timestepWeightGradient).toBeCloseTo(0.375);
+    expect(trace.backward.biasGradient).toBeCloseTo(0.5);
+  });
+
+  it("audits three slopes and learns a better noise predictor", () => {
+    const trace = traceOneDimensionalDiffusion();
+
+    expect(trace.gradientCheck.parameterOrder).toEqual([
+      "denoiser.sample_weight",
+      "denoiser.timestep_weight",
+      "denoiser.bias",
+    ]);
+    expect(trace.gradientCheck.maxAbsoluteError).toBeLessThan(1e-8);
+    expect(trace.updatedDenoiser).toEqual({
+      sampleWeight: -0.0875,
+      timestepWeight: -0.1875,
+      bias: -0.25,
+    });
+    expect(trace.postUpdateDenoising.map((row) => row.predictedNoise))
+      .toEqual([-0.3875, -0.45499999999999996]);
+    expect(trace.postUpdateMeanLoss).toBeCloseTo(0.0036703125);
+    expect(trace.postUpdateMeanLoss).toBeLessThan(trace.initialMeanLoss);
+  });
+
+  it("runs the updated denoiser through two deterministic reverse means", () => {
+    const trace = traceOneDimensionalDiffusion();
+
+    expect(trace.reverseSteps.map((row) => row.t)).toEqual([2, 1]);
+    expect(trace.reverseSteps[0]!.outputMean).toBeCloseTo(0.5984375);
+    expect(trace.reverseSteps[1]!.predictedNoise)
+      .toBeCloseTo(-0.39611328125);
+    expect(trace.finalReconstruction).toBeCloseTo(1.0451318359375);
+    expect(trace.finalAbsoluteError).toBeCloseTo(0.0451318359375);
+  });
+
+  it("rejects a malformed diffusion schedule", () => {
+    expect(() => traceOneDimensionalDiffusion(
+      1,
+      -0.5,
+      0.5,
+      { sampleWeight: 0, timestepWeight: 0, bias: 0 },
+      [
+        { t: 1, beta: 0.36, normalizedT: 0.5 },
+        { t: 3, beta: 0.4375, normalizedT: 1 },
+      ],
+    )).toThrow(/consecutive increasing diffusion steps/);
+  });
+
+  it("walks through forward noise, learning, and both reverse steps", () => {
+    render(React.createElement(RepresentationWorkbench));
+    fireEvent.click(screen.getByRole("button", { name: "Diffusion path" }));
+
+    expect(screen.getByRole("heading", {
+      name: "One clean number through a diffusion round trip",
+    })).toBeTruthy();
+    expect(screen.getByLabelText("Diffusion forward noise schedule").textContent)
+      .toMatch(/saved epsilon = -0\.5.*x0 = 1.*x1 = 0\.5.*alpha_bar = 0\.64.*x2 = 0\.2.*alpha_bar = 0\.36/s);
+    expect(screen.getByLabelText("Diffusion noise prediction objective").textContent)
+      .toMatch(/initial mean loss0\.125.*predicted 0.*target -0\.5/s);
+
+    fireEvent.click(screen.getByRole("button", { name: /Predict saved noise/ }));
+    expect(screen.getByLabelText("Diffusion noise prediction objective").textContent)
+      .toMatch(/mean loss after SGD0\.00367031.*predicted -0\.3875.*predicted -0\.455/s);
+    expect(screen.getByLabelText("Diffusion denoiser gradient and update").textContent)
+      .toMatch(/sample weight gradient0\.175.*timestep weight gradient0\.375.*bias gradient0\.5.*max error 6\.439e-12.*0\.125 -> 0\.00367031/s);
+
+    fireEvent.click(screen.getByRole("button", { name: /Denoise step 2/ }));
+    expect(screen.getByLabelText("Diffusion deterministic reverse mean path").textContent)
+      .toMatch(/reverse t = 2.*mean1 = 0\.5984375.*reverse t = 1\?/s);
+
+    fireEvent.click(screen.getByRole("button", { name: /Denoise step 1/ }));
+    expect(screen.getByLabelText("Diffusion deterministic reverse mean path").textContent)
+      .toMatch(/reverse t = 2.*mean1 = 0\.5984375.*reverse t = 1.*mean0 = 1\.04513184.*absolute error 0\.04513184/s);
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -66,6 +66,7 @@ import {
   DEFAULT_RECURRENT_INITIAL_STATE,
   DEFAULT_RECURRENT_INPUTS,
   DEFAULT_RECURRENT_PARAMETERS,
+  traceRecurrentBptt,
   traceRecurrentUnroll,
 } from "./recurrent-unroll-lab.js";
 
@@ -440,6 +441,58 @@ describe("training helpers", () => {
     expect(screen.getByText("final state").parentElement?.textContent).toContain("0");
     expect(screen.getByLabelText("Selected recurrent arithmetic").textContent)
       .toMatch(/carried state.*0\.5.*3.*0.*preactivation.*-1.*ReLU state.*0/s);
+  });
+
+  it("reverses the recurrent chain and accumulates shared gradients", () => {
+    const trace = traceRecurrentBptt();
+
+    expect(trace.loss).toBeCloseTo(0.28125);
+    expect(trace.backwardSteps.map((step) => step.time)).toEqual([2, 1, 0]);
+    expect(trace.backwardSteps.map((step) => step.stateGradient)).toEqual([
+      0.75,
+      0.375,
+      0.1875,
+    ]);
+    expect(trace.gradientTotals).toEqual({
+      inputWeight: 0.9375,
+      recurrentWeight: 3,
+      bias: 1.3125,
+      initialState: 0.09375,
+    });
+  });
+
+  it("checks BPTT independently and takes one loss-reducing step", () => {
+    const trace = traceRecurrentBptt();
+
+    expect(trace.maxGradientError).toBeLessThan(1e-9);
+    expect(trace.update.parameters.inputWeight).toBeCloseTo(1.90625);
+    expect(trace.update.parameters.recurrentWeight).toBeCloseTo(0.2);
+    expect(trace.update.parameters.bias).toBeCloseTo(-1.13125);
+    for (const [index, value] of [0.775, 2.83625, -0.564].entries()) {
+      expect(trace.update.preactivations[index]).toBeCloseTo(value);
+    }
+    for (const [index, value] of [0.775, 2.83625, 0].entries()) {
+      expect(trace.update.states[index]).toBeCloseTo(value);
+    }
+    expect(trace.update.loss).toBe(0);
+  });
+
+  it("switches the recurrent workbench into the backward microscope", () => {
+    render(React.createElement(RecurrentWorkbench));
+
+    fireEvent.click(screen.getByRole("button", { name: "Trace backward gradients" }));
+    expect(screen.getByRole("heading", { name: "Backpropagation-through-time microscope" })).toBeTruthy();
+    expect(screen.getByLabelText("Reverse-time gradient steps").textContent)
+      .toMatch(/reverse t = 2.*reverse t = 1.*reverse t = 0/s);
+    expect(screen.getByLabelText("Shared gradient reduction").textContent)
+      .toMatch(/dL\/dW_x.*0\.9375.*dL\/dW_h.*3.*dL\/db.*1\.3125/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select backward step 1" }));
+    expect(screen.getByLabelText("Selected backward arithmetic").textContent)
+      .toMatch(/direct loss.*0.*from future.*0\.375.*dL\/dh\[1\].*0\.375/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show forward unroll" }));
+    expect(screen.getByRole("heading", { name: "Recurrent-state unroller" })).toBeTruthy();
   });
 
   it("registers the hidden-layer teaching examples without sine yet", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -82,6 +82,10 @@ import {
   attentionSoftmaxRow,
   traceAttentionSoftmax,
 } from "./attention-softmax-lab.js";
+import {
+  multiHeadAttentionRow,
+  traceMultiHeadAttention,
+} from "./multi-head-attention-lab.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -774,5 +778,67 @@ describe("attention softmax and causal mask lab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Return to Q/K/V scores" }));
     expect(screen.getByRole("heading", { name: "Query-key score microscope" })).toBeTruthy();
+  });
+});
+
+describe("multi-head attention add-and-norm lab", () => {
+  it("runs two independent causal heads for the blue query", () => {
+    const blue = multiHeadAttentionRow(traceMultiHeadAttention(), "blue");
+
+    expect(blue.heads[0]!.weights).toEqual([0.5, 0.5, 0]);
+    expect(blue.heads[0]!.context).toBe(1);
+    expect(blue.heads[1]!.weights[0]).toBeCloseTo(0.2689414213699951);
+    expect(blue.heads[1]!.weights[1]).toBeCloseTo(0.7310585786300049);
+    expect(blue.heads[1]!.context).toBeCloseTo(0.7310585786300049);
+  });
+
+  it("concatenates, projects, adds the residual, and normalizes", () => {
+    const blue = multiHeadAttentionRow(traceMultiHeadAttention(), "blue");
+
+    expect(blue.concatenated).toEqual([1, 0.7310585786300049]);
+    expect(blue.projectedAttention).toEqual(blue.concatenated);
+    expect(blue.residualSum).toEqual([1, 1.7310585786300048]);
+    expect(blue.layerNorm.mean).toBeCloseTo(1.3655292893150024);
+    expect(blue.layerNorm.variance).toBeCloseTo(0.13361166134713073);
+    expect(blue.output[0]).toBeCloseTo(-0.9999625802171532);
+    expect(blue.output[1]).toBeCloseTo(0.9999625802171532);
+  });
+
+  it("keeps residual and normalization ablations numerically honest", () => {
+    const noResidual = multiHeadAttentionRow(
+      traceMultiHeadAttention(false, true),
+      "blue",
+    );
+    const rawAttention = multiHeadAttentionRow(
+      traceMultiHeadAttention(false, false),
+      "blue",
+    );
+
+    expect(noResidual.residualSum).toEqual(noResidual.projectedAttention);
+    expect(rawAttention.output).toEqual([1, 0.7310585786300049]);
+  });
+
+  it("walks from single-head weights through both heads and block ablations", () => {
+    render(React.createElement(AttentionWorkbench));
+    fireEvent.click(screen.getByRole("button", { name: "Apply softmax and causal mask" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open multi-head add and norm" }));
+
+    expect(screen.getByRole("heading", { name: "Multi-head add-and-norm block" })).toBeTruthy();
+    expect(screen.getByLabelText("Two attention heads for blue").textContent)
+      .toMatch(/Head A - horizontal.*context 1.*scores\[0, 0, 0\].*red0\.5.*blue0\.5.*purpleblocked.*Head B - vertical.*context 0\.731059.*scores\[0, 1, 1\].*red0\.268941.*blue0\.731059.*purpleblocked/s);
+    expect(screen.getByLabelText("Concatenate project and add residual trace").textContent)
+      .toMatch(/\[1, 0\.731059\].*\[0, 1\].*\[1, 1\.731059\]/s);
+    expect(screen.getByLabelText("Layer normalization arithmetic").textContent)
+      .toContain("[-0.999963, 0.999963]");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Add residual token/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /Apply layer normalization/ }));
+    expect(screen.getByText("residual removed")).toBeTruthy();
+    expect(screen.getByText("Layer normalization bypassed")).toBeTruthy();
+    expect(screen.getByLabelText("Layer normalization arithmetic").textContent)
+      .toContain("block output[1, 0.731059]");
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to single-head weights" }));
+    expect(screen.getByRole("heading", { name: "Causal-softmax mixer" })).toBeTruthy();
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -15,6 +15,7 @@ import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
+import { RepresentationWorkbench } from "./RepresentationWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import latticeSource from "./styles/app.lattice?raw";
@@ -28,6 +29,7 @@ import {
   type ModelState,
 } from "./training.js";
 import { LABS } from "./labs.js";
+import { traceScalarVariationalAutoencoder } from "./variational-lab.js";
 import {
   HIDDEN_LAYER_EXAMPLES,
   createInitialHiddenState,
@@ -996,5 +998,85 @@ describe("two-number autoencoder bottleneck lab", () => {
       .toMatch(/after one SGD step.*bottleneck z1\.442.*x_hat01\.9425.*x_hat1-1\.29755/s);
     expect(screen.getByLabelText("Selected autoencoder reconstruction 1").textContent)
       .toContain("error / loss gradient-0.29755");
+  });
+});
+
+describe("scalar variational autoencoder lab", () => {
+  it("keeps the variational workbench in the generated production stylesheet", () => {
+    const css = transpileLatticeInBrowser(latticeSource);
+
+    expect(css).toContain(".workspace--variational");
+    expect(css).toContain(".variational-sample-node");
+  });
+
+  it("turns saved noise into a reproducible latent sample", () => {
+    const trace = traceScalarVariationalAutoencoder();
+
+    expect(trace.forward.mean).toBeCloseTo(0.4);
+    expect(trace.forward.logVariance).toBe(0);
+    expect(trace.forward.standardDeviation).toBe(1);
+    expect(trace.forward.noiseContribution).toBe(0.5);
+    expect(trace.forward.latent).toBe(0.9);
+    expect(trace.forward.reconstruction).toBe(0.9);
+  });
+
+  it("keeps reconstruction and beta-weighted KL routes separate", () => {
+    const trace = traceScalarVariationalAutoencoder();
+
+    expect(trace.forward.reconstructionLoss).toBeCloseTo(0.005);
+    expect(trace.forward.kl).toBeCloseTo(0.08);
+    expect(trace.forward.weightedKl).toBeCloseTo(0.008);
+    expect(trace.forward.totalLoss).toBeCloseTo(0.013);
+    expect(trace.backward.reconstructionMeanGradient).toBeCloseTo(-0.1);
+    expect(trace.backward.weightedKlMeanGradient).toBeCloseTo(0.04);
+    expect(trace.backward.meanGradient).toBeCloseTo(-0.06);
+  });
+
+  it("shows beta cancelling and reversing the mean direction", () => {
+    const balanced = traceScalarVariationalAutoencoder(0.25);
+    const priorLed = traceScalarVariationalAutoencoder(1);
+
+    expect(balanced.backward.meanGradient).toBe(0);
+    expect(priorLed.backward.meanGradient).toBeCloseTo(0.3);
+    expect(balanced.samplingEpsilon).toBe(priorLed.samplingEpsilon);
+  });
+
+  it("audits all parameters and lowers the selected objective", () => {
+    const trace = traceScalarVariationalAutoencoder();
+
+    expect(trace.gradientCheck.parameterOrder).toHaveLength(6);
+    expect(trace.gradientCheck.maxAbsoluteError).toBeLessThan(1e-8);
+    expect(trace.updatedParameters.encoder.mean.weight).toBeCloseTo(0.406);
+    expect(trace.updatedParameters.encoder.mean.bias).toBeCloseTo(0.006);
+    expect(trace.postUpdate.mean).toBeCloseTo(0.412);
+    expect(trace.postUpdate.latent).toBeCloseTo(0.9132515638028976);
+    expect(trace.postUpdate.reconstruction).toBeCloseTo(0.9314708278771237);
+    expect(trace.postUpdate.totalLoss).toBeCloseTo(0.01083594975889346);
+    expect(trace.postUpdate.totalLoss).toBeLessThan(trace.forward.totalLoss);
+  });
+
+  it("switches representation labs, beta, gradient target, and updated model", () => {
+    render(React.createElement(RepresentationWorkbench));
+
+    expect(screen.getByRole("heading", { name: "Two numbers through one bottleneck" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Variational sample" }));
+
+    expect(screen.getByRole("heading", { name: "One Gaussian latent sample, fully unpacked" })).toBeTruthy();
+    expect(screen.getByLabelText("Variational encode sample and decode path").textContent)
+      .toMatch(/saved epsilon = 0\.5.*mean = 0\.4.*log var = 0.*sigma = 1.*z = 0\.9.*x_hat = 0\.9/s);
+    expect(screen.getByLabelText("Variational reconstruction and KL objective").textContent)
+      .toMatch(/reconstruction.*0\.005.*KL to Normal\(0, 1\).*0\.08.*beta0\.1.*weighted total.*0\.013/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "beta 0.25" }));
+    expect(screen.getByLabelText("Variational mean gradient tradeoff").textContent)
+      .toMatch(/reconstruction route-0\.1.*beta x KL route0\.25 x 0\.4.*0\.1.*combined mean gradient0.*routes cancel exactly/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "log-variance output" }));
+    expect(screen.getByLabelText("Variational log-variance gradient tradeoff").textContent)
+      .toContain("combined log-variance gradient-0.025");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Use updated parameters/ }));
+    expect(screen.getByLabelText("Variational encode sample and decode path").textContent)
+      .toMatch(/after one SGD step.*mean = 0\.4 \+ 0 = 0\.4.*log var = 0\.0025 \+ 0\.0025 = 0\.005.*z = 0\.90125156.*x_hat = 0\.91936283/s);
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -6,6 +6,7 @@ import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
 import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
+import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
 import { forwardLayered } from "./layered-network.js";
@@ -61,6 +62,12 @@ import {
   sameCorrelation,
   traceResidualBlock,
 } from "./residual-field-lab.js";
+import {
+  DEFAULT_RECURRENT_INITIAL_STATE,
+  DEFAULT_RECURRENT_INPUTS,
+  DEFAULT_RECURRENT_PARAMETERS,
+  traceRecurrentUnroll,
+} from "./recurrent-unroll-lab.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -388,6 +395,51 @@ describe("training helpers", () => {
     fireEvent.click(screen.getByRole("button", { name: "Select residual output 0" }));
     expect(screen.getByLabelText("Receptive field explorer").textContent)
       .toContain("receptive input indices = [0, 1, 2]");
+  });
+
+  it("unrolls one shared recurrent state through three exact steps", () => {
+    const trace = traceRecurrentUnroll();
+
+    expect(trace.states).toEqual([1, 3.5, 0.75]);
+    expect(trace.steps[1]).toMatchObject({
+      inputProduct: 4,
+      recurrentProduct: 0.5,
+      preactivation: 3.5,
+      state: 3.5,
+    });
+    expect(trace.steps[2]).toMatchObject({
+      input: 0,
+      previousState: 3.5,
+      inputProduct: 0,
+      recurrentProduct: 1.75,
+      state: 0.75,
+    });
+  });
+
+  it("isolates memory by cutting the recurrent contribution", () => {
+    const ablated = traceRecurrentUnroll(
+      DEFAULT_RECURRENT_INPUTS,
+      DEFAULT_RECURRENT_INITIAL_STATE,
+      DEFAULT_RECURRENT_PARAMETERS,
+      false,
+    );
+
+    expect(ablated.states).toEqual([1, 3, 0]);
+    expect(ablated.steps.every((step) => step.recurrentProduct === 0)).toBe(true);
+  });
+
+  it("selects an unrolled step and toggles recurrent memory interactively", () => {
+    render(React.createElement(RecurrentWorkbench));
+
+    expect(screen.getByRole("heading", { name: "Recurrent-state unroller" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Select recurrent step 2" }));
+    expect(screen.getByLabelText("Selected recurrent arithmetic").textContent)
+      .toMatch(/2.*0.*0.*0\.5.*3\.5.*1\.75.*0\.75.*0\.75/s);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Carry the previous state/ }));
+    expect(screen.getByText("final state").parentElement?.textContent).toContain("0");
+    expect(screen.getByLabelText("Selected recurrent arithmetic").textContent)
+      .toMatch(/carried state.*0\.5.*3.*0.*preactivation.*-1.*ReLU state.*0/s);
   });
 
   it("registers the hidden-layer teaching examples without sine yet", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -11,11 +11,14 @@ import {
   traceTinyDecoderTraining,
 } from "./decoder-language-model-lab.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
+import { DeepTrainingWorkbench } from "./DeepTrainingWorkbench.js";
 import { traceOneDimensionalDiffusion } from "./diffusion-lab.js";
 import { traceOneDimensionalGan } from "./gan-lab.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { GraphNeighborhoodWorkbench } from "./GraphNeighborhoodWorkbench.js";
 import { traceGraphNeighborhoodComparison } from "./graph-neighborhood-lab.js";
+import { GradientFlowWorkbench } from "./GradientFlowWorkbench.js";
+import { traceGradientFlow } from "./gradient-flow-lab.js";
 import { HopfieldWorkbench } from "./HopfieldWorkbench.js";
 import { traceHopfieldRecall } from "./hopfield-memory.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
@@ -1515,5 +1518,57 @@ describe("initialization and activation distributions", () => {
     fireEvent.click(screen.getByRole("button", { name: "ReLU" }));
     fireEvent.click(screen.getByRole("button", { name: /Layer 3.*std 6\.855655/ }));
     expect(screen.getByLabelText("Selected activation distribution").textContent).toMatch(/standard deviation6\.855655.*exact zeros62\.5%/s);
+  });
+});
+
+describe("vanishing and exploding gradients", () => {
+  it("keeps the gradient-flow explorer in the production stylesheet", () => {
+    expect(productionCss).toContain(".workspace--gradient-flow");
+    expect(productionCss).toContain(".gradient-chain-equation");
+  });
+
+  it("traces a small tanh chain from loss to input", () => {
+    const trace = traceGradientFlow("small-tanh");
+    expect(trace.classification).toBe("vanishing");
+    expect(trace.chainJacobian).toBeCloseTo(0.045877150455727246, 14);
+    expect(trace.inputGradient).toBeCloseTo(0.0025900181205328957, 14);
+    expect(trace.finiteDifferenceError).toBeLessThan(1e-10);
+  });
+
+  it("shows saturation can overwhelm large tanh weights", () => {
+    const trace = traceGradientFlow("saturated-tanh");
+    expect(trace.layers.map((layer) => layer.weight)).toEqual([3, 3, 3, 3]);
+    expect(trace.layers[0]!.activationDerivative).toBeCloseTo(0.009866037165440211, 14);
+    expect(trace.chainJacobian).toBeCloseTo(8.400447769691746e-7, 14);
+  });
+
+  it("keeps unit ReLU stable and makes large ReLU explode", () => {
+    const stable = traceGradientFlow("unit-relu");
+    const exploding = traceGradientFlow("large-relu");
+    expect(stable.chainJacobian).toBe(1);
+    expect(stable.inputGradient).toBe(1);
+    expect(exploding.layers.map((layer) => layer.activation)).toEqual([2, 4, 8, 16]);
+    expect(exploding.layers.map((layer) => layer.weightGradient)).toEqual([128, 128, 128, 128]);
+    expect(exploding.chainJacobian).toBe(16);
+    expect(exploding.inputGradient).toBe(256);
+  });
+
+  it("rejects invalid scenarios and finite-difference steps", () => {
+    expect(() => traceGradientFlow("missing")).toThrow(/unknown/);
+    expect(() => traceGradientFlow("small-tanh", 0)).toThrow(/positive/);
+  });
+
+  it("switches deep-training labs and gradient scenarios", () => {
+    render(React.createElement(DeepTrainingWorkbench));
+    fireEvent.click(screen.getByRole("button", { name: "Gradient flow" }));
+    expect(screen.getByRole("heading", { name: "Vanishing and exploding gradients" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Large ReLU.*Every layer doubles/ }));
+    expect(screen.getByLabelText("Gradient chain product").textContent).toMatch(/2.*2.*2.*2.*=.*16.*16 output error.*256.*input gradient/s);
+  });
+
+  it("opens any reverse-mode layer calculation", () => {
+    render(React.createElement(GradientFlowWorkbench));
+    fireEvent.click(screen.getByRole("button", { name: /layer 1.*upstream 0\.006587/ }));
+    expect(screen.getByLabelText("Selected gradient calculation").textContent).toMatch(/0\.006587 x 0\.786448 = 0\.00518.*0\.00518 x 0\.5 = 0\.00259/s);
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -69,6 +69,10 @@ import {
   traceRecurrentBptt,
   traceRecurrentUnroll,
 } from "./recurrent-unroll-lab.js";
+import {
+  traceGateCounterfactual,
+  traceGatedRecurrent,
+} from "./gated-recurrent-lab.js";
 
 describe("training helpers", () => {
   it("reduces MSE loss for a small learning rate", () => {
@@ -493,6 +497,52 @@ describe("training helpers", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Show forward unroll" }));
     expect(screen.getByRole("heading", { name: "Recurrent-state unroller" })).toBeTruthy();
+  });
+
+  it("routes the same memory through scalar GRU and LSTM gates", () => {
+    const trace = traceGatedRecurrent();
+
+    expect(trace.gru.resetGate.value).toBeCloseTo(0.5);
+    expect(trace.gru.updateGate.value).toBeCloseTo(0.25);
+    expect(trace.gru.candidate.value).toBeCloseTo(0.6);
+    expect(trace.gru.hiddenState).toBeCloseTo(0.75);
+    expect(trace.lstm.cellState).toBeCloseTo(0.55);
+    expect(trace.lstm.exposedCell).toBeCloseTo(0.5005202111902353);
+    expect(trace.lstm.hiddenState).toBeCloseTo(0.3753901583926764);
+  });
+
+  it("changes exactly one recurrent gate in a counterfactual", () => {
+    const trace = traceGatedRecurrent();
+    const resetOff = traceGateCounterfactual("gru", "reset", 0, trace);
+    const outputOff = traceGateCounterfactual("lstm", "output", 0, trace);
+    const outputOn = traceGateCounterfactual("lstm", "output", 1, trace);
+
+    expect(resetOff.candidate).toBeCloseTo(0.2850288981936261);
+    expect(resetOff.hiddenState).toBeCloseTo(0.6712572245484066);
+    expect(outputOff.cellState).toBeCloseTo(0.55);
+    expect(outputOff.hiddenState).toBe(0);
+    expect(outputOn.cellState).toBeCloseTo(outputOff.cellState!);
+    expect(outputOn.hiddenState).toBeCloseTo(0.5005202111902353);
+  });
+
+  it("compares GRU and LSTM gates interactively", () => {
+    render(React.createElement(RecurrentWorkbench));
+
+    fireEvent.click(screen.getByRole("button", { name: "Trace backward gradients" }));
+    fireEvent.click(screen.getByRole("button", { name: "Compare GRU and LSTM gates" }));
+    expect(screen.getByRole("heading", { name: "GRU and LSTM gate comparator" })).toBeTruthy();
+    expect(screen.getByLabelText("GRU memory lane").textContent)
+      .toMatch(/reset r.*0\.5.*candidate n.*0\.6.*update z.*0\.25.*next hidden.*0\.75/s);
+    expect(screen.getByLabelText("LSTM memory lane").textContent)
+      .toMatch(/forget f.*0\.5.*input i.*0\.25.*private cell.*0\.55.*output o.*0\.75.*next hidden.*0\.37539/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select LSTM output gate" }));
+    fireEvent.click(screen.getByRole("button", { name: "Force 0" }));
+    expect(screen.getByLabelText("Selected gate effect").textContent)
+      .toMatch(/selected value.*0.*next c 0\.55.*visible h 0/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to BPTT gradients" }));
+    expect(screen.getByRole("heading", { name: "Backpropagation-through-time microscope" })).toBeTruthy();
   });
 
   it("registers the hidden-layer teaching examples without sine yet", () => {

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { transpileLatticeInBrowser } from "@coding-adventures/lattice-transpiler/src/browser.js";
 import { activate } from "./activation.js";
 import { AttentionWorkbench } from "./AttentionWorkbench.js";
+import {
+  decoderTrainingRow,
+  traceTinyDecoderTraining,
+} from "./decoder-language-model-lab.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { HiddenLayerWorkbench } from "./HiddenLayerWorkbench.js";
 import { ImageCnnWorkbench } from "./ImageCnnWorkbench.js";
@@ -10,6 +15,7 @@ import { OptimizationWorkbench } from "./OptimizationWorkbench.js";
 import { RecurrentWorkbench } from "./RecurrentWorkbench.js";
 import { ResidualWorkbench } from "./ResidualWorkbench.js";
 import { TrainingStepMicroscope } from "./TrainingStepMicroscope.js";
+import latticeSource from "./styles/app.lattice?raw";
 import { forwardLayered } from "./layered-network.js";
 import {
   CELSIUS_DATASET,
@@ -840,5 +846,84 @@ describe("multi-head attention add-and-norm lab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Return to single-head weights" }));
     expect(screen.getByRole("heading", { name: "Causal-softmax mixer" })).toBeTruthy();
+  });
+});
+
+describe("tiny decoder-only language model training lab", () => {
+  it("keeps the decoder workbench in the generated production stylesheet", () => {
+    const css = transpileLatticeInBrowser(latticeSource);
+
+    expect(css).toContain(".workspace--decoder");
+    expect(css).toContain(".decoder-forward-flow");
+  });
+
+  it("shifts one sequence into two causal next-token examples", () => {
+    const trace = traceTinyDecoderTraining();
+
+    expect(trace.sequence).toEqual(["red", "blue", "purple"]);
+    expect(trace.rows.map((row) => ({
+      prefix: row.causalPrefix,
+      input: row.inputToken,
+      target: row.targetToken,
+    }))).toEqual([
+      { prefix: ["red"], input: "red", target: "blue" },
+      { prefix: ["red", "blue"], input: "blue", target: "purple" },
+    ]);
+  });
+
+  it("reproduces the hand-calculable logits, probabilities, and losses", () => {
+    const trace = traceTinyDecoderTraining();
+    const first = decoderTrainingRow(trace, 0);
+    const second = decoderTrainingRow(trace, 1);
+
+    expect(first.logitProducts).toEqual([[1, 0], [0, 0], [-1, 0]]);
+    expect(first.logits).toEqual([1, 0, -1]);
+    expect(first.probabilities.reduce((sum, value) => sum + value, 0)).toBeCloseTo(1);
+    expect(first.targetProbability).toBeCloseTo(0.24472847105479764);
+    expect(second.targetProbability).toBeCloseTo(0.09003057317038046);
+    expect(trace.meanLoss).toBeCloseTo(1.9076059644443801);
+  });
+
+  it("reduces shared gradients and lowers loss after one SGD step", () => {
+    const trace = traceTinyDecoderTraining();
+
+    expect(trace.unembeddingGradient[0]).toEqual([
+      0.3326204778874109,
+      -0.37763576447260117,
+      0.04501528658519023,
+    ]);
+    expect(trace.unembeddingGradient[1]).toEqual([
+      0.12236423552739882,
+      0.3326204778874109,
+      -0.4549847134148098,
+    ]);
+    expect(trace.updatedBias[2]).toBeCloseTo(0.20498471341480978);
+    expect(trace.gradientCheck.maxAbsoluteError).toBeLessThan(1e-8);
+    expect(trace.postUpdateMeanLoss).toBeCloseTo(1.456094285138867);
+    expect(trace.postUpdateMeanLoss).toBeLessThan(trace.meanLoss);
+  });
+
+  it("opens the decoder trace and compares the same position before and after update", () => {
+    render(React.createElement(AttentionWorkbench));
+    fireEvent.click(screen.getByRole("button", { name: "Apply softmax and causal mask" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open multi-head add and norm" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open tiny decoder training" }));
+
+    expect(screen.getByRole("heading", { name: "Tiny decoder training trace" })).toBeTruthy();
+    expect(screen.getByLabelText("Causal next-token sequence shift").textContent)
+      .toMatch(/position 0.*red.*blue.*position 1.*red blue.*purple/s);
+    expect(screen.getByLabelText("Selected decoder prediction at position 1").textContent)
+      .toMatch(/\[0, 1\].*\[0, 1, -1\].*P\(purple\) = 0\.090031.*2\.407606/s);
+    expect(screen.getByLabelText("Decoder loss gradient trace").textContent)
+      .toContain("[0.122364, 0.33262, -0.454985]");
+    expect(screen.getByLabelText("Shared decoder head SGD update").textContent)
+      .toMatch(/Central finite-difference audit.*max error 1\.979e-10.*mean loss before1\.907606.*mean loss after one step1\.456094/s);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Use updated vocabulary head/ }));
+    expect(screen.getByLabelText("Selected decoder prediction at position 1").textContent)
+      .toMatch(/updated logits.*P\(purple\) = 0\.15446.*1\.867817/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to multi-head block" }));
+    expect(screen.getByRole("heading", { name: "Multi-head add-and-norm block" })).toBeTruthy();
   });
 });

--- a/code/programs/typescript/ml-learning-visualizer/src/variational-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/variational-lab.ts
@@ -1,0 +1,315 @@
+export interface ScalarAffineParameters {
+  weight: number;
+  bias: number;
+}
+
+export interface VariationalParameters {
+  encoder: {
+    mean: ScalarAffineParameters;
+    logVariance: ScalarAffineParameters;
+  };
+  decoder: ScalarAffineParameters;
+}
+
+export interface VariationalForwardTrace {
+  meanProduct: number;
+  mean: number;
+  logVarianceProduct: number;
+  logVariance: number;
+  variance: number;
+  standardDeviation: number;
+  epsilon: number;
+  noiseContribution: number;
+  latent: number;
+  decoderProduct: number;
+  reconstruction: number;
+  error: number;
+  reconstructionLoss: number;
+  meanSquared: number;
+  kl: number;
+  weightedKl: number;
+  totalLoss: number;
+}
+
+export interface VariationalBackwardTrace {
+  reconstructionGradient: number;
+  decoderWeightGradient: number;
+  decoderBiasGradient: number;
+  latentGradient: number;
+  reconstructionMeanGradient: number;
+  reconstructionLogVarianceGradient: number;
+  klMeanGradient: number;
+  klLogVarianceGradient: number;
+  weightedKlMeanGradient: number;
+  weightedKlLogVarianceGradient: number;
+  meanGradient: number;
+  logVarianceGradient: number;
+  meanWeightGradient: number;
+  meanBiasGradient: number;
+  logVarianceWeightGradient: number;
+  logVarianceBiasGradient: number;
+}
+
+export interface VariationalTrace {
+  input: number;
+  beta: number;
+  samplingEpsilon: number;
+  learningRate: number;
+  parameters: VariationalParameters;
+  forward: VariationalForwardTrace;
+  backward: VariationalBackwardTrace;
+  gradientCheck: {
+    epsilon: number;
+    parameterOrder: string[];
+    analytical: number[];
+    numerical: number[];
+    maxAbsoluteError: number;
+  };
+  updatedParameters: VariationalParameters;
+  postUpdate: VariationalForwardTrace;
+}
+
+export const DEFAULT_VARIATIONAL_PARAMETERS: VariationalParameters = {
+  encoder: {
+    mean: { weight: 0.4, bias: 0 },
+    logVariance: { weight: 0, bias: 0 },
+  },
+  decoder: { weight: 1, bias: 0 },
+};
+export const DEFAULT_VARIATIONAL_INPUT = 1;
+export const DEFAULT_VARIATIONAL_EPSILON = 0.5;
+export const DEFAULT_VARIATIONAL_BETA = 0.1;
+export const DEFAULT_VARIATIONAL_LEARNING_RATE = 0.1;
+export const VARIATIONAL_PARAMETER_ORDER = [
+  "encoder.mean.weight",
+  "encoder.mean.bias",
+  "encoder.log_variance.weight",
+  "encoder.log_variance.bias",
+  "decoder.weight",
+  "decoder.bias",
+];
+
+function cleanZero(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
+}
+
+function copyParameters(parameters: VariationalParameters): VariationalParameters {
+  return {
+    encoder: {
+      mean: { ...parameters.encoder.mean },
+      logVariance: { ...parameters.encoder.logVariance },
+    },
+    decoder: { ...parameters.decoder },
+  };
+}
+
+function forwardVariational(
+  input: number,
+  parameters: VariationalParameters,
+  epsilon: number,
+  beta: number,
+): VariationalForwardTrace {
+  const meanProduct = cleanZero(input * parameters.encoder.mean.weight);
+  const mean = cleanZero(meanProduct + parameters.encoder.mean.bias);
+  const logVarianceProduct = cleanZero(
+    input * parameters.encoder.logVariance.weight,
+  );
+  const logVariance = cleanZero(
+    logVarianceProduct + parameters.encoder.logVariance.bias,
+  );
+  const variance = Math.exp(logVariance);
+  const standardDeviation = Math.exp(0.5 * logVariance);
+  const noiseContribution = cleanZero(standardDeviation * epsilon);
+  const latent = cleanZero(mean + noiseContribution);
+  const decoderProduct = cleanZero(latent * parameters.decoder.weight);
+  const reconstruction = cleanZero(decoderProduct + parameters.decoder.bias);
+  const error = cleanZero(reconstruction - input);
+  const reconstructionLoss = 0.5 * error * error;
+  const meanSquared = mean * mean;
+  const kl = 0.5 * (meanSquared + variance - 1 - logVariance);
+  const weightedKl = beta * kl;
+  return {
+    meanProduct,
+    mean,
+    logVarianceProduct,
+    logVariance,
+    variance,
+    standardDeviation,
+    epsilon,
+    noiseContribution,
+    latent,
+    decoderProduct,
+    reconstruction,
+    error,
+    reconstructionLoss,
+    meanSquared,
+    kl,
+    weightedKl,
+    totalLoss: reconstructionLoss + weightedKl,
+  };
+}
+
+function flattenParameters(parameters: VariationalParameters): number[] {
+  return [
+    parameters.encoder.mean.weight,
+    parameters.encoder.mean.bias,
+    parameters.encoder.logVariance.weight,
+    parameters.encoder.logVariance.bias,
+    parameters.decoder.weight,
+    parameters.decoder.bias,
+  ];
+}
+
+function parametersFromFlat(values: readonly number[]): VariationalParameters {
+  return {
+    encoder: {
+      mean: { weight: values[0]!, bias: values[1]! },
+      logVariance: { weight: values[2]!, bias: values[3]! },
+    },
+    decoder: { weight: values[4]!, bias: values[5]! },
+  };
+}
+
+export function traceScalarVariationalAutoencoder(
+  beta = DEFAULT_VARIATIONAL_BETA,
+  epsilon = DEFAULT_VARIATIONAL_EPSILON,
+  learningRate = DEFAULT_VARIATIONAL_LEARNING_RATE,
+  input = DEFAULT_VARIATIONAL_INPUT,
+  parameters: VariationalParameters = DEFAULT_VARIATIONAL_PARAMETERS,
+): VariationalTrace {
+  const flatInput = flattenParameters(parameters);
+  if (
+    !Number.isFinite(beta)
+    || beta < 0
+    || !Number.isFinite(epsilon)
+    || !Number.isFinite(learningRate)
+    || learningRate <= 0
+    || !Number.isFinite(input)
+    || !flatInput.every(Number.isFinite)
+  ) {
+    throw new Error(
+      "NN17 V1 needs finite scalar parameters, input and epsilon, non-negative beta, and a positive learning rate.",
+    );
+  }
+
+  const parameterCopy = copyParameters(parameters);
+  const forward = forwardVariational(input, parameterCopy, epsilon, beta);
+  if (
+    !Number.isFinite(forward.variance)
+    || !Number.isFinite(forward.standardDeviation)
+    || !Number.isFinite(forward.totalLoss)
+  ) {
+    throw new Error("NN17 V1 produced a non-finite Gaussian or objective.");
+  }
+
+  const reconstructionGradient = forward.error;
+  const decoderWeightGradient = cleanZero(
+    reconstructionGradient * forward.latent,
+  );
+  const decoderBiasGradient = reconstructionGradient;
+  const latentGradient = cleanZero(
+    reconstructionGradient * parameterCopy.decoder.weight,
+  );
+  const reconstructionMeanGradient = latentGradient;
+  const reconstructionLogVarianceGradient = cleanZero(
+    latentGradient * 0.5 * forward.standardDeviation * epsilon,
+  );
+  const klMeanGradient = forward.mean;
+  const klLogVarianceGradient = cleanZero(0.5 * (forward.variance - 1));
+  const weightedKlMeanGradient = cleanZero(beta * klMeanGradient);
+  const weightedKlLogVarianceGradient = cleanZero(
+    beta * klLogVarianceGradient,
+  );
+  const meanGradient = cleanZero(
+    reconstructionMeanGradient + weightedKlMeanGradient,
+  );
+  const logVarianceGradient = cleanZero(
+    reconstructionLogVarianceGradient + weightedKlLogVarianceGradient,
+  );
+  const meanWeightGradient = cleanZero(meanGradient * input);
+  const meanBiasGradient = meanGradient;
+  const logVarianceWeightGradient = cleanZero(logVarianceGradient * input);
+  const logVarianceBiasGradient = logVarianceGradient;
+  const backward: VariationalBackwardTrace = {
+    reconstructionGradient,
+    decoderWeightGradient,
+    decoderBiasGradient,
+    latentGradient,
+    reconstructionMeanGradient,
+    reconstructionLogVarianceGradient,
+    klMeanGradient,
+    klLogVarianceGradient,
+    weightedKlMeanGradient,
+    weightedKlLogVarianceGradient,
+    meanGradient,
+    logVarianceGradient,
+    meanWeightGradient,
+    meanBiasGradient,
+    logVarianceWeightGradient,
+    logVarianceBiasGradient,
+  };
+
+  const analytical = [
+    meanWeightGradient,
+    meanBiasGradient,
+    logVarianceWeightGradient,
+    logVarianceBiasGradient,
+    decoderWeightGradient,
+    decoderBiasGradient,
+  ];
+  const auditEpsilon = 1e-6;
+  const numerical = flatInput.map((_, parameterIndex) => {
+    const plus = [...flatInput];
+    const minus = [...flatInput];
+    plus[parameterIndex]! += auditEpsilon;
+    minus[parameterIndex]! -= auditEpsilon;
+    return (
+      forwardVariational(
+        input,
+        parametersFromFlat(plus),
+        epsilon,
+        beta,
+      ).totalLoss
+      - forwardVariational(
+        input,
+        parametersFromFlat(minus),
+        epsilon,
+        beta,
+      ).totalLoss
+    ) / (2 * auditEpsilon);
+  });
+  const maxAbsoluteError = Math.max(...analytical.map((value, index) => (
+    Math.abs(value - numerical[index]!)
+  )));
+
+  const updatedParameters = parametersFromFlat(
+    flatInput.map((value, index) => (
+      value - learningRate * analytical[index]!
+    )),
+  );
+  const postUpdate = forwardVariational(
+    input,
+    updatedParameters,
+    epsilon,
+    beta,
+  );
+
+  return {
+    input,
+    beta,
+    samplingEpsilon: epsilon,
+    learningRate,
+    parameters: parameterCopy,
+    forward,
+    backward,
+    gradientCheck: {
+      epsilon: auditEpsilon,
+      parameterOrder: [...VARIATIONAL_PARAMETER_ORDER],
+      analytical,
+      numerical,
+      maxAbsoluteError,
+    },
+    updatedParameters,
+    postUpdate,
+  };
+}

--- a/code/scripts/tests/test_attention_qkv_labs.py
+++ b/code/scripts/tests/test_attention_qkv_labs.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Tests for the NN12 attention QKV fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_attention_qkv_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_attention_qkv_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class AttentionQkvLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "attention-qkv-v1"
+            / "labs"
+            / "00-three-token-qkv.json"
+        )
+        self.lab = json.loads(path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual([path.name for path in paths], ["00-three-token-qkv.json"])
+
+    def test_projects_three_distinct_roles(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertEqual(trace["queries"], [[1, 0], [0, 1], [1, 1]])
+        self.assertEqual(trace["keys"], [[1, 1], [-1, 1], [0, 2]])
+        self.assertEqual(trace["values"], [[2, 0], [0, 1], [2, 1]])
+
+    def test_exposes_every_dot_product(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertEqual(len(trace["dot_products"]), 9)
+        blue_purple = trace["dot_products"][5]
+        self.assertEqual(blue_purple["products"], [0, 2])
+        self.assertEqual(blue_purple["raw_score"], 2)
+
+    def test_builds_query_by_key_score_matrix(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertEqual(trace["raw_score_matrix"], [[1, -1, 0], [1, 1, 2], [2, 0, 2]])
+
+    def test_scales_by_square_root_of_key_dimension(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertAlmostEqual(trace["scaled_score_matrix"][1][2], 2**0.5)
+        self.assertAlmostEqual(trace["scaled_score_matrix"][0][1], -(0.5**0.5))
+
+    def test_rejects_a_mutated_score(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["expected"]["dot_products"][5]["raw_score"] = 3
+        with self.assertRaises(validator.AttentionQkvValidationError):
+            validator.validate_lab(lab)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_attention_softmax_labs.py
+++ b/code/scripts/tests/test_attention_softmax_labs.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Tests for the NN13 attention softmax fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_attention_softmax_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_attention_softmax_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class AttentionSoftmaxLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "attention-softmax-v1"
+            / "labs"
+            / "00-three-token-causal-softmax.json"
+        )
+        self.lab = json.loads(path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual(
+            [path.name for path in paths], ["00-three-token-causal-softmax.json"]
+        )
+
+    def test_every_softmax_row_sums_to_one(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        for mode in ("unmasked", "causal"):
+            for row in trace[mode]:
+                self.assertAlmostEqual(sum(row["weights"]), 1)
+
+    def test_causal_mask_zeros_every_future_weight(self) -> None:
+        rows = validator.execute_lab(self.lab)["causal"]
+        for query_index, row in enumerate(rows):
+            for key_index in range(query_index + 1, 3):
+                self.assertIsNone(row["masked_scores"][key_index])
+                self.assertEqual(row["exponentials"][key_index], 0)
+                self.assertEqual(row["weights"][key_index], 0)
+
+    def test_blue_causal_row_is_hand_calculable(self) -> None:
+        row = validator.execute_lab(self.lab)["causal"][1]
+        self.assertEqual(row["shifted_scores"], [0, 0, None])
+        self.assertEqual(row["exponentials"], [1, 1, 0])
+        self.assertEqual(row["denominator"], 2)
+        self.assertEqual(row["weights"], [0.5, 0.5, 0])
+        self.assertEqual(row["context"], [1, 0.5])
+
+    def test_unmasked_blue_can_read_the_future_value(self) -> None:
+        row = validator.execute_lab(self.lab)["unmasked"][1]
+        self.assertAlmostEqual(row["weights"][2], 0.5034898434845538)
+        self.assertAlmostEqual(row["context"][0], 1.5034898434845538)
+        self.assertAlmostEqual(row["context"][1], 0.7517449217422769)
+
+    def test_max_subtraction_keeps_large_scores_finite(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["scaled_score_matrix"][0] = [1000, 999, 998]
+        row = validator.execute_lab(lab)["unmasked"][0]
+        self.assertEqual(row["shifted_scores"], [0, -1, -2])
+        self.assertTrue(all(math.isfinite(weight) for weight in row["weights"]))
+        self.assertAlmostEqual(sum(row["weights"]), 1)
+
+    def test_rejects_a_mutated_attention_weight(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["expected"]["causal"][1]["weights"][0] = 0.6
+        with self.assertRaises(validator.AttentionSoftmaxValidationError):
+            validator.validate_lab(lab)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_convolution_learning_labs.py
+++ b/code/scripts/tests/test_convolution_learning_labs.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Tests for the NN05 convolution-learning fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_convolution_learning_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_convolution_learning_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class ConvolutionLearningLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture_path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "convolution-learning-v1"
+            / "labs"
+            / "00-asymmetric-valid-kernel.json"
+        )
+        self.lab = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual(
+            [path.name for path in paths], ["00-asymmetric-valid-kernel.json"]
+        )
+
+    def test_reproduces_every_multiply_accumulate(self) -> None:
+        positions = validator.trace_valid_correlation(
+            self.lab["signal"], self.lab["kernel"]
+        )
+        self.assertEqual([position["output"] for position in positions], [7, -2, 11, 0])
+        self.assertEqual(positions[2]["products"], [3, 0, 8])
+        self.assertEqual(positions[2]["accumulator"], [0.0, 3.0, 3.0, 11.0])
+
+    def test_asymmetric_kernel_is_not_reversed(self) -> None:
+        reversed_positions = validator.trace_valid_correlation(
+            self.lab["signal"], list(reversed(self.lab["kernel"]))
+        )
+        self.assertEqual(
+            [position["output"] for position in reversed_positions], [6, -1, 10, -2]
+        )
+
+    def test_rejects_a_mutated_product_trace(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["expected"]["positions"][0]["products"][2] += 1
+        with self.assertRaises(validator.ConvolutionLabValidationError):
+            validator.validate_lab(lab)
+
+    def test_rejects_an_invalid_output_count(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["expected"]["outputs"].pop()
+        with self.assertRaises(validator.ConvolutionLabValidationError):
+            validator.validate_lab(lab)
+
+    def test_cli_rejects_an_empty_corpus(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            schema = {"$schema": "https://json-schema.org/draft/2020-12/schema"}
+            (root / "schema.json").write_text(json.dumps(schema), encoding="utf-8")
+            (root / "labs").mkdir()
+            with self.assertRaises(validator.ConvolutionLabValidationError):
+                validator.validate_corpus(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_convolution_training_labs.py
+++ b/code/scripts/tests/test_convolution_training_labs.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Tests for the NN06 convolution-training fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_convolution_training_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_convolution_training_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class ConvolutionTrainingLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture_path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "convolution-training-v1"
+            / "labs"
+            / "00-shared-kernel-gradient.json"
+        )
+        self.lab = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual(
+            [path.name for path in paths], ["00-shared-kernel-gradient.json"]
+        )
+
+    def test_accumulates_every_shared_weight_gradient(self) -> None:
+        trace = validator.trace_training(
+            self.lab["signal"], self.lab["kernel"], self.lab["targets"]
+        )
+        self.assertEqual(trace["outputs"], [7, -2, 11, 0])
+        self.assertEqual(trace["output_gradients"], [0.5, 0, 0.5, 0])
+        self.assertEqual(trace["kernel_gradient"], [2.5, 0.5, 3.5])
+        self.assertEqual(
+            trace["contributions"][2]["kernel_gradient"], [1.5, 0, 2]
+        )
+
+    def test_analytical_gradient_matches_independent_finite_difference(self) -> None:
+        trace = validator.trace_training(
+            self.lab["signal"], self.lab["kernel"], self.lab["targets"]
+        )
+        numerical = validator.numerical_kernel_gradient(
+            self.lab["signal"],
+            self.lab["kernel"],
+            self.lab["targets"],
+            self.lab["gradient_check"]["epsilon"],
+        )
+        for analytical, estimate in zip(trace["kernel_gradient"], numerical):
+            self.assertAlmostEqual(analytical, estimate, places=8)
+
+    def test_one_step_reduces_loss(self) -> None:
+        before = validator.trace_training(
+            self.lab["signal"], self.lab["kernel"], self.lab["targets"]
+        )
+        after = validator.optimizer_step(
+            self.lab["signal"],
+            self.lab["kernel"],
+            self.lab["targets"],
+            self.lab["optimizer_step"]["learning_rate"],
+        )
+        self.assertEqual(after["kernel"], [0.95, -1.01, 1.93])
+        self.assertAlmostEqual(after["loss"], 0.206525)
+        self.assertLess(after["loss"], before["loss"])
+
+    def test_rejects_a_mutated_contribution(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["gradient_check"]["expected"]["contributions"][0][
+            "kernel_gradient"
+        ][1] += 0.25
+        with self.assertRaises(validator.ConvolutionTrainingValidationError):
+            validator.validate_lab(lab)
+
+    def test_rejects_the_wrong_target_count(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["targets"].pop()
+        with self.assertRaises(validator.ConvolutionTrainingValidationError):
+            validator.validate_lab(lab)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_gated_recurrent_labs.py
+++ b/code/scripts/tests/test_gated_recurrent_labs.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Tests for the NN11 gated recurrent fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_gated_recurrent_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_gated_recurrent_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class GatedRecurrentLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture_path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "gated-recurrent-v1"
+            / "labs"
+            / "00-gru-lstm-gates.json"
+        )
+        self.lab = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual([path.name for path in paths], ["00-gru-lstm-gates.json"])
+
+    def test_reproduces_every_gate_activation(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertEqual(trace["gru"]["reset_gate"]["value"], 0.5)
+        self.assertEqual(trace["gru"]["update_gate"]["value"], 0.25)
+        self.assertEqual(trace["lstm"]["forget_gate"]["value"], 0.5)
+        self.assertEqual(trace["lstm"]["input_gate"]["value"], 0.25)
+        self.assertEqual(trace["lstm"]["output_gate"]["value"], 0.75)
+
+    def test_compares_one_state_with_a_private_cell(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertAlmostEqual(trace["gru"]["output"]["hidden_state"], 0.75)
+        self.assertAlmostEqual(trace["lstm"]["output"]["cell_state"], 0.55)
+        self.assertAlmostEqual(
+            trace["lstm"]["output"]["hidden_state"], 0.3753901583926764
+        )
+
+    def test_reset_gate_changes_candidate_construction(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        reset_off = trace["counterfactuals"]["gru"][2]
+        self.assertEqual(reset_off["gate"], "reset")
+        self.assertAlmostEqual(reset_off["candidate"], 0.2850288981936261)
+        self.assertLess(reset_off["hidden_state"], 0.75)
+
+    def test_output_gate_hides_but_does_not_erase_lstm_cell(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        output_off = trace["counterfactuals"]["lstm"][2]
+        output_on = trace["counterfactuals"]["lstm"][3]
+        self.assertEqual(output_off["cell_state"], output_on["cell_state"])
+        self.assertEqual(output_off["hidden_state"], 0)
+        self.assertGreater(output_on["hidden_state"], 0.5)
+
+    def test_rejects_a_mutated_gate_trace(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["lstm"]["output"]["cell_state"] = 0.7
+        with self.assertRaises(validator.GatedRecurrentValidationError):
+            validator.validate_lab(lab)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_gradient_flow_labs.py
+++ b/code/scripts/tests/test_gradient_flow_labs.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "code" / "scripts"))
+
+from validate_gradient_flow_labs import (
+    DEFAULT_FIXTURE_ROOT,
+    GradientFlowValidationError,
+    execute_lab,
+    load_json,
+    validate_corpus,
+    validate_document,
+)
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-four-layer-gradient-flow.json"
+
+
+def lab() -> dict[str, object]:
+    return load_json(LAB_PATH)
+
+
+def traces() -> list[dict[str, object]]:
+    return execute_lab(lab())["traces"]
+
+
+def test_schema_and_corpus() -> None:
+    schema = load_json(DEFAULT_FIXTURE_ROOT / "schema.json")
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(lab())
+    assert validate_corpus() == 1
+
+
+def test_small_tanh_gradient_vanishes() -> None:
+    trace = traces()[0]
+    assert trace["classification"] == "vanishing"
+    assert trace["chain_jacobian"] == pytest.approx(0.045877150455727246)
+    assert trace["input_gradient"] == pytest.approx(0.0025900181205328957)
+
+
+def test_saturated_tanh_derivatives_overwhelm_large_weights() -> None:
+    trace = traces()[1]
+    assert [layer["weight"] for layer in trace["layers"]] == [3, 3, 3, 3]
+    assert trace["layers"][0]["activation_derivative"] == pytest.approx(
+        0.009866037165440211
+    )
+    assert trace["chain_jacobian"] == pytest.approx(8.400447769691746e-7)
+
+
+def test_unit_relu_is_stable() -> None:
+    trace = traces()[2]
+    assert trace["classification"] == "stable"
+    assert trace["chain_jacobian"] == 1
+    assert trace["input_gradient"] == 1
+
+
+def test_large_relu_explodes_exactly() -> None:
+    trace = traces()[3]
+    assert trace["classification"] == "exploding"
+    assert [layer["activation"] for layer in trace["layers"]] == [2, 4, 8, 16]
+    assert [layer["weight_gradient"] for layer in trace["layers"]] == [
+        128,
+        128,
+        128,
+        128,
+    ]
+    assert trace["chain_jacobian"] == 16
+    assert trace["input_gradient"] == 256
+
+
+def test_all_input_gradients_pass_finite_difference() -> None:
+    for trace in validate_document(lab())["traces"]:
+        assert trace["finite_difference_error"] < 1e-8
+
+
+def test_rejects_unknown_keys_scenario_order_and_trace_drift() -> None:
+    document = lab()
+    document["surprise"] = True
+    with pytest.raises(GradientFlowValidationError, match="key mismatch"):
+        validate_document(document)
+    document = lab()
+    document["scenarios"][0]["id"] = "wrong"
+    with pytest.raises(GradientFlowValidationError, match="scenario order"):
+        validate_document(document)
+    document = lab()
+    document["expected"]["traces"][3]["input_gradient"] = 255
+    with pytest.raises(GradientFlowValidationError, match="input_gradient"):
+        validate_document(document)
+
+
+def test_loader_rejects_duplicate_and_non_finite(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text('{"x":1,"x":2}', encoding="utf-8")
+    with pytest.raises(GradientFlowValidationError, match="duplicate"):
+        load_json(path)
+    path.write_text('{"x":NaN}', encoding="utf-8")
+    with pytest.raises(GradientFlowValidationError, match="non-finite"):
+        load_json(path)

--- a/code/scripts/tests/test_graph_convolution_attention_labs.py
+++ b/code/scripts/tests/test_graph_convolution_attention_labs.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "code" / "scripts"))
+
+from validate_graph_convolution_attention_labs import (  # noqa: E402
+    DEFAULT_FIXTURE_ROOT,
+    GraphConvolutionAttentionValidationError,
+    execute_lab,
+    load_json,
+    validate_corpus,
+    validate_document,
+)
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-three-node-gcn-gat.json"
+
+
+def lab() -> dict[str, object]:
+    return load_json(LAB_PATH)
+
+
+def test_schema_and_corpus() -> None:
+    schema = load_json(DEFAULT_FIXTURE_ROOT / "schema.json")
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(lab())
+    assert validate_corpus() == 1
+
+
+def test_degrees_and_gcn_outputs() -> None:
+    result = execute_lab(lab())
+    assert result["degrees"] == [2, 3, 2]
+    assert result["gcn_outputs"] == pytest.approx(
+        [1.3164965809277263, 2 / 3, 0.31649658092772615]
+    )
+
+
+def test_middle_gcn_exposes_all_coefficients() -> None:
+    row = execute_lab(lab())["gcn"][1]
+    assert [item["coefficient"] for item in row["rows"]] == pytest.approx(
+        [1 / (6**0.5), 1 / 3, 1 / (6**0.5)]
+    )
+    assert [item["contribution"] for item in row["rows"]] == pytest.approx(
+        [0.4082482904638631, 2 / 3, -0.4082482904638631]
+    )
+
+
+def test_middle_attention_is_stable_and_normalized() -> None:
+    row = execute_lab(lab())["gat"][1]
+    assert row["maximum_score"] == 2
+    assert [item["shifted_score"] for item in row["rows"]] == [-1, 0, -3]
+    assert sum(item["attention_weight"] for item in row["rows"]) == pytest.approx(1)
+    assert row["output"] == pytest.approx(1.6351464587795619)
+
+
+def test_all_gat_outputs() -> None:
+    assert validate_document(lab())["gat_outputs"] == pytest.approx(
+        [1.7310585786300048, 1.6351464587795619, 1.8577223804673]
+    )
+
+
+def test_rejects_unknown_keys_and_trace_mismatch() -> None:
+    document = lab()
+    document["surprise"] = True
+    with pytest.raises(GraphConvolutionAttentionValidationError, match="key mismatch"):
+        validate_document(document)
+    document = lab()
+    document["expected"]["gat_outputs"][0] = 9
+    with pytest.raises(GraphConvolutionAttentionValidationError, match="gat_outputs"):
+        validate_document(document)
+
+
+def test_rejects_missing_self_loop_and_asymmetry() -> None:
+    document = lab()
+    document["neighborhoods"][0] = [1]
+    with pytest.raises(
+        GraphConvolutionAttentionValidationError, match="including self"
+    ):
+        validate_document(document)
+    document = lab()
+    document["neighborhoods"][0] = [0]
+    with pytest.raises(GraphConvolutionAttentionValidationError, match="symmetric"):
+        validate_document(document)
+
+
+def test_loader_rejects_duplicate_and_non_finite(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text('{"x":1,"x":2}', encoding="utf-8")
+    with pytest.raises(GraphConvolutionAttentionValidationError, match="duplicate"):
+        load_json(path)
+    path.write_text('{"x":NaN}', encoding="utf-8")
+    with pytest.raises(GraphConvolutionAttentionValidationError, match="non-finite"):
+        load_json(path)

--- a/code/scripts/tests/test_hopfield_associative_memory_labs.py
+++ b/code/scripts/tests/test_hopfield_associative_memory_labs.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "code" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from validate_hopfield_associative_memory_labs import (
+    DEFAULT_FIXTURE_ROOT,
+    HopfieldAssociativeMemoryValidationError,
+    execute_lab,
+    load_json,
+    validate_corpus,
+    validate_document,
+)
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-one-bit-recall.json"
+
+
+def lab() -> dict[str, object]:
+    return load_json(LAB_PATH)
+
+
+def test_schema_accepts_the_canonical_document() -> None:
+    schema = load_json(DEFAULT_FIXTURE_ROOT / "schema.json")
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(lab())
+
+
+def test_corpus_contains_one_validated_lab() -> None:
+    assert validate_corpus() == 1
+
+
+def test_hebbian_outer_product_is_symmetric_with_zero_diagonal() -> None:
+    result = execute_lab(lab())
+    assert result["weights"] == [
+        [0, -0.25, 0.25, -0.25],
+        [-0.25, 0, -0.25, 0.25],
+        [0.25, -0.25, 0, -0.25],
+        [-0.25, 0.25, -0.25, 0],
+    ]
+
+
+def test_corrupted_cue_begins_at_half_overlap_and_zero_energy() -> None:
+    result = execute_lab(lab())
+    assert result["initial_hamming_distance"] == 1
+    assert result["initial_overlap"] == pytest.approx(0.5)
+    assert result["initial_energy"] == pytest.approx(0)
+
+
+def test_first_asynchronous_update_repairs_the_flipped_bit() -> None:
+    first = execute_lab(lab())["updates"][0]
+    assert [row["contribution"] for row in first["incoming"]] == pytest.approx(
+        [0, 0.25, 0.25, 0.25]
+    )
+    assert first["local_field"] == pytest.approx(0.75)
+    assert first["previous_state"] == -1
+    assert first["next_state"] == 1
+    assert first["state_after"] == [1, -1, 1, -1]
+
+
+def test_energy_descends_and_the_remaining_sweep_is_stable() -> None:
+    result = validate_document(lab())
+    assert [
+        (row["energy_before"], row["energy_after"]) for row in result["updates"]
+    ] == [
+        (0, -1.5),
+        (-1.5, -1.5),
+        (-1.5, -1.5),
+        (-1.5, -1.5),
+    ]
+    assert [row["changed"] for row in result["updates"]] == [True, False, False, False]
+    assert result["final_state"] == [1, -1, 1, -1]
+    assert result["final_overlap"] == pytest.approx(1)
+    assert result["final_hamming_distance"] == 0
+    assert result["converged"] is True
+
+
+def test_rejects_unknown_document_keys() -> None:
+    document = lab()
+    document["surprise"] = True
+    with pytest.raises(HopfieldAssociativeMemoryValidationError, match="key mismatch"):
+        validate_document(document)
+
+
+def test_rejects_non_bipolar_states() -> None:
+    document = lab()
+    document["corrupted_state"][0] = 0
+    with pytest.raises(HopfieldAssociativeMemoryValidationError, match="bipolar"):
+        validate_document(document)
+
+
+def test_rejects_non_permutation_update_orders() -> None:
+    document = lab()
+    document["update_order"] = [0, 1, 1, 3]
+    with pytest.raises(HopfieldAssociativeMemoryValidationError, match="permutation"):
+        validate_document(document)
+
+
+def test_rejects_a_mismatched_expected_trace() -> None:
+    document = lab()
+    document["expected"]["final_energy"] = -1.4
+    with pytest.raises(HopfieldAssociativeMemoryValidationError, match="final_energy"):
+        validate_document(document)
+
+
+def test_loader_rejects_duplicate_and_non_finite_json(tmp_path: Path) -> None:
+    duplicate_path = tmp_path / "duplicate.json"
+    duplicate_path.write_text('{"id": "a", "id": "b"}', encoding="utf-8")
+    with pytest.raises(HopfieldAssociativeMemoryValidationError, match="duplicate"):
+        load_json(duplicate_path)
+
+    non_finite_path = tmp_path / "non-finite.json"
+    non_finite_path.write_text('{"value": NaN}', encoding="utf-8")
+    with pytest.raises(HopfieldAssociativeMemoryValidationError, match="non-finite"):
+        load_json(non_finite_path)
+
+
+def test_operation_contract_is_exact() -> None:
+    document = copy.deepcopy(lab())
+    document["operation"]["update"] = "parallel"
+    with pytest.raises(HopfieldAssociativeMemoryValidationError, match="operation"):
+        validate_document(document)
+
+
+def test_fixture_is_canonical_json() -> None:
+    document = lab()
+    reparsed = json.loads(json.dumps(document, allow_nan=False))
+    assert reparsed == document

--- a/code/scripts/tests/test_initialization_activation_distribution_labs.py
+++ b/code/scripts/tests/test_initialization_activation_distribution_labs.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "code" / "scripts"))
+
+from validate_initialization_activation_distribution_labs import (  # noqa: E402
+    DEFAULT_FIXTURE_ROOT,
+    InitializationDistributionValidationError,
+    execute_lab,
+    load_json,
+    validate_corpus,
+    validate_document,
+)
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-three-layer-scale-comparison.json"
+
+
+def lab() -> dict[str, object]:
+    return load_json(LAB_PATH)
+
+
+def test_schema_and_corpus() -> None:
+    schema = load_json(DEFAULT_FIXTURE_ROOT / "schema.json")
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(lab())
+    assert validate_corpus() == 1
+
+
+def test_canonical_xavier_tanh_trace() -> None:
+    result = execute_lab(lab())["canonical"]
+    assert result["layers"][0]["scale"] == pytest.approx(1 / (2**0.5))
+    assert result["layers"][0]["activations"][0] == pytest.approx(
+        [0.6088593650139138, -0.6088593650139138]
+    )
+    assert [
+        layer["summary"]["standard_deviation"] for layer in result["layers"]
+    ] == pytest.approx([0.6088593650139138, 0.49271338636057294, 0.4563673571184874])
+
+
+def test_tiny_relu_shrinks_across_layers() -> None:
+    row = execute_lab(lab())["comparison"][1]
+    assert row["initializer"] == "tiny"
+    assert row["activation"] == "relu"
+    assert row["standard_deviations"] == pytest.approx(
+        [0.05, 0.006959705453537528, 0.0008569568250501307]
+    )
+
+
+def test_large_modes_expose_saturation_and_growth() -> None:
+    comparison = execute_lab(lab())["comparison"]
+    large_tanh, large_relu = comparison[6], comparison[7]
+    assert large_tanh["saturated_fractions"] == [1, 0.5, 1]
+    assert large_relu["standard_deviations"] == pytest.approx(
+        [1, 2.7838821814150108, 6.855654600401044]
+    )
+
+
+def test_relu_zero_fraction_is_traced() -> None:
+    comparison = execute_lab(lab())["comparison"]
+    for row in comparison:
+        if row["activation"] == "relu":
+            assert row["zero_fractions"] == [0.5, 0.5, 0.625]
+            assert row["saturated_fractions"] == [0, 0, 0]
+
+
+def test_rejects_unknown_keys_and_trace_mismatch() -> None:
+    document = lab()
+    document["surprise"] = True
+    with pytest.raises(InitializationDistributionValidationError, match="key mismatch"):
+        validate_document(document)
+    document = lab()
+    document["expected"]["comparison"][0]["standard_deviations"][0] = 9
+    with pytest.raises(
+        InitializationDistributionValidationError, match="standard_deviations"
+    ):
+        validate_document(document)
+
+
+def test_rejects_bad_shape_and_operation() -> None:
+    document = lab()
+    document["inputs"][1] = [0, 1, 2]
+    with pytest.raises(InitializationDistributionValidationError, match="rectangular"):
+        validate_document(document)
+    document = lab()
+    document["weight_templates"][1] = [[1, -1]]
+    with pytest.raises(InitializationDistributionValidationError, match="fan-in"):
+        validate_document(document)
+    document = lab()
+    document["operation"]["variance"] = "sample"
+    with pytest.raises(InitializationDistributionValidationError, match="operation"):
+        validate_document(document)
+
+
+def test_loader_rejects_duplicate_and_non_finite(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text('{"x":1,"x":2}', encoding="utf-8")
+    with pytest.raises(InitializationDistributionValidationError, match="duplicate"):
+        load_json(path)
+    path.write_text('{"x":Infinity}', encoding="utf-8")
+    with pytest.raises(InitializationDistributionValidationError, match="non-finite"):
+        load_json(path)

--- a/code/scripts/tests/test_multi_head_attention_labs.py
+++ b/code/scripts/tests/test_multi_head_attention_labs.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for the NN14 multi-head attention fixture validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_multi_head_attention_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_multi_head_attention_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+DEFAULT_FIXTURE_ROOT = validator.DEFAULT_FIXTURE_ROOT
+MultiHeadAttentionValidationError = validator.MultiHeadAttentionValidationError
+execute_lab = validator.execute_lab
+load_json = validator.load_json
+validate_fixture_root = validator.validate_fixture_root
+validate_lab = validator.validate_lab
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-two-head-causal-add-norm.json"
+
+
+def test_checked_in_nn14_corpus_is_valid() -> None:
+    assert validate_fixture_root(DEFAULT_FIXTURE_ROOT) == 1
+
+
+def test_blue_heads_attend_differently() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    blue = result["rows"][1]
+
+    assert blue["heads"][0]["weights"] == [0.5, 0.5, 0.0]
+    assert blue["heads"][0]["context"] == 1.0
+    assert blue["heads"][1]["weights"][0] == pytest.approx(0.2689414213699951)
+    assert blue["heads"][1]["weights"][1] == pytest.approx(0.7310585786300049)
+    assert blue["heads"][1]["context"] == pytest.approx(0.7310585786300049)
+
+
+def test_blue_add_and_norm_trace_is_explicit() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    blue = result["rows"][1]
+
+    assert blue["concatenated"] == pytest.approx([1.0, 0.7310585786300049])
+    assert blue["projected_attention"] == pytest.approx(blue["concatenated"])
+    assert blue["residual_sum"] == pytest.approx([1.0, 1.7310585786300048])
+    assert blue["layer_norm"]["mean"] == pytest.approx(1.3655292893150024)
+    assert blue["layer_norm"]["output"] == pytest.approx(
+        [-0.9999625802171532, 0.9999625802171532]
+    )
+
+
+def test_causal_rows_normalize_inside_each_head() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    for row_index, row in enumerate(result["rows"]):
+        for head in row["heads"]:
+            assert sum(head["weights"]) == pytest.approx(1.0)
+            assert head["weights"][row_index + 1 :] == [0.0] * (2 - row_index)
+
+
+def test_validator_rejects_unknown_fields_and_wrong_shapes() -> None:
+    document = load_json(LAB_PATH)
+    with_extra = copy.deepcopy(document)
+    with_extra["heads"][0]["mystery"] = 3
+    with pytest.raises(MultiHeadAttentionValidationError, match="key mismatch"):
+        validate_lab(with_extra)
+
+    wrong_shape = copy.deepcopy(document)
+    wrong_shape["output_projection"] = [[1, 0]]
+    with pytest.raises(MultiHeadAttentionValidationError, match="expected 2 rows"):
+        validate_lab(wrong_shape)
+
+
+def test_validator_rejects_drifted_expected_trace() -> None:
+    document = load_json(LAB_PATH)
+    document["expected"]["rows"][1]["layer_norm"]["mean"] = 999
+    with pytest.raises(MultiHeadAttentionValidationError, match="expected.rows"):
+        validate_lab(document)
+
+
+def test_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version": 1, "schema_version": 1}', encoding="utf-8")
+    with pytest.raises(MultiHeadAttentionValidationError, match="duplicate JSON key"):
+        load_json(duplicate)
+
+
+def test_loader_rejects_non_finite_numbers(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"value": float("nan")}), encoding="utf-8")
+    with pytest.raises(MultiHeadAttentionValidationError, match="non-finite"):
+        load_json(invalid)

--- a/code/scripts/tests/test_one_dimensional_diffusion_labs.py
+++ b/code/scripts/tests/test_one_dimensional_diffusion_labs.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for the NN19 one-dimensional diffusion fixture validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = (
+    REPO_ROOT / "code" / "scripts" / "validate_one_dimensional_diffusion_labs.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "validate_one_dimensional_diffusion_labs",
+    MODULE_PATH,
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+DEFAULT_FIXTURE_ROOT = validator.DEFAULT_FIXTURE_ROOT
+OneDimensionalDiffusionValidationError = (
+    validator.OneDimensionalDiffusionValidationError
+)
+execute_lab = validator.execute_lab
+load_json = validator.load_json
+validate_fixture_root = validator.validate_fixture_root
+validate_lab = validator.validate_lab
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-two-level-forward-and-reverse.json"
+
+
+def test_canonical_corpus_validates() -> None:
+    assert validate_fixture_root(DEFAULT_FIXTURE_ROOT) == 1
+
+
+def test_forward_schedule_trades_signal_for_saved_noise() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+
+    assert [row["alpha_bar"] for row in result["forward_steps"]] == pytest.approx(
+        [0.64, 0.36]
+    )
+    assert [row["signal_scale"] for row in result["forward_steps"]] == pytest.approx(
+        [0.8, 0.6]
+    )
+    assert [row["noise_scale"] for row in result["forward_steps"]] == pytest.approx(
+        [0.6, 0.8]
+    )
+    assert [row["noisy_sample"] for row in result["forward_steps"]] == pytest.approx(
+        [0.5, 0.2]
+    )
+
+
+def test_initial_noise_predictions_share_one_mean_objective() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+
+    assert [row["predicted_noise"] for row in result["initial_denoising"]] == [
+        0,
+        0,
+    ]
+    assert [row["error"] for row in result["initial_denoising"]] == [0.5, 0.5]
+    assert result["initial_mean_loss"] == pytest.approx(0.125)
+
+
+def test_both_timesteps_reduce_into_shared_gradients() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    backward = result["backward"]
+
+    assert [
+        row["sample_weight_contribution"] for row in backward["per_step"]
+    ] == pytest.approx([0.125, 0.05])
+    assert backward["sample_weight_gradient"] == pytest.approx(0.175)
+    assert backward["timestep_weight_gradient"] == pytest.approx(0.375)
+    assert backward["bias_gradient"] == pytest.approx(0.5)
+
+
+def test_gradient_audit_matches_three_analytical_slopes() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    audit = result["gradient_check"]
+
+    assert audit["parameter_order"] == [
+        "denoiser.sample_weight",
+        "denoiser.timestep_weight",
+        "denoiser.bias",
+    ]
+    assert audit["analytical"] == pytest.approx([0.175, 0.375, 0.5])
+    assert audit["max_absolute_error"] < 1e-8
+
+
+def test_sgd_update_lowers_noise_prediction_loss() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+
+    assert result["updated_denoiser"] == pytest.approx(
+        {
+            "sample_weight": -0.0875,
+            "timestep_weight": -0.1875,
+            "bias": -0.25,
+        }
+    )
+    assert [
+        row["predicted_noise"] for row in result["post_update_denoising"]
+    ] == pytest.approx([-0.3875, -0.455])
+    assert result["post_update_mean_loss"] == pytest.approx(0.0036703125)
+    assert result["post_update_mean_loss"] < result["initial_mean_loss"]
+
+
+def test_reverse_mean_reconstructs_the_clean_sample() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+
+    assert [row["t"] for row in result["reverse_steps"]] == [2, 1]
+    assert [row["output_mean"] for row in result["reverse_steps"]] == pytest.approx(
+        [0.5984375, 1.0451318359375]
+    )
+    assert result["final_reconstruction"] == pytest.approx(1.0451318359375)
+    assert result["final_absolute_error"] == pytest.approx(0.0451318359375)
+
+
+def test_unknown_fields_are_rejected() -> None:
+    document = copy.deepcopy(load_json(LAB_PATH))
+    document["mystery"] = True
+
+    with pytest.raises(OneDimensionalDiffusionValidationError, match="key mismatch"):
+        validate_lab(document)
+
+
+def test_invalid_schedule_order_is_rejected() -> None:
+    document = copy.deepcopy(load_json(LAB_PATH))
+    document["schedule"][1]["t"] = 3
+
+    with pytest.raises(
+        OneDimensionalDiffusionValidationError,
+        match="consecutive timesteps",
+    ):
+        validate_lab(document)
+
+
+def test_mutated_expected_trace_is_rejected() -> None:
+    document = copy.deepcopy(load_json(LAB_PATH))
+    document["expected"]["final_reconstruction"] = 999
+
+    with pytest.raises(
+        OneDimensionalDiffusionValidationError,
+        match="expected.final_reconstruction",
+    ):
+        validate_lab(document)
+
+
+def test_loader_rejects_duplicate_and_non_finite_json(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version": 1, "schema_version": 1}')
+    with pytest.raises(OneDimensionalDiffusionValidationError, match="duplicate"):
+        load_json(duplicate)
+
+    non_finite = tmp_path / "non-finite.json"
+    non_finite.write_text(json.dumps({"value": float("nan")}))
+    with pytest.raises(OneDimensionalDiffusionValidationError, match="non-finite"):
+        load_json(non_finite)

--- a/code/scripts/tests/test_one_dimensional_gan_labs.py
+++ b/code/scripts/tests/test_one_dimensional_gan_labs.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Tests for the NN18 one-dimensional GAN fixture validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_one_dimensional_gan_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_one_dimensional_gan_labs",
+    MODULE_PATH,
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+DEFAULT_FIXTURE_ROOT = validator.DEFAULT_FIXTURE_ROOT
+OneDimensionalGanValidationError = validator.OneDimensionalGanValidationError
+execute_lab = validator.execute_lab
+load_json = validator.load_json
+validate_fixture_root = validator.validate_fixture_root
+validate_lab = validator.validate_lab
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-discriminator-generator-round.json"
+
+
+def test_checked_in_nn18_corpus_is_valid() -> None:
+    assert validate_fixture_root(DEFAULT_FIXTURE_ROOT) == 1
+
+
+def test_generator_maps_saved_noise_to_one_fake_point() -> None:
+    initial = execute_lab(load_json(LAB_PATH))["initial"]
+
+    assert initial["generator_product"] == pytest.approx(0.2)
+    assert initial["fake_sample"] == pytest.approx(0.2)
+    assert initial["real_probability"] == pytest.approx(0.7310585786300049)
+    assert initial["fake_probability"] == pytest.approx(0.549833997312478)
+
+
+def test_discriminator_combines_real_and_detached_fake_routes() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    backward = result["discriminator_backward"]
+
+    assert backward["real_logit_gradient"] == pytest.approx(-0.13447071068499755)
+    assert backward["fake_logit_gradient"] == pytest.approx(0.274916998656239)
+    assert backward["fake_value_gradient"] == 0
+    assert backward["weight_gradient"] == pytest.approx(-0.07948731095374975)
+    assert backward["bias_gradient"] == pytest.approx(0.14044628797124142)
+    assert (
+        result["after_discriminator"]["discriminator_loss"]
+        < result["initial"]["discriminator_loss"]
+    )
+
+
+def test_generator_uses_updated_frozen_discriminator_input_gradient() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    backward = result["generator_backward"]
+
+    assert backward["fake_logit_gradient"] == pytest.approx(-0.46562292571326525)
+    assert backward["fake_value_gradient"] == pytest.approx(-0.48412848285494775)
+    assert backward["weight_gradient"] == pytest.approx(-0.48412848285494775)
+    assert backward["bias_gradient"] == pytest.approx(-0.48412848285494775)
+
+
+def test_counter_move_lowers_generator_loss_and_raises_discriminator_loss() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+
+    assert result["after_generator"]["fake_sample"] == pytest.approx(
+        0.44206424142747386
+    )
+    assert result["after_generator"]["fake_probability"] == pytest.approx(
+        0.5961407441300886
+    )
+    assert (
+        result["after_generator"]["generator_loss"]
+        < result["after_discriminator"]["generator_loss"]
+    )
+    assert (
+        result["after_generator"]["discriminator_loss"]
+        > result["after_discriminator"]["discriminator_loss"]
+    )
+
+
+def test_both_player_specific_gradient_audits_pass() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+
+    for player in ("discriminator", "generator"):
+        check = result[f"{player}_gradient_check"]
+        assert len(check["parameter_order"]) == 2
+        assert check["numerical"] == pytest.approx(check["analytical"], abs=1e-8)
+        assert check["max_absolute_error"] < 1e-8
+
+
+def test_validator_rejects_unknown_fields_and_bad_learning_rate() -> None:
+    document = load_json(LAB_PATH)
+    with_extra = copy.deepcopy(document)
+    with_extra["generator"]["mystery"] = 3
+    with pytest.raises(OneDimensionalGanValidationError, match="key mismatch"):
+        validate_lab(with_extra)
+
+    bad_rate = copy.deepcopy(document)
+    bad_rate["optimizer"]["generator_learning_rate"] = 0
+    with pytest.raises(OneDimensionalGanValidationError, match="positive"):
+        validate_lab(bad_rate)
+
+
+def test_validator_rejects_drifted_expected_trace() -> None:
+    document = load_json(LAB_PATH)
+    document["expected"]["after_generator"]["fake_sample"] = 999
+    with pytest.raises(
+        OneDimensionalGanValidationError, match="expected.after_generator"
+    ):
+        validate_lab(document)
+
+
+def test_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version": 1, "schema_version": 1}', encoding="utf-8")
+    with pytest.raises(OneDimensionalGanValidationError, match="duplicate JSON key"):
+        load_json(duplicate)
+
+
+def test_loader_rejects_non_finite_numbers(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"value": float("nan")}), encoding="utf-8")
+    with pytest.raises(OneDimensionalGanValidationError, match="non-finite"):
+        load_json(invalid)

--- a/code/scripts/tests/test_optimization_learning_labs.py
+++ b/code/scripts/tests/test_optimization_learning_labs.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests for the NN04 optimization-learning fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_optimization_learning_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_optimization_learning_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class OptimizationLearningLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture_path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "optimization-learning-v1"
+            / "labs"
+            / "00-linear-loss-landscape.json"
+        )
+        self.lab = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual(
+            [path.name for path in paths], ["00-linear-loss-landscape.json"]
+        )
+
+    def test_reproduces_gradient_and_optimizer_oracles(self) -> None:
+        rows = validator._rows(self.lab)
+        parameters = self.lab["model"]["parameters"]
+        self.assertEqual(
+            validator.analytical_gradient(rows, parameters),
+            {"weight": -8.5, "bias": -4.5},
+        )
+        full_batch = validator.run_strategy(self.lab, "full-batch")
+        self.assertAlmostEqual(full_batch["loss"], 0.13251310567040367)
+
+    def test_rejects_a_mutated_numerical_gradient(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["gradient_check"]["expected"]["numerical"]["weight"] += 0.1
+        with self.assertRaises(validator.OptimizationLabValidationError):
+            validator.validate_lab(lab)
+
+    def test_rejects_a_missing_batch_strategy(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["optimizer_comparison"]["strategies"].pop()
+        with self.assertRaises(validator.OptimizationLabValidationError):
+            validator.validate_lab(lab)
+
+    def test_cli_rejects_an_empty_corpus(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            schema = {"$schema": "https://json-schema.org/draft/2020-12/schema"}
+            (root / "schema.json").write_text(json.dumps(schema), encoding="utf-8")
+            (root / "labs").mkdir()
+            with self.assertRaises(validator.OptimizationLabValidationError):
+                validator.validate_corpus(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_recurrent_bptt_labs.py
+++ b/code/scripts/tests/test_recurrent_bptt_labs.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Tests for the NN10 recurrent BPTT fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_recurrent_bptt_labs.py"
+SPEC = importlib.util.spec_from_file_location("validate_recurrent_bptt_labs", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class RecurrentBpttLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture_path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "recurrent-bptt-v1"
+            / "labs"
+            / "00-final-state-loss.json"
+        )
+        self.lab = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual([path.name for path in paths], ["00-final-state-loss.json"])
+
+    def test_backpropagates_state_gradient_in_reverse_time(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertEqual(
+            [step["time"] for step in trace["backward_steps"]], [2, 1, 0]
+        )
+        self.assertEqual(
+            [step["state_gradient"] for step in trace["backward_steps"]],
+            [0.75, 0.375, 0.1875],
+        )
+
+    def test_accumulates_each_shared_parameter_gradient(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertEqual(
+            trace["gradient_totals"],
+            {
+                "input_weight": 0.9375,
+                "recurrent_weight": 3.0,
+                "bias": 1.3125,
+                "initial_state": 0.09375,
+            },
+        )
+
+    def test_matches_central_finite_differences(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertLess(trace["gradient_check"]["max_absolute_error"], 1e-9)
+
+    def test_proposes_an_update_that_reduces_loss(self) -> None:
+        trace = validator.execute_lab(self.lab)
+        self.assertAlmostEqual(
+            trace["update"]["parameters"]["recurrent_weight"], 0.2
+        )
+        self.assertLess(trace["update"]["loss"], trace["forward"]["loss"])
+
+    def test_rejects_a_mutated_time_local_contribution(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["expected"]["backward_steps"][0]["recurrent_weight_gradient"] = 0
+        with self.assertRaises(validator.RecurrentBpttValidationError):
+            validator.validate_lab(lab)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_recurrent_unroll_labs.py
+++ b/code/scripts/tests/test_recurrent_unroll_labs.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Tests for the NN09 recurrent-unroll fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_recurrent_unroll_labs.py"
+SPEC = importlib.util.spec_from_file_location("validate_recurrent_unroll_labs", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class RecurrentUnrollLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture_path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "recurrent-unroll-v1"
+            / "labs"
+            / "00-three-step-relu-state.json"
+        )
+        self.lab = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual(
+            [path.name for path in paths], ["00-three-step-relu-state.json"]
+        )
+
+    def test_unrolls_three_steps_with_one_shared_parameter_set(self) -> None:
+        trace = validator.trace_recurrent(
+            self.lab["inputs"], self.lab["initial_state"], self.lab["parameters"]
+        )
+        self.assertEqual(trace["states"], [1, 3.5, 0.75])
+        self.assertEqual(trace["final_state"], 0.75)
+
+    def test_exposes_every_term_at_the_zero_input_step(self) -> None:
+        trace = validator.trace_recurrent(
+            self.lab["inputs"], self.lab["initial_state"], self.lab["parameters"]
+        )
+        final = trace["steps"][2]
+        self.assertEqual(final["input_product"], 0)
+        self.assertEqual(final["recurrent_product"], 1.75)
+        self.assertEqual(final["preactivation"], 0.75)
+        self.assertEqual(final["state"], 0.75)
+
+    def test_memory_ablation_removes_the_final_state(self) -> None:
+        trace = validator.trace_recurrent(
+            self.lab["inputs"],
+            self.lab["initial_state"],
+            self.lab["parameters"],
+            recurrent_enabled=False,
+        )
+        self.assertEqual(trace["states"], [1, 3, 0])
+
+    def test_rejects_a_mutated_recurrent_product(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["expected"]["steps"][1]["recurrent_product"] = 0
+        with self.assertRaises(validator.RecurrentUnrollValidationError):
+            validator.validate_lab(lab)
+
+    def test_rejects_a_fourth_time_step(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["inputs"].append(1)
+        with self.assertRaises(validator.RecurrentUnrollValidationError):
+            validator.validate_lab(lab)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_residual_receptive_labs.py
+++ b/code/scripts/tests/test_residual_receptive_labs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Tests for the NN08 residual/receptive-field fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_residual_receptive_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_residual_receptive_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class ResidualReceptiveLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture_path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "residual-receptive-v1"
+            / "labs"
+            / "00-two-layer-residual.json"
+        )
+        self.lab = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual([path.name for path in paths], ["00-two-layer-residual.json"])
+
+    def test_runs_two_same_padded_layers_and_identity_skip(self) -> None:
+        trace = validator.trace_residual(self.lab["input"], self.lab["kernels"])
+        self.assertEqual(trace["hidden"], [1, 3, 2, 3, 1])
+        self.assertEqual(trace["main"], [4, 6, 8, 6, 4])
+        self.assertEqual(trace["residual_sum"], [5, 6, 10, 6, 5])
+        self.assertEqual(trace["output"], [5, 6, 10, 6, 5])
+
+    def test_expands_center_output_to_five_input_positions(self) -> None:
+        trace = validator.trace_residual(self.lab["input"], self.lab["kernels"])
+        center = trace["traces"][2]
+        self.assertEqual(center["hidden_indices"], [1, 2, 3])
+        self.assertEqual(center["input_path_counts"], [1, 2, 3, 2, 1])
+        self.assertEqual(center["input_contributions"], [1, 0, 6, 0, 1])
+        self.assertEqual(center["receptive_field_indices"], [0, 1, 2, 3, 4])
+
+    def test_clips_in_range_receptive_fields_at_boundaries(self) -> None:
+        trace = validator.trace_residual(self.lab["input"], self.lab["kernels"])
+        self.assertEqual(trace["traces"][0]["receptive_field_indices"], [0, 1, 2])
+        self.assertEqual(trace["traces"][4]["receptive_field_indices"], [2, 3, 4])
+
+    def test_rejects_a_mutated_path_count(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["expected"]["traces"][2]["input_path_counts"][2] = 2
+        with self.assertRaises(validator.ResidualReceptiveValidationError):
+            validator.validate_lab(lab)
+
+    def test_rejects_a_non_identity_length_skip(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["input"].pop()
+        with self.assertRaises(validator.ResidualReceptiveValidationError):
+            validator.validate_lab(lab)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_tiny_decoder_training_labs.py
+++ b/code/scripts/tests/test_tiny_decoder_training_labs.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Tests for the NN15 tiny decoder training fixture validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_tiny_decoder_training_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_tiny_decoder_training_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+DEFAULT_FIXTURE_ROOT = validator.DEFAULT_FIXTURE_ROOT
+TinyDecoderTrainingValidationError = validator.TinyDecoderTrainingValidationError
+execute_lab = validator.execute_lab
+load_json = validator.load_json
+validate_fixture_root = validator.validate_fixture_root
+validate_lab = validator.validate_lab
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-two-position-next-token-step.json"
+
+
+def test_checked_in_nn15_corpus_is_valid() -> None:
+    assert validate_fixture_root(DEFAULT_FIXTURE_ROOT) == 1
+
+
+def test_sequence_shift_builds_two_causal_training_positions() -> None:
+    document = load_json(LAB_PATH)
+    result = execute_lab(document)
+
+    assert document["input_tokens"] == ["red", "blue"]
+    assert document["target_tokens"] == ["blue", "purple"]
+    assert [row["causal_prefix"] for row in result["rows"]] == [
+        ["red"],
+        ["red", "blue"],
+    ]
+
+
+def test_forward_trace_reproduces_logits_softmax_and_loss() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    first, second = result["rows"]
+
+    assert first["logit_products"] == [[1.0, 0.0], [0.0, 0.0], [-1.0, 0.0]]
+    assert first["logits"] == [1.0, 0.0, -1.0]
+    assert sum(first["probabilities"]) == pytest.approx(1.0)
+    assert first["target_probability"] == pytest.approx(0.24472847105479764)
+    assert second["target_probability"] == pytest.approx(0.09003057317038046)
+    assert result["mean_loss"] == pytest.approx(1.9076059644443801)
+
+
+def test_backward_trace_reduces_shared_gradients() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    first, second = result["rows"]
+
+    assert first["unembedding_gradient_contribution"][1] == [0.0, 0.0, 0.0]
+    assert second["unembedding_gradient_contribution"][0] == [0.0, 0.0, 0.0]
+    assert result["unembedding_gradient"][0] == pytest.approx(
+        [0.3326204778874109, -0.37763576447260117, 0.04501528658519023]
+    )
+    assert result["unembedding_gradient"][1] == pytest.approx(
+        [0.12236423552739882, 0.3326204778874109, -0.4549847134148098]
+    )
+    assert first["state_gradient"] == pytest.approx(
+        [
+            0.2876051913022207,
+            -0.4226510510577914,
+        ]
+    )
+
+
+def test_one_sgd_step_lowers_mean_loss() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+
+    assert result["updated_bias"] == pytest.approx(
+        [
+            -0.22749235670740486,
+            0.022507643292595136,
+            0.20498471341480978,
+        ]
+    )
+    assert result["post_update_mean_loss"] == pytest.approx(1.456094285138867)
+    assert result["post_update_mean_loss"] < result["mean_loss"]
+
+
+def test_central_finite_differences_audit_shared_head_gradients() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    check = result["gradient_check"]
+
+    assert check["epsilon"] == 1e-6
+    assert check["numerical_unembedding_gradient"][0] == pytest.approx(
+        result["unembedding_gradient"][0], abs=1e-8
+    )
+    assert check["numerical_unembedding_gradient"][1] == pytest.approx(
+        result["unembedding_gradient"][1], abs=1e-8
+    )
+    assert check["numerical_bias_gradient"] == pytest.approx(
+        result["bias_gradient"], abs=1e-8
+    )
+    assert check["max_absolute_error"] < 1e-8
+
+
+def test_validator_rejects_unknown_fields_and_broken_shift() -> None:
+    document = load_json(LAB_PATH)
+    with_extra = copy.deepcopy(document)
+    with_extra["mystery"] = 3
+    with pytest.raises(TinyDecoderTrainingValidationError, match="key mismatch"):
+        validate_lab(with_extra)
+
+    broken_shift = copy.deepcopy(document)
+    broken_shift["target_tokens"] = ["purple", "blue"]
+    with pytest.raises(TinyDecoderTrainingValidationError, match="sequence shift"):
+        validate_lab(broken_shift)
+
+
+def test_validator_rejects_drifted_expected_trace() -> None:
+    document = load_json(LAB_PATH)
+    document["expected"]["post_update_mean_loss"] = 999
+    with pytest.raises(TinyDecoderTrainingValidationError, match="expected"):
+        validate_lab(document)
+
+
+def test_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version": 1, "schema_version": 1}', encoding="utf-8")
+    with pytest.raises(TinyDecoderTrainingValidationError, match="duplicate JSON key"):
+        load_json(duplicate)
+
+
+def test_loader_rejects_non_finite_numbers(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"value": float("nan")}), encoding="utf-8")
+    with pytest.raises(TinyDecoderTrainingValidationError, match="non-finite"):
+        load_json(invalid)

--- a/code/scripts/tests/test_tiny_image_cnn_labs.py
+++ b/code/scripts/tests/test_tiny_image_cnn_labs.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Tests for the NN07 tiny-image CNN fixture validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_tiny_image_cnn_labs.py"
+SPEC = importlib.util.spec_from_file_location("validate_tiny_image_cnn_labs", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class TinyImageCnnLabTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture_path = (
+            REPO_ROOT
+            / "code"
+            / "specs"
+            / "fixtures"
+            / "tiny-image-cnn-v1"
+            / "labs"
+            / "00-two-channel-image.json"
+        )
+        self.lab = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    def test_validates_checked_in_corpus(self) -> None:
+        paths = validator.validate_corpus()
+        self.assertEqual([path.name for path in paths], ["00-two-channel-image.json"])
+
+    def test_accumulates_input_channels_and_bias(self) -> None:
+        trace = validator.trace_pipeline(deepcopy(self.lab))
+        self.assertEqual(
+            trace["channel_contributions"][0],
+            [[[0, 0], [4, 4]], [[0, 2], [0, 2]]],
+        )
+        self.assertEqual(trace["convolution"][0], [[0, 2], [4, 6]])
+        self.assertEqual(trace["convolution"][1], [[6, 4], [2, 0]])
+
+    def test_normalizes_each_output_channel_over_space(self) -> None:
+        trace = validator.trace_pipeline(deepcopy(self.lab))
+        normalization = trace["normalization"]
+        self.assertEqual(normalization["means"], [3, 3])
+        self.assertEqual(normalization["variances"], [5, 5])
+        self.assertEqual(normalization["denominators"], [3, 3])
+        self.assertAlmostEqual(normalization["maps"][0][0][1], -1 / 3)
+
+    def test_relu_and_pooling_preserve_winner_positions(self) -> None:
+        trace = validator.trace_pipeline(deepcopy(self.lab))
+        self.assertEqual(trace["activation"][0], [[0, 0], [1 / 3, 1]])
+        self.assertEqual(trace["activation"][1], [[1, 1 / 3], [0, 0]])
+        self.assertEqual(trace["pooling"], {"values": [1, 1], "argmax": [[1, 1], [0, 0]]})
+
+    def test_rejects_a_mutated_channel_contribution(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["expected"]["channel_contributions"][0][1][0][1] += 0.5
+        with self.assertRaises(validator.TinyImageCnnValidationError):
+            validator.validate_lab(lab)
+
+    def test_rejects_a_filter_without_every_input_channel(self) -> None:
+        lab = deepcopy(self.lab)
+        lab["filters"][0]["kernels"].pop()
+        with self.assertRaises(validator.TinyImageCnnValidationError):
+            validator.validate_lab(lab)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_tiny_message_passing_labs.py
+++ b/code/scripts/tests/test_tiny_message_passing_labs.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "code" / "scripts"))
+
+from validate_tiny_message_passing_labs import (
+    DEFAULT_FIXTURE_ROOT,
+    TinyMessagePassingValidationError,
+    execute_lab,
+    load_json,
+    validate_corpus,
+    validate_document,
+)
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-three-node-path.json"
+
+
+def lab() -> dict[str, object]:
+    return load_json(LAB_PATH)
+
+
+def test_schema_and_corpus() -> None:
+    schema = load_json(DEFAULT_FIXTURE_ROOT / "schema.json")
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(lab())
+    assert validate_corpus() == 1
+
+
+def test_expands_two_edges_into_four_sorted_messages() -> None:
+    messages = execute_lab(lab())["directed_messages"]
+    assert [(row["source"], row["target"]) for row in messages] == [
+        (1, 0),
+        (0, 1),
+        (2, 1),
+        (1, 2),
+    ]
+    assert [row["message"] for row in messages] == pytest.approx([1, 0.5, -0.5, 1])
+
+
+def test_middle_node_sums_two_opposing_messages() -> None:
+    middle = execute_lab(lab())["node_updates"][1]
+    assert [row["message"] for row in middle["incoming"]] == pytest.approx([0.5, -0.5])
+    assert middle["aggregate"] == pytest.approx(0)
+    assert middle["self_contribution"] == pytest.approx(0.5)
+    assert middle["preactivation"] == pytest.approx(0)
+    assert middle["output_feature"] == pytest.approx(0)
+
+
+def test_shared_update_produces_all_three_outputs() -> None:
+    result = validate_document(lab())
+    assert [row["aggregate"] for row in result["node_updates"]] == pytest.approx(
+        [1, 0, 1]
+    )
+    assert [row["preactivation"] for row in result["node_updates"]] == pytest.approx(
+        [0.75, 0, 0.25]
+    )
+    assert result["output_features"] == pytest.approx([0.75, 0, 0.25])
+
+
+def test_rejects_unknown_keys() -> None:
+    document = lab()
+    document["surprise"] = True
+    with pytest.raises(TinyMessagePassingValidationError, match="key mismatch"):
+        validate_document(document)
+
+
+def test_rejects_self_and_duplicate_edges() -> None:
+    document = lab()
+    document["edges"][0] = {"source": 0, "target": 0}
+    with pytest.raises(TinyMessagePassingValidationError, match="non-self"):
+        validate_document(document)
+    document = lab()
+    document["edges"] = [{"source": 0, "target": 1}, {"source": 1, "target": 0}]
+    with pytest.raises(TinyMessagePassingValidationError, match="duplicate"):
+        validate_document(document)
+
+
+def test_rejects_invalid_node_indices() -> None:
+    document = lab()
+    document["edges"][1]["target"] = 9
+    with pytest.raises(TinyMessagePassingValidationError, match="invalid"):
+        validate_document(document)
+
+
+def test_rejects_trace_mismatch() -> None:
+    document = lab()
+    document["expected"]["output_features"][0] = 0.8
+    with pytest.raises(TinyMessagePassingValidationError, match="output_features"):
+        validate_document(document)
+
+
+def test_operation_is_exact() -> None:
+    document = copy.deepcopy(lab())
+    document["operation"]["round"] = "asynchronous"
+    with pytest.raises(TinyMessagePassingValidationError, match="operation"):
+        validate_document(document)
+
+
+def test_loader_rejects_duplicate_and_non_finite_json(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"id":"a","id":"b"}', encoding="utf-8")
+    with pytest.raises(TinyMessagePassingValidationError, match="duplicate"):
+        load_json(duplicate)
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text('{"value":NaN}', encoding="utf-8")
+    with pytest.raises(TinyMessagePassingValidationError, match="non-finite"):
+        load_json(invalid)

--- a/code/scripts/tests/test_training_stabilizer_labs.py
+++ b/code/scripts/tests/test_training_stabilizer_labs.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "code" / "scripts"))
+
+from validate_training_stabilizer_labs import (
+    DEFAULT_FIXTURE_ROOT,
+    TrainingStabilizerValidationError,
+    execute_lab,
+    load_json,
+    validate_corpus,
+    validate_document,
+)
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-four-route-comparison.json"
+
+
+def lab() -> dict[str, object]:
+    return load_json(LAB_PATH)
+
+
+def trace() -> dict[str, object]:
+    return execute_lab(lab())
+
+
+def route(route_id: str) -> dict[str, object]:
+    return next(item for item in trace()["routes"] if item["id"] == route_id)
+
+
+def test_schema_and_corpus() -> None:
+    schema = load_json(DEFAULT_FIXTURE_ROOT / "schema.json")
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(lab())
+    assert validate_corpus() == 1
+
+
+def test_shared_branch_and_normalization_statistics() -> None:
+    result = trace()
+    assert result["branch"] == [0.5, 0.5, 1.5, 1.5]
+    assert result["normalization"] == {
+        "mean": 1.0,
+        "centered": [-0.5, -0.5, 0.5, 0.5],
+        "variance": 0.25,
+        "standard_deviation": 0.5,
+        "normalized": [-1.0, -1.0, 1.0, 1.0],
+        "upstream_sum": 0.0,
+        "upstream_dot_normalized": -2.0,
+    }
+
+
+def test_plain_route_is_the_control() -> None:
+    plain = route("plain")
+    assert plain["output"] == [0.5, 0.5, 1.5, 1.5]
+    assert plain["score"] == -1
+    assert plain["input_gradient"] == [0.5, 0, 0, -0.5]
+    assert plain["weight_gradient"] == -2
+
+
+def test_normalization_couples_coordinates_and_removes_common_scale() -> None:
+    normalized = route("normalization")
+    assert normalized["output"] == [-1, -1, 1, 1]
+    assert normalized["branch_gradient"] == [1, -1, 1, -1]
+    assert normalized["input_gradient"] == [0.5, -0.5, 0.5, -0.5]
+    assert normalized["weight_gradient"] == 0
+
+
+def test_inverted_dropout_pins_training_eval_and_expectation() -> None:
+    result = trace()
+    assert result["dropout"] == {
+        "scaled_mask": [2, 0, 2, 0],
+        "evaluation_output": [0.5, 0.5, 1.5, 1.5],
+        "training_expectation": [0.5, 0.5, 1.5, 1.5],
+    }
+    dropout = route("dropout")
+    assert dropout["output"] == [1, 0, 3, 0]
+    assert dropout["branch_gradient"] == [2, 0, 0, 0]
+    assert dropout["input_gradient"] == [1, 0, 0, 0]
+
+
+def test_residual_route_splits_identity_and_branch_gradients() -> None:
+    residual = route("residual")
+    assert residual["output"] == [1.5, 1.5, 4.5, 4.5]
+    assert residual["skip_gradient"] == [1, 0, 0, -1]
+    assert residual["input_gradient"] == [1.5, 0, 0, -1.5]
+    assert residual["weight_gradient"] == -2
+
+
+def test_every_analytical_gradient_passes_finite_difference() -> None:
+    for item in validate_document(lab())["routes"]:
+        assert max(item["input_gradient_absolute_error"]) < 1e-8
+        assert item["weight_gradient_absolute_error"] < 1e-8
+
+
+def test_rejects_unknown_keys_masks_order_and_trace_drift() -> None:
+    document = lab()
+    document["surprise"] = True
+    with pytest.raises(TrainingStabilizerValidationError, match="key mismatch"):
+        validate_document(document)
+    document = lab()
+    document["dropout_mask"] = [1, 2, 1, 0]
+    with pytest.raises(TrainingStabilizerValidationError, match="binary"):
+        validate_document(document)
+    document = lab()
+    document["expected"]["routes"][0]["id"] = "residual"
+    with pytest.raises(TrainingStabilizerValidationError, match="route order"):
+        validate_document(document)
+    document = lab()
+    document["expected"]["routes"][3]["input_gradient"][0] = 1.4
+    with pytest.raises(TrainingStabilizerValidationError, match="input_gradient"):
+        validate_document(document)
+
+
+def test_loader_rejects_duplicate_and_non_finite(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text('{"x":1,"x":2}', encoding="utf-8")
+    with pytest.raises(TrainingStabilizerValidationError, match="duplicate"):
+        load_json(path)
+    path.write_text('{"x":NaN}', encoding="utf-8")
+    with pytest.raises(TrainingStabilizerValidationError, match="non-finite"):
+        load_json(path)

--- a/code/scripts/tests/test_two_number_autoencoder_labs.py
+++ b/code/scripts/tests/test_two_number_autoencoder_labs.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Tests for the NN16 two-number autoencoder fixture validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "code" / "scripts" / "validate_two_number_autoencoder_labs.py"
+SPEC = importlib.util.spec_from_file_location(
+    "validate_two_number_autoencoder_labs", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+DEFAULT_FIXTURE_ROOT = validator.DEFAULT_FIXTURE_ROOT
+TwoNumberAutoencoderValidationError = validator.TwoNumberAutoencoderValidationError
+execute_lab = validator.execute_lab
+load_json = validator.load_json
+validate_fixture_root = validator.validate_fixture_root
+validate_lab = validator.validate_lab
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-linear-bottleneck-step.json"
+
+
+def test_checked_in_nn16_corpus_is_valid() -> None:
+    assert validate_fixture_root(DEFAULT_FIXTURE_ROOT) == 1
+
+
+def test_forward_trace_compresses_two_values_into_one() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    forward = result["forward"]
+
+    assert forward["encoder_products"] == pytest.approx([1.0, 0.25])
+    assert forward["bottleneck"] == pytest.approx(1.25)
+    assert forward["decoder_products"] == pytest.approx([1.5, -1.0])
+    assert forward["reconstruction"] == pytest.approx([1.6, -1.2])
+    assert forward["loss"] == pytest.approx(0.1)
+
+
+def test_both_reconstruction_errors_meet_at_bottleneck() -> None:
+    backward = execute_lab(load_json(LAB_PATH))["backward"]
+
+    assert backward["reconstruction_gradients"] == pytest.approx([-0.4, -0.2])
+    assert backward["bottleneck_gradient_contributions"] == pytest.approx([-0.48, 0.16])
+    assert backward["bottleneck_gradient"] == pytest.approx(-0.32)
+    assert backward["encoder_weight_gradients"] == pytest.approx([-0.64, 0.32])
+
+
+def test_central_finite_differences_audit_all_parameters() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+    check = result["gradient_check"]
+
+    assert len(check["parameter_order"]) == 7
+    assert check["numerical"] == pytest.approx(check["analytical"], abs=1e-8)
+    assert check["max_absolute_error"] < 1e-8
+
+
+def test_one_sgd_step_lowers_reconstruction_loss() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+
+    assert result["updated_parameters"]["encoder"]["weights"] == pytest.approx(
+        [0.564, -0.282]
+    )
+    assert result["post_update"]["bottleneck"] == pytest.approx(1.442)
+    assert result["post_update"]["reconstruction"] == pytest.approx([1.9425, -1.29755])
+    assert result["post_update"]["loss"] == pytest.approx(0.04592112625)
+    assert result["post_update"]["loss"] < result["forward"]["loss"]
+
+
+def test_validator_rejects_unknown_fields_and_wrong_shapes() -> None:
+    document = load_json(LAB_PATH)
+    with_extra = copy.deepcopy(document)
+    with_extra["encoder"]["mystery"] = 3
+    with pytest.raises(TwoNumberAutoencoderValidationError, match="key mismatch"):
+        validate_lab(with_extra)
+
+    wrong_shape = copy.deepcopy(document)
+    wrong_shape["decoder"]["weights"] = [1.2]
+    with pytest.raises(TwoNumberAutoencoderValidationError, match="expected 2 numbers"):
+        validate_lab(wrong_shape)
+
+
+def test_validator_rejects_drifted_expected_trace() -> None:
+    document = load_json(LAB_PATH)
+    document["expected"]["forward"]["bottleneck"] = 999
+    with pytest.raises(TwoNumberAutoencoderValidationError, match="expected.forward"):
+        validate_lab(document)
+
+
+def test_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version": 1, "schema_version": 1}', encoding="utf-8")
+    with pytest.raises(TwoNumberAutoencoderValidationError, match="duplicate JSON key"):
+        load_json(duplicate)
+
+
+def test_loader_rejects_non_finite_numbers(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"value": float("nan")}), encoding="utf-8")
+    with pytest.raises(TwoNumberAutoencoderValidationError, match="non-finite"):
+        load_json(invalid)

--- a/code/scripts/tests/test_variational_autoencoder_labs.py
+++ b/code/scripts/tests/test_variational_autoencoder_labs.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Tests for the NN17 scalar variational autoencoder fixture validator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = (
+    REPO_ROOT / "code" / "scripts" / "validate_variational_autoencoder_labs.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "validate_variational_autoencoder_labs",
+    MODULE_PATH,
+)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+DEFAULT_FIXTURE_ROOT = validator.DEFAULT_FIXTURE_ROOT
+VariationalAutoencoderValidationError = validator.VariationalAutoencoderValidationError
+execute_lab = validator.execute_lab
+load_json = validator.load_json
+validate_fixture_root = validator.validate_fixture_root
+validate_lab = validator.validate_lab
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-saved-noise-kl-step.json"
+
+
+def test_checked_in_nn17_corpus_is_valid() -> None:
+    assert validate_fixture_root(DEFAULT_FIXTURE_ROOT) == 1
+
+
+def test_saved_epsilon_makes_the_sample_reproducible() -> None:
+    result = execute_lab(load_json(LAB_PATH))["forward"]
+
+    assert result["mean"] == pytest.approx(0.4)
+    assert result["standard_deviation"] == pytest.approx(1)
+    assert result["epsilon"] == pytest.approx(0.5)
+    assert result["noise_contribution"] == pytest.approx(0.5)
+    assert result["latent"] == pytest.approx(0.9)
+    assert result["reconstruction"] == pytest.approx(0.9)
+
+
+def test_objective_keeps_reconstruction_and_kl_visible() -> None:
+    forward = execute_lab(load_json(LAB_PATH))["forward"]
+
+    assert forward["reconstruction_loss"] == pytest.approx(0.005)
+    assert forward["kl"] == pytest.approx(0.08)
+    assert forward["weighted_kl"] == pytest.approx(0.008)
+    assert forward["total_loss"] == pytest.approx(0.013)
+
+
+def test_reconstruction_and_kl_routes_add_at_encoder_outputs() -> None:
+    backward = execute_lab(load_json(LAB_PATH))["backward"]
+
+    assert backward["reconstruction_mean_gradient"] == pytest.approx(-0.1)
+    assert backward["weighted_kl_mean_gradient"] == pytest.approx(0.04)
+    assert backward["mean_gradient"] == pytest.approx(-0.06)
+    assert backward["reconstruction_log_variance_gradient"] == pytest.approx(-0.025)
+    assert backward["weighted_kl_log_variance_gradient"] == pytest.approx(0)
+    assert backward["log_variance_gradient"] == pytest.approx(-0.025)
+
+
+def test_central_finite_differences_hold_saved_noise_fixed() -> None:
+    check = execute_lab(load_json(LAB_PATH))["gradient_check"]
+
+    assert len(check["parameter_order"]) == 6
+    assert check["numerical"] == pytest.approx(check["analytical"], abs=1e-8)
+    assert check["max_absolute_error"] < 1e-8
+
+
+def test_one_sgd_step_lowers_total_vae_objective() -> None:
+    result = execute_lab(load_json(LAB_PATH))
+
+    assert result["updated_parameters"]["encoder"]["mean"] == pytest.approx(
+        {"weight": 0.406, "bias": 0.006}
+    )
+    assert result["post_update"]["mean"] == pytest.approx(0.412)
+    assert result["post_update"]["latent"] == pytest.approx(0.9132515638028976)
+    assert result["post_update"]["reconstruction"] == pytest.approx(0.9314708278771237)
+    assert result["post_update"]["total_loss"] == pytest.approx(0.01083594975889346)
+    assert result["post_update"]["total_loss"] < result["forward"]["total_loss"]
+
+
+def test_validator_rejects_unknown_fields_and_negative_beta() -> None:
+    document = load_json(LAB_PATH)
+    with_extra = copy.deepcopy(document)
+    with_extra["sample"]["mystery"] = 3
+    with pytest.raises(VariationalAutoencoderValidationError, match="key mismatch"):
+        validate_lab(with_extra)
+
+    negative_beta = copy.deepcopy(document)
+    negative_beta["objective"]["beta"] = -1
+    with pytest.raises(
+        VariationalAutoencoderValidationError,
+        match="non-negative",
+    ):
+        validate_lab(negative_beta)
+
+
+def test_validator_rejects_drifted_expected_trace() -> None:
+    document = load_json(LAB_PATH)
+    document["expected"]["forward"]["latent"] = 999
+    with pytest.raises(VariationalAutoencoderValidationError, match="expected.forward"):
+        validate_lab(document)
+
+
+def test_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version": 1, "schema_version": 1}', encoding="utf-8")
+    with pytest.raises(
+        VariationalAutoencoderValidationError,
+        match="duplicate JSON key",
+    ):
+        load_json(duplicate)
+
+
+def test_loader_rejects_non_finite_numbers(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"value": float("nan")}), encoding="utf-8")
+    with pytest.raises(VariationalAutoencoderValidationError, match="non-finite"):
+        load_json(invalid)

--- a/code/scripts/validate_attention_qkv_labs.py
+++ b/code/scripts/validate_attention_qkv_labs.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN12 attention QKV corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = REPO_ROOT / "code" / "specs" / "fixtures" / "attention-qkv-v1"
+
+
+class AttentionQkvValidationError(ValueError):
+    """Raised when an NN12 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise AttentionQkvValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                AttentionQkvValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise AttentionQkvValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise AttentionQkvValidationError("top-level JSON value must be an object")
+    return document
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AttentionQkvValidationError(f"{context}: expected an object")
+    missing = keys - value.keys()
+    extra = value.keys() - keys
+    if missing or extra:
+        raise AttentionQkvValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise AttentionQkvValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise AttentionQkvValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _matrix(value: Any, rows: int, columns: int, context: str) -> list[list[float]]:
+    if not isinstance(value, list) or len(value) != rows:
+        raise AttentionQkvValidationError(f"{context}: expected {rows} rows")
+    result: list[list[float]] = []
+    for row_index, row in enumerate(value):
+        if not isinstance(row, list) or len(row) != columns:
+            raise AttentionQkvValidationError(
+                f"{context}[{row_index}]: expected {columns} columns"
+            )
+        result.append(
+            [
+                _number(item, f"{context}[{row_index}][{column_index}]")
+                for column_index, item in enumerate(row)
+            ]
+        )
+    return result
+
+
+def _matmul(left: list[list[float]], right: list[list[float]]) -> list[list[float]]:
+    return [
+        [
+            sum(row[index] * right[index][column] for index in range(len(right)))
+            for column in range(len(right[0]))
+        ]
+        for row in left
+    ]
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    tokens = document["tokens"]
+    if not isinstance(tokens, list) or len(tokens) != 3:
+        raise AttentionQkvValidationError("tokens: expected three token objects")
+    token_ids: list[str] = []
+    embeddings: list[list[float]] = []
+    for index, token_value in enumerate(tokens):
+        token = _object(token_value, {"id", "embedding"}, f"tokens[{index}]")
+        if not isinstance(token["id"], str) or not token["id"]:
+            raise AttentionQkvValidationError(f"tokens[{index}].id: expected text")
+        token_ids.append(token["id"])
+        embeddings.append(
+            _matrix([token["embedding"]], 1, 2, f"tokens[{index}].embedding")[0]
+        )
+    if len(set(token_ids)) != 3:
+        raise AttentionQkvValidationError("tokens: ids must be unique")
+
+    matrices = _object(document["matrices"], {"query", "key", "value"}, "matrices")
+    query_matrix = _matrix(matrices["query"], 2, 2, "matrices.query")
+    key_matrix = _matrix(matrices["key"], 2, 2, "matrices.key")
+    value_matrix = _matrix(matrices["value"], 2, 2, "matrices.value")
+    queries = _matmul(embeddings, query_matrix)
+    keys = _matmul(embeddings, key_matrix)
+    values = _matmul(embeddings, value_matrix)
+    scale = math.sqrt(len(keys[0]))
+    dot_products: list[dict[str, Any]] = []
+    raw_score_matrix: list[list[float]] = []
+    scaled_score_matrix: list[list[float]] = []
+    for query_index, query in enumerate(queries):
+        raw_row: list[float] = []
+        scaled_row: list[float] = []
+        for key_index, key in enumerate(keys):
+            products = [query[index] * key[index] for index in range(len(key))]
+            raw_score = sum(products)
+            scaled_score = raw_score / scale
+            raw_row.append(raw_score)
+            scaled_row.append(scaled_score)
+            dot_products.append(
+                {
+                    "query": token_ids[query_index],
+                    "key": token_ids[key_index],
+                    "products": products,
+                    "raw_score": raw_score,
+                    "scaled_score": scaled_score,
+                }
+            )
+        raw_score_matrix.append(raw_row)
+        scaled_score_matrix.append(scaled_row)
+    return {
+        "queries": queries,
+        "keys": keys,
+        "values": values,
+        "dot_products": dot_products,
+        "raw_score_matrix": raw_score_matrix,
+        "scaled_score_matrix": scaled_score_matrix,
+    }
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            raise AttentionQkvValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(
+            float(expected), float(actual), rel_tol=0, abs_tol=tolerance
+        ):
+            raise AttentionQkvValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            raise AttentionQkvValidationError(f"{context}: length mismatch")
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _compare(expected_item, actual_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            raise AttentionQkvValidationError(f"{context}: key mismatch")
+        for key in expected:
+            _compare(expected[key], actual[key], tolerance, f"{context}.{key}")
+        return
+    if expected != actual:
+        raise AttentionQkvValidationError(
+            f"{context}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def validate_lab(document: dict[str, Any]) -> dict[str, Any]:
+    _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "tokens",
+            "matrices",
+            "expected",
+        },
+        "lab",
+    )
+    if document["schema_version"] != 1:
+        raise AttentionQkvValidationError("schema_version: expected 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(document[key], str) or not document[key]:
+            raise AttentionQkvValidationError(f"{key}: expected text")
+    tolerance = _number(document["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise AttentionQkvValidationError("absolute_tolerance: expected positive")
+    operation = _object(
+        document["operation"],
+        {"kind", "vector_orientation", "score_scaling", "softmax_applied"},
+        "operation",
+    )
+    if operation != {
+        "kind": "three-token-qkv-dot-products",
+        "vector_orientation": "row",
+        "score_scaling": "inverse-square-root-key-dimension",
+        "softmax_applied": False,
+    }:
+        raise AttentionQkvValidationError("operation: unsupported contract")
+    expected = _object(
+        document["expected"],
+        {
+            "queries",
+            "keys",
+            "values",
+            "dot_products",
+            "raw_score_matrix",
+            "scaled_score_matrix",
+        },
+        "expected",
+    )
+    actual = execute_lab(document)
+    _compare(expected, actual, tolerance, "expected")
+    return actual
+
+
+def validate_corpus(root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    paths = sorted((root / "labs").glob("*.json"))
+    if not paths:
+        raise AttentionQkvValidationError(f"no labs found under {root / 'labs'}")
+    for path in paths:
+        try:
+            validate_lab(load_json(path))
+        except AttentionQkvValidationError as error:
+            raise AttentionQkvValidationError(f"{path}: {error}") from error
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    paths = validate_corpus(args.root)
+    print(f"validated {len(paths)} attention QKV labs from {args.root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_attention_softmax_labs.py
+++ b/code/scripts/validate_attention_softmax_labs.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN13 attention softmax corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "attention-softmax-v1"
+)
+
+
+class AttentionSoftmaxValidationError(ValueError):
+    """Raised when an NN13 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise AttentionSoftmaxValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                AttentionSoftmaxValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise AttentionSoftmaxValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise AttentionSoftmaxValidationError("top-level JSON value must be an object")
+    return document
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AttentionSoftmaxValidationError(f"{context}: expected an object")
+    missing = keys - value.keys()
+    extra = value.keys() - keys
+    if missing or extra:
+        raise AttentionSoftmaxValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise AttentionSoftmaxValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise AttentionSoftmaxValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _matrix(value: Any, rows: int, columns: int, context: str) -> list[list[float]]:
+    if not isinstance(value, list) or len(value) != rows:
+        raise AttentionSoftmaxValidationError(f"{context}: expected {rows} rows")
+    result: list[list[float]] = []
+    for row_index, row in enumerate(value):
+        if not isinstance(row, list) or len(row) != columns:
+            raise AttentionSoftmaxValidationError(
+                f"{context}[{row_index}]: expected {columns} columns"
+            )
+        result.append(
+            [
+                _number(item, f"{context}[{row_index}][{column_index}]")
+                for column_index, item in enumerate(row)
+            ]
+        )
+    return result
+
+
+def _token_ids(value: Any) -> list[str]:
+    if not isinstance(value, list) or len(value) != 3:
+        raise AttentionSoftmaxValidationError("token_ids: expected three strings")
+    if any(not isinstance(item, str) or not item for item in value):
+        raise AttentionSoftmaxValidationError("token_ids: expected non-empty strings")
+    if len(set(value)) != len(value):
+        raise AttentionSoftmaxValidationError("token_ids: expected unique strings")
+    return value
+
+
+def _clean_zero(value: float) -> float:
+    return 0.0 if abs(value) < 1e-15 else value
+
+
+def _execute_mode(
+    token_ids: list[str],
+    scaled_scores: list[list[float]],
+    values: list[list[float]],
+    causal: bool,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for query_index, score_row in enumerate(scaled_scores):
+        allowed = [not causal or key_index <= query_index for key_index in range(3)]
+        masked_scores: list[float | None] = [
+            score if allowed[key_index] else None
+            for key_index, score in enumerate(score_row)
+        ]
+        row_max = max(score for score in masked_scores if score is not None)
+        shifted_scores: list[float | None] = [
+            _clean_zero(score - row_max) if score is not None else None
+            for score in masked_scores
+        ]
+        exponentials = [
+            math.exp(score) if score is not None else 0.0 for score in shifted_scores
+        ]
+        denominator = sum(exponentials)
+        weights = [_clean_zero(value / denominator) for value in exponentials]
+        value_contributions = [
+            [_clean_zero(weight * coordinate) for coordinate in values[key_index]]
+            for key_index, weight in enumerate(weights)
+        ]
+        context = [
+            _clean_zero(sum(row[coordinate] for row in value_contributions))
+            for coordinate in range(2)
+        ]
+        rows.append(
+            {
+                "query": token_ids[query_index],
+                "allowed": allowed,
+                "scaled_scores": score_row,
+                "masked_scores": masked_scores,
+                "row_max": row_max,
+                "shifted_scores": shifted_scores,
+                "exponentials": exponentials,
+                "denominator": denominator,
+                "weights": weights,
+                "value_contributions": value_contributions,
+                "context": context,
+            }
+        )
+    return rows
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    token_ids = _token_ids(document["token_ids"])
+    scaled_scores = _matrix(
+        document["scaled_score_matrix"], 3, 3, "scaled_score_matrix"
+    )
+    values = _matrix(document["values"], 3, 2, "values")
+    return {
+        "unmasked": _execute_mode(token_ids, scaled_scores, values, False),
+        "causal": _execute_mode(token_ids, scaled_scores, values, True),
+    }
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            raise AttentionSoftmaxValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(
+            float(expected), float(actual), rel_tol=0, abs_tol=tolerance
+        ):
+            raise AttentionSoftmaxValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            raise AttentionSoftmaxValidationError(f"{context}: length mismatch")
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _compare(expected_item, actual_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            raise AttentionSoftmaxValidationError(f"{context}: key mismatch")
+        for key in expected:
+            _compare(expected[key], actual[key], tolerance, f"{context}.{key}")
+        return
+    if expected != actual:
+        raise AttentionSoftmaxValidationError(
+            f"{context}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def validate_lab(document: dict[str, Any]) -> dict[str, Any]:
+    _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "token_ids",
+            "scaled_score_matrix",
+            "values",
+            "expected",
+        },
+        "lab",
+    )
+    if document["schema_version"] != 1:
+        raise AttentionSoftmaxValidationError("schema_version: expected 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(document[key], str) or not document[key]:
+            raise AttentionSoftmaxValidationError(f"{key}: expected text")
+    concepts = document["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(set(concepts)) != len(concepts)
+    ):
+        raise AttentionSoftmaxValidationError("concepts: expected unique text values")
+    tolerance = _number(document["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise AttentionSoftmaxValidationError("absolute_tolerance: expected positive")
+    operation = _object(
+        document["operation"],
+        {"kind", "softmax", "causal_rule", "masked_score_encoding"},
+        "operation",
+    )
+    if operation != {
+        "kind": "three-token-attention-softmax",
+        "softmax": "stable-row-wise",
+        "causal_rule": "key-index-less-than-or-equal-query-index",
+        "masked_score_encoding": "null",
+    }:
+        raise AttentionSoftmaxValidationError("operation: unsupported contract")
+    expected = _object(document["expected"], {"unmasked", "causal"}, "expected")
+    actual = execute_lab(document)
+    _compare(expected, actual, tolerance, "expected")
+    return actual
+
+
+def validate_corpus(root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    paths = sorted((root / "labs").glob("*.json"))
+    if not paths:
+        raise AttentionSoftmaxValidationError(f"no labs found under {root / 'labs'}")
+    for path in paths:
+        try:
+            validate_lab(load_json(path))
+        except AttentionSoftmaxValidationError as error:
+            raise AttentionSoftmaxValidationError(f"{path}: {error}") from error
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    paths = validate_corpus(args.root)
+    print(f"validated {len(paths)} attention softmax labs from {args.root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_convolution_learning_labs.py
+++ b/code/scripts/validate_convolution_learning_labs.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN05 convolution corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "convolution-learning-v1"
+)
+
+
+class ConvolutionLabValidationError(ValueError):
+    """Raised when a convolution lab is structurally or numerically invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ConvolutionLabValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ConvolutionLabValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise ConvolutionLabValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise ConvolutionLabValidationError(
+            f"{path}: top-level JSON value must be an object"
+        )
+    return document
+
+
+def _require_keys(value: dict[str, Any], required: set[str], context: str) -> None:
+    missing = required - value.keys()
+    extra = value.keys() - required
+    if missing:
+        raise ConvolutionLabValidationError(
+            f"{context}: missing keys {sorted(missing)}"
+        )
+    if extra:
+        raise ConvolutionLabValidationError(
+            f"{context}: unexpected keys {sorted(extra)}"
+        )
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ConvolutionLabValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ConvolutionLabValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _numbers(value: Any, context: str) -> list[float]:
+    if not isinstance(value, list) or not value:
+        raise ConvolutionLabValidationError(
+            f"{context}: expected a non-empty number array"
+        )
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def trace_valid_correlation(
+    signal: list[float], kernel: list[float]
+) -> list[dict[str, Any]]:
+    """Return every V1 output and multiply-accumulate intermediate."""
+    if not signal or not kernel or len(kernel) > len(signal):
+        raise ConvolutionLabValidationError(
+            "signal and kernel must be non-empty, with kernel no longer than signal"
+        )
+
+    positions: list[dict[str, Any]] = []
+    for start in range(len(signal) - len(kernel) + 1):
+        window = signal[start : start + len(kernel)]
+        products = [value * weight for value, weight in zip(window, kernel)]
+        accumulator = [0.0]
+        for product in products:
+            accumulator.append(accumulator[-1] + product)
+        positions.append(
+            {
+                "output_index": start,
+                "start_index": start,
+                "window": window,
+                "products": products,
+                "accumulator": accumulator,
+                "output": accumulator[-1],
+            }
+        )
+    return positions
+
+
+def validate_structure(lab: dict[str, Any], source: str = "lab") -> None:
+    _require_keys(
+        lab,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "concepts",
+            "operation",
+            "signal",
+            "kernel",
+            "expected",
+        },
+        source,
+    )
+    if lab["schema_version"] != 1:
+        raise ConvolutionLabValidationError(f"{source}.schema_version: expected 1")
+    for field in ("id", "title", "question"):
+        if not isinstance(lab[field], str) or not lab[field]:
+            raise ConvolutionLabValidationError(
+                f"{source}.{field}: expected a non-empty string"
+            )
+    concepts = lab["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(concepts) != len(set(concepts))
+    ):
+        raise ConvolutionLabValidationError(
+            f"{source}.concepts: expected unique non-empty strings"
+        )
+
+    operation = lab["operation"]
+    if not isinstance(operation, dict):
+        raise ConvolutionLabValidationError(f"{source}.operation: expected an object")
+    _require_keys(operation, {"kind", "padding", "stride"}, f"{source}.operation")
+    if operation != {
+        "kind": "cross-correlation-1d",
+        "padding": "valid",
+        "stride": 1,
+    }:
+        raise ConvolutionLabValidationError(
+            f"{source}.operation: V1 requires valid stride-one 1D cross-correlation"
+        )
+
+    signal = _numbers(lab["signal"], f"{source}.signal")
+    kernel = _numbers(lab["kernel"], f"{source}.kernel")
+    if len(kernel) > len(signal):
+        raise ConvolutionLabValidationError(
+            f"{source}.kernel: must be no longer than signal"
+        )
+
+    expected = lab["expected"]
+    if not isinstance(expected, dict):
+        raise ConvolutionLabValidationError(f"{source}.expected: expected an object")
+    _require_keys(
+        expected, {"absolute_tolerance", "outputs", "positions"}, f"{source}.expected"
+    )
+    tolerance = _number(
+        expected["absolute_tolerance"], f"{source}.expected.absolute_tolerance"
+    )
+    if tolerance <= 0:
+        raise ConvolutionLabValidationError(
+            f"{source}.expected.absolute_tolerance: expected a positive number"
+        )
+    output_count = len(signal) - len(kernel) + 1
+    if len(_numbers(expected["outputs"], f"{source}.expected.outputs")) != output_count:
+        raise ConvolutionLabValidationError(
+            f"{source}.expected.outputs: expected {output_count} values"
+        )
+    positions = expected["positions"]
+    if not isinstance(positions, list) or len(positions) != output_count:
+        raise ConvolutionLabValidationError(
+            f"{source}.expected.positions: expected {output_count} positions"
+        )
+    for index, position in enumerate(positions):
+        context = f"{source}.expected.positions[{index}]"
+        if not isinstance(position, dict):
+            raise ConvolutionLabValidationError(f"{context}: expected an object")
+        _require_keys(
+            position,
+            {
+                "output_index",
+                "start_index",
+                "window",
+                "products",
+                "accumulator",
+                "output",
+            },
+            context,
+        )
+        if position["output_index"] != index or position["start_index"] != index:
+            raise ConvolutionLabValidationError(
+                f"{context}: indices must equal the zero-based position"
+            )
+        for field, length in (
+            ("window", len(kernel)),
+            ("products", len(kernel)),
+            ("accumulator", len(kernel) + 1),
+        ):
+            if len(_numbers(position[field], f"{context}.{field}")) != length:
+                raise ConvolutionLabValidationError(
+                    f"{context}.{field}: expected {length} values"
+                )
+        _number(position["output"], f"{context}.output")
+
+
+def _compare(actual: float, expected: Any, tolerance: float, context: str) -> None:
+    expected_number = _number(expected, context)
+    if abs(actual - expected_number) > tolerance:
+        raise ConvolutionLabValidationError(
+            f"{context}: expected {expected_number!r}, got {actual!r} "
+            f"(tolerance {tolerance})"
+        )
+
+
+def validate_lab(lab: dict[str, Any], source: str = "lab") -> None:
+    validate_structure(lab, source)
+    signal = _numbers(lab["signal"], f"{source}.signal")
+    kernel = _numbers(lab["kernel"], f"{source}.kernel")
+    actual_positions = trace_valid_correlation(signal, kernel)
+    expected = lab["expected"]
+    tolerance = float(expected["absolute_tolerance"])
+
+    for index, actual in enumerate(actual_positions):
+        expected_position = expected["positions"][index]
+        for field in ("window", "products", "accumulator"):
+            for item_index, actual_value in enumerate(actual[field]):
+                _compare(
+                    actual_value,
+                    expected_position[field][item_index],
+                    tolerance,
+                    f"{source}.expected.positions[{index}].{field}[{item_index}]",
+                )
+        _compare(
+            actual["output"],
+            expected_position["output"],
+            tolerance,
+            f"{source}.expected.positions[{index}].output",
+        )
+        _compare(
+            actual["output"],
+            expected["outputs"][index],
+            tolerance,
+            f"{source}.expected.outputs[{index}]",
+        )
+
+
+def validate_corpus(fixture_root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    schema = load_json(fixture_root / "schema.json")
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        raise ConvolutionLabValidationError(
+            "schema.json: expected JSON Schema Draft 2020-12"
+        )
+    lab_paths = sorted((fixture_root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise ConvolutionLabValidationError(f"{fixture_root}: no lab fixtures found")
+    ids: set[str] = set()
+    for path in lab_paths:
+        lab = load_json(path)
+        validate_lab(lab, str(path))
+        if lab["id"] in ids:
+            raise ConvolutionLabValidationError(
+                f"{path}: duplicate lab id {lab['id']!r}"
+            )
+        ids.add(lab["id"])
+    return lab_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    try:
+        paths = validate_corpus(args.fixture_root)
+    except ConvolutionLabValidationError as error:
+        parser.exit(1, f"convolution learning corpus invalid: {error}\n")
+    print(f"validated {len(paths)} convolution learning labs from {args.fixture_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_convolution_training_labs.py
+++ b/code/scripts/validate_convolution_training_labs.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN06 convolution-training corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "convolution-training-v1"
+)
+
+
+class ConvolutionTrainingValidationError(ValueError):
+    """Raised when a convolution-training lab is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ConvolutionTrainingValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ConvolutionTrainingValidationError(
+                    f"non-finite JSON number: {value}"
+                )
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise ConvolutionTrainingValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise ConvolutionTrainingValidationError(
+            f"{path}: top-level JSON value must be an object"
+        )
+    return document
+
+
+def _require_keys(value: dict[str, Any], required: set[str], context: str) -> None:
+    missing = required - value.keys()
+    extra = value.keys() - required
+    if missing:
+        raise ConvolutionTrainingValidationError(
+            f"{context}: missing keys {sorted(missing)}"
+        )
+    if extra:
+        raise ConvolutionTrainingValidationError(
+            f"{context}: unexpected keys {sorted(extra)}"
+        )
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ConvolutionTrainingValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ConvolutionTrainingValidationError(
+            f"{context}: expected a finite number"
+        )
+    return result
+
+
+def _positive_number(value: Any, context: str) -> float:
+    result = _number(value, context)
+    if result <= 0:
+        raise ConvolutionTrainingValidationError(
+            f"{context}: expected a positive number"
+        )
+    return result
+
+
+def _numbers(value: Any, context: str) -> list[float]:
+    if not isinstance(value, list) or not value:
+        raise ConvolutionTrainingValidationError(
+            f"{context}: expected a non-empty number array"
+        )
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def valid_correlation(signal: list[float], kernel: list[float]) -> list[float]:
+    if not signal or not kernel or len(kernel) > len(signal):
+        raise ConvolutionTrainingValidationError(
+            "signal and kernel must be non-empty, with kernel no longer than signal"
+        )
+    return [
+        sum(signal[start + offset] * weight for offset, weight in enumerate(kernel))
+        for start in range(len(signal) - len(kernel) + 1)
+    ]
+
+
+def mean_squared_error(outputs: list[float], targets: list[float]) -> float:
+    if len(outputs) != len(targets) or not outputs:
+        raise ConvolutionTrainingValidationError(
+            "outputs and targets must have the same non-zero length"
+        )
+    return sum(
+        (output - target) ** 2 for output, target in zip(outputs, targets)
+    ) / len(outputs)
+
+
+def trace_training(
+    signal: list[float], kernel: list[float], targets: list[float]
+) -> dict[str, Any]:
+    outputs = valid_correlation(signal, kernel)
+    if len(outputs) != len(targets):
+        raise ConvolutionTrainingValidationError(
+            f"expected {len(outputs)} targets, got {len(targets)}"
+        )
+    errors = [output - target for output, target in zip(outputs, targets)]
+    scale = 2.0 / len(outputs)
+    output_gradients = [scale * error for error in errors]
+    contributions: list[dict[str, Any]] = []
+    kernel_gradient = [0.0 for _ in kernel]
+    for output_index, output_gradient in enumerate(output_gradients):
+        window = signal[output_index : output_index + len(kernel)]
+        contribution = [output_gradient * value for value in window]
+        for kernel_index, value in enumerate(contribution):
+            kernel_gradient[kernel_index] += value
+        contributions.append(
+            {
+                "output_index": output_index,
+                "window": window,
+                "output_gradient": output_gradient,
+                "kernel_gradient": contribution,
+            }
+        )
+    return {
+        "outputs": outputs,
+        "errors": errors,
+        "loss": mean_squared_error(outputs, targets),
+        "output_gradients": output_gradients,
+        "contributions": contributions,
+        "kernel_gradient": kernel_gradient,
+    }
+
+
+def numerical_kernel_gradient(
+    signal: list[float],
+    kernel: list[float],
+    targets: list[float],
+    epsilon: float,
+) -> list[float]:
+    result: list[float] = []
+    for index in range(len(kernel)):
+        plus = list(kernel)
+        minus = list(kernel)
+        plus[index] += epsilon
+        minus[index] -= epsilon
+        plus_loss = mean_squared_error(valid_correlation(signal, plus), targets)
+        minus_loss = mean_squared_error(valid_correlation(signal, minus), targets)
+        result.append((plus_loss - minus_loss) / (2.0 * epsilon))
+    return result
+
+
+def optimizer_step(
+    signal: list[float],
+    kernel: list[float],
+    targets: list[float],
+    learning_rate: float,
+) -> dict[str, Any]:
+    trace = trace_training(signal, kernel, targets)
+    next_kernel = [
+        value - learning_rate * gradient
+        for value, gradient in zip(kernel, trace["kernel_gradient"])
+    ]
+    outputs = valid_correlation(signal, next_kernel)
+    return {
+        "kernel": next_kernel,
+        "outputs": outputs,
+        "loss": mean_squared_error(outputs, targets),
+    }
+
+
+def validate_structure(lab: dict[str, Any], source: str = "lab") -> None:
+    _require_keys(
+        lab,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "concepts",
+            "operation",
+            "signal",
+            "kernel",
+            "targets",
+            "loss",
+            "gradient_check",
+            "optimizer_step",
+        },
+        source,
+    )
+    if lab["schema_version"] != 1:
+        raise ConvolutionTrainingValidationError(
+            f"{source}.schema_version: expected 1"
+        )
+    for field in ("id", "title", "question"):
+        if not isinstance(lab[field], str) or not lab[field]:
+            raise ConvolutionTrainingValidationError(
+                f"{source}.{field}: expected a non-empty string"
+            )
+    concepts = lab["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(concepts) != len(set(concepts))
+    ):
+        raise ConvolutionTrainingValidationError(
+            f"{source}.concepts: expected unique non-empty strings"
+        )
+
+    operation = lab["operation"]
+    if not isinstance(operation, dict):
+        raise ConvolutionTrainingValidationError(
+            f"{source}.operation: expected an object"
+        )
+    _require_keys(operation, {"kind", "padding", "stride"}, f"{source}.operation")
+    if operation != {
+        "kind": "cross-correlation-1d",
+        "padding": "valid",
+        "stride": 1,
+    }:
+        raise ConvolutionTrainingValidationError(
+            f"{source}.operation: V1 requires valid stride-one 1D cross-correlation"
+        )
+
+    signal = _numbers(lab["signal"], f"{source}.signal")
+    kernel = _numbers(lab["kernel"], f"{source}.kernel")
+    targets = _numbers(lab["targets"], f"{source}.targets")
+    if len(kernel) > len(signal):
+        raise ConvolutionTrainingValidationError(
+            f"{source}.kernel: must be no longer than signal"
+        )
+    output_count = len(signal) - len(kernel) + 1
+    if len(targets) != output_count:
+        raise ConvolutionTrainingValidationError(
+            f"{source}.targets: expected {output_count} values"
+        )
+
+    loss = lab["loss"]
+    if not isinstance(loss, dict):
+        raise ConvolutionTrainingValidationError(f"{source}.loss: expected an object")
+    _require_keys(loss, {"kind", "reduction"}, f"{source}.loss")
+    if loss != {"kind": "mean-squared-error", "reduction": "mean"}:
+        raise ConvolutionTrainingValidationError(
+            f"{source}.loss: V1 requires mean mean-squared-error"
+        )
+
+    check = lab["gradient_check"]
+    if not isinstance(check, dict):
+        raise ConvolutionTrainingValidationError(
+            f"{source}.gradient_check: expected an object"
+        )
+    _require_keys(
+        check, {"epsilon", "absolute_tolerance", "expected"},
+        f"{source}.gradient_check",
+    )
+    _positive_number(check["epsilon"], f"{source}.gradient_check.epsilon")
+    _positive_number(
+        check["absolute_tolerance"],
+        f"{source}.gradient_check.absolute_tolerance",
+    )
+    expected = check["expected"]
+    if not isinstance(expected, dict):
+        raise ConvolutionTrainingValidationError(
+            f"{source}.gradient_check.expected: expected an object"
+        )
+    expected_keys = {
+        "outputs",
+        "errors",
+        "loss",
+        "output_gradients",
+        "contributions",
+        "kernel_gradient",
+        "numerical_kernel_gradient",
+    }
+    _require_keys(expected, expected_keys, f"{source}.gradient_check.expected")
+    for field, length in (
+        ("outputs", output_count),
+        ("errors", output_count),
+        ("output_gradients", output_count),
+        ("kernel_gradient", len(kernel)),
+        ("numerical_kernel_gradient", len(kernel)),
+    ):
+        values = _numbers(expected[field], f"{source}.gradient_check.expected.{field}")
+        if len(values) != length:
+            raise ConvolutionTrainingValidationError(
+                f"{source}.gradient_check.expected.{field}: expected {length} values"
+            )
+    _number(expected["loss"], f"{source}.gradient_check.expected.loss")
+    contributions = expected["contributions"]
+    if not isinstance(contributions, list) or len(contributions) != output_count:
+        raise ConvolutionTrainingValidationError(
+            f"{source}.gradient_check.expected.contributions: "
+            f"expected {output_count} entries"
+        )
+    for index, contribution in enumerate(contributions):
+        context = f"{source}.gradient_check.expected.contributions[{index}]"
+        if not isinstance(contribution, dict):
+            raise ConvolutionTrainingValidationError(f"{context}: expected an object")
+        _require_keys(
+            contribution,
+            {"output_index", "window", "output_gradient", "kernel_gradient"},
+            context,
+        )
+        if contribution["output_index"] != index:
+            raise ConvolutionTrainingValidationError(
+                f"{context}.output_index: expected {index}"
+            )
+        for field in ("window", "kernel_gradient"):
+            if len(_numbers(contribution[field], f"{context}.{field}")) != len(kernel):
+                raise ConvolutionTrainingValidationError(
+                    f"{context}.{field}: expected {len(kernel)} values"
+                )
+        _number(contribution["output_gradient"], f"{context}.output_gradient")
+
+    step = lab["optimizer_step"]
+    if not isinstance(step, dict):
+        raise ConvolutionTrainingValidationError(
+            f"{source}.optimizer_step: expected an object"
+        )
+    _require_keys(
+        step,
+        {"learning_rate", "expected_kernel", "expected_outputs", "expected_loss"},
+        f"{source}.optimizer_step",
+    )
+    _positive_number(step["learning_rate"], f"{source}.optimizer_step.learning_rate")
+    if len(_numbers(step["expected_kernel"], f"{source}.optimizer_step.expected_kernel")) != len(kernel):
+        raise ConvolutionTrainingValidationError(
+            f"{source}.optimizer_step.expected_kernel: expected {len(kernel)} values"
+        )
+    if len(_numbers(step["expected_outputs"], f"{source}.optimizer_step.expected_outputs")) != output_count:
+        raise ConvolutionTrainingValidationError(
+            f"{source}.optimizer_step.expected_outputs: expected {output_count} values"
+        )
+    _number(step["expected_loss"], f"{source}.optimizer_step.expected_loss")
+
+
+def _compare(actual: float, expected: Any, tolerance: float, context: str) -> None:
+    expected_number = _number(expected, context)
+    if abs(actual - expected_number) > tolerance:
+        raise ConvolutionTrainingValidationError(
+            f"{context}: expected {expected_number!r}, got {actual!r} "
+            f"(tolerance {tolerance})"
+        )
+
+
+def _compare_arrays(
+    actual: list[float], expected: Any, tolerance: float, context: str
+) -> None:
+    expected_values = _numbers(expected, context)
+    for index, actual_value in enumerate(actual):
+        _compare(actual_value, expected_values[index], tolerance, f"{context}[{index}]")
+
+
+def validate_lab(lab: dict[str, Any], source: str = "lab") -> None:
+    validate_structure(lab, source)
+    signal = _numbers(lab["signal"], f"{source}.signal")
+    kernel = _numbers(lab["kernel"], f"{source}.kernel")
+    targets = _numbers(lab["targets"], f"{source}.targets")
+    check = lab["gradient_check"]
+    expected = check["expected"]
+    tolerance = float(check["absolute_tolerance"])
+    actual = trace_training(signal, kernel, targets)
+    for field in ("outputs", "errors", "output_gradients", "kernel_gradient"):
+        _compare_arrays(
+            actual[field], expected[field], tolerance,
+            f"{source}.gradient_check.expected.{field}",
+        )
+    _compare(
+        actual["loss"], expected["loss"], tolerance,
+        f"{source}.gradient_check.expected.loss",
+    )
+    for index, contribution in enumerate(actual["contributions"]):
+        expected_contribution = expected["contributions"][index]
+        _compare_arrays(
+            contribution["window"], expected_contribution["window"], tolerance,
+            f"{source}.gradient_check.expected.contributions[{index}].window",
+        )
+        _compare(
+            contribution["output_gradient"],
+            expected_contribution["output_gradient"],
+            tolerance,
+            f"{source}.gradient_check.expected.contributions[{index}].output_gradient",
+        )
+        _compare_arrays(
+            contribution["kernel_gradient"],
+            expected_contribution["kernel_gradient"],
+            tolerance,
+            f"{source}.gradient_check.expected.contributions[{index}].kernel_gradient",
+        )
+    numerical = numerical_kernel_gradient(
+        signal, kernel, targets, float(check["epsilon"])
+    )
+    _compare_arrays(
+        numerical,
+        expected["numerical_kernel_gradient"],
+        tolerance,
+        f"{source}.gradient_check.expected.numerical_kernel_gradient",
+    )
+
+    step = lab["optimizer_step"]
+    actual_step = optimizer_step(
+        signal, kernel, targets, float(step["learning_rate"])
+    )
+    _compare_arrays(
+        actual_step["kernel"], step["expected_kernel"], tolerance,
+        f"{source}.optimizer_step.expected_kernel",
+    )
+    _compare_arrays(
+        actual_step["outputs"], step["expected_outputs"], tolerance,
+        f"{source}.optimizer_step.expected_outputs",
+    )
+    _compare(
+        actual_step["loss"], step["expected_loss"], tolerance,
+        f"{source}.optimizer_step.expected_loss",
+    )
+
+
+def validate_corpus(fixture_root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    schema = load_json(fixture_root / "schema.json")
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        raise ConvolutionTrainingValidationError(
+            "schema.json: expected JSON Schema Draft 2020-12"
+        )
+    lab_paths = sorted((fixture_root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise ConvolutionTrainingValidationError(
+            f"{fixture_root}: no lab fixtures found"
+        )
+    ids: set[str] = set()
+    for path in lab_paths:
+        lab = load_json(path)
+        validate_lab(lab, str(path))
+        if lab["id"] in ids:
+            raise ConvolutionTrainingValidationError(
+                f"{path}: duplicate lab id {lab['id']!r}"
+            )
+        ids.add(lab["id"])
+    return lab_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    try:
+        paths = validate_corpus(args.fixture_root)
+    except ConvolutionTrainingValidationError as error:
+        parser.exit(1, f"convolution training corpus invalid: {error}\n")
+    print(f"validated {len(paths)} convolution training labs from {args.fixture_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_gated_recurrent_labs.py
+++ b/code/scripts/validate_gated_recurrent_labs.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN11 gated recurrent corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = REPO_ROOT / "code" / "specs" / "fixtures" / "gated-recurrent-v1"
+
+
+class GatedRecurrentValidationError(ValueError):
+    """Raised when an NN11 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise GatedRecurrentValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                GatedRecurrentValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise GatedRecurrentValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise GatedRecurrentValidationError(
+            f"{path}: top-level JSON value must be an object"
+        )
+    return document
+
+
+def _require_keys(value: Any, required: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GatedRecurrentValidationError(f"{context}: expected an object")
+    missing = required - value.keys()
+    extra = value.keys() - required
+    if missing:
+        raise GatedRecurrentValidationError(
+            f"{context}: missing keys {sorted(missing)}"
+        )
+    if extra:
+        raise GatedRecurrentValidationError(
+            f"{context}: unexpected keys {sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise GatedRecurrentValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise GatedRecurrentValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _sigmoid(value: float) -> float:
+    if value >= 0:
+        factor = math.exp(-value)
+        return 1.0 / (1.0 + factor)
+    factor = math.exp(value)
+    return factor / (1.0 + factor)
+
+
+def _gate(value: Any, context: str, activation: str) -> dict[str, float]:
+    gate = _require_keys(value, {"preactivation", "value"}, context)
+    preactivation = _number(gate["preactivation"], f"{context}.preactivation")
+    actual = (
+        _sigmoid(preactivation) if activation == "sigmoid" else math.tanh(preactivation)
+    )
+    return {"preactivation": preactivation, "value": actual}
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            raise GatedRecurrentValidationError(
+                f"{context}: expected {expected!r}, got {actual!r}"
+            )
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(
+            float(expected), float(actual), rel_tol=0, abs_tol=tolerance
+        ):
+            raise GatedRecurrentValidationError(
+                f"{context}: expected {expected!r}, got {actual!r}"
+            )
+        return
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            raise GatedRecurrentValidationError(
+                f"{context}: expected {len(expected)} items, got {len(actual)}"
+            )
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _compare(expected_item, actual_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            raise GatedRecurrentValidationError(
+                f"{context}: key mismatch {sorted(expected)} != {sorted(actual)}"
+            )
+        for key in expected:
+            _compare(expected[key], actual[key], tolerance, f"{context}.{key}")
+        return
+    if expected != actual:
+        raise GatedRecurrentValidationError(
+            f"{context}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def _execute_gru(
+    gru: dict[str, Any], input_value: float, previous_hidden: float
+) -> dict[str, Any]:
+    reset_gate = _gate(gru["reset_gate"], "gru.reset_gate", "sigmoid")
+    update_gate = _gate(gru["update_gate"], "gru.update_gate", "sigmoid")
+    candidate = _require_keys(
+        gru["candidate"],
+        {
+            "input_weight",
+            "input_product",
+            "reset_state",
+            "recurrent_weight",
+            "recurrent_product",
+            "bias",
+            "preactivation",
+            "value",
+        },
+        "gru.candidate",
+    )
+    input_weight = _number(candidate["input_weight"], "gru.candidate.input_weight")
+    recurrent_weight = _number(
+        candidate["recurrent_weight"], "gru.candidate.recurrent_weight"
+    )
+    bias = _number(candidate["bias"], "gru.candidate.bias")
+    input_product = input_weight * input_value
+    reset_state = reset_gate["value"] * previous_hidden
+    recurrent_product = recurrent_weight * reset_state
+    preactivation = input_product + recurrent_product + bias
+    candidate_value = math.tanh(preactivation)
+    retained_state = (1.0 - update_gate["value"]) * previous_hidden
+    candidate_write = update_gate["value"] * candidate_value
+    hidden_state = retained_state + candidate_write
+    return {
+        "reset_gate": reset_gate,
+        "update_gate": update_gate,
+        "candidate": {
+            "input_weight": input_weight,
+            "input_product": input_product,
+            "reset_state": reset_state,
+            "recurrent_weight": recurrent_weight,
+            "recurrent_product": recurrent_product,
+            "bias": bias,
+            "preactivation": preactivation,
+            "value": candidate_value,
+        },
+        "output": {
+            "retained_state": retained_state,
+            "candidate_write": candidate_write,
+            "hidden_state": hidden_state,
+        },
+    }
+
+
+def _execute_lstm(lstm: dict[str, Any], previous_cell: float) -> dict[str, Any]:
+    forget_gate = _gate(lstm["forget_gate"], "lstm.forget_gate", "sigmoid")
+    input_gate = _gate(lstm["input_gate"], "lstm.input_gate", "sigmoid")
+    output_gate = _gate(lstm["output_gate"], "lstm.output_gate", "sigmoid")
+    candidate = _gate(lstm["candidate"], "lstm.candidate", "tanh")
+    retained_cell = forget_gate["value"] * previous_cell
+    candidate_write = input_gate["value"] * candidate["value"]
+    cell_state = retained_cell + candidate_write
+    exposed_cell = math.tanh(cell_state)
+    hidden_state = output_gate["value"] * exposed_cell
+    return {
+        "forget_gate": forget_gate,
+        "input_gate": input_gate,
+        "output_gate": output_gate,
+        "candidate": candidate,
+        "output": {
+            "retained_cell": retained_cell,
+            "candidate_write": candidate_write,
+            "cell_state": cell_state,
+            "exposed_cell": exposed_cell,
+            "hidden_state": hidden_state,
+        },
+    }
+
+
+def _counterfactuals(
+    gru: dict[str, Any],
+    lstm: dict[str, Any],
+    previous_hidden: float,
+    previous_cell: float,
+) -> dict[str, list[dict[str, Any]]]:
+    gru_candidate = gru["candidate"]
+    update = gru["update_gate"]["value"]
+    reset_zero_candidate = math.tanh(
+        gru_candidate["input_product"] + gru_candidate["bias"]
+    )
+    canonical_candidate = gru_candidate["value"]
+    gru_rows = [
+        {
+            "gate": "update",
+            "gate_value": 0.0,
+            "candidate": canonical_candidate,
+            "cell_state": None,
+            "hidden_state": previous_hidden,
+        },
+        {
+            "gate": "update",
+            "gate_value": 1.0,
+            "candidate": canonical_candidate,
+            "cell_state": None,
+            "hidden_state": canonical_candidate,
+        },
+        {
+            "gate": "reset",
+            "gate_value": 0.0,
+            "candidate": reset_zero_candidate,
+            "cell_state": None,
+            "hidden_state": (1.0 - update) * previous_hidden
+            + update * reset_zero_candidate,
+        },
+    ]
+    forget = lstm["forget_gate"]["value"]
+    input_gate = lstm["input_gate"]["value"]
+    output = lstm["output_gate"]["value"]
+    candidate = lstm["candidate"]["value"]
+
+    def lstm_row(gate: str, gate_value: float) -> dict[str, Any]:
+        row_forget = gate_value if gate == "forget" else forget
+        row_input = gate_value if gate == "input" else input_gate
+        row_output = gate_value if gate == "output" else output
+        cell = row_forget * previous_cell + row_input * candidate
+        return {
+            "gate": gate,
+            "gate_value": gate_value,
+            "candidate": candidate,
+            "cell_state": cell,
+            "hidden_state": row_output * math.tanh(cell),
+        }
+
+    return {
+        "gru": gru_rows,
+        "lstm": [
+            lstm_row("forget", 0.0),
+            lstm_row("input", 0.0),
+            lstm_row("output", 0.0),
+            lstm_row("output", 1.0),
+        ],
+    }
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    inputs = _require_keys(
+        document["shared_inputs"],
+        {"input", "previous_hidden", "previous_cell"},
+        "shared_inputs",
+    )
+    input_value = _number(inputs["input"], "shared_inputs.input")
+    previous_hidden = _number(
+        inputs["previous_hidden"], "shared_inputs.previous_hidden"
+    )
+    previous_cell = _number(inputs["previous_cell"], "shared_inputs.previous_cell")
+    gru = _execute_gru(document["gru"], input_value, previous_hidden)
+    lstm = _execute_lstm(document["lstm"], previous_cell)
+    return {
+        "gru": gru,
+        "lstm": lstm,
+        "counterfactuals": _counterfactuals(gru, lstm, previous_hidden, previous_cell),
+    }
+
+
+def validate_lab(document: dict[str, Any]) -> dict[str, Any]:
+    _require_keys(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "shared_inputs",
+            "gru",
+            "lstm",
+            "counterfactuals",
+        },
+        "lab",
+    )
+    if document["schema_version"] != 1:
+        raise GatedRecurrentValidationError("lab.schema_version: expected 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(document[key], str) or not document[key]:
+            raise GatedRecurrentValidationError(f"lab.{key}: expected text")
+    concepts = document["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(set(concepts)) != len(concepts)
+    ):
+        raise GatedRecurrentValidationError("lab.concepts: expected unique text")
+    tolerance = _number(document["absolute_tolerance"], "lab.absolute_tolerance")
+    if tolerance <= 0:
+        raise GatedRecurrentValidationError(
+            "lab.absolute_tolerance: expected a positive number"
+        )
+    operation = _require_keys(
+        document["operation"],
+        {
+            "kind",
+            "gru_update_convention",
+            "gate_activation",
+            "candidate_activation",
+        },
+        "operation",
+    )
+    expected_operation = {
+        "kind": "scalar-gru-lstm-gate-comparison",
+        "gru_update_convention": "candidate-share",
+        "gate_activation": "sigmoid",
+        "candidate_activation": "tanh",
+    }
+    if operation != expected_operation:
+        raise GatedRecurrentValidationError(
+            f"operation: expected {expected_operation!r}"
+        )
+    _require_keys(
+        document["gru"],
+        {"reset_gate", "update_gate", "candidate", "output"},
+        "gru",
+    )
+    _require_keys(
+        document["lstm"],
+        {"forget_gate", "input_gate", "output_gate", "candidate", "output"},
+        "lstm",
+    )
+    actual = execute_lab(document)
+    _compare(document["gru"], actual["gru"], tolerance, "gru")
+    _compare(document["lstm"], actual["lstm"], tolerance, "lstm")
+    _compare(
+        document["counterfactuals"],
+        actual["counterfactuals"],
+        tolerance,
+        "counterfactuals",
+    )
+    return actual
+
+
+def validate_corpus(root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    lab_paths = sorted((root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise GatedRecurrentValidationError(f"no labs found under {root / 'labs'}")
+    for path in lab_paths:
+        try:
+            validate_lab(load_json(path))
+        except GatedRecurrentValidationError as error:
+            raise GatedRecurrentValidationError(f"{path}: {error}") from error
+    return lab_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    paths = validate_corpus(args.root)
+    print(f"validated {len(paths)} gated recurrent labs from {args.root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_gradient_flow_labs.py
+++ b/code/scripts/validate_gradient_flow_labs.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Validate and execute deterministic NN24 gradient-flow labs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = REPO_ROOT / "code" / "specs" / "fixtures" / "gradient-flow-v1"
+SCENARIO_IDS = ["small-tanh", "saturated-tanh", "unit-relu", "large-relu"]
+
+
+class GradientFlowValidationError(ValueError):
+    """Raised when an NN24 document or trace is invalid."""
+
+
+def _duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise GradientFlowValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_duplicates,
+            parse_constant=lambda item: (_ for _ in ()).throw(
+                GradientFlowValidationError(f"non-finite JSON number: {item}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise GradientFlowValidationError(f"{path}: {error}") from error
+    if not isinstance(value, dict):
+        raise GradientFlowValidationError("top-level JSON must be an object")
+    return value
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GradientFlowValidationError(f"{context}: expected object")
+    missing, extra = keys - value.keys(), value.keys() - keys
+    if missing or extra:
+        raise GradientFlowValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        raise GradientFlowValidationError(f"{context}: expected finite number")
+    return float(value)
+
+
+def _scenario(value: Any, index: int) -> dict[str, Any]:
+    scenario = _object(
+        value,
+        {"id", "label", "input", "weights", "activation", "target"},
+        f"scenarios[{index}]",
+    )
+    for key in ("id", "label"):
+        if not isinstance(scenario[key], str) or not scenario[key]:
+            raise GradientFlowValidationError(
+                f"scenarios[{index}].{key}: expected non-empty string"
+            )
+    scenario_input = _number(scenario["input"], f"scenarios[{index}].input")
+    target = _number(scenario["target"], f"scenarios[{index}].target")
+    weights = scenario["weights"]
+    if not isinstance(weights, list) or len(weights) < 2:
+        raise GradientFlowValidationError(
+            f"scenarios[{index}].weights: expected at least two values"
+        )
+    numeric_weights = [
+        _number(weight, f"scenarios[{index}].weights[{weight_index}]")
+        for weight_index, weight in enumerate(weights)
+    ]
+    if scenario["activation"] not in {"tanh", "relu"}:
+        raise GradientFlowValidationError(
+            f"scenarios[{index}].activation: expected tanh or relu"
+        )
+    return {
+        "id": scenario["id"],
+        "label": scenario["label"],
+        "input": scenario_input,
+        "weights": numeric_weights,
+        "activation": scenario["activation"],
+        "target": target,
+    }
+
+
+def _activate(value: float, activation: str) -> float:
+    return math.tanh(value) if activation == "tanh" else max(0.0, value)
+
+
+def _derivative(preactivation: float, activation: float, kind: str) -> float:
+    return 1 - activation**2 if kind == "tanh" else (1.0 if preactivation > 0 else 0.0)
+
+
+def _loss_at_input(scenario: dict[str, Any], scenario_input: float) -> float:
+    current = scenario_input
+    for weight in scenario["weights"]:
+        current = _activate(weight * current, scenario["activation"])
+    return 0.5 * (current - scenario["target"]) ** 2
+
+
+def _trace(scenario: dict[str, Any], epsilon: float) -> dict[str, Any]:
+    current = scenario["input"]
+    layers = []
+    for layer_index, weight in enumerate(scenario["weights"], start=1):
+        preactivation = weight * current
+        activation = _activate(preactivation, scenario["activation"])
+        activation_derivative = _derivative(
+            preactivation, activation, scenario["activation"]
+        )
+        layers.append(
+            {
+                "layer": layer_index,
+                "input": current,
+                "weight": weight,
+                "preactivation": preactivation,
+                "activation": activation,
+                "activation_derivative": activation_derivative,
+                "local_jacobian": weight * activation_derivative,
+                "upstream_gradient": 0.0,
+                "preactivation_gradient": 0.0,
+                "weight_gradient": 0.0,
+                "input_gradient": 0.0,
+            }
+        )
+        current = activation
+    output = current
+    output_error = output - scenario["target"]
+    loss = 0.5 * output_error**2
+    upstream = output_error
+    for layer in reversed(layers):
+        preactivation_gradient = upstream * layer["activation_derivative"]
+        layer["upstream_gradient"] = upstream
+        layer["preactivation_gradient"] = preactivation_gradient
+        layer["weight_gradient"] = preactivation_gradient * layer["input"]
+        layer["input_gradient"] = preactivation_gradient * layer["weight"]
+        upstream = layer["input_gradient"]
+    chain_jacobian = math.prod(layer["local_jacobian"] for layer in layers)
+    finite_difference = (
+        _loss_at_input(scenario, scenario["input"] + epsilon)
+        - _loss_at_input(scenario, scenario["input"] - epsilon)
+    ) / (2 * epsilon)
+    magnitude = abs(chain_jacobian)
+    classification = (
+        "vanishing" if magnitude < 0.1 else "exploding" if magnitude > 10 else "stable"
+    )
+    return {
+        "id": scenario["id"],
+        "output": output,
+        "output_error": output_error,
+        "loss": loss,
+        "chain_jacobian": chain_jacobian,
+        "input_gradient": upstream,
+        "finite_difference_input_gradient": finite_difference,
+        "finite_difference_error": abs(upstream - finite_difference),
+        "classification": classification,
+        "layers": layers,
+    }
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    epsilon = _number(
+        document["operation"]["finite_difference_epsilon"],
+        "operation.finite_difference_epsilon",
+    )
+    if epsilon <= 0:
+        raise GradientFlowValidationError(
+            "operation.finite_difference_epsilon must be positive"
+        )
+    raw_scenarios = document["scenarios"]
+    if not isinstance(raw_scenarios, list) or len(raw_scenarios) != 4:
+        raise GradientFlowValidationError("scenarios: expected four scenarios")
+    scenarios = [
+        _scenario(raw_scenario, index)
+        for index, raw_scenario in enumerate(raw_scenarios)
+    ]
+    if [scenario["id"] for scenario in scenarios] != SCENARIO_IDS:
+        raise GradientFlowValidationError("scenario order does not match NN24 V1")
+    return {"traces": [_trace(scenario, epsilon) for scenario in scenarios]}
+
+
+def _compare(actual: Any, expected: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool):
+        if actual is not expected:
+            raise GradientFlowValidationError(f"{context}: mismatch")
+    elif isinstance(expected, (int, float)):
+        if abs(_number(actual, context) - float(expected)) > tolerance:
+            raise GradientFlowValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+    elif isinstance(expected, str):
+        if actual != expected:
+            raise GradientFlowValidationError(f"{context}: mismatch")
+    elif isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            raise GradientFlowValidationError(f"{context}: array length mismatch")
+        for index, (left, right) in enumerate(zip(actual, expected)):
+            _compare(left, right, tolerance, f"{context}[{index}]")
+    elif isinstance(expected, dict):
+        value = _object(actual, set(expected), context)
+        for key, right in expected.items():
+            _compare(value[key], right, tolerance, f"{context}.{key}")
+    else:
+        raise GradientFlowValidationError(f"{context}: unsupported value")
+
+
+def validate_document(document: dict[str, Any]) -> dict[str, Any]:
+    root = _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "scenarios",
+            "expected",
+        },
+        "document",
+    )
+    if root["schema_version"] != 1:
+        raise GradientFlowValidationError("schema_version must be 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(root[key], str) or not root[key].strip():
+            raise GradientFlowValidationError(f"{key}: expected non-empty string")
+    tolerance = _number(root["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise GradientFlowValidationError("absolute_tolerance must be positive")
+    concepts = root["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or len(concepts) != len(set(concepts))
+        or any(not isinstance(item, str) or not item for item in concepts)
+    ):
+        raise GradientFlowValidationError("concepts must be unique non-empty strings")
+    operation = _object(
+        root["operation"],
+        {
+            "kind",
+            "loss",
+            "activation_derivative",
+            "finite_difference_epsilon",
+            "vanishing_threshold",
+            "exploding_threshold",
+        },
+        "operation",
+    )
+    required = {
+        "kind": "scalar-gradient-flow",
+        "loss": "half-squared-error",
+        "activation_derivative": "saved-output",
+        "finite_difference_epsilon": 1e-6,
+        "vanishing_threshold": 0.1,
+        "exploding_threshold": 10,
+    }
+    if operation != required:
+        raise GradientFlowValidationError("operation does not match NN24 V1")
+    actual = execute_lab(root)
+    if not isinstance(root["expected"], dict):
+        raise GradientFlowValidationError("expected must be object")
+    _compare(actual, root["expected"], tolerance, "expected")
+    if any(trace["finite_difference_error"] > 1e-8 for trace in actual["traces"]):
+        raise GradientFlowValidationError("input gradient finite difference failed")
+    return actual
+
+
+def validate_corpus(root: Path = DEFAULT_FIXTURE_ROOT) -> int:
+    load_json(root / "schema.json")
+    paths = sorted((root / "labs").glob("*.json"))
+    if not paths:
+        raise GradientFlowValidationError("no labs found")
+    for path in paths:
+        validate_document(load_json(path))
+        print(f"validated {path}")
+    return len(paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_corpus(args.fixture_root)
+    print(f"validated {count} NN24 gradient-flow lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_graph_convolution_attention_labs.py
+++ b/code/scripts/validate_graph_convolution_attention_labs.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Validate and execute deterministic NN22 GCN/GAT comparison labs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "graph-convolution-attention-v1"
+)
+
+
+class GraphConvolutionAttentionValidationError(ValueError):
+    """Raised when an NN22 document or trace is invalid."""
+
+
+def _duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise GraphConvolutionAttentionValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_duplicates,
+            parse_constant=lambda item: (_ for _ in ()).throw(
+                GraphConvolutionAttentionValidationError(
+                    f"non-finite JSON number: {item}"
+                )
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise GraphConvolutionAttentionValidationError(f"{path}: {error}") from error
+    if not isinstance(value, dict):
+        raise GraphConvolutionAttentionValidationError(
+            "top-level JSON must be an object"
+        )
+    return value
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GraphConvolutionAttentionValidationError(f"{context}: expected object")
+    missing, extra = keys - value.keys(), value.keys() - keys
+    if missing or extra:
+        raise GraphConvolutionAttentionValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        raise GraphConvolutionAttentionValidationError(
+            f"{context}: expected finite number"
+        )
+    return float(value)
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    raw_features = document["features"]
+    if not isinstance(raw_features, list) or len(raw_features) < 2:
+        raise GraphConvolutionAttentionValidationError(
+            "features: expected at least two values"
+        )
+    features = [
+        _number(value, f"features[{index}]") for index, value in enumerate(raw_features)
+    ]
+    raw_neighborhoods = document["neighborhoods"]
+    if not isinstance(raw_neighborhoods, list) or len(raw_neighborhoods) != len(
+        features
+    ):
+        raise GraphConvolutionAttentionValidationError(
+            "neighborhoods must align with features"
+        )
+    neighborhoods: list[list[int]] = []
+    for target, raw_sources in enumerate(raw_neighborhoods):
+        if (
+            not isinstance(raw_sources, list)
+            or not raw_sources
+            or any(
+                isinstance(source, bool) or not isinstance(source, int)
+                for source in raw_sources
+            )
+        ):
+            raise GraphConvolutionAttentionValidationError(
+                f"neighborhoods[{target}]: invalid indices"
+            )
+        sources = list(raw_sources)
+        if (
+            len(sources) != len(set(sources))
+            or target not in sources
+            or any(source < 0 or source >= len(features) for source in sources)
+        ):
+            raise GraphConvolutionAttentionValidationError(
+                f"neighborhoods[{target}]: must be unique valid indices including self"
+            )
+        neighborhoods.append(sources)
+    for target, sources in enumerate(neighborhoods):
+        if any(target not in neighborhoods[source] for source in sources):
+            raise GraphConvolutionAttentionValidationError(
+                "neighborhoods must be symmetric"
+            )
+
+    degrees = [len(sources) for sources in neighborhoods]
+    gcn = []
+    gat = []
+    for target, sources in enumerate(neighborhoods):
+        gcn_rows = []
+        for source in sources:
+            coefficient = 1 / math.sqrt(degrees[target] * degrees[source])
+            gcn_rows.append(
+                {
+                    "source": source,
+                    "source_feature": features[source],
+                    "source_degree": degrees[source],
+                    "target_degree": degrees[target],
+                    "coefficient": coefficient,
+                    "contribution": coefficient * features[source],
+                }
+            )
+        gcn_preactivation = sum(row["contribution"] for row in gcn_rows)
+        gcn.append(
+            {
+                "target": target,
+                "rows": gcn_rows,
+                "preactivation": gcn_preactivation,
+                "output": max(0.0, gcn_preactivation),
+            }
+        )
+
+        scores = [features[source] for source in sources]
+        maximum = max(scores)
+        exponentials = [math.exp(score - maximum) for score in scores]
+        denominator = sum(exponentials)
+        gat_rows = []
+        for index, source in enumerate(sources):
+            weight = exponentials[index] / denominator
+            gat_rows.append(
+                {
+                    "source": source,
+                    "source_feature": features[source],
+                    "score": scores[index],
+                    "shifted_score": scores[index] - maximum,
+                    "exponential": exponentials[index],
+                    "attention_weight": weight,
+                    "contribution": weight * features[source],
+                }
+            )
+        gat_preactivation = sum(row["contribution"] for row in gat_rows)
+        gat.append(
+            {
+                "target": target,
+                "maximum_score": maximum,
+                "denominator": denominator,
+                "rows": gat_rows,
+                "preactivation": gat_preactivation,
+                "output": max(0.0, gat_preactivation),
+            }
+        )
+    return {
+        "degrees": degrees,
+        "gcn": gcn,
+        "gat": gat,
+        "gcn_outputs": [row["output"] for row in gcn],
+        "gat_outputs": [row["output"] for row in gat],
+    }
+
+
+def _compare(actual: Any, expected: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool):
+        if actual is not expected:
+            raise GraphConvolutionAttentionValidationError(f"{context}: mismatch")
+    elif isinstance(expected, (int, float)):
+        if abs(_number(actual, context) - float(expected)) > tolerance:
+            raise GraphConvolutionAttentionValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+    elif isinstance(expected, str):
+        if actual != expected:
+            raise GraphConvolutionAttentionValidationError(f"{context}: mismatch")
+    elif isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            raise GraphConvolutionAttentionValidationError(
+                f"{context}: array length mismatch"
+            )
+        for index, (left, right) in enumerate(zip(actual, expected)):
+            _compare(left, right, tolerance, f"{context}[{index}]")
+    elif isinstance(expected, dict):
+        value = _object(actual, set(expected), context)
+        for key, right in expected.items():
+            _compare(value[key], right, tolerance, f"{context}.{key}")
+    else:
+        raise GraphConvolutionAttentionValidationError(f"{context}: unsupported value")
+
+
+def validate_document(document: dict[str, Any]) -> dict[str, Any]:
+    root = _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "features",
+            "neighborhoods",
+            "expected",
+        },
+        "document",
+    )
+    if root["schema_version"] != 1:
+        raise GraphConvolutionAttentionValidationError("schema_version must be 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(root[key], str) or not root[key].strip():
+            raise GraphConvolutionAttentionValidationError(
+                f"{key}: expected non-empty string"
+            )
+    tolerance = _number(root["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise GraphConvolutionAttentionValidationError(
+            "absolute_tolerance must be positive"
+        )
+    concepts = root["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or len(concepts) != len(set(concepts))
+    ):
+        raise GraphConvolutionAttentionValidationError("concepts must be unique")
+    operation = _object(
+        root["operation"],
+        {"kind", "gcn", "gat_score", "gat_normalization", "activation"},
+        "operation",
+    )
+    required = {
+        "kind": "graph-convolution-attention-comparison",
+        "gcn": "symmetric-degree-normalized-sum",
+        "gat_score": "source-feature",
+        "gat_normalization": "stable-neighborhood-softmax",
+        "activation": "relu",
+    }
+    if operation != required:
+        raise GraphConvolutionAttentionValidationError(
+            "operation does not match NN22 V1"
+        )
+    actual = execute_lab(root)
+    if not isinstance(root["expected"], dict):
+        raise GraphConvolutionAttentionValidationError("expected must be object")
+    _compare(actual, root["expected"], tolerance, "expected")
+    for row in actual["gat"]:
+        if abs(sum(item["attention_weight"] for item in row["rows"]) - 1) > tolerance:
+            raise GraphConvolutionAttentionValidationError(
+                "attention row must sum to one"
+            )
+    return actual
+
+
+def validate_corpus(root: Path = DEFAULT_FIXTURE_ROOT) -> int:
+    load_json(root / "schema.json")
+    paths = sorted((root / "labs").glob("*.json"))
+    if not paths:
+        raise GraphConvolutionAttentionValidationError("no labs found")
+    for path in paths:
+        validate_document(load_json(path))
+        print(f"validated {path}")
+    return len(paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_corpus(args.fixture_root)
+    print(f"validated {count} NN22 graph convolution/attention lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_hopfield_associative_memory_labs.py
+++ b/code/scripts/validate_hopfield_associative_memory_labs.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN20 Hopfield memory corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "hopfield-associative-memory-v1"
+)
+
+
+class HopfieldAssociativeMemoryValidationError(ValueError):
+    """Raised when an NN20 document or deterministic trace is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise HopfieldAssociativeMemoryValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                HopfieldAssociativeMemoryValidationError(
+                    f"non-finite JSON number: {value}"
+                )
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise HopfieldAssociativeMemoryValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise HopfieldAssociativeMemoryValidationError(
+            "top-level JSON value must be an object"
+        )
+    return document
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise HopfieldAssociativeMemoryValidationError(f"{context}: expected an object")
+    missing = keys - value.keys()
+    extra = value.keys() - keys
+    if missing or extra:
+        raise HopfieldAssociativeMemoryValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise HopfieldAssociativeMemoryValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise HopfieldAssociativeMemoryValidationError(
+            f"{context}: expected a finite number"
+        )
+    return result
+
+
+def _integer(value: Any, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise HopfieldAssociativeMemoryValidationError(
+            f"{context}: expected an integer"
+        )
+    return value
+
+
+def _bipolar_vector(value: Any, context: str) -> list[int]:
+    if not isinstance(value, list) or len(value) < 2:
+        raise HopfieldAssociativeMemoryValidationError(
+            f"{context}: expected at least two bipolar values"
+        )
+    result = [_integer(item, f"{context}[{index}]") for index, item in enumerate(value)]
+    if any(item not in (-1, 1) for item in result):
+        raise HopfieldAssociativeMemoryValidationError(
+            f"{context}: values must be bipolar (-1 or 1)"
+        )
+    return result
+
+
+def hopfield_weights(pattern: list[int]) -> list[list[float]]:
+    size = len(pattern)
+    return [
+        [
+            0.0 if row == column else pattern[row] * pattern[column] / size
+            for column in range(size)
+        ]
+        for row in range(size)
+    ]
+
+
+def hopfield_energy(state: list[int], weights: list[list[float]]) -> float:
+    directed_sum = sum(
+        weights[row][column] * state[row] * state[column]
+        for row in range(len(state))
+        for column in range(len(state))
+    )
+    return -0.5 * directed_sum
+
+
+def normalized_overlap(pattern: list[int], state: list[int]) -> float:
+    return sum(saved * current for saved, current in zip(pattern, state)) / len(pattern)
+
+
+def hamming_distance(pattern: list[int], state: list[int]) -> int:
+    return sum(saved != current for saved, current in zip(pattern, state))
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    pattern = _bipolar_vector(document["stored_pattern"], "stored_pattern")
+    corrupted = _bipolar_vector(document["corrupted_state"], "corrupted_state")
+    if len(corrupted) != len(pattern):
+        raise HopfieldAssociativeMemoryValidationError(
+            "stored_pattern and corrupted_state must have equal length"
+        )
+
+    order_value = document["update_order"]
+    if not isinstance(order_value, list):
+        raise HopfieldAssociativeMemoryValidationError(
+            "update_order: expected an array"
+        )
+    order = [
+        _integer(item, f"update_order[{index}]")
+        for index, item in enumerate(order_value)
+    ]
+    if sorted(order) != list(range(len(pattern))):
+        raise HopfieldAssociativeMemoryValidationError(
+            "update_order must be one permutation of every neuron index"
+        )
+
+    weights = hopfield_weights(pattern)
+    state = corrupted[:]
+    updates: list[dict[str, Any]] = []
+    for step, neuron_index in enumerate(order):
+        state_before = state[:]
+        incoming = [
+            {
+                "source_index": source_index,
+                "weight": weights[neuron_index][source_index],
+                "source_state": source_state,
+                "contribution": weights[neuron_index][source_index] * source_state,
+            }
+            for source_index, source_state in enumerate(state_before)
+        ]
+        local_field = sum(row["contribution"] for row in incoming)
+        previous_state = state_before[neuron_index]
+        next_state = 1 if local_field > 0 else -1 if local_field < 0 else previous_state
+        state = state_before[:]
+        state[neuron_index] = next_state
+        updates.append(
+            {
+                "step": step,
+                "neuron_index": neuron_index,
+                "state_before": state_before,
+                "incoming": incoming,
+                "local_field": local_field,
+                "previous_state": previous_state,
+                "next_state": next_state,
+                "changed": next_state != previous_state,
+                "state_after": state[:],
+                "energy_before": hopfield_energy(state_before, weights),
+                "energy_after": hopfield_energy(state, weights),
+                "overlap_before": normalized_overlap(pattern, state_before),
+                "overlap_after": normalized_overlap(pattern, state),
+            }
+        )
+
+    final_distance = hamming_distance(pattern, state)
+    return {
+        "normalization": len(pattern),
+        "weights": weights,
+        "initial_energy": hopfield_energy(corrupted, weights),
+        "initial_overlap": normalized_overlap(pattern, corrupted),
+        "initial_hamming_distance": hamming_distance(pattern, corrupted),
+        "updates": updates,
+        "final_state": state,
+        "final_energy": hopfield_energy(state, weights),
+        "final_overlap": normalized_overlap(pattern, state),
+        "final_hamming_distance": final_distance,
+        "converged": final_distance == 0
+        and all(row["energy_after"] <= row["energy_before"] + 1e-12 for row in updates),
+    }
+
+
+def _compare(actual: Any, expected: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool):
+        if actual is not expected:
+            raise HopfieldAssociativeMemoryValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, (int, float)) and not isinstance(expected, bool):
+        actual_number = _number(actual, context)
+        if abs(actual_number - float(expected)) > tolerance:
+            raise HopfieldAssociativeMemoryValidationError(
+                f"{context}: expected {expected}, got {actual_number}"
+            )
+        return
+    if isinstance(expected, str):
+        if actual != expected:
+            raise HopfieldAssociativeMemoryValidationError(
+                f"{context}: expected {expected!r}, got {actual!r}"
+            )
+        return
+    if isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            raise HopfieldAssociativeMemoryValidationError(
+                f"{context}: expected an array of length {len(expected)}"
+            )
+        for index, (actual_item, expected_item) in enumerate(zip(actual, expected)):
+            _compare(actual_item, expected_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict):
+        actual_object = _object(actual, set(expected), context)
+        for key, expected_value in expected.items():
+            _compare(actual_object[key], expected_value, tolerance, f"{context}.{key}")
+        return
+    raise HopfieldAssociativeMemoryValidationError(
+        f"{context}: unsupported expected value {expected!r}"
+    )
+
+
+def validate_document(document: dict[str, Any]) -> dict[str, Any]:
+    root = _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "stored_pattern",
+            "corrupted_state",
+            "update_order",
+            "expected",
+        },
+        "document",
+    )
+    if _integer(root["schema_version"], "schema_version") != 1:
+        raise HopfieldAssociativeMemoryValidationError("schema_version must be 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(root[key], str) or not root[key].strip():
+            raise HopfieldAssociativeMemoryValidationError(
+                f"{key}: expected a non-empty string"
+            )
+    tolerance = _number(root["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise HopfieldAssociativeMemoryValidationError(
+            "absolute_tolerance must be positive"
+        )
+    concepts = root["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(set(concepts)) != len(concepts)
+    ):
+        raise HopfieldAssociativeMemoryValidationError(
+            "concepts must contain unique non-empty strings"
+        )
+
+    operation = _object(
+        root["operation"],
+        {"kind", "storage", "activation", "update", "energy"},
+        "operation",
+    )
+    required_operation = {
+        "kind": "hopfield-associative-recall",
+        "storage": "single-pattern-normalized-hebbian",
+        "activation": "sign-preserve-zero",
+        "update": "asynchronous-in-place",
+        "energy": "symmetric-zero-diagonal-hopfield",
+    }
+    if operation != required_operation:
+        raise HopfieldAssociativeMemoryValidationError(
+            "operation does not match the NN20 V1 contract"
+        )
+
+    actual = execute_lab(root)
+    expected = root["expected"]
+    if not isinstance(expected, dict):
+        raise HopfieldAssociativeMemoryValidationError("expected: expected an object")
+    _compare(actual, expected, tolerance, "expected")
+
+    weights = actual["weights"]
+    for row in range(len(weights)):
+        if abs(weights[row][row]) > tolerance:
+            raise HopfieldAssociativeMemoryValidationError(
+                "weight matrix diagonal must be zero"
+            )
+        for column in range(len(weights)):
+            if abs(weights[row][column] - weights[column][row]) > tolerance:
+                raise HopfieldAssociativeMemoryValidationError(
+                    "weight matrix must be symmetric"
+                )
+    if any(
+        row["energy_after"] > row["energy_before"] + tolerance
+        for row in actual["updates"]
+    ):
+        raise HopfieldAssociativeMemoryValidationError(
+            "asynchronous Hopfield energy must not increase"
+        )
+    if actual["final_overlap"] <= actual["initial_overlap"]:
+        raise HopfieldAssociativeMemoryValidationError(
+            "fixture must improve normalized overlap"
+        )
+    if not actual["converged"]:
+        raise HopfieldAssociativeMemoryValidationError(
+            "fixture must recover the saved fixed point"
+        )
+    return actual
+
+
+def validate_corpus(fixture_root: Path = DEFAULT_FIXTURE_ROOT) -> int:
+    schema_path = fixture_root / "schema.json"
+    load_json(schema_path)
+    lab_paths = sorted((fixture_root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise HopfieldAssociativeMemoryValidationError(
+            f"no lab documents found under {fixture_root / 'labs'}"
+        )
+    seen_ids: set[str] = set()
+    for path in lab_paths:
+        document = load_json(path)
+        lab_id = document.get("id")
+        if lab_id in seen_ids:
+            raise HopfieldAssociativeMemoryValidationError(
+                f"duplicate lab id: {lab_id}"
+            )
+        seen_ids.add(str(lab_id))
+        validate_document(document)
+        print(f"validated {path}")
+    return len(lab_paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixture-root",
+        type=Path,
+        default=DEFAULT_FIXTURE_ROOT,
+        help="Hopfield V1 fixture directory",
+    )
+    args = parser.parse_args()
+    count = validate_corpus(args.fixture_root)
+    print(f"validated {count} NN20 Hopfield associative-memory lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_initialization_activation_distribution_labs.py
+++ b/code/scripts/validate_initialization_activation_distribution_labs.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Validate and execute deterministic NN23 initialization-distribution labs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT
+    / "code"
+    / "specs"
+    / "fixtures"
+    / "initialization-activation-distribution-v1"
+)
+
+INITIALIZERS = ["tiny", "xavier", "he", "large"]
+ACTIVATIONS = ["tanh", "relu"]
+
+
+class InitializationDistributionValidationError(ValueError):
+    """Raised when an NN23 document or trace is invalid."""
+
+
+def _duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise InitializationDistributionValidationError(
+                f"duplicate JSON key: {key}"
+            )
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_duplicates,
+            parse_constant=lambda item: (_ for _ in ()).throw(
+                InitializationDistributionValidationError(
+                    f"non-finite JSON number: {item}"
+                )
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise InitializationDistributionValidationError(f"{path}: {error}") from error
+    if not isinstance(value, dict):
+        raise InitializationDistributionValidationError(
+            "top-level JSON must be an object"
+        )
+    return value
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise InitializationDistributionValidationError(f"{context}: expected object")
+    missing, extra = keys - value.keys(), value.keys() - keys
+    if missing or extra:
+        raise InitializationDistributionValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        raise InitializationDistributionValidationError(
+            f"{context}: expected finite number"
+        )
+    return float(value)
+
+
+def _matrix(value: Any, context: str, minimum_rows: int = 1) -> list[list[float]]:
+    if not isinstance(value, list) or len(value) < minimum_rows:
+        raise InitializationDistributionValidationError(
+            f"{context}: expected at least {minimum_rows} rows"
+        )
+    rows: list[list[float]] = []
+    width: int | None = None
+    for row_index, raw_row in enumerate(value):
+        if not isinstance(raw_row, list) or not raw_row:
+            raise InitializationDistributionValidationError(
+                f"{context}[{row_index}]: expected non-empty row"
+            )
+        row = [
+            _number(item, f"{context}[{row_index}][{column}]")
+            for column, item in enumerate(raw_row)
+        ]
+        if width is None:
+            width = len(row)
+        elif len(row) != width:
+            raise InitializationDistributionValidationError(
+                f"{context}: expected rectangular matrix"
+            )
+        rows.append(row)
+    return rows
+
+
+def _scale(initializer: str, fan_in: int) -> float:
+    if fan_in < 1:
+        raise InitializationDistributionValidationError(
+            "fan-in must be a positive integer"
+        )
+    if initializer == "tiny":
+        return 0.1
+    if initializer == "xavier":
+        return math.sqrt(1 / fan_in)
+    if initializer == "he":
+        return math.sqrt(2 / fan_in)
+    if initializer == "large":
+        return 2.0
+    raise InitializationDistributionValidationError(
+        f"unsupported initializer: {initializer}"
+    )
+
+
+def _summary(matrix: list[list[float]], activation: str) -> dict[str, float]:
+    values = [value for row in matrix for value in row]
+    mean = sum(values) / len(values)
+    variance = sum((value - mean) ** 2 for value in values) / len(values)
+    return {
+        "mean": mean,
+        "variance": variance,
+        "standard_deviation": math.sqrt(variance),
+        "minimum": min(values),
+        "maximum": max(values),
+        "zero_fraction": sum(abs(value) < 1e-12 for value in values) / len(values),
+        "saturated_fraction": (
+            sum(abs(value) >= 0.95 for value in values) / len(values)
+            if activation == "tanh"
+            else 0.0
+        ),
+    }
+
+
+def _trace(
+    inputs: list[list[float]],
+    templates: list[list[list[float]]],
+    initializer: str,
+    activation: str,
+) -> list[dict[str, Any]]:
+    current = [row[:] for row in inputs]
+    layers: list[dict[str, Any]] = []
+    for layer_index, template in enumerate(templates, start=1):
+        fan_in = len(current[0])
+        if len(template) != fan_in:
+            raise InitializationDistributionValidationError(
+                f"weight_templates[{layer_index - 1}]: must match fan-in {fan_in}"
+            )
+        scale = _scale(initializer, fan_in)
+        weights = [[value * scale for value in row] for row in template]
+        width = len(weights[0])
+        preactivations = [
+            [
+                sum(
+                    row[input_index] * weights[input_index][output]
+                    for input_index in range(fan_in)
+                )
+                for output in range(width)
+            ]
+            for row in current
+        ]
+        activations = [
+            [
+                math.tanh(value) if activation == "tanh" else max(0.0, value)
+                for value in row
+            ]
+            for row in preactivations
+        ]
+        layers.append(
+            {
+                "layer": layer_index,
+                "scale": scale,
+                "preactivations": preactivations,
+                "activations": activations,
+                "summary": _summary(activations, activation),
+            }
+        )
+        current = activations
+    return layers
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    inputs = _matrix(document["inputs"], "inputs", minimum_rows=2)
+    raw_templates = document["weight_templates"]
+    if not isinstance(raw_templates, list) or not raw_templates:
+        raise InitializationDistributionValidationError(
+            "weight_templates: expected at least one matrix"
+        )
+    templates = [
+        _matrix(raw_template, f"weight_templates[{index}]")
+        for index, raw_template in enumerate(raw_templates)
+    ]
+    canonical_layers = _trace(inputs, templates, "xavier", "tanh")
+    comparison = []
+    for initializer in INITIALIZERS:
+        for activation in ACTIVATIONS:
+            layers = _trace(inputs, templates, initializer, activation)
+            comparison.append(
+                {
+                    "initializer": initializer,
+                    "activation": activation,
+                    "standard_deviations": [
+                        layer["summary"]["standard_deviation"] for layer in layers
+                    ],
+                    "zero_fractions": [
+                        layer["summary"]["zero_fraction"] for layer in layers
+                    ],
+                    "saturated_fractions": [
+                        layer["summary"]["saturated_fraction"] for layer in layers
+                    ],
+                }
+            )
+    return {
+        "canonical": {
+            "initializer": "xavier",
+            "activation": "tanh",
+            "layers": canonical_layers,
+        },
+        "comparison": comparison,
+    }
+
+
+def _compare(actual: Any, expected: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool):
+        if actual is not expected:
+            raise InitializationDistributionValidationError(f"{context}: mismatch")
+    elif isinstance(expected, (int, float)):
+        if abs(_number(actual, context) - float(expected)) > tolerance:
+            raise InitializationDistributionValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+    elif isinstance(expected, str):
+        if actual != expected:
+            raise InitializationDistributionValidationError(f"{context}: mismatch")
+    elif isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            raise InitializationDistributionValidationError(
+                f"{context}: array length mismatch"
+            )
+        for index, (left, right) in enumerate(zip(actual, expected)):
+            _compare(left, right, tolerance, f"{context}[{index}]")
+    elif isinstance(expected, dict):
+        value = _object(actual, set(expected), context)
+        for key, right in expected.items():
+            _compare(value[key], right, tolerance, f"{context}.{key}")
+    else:
+        raise InitializationDistributionValidationError(f"{context}: unsupported value")
+
+
+def validate_document(document: dict[str, Any]) -> dict[str, Any]:
+    root = _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "inputs",
+            "weight_templates",
+            "initializers",
+            "activations",
+            "expected",
+        },
+        "document",
+    )
+    if root["schema_version"] != 1:
+        raise InitializationDistributionValidationError("schema_version must be 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(root[key], str) or not root[key].strip():
+            raise InitializationDistributionValidationError(
+                f"{key}: expected non-empty string"
+            )
+    tolerance = _number(root["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise InitializationDistributionValidationError(
+            "absolute_tolerance must be positive"
+        )
+    concepts = root["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or len(concepts) != len(set(concepts))
+        or any(not isinstance(item, str) or not item for item in concepts)
+    ):
+        raise InitializationDistributionValidationError(
+            "concepts must be unique non-empty strings"
+        )
+    operation = _object(
+        root["operation"],
+        {
+            "kind",
+            "bias",
+            "variance",
+            "zero_threshold",
+            "tanh_saturation_threshold",
+            "canonical_initializer",
+            "canonical_activation",
+        },
+        "operation",
+    )
+    required = {
+        "kind": "initialization-activation-distribution",
+        "bias": "none",
+        "variance": "population",
+        "zero_threshold": 1e-12,
+        "tanh_saturation_threshold": 0.95,
+        "canonical_initializer": "xavier",
+        "canonical_activation": "tanh",
+    }
+    if operation != required:
+        raise InitializationDistributionValidationError(
+            "operation does not match NN23 V1"
+        )
+    if root["initializers"] != INITIALIZERS or root["activations"] != ACTIVATIONS:
+        raise InitializationDistributionValidationError(
+            "initializer or activation order does not match NN23 V1"
+        )
+    actual = execute_lab(root)
+    if not isinstance(root["expected"], dict):
+        raise InitializationDistributionValidationError("expected must be object")
+    _compare(actual, root["expected"], tolerance, "expected")
+    return actual
+
+
+def validate_corpus(root: Path = DEFAULT_FIXTURE_ROOT) -> int:
+    load_json(root / "schema.json")
+    paths = sorted((root / "labs").glob("*.json"))
+    if not paths:
+        raise InitializationDistributionValidationError("no labs found")
+    for path in paths:
+        validate_document(load_json(path))
+        print(f"validated {path}")
+    return len(paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_corpus(args.fixture_root)
+    print(f"validated {count} NN23 initialization-distribution lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_multi_head_attention_labs.py
+++ b/code/scripts/validate_multi_head_attention_labs.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN14 multi-head attention corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "multi-head-attention-v1"
+)
+
+
+class MultiHeadAttentionValidationError(ValueError):
+    """Raised when an NN14 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise MultiHeadAttentionValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                MultiHeadAttentionValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise MultiHeadAttentionValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise MultiHeadAttentionValidationError(
+            "top-level JSON value must be an object"
+        )
+    return document
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MultiHeadAttentionValidationError(f"{context}: expected an object")
+    missing = keys - value.keys()
+    extra = value.keys() - keys
+    if missing or extra:
+        raise MultiHeadAttentionValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise MultiHeadAttentionValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise MultiHeadAttentionValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _vector(value: Any, length: int, context: str) -> list[float]:
+    if not isinstance(value, list) or len(value) != length:
+        raise MultiHeadAttentionValidationError(f"{context}: expected {length} numbers")
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def _matrix(value: Any, rows: int, columns: int, context: str) -> list[list[float]]:
+    if not isinstance(value, list) or len(value) != rows:
+        raise MultiHeadAttentionValidationError(f"{context}: expected {rows} rows")
+    return [
+        _vector(row, columns, f"{context}[{index}]") for index, row in enumerate(value)
+    ]
+
+
+def _text_list(value: Any, length: int, context: str) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or len(value) != length
+        or any(not isinstance(item, str) or not item for item in value)
+    ):
+        raise MultiHeadAttentionValidationError(
+            f"{context}: expected {length} non-empty strings"
+        )
+    if len(set(value)) != len(value):
+        raise MultiHeadAttentionValidationError(f"{context}: expected unique strings")
+    return value
+
+
+def _clean_zero(value: float) -> float:
+    return 0.0 if abs(value) < 1e-15 else value
+
+
+def _dot_products(vector: list[float], projection: list[float]) -> list[float]:
+    return [_clean_zero(value * weight) for value, weight in zip(vector, projection)]
+
+
+def _execute_head(
+    embeddings: list[list[float]],
+    query_index: int,
+    head: dict[str, Any],
+) -> dict[str, Any]:
+    query_projection = head["query_projection"]
+    key_projection = head["key_projection"]
+    value_projection = head["value_projection"]
+    query_products = _dot_products(embeddings[query_index], query_projection)
+    query = _clean_zero(sum(query_products))
+    key_products = [
+        _dot_products(embedding, key_projection) for embedding in embeddings
+    ]
+    keys = [_clean_zero(sum(products)) for products in key_products]
+    value_products = [
+        _dot_products(embedding, value_projection) for embedding in embeddings
+    ]
+    values = [_clean_zero(sum(products)) for products in value_products]
+    scale_divisor = 1.0
+    scaled_scores = [_clean_zero(query * key / scale_divisor) for key in keys]
+    allowed = [key_index <= query_index for key_index in range(3)]
+    masked_scores: list[float | None] = [
+        score if allowed[key_index] else None
+        for key_index, score in enumerate(scaled_scores)
+    ]
+    row_max = max(score for score in masked_scores if score is not None)
+    shifted_scores: list[float | None] = [
+        _clean_zero(score - row_max) if score is not None else None
+        for score in masked_scores
+    ]
+    exponentials = [
+        math.exp(score) if score is not None else 0.0 for score in shifted_scores
+    ]
+    denominator = sum(exponentials)
+    weights = [_clean_zero(value / denominator) for value in exponentials]
+    value_contributions = [
+        _clean_zero(weight * value) for weight, value in zip(weights, values)
+    ]
+    return {
+        "id": head["id"],
+        "query_products": query_products,
+        "query": query,
+        "key_products": key_products,
+        "keys": keys,
+        "value_products": value_products,
+        "values": values,
+        "scale_divisor": scale_divisor,
+        "scaled_scores": scaled_scores,
+        "allowed": allowed,
+        "masked_scores": masked_scores,
+        "row_max": row_max,
+        "shifted_scores": shifted_scores,
+        "exponentials": exponentials,
+        "denominator": denominator,
+        "weights": weights,
+        "value_contributions": value_contributions,
+        "context": _clean_zero(sum(value_contributions)),
+    }
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    embeddings = _matrix(document["embeddings"], 3, 2, "embeddings")
+    output_projection = _matrix(
+        document["output_projection"], 2, 2, "output_projection"
+    )
+    normalization = document["normalization"]
+    epsilon = _number(normalization["epsilon"], "normalization.epsilon")
+    gamma = _vector(normalization["gamma"], 2, "normalization.gamma")
+    beta = _vector(normalization["beta"], 2, "normalization.beta")
+    rows: list[dict[str, Any]] = []
+
+    for query_index, embedding in enumerate(embeddings):
+        head_traces = [
+            _execute_head(embeddings, query_index, head) for head in document["heads"]
+        ]
+        concatenated = [head["context"] for head in head_traces]
+        output_projection_products = [
+            [
+                _clean_zero(
+                    concatenated[head_index]
+                    * output_projection[head_index][output_index]
+                )
+                for head_index in range(2)
+            ]
+            for output_index in range(2)
+        ]
+        projected_attention = [
+            _clean_zero(sum(products)) for products in output_projection_products
+        ]
+        residual_sum = [
+            _clean_zero(embedding[index] + projected_attention[index])
+            for index in range(2)
+        ]
+        mean = sum(residual_sum) / 2
+        centered = [_clean_zero(value - mean) for value in residual_sum]
+        squared_deviations = [value * value for value in centered]
+        variance = sum(squared_deviations) / 2
+        denominator = math.sqrt(variance + epsilon)
+        normalized = [_clean_zero(value / denominator) for value in centered]
+        affine_products = [
+            _clean_zero(value * gamma[index]) for index, value in enumerate(normalized)
+        ]
+        output = [
+            _clean_zero(value + beta[index])
+            for index, value in enumerate(affine_products)
+        ]
+        rows.append(
+            {
+                "token": document["token_ids"][query_index],
+                "input": embedding,
+                "heads": head_traces,
+                "concatenated": concatenated,
+                "output_projection_products": output_projection_products,
+                "projected_attention": projected_attention,
+                "residual_sum": residual_sum,
+                "layer_norm": {
+                    "mean": mean,
+                    "centered": centered,
+                    "squared_deviations": squared_deviations,
+                    "variance": variance,
+                    "denominator": denominator,
+                    "normalized": normalized,
+                    "affine_products": affine_products,
+                    "output": output,
+                },
+            }
+        )
+    return {"rows": rows}
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            raise MultiHeadAttentionValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(
+            float(expected), float(actual), rel_tol=0, abs_tol=tolerance
+        ):
+            raise MultiHeadAttentionValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            raise MultiHeadAttentionValidationError(f"{context}: length mismatch")
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _compare(expected_item, actual_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            raise MultiHeadAttentionValidationError(f"{context}: key mismatch")
+        for key in expected:
+            _compare(expected[key], actual[key], tolerance, f"{context}.{key}")
+        return
+    if expected != actual:
+        raise MultiHeadAttentionValidationError(
+            f"{context}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def validate_lab(document: dict[str, Any]) -> dict[str, Any]:
+    _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "token_ids",
+            "embeddings",
+            "heads",
+            "output_projection",
+            "normalization",
+            "expected",
+        },
+        "lab",
+    )
+    if document["schema_version"] != 1:
+        raise MultiHeadAttentionValidationError("schema_version: expected 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(document[key], str) or not document[key]:
+            raise MultiHeadAttentionValidationError(f"{key}: expected text")
+    concepts = document["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(set(concepts)) != len(concepts)
+    ):
+        raise MultiHeadAttentionValidationError(
+            "concepts: expected unique non-empty strings"
+        )
+    tolerance = _number(document["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise MultiHeadAttentionValidationError(
+            "absolute_tolerance: expected a positive number"
+        )
+
+    operation = _object(
+        document["operation"],
+        {
+            "kind",
+            "head_count",
+            "model_width",
+            "head_width",
+            "softmax",
+            "causal_rule",
+            "masked_score_encoding",
+            "block_order",
+            "layer_norm_variance",
+        },
+        "operation",
+    )
+    required_operation = {
+        "kind": "two-head-causal-attention-add-norm",
+        "head_count": 2,
+        "model_width": 2,
+        "head_width": 1,
+        "softmax": "stable-row-wise",
+        "causal_rule": "key-index-less-than-or-equal-query-index",
+        "masked_score_encoding": "null",
+        "block_order": "attention-output-projection-add-residual-layer-norm",
+        "layer_norm_variance": "population",
+    }
+    if operation != required_operation:
+        raise MultiHeadAttentionValidationError("operation: unsupported NN14 contract")
+
+    _text_list(document["token_ids"], 3, "token_ids")
+    _matrix(document["embeddings"], 3, 2, "embeddings")
+    heads = document["heads"]
+    if not isinstance(heads, list) or len(heads) != 2:
+        raise MultiHeadAttentionValidationError("heads: expected two heads")
+    head_ids: list[str] = []
+    for index, head_value in enumerate(heads):
+        head = _object(
+            head_value,
+            {"id", "query_projection", "key_projection", "value_projection"},
+            f"heads[{index}]",
+        )
+        if not isinstance(head["id"], str) or not head["id"]:
+            raise MultiHeadAttentionValidationError(f"heads[{index}].id: expected text")
+        head_ids.append(head["id"])
+        for projection in ("query_projection", "key_projection", "value_projection"):
+            head[projection] = _vector(
+                head[projection], 2, f"heads[{index}].{projection}"
+            )
+    if len(set(head_ids)) != 2:
+        raise MultiHeadAttentionValidationError("heads: expected unique IDs")
+    _matrix(document["output_projection"], 2, 2, "output_projection")
+    normalization = _object(
+        document["normalization"],
+        {"epsilon", "gamma", "beta"},
+        "normalization",
+    )
+    if _number(normalization["epsilon"], "normalization.epsilon") <= 0:
+        raise MultiHeadAttentionValidationError(
+            "normalization.epsilon: expected a positive number"
+        )
+    _vector(normalization["gamma"], 2, "normalization.gamma")
+    _vector(normalization["beta"], 2, "normalization.beta")
+    expected = _object(document["expected"], {"rows"}, "expected")
+    actual = execute_lab(document)
+    _compare(expected, actual, tolerance, "expected")
+    return actual
+
+
+def validate_fixture_root(root: Path) -> int:
+    labs = sorted((root / "labs").glob("*.json"))
+    if not labs:
+        raise MultiHeadAttentionValidationError(f"{root}: no lab documents found")
+    for path in labs:
+        validate_lab(load_json(path))
+        print(f"validated {path.relative_to(REPO_ROOT)}")
+    return len(labs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_fixture_root(args.root.resolve())
+    print(f"validated {count} NN14 multi-head attention lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_one_dimensional_diffusion_labs.py
+++ b/code/scripts/validate_one_dimensional_diffusion_labs.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN19 scalar diffusion corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "one-dimensional-diffusion-v1"
+)
+PARAMETER_ORDER = [
+    "denoiser.sample_weight",
+    "denoiser.timestep_weight",
+    "denoiser.bias",
+]
+
+
+class OneDimensionalDiffusionValidationError(ValueError):
+    """Raised when an NN19 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise OneDimensionalDiffusionValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                OneDimensionalDiffusionValidationError(
+                    f"non-finite JSON number: {value}"
+                )
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise OneDimensionalDiffusionValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise OneDimensionalDiffusionValidationError(
+            "top-level JSON value must be an object"
+        )
+    return document
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise OneDimensionalDiffusionValidationError(f"{context}: expected an object")
+    missing = keys - value.keys()
+    extra = value.keys() - keys
+    if missing or extra:
+        raise OneDimensionalDiffusionValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise OneDimensionalDiffusionValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise OneDimensionalDiffusionValidationError(
+            f"{context}: expected a finite number"
+        )
+    return result
+
+
+def _integer(value: Any, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise OneDimensionalDiffusionValidationError(f"{context}: expected an integer")
+    return value
+
+
+def _denoiser(value: Any, context: str) -> dict[str, float]:
+    parameters = _object(
+        value,
+        {"sample_weight", "timestep_weight", "bias"},
+        context,
+    )
+    return {
+        key: _number(parameters[key], f"{context}.{key}")
+        for key in ("sample_weight", "timestep_weight", "bias")
+    }
+
+
+def _forward_steps(
+    clean_sample: float,
+    saved_noise: float,
+    schedule: list[dict[str, float]],
+) -> list[dict[str, float | int]]:
+    alpha_bar = 1.0
+    steps: list[dict[str, float | int]] = []
+    for row in schedule:
+        alpha = 1 - row["beta"]
+        alpha_bar *= alpha
+        signal_scale = math.sqrt(alpha_bar)
+        noise_scale = math.sqrt(1 - alpha_bar)
+        signal_contribution = signal_scale * clean_sample
+        noise_contribution = noise_scale * saved_noise
+        steps.append(
+            {
+                "t": int(row["t"]),
+                "beta": row["beta"],
+                "alpha": alpha,
+                "alpha_bar": alpha_bar,
+                "normalized_t": row["normalized_t"],
+                "signal_scale": signal_scale,
+                "noise_scale": noise_scale,
+                "signal_contribution": signal_contribution,
+                "noise_contribution": noise_contribution,
+                "noisy_sample": signal_contribution + noise_contribution,
+            }
+        )
+    return steps
+
+
+def _prediction_steps(
+    forward_steps: list[dict[str, float | int]],
+    saved_noise: float,
+    denoiser: dict[str, float],
+) -> tuple[list[dict[str, float | int]], float]:
+    rows: list[dict[str, float | int]] = []
+    for step in forward_steps:
+        noisy_sample = float(step["noisy_sample"])
+        normalized_t = float(step["normalized_t"])
+        predicted_noise = (
+            denoiser["sample_weight"] * noisy_sample
+            + denoiser["timestep_weight"] * normalized_t
+            + denoiser["bias"]
+        )
+        error = predicted_noise - saved_noise
+        rows.append(
+            {
+                "t": step["t"],
+                "noisy_sample": noisy_sample,
+                "normalized_t": normalized_t,
+                "predicted_noise": predicted_noise,
+                "target_noise": saved_noise,
+                "error": error,
+                "loss": 0.5 * error * error,
+            }
+        )
+    mean_loss = sum(float(row["loss"]) for row in rows) / len(rows)
+    return rows, mean_loss
+
+
+def _gradient_check(
+    parameters: list[float],
+    analytical: list[float],
+    loss_function: Callable[[list[float]], float],
+) -> dict[str, Any]:
+    epsilon = 1e-6
+    numerical = []
+    for index in range(len(parameters)):
+        plus = parameters[:]
+        minus = parameters[:]
+        plus[index] += epsilon
+        minus[index] -= epsilon
+        numerical.append((loss_function(plus) - loss_function(minus)) / (2 * epsilon))
+    return {
+        "epsilon": epsilon,
+        "parameter_order": PARAMETER_ORDER,
+        "analytical": analytical,
+        "numerical": numerical,
+        "max_absolute_error": max(
+            abs(analytical_value - numerical_value)
+            for analytical_value, numerical_value in zip(analytical, numerical)
+        ),
+    }
+
+
+def _reverse_steps(
+    forward_steps: list[dict[str, float | int]],
+    denoiser: dict[str, float],
+) -> list[dict[str, float | int]]:
+    current_sample = float(forward_steps[-1]["noisy_sample"])
+    reverse: list[dict[str, float | int]] = []
+    for step in reversed(forward_steps):
+        normalized_t = float(step["normalized_t"])
+        predicted_noise = (
+            denoiser["sample_weight"] * current_sample
+            + denoiser["timestep_weight"] * normalized_t
+            + denoiser["bias"]
+        )
+        noise_coefficient = float(step["beta"]) / float(step["noise_scale"])
+        scaled_noise_correction = noise_coefficient * predicted_noise
+        corrected_sample = current_sample - scaled_noise_correction
+        alpha_scale = math.sqrt(float(step["alpha"]))
+        output_mean = corrected_sample / alpha_scale
+        reverse.append(
+            {
+                "t": step["t"],
+                "input_sample": current_sample,
+                "normalized_t": normalized_t,
+                "predicted_noise": predicted_noise,
+                "noise_coefficient": noise_coefficient,
+                "scaled_noise_correction": scaled_noise_correction,
+                "corrected_sample": corrected_sample,
+                "alpha_scale": alpha_scale,
+                "output_mean": output_mean,
+            }
+        )
+        current_sample = output_mean
+    return reverse
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    clean_sample = _number(document["clean_sample"], "clean_sample")
+    saved_noise = _number(document["saved_noise"], "saved_noise")
+    schedule = [
+        {
+            "t": _integer(row["t"], f"schedule[{index}].t"),
+            "beta": _number(row["beta"], f"schedule[{index}].beta"),
+            "normalized_t": _number(
+                row["normalized_t"], f"schedule[{index}].normalized_t"
+            ),
+        }
+        for index, row in enumerate(document["schedule"])
+    ]
+    denoiser = _denoiser(document["denoiser"], "denoiser")
+    learning_rate = _number(
+        document["optimizer"]["learning_rate"],
+        "optimizer.learning_rate",
+    )
+
+    forward_steps = _forward_steps(clean_sample, saved_noise, schedule)
+    initial_denoising, initial_mean_loss = _prediction_steps(
+        forward_steps,
+        saved_noise,
+        denoiser,
+    )
+    count = len(initial_denoising)
+    per_step: list[dict[str, float | int]] = []
+    for row in initial_denoising:
+        prediction_gradient = float(row["error"]) / count
+        per_step.append(
+            {
+                "t": row["t"],
+                "prediction_gradient": prediction_gradient,
+                "sample_weight_contribution": prediction_gradient
+                * float(row["noisy_sample"]),
+                "timestep_weight_contribution": prediction_gradient
+                * float(row["normalized_t"]),
+                "bias_contribution": prediction_gradient,
+            }
+        )
+    sample_weight_gradient = sum(
+        float(row["sample_weight_contribution"]) for row in per_step
+    )
+    timestep_weight_gradient = sum(
+        float(row["timestep_weight_contribution"]) for row in per_step
+    )
+    bias_gradient = sum(float(row["bias_contribution"]) for row in per_step)
+    analytical = [
+        sample_weight_gradient,
+        timestep_weight_gradient,
+        bias_gradient,
+    ]
+    initial_parameters = [
+        denoiser["sample_weight"],
+        denoiser["timestep_weight"],
+        denoiser["bias"],
+    ]
+
+    def loss_for(values: list[float]) -> float:
+        return _prediction_steps(
+            forward_steps,
+            saved_noise,
+            {
+                "sample_weight": values[0],
+                "timestep_weight": values[1],
+                "bias": values[2],
+            },
+        )[1]
+
+    gradient_check = _gradient_check(
+        initial_parameters,
+        analytical,
+        loss_for,
+    )
+    updated_values = [
+        value - learning_rate * gradient
+        for value, gradient in zip(initial_parameters, analytical)
+    ]
+    updated_denoiser = {
+        "sample_weight": updated_values[0],
+        "timestep_weight": updated_values[1],
+        "bias": updated_values[2],
+    }
+    post_update_denoising, post_update_mean_loss = _prediction_steps(
+        forward_steps,
+        saved_noise,
+        updated_denoiser,
+    )
+    reverse_steps = _reverse_steps(forward_steps, updated_denoiser)
+    final_reconstruction = float(reverse_steps[-1]["output_mean"])
+    return {
+        "forward_steps": forward_steps,
+        "initial_denoising": initial_denoising,
+        "initial_mean_loss": initial_mean_loss,
+        "backward": {
+            "per_step": per_step,
+            "sample_weight_gradient": sample_weight_gradient,
+            "timestep_weight_gradient": timestep_weight_gradient,
+            "bias_gradient": bias_gradient,
+        },
+        "gradient_check": gradient_check,
+        "updated_denoiser": updated_denoiser,
+        "post_update_denoising": post_update_denoising,
+        "post_update_mean_loss": post_update_mean_loss,
+        "reverse_steps": reverse_steps,
+        "final_reconstruction": final_reconstruction,
+        "final_absolute_error": abs(final_reconstruction - clean_sample),
+    }
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            raise OneDimensionalDiffusionValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(
+            float(expected),
+            float(actual),
+            rel_tol=0,
+            abs_tol=tolerance,
+        ):
+            raise OneDimensionalDiffusionValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            raise OneDimensionalDiffusionValidationError(f"{context}: length mismatch")
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _compare(expected_item, actual_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            raise OneDimensionalDiffusionValidationError(f"{context}: key mismatch")
+        for key in expected:
+            _compare(expected[key], actual[key], tolerance, f"{context}.{key}")
+        return
+    if expected != actual:
+        raise OneDimensionalDiffusionValidationError(
+            f"{context}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def validate_lab(document: dict[str, Any]) -> dict[str, Any]:
+    _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "clean_sample",
+            "saved_noise",
+            "schedule",
+            "denoiser",
+            "optimizer",
+            "expected",
+        },
+        "lab",
+    )
+    if document["schema_version"] != 1:
+        raise OneDimensionalDiffusionValidationError("schema_version: expected 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(document[key], str) or not document[key]:
+            raise OneDimensionalDiffusionValidationError(f"{key}: expected text")
+    concepts = document["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(set(concepts)) != len(concepts)
+    ):
+        raise OneDimensionalDiffusionValidationError(
+            "concepts: expected unique non-empty strings"
+        )
+    tolerance = _number(document["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise OneDimensionalDiffusionValidationError(
+            "absolute_tolerance: expected a positive number"
+        )
+    required_operation = {
+        "kind": "one-dimensional-diffusion-round",
+        "forward": "closed-form-saved-noise",
+        "denoiser": "scalar-affine-with-normalized-timestep",
+        "loss": "mean-half-squared-noise-error",
+        "reverse": "deterministic-ddpm-mean",
+        "update": "sgd",
+    }
+    operation = _object(
+        document["operation"],
+        set(required_operation),
+        "operation",
+    )
+    if operation != required_operation:
+        raise OneDimensionalDiffusionValidationError(
+            "operation: unsupported NN19 contract"
+        )
+    _number(document["clean_sample"], "clean_sample")
+    _number(document["saved_noise"], "saved_noise")
+    _denoiser(document["denoiser"], "denoiser")
+    optimizer = _object(document["optimizer"], {"learning_rate"}, "optimizer")
+    if _number(optimizer["learning_rate"], "optimizer.learning_rate") <= 0:
+        raise OneDimensionalDiffusionValidationError(
+            "optimizer.learning_rate: expected a positive number"
+        )
+
+    schedule = document["schedule"]
+    if not isinstance(schedule, list) or len(schedule) < 2:
+        raise OneDimensionalDiffusionValidationError(
+            "schedule: expected at least two steps"
+        )
+    previous_normalized_t = 0.0
+    for index, raw_row in enumerate(schedule):
+        row = _object(raw_row, {"t", "beta", "normalized_t"}, f"schedule[{index}]")
+        if _integer(row["t"], f"schedule[{index}].t") != index + 1:
+            raise OneDimensionalDiffusionValidationError(
+                f"schedule[{index}].t: expected consecutive timesteps"
+            )
+        beta = _number(row["beta"], f"schedule[{index}].beta")
+        if not 0 < beta < 1:
+            raise OneDimensionalDiffusionValidationError(
+                f"schedule[{index}].beta: expected 0 < beta < 1"
+            )
+        normalized_t = _number(
+            row["normalized_t"],
+            f"schedule[{index}].normalized_t",
+        )
+        if not previous_normalized_t < normalized_t <= 1:
+            raise OneDimensionalDiffusionValidationError(
+                f"schedule[{index}].normalized_t: expected increasing values in (0, 1]"
+            )
+        previous_normalized_t = normalized_t
+    if not math.isclose(previous_normalized_t, 1, rel_tol=0, abs_tol=1e-12):
+        raise OneDimensionalDiffusionValidationError(
+            "schedule: final normalized timestep must equal 1"
+        )
+
+    _object(
+        document["expected"],
+        {
+            "forward_steps",
+            "initial_denoising",
+            "initial_mean_loss",
+            "backward",
+            "gradient_check",
+            "updated_denoiser",
+            "post_update_denoising",
+            "post_update_mean_loss",
+            "reverse_steps",
+            "final_reconstruction",
+            "final_absolute_error",
+        },
+        "expected",
+    )
+    actual = execute_lab(document)
+    _compare(document["expected"], actual, tolerance, "expected")
+    if actual["gradient_check"]["max_absolute_error"] >= 1e-8:
+        raise OneDimensionalDiffusionValidationError(
+            "expected.gradient_check: gradients disagree"
+        )
+    if actual["post_update_mean_loss"] >= actual["initial_mean_loss"]:
+        raise OneDimensionalDiffusionValidationError(
+            "expected.post_update_mean_loss: SGD step must lower the objective"
+        )
+    noisiest_error = abs(
+        float(actual["forward_steps"][-1]["noisy_sample"])
+        - float(document["clean_sample"])
+    )
+    if actual["final_absolute_error"] >= noisiest_error:
+        raise OneDimensionalDiffusionValidationError(
+            "expected.final_absolute_error: reverse mean must improve on x_T"
+        )
+    return actual
+
+
+def validate_fixture_root(root: Path) -> int:
+    labs = sorted((root / "labs").glob("*.json"))
+    if not labs:
+        raise OneDimensionalDiffusionValidationError(f"{root}: no lab documents found")
+    for path in labs:
+        validate_lab(load_json(path))
+        print(f"validated {path.relative_to(REPO_ROOT)}")
+    return len(labs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_fixture_root(args.root.resolve())
+    print(f"validated {count} NN19 one-dimensional diffusion lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_one_dimensional_gan_labs.py
+++ b/code/scripts/validate_one_dimensional_gan_labs.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN18 one-dimensional GAN corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "one-dimensional-gan-v1"
+)
+DISCRIMINATOR_PARAMETER_ORDER = [
+    "discriminator.weight",
+    "discriminator.bias",
+]
+GENERATOR_PARAMETER_ORDER = ["generator.weight", "generator.bias"]
+
+
+class OneDimensionalGanValidationError(ValueError):
+    """Raised when an NN18 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise OneDimensionalGanValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                OneDimensionalGanValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise OneDimensionalGanValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise OneDimensionalGanValidationError("top-level JSON value must be an object")
+    return document
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise OneDimensionalGanValidationError(f"{context}: expected an object")
+    missing = keys - value.keys()
+    extra = value.keys() - keys
+    if missing or extra:
+        raise OneDimensionalGanValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise OneDimensionalGanValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise OneDimensionalGanValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _affine(value: Any, context: str) -> dict[str, float]:
+    affine = _object(value, {"weight", "bias"}, context)
+    return {
+        "weight": _number(affine["weight"], f"{context}.weight"),
+        "bias": _number(affine["bias"], f"{context}.bias"),
+    }
+
+
+def _sigmoid(value: float) -> float:
+    if value >= 0:
+        negative = math.exp(-value)
+        return 1 / (1 + negative)
+    positive = math.exp(value)
+    return positive / (1 + positive)
+
+
+def _state(
+    real_sample: float,
+    noise: float,
+    generator: dict[str, float],
+    discriminator: dict[str, float],
+) -> dict[str, float]:
+    generator_product = noise * generator["weight"]
+    fake_sample = generator_product + generator["bias"]
+    real_logit = discriminator["weight"] * real_sample + discriminator["bias"]
+    fake_logit = discriminator["weight"] * fake_sample + discriminator["bias"]
+    real_probability = _sigmoid(real_logit)
+    fake_probability = _sigmoid(fake_logit)
+    if not 0 < real_probability < 1 or not 0 < fake_probability < 1:
+        raise OneDimensionalGanValidationError(
+            "canonical logits must produce open-interval probabilities"
+        )
+    discriminator_loss = -0.5 * (
+        math.log(real_probability) + math.log(1 - fake_probability)
+    )
+    generator_loss = -math.log(fake_probability)
+    return {
+        "generator_product": generator_product,
+        "fake_sample": fake_sample,
+        "real_logit": real_logit,
+        "real_probability": real_probability,
+        "fake_logit": fake_logit,
+        "fake_probability": fake_probability,
+        "discriminator_loss": discriminator_loss,
+        "generator_loss": generator_loss,
+    }
+
+
+def _gradient_check(
+    parameters: list[float],
+    analytical: list[float],
+    parameter_order: list[str],
+    loss_function: Any,
+) -> dict[str, Any]:
+    epsilon = 1e-6
+    numerical = []
+    for index in range(len(parameters)):
+        plus = parameters[:]
+        minus = parameters[:]
+        plus[index] += epsilon
+        minus[index] -= epsilon
+        numerical.append((loss_function(plus) - loss_function(minus)) / (2 * epsilon))
+    return {
+        "epsilon": epsilon,
+        "parameter_order": parameter_order,
+        "analytical": analytical,
+        "numerical": numerical,
+        "max_absolute_error": max(
+            abs(analytical_value - numerical_value)
+            for analytical_value, numerical_value in zip(analytical, numerical)
+        ),
+    }
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    real_sample = _number(document["real_sample"], "real_sample")
+    noise = _number(document["noise"], "noise")
+    generator = _affine(document["generator"], "generator")
+    discriminator = _affine(document["discriminator"], "discriminator")
+    discriminator_learning_rate = _number(
+        document["optimizer"]["discriminator_learning_rate"],
+        "optimizer.discriminator_learning_rate",
+    )
+    generator_learning_rate = _number(
+        document["optimizer"]["generator_learning_rate"],
+        "optimizer.generator_learning_rate",
+    )
+
+    initial = _state(real_sample, noise, generator, discriminator)
+    real_logit_gradient = 0.5 * (initial["real_probability"] - 1)
+    fake_logit_gradient = 0.5 * initial["fake_probability"]
+    discriminator_weight_gradient = (
+        real_logit_gradient * real_sample + fake_logit_gradient * initial["fake_sample"]
+    )
+    discriminator_bias_gradient = real_logit_gradient + fake_logit_gradient
+    discriminator_backward = {
+        "real_logit_gradient": real_logit_gradient,
+        "fake_logit_gradient": fake_logit_gradient,
+        "fake_value_gradient": 0.0,
+        "weight_gradient": discriminator_weight_gradient,
+        "bias_gradient": discriminator_bias_gradient,
+    }
+    updated_discriminator = {
+        "weight": discriminator["weight"]
+        - discriminator_learning_rate * discriminator_weight_gradient,
+        "bias": discriminator["bias"]
+        - discriminator_learning_rate * discriminator_bias_gradient,
+    }
+    after_discriminator = _state(
+        real_sample,
+        noise,
+        generator,
+        updated_discriminator,
+    )
+    discriminator_gradient_check = _gradient_check(
+        [discriminator["weight"], discriminator["bias"]],
+        [discriminator_weight_gradient, discriminator_bias_gradient],
+        DISCRIMINATOR_PARAMETER_ORDER,
+        lambda values: _state(
+            real_sample,
+            noise,
+            generator,
+            {"weight": values[0], "bias": values[1]},
+        )["discriminator_loss"],
+    )
+
+    generator_fake_logit_gradient = after_discriminator["fake_probability"] - 1
+    fake_value_gradient = (
+        generator_fake_logit_gradient * updated_discriminator["weight"]
+    )
+    generator_weight_gradient = fake_value_gradient * noise
+    generator_bias_gradient = fake_value_gradient
+    generator_backward = {
+        "fake_logit_gradient": generator_fake_logit_gradient,
+        "fake_value_gradient": fake_value_gradient,
+        "weight_gradient": generator_weight_gradient,
+        "bias_gradient": generator_bias_gradient,
+    }
+    updated_generator = {
+        "weight": generator["weight"]
+        - generator_learning_rate * generator_weight_gradient,
+        "bias": generator["bias"] - generator_learning_rate * generator_bias_gradient,
+    }
+    after_generator = _state(
+        real_sample,
+        noise,
+        updated_generator,
+        updated_discriminator,
+    )
+    generator_gradient_check = _gradient_check(
+        [generator["weight"], generator["bias"]],
+        [generator_weight_gradient, generator_bias_gradient],
+        GENERATOR_PARAMETER_ORDER,
+        lambda values: _state(
+            real_sample,
+            noise,
+            {"weight": values[0], "bias": values[1]},
+            updated_discriminator,
+        )["generator_loss"],
+    )
+    return {
+        "initial": initial,
+        "discriminator_backward": discriminator_backward,
+        "updated_discriminator": updated_discriminator,
+        "after_discriminator": after_discriminator,
+        "discriminator_gradient_check": discriminator_gradient_check,
+        "generator_backward": generator_backward,
+        "updated_generator": updated_generator,
+        "after_generator": after_generator,
+        "generator_gradient_check": generator_gradient_check,
+    }
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            raise OneDimensionalGanValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(
+            float(expected),
+            float(actual),
+            rel_tol=0,
+            abs_tol=tolerance,
+        ):
+            raise OneDimensionalGanValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            raise OneDimensionalGanValidationError(f"{context}: length mismatch")
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _compare(expected_item, actual_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            raise OneDimensionalGanValidationError(f"{context}: key mismatch")
+        for key in expected:
+            _compare(expected[key], actual[key], tolerance, f"{context}.{key}")
+        return
+    if expected != actual:
+        raise OneDimensionalGanValidationError(
+            f"{context}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def validate_lab(document: dict[str, Any]) -> dict[str, Any]:
+    _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "real_sample",
+            "noise",
+            "generator",
+            "discriminator",
+            "optimizer",
+            "expected",
+        },
+        "lab",
+    )
+    if document["schema_version"] != 1:
+        raise OneDimensionalGanValidationError("schema_version: expected 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(document[key], str) or not document[key]:
+            raise OneDimensionalGanValidationError(f"{key}: expected text")
+    concepts = document["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(set(concepts)) != len(concepts)
+    ):
+        raise OneDimensionalGanValidationError(
+            "concepts: expected unique non-empty strings"
+        )
+    tolerance = _number(document["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise OneDimensionalGanValidationError(
+            "absolute_tolerance: expected a positive number"
+        )
+
+    operation = _object(
+        document["operation"],
+        {
+            "kind",
+            "generator",
+            "discriminator",
+            "discriminator_loss",
+            "generator_loss",
+            "schedule",
+            "fake_handling",
+            "update",
+        },
+        "operation",
+    )
+    required_operation = {
+        "kind": "one-dimensional-gan-round",
+        "generator": "scalar-affine",
+        "discriminator": "sigmoid-of-scalar-affine",
+        "discriminator_loss": "mean-binary-cross-entropy",
+        "generator_loss": "non-saturating-binary-cross-entropy",
+        "schedule": "discriminator-then-generator",
+        "fake_handling": "detach-during-discriminator-step",
+        "update": "sgd",
+    }
+    if operation != required_operation:
+        raise OneDimensionalGanValidationError("operation: unsupported NN18 contract")
+
+    _number(document["real_sample"], "real_sample")
+    _number(document["noise"], "noise")
+    _affine(document["generator"], "generator")
+    _affine(document["discriminator"], "discriminator")
+    optimizer = _object(
+        document["optimizer"],
+        {"discriminator_learning_rate", "generator_learning_rate"},
+        "optimizer",
+    )
+    for key in ("discriminator_learning_rate", "generator_learning_rate"):
+        if _number(optimizer[key], f"optimizer.{key}") <= 0:
+            raise OneDimensionalGanValidationError(
+                f"optimizer.{key}: expected a positive number"
+            )
+    _object(
+        document["expected"],
+        {
+            "initial",
+            "discriminator_backward",
+            "updated_discriminator",
+            "after_discriminator",
+            "discriminator_gradient_check",
+            "generator_backward",
+            "updated_generator",
+            "after_generator",
+            "generator_gradient_check",
+        },
+        "expected",
+    )
+    actual = execute_lab(document)
+    _compare(document["expected"], actual, tolerance, "expected")
+    for player in ("discriminator", "generator"):
+        if actual[f"{player}_gradient_check"]["max_absolute_error"] >= 1e-8:
+            raise OneDimensionalGanValidationError(
+                f"expected.{player}_gradient_check: gradients disagree"
+            )
+    if (
+        actual["after_discriminator"]["discriminator_loss"]
+        >= actual["initial"]["discriminator_loss"]
+    ):
+        raise OneDimensionalGanValidationError(
+            "expected.after_discriminator: discriminator step must lower its loss"
+        )
+    if (
+        actual["after_generator"]["generator_loss"]
+        >= actual["after_discriminator"]["generator_loss"]
+    ):
+        raise OneDimensionalGanValidationError(
+            "expected.after_generator: generator step must lower its loss"
+        )
+    return actual
+
+
+def validate_fixture_root(root: Path) -> int:
+    labs = sorted((root / "labs").glob("*.json"))
+    if not labs:
+        raise OneDimensionalGanValidationError(f"{root}: no lab documents found")
+    for path in labs:
+        validate_lab(load_json(path))
+        print(f"validated {path.relative_to(REPO_ROOT)}")
+    return len(labs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_fixture_root(args.root.resolve())
+    print(f"validated {count} NN18 one-dimensional GAN lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_optimization_learning_labs.py
+++ b/code/scripts/validate_optimization_learning_labs.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN04 optimization corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "optimization-learning-v1"
+)
+STRATEGIES = {"stochastic", "mini-batch", "full-batch"}
+
+
+class OptimizationLabValidationError(ValueError):
+    """Raised when an optimization lab is structurally or numerically invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise OptimizationLabValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                OptimizationLabValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise OptimizationLabValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise OptimizationLabValidationError(
+            f"{path}: top-level JSON value must be an object"
+        )
+    return document
+
+
+def _require_keys(value: dict[str, Any], required: set[str], context: str) -> None:
+    missing = required - value.keys()
+    extra = value.keys() - required
+    if missing:
+        raise OptimizationLabValidationError(
+            f"{context}: missing keys {sorted(missing)}"
+        )
+    if extra:
+        raise OptimizationLabValidationError(
+            f"{context}: unexpected keys {sorted(extra)}"
+        )
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise OptimizationLabValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise OptimizationLabValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _positive_number(value: Any, context: str) -> float:
+    result = _number(value, context)
+    if result <= 0:
+        raise OptimizationLabValidationError(f"{context}: expected a positive number")
+    return result
+
+
+def _parameters(value: Any, context: str) -> dict[str, float]:
+    if not isinstance(value, dict):
+        raise OptimizationLabValidationError(f"{context}: expected an object")
+    _require_keys(value, {"weight", "bias"}, context)
+    return {
+        "weight": _number(value["weight"], f"{context}.weight"),
+        "bias": _number(value["bias"], f"{context}.bias"),
+    }
+
+
+def validate_structure(lab: dict[str, Any], source: str = "lab") -> None:
+    _require_keys(
+        lab,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "concepts",
+            "model",
+            "dataset",
+            "loss",
+            "gradient_check",
+            "optimizer_comparison",
+        },
+        source,
+    )
+    if lab["schema_version"] != 1:
+        raise OptimizationLabValidationError(f"{source}.schema_version: expected 1")
+    for field in ("id", "title", "question"):
+        if not isinstance(lab[field], str) or not lab[field]:
+            raise OptimizationLabValidationError(
+                f"{source}.{field}: expected a non-empty string"
+            )
+    if not isinstance(lab["concepts"], list) or not lab["concepts"]:
+        raise OptimizationLabValidationError(
+            f"{source}.concepts: expected a non-empty list"
+        )
+    if len(set(lab["concepts"])) != len(lab["concepts"]):
+        raise OptimizationLabValidationError(
+            f"{source}.concepts: values must be unique"
+        )
+
+    model = lab["model"]
+    if not isinstance(model, dict):
+        raise OptimizationLabValidationError(f"{source}.model: expected an object")
+    _require_keys(model, {"kind", "parameters"}, f"{source}.model")
+    if model["kind"] != "linear-neuron":
+        raise OptimizationLabValidationError(
+            f"{source}.model.kind: V1 requires linear-neuron"
+        )
+    _parameters(model["parameters"], f"{source}.model.parameters")
+
+    dataset = lab["dataset"]
+    if not isinstance(dataset, dict):
+        raise OptimizationLabValidationError(f"{source}.dataset: expected an object")
+    _require_keys(dataset, {"rows"}, f"{source}.dataset")
+    rows = dataset["rows"]
+    if not isinstance(rows, list) or len(rows) < 2:
+        raise OptimizationLabValidationError(
+            f"{source}.dataset.rows: expected at least two rows"
+        )
+    labels: set[str] = set()
+    for index, row in enumerate(rows):
+        context = f"{source}.dataset.rows[{index}]"
+        if not isinstance(row, dict):
+            raise OptimizationLabValidationError(f"{context}: expected an object")
+        _require_keys(row, {"label", "x", "target"}, context)
+        if not isinstance(row["label"], str) or not row["label"]:
+            raise OptimizationLabValidationError(
+                f"{context}.label: expected a non-empty string"
+            )
+        if row["label"] in labels:
+            raise OptimizationLabValidationError(
+                f"{context}.label: duplicate label {row['label']!r}"
+            )
+        labels.add(row["label"])
+        _number(row["x"], f"{context}.x")
+        _number(row["target"], f"{context}.target")
+
+    loss = lab["loss"]
+    if not isinstance(loss, dict):
+        raise OptimizationLabValidationError(f"{source}.loss: expected an object")
+    _require_keys(loss, {"kind", "reduction"}, f"{source}.loss")
+    if loss != {"kind": "mean-squared-error", "reduction": "mean"}:
+        raise OptimizationLabValidationError(
+            f"{source}.loss: V1 requires mean mean-squared-error"
+        )
+
+    gradient_check = lab["gradient_check"]
+    if not isinstance(gradient_check, dict):
+        raise OptimizationLabValidationError(
+            f"{source}.gradient_check: expected an object"
+        )
+    _require_keys(gradient_check, {"epsilon", "expected"}, f"{source}.gradient_check")
+    _positive_number(gradient_check["epsilon"], f"{source}.gradient_check.epsilon")
+    expected = gradient_check["expected"]
+    if not isinstance(expected, dict):
+        raise OptimizationLabValidationError(
+            f"{source}.gradient_check.expected: expected an object"
+        )
+    _require_keys(
+        expected,
+        {"absolute_tolerance", "loss", "analytical", "numerical"},
+        f"{source}.gradient_check.expected",
+    )
+    _positive_number(
+        expected["absolute_tolerance"],
+        f"{source}.gradient_check.expected.absolute_tolerance",
+    )
+    _number(expected["loss"], f"{source}.gradient_check.expected.loss")
+    _parameters(expected["analytical"], f"{source}.gradient_check.expected.analytical")
+    _parameters(expected["numerical"], f"{source}.gradient_check.expected.numerical")
+
+    comparison = lab["optimizer_comparison"]
+    if not isinstance(comparison, dict):
+        raise OptimizationLabValidationError(
+            f"{source}.optimizer_comparison: expected an object"
+        )
+    _require_keys(
+        comparison,
+        {"learning_rate", "steps", "absolute_tolerance", "strategies"},
+        f"{source}.optimizer_comparison",
+    )
+    _positive_number(
+        comparison["learning_rate"],
+        f"{source}.optimizer_comparison.learning_rate",
+    )
+    if (
+        not isinstance(comparison["steps"], int)
+        or isinstance(comparison["steps"], bool)
+        or comparison["steps"] < 1
+    ):
+        raise OptimizationLabValidationError(
+            f"{source}.optimizer_comparison.steps: expected a positive integer"
+        )
+    _positive_number(
+        comparison["absolute_tolerance"],
+        f"{source}.optimizer_comparison.absolute_tolerance",
+    )
+    strategies = comparison["strategies"]
+    if not isinstance(strategies, list) or len(strategies) != 3:
+        raise OptimizationLabValidationError(
+            f"{source}.optimizer_comparison.strategies: expected three strategies"
+        )
+    found: set[str] = set()
+    expected_batch_sizes = {
+        "stochastic": 1,
+        "mini-batch": 2,
+        "full-batch": len(rows),
+    }
+    for index, strategy in enumerate(strategies):
+        context = f"{source}.optimizer_comparison.strategies[{index}]"
+        if not isinstance(strategy, dict):
+            raise OptimizationLabValidationError(f"{context}: expected an object")
+        _require_keys(
+            strategy,
+            {"kind", "batch_size", "expected_parameters", "expected_loss"},
+            context,
+        )
+        kind = strategy["kind"]
+        if kind not in STRATEGIES or kind in found:
+            raise OptimizationLabValidationError(
+                f"{context}.kind: expected each V1 strategy exactly once"
+            )
+        found.add(kind)
+        if strategy["batch_size"] != expected_batch_sizes[kind]:
+            raise OptimizationLabValidationError(
+                f"{context}.batch_size: inconsistent with {kind}"
+            )
+        _parameters(strategy["expected_parameters"], f"{context}.expected_parameters")
+        _number(strategy["expected_loss"], f"{context}.expected_loss")
+
+
+def _rows(lab: dict[str, Any]) -> list[dict[str, float]]:
+    return [
+        {"x": float(row["x"]), "target": float(row["target"])}
+        for row in lab["dataset"]["rows"]
+    ]
+
+
+def mean_squared_error(
+    rows: list[dict[str, float]], parameters: dict[str, float]
+) -> float:
+    return sum(
+        (parameters["weight"] * row["x"] + parameters["bias"] - row["target"]) ** 2
+        for row in rows
+    ) / len(rows)
+
+
+def analytical_gradient(
+    rows: list[dict[str, float]], parameters: dict[str, float]
+) -> dict[str, float]:
+    scale = 2.0 / len(rows)
+    weight = 0.0
+    bias = 0.0
+    for row in rows:
+        error = parameters["weight"] * row["x"] + parameters["bias"] - row["target"]
+        weight += scale * error * row["x"]
+        bias += scale * error
+    return {"weight": weight, "bias": bias}
+
+
+def numerical_gradient(
+    rows: list[dict[str, float]], parameters: dict[str, float], epsilon: float
+) -> dict[str, float]:
+    result: dict[str, float] = {}
+    for field in ("weight", "bias"):
+        plus = dict(parameters)
+        minus = dict(parameters)
+        plus[field] += epsilon
+        minus[field] -= epsilon
+        result[field] = (
+            mean_squared_error(rows, plus) - mean_squared_error(rows, minus)
+        ) / (2.0 * epsilon)
+    return result
+
+
+def batch_indices(kind: str, step: int, row_count: int) -> list[int]:
+    if kind == "full-batch":
+        return list(range(row_count))
+    if kind == "stochastic":
+        return [step % row_count]
+    start = (step * 2) % row_count
+    return [start, (start + 1) % row_count]
+
+
+def run_strategy(lab: dict[str, Any], kind: str) -> dict[str, Any]:
+    rows = _rows(lab)
+    parameters = _parameters(lab["model"]["parameters"], "model.parameters")
+    comparison = lab["optimizer_comparison"]
+    learning_rate = float(comparison["learning_rate"])
+    for step in range(comparison["steps"]):
+        selected = [rows[index] for index in batch_indices(kind, step, len(rows))]
+        gradient = analytical_gradient(selected, parameters)
+        parameters = {
+            "weight": parameters["weight"] - learning_rate * gradient["weight"],
+            "bias": parameters["bias"] - learning_rate * gradient["bias"],
+        }
+    return {"parameters": parameters, "loss": mean_squared_error(rows, parameters)}
+
+
+def _compare(actual: float, expected: Any, tolerance: float, context: str) -> None:
+    expected_number = _number(expected, context)
+    if abs(actual - expected_number) > tolerance:
+        raise OptimizationLabValidationError(
+            f"{context}: expected {expected_number!r}, got {actual!r} "
+            f"(tolerance {tolerance})"
+        )
+
+
+def validate_lab(lab: dict[str, Any], source: str = "lab") -> None:
+    validate_structure(lab, source)
+    rows = _rows(lab)
+    parameters = _parameters(lab["model"]["parameters"], f"{source}.model.parameters")
+    gradient_check = lab["gradient_check"]
+    expected_gradient = gradient_check["expected"]
+    gradient_tolerance = float(expected_gradient["absolute_tolerance"])
+    _compare(
+        mean_squared_error(rows, parameters),
+        expected_gradient["loss"],
+        gradient_tolerance,
+        f"{source}.gradient_check.expected.loss",
+    )
+    for name, actual in (
+        ("analytical", analytical_gradient(rows, parameters)),
+        (
+            "numerical",
+            numerical_gradient(rows, parameters, float(gradient_check["epsilon"])),
+        ),
+    ):
+        for field in ("weight", "bias"):
+            _compare(
+                actual[field],
+                expected_gradient[name][field],
+                gradient_tolerance,
+                f"{source}.gradient_check.expected.{name}.{field}",
+            )
+
+    comparison = lab["optimizer_comparison"]
+    optimizer_tolerance = float(comparison["absolute_tolerance"])
+    for strategy in comparison["strategies"]:
+        actual = run_strategy(lab, strategy["kind"])
+        for field in ("weight", "bias"):
+            _compare(
+                actual["parameters"][field],
+                strategy["expected_parameters"][field],
+                optimizer_tolerance,
+                f"{source}.optimizer_comparison.{strategy['kind']}.{field}",
+            )
+        _compare(
+            actual["loss"],
+            strategy["expected_loss"],
+            optimizer_tolerance,
+            f"{source}.optimizer_comparison.{strategy['kind']}.loss",
+        )
+
+
+def validate_corpus(fixture_root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    schema = load_json(fixture_root / "schema.json")
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        raise OptimizationLabValidationError(
+            "schema.json: expected JSON Schema Draft 2020-12"
+        )
+    lab_paths = sorted((fixture_root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise OptimizationLabValidationError(f"{fixture_root}: no lab fixtures found")
+    ids: set[str] = set()
+    for path in lab_paths:
+        lab = load_json(path)
+        validate_lab(lab, str(path))
+        if lab["id"] in ids:
+            raise OptimizationLabValidationError(
+                f"{path}: duplicate lab id {lab['id']!r}"
+            )
+        ids.add(lab["id"])
+    return lab_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    try:
+        paths = validate_corpus(args.fixture_root)
+    except OptimizationLabValidationError as error:
+        parser.exit(1, f"optimization learning corpus invalid: {error}\n")
+    print(f"validated {len(paths)} optimization learning labs from {args.fixture_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_recurrent_bptt_labs.py
+++ b/code/scripts/validate_recurrent_bptt_labs.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN10 recurrent BPTT corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "recurrent-bptt-v1"
+)
+PARAMETER_KEYS = ("input_weight", "recurrent_weight", "bias")
+
+
+class RecurrentBpttValidationError(ValueError):
+    """Raised when an NN10 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise RecurrentBpttValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                RecurrentBpttValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise RecurrentBpttValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise RecurrentBpttValidationError(
+            f"{path}: top-level JSON value must be an object"
+        )
+    return document
+
+
+def _require_keys(value: dict[str, Any], required: set[str], context: str) -> None:
+    missing = required - value.keys()
+    extra = value.keys() - required
+    if missing:
+        raise RecurrentBpttValidationError(
+            f"{context}: missing keys {sorted(missing)}"
+        )
+    if extra:
+        raise RecurrentBpttValidationError(
+            f"{context}: unexpected keys {sorted(extra)}"
+        )
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RecurrentBpttValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise RecurrentBpttValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _positive_number(value: Any, context: str) -> float:
+    result = _number(value, context)
+    if result <= 0:
+        raise RecurrentBpttValidationError(
+            f"{context}: expected a positive number"
+        )
+    return result
+
+
+def _numbers(value: Any, context: str, length: int) -> list[float]:
+    if not isinstance(value, list) or len(value) != length:
+        raise RecurrentBpttValidationError(
+            f"{context}: expected {length} numbers"
+        )
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def _parameters(value: Any, context: str) -> dict[str, float]:
+    if not isinstance(value, dict):
+        raise RecurrentBpttValidationError(f"{context}: expected an object")
+    _require_keys(value, set(PARAMETER_KEYS), context)
+    return {key: _number(value[key], f"{context}.{key}") for key in PARAMETER_KEYS}
+
+
+def forward_trace(
+    inputs: list[float],
+    initial_state: float,
+    parameters: dict[str, float],
+    target: float,
+) -> dict[str, Any]:
+    previous_state = initial_state
+    preactivations: list[float] = []
+    states: list[float] = []
+    for input_value in inputs:
+        preactivation = (
+            parameters["input_weight"] * input_value
+            + parameters["recurrent_weight"] * previous_state
+            + parameters["bias"]
+        )
+        state = max(0.0, preactivation)
+        preactivations.append(preactivation)
+        states.append(state)
+        previous_state = state
+    prediction = states[-1]
+    return {
+        "preactivations": preactivations,
+        "states": states,
+        "prediction": prediction,
+        "loss": 0.5 * (prediction - target) ** 2,
+    }
+
+
+def bptt_trace(
+    inputs: list[float],
+    initial_state: float,
+    parameters: dict[str, float],
+    target: float,
+) -> dict[str, Any]:
+    forward = forward_trace(inputs, initial_state, parameters, target)
+    backward_steps: list[dict[str, float | int]] = []
+    future_state_gradient = 0.0
+    input_weight_gradient = 0.0
+    recurrent_weight_gradient = 0.0
+    bias_gradient = 0.0
+    final_time = len(inputs) - 1
+    for time in range(final_time, -1, -1):
+        direct_loss_gradient = (
+            forward["prediction"] - target if time == final_time else 0.0
+        )
+        state_gradient = direct_loss_gradient + future_state_gradient
+        relu_derivative = 1.0 if forward["preactivations"][time] > 0 else 0.0
+        preactivation_gradient = state_gradient * relu_derivative
+        previous_state = initial_state if time == 0 else forward["states"][time - 1]
+        local_input_weight_gradient = preactivation_gradient * inputs[time]
+        local_recurrent_weight_gradient = preactivation_gradient * previous_state
+        local_bias_gradient = preactivation_gradient
+        previous_state_gradient = (
+            preactivation_gradient * parameters["recurrent_weight"]
+        )
+        backward_steps.append(
+            {
+                "time": time,
+                "direct_loss_gradient": direct_loss_gradient,
+                "future_state_gradient": future_state_gradient,
+                "state_gradient": state_gradient,
+                "relu_derivative": relu_derivative,
+                "preactivation_gradient": preactivation_gradient,
+                "input_weight_gradient": local_input_weight_gradient,
+                "recurrent_weight_gradient": local_recurrent_weight_gradient,
+                "bias_gradient": local_bias_gradient,
+                "previous_state_gradient": previous_state_gradient,
+            }
+        )
+        input_weight_gradient += local_input_weight_gradient
+        recurrent_weight_gradient += local_recurrent_weight_gradient
+        bias_gradient += local_bias_gradient
+        future_state_gradient = previous_state_gradient
+    return {
+        "forward": forward,
+        "backward_steps": backward_steps,
+        "gradient_totals": {
+            "input_weight": input_weight_gradient,
+            "recurrent_weight": recurrent_weight_gradient,
+            "bias": bias_gradient,
+            "initial_state": future_state_gradient,
+        },
+    }
+
+
+def numerical_gradients(
+    inputs: list[float],
+    initial_state: float,
+    parameters: dict[str, float],
+    target: float,
+    epsilon: float,
+) -> dict[str, float]:
+    gradients: dict[str, float] = {}
+    for key in PARAMETER_KEYS:
+        plus = dict(parameters)
+        minus = dict(parameters)
+        plus[key] += epsilon
+        minus[key] -= epsilon
+        plus_loss = forward_trace(inputs, initial_state, plus, target)["loss"]
+        minus_loss = forward_trace(inputs, initial_state, minus, target)["loss"]
+        gradients[key] = (plus_loss - minus_loss) / (2 * epsilon)
+    return gradients
+
+
+def execute_lab(lab: dict[str, Any]) -> dict[str, Any]:
+    inputs = [float(value) for value in lab["inputs"]]
+    initial_state = float(lab["initial_state"])
+    target = float(lab["target"])
+    parameters = {key: float(value) for key, value in lab["parameters"].items()}
+    trace = bptt_trace(inputs, initial_state, parameters, target)
+    numerical = numerical_gradients(
+        inputs,
+        initial_state,
+        parameters,
+        target,
+        float(lab["finite_difference_epsilon"]),
+    )
+    analytical = trace["gradient_totals"]
+    errors = {
+        key: abs(numerical[key] - analytical[key]) for key in PARAMETER_KEYS
+    }
+    next_parameters = {
+        key: parameters[key] - float(lab["learning_rate"]) * analytical[key]
+        for key in PARAMETER_KEYS
+    }
+    updated_forward = forward_trace(
+        inputs, initial_state, next_parameters, target
+    )
+    return {
+        **trace,
+        "gradient_check": {
+            "numerical": numerical,
+            "absolute_errors": errors,
+            "max_absolute_error": max(errors.values()),
+        },
+        "update": {
+            "parameters": next_parameters,
+            "preactivations": updated_forward["preactivations"],
+            "states": updated_forward["states"],
+            "loss": updated_forward["loss"],
+        },
+    }
+
+
+def validate_structure(lab: dict[str, Any], source: str = "lab") -> None:
+    _require_keys(
+        lab,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "initial_state",
+            "inputs",
+            "target",
+            "parameters",
+            "learning_rate",
+            "finite_difference_epsilon",
+            "expected",
+        },
+        source,
+    )
+    if lab["schema_version"] != 1:
+        raise RecurrentBpttValidationError(f"{source}.schema_version: expected 1")
+    for field in ("id", "title", "question"):
+        if not isinstance(lab[field], str) or not lab[field]:
+            raise RecurrentBpttValidationError(
+                f"{source}.{field}: expected a non-empty string"
+            )
+    _positive_number(lab["absolute_tolerance"], f"{source}.absolute_tolerance")
+    concepts = lab["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(concepts) != len(set(concepts))
+    ):
+        raise RecurrentBpttValidationError(
+            f"{source}.concepts: expected unique non-empty strings"
+        )
+    expected_operation = {
+        "kind": "scalar-elman-rnn-bptt",
+        "steps": 3,
+        "activation": "relu",
+        "loss": "half-squared-error",
+        "parameter_sharing": "all-steps",
+    }
+    operation = lab["operation"]
+    if not isinstance(operation, dict):
+        raise RecurrentBpttValidationError(f"{source}.operation: expected an object")
+    _require_keys(operation, set(expected_operation), f"{source}.operation")
+    if operation != expected_operation:
+        raise RecurrentBpttValidationError(
+            f"{source}.operation: unsupported V1 operation"
+        )
+    _number(lab["initial_state"], f"{source}.initial_state")
+    _numbers(lab["inputs"], f"{source}.inputs", 3)
+    _number(lab["target"], f"{source}.target")
+    _parameters(lab["parameters"], f"{source}.parameters")
+    _positive_number(lab["learning_rate"], f"{source}.learning_rate")
+    _positive_number(
+        lab["finite_difference_epsilon"],
+        f"{source}.finite_difference_epsilon",
+    )
+    expected = lab["expected"]
+    if not isinstance(expected, dict):
+        raise RecurrentBpttValidationError(f"{source}.expected: expected an object")
+    _require_keys(
+        expected,
+        {"forward", "backward_steps", "gradient_totals", "gradient_check", "update"},
+        f"{source}.expected",
+    )
+    steps = expected["backward_steps"]
+    if not isinstance(steps, list) or len(steps) != 3:
+        raise RecurrentBpttValidationError(
+            f"{source}.expected.backward_steps: expected three steps"
+        )
+    if [step.get("time") if isinstance(step, dict) else None for step in steps] != [2, 1, 0]:
+        raise RecurrentBpttValidationError(
+            f"{source}.expected.backward_steps: expected reverse time order"
+        )
+
+
+def _compare_nested(actual: Any, expected: Any, tolerance: float, context: str) -> None:
+    if isinstance(actual, dict):
+        if not isinstance(expected, dict) or actual.keys() != expected.keys():
+            raise RecurrentBpttValidationError(f"{context}: object keys do not match")
+        for key, actual_value in actual.items():
+            _compare_nested(actual_value, expected[key], tolerance, f"{context}.{key}")
+        return
+    if isinstance(actual, list):
+        if not isinstance(expected, list) or len(actual) != len(expected):
+            raise RecurrentBpttValidationError(f"{context}: list lengths do not match")
+        for index, actual_value in enumerate(actual):
+            _compare_nested(
+                actual_value, expected[index], tolerance, f"{context}[{index}]"
+            )
+        return
+    actual_number = _number(actual, context)
+    expected_number = _number(expected, context)
+    if abs(actual_number - expected_number) > tolerance:
+        raise RecurrentBpttValidationError(
+            f"{context}: expected {expected_number!r}, got {actual_number!r} "
+            f"(tolerance {tolerance})"
+        )
+
+
+def validate_lab(lab: dict[str, Any], source: str = "lab") -> None:
+    validate_structure(lab, source)
+    _compare_nested(
+        execute_lab(lab),
+        lab["expected"],
+        float(lab["absolute_tolerance"]),
+        f"{source}.expected",
+    )
+
+
+def validate_corpus(fixture_root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    schema = load_json(fixture_root / "schema.json")
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        raise RecurrentBpttValidationError(
+            "schema.json: expected JSON Schema Draft 2020-12"
+        )
+    lab_paths = sorted((fixture_root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise RecurrentBpttValidationError(f"{fixture_root}: no lab fixtures found")
+    ids: set[str] = set()
+    for path in lab_paths:
+        lab = load_json(path)
+        validate_lab(lab, str(path))
+        if lab["id"] in ids:
+            raise RecurrentBpttValidationError(
+                f"{path}: duplicate lab id {lab['id']!r}"
+            )
+        ids.add(lab["id"])
+    return lab_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    try:
+        paths = validate_corpus(args.fixture_root)
+    except RecurrentBpttValidationError as error:
+        parser.exit(1, f"recurrent BPTT corpus invalid: {error}\n")
+    print(f"validated {len(paths)} recurrent BPTT labs from {args.fixture_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_recurrent_unroll_labs.py
+++ b/code/scripts/validate_recurrent_unroll_labs.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN09 recurrent-unroll corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "recurrent-unroll-v1"
+)
+
+
+class RecurrentUnrollValidationError(ValueError):
+    """Raised when an NN09 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise RecurrentUnrollValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                RecurrentUnrollValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise RecurrentUnrollValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise RecurrentUnrollValidationError(
+            f"{path}: top-level JSON value must be an object"
+        )
+    return document
+
+
+def _require_keys(value: dict[str, Any], required: set[str], context: str) -> None:
+    missing = required - value.keys()
+    extra = value.keys() - required
+    if missing:
+        raise RecurrentUnrollValidationError(
+            f"{context}: missing keys {sorted(missing)}"
+        )
+    if extra:
+        raise RecurrentUnrollValidationError(
+            f"{context}: unexpected keys {sorted(extra)}"
+        )
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RecurrentUnrollValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise RecurrentUnrollValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _numbers(value: Any, context: str, length: int | None = None) -> list[float]:
+    if not isinstance(value, list) or not value:
+        raise RecurrentUnrollValidationError(
+            f"{context}: expected a non-empty number array"
+        )
+    result = [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+    if length is not None and len(result) != length:
+        raise RecurrentUnrollValidationError(
+            f"{context}: expected {length} values"
+        )
+    return result
+
+
+def _positive_number(value: Any, context: str) -> float:
+    result = _number(value, context)
+    if result <= 0:
+        raise RecurrentUnrollValidationError(
+            f"{context}: expected a positive number"
+        )
+    return result
+
+
+def trace_recurrent(
+    inputs: list[float],
+    initial_state: float,
+    parameters: dict[str, float],
+    *,
+    recurrent_enabled: bool = True,
+) -> dict[str, Any]:
+    """Run one shared scalar ReLU cell over an input sequence."""
+
+    if not inputs:
+        raise RecurrentUnrollValidationError("recurrent trace needs an input")
+    _require_keys(
+        parameters,
+        {"input_weight", "recurrent_weight", "bias"},
+        "parameters",
+    )
+    input_weight = _number(parameters["input_weight"], "parameters.input_weight")
+    recurrent_weight = _number(
+        parameters["recurrent_weight"], "parameters.recurrent_weight"
+    )
+    bias = _number(parameters["bias"], "parameters.bias")
+    previous_state = _number(initial_state, "initial_state")
+    steps: list[dict[str, float | int]] = []
+    states: list[float] = []
+    for time, input_value in enumerate(inputs):
+        input_number = _number(input_value, f"inputs[{time}]")
+        input_product = input_weight * input_number
+        recurrent_product = (
+            recurrent_weight * previous_state if recurrent_enabled else 0.0
+        )
+        preactivation = input_product + recurrent_product + bias
+        state = max(0.0, preactivation)
+        steps.append(
+            {
+                "time": time,
+                "input": input_number,
+                "previous_state": previous_state,
+                "input_product": input_product,
+                "recurrent_product": recurrent_product,
+                "bias": bias,
+                "preactivation": preactivation,
+                "state": state,
+            }
+        )
+        states.append(state)
+        previous_state = state
+    return {"steps": steps, "states": states, "final_state": states[-1]}
+
+
+def validate_structure(lab: dict[str, Any], source: str = "lab") -> None:
+    _require_keys(
+        lab,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "initial_state",
+            "inputs",
+            "parameters",
+            "expected",
+        },
+        source,
+    )
+    if lab["schema_version"] != 1:
+        raise RecurrentUnrollValidationError(f"{source}.schema_version: expected 1")
+    for field in ("id", "title", "question"):
+        if not isinstance(lab[field], str) or not lab[field]:
+            raise RecurrentUnrollValidationError(
+                f"{source}.{field}: expected a non-empty string"
+            )
+    _positive_number(lab["absolute_tolerance"], f"{source}.absolute_tolerance")
+    concepts = lab["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(concepts) != len(set(concepts))
+    ):
+        raise RecurrentUnrollValidationError(
+            f"{source}.concepts: expected unique non-empty strings"
+        )
+
+    expected_operation = {
+        "kind": "scalar-elman-rnn-forward",
+        "steps": 3,
+        "state_size": 1,
+        "activation": "relu",
+        "parameter_sharing": "all-steps",
+    }
+    operation = lab["operation"]
+    if not isinstance(operation, dict):
+        raise RecurrentUnrollValidationError(f"{source}.operation: expected an object")
+    _require_keys(operation, set(expected_operation), f"{source}.operation")
+    if operation != expected_operation:
+        raise RecurrentUnrollValidationError(
+            f"{source}.operation: unsupported V1 operation"
+        )
+
+    _number(lab["initial_state"], f"{source}.initial_state")
+    _numbers(lab["inputs"], f"{source}.inputs", 3)
+    parameters = lab["parameters"]
+    if not isinstance(parameters, dict):
+        raise RecurrentUnrollValidationError(
+            f"{source}.parameters: expected an object"
+        )
+    _require_keys(
+        parameters,
+        {"input_weight", "recurrent_weight", "bias"},
+        f"{source}.parameters",
+    )
+    for field in ("input_weight", "recurrent_weight", "bias"):
+        _number(parameters[field], f"{source}.parameters.{field}")
+
+    expected = lab["expected"]
+    if not isinstance(expected, dict):
+        raise RecurrentUnrollValidationError(f"{source}.expected: expected an object")
+    _require_keys(
+        expected,
+        {"steps", "states", "final_state", "memory_ablation"},
+        f"{source}.expected",
+    )
+    steps = expected["steps"]
+    if not isinstance(steps, list) or len(steps) != 3:
+        raise RecurrentUnrollValidationError(
+            f"{source}.expected.steps: expected three steps"
+        )
+    step_keys = {
+        "time",
+        "input",
+        "previous_state",
+        "input_product",
+        "recurrent_product",
+        "bias",
+        "preactivation",
+        "state",
+    }
+    for time, step in enumerate(steps):
+        context = f"{source}.expected.steps[{time}]"
+        if not isinstance(step, dict):
+            raise RecurrentUnrollValidationError(f"{context}: expected an object")
+        _require_keys(step, step_keys, context)
+        if step["time"] != time:
+            raise RecurrentUnrollValidationError(f"{context}.time: expected {time}")
+        for field in step_keys - {"time"}:
+            _number(step[field], f"{context}.{field}")
+    _numbers(expected["states"], f"{source}.expected.states", 3)
+    _number(expected["final_state"], f"{source}.expected.final_state")
+    ablation = expected["memory_ablation"]
+    if not isinstance(ablation, dict):
+        raise RecurrentUnrollValidationError(
+            f"{source}.expected.memory_ablation: expected an object"
+        )
+    _require_keys(
+        ablation,
+        {"preactivations", "states", "state_differences"},
+        f"{source}.expected.memory_ablation",
+    )
+    for field in ("preactivations", "states", "state_differences"):
+        _numbers(ablation[field], f"{source}.expected.memory_ablation.{field}", 3)
+
+
+def _compare_nested(actual: Any, expected: Any, tolerance: float, context: str) -> None:
+    if isinstance(actual, dict):
+        if not isinstance(expected, dict) or actual.keys() != expected.keys():
+            raise RecurrentUnrollValidationError(f"{context}: object keys do not match")
+        for key, actual_value in actual.items():
+            _compare_nested(actual_value, expected[key], tolerance, f"{context}.{key}")
+        return
+    if isinstance(actual, list):
+        if not isinstance(expected, list) or len(actual) != len(expected):
+            raise RecurrentUnrollValidationError(f"{context}: list lengths do not match")
+        for index, actual_value in enumerate(actual):
+            _compare_nested(
+                actual_value, expected[index], tolerance, f"{context}[{index}]"
+            )
+        return
+    actual_number = _number(actual, context)
+    expected_number = _number(expected, context)
+    if abs(actual_number - expected_number) > tolerance:
+        raise RecurrentUnrollValidationError(
+            f"{context}: expected {expected_number!r}, got {actual_number!r} "
+            f"(tolerance {tolerance})"
+        )
+
+
+def validate_lab(lab: dict[str, Any], source: str = "lab") -> None:
+    validate_structure(lab, source)
+    inputs = [float(value) for value in lab["inputs"]]
+    initial_state = float(lab["initial_state"])
+    parameters = {key: float(value) for key, value in lab["parameters"].items()}
+    forward = trace_recurrent(inputs, initial_state, parameters)
+    ablated = trace_recurrent(
+        inputs, initial_state, parameters, recurrent_enabled=False
+    )
+    actual = {
+        **forward,
+        "memory_ablation": {
+            "preactivations": [step["preactivation"] for step in ablated["steps"]],
+            "states": ablated["states"],
+            "state_differences": [
+                state - ablated_state
+                for state, ablated_state in zip(
+                    forward["states"], ablated["states"]
+                )
+            ],
+        },
+    }
+    _compare_nested(
+        actual,
+        lab["expected"],
+        float(lab["absolute_tolerance"]),
+        f"{source}.expected",
+    )
+
+
+def validate_corpus(fixture_root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    schema = load_json(fixture_root / "schema.json")
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        raise RecurrentUnrollValidationError(
+            "schema.json: expected JSON Schema Draft 2020-12"
+        )
+    lab_paths = sorted((fixture_root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise RecurrentUnrollValidationError(f"{fixture_root}: no lab fixtures found")
+    ids: set[str] = set()
+    for path in lab_paths:
+        lab = load_json(path)
+        validate_lab(lab, str(path))
+        if lab["id"] in ids:
+            raise RecurrentUnrollValidationError(
+                f"{path}: duplicate lab id {lab['id']!r}"
+            )
+        ids.add(lab["id"])
+    return lab_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    try:
+        paths = validate_corpus(args.fixture_root)
+    except RecurrentUnrollValidationError as error:
+        parser.exit(1, f"recurrent-unroll corpus invalid: {error}\n")
+    print(f"validated {len(paths)} recurrent-unroll labs from {args.fixture_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_residual_receptive_labs.py
+++ b/code/scripts/validate_residual_receptive_labs.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN08 residual/receptive corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "residual-receptive-v1"
+)
+
+
+class ResidualReceptiveValidationError(ValueError):
+    """Raised when an NN08 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ResidualReceptiveValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ResidualReceptiveValidationError(
+                    f"non-finite JSON number: {value}"
+                )
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise ResidualReceptiveValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise ResidualReceptiveValidationError(
+            f"{path}: top-level JSON value must be an object"
+        )
+    return document
+
+
+def _require_keys(value: dict[str, Any], required: set[str], context: str) -> None:
+    missing = required - value.keys()
+    extra = value.keys() - required
+    if missing:
+        raise ResidualReceptiveValidationError(
+            f"{context}: missing keys {sorted(missing)}"
+        )
+    if extra:
+        raise ResidualReceptiveValidationError(
+            f"{context}: unexpected keys {sorted(extra)}"
+        )
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ResidualReceptiveValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ResidualReceptiveValidationError(
+            f"{context}: expected a finite number"
+        )
+    return result
+
+
+def _positive_number(value: Any, context: str) -> float:
+    result = _number(value, context)
+    if result <= 0:
+        raise ResidualReceptiveValidationError(
+            f"{context}: expected a positive number"
+        )
+    return result
+
+
+def _numbers(value: Any, context: str) -> list[float]:
+    if not isinstance(value, list) or not value:
+        raise ResidualReceptiveValidationError(
+            f"{context}: expected a non-empty number array"
+        )
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def _indices(value: Any, context: str) -> list[int]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(isinstance(item, bool) or not isinstance(item, int) or item < 0 for item in value)
+    ):
+        raise ResidualReceptiveValidationError(
+            f"{context}: expected non-negative integer indices"
+        )
+    return value
+
+
+def same_correlation(signal: list[float], kernel: list[float]) -> list[float]:
+    if not signal or not kernel or len(kernel) % 2 == 0:
+        raise ResidualReceptiveValidationError(
+            "same correlation requires a non-empty signal and odd kernel"
+        )
+    radius = len(kernel) // 2
+    return [
+        sum(
+            (signal[index + offset] if 0 <= index + offset < len(signal) else 0.0)
+            * kernel[offset + radius]
+            for offset in range(-radius, radius + 1)
+        )
+        for index in range(len(signal))
+    ]
+
+
+def trace_residual(input_values: list[float], kernels: list[list[float]]) -> dict[str, Any]:
+    if len(kernels) != 2 or any(kernel != [1.0, 1.0, 1.0] for kernel in kernels):
+        raise ResidualReceptiveValidationError(
+            "V1 requires two [1, 1, 1] kernels"
+        )
+    hidden = same_correlation(input_values, kernels[0])
+    main = same_correlation(hidden, kernels[1])
+    skip = list(input_values)
+    residual_sum = [main_value + skip_value for main_value, skip_value in zip(main, skip)]
+    output = [max(0.0, value) for value in residual_sum]
+    traces: list[dict[str, Any]] = []
+    for output_index in range(len(input_values)):
+        hidden_indices = [
+            index
+            for index in range(output_index - 1, output_index + 2)
+            if 0 <= index < len(input_values)
+        ]
+        path_counts = [0 for _ in input_values]
+        hidden_paths: list[dict[str, Any]] = []
+        for hidden_index in hidden_indices:
+            input_indices = [
+                index
+                for index in range(hidden_index - 1, hidden_index + 2)
+                if 0 <= index < len(input_values)
+            ]
+            for input_index in input_indices:
+                path_counts[input_index] += 1
+            hidden_paths.append(
+                {
+                    "hidden_index": hidden_index,
+                    "input_indices": input_indices,
+                    "input_values": [input_values[index] for index in input_indices],
+                    "subtotal": hidden[hidden_index],
+                }
+            )
+        traces.append(
+            {
+                "output_index": output_index,
+                "hidden_indices": hidden_indices,
+                "hidden_values": [hidden[index] for index in hidden_indices],
+                "hidden_paths": hidden_paths,
+                "input_path_counts": path_counts,
+                "input_contributions": [
+                    input_values[index] * path_counts[index]
+                    for index in range(len(input_values))
+                ],
+                "receptive_field_indices": [
+                    index for index, count in enumerate(path_counts) if count > 0
+                ],
+                "main_output": main[output_index],
+                "skip_contribution": skip[output_index],
+                "residual_sum": residual_sum[output_index],
+                "output": output[output_index],
+            }
+        )
+    return {
+        "hidden": hidden,
+        "main": main,
+        "skip": skip,
+        "residual_sum": residual_sum,
+        "output": output,
+        "traces": traces,
+    }
+
+
+def validate_structure(lab: dict[str, Any], source: str = "lab") -> None:
+    _require_keys(
+        lab,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "input",
+            "kernels",
+            "expected",
+        },
+        source,
+    )
+    if lab["schema_version"] != 1:
+        raise ResidualReceptiveValidationError(
+            f"{source}.schema_version: expected 1"
+        )
+    for field in ("id", "title", "question"):
+        if not isinstance(lab[field], str) or not lab[field]:
+            raise ResidualReceptiveValidationError(
+                f"{source}.{field}: expected a non-empty string"
+            )
+    _positive_number(lab["absolute_tolerance"], f"{source}.absolute_tolerance")
+    concepts = lab["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(concepts) != len(set(concepts))
+    ):
+        raise ResidualReceptiveValidationError(
+            f"{source}.concepts: expected unique non-empty strings"
+        )
+
+    operation = lab["operation"]
+    expected_operation = {
+        "kind": "residual-correlation-1d",
+        "padding": "same-zero",
+        "stride": 1,
+        "layers": 2,
+        "skip": "identity",
+        "activation": "relu",
+    }
+    if not isinstance(operation, dict):
+        raise ResidualReceptiveValidationError(
+            f"{source}.operation: expected an object"
+        )
+    _require_keys(operation, set(expected_operation), f"{source}.operation")
+    if operation != expected_operation:
+        raise ResidualReceptiveValidationError(
+            f"{source}.operation: unsupported V1 operation"
+        )
+
+    input_values = _numbers(lab["input"], f"{source}.input")
+    if len(input_values) != 5:
+        raise ResidualReceptiveValidationError(
+            f"{source}.input: V1 requires five values"
+        )
+    kernels_value = lab["kernels"]
+    if not isinstance(kernels_value, list) or len(kernels_value) != 2:
+        raise ResidualReceptiveValidationError(
+            f"{source}.kernels: expected two kernels"
+        )
+    kernels = [
+        _numbers(kernel, f"{source}.kernels[{index}]")
+        for index, kernel in enumerate(kernels_value)
+    ]
+    if any(kernel != [1.0, 1.0, 1.0] for kernel in kernels):
+        raise ResidualReceptiveValidationError(
+            f"{source}.kernels: V1 requires two [1, 1, 1] kernels"
+        )
+
+    expected = lab["expected"]
+    if not isinstance(expected, dict):
+        raise ResidualReceptiveValidationError(
+            f"{source}.expected: expected an object"
+        )
+    _require_keys(
+        expected,
+        {"hidden", "main", "skip", "residual_sum", "output", "traces"},
+        f"{source}.expected",
+    )
+    for field in ("hidden", "main", "skip", "residual_sum", "output"):
+        if len(_numbers(expected[field], f"{source}.expected.{field}")) != 5:
+            raise ResidualReceptiveValidationError(
+                f"{source}.expected.{field}: expected five values"
+            )
+    traces = expected["traces"]
+    if not isinstance(traces, list) or len(traces) != 5:
+        raise ResidualReceptiveValidationError(
+            f"{source}.expected.traces: expected five traces"
+        )
+    trace_keys = {
+        "output_index",
+        "hidden_indices",
+        "hidden_values",
+        "hidden_paths",
+        "input_path_counts",
+        "input_contributions",
+        "receptive_field_indices",
+        "main_output",
+        "skip_contribution",
+        "residual_sum",
+        "output",
+    }
+    for index, trace in enumerate(traces):
+        context = f"{source}.expected.traces[{index}]"
+        if not isinstance(trace, dict):
+            raise ResidualReceptiveValidationError(f"{context}: expected an object")
+        _require_keys(trace, trace_keys, context)
+        if trace["output_index"] != index:
+            raise ResidualReceptiveValidationError(
+                f"{context}.output_index: expected {index}"
+            )
+        hidden_indices = _indices(trace["hidden_indices"], f"{context}.hidden_indices")
+        if len(_numbers(trace["hidden_values"], f"{context}.hidden_values")) != len(hidden_indices):
+            raise ResidualReceptiveValidationError(
+                f"{context}.hidden_values: must match hidden indices"
+            )
+        paths = trace["hidden_paths"]
+        if not isinstance(paths, list) or len(paths) != len(hidden_indices):
+            raise ResidualReceptiveValidationError(
+                f"{context}.hidden_paths: must match hidden indices"
+            )
+        for path_index, path in enumerate(paths):
+            path_context = f"{context}.hidden_paths[{path_index}]"
+            if not isinstance(path, dict):
+                raise ResidualReceptiveValidationError(
+                    f"{path_context}: expected an object"
+                )
+            _require_keys(
+                path,
+                {"hidden_index", "input_indices", "input_values", "subtotal"},
+                path_context,
+            )
+            input_indices = _indices(
+                path["input_indices"], f"{path_context}.input_indices"
+            )
+            if len(_numbers(path["input_values"], f"{path_context}.input_values")) != len(input_indices):
+                raise ResidualReceptiveValidationError(
+                    f"{path_context}.input_values: must match input indices"
+                )
+            _number(path["subtotal"], f"{path_context}.subtotal")
+        for field in ("input_path_counts", "input_contributions"):
+            if len(_numbers(trace[field], f"{context}.{field}")) != 5:
+                raise ResidualReceptiveValidationError(
+                    f"{context}.{field}: expected five values"
+                )
+        _indices(
+            trace["receptive_field_indices"],
+            f"{context}.receptive_field_indices",
+        )
+        for field in ("main_output", "skip_contribution", "residual_sum", "output"):
+            _number(trace[field], f"{context}.{field}")
+
+
+def _compare_nested(actual: Any, expected: Any, tolerance: float, context: str) -> None:
+    if isinstance(actual, dict):
+        if not isinstance(expected, dict) or actual.keys() != expected.keys():
+            raise ResidualReceptiveValidationError(
+                f"{context}: object keys do not match"
+            )
+        for key, actual_value in actual.items():
+            _compare_nested(actual_value, expected[key], tolerance, f"{context}.{key}")
+        return
+    if isinstance(actual, list):
+        if not isinstance(expected, list) or len(actual) != len(expected):
+            raise ResidualReceptiveValidationError(
+                f"{context}: expected a list of length {len(actual)}"
+            )
+        for index, actual_value in enumerate(actual):
+            _compare_nested(
+                actual_value, expected[index], tolerance, f"{context}[{index}]"
+            )
+        return
+    actual_number = _number(actual, context)
+    expected_number = _number(expected, context)
+    if abs(actual_number - expected_number) > tolerance:
+        raise ResidualReceptiveValidationError(
+            f"{context}: expected {expected_number!r}, got {actual_number!r} "
+            f"(tolerance {tolerance})"
+        )
+
+
+def validate_lab(lab: dict[str, Any], source: str = "lab") -> None:
+    validate_structure(lab, source)
+    actual = trace_residual(
+        [float(value) for value in lab["input"]],
+        [[float(value) for value in kernel] for kernel in lab["kernels"]],
+    )
+    _compare_nested(
+        actual,
+        lab["expected"],
+        float(lab["absolute_tolerance"]),
+        f"{source}.expected",
+    )
+
+
+def validate_corpus(fixture_root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    schema = load_json(fixture_root / "schema.json")
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        raise ResidualReceptiveValidationError(
+            "schema.json: expected JSON Schema Draft 2020-12"
+        )
+    lab_paths = sorted((fixture_root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise ResidualReceptiveValidationError(
+            f"{fixture_root}: no lab fixtures found"
+        )
+    ids: set[str] = set()
+    for path in lab_paths:
+        lab = load_json(path)
+        validate_lab(lab, str(path))
+        if lab["id"] in ids:
+            raise ResidualReceptiveValidationError(
+                f"{path}: duplicate lab id {lab['id']!r}"
+            )
+        ids.add(lab["id"])
+    return lab_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    try:
+        paths = validate_corpus(args.fixture_root)
+    except ResidualReceptiveValidationError as error:
+        parser.exit(1, f"residual/receptive corpus invalid: {error}\n")
+    print(f"validated {len(paths)} residual/receptive labs from {args.fixture_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_tiny_decoder_training_labs.py
+++ b/code/scripts/validate_tiny_decoder_training_labs.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN15 tiny decoder training corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "tiny-decoder-training-v1"
+)
+
+
+class TinyDecoderTrainingValidationError(ValueError):
+    """Raised when an NN15 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise TinyDecoderTrainingValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                TinyDecoderTrainingValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise TinyDecoderTrainingValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise TinyDecoderTrainingValidationError(
+            "top-level JSON value must be an object"
+        )
+    return document
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TinyDecoderTrainingValidationError(f"{context}: expected an object")
+    missing = keys - value.keys()
+    extra = value.keys() - keys
+    if missing or extra:
+        raise TinyDecoderTrainingValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TinyDecoderTrainingValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise TinyDecoderTrainingValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _vector(value: Any, length: int, context: str) -> list[float]:
+    if not isinstance(value, list) or len(value) != length:
+        raise TinyDecoderTrainingValidationError(
+            f"{context}: expected {length} numbers"
+        )
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def _matrix(value: Any, rows: int, columns: int, context: str) -> list[list[float]]:
+    if not isinstance(value, list) or len(value) != rows:
+        raise TinyDecoderTrainingValidationError(f"{context}: expected {rows} rows")
+    return [
+        _vector(row, columns, f"{context}[{index}]") for index, row in enumerate(value)
+    ]
+
+
+def _text_list(
+    value: Any,
+    length: int,
+    context: str,
+    *,
+    unique: bool = False,
+) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or len(value) != length
+        or any(not isinstance(item, str) or not item for item in value)
+    ):
+        raise TinyDecoderTrainingValidationError(
+            f"{context}: expected {length} non-empty strings"
+        )
+    if unique and len(set(value)) != length:
+        raise TinyDecoderTrainingValidationError(f"{context}: expected unique strings")
+    return value
+
+
+def _clean_zero(value: float) -> float:
+    return 0.0 if abs(value) < 1e-15 else value
+
+
+def _forward_row(
+    state: list[float],
+    target_index: int,
+    unembedding: list[list[float]],
+    bias: list[float],
+) -> dict[str, Any]:
+    logit_products = [
+        [
+            _clean_zero(state[dimension] * unembedding[dimension][vocab_index])
+            for dimension in range(2)
+        ]
+        for vocab_index in range(3)
+    ]
+    logits = [
+        _clean_zero(sum(products) + bias[vocab_index])
+        for vocab_index, products in enumerate(logit_products)
+    ]
+    row_max = max(logits)
+    shifted_logits = [_clean_zero(logit - row_max) for logit in logits]
+    exponentials = [math.exp(logit) for logit in shifted_logits]
+    denominator = sum(exponentials)
+    probabilities = [value / denominator for value in exponentials]
+    target_probability = probabilities[target_index]
+    return {
+        "logit_products": logit_products,
+        "logits": logits,
+        "row_max": row_max,
+        "shifted_logits": shifted_logits,
+        "exponentials": exponentials,
+        "denominator": denominator,
+        "probabilities": probabilities,
+        "target_probability": target_probability,
+        "loss": -math.log(target_probability),
+    }
+
+
+def _mean_loss(
+    states: list[list[float]],
+    target_indices: list[int],
+    unembedding: list[list[float]],
+    bias: list[float],
+) -> float:
+    return sum(
+        _forward_row(state, target_index, unembedding, bias)["loss"]
+        for state, target_index in zip(states, target_indices)
+    ) / len(states)
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    vocabulary = _text_list(document["vocabulary"], 3, "vocabulary", unique=True)
+    states = _matrix(document["decoder_states"], 2, 2, "decoder_states")
+    unembedding = _matrix(document["unembedding"], 2, 3, "unembedding")
+    bias = _vector(document["bias"], 3, "bias")
+    target_tokens = _text_list(document["target_tokens"], 2, "target_tokens")
+    target_indices = [vocabulary.index(token) for token in target_tokens]
+    learning_rate = _number(
+        document["optimizer"]["learning_rate"], "optimizer.learning_rate"
+    )
+
+    rows: list[dict[str, Any]] = []
+    unembedding_gradient = [[0.0] * 3 for _ in range(2)]
+    bias_gradient = [0.0] * 3
+    for position, (state, target_index) in enumerate(zip(states, target_indices)):
+        forward = _forward_row(state, target_index, unembedding, bias)
+        probabilities = forward["probabilities"]
+        logit_gradients = [
+            (probability - (1.0 if vocab_index == target_index else 0.0)) / 2
+            for vocab_index, probability in enumerate(probabilities)
+        ]
+        contribution = [
+            [
+                _clean_zero(state[dimension] * logit_gradients[vocab_index])
+                for vocab_index in range(3)
+            ]
+            for dimension in range(2)
+        ]
+        for dimension in range(2):
+            for vocab_index in range(3):
+                unembedding_gradient[dimension][vocab_index] += contribution[dimension][
+                    vocab_index
+                ]
+        for vocab_index in range(3):
+            bias_gradient[vocab_index] += logit_gradients[vocab_index]
+        state_gradient = [
+            _clean_zero(
+                sum(
+                    logit_gradients[vocab_index] * unembedding[dimension][vocab_index]
+                    for vocab_index in range(3)
+                )
+            )
+            for dimension in range(2)
+        ]
+        rows.append(
+            {
+                "position": position,
+                "input_token": document["input_tokens"][position],
+                "target_token": target_tokens[position],
+                "causal_prefix": document["causal_prefixes"][position],
+                "decoder_state": state,
+                **forward,
+                "logit_gradients": logit_gradients,
+                "unembedding_gradient_contribution": contribution,
+                "bias_gradient_contribution": logit_gradients,
+                "state_gradient": state_gradient,
+            }
+        )
+
+    mean_loss = sum(row["loss"] for row in rows) / 2
+    gradient_epsilon = 1e-6
+    numerical_unembedding_gradient = [[0.0] * 3 for _ in range(2)]
+    for dimension in range(2):
+        for vocabulary_index in range(3):
+            plus = [row[:] for row in unembedding]
+            minus = [row[:] for row in unembedding]
+            plus[dimension][vocabulary_index] += gradient_epsilon
+            minus[dimension][vocabulary_index] -= gradient_epsilon
+            numerical_unembedding_gradient[dimension][vocabulary_index] = (
+                _mean_loss(states, target_indices, plus, bias)
+                - _mean_loss(states, target_indices, minus, bias)
+            ) / (2 * gradient_epsilon)
+    numerical_bias_gradient = []
+    for vocabulary_index in range(3):
+        plus_bias = bias[:]
+        minus_bias = bias[:]
+        plus_bias[vocabulary_index] += gradient_epsilon
+        minus_bias[vocabulary_index] -= gradient_epsilon
+        numerical_bias_gradient.append(
+            (
+                _mean_loss(states, target_indices, unembedding, plus_bias)
+                - _mean_loss(states, target_indices, unembedding, minus_bias)
+            )
+            / (2 * gradient_epsilon)
+        )
+    gradient_errors = [
+        abs(
+            numerical_unembedding_gradient[dimension][vocabulary_index]
+            - unembedding_gradient[dimension][vocabulary_index]
+        )
+        for dimension in range(2)
+        for vocabulary_index in range(3)
+    ] + [
+        abs(numerical_bias_gradient[index] - bias_gradient[index]) for index in range(3)
+    ]
+    updated_unembedding = [
+        [
+            unembedding[dimension][vocab_index]
+            - learning_rate * unembedding_gradient[dimension][vocab_index]
+            for vocab_index in range(3)
+        ]
+        for dimension in range(2)
+    ]
+    updated_bias = [
+        bias[index] - learning_rate * bias_gradient[index] for index in range(3)
+    ]
+    post_update_rows = []
+    for position, (state, target_index) in enumerate(zip(states, target_indices)):
+        forward = _forward_row(state, target_index, updated_unembedding, updated_bias)
+        post_update_rows.append(
+            {
+                "position": position,
+                "logits": forward["logits"],
+                "probabilities": forward["probabilities"],
+                "target_probability": forward["target_probability"],
+                "loss": forward["loss"],
+            }
+        )
+
+    return {
+        "rows": rows,
+        "mean_loss": mean_loss,
+        "unembedding_gradient": unembedding_gradient,
+        "bias_gradient": bias_gradient,
+        "gradient_check": {
+            "epsilon": gradient_epsilon,
+            "numerical_unembedding_gradient": numerical_unembedding_gradient,
+            "numerical_bias_gradient": numerical_bias_gradient,
+            "max_absolute_error": max(gradient_errors),
+        },
+        "updated_unembedding": updated_unembedding,
+        "updated_bias": updated_bias,
+        "post_update_rows": post_update_rows,
+        "post_update_mean_loss": sum(row["loss"] for row in post_update_rows) / 2,
+    }
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            raise TinyDecoderTrainingValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(
+            float(expected), float(actual), rel_tol=0, abs_tol=tolerance
+        ):
+            raise TinyDecoderTrainingValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            raise TinyDecoderTrainingValidationError(f"{context}: length mismatch")
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _compare(expected_item, actual_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            raise TinyDecoderTrainingValidationError(f"{context}: key mismatch")
+        for key in expected:
+            _compare(expected[key], actual[key], tolerance, f"{context}.{key}")
+        return
+    if expected != actual:
+        raise TinyDecoderTrainingValidationError(
+            f"{context}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def validate_lab(document: dict[str, Any]) -> dict[str, Any]:
+    _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "vocabulary",
+            "sequence",
+            "input_tokens",
+            "target_tokens",
+            "causal_prefixes",
+            "decoder_states",
+            "unembedding",
+            "bias",
+            "optimizer",
+            "expected",
+        },
+        "lab",
+    )
+    if document["schema_version"] != 1:
+        raise TinyDecoderTrainingValidationError("schema_version: expected 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(document[key], str) or not document[key]:
+            raise TinyDecoderTrainingValidationError(f"{key}: expected text")
+    concepts = document["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(set(concepts)) != len(concepts)
+    ):
+        raise TinyDecoderTrainingValidationError(
+            "concepts: expected unique non-empty strings"
+        )
+    tolerance = _number(document["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise TinyDecoderTrainingValidationError(
+            "absolute_tolerance: expected a positive number"
+        )
+
+    operation = _object(
+        document["operation"],
+        {
+            "kind",
+            "position_count",
+            "model_width",
+            "vocabulary_size",
+            "state_source",
+            "objective",
+            "softmax",
+            "reduction",
+            "trainable_parameters",
+            "update",
+        },
+        "operation",
+    )
+    required_operation = {
+        "kind": "saved-causal-decoder-state-next-token-step",
+        "position_count": 2,
+        "model_width": 2,
+        "vocabulary_size": 3,
+        "state_source": "frozen-causal-decoder-block-output",
+        "objective": "next-token-cross-entropy",
+        "softmax": "stable-row-wise",
+        "reduction": "mean-over-positions",
+        "trainable_parameters": ["unembedding", "bias"],
+        "update": "sgd",
+    }
+    if operation != required_operation:
+        raise TinyDecoderTrainingValidationError("operation: unsupported NN15 contract")
+
+    vocabulary = _text_list(document["vocabulary"], 3, "vocabulary", unique=True)
+    sequence = _text_list(document["sequence"], 3, "sequence")
+    input_tokens = _text_list(document["input_tokens"], 2, "input_tokens")
+    target_tokens = _text_list(document["target_tokens"], 2, "target_tokens")
+    if any(token not in vocabulary for token in sequence):
+        raise TinyDecoderTrainingValidationError("sequence: token outside vocabulary")
+    if input_tokens != sequence[:-1] or target_tokens != sequence[1:]:
+        raise TinyDecoderTrainingValidationError(
+            "sequence shift: inputs and targets must be adjacent slices"
+        )
+    prefixes = document["causal_prefixes"]
+    if prefixes != [sequence[:1], sequence[:2]]:
+        raise TinyDecoderTrainingValidationError(
+            "causal_prefixes: expected growing sequence prefixes"
+        )
+    _matrix(document["decoder_states"], 2, 2, "decoder_states")
+    _matrix(document["unembedding"], 2, 3, "unembedding")
+    _vector(document["bias"], 3, "bias")
+    optimizer = _object(document["optimizer"], {"learning_rate"}, "optimizer")
+    if _number(optimizer["learning_rate"], "optimizer.learning_rate") <= 0:
+        raise TinyDecoderTrainingValidationError(
+            "optimizer.learning_rate: expected a positive number"
+        )
+    expected = _object(
+        document["expected"],
+        {
+            "rows",
+            "mean_loss",
+            "unembedding_gradient",
+            "bias_gradient",
+            "gradient_check",
+            "updated_unembedding",
+            "updated_bias",
+            "post_update_rows",
+            "post_update_mean_loss",
+        },
+        "expected",
+    )
+    actual = execute_lab(document)
+    _compare(expected, actual, tolerance, "expected")
+    if actual["post_update_mean_loss"] >= actual["mean_loss"]:
+        raise TinyDecoderTrainingValidationError(
+            "expected.post_update_mean_loss: canonical update must lower loss"
+        )
+    return actual
+
+
+def validate_fixture_root(root: Path) -> int:
+    labs = sorted((root / "labs").glob("*.json"))
+    if not labs:
+        raise TinyDecoderTrainingValidationError(f"{root}: no lab documents found")
+    for path in labs:
+        validate_lab(load_json(path))
+        print(f"validated {path.relative_to(REPO_ROOT)}")
+    return len(labs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_fixture_root(args.root.resolve())
+    print(f"validated {count} NN15 tiny decoder training lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_tiny_image_cnn_labs.py
+++ b/code/scripts/validate_tiny_image_cnn_labs.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN07 tiny-image CNN corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "tiny-image-cnn-v1"
+)
+
+
+class TinyImageCnnValidationError(ValueError):
+    """Raised when an NN07 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise TinyImageCnnValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                TinyImageCnnValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise TinyImageCnnValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise TinyImageCnnValidationError(
+            f"{path}: top-level JSON value must be an object"
+        )
+    return document
+
+
+def _require_keys(value: dict[str, Any], required: set[str], context: str) -> None:
+    missing = required - value.keys()
+    extra = value.keys() - required
+    if missing:
+        raise TinyImageCnnValidationError(
+            f"{context}: missing keys {sorted(missing)}"
+        )
+    if extra:
+        raise TinyImageCnnValidationError(
+            f"{context}: unexpected keys {sorted(extra)}"
+        )
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TinyImageCnnValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise TinyImageCnnValidationError(f"{context}: expected a finite number")
+    return result
+
+
+def _positive_number(value: Any, context: str) -> float:
+    result = _number(value, context)
+    if result <= 0:
+        raise TinyImageCnnValidationError(f"{context}: expected a positive number")
+    return result
+
+
+def _numbers(value: Any, context: str) -> list[float]:
+    if not isinstance(value, list) or not value:
+        raise TinyImageCnnValidationError(
+            f"{context}: expected a non-empty number array"
+        )
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def _matrix(value: Any, context: str) -> list[list[float]]:
+    if not isinstance(value, list) or not value:
+        raise TinyImageCnnValidationError(
+            f"{context}: expected a non-empty matrix"
+        )
+    rows = [_numbers(row, f"{context}[{index}]") for index, row in enumerate(value)]
+    width = len(rows[0])
+    if any(len(row) != width for row in rows):
+        raise TinyImageCnnValidationError(f"{context}: matrix must be rectangular")
+    return rows
+
+
+def _shape(matrix: list[list[float]]) -> tuple[int, int]:
+    return len(matrix), len(matrix[0])
+
+
+def correlate_channels(
+    channels: list[list[list[float]]],
+    filters: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Run valid stride-one 2D cross-correlation and preserve channel sums."""
+    if not channels or not filters:
+        raise TinyImageCnnValidationError("channels and filters must be non-empty")
+    input_height, input_width = _shape(channels[0])
+    if any(_shape(channel) != (input_height, input_width) for channel in channels):
+        raise TinyImageCnnValidationError("all input channels must share one shape")
+
+    all_contributions: list[list[list[list[float]]]] = []
+    outputs: list[list[list[float]]] = []
+    for filter_index, filter_value in enumerate(filters):
+        kernels = filter_value["kernels"]
+        if len(kernels) != len(channels):
+            raise TinyImageCnnValidationError(
+                f"filter {filter_index}: expected {len(channels)} kernels"
+            )
+        kernel_height, kernel_width = _shape(kernels[0])
+        if any(_shape(kernel) != (kernel_height, kernel_width) for kernel in kernels):
+            raise TinyImageCnnValidationError(
+                f"filter {filter_index}: all kernels must share one shape"
+            )
+        if kernel_height > input_height or kernel_width > input_width:
+            raise TinyImageCnnValidationError(
+                f"filter {filter_index}: kernel must fit inside the image"
+            )
+        output_height = input_height - kernel_height + 1
+        output_width = input_width - kernel_width + 1
+        contribution_maps = [
+            [[0.0 for _ in range(output_width)] for _ in range(output_height)]
+            for _ in channels
+        ]
+        output_map = [
+            [float(filter_value["bias"]) for _ in range(output_width)]
+            for _ in range(output_height)
+        ]
+        for row in range(output_height):
+            for column in range(output_width):
+                for channel_index, (channel, kernel) in enumerate(
+                    zip(channels, kernels)
+                ):
+                    contribution = sum(
+                        channel[row + kernel_row][column + kernel_column]
+                        * kernel[kernel_row][kernel_column]
+                        for kernel_row in range(kernel_height)
+                        for kernel_column in range(kernel_width)
+                    )
+                    contribution_maps[channel_index][row][column] = contribution
+                    output_map[row][column] += contribution
+        all_contributions.append(contribution_maps)
+        outputs.append(output_map)
+    return {"channel_contributions": all_contributions, "convolution": outputs}
+
+
+def normalize_spatial(
+    maps: list[list[list[float]]],
+    epsilon: float,
+    gamma: list[float],
+    beta: list[float],
+) -> dict[str, Any]:
+    if len(gamma) != len(maps) or len(beta) != len(maps):
+        raise TinyImageCnnValidationError(
+            "normalization gamma and beta must match output channels"
+        )
+    means: list[float] = []
+    variances: list[float] = []
+    denominators: list[float] = []
+    normalized_maps: list[list[list[float]]] = []
+    for index, feature_map in enumerate(maps):
+        values = [value for row in feature_map for value in row]
+        mean = sum(values) / len(values)
+        variance = sum((value - mean) ** 2 for value in values) / len(values)
+        denominator = math.sqrt(variance + epsilon)
+        means.append(mean)
+        variances.append(variance)
+        denominators.append(denominator)
+        normalized_maps.append(
+            [
+                [
+                    gamma[index] * (value - mean) / denominator + beta[index]
+                    for value in row
+                ]
+                for row in feature_map
+            ]
+        )
+    return {
+        "means": means,
+        "variances": variances,
+        "denominators": denominators,
+        "maps": normalized_maps,
+    }
+
+
+def relu_maps(maps: list[list[list[float]]]) -> list[list[list[float]]]:
+    return [
+        [[max(0.0, value) for value in row] for row in feature_map]
+        for feature_map in maps
+    ]
+
+
+def max_pool_entire_maps(
+    maps: list[list[list[float]]],
+) -> dict[str, Any]:
+    values: list[float] = []
+    argmax: list[list[int]] = []
+    for feature_map in maps:
+        best_value = -math.inf
+        best_position = [0, 0]
+        for row_index, row in enumerate(feature_map):
+            for column_index, value in enumerate(row):
+                if value > best_value:
+                    best_value = value
+                    best_position = [row_index, column_index]
+        values.append(best_value)
+        argmax.append(best_position)
+    return {"values": values, "argmax": argmax}
+
+
+def trace_pipeline(lab: dict[str, Any]) -> dict[str, Any]:
+    channels = [channel["values"] for channel in lab["input"]["channels"]]
+    convolution = correlate_channels(channels, lab["filters"])
+    normalization = normalize_spatial(
+        convolution["convolution"],
+        float(lab["normalization"]["epsilon"]),
+        lab["normalization"]["gamma"],
+        lab["normalization"]["beta"],
+    )
+    activation = relu_maps(normalization["maps"])
+    return {
+        **convolution,
+        "normalization": normalization,
+        "activation": activation,
+        "pooling": max_pool_entire_maps(activation),
+    }
+
+
+def validate_structure(lab: dict[str, Any], source: str = "lab") -> None:
+    _require_keys(
+        lab,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "input",
+            "filters",
+            "normalization",
+            "expected",
+        },
+        source,
+    )
+    if lab["schema_version"] != 1:
+        raise TinyImageCnnValidationError(f"{source}.schema_version: expected 1")
+    for field in ("id", "title", "question"):
+        if not isinstance(lab[field], str) or not lab[field]:
+            raise TinyImageCnnValidationError(
+                f"{source}.{field}: expected a non-empty string"
+            )
+    _positive_number(lab["absolute_tolerance"], f"{source}.absolute_tolerance")
+    concepts = lab["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(concepts) != len(set(concepts))
+    ):
+        raise TinyImageCnnValidationError(
+            f"{source}.concepts: expected unique non-empty strings"
+        )
+
+    operation = lab["operation"]
+    if not isinstance(operation, dict):
+        raise TinyImageCnnValidationError(f"{source}.operation: expected an object")
+    _require_keys(
+        operation,
+        {"kind", "padding", "stride", "activation", "pooling"},
+        f"{source}.operation",
+    )
+    pooling = operation["pooling"]
+    if not isinstance(pooling, dict):
+        raise TinyImageCnnValidationError(
+            f"{source}.operation.pooling: expected an object"
+        )
+    _require_keys(
+        pooling,
+        {"kind", "window", "stride", "tie_break"},
+        f"{source}.operation.pooling",
+    )
+    expected_operation = {
+        "kind": "cross-correlation-2d",
+        "padding": "valid",
+        "stride": [1, 1],
+        "activation": "relu",
+    }
+    if {key: operation[key] for key in expected_operation} != expected_operation:
+        raise TinyImageCnnValidationError(
+            f"{source}.operation: V1 requires valid stride-one 2D correlation and ReLU"
+        )
+    if pooling != {
+        "kind": "max",
+        "window": [2, 2],
+        "stride": [2, 2],
+        "tie_break": "first-row-major",
+    }:
+        raise TinyImageCnnValidationError(
+            f"{source}.operation.pooling: V1 requires row-major 2 x 2 max pooling"
+        )
+
+    input_value = lab["input"]
+    if not isinstance(input_value, dict):
+        raise TinyImageCnnValidationError(f"{source}.input: expected an object")
+    _require_keys(input_value, {"shape", "channels"}, f"{source}.input")
+    if input_value["shape"] != [2, 3, 3]:
+        raise TinyImageCnnValidationError(
+            f"{source}.input.shape: V1 requires [2, 3, 3]"
+        )
+    channels = input_value["channels"]
+    if not isinstance(channels, list) or len(channels) != 2:
+        raise TinyImageCnnValidationError(
+            f"{source}.input.channels: expected two channels"
+        )
+    parsed_channels: list[list[list[float]]] = []
+    for index, channel in enumerate(channels):
+        context = f"{source}.input.channels[{index}]"
+        if not isinstance(channel, dict):
+            raise TinyImageCnnValidationError(f"{context}: expected an object")
+        _require_keys(channel, {"name", "values"}, context)
+        if not isinstance(channel["name"], str) or not channel["name"]:
+            raise TinyImageCnnValidationError(f"{context}.name: expected text")
+        values = _matrix(channel["values"], f"{context}.values")
+        if _shape(values) != (3, 3):
+            raise TinyImageCnnValidationError(
+                f"{context}.values: expected a 3 x 3 matrix"
+            )
+        parsed_channels.append(values)
+
+    filters = lab["filters"]
+    if not isinstance(filters, list) or len(filters) != 2:
+        raise TinyImageCnnValidationError(f"{source}.filters: expected two filters")
+    for filter_index, filter_value in enumerate(filters):
+        context = f"{source}.filters[{filter_index}]"
+        if not isinstance(filter_value, dict):
+            raise TinyImageCnnValidationError(f"{context}: expected an object")
+        _require_keys(filter_value, {"name", "kernels", "bias"}, context)
+        if not isinstance(filter_value["name"], str) or not filter_value["name"]:
+            raise TinyImageCnnValidationError(f"{context}.name: expected text")
+        _number(filter_value["bias"], f"{context}.bias")
+        kernels = filter_value["kernels"]
+        if not isinstance(kernels, list) or len(kernels) != 2:
+            raise TinyImageCnnValidationError(
+                f"{context}.kernels: expected one kernel per input channel"
+            )
+        filter_value["kernels"] = [
+            _matrix(kernel, f"{context}.kernels[{index}]")
+            for index, kernel in enumerate(kernels)
+        ]
+        if any(_shape(kernel) != (2, 2) for kernel in filter_value["kernels"]):
+            raise TinyImageCnnValidationError(
+                f"{context}.kernels: V1 requires 2 x 2 kernels"
+            )
+
+    normalization = lab["normalization"]
+    if not isinstance(normalization, dict):
+        raise TinyImageCnnValidationError(
+            f"{source}.normalization: expected an object"
+        )
+    _require_keys(
+        normalization,
+        {"kind", "epsilon", "gamma", "beta"},
+        f"{source}.normalization",
+    )
+    if normalization["kind"] != "spatial-per-output-channel":
+        raise TinyImageCnnValidationError(
+            f"{source}.normalization.kind: unsupported normalization"
+        )
+    _positive_number(normalization["epsilon"], f"{source}.normalization.epsilon")
+    for field in ("gamma", "beta"):
+        values = _numbers(normalization[field], f"{source}.normalization.{field}")
+        if len(values) != 2:
+            raise TinyImageCnnValidationError(
+                f"{source}.normalization.{field}: expected two values"
+            )
+
+    expected = lab["expected"]
+    if not isinstance(expected, dict):
+        raise TinyImageCnnValidationError(f"{source}.expected: expected an object")
+    _require_keys(
+        expected,
+        {"channel_contributions", "convolution", "normalization", "activation", "pooling"},
+        f"{source}.expected",
+    )
+    expected_normalization = expected["normalization"]
+    expected_pooling = expected["pooling"]
+    if not isinstance(expected_normalization, dict) or not isinstance(expected_pooling, dict):
+        raise TinyImageCnnValidationError(
+            f"{source}.expected: normalization and pooling must be objects"
+        )
+    _require_keys(
+        expected_normalization,
+        {"means", "variances", "denominators", "maps"},
+        f"{source}.expected.normalization",
+    )
+    _require_keys(
+        expected_pooling,
+        {"values", "argmax"},
+        f"{source}.expected.pooling",
+    )
+
+
+def _compare_nested(
+    actual: Any, expected: Any, tolerance: float, context: str
+) -> None:
+    if isinstance(actual, list):
+        if not isinstance(expected, list) or len(actual) != len(expected):
+            raise TinyImageCnnValidationError(
+                f"{context}: expected a list of length {len(actual)}"
+            )
+        for index, actual_value in enumerate(actual):
+            _compare_nested(
+                actual_value, expected[index], tolerance, f"{context}[{index}]"
+            )
+        return
+    actual_number = _number(actual, context)
+    expected_number = _number(expected, context)
+    if abs(actual_number - expected_number) > tolerance:
+        raise TinyImageCnnValidationError(
+            f"{context}: expected {expected_number!r}, got {actual_number!r} "
+            f"(tolerance {tolerance})"
+        )
+
+
+def validate_lab(lab: dict[str, Any], source: str = "lab") -> None:
+    validate_structure(lab, source)
+    actual = trace_pipeline(lab)
+    expected = lab["expected"]
+    tolerance = float(lab["absolute_tolerance"])
+    for field in ("channel_contributions", "convolution", "activation"):
+        _compare_nested(
+            actual[field], expected[field], tolerance, f"{source}.expected.{field}"
+        )
+    for field in ("means", "variances", "denominators", "maps"):
+        _compare_nested(
+            actual["normalization"][field],
+            expected["normalization"][field],
+            tolerance,
+            f"{source}.expected.normalization.{field}",
+        )
+    _compare_nested(
+        actual["pooling"]["values"],
+        expected["pooling"]["values"],
+        tolerance,
+        f"{source}.expected.pooling.values",
+    )
+    if actual["pooling"]["argmax"] != expected["pooling"]["argmax"]:
+        raise TinyImageCnnValidationError(
+            f"{source}.expected.pooling.argmax: expected "
+            f"{expected['pooling']['argmax']!r}, got {actual['pooling']['argmax']!r}"
+        )
+
+
+def validate_corpus(fixture_root: Path = DEFAULT_FIXTURE_ROOT) -> list[Path]:
+    schema = load_json(fixture_root / "schema.json")
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        raise TinyImageCnnValidationError(
+            "schema.json: expected JSON Schema Draft 2020-12"
+        )
+    lab_paths = sorted((fixture_root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise TinyImageCnnValidationError(f"{fixture_root}: no lab fixtures found")
+    ids: set[str] = set()
+    for path in lab_paths:
+        lab = load_json(path)
+        validate_lab(lab, str(path))
+        if lab["id"] in ids:
+            raise TinyImageCnnValidationError(
+                f"{path}: duplicate lab id {lab['id']!r}"
+            )
+        ids.add(lab["id"])
+    return lab_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    try:
+        paths = validate_corpus(args.fixture_root)
+    except TinyImageCnnValidationError as error:
+        parser.exit(1, f"tiny image CNN corpus invalid: {error}\n")
+    print(f"validated {len(paths)} tiny image CNN labs from {args.fixture_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_tiny_message_passing_labs.py
+++ b/code/scripts/validate_tiny_message_passing_labs.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN21 tiny message-passing corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "tiny-message-passing-v1"
+)
+
+
+class TinyMessagePassingValidationError(ValueError):
+    """Raised when an NN21 document or trace is invalid."""
+
+
+def _reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise TinyMessagePassingValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicates,
+            parse_constant=lambda item: (_ for _ in ()).throw(
+                TinyMessagePassingValidationError(f"non-finite JSON number: {item}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise TinyMessagePassingValidationError(f"{path}: {error}") from error
+    if not isinstance(value, dict):
+        raise TinyMessagePassingValidationError(
+            "top-level JSON value must be an object"
+        )
+    return value
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TinyMessagePassingValidationError(f"{context}: expected an object")
+    missing, extra = keys - value.keys(), value.keys() - keys
+    if missing or extra:
+        raise TinyMessagePassingValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        raise TinyMessagePassingValidationError(f"{context}: expected a finite number")
+    return float(value)
+
+
+def _integer(value: Any, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TinyMessagePassingValidationError(f"{context}: expected an integer")
+    return value
+
+
+def _zero(value: float) -> float:
+    return 0.0 if abs(value) < 1e-12 else value
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    raw_features = document["node_features"]
+    if not isinstance(raw_features, list) or len(raw_features) < 2:
+        raise TinyMessagePassingValidationError(
+            "node_features: expected at least two values"
+        )
+    features = [
+        _number(value, f"node_features[{index}]")
+        for index, value in enumerate(raw_features)
+    ]
+    parameters = _object(
+        document["parameters"], {"message_weight", "self_weight", "bias"}, "parameters"
+    )
+    message_weight = _number(parameters["message_weight"], "parameters.message_weight")
+    self_weight = _number(parameters["self_weight"], "parameters.self_weight")
+    bias = _number(parameters["bias"], "parameters.bias")
+    raw_edges = document["edges"]
+    if not isinstance(raw_edges, list) or not raw_edges:
+        raise TinyMessagePassingValidationError("edges: expected a non-empty array")
+    edges: list[tuple[int, int]] = []
+    keys: set[tuple[int, int]] = set()
+    for index, raw_edge in enumerate(raw_edges):
+        edge = _object(raw_edge, {"source", "target"}, f"edges[{index}]")
+        source = _integer(edge["source"], f"edges[{index}].source")
+        target = _integer(edge["target"], f"edges[{index}].target")
+        if (
+            source == target
+            or min(source, target) < 0
+            or max(source, target) >= len(features)
+        ):
+            raise TinyMessagePassingValidationError(
+                f"edges[{index}]: invalid non-self edge"
+            )
+        key = (min(source, target), max(source, target))
+        if key in keys:
+            raise TinyMessagePassingValidationError("edges: duplicate undirected edge")
+        keys.add(key)
+        edges.append((source, target))
+
+    directed: list[dict[str, Any]] = []
+    for source, target in edges:
+        for directed_source, directed_target in ((source, target), (target, source)):
+            directed.append(
+                {
+                    "source": directed_source,
+                    "target": directed_target,
+                    "source_feature": features[directed_source],
+                    "message_weight": message_weight,
+                    "message": _zero(message_weight * features[directed_source]),
+                }
+            )
+    directed.sort(key=lambda row: (row["target"], row["source"]))
+    updates = []
+    for node, old_feature in enumerate(features):
+        incoming = [row for row in directed if row["target"] == node]
+        if not incoming:
+            raise TinyMessagePassingValidationError(
+                f"node {node} has no incoming messages"
+            )
+        aggregate = _zero(sum(row["message"] for row in incoming))
+        self_contribution = _zero(self_weight * old_feature)
+        preactivation = _zero(self_contribution + aggregate + bias)
+        updates.append(
+            {
+                "node": node,
+                "old_feature": old_feature,
+                "incoming": incoming,
+                "aggregate": aggregate,
+                "self_contribution": self_contribution,
+                "bias": bias,
+                "preactivation": preactivation,
+                "output_feature": max(0.0, preactivation),
+            }
+        )
+    return {
+        "directed_messages": directed,
+        "node_updates": updates,
+        "output_features": [row["output_feature"] for row in updates],
+    }
+
+
+def _compare(actual: Any, expected: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool):
+        if actual is not expected:
+            raise TinyMessagePassingValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+    elif isinstance(expected, (int, float)):
+        if abs(_number(actual, context) - float(expected)) > tolerance:
+            raise TinyMessagePassingValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+    elif isinstance(expected, str):
+        if actual != expected:
+            raise TinyMessagePassingValidationError(
+                f"{context}: expected {expected!r}, got {actual!r}"
+            )
+    elif isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            raise TinyMessagePassingValidationError(f"{context}: array length mismatch")
+        for index, (left, right) in enumerate(zip(actual, expected)):
+            _compare(left, right, tolerance, f"{context}[{index}]")
+    elif isinstance(expected, dict):
+        value = _object(actual, set(expected), context)
+        for key, right in expected.items():
+            _compare(value[key], right, tolerance, f"{context}.{key}")
+    else:
+        raise TinyMessagePassingValidationError(
+            f"{context}: unsupported expected value"
+        )
+
+
+def validate_document(document: dict[str, Any]) -> dict[str, Any]:
+    root = _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "node_features",
+            "edges",
+            "parameters",
+            "expected",
+        },
+        "document",
+    )
+    if _integer(root["schema_version"], "schema_version") != 1:
+        raise TinyMessagePassingValidationError("schema_version must be 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(root[key], str) or not root[key].strip():
+            raise TinyMessagePassingValidationError(
+                f"{key}: expected a non-empty string"
+            )
+    tolerance = _number(root["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise TinyMessagePassingValidationError("absolute_tolerance must be positive")
+    concepts = root["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or len(concepts) != len(set(concepts))
+        or any(not isinstance(item, str) or not item for item in concepts)
+    ):
+        raise TinyMessagePassingValidationError(
+            "concepts must contain unique non-empty strings"
+        )
+    operation = _object(
+        root["operation"],
+        {"kind", "edge_mode", "message", "aggregation", "update", "round"},
+        "operation",
+    )
+    required = {
+        "kind": "tiny-graph-message-passing",
+        "edge_mode": "undirected-expanded-both-directions",
+        "message": "source-feature-times-shared-weight",
+        "aggregation": "sum",
+        "update": "shared-affine-plus-relu",
+        "round": "synchronous",
+    }
+    if operation != required:
+        raise TinyMessagePassingValidationError("operation does not match NN21 V1")
+    actual = execute_lab(root)
+    if not isinstance(root["expected"], dict):
+        raise TinyMessagePassingValidationError("expected: expected an object")
+    _compare(actual, root["expected"], tolerance, "expected")
+    return actual
+
+
+def validate_corpus(root: Path = DEFAULT_FIXTURE_ROOT) -> int:
+    load_json(root / "schema.json")
+    paths = sorted((root / "labs").glob("*.json"))
+    if not paths:
+        raise TinyMessagePassingValidationError("no lab documents found")
+    seen: set[str] = set()
+    for path in paths:
+        document = load_json(path)
+        if document.get("id") in seen:
+            raise TinyMessagePassingValidationError(
+                f"duplicate lab id: {document.get('id')}"
+            )
+        seen.add(str(document.get("id")))
+        validate_document(document)
+        print(f"validated {path}")
+    return len(paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_corpus(args.fixture_root)
+    print(f"validated {count} NN21 tiny message-passing lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_training_stabilizer_labs.py
+++ b/code/scripts/validate_training_stabilizer_labs.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Validate and execute deterministic NN25 training-stabilizer labs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "training-stabilizers-v1"
+)
+ROUTE_IDS = ["plain", "normalization", "dropout", "residual"]
+
+
+class TrainingStabilizerValidationError(ValueError):
+    """Raised when an NN25 document or trace is invalid."""
+
+
+def _duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise TrainingStabilizerValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_duplicates,
+            parse_constant=lambda item: (_ for _ in ()).throw(
+                TrainingStabilizerValidationError(f"non-finite JSON number: {item}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise TrainingStabilizerValidationError(f"{path}: {error}") from error
+    if not isinstance(value, dict):
+        raise TrainingStabilizerValidationError("top-level JSON must be an object")
+    return value
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TrainingStabilizerValidationError(f"{context}: expected object")
+    missing, extra = keys - value.keys(), value.keys() - keys
+    if missing or extra:
+        raise TrainingStabilizerValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        raise TrainingStabilizerValidationError(f"{context}: expected finite number")
+    return float(value)
+
+
+def _vector(value: Any, context: str) -> list[float]:
+    if not isinstance(value, list) or len(value) != 4:
+        raise TrainingStabilizerValidationError(f"{context}: expected four values")
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def _dot(left: list[float], right: list[float]) -> float:
+    return sum(a * b for a, b in zip(left, right))
+
+
+def _normalization(
+    values: list[float], upstream: list[float], epsilon: float
+) -> dict[str, Any]:
+    mean = sum(values) / len(values)
+    centered = [value - mean for value in values]
+    variance = sum(value * value for value in centered) / len(values)
+    standard_deviation = math.sqrt(variance + epsilon)
+    if standard_deviation == 0:
+        raise TrainingStabilizerValidationError(
+            "normalization variance must be positive"
+        )
+    normalized = [value / standard_deviation for value in centered]
+    return {
+        "mean": mean,
+        "centered": centered,
+        "variance": variance,
+        "standard_deviation": standard_deviation,
+        "normalized": normalized,
+        "upstream_sum": sum(upstream),
+        "upstream_dot_normalized": _dot(upstream, normalized),
+    }
+
+
+def _route_output(
+    route_id: str,
+    inputs: list[float],
+    branch_weight: float,
+    mask: list[float],
+    keep_probability: float,
+    normalization_epsilon: float,
+) -> list[float]:
+    branch = [branch_weight * value for value in inputs]
+    if route_id == "plain":
+        return branch
+    if route_id == "normalization":
+        return _normalization(branch, [0.0] * 4, normalization_epsilon)["normalized"]
+    if route_id == "dropout":
+        return [
+            value * mask[index] / keep_probability for index, value in enumerate(branch)
+        ]
+    if route_id == "residual":
+        return [value + inputs[index] for index, value in enumerate(branch)]
+    raise TrainingStabilizerValidationError(f"unknown route: {route_id}")
+
+
+def _trace_route(
+    route_id: str,
+    inputs: list[float],
+    branch_weight: float,
+    upstream: list[float],
+    mask: list[float],
+    keep_probability: float,
+    normalization_epsilon: float,
+    finite_difference_epsilon: float,
+    normalization: dict[str, Any],
+) -> dict[str, Any]:
+    output = _route_output(
+        route_id,
+        inputs,
+        branch_weight,
+        mask,
+        keep_probability,
+        normalization_epsilon,
+    )
+    if route_id == "normalization":
+        count = len(inputs)
+        denominator = count * normalization["standard_deviation"]
+        branch_gradient = [
+            (
+                count * upstream[index]
+                - normalization["upstream_sum"]
+                - normalization["normalized"][index]
+                * normalization["upstream_dot_normalized"]
+            )
+            / denominator
+            for index in range(count)
+        ]
+    elif route_id == "dropout":
+        branch_gradient = [
+            upstream[index] * mask[index] / keep_probability
+            for index in range(len(inputs))
+        ]
+    else:
+        branch_gradient = list(upstream)
+    skip_gradient = list(upstream) if route_id == "residual" else [0.0] * len(inputs)
+    input_gradient = [
+        branch_weight * branch_gradient[index] + skip_gradient[index]
+        for index in range(len(inputs))
+    ]
+    weight_gradient = _dot(branch_gradient, inputs)
+    score = _dot(upstream, output)
+
+    finite_difference_input_gradient = []
+    for index in range(len(inputs)):
+        positive = list(inputs)
+        negative = list(inputs)
+        positive[index] += finite_difference_epsilon
+        negative[index] -= finite_difference_epsilon
+        positive_score = _dot(
+            upstream,
+            _route_output(
+                route_id,
+                positive,
+                branch_weight,
+                mask,
+                keep_probability,
+                normalization_epsilon,
+            ),
+        )
+        negative_score = _dot(
+            upstream,
+            _route_output(
+                route_id,
+                negative,
+                branch_weight,
+                mask,
+                keep_probability,
+                normalization_epsilon,
+            ),
+        )
+        finite_difference_input_gradient.append(
+            (positive_score - negative_score) / (2 * finite_difference_epsilon)
+        )
+    positive_weight_score = _dot(
+        upstream,
+        _route_output(
+            route_id,
+            inputs,
+            branch_weight + finite_difference_epsilon,
+            mask,
+            keep_probability,
+            normalization_epsilon,
+        ),
+    )
+    negative_weight_score = _dot(
+        upstream,
+        _route_output(
+            route_id,
+            inputs,
+            branch_weight - finite_difference_epsilon,
+            mask,
+            keep_probability,
+            normalization_epsilon,
+        ),
+    )
+    finite_difference_weight_gradient = (
+        positive_weight_score - negative_weight_score
+    ) / (2 * finite_difference_epsilon)
+    return {
+        "id": route_id,
+        "output": output,
+        "score": score,
+        "branch_gradient": branch_gradient,
+        "skip_gradient": skip_gradient,
+        "input_gradient": input_gradient,
+        "weight_gradient": weight_gradient,
+        "finite_difference_input_gradient": finite_difference_input_gradient,
+        "finite_difference_weight_gradient": finite_difference_weight_gradient,
+        "input_gradient_absolute_error": [
+            abs(actual - numerical)
+            for actual, numerical in zip(
+                input_gradient, finite_difference_input_gradient
+            )
+        ],
+        "weight_gradient_absolute_error": abs(
+            weight_gradient - finite_difference_weight_gradient
+        ),
+    }
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    operation = document["operation"]
+    inputs = _vector(document["input"], "input")
+    branch_weight = _number(document["branch_weight"], "branch_weight")
+    upstream = _vector(document["upstream_gradient"], "upstream_gradient")
+    raw_mask = document["dropout_mask"]
+    if (
+        not isinstance(raw_mask, list)
+        or len(raw_mask) != 4
+        or any(isinstance(item, bool) or item not in {0, 1} for item in raw_mask)
+    ):
+        raise TrainingStabilizerValidationError(
+            "dropout_mask must contain four binary values"
+        )
+    mask = [float(item) for item in raw_mask]
+    keep_probability = _number(
+        operation["keep_probability"], "operation.keep_probability"
+    )
+    normalization_epsilon = _number(
+        operation["normalization_epsilon"], "operation.normalization_epsilon"
+    )
+    finite_difference_epsilon = _number(
+        operation["finite_difference_epsilon"], "operation.finite_difference_epsilon"
+    )
+    if not 0 < keep_probability <= 1:
+        raise TrainingStabilizerValidationError("keep_probability must be in (0, 1]")
+    if normalization_epsilon < 0 or finite_difference_epsilon <= 0:
+        raise TrainingStabilizerValidationError(
+            "epsilon values must be nonnegative and finite-difference epsilon positive"
+        )
+    branch = [branch_weight * value for value in inputs]
+    normalization = _normalization(branch, upstream, normalization_epsilon)
+    scaled_mask = [value / keep_probability for value in mask]
+    dropout = {
+        "scaled_mask": scaled_mask,
+        "evaluation_output": list(branch),
+        "training_expectation": list(branch),
+    }
+    routes = [
+        _trace_route(
+            route_id,
+            inputs,
+            branch_weight,
+            upstream,
+            mask,
+            keep_probability,
+            normalization_epsilon,
+            finite_difference_epsilon,
+            normalization,
+        )
+        for route_id in ROUTE_IDS
+    ]
+    return {
+        "branch": branch,
+        "normalization": normalization,
+        "dropout": dropout,
+        "routes": routes,
+    }
+
+
+def _compare(actual: Any, expected: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool):
+        if actual is not expected:
+            raise TrainingStabilizerValidationError(f"{context}: mismatch")
+    elif isinstance(expected, (int, float)):
+        if abs(_number(actual, context) - float(expected)) > tolerance:
+            raise TrainingStabilizerValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+    elif isinstance(expected, str):
+        if actual != expected:
+            raise TrainingStabilizerValidationError(f"{context}: mismatch")
+    elif isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            raise TrainingStabilizerValidationError(f"{context}: array length mismatch")
+        for index, (left, right) in enumerate(zip(actual, expected)):
+            _compare(left, right, tolerance, f"{context}[{index}]")
+    elif isinstance(expected, dict):
+        value = _object(actual, set(expected), context)
+        for key, right in expected.items():
+            _compare(value[key], right, tolerance, f"{context}.{key}")
+    else:
+        raise TrainingStabilizerValidationError(f"{context}: unsupported value")
+
+
+def validate_document(document: dict[str, Any]) -> dict[str, Any]:
+    root = _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "input",
+            "branch_weight",
+            "upstream_gradient",
+            "dropout_mask",
+            "expected",
+        },
+        "document",
+    )
+    if root["schema_version"] != 1:
+        raise TrainingStabilizerValidationError("schema_version must be 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(root[key], str) or not root[key].strip():
+            raise TrainingStabilizerValidationError(f"{key}: expected non-empty string")
+    tolerance = _number(root["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise TrainingStabilizerValidationError("absolute_tolerance must be positive")
+    concepts = root["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or len(concepts) != len(set(concepts))
+        or any(not isinstance(item, str) or not item for item in concepts)
+    ):
+        raise TrainingStabilizerValidationError(
+            "concepts must be unique non-empty strings"
+        )
+    operation = _object(
+        root["operation"],
+        {
+            "kind",
+            "normalization",
+            "normalization_epsilon",
+            "dropout",
+            "keep_probability",
+            "finite_difference_epsilon",
+        },
+        "operation",
+    )
+    required = {
+        "kind": "vector-training-stabilizers",
+        "normalization": "population-layer-normalization",
+        "normalization_epsilon": 0,
+        "dropout": "inverted-training-dropout",
+        "keep_probability": 0.5,
+        "finite_difference_epsilon": 1e-6,
+    }
+    if operation != required:
+        raise TrainingStabilizerValidationError("operation does not match NN25 V1")
+    expected = root["expected"]
+    if not isinstance(expected, dict):
+        raise TrainingStabilizerValidationError("expected must be object")
+    raw_routes = expected.get("routes")
+    if (
+        not isinstance(raw_routes, list)
+        or [item.get("id") for item in raw_routes if isinstance(item, dict)]
+        != ROUTE_IDS
+    ):
+        raise TrainingStabilizerValidationError(
+            "expected route order does not match NN25 V1"
+        )
+    actual = execute_lab(root)
+    _compare(actual, expected, tolerance, "expected")
+    for route in actual["routes"]:
+        if (
+            max(route["input_gradient_absolute_error"]) > 1e-8
+            or route["weight_gradient_absolute_error"] > 1e-8
+        ):
+            raise TrainingStabilizerValidationError(
+                f"{route['id']}: finite-difference gradient check failed"
+            )
+    return actual
+
+
+def validate_corpus(root: Path = DEFAULT_FIXTURE_ROOT) -> int:
+    load_json(root / "schema.json")
+    paths = sorted((root / "labs").glob("*.json"))
+    if not paths:
+        raise TrainingStabilizerValidationError("no labs found")
+    for path in paths:
+        validate_document(load_json(path))
+        print(f"validated {path}")
+    return len(paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture-root", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_corpus(args.fixture_root)
+    print(f"validated {count} NN25 training-stabilizer lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_two_number_autoencoder_labs.py
+++ b/code/scripts/validate_two_number_autoencoder_labs.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN16 two-number autoencoder corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "two-number-autoencoder-v1"
+)
+PARAMETER_ORDER = [
+    "encoder.weights[0]",
+    "encoder.weights[1]",
+    "encoder.bias",
+    "decoder.weights[0]",
+    "decoder.weights[1]",
+    "decoder.bias[0]",
+    "decoder.bias[1]",
+]
+
+
+class TwoNumberAutoencoderValidationError(ValueError):
+    """Raised when an NN16 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise TwoNumberAutoencoderValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                TwoNumberAutoencoderValidationError(f"non-finite JSON number: {value}")
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise TwoNumberAutoencoderValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise TwoNumberAutoencoderValidationError(
+            "top-level JSON value must be an object"
+        )
+    return document
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TwoNumberAutoencoderValidationError(f"{context}: expected an object")
+    missing = keys - value.keys()
+    extra = value.keys() - keys
+    if missing or extra:
+        raise TwoNumberAutoencoderValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TwoNumberAutoencoderValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise TwoNumberAutoencoderValidationError(
+            f"{context}: expected a finite number"
+        )
+    return result
+
+
+def _vector(value: Any, length: int, context: str) -> list[float]:
+    if not isinstance(value, list) or len(value) != length:
+        raise TwoNumberAutoencoderValidationError(
+            f"{context}: expected {length} numbers"
+        )
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def _clean_zero(value: float) -> float:
+    return 0.0 if abs(value) < 1e-15 else value
+
+
+def _forward(
+    input_values: list[float],
+    encoder_weights: list[float],
+    encoder_bias: float,
+    decoder_weights: list[float],
+    decoder_bias: list[float],
+) -> dict[str, Any]:
+    encoder_products = [
+        _clean_zero(value * encoder_weights[index])
+        for index, value in enumerate(input_values)
+    ]
+    bottleneck = _clean_zero(sum(encoder_products) + encoder_bias)
+    decoder_products = [_clean_zero(bottleneck * weight) for weight in decoder_weights]
+    reconstruction = [
+        _clean_zero(product + decoder_bias[index])
+        for index, product in enumerate(decoder_products)
+    ]
+    errors = [
+        _clean_zero(value - input_values[index])
+        for index, value in enumerate(reconstruction)
+    ]
+    squared_errors = [value * value for value in errors]
+    return {
+        "encoder_products": encoder_products,
+        "bottleneck": bottleneck,
+        "decoder_products": decoder_products,
+        "reconstruction": reconstruction,
+        "errors": errors,
+        "squared_errors": squared_errors,
+        "loss": sum(squared_errors) / 2,
+    }
+
+
+def _unpack_parameters(
+    parameters: list[float],
+) -> tuple[list[float], float, list[float], list[float]]:
+    return parameters[:2], parameters[2], parameters[3:5], parameters[5:7]
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    input_values = _vector(document["input"], 2, "input")
+    encoder_weights = _vector(document["encoder"]["weights"], 2, "encoder.weights")
+    encoder_bias = _number(document["encoder"]["bias"], "encoder.bias")
+    decoder_weights = _vector(document["decoder"]["weights"], 2, "decoder.weights")
+    decoder_bias = _vector(document["decoder"]["bias"], 2, "decoder.bias")
+    learning_rate = _number(
+        document["optimizer"]["learning_rate"], "optimizer.learning_rate"
+    )
+    forward = _forward(
+        input_values,
+        encoder_weights,
+        encoder_bias,
+        decoder_weights,
+        decoder_bias,
+    )
+
+    reconstruction_gradients = forward["errors"][:]
+    decoder_weight_gradients = [
+        _clean_zero(gradient * forward["bottleneck"])
+        for gradient in reconstruction_gradients
+    ]
+    decoder_bias_gradients = reconstruction_gradients[:]
+    bottleneck_gradient_contributions = [
+        _clean_zero(gradient * decoder_weights[index])
+        for index, gradient in enumerate(reconstruction_gradients)
+    ]
+    bottleneck_gradient = _clean_zero(sum(bottleneck_gradient_contributions))
+    encoder_weight_gradients = [
+        _clean_zero(bottleneck_gradient * value) for value in input_values
+    ]
+    encoder_bias_gradient = bottleneck_gradient
+    backward = {
+        "reconstruction_gradients": reconstruction_gradients,
+        "decoder_weight_gradients": decoder_weight_gradients,
+        "decoder_bias_gradients": decoder_bias_gradients,
+        "bottleneck_gradient_contributions": bottleneck_gradient_contributions,
+        "bottleneck_gradient": bottleneck_gradient,
+        "encoder_weight_gradients": encoder_weight_gradients,
+        "encoder_bias_gradient": encoder_bias_gradient,
+    }
+
+    analytical = [
+        *encoder_weight_gradients,
+        encoder_bias_gradient,
+        *decoder_weight_gradients,
+        *decoder_bias_gradients,
+    ]
+    parameters = [
+        *encoder_weights,
+        encoder_bias,
+        *decoder_weights,
+        *decoder_bias,
+    ]
+    epsilon = 1e-6
+    numerical = []
+    for parameter_index in range(len(parameters)):
+        plus = parameters[:]
+        minus = parameters[:]
+        plus[parameter_index] += epsilon
+        minus[parameter_index] -= epsilon
+        plus_forward = _forward(input_values, *_unpack_parameters(plus))
+        minus_forward = _forward(input_values, *_unpack_parameters(minus))
+        numerical.append((plus_forward["loss"] - minus_forward["loss"]) / (2 * epsilon))
+    gradient_check = {
+        "epsilon": epsilon,
+        "parameter_order": PARAMETER_ORDER,
+        "analytical": analytical,
+        "numerical": numerical,
+        "max_absolute_error": max(
+            abs(analytical_value - numerical_value)
+            for analytical_value, numerical_value in zip(analytical, numerical)
+        ),
+    }
+
+    updated_encoder_weights = [
+        value - learning_rate * encoder_weight_gradients[index]
+        for index, value in enumerate(encoder_weights)
+    ]
+    updated_encoder_bias = encoder_bias - learning_rate * encoder_bias_gradient
+    updated_decoder_weights = [
+        value - learning_rate * decoder_weight_gradients[index]
+        for index, value in enumerate(decoder_weights)
+    ]
+    updated_decoder_bias = [
+        value - learning_rate * decoder_bias_gradients[index]
+        for index, value in enumerate(decoder_bias)
+    ]
+    updated_parameters = {
+        "encoder": {
+            "weights": updated_encoder_weights,
+            "bias": updated_encoder_bias,
+        },
+        "decoder": {
+            "weights": updated_decoder_weights,
+            "bias": updated_decoder_bias,
+        },
+    }
+    post_update = _forward(
+        input_values,
+        updated_encoder_weights,
+        updated_encoder_bias,
+        updated_decoder_weights,
+        updated_decoder_bias,
+    )
+    return {
+        "forward": forward,
+        "backward": backward,
+        "gradient_check": gradient_check,
+        "updated_parameters": updated_parameters,
+        "post_update": post_update,
+    }
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            raise TwoNumberAutoencoderValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(
+            float(expected), float(actual), rel_tol=0, abs_tol=tolerance
+        ):
+            raise TwoNumberAutoencoderValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            raise TwoNumberAutoencoderValidationError(f"{context}: length mismatch")
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _compare(expected_item, actual_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            raise TwoNumberAutoencoderValidationError(f"{context}: key mismatch")
+        for key in expected:
+            _compare(expected[key], actual[key], tolerance, f"{context}.{key}")
+        return
+    if expected != actual:
+        raise TwoNumberAutoencoderValidationError(
+            f"{context}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def validate_lab(document: dict[str, Any]) -> dict[str, Any]:
+    _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "input",
+            "encoder",
+            "decoder",
+            "optimizer",
+            "expected",
+        },
+        "lab",
+    )
+    if document["schema_version"] != 1:
+        raise TwoNumberAutoencoderValidationError("schema_version: expected 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(document[key], str) or not document[key]:
+            raise TwoNumberAutoencoderValidationError(f"{key}: expected text")
+    concepts = document["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(set(concepts)) != len(concepts)
+    ):
+        raise TwoNumberAutoencoderValidationError(
+            "concepts: expected unique non-empty strings"
+        )
+    tolerance = _number(document["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise TwoNumberAutoencoderValidationError(
+            "absolute_tolerance: expected a positive number"
+        )
+
+    operation = _object(
+        document["operation"],
+        {
+            "kind",
+            "input_width",
+            "bottleneck_width",
+            "output_width",
+            "encoder_activation",
+            "decoder_activation",
+            "loss",
+            "reduction",
+            "trainable_parameters",
+            "update",
+        },
+        "operation",
+    )
+    required_operation = {
+        "kind": "two-to-one-to-two-autoencoder-step",
+        "input_width": 2,
+        "bottleneck_width": 1,
+        "output_width": 2,
+        "encoder_activation": "identity",
+        "decoder_activation": "identity",
+        "loss": "mean-squared-reconstruction-error",
+        "reduction": "mean-over-output-coordinates",
+        "trainable_parameters": [
+            "encoder.weights",
+            "encoder.bias",
+            "decoder.weights",
+            "decoder.bias",
+        ],
+        "update": "sgd",
+    }
+    if operation != required_operation:
+        raise TwoNumberAutoencoderValidationError(
+            "operation: unsupported NN16 contract"
+        )
+
+    _vector(document["input"], 2, "input")
+    encoder = _object(document["encoder"], {"weights", "bias"}, "encoder")
+    _vector(encoder["weights"], 2, "encoder.weights")
+    _number(encoder["bias"], "encoder.bias")
+    decoder = _object(document["decoder"], {"weights", "bias"}, "decoder")
+    _vector(decoder["weights"], 2, "decoder.weights")
+    _vector(decoder["bias"], 2, "decoder.bias")
+    optimizer = _object(document["optimizer"], {"learning_rate"}, "optimizer")
+    if _number(optimizer["learning_rate"], "optimizer.learning_rate") <= 0:
+        raise TwoNumberAutoencoderValidationError(
+            "optimizer.learning_rate: expected a positive number"
+        )
+    _object(
+        document["expected"],
+        {
+            "forward",
+            "backward",
+            "gradient_check",
+            "updated_parameters",
+            "post_update",
+        },
+        "expected",
+    )
+    actual = execute_lab(document)
+    _compare(document["expected"], actual, tolerance, "expected")
+    if actual["gradient_check"]["max_absolute_error"] >= 1e-8:
+        raise TwoNumberAutoencoderValidationError(
+            "expected.gradient_check: analytical and numerical gradients disagree"
+        )
+    if actual["post_update"]["loss"] >= actual["forward"]["loss"]:
+        raise TwoNumberAutoencoderValidationError(
+            "expected.post_update.loss: canonical update must lower loss"
+        )
+    return actual
+
+
+def validate_fixture_root(root: Path) -> int:
+    labs = sorted((root / "labs").glob("*.json"))
+    if not labs:
+        raise TwoNumberAutoencoderValidationError(f"{root}: no lab documents found")
+    for path in labs:
+        validate_lab(load_json(path))
+        print(f"validated {path.relative_to(REPO_ROOT)}")
+    return len(labs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_fixture_root(args.root.resolve())
+    print(f"validated {count} NN16 two-number autoencoder lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/validate_variational_autoencoder_labs.py
+++ b/code/scripts/validate_variational_autoencoder_labs.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Validate and execute the deterministic NN17 scalar VAE corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "variational-autoencoder-v1"
+)
+PARAMETER_ORDER = [
+    "encoder.mean.weight",
+    "encoder.mean.bias",
+    "encoder.log_variance.weight",
+    "encoder.log_variance.bias",
+    "decoder.weight",
+    "decoder.bias",
+]
+
+
+class VariationalAutoencoderValidationError(ValueError):
+    """Raised when an NN17 document or deterministic result is invalid."""
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise VariationalAutoencoderValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                VariationalAutoencoderValidationError(
+                    f"non-finite JSON number: {value}"
+                )
+            ),
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        raise VariationalAutoencoderValidationError(f"{path}: {error}") from error
+    if not isinstance(document, dict):
+        raise VariationalAutoencoderValidationError(
+            "top-level JSON value must be an object"
+        )
+    return document
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise VariationalAutoencoderValidationError(f"{context}: expected an object")
+    missing = keys - value.keys()
+    extra = value.keys() - keys
+    if missing or extra:
+        raise VariationalAutoencoderValidationError(
+            f"{context}: key mismatch missing={sorted(missing)} extra={sorted(extra)}"
+        )
+    return value
+
+
+def _number(value: Any, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VariationalAutoencoderValidationError(f"{context}: expected a number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise VariationalAutoencoderValidationError(
+            f"{context}: expected a finite number"
+        )
+    return result
+
+
+def _affine(value: Any, context: str) -> dict[str, float]:
+    affine = _object(value, {"weight", "bias"}, context)
+    return {
+        "weight": _number(affine["weight"], f"{context}.weight"),
+        "bias": _number(affine["bias"], f"{context}.bias"),
+    }
+
+
+def _clean_zero(value: float) -> float:
+    return 0.0 if abs(value) < 1e-15 else value
+
+
+def _forward(
+    input_value: float,
+    parameters: dict[str, Any],
+    epsilon: float,
+    beta: float,
+) -> dict[str, float]:
+    mean_product = _clean_zero(input_value * parameters["encoder"]["mean"]["weight"])
+    mean = _clean_zero(mean_product + parameters["encoder"]["mean"]["bias"])
+    log_variance_product = _clean_zero(
+        input_value * parameters["encoder"]["log_variance"]["weight"]
+    )
+    log_variance = _clean_zero(
+        log_variance_product + parameters["encoder"]["log_variance"]["bias"]
+    )
+    try:
+        variance = math.exp(log_variance)
+        standard_deviation = math.exp(0.5 * log_variance)
+    except OverflowError as error:
+        raise VariationalAutoencoderValidationError(
+            "encoder.log_variance: exponential overflow"
+        ) from error
+    if not math.isfinite(variance) or not math.isfinite(standard_deviation):
+        raise VariationalAutoencoderValidationError(
+            "encoder.log_variance: non-finite exponential"
+        )
+    noise_contribution = _clean_zero(standard_deviation * epsilon)
+    latent = _clean_zero(mean + noise_contribution)
+    decoder_product = _clean_zero(latent * parameters["decoder"]["weight"])
+    reconstruction = _clean_zero(decoder_product + parameters["decoder"]["bias"])
+    error = _clean_zero(reconstruction - input_value)
+    reconstruction_loss = 0.5 * error * error
+    mean_squared = mean * mean
+    kl = 0.5 * (mean_squared + variance - 1 - log_variance)
+    weighted_kl = beta * kl
+    return {
+        "mean_product": mean_product,
+        "mean": mean,
+        "log_variance_product": log_variance_product,
+        "log_variance": log_variance,
+        "variance": variance,
+        "standard_deviation": standard_deviation,
+        "epsilon": epsilon,
+        "noise_contribution": noise_contribution,
+        "latent": latent,
+        "decoder_product": decoder_product,
+        "reconstruction": reconstruction,
+        "error": error,
+        "reconstruction_loss": reconstruction_loss,
+        "mean_squared": mean_squared,
+        "kl": kl,
+        "weighted_kl": weighted_kl,
+        "total_loss": reconstruction_loss + weighted_kl,
+    }
+
+
+def _flatten(parameters: dict[str, Any]) -> list[float]:
+    return [
+        parameters["encoder"]["mean"]["weight"],
+        parameters["encoder"]["mean"]["bias"],
+        parameters["encoder"]["log_variance"]["weight"],
+        parameters["encoder"]["log_variance"]["bias"],
+        parameters["decoder"]["weight"],
+        parameters["decoder"]["bias"],
+    ]
+
+
+def _from_flat(values: list[float]) -> dict[str, Any]:
+    return {
+        "encoder": {
+            "mean": {"weight": values[0], "bias": values[1]},
+            "log_variance": {"weight": values[2], "bias": values[3]},
+        },
+        "decoder": {"weight": values[4], "bias": values[5]},
+    }
+
+
+def execute_lab(document: dict[str, Any]) -> dict[str, Any]:
+    input_value = _number(document["input"], "input")
+    parameters = {
+        "encoder": {
+            "mean": _affine(document["encoder"]["mean"], "encoder.mean"),
+            "log_variance": _affine(
+                document["encoder"]["log_variance"],
+                "encoder.log_variance",
+            ),
+        },
+        "decoder": _affine(document["decoder"], "decoder"),
+    }
+    epsilon = _number(document["sample"]["epsilon"], "sample.epsilon")
+    beta = _number(document["objective"]["beta"], "objective.beta")
+    learning_rate = _number(
+        document["optimizer"]["learning_rate"],
+        "optimizer.learning_rate",
+    )
+    forward = _forward(input_value, parameters, epsilon, beta)
+
+    reconstruction_gradient = forward["error"]
+    decoder_weight_gradient = _clean_zero(reconstruction_gradient * forward["latent"])
+    decoder_bias_gradient = reconstruction_gradient
+    latent_gradient = _clean_zero(
+        reconstruction_gradient * parameters["decoder"]["weight"]
+    )
+    reconstruction_mean_gradient = latent_gradient
+    reconstruction_log_variance_gradient = _clean_zero(
+        latent_gradient * 0.5 * forward["standard_deviation"] * epsilon
+    )
+    kl_mean_gradient = forward["mean"]
+    kl_log_variance_gradient = _clean_zero(0.5 * (forward["variance"] - 1))
+    weighted_kl_mean_gradient = _clean_zero(beta * kl_mean_gradient)
+    weighted_kl_log_variance_gradient = _clean_zero(beta * kl_log_variance_gradient)
+    mean_gradient = _clean_zero(
+        reconstruction_mean_gradient + weighted_kl_mean_gradient
+    )
+    log_variance_gradient = _clean_zero(
+        reconstruction_log_variance_gradient + weighted_kl_log_variance_gradient
+    )
+    mean_weight_gradient = _clean_zero(mean_gradient * input_value)
+    mean_bias_gradient = mean_gradient
+    log_variance_weight_gradient = _clean_zero(log_variance_gradient * input_value)
+    log_variance_bias_gradient = log_variance_gradient
+    backward = {
+        "reconstruction_gradient": reconstruction_gradient,
+        "decoder_weight_gradient": decoder_weight_gradient,
+        "decoder_bias_gradient": decoder_bias_gradient,
+        "latent_gradient": latent_gradient,
+        "reconstruction_mean_gradient": reconstruction_mean_gradient,
+        "reconstruction_log_variance_gradient": (reconstruction_log_variance_gradient),
+        "kl_mean_gradient": kl_mean_gradient,
+        "kl_log_variance_gradient": kl_log_variance_gradient,
+        "weighted_kl_mean_gradient": weighted_kl_mean_gradient,
+        "weighted_kl_log_variance_gradient": weighted_kl_log_variance_gradient,
+        "mean_gradient": mean_gradient,
+        "log_variance_gradient": log_variance_gradient,
+        "mean_weight_gradient": mean_weight_gradient,
+        "mean_bias_gradient": mean_bias_gradient,
+        "log_variance_weight_gradient": log_variance_weight_gradient,
+        "log_variance_bias_gradient": log_variance_bias_gradient,
+    }
+
+    analytical = [
+        mean_weight_gradient,
+        mean_bias_gradient,
+        log_variance_weight_gradient,
+        log_variance_bias_gradient,
+        decoder_weight_gradient,
+        decoder_bias_gradient,
+    ]
+    flat_parameters = _flatten(parameters)
+    audit_epsilon = 1e-6
+    numerical = []
+    for parameter_index in range(len(flat_parameters)):
+        plus = flat_parameters[:]
+        minus = flat_parameters[:]
+        plus[parameter_index] += audit_epsilon
+        minus[parameter_index] -= audit_epsilon
+        plus_loss = _forward(
+            input_value,
+            _from_flat(plus),
+            epsilon,
+            beta,
+        )["total_loss"]
+        minus_loss = _forward(
+            input_value,
+            _from_flat(minus),
+            epsilon,
+            beta,
+        )["total_loss"]
+        numerical.append((plus_loss - minus_loss) / (2 * audit_epsilon))
+    gradient_check = {
+        "epsilon": audit_epsilon,
+        "parameter_order": PARAMETER_ORDER,
+        "analytical": analytical,
+        "numerical": numerical,
+        "max_absolute_error": max(
+            abs(analytical_value - numerical_value)
+            for analytical_value, numerical_value in zip(analytical, numerical)
+        ),
+    }
+
+    updated_parameters = _from_flat(
+        [
+            value - learning_rate * analytical[index]
+            for index, value in enumerate(flat_parameters)
+        ]
+    )
+    post_update = _forward(
+        input_value,
+        updated_parameters,
+        epsilon,
+        beta,
+    )
+    return {
+        "forward": forward,
+        "backward": backward,
+        "gradient_check": gradient_check,
+        "updated_parameters": updated_parameters,
+        "post_update": post_update,
+    }
+
+
+def _compare(expected: Any, actual: Any, tolerance: float, context: str) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected != actual:
+            raise VariationalAutoencoderValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        if not math.isclose(
+            float(expected),
+            float(actual),
+            rel_tol=0,
+            abs_tol=tolerance,
+        ):
+            raise VariationalAutoencoderValidationError(
+                f"{context}: expected {expected}, got {actual}"
+            )
+        return
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            raise VariationalAutoencoderValidationError(f"{context}: length mismatch")
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _compare(expected_item, actual_item, tolerance, f"{context}[{index}]")
+        return
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if expected.keys() != actual.keys():
+            raise VariationalAutoencoderValidationError(f"{context}: key mismatch")
+        for key in expected:
+            _compare(expected[key], actual[key], tolerance, f"{context}.{key}")
+        return
+    if expected != actual:
+        raise VariationalAutoencoderValidationError(
+            f"{context}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def validate_lab(document: dict[str, Any]) -> dict[str, Any]:
+    _object(
+        document,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "concepts",
+            "operation",
+            "input",
+            "encoder",
+            "decoder",
+            "sample",
+            "objective",
+            "optimizer",
+            "expected",
+        },
+        "lab",
+    )
+    if document["schema_version"] != 1:
+        raise VariationalAutoencoderValidationError("schema_version: expected 1")
+    for key in ("id", "title", "question"):
+        if not isinstance(document[key], str) or not document[key]:
+            raise VariationalAutoencoderValidationError(f"{key}: expected text")
+    concepts = document["concepts"]
+    if (
+        not isinstance(concepts, list)
+        or not concepts
+        or any(not isinstance(item, str) or not item for item in concepts)
+        or len(set(concepts)) != len(concepts)
+    ):
+        raise VariationalAutoencoderValidationError(
+            "concepts: expected unique non-empty strings"
+        )
+    tolerance = _number(document["absolute_tolerance"], "absolute_tolerance")
+    if tolerance <= 0:
+        raise VariationalAutoencoderValidationError(
+            "absolute_tolerance: expected a positive number"
+        )
+
+    operation = _object(
+        document["operation"],
+        {
+            "kind",
+            "input_width",
+            "latent_width",
+            "output_width",
+            "posterior",
+            "sampling",
+            "decoder_activation",
+            "reconstruction_loss",
+            "kl_prior",
+            "objective",
+            "trainable_parameters",
+            "update",
+        },
+        "operation",
+    )
+    required_operation = {
+        "kind": "scalar-variational-autoencoder-step",
+        "input_width": 1,
+        "latent_width": 1,
+        "output_width": 1,
+        "posterior": "diagonal-gaussian",
+        "sampling": "reparameterization-with-saved-epsilon",
+        "decoder_activation": "identity",
+        "reconstruction_loss": "half-squared-error",
+        "kl_prior": "standard-normal",
+        "objective": "beta-vae",
+        "trainable_parameters": [
+            "encoder.mean",
+            "encoder.log_variance",
+            "decoder",
+        ],
+        "update": "sgd",
+    }
+    if operation != required_operation:
+        raise VariationalAutoencoderValidationError(
+            "operation: unsupported NN17 contract"
+        )
+
+    _number(document["input"], "input")
+    encoder = _object(
+        document["encoder"],
+        {"mean", "log_variance"},
+        "encoder",
+    )
+    _affine(encoder["mean"], "encoder.mean")
+    _affine(encoder["log_variance"], "encoder.log_variance")
+    _affine(document["decoder"], "decoder")
+    sample = _object(document["sample"], {"epsilon"}, "sample")
+    _number(sample["epsilon"], "sample.epsilon")
+    objective = _object(document["objective"], {"beta"}, "objective")
+    if _number(objective["beta"], "objective.beta") < 0:
+        raise VariationalAutoencoderValidationError(
+            "objective.beta: expected a non-negative number"
+        )
+    optimizer = _object(
+        document["optimizer"],
+        {"learning_rate"},
+        "optimizer",
+    )
+    if _number(optimizer["learning_rate"], "optimizer.learning_rate") <= 0:
+        raise VariationalAutoencoderValidationError(
+            "optimizer.learning_rate: expected a positive number"
+        )
+    _object(
+        document["expected"],
+        {
+            "forward",
+            "backward",
+            "gradient_check",
+            "updated_parameters",
+            "post_update",
+        },
+        "expected",
+    )
+    actual = execute_lab(document)
+    _compare(document["expected"], actual, tolerance, "expected")
+    if actual["gradient_check"]["max_absolute_error"] >= 1e-8:
+        raise VariationalAutoencoderValidationError(
+            "expected.gradient_check: analytical and numerical gradients disagree"
+        )
+    if actual["post_update"]["total_loss"] >= actual["forward"]["total_loss"]:
+        raise VariationalAutoencoderValidationError(
+            "expected.post_update.total_loss: canonical update must lower loss"
+        )
+    return actual
+
+
+def validate_fixture_root(root: Path) -> int:
+    labs = sorted((root / "labs").glob("*.json"))
+    if not labs:
+        raise VariationalAutoencoderValidationError(f"{root}: no lab documents found")
+    for path in labs:
+        validate_lab(load_json(path))
+        print(f"validated {path.relative_to(REPO_ROOT)}")
+    return len(labs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=DEFAULT_FIXTURE_ROOT)
+    args = parser.parse_args()
+    count = validate_fixture_root(args.root.resolve())
+    print(f"validated {count} NN17 scalar variational autoencoder lab document(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/specs/NN04-optimization-learning-labs.md
+++ b/code/specs/NN04-optimization-learning-labs.md
@@ -1,0 +1,111 @@
+# NN04: Optimization Learning Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral optimization traces.
+
+## Purpose
+
+NN03 pins forward passes and a first full-batch training step. NN04 isolates the
+next layer of behavior learners need to inspect:
+
+- the loss at one parameter location;
+- analytical gradients;
+- central finite-difference gradients;
+- deterministic stochastic, mini-batch, and full-batch trajectories.
+
+The same fixture should drive a browser visualizer, a hand-worked lesson, a
+native implementation, or a consumer of the Rust execution core.
+
+## V1 Model
+
+V1 deliberately uses one scalar linear neuron:
+
+```text
+prediction = weight * x + bias
+```
+
+For `n` selected rows, mean squared error and its gradients are:
+
+```text
+loss       = sum((prediction - target)^2) / n
+dL/dweight = (2/n) * sum((prediction - target) * x)
+dL/dbias   = (2/n) * sum(prediction - target)
+```
+
+All arithmetic uses binary64 semantics. Implementations may use a wider
+intermediate representation but must compare their final results with the
+fixture tolerance.
+
+## Finite-Difference Check
+
+For parameter `p` and positive `epsilon`, V1 uses the central difference:
+
+```text
+numeric_gradient(p) = (loss(p + epsilon) - loss(p - epsilon)) / (2 * epsilon)
+```
+
+Only the selected parameter changes in each evaluation. The dataset, other
+parameter, and reduction remain fixed.
+
+The finite-difference result is an independent correctness oracle. It must not
+reuse the analytical-gradient implementation.
+
+## Deterministic Batch Order
+
+Dataset rows retain their JSON order and are indexed from zero. No shuffling is
+performed in V1.
+
+For update number `step`, beginning at zero:
+
+- `stochastic`: select `[step mod n]`;
+- `mini-batch`: select two consecutive rows beginning at
+  `[(step * 2) mod n]`, wrapping at the end;
+- `full-batch`: select every row in order.
+
+The gradient is averaged over the selected batch. After every update, the
+reported loss is evaluated over the full dataset.
+
+## Parameter Update
+
+Every strategy uses plain gradient descent:
+
+```text
+weight = weight - learning_rate * dL/dweight
+bias   = bias   - learning_rate * dL/dbias
+```
+
+The strategies differ only in which rows estimate the gradient.
+
+## Fixture Layout
+
+The V1 corpus lives in:
+
+```text
+code/specs/fixtures/optimization-learning-v1/
+  schema.json
+  labs/*.json
+```
+
+Each lab stores the dataset, initial parameters, finite-difference epsilon,
+analytical and numerical oracles, optimizer configuration, and final values for
+all three strategies.
+
+Validate the corpus with:
+
+```text
+python code/scripts/validate_optimization_learning_labs.py
+```
+
+## Conformance Levels
+
+- **Trace conformance:** reproduce the loss and both gradient calculations.
+- **Optimizer conformance:** reproduce all deterministic final parameters and
+  full-dataset losses.
+- **Inspectable conformance:** expose selected row indices and intermediate
+  errors to a learner.
+- **Accelerated conformance:** execute through a native or Rust-backed tensor
+  core while retaining the same numerical oracle.
+
+Later versions can add seeded shuffling, momentum, adaptive optimizers, tensor
+parameters, and mixed precision without changing V1 behavior.

--- a/code/specs/NN05-convolution-learning-labs.md
+++ b/code/specs/NN05-convolution-learning-labs.md
@@ -1,0 +1,87 @@
+# NN05: Convolution Learning Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral spatial traces.
+
+## Purpose
+
+NN03 exposes neuron arithmetic and NN04 exposes optimization. NN05 begins the
+spatial track with the smallest useful operation: slide one shared kernel over
+a one-dimensional signal and reveal every multiply-accumulate.
+
+The same fixture can drive a browser visualizer, a hand-worked lesson, a native
+implementation, or an adapter over the Rust DSP core.
+
+## V1 Operation
+
+V1 uses the convention called **convolution** by neural-network libraries but
+mathematically defined as cross-correlation:
+
+```text
+output[i] = sum(signal[i + j] * kernel[j] for j = 0..K-1)
+```
+
+The kernel is not reversed. V1 is deliberately limited to:
+
+- one one-dimensional signal;
+- one one-dimensional kernel;
+- stride one;
+- valid padding, so the kernel never extends beyond the signal;
+- no bias or activation;
+- binary64 arithmetic.
+
+For signal length `N` and kernel length `K`, V1 produces `N - K + 1` values.
+The kernel must be non-empty and no longer than the signal.
+
+## Trace Contract
+
+Every output position stores enough information to reproduce the computation:
+
+- `start_index`: the zero-based signal index beneath kernel element zero;
+- `window`: the `K` signal values under the kernel;
+- `products`: element-wise `window[j] * kernel[j]` values;
+- `accumulator`: the running sum, including the initial zero;
+- `output`: the final accumulator value.
+
+Thus `accumulator` always contains `K + 1` values and begins with zero. Its last
+value must equal both the position's `output` and the corresponding value in
+`expected.outputs`.
+
+## Why an Asymmetric Kernel
+
+The canonical fixture uses `[1, -1, 2]`. Reversing it changes the answer, so an
+implementation cannot accidentally substitute mathematical convolution for
+the neural-network convention and still pass.
+
+## Fixture Layout
+
+The V1 corpus lives in:
+
+```text
+code/specs/fixtures/convolution-learning-v1/
+  schema.json
+  labs/*.json
+```
+
+Validate and execute it with:
+
+```text
+python code/scripts/validate_convolution_learning_labs.py
+```
+
+## Conformance Levels
+
+- **Output conformance:** reproduce every final output within tolerance.
+- **Trace conformance:** reproduce every window, product, and accumulator.
+- **Inspectable conformance:** let a learner select a position and see how the
+  shared kernel produced it.
+- **Accelerated conformance:** execute through a native or Rust-backed core
+  while preserving the same trace oracle.
+
+The existing Rust `dsp-conv` package implements same-size mathematical
+convolution. A conforming NN05 adapter can reverse the neural kernel before the
+call and select the valid interior, or implement the V1 cross-correlation loop
+directly. Either path must be checked against this corpus. Later NN05 versions
+can add bias, padding, stride, channels, trainable kernels, and gradients
+without changing V1 behavior.

--- a/code/specs/NN06-convolution-training-labs.md
+++ b/code/specs/NN06-convolution-training-labs.md
@@ -1,0 +1,110 @@
+# NN06: Convolution Training Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral 1D convolution
+gradient traces.
+
+## Purpose
+
+NN05 shows how one shared kernel produces a feature map. NN06 makes that
+kernel trainable and exposes the key consequence of weight sharing: every
+output position can contribute to the gradient of every kernel weight.
+
+The V1 fixture pins one forward pass, one analytical backward pass, an
+independent finite-difference check, and one gradient-descent update.
+
+## V1 Operation
+
+V1 retains the NN05 forward convention:
+
+```text
+output[i] = sum(signal[i + j] * kernel[j] for j = 0..K-1)
+```
+
+The kernel is not reversed. Padding is valid, stride is one, and there is one
+signal, one kernel, no bias, and no activation.
+
+For `M = N - K + 1` outputs and targets, V1 uses mean squared error:
+
+```text
+error[i]          = output[i] - target[i]
+loss              = sum(error[i]^2) / M
+dLoss/dOutput[i]  = 2 * error[i] / M
+```
+
+## Shared-Kernel Gradient
+
+Kernel weight `j` appears once in every output window. Its gradient is the sum
+of all those paths:
+
+```text
+contribution[i][j] = dLoss/dOutput[i] * signal[i + j]
+dLoss/dKernel[j]   = sum(contribution[i][j] for i = 0..M-1)
+```
+
+The trace stores every per-output contribution before the reduction. This is
+the central learning goal of NN06: shared parameters accumulate gradients.
+
+## Independent Gradient Check
+
+For each kernel weight `k[j]`, V1 uses a central finite difference while all
+other values remain fixed:
+
+```text
+numeric[j] = (loss(k[j] + epsilon) - loss(k[j] - epsilon)) / (2 * epsilon)
+```
+
+The numerical implementation must not call or reuse the analytical backward
+pass.
+
+## Update
+
+One plain gradient-descent step updates every kernel weight simultaneously:
+
+```text
+next_kernel[j] = kernel[j] - learning_rate * dLoss/dKernel[j]
+```
+
+The expected next outputs and loss are evaluated after the complete kernel has
+been updated.
+
+## Fixture Layout
+
+The V1 corpus lives in:
+
+```text
+code/specs/fixtures/convolution-training-v1/
+  schema.json
+  labs/*.json
+```
+
+Validate and execute it with:
+
+```text
+python code/scripts/validate_convolution_training_labs.py
+```
+
+## Conformance Levels
+
+- **Forward conformance:** reproduce outputs, errors, and loss.
+- **Backward conformance:** reproduce every contribution and reduced kernel
+  gradient.
+- **Gradient-check conformance:** independently match the numerical gradient.
+- **Update conformance:** reproduce the next kernel, outputs, and loss.
+- **Inspectable conformance:** let a learner follow one output's path into each
+  shared weight, then see the cross-position reduction.
+
+## Native and Rust Direction
+
+The existing Rust `dsp-conv` package can accelerate the adapted forward pass,
+but it does not currently define neural-network gradients. A small Rust NN
+kernel should expose valid cross-correlation forward and backward operations
+over caller-owned contiguous buffers. Thin language bindings can pass signal,
+kernel, and output-gradient pointers through a stable C ABI, while native
+implementations use the same JSON fixture as their oracle.
+
+The backward kernel is deliberately just the formula above. A future tensor
+runtime may lower it to matrix or convolution primitives, but the simple loop
+must remain available as the reference path and finite-difference checks must
+continue to validate accelerated implementations.

--- a/code/specs/NN07-tiny-image-cnn-labs.md
+++ b/code/specs/NN07-tiny-image-cnn-labs.md
@@ -1,0 +1,125 @@
+# NN07: Tiny Image CNN Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral image convolution,
+channel reduction, normalization, activation, and pooling traces.
+
+## Purpose
+
+NN05 and NN06 introduce one-dimensional shared kernels. NN07 turns the signal
+into a tiny image and makes the dimensions that are usually hidden inside a
+tensor library explicit:
+
+1. each output filter owns one kernel for every input channel;
+2. each channel produces a partial sum at the same spatial position;
+3. the partial sums and one bias become a feature-map value;
+4. each output channel is normalized over its spatial positions;
+5. ReLU removes negative normalized values; and
+6. max pooling keeps the strongest value and its location.
+
+The fixture is deliberately small enough to calculate on paper: two `3 x 3`
+input channels, two `2 x 2` filters, two `2 x 2` output maps, and one pooled
+value per output channel.
+
+## V1 Forward Pipeline
+
+V1 uses cross-correlation, so kernels are not reversed. For output filter `f`
+at row `r`, column `c`:
+
+```text
+channel_sum[f, d, r, c] =
+  sum(input[d, r + kr, c + kc] * kernel[f, d, kr, kc])
+
+convolution[f, r, c] = bias[f] + sum(channel_sum[f, d, r, c] for d)
+```
+
+Padding is valid and both spatial strides are one.
+
+## Spatial Per-Channel Normalization
+
+V1 normalizes the four values in each output channel independently. Population
+variance is used, followed by an affine scale and shift:
+
+```text
+mean[f]     = sum(convolution[f]) / spatial_count
+variance[f] = sum((value - mean[f])^2) / spatial_count
+denom[f]    = sqrt(variance[f] + epsilon)
+
+normalized[f, r, c] =
+  gamma[f] * (convolution[f, r, c] - mean[f]) / denom[f] + beta[f]
+```
+
+This is an intentionally small normalization primitive, not a claim that all
+frameworks use the same axes. Batch normalization, instance normalization, and
+layer normalization differ mainly in which values share the statistics.
+
+The teaching fixture uses `variance = 5` and `epsilon = 4`, giving a denominator
+of exactly `3`. The unusually large epsilon is pedagogical: it keeps every
+normalization result hand-calculable while still pinning the stabilizing term.
+Stored floating-point results use the fixture's `absolute_tolerance` for
+comparison.
+
+## Activation and Pooling
+
+ReLU is elementwise:
+
+```text
+activated = max(0, normalized)
+```
+
+V1 then applies non-overlapping `2 x 2` max pooling. The expected fixture stores
+both each pooled value and its zero-based `[row, column]` winner. Ties are broken
+by the first value in row-major order.
+
+## Fixture Layout
+
+The V1 corpus lives in:
+
+```text
+code/specs/fixtures/tiny-image-cnn-v1/
+  schema.json
+  labs/*.json
+```
+
+Validate and execute it with:
+
+```text
+python code/scripts/validate_tiny_image_cnn_labs.py
+```
+
+## Conformance Levels
+
+- **Channel conformance:** reproduce each input channel's partial contribution.
+- **Convolution conformance:** reduce channels, add bias, and reproduce both
+  feature maps.
+- **Normalization conformance:** reproduce means, population variances,
+  denominators, and normalized maps.
+- **Activation conformance:** reproduce the ReLU maps.
+- **Pooling conformance:** reproduce max values and row-major winner positions.
+- **Inspectable conformance:** expose the window, products, channel sums, bias,
+  normalization arithmetic, and pool winner for a selected output.
+
+## Native and Rust Direction
+
+The existing Rust `dsp-conv::conv2d` primitive already handles row-major 2D
+images, but it performs centered, same-size mathematical convolution one
+channel at a time. NN07 instead pins valid, unflipped cross-correlation followed
+by a reduction across input channels and a bias. A tensor-facing adapter can
+flip and crop around `dsp-conv` for an initial parity experiment, but the
+long-term Rust NN core should expose this convention directly with explicit
+NCHW or NHWC layout, normalization, ReLU, and pooling over caller-owned
+contiguous buffers.
+
+The Rust `feature-normalization` package demonstrates deterministic population
+mean and variance over table columns. Its reductions are useful reference code,
+but its grouping axes and zero-variance behavior are not yet NN07's per-output-
+channel affine normalization. The first stable C ABI should take dimensions,
+strides, scalar parameters, and pointers explicitly rather than exposing Rust
+containers.
+
+Every native implementation and binding should consume this JSON fixture before
+an accelerated path is considered conformant. Later lowering work can fuse the
+pipeline, but a reference mode must retain intermediate channel contributions,
+normalization statistics, and pool indices so learners and debuggers can still
+open the fused operation.

--- a/code/specs/NN08-residual-receptive-labs.md
+++ b/code/specs/NN08-residual-receptive-labs.md
@@ -1,0 +1,120 @@
+# NN08: Residual Paths and Receptive Fields
+
+## Status
+
+Draft specification for deterministic, language-neutral residual-block and
+receptive-field traces.
+
+## Purpose
+
+NN08 explains two ideas that make deep spatial networks easier to reason about:
+
+- stacked convolutions let one output depend on a wider input region; and
+- an identity skip gives that output a direct path to its matching input.
+
+The V1 fixture uses five scalar positions, two same-padded three-tap layers,
+an identity skip, and ReLU. All weights are one. The center main-path value is
+`8`; the skip contributes input value `2`; the residual output is `10`.
+
+## V1 Same-Padded Correlation
+
+For an input with `N` values and the three-tap kernel `[1, 1, 1]`:
+
+```text
+correlate(input)[i] = input[i - 1] + input[i] + input[i + 1]
+```
+
+Out-of-range values are zero. The kernel is not reversed. V1 applies this
+operation twice:
+
+```text
+hidden = correlate(input)
+main   = correlate(hidden)
+```
+
+Because the fixture kernel is symmetric, mathematical convolution and
+cross-correlation produce the same numbers. The convention still remains
+explicit so later asymmetric fixtures cannot silently flip weights.
+
+## Residual Addition
+
+The identity skip preserves shape and adds the original input position by
+position before ReLU:
+
+```text
+preactivation[i] = main[i] + input[i]
+output[i]        = max(0, preactivation[i])
+```
+
+V1 stores the main output, skip contribution, residual sum, and activated
+output for every position. This makes it possible to disable the skip in a
+visualizer without changing the main path.
+
+## Receptive-Field Trace
+
+For one selected output, V1 stores:
+
+- the hidden positions read by layer two;
+- the input positions read by each of those hidden positions;
+- how many computational paths connect each input to the output;
+- each input value multiplied by its path count; and
+- the union of in-range input indices in the receptive field.
+
+For center output `2`, the three hidden positions expand as:
+
+```text
+hidden[1] <- input[0, 1, 2]
+hidden[2] <- input[1, 2, 3]
+hidden[3] <- input[2, 3, 4]
+```
+
+The input path counts are `[1, 2, 3, 2, 1]`. Multiplying by input
+`[1, 0, 2, 0, 1]` gives `[1, 0, 6, 0, 1]`, which sums to main output `8`.
+The structural receptive field is five positions wide even though zero-valued
+inputs make some numerical contributions zero.
+
+At boundaries, same padding preserves output length but the in-range receptive
+field is clipped. The first and last outputs each reach three actual input
+positions; the center reaches all five.
+
+## Fixture Layout
+
+The V1 corpus lives in:
+
+```text
+code/specs/fixtures/residual-receptive-v1/
+  schema.json
+  labs/*.json
+```
+
+Validate and execute it with:
+
+```text
+python code/scripts/validate_residual_receptive_labs.py
+```
+
+## Conformance Levels
+
+- **Main-path conformance:** reproduce both same-padded convolution layers.
+- **Residual conformance:** reproduce skip contributions, sums, and ReLU.
+- **Path conformance:** reproduce hidden paths, path counts, and numerical input
+  contributions for every output.
+- **Receptive-field conformance:** reproduce the in-range index union at the
+  center and boundaries.
+- **Inspectable conformance:** let a learner select an output, toggle the skip,
+  and follow both the short identity route and every main-path dependency.
+
+## Native and Rust Direction
+
+The existing Rust `dsp-conv::conv1d` primitive with `BoundaryMode::Zero`
+directly reproduces each V1 main-path layer because the kernel is symmetric and
+the primitive is centered and same-size. A Rust consumer can run it twice,
+then use a small vector loop for identity addition and ReLU. The NN08 fixture
+should be the parity oracle for that adapter.
+
+A future neural Rust core should expose same-padded correlation without relying
+on symmetry, residual addition, activation, and an optional inspectable trace
+over caller-owned contiguous buffers. A stable C ABI should pass pointers,
+lengths, kernel sizes, padding modes, and output buffers explicitly. Accelerated
+or fused residual blocks remain conformant only if a reference/debug mode can
+recover the main path, skip path, and receptive-field metadata pinned here.

--- a/code/specs/NN09-recurrent-unroll-labs.md
+++ b/code/specs/NN09-recurrent-unroll-labs.md
@@ -1,0 +1,105 @@
+# NN09: Recurrent Unroll Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral scalar recurrent
+forward traces.
+
+## Purpose
+
+NN09 introduces sequence networks with one hidden-state value and three time
+steps. It separates three ideas that are easy to blur together:
+
+- the input changes at every step;
+- the previous hidden state becomes an input to the next step; and
+- the same parameters are reused at every step.
+
+The V1 fixture uses ReLU so every value can be calculated by hand without a
+scientific calculator.
+
+## V1 Recurrence
+
+For time step `t`:
+
+```text
+input_product[t]     = input_weight * input[t]
+recurrent_product[t] = recurrent_weight * state[t - 1]
+preactivation[t]     = input_product[t] + recurrent_product[t] + bias
+state[t]             = max(0, preactivation[t])
+```
+
+`state[-1]` is the explicit initial state. V1 uses:
+
+```text
+input               = [1, 2, 0]
+state[-1]           = 0
+input_weight        = 2
+recurrent_weight    = 0.5
+bias                = -1
+```
+
+The three resulting states are `[1, 3.5, 0.75]`. The final input is zero, but
+the final state remains positive because the preceding `3.5` travels through
+the recurrent connection.
+
+## Unrolling and Sharing
+
+An implementation may execute one cell three times in a loop or build a
+three-cell acyclic graph. The trace must make both views equivalent:
+
+```text
+state[-1] -> cell 0 -> state[0] -> cell 1 -> state[1] -> cell 2 -> state[2]
+                x[0] ^                x[1] ^                x[2] ^
+```
+
+The three drawn cells are not three independently parameterized layers. Their
+`input_weight`, `recurrent_weight`, and `bias` values refer to one shared
+parameter set.
+
+## Memory Ablation
+
+V1 also pins a counterfactual run in which the recurrent contribution is zero
+at every step while every other value stays fixed. Its states are `[1, 3, 0]`.
+The state differences `[0, 0.5, 0.75]` isolate what the recurrent path adds.
+This ablation is a teaching comparison, not a second model family.
+
+## Fixture Layout
+
+The V1 corpus lives in:
+
+```text
+code/specs/fixtures/recurrent-unroll-v1/
+  schema.json
+  labs/*.json
+```
+
+Validate and execute it with:
+
+```text
+python code/scripts/validate_recurrent_unroll_labs.py
+```
+
+## Conformance Levels
+
+- **Step conformance:** reproduce both products, preactivation, and activated
+  state for every time step.
+- **State-chain conformance:** feed each resulting state into the next step and
+  reproduce the final state.
+- **Sharing conformance:** use the same three parameter values at all steps.
+- **Ablation conformance:** reproduce the no-recurrence states and differences.
+- **Inspectable conformance:** let a learner select one step and distinguish
+  its new input, carried state, shared parameters, and activation.
+
+## Native and Rust Direction
+
+The existing Rust `neural-network` and `neural-graph-vm` packages model and run
+acyclic neural graphs. A V1 consumer can either execute this scalar recurrence
+with a small Rust loop or statically unroll three cells into a DAG. Static
+unrolling must preserve parameter identity even if three graph edges carry the
+same numeric value.
+
+A future Rust sequence core should accept caller-owned input and state buffers,
+explicit sequence and state sizes, parameter buffers, activation choice, and an
+optional trace output. Its C ABI must make initial-state ownership and final-
+state writeback explicit. Batched or fused kernels remain conformant only when
+a reference/debug path can recover the per-step values pinned by NN09.

--- a/code/specs/NN10-recurrent-bptt-labs.md
+++ b/code/specs/NN10-recurrent-bptt-labs.md
@@ -1,0 +1,113 @@
+# NN10: Recurrent Backpropagation Through Time Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral scalar BPTT traces.
+
+## Purpose
+
+NN10 reverses NN09's three-step recurrent chain. It shows how a final-state
+loss travels backward through time and how one shared parameter receives a
+separate gradient contribution from each execution of the recurrent cell.
+
+## Forward Contract
+
+V1 reuses NN09's scalar ReLU recurrence:
+
+```text
+a[t] = W_x * x[t] + W_h * h[t - 1] + b
+h[t] = ReLU(a[t])
+```
+
+with `x = [1, 2, 0]`, `h[-1] = 0`, `W_x = 2`, `W_h = 0.5`, and `b = -1`.
+The states are `[1, 3.5, 0.75]`.
+
+V1 measures only the final state against target `0`:
+
+```text
+loss = 0.5 * (h[2] - target)^2 = 0.28125
+```
+
+## Backward Contract
+
+Walk from time `2` to time `0`. At each step:
+
+```text
+dL/dh[t] = direct_loss_gradient[t] + future_state_gradient[t]
+dL/da[t] = dL/dh[t] * ReLU'(a[t])
+
+local dW_x[t] = dL/da[t] * x[t]
+local dW_h[t] = dL/da[t] * h[t - 1]
+local db[t]    = dL/da[t]
+
+future_state_gradient[t - 1] = dL/da[t] * W_h
+```
+
+All V1 preactivations are positive, so every ReLU derivative is one. The state
+gradients are `0.75`, `0.375`, and `0.1875` in backward execution order.
+
+## Shared-Parameter Reduction
+
+The time-local contributions must be added because all three executions refer
+to one parameter set:
+
+```text
+dW_x = 0 + 0.75 + 0.1875 = 0.9375
+dW_h = 2.625 + 0.375 + 0 = 3
+db   = 0.75 + 0.375 + 0.1875 = 1.3125
+```
+
+Overwriting the shared gradient at each time step is non-conformant.
+
+## Independent Gradient Check and Update
+
+V1 checks all three analytical totals with central finite differences using
+epsilon `1e-6`. The maximum absolute difference is below `1e-9`.
+
+One gradient-descent update with learning rate `0.1` produces:
+
+```text
+W_x = 1.90625
+W_h = 0.2
+b   = -1.13125
+```
+
+The updated states are `[0.775, 2.83625, 0]`, so the final loss is `0`.
+
+## Fixture Layout
+
+```text
+code/specs/fixtures/recurrent-bptt-v1/
+  schema.json
+  labs/*.json
+```
+
+Validate it with:
+
+```text
+python code/scripts/validate_recurrent_bptt_labs.py
+```
+
+## Conformance Levels
+
+- **Forward conformance:** reproduce all preactivations, states, prediction,
+  and loss.
+- **Backward conformance:** reproduce every backward-time chain-rule value.
+- **Accumulation conformance:** reproduce every time-local parameter
+  contribution and its shared total.
+- **Audit conformance:** match central finite differences within tolerance.
+- **Update conformance:** reproduce the proposed parameters, states, and loss.
+- **Inspectable conformance:** let a learner select one backward step and trace
+  its incoming gradient, local contributions, and gradient to the prior state.
+
+## Native and Rust Direction
+
+A Rust reference can statically unroll V1 or run a reverse loop over saved
+forward values. A future sequence core needs explicit saved-state or
+recomputation policy, caller-owned gradient buffers, accumulation semantics,
+and a way to distinguish zeroing a gradient buffer from adding into it.
+
+The stable C ABI should take forward inputs/states, upstream gradients,
+parameter buffers, and output gradient buffers with documented shapes and
+ownership. Fused BPTT kernels remain conformant only when a debug path can
+recover the time-local contributions and reduction pinned by NN10.

--- a/code/specs/NN11-gated-recurrent-labs.md
+++ b/code/specs/NN11-gated-recurrent-labs.md
@@ -1,0 +1,110 @@
+# NN11: GRU and LSTM Gate Comparison Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral scalar gated-cell
+traces.
+
+## Purpose
+
+NN11 compares the two most common gated recurrent cells with one shared scalar
+example. The fixture exposes every gate activation, candidate calculation,
+memory contribution, and output so a learner can see what GRUs combine and
+what LSTMs keep separate.
+
+## Shared Input Contract
+
+V1 receives:
+
+```text
+x = 1
+h_previous = 0.8
+c_previous = 0.8
+```
+
+`c_previous` is used only by the LSTM. Gate preactivations are included so
+consumers must reproduce the sigmoid or tanh activation rather than treating
+gate values as unexplained constants.
+
+## Scalar GRU Contract
+
+V1 uses the update-gate convention in which `z` selects the new candidate:
+
+```text
+r = sigmoid(a_reset)
+z = sigmoid(a_update)
+n = tanh(input_product + recurrent_weight * (r * h_previous) + bias)
+h = (1 - z) * h_previous + z * n
+```
+
+The canonical gate values are `r = 0.5`, `z = 0.25`, and `n = 0.6`. The
+previous-state contribution is `0.6`, the candidate write is `0.15`, and the
+next hidden state is `0.75`.
+
+Some libraries define `z` as the amount of old state to retain. A conforming
+NN11 consumer must use the explicit V1 equation above and document any adapter
+needed for a library with the opposite naming convention.
+
+## Scalar LSTM Contract
+
+V1 uses:
+
+```text
+f = sigmoid(a_forget)
+i = sigmoid(a_input)
+o = sigmoid(a_output)
+g = tanh(a_candidate)
+c = f * c_previous + i * g
+h = o * tanh(c)
+```
+
+The canonical values are `f = 0.5`, `i = 0.25`, `o = 0.75`, and `g = 0.6`.
+The next cell state is `0.55`; `tanh(c)` is `0.5005202111902353`; and the next
+hidden state is `0.3753901583926764`.
+
+## Counterfactual Contract
+
+The fixture changes one gate at a time without changing the other inputs:
+
+- GRU update `0` preserves the old hidden state; update `1` selects the
+  candidate.
+- GRU reset `0` removes the old hidden state from candidate construction.
+- LSTM forget `0` removes the old cell-state contribution.
+- LSTM input `0` prevents the candidate write.
+- LSTM output `0` hides the cell without erasing it; output `1` reveals the
+  complete squashed cell.
+
+These are controlled counterfactuals, not trained trajectories.
+
+## Fixture Layout
+
+The V1 corpus lives at:
+
+```text
+code/specs/fixtures/gated-recurrent-v1/
+  schema.json
+  labs/00-gru-lstm-gates.json
+```
+
+All numbers are JSON numbers. Consumers compare derived values with
+`absolute_tolerance` and reject duplicate keys, non-finite values, unknown
+fields, unsupported operations, and missing counterfactuals.
+
+## Conformance Levels
+
+1. **Gate:** reproduce sigmoid/tanh gate values from preactivations.
+2. **Cell:** reproduce the complete canonical GRU and LSTM traces.
+3. **Counterfactual:** reproduce every one-gate intervention.
+4. **Trace:** expose the same named intermediates to a learner or debugger.
+
+## Cross-Language and Rust-Core Direction
+
+V1 needs only scalar arithmetic, so every language should implement it
+directly first. A Rust sequence core can later batch these equations over
+vectors while preserving a trace mode containing gate preactivations,
+activations, state contributions, cell state, and hidden state.
+
+A future C ABI should use explicit input/output buffers and caller-owned state.
+GRU hidden state and the LSTM `(hidden, cell)` pair must have different typed
+descriptors; packing the LSTM cell into invisible runtime state would break
+chunked inference and cross-language reproducibility.

--- a/code/specs/NN12-attention-qkv-labs.md
+++ b/code/specs/NN12-attention-qkv-labs.md
@@ -1,0 +1,91 @@
+# NN12: Three-Token Query, Key, and Value Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral Q/K/V projection and
+dot-product traces.
+
+## Purpose
+
+NN12 opens the first arithmetic stage of self-attention. Three two-dimensional
+token embeddings are projected into queries, keys, and values. Every query is
+then dotted with every key. Softmax, masking, and value mixing are deliberately
+reserved for later specifications.
+
+## Input and Projection Contract
+
+V1 uses row vectors and right-multiplies each embedding by a `2 x 2` matrix:
+
+```text
+Q = X W_q
+K = X W_k
+V = X W_v
+```
+
+The tokens are `red = [1, 0]`, `blue = [0, 1]`, and
+`purple = [1, 1]`. The matrices are:
+
+```text
+W_q = [[ 1, 0], [ 0, 1]]
+W_k = [[ 1, 1], [-1, 1]]
+W_v = [[ 2, 0], [ 0, 1]]
+```
+
+## Dot-Product Contract
+
+For every query row `i` and key row `j`:
+
+```text
+raw_score[i, j] = Q[i] dot K[j]
+scaled_score[i, j] = raw_score[i, j] / sqrt(key_dimension)
+```
+
+The key dimension is `2`. Scaling is included because it is the input to the
+next attention stage, but NN12 does not normalize scores into probabilities.
+
+The raw score matrix is:
+
+```text
+[[ 1, -1, 0],
+ [ 1,  1, 2],
+ [ 2,  0, 2]]
+```
+
+Each of its nine cells includes the two element-wise products that were summed.
+
+## Value Boundary
+
+Values are payload vectors. They do not participate in query-key score
+calculation. NN12 projects and displays `V`, then stops. A later specification
+will apply normalized attention weights to these rows.
+
+## Fixture Layout
+
+```text
+code/specs/fixtures/attention-qkv-v1/
+  schema.json
+  labs/00-three-token-qkv.json
+```
+
+Consumers reject duplicate keys, non-finite numbers, unknown fields, incorrect
+matrix shapes, unsupported operations, and trace values outside
+`absolute_tolerance`.
+
+## Conformance Levels
+
+1. **Projection:** reproduce all Q, K, and V rows.
+2. **Dot product:** reproduce all nine product pairs and raw scores.
+3. **Scaling:** reproduce the `1 / sqrt(2)` score matrix.
+4. **Trace:** expose the selected query, key, product pair, raw score, scaled
+   score, and unused value payload to a learner or debugger.
+
+## Cross-Language and Rust-Core Direction
+
+Every language should implement V1 with explicit loops first. A Rust core can
+later lower `XW` and `QK^T` to the repository's matrix backend, while trace mode
+retains row identities and per-coordinate products.
+
+A future C ABI should describe row-major shapes, strides, element type, and
+caller-owned Q/K/V and score buffers. Projection matrices must remain separate
+logical parameters even if a fast implementation packs them into one fused
+allocation.

--- a/code/specs/NN13-attention-softmax-labs.md
+++ b/code/specs/NN13-attention-softmax-labs.md
@@ -1,0 +1,96 @@
+# NN13: Attention Softmax and Causal-Mask Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral stable-softmax,
+causal-mask, and weighted-value traces.
+
+## Purpose
+
+NN13 continues the three-token NN12 example. It turns each row of scaled
+query-key scores into weights and uses those weights to mix value vectors. A
+causal version prevents a token from reading keys to its right.
+
+## Input Contract
+
+V1 takes three token identifiers, a `3 x 3` scaled score matrix, and three
+two-number value rows. The checked-in lab reuses NN12's values and scores, but
+the fixture is standalone so consumers do not need to load another document.
+
+## Stable Softmax Contract
+
+For each query row, first remove disallowed key positions. Never encode their
+conceptual negative infinity as a JSON non-finite number; trace them as `null`.
+Then compute:
+
+```text
+row_max = max(allowed scores)
+shifted[j] = score[j] - row_max
+exponential[j] = exp(shifted[j])
+denominator = sum(exponential)
+weight[j] = exponential[j] / denominator
+```
+
+Masked positions have `null` shifted scores, zero exponentials, and zero
+weights. Subtracting the row maximum is numerically important even though it
+does not change the normalized result.
+
+## Causal-Mask Contract
+
+Tokens are ordered left to right. Query row `i` may read key column `j` only
+when:
+
+```text
+j <= i
+```
+
+The first token can read only itself. The second can read the first two. The
+third can read all three. An unmasked trace is also included as a controlled
+comparison.
+
+## Value-Mixing Contract
+
+Every output context row is the weighted sum of value rows:
+
+```text
+contribution[j] = weight[j] * value[j]
+context = sum(contribution rows)
+```
+
+For the causal blue query, the future purple key is blocked. The two remaining
+scores are equal, so the weights are `[0.5, 0.5, 0]` and the context is
+`[1, 0.5]`.
+
+## Fixture Layout
+
+```text
+code/specs/fixtures/attention-softmax-v1/
+  schema.json
+  labs/00-three-token-causal-softmax.json
+```
+
+Consumers reject duplicate keys, non-finite numbers, unknown fields, incorrect
+shapes, unsupported operations, and trace values outside
+`absolute_tolerance`.
+
+## Conformance Levels
+
+1. **Mask:** reproduce every allowed position and `null` masked score.
+2. **Softmax:** reproduce row maxima, shifts, exponentials, denominators, and
+   weights for masked and unmasked modes.
+3. **Mix:** reproduce every weighted value contribution and output context.
+4. **Trace:** retain token identities so a learner can connect a weight to its
+   query row, key column, and value payload.
+
+## Cross-Language and Rust-Core Direction
+
+Every language should implement the three-row scalar loop first. A Rust core
+can later expose stable masked-softmax and weighted-reduction kernels without
+changing the fixture semantics.
+
+A future C ABI should pass explicit row/column sizes, strides, a mask buffer,
+score and value buffers, and caller-owned weight/context outputs. Trace mode
+should optionally return row maxima and normalization denominators. An
+implementation may fuse softmax and value reduction internally, but it must
+still offer reproducible weights and trace intermediates for teaching and
+cross-language parity.

--- a/code/specs/NN14-multi-head-add-norm-labs.md
+++ b/code/specs/NN14-multi-head-add-norm-labs.md
@@ -1,0 +1,119 @@
+# NN14: Multi-Head Attention, Residual, and Layer-Norm Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral multi-head causal
+attention, output projection, residual addition, and layer-normalization traces.
+
+## Purpose
+
+NN14 continues the three-token attention sequence without hiding the block
+around attention. Two one-dimensional heads inspect different coordinates,
+their contexts are concatenated, an output projection restores the model
+width, the original token rejoins through a residual path, and layer
+normalization produces the block output.
+
+## Input Contract
+
+V1 takes three two-coordinate token embeddings, exactly two attention heads,
+a `2 x 2` output projection, and layer-normalization parameters. Each head has
+two-coordinate query, key, and value projection vectors. The projected query,
+key, and value for one head are scalars, so its scale divisor is
+`sqrt(head_width) = 1`.
+
+The checked-in lab deliberately uses simple projections:
+
+- the `horizontal` head reads the first embedding coordinate;
+- the `vertical` head reads the second embedding coordinate.
+
+Different heads therefore produce different causal weight rows for the same
+token.
+
+## Multi-Head Contract
+
+For head `h` and token row `i`:
+
+```text
+q_h[i] = dot(x[i], Wq_h)
+k_h[j] = dot(x[j], Wk_h)
+v_h[j] = dot(x[j], Wv_h)
+score_h[i,j] = q_h[i] * k_h[j] / sqrt(head_width)
+```
+
+Apply the NN13 stable causal softmax independently inside every head, then
+reduce its scalar values:
+
+```text
+context_h[i] = sum_j(weight_h[i,j] * v_h[j])
+```
+
+Concatenate head contexts in fixture order. For two scalar heads this restores
+the two-coordinate model width:
+
+```text
+concat[i] = [context_horizontal[i], context_vertical[i]]
+```
+
+## Output Projection and Residual Contract
+
+Treat vectors as rows. Output coordinate `o` is:
+
+```text
+attention[i,o] = sum_h(concat[i,h] * output_projection[h,o])
+residual_sum[i,o] = embedding[i,o] + attention[i,o]
+```
+
+The V1 output projection is the identity matrix so the first lab exposes the
+shape transition without adding arbitrary mixing. Consumers must still perform
+and trace the matrix multiplication.
+
+## Layer-Normalization Contract
+
+Normalize each token row independently across its two model coordinates. V1
+uses population variance:
+
+```text
+mean = sum(residual_sum) / model_width
+centered[o] = residual_sum[o] - mean
+variance = sum(centered[o]^2) / model_width
+denominator = sqrt(variance + epsilon)
+normalized[o] = centered[o] / denominator
+output[o] = normalized[o] * gamma[o] + beta[o]
+```
+
+Epsilon lives inside the square root. The trace retains centered and squared
+deviations so the variance can be checked by hand.
+
+## Fixture Layout
+
+```text
+code/specs/fixtures/multi-head-attention-v1/
+  schema.json
+  labs/00-two-head-causal-add-norm.json
+```
+
+Consumers reject duplicate keys, non-finite numbers, unknown fields, incorrect
+shapes, unsupported operations, and values outside `absolute_tolerance`.
+
+## Conformance Levels
+
+1. **Project:** reproduce every scalar query, key, value, and product.
+2. **Attend:** reproduce both heads' causal score and stable-softmax traces.
+3. **Join:** reproduce concatenation and every output-projection product.
+4. **Add:** reproduce the attention-plus-residual coordinates.
+5. **Normalize:** reproduce the mean, deviations, variance, denominator,
+   affine products, and final output.
+
+## Cross-Language and Rust-Core Direction
+
+Every language should implement the tiny scalar loops first. A performant Rust
+core can later expose batched projection, masked-softmax, value reduction,
+output projection, residual addition, and layer-normalization kernels without
+changing the fixture semantics.
+
+A future C ABI should make batch size, token count, head count, head width,
+model width, strides, masks, epsilon, and caller-owned outputs explicit. Trace
+mode should optionally return per-head scores and weights plus pre-normalized
+rows and normalization statistics. Fused execution is welcome, but it must not
+erase the intermediate oracle needed by learning tools and cross-language
+parity tests.

--- a/code/specs/NN15-tiny-decoder-training-labs.md
+++ b/code/specs/NN15-tiny-decoder-training-labs.md
@@ -1,0 +1,138 @@
+# NN15: Tiny Decoder-Only Language Model Training Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral next-token loss and
+output-head update traces over saved causal decoder states.
+
+## Purpose
+
+NN15 closes the first transformer learning loop. Earlier labs produced causal
+decoder states. This lab shifts a three-token sequence into two next-token
+examples, turns each saved state into vocabulary logits, applies stable
+softmax and mean cross-entropy, sends the error back into the decoder stream,
+reduces shared gradients, and performs one SGD update.
+
+The decoder body is intentionally frozen for this first optimizer trace. The
+fixture still records the gradient entering each saved decoder state, while
+only the shared unembedding matrix and bias are updated. A later automatic-
+differentiation tranche can continue those state gradients through every
+attention and feed-forward parameter without changing this contract.
+
+## Sequence Shift and Causal Contract
+
+V1 uses the vocabulary `red`, `blue`, `purple` and the sequence:
+
+```text
+red blue purple
+```
+
+The model never receives the token it must predict at the same position:
+
+```text
+decoder input  = [red, blue]
+next targets   = [blue, purple]
+causal prefixes = [[red], [red, blue]]
+```
+
+The saved two-coordinate decoder states are `[1,0]` and `[0,1]`. They stand at
+the boundary after a causal decoder block and before the vocabulary head.
+
+## Forward Contract
+
+Treat each decoder state as a row and the unembedding as a
+`model_width x vocabulary_size` matrix. For position `i` and vocabulary item
+`v`:
+
+```text
+logit_products[i,v,d] = state[i,d] * unembedding[d,v]
+logit[i,v] = sum_d(logit_products[i,v,d]) + bias[v]
+```
+
+Apply stable softmax separately at each position:
+
+```text
+row_max = max(logits)
+shifted[v] = logits[v] - row_max
+probability[v] = exp(shifted[v]) / sum_k(exp(shifted[k]))
+```
+
+The position loss is the negative log probability of its next-token target.
+The batch loss is the arithmetic mean across both positions.
+
+## Backward and Update Contract
+
+Because the loss reduction is `mean`, the logit gradient already contains the
+factor `1 / position_count`:
+
+```text
+d_mean_loss/d_logit[i,v]
+  = (probability[i,v] - one_hot(target[i],v)) / position_count
+```
+
+Each position contributes to the same parameters:
+
+```text
+unembedding_gradient_contribution[i,d,v]
+  = state[i,d] * logit_gradient[i,v]
+
+bias_gradient_contribution[i,v] = logit_gradient[i,v]
+
+state_gradient[i,d]
+  = sum_v(logit_gradient[i,v] * unembedding[d,v])
+```
+
+Reduce position contributions by addition, then apply SGD:
+
+```text
+parameter_after = parameter_before - learning_rate * gradient
+```
+
+Before the update, independently perturb every unembedding and bias parameter
+by `+epsilon` and `-epsilon`, rerun the mean loss, and estimate its gradient:
+
+```text
+numerical_gradient
+  = (loss(parameter + epsilon) - loss(parameter - epsilon)) / (2 * epsilon)
+```
+
+The canonical lab uses `epsilon = 1e-6` and records every numerical gradient
+plus the maximum absolute difference from the analytical gradients.
+
+The post-update trace reruns logits, stable softmax, and loss with the updated
+unembedding and bias. Its mean loss must be lower for the canonical lab.
+
+## Fixture Layout
+
+```text
+code/specs/fixtures/tiny-decoder-training-v1/
+  schema.json
+  labs/00-two-position-next-token-step.json
+```
+
+Consumers reject duplicate keys, non-finite numbers, unknown fields, incorrect
+shapes, unsupported operation metadata, and trace values outside the declared
+absolute tolerance.
+
+## Conformance Levels
+
+1. **Shift:** reproduce the input/target alignment and causal prefixes.
+2. **Predict:** reproduce every unembedding product, logit, and softmax value.
+3. **Measure:** reproduce target probabilities, position losses, and mean loss.
+4. **Differentiate:** reproduce logit, state, and per-position parameter gradients.
+5. **Audit:** reproduce the central finite-difference gradient check.
+6. **Update:** reduce shared gradients, perform SGD, and reproduce post-update loss.
+
+## Cross-Language and Rust-Core Direction
+
+Every language should implement these tiny scalar loops first. The fixture is
+the portable oracle for row-major and column-major implementations alike; only
+the mathematical indices, not an in-memory layout, are normative.
+
+A performant Rust core can later expose batched matrix multiplication,
+stable-softmax cross-entropy, fused logit gradients, shared-gradient reduction,
+and SGD kernels through a stable C ABI. That ABI should make batch size,
+position count, model width, vocabulary size, strides, target indices,
+reduction, learning rate, and caller-owned buffers explicit. A trace mode must
+be able to return logits, probabilities, per-position losses, state gradients,
+and reduced parameter gradients even when the fast path fuses operations.

--- a/code/specs/NN16-two-number-autoencoder-labs.md
+++ b/code/specs/NN16-two-number-autoencoder-labs.md
@@ -1,0 +1,140 @@
+# NN16: Two-Number Autoencoder Bottleneck Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral `2 -> 1 -> 2` linear
+autoencoder forward, reconstruction-loss, backward, gradient-audit, and update
+traces.
+
+## Purpose
+
+NN16 begins representation learning with the smallest undercomplete network.
+Two input coordinates must pass through one scalar bottleneck before the model
+can reconstruct both coordinates. The trace exposes what is compressed, what
+is lost, how both reconstruction errors meet at the bottleneck, and how one SGD
+step changes every encoder and decoder parameter.
+
+## Architecture Contract
+
+V1 uses one two-number example, identity activations, one scalar bottleneck,
+and a two-number reconstruction:
+
+```text
+input width 2 -> bottleneck width 1 -> reconstruction width 2
+```
+
+For input coordinate `i` and output coordinate `j`:
+
+```text
+encoder_product[i] = input[i] * encoder_weight[i]
+bottleneck = sum_i(encoder_product[i]) + encoder_bias
+
+decoder_product[j] = bottleneck * decoder_weight[j]
+reconstruction[j] = decoder_product[j] + decoder_bias[j]
+```
+
+Identity activations keep the compression boundary visible. Later labs may add
+nonlinear encoders, larger datasets, and higher-dimensional bottlenecks without
+changing the meaning of reconstruction.
+
+## Loss Contract
+
+The error uses `reconstruction - input`. The objective is mean squared error
+across the two reconstructed coordinates:
+
+```text
+error[j] = reconstruction[j] - input[j]
+squared_error[j] = error[j]^2
+loss = sum_j(squared_error[j]) / output_width
+```
+
+Because `output_width = 2`, the reconstruction gradient simplifies to the
+error itself:
+
+```text
+d_loss/d_reconstruction[j] = error[j]
+```
+
+## Backward Contract
+
+The decoder gradients are:
+
+```text
+decoder_weight_gradient[j]
+  = reconstruction_gradient[j] * bottleneck
+decoder_bias_gradient[j] = reconstruction_gradient[j]
+
+bottleneck_gradient_contribution[j]
+  = reconstruction_gradient[j] * decoder_weight[j]
+bottleneck_gradient = sum_j(bottleneck_gradient_contribution[j])
+```
+
+Both reconstructed coordinates therefore meet at the one-number bottleneck.
+Continue that combined signal through the encoder:
+
+```text
+encoder_weight_gradient[i] = bottleneck_gradient * input[i]
+encoder_bias_gradient = bottleneck_gradient
+```
+
+## Numerical Audit and Update Contract
+
+Independently perturb all seven trainable scalars by `+epsilon` and `-epsilon`
+and estimate the centered slope of the same mean loss:
+
+```text
+numerical_gradient
+  = (loss(parameter + epsilon) - loss(parameter - epsilon)) / (2 * epsilon)
+```
+
+The canonical lab uses `epsilon = 1e-6` and records analytical and numerical
+gradients in this order:
+
+```text
+encoder weights, encoder bias, decoder weights, decoder biases
+```
+
+Apply one SGD step to all parameters:
+
+```text
+parameter_after = parameter_before - learning_rate * gradient
+```
+
+The post-update trace reruns the complete encoder, bottleneck, decoder, and
+loss. Its loss must be lower for the canonical lab.
+
+## Fixture Layout
+
+```text
+code/specs/fixtures/two-number-autoencoder-v1/
+  schema.json
+  labs/00-linear-bottleneck-step.json
+```
+
+Consumers reject duplicate keys, non-finite numbers, unknown fields, incorrect
+shapes, unsupported operation metadata, and trace values outside the declared
+absolute tolerance.
+
+## Conformance Levels
+
+1. **Encode:** reproduce both encoder products and the scalar bottleneck.
+2. **Decode:** reproduce both decoder products and reconstructed coordinates.
+3. **Measure:** reproduce errors, squared errors, and mean reconstruction loss.
+4. **Differentiate:** reproduce decoder, bottleneck, and encoder gradients.
+5. **Audit:** reproduce all seven central finite-difference gradients.
+6. **Update:** apply SGD and reproduce the lower post-update loss.
+
+## Cross-Language and Rust-Core Direction
+
+Every language should implement the two scalar dense layers directly first.
+The fixture indexes weights mathematically and does not require a particular
+row-major or column-major in-memory layout.
+
+A performant Rust core can later expose batched encoder and decoder matrix
+multiplication, activation, reconstruction loss, backward reduction, and
+optimizer kernels through a stable C ABI. The ABI should make batch size,
+input width, bottleneck width, output width, strides, activation identifiers,
+loss reduction, learning rate, and caller-owned buffers explicit. Trace mode
+must optionally return encoded values, reconstructions, coordinate errors,
+bottleneck gradients, and parameter gradients even when the fast path fuses
+operations.

--- a/code/specs/NN17-variational-autoencoder-labs.md
+++ b/code/specs/NN17-variational-autoencoder-labs.md
@@ -1,0 +1,162 @@
+# NN17: Scalar Variational Autoencoder Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral scalar variational
+autoencoder sampling, beta-weighted KL divergence, backward, gradient-audit,
+and update traces.
+
+## Purpose
+
+NN17 adds uncertainty to the smallest autoencoder. Instead of encoding one
+fixed latent number, the encoder produces a Gaussian mean and log-variance.
+A saved noise value is transformed into one reproducible sample so learners can
+see both the stochastic model and a deterministic execution trace.
+
+The objective keeps two pressures separate:
+
+- reconstruction asks the sample to preserve this input;
+- KL divergence asks the encoded distribution to stay near a standard normal
+  prior that can be sampled later.
+
+## Architecture Contract
+
+V1 uses one scalar input, one scalar Gaussian latent variable, identity decoder,
+and one scalar reconstruction:
+
+```text
+input -> [mean, log variance] -> saved epsilon -> latent z -> reconstruction
+```
+
+```text
+mean = input * mean_weight + mean_bias
+log_variance = input * log_variance_weight + log_variance_bias
+variance = exp(log_variance)
+standard_deviation = exp(0.5 * log_variance)
+noise_contribution = standard_deviation * epsilon
+latent = mean + noise_contribution
+reconstruction = latent * decoder_weight + decoder_bias
+```
+
+`epsilon` is part of the fixture. Consumers must not call a random-number
+generator while replaying a conformance document.
+
+## Objective Contract
+
+The reconstruction term uses half squared error:
+
+```text
+error = reconstruction - input
+reconstruction_loss = 0.5 * error^2
+```
+
+The scalar Gaussian KL divergence against `Normal(0, 1)` is:
+
+```text
+kl = 0.5 * (mean^2 + variance - 1 - log_variance)
+weighted_kl = beta * kl
+total_loss = reconstruction_loss + weighted_kl
+```
+
+The canonical lab uses `beta = 0.1`. A larger beta gives the prior-matching
+term more influence; beta zero reduces this saved-sample step to reconstruction
+training alone.
+
+## Backward Contract
+
+Start at the decoder and follow the saved sample:
+
+```text
+reconstruction_gradient = error
+decoder_weight_gradient = reconstruction_gradient * latent
+decoder_bias_gradient = reconstruction_gradient
+latent_gradient = reconstruction_gradient * decoder_weight
+
+reconstruction_mean_gradient = latent_gradient
+reconstruction_log_variance_gradient
+  = latent_gradient * 0.5 * standard_deviation * epsilon
+```
+
+Differentiate the KL term independently:
+
+```text
+kl_mean_gradient = mean
+kl_log_variance_gradient = 0.5 * (variance - 1)
+
+mean_gradient
+  = reconstruction_mean_gradient + beta * kl_mean_gradient
+log_variance_gradient
+  = reconstruction_log_variance_gradient
+  + beta * kl_log_variance_gradient
+```
+
+Finish at the two encoder heads:
+
+```text
+mean_weight_gradient = mean_gradient * input
+mean_bias_gradient = mean_gradient
+log_variance_weight_gradient = log_variance_gradient * input
+log_variance_bias_gradient = log_variance_gradient
+```
+
+## Numerical Audit and Update Contract
+
+Independently perturb all six trainable scalars by `+epsilon` and `-epsilon`
+while holding the saved sampling noise fixed:
+
+```text
+numerical_gradient
+  = (total_loss(parameter + epsilon)
+    - total_loss(parameter - epsilon)) / (2 * epsilon)
+```
+
+The canonical audit uses `epsilon = 1e-6` and this order:
+
+```text
+mean weight, mean bias,
+log-variance weight, log-variance bias,
+decoder weight, decoder bias
+```
+
+Apply one SGD step to all six parameters and rerun the complete distribution,
+sample, reconstruction, KL, and total objective. The canonical post-update total
+loss must be lower.
+
+## Fixture Layout
+
+```text
+code/specs/fixtures/variational-autoencoder-v1/
+  schema.json
+  labs/00-saved-noise-kl-step.json
+```
+
+Consumers reject duplicate keys, non-finite numbers, unknown fields, incorrect
+shapes, unsupported operation metadata, and trace values outside the declared
+absolute tolerance.
+
+## Conformance Levels
+
+1. **Parameterize:** reproduce the mean, log-variance, variance, and standard
+   deviation.
+2. **Sample:** reproduce the noise contribution and latent value from saved
+   epsilon.
+3. **Decode:** reproduce the reconstruction and half-squared error.
+4. **Regularize:** reproduce KL divergence, its beta weighting, and total loss.
+5. **Differentiate:** keep reconstruction and KL gradient routes separate before
+   adding them at both encoder outputs.
+6. **Audit and update:** reproduce all six central finite differences, one SGD
+   step, and the lower post-update total loss.
+
+## Cross-Language and Rust-Core Direction
+
+Every host language should implement the scalar exponential, saved-noise
+reparameterization, KL term, and backward equations directly first. A fast Rust
+core can later expose batched mean and log-variance heads, caller-supplied random
+samples, decoder kernels, KL reductions, backward reductions, and optimizers
+through a stable C ABI.
+
+The ABI must make batch size, latent width, strides, beta, reduction rules,
+random-number ownership, seed or caller-owned epsilon buffers, and output buffers
+explicit. Trace mode must optionally return means, log-variances, standard
+deviations, samples, reconstruction losses, KL terms, and both gradient routes so
+bindings never hide the stochastic boundary behind a fused kernel.

--- a/code/specs/NN18-one-dimensional-gan-labs.md
+++ b/code/specs/NN18-one-dimensional-gan-labs.md
@@ -1,0 +1,138 @@
+# NN18: One-Dimensional GAN Game Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral one-dimensional
+generative adversarial network forward, alternating-update, gradient-audit, and
+counter-move traces.
+
+## Purpose
+
+NN18 turns adversarial training into the smallest possible game. A scalar
+generator maps one saved noise value to one fake point. A scalar discriminator
+assigns real probabilities to one real point and the fake point. The
+discriminator moves first; the generator then responds against the updated,
+frozen discriminator.
+
+The trace exposes three facts that large GANs can hide:
+
+- discriminator gradients combine a real example and a detached fake example;
+- generator gradients travel through the discriminator without updating it;
+- improving one player can worsen the other player's objective.
+
+## Model Contract
+
+V1 uses scalar affine functions and a sigmoid discriminator:
+
+```text
+fake = generator_weight * noise + generator_bias
+discriminator_logit(x) = discriminator_weight * x + discriminator_bias
+discriminator_probability(x) = sigmoid(discriminator_logit(x))
+```
+
+The fixture provides one real sample and one saved noise value. Consumers do not
+draw new noise while replaying the document.
+
+## Loss Contract
+
+The discriminator uses mean binary cross-entropy over the real label `1` and
+fake label `0`:
+
+```text
+discriminator_loss
+  = -0.5 * (log(real_probability) + log(1 - fake_probability))
+```
+
+The generator uses the non-saturating objective, asking the discriminator to
+classify the fake point as real:
+
+```text
+generator_loss = -log(fake_probability)
+```
+
+Probabilities are derived with the stable sigmoid and losses are evaluated from
+finite canonical logits.
+
+## Discriminator Step Contract
+
+Hold the fake point fixed and detached. For mean binary cross-entropy:
+
+```text
+real_logit_gradient = 0.5 * (real_probability - 1)
+fake_logit_gradient = 0.5 * fake_probability
+
+discriminator_weight_gradient
+  = real_logit_gradient * real_sample
+  + fake_logit_gradient * fake_sample
+discriminator_bias_gradient
+  = real_logit_gradient + fake_logit_gradient
+```
+
+Apply the discriminator learning rate, then rerun both classifications and both
+reported losses without moving the generator.
+
+## Generator Counter-Step Contract
+
+Freeze the updated discriminator. The non-saturating generator loss gives:
+
+```text
+fake_logit_gradient = fake_probability - 1
+fake_value_gradient
+  = fake_logit_gradient * updated_discriminator_weight
+
+generator_weight_gradient = fake_value_gradient * noise
+generator_bias_gradient = fake_value_gradient
+```
+
+Apply the generator learning rate and rerun the fake point through the frozen
+updated discriminator. The canonical generator loss must fall. The reported
+discriminator loss may rise because the generator has just made its fake harder
+to reject.
+
+## Numerical Audit Contract
+
+Use centered finite differences with `epsilon = 1e-6`:
+
+1. Audit discriminator weight and bias on the initial discriminator objective,
+   holding the fake sample detached and fixed.
+2. Audit generator weight and bias on the generator objective, holding the
+   updated discriminator fixed and reusing the saved noise.
+
+The two audits deliberately target different objectives and moments in the
+alternating schedule. There is no single joint gradient for this game round.
+
+## Fixture Layout
+
+```text
+code/specs/fixtures/one-dimensional-gan-v1/
+  schema.json
+  labs/00-discriminator-generator-round.json
+```
+
+Consumers reject duplicate keys, non-finite numbers, unknown fields,
+unsupported metadata, and trace values outside the declared absolute tolerance.
+
+## Conformance Levels
+
+1. **Generate:** reproduce the scalar fake point from saved noise.
+2. **Judge:** reproduce both logits, probabilities, and initial losses.
+3. **Discriminate:** detach the fake point, reproduce both classification
+   gradient routes, update only the discriminator, and lower its loss.
+4. **Counter:** freeze the updated discriminator, pass its input gradient into
+   the generator, update only the generator, and lower generator loss.
+5. **Audit:** reproduce both two-parameter centered finite-difference checks.
+6. **Replay:** reproduce the final fake point and the counter-move's effect on
+   both players' reported losses.
+
+## Cross-Language and Rust-Core Direction
+
+Every host language should implement the scalar schedule directly first. A fast
+Rust core can later expose batched generator and discriminator forwards, stable
+binary-cross-entropy kernels, detach boundaries, backward kernels, and optimizer
+steps through a stable C ABI.
+
+The ABI must make batch sizes, real/fake labels, saved-noise ownership, player
+being updated, frozen parameter buffers, update order, reduction rules, and
+caller-owned outputs explicit. Trace mode must optionally return real/fake
+logits, probabilities, per-example gradient routes, detached fake values, input
+gradients crossing into the generator, and both player losses at every phase.

--- a/code/specs/NN19-one-dimensional-diffusion-labs.md
+++ b/code/specs/NN19-one-dimensional-diffusion-labs.md
@@ -1,0 +1,119 @@
+# NN19: One-Dimensional Diffusion Labs
+
+## Status
+
+Draft specification for deterministic, language-neutral scalar diffusion
+forward-noising, noise-prediction training, gradient-audit, and reverse-mean
+traces.
+
+## Purpose
+
+NN19 turns diffusion into two visible operations: deliberately mix a clean
+sample with saved noise at known levels, then train a model to predict that
+noise so the process can run backward. One clean scalar and two timesteps are
+enough to expose signal decay, noise growth, timestep conditioning, the
+noise-prediction objective, and iterative denoising.
+
+## Forward Schedule Contract
+
+For every schedule row:
+
+```text
+alpha_t = 1 - beta_t
+alpha_bar_t = product(alpha_1 through alpha_t)
+signal_scale_t = sqrt(alpha_bar_t)
+noise_scale_t = sqrt(1 - alpha_bar_t)
+
+x_t = signal_scale_t * clean_sample
+    + noise_scale_t * saved_noise
+```
+
+V1 uses the same saved noise at both levels so learners can compare how the
+coefficients trade signal for noise. The rows are direct closed-form samples
+from `x_0`; they are not claimed to be one Markov forward trajectory.
+
+## Noise Predictor Contract
+
+The scalar denoiser sees the noisy sample and a normalized timestep:
+
+```text
+predicted_noise
+  = sample_weight * x_t
+  + timestep_weight * normalized_t
+  + bias
+```
+
+Its target is the saved noise used to construct that `x_t`. For two schedule
+rows, V1 uses mean half-squared error:
+
+```text
+row_loss = 0.5 * (predicted_noise - saved_noise)^2
+mean_loss = (row_loss_1 + row_loss_2) / 2
+```
+
+The prediction gradient reported for each row already includes the mean
+reduction factor.
+
+## Update and Numerical Audit Contract
+
+Add both rows' contributions into the three shared parameter gradients, audit
+the initial mean objective with centered finite differences and
+`epsilon = 1e-6`, then apply one SGD update. The post-update mean loss must be
+lower than the initial mean loss.
+
+## Reverse Mean Contract
+
+Start from the noisiest forward sample. Iterate the schedule in reverse using
+the updated denoiser and the deterministic DDPM mean:
+
+```text
+noise_coefficient_t = beta_t / sqrt(1 - alpha_bar_t)
+
+corrected_sample
+  = current_sample - noise_coefficient_t * predicted_noise
+
+previous_mean = corrected_sample / sqrt(alpha_t)
+```
+
+Feed each `previous_mean` into the next lower timestep. V1 adds no fresh reverse
+noise, so every consumer replays the same mean path. The final reconstruction
+need not equal the clean sample exactly; its remaining error makes model quality
+visible.
+
+## Fixture Layout
+
+```text
+code/specs/fixtures/one-dimensional-diffusion-v1/
+  schema.json
+  labs/00-two-level-forward-and-reverse.json
+```
+
+Consumers reject duplicate keys, non-finite numbers, unknown fields,
+unsupported metadata, invalid timestep order, schedule inconsistencies, and
+trace values outside the declared absolute tolerance.
+
+## Conformance Levels
+
+1. **Noise:** reproduce every alpha, cumulative alpha, scale, contribution, and
+   noisy sample.
+2. **Predict:** reproduce both timestep-conditioned noise predictions and the
+   initial mean loss.
+3. **Differentiate:** reproduce both rows' gradient contributions and their
+   three shared reductions.
+4. **Audit:** reproduce the three-parameter centered finite-difference check.
+5. **Learn:** apply SGD, rerun both rows, and lower mean noise-prediction loss.
+6. **Reverse:** replay both deterministic reverse means and the final clean
+   reconstruction error.
+
+## Cross-Language and Rust-Core Direction
+
+Every host language should implement the scalar schedule directly first. A
+Rust core can later batch schedule coefficient generation, saved-noise mixing,
+timestep-conditioned denoiser calls, MSE reductions, backward kernels, and
+reverse steps behind a stable C ABI.
+
+The ABI must make tensor shape, dtype, beta schedule, timestep normalization,
+random-number ownership, reduction rule, reverse variance policy, and
+caller-owned output buffers explicit. Trace mode should optionally return
+per-timestep signal/noise contributions, predicted noise, gradient
+contributions, reverse corrections, and reconstruction estimates.

--- a/code/specs/NN20-hopfield-associative-memory-labs.md
+++ b/code/specs/NN20-hopfield-associative-memory-labs.md
@@ -1,0 +1,81 @@
+# NN20 Hopfield Associative Memory Labs
+
+Status: Draft
+
+NN20 defines a deterministic, language-neutral contract for the smallest useful
+Hopfield recall loop. It makes storage, corruption, asynchronous updates, and
+energy descent visible without requiring a tensor framework.
+
+## Learning Goal
+
+A consumer must show that a memory can be represented as a low-energy state:
+
+1. encode one bipolar pattern with a normalized Hebbian outer product;
+2. remove self-connections by zeroing the diagonal;
+3. start from a cue with one flipped bit;
+4. update neurons in the fixture order using the newest state immediately;
+5. verify energy never increases and the stored pattern is recovered.
+
+## V1 Operation
+
+For a saved pattern `p` of length `N`:
+
+```text
+w_ij = p_i * p_j / N  when i != j
+w_ii = 0
+```
+
+For one asynchronous neuron update:
+
+```text
+field_i = sum_j(w_ij * state_j)
+state_i = +1 when field_i > 0
+state_i = -1 when field_i < 0
+state_i = previous state_i when field_i = 0
+```
+
+The zero-field rule is part of the contract. It removes a common cross-language
+disagreement about whether `sign(0)` returns zero or a bipolar value.
+
+## Audit Quantities
+
+The Hopfield energy is:
+
+```text
+E(state) = -1/2 * sum_i sum_j(w_ij * state_i * state_j)
+```
+
+The normalized overlap with the stored pattern is:
+
+```text
+overlap = sum_i(p_i * state_i) / N
+```
+
+The fixture records every incoming weighted vote, field, state transition,
+energy, and overlap. The matrix must be symmetric, its diagonal must be zero,
+and each asynchronous update must have `energy_after <= energy_before` within
+the document tolerance.
+
+## Determinism
+
+V1 stores exactly one pattern and saves a complete update-order permutation.
+Consumers must update in place: later neurons see the state produced by earlier
+neurons. There is no randomness and no parallel-update interpretation.
+
+## Corpus
+
+The canonical corpus is
+`code/specs/fixtures/hopfield-associative-memory-v1`. Each JSON document is
+strict: duplicate keys, unknown keys, non-finite numbers, non-bipolar states,
+non-permutation update orders, asymmetric weights, nonzero diagonals, and
+mismatched traces are errors.
+
+## Cross-Language and Rust-Core Direction
+
+Every host language should first implement this four-neuron loop directly and
+compare its full trace with the fixture. A future Rust core can batch outer
+products, energy evaluation, overlap, and deterministic recall sweeps. Stable
+bindings should accept flat bipolar buffers plus an explicit update-order
+buffer, expose a C ABI for native languages, and reuse that ABI from WASM and
+higher-level language adapters. Trace mode must remain available beside any
+optimized fixed-point-only path.

--- a/code/specs/NN21-tiny-message-passing-labs.md
+++ b/code/specs/NN21-tiny-message-passing-labs.md
@@ -1,0 +1,40 @@
+# NN21 Tiny Message Passing Labs
+
+Status: Draft
+
+NN21 defines a deterministic, language-neutral first graph-neural computation:
+one synchronous message-passing round on a tiny undirected graph.
+
+## Contract
+
+Each saved undirected edge `{u, v}` expands into directed messages `u -> v` and
+`v -> u`. With scalar features and shared parameters:
+
+```text
+message(source -> target) = message_weight * old_feature[source]
+aggregate[target] = sum(incoming messages)
+preactivation[target] = self_weight * old_feature[target] + aggregate[target] + bias
+new_feature[target] = ReLU(preactivation[target])
+```
+
+All messages use the original feature snapshot. Updated values cannot influence
+another node until the next round. Directed messages are ordered by target and
+then source; this order is for trace portability, while the sum itself is
+permutation invariant.
+
+## Corpus and Validation
+
+The corpus at `code/specs/fixtures/tiny-message-passing-v1` records original
+features, canonical undirected edges, parameters, all directed messages, every
+node inbox, aggregates, affine terms, ReLU inputs, and outputs. Duplicate or
+unknown keys, non-finite numbers, self edges, duplicate undirected edges,
+invalid indices, and mismatched traces are errors.
+
+## Cross-Language and Rust-Core Direction
+
+Implement the three-node scalar loop directly in each host language first. A
+Rust core can later accept CSR/COO edge buffers and dense feature buffers,
+expand or traverse directed adjacency, reduce messages deterministically, and
+apply fused node updates. A stable C ABI plus WASM and idiomatic wrappers can
+share the fast path. Trace mode must preserve source/target identities and
+per-message values even when production kernels fuse the round.

--- a/code/specs/NN22-graph-convolution-attention-labs.md
+++ b/code/specs/NN22-graph-convolution-attention-labs.md
@@ -1,0 +1,30 @@
+# NN22 Graph Convolution and Attention Labs
+
+Status: Draft
+
+NN22 compares two ways to weight the same self-looped graph neighborhood.
+
+For GCN, each source contribution uses:
+
+```text
+coefficient(source -> target) = 1 / sqrt(degree_target * degree_source)
+contribution = coefficient * source_feature
+output = ReLU(sum(contributions))
+```
+
+For the first GAT trace, the score is the transformed scalar source feature.
+Scores are normalized only across the selected target's neighborhood with
+stable softmax. The fixture records the row maximum, shifted scores,
+exponentials, denominator, weights, weighted values, and output.
+
+All neighborhoods include self and must be symmetric, unique, and index-valid.
+The corpus at `code/specs/fixtures/graph-convolution-attention-v1` is strict and
+language neutral.
+
+## Cross-Language and Rust-Core Direction
+
+Direct host implementations should reproduce the scalar oracle first. A Rust
+core can later traverse CSR neighborhoods, precompute degree factors, execute
+segmented stable softmax, and fuse weighted reductions. C ABI, WASM, and other
+bindings should share buffers and retain an optional per-edge trace mode for
+explaining optimized kernels.

--- a/code/specs/NN23-initialization-activation-distribution-labs.md
+++ b/code/specs/NN23-initialization-activation-distribution-labs.md
@@ -1,0 +1,35 @@
+# NN23 Initialization and Activation Distribution Labs
+
+Status: Draft
+
+NN23 isolates one deep-training question: how does the first weight scale alter
+the values that reach later layers?
+
+The V1 corpus fixes four two-value inputs and three two-by-two sign templates.
+It applies four scaling rules without random sampling:
+
+```text
+tiny    = 0.1
+Xavier  = sqrt(1 / fan_in)
+He      = sqrt(2 / fan_in)
+large   = 2
+```
+
+Each layer computes a bias-free matrix product followed by `tanh` or ReLU. The
+trace records every preactivation and activation. Distribution summaries use
+population variance, count values with absolute magnitude below `1e-12` as
+zero, and count `tanh` values with absolute magnitude at least `0.95` as
+saturated.
+
+The fixed signs are an educational oracle, not a replacement for pseudorandom
+initialization. They make scale the only changing variable and let every
+language reproduce the experiment exactly.
+
+## Cross-Language and Rust-Core Direction
+
+Consumers should reproduce the scalar fixture before using native random-number
+generators. A Rust core can later accept row-major input and weight-template
+buffers, derive initializer scales, run fused matrix-plus-activation kernels,
+and reduce distribution statistics with SIMD. C ABI and WASM bindings should
+preserve the documented row order and population-variance convention, with an
+optional trace mode that returns the unfused per-layer buffers.

--- a/code/specs/NN24-gradient-flow-labs.md
+++ b/code/specs/NN24-gradient-flow-labs.md
@@ -1,0 +1,37 @@
+# NN24 Gradient Flow Labs
+
+Status: Draft
+
+NN24 traces one scalar loss backward through four scalar layers. Each layer
+records its saved forward input, weight, preactivation, activation, activation
+derivative, and local Jacobian:
+
+```text
+local_jacobian = weight * activation_derivative
+```
+
+The backward pass starts with the half-squared-error derivative at the output.
+For each layer in reverse order it records:
+
+```text
+dL/dz       = upstream_gradient * activation_derivative
+dL/dinput   = dL/dz * weight
+dL/dweight  = dL/dz * saved_input
+```
+
+V1 compares small-weight tanh, saturated tanh, unit-weight ReLU, and
+large-weight ReLU. A chain-Jacobian magnitude below `0.1` is labeled vanishing;
+a magnitude above `10` is labeled exploding. These thresholds describe the toy
+experiment rather than a universal production rule.
+
+The fixture also checks `dL/dinput` with a central finite difference using
+epsilon `1e-6`.
+
+## Cross-Language and Rust-Core Direction
+
+Direct consumers should reproduce the four scalar chains before generalizing
+to tensors. A Rust core can store saved activations and derivative masks in a
+contiguous tape, traverse that tape in reverse, and fuse vector-Jacobian
+products and parameter-gradient reductions. C ABI and WASM bindings should
+expose both an optimized gradient buffer and an optional per-operation trace so
+other languages can explain the same reverse pass.

--- a/code/specs/NN25-normalization-dropout-residual-labs.md
+++ b/code/specs/NN25-normalization-dropout-residual-labs.md
@@ -1,0 +1,45 @@
+# NN25 Normalization, Dropout, and Residual Labs
+
+Status: Draft
+
+NN25 compares four routes through one four-coordinate branch. Every route starts
+with the same input and scalar branch weight:
+
+```text
+h[i] = branch_weight * input[i]
+score = sum(upstream_gradient[i] * output[i])
+```
+
+The plain route returns `h`. The normalization route applies population layer
+normalization across all four coordinates. V1 deliberately uses zero numerical
+epsilon with a nonzero-variance fixture so the mean, variance, standard
+deviation, normalized values, and backward formula remain hand-calculable.
+Production implementations must accept and apply a caller-visible positive
+epsilon.
+
+The dropout route applies a pinned binary mask with inverted training-time
+scaling:
+
+```text
+output[i] = h[i] * mask[i] / keep_probability
+```
+
+The fixture also records dropout's evaluation-time output and the exact
+training-mask expectation. The residual route returns `input + h` and splits
+its input gradient into the learned branch contribution and the identity skip
+contribution.
+
+Every route records its output, scalar score, gradient entering the shared
+branch, skip gradient, input gradient, and branch-weight gradient. Central
+finite differences independently check every input coordinate and the scalar
+branch weight with epsilon `1e-6`.
+
+## Cross-Language and Rust-Core Direction
+
+Direct consumers should reproduce the four small vector traces before adding
+tensor broadcasting or random mask generation. A Rust core can later expose
+normalization statistics, caller-supplied dropout masks or seeds, residual
+aliases, and vector-Jacobian products through a stable C ABI and WASM surface.
+Optimized paths may fuse the operations, but an optional trace mode should keep
+the saved mean, standard deviation, scaled mask, and split residual gradients
+available to every host language.

--- a/code/specs/fixtures/attention-qkv-v1/CHANGELOG.md
+++ b/code/specs/fixtures/attention-qkv-v1/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add three-token Q/K/V projections and all nine query-key dot products.
+- Add raw and square-root-scaled score matrices.

--- a/code/specs/fixtures/attention-qkv-v1/README.md
+++ b/code/specs/fixtures/attention-qkv-v1/README.md
@@ -1,0 +1,10 @@
+# Attention QKV V1 Fixtures
+
+This corpus pins one three-token self-attention projection and query-key score
+trace for NN12. It stops before softmax, masking, or value mixing.
+
+```text
+python code/scripts/validate_attention_qkv_labs.py
+```
+
+See [`NN12-attention-qkv-labs.md`](../../NN12-attention-qkv-labs.md).

--- a/code/specs/fixtures/attention-qkv-v1/labs/00-three-token-qkv.json
+++ b/code/specs/fixtures/attention-qkv-v1/labs/00-three-token-qkv.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "id": "three-token-qkv",
+  "title": "Project and compare three token vectors",
+  "question": "How does every query compare with every key before softmax?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "self-attention",
+    "query projection",
+    "key projection",
+    "value projection",
+    "dot product",
+    "scaled attention score"
+  ],
+  "operation": {
+    "kind": "three-token-qkv-dot-products",
+    "vector_orientation": "row",
+    "score_scaling": "inverse-square-root-key-dimension",
+    "softmax_applied": false
+  },
+  "tokens": [
+    { "id": "red", "embedding": [1, 0] },
+    { "id": "blue", "embedding": [0, 1] },
+    { "id": "purple", "embedding": [1, 1] }
+  ],
+  "matrices": {
+    "query": [[1, 0], [0, 1]],
+    "key": [[1, 1], [-1, 1]],
+    "value": [[2, 0], [0, 1]]
+  },
+  "expected": {
+    "queries": [[1, 0], [0, 1], [1, 1]],
+    "keys": [[1, 1], [-1, 1], [0, 2]],
+    "values": [[2, 0], [0, 1], [2, 1]],
+    "dot_products": [
+      { "query": "red", "key": "red", "products": [1, 0], "raw_score": 1, "scaled_score": 0.7071067811865475 },
+      { "query": "red", "key": "blue", "products": [-1, 0], "raw_score": -1, "scaled_score": -0.7071067811865475 },
+      { "query": "red", "key": "purple", "products": [0, 0], "raw_score": 0, "scaled_score": 0 },
+      { "query": "blue", "key": "red", "products": [0, 1], "raw_score": 1, "scaled_score": 0.7071067811865475 },
+      { "query": "blue", "key": "blue", "products": [0, 1], "raw_score": 1, "scaled_score": 0.7071067811865475 },
+      { "query": "blue", "key": "purple", "products": [0, 2], "raw_score": 2, "scaled_score": 1.414213562373095 },
+      { "query": "purple", "key": "red", "products": [1, 1], "raw_score": 2, "scaled_score": 1.414213562373095 },
+      { "query": "purple", "key": "blue", "products": [-1, 1], "raw_score": 0, "scaled_score": 0 },
+      { "query": "purple", "key": "purple", "products": [0, 2], "raw_score": 2, "scaled_score": 1.414213562373095 }
+    ],
+    "raw_score_matrix": [[1, -1, 0], [1, 1, 2], [2, 0, 2]],
+    "scaled_score_matrix": [
+      [0.7071067811865475, -0.7071067811865475, 0],
+      [0.7071067811865475, 0.7071067811865475, 1.414213562373095],
+      [1.414213562373095, 0, 1.414213562373095]
+    ]
+  }
+}

--- a/code/specs/fixtures/attention-qkv-v1/schema.json
+++ b/code/specs/fixtures/attention-qkv-v1/schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/attention-qkv-v1.json",
+  "title": "Attention QKV learning lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "tokens", "matrices", "expected"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "vector_orientation", "score_scaling", "softmax_applied"],
+      "properties": {
+        "kind": { "const": "three-token-qkv-dot-products" },
+        "vector_orientation": { "const": "row" },
+        "score_scaling": { "const": "inverse-square-root-key-dimension" },
+        "softmax_applied": { "const": false }
+      }
+    },
+    "tokens": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "embedding"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "embedding": { "$ref": "#/$defs/vector2" }
+        }
+      }
+    },
+    "matrices": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["query", "key", "value"],
+      "properties": {
+        "query": { "$ref": "#/$defs/matrix2" },
+        "key": { "$ref": "#/$defs/matrix2" },
+        "value": { "$ref": "#/$defs/matrix2" }
+      }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["queries", "keys", "values", "dot_products", "raw_score_matrix", "scaled_score_matrix"],
+      "properties": {
+        "queries": { "$ref": "#/$defs/matrix3x2" },
+        "keys": { "$ref": "#/$defs/matrix3x2" },
+        "values": { "$ref": "#/$defs/matrix3x2" },
+        "dot_products": {
+          "type": "array",
+          "minItems": 9,
+          "maxItems": 9,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["query", "key", "products", "raw_score", "scaled_score"],
+            "properties": {
+              "query": { "type": "string", "minLength": 1 },
+              "key": { "type": "string", "minLength": 1 },
+              "products": { "$ref": "#/$defs/vector2" },
+              "raw_score": { "type": "number" },
+              "scaled_score": { "type": "number" }
+            }
+          }
+        },
+        "raw_score_matrix": { "$ref": "#/$defs/matrix3x3" },
+        "scaled_score_matrix": { "$ref": "#/$defs/matrix3x3" }
+      }
+    }
+  },
+  "$defs": {
+    "vector2": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "number" } },
+    "vector3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "number" } },
+    "matrix2": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "$ref": "#/$defs/vector2" } },
+    "matrix3x2": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "$ref": "#/$defs/vector2" } },
+    "matrix3x3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "$ref": "#/$defs/vector3" } }
+  }
+}

--- a/code/specs/fixtures/attention-softmax-v1/CHANGELOG.md
+++ b/code/specs/fixtures/attention-softmax-v1/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add stable softmax traces for all three scaled score rows.
+- Add causal masking and weighted value contributions.

--- a/code/specs/fixtures/attention-softmax-v1/README.md
+++ b/code/specs/fixtures/attention-softmax-v1/README.md
@@ -1,0 +1,10 @@
+# Attention Softmax V1 Fixtures
+
+This corpus pins stable row-wise softmax, a left-to-right causal mask, and
+weighted value mixing for the three-token NN13 lab.
+
+```text
+python code/scripts/validate_attention_softmax_labs.py
+```
+
+See [`NN13-attention-softmax-labs.md`](../../NN13-attention-softmax-labs.md).

--- a/code/specs/fixtures/attention-softmax-v1/labs/00-three-token-causal-softmax.json
+++ b/code/specs/fixtures/attention-softmax-v1/labs/00-three-token-causal-softmax.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "id": "three-token-causal-softmax",
+  "title": "Normalize and causally mask three attention rows",
+  "question": "How does a causal mask change softmax weights and the resulting value mix?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "stable softmax",
+    "causal mask",
+    "attention weights",
+    "weighted value sum"
+  ],
+  "operation": {
+    "kind": "three-token-attention-softmax",
+    "softmax": "stable-row-wise",
+    "causal_rule": "key-index-less-than-or-equal-query-index",
+    "masked_score_encoding": "null"
+  },
+  "token_ids": ["red", "blue", "purple"],
+  "scaled_score_matrix": [
+    [0.7071067811865475, -0.7071067811865475, 0],
+    [0.7071067811865475, 0.7071067811865475, 1.414213562373095],
+    [1.414213562373095, 0, 1.414213562373095]
+  ],
+  "values": [[2, 0], [0, 1], [2, 1]],
+  "expected": {
+    "unmasked": [
+      {
+        "query": "red",
+        "allowed": [true, true, true],
+        "scaled_scores": [0.7071067811865475, -0.7071067811865475, 0],
+        "masked_scores": [0.7071067811865475, -0.7071067811865475, 0],
+        "row_max": 0.7071067811865475,
+        "shifted_scores": [0, -1.414213562373095, -0.7071067811865475],
+        "exponentials": [1, 0.24311673443421425, 0.49306869139523984],
+        "denominator": 1.736185425829454,
+        "weights": [0.575975345215362, 0.14002924504337802, 0.28399540974126003],
+        "value_contributions": [[1.151950690430724, 0], [0, 0.14002924504337802], [0.5679908194825201, 0.28399540974126003]],
+        "context": [1.719941509913244, 0.424024654784638]
+      },
+      {
+        "query": "blue",
+        "allowed": [true, true, true],
+        "scaled_scores": [0.7071067811865475, 0.7071067811865475, 1.414213562373095],
+        "masked_scores": [0.7071067811865475, 0.7071067811865475, 1.414213562373095],
+        "row_max": 1.414213562373095,
+        "shifted_scores": [-0.7071067811865475, -0.7071067811865475, 0],
+        "exponentials": [0.49306869139523984, 0.49306869139523984, 1],
+        "denominator": 1.9861373827904796,
+        "weights": [0.2482550782577231, 0.2482550782577231, 0.5034898434845538],
+        "value_contributions": [[0.4965101565154462, 0], [0, 0.2482550782577231], [1.0069796869691077, 0.5034898434845538]],
+        "context": [1.5034898434845538, 0.7517449217422769]
+      },
+      {
+        "query": "purple",
+        "allowed": [true, true, true],
+        "scaled_scores": [1.414213562373095, 0, 1.414213562373095],
+        "masked_scores": [1.414213562373095, 0, 1.414213562373095],
+        "row_max": 1.414213562373095,
+        "shifted_scores": [0, -1.414213562373095, 0],
+        "exponentials": [1, 0.24311673443421425, 1],
+        "denominator": 2.2431167344342144,
+        "weights": [0.44580827410760315, 0.10838345178479356, 0.44580827410760315],
+        "value_contributions": [[0.8916165482152063, 0], [0, 0.10838345178479356], [0.8916165482152063, 0.44580827410760315]],
+        "context": [1.7832330964304126, 0.5541917258923967]
+      }
+    ],
+    "causal": [
+      {
+        "query": "red",
+        "allowed": [true, false, false],
+        "scaled_scores": [0.7071067811865475, -0.7071067811865475, 0],
+        "masked_scores": [0.7071067811865475, null, null],
+        "row_max": 0.7071067811865475,
+        "shifted_scores": [0, null, null],
+        "exponentials": [1, 0, 0],
+        "denominator": 1,
+        "weights": [1, 0, 0],
+        "value_contributions": [[2, 0], [0, 0], [0, 0]],
+        "context": [2, 0]
+      },
+      {
+        "query": "blue",
+        "allowed": [true, true, false],
+        "scaled_scores": [0.7071067811865475, 0.7071067811865475, 1.414213562373095],
+        "masked_scores": [0.7071067811865475, 0.7071067811865475, null],
+        "row_max": 0.7071067811865475,
+        "shifted_scores": [0, 0, null],
+        "exponentials": [1, 1, 0],
+        "denominator": 2,
+        "weights": [0.5, 0.5, 0],
+        "value_contributions": [[1, 0], [0, 0.5], [0, 0]],
+        "context": [1, 0.5]
+      },
+      {
+        "query": "purple",
+        "allowed": [true, true, true],
+        "scaled_scores": [1.414213562373095, 0, 1.414213562373095],
+        "masked_scores": [1.414213562373095, 0, 1.414213562373095],
+        "row_max": 1.414213562373095,
+        "shifted_scores": [0, -1.414213562373095, 0],
+        "exponentials": [1, 0.24311673443421425, 1],
+        "denominator": 2.2431167344342144,
+        "weights": [0.44580827410760315, 0.10838345178479356, 0.44580827410760315],
+        "value_contributions": [[0.8916165482152063, 0], [0, 0.10838345178479356], [0.8916165482152063, 0.44580827410760315]],
+        "context": [1.7832330964304126, 0.5541917258923967]
+      }
+    ]
+  }
+}

--- a/code/specs/fixtures/attention-softmax-v1/schema.json
+++ b/code/specs/fixtures/attention-softmax-v1/schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/attention-softmax-v1.json",
+  "title": "Attention softmax learning lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "token_ids", "scaled_score_matrix", "values", "expected"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "softmax", "causal_rule", "masked_score_encoding"],
+      "properties": {
+        "kind": { "const": "three-token-attention-softmax" },
+        "softmax": { "const": "stable-row-wise" },
+        "causal_rule": { "const": "key-index-less-than-or-equal-query-index" },
+        "masked_score_encoding": { "const": "null" }
+      }
+    },
+    "token_ids": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "scaled_score_matrix": { "$ref": "#/$defs/matrix3x3" },
+    "values": { "$ref": "#/$defs/matrix3x2" },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["unmasked", "causal"],
+      "properties": {
+        "unmasked": { "$ref": "#/$defs/traceRows" },
+        "causal": { "$ref": "#/$defs/traceRows" }
+      }
+    }
+  },
+  "$defs": {
+    "vector2": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "number" } },
+    "vector3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "number" } },
+    "boolean3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "boolean" } },
+    "nullableVector3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": ["number", "null"] } },
+    "matrix3x2": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "$ref": "#/$defs/vector2" } },
+    "matrix3x3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "$ref": "#/$defs/vector3" } },
+    "traceRows": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "$ref": "#/$defs/traceRow" } },
+    "traceRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["query", "allowed", "scaled_scores", "masked_scores", "row_max", "shifted_scores", "exponentials", "denominator", "weights", "value_contributions", "context"],
+      "properties": {
+        "query": { "type": "string", "minLength": 1 },
+        "allowed": { "$ref": "#/$defs/boolean3" },
+        "scaled_scores": { "$ref": "#/$defs/vector3" },
+        "masked_scores": { "$ref": "#/$defs/nullableVector3" },
+        "row_max": { "type": "number" },
+        "shifted_scores": { "$ref": "#/$defs/nullableVector3" },
+        "exponentials": { "$ref": "#/$defs/vector3" },
+        "denominator": { "type": "number", "exclusiveMinimum": 0 },
+        "weights": { "$ref": "#/$defs/vector3" },
+        "value_contributions": { "$ref": "#/$defs/matrix3x2" },
+        "context": { "$ref": "#/$defs/vector2" }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/convolution-learning-v1/CHANGELOG.md
+++ b/code/specs/fixtures/convolution-learning-v1/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0
+
+- Define valid, stride-one, single-channel 1D cross-correlation.
+- Add an asymmetric-kernel fixture with complete multiply-accumulate traces.

--- a/code/specs/fixtures/convolution-learning-v1/README.md
+++ b/code/specs/fixtures/convolution-learning-v1/README.md
@@ -1,0 +1,14 @@
+# Convolution Learning Fixtures V1
+
+This corpus accompanies NN05. It pins a neural-network-style valid 1D
+cross-correlation and exposes every multiply-accumulate performed while the
+shared kernel slides across the signal.
+
+Validate it from the repository root:
+
+```text
+python code/scripts/validate_convolution_learning_labs.py
+```
+
+The first lab deliberately uses an asymmetric kernel so that reversing the
+kernel produces different answers and fails validation.

--- a/code/specs/fixtures/convolution-learning-v1/labs/00-asymmetric-valid-kernel.json
+++ b/code/specs/fixtures/convolution-learning-v1/labs/00-asymmetric-valid-kernel.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "id": "asymmetric-valid-kernel",
+  "title": "Slide one feature detector",
+  "question": "How does one shared kernel turn six signal values into four feature values?",
+  "concepts": [
+    "local receptive field",
+    "shared weights",
+    "valid cross-correlation",
+    "multiply-accumulate"
+  ],
+  "operation": {
+    "kind": "cross-correlation-1d",
+    "padding": "valid",
+    "stride": 1
+  },
+  "signal": [2, 1, 3, 0, 4, 2],
+  "kernel": [1, -1, 2],
+  "expected": {
+    "absolute_tolerance": 1e-12,
+    "outputs": [7, -2, 11, 0],
+    "positions": [
+      {
+        "output_index": 0,
+        "start_index": 0,
+        "window": [2, 1, 3],
+        "products": [2, -1, 6],
+        "accumulator": [0, 2, 1, 7],
+        "output": 7
+      },
+      {
+        "output_index": 1,
+        "start_index": 1,
+        "window": [1, 3, 0],
+        "products": [1, -3, 0],
+        "accumulator": [0, 1, -2, -2],
+        "output": -2
+      },
+      {
+        "output_index": 2,
+        "start_index": 2,
+        "window": [3, 0, 4],
+        "products": [3, 0, 8],
+        "accumulator": [0, 3, 3, 11],
+        "output": 11
+      },
+      {
+        "output_index": 3,
+        "start_index": 3,
+        "window": [0, 4, 2],
+        "products": [0, -4, 4],
+        "accumulator": [0, 0, -4, 0],
+        "output": 0
+      }
+    ]
+  }
+}

--- a/code/specs/fixtures/convolution-learning-v1/schema.json
+++ b/code/specs/fixtures/convolution-learning-v1/schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/convolution-learning-v1.json",
+  "title": "Convolution learning lab v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "question",
+    "concepts",
+    "operation",
+    "signal",
+    "kernel",
+    "expected"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "padding", "stride"],
+      "properties": {
+        "kind": { "const": "cross-correlation-1d" },
+        "padding": { "const": "valid" },
+        "stride": { "const": 1 }
+      }
+    },
+    "signal": { "$ref": "#/$defs/non_empty_numbers" },
+    "kernel": { "$ref": "#/$defs/non_empty_numbers" },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["absolute_tolerance", "outputs", "positions"],
+      "properties": {
+        "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+        "outputs": { "$ref": "#/$defs/non_empty_numbers" },
+        "positions": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/position" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "non_empty_numbers": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "number" }
+    },
+    "position": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "output_index",
+        "start_index",
+        "window",
+        "products",
+        "accumulator",
+        "output"
+      ],
+      "properties": {
+        "output_index": { "type": "integer", "minimum": 0 },
+        "start_index": { "type": "integer", "minimum": 0 },
+        "window": { "$ref": "#/$defs/non_empty_numbers" },
+        "products": { "$ref": "#/$defs/non_empty_numbers" },
+        "accumulator": { "$ref": "#/$defs/non_empty_numbers" },
+        "output": { "type": "number" }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/convolution-training-v1/CHANGELOG.md
+++ b/code/specs/fixtures/convolution-training-v1/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0
+
+- Define one full-batch mean-squared-error gradient step for a valid,
+  stride-one, single-channel 1D cross-correlation kernel.
+- Store every shared-weight gradient contribution and a central finite-
+  difference oracle.

--- a/code/specs/fixtures/convolution-training-v1/README.md
+++ b/code/specs/fixtures/convolution-training-v1/README.md
@@ -1,0 +1,15 @@
+# Convolution Training Fixtures V1
+
+This corpus accompanies NN06. It pins one trainable valid 1D
+cross-correlation step: forward outputs, mean-squared-error derivatives,
+per-position shared-kernel gradient contributions, an independent numerical
+gradient, and the updated kernel and loss.
+
+Validate it from the repository root:
+
+```text
+python code/scripts/validate_convolution_training_labs.py
+```
+
+The first lab reuses NN05's signal and asymmetric kernel. Only two outputs are
+wrong, keeping the complete backward pass small enough to reproduce by hand.

--- a/code/specs/fixtures/convolution-training-v1/labs/00-shared-kernel-gradient.json
+++ b/code/specs/fixtures/convolution-training-v1/labs/00-shared-kernel-gradient.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "id": "shared-kernel-gradient",
+  "title": "Train one shared feature detector",
+  "question": "How do four output positions combine their evidence into one gradient for each shared kernel weight?",
+  "concepts": [
+    "shared parameter gradient",
+    "gradient accumulation",
+    "mean squared error",
+    "finite-difference gradient check"
+  ],
+  "operation": {
+    "kind": "cross-correlation-1d",
+    "padding": "valid",
+    "stride": 1
+  },
+  "signal": [2, 1, 3, 0, 4, 2],
+  "kernel": [1, -1, 2],
+  "targets": [6, -2, 10, 0],
+  "loss": {
+    "kind": "mean-squared-error",
+    "reduction": "mean"
+  },
+  "gradient_check": {
+    "epsilon": 0.000001,
+    "absolute_tolerance": 1e-9,
+    "expected": {
+      "outputs": [7, -2, 11, 0],
+      "errors": [1, 0, 1, 0],
+      "loss": 0.5,
+      "output_gradients": [0.5, 0, 0.5, 0],
+      "contributions": [
+        {
+          "output_index": 0,
+          "window": [2, 1, 3],
+          "output_gradient": 0.5,
+          "kernel_gradient": [1, 0.5, 1.5]
+        },
+        {
+          "output_index": 1,
+          "window": [1, 3, 0],
+          "output_gradient": 0,
+          "kernel_gradient": [0, 0, 0]
+        },
+        {
+          "output_index": 2,
+          "window": [3, 0, 4],
+          "output_gradient": 0.5,
+          "kernel_gradient": [1.5, 0, 2]
+        },
+        {
+          "output_index": 3,
+          "window": [0, 4, 2],
+          "output_gradient": 0,
+          "kernel_gradient": [0, 0, 0]
+        }
+      ],
+      "kernel_gradient": [2.5, 0.5, 3.5],
+      "numerical_kernel_gradient": [
+        2.4999999999053557,
+        0.500000000069889,
+        3.5000000002671783
+      ]
+    }
+  },
+  "optimizer_step": {
+    "learning_rate": 0.02,
+    "expected_kernel": [0.95, -1.01, 1.93],
+    "expected_outputs": [6.68, -2.08, 10.57, -0.18000000000000016],
+    "expected_loss": 0.206525
+  }
+}

--- a/code/specs/fixtures/convolution-training-v1/schema.json
+++ b/code/specs/fixtures/convolution-training-v1/schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/convolution-training-v1.json",
+  "title": "Convolution training lab v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "question",
+    "concepts",
+    "operation",
+    "signal",
+    "kernel",
+    "targets",
+    "loss",
+    "gradient_check",
+    "optimizer_step"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "padding", "stride"],
+      "properties": {
+        "kind": { "const": "cross-correlation-1d" },
+        "padding": { "const": "valid" },
+        "stride": { "const": 1 }
+      }
+    },
+    "signal": { "$ref": "#/$defs/numbers" },
+    "kernel": { "$ref": "#/$defs/numbers" },
+    "targets": { "$ref": "#/$defs/numbers" },
+    "loss": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "reduction"],
+      "properties": {
+        "kind": { "const": "mean-squared-error" },
+        "reduction": { "const": "mean" }
+      }
+    },
+    "gradient_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon", "absolute_tolerance", "expected"],
+      "properties": {
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+        "expected": { "$ref": "#/$defs/gradient_expected" }
+      }
+    },
+    "optimizer_step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "learning_rate",
+        "expected_kernel",
+        "expected_outputs",
+        "expected_loss"
+      ],
+      "properties": {
+        "learning_rate": { "type": "number", "exclusiveMinimum": 0 },
+        "expected_kernel": { "$ref": "#/$defs/numbers" },
+        "expected_outputs": { "$ref": "#/$defs/numbers" },
+        "expected_loss": { "type": "number", "minimum": 0 }
+      }
+    }
+  },
+  "$defs": {
+    "numbers": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "number" }
+    },
+    "contribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "output_index",
+        "window",
+        "output_gradient",
+        "kernel_gradient"
+      ],
+      "properties": {
+        "output_index": { "type": "integer", "minimum": 0 },
+        "window": { "$ref": "#/$defs/numbers" },
+        "output_gradient": { "type": "number" },
+        "kernel_gradient": { "$ref": "#/$defs/numbers" }
+      }
+    },
+    "gradient_expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outputs",
+        "errors",
+        "loss",
+        "output_gradients",
+        "contributions",
+        "kernel_gradient",
+        "numerical_kernel_gradient"
+      ],
+      "properties": {
+        "outputs": { "$ref": "#/$defs/numbers" },
+        "errors": { "$ref": "#/$defs/numbers" },
+        "loss": { "type": "number", "minimum": 0 },
+        "output_gradients": { "$ref": "#/$defs/numbers" },
+        "contributions": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/contribution" }
+        },
+        "kernel_gradient": { "$ref": "#/$defs/numbers" },
+        "numerical_kernel_gradient": { "$ref": "#/$defs/numbers" }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/gated-recurrent-v1/CHANGELOG.md
+++ b/code/specs/fixtures/gated-recurrent-v1/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add the scalar GRU/LSTM gate comparison.
+- Add update, reset, forget, input, and output gate counterfactuals.

--- a/code/specs/fixtures/gated-recurrent-v1/README.md
+++ b/code/specs/fixtures/gated-recurrent-v1/README.md
@@ -1,0 +1,13 @@
+# Gated Recurrent V1 Fixtures
+
+This corpus pins one scalar GRU/LSTM comparison for NN11. It includes gate
+preactivations, canonical cell traces, and one-gate counterfactuals.
+
+Validate it from the repository root:
+
+```text
+python code/scripts/validate_gated_recurrent_labs.py
+```
+
+See [`NN11-gated-recurrent-labs.md`](../../NN11-gated-recurrent-labs.md) for
+the equations and conformance levels.

--- a/code/specs/fixtures/gated-recurrent-v1/labs/00-gru-lstm-gates.json
+++ b/code/specs/fixtures/gated-recurrent-v1/labs/00-gru-lstm-gates.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "id": "gru-lstm-gates",
+  "title": "Compare one scalar GRU and LSTM gate trace",
+  "question": "How do GRU and LSTM gates route the same previous memory and candidate?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "gated recurrent unit",
+    "long short-term memory",
+    "reset gate",
+    "update gate",
+    "forget gate",
+    "input gate",
+    "output gate"
+  ],
+  "operation": {
+    "kind": "scalar-gru-lstm-gate-comparison",
+    "gru_update_convention": "candidate-share",
+    "gate_activation": "sigmoid",
+    "candidate_activation": "tanh"
+  },
+  "shared_inputs": {
+    "input": 1,
+    "previous_hidden": 0.8,
+    "previous_cell": 0.8
+  },
+  "gru": {
+    "reset_gate": {
+      "preactivation": 0,
+      "value": 0.5
+    },
+    "update_gate": {
+      "preactivation": -1.0986122886681098,
+      "value": 0.25
+    },
+    "candidate": {
+      "input_weight": 0,
+      "input_product": 0,
+      "reset_state": 0.4,
+      "recurrent_weight": 1,
+      "recurrent_product": 0.4,
+      "bias": 0.29314718055994526,
+      "preactivation": 0.6931471805599453,
+      "value": 0.6
+    },
+    "output": {
+      "retained_state": 0.6000000000000001,
+      "candidate_write": 0.15,
+      "hidden_state": 0.7500000000000001
+    }
+  },
+  "lstm": {
+    "forget_gate": {
+      "preactivation": 0,
+      "value": 0.5
+    },
+    "input_gate": {
+      "preactivation": -1.0986122886681098,
+      "value": 0.25
+    },
+    "output_gate": {
+      "preactivation": 1.0986122886681098,
+      "value": 0.75
+    },
+    "candidate": {
+      "preactivation": 0.6931471805599453,
+      "value": 0.6
+    },
+    "output": {
+      "retained_cell": 0.4,
+      "candidate_write": 0.15,
+      "cell_state": 0.55,
+      "exposed_cell": 0.5005202111902353,
+      "hidden_state": 0.3753901583926764
+    }
+  },
+  "counterfactuals": {
+    "gru": [
+      {
+        "gate": "update",
+        "gate_value": 0,
+        "candidate": 0.6,
+        "cell_state": null,
+        "hidden_state": 0.8
+      },
+      {
+        "gate": "update",
+        "gate_value": 1,
+        "candidate": 0.6,
+        "cell_state": null,
+        "hidden_state": 0.6
+      },
+      {
+        "gate": "reset",
+        "gate_value": 0,
+        "candidate": 0.2850288981936261,
+        "cell_state": null,
+        "hidden_state": 0.6712572245484066
+      }
+    ],
+    "lstm": [
+      {
+        "gate": "forget",
+        "gate_value": 0,
+        "candidate": 0.6,
+        "cell_state": 0.15,
+        "hidden_state": 0.11166377521748849
+      },
+      {
+        "gate": "input",
+        "gate_value": 0,
+        "candidate": 0.6,
+        "cell_state": 0.4,
+        "hidden_state": 0.28496172169141865
+      },
+      {
+        "gate": "output",
+        "gate_value": 0,
+        "candidate": 0.6,
+        "cell_state": 0.55,
+        "hidden_state": 0
+      },
+      {
+        "gate": "output",
+        "gate_value": 1,
+        "candidate": 0.6,
+        "cell_state": 0.55,
+        "hidden_state": 0.5005202111902353
+      }
+    ]
+  }
+}

--- a/code/specs/fixtures/gated-recurrent-v1/schema.json
+++ b/code/specs/fixtures/gated-recurrent-v1/schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/gated-recurrent-v1.json",
+  "title": "Gated recurrent learning lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "question",
+    "absolute_tolerance",
+    "concepts",
+    "operation",
+    "shared_inputs",
+    "gru",
+    "lstm",
+    "counterfactuals"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "gru_update_convention", "gate_activation", "candidate_activation"],
+      "properties": {
+        "kind": { "const": "scalar-gru-lstm-gate-comparison" },
+        "gru_update_convention": { "const": "candidate-share" },
+        "gate_activation": { "const": "sigmoid" },
+        "candidate_activation": { "const": "tanh" }
+      }
+    },
+    "shared_inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input", "previous_hidden", "previous_cell"],
+      "properties": {
+        "input": { "type": "number" },
+        "previous_hidden": { "type": "number" },
+        "previous_cell": { "type": "number" }
+      }
+    },
+    "gru": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reset_gate", "update_gate", "candidate", "output"],
+      "properties": {
+        "reset_gate": { "$ref": "#/$defs/gate" },
+        "update_gate": { "$ref": "#/$defs/gate" },
+        "candidate": { "$ref": "#/$defs/gruCandidate" },
+        "output": { "$ref": "#/$defs/gruOutput" }
+      }
+    },
+    "lstm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["forget_gate", "input_gate", "output_gate", "candidate", "output"],
+      "properties": {
+        "forget_gate": { "$ref": "#/$defs/gate" },
+        "input_gate": { "$ref": "#/$defs/gate" },
+        "output_gate": { "$ref": "#/$defs/gate" },
+        "candidate": { "$ref": "#/$defs/gate" },
+        "output": { "$ref": "#/$defs/lstmOutput" }
+      }
+    },
+    "counterfactuals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gru", "lstm"],
+      "properties": {
+        "gru": {
+          "type": "array",
+          "minItems": 3,
+          "items": { "$ref": "#/$defs/counterfactual" }
+        },
+        "lstm": {
+          "type": "array",
+          "minItems": 4,
+          "items": { "$ref": "#/$defs/counterfactual" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["preactivation", "value"],
+      "properties": {
+        "preactivation": { "type": "number" },
+        "value": { "type": "number" }
+      }
+    },
+    "gruCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_weight",
+        "input_product",
+        "reset_state",
+        "recurrent_weight",
+        "recurrent_product",
+        "bias",
+        "preactivation",
+        "value"
+      ],
+      "properties": {
+        "input_weight": { "type": "number" },
+        "input_product": { "type": "number" },
+        "reset_state": { "type": "number" },
+        "recurrent_weight": { "type": "number" },
+        "recurrent_product": { "type": "number" },
+        "bias": { "type": "number" },
+        "preactivation": { "type": "number" },
+        "value": { "type": "number" }
+      }
+    },
+    "gruOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["retained_state", "candidate_write", "hidden_state"],
+      "properties": {
+        "retained_state": { "type": "number" },
+        "candidate_write": { "type": "number" },
+        "hidden_state": { "type": "number" }
+      }
+    },
+    "lstmOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "retained_cell",
+        "candidate_write",
+        "cell_state",
+        "exposed_cell",
+        "hidden_state"
+      ],
+      "properties": {
+        "retained_cell": { "type": "number" },
+        "candidate_write": { "type": "number" },
+        "cell_state": { "type": "number" },
+        "exposed_cell": { "type": "number" },
+        "hidden_state": { "type": "number" }
+      }
+    },
+    "counterfactual": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gate", "gate_value", "candidate", "cell_state", "hidden_state"],
+      "properties": {
+        "gate": {
+          "enum": ["reset", "update", "forget", "input", "output"]
+        },
+        "gate_value": { "type": "number", "minimum": 0, "maximum": 1 },
+        "candidate": { "type": "number" },
+        "cell_state": { "type": ["number", "null"] },
+        "hidden_state": { "type": "number" }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/gradient-flow-v1/CHANGELOG.md
+++ b/code/specs/fixtures/gradient-flow-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add four deterministic scalar gradient-flow scenarios.
+- Pin forward activations, local Jacobians, and all reverse-mode gradients.
+- Add input-gradient finite-difference audits and flow classifications.

--- a/code/specs/fixtures/gradient-flow-v1/README.md
+++ b/code/specs/fixtures/gradient-flow-v1/README.md
@@ -1,0 +1,12 @@
+# Gradient Flow V1 Fixtures
+
+This NN24 corpus follows one half-squared-error gradient through four scalar
+layers. It pins small-tanh and saturated-tanh vanishing paths, a unit-ReLU
+control, a large-ReLU exploding path, every reverse-mode intermediate, and a
+central finite-difference audit of the input gradient.
+
+Validate it with:
+
+```text
+python code/scripts/validate_gradient_flow_labs.py
+```

--- a/code/specs/fixtures/gradient-flow-v1/labs/00-four-layer-gradient-flow.json
+++ b/code/specs/fixtures/gradient-flow-v1/labs/00-four-layer-gradient-flow.json
@@ -1,0 +1,190 @@
+{
+  "schema_version": 1,
+  "id": "nn24-four-layer-gradient-flow",
+  "title": "Four-layer vanishing and exploding gradient comparison",
+  "question": "How do weights and activation derivatives change a loss gradient as it crosses four layers?",
+  "absolute_tolerance": 1e-9,
+  "concepts": ["reverse mode", "chain rule", "local Jacobian", "vanishing gradient", "exploding gradient", "tanh saturation", "finite difference"],
+  "operation": {
+    "kind": "scalar-gradient-flow",
+    "loss": "half-squared-error",
+    "activation_derivative": "saved-output",
+    "finite_difference_epsilon": 1e-6,
+    "vanishing_threshold": 0.1,
+    "exploding_threshold": 10
+  },
+  "scenarios": [
+    {"id": "small-tanh", "label": "Small tanh", "input": 1, "weights": [0.5, 0.5, 0.5, 0.5], "activation": "tanh", "target": 0},
+    {"id": "saturated-tanh", "label": "Saturated tanh", "input": 1, "weights": [3, 3, 3, 3], "activation": "tanh", "target": 0},
+    {"id": "unit-relu", "label": "Unit ReLU", "input": 1, "weights": [1, 1, 1, 1], "activation": "relu", "target": 0},
+    {"id": "large-relu", "label": "Large ReLU", "input": 1, "weights": [2, 2, 2, 2], "activation": "relu", "target": 0}
+  ],
+  "expected": {
+    "traces": [
+      {
+        "id": "small-tanh",
+        "output": 0.05645551423322024,
+        "output_error": 0.05645551423322024,
+        "loss": 0.0015936125436686666,
+        "chain_jacobian": 0.045877150455727246,
+        "input_gradient": 0.0025900181205328957,
+        "finite_difference_input_gradient": 0.002590018120546961,
+        "finite_difference_error": 1.4065137943219952e-14,
+        "classification": "vanishing",
+        "layers": [
+          {
+            "layer": 1,
+            "input": 1,
+            "weight": 0.5,
+            "preactivation": 0.5,
+            "activation": 0.46211715726000974,
+            "activation_derivative": 0.7864477329659274,
+            "local_jacobian": 0.3932238664829637,
+            "upstream_gradient": 0.006586624926147781,
+            "preactivation_gradient": 0.005180036241065791,
+            "weight_gradient": 0.005180036241065791,
+            "input_gradient": 0.0025900181205328957
+          },
+          {
+            "layer": 2,
+            "input": 0.46211715726000974,
+            "weight": 0.5,
+            "preactivation": 0.23105857863000487,
+            "activation": 0.2270326087174543,
+            "activation_derivative": 0.9484561945789473,
+            "local_jacobian": 0.4742280972894736,
+            "upstream_gradient": 0.013889149470043397,
+            "preactivation_gradient": 0.013173249852295562,
+            "weight_gradient": 0.006087584773618668,
+            "input_gradient": 0.006586624926147781
+          },
+          {
+            "layer": 3,
+            "input": 0.2270326087174543,
+            "weight": 0.5,
+            "preactivation": 0.11351630435872714,
+            "activation": 0.11303121601000445,
+            "activation_derivative": 0.9872239442072998,
+            "local_jacobian": 0.4936119721036499,
+            "upstream_gradient": 0.028137788900968793,
+            "preactivation_gradient": 0.027778298940086793,
+            "weight_gradient": 0.0063065796741012,
+            "input_gradient": 0.013889149470043397
+          },
+          {
+            "layer": 4,
+            "input": 0.11303121601000445,
+            "weight": 0.5,
+            "preactivation": 0.05651560800500222,
+            "activation": 0.05645551423322024,
+            "activation_derivative": 0.9968127749126626,
+            "local_jacobian": 0.4984063874563313,
+            "upstream_gradient": 0.05645551423322024,
+            "preactivation_gradient": 0.056275577801937586,
+            "weight_gradient": 0.006360896990618619,
+            "input_gradient": 0.028137788900968793
+          }
+        ]
+      },
+      {
+        "id": "saturated-tanh",
+        "output": 0.9949015328034738,
+        "output_error": 0.9949015328034738,
+        "loss": 0.49491452998735086,
+        "chain_jacobian": 8.400447769691746e-7,
+        "input_gradient": 8.357618362301841e-7,
+        "finite_difference_input_gradient": 8.357758929378178e-7,
+        "finite_difference_error": 1.4056707633724826e-11,
+        "classification": "vanishing",
+        "layers": [
+          {
+            "layer": 1,
+            "input": 1,
+            "weight": 3,
+            "preactivation": 3,
+            "activation": 0.9950547536867305,
+            "activation_derivative": 0.009866037165440211,
+            "local_jacobian": 0.029598111496320634,
+            "upstream_gradient": 2.8236998713045537e-5,
+            "preactivation_gradient": 2.785872787433947e-7,
+            "weight_gradient": 2.785872787433947e-7,
+            "input_gradient": 8.357618362301841e-7
+          },
+          {
+            "layer": 2,
+            "input": 0.9950547536867305,
+            "weight": 3,
+            "preactivation": 2.9851642610601914,
+            "activation": 0.9949062016530742,
+            "activation_derivative": 0.010161649912252435,
+            "local_jacobian": 0.030484949736757305,
+            "upstream_gradient": 0.0009262603008001258,
+            "preactivation_gradient": 9.412332904348513e-6,
+            "weight_gradient": 9.365786599754017e-6,
+            "input_gradient": 2.8236998713045537e-5
+          },
+          {
+            "layer": 3,
+            "input": 0.9949062016530742,
+            "weight": 3,
+            "preactivation": 2.9847186049592227,
+            "activation": 0.9949016710432858,
+            "activation_derivative": 0.01017066495527763,
+            "local_jacobian": 0.030511994865832892,
+            "upstream_gradient": 0.030357251463664386,
+            "preactivation_gradient": 0.00030875343360004193,
+            "weight_gradient": 0.0003071807058703624,
+            "input_gradient": 0.0009262603008001258
+          },
+          {
+            "layer": 4,
+            "input": 0.9949016710432858,
+            "weight": 3,
+            "preactivation": 2.984705013129857,
+            "activation": 0.9949015328034738,
+            "activation_derivative": 0.01017094002529828,
+            "local_jacobian": 0.030512820075894842,
+            "upstream_gradient": 0.9949015328034738,
+            "preactivation_gradient": 0.010119083821221462,
+            "weight_gradient": 0.01006749340316031,
+            "input_gradient": 0.030357251463664386
+          }
+        ]
+      },
+      {
+        "id": "unit-relu",
+        "output": 1,
+        "output_error": 1,
+        "loss": 0.5,
+        "chain_jacobian": 1,
+        "input_gradient": 1,
+        "finite_difference_input_gradient": 1.000000000001,
+        "finite_difference_error": 1.000088900582341e-12,
+        "classification": "stable",
+        "layers": [
+          {"layer": 1, "input": 1, "weight": 1, "preactivation": 1, "activation": 1, "activation_derivative": 1, "local_jacobian": 1, "upstream_gradient": 1, "preactivation_gradient": 1, "weight_gradient": 1, "input_gradient": 1},
+          {"layer": 2, "input": 1, "weight": 1, "preactivation": 1, "activation": 1, "activation_derivative": 1, "local_jacobian": 1, "upstream_gradient": 1, "preactivation_gradient": 1, "weight_gradient": 1, "input_gradient": 1},
+          {"layer": 3, "input": 1, "weight": 1, "preactivation": 1, "activation": 1, "activation_derivative": 1, "local_jacobian": 1, "upstream_gradient": 1, "preactivation_gradient": 1, "weight_gradient": 1, "input_gradient": 1},
+          {"layer": 4, "input": 1, "weight": 1, "preactivation": 1, "activation": 1, "activation_derivative": 1, "local_jacobian": 1, "upstream_gradient": 1, "preactivation_gradient": 1, "weight_gradient": 1, "input_gradient": 1}
+        ]
+      },
+      {
+        "id": "large-relu",
+        "output": 16,
+        "output_error": 16,
+        "loss": 128,
+        "chain_jacobian": 16,
+        "input_gradient": 256,
+        "finite_difference_input_gradient": 256.000000000256,
+        "finite_difference_error": 2.560227585490793e-10,
+        "classification": "exploding",
+        "layers": [
+          {"layer": 1, "input": 1, "weight": 2, "preactivation": 2, "activation": 2, "activation_derivative": 1, "local_jacobian": 2, "upstream_gradient": 128, "preactivation_gradient": 128, "weight_gradient": 128, "input_gradient": 256},
+          {"layer": 2, "input": 2, "weight": 2, "preactivation": 4, "activation": 4, "activation_derivative": 1, "local_jacobian": 2, "upstream_gradient": 64, "preactivation_gradient": 64, "weight_gradient": 128, "input_gradient": 128},
+          {"layer": 3, "input": 4, "weight": 2, "preactivation": 8, "activation": 8, "activation_derivative": 1, "local_jacobian": 2, "upstream_gradient": 32, "preactivation_gradient": 32, "weight_gradient": 128, "input_gradient": 64},
+          {"layer": 4, "input": 8, "weight": 2, "preactivation": 16, "activation": 16, "activation_derivative": 1, "local_jacobian": 2, "upstream_gradient": 16, "preactivation_gradient": 16, "weight_gradient": 128, "input_gradient": 32}
+        ]
+      }
+    ]
+  }
+}

--- a/code/specs/fixtures/gradient-flow-v1/schema.json
+++ b/code/specs/fixtures/gradient-flow-v1/schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/gradient-flow-v1.json",
+  "title": "Gradient flow V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "scenarios", "expected"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "id": {"type": "string", "minLength": 1},
+    "title": {"type": "string", "minLength": 1},
+    "question": {"type": "string", "minLength": 1},
+    "absolute_tolerance": {"type": "number", "exclusiveMinimum": 0},
+    "concepts": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "loss", "activation_derivative", "finite_difference_epsilon", "vanishing_threshold", "exploding_threshold"],
+      "properties": {
+        "kind": {"const": "scalar-gradient-flow"},
+        "loss": {"const": "half-squared-error"},
+        "activation_derivative": {"const": "saved-output"},
+        "finite_difference_epsilon": {"const": 1e-6},
+        "vanishing_threshold": {"const": 0.1},
+        "exploding_threshold": {"const": 10}
+      }
+    },
+    "scenarios": {"type": "array", "minItems": 4, "maxItems": 4, "items": {"$ref": "#/$defs/scenario"}},
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["traces"],
+      "properties": {"traces": {"type": "array", "minItems": 4, "maxItems": 4, "items": {"$ref": "#/$defs/trace"}}}
+    }
+  },
+  "$defs": {
+    "numberArray": {"type": "array", "minItems": 2, "items": {"type": "number"}},
+    "scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "input", "weights", "activation", "target"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "label": {"type": "string", "minLength": 1},
+        "input": {"type": "number"},
+        "weights": {"$ref": "#/$defs/numberArray"},
+        "activation": {"enum": ["tanh", "relu"]},
+        "target": {"type": "number"}
+      }
+    },
+    "layer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["layer", "input", "weight", "preactivation", "activation", "activation_derivative", "local_jacobian", "upstream_gradient", "preactivation_gradient", "weight_gradient", "input_gradient"],
+      "properties": {
+        "layer": {"type": "integer", "minimum": 1},
+        "input": {"type": "number"},
+        "weight": {"type": "number"},
+        "preactivation": {"type": "number"},
+        "activation": {"type": "number"},
+        "activation_derivative": {"type": "number"},
+        "local_jacobian": {"type": "number"},
+        "upstream_gradient": {"type": "number"},
+        "preactivation_gradient": {"type": "number"},
+        "weight_gradient": {"type": "number"},
+        "input_gradient": {"type": "number"}
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "output", "output_error", "loss", "chain_jacobian", "input_gradient", "finite_difference_input_gradient", "finite_difference_error", "classification", "layers"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "output": {"type": "number"},
+        "output_error": {"type": "number"},
+        "loss": {"type": "number", "minimum": 0},
+        "chain_jacobian": {"type": "number"},
+        "input_gradient": {"type": "number"},
+        "finite_difference_input_gradient": {"type": "number"},
+        "finite_difference_error": {"type": "number", "minimum": 0},
+        "classification": {"enum": ["vanishing", "stable", "exploding"]},
+        "layers": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/layer"}}
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/graph-convolution-attention-v1/CHANGELOG.md
+++ b/code/specs/fixtures/graph-convolution-attention-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Pin self-looped neighborhoods and degrees.
+- Add symmetric-normalized GCN traces.
+- Add stable neighborhood-softmax GAT traces on the same graph.

--- a/code/specs/fixtures/graph-convolution-attention-v1/README.md
+++ b/code/specs/fixtures/graph-convolution-attention-v1/README.md
@@ -1,0 +1,10 @@
+# Graph Convolution and Attention V1 Fixtures
+
+This corpus compares degree-normalized graph convolution with stable-softmax
+graph attention on the same self-looped three-node path. It pins every GCN
+coefficient and contribution plus every GAT score, shift, exponential,
+attention weight, contribution, and output.
+
+```text
+python code/scripts/validate_graph_convolution_attention_labs.py
+```

--- a/code/specs/fixtures/graph-convolution-attention-v1/labs/00-three-node-gcn-gat.json
+++ b/code/specs/fixtures/graph-convolution-attention-v1/labs/00-three-node-gcn-gat.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "id": "three-node-gcn-gat",
+  "title": "GCN and GAT on one three-node path",
+  "question": "How do structural degree weights and feature-dependent attention weight the same neighborhoods?",
+  "absolute_tolerance": 1e-12,
+  "concepts": ["self-loop", "symmetric-degree-normalization", "graph-convolution", "stable-neighborhood-softmax", "graph-attention", "weighted-neighbor-aggregation"],
+  "operation": {"kind": "graph-convolution-attention-comparison", "gcn": "symmetric-degree-normalized-sum", "gat_score": "source-feature", "gat_normalization": "stable-neighborhood-softmax", "activation": "relu"},
+  "features": [1, 2, -1],
+  "neighborhoods": [[0, 1], [0, 1, 2], [1, 2]],
+  "expected": {
+    "degrees": [2, 3, 2],
+    "gcn": [
+      {"target": 0, "rows": [{"source": 0, "source_feature": 1, "source_degree": 2, "target_degree": 2, "coefficient": 0.5, "contribution": 0.5}, {"source": 1, "source_feature": 2, "source_degree": 3, "target_degree": 2, "coefficient": 0.4082482904638631, "contribution": 0.8164965809277261}], "preactivation": 1.3164965809277263, "output": 1.3164965809277263},
+      {"target": 1, "rows": [{"source": 0, "source_feature": 1, "source_degree": 2, "target_degree": 3, "coefficient": 0.4082482904638631, "contribution": 0.4082482904638631}, {"source": 1, "source_feature": 2, "source_degree": 3, "target_degree": 3, "coefficient": 0.3333333333333333, "contribution": 0.6666666666666666}, {"source": 2, "source_feature": -1, "source_degree": 2, "target_degree": 3, "coefficient": 0.4082482904638631, "contribution": -0.4082482904638631}], "preactivation": 0.6666666666666665, "output": 0.6666666666666665},
+      {"target": 2, "rows": [{"source": 1, "source_feature": 2, "source_degree": 3, "target_degree": 2, "coefficient": 0.4082482904638631, "contribution": 0.8164965809277261}, {"source": 2, "source_feature": -1, "source_degree": 2, "target_degree": 2, "coefficient": 0.5, "contribution": -0.5}], "preactivation": 0.31649658092772615, "output": 0.31649658092772615}
+    ],
+    "gat": [
+      {"target": 0, "maximum_score": 2, "denominator": 1.3678794411714423, "rows": [{"source": 0, "source_feature": 1, "score": 1, "shifted_score": -1, "exponential": 0.36787944117144233, "attention_weight": 0.2689414213699951, "contribution": 0.2689414213699951}, {"source": 1, "source_feature": 2, "score": 2, "shifted_score": 0, "exponential": 1, "attention_weight": 0.7310585786300049, "contribution": 1.4621171572600098}], "preactivation": 1.7310585786300048, "output": 1.7310585786300048},
+      {"target": 1, "maximum_score": 2, "denominator": 1.4176665095393062, "rows": [{"source": 0, "source_feature": 1, "score": 1, "shifted_score": -1, "exponential": 0.36787944117144233, "attention_weight": 0.25949646034241913, "contribution": 0.25949646034241913}, {"source": 1, "source_feature": 2, "score": 2, "shifted_score": 0, "exponential": 1, "attention_weight": 0.7053845126982412, "contribution": 1.4107690253964824}, {"source": 2, "source_feature": -1, "score": -1, "shifted_score": -3, "exponential": 0.049787068367863944, "attention_weight": 0.03511902695933973, "contribution": -0.03511902695933973}], "preactivation": 1.6351464587795619, "output": 1.6351464587795619},
+      {"target": 2, "maximum_score": 2, "denominator": 1.0497870683678638, "rows": [{"source": 1, "source_feature": 2, "score": 2, "shifted_score": 0, "exponential": 1, "attention_weight": 0.9525741268224334, "contribution": 1.9051482536448667}, {"source": 2, "source_feature": -1, "score": -1, "shifted_score": -3, "exponential": 0.049787068367863944, "attention_weight": 0.04742587317756679, "contribution": -0.04742587317756679}], "preactivation": 1.8577223804673, "output": 1.8577223804673}
+    ],
+    "gcn_outputs": [1.3164965809277263, 0.6666666666666665, 0.31649658092772615],
+    "gat_outputs": [1.7310585786300048, 1.6351464587795619, 1.8577223804673]
+  }
+}

--- a/code/specs/fixtures/graph-convolution-attention-v1/schema.json
+++ b/code/specs/fixtures/graph-convolution-attention-v1/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/graph-convolution-attention-v1.json",
+  "title": "Graph convolution and attention V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "features", "neighborhoods", "expected"],
+  "properties": {
+    "schema_version": {"const": 1}, "id": {"type": "string", "minLength": 1}, "title": {"type": "string", "minLength": 1}, "question": {"type": "string", "minLength": 1}, "absolute_tolerance": {"type": "number", "exclusiveMinimum": 0},
+    "concepts": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "operation": {"type": "object", "additionalProperties": false, "required": ["kind", "gcn", "gat_score", "gat_normalization", "activation"], "properties": {"kind": {"const": "graph-convolution-attention-comparison"}, "gcn": {"const": "symmetric-degree-normalized-sum"}, "gat_score": {"const": "source-feature"}, "gat_normalization": {"const": "stable-neighborhood-softmax"}, "activation": {"const": "relu"}}},
+    "features": {"type": "array", "minItems": 2, "items": {"type": "number"}},
+    "neighborhoods": {"type": "array", "minItems": 2, "items": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "integer", "minimum": 0}}},
+    "expected": {"type": "object", "additionalProperties": false, "required": ["degrees", "gcn", "gat", "gcn_outputs", "gat_outputs"], "properties": {"degrees": {"type": "array", "items": {"type": "integer", "minimum": 1}}, "gcn": {"type": "array", "items": {"type": "object"}}, "gat": {"type": "array", "items": {"type": "object"}}, "gcn_outputs": {"type": "array", "items": {"type": "number", "minimum": 0}}, "gat_outputs": {"type": "array", "items": {"type": "number", "minimum": 0}}}}
+  }
+}

--- a/code/specs/fixtures/hopfield-associative-memory-v1/CHANGELOG.md
+++ b/code/specs/fixtures/hopfield-associative-memory-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Define normalized single-pattern Hebbian storage.
+- Pin zero-diagonal symmetric weights and sign-with-zero-preservation.
+- Add one-bit asynchronous recall with energy and overlap traces.

--- a/code/specs/fixtures/hopfield-associative-memory-v1/README.md
+++ b/code/specs/fixtures/hopfield-associative-memory-v1/README.md
@@ -1,0 +1,16 @@
+# Hopfield Associative Memory V1 Fixtures
+
+This corpus pins one deterministic four-neuron associative recall round. The
+fixture stores a bipolar pattern with the normalized Hebbian outer product,
+zeros the diagonal, damages one bit, and performs one asynchronous in-place
+sweep in the saved order.
+
+Every consumer must reproduce the weight matrix, every incoming contribution,
+local field, state transition, energy, overlap, and final fixed point within the
+document tolerance. A zero local field preserves the previous state.
+
+Validate the corpus from the repository root:
+
+```text
+python code/scripts/validate_hopfield_associative_memory_labs.py
+```

--- a/code/specs/fixtures/hopfield-associative-memory-v1/labs/00-one-bit-recall.json
+++ b/code/specs/fixtures/hopfield-associative-memory-v1/labs/00-one-bit-recall.json
@@ -1,0 +1,124 @@
+{
+  "schema_version": 1,
+  "id": "one-bit-recall",
+  "title": "Recall one corrupted bipolar bit",
+  "question": "Can four asynchronous Hopfield neurons restore one flipped bit while energy never increases?",
+  "absolute_tolerance": 1e-12,
+  "concepts": [
+    "bipolar-pattern",
+    "hebbian-outer-product",
+    "zero-diagonal",
+    "asynchronous-recall",
+    "energy-descent",
+    "normalized-overlap"
+  ],
+  "operation": {
+    "kind": "hopfield-associative-recall",
+    "storage": "single-pattern-normalized-hebbian",
+    "activation": "sign-preserve-zero",
+    "update": "asynchronous-in-place",
+    "energy": "symmetric-zero-diagonal-hopfield"
+  },
+  "stored_pattern": [1, -1, 1, -1],
+  "corrupted_state": [-1, -1, 1, -1],
+  "update_order": [0, 1, 2, 3],
+  "expected": {
+    "normalization": 4,
+    "weights": [
+      [0, -0.25, 0.25, -0.25],
+      [-0.25, 0, -0.25, 0.25],
+      [0.25, -0.25, 0, -0.25],
+      [-0.25, 0.25, -0.25, 0]
+    ],
+    "initial_energy": 0,
+    "initial_overlap": 0.5,
+    "initial_hamming_distance": 1,
+    "updates": [
+      {
+        "step": 0,
+        "neuron_index": 0,
+        "state_before": [-1, -1, 1, -1],
+        "incoming": [
+          {"source_index": 0, "weight": 0, "source_state": -1, "contribution": 0},
+          {"source_index": 1, "weight": -0.25, "source_state": -1, "contribution": 0.25},
+          {"source_index": 2, "weight": 0.25, "source_state": 1, "contribution": 0.25},
+          {"source_index": 3, "weight": -0.25, "source_state": -1, "contribution": 0.25}
+        ],
+        "local_field": 0.75,
+        "previous_state": -1,
+        "next_state": 1,
+        "changed": true,
+        "state_after": [1, -1, 1, -1],
+        "energy_before": 0,
+        "energy_after": -1.5,
+        "overlap_before": 0.5,
+        "overlap_after": 1
+      },
+      {
+        "step": 1,
+        "neuron_index": 1,
+        "state_before": [1, -1, 1, -1],
+        "incoming": [
+          {"source_index": 0, "weight": -0.25, "source_state": 1, "contribution": -0.25},
+          {"source_index": 1, "weight": 0, "source_state": -1, "contribution": 0},
+          {"source_index": 2, "weight": -0.25, "source_state": 1, "contribution": -0.25},
+          {"source_index": 3, "weight": 0.25, "source_state": -1, "contribution": -0.25}
+        ],
+        "local_field": -0.75,
+        "previous_state": -1,
+        "next_state": -1,
+        "changed": false,
+        "state_after": [1, -1, 1, -1],
+        "energy_before": -1.5,
+        "energy_after": -1.5,
+        "overlap_before": 1,
+        "overlap_after": 1
+      },
+      {
+        "step": 2,
+        "neuron_index": 2,
+        "state_before": [1, -1, 1, -1],
+        "incoming": [
+          {"source_index": 0, "weight": 0.25, "source_state": 1, "contribution": 0.25},
+          {"source_index": 1, "weight": -0.25, "source_state": -1, "contribution": 0.25},
+          {"source_index": 2, "weight": 0, "source_state": 1, "contribution": 0},
+          {"source_index": 3, "weight": -0.25, "source_state": -1, "contribution": 0.25}
+        ],
+        "local_field": 0.75,
+        "previous_state": 1,
+        "next_state": 1,
+        "changed": false,
+        "state_after": [1, -1, 1, -1],
+        "energy_before": -1.5,
+        "energy_after": -1.5,
+        "overlap_before": 1,
+        "overlap_after": 1
+      },
+      {
+        "step": 3,
+        "neuron_index": 3,
+        "state_before": [1, -1, 1, -1],
+        "incoming": [
+          {"source_index": 0, "weight": -0.25, "source_state": 1, "contribution": -0.25},
+          {"source_index": 1, "weight": 0.25, "source_state": -1, "contribution": -0.25},
+          {"source_index": 2, "weight": -0.25, "source_state": 1, "contribution": -0.25},
+          {"source_index": 3, "weight": 0, "source_state": -1, "contribution": 0}
+        ],
+        "local_field": -0.75,
+        "previous_state": -1,
+        "next_state": -1,
+        "changed": false,
+        "state_after": [1, -1, 1, -1],
+        "energy_before": -1.5,
+        "energy_after": -1.5,
+        "overlap_before": 1,
+        "overlap_after": 1
+      }
+    ],
+    "final_state": [1, -1, 1, -1],
+    "final_energy": -1.5,
+    "final_overlap": 1,
+    "final_hamming_distance": 0,
+    "converged": true
+  }
+}

--- a/code/specs/fixtures/hopfield-associative-memory-v1/schema.json
+++ b/code/specs/fixtures/hopfield-associative-memory-v1/schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/hopfield-associative-memory-v1.json",
+  "title": "Hopfield associative memory learning lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "stored_pattern", "corrupted_state", "update_order", "expected"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "id": {"type": "string", "minLength": 1},
+    "title": {"type": "string", "minLength": 1},
+    "question": {"type": "string", "minLength": 1},
+    "absolute_tolerance": {"type": "number", "exclusiveMinimum": 0},
+    "concepts": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "storage", "activation", "update", "energy"],
+      "properties": {
+        "kind": {"const": "hopfield-associative-recall"},
+        "storage": {"const": "single-pattern-normalized-hebbian"},
+        "activation": {"const": "sign-preserve-zero"},
+        "update": {"const": "asynchronous-in-place"},
+        "energy": {"const": "symmetric-zero-diagonal-hopfield"}
+      }
+    },
+    "stored_pattern": {"$ref": "#/$defs/bipolarVector"},
+    "corrupted_state": {"$ref": "#/$defs/bipolarVector"},
+    "update_order": {"type": "array", "minItems": 2, "uniqueItems": true, "items": {"type": "integer", "minimum": 0}},
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["normalization", "weights", "initial_energy", "initial_overlap", "initial_hamming_distance", "updates", "final_state", "final_energy", "final_overlap", "final_hamming_distance", "converged"],
+      "properties": {
+        "normalization": {"type": "integer", "minimum": 2},
+        "weights": {"type": "array", "minItems": 2, "items": {"type": "array", "minItems": 2, "items": {"type": "number"}}},
+        "initial_energy": {"type": "number"},
+        "initial_overlap": {"type": "number", "minimum": -1, "maximum": 1},
+        "initial_hamming_distance": {"type": "integer", "minimum": 0},
+        "updates": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/updateStep"}},
+        "final_state": {"$ref": "#/$defs/bipolarVector"},
+        "final_energy": {"type": "number"},
+        "final_overlap": {"type": "number", "minimum": -1, "maximum": 1},
+        "final_hamming_distance": {"type": "integer", "minimum": 0},
+        "converged": {"type": "boolean"}
+      }
+    }
+  },
+  "$defs": {
+    "bipolarVector": {
+      "type": "array",
+      "minItems": 2,
+      "items": {"type": "integer", "enum": [-1, 1]}
+    },
+    "incomingContribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_index", "weight", "source_state", "contribution"],
+      "properties": {
+        "source_index": {"type": "integer", "minimum": 0},
+        "weight": {"type": "number"},
+        "source_state": {"type": "integer", "enum": [-1, 1]},
+        "contribution": {"type": "number"}
+      }
+    },
+    "updateStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step", "neuron_index", "state_before", "incoming", "local_field", "previous_state", "next_state", "changed", "state_after", "energy_before", "energy_after", "overlap_before", "overlap_after"],
+      "properties": {
+        "step": {"type": "integer", "minimum": 0},
+        "neuron_index": {"type": "integer", "minimum": 0},
+        "state_before": {"$ref": "#/$defs/bipolarVector"},
+        "incoming": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/incomingContribution"}},
+        "local_field": {"type": "number"},
+        "previous_state": {"type": "integer", "enum": [-1, 1]},
+        "next_state": {"type": "integer", "enum": [-1, 1]},
+        "changed": {"type": "boolean"},
+        "state_after": {"$ref": "#/$defs/bipolarVector"},
+        "energy_before": {"type": "number"},
+        "energy_after": {"type": "number"},
+        "overlap_before": {"type": "number", "minimum": -1, "maximum": 1},
+        "overlap_after": {"type": "number", "minimum": -1, "maximum": 1}
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/initialization-activation-distribution-v1/CHANGELOG.md
+++ b/code/specs/fixtures/initialization-activation-distribution-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add the canonical three-layer Xavier-plus-tanh trace.
+- Compare tiny, Xavier, He, and large scaling under tanh and ReLU.
+- Pin population standard deviation, exact-zero fractions, and tanh saturation.

--- a/code/specs/fixtures/initialization-activation-distribution-v1/README.md
+++ b/code/specs/fixtures/initialization-activation-distribution-v1/README.md
@@ -1,0 +1,12 @@
+# Initialization and Activation Distribution V1 Fixtures
+
+This NN23 corpus compares tiny, Xavier, He, and deliberately large weight
+scales under `tanh` and ReLU. The three-layer experiment fixes its inputs and
+weight signs so every consumer can reproduce activation values and population
+statistics without agreeing on a random-number generator.
+
+Validate it with:
+
+```text
+python code/scripts/validate_initialization_activation_distribution_labs.py
+```

--- a/code/specs/fixtures/initialization-activation-distribution-v1/labs/00-three-layer-scale-comparison.json
+++ b/code/specs/fixtures/initialization-activation-distribution-v1/labs/00-three-layer-scale-comparison.json
@@ -1,0 +1,166 @@
+{
+  "schema_version": 1,
+  "id": "nn23-three-layer-scale-comparison",
+  "title": "Three-layer initialization and activation comparison",
+  "question": "How do weight scale and activation choice change signal spread across three layers?",
+  "absolute_tolerance": 1e-12,
+  "concepts": ["weight initialization", "Xavier scale", "He scale", "activation distribution", "population variance", "tanh saturation", "ReLU zeros"],
+  "operation": {
+    "kind": "initialization-activation-distribution",
+    "bias": "none",
+    "variance": "population",
+    "zero_threshold": 1e-12,
+    "tanh_saturation_threshold": 0.95,
+    "canonical_initializer": "xavier",
+    "canonical_activation": "tanh"
+  },
+  "inputs": [[1, 0], [0, 1], [-1, 0], [0, -1]],
+  "weight_templates": [
+    [[1, -1], [1, 1]],
+    [[1, -1], [1, 1]],
+    [[1, -1], [1, 1]]
+  ],
+  "initializers": ["tiny", "xavier", "he", "large"],
+  "activations": ["tanh", "relu"],
+  "expected": {
+    "canonical": {
+      "initializer": "xavier",
+      "activation": "tanh",
+      "layers": [
+        {
+          "layer": 1,
+          "scale": 0.7071067811865475,
+          "preactivations": [
+            [0.7071067811865475, -0.7071067811865475],
+            [0.7071067811865475, 0.7071067811865475],
+            [-0.7071067811865475, 0.7071067811865475],
+            [-0.7071067811865475, -0.7071067811865475]
+          ],
+          "activations": [
+            [0.6088593650139138, -0.6088593650139138],
+            [0.6088593650139138, 0.6088593650139138],
+            [-0.6088593650139138, 0.6088593650139138],
+            [-0.6088593650139138, -0.6088593650139138]
+          ],
+          "summary": {
+            "mean": 0,
+            "variance": 0.3707097263651463,
+            "standard_deviation": 0.6088593650139138,
+            "minimum": -0.6088593650139138,
+            "maximum": 0.6088593650139138,
+            "zero_fraction": 0,
+            "saturated_fraction": 0
+          }
+        },
+        {
+          "layer": 2,
+          "scale": 0.7071067811865475,
+          "preactivations": [
+            [0, -0.8610571715805475],
+            [0.8610571715805475, 0],
+            [0, 0.8610571715805475],
+            [-0.8610571715805475, 0]
+          ],
+          "activations": [
+            [0, -0.6968019533538969],
+            [0.6968019533538969, 0],
+            [0, 0.6968019533538969],
+            [-0.6968019533538969, 0]
+          ],
+          "summary": {
+            "mean": 0,
+            "variance": 0.2427664810989032,
+            "standard_deviation": 0.49271338636057294,
+            "minimum": -0.6968019533538969,
+            "maximum": 0.6968019533538969,
+            "zero_fraction": 0.5,
+            "saturated_fraction": 0
+          }
+        },
+        {
+          "layer": 3,
+          "scale": 0.7071067811865475,
+          "preactivations": [
+            [-0.4927133863605729, -0.4927133863605729],
+            [0.4927133863605729, -0.4927133863605729],
+            [0.4927133863605729, 0.4927133863605729],
+            [-0.4927133863605729, 0.4927133863605729]
+          ],
+          "activations": [
+            [-0.4563673571184874, -0.4563673571184874],
+            [0.4563673571184874, -0.4563673571184874],
+            [0.4563673571184874, 0.4563673571184874],
+            [-0.4563673571184874, 0.4563673571184874]
+          ],
+          "summary": {
+            "mean": 0,
+            "variance": 0.20827116464331302,
+            "standard_deviation": 0.4563673571184874,
+            "minimum": -0.4563673571184874,
+            "maximum": 0.4563673571184874,
+            "zero_fraction": 0,
+            "saturated_fraction": 0
+          }
+        }
+      ]
+    },
+    "comparison": [
+      {
+        "initializer": "tiny",
+        "activation": "tanh",
+        "standard_deviations": [0.09966799462495582, 0.014093316370682047, 0.0019930932758819753],
+        "zero_fractions": [0, 0.5, 0],
+        "saturated_fractions": [0, 0, 0]
+      },
+      {
+        "initializer": "tiny",
+        "activation": "relu",
+        "standard_deviations": [0.05, 0.006959705453537528, 0.0008569568250501307],
+        "zero_fractions": [0.5, 0.5, 0.625],
+        "saturated_fractions": [0, 0, 0]
+      },
+      {
+        "initializer": "xavier",
+        "activation": "tanh",
+        "standard_deviations": [0.6088593650139138, 0.49271338636057294, 0.4563673571184874],
+        "zero_fractions": [0, 0.5, 0],
+        "saturated_fractions": [0, 0, 0]
+      },
+      {
+        "initializer": "xavier",
+        "activation": "relu",
+        "standard_deviations": [0.35355339059327373, 0.3479852726768763, 0.3029799910885205],
+        "zero_fractions": [0.5, 0.5, 0.625],
+        "saturated_fractions": [0, 0, 0]
+      },
+      {
+        "initializer": "he",
+        "activation": "tanh",
+        "standard_deviations": [0.7615941559557649, 0.642938024488458, 0.7207728874757855],
+        "zero_fractions": [0, 0.5, 0],
+        "saturated_fractions": [0, 0, 0]
+      },
+      {
+        "initializer": "he",
+        "activation": "relu",
+        "standard_deviations": [0.5, 0.6959705453537527, 0.8569568250501305],
+        "zero_fractions": [0.5, 0.5, 0.625],
+        "saturated_fractions": [0, 0, 0]
+      },
+      {
+        "initializer": "large",
+        "activation": "tanh",
+        "standard_deviations": [0.9640275800758169, 0.7064744481065454, 0.9639010024012616],
+        "zero_fractions": [0, 0.5, 0],
+        "saturated_fractions": [1, 0.5, 1]
+      },
+      {
+        "initializer": "large",
+        "activation": "relu",
+        "standard_deviations": [1, 2.7838821814150108, 6.855654600401044],
+        "zero_fractions": [0.5, 0.5, 0.625],
+        "saturated_fractions": [0, 0, 0]
+      }
+    ]
+  }
+}

--- a/code/specs/fixtures/initialization-activation-distribution-v1/schema.json
+++ b/code/specs/fixtures/initialization-activation-distribution-v1/schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/initialization-activation-distribution-v1.json",
+  "title": "Initialization and activation distribution V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "inputs", "weight_templates", "initializers", "activations", "expected"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "id": {"type": "string", "minLength": 1},
+    "title": {"type": "string", "minLength": 1},
+    "question": {"type": "string", "minLength": 1},
+    "absolute_tolerance": {"type": "number", "exclusiveMinimum": 0},
+    "concepts": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "bias", "variance", "zero_threshold", "tanh_saturation_threshold", "canonical_initializer", "canonical_activation"],
+      "properties": {
+        "kind": {"const": "initialization-activation-distribution"},
+        "bias": {"const": "none"},
+        "variance": {"const": "population"},
+        "zero_threshold": {"const": 1e-12},
+        "tanh_saturation_threshold": {"const": 0.95},
+        "canonical_initializer": {"const": "xavier"},
+        "canonical_activation": {"const": "tanh"}
+      }
+    },
+    "inputs": {"$ref": "#/$defs/matrix"},
+    "weight_templates": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/matrix"}},
+    "initializers": {"const": ["tiny", "xavier", "he", "large"]},
+    "activations": {"const": ["tanh", "relu"]},
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canonical", "comparison"],
+      "properties": {
+        "canonical": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["initializer", "activation", "layers"],
+          "properties": {
+            "initializer": {"const": "xavier"},
+            "activation": {"const": "tanh"},
+            "layers": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/layer"}}
+          }
+        },
+        "comparison": {"type": "array", "minItems": 8, "maxItems": 8, "items": {"$ref": "#/$defs/comparison"}}
+      }
+    }
+  },
+  "$defs": {
+    "numberArray": {"type": "array", "minItems": 1, "items": {"type": "number"}},
+    "matrix": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/numberArray"}},
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mean", "variance", "standard_deviation", "minimum", "maximum", "zero_fraction", "saturated_fraction"],
+      "properties": {
+        "mean": {"type": "number"},
+        "variance": {"type": "number", "minimum": 0},
+        "standard_deviation": {"type": "number", "minimum": 0},
+        "minimum": {"type": "number"},
+        "maximum": {"type": "number"},
+        "zero_fraction": {"type": "number", "minimum": 0, "maximum": 1},
+        "saturated_fraction": {"type": "number", "minimum": 0, "maximum": 1}
+      }
+    },
+    "layer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["layer", "scale", "preactivations", "activations", "summary"],
+      "properties": {
+        "layer": {"type": "integer", "minimum": 1},
+        "scale": {"type": "number", "exclusiveMinimum": 0},
+        "preactivations": {"$ref": "#/$defs/matrix"},
+        "activations": {"$ref": "#/$defs/matrix"},
+        "summary": {"$ref": "#/$defs/summary"}
+      }
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["initializer", "activation", "standard_deviations", "zero_fractions", "saturated_fractions"],
+      "properties": {
+        "initializer": {"enum": ["tiny", "xavier", "he", "large"]},
+        "activation": {"enum": ["tanh", "relu"]},
+        "standard_deviations": {"$ref": "#/$defs/numberArray"},
+        "zero_fractions": {"type": "array", "minItems": 1, "items": {"type": "number", "minimum": 0, "maximum": 1}},
+        "saturated_fractions": {"type": "array", "minItems": 1, "items": {"type": "number", "minimum": 0, "maximum": 1}}
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/multi-head-attention-v1/CHANGELOG.md
+++ b/code/specs/fixtures/multi-head-attention-v1/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add two independently projected causal attention heads.
+- Add context concatenation, output projection, residual, and layer-norm traces.

--- a/code/specs/fixtures/multi-head-attention-v1/README.md
+++ b/code/specs/fixtures/multi-head-attention-v1/README.md
@@ -1,0 +1,10 @@
+# Multi-Head Attention V1 Fixtures
+
+This corpus pins two-head causal attention, context concatenation, output
+projection, residual addition, and per-token layer normalization for NN14.
+
+```text
+python code/scripts/validate_multi_head_attention_labs.py
+```
+
+See [`NN14-multi-head-add-norm-labs.md`](../../NN14-multi-head-add-norm-labs.md).

--- a/code/specs/fixtures/multi-head-attention-v1/labs/00-two-head-causal-add-norm.json
+++ b/code/specs/fixtures/multi-head-attention-v1/labs/00-two-head-causal-add-norm.json
@@ -1,0 +1,231 @@
+{
+  "schema_version": 1,
+  "id": "two-head-causal-add-norm",
+  "title": "Join two causal attention heads, add a residual, and normalize",
+  "question": "How do independent attention heads rejoin the model stream without losing the original token?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "multi-head attention",
+    "head concatenation",
+    "output projection",
+    "residual connection",
+    "layer normalization"
+  ],
+  "operation": {
+    "kind": "two-head-causal-attention-add-norm",
+    "head_count": 2,
+    "model_width": 2,
+    "head_width": 1,
+    "softmax": "stable-row-wise",
+    "causal_rule": "key-index-less-than-or-equal-query-index",
+    "masked_score_encoding": "null",
+    "block_order": "attention-output-projection-add-residual-layer-norm",
+    "layer_norm_variance": "population"
+  },
+  "token_ids": ["red", "blue", "purple"],
+  "embeddings": [[2, 0], [0, 1], [2, 1]],
+  "heads": [
+    {
+      "id": "horizontal",
+      "query_projection": [0.5, 0],
+      "key_projection": [0.5, 0],
+      "value_projection": [1, 0]
+    },
+    {
+      "id": "vertical",
+      "query_projection": [0, 1],
+      "key_projection": [0, 1],
+      "value_projection": [0, 1]
+    }
+  ],
+  "output_projection": [[1, 0], [0, 1]],
+  "normalization": {
+    "epsilon": 0.00001,
+    "gamma": [1, 1],
+    "beta": [0, 0]
+  },
+  "expected": {
+    "rows": [
+      {
+        "token": "red",
+        "input": [2, 0],
+        "heads": [
+          {
+            "id": "horizontal",
+            "query_products": [1, 0],
+            "query": 1,
+            "key_products": [[1, 0], [0, 0], [1, 0]],
+            "keys": [1, 0, 1],
+            "value_products": [[2, 0], [0, 0], [2, 0]],
+            "values": [2, 0, 2],
+            "scale_divisor": 1,
+            "scaled_scores": [1, 0, 1],
+            "allowed": [true, false, false],
+            "masked_scores": [1, null, null],
+            "row_max": 1,
+            "shifted_scores": [0, null, null],
+            "exponentials": [1, 0, 0],
+            "denominator": 1,
+            "weights": [1, 0, 0],
+            "value_contributions": [2, 0, 0],
+            "context": 2
+          },
+          {
+            "id": "vertical",
+            "query_products": [0, 0],
+            "query": 0,
+            "key_products": [[0, 0], [0, 1], [0, 1]],
+            "keys": [0, 1, 1],
+            "value_products": [[0, 0], [0, 1], [0, 1]],
+            "values": [0, 1, 1],
+            "scale_divisor": 1,
+            "scaled_scores": [0, 0, 0],
+            "allowed": [true, false, false],
+            "masked_scores": [0, null, null],
+            "row_max": 0,
+            "shifted_scores": [0, null, null],
+            "exponentials": [1, 0, 0],
+            "denominator": 1,
+            "weights": [1, 0, 0],
+            "value_contributions": [0, 0, 0],
+            "context": 0
+          }
+        ],
+        "concatenated": [2, 0],
+        "output_projection_products": [[2, 0], [0, 0]],
+        "projected_attention": [2, 0],
+        "residual_sum": [4, 0],
+        "layer_norm": {
+          "mean": 2,
+          "centered": [2, -2],
+          "squared_deviations": [4, 4],
+          "variance": 4,
+          "denominator": 2.0000024999984376,
+          "normalized": [0.9999987500023437, -0.9999987500023437],
+          "affine_products": [0.9999987500023437, -0.9999987500023437],
+          "output": [0.9999987500023437, -0.9999987500023437]
+        }
+      },
+      {
+        "token": "blue",
+        "input": [0, 1],
+        "heads": [
+          {
+            "id": "horizontal",
+            "query_products": [0, 0],
+            "query": 0,
+            "key_products": [[1, 0], [0, 0], [1, 0]],
+            "keys": [1, 0, 1],
+            "value_products": [[2, 0], [0, 0], [2, 0]],
+            "values": [2, 0, 2],
+            "scale_divisor": 1,
+            "scaled_scores": [0, 0, 0],
+            "allowed": [true, true, false],
+            "masked_scores": [0, 0, null],
+            "row_max": 0,
+            "shifted_scores": [0, 0, null],
+            "exponentials": [1, 1, 0],
+            "denominator": 2,
+            "weights": [0.5, 0.5, 0],
+            "value_contributions": [1, 0, 0],
+            "context": 1
+          },
+          {
+            "id": "vertical",
+            "query_products": [0, 1],
+            "query": 1,
+            "key_products": [[0, 0], [0, 1], [0, 1]],
+            "keys": [0, 1, 1],
+            "value_products": [[0, 0], [0, 1], [0, 1]],
+            "values": [0, 1, 1],
+            "scale_divisor": 1,
+            "scaled_scores": [0, 1, 1],
+            "allowed": [true, true, false],
+            "masked_scores": [0, 1, null],
+            "row_max": 1,
+            "shifted_scores": [-1, 0, null],
+            "exponentials": [0.36787944117144233, 1, 0],
+            "denominator": 1.3678794411714423,
+            "weights": [0.2689414213699951, 0.7310585786300049, 0],
+            "value_contributions": [0, 0.7310585786300049, 0],
+            "context": 0.7310585786300049
+          }
+        ],
+        "concatenated": [1, 0.7310585786300049],
+        "output_projection_products": [[1, 0], [0, 0.7310585786300049]],
+        "projected_attention": [1, 0.7310585786300049],
+        "residual_sum": [1, 1.7310585786300048],
+        "layer_norm": {
+          "mean": 1.3655292893150024,
+          "centered": [-0.3655292893150024, 0.3655292893150024],
+          "squared_deviations": [0.13361166134713073, 0.13361166134713073],
+          "variance": 0.13361166134713073,
+          "denominator": 0.3655429678534806,
+          "normalized": [-0.9999625802171532, 0.9999625802171532],
+          "affine_products": [-0.9999625802171532, 0.9999625802171532],
+          "output": [-0.9999625802171532, 0.9999625802171532]
+        }
+      },
+      {
+        "token": "purple",
+        "input": [2, 1],
+        "heads": [
+          {
+            "id": "horizontal",
+            "query_products": [1, 0],
+            "query": 1,
+            "key_products": [[1, 0], [0, 0], [1, 0]],
+            "keys": [1, 0, 1],
+            "value_products": [[2, 0], [0, 0], [2, 0]],
+            "values": [2, 0, 2],
+            "scale_divisor": 1,
+            "scaled_scores": [1, 0, 1],
+            "allowed": [true, true, true],
+            "masked_scores": [1, 0, 1],
+            "row_max": 1,
+            "shifted_scores": [0, -1, 0],
+            "exponentials": [1, 0.36787944117144233, 1],
+            "denominator": 2.3678794411714423,
+            "weights": [0.4223187982515182, 0.15536240349696362, 0.4223187982515182],
+            "value_contributions": [0.8446375965030364, 0, 0.8446375965030364],
+            "context": 1.6892751930060728
+          },
+          {
+            "id": "vertical",
+            "query_products": [0, 1],
+            "query": 1,
+            "key_products": [[0, 0], [0, 1], [0, 1]],
+            "keys": [0, 1, 1],
+            "value_products": [[0, 0], [0, 1], [0, 1]],
+            "values": [0, 1, 1],
+            "scale_divisor": 1,
+            "scaled_scores": [0, 1, 1],
+            "allowed": [true, true, true],
+            "masked_scores": [0, 1, 1],
+            "row_max": 1,
+            "shifted_scores": [-1, 0, 0],
+            "exponentials": [0.36787944117144233, 1, 1],
+            "denominator": 2.3678794411714423,
+            "weights": [0.15536240349696362, 0.4223187982515182, 0.4223187982515182],
+            "value_contributions": [0, 0.4223187982515182, 0.4223187982515182],
+            "context": 0.8446375965030364
+          }
+        ],
+        "concatenated": [1.6892751930060728, 0.8446375965030364],
+        "output_projection_products": [[1.6892751930060728, 0], [0, 0.8446375965030364]],
+        "projected_attention": [1.6892751930060728, 0.8446375965030364],
+        "residual_sum": [3.6892751930060728, 1.8446375965030364],
+        "layer_norm": {
+          "mean": 2.766956394754555,
+          "centered": [0.922318798251518, -0.9223187982515184],
+          "squared_deviations": [0.8506719656081243, 0.8506719656081251],
+          "variance": 0.8506719656081247,
+          "denominator": 0.9223242193546284,
+          "normalized": [0.9999941223454869, -0.9999941223454873],
+          "affine_products": [0.9999941223454869, -0.9999941223454873],
+          "output": [0.9999941223454869, -0.9999941223454873]
+        }
+      }
+    ]
+  }
+}

--- a/code/specs/fixtures/multi-head-attention-v1/schema.json
+++ b/code/specs/fixtures/multi-head-attention-v1/schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/multi-head-attention-v1.json",
+  "title": "Multi-head attention learning lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "token_ids", "embeddings", "heads", "output_projection", "normalization", "expected"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "head_count", "model_width", "head_width", "softmax", "causal_rule", "masked_score_encoding", "block_order", "layer_norm_variance"],
+      "properties": {
+        "kind": { "const": "two-head-causal-attention-add-norm" },
+        "head_count": { "const": 2 },
+        "model_width": { "const": 2 },
+        "head_width": { "const": 1 },
+        "softmax": { "const": "stable-row-wise" },
+        "causal_rule": { "const": "key-index-less-than-or-equal-query-index" },
+        "masked_score_encoding": { "const": "null" },
+        "block_order": { "const": "attention-output-projection-add-residual-layer-norm" },
+        "layer_norm_variance": { "const": "population" }
+      }
+    },
+    "token_ids": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "embeddings": { "$ref": "#/$defs/matrix3x2" },
+    "heads": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": { "$ref": "#/$defs/headParameters" }
+    },
+    "output_projection": { "$ref": "#/$defs/matrix2x2" },
+    "normalization": { "$ref": "#/$defs/normalizationParameters" },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rows"],
+      "properties": {
+        "rows": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "$ref": "#/$defs/traceRow" } }
+      }
+    }
+  },
+  "$defs": {
+    "vector2": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "number" } },
+    "vector3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "number" } },
+    "boolean3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "boolean" } },
+    "nullableVector3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": ["number", "null"] } },
+    "matrix2x2": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "$ref": "#/$defs/vector2" } },
+    "matrix3x2": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "$ref": "#/$defs/vector2" } },
+    "headParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "query_projection", "key_projection", "value_projection"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "query_projection": { "$ref": "#/$defs/vector2" },
+        "key_projection": { "$ref": "#/$defs/vector2" },
+        "value_projection": { "$ref": "#/$defs/vector2" }
+      }
+    },
+    "normalizationParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon", "gamma", "beta"],
+      "properties": {
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "gamma": { "$ref": "#/$defs/vector2" },
+        "beta": { "$ref": "#/$defs/vector2" }
+      }
+    },
+    "headTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "query_products", "query", "key_products", "keys", "value_products", "values", "scale_divisor", "scaled_scores", "allowed", "masked_scores", "row_max", "shifted_scores", "exponentials", "denominator", "weights", "value_contributions", "context"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "query_products": { "$ref": "#/$defs/vector2" },
+        "query": { "type": "number" },
+        "key_products": { "$ref": "#/$defs/matrix3x2" },
+        "keys": { "$ref": "#/$defs/vector3" },
+        "value_products": { "$ref": "#/$defs/matrix3x2" },
+        "values": { "$ref": "#/$defs/vector3" },
+        "scale_divisor": { "type": "number", "exclusiveMinimum": 0 },
+        "scaled_scores": { "$ref": "#/$defs/vector3" },
+        "allowed": { "$ref": "#/$defs/boolean3" },
+        "masked_scores": { "$ref": "#/$defs/nullableVector3" },
+        "row_max": { "type": "number" },
+        "shifted_scores": { "$ref": "#/$defs/nullableVector3" },
+        "exponentials": { "$ref": "#/$defs/vector3" },
+        "denominator": { "type": "number", "exclusiveMinimum": 0 },
+        "weights": { "$ref": "#/$defs/vector3" },
+        "value_contributions": { "$ref": "#/$defs/vector3" },
+        "context": { "type": "number" }
+      }
+    },
+    "layerNormTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mean", "centered", "squared_deviations", "variance", "denominator", "normalized", "affine_products", "output"],
+      "properties": {
+        "mean": { "type": "number" },
+        "centered": { "$ref": "#/$defs/vector2" },
+        "squared_deviations": { "$ref": "#/$defs/vector2" },
+        "variance": { "type": "number", "minimum": 0 },
+        "denominator": { "type": "number", "exclusiveMinimum": 0 },
+        "normalized": { "$ref": "#/$defs/vector2" },
+        "affine_products": { "$ref": "#/$defs/vector2" },
+        "output": { "$ref": "#/$defs/vector2" }
+      }
+    },
+    "traceRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["token", "input", "heads", "concatenated", "output_projection_products", "projected_attention", "residual_sum", "layer_norm"],
+      "properties": {
+        "token": { "type": "string", "minLength": 1 },
+        "input": { "$ref": "#/$defs/vector2" },
+        "heads": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "$ref": "#/$defs/headTrace" } },
+        "concatenated": { "$ref": "#/$defs/vector2" },
+        "output_projection_products": { "$ref": "#/$defs/matrix2x2" },
+        "projected_attention": { "$ref": "#/$defs/vector2" },
+        "residual_sum": { "$ref": "#/$defs/vector2" },
+        "layer_norm": { "$ref": "#/$defs/layerNormTrace" }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/one-dimensional-diffusion-v1/CHANGELOG.md
+++ b/code/specs/fixtures/one-dimensional-diffusion-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to the NN19 fixture corpus are recorded here.
+
+## 1.0.0 - 2026-08-02
+
+- Add the two-level scalar forward-noise, denoiser-update, and reverse-mean fixture.

--- a/code/specs/fixtures/one-dimensional-diffusion-v1/README.md
+++ b/code/specs/fixtures/one-dimensional-diffusion-v1/README.md
@@ -1,0 +1,14 @@
+# One-Dimensional Diffusion V1 Fixtures
+
+This corpus pins one complete scalar diffusion learning loop: two closed-form
+forward noise levels using a saved noise value, a timestep-aware noise
+predictor, per-level gradient contributions, a three-parameter finite-
+difference audit, one loss-reducing SGD step, and a deterministic two-step
+reverse mean.
+
+```text
+python code/scripts/validate_one_dimensional_diffusion_labs.py
+```
+
+See
+[`NN19-one-dimensional-diffusion-labs.md`](../../NN19-one-dimensional-diffusion-labs.md).

--- a/code/specs/fixtures/one-dimensional-diffusion-v1/labs/00-two-level-forward-and-reverse.json
+++ b/code/specs/fixtures/one-dimensional-diffusion-v1/labs/00-two-level-forward-and-reverse.json
@@ -1,0 +1,164 @@
+{
+  "schema_version": 1,
+  "id": "two-level-forward-and-reverse",
+  "title": "Add saved noise at two levels, learn it, then reverse the mean path",
+  "question": "How does a diffusion model trade clean signal for noise and use a timestep-aware noise prediction to run the process backward?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "diffusion model",
+    "forward noising schedule",
+    "cumulative alpha",
+    "timestep conditioning",
+    "noise prediction",
+    "deterministic reverse mean"
+  ],
+  "operation": {
+    "kind": "one-dimensional-diffusion-round",
+    "forward": "closed-form-saved-noise",
+    "denoiser": "scalar-affine-with-normalized-timestep",
+    "loss": "mean-half-squared-noise-error",
+    "reverse": "deterministic-ddpm-mean",
+    "update": "sgd"
+  },
+  "clean_sample": 1,
+  "saved_noise": -0.5,
+  "schedule": [
+    { "t": 1, "beta": 0.36, "normalized_t": 0.5 },
+    { "t": 2, "beta": 0.4375, "normalized_t": 1 }
+  ],
+  "denoiser": {
+    "sample_weight": 0,
+    "timestep_weight": 0,
+    "bias": 0
+  },
+  "optimizer": { "learning_rate": 0.5 },
+  "expected": {
+    "forward_steps": [
+      {
+        "t": 1,
+        "beta": 0.36,
+        "alpha": 0.64,
+        "alpha_bar": 0.64,
+        "normalized_t": 0.5,
+        "signal_scale": 0.8,
+        "noise_scale": 0.6,
+        "signal_contribution": 0.8,
+        "noise_contribution": -0.3,
+        "noisy_sample": 0.5
+      },
+      {
+        "t": 2,
+        "beta": 0.4375,
+        "alpha": 0.5625,
+        "alpha_bar": 0.36,
+        "normalized_t": 1,
+        "signal_scale": 0.6,
+        "noise_scale": 0.8,
+        "signal_contribution": 0.6,
+        "noise_contribution": -0.4,
+        "noisy_sample": 0.2
+      }
+    ],
+    "initial_denoising": [
+      {
+        "t": 1,
+        "noisy_sample": 0.5,
+        "normalized_t": 0.5,
+        "predicted_noise": 0,
+        "target_noise": -0.5,
+        "error": 0.5,
+        "loss": 0.125
+      },
+      {
+        "t": 2,
+        "noisy_sample": 0.2,
+        "normalized_t": 1,
+        "predicted_noise": 0,
+        "target_noise": -0.5,
+        "error": 0.5,
+        "loss": 0.125
+      }
+    ],
+    "initial_mean_loss": 0.125,
+    "backward": {
+      "per_step": [
+        {
+          "t": 1,
+          "prediction_gradient": 0.25,
+          "sample_weight_contribution": 0.125,
+          "timestep_weight_contribution": 0.125,
+          "bias_contribution": 0.25
+        },
+        {
+          "t": 2,
+          "prediction_gradient": 0.25,
+          "sample_weight_contribution": 0.05,
+          "timestep_weight_contribution": 0.25,
+          "bias_contribution": 0.25
+        }
+      ],
+      "sample_weight_gradient": 0.175,
+      "timestep_weight_gradient": 0.375,
+      "bias_gradient": 0.5
+    },
+    "gradient_check": {
+      "epsilon": 1e-6,
+      "parameter_order": ["denoiser.sample_weight", "denoiser.timestep_weight", "denoiser.bias"],
+      "analytical": [0.175, 0.375, 0.5],
+      "numerical": [0.17499999999809335, 0.3749999999969056, 0.49999999999356115],
+      "max_absolute_error": 6.438849453616058e-12
+    },
+    "updated_denoiser": {
+      "sample_weight": -0.0875,
+      "timestep_weight": -0.1875,
+      "bias": -0.25
+    },
+    "post_update_denoising": [
+      {
+        "t": 1,
+        "noisy_sample": 0.5,
+        "normalized_t": 0.5,
+        "predicted_noise": -0.3875,
+        "target_noise": -0.5,
+        "error": 0.1125,
+        "loss": 0.006328125
+      },
+      {
+        "t": 2,
+        "noisy_sample": 0.2,
+        "normalized_t": 1,
+        "predicted_noise": -0.455,
+        "target_noise": -0.5,
+        "error": 0.045,
+        "loss": 0.0010125
+      }
+    ],
+    "post_update_mean_loss": 0.0036703125,
+    "reverse_steps": [
+      {
+        "t": 2,
+        "input_sample": 0.2,
+        "normalized_t": 1,
+        "predicted_noise": -0.455,
+        "noise_coefficient": 0.546875,
+        "scaled_noise_correction": -0.248828125,
+        "corrected_sample": 0.448828125,
+        "alpha_scale": 0.75,
+        "output_mean": 0.5984375
+      },
+      {
+        "t": 1,
+        "input_sample": 0.5984375,
+        "normalized_t": 0.5,
+        "predicted_noise": -0.39611328125,
+        "noise_coefficient": 0.6,
+        "scaled_noise_correction": -0.23766796875,
+        "corrected_sample": 0.83610546875,
+        "alpha_scale": 0.8,
+        "output_mean": 1.0451318359375
+      }
+    ],
+    "final_reconstruction": 1.0451318359375,
+    "final_absolute_error": 0.0451318359375
+  }
+}

--- a/code/specs/fixtures/one-dimensional-diffusion-v1/schema.json
+++ b/code/specs/fixtures/one-dimensional-diffusion-v1/schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/one-dimensional-diffusion-v1.json",
+  "title": "One-dimensional diffusion learning lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "clean_sample", "saved_noise", "schedule", "denoiser", "optimizer", "expected"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "forward", "denoiser", "loss", "reverse", "update"],
+      "properties": {
+        "kind": { "const": "one-dimensional-diffusion-round" },
+        "forward": { "const": "closed-form-saved-noise" },
+        "denoiser": { "const": "scalar-affine-with-normalized-timestep" },
+        "loss": { "const": "mean-half-squared-noise-error" },
+        "reverse": { "const": "deterministic-ddpm-mean" },
+        "update": { "const": "sgd" }
+      }
+    },
+    "clean_sample": { "type": "number" },
+    "saved_noise": { "type": "number" },
+    "schedule": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "$ref": "#/$defs/scheduleStep" }
+    },
+    "denoiser": { "$ref": "#/$defs/denoiserParameters" },
+    "optimizer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["learning_rate"],
+      "properties": { "learning_rate": { "type": "number", "exclusiveMinimum": 0 } }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["forward_steps", "initial_denoising", "initial_mean_loss", "backward", "gradient_check", "updated_denoiser", "post_update_denoising", "post_update_mean_loss", "reverse_steps", "final_reconstruction", "final_absolute_error"],
+      "properties": {
+        "forward_steps": { "type": "array", "items": { "$ref": "#/$defs/forwardStep" } },
+        "initial_denoising": { "type": "array", "items": { "$ref": "#/$defs/predictionStep" } },
+        "initial_mean_loss": { "type": "number", "minimum": 0 },
+        "backward": { "$ref": "#/$defs/backwardTrace" },
+        "gradient_check": { "$ref": "#/$defs/gradientCheck" },
+        "updated_denoiser": { "$ref": "#/$defs/denoiserParameters" },
+        "post_update_denoising": { "type": "array", "items": { "$ref": "#/$defs/predictionStep" } },
+        "post_update_mean_loss": { "type": "number", "minimum": 0 },
+        "reverse_steps": { "type": "array", "items": { "$ref": "#/$defs/reverseStep" } },
+        "final_reconstruction": { "type": "number" },
+        "final_absolute_error": { "type": "number", "minimum": 0 }
+      }
+    }
+  },
+  "$defs": {
+    "scheduleStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["t", "beta", "normalized_t"],
+      "properties": {
+        "t": { "type": "integer", "minimum": 1 },
+        "beta": { "type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1 },
+        "normalized_t": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 }
+      }
+    },
+    "denoiserParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sample_weight", "timestep_weight", "bias"],
+      "properties": {
+        "sample_weight": { "type": "number" },
+        "timestep_weight": { "type": "number" },
+        "bias": { "type": "number" }
+      }
+    },
+    "forwardStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["t", "beta", "alpha", "alpha_bar", "normalized_t", "signal_scale", "noise_scale", "signal_contribution", "noise_contribution", "noisy_sample"],
+      "properties": {
+        "t": { "type": "integer" },
+        "beta": { "type": "number" },
+        "alpha": { "type": "number" },
+        "alpha_bar": { "type": "number" },
+        "normalized_t": { "type": "number" },
+        "signal_scale": { "type": "number" },
+        "noise_scale": { "type": "number" },
+        "signal_contribution": { "type": "number" },
+        "noise_contribution": { "type": "number" },
+        "noisy_sample": { "type": "number" }
+      }
+    },
+    "predictionStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["t", "noisy_sample", "normalized_t", "predicted_noise", "target_noise", "error", "loss"],
+      "properties": {
+        "t": { "type": "integer" },
+        "noisy_sample": { "type": "number" },
+        "normalized_t": { "type": "number" },
+        "predicted_noise": { "type": "number" },
+        "target_noise": { "type": "number" },
+        "error": { "type": "number" },
+        "loss": { "type": "number", "minimum": 0 }
+      }
+    },
+    "gradientContribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["t", "prediction_gradient", "sample_weight_contribution", "timestep_weight_contribution", "bias_contribution"],
+      "properties": {
+        "t": { "type": "integer" },
+        "prediction_gradient": { "type": "number" },
+        "sample_weight_contribution": { "type": "number" },
+        "timestep_weight_contribution": { "type": "number" },
+        "bias_contribution": { "type": "number" }
+      }
+    },
+    "backwardTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["per_step", "sample_weight_gradient", "timestep_weight_gradient", "bias_gradient"],
+      "properties": {
+        "per_step": { "type": "array", "items": { "$ref": "#/$defs/gradientContribution" } },
+        "sample_weight_gradient": { "type": "number" },
+        "timestep_weight_gradient": { "type": "number" },
+        "bias_gradient": { "type": "number" }
+      }
+    },
+    "vector3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "number" } },
+    "gradientCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon", "parameter_order", "analytical", "numerical", "max_absolute_error"],
+      "properties": {
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "parameter_order": { "const": ["denoiser.sample_weight", "denoiser.timestep_weight", "denoiser.bias"] },
+        "analytical": { "$ref": "#/$defs/vector3" },
+        "numerical": { "$ref": "#/$defs/vector3" },
+        "max_absolute_error": { "type": "number", "minimum": 0 }
+      }
+    },
+    "reverseStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["t", "input_sample", "normalized_t", "predicted_noise", "noise_coefficient", "scaled_noise_correction", "corrected_sample", "alpha_scale", "output_mean"],
+      "properties": {
+        "t": { "type": "integer" },
+        "input_sample": { "type": "number" },
+        "normalized_t": { "type": "number" },
+        "predicted_noise": { "type": "number" },
+        "noise_coefficient": { "type": "number" },
+        "scaled_noise_correction": { "type": "number" },
+        "corrected_sample": { "type": "number" },
+        "alpha_scale": { "type": "number" },
+        "output_mean": { "type": "number" }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/one-dimensional-gan-v1/CHANGELOG.md
+++ b/code/specs/fixtures/one-dimensional-gan-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to the NN18 fixture corpus are recorded here.
+
+## 1.0.0 - 2026-08-02
+
+- Add the scalar discriminator-then-generator adversarial round fixture.

--- a/code/specs/fixtures/one-dimensional-gan-v1/README.md
+++ b/code/specs/fixtures/one-dimensional-gan-v1/README.md
@@ -1,0 +1,12 @@
+# One-Dimensional GAN V1 Fixtures
+
+This corpus pins one complete scalar GAN round: saved noise, one real and one
+fake point, discriminator probabilities, detached discriminator gradients, one
+discriminator update, a frozen-discriminator generator counter-step, two
+finite-difference audits, and both players' resulting losses.
+
+```text
+python code/scripts/validate_one_dimensional_gan_labs.py
+```
+
+See [`NN18-one-dimensional-gan-labs.md`](../../NN18-one-dimensional-gan-labs.md).

--- a/code/specs/fixtures/one-dimensional-gan-v1/labs/00-discriminator-generator-round.json
+++ b/code/specs/fixtures/one-dimensional-gan-v1/labs/00-discriminator-generator-round.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": 1,
+  "id": "discriminator-generator-round",
+  "title": "Let a scalar discriminator move, then let the generator answer",
+  "question": "How do two separately optimized networks push one fake point in opposite directions during one alternating GAN round?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "generative adversarial network",
+    "alternating optimization",
+    "detached fake sample",
+    "binary cross-entropy",
+    "non-saturating generator loss",
+    "adversarial counter-move"
+  ],
+  "operation": {
+    "kind": "one-dimensional-gan-round",
+    "generator": "scalar-affine",
+    "discriminator": "sigmoid-of-scalar-affine",
+    "discriminator_loss": "mean-binary-cross-entropy",
+    "generator_loss": "non-saturating-binary-cross-entropy",
+    "schedule": "discriminator-then-generator",
+    "fake_handling": "detach-during-discriminator-step",
+    "update": "sgd"
+  },
+  "real_sample": 1,
+  "noise": 1,
+  "generator": { "weight": 0.2, "bias": 0 },
+  "discriminator": { "weight": 1, "bias": 0 },
+  "optimizer": {
+    "discriminator_learning_rate": 0.5,
+    "generator_learning_rate": 0.25
+  },
+  "expected": {
+    "initial": {
+      "generator_product": 0.2,
+      "fake_sample": 0.2,
+      "real_logit": 1,
+      "real_probability": 0.7310585786300049,
+      "fake_logit": 0.2,
+      "fake_probability": 0.549833997312478,
+      "discriminator_loss": 0.5557002784499074,
+      "generator_loss": 0.5981388693815918
+    },
+    "discriminator_backward": {
+      "real_logit_gradient": -0.13447071068499755,
+      "fake_logit_gradient": 0.274916998656239,
+      "fake_value_gradient": 0,
+      "weight_gradient": -0.07948731095374975,
+      "bias_gradient": 0.14044628797124142
+    },
+    "updated_discriminator": {
+      "weight": 1.0397436554768749,
+      "bias": -0.07022314398562071
+    },
+    "after_discriminator": {
+      "generator_product": 0.2,
+      "fake_sample": 0.2,
+      "real_logit": 0.9695205114912542,
+      "real_probability": 0.7250239152436962,
+      "fake_logit": 0.13772558710975427,
+      "fake_probability": 0.5343770742867348,
+      "discriminator_loss": 0.5429648914153535,
+      "generator_loss": 0.6266535575924759
+    },
+    "discriminator_gradient_check": {
+      "epsilon": 1e-6,
+      "parameter_order": ["discriminator.weight", "discriminator.bias"],
+      "analytical": [-0.07948731095374975, 0.14044628797124142],
+      "numerical": [-0.07948731090001715, 0.14044628798837167],
+      "max_absolute_error": 5.373260170138394e-11
+    },
+    "generator_backward": {
+      "fake_logit_gradient": -0.46562292571326525,
+      "fake_value_gradient": -0.48412848285494775,
+      "weight_gradient": -0.48412848285494775,
+      "bias_gradient": -0.48412848285494775
+    },
+    "updated_generator": {
+      "weight": 0.32103212071373693,
+      "bias": 0.12103212071373694
+    },
+    "after_generator": {
+      "generator_product": 0.32103212071373693,
+      "fake_sample": 0.44206424142747386,
+      "real_logit": 0.9695205114912542,
+      "real_probability": 0.7250239152436962,
+      "fake_logit": 0.3894103463517927,
+      "fake_probability": 0.5961407441300886,
+      "discriminator_loss": 0.6141197382031501,
+      "generator_loss": 0.5172784919260304
+    },
+    "generator_gradient_check": {
+      "epsilon": 1e-6,
+      "parameter_order": ["generator.weight", "generator.bias"],
+      "analytical": [-0.48412848285494775, -0.48412848285494775],
+      "numerical": [-0.4841284828582815, -0.4841284828582815],
+      "max_absolute_error": 3.333722187193189e-12
+    }
+  }
+}

--- a/code/specs/fixtures/one-dimensional-gan-v1/schema.json
+++ b/code/specs/fixtures/one-dimensional-gan-v1/schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/one-dimensional-gan-v1.json",
+  "title": "One-dimensional GAN learning lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "real_sample", "noise", "generator", "discriminator", "optimizer", "expected"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "generator", "discriminator", "discriminator_loss", "generator_loss", "schedule", "fake_handling", "update"],
+      "properties": {
+        "kind": { "const": "one-dimensional-gan-round" },
+        "generator": { "const": "scalar-affine" },
+        "discriminator": { "const": "sigmoid-of-scalar-affine" },
+        "discriminator_loss": { "const": "mean-binary-cross-entropy" },
+        "generator_loss": { "const": "non-saturating-binary-cross-entropy" },
+        "schedule": { "const": "discriminator-then-generator" },
+        "fake_handling": { "const": "detach-during-discriminator-step" },
+        "update": { "const": "sgd" }
+      }
+    },
+    "real_sample": { "type": "number" },
+    "noise": { "type": "number" },
+    "generator": { "$ref": "#/$defs/affineParameters" },
+    "discriminator": { "$ref": "#/$defs/affineParameters" },
+    "optimizer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["discriminator_learning_rate", "generator_learning_rate"],
+      "properties": {
+        "discriminator_learning_rate": { "type": "number", "exclusiveMinimum": 0 },
+        "generator_learning_rate": { "type": "number", "exclusiveMinimum": 0 }
+      }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["initial", "discriminator_backward", "updated_discriminator", "after_discriminator", "discriminator_gradient_check", "generator_backward", "updated_generator", "after_generator", "generator_gradient_check"],
+      "properties": {
+        "initial": { "$ref": "#/$defs/stateTrace" },
+        "discriminator_backward": { "$ref": "#/$defs/discriminatorBackward" },
+        "updated_discriminator": { "$ref": "#/$defs/affineParameters" },
+        "after_discriminator": { "$ref": "#/$defs/stateTrace" },
+        "discriminator_gradient_check": { "$ref": "#/$defs/discriminatorGradientCheck" },
+        "generator_backward": { "$ref": "#/$defs/generatorBackward" },
+        "updated_generator": { "$ref": "#/$defs/affineParameters" },
+        "after_generator": { "$ref": "#/$defs/stateTrace" },
+        "generator_gradient_check": { "$ref": "#/$defs/generatorGradientCheck" }
+      }
+    }
+  },
+  "$defs": {
+    "affineParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["weight", "bias"],
+      "properties": {
+        "weight": { "type": "number" },
+        "bias": { "type": "number" }
+      }
+    },
+    "stateTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generator_product", "fake_sample", "real_logit", "real_probability", "fake_logit", "fake_probability", "discriminator_loss", "generator_loss"],
+      "properties": {
+        "generator_product": { "type": "number" },
+        "fake_sample": { "type": "number" },
+        "real_logit": { "type": "number" },
+        "real_probability": { "$ref": "#/$defs/probability" },
+        "fake_logit": { "type": "number" },
+        "fake_probability": { "$ref": "#/$defs/probability" },
+        "discriminator_loss": { "type": "number", "minimum": 0 },
+        "generator_loss": { "type": "number", "minimum": 0 }
+      }
+    },
+    "probability": { "type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1 },
+    "discriminatorBackward": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["real_logit_gradient", "fake_logit_gradient", "fake_value_gradient", "weight_gradient", "bias_gradient"],
+      "properties": {
+        "real_logit_gradient": { "type": "number" },
+        "fake_logit_gradient": { "type": "number" },
+        "fake_value_gradient": { "const": 0 },
+        "weight_gradient": { "type": "number" },
+        "bias_gradient": { "type": "number" }
+      }
+    },
+    "generatorBackward": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fake_logit_gradient", "fake_value_gradient", "weight_gradient", "bias_gradient"],
+      "properties": {
+        "fake_logit_gradient": { "type": "number" },
+        "fake_value_gradient": { "type": "number" },
+        "weight_gradient": { "type": "number" },
+        "bias_gradient": { "type": "number" }
+      }
+    },
+    "vector2": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "number" } },
+    "discriminatorGradientCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon", "parameter_order", "analytical", "numerical", "max_absolute_error"],
+      "properties": {
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "parameter_order": { "const": ["discriminator.weight", "discriminator.bias"] },
+        "analytical": { "$ref": "#/$defs/vector2" },
+        "numerical": { "$ref": "#/$defs/vector2" },
+        "max_absolute_error": { "type": "number", "minimum": 0 }
+      }
+    },
+    "generatorGradientCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon", "parameter_order", "analytical", "numerical", "max_absolute_error"],
+      "properties": {
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "parameter_order": { "const": ["generator.weight", "generator.bias"] },
+        "analytical": { "$ref": "#/$defs/vector2" },
+        "numerical": { "$ref": "#/$defs/vector2" },
+        "max_absolute_error": { "type": "number", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/optimization-learning-v1/CHANGELOG.md
+++ b/code/specs/fixtures/optimization-learning-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0
+
+- Add the four-point linear loss landscape.
+- Pin analytical and central finite-difference gradients.
+- Pin twelve-step stochastic, mini-batch, and full-batch trajectories.

--- a/code/specs/fixtures/optimization-learning-v1/README.md
+++ b/code/specs/fixtures/optimization-learning-v1/README.md
@@ -1,0 +1,15 @@
+# Optimization Learning Fixtures V1
+
+This corpus accompanies NN04. It pins analytical gradients, independent
+central finite differences, and deterministic optimizer trajectories for a
+small linear problem.
+
+Validate it from the repository root:
+
+```text
+python code/scripts/validate_optimization_learning_labs.py
+```
+
+The first lab uses four points on `y = 2x + 1`, starts away from the minimum,
+and compares one-row stochastic updates, two-row mini-batches, and full-batch
+updates.

--- a/code/specs/fixtures/optimization-learning-v1/labs/00-linear-loss-landscape.json
+++ b/code/specs/fixtures/optimization-learning-v1/labs/00-linear-loss-landscape.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "id": "linear-loss-landscape",
+  "title": "A Linear Neuron on Its Loss Landscape",
+  "question": "How can we verify a gradient and compare batch strategies without hiding the arithmetic?",
+  "concepts": [
+    "mean-squared-error",
+    "analytical-gradient",
+    "finite-difference",
+    "stochastic-gradient-descent",
+    "mini-batch",
+    "full-batch"
+  ],
+  "model": {
+    "kind": "linear-neuron",
+    "parameters": {
+      "weight": -0.5,
+      "bias": 0.0
+    }
+  },
+  "dataset": {
+    "rows": [
+      { "label": "x-minus-one", "x": -1.0, "target": -1.0 },
+      { "label": "x-zero", "x": 0.0, "target": 1.0 },
+      { "label": "x-one", "x": 1.0, "target": 3.0 },
+      { "label": "x-two", "x": 2.0, "target": 5.0 }
+    ]
+  },
+  "loss": {
+    "kind": "mean-squared-error",
+    "reduction": "mean"
+  },
+  "gradient_check": {
+    "epsilon": 0.00001,
+    "expected": {
+      "absolute_tolerance": 1e-9,
+      "loss": 12.875,
+      "analytical": {
+        "weight": -8.5,
+        "bias": -4.5
+      },
+      "numerical": {
+        "weight": -8.50000000003348,
+        "bias": -4.499999999918458
+      }
+    }
+  },
+  "optimizer_comparison": {
+    "learning_rate": 0.05,
+    "steps": 12,
+    "absolute_tolerance": 1e-9,
+    "strategies": [
+      {
+        "kind": "stochastic",
+        "batch_size": 1,
+        "expected_parameters": {
+          "weight": 1.761738097196,
+          "bias": 1.1038861280305
+        },
+        "expected_loss": 0.07119332254935665
+      },
+      {
+        "kind": "mini-batch",
+        "batch_size": 2,
+        "expected_parameters": {
+          "weight": 1.7373974644419516,
+          "bias": 1.0625041671183766
+        },
+        "expected_loss": 0.09093315566120634
+      },
+      {
+        "kind": "full-batch",
+        "batch_size": 4,
+        "expected_parameters": {
+          "weight": 1.6909794672603606,
+          "bias": 1.0398542870140077
+        },
+        "expected_loss": 0.13251310567040367
+      }
+    ]
+  }
+}

--- a/code/specs/fixtures/optimization-learning-v1/schema.json
+++ b/code/specs/fixtures/optimization-learning-v1/schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/optimization-learning-v1.json",
+  "title": "Optimization learning lab v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "question",
+    "concepts",
+    "model",
+    "dataset",
+    "loss",
+    "gradient_check",
+    "optimizer_comparison"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "model": { "$ref": "#/$defs/model" },
+    "dataset": { "$ref": "#/$defs/dataset" },
+    "loss": { "$ref": "#/$defs/loss" },
+    "gradient_check": { "$ref": "#/$defs/gradient_check" },
+    "optimizer_comparison": { "$ref": "#/$defs/optimizer_comparison" }
+  },
+  "$defs": {
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["weight", "bias"],
+      "properties": {
+        "weight": { "type": "number" },
+        "bias": { "type": "number" }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "parameters"],
+      "properties": {
+        "kind": { "const": "linear-neuron" },
+        "parameters": { "$ref": "#/$defs/parameters" }
+      }
+    },
+    "row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "x", "target"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "x": { "type": "number" },
+        "target": { "type": "number" }
+      }
+    },
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rows"],
+      "properties": {
+        "rows": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/row" }
+        }
+      }
+    },
+    "loss": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "reduction"],
+      "properties": {
+        "kind": { "const": "mean-squared-error" },
+        "reduction": { "const": "mean" }
+      }
+    },
+    "gradient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["weight", "bias"],
+      "properties": {
+        "weight": { "type": "number" },
+        "bias": { "type": "number" }
+      }
+    },
+    "gradient_expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["absolute_tolerance", "loss", "analytical", "numerical"],
+      "properties": {
+        "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+        "loss": { "type": "number", "minimum": 0 },
+        "analytical": { "$ref": "#/$defs/gradient" },
+        "numerical": { "$ref": "#/$defs/gradient" }
+      }
+    },
+    "gradient_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon", "expected"],
+      "properties": {
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "expected": { "$ref": "#/$defs/gradient_expected" }
+      }
+    },
+    "strategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "batch_size", "expected_parameters", "expected_loss"],
+      "properties": {
+        "kind": { "enum": ["stochastic", "mini-batch", "full-batch"] },
+        "batch_size": { "type": "integer", "minimum": 1 },
+        "expected_parameters": { "$ref": "#/$defs/parameters" },
+        "expected_loss": { "type": "number", "minimum": 0 }
+      }
+    },
+    "optimizer_comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["learning_rate", "steps", "absolute_tolerance", "strategies"],
+      "properties": {
+        "learning_rate": { "type": "number", "exclusiveMinimum": 0 },
+        "steps": { "type": "integer", "minimum": 1 },
+        "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+        "strategies": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": { "$ref": "#/$defs/strategy" }
+        }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/recurrent-bptt-v1/CHANGELOG.md
+++ b/code/specs/fixtures/recurrent-bptt-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0
+
+- Add the three-step scalar BPTT fixture.
+- Pin every backward-time state and parameter gradient contribution.
+- Pin finite-difference checks and one loss-reducing update.

--- a/code/specs/fixtures/recurrent-bptt-v1/README.md
+++ b/code/specs/fixtures/recurrent-bptt-v1/README.md
@@ -1,0 +1,13 @@
+# Recurrent BPTT Fixtures V1
+
+This corpus pins NN10's three-step scalar backpropagation-through-time trace,
+shared-parameter gradient reduction, finite-difference audit, and one update.
+
+Validate it from the repository root:
+
+```text
+python code/scripts/validate_recurrent_bptt_labs.py
+```
+
+See [`../../NN10-recurrent-bptt-labs.md`](../../NN10-recurrent-bptt-labs.md)
+for formulas, conformance levels, and the Rust-core direction.

--- a/code/specs/fixtures/recurrent-bptt-v1/labs/00-final-state-loss.json
+++ b/code/specs/fixtures/recurrent-bptt-v1/labs/00-final-state-loss.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "id": "final-state-loss",
+  "title": "Backpropagate one final-state loss through three steps",
+  "question": "How do three executions contribute to gradients for one shared recurrent parameter set?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "backpropagation through time",
+    "shared parameter gradient",
+    "gradient accumulation",
+    "finite difference",
+    "recurrent update"
+  ],
+  "operation": {
+    "kind": "scalar-elman-rnn-bptt",
+    "steps": 3,
+    "activation": "relu",
+    "loss": "half-squared-error",
+    "parameter_sharing": "all-steps"
+  },
+  "initial_state": 0,
+  "inputs": [1, 2, 0],
+  "target": 0,
+  "parameters": {
+    "input_weight": 2,
+    "recurrent_weight": 0.5,
+    "bias": -1
+  },
+  "learning_rate": 0.1,
+  "finite_difference_epsilon": 1e-6,
+  "expected": {
+    "forward": {
+      "preactivations": [1, 3.5, 0.75],
+      "states": [1, 3.5, 0.75],
+      "prediction": 0.75,
+      "loss": 0.28125
+    },
+    "backward_steps": [
+      {
+        "time": 2,
+        "direct_loss_gradient": 0.75,
+        "future_state_gradient": 0,
+        "state_gradient": 0.75,
+        "relu_derivative": 1,
+        "preactivation_gradient": 0.75,
+        "input_weight_gradient": 0,
+        "recurrent_weight_gradient": 2.625,
+        "bias_gradient": 0.75,
+        "previous_state_gradient": 0.375
+      },
+      {
+        "time": 1,
+        "direct_loss_gradient": 0,
+        "future_state_gradient": 0.375,
+        "state_gradient": 0.375,
+        "relu_derivative": 1,
+        "preactivation_gradient": 0.375,
+        "input_weight_gradient": 0.75,
+        "recurrent_weight_gradient": 0.375,
+        "bias_gradient": 0.375,
+        "previous_state_gradient": 0.1875
+      },
+      {
+        "time": 0,
+        "direct_loss_gradient": 0,
+        "future_state_gradient": 0.1875,
+        "state_gradient": 0.1875,
+        "relu_derivative": 1,
+        "preactivation_gradient": 0.1875,
+        "input_weight_gradient": 0.1875,
+        "recurrent_weight_gradient": 0,
+        "bias_gradient": 0.1875,
+        "previous_state_gradient": 0.09375
+      }
+    ],
+    "gradient_totals": {
+      "input_weight": 0.9375,
+      "recurrent_weight": 3,
+      "bias": 1.3125,
+      "initial_state": 0.09375
+    },
+    "gradient_check": {
+      "numerical": {
+        "input_weight": 0.9375000001310418,
+        "recurrent_weight": 3.000000000086267,
+        "bias": 1.3125000000446807
+      },
+      "absolute_errors": {
+        "input_weight": 1.3104184404255648e-10,
+        "recurrent_weight": 8.626699354863376e-11,
+        "bias": 4.46807035814345e-11
+      },
+      "max_absolute_error": 1.3104184404255648e-10
+    },
+    "update": {
+      "parameters": {
+        "input_weight": 1.90625,
+        "recurrent_weight": 0.2,
+        "bias": -1.13125
+      },
+      "preactivations": [0.775, 2.83625, -0.564],
+      "states": [0.775, 2.83625, 0],
+      "loss": 0
+    }
+  }
+}

--- a/code/specs/fixtures/recurrent-bptt-v1/schema.json
+++ b/code/specs/fixtures/recurrent-bptt-v1/schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/recurrent-bptt-v1.json",
+  "title": "Recurrent BPTT lab v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "question",
+    "absolute_tolerance",
+    "concepts",
+    "operation",
+    "initial_state",
+    "inputs",
+    "target",
+    "parameters",
+    "learning_rate",
+    "finite_difference_epsilon",
+    "expected"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "steps", "activation", "loss", "parameter_sharing"],
+      "properties": {
+        "kind": { "const": "scalar-elman-rnn-bptt" },
+        "steps": { "const": 3 },
+        "activation": { "const": "relu" },
+        "loss": { "const": "half-squared-error" },
+        "parameter_sharing": { "const": "all-steps" }
+      }
+    },
+    "initial_state": { "type": "number" },
+    "inputs": { "$ref": "#/$defs/three_numbers" },
+    "target": { "type": "number" },
+    "parameters": { "$ref": "#/$defs/parameters" },
+    "learning_rate": { "type": "number", "exclusiveMinimum": 0 },
+    "finite_difference_epsilon": { "type": "number", "exclusiveMinimum": 0 },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["forward", "backward_steps", "gradient_totals", "gradient_check", "update"],
+      "properties": {
+        "forward": { "$ref": "#/$defs/forward" },
+        "backward_steps": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": { "$ref": "#/$defs/backward_step" }
+        },
+        "gradient_totals": { "$ref": "#/$defs/gradient_totals" },
+        "gradient_check": { "$ref": "#/$defs/gradient_check" },
+        "update": { "$ref": "#/$defs/update" }
+      }
+    }
+  },
+  "$defs": {
+    "three_numbers": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": { "type": "number" }
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_weight", "recurrent_weight", "bias"],
+      "properties": {
+        "input_weight": { "type": "number" },
+        "recurrent_weight": { "type": "number" },
+        "bias": { "type": "number" }
+      }
+    },
+    "forward": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["preactivations", "states", "prediction", "loss"],
+      "properties": {
+        "preactivations": { "$ref": "#/$defs/three_numbers" },
+        "states": { "$ref": "#/$defs/three_numbers" },
+        "prediction": { "type": "number" },
+        "loss": { "type": "number", "minimum": 0 }
+      }
+    },
+    "backward_step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "time",
+        "direct_loss_gradient",
+        "future_state_gradient",
+        "state_gradient",
+        "relu_derivative",
+        "preactivation_gradient",
+        "input_weight_gradient",
+        "recurrent_weight_gradient",
+        "bias_gradient",
+        "previous_state_gradient"
+      ],
+      "properties": {
+        "time": { "type": "integer", "minimum": 0, "maximum": 2 },
+        "direct_loss_gradient": { "type": "number" },
+        "future_state_gradient": { "type": "number" },
+        "state_gradient": { "type": "number" },
+        "relu_derivative": { "type": "number" },
+        "preactivation_gradient": { "type": "number" },
+        "input_weight_gradient": { "type": "number" },
+        "recurrent_weight_gradient": { "type": "number" },
+        "bias_gradient": { "type": "number" },
+        "previous_state_gradient": { "type": "number" }
+      }
+    },
+    "gradient_totals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_weight", "recurrent_weight", "bias", "initial_state"],
+      "properties": {
+        "input_weight": { "type": "number" },
+        "recurrent_weight": { "type": "number" },
+        "bias": { "type": "number" },
+        "initial_state": { "type": "number" }
+      }
+    },
+    "gradient_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["numerical", "absolute_errors", "max_absolute_error"],
+      "properties": {
+        "numerical": { "$ref": "#/$defs/parameters" },
+        "absolute_errors": { "$ref": "#/$defs/parameters" },
+        "max_absolute_error": { "type": "number", "minimum": 0 }
+      }
+    },
+    "update": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["parameters", "preactivations", "states", "loss"],
+      "properties": {
+        "parameters": { "$ref": "#/$defs/parameters" },
+        "preactivations": { "$ref": "#/$defs/three_numbers" },
+        "states": { "$ref": "#/$defs/three_numbers" },
+        "loss": { "type": "number", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/recurrent-unroll-v1/CHANGELOG.md
+++ b/code/specs/fixtures/recurrent-unroll-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0
+
+- Add the three-step scalar ReLU recurrence fixture.
+- Pin every input, recurrent, bias, preactivation, and state value.
+- Pin the no-recurrence ablation and per-step state differences.

--- a/code/specs/fixtures/recurrent-unroll-v1/README.md
+++ b/code/specs/fixtures/recurrent-unroll-v1/README.md
@@ -1,0 +1,13 @@
+# Recurrent Unroll Fixtures V1
+
+This corpus pins NN09's three-step scalar recurrent forward pass, shared
+parameters, explicit initial state, and no-recurrence teaching ablation.
+
+Validate it from the repository root:
+
+```text
+python code/scripts/validate_recurrent_unroll_labs.py
+```
+
+See [`../../NN09-recurrent-unroll-labs.md`](../../NN09-recurrent-unroll-labs.md)
+for formulas, conformance levels, and the Rust-core direction.

--- a/code/specs/fixtures/recurrent-unroll-v1/labs/00-three-step-relu-state.json
+++ b/code/specs/fixtures/recurrent-unroll-v1/labs/00-three-step-relu-state.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "id": "three-step-relu-state",
+  "title": "Carry one scalar state through three time steps",
+  "question": "How can the final hidden state remember earlier inputs when the final input is zero?",
+  "absolute_tolerance": 1e-12,
+  "concepts": [
+    "recurrent state",
+    "time unrolling",
+    "shared parameters",
+    "initial state",
+    "memory ablation"
+  ],
+  "operation": {
+    "kind": "scalar-elman-rnn-forward",
+    "steps": 3,
+    "state_size": 1,
+    "activation": "relu",
+    "parameter_sharing": "all-steps"
+  },
+  "initial_state": 0,
+  "inputs": [1, 2, 0],
+  "parameters": {
+    "input_weight": 2,
+    "recurrent_weight": 0.5,
+    "bias": -1
+  },
+  "expected": {
+    "steps": [
+      {
+        "time": 0,
+        "input": 1,
+        "previous_state": 0,
+        "input_product": 2,
+        "recurrent_product": 0,
+        "bias": -1,
+        "preactivation": 1,
+        "state": 1
+      },
+      {
+        "time": 1,
+        "input": 2,
+        "previous_state": 1,
+        "input_product": 4,
+        "recurrent_product": 0.5,
+        "bias": -1,
+        "preactivation": 3.5,
+        "state": 3.5
+      },
+      {
+        "time": 2,
+        "input": 0,
+        "previous_state": 3.5,
+        "input_product": 0,
+        "recurrent_product": 1.75,
+        "bias": -1,
+        "preactivation": 0.75,
+        "state": 0.75
+      }
+    ],
+    "states": [1, 3.5, 0.75],
+    "final_state": 0.75,
+    "memory_ablation": {
+      "preactivations": [1, 3, -1],
+      "states": [1, 3, 0],
+      "state_differences": [0, 0.5, 0.75]
+    }
+  }
+}

--- a/code/specs/fixtures/recurrent-unroll-v1/schema.json
+++ b/code/specs/fixtures/recurrent-unroll-v1/schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/recurrent-unroll-v1.json",
+  "title": "Recurrent unroll lab v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "question",
+    "absolute_tolerance",
+    "concepts",
+    "operation",
+    "initial_state",
+    "inputs",
+    "parameters",
+    "expected"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "steps", "state_size", "activation", "parameter_sharing"],
+      "properties": {
+        "kind": { "const": "scalar-elman-rnn-forward" },
+        "steps": { "const": 3 },
+        "state_size": { "const": 1 },
+        "activation": { "const": "relu" },
+        "parameter_sharing": { "const": "all-steps" }
+      }
+    },
+    "initial_state": { "type": "number" },
+    "inputs": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": { "type": "number" }
+    },
+    "parameters": { "$ref": "#/$defs/parameters" },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["steps", "states", "final_state", "memory_ablation"],
+      "properties": {
+        "steps": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": { "$ref": "#/$defs/step" }
+        },
+        "states": { "$ref": "#/$defs/three_numbers" },
+        "final_state": { "type": "number" },
+        "memory_ablation": { "$ref": "#/$defs/memory_ablation" }
+      }
+    }
+  },
+  "$defs": {
+    "three_numbers": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": { "type": "number" }
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_weight", "recurrent_weight", "bias"],
+      "properties": {
+        "input_weight": { "type": "number" },
+        "recurrent_weight": { "type": "number" },
+        "bias": { "type": "number" }
+      }
+    },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "time",
+        "input",
+        "previous_state",
+        "input_product",
+        "recurrent_product",
+        "bias",
+        "preactivation",
+        "state"
+      ],
+      "properties": {
+        "time": { "type": "integer", "minimum": 0, "maximum": 2 },
+        "input": { "type": "number" },
+        "previous_state": { "type": "number" },
+        "input_product": { "type": "number" },
+        "recurrent_product": { "type": "number" },
+        "bias": { "type": "number" },
+        "preactivation": { "type": "number" },
+        "state": { "type": "number" }
+      }
+    },
+    "memory_ablation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["preactivations", "states", "state_differences"],
+      "properties": {
+        "preactivations": { "$ref": "#/$defs/three_numbers" },
+        "states": { "$ref": "#/$defs/three_numbers" },
+        "state_differences": { "$ref": "#/$defs/three_numbers" }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/residual-receptive-v1/CHANGELOG.md
+++ b/code/specs/fixtures/residual-receptive-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0
+
+- Add the five-position, two-layer residual-block fixture.
+- Pin identity-skip addition and ReLU outputs.
+- Pin every hidden dependency, input path count, and receptive-field index.

--- a/code/specs/fixtures/residual-receptive-v1/README.md
+++ b/code/specs/fixtures/residual-receptive-v1/README.md
@@ -1,0 +1,14 @@
+# Residual and Receptive-Field Fixtures V1
+
+This corpus pins the NN08 forward path through two same-padded convolutions,
+an identity residual addition, ReLU, and a complete receptive-field trace for
+every output position.
+
+Validate it from the repository root:
+
+```text
+python code/scripts/validate_residual_receptive_labs.py
+```
+
+See [`../../NN08-residual-receptive-labs.md`](../../NN08-residual-receptive-labs.md)
+for formulas, conformance levels, and the Rust-core direction.

--- a/code/specs/fixtures/residual-receptive-v1/labs/00-two-layer-residual.json
+++ b/code/specs/fixtures/residual-receptive-v1/labs/00-two-layer-residual.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "id": "two-layer-residual",
+  "title": "Trace a residual block and its receptive field",
+  "question": "How do two local layers reach five input positions while an identity skip stays one step long?",
+  "absolute_tolerance": 1e-12,
+  "concepts": [
+    "residual connection",
+    "identity skip",
+    "same padding",
+    "receptive field",
+    "computational path multiplicity"
+  ],
+  "operation": {
+    "kind": "residual-correlation-1d",
+    "padding": "same-zero",
+    "stride": 1,
+    "layers": 2,
+    "skip": "identity",
+    "activation": "relu"
+  },
+  "input": [1, 0, 2, 0, 1],
+  "kernels": [[1, 1, 1], [1, 1, 1]],
+  "expected": {
+    "hidden": [1, 3, 2, 3, 1],
+    "main": [4, 6, 8, 6, 4],
+    "skip": [1, 0, 2, 0, 1],
+    "residual_sum": [5, 6, 10, 6, 5],
+    "output": [5, 6, 10, 6, 5],
+    "traces": [
+      {
+        "output_index": 0,
+        "hidden_indices": [0, 1],
+        "hidden_values": [1, 3],
+        "hidden_paths": [
+          {"hidden_index": 0, "input_indices": [0, 1], "input_values": [1, 0], "subtotal": 1},
+          {"hidden_index": 1, "input_indices": [0, 1, 2], "input_values": [1, 0, 2], "subtotal": 3}
+        ],
+        "input_path_counts": [2, 2, 1, 0, 0],
+        "input_contributions": [2, 0, 2, 0, 0],
+        "receptive_field_indices": [0, 1, 2],
+        "main_output": 4,
+        "skip_contribution": 1,
+        "residual_sum": 5,
+        "output": 5
+      },
+      {
+        "output_index": 1,
+        "hidden_indices": [0, 1, 2],
+        "hidden_values": [1, 3, 2],
+        "hidden_paths": [
+          {"hidden_index": 0, "input_indices": [0, 1], "input_values": [1, 0], "subtotal": 1},
+          {"hidden_index": 1, "input_indices": [0, 1, 2], "input_values": [1, 0, 2], "subtotal": 3},
+          {"hidden_index": 2, "input_indices": [1, 2, 3], "input_values": [0, 2, 0], "subtotal": 2}
+        ],
+        "input_path_counts": [2, 3, 2, 1, 0],
+        "input_contributions": [2, 0, 4, 0, 0],
+        "receptive_field_indices": [0, 1, 2, 3],
+        "main_output": 6,
+        "skip_contribution": 0,
+        "residual_sum": 6,
+        "output": 6
+      },
+      {
+        "output_index": 2,
+        "hidden_indices": [1, 2, 3],
+        "hidden_values": [3, 2, 3],
+        "hidden_paths": [
+          {"hidden_index": 1, "input_indices": [0, 1, 2], "input_values": [1, 0, 2], "subtotal": 3},
+          {"hidden_index": 2, "input_indices": [1, 2, 3], "input_values": [0, 2, 0], "subtotal": 2},
+          {"hidden_index": 3, "input_indices": [2, 3, 4], "input_values": [2, 0, 1], "subtotal": 3}
+        ],
+        "input_path_counts": [1, 2, 3, 2, 1],
+        "input_contributions": [1, 0, 6, 0, 1],
+        "receptive_field_indices": [0, 1, 2, 3, 4],
+        "main_output": 8,
+        "skip_contribution": 2,
+        "residual_sum": 10,
+        "output": 10
+      },
+      {
+        "output_index": 3,
+        "hidden_indices": [2, 3, 4],
+        "hidden_values": [2, 3, 1],
+        "hidden_paths": [
+          {"hidden_index": 2, "input_indices": [1, 2, 3], "input_values": [0, 2, 0], "subtotal": 2},
+          {"hidden_index": 3, "input_indices": [2, 3, 4], "input_values": [2, 0, 1], "subtotal": 3},
+          {"hidden_index": 4, "input_indices": [3, 4], "input_values": [0, 1], "subtotal": 1}
+        ],
+        "input_path_counts": [0, 1, 2, 3, 2],
+        "input_contributions": [0, 0, 4, 0, 2],
+        "receptive_field_indices": [1, 2, 3, 4],
+        "main_output": 6,
+        "skip_contribution": 0,
+        "residual_sum": 6,
+        "output": 6
+      },
+      {
+        "output_index": 4,
+        "hidden_indices": [3, 4],
+        "hidden_values": [3, 1],
+        "hidden_paths": [
+          {"hidden_index": 3, "input_indices": [2, 3, 4], "input_values": [2, 0, 1], "subtotal": 3},
+          {"hidden_index": 4, "input_indices": [3, 4], "input_values": [0, 1], "subtotal": 1}
+        ],
+        "input_path_counts": [0, 0, 1, 2, 2],
+        "input_contributions": [0, 0, 2, 0, 2],
+        "receptive_field_indices": [2, 3, 4],
+        "main_output": 4,
+        "skip_contribution": 1,
+        "residual_sum": 5,
+        "output": 5
+      }
+    ]
+  }
+}

--- a/code/specs/fixtures/residual-receptive-v1/schema.json
+++ b/code/specs/fixtures/residual-receptive-v1/schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/residual-receptive-v1.json",
+  "title": "Residual and receptive-field lab v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "question",
+    "absolute_tolerance",
+    "concepts",
+    "operation",
+    "input",
+    "kernels",
+    "expected"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "padding", "stride", "layers", "skip", "activation"],
+      "properties": {
+        "kind": { "const": "residual-correlation-1d" },
+        "padding": { "const": "same-zero" },
+        "stride": { "const": 1 },
+        "layers": { "const": 2 },
+        "skip": { "const": "identity" },
+        "activation": { "const": "relu" }
+      }
+    },
+    "input": { "$ref": "#/$defs/numbers" },
+    "kernels": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": { "$ref": "#/$defs/numbers" }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hidden", "main", "skip", "residual_sum", "output", "traces"],
+      "properties": {
+        "hidden": { "$ref": "#/$defs/numbers" },
+        "main": { "$ref": "#/$defs/numbers" },
+        "skip": { "$ref": "#/$defs/numbers" },
+        "residual_sum": { "$ref": "#/$defs/numbers" },
+        "output": { "$ref": "#/$defs/numbers" },
+        "traces": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/trace" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "numbers": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "number" }
+    },
+    "indices": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "integer", "minimum": 0 }
+    },
+    "path": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hidden_index", "input_indices", "input_values", "subtotal"],
+      "properties": {
+        "hidden_index": { "type": "integer", "minimum": 0 },
+        "input_indices": { "$ref": "#/$defs/indices" },
+        "input_values": { "$ref": "#/$defs/numbers" },
+        "subtotal": { "type": "number" }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "output_index",
+        "hidden_indices",
+        "hidden_values",
+        "hidden_paths",
+        "input_path_counts",
+        "input_contributions",
+        "receptive_field_indices",
+        "main_output",
+        "skip_contribution",
+        "residual_sum",
+        "output"
+      ],
+      "properties": {
+        "output_index": { "type": "integer", "minimum": 0 },
+        "hidden_indices": { "$ref": "#/$defs/indices" },
+        "hidden_values": { "$ref": "#/$defs/numbers" },
+        "hidden_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/path" }
+        },
+        "input_path_counts": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "integer", "minimum": 0 }
+        },
+        "input_contributions": { "$ref": "#/$defs/numbers" },
+        "receptive_field_indices": { "$ref": "#/$defs/indices" },
+        "main_output": { "type": "number" },
+        "skip_contribution": { "type": "number" },
+        "residual_sum": { "type": "number" },
+        "output": { "type": "number" }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/tiny-decoder-training-v1/CHANGELOG.md
+++ b/code/specs/fixtures/tiny-decoder-training-v1/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add a two-position causal next-token shift and saved decoder states.
+- Add unembedding, stable-softmax, mean cross-entropy, and full gradient traces.
+- Add an independent central finite-difference audit of every trainable gradient.
+- Add one shared-head SGD update and a deterministic post-update loss check.

--- a/code/specs/fixtures/tiny-decoder-training-v1/README.md
+++ b/code/specs/fixtures/tiny-decoder-training-v1/README.md
@@ -1,0 +1,13 @@
+# Tiny Decoder Training V1 Fixtures
+
+This corpus pins a two-position decoder-only next-token training step: causal
+sequence shift, shared unembedding logits, stable softmax, mean cross-entropy,
+state and parameter gradients, one SGD update, and the resulting lower loss.
+The analytical shared-head gradients are also checked by central finite
+differences.
+
+```text
+python code/scripts/validate_tiny_decoder_training_labs.py
+```
+
+See [`NN15-tiny-decoder-training-labs.md`](../../NN15-tiny-decoder-training-labs.md).

--- a/code/specs/fixtures/tiny-decoder-training-v1/labs/00-two-position-next-token-step.json
+++ b/code/specs/fixtures/tiny-decoder-training-v1/labs/00-two-position-next-token-step.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "id": "two-position-next-token-step",
+  "title": "Train one tiny decoder output head on two next-token positions",
+  "question": "How does a causal decoder turn two saved states into next-token loss, shared gradients, and a loss-reducing update?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "decoder-only language model",
+    "causal next-token shift",
+    "unembedding",
+    "cross-entropy",
+    "shared parameter gradients",
+    "stochastic gradient descent"
+  ],
+  "operation": {
+    "kind": "saved-causal-decoder-state-next-token-step",
+    "position_count": 2,
+    "model_width": 2,
+    "vocabulary_size": 3,
+    "state_source": "frozen-causal-decoder-block-output",
+    "objective": "next-token-cross-entropy",
+    "softmax": "stable-row-wise",
+    "reduction": "mean-over-positions",
+    "trainable_parameters": ["unembedding", "bias"],
+    "update": "sgd"
+  },
+  "vocabulary": ["red", "blue", "purple"],
+  "sequence": ["red", "blue", "purple"],
+  "input_tokens": ["red", "blue"],
+  "target_tokens": ["blue", "purple"],
+  "causal_prefixes": [["red"], ["red", "blue"]],
+  "decoder_states": [[1, 0], [0, 1]],
+  "unembedding": [[1, 0, -1], [0, 1, -1]],
+  "bias": [0, 0, 0],
+  "optimizer": {
+    "learning_rate": 0.5
+  },
+  "expected": {
+    "rows": [
+      {
+        "position": 0,
+        "input_token": "red",
+        "target_token": "blue",
+        "causal_prefix": ["red"],
+        "decoder_state": [1, 0],
+        "logit_products": [[1, 0], [0, 0], [-1, 0]],
+        "logits": [1, 0, -1],
+        "row_max": 1,
+        "shifted_logits": [0, -1, -2],
+        "exponentials": [1, 0.36787944117144233, 0.1353352832366127],
+        "denominator": 1.5032147244080551,
+        "probabilities": [0.6652409557748218, 0.24472847105479764, 0.09003057317038046],
+        "target_probability": 0.24472847105479764,
+        "loss": 1.4076059644443804,
+        "logit_gradients": [0.3326204778874109, -0.37763576447260117, 0.04501528658519023],
+        "unembedding_gradient_contribution": [[0.3326204778874109, -0.37763576447260117, 0.04501528658519023], [0, 0, 0]],
+        "bias_gradient_contribution": [0.3326204778874109, -0.37763576447260117, 0.04501528658519023],
+        "state_gradient": [0.2876051913022207, -0.4226510510577914]
+      },
+      {
+        "position": 1,
+        "input_token": "blue",
+        "target_token": "purple",
+        "causal_prefix": ["red", "blue"],
+        "decoder_state": [0, 1],
+        "logit_products": [[0, 0], [0, 1], [0, -1]],
+        "logits": [0, 1, -1],
+        "row_max": 1,
+        "shifted_logits": [-1, 0, -2],
+        "exponentials": [0.36787944117144233, 1, 0.1353352832366127],
+        "denominator": 1.5032147244080551,
+        "probabilities": [0.24472847105479764, 0.6652409557748218, 0.09003057317038046],
+        "target_probability": 0.09003057317038046,
+        "loss": 2.40760596444438,
+        "logit_gradients": [0.12236423552739882, 0.3326204778874109, -0.4549847134148098],
+        "unembedding_gradient_contribution": [[0, 0, 0], [0.12236423552739882, 0.3326204778874109, -0.4549847134148098]],
+        "bias_gradient_contribution": [0.12236423552739882, 0.3326204778874109, -0.4549847134148098],
+        "state_gradient": [0.5773489489422086, 0.7876051913022206]
+      }
+    ],
+    "mean_loss": 1.9076059644443801,
+    "unembedding_gradient": [[0.3326204778874109, -0.37763576447260117, 0.04501528658519023], [0.12236423552739882, 0.3326204778874109, -0.4549847134148098]],
+    "bias_gradient": [0.4549847134148097, -0.04501528658519027, -0.40996942682961957],
+    "gradient_check": {
+      "epsilon": 1e-6,
+      "numerical_unembedding_gradient": [[0.332620477827561, -0.37763576443694546, 0.045015286609384475], [0.12236423541089891, 0.3326204780496056, -0.4549847134605045]],
+      "numerical_bias_gradient": [0.4549847133494822, -0.04501528638733987, -0.40996942685112003],
+      "max_absolute_error": 1.9785040272779497e-10
+    },
+    "updated_unembedding": [[0.8336897610562946, 0.18881788223630058, -1.022507643292595], [-0.06118211776369941, 0.8336897610562946, -0.7725076432925951]],
+    "updated_bias": [-0.22749235670740486, 0.022507643292595136, 0.20498471341480978],
+    "post_update_rows": [
+      {
+        "position": 0,
+        "logits": [0.6061974043488897, 0.21132552552889572, -0.8175229298777853],
+        "probabilities": [0.5223070040134588, 0.35191288756995204, 0.12578010841658918],
+        "target_probability": 0.35191288756995204,
+        "loss": 1.0443716125063502
+      },
+      {
+        "position": 1,
+        "logits": [-0.2886744744711043, 0.8561974043488897, -0.5675229298777853],
+        "probabilities": [0.2041360690449428, 0.641403443158851, 0.1544604877962062],
+        "target_probability": 0.1544604877962062,
+        "loss": 1.8678169577713835
+      }
+    ],
+    "post_update_mean_loss": 1.456094285138867
+  }
+}

--- a/code/specs/fixtures/tiny-decoder-training-v1/schema.json
+++ b/code/specs/fixtures/tiny-decoder-training-v1/schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/tiny-decoder-training-v1.json",
+  "title": "Tiny decoder-only language model training lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "vocabulary", "sequence", "input_tokens", "target_tokens", "causal_prefixes", "decoder_states", "unembedding", "bias", "optimizer", "expected"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "position_count", "model_width", "vocabulary_size", "state_source", "objective", "softmax", "reduction", "trainable_parameters", "update"],
+      "properties": {
+        "kind": { "const": "saved-causal-decoder-state-next-token-step" },
+        "position_count": { "const": 2 },
+        "model_width": { "const": 2 },
+        "vocabulary_size": { "const": 3 },
+        "state_source": { "const": "frozen-causal-decoder-block-output" },
+        "objective": { "const": "next-token-cross-entropy" },
+        "softmax": { "const": "stable-row-wise" },
+        "reduction": { "const": "mean-over-positions" },
+        "trainable_parameters": { "const": ["unembedding", "bias"] },
+        "update": { "const": "sgd" }
+      }
+    },
+    "vocabulary": { "$ref": "#/$defs/uniqueVector3Text" },
+    "sequence": { "$ref": "#/$defs/vector3Text" },
+    "input_tokens": { "$ref": "#/$defs/vector2Text" },
+    "target_tokens": { "$ref": "#/$defs/vector2Text" },
+    "causal_prefixes": {
+      "type": "array",
+      "prefixItems": [
+        { "type": "array", "minItems": 1, "maxItems": 1, "items": { "type": "string", "minLength": 1 } },
+        { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "string", "minLength": 1 } }
+      ],
+      "items": false
+    },
+    "decoder_states": { "$ref": "#/$defs/matrix2x2" },
+    "unembedding": { "$ref": "#/$defs/matrix2x3" },
+    "bias": { "$ref": "#/$defs/vector3" },
+    "optimizer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["learning_rate"],
+      "properties": { "learning_rate": { "type": "number", "exclusiveMinimum": 0 } }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rows", "mean_loss", "unembedding_gradient", "bias_gradient", "gradient_check", "updated_unembedding", "updated_bias", "post_update_rows", "post_update_mean_loss"],
+      "properties": {
+        "rows": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "$ref": "#/$defs/trainingRow" } },
+        "mean_loss": { "type": "number", "minimum": 0 },
+        "unembedding_gradient": { "$ref": "#/$defs/matrix2x3" },
+        "bias_gradient": { "$ref": "#/$defs/vector3" },
+        "gradient_check": { "$ref": "#/$defs/gradientCheck" },
+        "updated_unembedding": { "$ref": "#/$defs/matrix2x3" },
+        "updated_bias": { "$ref": "#/$defs/vector3" },
+        "post_update_rows": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "$ref": "#/$defs/postUpdateRow" } },
+        "post_update_mean_loss": { "type": "number", "minimum": 0 }
+      }
+    }
+  },
+  "$defs": {
+    "vector2": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "number" } },
+    "vector3": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "number" } },
+    "vector2Text": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "string", "minLength": 1 } },
+    "vector3Text": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "type": "string", "minLength": 1 } },
+    "uniqueVector3Text": { "type": "array", "minItems": 3, "maxItems": 3, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "matrix2x2": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "$ref": "#/$defs/vector2" } },
+    "matrix2x3": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "$ref": "#/$defs/vector3" } },
+    "matrix3x2": { "type": "array", "minItems": 3, "maxItems": 3, "items": { "$ref": "#/$defs/vector2" } },
+    "trainingRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["position", "input_token", "target_token", "causal_prefix", "decoder_state", "logit_products", "logits", "row_max", "shifted_logits", "exponentials", "denominator", "probabilities", "target_probability", "loss", "logit_gradients", "unembedding_gradient_contribution", "bias_gradient_contribution", "state_gradient"],
+      "properties": {
+        "position": { "type": "integer", "minimum": 0, "maximum": 1 },
+        "input_token": { "type": "string", "minLength": 1 },
+        "target_token": { "type": "string", "minLength": 1 },
+        "causal_prefix": { "type": "array", "minItems": 1, "maxItems": 2, "items": { "type": "string", "minLength": 1 } },
+        "decoder_state": { "$ref": "#/$defs/vector2" },
+        "logit_products": { "$ref": "#/$defs/matrix3x2" },
+        "logits": { "$ref": "#/$defs/vector3" },
+        "row_max": { "type": "number" },
+        "shifted_logits": { "$ref": "#/$defs/vector3" },
+        "exponentials": { "$ref": "#/$defs/vector3" },
+        "denominator": { "type": "number", "exclusiveMinimum": 0 },
+        "probabilities": { "$ref": "#/$defs/vector3" },
+        "target_probability": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+        "loss": { "type": "number", "minimum": 0 },
+        "logit_gradients": { "$ref": "#/$defs/vector3" },
+        "unembedding_gradient_contribution": { "$ref": "#/$defs/matrix2x3" },
+        "bias_gradient_contribution": { "$ref": "#/$defs/vector3" },
+        "state_gradient": { "$ref": "#/$defs/vector2" }
+      }
+    },
+    "postUpdateRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["position", "logits", "probabilities", "target_probability", "loss"],
+      "properties": {
+        "position": { "type": "integer", "minimum": 0, "maximum": 1 },
+        "logits": { "$ref": "#/$defs/vector3" },
+        "probabilities": { "$ref": "#/$defs/vector3" },
+        "target_probability": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+        "loss": { "type": "number", "minimum": 0 }
+      }
+    },
+    "gradientCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon", "numerical_unembedding_gradient", "numerical_bias_gradient", "max_absolute_error"],
+      "properties": {
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "numerical_unembedding_gradient": { "$ref": "#/$defs/matrix2x3" },
+        "numerical_bias_gradient": { "$ref": "#/$defs/vector3" },
+        "max_absolute_error": { "type": "number", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/tiny-image-cnn-v1/CHANGELOG.md
+++ b/code/specs/fixtures/tiny-image-cnn-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0
+
+- Add the two-channel `3 x 3` image fixture.
+- Pin two-filter channel contributions and convolution outputs.
+- Pin spatial normalization statistics, ReLU outputs, and max-pool winners.

--- a/code/specs/fixtures/tiny-image-cnn-v1/README.md
+++ b/code/specs/fixtures/tiny-image-cnn-v1/README.md
@@ -1,0 +1,13 @@
+# Tiny Image CNN Fixtures V1
+
+This corpus pins the NN07 forward path from two image channels through channel
+accumulation, spatial normalization, ReLU, and max pooling.
+
+Validate it from the repository root:
+
+```text
+python code/scripts/validate_tiny_image_cnn_labs.py
+```
+
+See [`../../NN07-tiny-image-cnn-labs.md`](../../NN07-tiny-image-cnn-labs.md)
+for formulas, conformance levels, and the Rust-core direction.

--- a/code/specs/fixtures/tiny-image-cnn-v1/labs/00-two-channel-image.json
+++ b/code/specs/fixtures/tiny-image-cnn-v1/labs/00-two-channel-image.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "id": "two-channel-image",
+  "title": "Follow two image channels through a tiny CNN",
+  "question": "How do channel-specific kernels become normalized and pooled feature values?",
+  "absolute_tolerance": 1e-12,
+  "concepts": [
+    "two-dimensional cross-correlation",
+    "input and output channels",
+    "spatial normalization",
+    "ReLU activation",
+    "max pooling"
+  ],
+  "operation": {
+    "kind": "cross-correlation-2d",
+    "padding": "valid",
+    "stride": [1, 1],
+    "activation": "relu",
+    "pooling": {
+      "kind": "max",
+      "window": [2, 2],
+      "stride": [2, 2],
+      "tie_break": "first-row-major"
+    }
+  },
+  "input": {
+    "shape": [2, 3, 3],
+    "channels": [
+      {
+        "name": "vertical-position",
+        "values": [[0, 0, 0], [1, 1, 1], [2, 2, 2]]
+      },
+      {
+        "name": "horizontal-position",
+        "values": [[0, 1, 2], [0, 1, 2], [0, 1, 2]]
+      }
+    ]
+  },
+  "filters": [
+    {
+      "name": "toward-bottom-right",
+      "kernels": [
+        [[4, 0], [0, 0]],
+        [[2, 0], [0, 0]]
+      ],
+      "bias": 0
+    },
+    {
+      "name": "toward-top-left",
+      "kernels": [
+        [[-4, 0], [0, 0]],
+        [[-2, 0], [0, 0]]
+      ],
+      "bias": 6
+    }
+  ],
+  "normalization": {
+    "kind": "spatial-per-output-channel",
+    "epsilon": 4,
+    "gamma": [1, 1],
+    "beta": [0, 0]
+  },
+  "expected": {
+    "channel_contributions": [
+      [
+        [[0, 0], [4, 4]],
+        [[0, 2], [0, 2]]
+      ],
+      [
+        [[0, 0], [-4, -4]],
+        [[0, -2], [0, -2]]
+      ]
+    ],
+    "convolution": [
+      [[0, 2], [4, 6]],
+      [[6, 4], [2, 0]]
+    ],
+    "normalization": {
+      "means": [3, 3],
+      "variances": [5, 5],
+      "denominators": [3, 3],
+      "maps": [
+        [[-1, -0.3333333333333333], [0.3333333333333333, 1]],
+        [[1, 0.3333333333333333], [-0.3333333333333333, -1]]
+      ]
+    },
+    "activation": [
+      [[0, 0], [0.3333333333333333, 1]],
+      [[1, 0.3333333333333333], [0, 0]]
+    ],
+    "pooling": {
+      "values": [1, 1],
+      "argmax": [[1, 1], [0, 0]]
+    }
+  }
+}

--- a/code/specs/fixtures/tiny-image-cnn-v1/schema.json
+++ b/code/specs/fixtures/tiny-image-cnn-v1/schema.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/tiny-image-cnn-v1.json",
+  "title": "Tiny image CNN lab v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "question",
+    "absolute_tolerance",
+    "concepts",
+    "operation",
+    "input",
+    "filters",
+    "normalization",
+    "expected"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "padding", "stride", "activation", "pooling"],
+      "properties": {
+        "kind": { "const": "cross-correlation-2d" },
+        "padding": { "const": "valid" },
+        "stride": { "$ref": "#/$defs/one_pair" },
+        "activation": { "const": "relu" },
+        "pooling": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "window", "stride", "tie_break"],
+          "properties": {
+            "kind": { "const": "max" },
+            "window": { "$ref": "#/$defs/two_pair" },
+            "stride": { "$ref": "#/$defs/two_pair" },
+            "tie_break": { "const": "first-row-major" }
+          }
+        }
+      }
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["shape", "channels"],
+      "properties": {
+        "shape": {
+          "type": "array",
+          "prefixItems": [
+            { "type": "integer", "minimum": 1 },
+            { "type": "integer", "minimum": 1 },
+            { "type": "integer", "minimum": 1 }
+          ],
+          "items": false,
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "channels": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "values"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "values": { "$ref": "#/$defs/matrix" }
+            }
+          }
+        }
+      }
+    },
+    "filters": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "kernels", "bias"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "kernels": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/$defs/matrix" }
+          },
+          "bias": { "type": "number" }
+        }
+      }
+    },
+    "normalization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "epsilon", "gamma", "beta"],
+      "properties": {
+        "kind": { "const": "spatial-per-output-channel" },
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "gamma": { "$ref": "#/$defs/numbers" },
+        "beta": { "$ref": "#/$defs/numbers" }
+      }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "channel_contributions",
+        "convolution",
+        "normalization",
+        "activation",
+        "pooling"
+      ],
+      "properties": {
+        "channel_contributions": { "$ref": "#/$defs/tensor4" },
+        "convolution": { "$ref": "#/$defs/tensor3" },
+        "normalization": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["means", "variances", "denominators", "maps"],
+          "properties": {
+            "means": { "$ref": "#/$defs/numbers" },
+            "variances": { "$ref": "#/$defs/numbers" },
+            "denominators": { "$ref": "#/$defs/numbers" },
+            "maps": { "$ref": "#/$defs/tensor3" }
+          }
+        },
+        "activation": { "$ref": "#/$defs/tensor3" },
+        "pooling": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["values", "argmax"],
+          "properties": {
+            "values": { "$ref": "#/$defs/numbers" },
+            "argmax": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/index_pair" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "numbers": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "number" }
+    },
+    "matrix": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/numbers" }
+    },
+    "tensor3": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/matrix" }
+    },
+    "tensor4": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/tensor3" }
+    },
+    "index_pair": {
+      "type": "array",
+      "prefixItems": [
+        { "type": "integer", "minimum": 0 },
+        { "type": "integer", "minimum": 0 }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "one_pair": {
+      "type": "array",
+      "prefixItems": [{ "const": 1 }, { "const": 1 }],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "two_pair": {
+      "type": "array",
+      "prefixItems": [{ "const": 2 }, { "const": 2 }],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  }
+}

--- a/code/specs/fixtures/tiny-message-passing-v1/CHANGELOG.md
+++ b/code/specs/fixtures/tiny-message-passing-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Pin undirected-to-directed edge expansion.
+- Add source-weighted messages, sum aggregation, and synchronous node updates.
+- Record every message, inbox, affine term, ReLU input, and output feature.

--- a/code/specs/fixtures/tiny-message-passing-v1/README.md
+++ b/code/specs/fixtures/tiny-message-passing-v1/README.md
@@ -1,0 +1,12 @@
+# Tiny Message Passing V1 Fixtures
+
+This corpus pins one synchronous message-passing round on a three-node
+undirected path. Each edge expands into two directed messages, every message
+uses the original source feature, each target sums its inbox, and one shared
+affine-plus-ReLU rule updates the nodes.
+
+Validate from the repository root:
+
+```text
+python code/scripts/validate_tiny_message_passing_labs.py
+```

--- a/code/specs/fixtures/tiny-message-passing-v1/labs/00-three-node-path.json
+++ b/code/specs/fixtures/tiny-message-passing-v1/labs/00-three-node-path.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "id": "three-node-path",
+  "title": "One synchronous round on a three-node path",
+  "question": "How do four directed messages become three updated node features?",
+  "absolute_tolerance": 1e-12,
+  "concepts": ["undirected-edge-expansion", "directed-message", "sum-aggregation", "synchronous-update", "shared-node-rule", "relu"],
+  "operation": {"kind": "tiny-graph-message-passing", "edge_mode": "undirected-expanded-both-directions", "message": "source-feature-times-shared-weight", "aggregation": "sum", "update": "shared-affine-plus-relu", "round": "synchronous"},
+  "node_features": [1, 2, -1],
+  "edges": [{"source": 0, "target": 1}, {"source": 1, "target": 2}],
+  "parameters": {"message_weight": 0.5, "self_weight": 0.25, "bias": -0.5},
+  "expected": {
+    "directed_messages": [
+      {"source": 1, "target": 0, "source_feature": 2, "message_weight": 0.5, "message": 1},
+      {"source": 0, "target": 1, "source_feature": 1, "message_weight": 0.5, "message": 0.5},
+      {"source": 2, "target": 1, "source_feature": -1, "message_weight": 0.5, "message": -0.5},
+      {"source": 1, "target": 2, "source_feature": 2, "message_weight": 0.5, "message": 1}
+    ],
+    "node_updates": [
+      {"node": 0, "old_feature": 1, "incoming": [{"source": 1, "target": 0, "source_feature": 2, "message_weight": 0.5, "message": 1}], "aggregate": 1, "self_contribution": 0.25, "bias": -0.5, "preactivation": 0.75, "output_feature": 0.75},
+      {"node": 1, "old_feature": 2, "incoming": [{"source": 0, "target": 1, "source_feature": 1, "message_weight": 0.5, "message": 0.5}, {"source": 2, "target": 1, "source_feature": -1, "message_weight": 0.5, "message": -0.5}], "aggregate": 0, "self_contribution": 0.5, "bias": -0.5, "preactivation": 0, "output_feature": 0},
+      {"node": 2, "old_feature": -1, "incoming": [{"source": 1, "target": 2, "source_feature": 2, "message_weight": 0.5, "message": 1}], "aggregate": 1, "self_contribution": -0.25, "bias": -0.5, "preactivation": 0.25, "output_feature": 0.25}
+    ],
+    "output_features": [0.75, 0, 0.25]
+  }
+}

--- a/code/specs/fixtures/tiny-message-passing-v1/schema.json
+++ b/code/specs/fixtures/tiny-message-passing-v1/schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/tiny-message-passing-v1.json",
+  "title": "Tiny graph message passing V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "node_features", "edges", "parameters", "expected"],
+  "properties": {
+    "schema_version": {"const": 1}, "id": {"type": "string", "minLength": 1}, "title": {"type": "string", "minLength": 1}, "question": {"type": "string", "minLength": 1},
+    "absolute_tolerance": {"type": "number", "exclusiveMinimum": 0},
+    "concepts": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "operation": {"type": "object", "additionalProperties": false, "required": ["kind", "edge_mode", "message", "aggregation", "update", "round"], "properties": {"kind": {"const": "tiny-graph-message-passing"}, "edge_mode": {"const": "undirected-expanded-both-directions"}, "message": {"const": "source-feature-times-shared-weight"}, "aggregation": {"const": "sum"}, "update": {"const": "shared-affine-plus-relu"}, "round": {"const": "synchronous"}}},
+    "node_features": {"type": "array", "minItems": 2, "items": {"type": "number"}},
+    "edges": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/edge"}},
+    "parameters": {"$ref": "#/$defs/parameters"},
+    "expected": {"type": "object", "additionalProperties": false, "required": ["directed_messages", "node_updates", "output_features"], "properties": {"directed_messages": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/message"}}, "node_updates": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/update"}}, "output_features": {"type": "array", "minItems": 2, "items": {"type": "number"}}}}
+  },
+  "$defs": {
+    "edge": {"type": "object", "additionalProperties": false, "required": ["source", "target"], "properties": {"source": {"type": "integer", "minimum": 0}, "target": {"type": "integer", "minimum": 0}}},
+    "parameters": {"type": "object", "additionalProperties": false, "required": ["message_weight", "self_weight", "bias"], "properties": {"message_weight": {"type": "number"}, "self_weight": {"type": "number"}, "bias": {"type": "number"}}},
+    "message": {"type": "object", "additionalProperties": false, "required": ["source", "target", "source_feature", "message_weight", "message"], "properties": {"source": {"type": "integer"}, "target": {"type": "integer"}, "source_feature": {"type": "number"}, "message_weight": {"type": "number"}, "message": {"type": "number"}}},
+    "update": {"type": "object", "additionalProperties": false, "required": ["node", "old_feature", "incoming", "aggregate", "self_contribution", "bias", "preactivation", "output_feature"], "properties": {"node": {"type": "integer"}, "old_feature": {"type": "number"}, "incoming": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/message"}}, "aggregate": {"type": "number"}, "self_contribution": {"type": "number"}, "bias": {"type": "number"}, "preactivation": {"type": "number"}, "output_feature": {"type": "number", "minimum": 0}}}
+  }
+}

--- a/code/specs/fixtures/training-stabilizers-v1/CHANGELOG.md
+++ b/code/specs/fixtures/training-stabilizers-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add one deterministic four-coordinate stabilizer comparison.
+- Pin plain, layer-normalized, inverted-dropout, and residual traces.
+- Add input and branch-weight finite-difference audits.

--- a/code/specs/fixtures/training-stabilizers-v1/README.md
+++ b/code/specs/fixtures/training-stabilizers-v1/README.md
@@ -1,0 +1,12 @@
+# Training Stabilizers V1 Fixtures
+
+This NN25 corpus sends one four-coordinate branch through plain, population
+layer-normalized, deterministic inverted-dropout, and residual routes. It pins
+every forward value, vector-Jacobian product, input gradient, branch-weight
+gradient, dropout expectation, and central finite-difference audit.
+
+Validate it with:
+
+```text
+python code/scripts/validate_training_stabilizer_labs.py
+```

--- a/code/specs/fixtures/training-stabilizers-v1/labs/00-four-route-comparison.json
+++ b/code/specs/fixtures/training-stabilizers-v1/labs/00-four-route-comparison.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": 1,
+  "id": "nn25-four-route-stabilizer-comparison",
+  "title": "Plain, normalized, dropout, and residual branch comparison",
+  "question": "How do normalization, dropout, and an identity residual change the same branch's forward values and reverse gradient?",
+  "absolute_tolerance": 1e-9,
+  "concepts": ["layer normalization", "population variance", "inverted dropout", "dropout expectation", "residual path", "vector-Jacobian product", "finite difference"],
+  "operation": {
+    "kind": "vector-training-stabilizers",
+    "normalization": "population-layer-normalization",
+    "normalization_epsilon": 0,
+    "dropout": "inverted-training-dropout",
+    "keep_probability": 0.5,
+    "finite_difference_epsilon": 1e-6
+  },
+  "input": [1, 1, 3, 3],
+  "branch_weight": 0.5,
+  "upstream_gradient": [1, 0, 0, -1],
+  "dropout_mask": [1, 0, 1, 0],
+  "expected": {
+    "branch": [0.5, 0.5, 1.5, 1.5],
+    "normalization": {
+      "mean": 1,
+      "centered": [-0.5, -0.5, 0.5, 0.5],
+      "variance": 0.25,
+      "standard_deviation": 0.5,
+      "normalized": [-1, -1, 1, 1],
+      "upstream_sum": 0,
+      "upstream_dot_normalized": -2
+    },
+    "dropout": {
+      "scaled_mask": [2, 0, 2, 0],
+      "evaluation_output": [0.5, 0.5, 1.5, 1.5],
+      "training_expectation": [0.5, 0.5, 1.5, 1.5]
+    },
+    "routes": [
+      {
+        "id": "plain",
+        "output": [0.5, 0.5, 1.5, 1.5],
+        "score": -1,
+        "branch_gradient": [1, 0, 0, -1],
+        "skip_gradient": [0, 0, 0, 0],
+        "input_gradient": [0.5, 0, 0, -0.5],
+        "weight_gradient": -2,
+        "finite_difference_input_gradient": [0.5000000000143778, 0, 0, -0.500000000069889],
+        "finite_difference_weight_gradient": -1.999999999946489,
+        "input_gradient_absolute_error": [1.4377832258105627e-11, 0, 0, 6.988898348936345e-11],
+        "weight_gradient_absolute_error": 5.3510973430093145e-11
+      },
+      {
+        "id": "normalization",
+        "output": [-1, -1, 1, 1],
+        "score": -2,
+        "branch_gradient": [1, -1, 1, -1],
+        "skip_gradient": [0, 0, 0, 0],
+        "input_gradient": [0.5, -0.5, 0.5, -0.5],
+        "weight_gradient": 0,
+        "finite_difference_input_gradient": [0.500000000069889, -0.4999999997368221, 0.4999999999588667, -0.500000000069889],
+        "finite_difference_weight_gradient": 0,
+        "input_gradient_absolute_error": [6.988898348936345e-11, 2.631779238981835e-10, 4.11333189731522e-11, 6.988898348936345e-11],
+        "weight_gradient_absolute_error": 0
+      },
+      {
+        "id": "dropout",
+        "output": [1, 0, 3, 0],
+        "score": 1,
+        "branch_gradient": [2, 0, 0, 0],
+        "skip_gradient": [0, 0, 0, 0],
+        "input_gradient": [1, 0, 0, 0],
+        "weight_gradient": 2,
+        "finite_difference_input_gradient": [0.9999999999732445, 0, 0, 0],
+        "finite_difference_weight_gradient": 2.000000000002,
+        "input_gradient_absolute_error": [2.6755486715046572e-11, 0, 0, 0],
+        "weight_gradient_absolute_error": 2.000177801164682e-12
+      },
+      {
+        "id": "residual",
+        "output": [1.5, 1.5, 4.5, 4.5],
+        "score": -3,
+        "branch_gradient": [1, 0, 0, -1],
+        "skip_gradient": [1, 0, 0, -1],
+        "input_gradient": [1.5, 0, 0, -1.5],
+        "weight_gradient": -2,
+        "finite_difference_input_gradient": [1.4999999997655777, 0, 0, -1.4999999997655777],
+        "finite_difference_weight_gradient": -1.9999999993913775,
+        "input_gradient_absolute_error": [2.3442225938197225e-10, 0, 0, 2.3442225938197225e-10],
+        "weight_gradient_absolute_error": 6.086224857426714e-10
+      }
+    ]
+  }
+}

--- a/code/specs/fixtures/training-stabilizers-v1/schema.json
+++ b/code/specs/fixtures/training-stabilizers-v1/schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/training-stabilizers-v1.json",
+  "title": "Training stabilizers V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "input", "branch_weight", "upstream_gradient", "dropout_mask", "expected"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "id": {"type": "string", "minLength": 1},
+    "title": {"type": "string", "minLength": 1},
+    "question": {"type": "string", "minLength": 1},
+    "absolute_tolerance": {"type": "number", "exclusiveMinimum": 0},
+    "concepts": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "normalization", "normalization_epsilon", "dropout", "keep_probability", "finite_difference_epsilon"],
+      "properties": {
+        "kind": {"const": "vector-training-stabilizers"},
+        "normalization": {"const": "population-layer-normalization"},
+        "normalization_epsilon": {"const": 0},
+        "dropout": {"const": "inverted-training-dropout"},
+        "keep_probability": {"const": 0.5},
+        "finite_difference_epsilon": {"const": 1e-6}
+      }
+    },
+    "input": {"$ref": "#/$defs/vector4"},
+    "branch_weight": {"type": "number"},
+    "upstream_gradient": {"$ref": "#/$defs/vector4"},
+    "dropout_mask": {"$ref": "#/$defs/mask4"},
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["branch", "normalization", "dropout", "routes"],
+      "properties": {
+        "branch": {"$ref": "#/$defs/vector4"},
+        "normalization": {"$ref": "#/$defs/normalization"},
+        "dropout": {"$ref": "#/$defs/dropout"},
+        "routes": {"type": "array", "minItems": 4, "maxItems": 4, "items": {"$ref": "#/$defs/route"}}
+      }
+    }
+  },
+  "$defs": {
+    "vector4": {"type": "array", "minItems": 4, "maxItems": 4, "items": {"type": "number"}},
+    "mask4": {"type": "array", "minItems": 4, "maxItems": 4, "items": {"enum": [0, 1]}},
+    "normalization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mean", "centered", "variance", "standard_deviation", "normalized", "upstream_sum", "upstream_dot_normalized"],
+      "properties": {
+        "mean": {"type": "number"},
+        "centered": {"$ref": "#/$defs/vector4"},
+        "variance": {"type": "number", "minimum": 0},
+        "standard_deviation": {"type": "number", "exclusiveMinimum": 0},
+        "normalized": {"$ref": "#/$defs/vector4"},
+        "upstream_sum": {"type": "number"},
+        "upstream_dot_normalized": {"type": "number"}
+      }
+    },
+    "dropout": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scaled_mask", "evaluation_output", "training_expectation"],
+      "properties": {
+        "scaled_mask": {"$ref": "#/$defs/vector4"},
+        "evaluation_output": {"$ref": "#/$defs/vector4"},
+        "training_expectation": {"$ref": "#/$defs/vector4"}
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "output", "score", "branch_gradient", "skip_gradient", "input_gradient", "weight_gradient", "finite_difference_input_gradient", "finite_difference_weight_gradient", "input_gradient_absolute_error", "weight_gradient_absolute_error"],
+      "properties": {
+        "id": {"enum": ["plain", "normalization", "dropout", "residual"]},
+        "output": {"$ref": "#/$defs/vector4"},
+        "score": {"type": "number"},
+        "branch_gradient": {"$ref": "#/$defs/vector4"},
+        "skip_gradient": {"$ref": "#/$defs/vector4"},
+        "input_gradient": {"$ref": "#/$defs/vector4"},
+        "weight_gradient": {"type": "number"},
+        "finite_difference_input_gradient": {"$ref": "#/$defs/vector4"},
+        "finite_difference_weight_gradient": {"type": "number"},
+        "input_gradient_absolute_error": {"$ref": "#/$defs/vector4"},
+        "weight_gradient_absolute_error": {"type": "number", "minimum": 0}
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/two-number-autoencoder-v1/CHANGELOG.md
+++ b/code/specs/fixtures/two-number-autoencoder-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add a two-coordinate input, one-scalar bottleneck, and two-coordinate reconstruction.
+- Add explicit reconstruction-loss and complete encoder/decoder gradient traces.
+- Add a seven-parameter finite-difference audit and one loss-reducing SGD step.

--- a/code/specs/fixtures/two-number-autoencoder-v1/README.md
+++ b/code/specs/fixtures/two-number-autoencoder-v1/README.md
@@ -1,0 +1,12 @@
+# Two-Number Autoencoder V1 Fixtures
+
+This corpus pins a complete `2 -> 1 -> 2` linear autoencoder training step:
+encoding products, scalar bottleneck, reconstruction, mean squared error,
+backpropagation through both decoder branches, a seven-parameter central
+finite-difference audit, one SGD update, and the resulting lower loss.
+
+```text
+python code/scripts/validate_two_number_autoencoder_labs.py
+```
+
+See [`NN16-two-number-autoencoder-labs.md`](../../NN16-two-number-autoencoder-labs.md).

--- a/code/specs/fixtures/two-number-autoencoder-v1/labs/00-linear-bottleneck-step.json
+++ b/code/specs/fixtures/two-number-autoencoder-v1/labs/00-linear-bottleneck-step.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "id": "linear-bottleneck-step",
+  "title": "Compress two numbers into one and reconstruct both",
+  "question": "How do two reconstruction errors meet at one bottleneck and train both sides of an autoencoder?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "autoencoder",
+    "undercomplete bottleneck",
+    "representation learning",
+    "reconstruction loss",
+    "gradient accumulation",
+    "stochastic gradient descent"
+  ],
+  "operation": {
+    "kind": "two-to-one-to-two-autoencoder-step",
+    "input_width": 2,
+    "bottleneck_width": 1,
+    "output_width": 2,
+    "encoder_activation": "identity",
+    "decoder_activation": "identity",
+    "loss": "mean-squared-reconstruction-error",
+    "reduction": "mean-over-output-coordinates",
+    "trainable_parameters": ["encoder.weights", "encoder.bias", "decoder.weights", "decoder.bias"],
+    "update": "sgd"
+  },
+  "input": [2, -1],
+  "encoder": {
+    "weights": [0.5, -0.25],
+    "bias": 0
+  },
+  "decoder": {
+    "weights": [1.2, -0.8],
+    "bias": [0.1, -0.2]
+  },
+  "optimizer": {
+    "learning_rate": 0.1
+  },
+  "expected": {
+    "forward": {
+      "encoder_products": [1, 0.25],
+      "bottleneck": 1.25,
+      "decoder_products": [1.5, -1],
+      "reconstruction": [1.6, -1.2],
+      "errors": [-0.4, -0.2],
+      "squared_errors": [0.16, 0.04],
+      "loss": 0.1
+    },
+    "backward": {
+      "reconstruction_gradients": [-0.4, -0.2],
+      "decoder_weight_gradients": [-0.5, -0.25],
+      "decoder_bias_gradients": [-0.4, -0.2],
+      "bottleneck_gradient_contributions": [-0.48, 0.16],
+      "bottleneck_gradient": -0.32,
+      "encoder_weight_gradients": [-0.64, 0.32],
+      "encoder_bias_gradient": -0.32
+    },
+    "gradient_check": {
+      "epsilon": 1e-6,
+      "parameter_order": ["encoder.weights[0]", "encoder.weights[1]", "encoder.bias", "decoder.weights[0]", "decoder.weights[1]", "decoder.bias[0]", "decoder.bias[1]"],
+      "analytical": [-0.64, 0.32, -0.32, -0.5, -0.25, -0.4, -0.2],
+      "numerical": [-0.6399999999961992, 0.3199999999842218, -0.3199999999842218, -0.49999999997968336, -0.2500000000141278, -0.40000000001150227, -0.20000000000575113],
+      "max_absolute_error": 2.0316526239128052e-11
+    },
+    "updated_parameters": {
+      "encoder": {
+        "weights": [0.564, -0.282],
+        "bias": 0.032
+      },
+      "decoder": {
+        "weights": [1.25, -0.775],
+        "bias": [0.14, -0.18]
+      }
+    },
+    "post_update": {
+      "encoder_products": [1.128, 0.282],
+      "bottleneck": 1.442,
+      "decoder_products": [1.8025, -1.11755],
+      "reconstruction": [1.9425, -1.29755],
+      "errors": [-0.0575, -0.29755],
+      "squared_errors": [0.00330625, 0.0885360025],
+      "loss": 0.04592112625
+    }
+  }
+}

--- a/code/specs/fixtures/two-number-autoencoder-v1/schema.json
+++ b/code/specs/fixtures/two-number-autoencoder-v1/schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/two-number-autoencoder-v1.json",
+  "title": "Two-number autoencoder learning lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "input", "encoder", "decoder", "optimizer", "expected"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "input_width", "bottleneck_width", "output_width", "encoder_activation", "decoder_activation", "loss", "reduction", "trainable_parameters", "update"],
+      "properties": {
+        "kind": { "const": "two-to-one-to-two-autoencoder-step" },
+        "input_width": { "const": 2 },
+        "bottleneck_width": { "const": 1 },
+        "output_width": { "const": 2 },
+        "encoder_activation": { "const": "identity" },
+        "decoder_activation": { "const": "identity" },
+        "loss": { "const": "mean-squared-reconstruction-error" },
+        "reduction": { "const": "mean-over-output-coordinates" },
+        "trainable_parameters": { "const": ["encoder.weights", "encoder.bias", "decoder.weights", "decoder.bias"] },
+        "update": { "const": "sgd" }
+      }
+    },
+    "input": { "$ref": "#/$defs/vector2" },
+    "encoder": { "$ref": "#/$defs/encoderParameters" },
+    "decoder": { "$ref": "#/$defs/decoderParameters" },
+    "optimizer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["learning_rate"],
+      "properties": { "learning_rate": { "type": "number", "exclusiveMinimum": 0 } }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["forward", "backward", "gradient_check", "updated_parameters", "post_update"],
+      "properties": {
+        "forward": { "$ref": "#/$defs/forwardTrace" },
+        "backward": { "$ref": "#/$defs/backwardTrace" },
+        "gradient_check": { "$ref": "#/$defs/gradientCheck" },
+        "updated_parameters": { "$ref": "#/$defs/updatedParameters" },
+        "post_update": { "$ref": "#/$defs/forwardTrace" }
+      }
+    }
+  },
+  "$defs": {
+    "vector2": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "number" } },
+    "vector7": { "type": "array", "minItems": 7, "maxItems": 7, "items": { "type": "number" } },
+    "encoderParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["weights", "bias"],
+      "properties": {
+        "weights": { "$ref": "#/$defs/vector2" },
+        "bias": { "type": "number" }
+      }
+    },
+    "decoderParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["weights", "bias"],
+      "properties": {
+        "weights": { "$ref": "#/$defs/vector2" },
+        "bias": { "$ref": "#/$defs/vector2" }
+      }
+    },
+    "forwardTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["encoder_products", "bottleneck", "decoder_products", "reconstruction", "errors", "squared_errors", "loss"],
+      "properties": {
+        "encoder_products": { "$ref": "#/$defs/vector2" },
+        "bottleneck": { "type": "number" },
+        "decoder_products": { "$ref": "#/$defs/vector2" },
+        "reconstruction": { "$ref": "#/$defs/vector2" },
+        "errors": { "$ref": "#/$defs/vector2" },
+        "squared_errors": { "$ref": "#/$defs/vector2" },
+        "loss": { "type": "number", "minimum": 0 }
+      }
+    },
+    "backwardTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reconstruction_gradients", "decoder_weight_gradients", "decoder_bias_gradients", "bottleneck_gradient_contributions", "bottleneck_gradient", "encoder_weight_gradients", "encoder_bias_gradient"],
+      "properties": {
+        "reconstruction_gradients": { "$ref": "#/$defs/vector2" },
+        "decoder_weight_gradients": { "$ref": "#/$defs/vector2" },
+        "decoder_bias_gradients": { "$ref": "#/$defs/vector2" },
+        "bottleneck_gradient_contributions": { "$ref": "#/$defs/vector2" },
+        "bottleneck_gradient": { "type": "number" },
+        "encoder_weight_gradients": { "$ref": "#/$defs/vector2" },
+        "encoder_bias_gradient": { "type": "number" }
+      }
+    },
+    "gradientCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon", "parameter_order", "analytical", "numerical", "max_absolute_error"],
+      "properties": {
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "parameter_order": { "const": ["encoder.weights[0]", "encoder.weights[1]", "encoder.bias", "decoder.weights[0]", "decoder.weights[1]", "decoder.bias[0]", "decoder.bias[1]"] },
+        "analytical": { "$ref": "#/$defs/vector7" },
+        "numerical": { "$ref": "#/$defs/vector7" },
+        "max_absolute_error": { "type": "number", "minimum": 0 }
+      }
+    },
+    "updatedParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["encoder", "decoder"],
+      "properties": {
+        "encoder": { "$ref": "#/$defs/encoderParameters" },
+        "decoder": { "$ref": "#/$defs/decoderParameters" }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/variational-autoencoder-v1/CHANGELOG.md
+++ b/code/specs/fixtures/variational-autoencoder-v1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to the NN17 fixture corpus are recorded here.
+
+## 1.0.0 - 2026-08-02
+
+- Add the saved-noise scalar variational autoencoder training-step fixture.

--- a/code/specs/fixtures/variational-autoencoder-v1/README.md
+++ b/code/specs/fixtures/variational-autoencoder-v1/README.md
@@ -1,0 +1,12 @@
+# Variational Autoencoder V1 Fixtures
+
+This corpus pins one complete scalar VAE step: Gaussian parameters, a saved
+noise sample, reparameterization, reconstruction error, beta-weighted KL
+divergence, both backward routes, six central finite differences, one SGD
+update, and the resulting lower total loss.
+
+```text
+python code/scripts/validate_variational_autoencoder_labs.py
+```
+
+See [`NN17-variational-autoencoder-labs.md`](../../NN17-variational-autoencoder-labs.md).

--- a/code/specs/fixtures/variational-autoencoder-v1/labs/00-saved-noise-kl-step.json
+++ b/code/specs/fixtures/variational-autoencoder-v1/labs/00-saved-noise-kl-step.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "id": "saved-noise-kl-step",
+  "title": "Sample one latent number and balance reconstruction with KL",
+  "question": "How does saved Gaussian noise keep a variational sample differentiable, and how does beta trade reconstruction against a sampleable prior?",
+  "absolute_tolerance": 1e-9,
+  "concepts": [
+    "variational autoencoder",
+    "Gaussian latent variable",
+    "reparameterization trick",
+    "KL divergence",
+    "beta-VAE objective",
+    "central finite differences"
+  ],
+  "operation": {
+    "kind": "scalar-variational-autoencoder-step",
+    "input_width": 1,
+    "latent_width": 1,
+    "output_width": 1,
+    "posterior": "diagonal-gaussian",
+    "sampling": "reparameterization-with-saved-epsilon",
+    "decoder_activation": "identity",
+    "reconstruction_loss": "half-squared-error",
+    "kl_prior": "standard-normal",
+    "objective": "beta-vae",
+    "trainable_parameters": ["encoder.mean", "encoder.log_variance", "decoder"],
+    "update": "sgd"
+  },
+  "input": 1,
+  "encoder": {
+    "mean": { "weight": 0.4, "bias": 0 },
+    "log_variance": { "weight": 0, "bias": 0 }
+  },
+  "decoder": { "weight": 1, "bias": 0 },
+  "sample": { "epsilon": 0.5 },
+  "objective": { "beta": 0.1 },
+  "optimizer": { "learning_rate": 0.1 },
+  "expected": {
+    "forward": {
+      "mean_product": 0.4,
+      "mean": 0.4,
+      "log_variance_product": 0,
+      "log_variance": 0,
+      "variance": 1,
+      "standard_deviation": 1,
+      "epsilon": 0.5,
+      "noise_contribution": 0.5,
+      "latent": 0.9,
+      "decoder_product": 0.9,
+      "reconstruction": 0.9,
+      "error": -0.1,
+      "reconstruction_loss": 0.005,
+      "mean_squared": 0.16,
+      "kl": 0.08,
+      "weighted_kl": 0.008,
+      "total_loss": 0.013
+    },
+    "backward": {
+      "reconstruction_gradient": -0.1,
+      "decoder_weight_gradient": -0.09,
+      "decoder_bias_gradient": -0.1,
+      "latent_gradient": -0.1,
+      "reconstruction_mean_gradient": -0.1,
+      "reconstruction_log_variance_gradient": -0.025,
+      "kl_mean_gradient": 0.4,
+      "kl_log_variance_gradient": 0,
+      "weighted_kl_mean_gradient": 0.04,
+      "weighted_kl_log_variance_gradient": 0,
+      "mean_gradient": -0.06,
+      "log_variance_gradient": -0.025,
+      "mean_weight_gradient": -0.06,
+      "mean_bias_gradient": -0.06,
+      "log_variance_weight_gradient": -0.025,
+      "log_variance_bias_gradient": -0.025
+    },
+    "gradient_check": {
+      "epsilon": 1e-6,
+      "parameter_order": ["encoder.mean.weight", "encoder.mean.bias", "encoder.log_variance.weight", "encoder.log_variance.bias", "decoder.weight", "decoder.bias"],
+      "analytical": [-0.06, -0.06, -0.025, -0.025, -0.09, -0.1],
+      "numerical": [-0.06000000000311312, -0.06000000000311312, -0.025000000007657786, -0.025000000007657786, -0.09000000000293495, -0.10000000000287557],
+      "max_absolute_error": 7.657791067927633e-12
+    },
+    "updated_parameters": {
+      "encoder": {
+        "mean": { "weight": 0.406, "bias": 0.006 },
+        "log_variance": { "weight": 0.0025, "bias": 0.0025 }
+      },
+      "decoder": { "weight": 1.009, "bias": 0.01 }
+    },
+    "post_update": {
+      "mean_product": 0.406,
+      "mean": 0.412,
+      "log_variance_product": 0.0025,
+      "log_variance": 0.005,
+      "variance": 1.005012520859401,
+      "standard_deviation": 1.0025031276057952,
+      "epsilon": 0.5,
+      "noise_contribution": 0.5012515638028976,
+      "latent": 0.9132515638028976,
+      "decoder_product": 0.9214708278771237,
+      "reconstruction": 0.9314708278771237,
+      "error": -0.06852917212287635,
+      "reconstruction_loss": 0.002348123715923406,
+      "mean_squared": 0.16974400000000003,
+      "kl": 0.08487826042970054,
+      "weighted_kl": 0.008487826042970053,
+      "total_loss": 0.01083594975889346
+    }
+  }
+}

--- a/code/specs/fixtures/variational-autoencoder-v1/schema.json
+++ b/code/specs/fixtures/variational-autoencoder-v1/schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/variational-autoencoder-v1.json",
+  "title": "Scalar variational autoencoder learning lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "title", "question", "absolute_tolerance", "concepts", "operation", "input", "encoder", "decoder", "sample", "objective", "optimizer", "expected"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "question": { "type": "string", "minLength": 1 },
+    "absolute_tolerance": { "type": "number", "exclusiveMinimum": 0 },
+    "concepts": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "input_width", "latent_width", "output_width", "posterior", "sampling", "decoder_activation", "reconstruction_loss", "kl_prior", "objective", "trainable_parameters", "update"],
+      "properties": {
+        "kind": { "const": "scalar-variational-autoencoder-step" },
+        "input_width": { "const": 1 },
+        "latent_width": { "const": 1 },
+        "output_width": { "const": 1 },
+        "posterior": { "const": "diagonal-gaussian" },
+        "sampling": { "const": "reparameterization-with-saved-epsilon" },
+        "decoder_activation": { "const": "identity" },
+        "reconstruction_loss": { "const": "half-squared-error" },
+        "kl_prior": { "const": "standard-normal" },
+        "objective": { "const": "beta-vae" },
+        "trainable_parameters": { "const": ["encoder.mean", "encoder.log_variance", "decoder"] },
+        "update": { "const": "sgd" }
+      }
+    },
+    "input": { "type": "number" },
+    "encoder": { "$ref": "#/$defs/encoderParameters" },
+    "decoder": { "$ref": "#/$defs/affineParameters" },
+    "sample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon"],
+      "properties": { "epsilon": { "type": "number" } }
+    },
+    "objective": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["beta"],
+      "properties": { "beta": { "type": "number", "minimum": 0 } }
+    },
+    "optimizer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["learning_rate"],
+      "properties": { "learning_rate": { "type": "number", "exclusiveMinimum": 0 } }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["forward", "backward", "gradient_check", "updated_parameters", "post_update"],
+      "properties": {
+        "forward": { "$ref": "#/$defs/forwardTrace" },
+        "backward": { "$ref": "#/$defs/backwardTrace" },
+        "gradient_check": { "$ref": "#/$defs/gradientCheck" },
+        "updated_parameters": { "$ref": "#/$defs/updatedParameters" },
+        "post_update": { "$ref": "#/$defs/forwardTrace" }
+      }
+    }
+  },
+  "$defs": {
+    "affineParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["weight", "bias"],
+      "properties": {
+        "weight": { "type": "number" },
+        "bias": { "type": "number" }
+      }
+    },
+    "encoderParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mean", "log_variance"],
+      "properties": {
+        "mean": { "$ref": "#/$defs/affineParameters" },
+        "log_variance": { "$ref": "#/$defs/affineParameters" }
+      }
+    },
+    "forwardTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mean_product", "mean", "log_variance_product", "log_variance", "variance", "standard_deviation", "epsilon", "noise_contribution", "latent", "decoder_product", "reconstruction", "error", "reconstruction_loss", "mean_squared", "kl", "weighted_kl", "total_loss"],
+      "properties": {
+        "mean_product": { "type": "number" },
+        "mean": { "type": "number" },
+        "log_variance_product": { "type": "number" },
+        "log_variance": { "type": "number" },
+        "variance": { "type": "number", "exclusiveMinimum": 0 },
+        "standard_deviation": { "type": "number", "exclusiveMinimum": 0 },
+        "epsilon": { "type": "number" },
+        "noise_contribution": { "type": "number" },
+        "latent": { "type": "number" },
+        "decoder_product": { "type": "number" },
+        "reconstruction": { "type": "number" },
+        "error": { "type": "number" },
+        "reconstruction_loss": { "type": "number", "minimum": 0 },
+        "mean_squared": { "type": "number", "minimum": 0 },
+        "kl": { "type": "number", "minimum": 0 },
+        "weighted_kl": { "type": "number", "minimum": 0 },
+        "total_loss": { "type": "number", "minimum": 0 }
+      }
+    },
+    "backwardTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reconstruction_gradient", "decoder_weight_gradient", "decoder_bias_gradient", "latent_gradient", "reconstruction_mean_gradient", "reconstruction_log_variance_gradient", "kl_mean_gradient", "kl_log_variance_gradient", "weighted_kl_mean_gradient", "weighted_kl_log_variance_gradient", "mean_gradient", "log_variance_gradient", "mean_weight_gradient", "mean_bias_gradient", "log_variance_weight_gradient", "log_variance_bias_gradient"],
+      "properties": {
+        "reconstruction_gradient": { "type": "number" },
+        "decoder_weight_gradient": { "type": "number" },
+        "decoder_bias_gradient": { "type": "number" },
+        "latent_gradient": { "type": "number" },
+        "reconstruction_mean_gradient": { "type": "number" },
+        "reconstruction_log_variance_gradient": { "type": "number" },
+        "kl_mean_gradient": { "type": "number" },
+        "kl_log_variance_gradient": { "type": "number" },
+        "weighted_kl_mean_gradient": { "type": "number" },
+        "weighted_kl_log_variance_gradient": { "type": "number" },
+        "mean_gradient": { "type": "number" },
+        "log_variance_gradient": { "type": "number" },
+        "mean_weight_gradient": { "type": "number" },
+        "mean_bias_gradient": { "type": "number" },
+        "log_variance_weight_gradient": { "type": "number" },
+        "log_variance_bias_gradient": { "type": "number" }
+      }
+    },
+    "gradientCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["epsilon", "parameter_order", "analytical", "numerical", "max_absolute_error"],
+      "properties": {
+        "epsilon": { "type": "number", "exclusiveMinimum": 0 },
+        "parameter_order": { "const": ["encoder.mean.weight", "encoder.mean.bias", "encoder.log_variance.weight", "encoder.log_variance.bias", "decoder.weight", "decoder.bias"] },
+        "analytical": { "$ref": "#/$defs/vector6" },
+        "numerical": { "$ref": "#/$defs/vector6" },
+        "max_absolute_error": { "type": "number", "minimum": 0 }
+      }
+    },
+    "vector6": { "type": "array", "minItems": 6, "maxItems": 6, "items": { "type": "number" } },
+    "updatedParameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["encoder", "decoder"],
+      "properties": {
+        "encoder": { "$ref": "#/$defs/encoderParameters" },
+        "decoder": { "$ref": "#/$defs/affineParameters" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Goal

Build a learning corpus that removes the “magic” from neural networks, beginning with hand-calculable arithmetic and growing through spatial, sequence, attention, generative, graph, autograd, compiler, and accelerated execution topics.

This is intentionally a long-lived draft PR. Each curriculum tranche will be added as a separate validated commit on the same branch, and `code/learning/machine-learning/ROADMAP.md` tracks completion.

## First commit: optimization fundamentals

- add an Optimization Microscope with a loss landscape, analytical-versus-finite-difference gradient audit, and synchronized stochastic/mini-batch/full-batch trajectories
- add a hand-worked optimization lesson
- define NN04 and a language-neutral optimization fixture
- add a standard-library validator and five focused tests
- expand the visualizer test suite from 17 to 21 tests
- add the delivery roadmap and refresh learning coverage

## Loop discipline

- keep one neural-learning PR active
- inspect CI before beginning another tranche
- push only validated, reviewable commits to this branch
- update the roadmap with each tranche
- preserve numerical oracles and browser interaction evidence
- do not merge autonomously

## Validation

- `python code/scripts/validate_neural_learning_labs.py`
- `python code/scripts/validate_optimization_learning_labs.py`
- `python code/scripts/tests/test_neural_learning_labs.py` — 4 tests
- `python code/scripts/tests/test_optimization_learning_labs.py` — 5 tests
- `python code/scripts/tests/test_learning_coverage_report.py` — 5 tests
- Ruff lint and format checks for both corpus validators and tests
- `npm run build` in `code/programs/typescript/ml-learning-visualizer`
- `npm test` in the visualizer — 21 tests
- desktop and 390px responsive browser QA, interaction checks, and a clean console
- relative Markdown link validation
- `git diff --check`
