### PR TITLE
test(venture): exercise generated history controls

### DIFF
--- a/code/packages/rust/mosaic-emit-swiftui/tests/venture_chrome_compiles_to_swiftui.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/tests/venture_chrome_compiles_to_swiftui.rs
@@ -67,7 +67,12 @@ fn venture_chrome_lowers_to_native_swiftui_controls_and_project_shell() {
             "TextField(\"Enter a URL\", text: Binding(get: { address }, set: { dispatch(.addressChange(value: $0)) }))"
         ));
         assert!(result.output.contains(".onSubmit { dispatch(.navigate) }"));
-        for part in ["back-button", "address-input", "go-button"] {
+        for part in [
+            "back-button",
+            "forward-button",
+            "address-input",
+            "go-button",
+        ] {
             assert!(
                 result
                     .output

--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased] — VC2-xaml Grid: WinUI value translation + nested-For + per-column widths
 
+### Fixed - Live native disabled state
+
+Slot-backed `disabled` properties now lower to one-way WinUI `IsEnabled`
+bindings. Generated buttons and inputs therefore observe runtime Mosaic state
+changes instead of retaining the value captured when their XAML first loads.
+
 ### Added - optional generated-shell interaction acceptance
 
 Generated WinUI applications now invoke an optional package-host interaction

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -5283,7 +5283,9 @@ fn emit_host_button(
                 return_type: "bool".to_string(),
                 body: "!b".to_string(),
             });
-            attrs.push_str(&format!(" IsEnabled=\"{{x:Bind Not({pascal})}}\""));
+            attrs.push_str(&format!(
+                " IsEnabled=\"{{x:Bind Not({pascal}), Mode=OneWay}}\""
+            ));
         }
         Some(LayoutPropValue::Keyword(k)) if k == "true" => {
             attrs.push_str(" IsEnabled=\"False\"");
@@ -5360,7 +5362,7 @@ fn host_button_click_payload_expr(emit_name: &str, ctx: &EmitContext<'_>) -> Opt
 /// |---|---|
 /// | `checked: slot: c`      | `IsChecked="{x:Bind C, Mode=OneWay}"`                       |
 /// | `checked: true/false`   | `IsChecked="True"` / `IsChecked="False"`                    |
-/// | `disabled: slot: d`     | `IsEnabled="{x:Bind Not(D)}"` (shared Not(bool) helper)     |
+/// | `disabled: slot: d`     | `IsEnabled="{x:Bind Not(D), Mode=OneWay}"` (shared helper)  |
 /// | `disabled: true/false`  | `IsEnabled="False"` / `IsEnabled="True"`                    |
 /// | `indeterminate: slot:i` | `IsThreeState="True"` + binding via code-behind             |
 /// | `label: str / slot`     | `Content="..."` / `Content="{x:Bind Label}"`                |
@@ -5473,7 +5475,9 @@ fn emit_host_checkbox(
                 return_type: "bool".to_string(),
                 body: "!b".to_string(),
             });
-            attrs.push_str(&format!(" IsEnabled=\"{{x:Bind Not({pascal})}}\""));
+            attrs.push_str(&format!(
+                " IsEnabled=\"{{x:Bind Not({pascal}), Mode=OneWay}}\""
+            ));
         }
         Some(LayoutPropValue::Keyword(k)) if k == "true" => {
             attrs.push_str(" IsEnabled=\"False\"");
@@ -5635,7 +5639,9 @@ fn emit_host_radio(
                 return_type: "bool".to_string(),
                 body: "!b".to_string(),
             });
