### PR TITLE
fix(spice): validate MOS model surface mobility

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `U0` / `UO` values
+  before lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `TOX` values
   before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS instance `PS` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1831,6 +1831,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        for surface_mobility in [params.get("U0"), params.get("UO")].into_iter().flatten() {
+            if !surface_mobility.is_finite() || *surface_mobility < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET U0 must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1577,6 +1577,35 @@ fn rejects_invalid_mosfet_model_oxide_thicknesses() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_surface_mobility_aliases() {
+    for alias in ["U0", "UO"] {
+        for surface_mobility in ["-1", "1e999"] {
+            let error = parse_netlist(&format!(
+                ".model mobile NMOS({alias}={surface_mobility})\nM1 d g s b mobile"
+            ))
+            .unwrap_err();
+
+            assert!(error
+                .to_string()
+                .contains("MOSFET U0 must be finite and non-negative"));
+        }
+    }
+}
+
+#[test]
+fn accepts_zero_mosfet_model_surface_mobility_aliases() {
+    for alias in ["U0", "UO"] {
+        let parsed =
+            parse_netlist(&format!(".model mobile NMOS({alias}=0)\nM1 d g s b mobile")).unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.surface_mobility, 0.0);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card oxide-thickness validation.
+1. Rust Berkeley SPICE MOS model-card surface-mobility validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite model-card `TOX` values before
+   - Reject negative and non-finite model-card `U0` / `UO` values before
      lowering MOS elements into engine parameters.
-   - Preserve positive oxide thicknesses for mobility-derived transconductance.
+   - Preserve zero and positive surface mobility, including the `UO` alias.
 
 ## Completed Slices
 
@@ -3918,6 +3918,13 @@ the Rust, Python, and TypeScript surfaces together.
      MOS elements into engine parameters.
    - Zero and positive source perimeters remain accepted for sidewall-junction
      behavior.
+
+335. Rust Berkeley SPICE MOS model-card oxide-thickness validation.
+   - Status: completed in PR 9453.
+   - Zero, negative, and non-finite model-card `TOX` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Positive oxide thicknesses remain accepted for mobility-derived
+     transconductance.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `U0` and `UO` values in the Rust Berkeley parser facade
- preserve zero and positive surface mobility for both aliases
- reconcile the SPICE completion plan after PR #9453

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's surface-mobility semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.