### PR TITLE
fix(spice): validate MOS model oxide thickness

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS model-card `TOX` values
+  before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `PS` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `PD` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1822,10 +1822,20 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
     if params_text.starts_with('(') && params_text.ends_with(')') {
         params_text = &params_text[1..params_text.len() - 1];
     }
+    let params = parse_model_params(params_text)?;
+    if matches!(kind.as_str(), "NMOS" | "PMOS") {
+        if let Some(oxide_thickness) = params.get("TOX") {
+            if !oxide_thickness.is_finite() || *oxide_thickness <= 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET TOX must be finite and positive",
+                ));
+            }
+        }
+    }
     Ok(ModelCard {
         name: fields[1].clone(),
         kind,
-        params: parse_model_params(params_text)?,
+        params,
     })
 }
 

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1563,6 +1563,20 @@ fn derives_mosfet_transconductance_from_surface_mobility_and_oxide_thickness() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_oxide_thicknesses() {
+    for oxide_thickness in ["0", "-1n", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model mobile NMOS(TOX={oxide_thickness})\nM1 d g s b mobile"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET TOX must be finite and positive"));
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS instance source-perimeter validation.
+1. Rust Berkeley SPICE MOS model-card oxide-thickness validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite instance `PS` values before lowering MOS
-     elements into engine parameters.
-   - Preserve zero and positive source perimeters for sidewall-junction behavior.
+   - Reject zero, negative, and non-finite model-card `TOX` values before
+     lowering MOS elements into engine parameters.
+   - Preserve positive oxide thicknesses for mobility-derived transconductance.
 
 ## Completed Slices
 
@@ -3910,6 +3910,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite instance `PD` values are rejected before lowering
      MOS elements into engine parameters.
    - Zero and positive drain perimeters remain accepted for sidewall-junction
+     behavior.
+
+334. Rust Berkeley SPICE MOS instance source-perimeter validation.
+   - Status: completed in PR 9450.
+   - Negative and non-finite instance `PS` values are rejected before lowering
+     MOS elements into engine parameters.
+   - Zero and positive source perimeters remain accepted for sidewall-junction
      behavior.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite Level-1 MOS model-card `TOX` values before element lowering
- preserve positive oxide thicknesses used for mobility-derived transconductance
- reconcile the SPICE completion plan after PR #9450

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

Rust-only parser-facade behavior changed; shared engine semantics are unchanged and no Python or TypeScript package was touched.