-            attrs.push_str(&format!(" IsEnabled=\"{{x:Bind Not({pascal})}}\""));
+            attrs.push_str(&format!(
+                " IsEnabled=\"{{x:Bind Not({pascal}), Mode=OneWay}}\""
+            ));
         }
         Some(LayoutPropValue::Keyword(k)) if k == "true" => {
             attrs.push_str(" IsEnabled=\"False\"");
@@ -5896,7 +5902,7 @@ fn emit_host_tooltip(
 /// | `max: <n>`      | `Maximum="<n>"`                                            |
 /// | `step: <n>`     | `SmallChange="<n>"`                                        |
 /// | `placeholder`   | `PlaceholderText="..."` / bound                            |
-/// | `disabled`      | `IsEnabled="{x:Bind Not(D)}"` (polarity flip via Not helper) |
+/// | `disabled`      | `IsEnabled="{x:Bind Not(D), Mode=OneWay}"` (via Not helper)  |
 /// | `onChange: emit`| `ValueChanged="X_ValueChanged"` (only fires on commit, not per-keystroke) |
 fn emit_host_number_input(
     node: &LayoutNode,
@@ -5956,7 +5962,9 @@ fn emit_host_number_input(
                 return_type: "bool".to_string(),
                 body: "!b".to_string(),
             });
-            attrs.push_str(&format!(" IsEnabled=\"{{x:Bind Not({pascal})}}\""));
+            attrs.push_str(&format!(
+                " IsEnabled=\"{{x:Bind Not({pascal}), Mode=OneWay}}\""
+            ));
         }
         Some(LayoutPropValue::Keyword(k)) if k == "true" => {
             attrs.push_str(" IsEnabled=\"False\"");
@@ -8700,7 +8708,8 @@ mod tests {
         );
         let r = compile(&c, &l, &empty_style("Foo"));
         assert!(
-            r.xaml.contains("IsEnabled=\"{x:Bind Not(IsBusy)}\""),
+            r.xaml
+                .contains("IsEnabled=\"{x:Bind Not(IsBusy), Mode=OneWay}\""),
             "got:\n{}",
             r.xaml
         );
@@ -10132,8 +10141,9 @@ mod tests {
         }]);
         let r = compile(&c, &l, &empty_style("X"));
         assert!(
-            r.xaml.contains("IsEnabled=\"{x:Bind Not(Locked)}\""),
-            "expected `IsEnabled=\"{{x:Bind Not(Locked)}}\"`, got:\n{}",
+            r.xaml
+                .contains("IsEnabled=\"{x:Bind Not(Locked), Mode=OneWay}\""),
+            "expected a one-way IsEnabled binding for Locked, got:\n{}",
             r.xaml
         );
     }

