### PR TITLE
test(venture): exercise generated Home and Reload controls

### DIFF
--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Extend direct generated-app interaction acceptance through the native Back
   and Forward buttons, requiring both history entries to reload through the
   shared Rust session before the gate succeeds.
+- Extend that direct acceptance through the Mosaic-authored Reload and Home
+  controls, requiring Reload to fetch changed content at the current URL and
+  Home to return through the shared Rust navigation session.
 
 ## 0.1.0
 

--- a/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
+++ b/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
@@ -50,11 +50,11 @@ fn build_native_bridge(output: &Path) -> PathBuf {
     target.join("debug/libventure_browser_macos.dylib")
 }
 
-fn serve_html_twice(title: &'static str) -> String {
+fn serve_html_sequence(titles: Vec<&'static str>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind acceptance server");
     let address = listener.local_addr().expect("read acceptance address");
     thread::spawn(move || {
-        for _ in 0..2 {
+        for title in titles {
             let (mut stream, _) = listener.accept().expect("accept Venture request");
             let mut request = [0_u8; 1024];
             let _ = stream.read(&mut request);
@@ -134,8 +134,16 @@ fn package_owned_swiftui_project_launches_renders_and_interacts() {
 
     let marker = output.join("swiftui-ready.json");
     let interaction_marker = output.join("swiftui-interaction.json");
-    let start_url = serve_html_twice("Venture launch acceptance");
-    let target_url = serve_html_twice("Venture interaction acceptance");
+    let start_url = serve_html_sequence(vec![
+        "Venture launch acceptance",
+        "Venture launch acceptance",
+        "Venture launch acceptance",
+    ]);
+    let target_url = serve_html_sequence(vec![
+        "Venture interaction acceptance",
+        "Venture interaction acceptance",
+        "Venture reload acceptance",
+    ]);
     let app_log = output.join("swiftui-app.log");
     let log = File::create(&app_log).expect("create SwiftUI app log");
     let mut child = Command::new(project.join(".build/debug/App"))
@@ -174,14 +182,15 @@ fn package_owned_swiftui_project_launches_renders_and_interacts() {
         interaction.contains("\"status\":\"interacted\""),
         "SwiftUI interaction failed: {interaction}"
     );
-    assert!(interaction.contains("\"history\":\"back-forward\""));
+    assert!(interaction.contains("\"controls\":\"back-forward-reload-home\""));
+    assert!(interaction.contains("\"reloadTitle\":\"Venture reload acceptance\""));
     assert!(
         interaction.contains(&start_url) || interaction.contains(&start_url.replace('/', "\\/"))
     );
     assert!(
         interaction.contains(&target_url) || interaction.contains(&target_url.replace('/', "\\/"))
     );
-    assert!(interaction.contains("Venture interaction acceptance"));
+    assert!(interaction.contains("Venture launch acceptance"));
     let diagnostics = fs::read_to_string(&app_log).expect("read SwiftUI app log");
     assert!(
         !diagnostics.contains("assertion failed") && !diagnostics.contains("Assertion failed"),

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -19,3 +19,6 @@
 - Extend direct generated-app interaction acceptance through the native WinUI
   Back and Forward invoke providers, requiring both history entries to reload
   through the shared Rust session before the gate succeeds.
+- Extend that direct acceptance through the native WinUI Reload and Home
+  invoke providers, requiring changed reload content and shared-session home
+  navigation before the generated shell reports success.

--- a/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
+++ b/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
@@ -47,11 +47,11 @@ fn build_native_bridge(output: &Path) -> PathBuf {
     target.join("debug/venture_browser_windows.dll")
 }
 
-fn serve_html_twice(title: &'static str) -> String {
+fn serve_html_sequence(titles: Vec<&'static str>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind acceptance server");
     let address = listener.local_addr().expect("read acceptance address");
     thread::spawn(move || {
-        for _ in 0..2 {
+        for title in titles {
             let (mut stream, _) = listener.accept().expect("accept Venture request");
             let mut request = [0_u8; 1024];
             let _ = stream.read(&mut request);
@@ -191,8 +191,16 @@ fn package_owned_xaml_project_builds_launches_and_interacts() {
     let marker = output.join("xaml-ready.json");
     let interaction_marker = output.join("xaml-interaction.json");
     let phase_log = output.join("xaml-phase.json");
-    let start_url = serve_html_twice("Venture launch acceptance");
-    let target_url = serve_html_twice("Venture interaction acceptance");
+    let start_url = serve_html_sequence(vec![
+        "Venture launch acceptance",
+        "Venture launch acceptance",
+        "Venture launch acceptance",
+    ]);
+    let target_url = serve_html_sequence(vec![
+        "Venture interaction acceptance",
+        "Venture interaction acceptance",
+        "Venture reload acceptance",
+    ]);
     let app_log = output.join("xaml-app.log");
     let log = File::create(&app_log).expect("create WinUI app log");
     let mut child = Command::new(&executable)
@@ -239,14 +247,15 @@ fn package_owned_xaml_project_builds_launches_and_interacts() {
         interaction.contains("\"status\":\"interacted\""),
         "WinUI interaction failed: {interaction}"
     );
-    assert!(interaction.contains("\"history\":\"back-forward\""));
+    assert!(interaction.contains("\"controls\":\"back-forward-reload-home\""));
+    assert!(interaction.contains("\"reloadTitle\":\"Venture reload acceptance\""));
     assert!(
         interaction.contains(&start_url) || interaction.contains(&start_url.replace('/', "\\/"))
     );
     assert!(
         interaction.contains(&target_url) || interaction.contains(&target_url.replace('/', "\\/"))
     );
-    assert!(interaction.contains("Venture interaction acceptance"));
+    assert!(interaction.contains("Venture launch acceptance"));
     let diagnostics = fs::read_to_string(&app_log).expect("read WinUI app log");
     assert!(
         !diagnostics.contains("assertion failed") && !diagnostics.contains("Assertion failed"),

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -46,6 +46,9 @@
 - Direct native history acceptance for both emitted applications: the package
   hosts activate the generated Back and Forward controls, then require the
   shared Rust session to reload and retitle both deterministic local pages.
+- Direct native Reload and Home acceptance for both emitted applications: the
+  generated controls must fetch a changed response at the current URL and then
+  return to the shared session's home URL before the gate succeeds.
 - The XAML host writes rendered BGRA pixels through WinRT's supported
   `IBuffer.AsStream()` projection, avoiding a native COM projection crash in
   the emitted WinUI application.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -102,8 +102,10 @@ cargo test -p venture-browser-macos
 cargo test -p venture-browser-windows
 ```
 
-These gates stop after the generated window mounts and renders; they do not yet
-claim direct UI interaction acceptance.
+These gates launch the generated window, render the host surface, edit and
+navigate the native address control, and invoke the Mosaic-authored Back,
+Forward, Reload, and Home controls. They require every transition to update the
+shared Rust browser session before the generated shell reports success.
 
 This package is a browser-wiring milestone, not a claim of complete Venture or
 HTML conformance.

--- a/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
@@ -297,12 +297,16 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
     let address = props?["address"] as? String ?? ""
     let pageTitle = props?["page-title"] as? String ?? ""
     if address == targetURL, pageTitle == "Venture interaction acceptance" {
-      writeInteractionResult(
-        [
-          "backend": "swiftui", "status": "interacted", "history": "back-forward",
-          "backAddress": startURL, "address": address, "pageTitle": pageTitle,
-        ],
-        to: markerPath)
+      guard performNativeButtonClick(identifier: "reload-button") else {
+        writeInteractionResult(
+          ["backend": "swiftui", "status": "error", "error": "reload-button not found"],
+          to: markerPath)
+        return
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+        self?.verifyReload(
+          startURL: startURL, targetURL: targetURL, markerPath: markerPath, remaining: 50)
+      }
       return
     }
     guard remaining > 0 else {
@@ -316,6 +320,75 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
     }
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
       self?.verifyForwardNavigation(
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath,
+        remaining: remaining - 1)
+    }
+  }
+
+  private func verifyReload(
+    startURL: String, targetURL: String, markerPath: String, remaining: Int
+  ) {
+    let response = applyProps()
+    let props = response?["props"] as? NSDictionary
+    let address = props?["address"] as? String ?? ""
+    let pageTitle = props?["page-title"] as? String ?? ""
+    if address == targetURL, pageTitle == "Venture reload acceptance" {
+      guard performNativeButtonClick(identifier: "home-button") else {
+        writeInteractionResult(
+          ["backend": "swiftui", "status": "error", "error": "home-button not found"],
+          to: markerPath)
+        return
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+        self?.verifyHome(
+          startURL: startURL, targetURL: targetURL, markerPath: markerPath, remaining: 50)
+      }
+      return
+    }
+    guard remaining > 0 else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error", "address": address,
+          "pageTitle": pageTitle, "error": "reload state did not update",
+        ],
+        to: markerPath)
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+      self?.verifyReload(
+        startURL: startURL, targetURL: targetURL, markerPath: markerPath,
+        remaining: remaining - 1)
+    }
+  }
+
+  private func verifyHome(
+    startURL: String, targetURL: String, markerPath: String, remaining: Int
+  ) {
+    let response = applyProps()
+    let props = response?["props"] as? NSDictionary
+    let address = props?["address"] as? String ?? ""
+    let pageTitle = props?["page-title"] as? String ?? ""
+    if address == startURL, pageTitle == "Venture launch acceptance" {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "interacted",
+          "controls": "back-forward-reload-home", "reloadTitle": "Venture reload acceptance",
+          "homeAddress": address, "targetAddress": targetURL, "pageTitle": pageTitle,
+        ],
+        to: markerPath)
+      return
+    }
+    guard remaining > 0 else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error", "address": address,
+          "pageTitle": pageTitle, "error": "home navigation state did not update",
+        ],
+        to: markerPath)
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+      self?.verifyHome(
         startURL: startURL, targetURL: targetURL, markerPath: markerPath,
         remaining: remaining - 1)
     }
@@ -341,6 +414,8 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
     switch identifier {
     case "back-button": position = 0.12
     case "forward-button": position = 0.34
+    case "home-button": position = 0.56
+    case "reload-button": position = 0.78
     default: return false
     }
     var visited = Set<ObjectIdentifier>()

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -91,10 +91,15 @@ public static class MosaicHost
                 var backButton = await FindAutomationElementAsync<Button>(component, "back-button");
                 var forwardButton = await FindAutomationElementAsync<Button>(
                     component, "forward-button");
+                var homeButton = await FindAutomationElementAsync<Button>(component, "home-button");
+                var reloadButton = await FindAutomationElementAsync<Button>(
+                    component, "reload-button");
                 var goButton = await FindAutomationElementAsync<Button>(component, "go-button");
                 if (addressInput is null
                     || backButton is null
                     || forwardButton is null
+                    || homeButton is null
+                    || reloadButton is null
                     || goButton is null)
                 {
                     WriteInteractionResult(markerPath, new
@@ -225,13 +230,84 @@ public static class MosaicHost
                     return;
                 }
 
+                if (!await WaitForEnabledAsync(reloadButton))
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native Reload button did not become enabled",
+                    });
+                    return;
+                }
+                var reloadProvider = new ButtonAutomationPeer(reloadButton) as IInvokeProvider;
+                if (reloadProvider is null)
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native Reload automation provider unavailable",
+                    });
+                    return;
+                }
+                reloadProvider.Invoke();
+                if (!await WaitForPageAsync(component, targetUrl, "Venture reload acceptance"))
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        address = component.Address,
+                        pageTitle = component.PageTitle,
+                        error = "reload state did not update",
+                    });
+                    return;
+                }
+
+                if (!await WaitForEnabledAsync(homeButton))
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native Home button did not become enabled",
+                    });
+                    return;
+                }
+                var homeProvider = new ButtonAutomationPeer(homeButton) as IInvokeProvider;
+                if (homeProvider is null)
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native Home automation provider unavailable",
+                    });
+                    return;
+                }
+                homeProvider.Invoke();
+                if (!await WaitForPageAsync(component, startUrl, "Venture launch acceptance"))
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        address = component.Address,
+                        pageTitle = component.PageTitle,
+                        error = "home navigation state did not update",
+                    });
+                    return;
+                }
+
                 WriteInteractionResult(markerPath, new
                 {
                     backend = "xaml",
                     status = "interacted",
-                    history = "back-forward",
-                    backAddress = startUrl,
-                    address = component.Address,
+                    controls = "back-forward-reload-home",
+                    reloadTitle = "Venture reload acceptance",
+                    homeAddress = component.Address,
+                    targetAddress = targetUrl,
                     pageTitle = component.PageTitle,
                 });
             }


### PR DESCRIPTION
## Summary

- extend Venture's package-owned SwiftUI and WinUI interaction acceptance through Reload and Home after Address/Go, Back, and Forward
- verify Reload fetches changed content at the current URL and Home returns the shared Rust browser session to its configured start page
- keep the browser chrome in the shared Mosaic package while driving the emitted native controls through SwiftUI and WinUI automation

## Why

The previous slice proved generated history controls. This closes the remaining direct toolbar-action gap for the shared Mosaic-authored chrome without adding parallel handwritten platform UI.

## Validation

- `cargo test -p mosaic-emit-swiftui -p mosaic-emit-xaml -p mosaic-package-artifact-builder -p venture-browser-macos -p venture-browser-windows`
- `cargo test -p venture-browser-macos --test swiftui_project_launch -- --nocapture`
- `cargo clippy -p mosaic-emit-swiftui -p mosaic-emit-xaml -p mosaic-package-artifact-builder -p venture-browser-macos -p venture-browser-windows --all-targets -- -D warnings`
- `code/programs/mosaic/venture-browser/scripts/build-all.sh --emit-only`
- `cargo test -q -p coding-adventures-html-parser --test html5lib_coverage_audit_test`

The checked parser audit remains exactly at tree-construction missing `0`, tokenizer missing `0`, and normalized tokenizer skipped `0`. The Windows launch/interaction test is target-gated and will execute on the Windows CI runner. This is a bounded browser-wiring acceptance slice, not a claim of full browser conformance.