--- a/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
@@ -48,8 +48,11 @@ fn venture_chrome_lowers_to_native_xaml_controls_and_project_shell() {
         .expect("emit Venture XAML project");
 
         assert!(result.xaml.contains(
-            "<Button x:Name=\"BackButton\" AutomationProperties.AutomationId=\"back-button\" Content=\"Back\" IsEnabled=\"{x:Bind Not(BackDisabled)}\""
+            "<Button x:Name=\"BackButton\" AutomationProperties.AutomationId=\"back-button\" Content=\"Back\" IsEnabled=\"{x:Bind Not(BackDisabled), Mode=OneWay}\""
         ));
+        assert!(result
+            .xaml
+            .contains("IsEnabled=\"{x:Bind Not(ForwardDisabled), Mode=OneWay}\""));
         assert!(result.xaml.contains(
             "<TextBox x:Name=\"AddressInput\" AutomationProperties.AutomationId=\"address-input\" Text=\"{x:Bind Address, Mode=TwoWay}\" IsReadOnly=\"{x:Bind NavigationDisabled}\""
         ));

--- a/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
@@ -57,7 +57,12 @@ fn venture_chrome_lowers_to_native_xaml_controls_and_project_shell() {
             .xaml
             .contains("TextChanged=\"AddressInput_TextChanged\""));
         assert!(result.xaml.contains("KeyDown=\"AddressInput_KeyDown\""));
-        for part in ["back-button", "address-input", "go-button"] {
+        for part in [
+            "back-button",
+            "forward-button",
+            "address-input",
+            "go-button",
+        ] {
             assert!(
                 result
                     .xaml

--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -21,6 +21,9 @@
 - Extend the generated-app launch gate through native address editing and Go
   activation, requiring the shared Rust session to load and title a second
   deterministic page.
+- Extend direct generated-app interaction acceptance through the native Back
+  and Forward buttons, requiring both history entries to reload through the
+  shared Rust session before the gate succeeds.
 
 ## 0.1.0
 

--- a/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
+++ b/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
@@ -50,23 +50,25 @@ fn build_native_bridge(output: &Path) -> PathBuf {
     target.join("debug/libventure_browser_macos.dylib")
 }
 
-fn serve_html_once(title: &'static str) -> String {
+fn serve_html_twice(title: &'static str) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind acceptance server");
     let address = listener.local_addr().expect("read acceptance address");
     thread::spawn(move || {
-        let (mut stream, _) = listener.accept().expect("accept Venture request");
-        let mut request = [0_u8; 1024];
-        let _ = stream.read(&mut request);
-        let body = format!("<!doctype html><title>{title}</title><main>Ready</main>");
-        write!(
-            stream,
-            "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-            body.len()
-        )
-        .expect("write acceptance response headers");
-        stream
-            .write_all(body.as_bytes())
-            .expect("write acceptance response body");
+        for _ in 0..2 {
+            let (mut stream, _) = listener.accept().expect("accept Venture request");
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            let body = format!("<!doctype html><title>{title}</title><main>Ready</main>");
+            write!(
+                stream,
+                "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .expect("write acceptance response headers");
+            stream
+                .write_all(body.as_bytes())
+                .expect("write acceptance response body");
+        }
     });
     format!("http://{address}/")
 }
@@ -132,13 +134,13 @@ fn package_owned_swiftui_project_launches_renders_and_interacts() {
 
     let marker = output.join("swiftui-ready.json");
     let interaction_marker = output.join("swiftui-interaction.json");
-    let start_url = serve_html_once("Venture launch acceptance");
-    let target_url = serve_html_once("Venture interaction acceptance");
+    let start_url = serve_html_twice("Venture launch acceptance");
+    let target_url = serve_html_twice("Venture interaction acceptance");
     let app_log = output.join("swiftui-app.log");
     let log = File::create(&app_log).expect("create SwiftUI app log");
     let mut child = Command::new(project.join(".build/debug/App"))
         .current_dir(&project)
-        .env("VENTURE_START_URL", start_url)
+        .env("VENTURE_START_URL", &start_url)
         .env("VENTURE_BROWSER_LIBRARY", &library)
         .env("VENTURE_BROWSER_ACCEPTANCE_PATH", &marker)
         .env("VENTURE_BROWSER_INTERACTION_URL", &target_url)
@@ -164,8 +166,18 @@ fn package_owned_swiftui_project_launches_renders_and_interacts() {
     assert!(readiness.contains("\"status\":\"ready\""));
     let interaction =
         fs::read_to_string(&interaction_marker).expect("read SwiftUI interaction marker");
-    assert!(interaction.contains("\"backend\":\"swiftui\""));
-    assert!(interaction.contains("\"status\":\"interacted\""));
+    assert!(
+        interaction.contains("\"backend\":\"swiftui\""),
+        "unexpected SwiftUI interaction marker: {interaction}"
+    );
+    assert!(
+        interaction.contains("\"status\":\"interacted\""),
+        "SwiftUI interaction failed: {interaction}"
+    );
+    assert!(interaction.contains("\"history\":\"back-forward\""));
+    assert!(
+        interaction.contains(&start_url) || interaction.contains(&start_url.replace('/', "\\/"))
+    );
     assert!(
         interaction.contains(&target_url) || interaction.contains(&target_url.replace('/', "\\/"))
     );

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -16,3 +16,6 @@
 - Extend the generated-app launch gate through the native WinUI address
   control and button invoke provider, requiring the shared Rust session to
   load and title a second deterministic page.
+- Extend direct generated-app interaction acceptance through the native WinUI
+  Back and Forward invoke providers, requiring both history entries to reload
+  through the shared Rust session before the gate succeeds.

--- a/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
+++ b/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
@@ -47,23 +47,25 @@ fn build_native_bridge(output: &Path) -> PathBuf {
     target.join("debug/venture_browser_windows.dll")
 }
 
-fn serve_html_once(title: &'static str) -> String {
+fn serve_html_twice(title: &'static str) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind acceptance server");
     let address = listener.local_addr().expect("read acceptance address");
     thread::spawn(move || {
-        let (mut stream, _) = listener.accept().expect("accept Venture request");
-        let mut request = [0_u8; 1024];
-        let _ = stream.read(&mut request);
-        let body = format!("<!doctype html><title>{title}</title><main>Ready</main>");
-        write!(
-            stream,
-            "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-            body.len()
-        )
-        .expect("write acceptance response headers");
-        stream
-            .write_all(body.as_bytes())
-            .expect("write acceptance response body");
+        for _ in 0..2 {
+            let (mut stream, _) = listener.accept().expect("accept Venture request");
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            let body = format!("<!doctype html><title>{title}</title><main>Ready</main>");
+            write!(
+                stream,
+                "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .expect("write acceptance response headers");
+            stream
+                .write_all(body.as_bytes())
+                .expect("write acceptance response body");
+        }
     });
     format!("http://{address}/")
 }
@@ -189,13 +191,13 @@ fn package_owned_xaml_project_builds_launches_and_interacts() {
     let marker = output.join("xaml-ready.json");
     let interaction_marker = output.join("xaml-interaction.json");
     let phase_log = output.join("xaml-phase.json");
-    let start_url = serve_html_once("Venture launch acceptance");
-    let target_url = serve_html_once("Venture interaction acceptance");
+    let start_url = serve_html_twice("Venture launch acceptance");
+    let target_url = serve_html_twice("Venture interaction acceptance");
     let app_log = output.join("xaml-app.log");
     let log = File::create(&app_log).expect("create WinUI app log");
     let mut child = Command::new(&executable)
         .current_dir(executable.parent().expect("WinUI executable directory"))
-        .env("VENTURE_START_URL", start_url)
+        .env("VENTURE_START_URL", &start_url)
         .env("VENTURE_BROWSER_ACCEPTANCE_PATH", &marker)
         .env("VENTURE_BROWSER_ACCEPTANCE_DIAGNOSTIC_PATH", &phase_log)
         .env("VENTURE_BROWSER_INTERACTION_URL", &target_url)
@@ -236,6 +238,10 @@ fn package_owned_xaml_project_builds_launches_and_interacts() {
     assert!(
         interaction.contains("\"status\":\"interacted\""),
         "WinUI interaction failed: {interaction}"
+    );
+    assert!(interaction.contains("\"history\":\"back-forward\""));
+    assert!(
+        interaction.contains(&start_url) || interaction.contains(&start_url.replace('/', "\\/"))
     );
     assert!(
         interaction.contains(&target_url) || interaction.contains(&target_url.replace('/', "\\/"))

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -43,6 +43,9 @@
 - Direct interaction acceptance for both emitted applications: the package
   hosts edit the generated native address control and activate navigation,
   then require the shared Rust session to load and title a second local page.
+- Direct native history acceptance for both emitted applications: the package
+  hosts activate the generated Back and Forward controls, then require the
+  shared Rust session to reload and retitle both deterministic local pages.
 - The XAML host writes rendered BGRA pixels through WinRT's supported
   `IBuffer.AsStream()` projection, avoiding a native COM projection crash in
   the emitted WinUI application.

--- a/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
@@ -147,22 +147,30 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
     let environment = ProcessInfo.processInfo.environment
     guard !interactionAcceptanceStarted,
       let markerPath = environment["VENTURE_BROWSER_INTERACTION_ACCEPTANCE_PATH"],
-      let targetURL = environment["VENTURE_BROWSER_INTERACTION_URL"]
+      let targetURL = environment["VENTURE_BROWSER_INTERACTION_URL"],
+      let startURL = environment["VENTURE_START_URL"]
     else { return }
     interactionAcceptanceStarted = true
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
-      self?.attemptInteraction(targetURL: targetURL, markerPath: markerPath, remaining: 50)
+      self?.attemptInteraction(
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath, remaining: 50)
     }
   }
 
-  private func attemptInteraction(targetURL: String, markerPath: String, remaining: Int) {
+  private func attemptInteraction(
+    startURL: String, targetURL: String, markerPath: String, remaining: Int
+  ) {
     guard !NSApp.windows.isEmpty else {
-      retryInteraction(targetURL: targetURL, markerPath: markerPath, remaining: remaining)
+      retryInteraction(
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath,
+        remaining: remaining)
       return
     }
     var visited = Set<ObjectIdentifier>()
     guard let address = findEditableTextField(in: NSApp, visited: &visited) else {
-      retryInteraction(targetURL: targetURL, markerPath: markerPath, remaining: remaining)
+      retryInteraction(
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath,
+        remaining: remaining)
       return
     }
 
@@ -185,11 +193,14 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
         to: window)
     }
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-      self?.verifyInteraction(targetURL: targetURL, markerPath: markerPath, remaining: 50)
+      self?.verifyInitialNavigation(
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath, remaining: 50)
     }
   }
 
-  private func retryInteraction(targetURL: String, markerPath: String, remaining: Int) {
+  private func retryInteraction(
+    startURL: String, targetURL: String, markerPath: String, remaining: Int
+  ) {
     guard remaining > 0 else {
       writeInteractionResult(
         ["backend": "swiftui", "status": "error", "error": "native controls not found"],
@@ -198,22 +209,29 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
     }
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
       self?.attemptInteraction(
-        targetURL: targetURL, markerPath: markerPath, remaining: remaining - 1)
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath,
+        remaining: remaining - 1)
     }
   }
 
-  private func verifyInteraction(targetURL: String, markerPath: String, remaining: Int) {
+  private func verifyInitialNavigation(
+    startURL: String, targetURL: String, markerPath: String, remaining: Int
+  ) {
     let response = applyProps()
     let props = response?["props"] as? NSDictionary
     let address = props?["address"] as? String ?? ""
     let pageTitle = props?["page-title"] as? String ?? ""
     if address == targetURL, pageTitle == "Venture interaction acceptance" {
-      writeInteractionResult(
-        [
-          "backend": "swiftui", "status": "interacted", "address": address,
-          "pageTitle": pageTitle,
-        ],
-        to: markerPath)
+      guard performNativeButtonClick(identifier: "back-button") else {
+        writeInteractionResult(
+          ["backend": "swiftui", "status": "error", "error": "back-button not found"],
+          to: markerPath)
+        return
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+        self?.verifyBackNavigation(
+          startURL: startURL, targetURL: targetURL, markerPath: markerPath, remaining: 50)
+      }
       return
     }
     guard remaining > 0 else {
@@ -226,8 +244,80 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
       return
     }
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-      self?.verifyInteraction(
-        targetURL: targetURL, markerPath: markerPath, remaining: remaining - 1)
+      self?.verifyInitialNavigation(
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath,
+        remaining: remaining - 1)
+    }
+  }
+
+  private func verifyBackNavigation(
+    startURL: String, targetURL: String, markerPath: String, remaining: Int
+  ) {
+    let response = applyProps()
+    let props = response?["props"] as? NSDictionary
+    let address = props?["address"] as? String ?? ""
+    let pageTitle = props?["page-title"] as? String ?? ""
+    if address == startURL, pageTitle == "Venture launch acceptance" {
+      guard performNativeButtonClick(identifier: "forward-button") else {
+        writeInteractionResult(
+          [
+            "backend": "swiftui", "status": "error",
+            "error": "forward-button not found",
+          ],
+          to: markerPath)
+        return
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+        self?.verifyForwardNavigation(
+          startURL: startURL, targetURL: targetURL, markerPath: markerPath, remaining: 50)
+      }
+      return
+    }
+    guard remaining > 0 else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error", "address": address,
+          "pageTitle": pageTitle, "error": "back navigation state did not update",
+        ],
+        to: markerPath)
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+      self?.verifyBackNavigation(
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath,
+        remaining: remaining - 1)
+    }
+  }
+
+  private func verifyForwardNavigation(
+    startURL: String, targetURL: String, markerPath: String, remaining: Int
+  ) {
+    let response = applyProps()
+    let props = response?["props"] as? NSDictionary
+    let address = props?["address"] as? String ?? ""
+    let pageTitle = props?["page-title"] as? String ?? ""
+    if address == targetURL, pageTitle == "Venture interaction acceptance" {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "interacted", "history": "back-forward",
+          "backAddress": startURL, "address": address, "pageTitle": pageTitle,
+        ],
+        to: markerPath)
+      return
+    }
+    guard remaining > 0 else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error", "address": address,
+          "pageTitle": pageTitle, "error": "forward navigation state did not update",
+        ],
+        to: markerPath)
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+      self?.verifyForwardNavigation(
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath,
+        remaining: remaining - 1)
     }
   }
 
@@ -243,6 +333,31 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
       }
     }
     return nil
+  }
+
+  private func performNativeButtonClick(identifier: String) -> Bool {
+    NSApp.activate(ignoringOtherApps: true)
+    let position: CGFloat
+    switch identifier {
+    case "back-button": position = 0.12
+    case "forward-button": position = 0.34
+    default: return false
+    }
+    var visited = Set<ObjectIdentifier>()
+    guard let address = findEditableTextField(in: NSApp, visited: &visited),
+      let window = address.window, let contentView = window.contentView
+    else { return false }
+    // SwiftUI owns these buttons inside its hosting view. Target their stable Mosaic toolbar
+    // positions relative to the real native address field, then send ordinary AppKit events.
+    let addressFrame = address.convert(address.bounds, to: contentView)
+    let leadingChromeWidth = addressFrame.minX - contentView.bounds.minX
+    let windowPoint = contentView.convert(
+      NSPoint(
+        x: contentView.bounds.minX + leadingChromeWidth * position,
+        y: addressFrame.midY),
+      to: nil)
+    sendPrimaryClick(at: windowPoint, to: window)
+    return true
   }
 
   private func sendPrimaryClick(at location: NSPoint, to window: NSWindow) {

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -106,16 +106,14 @@ public static class MosaicHost
                     return;
                 }
 
-                var backProvider = new ButtonAutomationPeer(backButton) as IInvokeProvider;
-                var forwardProvider = new ButtonAutomationPeer(forwardButton) as IInvokeProvider;
                 var invokeProvider = new ButtonAutomationPeer(goButton) as IInvokeProvider;
-                if (backProvider is null || forwardProvider is null || invokeProvider is null)
+                if (invokeProvider is null)
                 {
                     WriteInteractionResult(markerPath, new
                     {
                         backend = "xaml",
                         status = "error",
-                        error = "native history automation provider unavailable",
+                        error = "native Go automation provider unavailable",
                     });
                     return;
                 }
@@ -156,6 +154,27 @@ public static class MosaicHost
                     return;
                 }
 
+                if (!await WaitForEnabledAsync(backButton))
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native Back button did not become enabled",
+                    });
+                    return;
+                }
+                var backProvider = new ButtonAutomationPeer(backButton) as IInvokeProvider;
+                if (backProvider is null)
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native Back automation provider unavailable",
+                    });
+                    return;
+                }
                 backProvider.Invoke();
                 if (!await WaitForPageAsync(component, startUrl, "Venture launch acceptance"))
                 {
@@ -170,6 +189,27 @@ public static class MosaicHost
                     return;
                 }
 
+                if (!await WaitForEnabledAsync(forwardButton))
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native Forward button did not become enabled",
+                    });
+                    return;
+                }
+                var forwardProvider = new ButtonAutomationPeer(forwardButton) as IInvokeProvider;
+                if (forwardProvider is null)
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native Forward automation provider unavailable",
+                    });
+                    return;
+                }
                 forwardProvider.Invoke();
                 if (!await WaitForPageAsync(
                     component, targetUrl, "Venture interaction acceptance"))
@@ -218,6 +258,19 @@ public static class MosaicHost
             _ = ApplyProps(component);
             if (string.Equals(component.Address, address, StringComparison.Ordinal)
                 && string.Equals(component.PageTitle, pageTitle, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static async System.Threading.Tasks.Task<bool> WaitForEnabledAsync(Button button)
+    {
+        for (var remaining = 50; remaining >= 0; remaining--)
+        {
+            await System.Threading.Tasks.Task.Delay(50);
+            if (button.IsEnabled)
             {
                 return true;
             }

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -73,8 +73,10 @@ public static class MosaicHost
         var markerPath = Environment.GetEnvironmentVariable(
             "VENTURE_BROWSER_INTERACTION_ACCEPTANCE_PATH");
         var targetUrl = Environment.GetEnvironmentVariable("VENTURE_BROWSER_INTERACTION_URL");
+        var startUrl = Environment.GetEnvironmentVariable("VENTURE_START_URL");
         if (string.IsNullOrWhiteSpace(markerPath)
             || string.IsNullOrWhiteSpace(targetUrl)
+            || string.IsNullOrWhiteSpace(startUrl)
             || System.Threading.Interlocked.Exchange(ref interactionAcceptanceStarted, 1) != 0)
         {
             return;
@@ -86,8 +88,14 @@ public static class MosaicHost
             {
                 var addressInput = await FindAutomationElementAsync<TextBox>(
                     component, "address-input");
+                var backButton = await FindAutomationElementAsync<Button>(component, "back-button");
+                var forwardButton = await FindAutomationElementAsync<Button>(
+                    component, "forward-button");
                 var goButton = await FindAutomationElementAsync<Button>(component, "go-button");
-                if (addressInput is null || goButton is null)
+                if (addressInput is null
+                    || backButton is null
+                    || forwardButton is null
+                    || goButton is null)
                 {
                     WriteInteractionResult(markerPath, new
                     {
@@ -98,14 +106,16 @@ public static class MosaicHost
                     return;
                 }
 
+                var backProvider = new ButtonAutomationPeer(backButton) as IInvokeProvider;
+                var forwardProvider = new ButtonAutomationPeer(forwardButton) as IInvokeProvider;
                 var invokeProvider = new ButtonAutomationPeer(goButton) as IInvokeProvider;
-                if (invokeProvider is null)
+                if (backProvider is null || forwardProvider is null || invokeProvider is null)
                 {
                     WriteInteractionResult(markerPath, new
                     {
                         backend = "xaml",
                         status = "error",
-                        error = "native button automation provider unavailable",
+                        error = "native history automation provider unavailable",
                     });
                     return;
                 }
@@ -132,34 +142,57 @@ public static class MosaicHost
                     return;
                 }
                 invokeProvider.Invoke();
-                for (var remaining = 50; remaining >= 0; remaining--)
+                if (!await WaitForPageAsync(
+                    component, targetUrl, "Venture interaction acceptance"))
                 {
-                    await System.Threading.Tasks.Task.Delay(100);
-                    _ = ApplyProps(component);
-                    if (string.Equals(component.Address, targetUrl, StringComparison.Ordinal)
-                        && string.Equals(
-                            component.PageTitle,
-                            "Venture interaction acceptance",
-                            StringComparison.Ordinal))
+                    WriteInteractionResult(markerPath, new
                     {
-                        WriteInteractionResult(markerPath, new
-                        {
-                            backend = "xaml",
-                            status = "interacted",
-                            address = component.Address,
-                            pageTitle = component.PageTitle,
-                        });
-                        return;
-                    }
+                        backend = "xaml",
+                        status = "error",
+                        address = component.Address,
+                        pageTitle = component.PageTitle,
+                        error = "navigation state did not update",
+                    });
+                    return;
+                }
+
+                backProvider.Invoke();
+                if (!await WaitForPageAsync(component, startUrl, "Venture launch acceptance"))
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        address = component.Address,
+                        pageTitle = component.PageTitle,
+                        error = "back navigation state did not update",
+                    });
+                    return;
+                }
+
+                forwardProvider.Invoke();
+                if (!await WaitForPageAsync(
+                    component, targetUrl, "Venture interaction acceptance"))
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        address = component.Address,
+                        pageTitle = component.PageTitle,
+                        error = "forward navigation state did not update",
+                    });
+                    return;
                 }
 
                 WriteInteractionResult(markerPath, new
                 {
                     backend = "xaml",
-                    status = "error",
+                    status = "interacted",
+                    history = "back-forward",
+                    backAddress = startUrl,
                     address = component.Address,
                     pageTitle = component.PageTitle,
-                    error = "navigation state did not update",
                 });
             }
             catch (Exception ex)
@@ -172,6 +205,24 @@ public static class MosaicHost
                 });
             }
         };
+    }
+
+    private static async System.Threading.Tasks.Task<bool> WaitForPageAsync(
+        VentureChrome component,
+        string address,
+        string pageTitle)
+    {
+        for (var remaining = 50; remaining >= 0; remaining--)
+        {
+            await System.Threading.Tasks.Task.Delay(100);
+            _ = ApplyProps(component);
+            if (string.Equals(component.Address, address, StringComparison.Ordinal)
+                && string.Equals(component.PageTitle, pageTitle, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static async System.Threading.Tasks.Task<T?> FindAutomationElementAsync<T>(


### PR DESCRIPTION
## Summary

- extend the package-owned SwiftUI and WinUI launch acceptance flow from Address/Go through Back and Forward
- drive the generated Mosaic chrome with native platform events and verify the shared Rust browser session reloads both history entries
- ratchet both native emitters so Venture's Back, Forward, Address, and Go controls retain their automation identifiers

## Why

The prior gate proved one generated Address-to-Go interaction. This adds the next bounded browser-chrome slice: native history controls must dispatch through the Mosaic-generated shell while the Rust Venture session remains the source of navigation history and rendered page state.

## Validation

- `cargo test -p mosaic-emit-swiftui -p mosaic-emit-xaml -p mosaic-package-artifact-builder -p venture-browser-macos -p venture-browser-windows`
- `cargo clippy -p mosaic-emit-swiftui -p mosaic-emit-xaml -p mosaic-package-artifact-builder -p venture-browser-macos -p venture-browser-windows --all-targets -- -D warnings`
- `code/programs/mosaic/venture-browser/scripts/build-all.sh --emit-only`
- `cargo test -q -p coding-adventures-html-parser --test html5lib_coverage_audit_test`

The exact parser audit remains at tree-construction missing `0`, tokenizer missing `0`, and normalized tokenizer skipped `0`. The Windows launch/interaction test is target-gated and will execute on the Windows CI runner.
