### PR TITLE
Human languages: shared spine, Persian/Urdu, and book downloads

### DIFF
--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -1,11 +1,11 @@
-# Build the Human Languages curriculum's LaTeX books to PDF. Pull requests
-# retain the PDFs as build artifacts; main-branch builds also publish a stable
-# download catalog to GitHub Pages.
+# Build every Human Languages LaTeX book in one job. Pull requests retain one
+# complete publication bundle as a build artifact; main-branch builds publish
+# that same bundle as a stable download catalog on GitHub Pages.
 #
 # Each language track under code/learning/human-languages/<lang>/book/
 # contains a self-contained XeLaTeX book (see HL00 spec). This workflow
-# discovers every such book/ directory dynamically, so adding a new
-# language track needs zero changes here.
+# discovers every such book/ directory dynamically, installs TeX once, and
+# compiles the books sequentially so adding a new track needs zero changes here.
 
 name: Human Languages Books
 
@@ -25,45 +25,18 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: human-languages-books-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  discover:
+  build-and-publish:
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.find-books.outputs.matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Find book directories
-        id: find-books
-        run: |
-          dirs=$(find code/learning/human-languages -mindepth 2 -maxdepth 2 -type d -name book | sort)
-          json=$(printf '%s\n' "$dirs" | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "matrix=$json" >> "$GITHUB_OUTPUT"
-
-  build:
-    needs: discover
-    if: needs.discover.outputs.matrix != '[]'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        book_dir: ${{ fromJson(needs.discover.outputs.matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Determine language name
-        id: lang
-        run: |
-          name=$(basename "$(dirname "${{ matrix.book_dir }}")")
-          echo "name=$name" >> "$GITHUB_OUTPUT"
 
       # Install the COMPLETE TeX Live distribution rather than a hand-picked
       # list of texlive-* sub-packages. The earlier granular approach broke
@@ -83,41 +56,32 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             texlive-full latexmk fonts-noto-core fonts-noto-extra
 
-      - name: Build ${{ steps.lang.outputs.name }} book
-        working-directory: ${{ matrix.book_dir }}
-        run: latexmk -xelatex -interaction=nonstopmode -halt-on-error book.tex
-
-      - name: Stage PDF with a stable filename
+      - name: Build every book
         run: |
-          mkdir -p dist
-          cp "${{ matrix.book_dir }}/book.pdf" "dist/${{ steps.lang.outputs.name }}.pdf"
+          set -euo pipefail
+          output_dir="dist/human-languages/books"
+          mkdir -p "$output_dir"
+          book_count=0
 
-      - name: Upload PDF
-        uses: actions/upload-artifact@v4
-        with:
-          name: human-language-book-${{ steps.lang.outputs.name }}
-          path: dist/${{ steps.lang.outputs.name }}.pdf
-          if-no-files-found: error
-          retention-days: 30
+          while IFS= read -r book_dir; do
+            language=$(basename "$(dirname "$book_dir")")
+            echo "::group::Build $language"
+            (
+              cd "$book_dir"
+              latexmk -xelatex -interaction=nonstopmode -halt-on-error book.tex
+            )
+            cp "$book_dir/book.pdf" "$output_dir/$language.pdf"
+            echo "::endgroup::"
+            book_count=$((book_count + 1))
+          done < <(
+            find code/learning/human-languages \
+              -mindepth 2 -maxdepth 2 -type d -name book | sort
+          )
 
-  publish:
-    needs: [discover, build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+          test "$book_count" -gt 0
+          echo "Built $book_count human-language books"
 
-      - name: Download every compiled book
-        uses: actions/download-artifact@v4
-        with:
-          pattern: human-language-book-*
-          path: dist/human-languages/books
-          merge-multiple: true
-
-      - name: Build public download catalog
+      - name: Build download catalog
         run: |
           python code/scripts/build_human_language_book_catalog.py \
             --pdf-dir dist/human-languages/books \
@@ -130,7 +94,16 @@ jobs:
           test -s dist/human-languages/books/catalog.json
           test -n "$(find dist/human-languages/books -maxdepth 1 -name '*.pdf' -print -quit)"
 
+      - name: Upload complete publication bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: human-language-books
+          path: dist/human-languages/books
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Publish books to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -1,5 +1,6 @@
-# Build the Human Languages curriculum's LaTeX books to PDF and upload
-# them as build artifacts.
+# Build the Human Languages curriculum's LaTeX books to PDF. Pull requests
+# retain the PDFs as build artifacts; main-branch builds also publish a stable
+# download catalog to GitHub Pages.
 #
 # Each language track under code/learning/human-languages/<lang>/book/
 # contains a self-contained XeLaTeX book (see HL00 spec). This workflow
@@ -10,13 +11,17 @@ name: Human Languages Books
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
     paths:
-      - "code/learning/human-languages/**/book/**"
+      - "code/learning/human-languages/**"
+      - "code/scripts/build_human_language_book_catalog.py"
+      - ".github/workflows/human-languages-books.yml"
   pull_request:
     branches: [main]
     paths:
-      - "code/learning/human-languages/**/book/**"
+      - "code/learning/human-languages/**"
+      - "code/scripts/build_human_language_book_catalog.py"
+      - ".github/workflows/human-languages-books.yml"
   workflow_dispatch:
 
 permissions:
@@ -82,9 +87,53 @@ jobs:
         working-directory: ${{ matrix.book_dir }}
         run: latexmk -xelatex -interaction=nonstopmode -halt-on-error book.tex
 
+      - name: Stage PDF with a stable filename
+        run: |
+          mkdir -p dist
+          cp "${{ matrix.book_dir }}/book.pdf" "dist/${{ steps.lang.outputs.name }}.pdf"
+
       - name: Upload PDF
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.lang.outputs.name }}-book
-          path: ${{ matrix.book_dir }}/book.pdf
+          name: human-language-book-${{ steps.lang.outputs.name }}
+          path: dist/${{ steps.lang.outputs.name }}.pdf
           if-no-files-found: error
+          retention-days: 30
+
+  publish:
+    needs: [discover, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download every compiled book
+        uses: actions/download-artifact@v4
+        with:
+          pattern: human-language-book-*
+          path: dist/human-languages/books
+          merge-multiple: true
+
+      - name: Build public download catalog
+        run: |
+          python code/scripts/build_human_language_book_catalog.py \
+            --pdf-dir dist/human-languages/books \
+            --registry code/learning/human-languages/core/languages.json \
+            --output-dir dist/human-languages/books
+
+      - name: Verify publication bundle
+        run: |
+          test -s dist/human-languages/books/index.html
+          test -s dist/human-languages/books/catalog.json
+          test -n "$(find dist/human-languages/books -maxdepth 1 -name '*.pdf' -print -quit)"
+
+      - name: Publish books to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist/human-languages/books
+          destination_dir: human-languages/books
+          keep_files: true

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -5,11 +5,15 @@ delivered two ways from the same content: a LaTeX **book** per language
 (meant for free publication, CC BY-SA 4.0) and ~5-minute **units** meant to
 be consumed by ear during a daily car commute. Framework and rationale live
 in [`HL00`](../../specs/HL00-human-language-curriculum-framework.md) — read
-that first; this page is just an index.
+that first. The migration to an ordered shared spine, strict sub-five-minute
+lessons, Persian and Urdu extensions, and a single book/app/practice content
+pipeline is specified in
+[`HL04`](../../specs/HL04-shared-spine-and-content-pipeline.md). This page is
+just an index.
 
 Every track shares the same shape:
 
-```
+```text
 <language>/
   README.md                  what this track is, how to use it, current progress
   CHANGELOG.md                per-chapter content additions
@@ -19,6 +23,29 @@ Every track shares the same shape:
   lessons/*.md                 deep one-word practice lessons (slug-named)
   book/                        the LaTeX book (book.tex, chapters/*.tex)
 ```
+
+The machine-readable layer alongside the tracks is:
+
+```text
+core/languages.json             complete active-language registry and default mix order
+core/spine.json                 ordered, language-independent can-do spine
+concepts/taxonomy.json          cross-language semantic join keys
+data/scripts/*.json             writing-system inventories and teaching metadata
+```
+
+The data package also loads every existing `book/book.tex` and `book/chapters/ch*.tex`
+losslessly and checks that each authored book chapter maps to its short Markdown
+lessons. This preserves the well-received book narrative while the pipeline moves
+toward generating book and app views from one lesson AST.
+
+## Download the books
+
+The [public book catalog](https://adhithyan15.github.io/coding-adventures/human-languages/books/)
+offers every currently authored LaTeX book as a free PDF download. Pull requests
+compile all books and retain their PDFs as workflow artifacts for review. After a
+change reaches `main`, the same validated PDFs and a machine-readable `catalog.json`
+are published to GitHub Pages automatically. Tracks without a `book/` directory are
+omitted until their long-form edition is authored.
 
 ## Tracks
 
@@ -41,6 +68,9 @@ Every track shares the same shape:
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Latin](./latin/README.md) | Italic / Latin (**taproot**) | Chapter 1 (Greetings) authored (lessons + book) |
 | [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari (**taproot**) | Chapter 1 (Greetings) authored (lessons + book) |
+| [Russian](./russian/README.md) | Slavic / Cyrillic | Starter curriculum authored |
+| [Persian](./persian/README.md) | Iranian / Perso-Arabic | Shared-spine pilot: greetings, responses, and self-introduction |
+| [Urdu](./urdu/README.md) | Indo-Aryan / Urdu Nastaliq | Shared-spine pilot: greetings, responses, and self-introduction |
 
 Spanish is the pilot that proved the format; every other track replicates it,
 grounding each word against English plus whatever languages the learner already

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -42,10 +42,11 @@ toward generating book and app views from one lesson AST.
 
 The [public book catalog](https://adhithyan15.github.io/coding-adventures/human-languages/books/)
 offers every currently authored LaTeX book as a free PDF download. Pull requests
-compile all books and retain their PDFs as workflow artifacts for review. After a
-change reaches `main`, the same validated PDFs and a machine-readable `catalog.json`
-are published to GitHub Pages automatically. Tracks without a `book/` directory are
-omitted until their long-form edition is authored.
+install TeX once, compile every book in one job, and retain the complete publication
+bundle as a workflow artifact for review. After a change reaches `main`, the same
+validated PDFs and a machine-readable `catalog.json` are published to GitHub Pages
+automatically. Tracks without a `book/` directory are omitted until their long-form
+edition is authored.
 
 ## Tracks
 

--- a/code/learning/human-languages/core/languages.json
+++ b/code/learning/human-languages/core/languages.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "languages": [
+    { "id": "spanish", "name": "Spanish", "family": "Romance", "script": "latin", "status": "active", "bridges": ["latin", "french", "italian", "portuguese"] },
+    { "id": "latin", "name": "Latin", "family": "Italic", "script": "latin", "status": "active", "bridges": ["spanish", "french", "italian", "portuguese"] },
+    { "id": "french", "name": "French", "family": "Romance", "script": "latin", "status": "active", "bridges": ["latin", "spanish"] },
+    { "id": "german", "name": "German", "family": "Germanic", "script": "latin", "status": "active", "bridges": ["english"] },
+    { "id": "arabic", "name": "Arabic", "family": "Semitic", "script": "arabic", "status": "active", "bridges": ["persian", "urdu", "hindi"] },
+    { "id": "hindi", "name": "Hindi", "family": "Indo-Aryan", "script": "devanagari", "status": "active", "bridges": ["urdu", "sanskrit", "marathi"] },
+    { "id": "tamil", "name": "Tamil", "family": "Dravidian", "script": "tamil", "status": "active", "bridges": ["kannada", "telugu", "malayalam"] },
+    { "id": "kannada", "name": "Kannada", "family": "Dravidian", "script": "kannada", "status": "active", "bridges": ["tamil", "telugu", "sanskrit"] },
+    { "id": "telugu", "name": "Telugu", "family": "Dravidian", "script": "telugu", "status": "active", "bridges": ["kannada", "sanskrit"] },
+    { "id": "malayalam", "name": "Malayalam", "family": "Dravidian", "script": "malayalam", "status": "active", "bridges": ["tamil", "sanskrit"] },
+    { "id": "italian", "name": "Italian", "family": "Romance", "script": "latin", "status": "active", "bridges": ["latin", "spanish"] },
+    { "id": "portuguese", "name": "Portuguese", "family": "Romance", "script": "latin", "status": "active", "bridges": ["latin", "spanish"] },
+    { "id": "marathi", "name": "Marathi", "family": "Indo-Aryan", "script": "devanagari", "status": "active", "bridges": ["hindi", "sanskrit"] },
+    { "id": "punjabi", "name": "Punjabi", "family": "Indo-Aryan", "script": "gurmukhi", "status": "active", "bridges": ["hindi", "urdu", "sanskrit"] },
+    { "id": "bengali", "name": "Bengali", "family": "Indo-Aryan", "script": "bengali", "status": "active", "bridges": ["sanskrit", "hindi"] },
+    { "id": "gujarati", "name": "Gujarati", "family": "Indo-Aryan", "script": "gujarati", "status": "active", "bridges": ["sanskrit", "hindi"] },
+    { "id": "russian", "name": "Russian", "family": "Slavic", "script": "cyrillic", "status": "active", "bridges": ["sanskrit", "german"] },
+    { "id": "sanskrit", "name": "Sanskrit", "family": "Indo-Aryan", "script": "devanagari", "status": "active", "bridges": ["hindi", "marathi", "bengali", "gujarati", "punjabi"] },
+    { "id": "persian", "name": "Persian", "family": "Iranian", "script": "perso-arabic", "status": "active", "bridges": ["arabic", "urdu", "hindi"] },
+    { "id": "urdu", "name": "Urdu", "family": "Indo-Aryan", "script": "urdu-nastaliq", "status": "active", "bridges": ["hindi", "persian", "arabic"] }
+  ]
+}

--- a/code/learning/human-languages/core/spine.json
+++ b/code/learning/human-languages/core/spine.json
@@ -1,0 +1,86 @@
+{
+  "version": 1,
+  "stages": ["pre-A1", "A1", "A2", "B1"],
+  "nodes": [
+    {
+      "id": "SPINE-MEET-GREET",
+      "stage": "pre-A1",
+      "canDo": "I can recognize and use an appropriate greeting when I meet someone.",
+      "prerequisites": [],
+      "core": true,
+      "concepts": ["GREETING-HELLO", "GREETING-FORMAL", "GREETING-PEACE", "GREETING-WELCOME"]
+    },
+    {
+      "id": "SPINE-COURTESY-THANK",
+      "stage": "pre-A1",
+      "canDo": "I can thank someone and respond appropriately to thanks.",
+      "prerequisites": ["SPINE-MEET-GREET"],
+      "core": true,
+      "concepts": ["COURTESY-THANKS", "COURTESY-THANKS-CASUAL", "COURTESY-YOUREWELCOME"]
+    },
+    {
+      "id": "SPINE-RESPOND-BASIC",
+      "stage": "pre-A1",
+      "canDo": "I can give a basic yes, no, or okay response.",
+      "prerequisites": ["SPINE-MEET-GREET"],
+      "core": true,
+      "concepts": ["RESPONSE-YES", "RESPONSE-NO", "RESPONSE-YESNO", "RESPONSE-OKAY"]
+    },
+    {
+      "id": "SPINE-EXCHANGE-NAMES",
+      "stage": "pre-A1",
+      "canDo": "I can ask someone's name, give my own, and acknowledge the introduction.",
+      "prerequisites": ["SPINE-MEET-GREET", "SPINE-RESPOND-BASIC"],
+      "core": true,
+      "concepts": ["QUESTION-WHAT", "PRONOUN-I", "PRONOUN-ME", "PRONOUN-YOU", "PRONOUN-MY", "WORD-NAME", "WORD-IS", "INTRO-MY-NAME-IS", "INTRO-WHATS-YOUR-NAME", "INTRO-NICE-TO-MEET-YOU"]
+    },
+    {
+      "id": "SPINE-CHECK-WELLBEING",
+      "stage": "pre-A1",
+      "canDo": "I can ask how someone is and give a simple answer.",
+      "prerequisites": ["SPINE-EXCHANGE-NAMES"],
+      "core": true,
+      "concepts": ["QUESTION-HOW", "STATE-HOW-ARE-YOU", "WORD-GOOD", "WORD-WELL", "WORD-SOSO"]
+    },
+    {
+      "id": "SPINE-POLITE-REQUEST-REPAIR",
+      "stage": "pre-A1",
+      "canDo": "I can make a request politely and repair a small social mistake.",
+      "prerequisites": ["SPINE-COURTESY-THANK"],
+      "core": true,
+      "concepts": ["COURTESY-PLEASE", "COURTESY-SORRY"]
+    },
+    {
+      "id": "SPINE-TAKE-LEAVE",
+      "stage": "pre-A1",
+      "canDo": "I can end a short interaction and choose a suitable parting expression.",
+      "prerequisites": ["SPINE-CHECK-WELLBEING"],
+      "core": true,
+      "concepts": ["FAREWELL", "FAREWELL-CASUAL", "FAREWELL-LATER", "FAREWELL-SOON", "FAREWELL-TOMORROW", "GREETING-GOODNIGHT"]
+    },
+    {
+      "id": "SPINE-TIME-OF-DAY",
+      "stage": "A1",
+      "canDo": "I can recognize basic times of day and choose a time-appropriate greeting.",
+      "prerequisites": ["SPINE-MEET-GREET"],
+      "core": true,
+      "concepts": ["TIME-DAY", "TIME-MORNING", "TIME-AFTERNOON", "TIME-EVENING", "TIME-NIGHT", "GREETING-DAY", "GREETING-MORNING", "GREETING-AFTERNOON", "GREETING-EVENING"]
+    },
+    {
+      "id": "SPINE-ASK-LOCATION",
+      "stage": "A1",
+      "canDo": "I can ask where a familiar person, place, or object is.",
+      "prerequisites": ["SPINE-EXCHANGE-NAMES"],
+      "core": true,
+      "concepts": ["QUESTION-WHERE"]
+    },
+    {
+      "id": "SPINE-DEFINITE-REFERENCE",
+      "stage": "A1",
+      "canDo": "I can recognize how this language marks a specific known person or thing when it does so.",
+      "prerequisites": ["SPINE-EXCHANGE-NAMES"],
+      "core": false,
+      "concepts": ["GRAMMAR-THE"]
+    }
+  ]
+}

--- a/code/learning/human-languages/data/scripts/perso-arabic.json
+++ b/code/learning/human-languages/data/scripts/perso-arabic.json
@@ -1,0 +1,22 @@
+{
+  "script": "perso-arabic",
+  "name": "Persian alphabet",
+  "font": "_fonts/NotoNaskhArabic-Static.ttf",
+  "direction": "rtl",
+  "system": "abjad",
+  "signature": "Right-to-left joined letters on a flowing baseline; most short vowels are understood rather than printed.",
+  "complete": false,
+  "combination": "Most letters join and change shape by position. Alif ا and vav و do not connect to the following letter. Short vowels are normally omitted. Persian adds پ چ ژ گ to the Arabic inventory as the course expands.",
+  "notes": "Starter inventory for the first Persian shared-spine lessons. Contextual shapes and stroke descriptions follow common Naskh handwriting; the course will grow toward the full Persian alphabet.",
+  "letters": [
+    { "glyph": "ا", "sound": "â / vowel carrier", "role": "letter", "forms": { "isolated": "ا", "initial": "ا", "medial": "ـا", "final": "ـا" }, "components": ["one tall vertical stroke"], "strokeOrder": ["downward vertical"], "strokeOrderNote": "common handwriting order", "notes": "Does not join to the following letter." },
+    { "glyph": "ب", "sound": "b", "role": "consonant", "forms": { "isolated": "ب", "initial": "بـ", "medial": "ـبـ", "final": "ـب" }, "components": ["shallow bowl", "one dot below"], "strokeOrder": ["bowl", "dot"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ت", "sound": "t", "role": "consonant", "forms": { "isolated": "ت", "initial": "تـ", "medial": "ـتـ", "final": "ـت" }, "components": ["shallow bowl", "two dots above"], "strokeOrder": ["bowl", "dots"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "س", "sound": "s", "role": "consonant", "forms": { "isolated": "س", "initial": "سـ", "medial": "ـسـ", "final": "ـس" }, "components": ["three teeth", "final bowl"], "strokeOrder": ["teeth", "bowl"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ل", "sound": "l", "role": "consonant", "forms": { "isolated": "ل", "initial": "لـ", "medial": "ـلـ", "final": "ـل" }, "components": ["tall upright", "base curve"], "strokeOrder": ["upright", "curve"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "م", "sound": "m", "role": "consonant", "forms": { "isolated": "م", "initial": "مـ", "medial": "ـمـ", "final": "ـم" }, "components": ["round head", "descending tail when final"], "strokeOrder": ["head", "tail"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ن", "sound": "n", "role": "consonant", "forms": { "isolated": "ن", "initial": "نـ", "medial": "ـنـ", "final": "ـن" }, "components": ["bowl", "one dot above"], "strokeOrder": ["bowl", "dot"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ه", "sound": "h / final e", "role": "consonant", "forms": { "isolated": "ه", "initial": "هـ", "medial": "ـهـ", "final": "ـه" }, "components": ["looping body"], "strokeOrder": ["loop"], "strokeOrderNote": "common handwriting order", "notes": "A final he can help write the vowel e." },
+    { "glyph": "و", "sound": "v / u / o", "role": "letter", "forms": { "isolated": "و", "initial": "و", "medial": "ـو", "final": "ـو" }, "components": ["small head", "curving tail"], "strokeOrder": ["head", "tail"], "strokeOrderNote": "common handwriting order", "notes": "Does not join to the following letter." }
+  ]
+}

--- a/code/learning/human-languages/data/scripts/urdu-nastaliq.json
+++ b/code/learning/human-languages/data/scripts/urdu-nastaliq.json
@@ -1,0 +1,26 @@
+{
+  "script": "urdu-nastaliq",
+  "name": "Urdu alphabet (Nastaliq)",
+  "font": "_fonts/NotoNaskhArabic-Static.ttf",
+  "direction": "rtl",
+  "system": "abjad",
+  "signature": "Right-to-left words descend diagonally in calligraphic Nastaliq, with dense joins and carefully placed dots.",
+  "complete": false,
+  "combination": "Letters join right-to-left and change shape by position. Urdu is conventionally printed in Nastaliq; the bundled Naskh font is currently a readable fallback while the course data records Nastaliq structure. Short vowels are normally omitted.",
+  "notes": "Starter inventory for the first Urdu shared-spine lessons, grounded in Zero Zabar. A true vendored Nastaliq font and full letter inventory are explicit next-track work.",
+  "letters": [
+    { "glyph": "ا", "sound": "ā / vowel carrier", "role": "letter", "forms": { "isolated": "ا", "initial": "ا", "medial": "ـا", "final": "ـا" }, "components": ["one tall vertical"], "strokeOrder": ["downward vertical"], "strokeOrderNote": "common handwriting order", "notes": "Does not join to the following letter." },
+    { "glyph": "ج", "sound": "j", "role": "consonant", "forms": { "isolated": "ج", "initial": "جـ", "medial": "ـجـ", "final": "ـج" }, "components": ["curved body and tail", "one dot below"], "strokeOrder": ["body", "tail", "dot"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ر", "sound": "r", "role": "consonant", "forms": { "isolated": "ر", "initial": "ر", "medial": "ـر", "final": "ـر" }, "components": ["one descending curve"], "strokeOrder": ["curve"], "strokeOrderNote": "common handwriting order", "notes": "Does not join to the following letter." },
+    { "glyph": "س", "sound": "s", "role": "consonant", "forms": { "isolated": "س", "initial": "سـ", "medial": "ـسـ", "final": "ـس" }, "components": ["three teeth", "final bowl"], "strokeOrder": ["teeth", "bowl"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ش", "sound": "sh", "role": "consonant", "forms": { "isolated": "ش", "initial": "شـ", "medial": "ـشـ", "final": "ـش" }, "components": ["three teeth and bowl", "three dots above"], "strokeOrder": ["body", "dots"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ک", "sound": "k", "role": "consonant", "forms": { "isolated": "ک", "initial": "کـ", "medial": "ـکـ", "final": "ـک" }, "components": ["angled body", "upper hook"], "strokeOrder": ["body", "hook"], "strokeOrderNote": "common handwriting order", "notes": "Urdu uses this kaf shape rather than Arabic ك." },
+    { "glyph": "ل", "sound": "l", "role": "consonant", "forms": { "isolated": "ل", "initial": "لـ", "medial": "ـلـ", "final": "ـل" }, "components": ["tall upright", "base curve"], "strokeOrder": ["upright", "curve"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "م", "sound": "m", "role": "consonant", "forms": { "isolated": "م", "initial": "مـ", "medial": "ـمـ", "final": "ـم" }, "components": ["round head", "descending tail"], "strokeOrder": ["head", "tail"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ن", "sound": "n", "role": "consonant", "forms": { "isolated": "ن", "initial": "نـ", "medial": "ـنـ", "final": "ـن" }, "components": ["bowl", "one dot above"], "strokeOrder": ["bowl", "dot"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ہ", "sound": "h", "role": "consonant", "forms": { "isolated": "ہ", "initial": "ہـ", "medial": "ـہـ", "final": "ـہ" }, "components": ["looping do-chashmi he body"], "strokeOrder": ["looping body"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ی", "sound": "y / ī", "role": "letter", "forms": { "isolated": "ی", "initial": "یـ", "medial": "ـیـ", "final": "ـی" }, "components": ["joined tooth or final bowl"], "strokeOrder": ["body"], "strokeOrderNote": "common handwriting order" },
+    { "glyph": "ں", "sound": "nasalizes the preceding vowel", "role": "other", "forms": { "isolated": "ں", "final": "ـں" }, "components": ["dotless noon bowl"], "strokeOrder": ["bowl"], "strokeOrderNote": "common handwriting order", "notes": "Noon ghunna marks a nasal vowel and lacks the dot of ن." },
+    { "glyph": "ے", "sound": "e / ai", "role": "letter", "forms": { "isolated": "ے", "final": "ـے" }, "components": ["broad final bowl"], "strokeOrder": ["bowl"], "strokeOrderNote": "common handwriting order", "notes": "Bari ye usually occurs at the end of a word." }
+  ]
+}

--- a/code/learning/human-languages/persian/README.md
+++ b/code/learning/human-languages/persian/README.md
@@ -1,0 +1,14 @@
+# Persian
+
+This track teaches contemporary Iranian Persian through the shared human-language
+spine. Every lesson is designed for a fresh learner, takes under five minutes,
+and introduces only the script needed for the expression on the page.
+
+The first five lessons establish a complete miniature exchange: greet someone,
+thank them, answer yes or no, and give your name. Persian-specific extensions
+will add the ezafe linker, colloquial verb forms, the present stem, past stems,
+and the Persian script's joined shapes without forcing those topics into every
+other language.
+
+The script notes follow the University of Texas Persian Online writing-system
+materials. Romanization is a learning aid, not a substitute for reading Persian.

--- a/code/learning/human-languages/persian/lessons/FA-C01-bale.md
+++ b/code/learning/human-languages/persian/lessons/FA-C01-bale.md
@@ -1,0 +1,41 @@
+---
+id: FA-C01-bale
+chapter: 1
+type: word
+headword: بله
+romanization: bale
+gloss: yes
+concept_tag: RESPONSE-YES
+prerequisites: [FA-C01-mamnoon]
+sounds: [rtl, short-vowels-unwritten]
+roots: []
+etymology_hook: Bale is the standard polite Persian affirmative; learn its three-letter shape as a whole.
+est_minutes: 3
+reviews_of: []
+---
+
+# بله — yes
+
+## Three letters, two hidden vowels
+
+Read **بله** from right to left: **ب** *b*, **ل** *l*, **ه** *h*. Persian does
+not normally print the short vowels, but speakers supply them:
+
+> ب · ل · ه → **bale** → yes
+
+The last **ه** is written even though careful speech ends with a light vowel
+sound rather than a strong English *h*. Listen for the whole word; do not force
+every letter to sound identical in every position.
+
+## Use it
+
+**bale** is a standard, polite “yes.” A more casual *âre* exists, but one clear
+affirmative is enough for this lesson.
+
+- “Is this Persian?” — **Bale.**
+- “Are you ready?” — **Bale, mamnun.** — Yes, thank you.
+
+## Quick recall
+
+Cover the romanization. Read **بله**. Which sounds are not written as separate
+letters? The short *a* and *e*. Answer once: **bale**.

--- a/code/learning/human-languages/persian/lessons/FA-C01-mamnoon.md
+++ b/code/learning/human-languages/persian/lessons/FA-C01-mamnoon.md
@@ -1,0 +1,47 @@
+---
+id: FA-C01-mamnoon
+chapter: 1
+type: word
+headword: ممنون
+romanization: mamnun
+gloss: thank you / grateful
+concept_tag: COURTESY-THANKS
+prerequisites: [FA-C01-salam]
+sounds: [rtl, short-vowels-unwritten, long-u]
+roots: [m-n-n]
+etymology_hook: Persian mamnun came through Arabic and originally carried the sense favored or obliged.
+est_minutes: 4
+reviews_of: []
+---
+
+# ممنون — thank you
+
+## Reuse what you know
+
+You already know final **م** *m* from **سلام**. In **ممنون**, it appears first,
+on the right. Read the visible consonants right to left:
+
+> م · م · ن · و · ن → **mamnun**
+
+Persian normally leaves short vowels unwritten, so the first *a* is something
+you learn with the word. **و** supplies the long *u* sound here. Its sound can
+change in other words; today, it is simply *u*.
+
+## Meaning and history
+
+**mamnun** literally describes someone as grateful or obliged, and in ordinary
+conversation it works as “thanks.” Persian received the word from Arabic. Its
+consonant family is **m-n-n**, associated in Arabic with favor or kindness.
+
+## Build the exchange
+
+- A: **سلام** — *salâm* — Hello.
+- B: **سلام** — *salâm* — Hello.
+- A: **ممنون** — *mamnun* — Thank you.
+
+Do not add a new grammar rule. Treat **mamnun** as one useful social move.
+
+## Quick recall
+
+Which direction do you read? Right to left. Which visible letter carries long
+*u* here? **و**. Say: **salâm — mamnun**.

--- a/code/learning/human-languages/persian/lessons/FA-C01-na.md
+++ b/code/learning/human-languages/persian/lessons/FA-C01-na.md
@@ -1,0 +1,45 @@
+---
+id: FA-C01-na
+chapter: 1
+type: word
+headword: نه
+romanization: na
+gloss: no
+concept_tag: RESPONSE-NO
+prerequisites: [FA-C01-bale]
+sounds: [rtl, short-vowels-unwritten]
+roots: [indo-iranian-na]
+etymology_hook: Persian na continues an ancient Indo-Iranian negative found across related languages.
+est_minutes: 3
+reviews_of: []
+---
+
+# نه — no
+
+## One new letter
+
+You know final **ه** from **بله**. Add **ن** *n* on its right:
+
+> ن · ه → **na** → no
+
+The short *a* is understood rather than printed. The same **ن** appeared inside
+**ممنون**, so this is mostly recognition, not a fresh alphabet lesson.
+
+## A very old negative
+
+Persian **na** belongs to an old Indo-Iranian negative family. Related forms
+turn up across Iranian and Indo-Aryan languages. That bridge will be useful
+when you compare Persian with Hindi or Urdu, but for now the job is simple:
+**bale** affirms; **na** rejects.
+
+## Contrast
+
+- **بله** — *bale* — yes
+- **نه** — *na* — no
+
+Say the pair twice, changing only the answer: **bale — na**.
+
+## Quick recall
+
+Read **نه** from right to left. Which first sound does **ن** make? *n*.
+Answer “no” in Persian: **na**.

--- a/code/learning/human-languages/persian/lessons/FA-C01-salam.md
+++ b/code/learning/human-languages/persian/lessons/FA-C01-salam.md
@@ -1,0 +1,52 @@
+---
+id: FA-C01-salam
+chapter: 1
+type: word
+headword: سلام
+romanization: salâm
+gloss: hello / peace
+concept_tag: GREETING-HELLO
+prerequisites: []
+sounds: [rtl, long-a]
+roots: [s-l-m]
+etymology_hook: A shared Semitic peace-root links Persian salâm, Arabic salām, and Hebrew shalom.
+est_minutes: 4
+reviews_of: []
+---
+
+# سلام — hello, one joined word at a time
+
+## Notice
+
+Persian runs **right to left**. Start at the right edge of **سلام**. Its four
+letters are **س** *s*, **ل** *l*, **ا** long *â*, and **م** *m*:
+
+> س · ل · ا · م → **salâm**
+
+The shapes touch because Persian letters usually join inside a word. The tall
+**ا** does not join to the letter after it, so the final **م** begins a new
+stroke group. You do not need the rest of the alphabet yet.
+
+## Meaning and history
+
+**salâm** means “hello” and literally evokes peace. Persian borrowed it from
+Arabic, where the consonants **s-l-m** organize a family concerned with peace,
+safety, and wholeness. That same old Semitic family also includes Hebrew
+*shalom*. The word is now thoroughly everyday Persian.
+
+## Use it
+
+Say **salâm** to one person or a group. It is neutral, friendly, and safe in
+most situations.
+
+- See a neighbor: **Salâm!**
+- Answer a greeting: **Salâm!**
+
+## Quick recall
+
+Read **سلام** from right to left. Which letter makes the long *â*? **ا**.
+Now say the word once without looking: **salâm**.
+
+## Source
+
+[Persian Online: the writing system](https://sites.la.utexas.edu/persian_online_resources/the-writing-system/)

--- a/code/learning/human-languages/persian/lessons/FA-C02-esm-e-man.md
+++ b/code/learning/human-languages/persian/lessons/FA-C02-esm-e-man.md
@@ -1,0 +1,52 @@
+---
+id: FA-C02-esm-e-man
+chapter: 2
+type: phrase
+headword: اسم من ... است
+romanization: esm-e man ... ast
+gloss: my name is ...
+concept_tag: INTRO-MY-NAME-IS
+prerequisites: [FA-C01-na]
+sounds: [rtl, ezafe-e, short-vowels-unwritten]
+roots: [ism, indo-iranian-man]
+etymology_hook: Arabic esm joined native Persian man and ast; the tiny ezafe vowel links the words.
+est_minutes: 4
+reviews_of: []
+---
+
+# اسم من ... است — my name is ...
+
+## Assemble familiar-sized pieces
+
+Read the phrase from right to left, but say its words in this order:
+
+> **اسمِ من ... است** — *esm-e man ... ast*
+
+- **اسم** *esm* = name. You already recognize **ا**, **س**, and **م**.
+- The small spoken **-e** after *esm* links “name” to its owner. This linker is
+  called **ezafe**. It is often not written in ordinary text.
+- **من** *man* = I / me; after the linker it means “my.”
+- **است** *ast* = is.
+
+Only one grammar idea is new: **noun + -e + owner**. Do not generalize further
+yet.
+
+## Meaning and history
+
+**esm** is an Arabic loan related to Arabic *ism*, while **man** and **ast**
+belong to Persian's inherited Iranian core. One tiny sentence can therefore
+show two major layers of Persian vocabulary.
+
+## Say your name
+
+Replace the dots with your name:
+
+> **اسم من سارا است.** — *esm-e man Sârâ ast.* — My name is Sara.
+
+In everyday speech, the ending is often shortened. Keep the careful full form
+for now; it makes every part visible.
+
+## Quick recall
+
+What links *esm* to *man*? The spoken **-e**, or ezafe. Say “My name is …” once
+with your own name.

--- a/code/learning/human-languages/persian/track.json
+++ b/code/learning/human-languages/persian/track.json
@@ -1,0 +1,7 @@
+{
+  "language": "persian",
+  "name": "Persian",
+  "variety": "contemporary Iranian Persian",
+  "family": "Iranian",
+  "script": "perso-arabic"
+}

--- a/code/learning/human-languages/urdu/README.md
+++ b/code/learning/human-languages/urdu/README.md
@@ -1,0 +1,15 @@
+# Urdu
+
+This track teaches contemporary standard Urdu through the shared
+human-language spine. Lessons are under five minutes and introduce Nastaliq
+script features only as the learner encounters them.
+
+The first five lessons form a miniature exchange: greeting, thanks, yes, no,
+and a name introduction. Urdu-specific extensions will grow the spine with
+gender agreement, postpositions, oblique forms, honorific levels, the compound
+verb system, and the distinctive Nastaliq letter shapes.
+
+Urdu and Hindi share a large grammatical core, while the formal lexicon and
+writing systems make their histories visible. Cross-language practice should
+surface both the shared structure and the Persian-Arabic vocabulary bridges.
+Script conventions are grounded in Northwestern University's *Zero Zabar*.

--- a/code/learning/human-languages/urdu/lessons/UR-C01-ji-han.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C01-ji-han.md
@@ -1,0 +1,42 @@
+---
+id: UR-C01-ji-han
+chapter: 1
+type: phrase
+headword: جی ہاں
+romanization: jī hā̃
+gloss: yes
+concept_tag: RESPONSE-YES
+prerequisites: [UR-C01-shukriya]
+sounds: [rtl, long-i, nasal-vowel]
+roots: []
+etymology_hook: Urdu pairs respectful jī with hā̃, making affirmation carry social warmth as well as meaning.
+est_minutes: 4
+reviews_of: []
+---
+
+# جی ہاں — yes, respectfully
+
+## Two small words
+
+The phrase is written right to left, so **جی** is the word on the right:
+
+> **جی** *jī* + **ہاں** *hā̃* → **jī hā̃** → yes
+
+In **جی**, **ج** gives *j* and **ی** stretches the vowel to *ī*. In **ہاں**,
+the final sign **ں** marks a nasal vowel: let some air pass through your nose
+as you say *ā*. It is not a full English *n* at the end.
+
+## Why two words?
+
+**ہاں** alone means “yes.” **جی** adds respect and attentive warmth; it can also
+be used by itself as a polite response. Learning **jī hā̃** first gives you a
+safe answer for many situations.
+
+## Use it
+
+- “Do you understand?” — **جی ہاں۔** — *jī hā̃.*
+- “Would you like to continue?” — **جی ہاں، شکریہ۔** — Yes, thank you.
+
+## Quick recall
+
+Which mark makes the vowel nasal? Final **ں**. Answer politely: **jī hā̃**.

--- a/code/learning/human-languages/urdu/lessons/UR-C01-nahin.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C01-nahin.md
@@ -1,0 +1,44 @@
+---
+id: UR-C01-nahin
+chapter: 1
+type: word
+headword: نہیں
+romanization: nahī̃
+gloss: no / not
+concept_tag: RESPONSE-NO
+prerequisites: [UR-C01-ji-han]
+sounds: [rtl, long-i, nasal-vowel]
+roots: [indo-aryan-negative]
+etymology_hook: Nahī̃ belongs to Urdu's inherited Indo-Aryan core and links its grammar closely with Hindi.
+est_minutes: 3
+reviews_of: []
+---
+
+# نہیں — no, and later “not”
+
+## Recombine known shapes
+
+You have seen **ہ**, **ی**, and nasal **ں**. Add **ن** *n* at the right:
+
+> ن · ہ · ی · ں → **nahī̃**
+
+Stretch *ī* slightly and nasalize it. The final **ں** does not add a strong
+separate *n* sound.
+
+## One word, two future jobs
+
+As a complete answer, **nahī̃** means “no.” Inside a sentence it commonly means
+“not.” That second job will matter when the track introduces verbs. Today you
+only need the complete answer.
+
+This is inherited Indo-Aryan vocabulary and is shared with Hindi **नहीं**
+*nahī̃*. The scripts differ, but the spoken word and grammar align closely.
+
+## Contrast
+
+- **جی ہاں** — *jī hā̃* — yes
+- **نہیں** — *nahī̃* — no
+
+## Quick recall
+
+What does final **ں** do? It nasalizes the vowel. Answer “no”: **nahī̃**.

--- a/code/learning/human-languages/urdu/lessons/UR-C01-salam.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C01-salam.md
@@ -1,0 +1,51 @@
+---
+id: UR-C01-salam
+chapter: 1
+type: word
+headword: سلام
+romanization: salām
+gloss: hello / peace
+concept_tag: GREETING-HELLO
+prerequisites: []
+sounds: [rtl, long-a]
+roots: [s-l-m]
+etymology_hook: Urdu salām shares its peace-root with Persian salâm, Arabic salām, and Hebrew shalom.
+est_minutes: 4
+reviews_of: []
+---
+
+# سلام — hello across a family of languages
+
+## Notice the direction
+
+Urdu is written **right to left**, traditionally in the flowing Nastaliq style.
+Begin with four letters:
+
+> س *s* · ل *l* · ا long *ā* · م *m* → **salām**
+
+Letters usually connect inside a word. The tall **ا** does not connect onward
+to the final **م**, creating a visible break. That is enough script for today.
+
+## Meaning and history
+
+**salām** is both a greeting and the word “peace.” Urdu received it through the
+Persian-Arabic literary world. Its consonants **s-l-m** belong to a Semitic
+family concerned with peace, safety, and wholeness. Persian *salâm* and Arabic
+*salām* are the same historical word; Hebrew *shalom* is a relative.
+
+## Use it
+
+Say **salām** as a friendly short greeting. You will later extend it into the
+full conventional exchange.
+
+- A: **سلام!** — *salām!*
+- B: **سلام!** — *salām!*
+
+## Quick recall
+
+Read **سلام** right to left. Which letter carries the long *ā*? **ا**.
+Say **salām** once while picturing the meaning “peace.”
+
+## Source
+
+[Zero Zabar: the Urdu alphabet](https://openbooks.library.northwestern.edu/zerozabar/chapter/the-urdu-alphabet/)

--- a/code/learning/human-languages/urdu/lessons/UR-C01-shukriya.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C01-shukriya.md
@@ -1,0 +1,47 @@
+---
+id: UR-C01-shukriya
+chapter: 1
+type: word
+headword: شکریہ
+romanization: shukriyā
+gloss: thank you
+concept_tag: COURTESY-THANKS
+prerequisites: [UR-C01-salam]
+sounds: [rtl, short-vowels-unwritten, long-a]
+roots: [sh-k-r]
+etymology_hook: Shukriya belongs to the Arabic sh-k-r family of gratitude, carried into Urdu through Persianate usage.
+est_minutes: 4
+reviews_of: []
+---
+
+# شکریہ — thank you
+
+## Read only what you need
+
+Urdu normally omits short-vowel marks. In **شکریہ**, the visible letters guide
+you, while the vowels complete the learned word:
+
+> ش · ک · ر · ی · ہ → **shukriyā**
+
+Meet **ش** *sh*, **ک** *k*, **ر** *r*, **ی** *y/i*, and final **ہ**. The final
+vowel is pronounced long *ā* in this familiar expression. Treat the joined
+shape as one word before worrying about every possible letter form.
+
+## Meaning and history
+
+The central consonants **sh-k-r** belong to the Arabic family for gratitude
+and thanks; Arabic *shukran* is a close comparison. Urdu **shukriyā** reflects
+the centuries-long Persian-Arabic layer of its vocabulary.
+
+## Build the exchange
+
+- **سلام** — *salām* — Hello.
+- **شکریہ** — *shukriyā* — Thank you.
+
+Say the second word slowly once, then at a natural pace. Keep *shuk-ri-yā* as
+three light beats.
+
+## Quick recall
+
+Which new letter begins the word? **ش**, *sh*. Greet, then thank:
+**salām — shukriyā**.

--- a/code/learning/human-languages/urdu/lessons/UR-C02-mera-naam.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C02-mera-naam.md
@@ -1,0 +1,47 @@
+---
+id: UR-C02-mera-naam
+chapter: 2
+type: phrase
+headword: میرا نام ... ہے
+romanization: merā nām ... hai
+gloss: my name is ...
+concept_tag: INTRO-MY-NAME-IS
+prerequisites: [UR-C01-nahin]
+sounds: [rtl, long-vowels, hai-diphthong]
+roots: [indo-aryan-main, indo-european-name]
+etymology_hook: Mera and hai expose Urdu's Indo-Aryan grammar, while nām belongs to the ancient Indo-European name family.
+est_minutes: 4
+reviews_of: []
+---
+
+# میرا نام ... ہے — my name is ...
+
+## Four slots
+
+Read the line right to left, but keep its spoken order:
+
+> **میرا | نام | ... | ہے** — *merā nām ... hai*
+
+- **میرا** *merā* = my
+- **نام** *nām* = name
+- your name goes in the open slot
+- **ہے** *hai* = is
+
+Urdu puts **hai** at the end. That is the only sentence-pattern fact to learn
+now: **my + name + NAME + is**.
+
+The word **nām** is an old Indo-Aryan relative of Sanskrit *nāman* and distant
+English *name*. **merā** and **hai** show Urdu's inherited grammatical core,
+shared closely with Hindi even though the two languages use different scripts.
+
+## Say your name
+
+> **میرا نام سارا ہے۔** — *merā nām Sārā hai.* — My name is Sara.
+
+Replace **Sārā** with your own name. Do not add agreement rules yet; this exact
+frame is enough for the introduction.
+
+## Quick recall
+
+Where does “is” go in this Urdu sentence? At the end. Say the four slots, then
+say the full sentence with your name.

--- a/code/learning/human-languages/urdu/track.json
+++ b/code/learning/human-languages/urdu/track.json
@@ -1,0 +1,7 @@
+{
+  "language": "urdu",
+  "name": "Urdu",
+  "variety": "contemporary standard Urdu",
+  "family": "Indo-Aryan",
+  "script": "urdu-nastaliq"
+}

--- a/code/packages/typescript/human-language-data/src/constants.ts
+++ b/code/packages/typescript/human-language-data/src/constants.ts
@@ -24,6 +24,9 @@ export const LANGUAGE_SCRIPT: Record<string, Script> = {
   telugu: "telugu",
   malayalam: "malayalam",
   arabic: "arabic",
+  russian: "cyrillic",
+  persian: "perso-arabic",
+  urdu: "urdu-nastaliq",
 };
 
 /** Lesson types that teach a real concept and take part in the cross-language join. */

--- a/code/packages/typescript/human-language-data/src/curriculum.ts
+++ b/code/packages/typescript/human-language-data/src/curriculum.ts
@@ -1,0 +1,179 @@
+// Pure validation for the structured HL04 language registry and shared spine.
+
+import { CONTENT_TYPES, hasOwn } from "./constants.js";
+import type {
+  BookCorpus,
+  CurriculumSpine,
+  Issue,
+  LanguageRegistry,
+  Taxonomy,
+} from "./types.js";
+import type { ParsedLesson } from "./parse.js";
+
+export interface CurriculumValidationInput {
+  registry: LanguageRegistry;
+  spine: CurriculumSpine;
+  taxonomy: Taxonomy;
+  lessons: ParsedLesson[];
+  books?: BookCorpus;
+}
+
+export function validateCurriculum(input: CurriculumValidationInput): Issue[] {
+  const { registry, spine, taxonomy, lessons, books } = input;
+  const issues: Issue[] = [];
+  const error = (code: string, message: string) =>
+    issues.push({ level: "error", code, message });
+  const warning = (code: string, message: string, lessonId?: string) =>
+    issues.push({ level: "warning", code, message, lessonId });
+
+  const languageIds = new Set<string>();
+  for (const language of registry.languages) {
+    if (languageIds.has(language.id)) {
+      error("duplicate-language", `language registry contains '${language.id}' twice`);
+    }
+    languageIds.add(language.id);
+    if (language.name.trim() === "") {
+      error("missing-language-name", `${language.id}: language name is empty`);
+    }
+    if (language.script.trim() === "") {
+      error("missing-language-script", `${language.id}: script id is empty`);
+    }
+  }
+
+  for (const book of books?.books ?? []) {
+    if (!languageIds.has(book.language)) {
+      error("unregistered-book-language", `${book.language}: LaTeX book is absent from core/languages.json`);
+    }
+    const chapterNumbers = new Set<number>();
+    for (const chapter of book.chapters) {
+      if (chapterNumbers.has(chapter.chapter)) {
+        error("duplicate-book-chapter", `${book.language}: book chapter ${chapter.chapter} occurs twice`);
+      }
+      chapterNumbers.add(chapter.chapter);
+      const hasLesson = lessons.some(
+        (lesson) => lesson.language === book.language && lesson.realization.chapter === chapter.chapter,
+      );
+      if (!hasLesson) {
+        error(
+          "book-chapter-without-lessons",
+          `${chapter.source}: no chapter ${chapter.chapter} Markdown lessons exist`,
+        );
+      }
+    }
+  }
+
+  const lessonLanguages = new Set(lessons.map((lesson) => lesson.language));
+  for (const language of lessonLanguages) {
+    if (!languageIds.has(language)) {
+      error("unregistered-language", `${language}: lesson track is absent from core/languages.json`);
+    }
+  }
+  for (const language of registry.languages) {
+    if (language.status === "active" && !lessonLanguages.has(language.id)) {
+      error("active-language-without-lessons", `${language.id}: active language has no lessons`);
+    }
+  }
+
+  const lessonById = new Map<string, ParsedLesson>();
+  for (const lesson of lessons) {
+    const id = lesson.realization.lessonId;
+    if (lessonById.has(id)) error("duplicate-lesson-id", `lesson id '${id}' occurs twice`);
+    else lessonById.set(id, lesson);
+    const estimate = Number(lesson.frontmatter.est_minutes);
+    if (Number.isFinite(estimate) && estimate > 5) {
+      warning("long-micro-lesson", `${id}: estimated at ${estimate} minutes; new spine lessons should be at most 5`, id);
+    }
+    if (lesson.body.trim() === "") warning("empty-lesson-body", `${id}: lesson has no authored body`, id);
+  }
+
+  const prerequisites = (lesson: ParsedLesson): string[] => {
+    const value = lesson.frontmatter.prerequisites;
+    return Array.isArray(value) ? value : typeof value === "string" && value !== "" ? [value] : [];
+  };
+  for (const lesson of lessons) {
+    for (const prerequisite of prerequisites(lesson)) {
+      if (!lessonById.has(prerequisite)) {
+        error(
+          "unknown-lesson-prerequisite",
+          `${lesson.realization.lessonId}: unknown prerequisite '${prerequisite}'`,
+        );
+      }
+    }
+  }
+  const visitingLessons = new Set<string>();
+  const visitedLessons = new Set<string>();
+  const visitLesson = (id: string): void => {
+    if (visitedLessons.has(id)) return;
+    if (visitingLessons.has(id)) {
+      error("lesson-prerequisite-cycle", `lesson prerequisites contain a cycle through '${id}'`);
+      return;
+    }
+    visitingLessons.add(id);
+    const lesson = lessonById.get(id);
+    if (lesson) for (const prerequisite of prerequisites(lesson)) visitLesson(prerequisite);
+    visitingLessons.delete(id);
+    visitedLessons.add(id);
+  };
+  for (const id of lessonById.keys()) visitLesson(id);
+
+  const nodeIds = new Set<string>();
+  const conceptOwner = new Map<string, string>();
+  for (const node of spine.nodes) {
+    if (nodeIds.has(node.id)) error("duplicate-spine-node", `spine node '${node.id}' is duplicated`);
+    nodeIds.add(node.id);
+    if (node.canDo.trim() === "") error("missing-can-do", `${node.id}: canDo is empty`);
+    if (!spine.stages.includes(node.stage)) {
+      error("unknown-spine-stage", `${node.id}: stage '${node.stage}' is not declared`);
+    }
+    for (const concept of node.concepts) {
+      if (!hasOwn(taxonomy.concepts, concept)) {
+        error("unknown-spine-concept", `${node.id}: concept '${concept}' is not canonical`);
+      }
+      const previous = conceptOwner.get(concept);
+      if (previous) {
+        error("duplicate-spine-concept", `concept '${concept}' occurs in ${previous} and ${node.id}`);
+      } else {
+        conceptOwner.set(concept, node.id);
+      }
+    }
+  }
+
+  for (const node of spine.nodes) {
+    for (const prerequisite of node.prerequisites) {
+      if (!nodeIds.has(prerequisite)) {
+        error("unknown-spine-prerequisite", `${node.id}: unknown prerequisite '${prerequisite}'`);
+      }
+    }
+  }
+
+  const byId = new Map(spine.nodes.map((node) => [node.id, node]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (id: string): void => {
+    if (visited.has(id)) return;
+    if (visiting.has(id)) {
+      error("spine-cycle", `shared spine contains a cycle through '${id}'`);
+      return;
+    }
+    visiting.add(id);
+    for (const prerequisite of byId.get(id)?.prerequisites ?? []) visit(prerequisite);
+    visiting.delete(id);
+    visited.add(id);
+  };
+  for (const id of nodeIds) visit(id);
+
+  const spineConcepts = new Set(conceptOwner.keys());
+  for (const language of registry.languages) {
+    const hasSpineRealization = lessons.some(
+      (lesson) =>
+        lesson.language === language.id &&
+        CONTENT_TYPES.has(lesson.realization.type) &&
+        spineConcepts.has(lesson.realization.concept),
+    );
+    if (!hasSpineRealization) {
+      error("language-without-spine-realization", `${language.id}: no lesson realizes the shared spine`);
+    }
+  }
+
+  return issues;
+}

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -16,9 +16,16 @@ export {
 } from "./queries.js";
 export { validate, hasErrors, summarize, type ValidateInput } from "./validate.js";
 export {
+  validateCurriculum,
+  type CurriculumValidationInput,
+} from "./curriculum.js";
+export {
   defaultCurriculumRoot,
   trackScript,
   loadTaxonomy,
+  loadLanguageRegistry,
+  loadCurriculumSpine,
+  loadBookCorpus,
   loadLessons,
   loadScripts,
   loadEverything,

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -6,7 +6,16 @@ import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildDataset, parseLesson, type ParsedLesson } from "./parse.js";
-import type { Dataset, Script, ScriptData, Taxonomy } from "./types.js";
+import type {
+  BookChapter,
+  BookCorpus,
+  CurriculumSpine,
+  Dataset,
+  LanguageRegistry,
+  Script,
+  ScriptData,
+  Taxonomy,
+} from "./types.js";
 
 /** Default curriculum root: code/learning/human-languages, relative to this package. */
 export function defaultCurriculumRoot(): string {
@@ -18,6 +27,57 @@ export function defaultCurriculumRoot(): string {
 export function loadTaxonomy(root = defaultCurriculumRoot()): Taxonomy {
   const raw = JSON.parse(readFileSync(join(root, "concepts", "taxonomy.json"), "utf8"));
   return { version: raw.version ?? 1, concepts: raw.concepts ?? {} };
+}
+
+export function loadLanguageRegistry(root = defaultCurriculumRoot()): LanguageRegistry {
+  return JSON.parse(
+    readFileSync(join(root, "core", "languages.json"), "utf8"),
+  ) as LanguageRegistry;
+}
+
+export function loadCurriculumSpine(root = defaultCurriculumRoot()): CurriculumSpine {
+  return JSON.parse(
+    readFileSync(join(root, "core", "spine.json"), "utf8"),
+  ) as CurriculumSpine;
+}
+
+/**
+ * Load the existing authored LaTeX books losslessly. The short Markdown lessons
+ * remain the smallest teaching units; chapters are the narrative and sequencing
+ * layer around them. Keeping both in the data package prevents an app or future
+ * book generator from silently forgetting either source.
+ */
+export function loadBookCorpus(root = defaultCurriculumRoot()): BookCorpus {
+  const books: BookCorpus["books"] = [];
+  for (const track of readdirSync(root, { withFileTypes: true })) {
+    if (!track.isDirectory()) continue;
+    const bookDir = join(root, track.name, "book");
+    const entrypoint = join(bookDir, "book.tex");
+    const chaptersDir = join(bookDir, "chapters");
+    if (!existsSync(entrypoint) || !existsSync(chaptersDir)) continue;
+
+    const chapters: BookChapter[] = [];
+    for (const file of readdirSync(chaptersDir).sort()) {
+      const match = /^ch(\d+)-(.+)\.tex$/.exec(file);
+      if (!match) continue;
+      const tex = readFileSync(join(chaptersDir, file), "utf8");
+      const title = /\\chapter(?:\[[^\]]*\])?\{([^}]*)\}/.exec(tex)?.[1] ?? match[2];
+      chapters.push({
+        language: track.name,
+        chapter: Number(match[1]),
+        slug: match[2],
+        title,
+        source: `${track.name}/book/chapters/${file}`,
+        tex,
+      });
+    }
+    books.push({
+      language: track.name,
+      entrypoint: `${track.name}/book/book.tex`,
+      chapters,
+    });
+  }
+  return { books: books.sort((a, b) => a.language.localeCompare(b.language)) };
 }
 
 /**
@@ -69,12 +129,26 @@ export function loadScripts(root = defaultCurriculumRoot()): Record<string, Scri
 /** Load and build everything from disk in one call. */
 export function loadEverything(root = defaultCurriculumRoot()): {
   taxonomy: Taxonomy;
+  registry: LanguageRegistry;
+  spine: CurriculumSpine;
+  books: BookCorpus;
   lessons: ParsedLesson[];
   scripts: Record<string, ScriptData>;
   dataset: Dataset;
 } {
   const taxonomy = loadTaxonomy(root);
+  const registry = loadLanguageRegistry(root);
+  const spine = loadCurriculumSpine(root);
+  const books = loadBookCorpus(root);
   const lessons = loadLessons(root);
   const scripts = loadScripts(root);
-  return { taxonomy, lessons, scripts, dataset: buildDataset(taxonomy, lessons) };
+  return {
+    taxonomy,
+    registry,
+    spine,
+    books,
+    lessons,
+    scripts,
+    dataset: buildDataset(taxonomy, lessons),
+  };
 }

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -19,6 +19,8 @@ export interface ParsedLesson {
   language: string;
   script: Script;
   frontmatter: Frontmatter;
+  /** Lossless Markdown after the frontmatter, used by both books and apps. */
+  body: string;
   realization: Realization;
 }
 
@@ -56,7 +58,7 @@ export function parseLesson(
   language: string,
   script?: Script,
 ): ParsedLesson {
-  const { frontmatter } = splitFrontmatter(source);
+  const { frontmatter, body } = splitFrontmatter(source);
   const fm = frontmatter ?? {};
   const resolvedScript: Script =
     script ?? (hasOwn(LANGUAGE_SCRIPT, language) ? LANGUAGE_SCRIPT[language] : "latin");
@@ -81,7 +83,7 @@ export function parseLesson(
     roots: arrayify(fm.roots),
     etymologyHook: str(fm.etymology_hook),
   };
-  return { language, script: resolvedScript, frontmatter: fm, realization };
+  return { language, script: resolvedScript, frontmatter: fm, body, realization };
 }
 
 /**

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -74,6 +74,65 @@ export interface Dataset {
   languages: string[];
 }
 
+// ---- Shared curriculum spine (HL04) ---------------------------------------
+
+export type CurriculumStage = "pre-A1" | "A1" | "A2" | "B1" | string;
+
+export interface LanguageDefinition {
+  id: string;
+  name: string;
+  family: string;
+  script: Script;
+  status: "active" | "planned" | string;
+  /** Languages whose history, vocabulary, or structure gives this track a bridge. */
+  bridges: string[];
+}
+
+export interface LanguageRegistry {
+  version: number;
+  /** Authored order used as the default cross-language walk. */
+  languages: LanguageDefinition[];
+}
+
+export interface SpineNode {
+  id: string;
+  stage: CurriculumStage;
+  canDo: string;
+  prerequisites: string[];
+  core: boolean;
+  /** Canonical concept ids taught inside this communicative ability. */
+  concepts: string[];
+}
+
+export interface CurriculumSpine {
+  version: number;
+  stages: CurriculumStage[];
+  nodes: SpineNode[];
+}
+
+/** One authored chapter from an existing LaTeX book. */
+export interface BookChapter {
+  language: string;
+  chapter: number;
+  slug: string;
+  title: string;
+  /** Curriculum-root-relative path, suitable for provenance and diagnostics. */
+  source: string;
+  /** Original LaTeX. Kept losslessly so future renderers do not scrape PDFs. */
+  tex: string;
+}
+
+/** The authored LaTeX layer that surrounds and sequences the short lessons. */
+export interface LanguageBook {
+  language: string;
+  entrypoint: string;
+  chapters: BookChapter[];
+}
+
+export interface BookCorpus {
+  books: LanguageBook[];
+}
+
 // ---- Script / character-breakdown data (data/scripts/<script>.json) ----
 //
 // Deliberately GENERAL, so one schema can teach any writing system. It has to

--- a/code/packages/typescript/human-language-data/tests/curriculum.test.ts
+++ b/code/packages/typescript/human-language-data/tests/curriculum.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { validateCurriculum } from "../src/curriculum.js";
+import { parseLesson } from "../src/parse.js";
+import type { CurriculumSpine, LanguageRegistry, Taxonomy } from "../src/types.js";
+
+const registry: LanguageRegistry = {
+  version: 1,
+  languages: [{ id: "test", name: "Test", family: "Test", script: "latin", status: "active", bridges: [] }],
+};
+const taxonomy: Taxonomy = {
+  version: 1,
+  concepts: { "GREETING-HELLO": { family: "GREETING", gloss: "hello", core: true } },
+};
+const spine: CurriculumSpine = {
+  version: 1,
+  stages: ["pre-A1"],
+  nodes: [{ id: "HELLO", stage: "pre-A1", canDo: "I can greet someone.", prerequisites: [], core: true, concepts: ["GREETING-HELLO"] }],
+};
+const source = (id: string, type: string, concept: string, prerequisites: string[]) => `---
+id: ${id}
+chapter: 1
+type: ${type}
+headword: hello
+gloss: hello
+concept_tag: ${concept}
+prerequisites: [${prerequisites.join(", ")}]
+est_minutes: 4
+reviews_of: []
+---
+
+# A real body
+`;
+
+describe("curriculum prerequisite validation", () => {
+  it("rejects an unknown lesson prerequisite", () => {
+    const lessons = [parseLesson(source("A", "word", "GREETING-HELLO", ["MISSING"]), "test")];
+    expect(validateCurriculum({ registry, taxonomy, spine, lessons }).map((issue) => issue.code))
+      .toContain("unknown-lesson-prerequisite");
+  });
+
+  it("rejects a prerequisite cycle", () => {
+    const lessons = [
+      parseLesson(source("A", "word", "GREETING-HELLO", ["B"]), "test"),
+      parseLesson(source("B", "practice", "TEST-PRACTICE", ["A"]), "test"),
+    ];
+    expect(validateCurriculum({ registry, taxonomy, spine, lessons }).map((issue) => issue.code))
+      .toContain("lesson-prerequisite-cycle");
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -5,9 +5,10 @@
 import { describe, it, expect } from "vitest";
 import { loadEverything } from "../src/loader.js";
 import { validate, hasErrors } from "../src/validate.js";
+import { validateCurriculum } from "../src/curriculum.js";
 import { languagesForConcept } from "../src/queries.js";
 
-const { taxonomy, lessons, scripts, dataset } = loadEverything();
+const { taxonomy, registry, spine, books, lessons, scripts, dataset } = loadEverything();
 
 describe("real curriculum", () => {
   it("has zero validation errors", () => {
@@ -19,10 +20,26 @@ describe("real curriculum", () => {
   });
 
   it("loaded every track (17+ and growing)", () => {
-    expect(dataset.languages.length).toBeGreaterThanOrEqual(17);
-    for (const t of ["spanish", "telugu", "arabic", "russian"]) {
+    expect(dataset.languages.length).toBeGreaterThanOrEqual(20);
+    for (const t of ["spanish", "telugu", "arabic", "russian", "persian", "urdu"]) {
       expect(dataset.languages).toContain(t);
     }
+  });
+
+  it("has a valid shared spine covering every registered language", () => {
+    const issues = validateCurriculum({ registry, spine, taxonomy, lessons, books });
+    expect(issues.filter((issue) => issue.level === "error").map((issue) => issue.message)).toEqual([]);
+    expect(registry.languages.map((language) => language.id)).toEqual(dataset.languages.sort((a, b) => {
+      const order = new Map(registry.languages.map((language, index) => [language.id, index]));
+      return order.get(a)! - order.get(b)!;
+    }));
+  });
+
+  it("preserves every existing LaTeX book and maps each chapter to short lessons", () => {
+    expect(books.books.length).toBeGreaterThanOrEqual(17);
+    expect(books.books.reduce((sum, book) => sum + book.chapters.length, 0)).toBeGreaterThanOrEqual(100);
+    expect(books.books.find((book) => book.language === "spanish")?.chapters.length).toBe(18);
+    expect(books.books.every((book) => book.chapters.every((chapter) => chapter.tex.length > 100))).toBe(true);
   });
 
   it("GREETING-HELLO joins every track (the normalization payoff)", () => {

--- a/code/packages/typescript/human-language-data/tests/parse.test.ts
+++ b/code/packages/typescript/human-language-data/tests/parse.test.ts
@@ -22,6 +22,7 @@ describe("parseLesson", () => {
     expect(p.script).toBe("latin");
     expect(p.realization.romanization).toBe("hola");
     expect(p.realization.concept).toBe("GREETING-HELLO");
+    expect(p.body).toBe("body");
   });
 
   it("keeps romanization empty for a non-Latin lesson that omits it", () => {

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -2,8 +2,8 @@
 
 **The HL03 unified curriculum learning app** (it began life as the HL02
 `script-writing-visualizer` and has subsumed that app's modes). Five modes.
-**Learn** (the default) walks the curriculum the way the book does — one concept
-at a time, forward along the language chain, each new language showing its
+**Learn** (the default) walks the structured shared spine — one concept
+at a time, across the learner's selected language mix, each new language showing its
 threads back to the ones already learned, then reviewing it all with a
 randomised SRS quiz. **Browse** and **Practice** work on *script letters*;
 **Lessons** drills the *written curriculum* — every lesson in every track — on a
@@ -13,21 +13,23 @@ one idea in every language that has it, side by side.
 ## Learn mode (the curriculum session)
 
 The spine of the app: [HL03](../../../specs/HL03-unified-language-learning-app.md)
-in one screen. For each concept in book order (`sweepableConcepts`), the
+and [HL04](../../../specs/HL04-shared-spine-and-content-pipeline.md) in one screen.
+For each concept in the explicit `core/spine.json` order, the
 engine's *teaching pass* (`sessionplan.ts` → `planSession`) is rendered as a
-numbered sweep — one card per language that teaches it, in chain order
-(Spanish → Latin → French → … → Malayalam). Each card carries the word in its
-own script, its etymology hook, and the **connections back** to earlier
+numbered sweep — one card per selected language that teaches it, in registry
+order. The picker includes every current track, including Russian, Persian, and
+Urdu. Each card carries the word in its own script, its etymology hook, its full
+authored Markdown micro-lesson, and the **connections back** to earlier
 languages that share a root, so the cross-language memory the interleaving is
 meant to build is made visible rather than left implicit. Prev / Next walk the
 spine, and a **jump picker** (a `<select>` of the whole book-ordered spine) leaps
-straight to any concept; a slim **progress bar** shows how far along the 186-
-concept walk you are. Consolidation lessons (`practice`/`review`) are left to the
+straight to any concept; a slim **progress bar** shows progress through the
+selected portion of the shared spine. Consolidation lessons (`practice`/`review`) are left to the
 review quiz, not the teaching sweep.
 
 The session **introduces writing systems as-needed** (`scriptintro.ts`): the
-first time the walk reaches a non-Latin script — Arabic, then Devanagari, then
-Tamil — that step gets a compact *"New script"* note (name, system, and how to
+first time the walk reaches a non-Latin script — including Persian and Urdu's
+distinct script identities — that step gets a compact *"New script"* note (name, system, and how to
 recognise it, from the script data's `signature`), shown once at the earliest
 concept that teaches it. It's grounded: a script with no data (Kannada / Telugu
 / Malayalam today) gets no note rather than an invented one.
@@ -50,7 +52,8 @@ to is saved on each Prev/Next and restored at startup, so the app resumes where
 you left off rather than back at the first concept. The restored index is
 clamped to the current spine, and a bad blob falls back to the start.
 
-A quiet **"Reset progress"** control at the foot of the Learn view clears it all
+A quiet **"Reset progress"** control at the foot of the Learn view clears it all,
+including the saved language mix,
 (`reset.ts` — only the keys this app owns), behind a two-click confirm so a stray
 tap can't wipe everything.
 
@@ -64,7 +67,7 @@ This mode is that join, and it is the data package's own
 `languagesForConcept` — a function shipped from the start, documented as "what
 the companion app calls," which until now had **no caller**.
 
-- **39 concepts are shared by two or more tracks**, from 701 lessons. A concept
+- **42 concepts are shared by two or more tracks**, from 973 lessons. A concept
   only one language tags is filtered out: there is nothing to compare it with,
   which also removes almost every namespaced (`ES-…`) tag without a special case.
 - Each row shows the **headword**, a **romanization** where it differs, and the
@@ -76,7 +79,7 @@ the companion app calls," which until now had **no caller**.
 
 ## Lessons mode
 
-Reads all **701 lessons across 18 languages** straight from the curriculum via
+Reads all **973 lessons across 20 languages** straight from the curriculum via
 `@coding-adventures/human-language-data`, and schedules them with the same
 Leitner machinery the letter drills use (`scheduler.ts` is generic over an
 index; it never needed to know what an item is).
@@ -85,7 +88,9 @@ index; it never needed to know what an item is).
   id** — never by array index, because indices shift every time a lesson is
   added and saving by position would reattribute your history to the wrong
   lesson. New lessons simply appear as unseen items.
-- **It mixes languages.** Consecutive reviews round-robin across tracks — Arabic,
+- **It uses the same authored content as the books.** Reveal opens the complete
+  Markdown micro-lesson rather than discarding its explanations and practice.
+- **It mixes the languages you selected.** Consecutive reviews round-robin across tracks — Arabic,
   then Bengali, then French — rather than marching through one language. That
   interleaving is deliberate: it forces discrimination instead of coasting.
 - **Recall, not recognition.** You see the headword in its own script; the

--- a/code/programs/typescript/language-ladder/src/concepts.ts
+++ b/code/programs/typescript/language-ladder/src/concepts.ts
@@ -105,6 +105,7 @@ export function datasetFromLessons(
     // `buildDataset` reads only `.realization`; frontmatter is inert here, and
     // an empty object is honest about that rather than reconstructing a fake.
     frontmatter: {},
+    body: l.body,
     realization: {
       concept: l.concept,
       language: l.language,
@@ -135,17 +136,16 @@ export function datasetFromLessons(
  * Is this lesson teachable yet?
  *
  * A lesson unlocks when every id in its `prerequisites` has been seen. Unknown
- * ids — a typo, or a prerequisite pointing at a lesson not yet written — are
- * treated as ALREADY SATISFIED rather than as a permanent lock. A curriculum
- * bug should degrade to "shown slightly early", never to "silently unreachable
- * forever," which is the failure mode nobody notices.
+ * ids — a typo, or a prerequisite pointing at a lesson not yet written — fail
+ * closed. The curriculum validator must surface the data bug; the app must not
+ * teach material whose declared foundation it cannot prove was learned.
  */
 export function isUnlocked(
   lesson: Lesson,
   seen: ReadonlySet<string>,
   known: ReadonlySet<string>,
 ): boolean {
-  return lesson.prerequisites.every((id) => !known.has(id) || seen.has(id));
+  return lesson.prerequisites.every((id) => known.has(id) && seen.has(id));
 }
 
 /**
@@ -172,17 +172,15 @@ export function unlockedIndices(
 }
 
 /**
- * `unlockedIndices`, but never empty — falls back to every index.
- *
- * Practice stalling completely is the one outcome worse than practising
- * something slightly too early, so the gate is allowed to fail open.
+ * Compatibility name retained for callers. It now fails closed exactly like
+ * `unlockedIndices`; an empty result is a visible curriculum problem, never
+ * permission to show material early.
  */
 export function unlockedOrAll(
   lessons: Lesson[],
   seen: ReadonlySet<string>,
 ): number[] {
-  const gated = unlockedIndices(lessons, seen);
-  return gated.length > 0 ? gated : lessons.map((_, i) => i);
+  return unlockedIndices(lessons, seen);
 }
 
 /**

--- a/code/programs/typescript/language-ladder/src/curriculum.ts
+++ b/code/programs/typescript/language-ladder/src/curriculum.ts
@@ -1,0 +1,46 @@
+// Browser-safe access to the structured HL04 curriculum. These JSON files are
+// the source of truth shared with validators and future book generators.
+
+import registryJson from "../../../../learning/human-languages/core/languages.json";
+import spineJson from "../../../../learning/human-languages/core/spine.json";
+
+export interface LanguageDefinition {
+  id: string;
+  name: string;
+  family: string;
+  script: string;
+  status: string;
+  bridges: string[];
+}
+export interface SpineNode {
+  id: string;
+  stage: string;
+  canDo: string;
+  prerequisites: string[];
+  core: boolean;
+  concepts: string[];
+}
+
+export const LANGUAGE_REGISTRY = registryJson.languages as LanguageDefinition[];
+export const LANGUAGE_ORDER: string[] = LANGUAGE_REGISTRY
+  .filter((language) => language.status === "active")
+  .map((language) => language.id);
+export const SPINE_NODES = spineJson.nodes as SpineNode[];
+export const SPINE_CONCEPTS: string[] = SPINE_NODES.flatMap((node) => node.concepts);
+
+const LANGUAGE_BY_ID = new Map(LANGUAGE_REGISTRY.map((language) => [language.id, language]));
+const NODE_BY_CONCEPT = new Map(
+  SPINE_NODES.flatMap((node) => node.concepts.map((concept) => [concept, node] as const)),
+);
+
+export function languageDefinition(id: string): LanguageDefinition | undefined {
+  return LANGUAGE_BY_ID.get(id);
+}
+
+export function languageName(id: string): string {
+  return languageDefinition(id)?.name ?? id;
+}
+
+export function spineNodeForConcept(concept: string): SpineNode | undefined {
+  return NODE_BY_CONCEPT.get(concept);
+}

--- a/code/programs/typescript/language-ladder/src/data.ts
+++ b/code/programs/typescript/language-ladder/src/data.ts
@@ -12,6 +12,8 @@ import cyrillic from "../../../../learning/human-languages/data/scripts/cyrillic
 import hebrew from "../../../../learning/human-languages/data/scripts/hebrew.json";
 import chinese from "../../../../learning/human-languages/data/scripts/chinese.json";
 import arabic from "../../../../learning/human-languages/data/scripts/arabic.json";
+import persoArabic from "../../../../learning/human-languages/data/scripts/perso-arabic.json";
+import urduNastaliq from "../../../../learning/human-languages/data/scripts/urdu-nastaliq.json";
 import devanagari from "../../../../learning/human-languages/data/scripts/devanagari.json";
 import gujarati from "../../../../learning/human-languages/data/scripts/gujarati.json";
 import tamil from "../../../../learning/human-languages/data/scripts/tamil.json";
@@ -28,6 +30,8 @@ export const SCRIPTS: ScriptData[] = [
   hebrew as ScriptData,
   chinese as ScriptData,
   arabic as ScriptData,
+  persoArabic as ScriptData,
+  urduNastaliq as ScriptData,
   devanagari as ScriptData,
   gujarati as ScriptData,
   tamil as ScriptData,

--- a/code/programs/typescript/language-ladder/src/languagestore.ts
+++ b/code/programs/typescript/language-ladder/src/languagestore.ts
@@ -1,0 +1,47 @@
+// Persist the set of languages a learner wants to mix. Values are normalized
+// against the current registry, so removed tracks cannot poison saved state and
+// newly added tracks are available from the picker immediately.
+
+export const LANGUAGE_STORAGE_KEY = "language-ladder.languages.v1";
+
+export interface LanguageStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+export function normalizeLanguageSelection(
+  candidate: Iterable<string>,
+  available: readonly string[],
+): string[] {
+  const wanted = new Set(candidate);
+  const normalized = available.filter((id) => wanted.has(id));
+  return normalized.length > 0 ? normalized : [...available];
+}
+
+export function loadLanguages(
+  storage: LanguageStorage | null,
+  available: readonly string[],
+): string[] {
+  if (!storage) return [...available];
+  try {
+    const raw = storage.getItem(LANGUAGE_STORAGE_KEY);
+    if (!raw) return [...available];
+    const parsed: unknown = JSON.parse(raw);
+    return normalizeLanguageSelection(Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [], available);
+  } catch {
+    return [...available];
+  }
+}
+
+export function saveLanguages(
+  storage: LanguageStorage | null,
+  selection: Iterable<string>,
+  available: readonly string[],
+): string[] {
+  const normalized = normalizeLanguageSelection(selection, available);
+  try {
+    storage?.setItem(LANGUAGE_STORAGE_KEY, JSON.stringify(normalized));
+  } catch {
+    // Persistence is an enhancement; an unavailable store must not block study.
+  }
+  return normalized;
+}

--- a/code/programs/typescript/language-ladder/src/lessonbody.ts
+++ b/code/programs/typescript/language-ladder/src/lessonbody.ts
@@ -1,0 +1,51 @@
+// A deliberately small Markdown-to-view-model parser for authored lesson bodies.
+// We preserve the source in `Lesson.body`; this layer only extracts readable
+// sections for the DOM without injecting HTML.
+
+export interface LessonSection {
+  title: string;
+  blocks: string[];
+}
+function plainInline(markdown: string): string {
+  return markdown
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/[*_`]/g, "")
+    .replace(/^>\s?/, "")
+    .trim();
+}
+
+export function lessonSections(markdown: string): LessonSection[] {
+  const sections: LessonSection[] = [];
+  let current: LessonSection = { title: "Lesson", blocks: [] };
+  let paragraph: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    current.blocks.push(plainInline(paragraph.join(" ")));
+    paragraph = [];
+  };
+  const flushSection = () => {
+    flushParagraph();
+    if (current.blocks.length > 0) sections.push(current);
+  };
+
+  for (const raw of markdown.replace(/\r\n/g, "\n").split("\n")) {
+    const line = raw.trim();
+    if (/^#\s+/.test(line)) continue; // card already displays the lesson title
+    const heading = /^##\s+(.+)$/.exec(line);
+    if (heading) {
+      flushSection();
+      current = { title: plainInline(heading[1]!), blocks: [] };
+    } else if (line === "") {
+      flushParagraph();
+    } else if (/^[-*]\s+/.test(line)) {
+      flushParagraph();
+      current.blocks.push(`• ${plainInline(line.replace(/^[-*]\s+/, ""))}`);
+    } else {
+      paragraph.push(line);
+    }
+  }
+  flushSection();
+  return sections;
+}

--- a/code/programs/typescript/language-ladder/src/lessons.ts
+++ b/code/programs/typescript/language-ladder/src/lessons.ts
@@ -63,6 +63,10 @@ export interface Lesson {
   script: string;
   /** ≤120-char memory anchor; "" when not yet authored. */
   etymologyHook: string;
+  /** Lossless authored lesson Markdown, shared with the book corpus. */
+  body: string;
+  /** The author's upper bound for this micro-lesson. */
+  estMinutes: number;
 }
 
 /**
@@ -110,6 +114,8 @@ export function toLesson(parsed: ParsedLesson): Lesson | null {
     romanization: r.romanization,
     script: r.script,
     etymologyHook: r.etymologyHook,
+    body: parsed.body,
+    estMinutes: Number(typeof fm.est_minutes === "string" ? fm.est_minutes : 0),
   };
 }
 

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -55,11 +55,10 @@ import {
   scriptsById,
   firstIntroductionByScript,
   scriptIntroFor,
+  scriptOf,
   type ScriptIntro,
 } from "./scriptintro.ts";
 import {
-  sweepableConcepts,
-  activeChain,
   LANGUAGE_CHAIN,
   spineProgress,
 } from "./sequence.ts";
@@ -67,9 +66,12 @@ import type { SessionStep } from "./session.ts";
 import {
   crossLanguageConcepts,
   datasetFromLessons,
-  unlockedOrAll,
+  unlockedIndices,
   type ConceptCard,
 } from "./concepts.ts";
+import { LANGUAGE_REGISTRY, SPINE_CONCEPTS, languageName, spineNodeForConcept } from "./curriculum.ts";
+import { loadLanguages, saveLanguages } from "./languagestore.ts";
+import { lessonSections } from "./lessonbody.ts";
 import taxonomyJson from "../../../../learning/human-languages/concepts/taxonomy.json";
 import type { Taxonomy } from "@coding-adventures/human-language-data/src/types.ts";
 import {
@@ -78,7 +80,6 @@ import {
   fromSaved,
   loadProgress,
   saveProgress,
-  seenCount,
   toSaved,
 } from "./progress.ts";
 import "./styles.css";
@@ -98,13 +99,12 @@ let mode: Mode = "learn";
 // teaching sweep across the active chain, each stop carrying its connections
 // back to earlier languages that share a root.
 //
-// The whole chain is active: a concept simply appears in whichever of the ten
-// languages actually teach it (a sweep is "the languages that CAN show it").
-const ACTIVE_COUNT = LANGUAGE_CHAIN.length;
+// Languages are selected explicitly by the learner from the complete registry.
+// The authored registry order remains the stable order of every mixed sweep.
 // How far along the spine the learner has walked. Everything up to and including
 // this concept is "covered" (what the review quiz will later draw from); this
-// concept is the one currently being taught. The spine itself (CONCEPT_SPINE) is
-// built just below, once LESSONS is loaded.
+// concept is the one currently being taught. The spine is filtered from the
+// structured curriculum once lessons and the learner's language mix are known.
 let conceptCursor = 0;
 
 // --- lesson review state ----------------------------------------------------
@@ -116,6 +116,11 @@ let conceptCursor = 0;
 // written to localStorage (see progress.ts), so the app finally remembers you.
 const LESSONS = loadLessons();
 const LESSON_IDS = LESSONS.map((l) => l.id);
+const REVIEW_STORAGE = browserStorage();
+const AVAILABLE_LANGUAGE_IDS = LANGUAGE_CHAIN.filter((language) =>
+  LESSONS.some((lesson) => lesson.language === language),
+);
+let selectedLanguages = loadLanguages(REVIEW_STORAGE, AVAILABLE_LANGUAGE_IDS);
 // Consolidation lessons — chapter practice, mixed drills, dialogues, reviews —
 // are not atomic concepts: their headword is a placeholder ("(practice)"), they
 // carry no roots, and they exist to REVISIT earlier lessons (`reviews_of`).
@@ -124,10 +129,17 @@ const LESSON_IDS = LESSONS.map((l) => l.id);
 // grammar, one concept at a time, not land on "(practice)".
 const CONSOLIDATION_TYPES = new Set(["practice", "practice-mix", "review"]);
 const CONCEPT_LESSONS = LESSONS.filter((l) => !CONSOLIDATION_TYPES.has(l.type));
-// The book-ordered concept spine the Learn session walks — the concepts taught
-// by any active language, in the order the book first introduces them. Constant
-// for the page's lifetime (the curriculum does not change while it is open).
-const CONCEPT_SPINE = sweepableConcepts(CONCEPT_LESSONS, activeChain(ACTIVE_COUNT));
+// The explicit shared spine, filtered to concepts represented in the selected
+// languages. Language-local extensions remain available in Lessons mode.
+function activeConceptSpine(): string[] {
+  const selected = new Set(selectedLanguages);
+  const realized = new Set(
+    CONCEPT_LESSONS
+      .filter((lesson) => selected.has(lesson.language))
+      .map((lesson) => lesson.concept),
+  );
+  return SPINE_CONCEPTS.filter((concept) => realized.has(concept));
+}
 
 // Script introductions (phase 7). Index the script data by id, then precompute
 // which concept is the FIRST (in book order) to teach each non-Latin script we
@@ -135,7 +147,7 @@ const CONCEPT_SPINE = sweepableConcepts(CONCEPT_LESSONS, activeChain(ACTIVE_COUN
 // are constant for the page's lifetime and grounded in the real scripts JSON.
 const SCRIPTS_BY_ID = scriptsById(SCRIPTS);
 const SCRIPT_INTRO_AT = firstIntroductionByScript(
-  CONCEPT_SPINE,
+  SPINE_CONCEPTS,
   CONCEPT_LESSONS,
   new Set(SCRIPTS_BY_ID.keys()),
 );
@@ -162,7 +174,6 @@ const LESSON_BY_ID = new Map(LESSONS.map((l) => [l.id, l]));
 // Restore the review's SRS state + answer log from localStorage so the quiz
 // remembers you between visits (reusing the same storage port progress.ts owns).
 // A missing, corrupt, or wrong-version blob restores as empty — never throws.
-const REVIEW_STORAGE = browserStorage();
 const restoredReview = loadReview(REVIEW_STORAGE);
 let reviewProgress: Progress = restoredReview.progress;
 let reviewSession = restoredReview.session; // advances once per answered question — the SRS clock
@@ -173,7 +184,7 @@ let reviewChosen: string | null = null; // cellKey of the picked option; null = 
 // Resume the teaching walk where it was left off: restore the concept cursor
 // from storage, clamped to the current spine (the curriculum may have grown or
 // shrunk since the save). A missing/corrupt value starts at 0.
-conceptCursor = loadCursor(REVIEW_STORAGE, CONCEPT_SPINE.length);
+conceptCursor = loadCursor(REVIEW_STORAGE, activeConceptSpine().length);
 
 // "Reset progress" is a two-click confirm: the first click ARMS it (so a stray
 // tap can't wipe everything), the second executes. This flag is that arming.
@@ -267,7 +278,7 @@ function syllabaryGate(): SyllabaryGate | null {
 
 const SUBTITLES: Record<Mode, string> = {
   learn:
-    "Walk the curriculum the way the book does — one concept at a time, across every language that teaches it, with the threads back to what you already know.",
+    "Walk the shared spine one concept at a time, across the languages you choose, with the threads back to what you already know.",
   browse:
     "Pick a script and a letter to see its pieces and stroke order — for pen-and-paper practice.",
   practice:
@@ -771,7 +782,12 @@ function pickLesson(): void {
   //
   // Recomputed per pick because `seen` grows as you study; it is a single pass
   // over ~700 lessons, dwarfed by the render that follows.
-  const open = new Set(unlockedOrAll(LESSONS, seenLessonIds()));
+  const selected = new Set(selectedLanguages);
+  const open = new Set(
+    unlockedIndices(LESSONS, seenLessonIds()).filter((index) =>
+      selected.has(LESSONS[index]!.language),
+    ),
+  );
 
   // The scan itself is a pure function in lessons.ts (and tested there); this
   // only threads the cursor. LESSON_GROUPS / LESSON_POOL are computed once —
@@ -846,6 +862,69 @@ function firstGloss(teaching: SessionStep[]): string {
   return teaching[0]?.lessons[0]?.gloss ?? "";
 }
 
+/** The complete registry-backed language mixer shared by Learn and practice views. */
+function renderLanguagePicker(): HTMLElement {
+  const details = el("details", "language-picker") as HTMLDetailsElement;
+  const summary = el("summary", "language-picker__summary");
+  summary.textContent = `Languages · ${selectedLanguages.length} of ${AVAILABLE_LANGUAGE_IDS.length} selected`;
+  details.appendChild(summary);
+
+  const note = el("p", "muted language-picker__note");
+  note.textContent = "Choose any mix. The shared spine stays in the same order; each language contributes its own realization and extensions.";
+  details.appendChild(note);
+
+  const grid = el("div", "language-picker__grid");
+  const selected = new Set(selectedLanguages);
+  for (const definition of LANGUAGE_REGISTRY.filter((language) =>
+    AVAILABLE_LANGUAGE_IDS.includes(language.id),
+  )) {
+    const label = el("label", "language-picker__item");
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.value = definition.id;
+    input.checked = selected.has(definition.id);
+    input.onchange = () => {
+      const next = new Set(selectedLanguages);
+      if (input.checked) next.add(definition.id);
+      else next.delete(definition.id);
+      selectedLanguages = saveLanguages(REVIEW_STORAGE, next, AVAILABLE_LANGUAGE_IDS);
+      conceptCursor = Math.max(0, Math.min(conceptCursor, activeConceptSpine().length - 1));
+      reviewCell = null;
+      lessonIndex = null;
+      pickLesson();
+      render();
+    };
+    const text = el("span", "");
+    text.textContent = `${definition.name} · ${definition.script}`;
+    label.append(input, text);
+    grid.appendChild(label);
+  }
+  details.appendChild(grid);
+  return details;
+}
+
+/** Render the authored Markdown as text-only sections; no unsafe HTML path. */
+function renderLessonBody(lesson: (typeof LESSONS)[number], initiallyOpen = false): HTMLElement {
+  const details = el("details", "lesson-body") as HTMLDetailsElement;
+  details.open = initiallyOpen;
+  const summary = el("summary", "lesson-body__summary");
+  summary.textContent = `Open ${lesson.estMinutes || 5}-minute lesson`;
+  details.appendChild(summary);
+  for (const sectionData of lessonSections(lesson.body)) {
+    const sectionEl = el("section", "lesson-body__section");
+    const heading = el("h4", "lesson-body__heading");
+    heading.textContent = sectionData.title;
+    sectionEl.appendChild(heading);
+    for (const block of sectionData.blocks) {
+      const p = el("p", block.startsWith("• ") ? "lesson-body__bullet" : "");
+      p.textContent = block;
+      sectionEl.appendChild(p);
+    }
+    details.appendChild(sectionEl);
+  }
+  return details;
+}
+
 /** One stop of the sweep: a language, its word(s) for the concept, its threads back. */
 function renderTeachingStep(
   step: SessionStep,
@@ -853,12 +932,13 @@ function renderTeachingStep(
   intro: ScriptIntro | null,
 ): HTMLElement {
   const card = el("div", "step");
+  card.dataset.language = step.language;
 
   const head = el("div", "step__head");
   const num = el("span", "step__num");
   num.textContent = String(ordinal + 1);
   const lang = el("span", "step__lang");
-  lang.textContent = step.language;
+  lang.textContent = languageName(step.language);
   head.append(num, lang);
   if (ordinal === 0) {
     // The first stop has no connections — it is where the concept enters.
@@ -889,6 +969,7 @@ function renderTeachingStep(
     const row = el("div", "step__word");
     const glyph = el("span", "step__glyph");
     glyph.textContent = lesson.headword; // in its own script
+    glyph.dir = SCRIPTS_BY_ID.get(lesson.script)?.direction ?? "auto";
     row.appendChild(glyph);
 
     const meta = el("div", "step__meta");
@@ -909,6 +990,7 @@ function renderTeachingStep(
       hook.textContent = lesson.etymologyHook;
       card.appendChild(hook);
     }
+    if (lesson.body.trim() !== "") card.appendChild(renderLessonBody(lesson));
   }
 
   // The threads back to earlier languages — the spiral, made literal. Each is a
@@ -928,8 +1010,8 @@ function renderTeachingStep(
  * (the covered set changed), persists so the app resumes here, and re-renders.
  * A no-op if the target is where we already are.
  */
-function jumpToConcept(index: number): void {
-  const target = Math.max(0, Math.min(index, CONCEPT_SPINE.length - 1));
+function jumpToConcept(index: number, spine = activeConceptSpine()): void {
+  const target = Math.max(0, Math.min(index, spine.length - 1));
   if (target === conceptCursor) return;
   conceptCursor = target;
   reviewCell = null;
@@ -937,7 +1019,7 @@ function jumpToConcept(index: number): void {
   render();
 }
 
-function renderLearnNav(): HTMLElement {
+function renderLearnNav(spine: readonly string[]): HTMLElement {
   const nav = el("div", "learn__nav");
 
   const prev = el("button", "opt") as HTMLButtonElement;
@@ -949,19 +1031,19 @@ function renderLearnNav(): HTMLElement {
   // A native <select> gives free keyboard type-ahead over the book-ordered list.
   const jump = el("select", "learn__jump") as HTMLSelectElement;
   jump.title = "Jump to concept";
-  CONCEPT_SPINE.forEach((concept, i) => {
+  spine.forEach((concept, i) => {
     const opt = el("option", "") as HTMLOptionElement;
     opt.value = String(i);
     opt.textContent = `${i + 1}. ${conceptTitle(concept)}`;
     if (i === conceptCursor) opt.selected = true;
     jump.appendChild(opt);
   });
-  jump.onchange = () => jumpToConcept(Number(jump.value));
+  jump.onchange = () => jumpToConcept(Number(jump.value), spine);
 
   const next = el("button", "opt") as HTMLButtonElement;
   next.textContent = "Next →";
-  next.disabled = conceptCursor >= CONCEPT_SPINE.length - 1;
-  next.onclick = () => jumpToConcept(conceptCursor + 1);
+  next.disabled = conceptCursor >= spine.length - 1;
+  next.onclick = () => jumpToConcept(conceptCursor + 1, spine);
 
   nav.append(prev, jump, next);
   return nav;
@@ -969,8 +1051,10 @@ function renderLearnNav(): HTMLElement {
 
 function renderLearn(): HTMLElement {
   const wrap = el("div", "learn");
+  wrap.appendChild(renderLanguagePicker());
+  const conceptSpine = activeConceptSpine();
 
-  if (CONCEPT_SPINE.length === 0) {
+  if (conceptSpine.length === 0) {
     const empty = el("p", "muted");
     empty.textContent = "No concepts to walk yet.";
     wrap.appendChild(empty);
@@ -979,18 +1063,18 @@ function renderLearn(): HTMLElement {
 
   // The cursor only moves via the nav buttons, but clamp defensively so a stray
   // value can never index off the end of the spine.
-  conceptCursor = Math.max(0, Math.min(conceptCursor, CONCEPT_SPINE.length - 1));
+  conceptCursor = Math.max(0, Math.min(conceptCursor, conceptSpine.length - 1));
 
-  const concept = CONCEPT_SPINE[conceptCursor]!;
+  const concept = conceptSpine[conceptCursor]!;
   // Everything up to and including the current concept is "covered" — the review
   // quiz (a later slice) draws from exactly this. Here we render the teaching
   // pass: the current concept alone, swept across the chain.
-  const covered = CONCEPT_SPINE.slice(0, conceptCursor + 1);
-  const plan = planSession(concept, covered, CONCEPT_LESSONS, ACTIVE_COUNT);
+  const covered = conceptSpine.slice(0, conceptCursor + 1);
+  const plan = planSession(concept, covered, CONCEPT_LESSONS, selectedLanguages);
 
   const progress = el("p", "score");
   progress.textContent =
-    `Concept ${conceptCursor + 1} of ${CONCEPT_SPINE.length}` +
+    `Concept ${conceptCursor + 1} of ${conceptSpine.length}` +
     ` · taught in ${plan.teaching.length} language${plan.teaching.length === 1 ? "" : "s"}`;
   wrap.appendChild(progress);
 
@@ -998,7 +1082,7 @@ function renderLearn(): HTMLElement {
   // journey that the bare "N of M" count doesn't convey at a glance.
   const track = el("div", "progress");
   const fill = el("div", "progress__fill");
-  const pct = spineProgress(conceptCursor, CONCEPT_SPINE.length) * 100;
+  const pct = spineProgress(conceptCursor, conceptSpine.length) * 100;
   fill.style.width = `${pct}%`;
   track.appendChild(fill);
   wrap.appendChild(track);
@@ -1006,6 +1090,12 @@ function renderLearn(): HTMLElement {
   const heading = el("h2", "learn__concept");
   heading.textContent = conceptTitle(concept);
   wrap.appendChild(heading);
+  const node = spineNodeForConcept(concept);
+  if (node) {
+    const canDo = el("p", "learn__can-do");
+    canDo.textContent = `${node.stage} · ${node.canDo}`;
+    wrap.appendChild(canDo);
+  }
   const gloss = firstGloss(plan.teaching);
   if (gloss) {
     const g = el("p", "muted learn__gloss");
@@ -1020,13 +1110,18 @@ function renderLearn(): HTMLElement {
   } else {
     const sweep = el("div", "sweep");
     plan.teaching.forEach((step, i) => {
-      const intro = scriptIntroFor(concept, step.language, SCRIPT_INTRO_AT, SCRIPTS_BY_ID);
+      const scriptAlreadyIntroduced = plan.teaching
+        .slice(0, i)
+        .some((earlier) => scriptOf(earlier.language) === scriptOf(step.language));
+      const intro = scriptAlreadyIntroduced
+        ? null
+        : scriptIntroFor(concept, step.language, SCRIPT_INTRO_AT, SCRIPTS_BY_ID);
       sweep.appendChild(renderTeachingStep(step, i, intro));
     });
     wrap.appendChild(sweep);
   }
 
-  wrap.appendChild(renderLearnNav());
+  wrap.appendChild(renderLearnNav(conceptSpine));
 
   // The review pass: a cumulative, SRS-weighted quiz over everything covered so
   // far (this concept and all before it). `plan.reviewGrid` is exactly that grid.
@@ -1047,6 +1142,7 @@ function executeReset(): void {
   reviewOptions = [];
   reviewChosen = null;
   conceptCursor = 0;
+  selectedLanguages = [...AVAILABLE_LANGUAGE_IDS];
   // The Lessons-mode schedule is one of the cleared keys, so its in-memory state
   // must be zeroed too — otherwise Lessons still shows the old stats and the next
   // grade would `persistLessons()` the stale schedule straight back into the key
@@ -1289,14 +1385,21 @@ function renderReview(grid: GridCell[]): HTMLElement {
  */
 function renderConcepts(): HTMLElement {
   const wrap = el("div", "practice");
+  wrap.appendChild(renderLanguagePicker());
+  const selected = new Set(selectedLanguages);
+  const cards = CONCEPT_CARDS.map((card) => ({
+    ...card,
+    realizations: card.realizations.filter((realization) => selected.has(realization.language)),
+  })).filter((card) => new Set(card.realizations.map((realization) => realization.language)).size >= 2);
+  const selectedLessonCount = LESSONS.filter((lesson) => selected.has(lesson.language)).length;
 
   const stats = el("p", "score");
   stats.textContent =
-    `${CONCEPT_CARDS.length} concepts shared by two or more languages` +
-    ` · from ${LESSONS.length} lessons`;
+    `${cards.length} concepts shared by two or more selected languages` +
+    ` · from ${selectedLessonCount} lessons`;
   wrap.appendChild(stats);
 
-  if (CONCEPT_CARDS.length === 0) {
+  if (cards.length === 0) {
     const empty = el("p", "muted");
     empty.textContent = "No concept is taught in more than one language yet.";
     wrap.appendChild(empty);
@@ -1304,7 +1407,7 @@ function renderConcepts(): HTMLElement {
   }
 
   const list = el("div", "concept-list");
-  for (const card of CONCEPT_CARDS) {
+  for (const card of cards) {
     const item = el("div", "concept");
 
     const langs = new Set(card.realizations.map((r) => r.language));
@@ -1333,7 +1436,7 @@ function renderConcepts(): HTMLElement {
         const row = el("div", "concept__row");
 
         const lang = el("span", "concept__lang");
-        lang.textContent = r.language;
+        lang.textContent = languageName(r.language);
         row.appendChild(lang);
 
         const word = el("span", "concept__word");
@@ -1378,13 +1481,19 @@ function renderConcepts(): HTMLElement {
 
 function renderLessons(): HTMLElement {
   const wrap = el("div", "practice");
+  wrap.appendChild(renderLanguagePicker());
+  const selected = new Set(selectedLanguages);
+  const selectedIndices = LESSONS.map((lesson, index) => ({ lesson, index }))
+    .filter(({ lesson }) => selected.has(lesson.language))
+    .map(({ index }) => index);
+  const selectedStates = selectedIndices.map((index) => lessonSchedule[index]!);
 
-  const due = lessonSchedule.filter((s) => s.dueAtSession <= lessonSession).length;
-  const seen = seenCount(LESSON_IDS, savedProgress);
+  const due = selectedStates.filter((s) => s.dueAtSession <= lessonSession).length;
+  const seen = selectedStates.filter((s) => s.reps > 0 || s.lapses > 0 || s.box > 0).length;
   const stats = el("p", "score");
   stats.textContent =
-    `${LESSONS.length} lessons · ${due} due · ` +
-    `${seen} started · mastered ${masteredCount(lessonSchedule)}`;
+    `${selectedIndices.length} lessons · ${due} due · ` +
+    `${seen} started · mastered ${masteredCount(selectedStates)}`;
   wrap.appendChild(stats);
 
   if (lessonIndex === null) {
@@ -1396,13 +1505,14 @@ function renderLessons(): HTMLElement {
 
   const lesson = LESSONS[lessonIndex]!;
   const meta = el("p", "muted");
-  meta.textContent = `${lesson.language} · chapter ${lesson.chapter} · ${lesson.id}`;
+  meta.textContent = `${languageName(lesson.language)} · chapter ${lesson.chapter} · ${lesson.id}`;
   wrap.appendChild(meta);
 
   // Prompt: the headword, in its own script. Answer hidden until asked for —
   // recall, not recognition.
   const prompt = el("p", "prompt-glyph");
   prompt.textContent = lesson.headword;
+  prompt.dir = SCRIPTS_BY_ID.get(lesson.script)?.direction ?? "auto";
   wrap.appendChild(prompt);
 
   if (!lessonRevealed) {
@@ -1419,6 +1529,7 @@ function renderLessons(): HTMLElement {
   const gloss = el("p", "");
   gloss.textContent = lesson.gloss;
   wrap.appendChild(gloss);
+  if (lesson.body.trim() !== "") wrap.appendChild(renderLessonBody(lesson, true));
 
   const buttons = el("div", "opts");
   ([["Again", false], ["Got it", true]] as [string, boolean][]).forEach(

--- a/code/programs/typescript/language-ladder/src/quiz.ts
+++ b/code/programs/typescript/language-ladder/src/quiz.ts
@@ -23,7 +23,7 @@
 // ---------------------------------------------------------------------------
 
 import type { Lesson } from "./lessons";
-import { activeChain, teachingSweep, type ChainLanguage } from "./sequence";
+import { resolveActiveLanguages, teachingSweep, type ChainLanguage, type LanguageSelection } from "./sequence";
 
 /**
  * One quizzable item: a concept, the language it is asked in, and the lesson
@@ -48,9 +48,9 @@ export interface GridCell {
 export function coveredGrid(
   covered: Iterable<string>,
   lessons: Lesson[],
-  activeCount: number,
+  activeSelection: LanguageSelection,
 ): GridCell[] {
-  const active = activeChain(activeCount);
+  const active = resolveActiveLanguages(activeSelection);
   const concepts = [...new Set(covered)].filter((c) => c !== "").sort();
 
   const grid: GridCell[] = [];

--- a/code/programs/typescript/language-ladder/src/reset.ts
+++ b/code/programs/typescript/language-ladder/src/reset.ts
@@ -17,6 +17,7 @@
 import { STORAGE_KEY as LESSON_SCHEDULE_KEY } from "./progress.ts";
 import { REVIEW_STORAGE_KEY } from "./reviewstore.ts";
 import { CURSOR_STORAGE_KEY } from "./cursorstore.ts";
+import { LANGUAGE_STORAGE_KEY } from "./languagestore.ts";
 
 /**
  * Every localStorage key this app owns. Sourced from the owning modules'
@@ -27,6 +28,7 @@ export const OWNED_STORAGE_KEYS: readonly string[] = [
   REVIEW_STORAGE_KEY,
   CURSOR_STORAGE_KEY,
   LESSON_SCHEDULE_KEY,
+  LANGUAGE_STORAGE_KEY,
 ];
 
 /** The slice of the Storage API a reset needs — just removal. Easy to fake. */

--- a/code/programs/typescript/language-ladder/src/scriptintro.ts
+++ b/code/programs/typescript/language-ladder/src/scriptintro.ts
@@ -18,33 +18,21 @@
 // stop?" is unit-testable without a browser.
 // ---------------------------------------------------------------------------
 
-import type { ChainLanguage } from "./sequence.ts";
 import type { ScriptData } from "./types.ts";
+import { LANGUAGE_REGISTRY } from "./curriculum.ts";
 
 /**
- * Which writing system each chain language uses. The four Latin-script languages
- * map to "latin" — the base the learner already reads, so it is never
- * "introduced". The Dravidian trio (kannada/telugu/malayalam) map to their own
- * scripts even though we may not yet have `signature` data for them: the mapping
- * is the truth about the language; whether a NOTE shows is gated separately on
- * having data, so we never fabricate one.
+ * Which writing system each registered language uses. This is derived from the
+ * same registry as the language picker, so new tracks cannot silently fall back
+ * to Latin in script introductions.
  */
-export const LANGUAGE_SCRIPT: Record<ChainLanguage, string> = {
-  spanish: "latin",
-  latin: "latin",
-  french: "latin",
-  german: "latin",
-  arabic: "arabic",
-  hindi: "devanagari",
-  tamil: "tamil",
-  kannada: "kannada",
-  telugu: "telugu",
-  malayalam: "malayalam",
-};
+export const LANGUAGE_SCRIPT: Record<string, string> = Object.fromEntries(
+  LANGUAGE_REGISTRY.map((language) => [language.id, language.script]),
+);
 
 /** The script id a language is written in; "latin" for anything off the chain. */
 export function scriptOf(language: string): string {
-  return LANGUAGE_SCRIPT[language as ChainLanguage] ?? "latin";
+  return LANGUAGE_SCRIPT[language] ?? "latin";
 }
 
 /** Index script data by its `script` id for O(1) lookup. */

--- a/code/programs/typescript/language-ladder/src/sequence.ts
+++ b/code/programs/typescript/language-ladder/src/sequence.ts
@@ -2,12 +2,9 @@
 // sequence.ts — the language CHAIN and the per-concept TEACHING SWEEP (HL03)
 // ---------------------------------------------------------------------------
 //
-// The unified app (HL03) teaches along a fixed CHAIN of languages, each hop
-// chosen because a bridge already exists to a language learned earlier:
-//
-//   Spanish → Latin (the roots beneath Spanish) → French → German (the English
-//   twins) → Arabic → Hindi (where Arabic, Persian and Sanskrit meet) → Tamil
-//   (first Dravidian) → Kannada (Tamil's cousin, + Sanskrit) → Telugu → Malayalam
+// The unified app (HL03/HL04) teaches along a registry-authored order containing
+// every active track. A learner may select any subset; registry order keeps
+// sweeps and comparisons stable while the subset changes.
 //
 // Learning moves CONCEPT BY CONCEPT. To learn a concept is to walk it across
 // every language the learner has added so far — the "active" prefix of the
@@ -23,26 +20,15 @@
 // ---------------------------------------------------------------------------
 
 import type { Lesson } from "./lessons";
+import { LANGUAGE_ORDER } from "./curriculum";
 
 /**
- * The chain, in the order languages are added. These are track directory names
- * under `code/learning/human-languages/`. The order is not arbitrary — it is a
- * connected path where each language reaches back to one already known.
+ * Every active language, in the default order authored in core/languages.json.
  */
-export const LANGUAGE_CHAIN = [
-  "spanish",
-  "latin",
-  "french",
-  "german",
-  "arabic",
-  "hindi",
-  "tamil",
-  "kannada",
-  "telugu",
-  "malayalam",
-] as const;
+export const LANGUAGE_CHAIN: readonly string[] = LANGUAGE_ORDER;
 
-export type ChainLanguage = (typeof LANGUAGE_CHAIN)[number];
+export type ChainLanguage = string;
+export type LanguageSelection = number | readonly string[];
 
 /** Position of a language in the chain, or -1 if it is not on the chain. */
 export function chainIndex(language: string): number {
@@ -62,6 +48,13 @@ export function isChainLanguage(language: string): language is ChainLanguage {
 export function activeChain(count: number): ChainLanguage[] {
   const n = Math.max(0, Math.min(Math.floor(count), LANGUAGE_CHAIN.length));
   return LANGUAGE_CHAIN.slice(0, n);
+}
+
+/** Resolve either the legacy prefix count or an explicit learner-selected mix. */
+export function resolveActiveLanguages(active: LanguageSelection): ChainLanguage[] {
+  if (typeof active === "number") return activeChain(active);
+  const selected = new Set(active);
+  return LANGUAGE_CHAIN.filter((language) => selected.has(language));
 }
 
 /** One stop on a sweep: a language, and the lesson(s) there that teach the concept. */

--- a/code/programs/typescript/language-ladder/src/session.ts
+++ b/code/programs/typescript/language-ladder/src/session.ts
@@ -26,7 +26,7 @@
 // ---------------------------------------------------------------------------
 
 import type { Lesson } from "./lessons";
-import { activeChain, teachingSweep, type ChainLanguage, type SweepStop } from "./sequence";
+import { resolveActiveLanguages, teachingSweep, type ChainLanguage, type LanguageSelection, type SweepStop } from "./sequence";
 
 /**
  * A link from one stop in the sweep back to an EARLIER one, justified by the
@@ -68,9 +68,9 @@ function rootsOfStop(stop: SweepStop): Set<string> {
 export function buildSession(
   concept: string,
   lessons: Lesson[],
-  activeCount: number,
+  active: LanguageSelection,
 ): SessionStep[] {
-  const sweep = teachingSweep(concept, lessons, activeChain(activeCount));
+  const sweep = teachingSweep(concept, lessons, resolveActiveLanguages(active));
 
   const steps: SessionStep[] = [];
   const seen: Array<{ language: ChainLanguage; roots: Set<string> }> = [];

--- a/code/programs/typescript/language-ladder/src/sessionplan.ts
+++ b/code/programs/typescript/language-ladder/src/sessionplan.ts
@@ -25,6 +25,7 @@ import { buildSession, type SessionStep } from "./session";
 import { coveredGrid, cellKey, type GridCell, type QuizState } from "./quiz";
 import { recordAnswer, demote, type AnswerRecord } from "./mistakes";
 import { intervalFor, MAX_BOX } from "./scheduler";
+import type { LanguageSelection } from "./sequence";
 
 /** Everything the UI needs to run one session, assembled from the engine. */
 export interface SessionPlan {
@@ -45,12 +46,12 @@ export function planSession(
   current: string,
   covered: Iterable<string>,
   lessons: Lesson[],
-  activeCount: number,
+  active: LanguageSelection,
 ): SessionPlan {
   return {
     concept: current,
-    teaching: buildSession(current, lessons, activeCount),
-    reviewGrid: coveredGrid(covered, lessons, activeCount),
+    teaching: buildSession(current, lessons, active),
+    reviewGrid: coveredGrid(covered, lessons, active),
   };
 }
 

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -1,3 +1,9 @@
+@font-face {
+  font-family: "Curriculum Naskh";
+  src: url("../../../../learning/human-languages/_fonts/NotoNaskhArabic-Static.ttf") format("truetype");
+  font-display: swap;
+}
+
 :root {
   --bg: #faf9f7;
   --card: #ffffff;
@@ -281,6 +287,46 @@ body {
   text-transform: capitalize;
 }
 .learn__gloss { margin: 0 0 18px; font-size: 1rem; font-style: normal; }
+.learn__can-do {
+  margin: 0 0 18px;
+  padding: 9px 12px;
+  border-left: 3px solid var(--accent);
+  background: #eef1fd;
+  color: var(--ink);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+/* Registry-backed cross-language mixer. */
+.language-picker {
+  margin: 0 0 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--card);
+}
+.language-picker__summary {
+  padding: 10px 13px;
+  cursor: pointer;
+  font-weight: 650;
+}
+.language-picker__note { margin: 0; padding: 0 13px 10px; line-height: 1.45; }
+.language-picker__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 7px;
+  padding: 0 13px 13px;
+}
+.language-picker__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: var(--bg);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.language-picker__item input { accent-color: var(--accent); }
 
 /* The sweep: one card per language stop, read top-to-bottom in chain order. */
 .sweep { display: flex; flex-direction: column; gap: 12px; }
@@ -322,10 +368,22 @@ body {
 }
 .step__word { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
 .step__glyph { font-size: 1.9rem; line-height: 1.2; }
+.step[data-language="persian"] .step__glyph,
+.step[data-language="urdu"] .step__glyph { font-family: "Curriculum Naskh", serif; }
 .step__meta { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
 .step__rom { color: var(--muted); font-style: italic; font-size: 0.95rem; }
 .step__gloss { font-size: 0.95rem; }
 .step__hook { margin: 8px 0 0; font-size: 0.85rem; line-height: 1.5; color: var(--muted); }
+.lesson-body {
+  margin-top: 10px;
+  border-top: 1px solid var(--line);
+  padding-top: 8px;
+}
+.lesson-body__summary { color: var(--accent); cursor: pointer; font-size: 0.85rem; font-weight: 650; }
+.lesson-body__section { margin-top: 12px; }
+.lesson-body__heading { margin: 0 0 5px; font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.035em; color: var(--muted); }
+.lesson-body__section p { margin: 5px 0; font-size: 0.9rem; line-height: 1.58; }
+.lesson-body__bullet { padding-left: 10px; }
 /* The threads back to earlier languages — the reason the whole app exists. */
 .step__conn {
   margin: 8px 0 0;

--- a/code/programs/typescript/language-ladder/tests/concepts.test.ts
+++ b/code/programs/typescript/language-ladder/tests/concepts.test.ts
@@ -36,6 +36,8 @@ function lesson(over: Partial<Lesson> & { id: string }): Lesson {
     romanization: "",
     script: "latin",
     etymologyHook: "",
+    body: "",
+    estMinutes: 5,
     ...over,
   };
 }
@@ -58,10 +60,9 @@ describe("prerequisite gating", () => {
     expect(isUnlocked(l, new Set(["A", "B"]), known(["A", "B", "C"]))).toBe(true);
   });
 
-  // The important one: a curriculum typo must not make a lesson unreachable.
-  it("treats an UNKNOWN prerequisite as satisfied, not as a permanent lock", () => {
+  it("fails closed for an unknown prerequisite", () => {
     const l = lesson({ id: "D", prerequisites: ["ES-C99-typo"] });
-    expect(isUnlocked(l, new Set(), known(["D"]))).toBe(true);
+    expect(isUnlocked(l, new Set(), known(["D"]))).toBe(false);
   });
 
   it("returns the indices of teachable lessons only", () => {
@@ -83,14 +84,13 @@ describe("prerequisite gating", () => {
     expect(unlockedIndices(lessons, new Set())).toEqual([0]);
   });
 
-  it("fails OPEN rather than stalling when everything is locked", () => {
-    // A cycle locks both lessons; practice must not simply stop.
+  it("fails closed when a cycle locks everything", () => {
     const lessons = [
       lesson({ id: "A", prerequisites: ["B"] }),
       lesson({ id: "B", prerequisites: ["A"] }),
     ];
     expect(unlockedIndices(lessons, new Set())).toEqual([]);
-    expect(unlockedOrAll(lessons, new Set())).toEqual([0, 1]);
+    expect(unlockedOrAll(lessons, new Set())).toEqual([]);
   });
 
   it("prefers the gated pool when one exists", () => {

--- a/code/programs/typescript/language-ladder/tests/languagestore.test.ts
+++ b/code/programs/typescript/language-ladder/tests/languagestore.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { LANGUAGE_STORAGE_KEY, loadLanguages, normalizeLanguageSelection, saveLanguages } from "../src/languagestore.ts";
+
+class MemoryStorage {
+  value: string | null = null;
+  getItem(key: string): string | null { return key === LANGUAGE_STORAGE_KEY ? this.value : null; }
+  setItem(key: string, value: string): void { if (key === LANGUAGE_STORAGE_KEY) this.value = value; }
+}
+
+describe("language selection", () => {
+  const available = ["spanish", "persian", "urdu"];
+
+  it("keeps registry order, removes unknowns and duplicates", () => {
+    expect(normalizeLanguageSelection(["urdu", "unknown", "urdu", "spanish"], available))
+      .toEqual(["spanish", "urdu"]);
+  });
+
+  it("never leaves the learner with an empty mix", () => {
+    expect(normalizeLanguageSelection([], available)).toEqual(available);
+  });
+
+  it("round-trips through storage", () => {
+    const storage = new MemoryStorage();
+    expect(saveLanguages(storage, ["persian", "urdu"], available)).toEqual(["persian", "urdu"]);
+    expect(loadLanguages(storage, available)).toEqual(["persian", "urdu"]);
+  });
+});

--- a/code/programs/typescript/language-ladder/tests/lessonbody.test.ts
+++ b/code/programs/typescript/language-ladder/tests/lessonbody.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { lessonSections } from "../src/lessonbody.ts";
+
+describe("lessonSections", () => {
+  it("turns authored Markdown into safe readable sections", () => {
+    expect(lessonSections(`# Title\n\n## Notice\nRead **سلام**.\n\n- Say [salâm](https://example.test).`)).toEqual([
+      { title: "Notice", blocks: ["Read سلام.", "• Say salâm."] },
+    ]);
+  });
+});

--- a/code/programs/typescript/language-ladder/tests/lessons.test.ts
+++ b/code/programs/typescript/language-ladder/tests/lessons.test.ts
@@ -73,6 +73,7 @@ describe("toLesson", () => {
     expect(lesson!.chapter).toBe(17);
     expect(lesson!.prerequisites).toEqual(["ES-C16-practice"]);
     expect(lesson!.reviewsOf).toEqual(["ES-C16-practice", "ES-C06-hablar"]);
+    expect(lesson!.body).toContain("# body");
   });
 
   it("skips a lesson with no id rather than inventing one", () => {
@@ -136,6 +137,8 @@ export function lesson(over: Partial<Lesson> & { id: string }): Lesson {
     romanization: "",
     script: "latin",
     etymologyHook: "",
+    body: "",
+    estMinutes: 5,
     ...over,
   };
 }

--- a/code/programs/typescript/language-ladder/tests/quiz.test.ts
+++ b/code/programs/typescript/language-ladder/tests/quiz.test.ts
@@ -18,6 +18,8 @@ function L(language: string, concept: string, id: string, chapter = 1): Lesson {
     romanization: "x",
     script: language,
     etymologyHook: "",
+    body: "",
+    estMinutes: 5,
   };
 }
 

--- a/code/programs/typescript/language-ladder/tests/reset.test.ts
+++ b/code/programs/typescript/language-ladder/tests/reset.test.ts
@@ -7,6 +7,7 @@ import {
 import { REVIEW_STORAGE_KEY } from "../src/reviewstore";
 import { CURSOR_STORAGE_KEY } from "../src/cursorstore";
 import { STORAGE_KEY as LESSON_SCHEDULE_KEY } from "../src/progress";
+import { LANGUAGE_STORAGE_KEY } from "../src/languagestore";
 
 function fakeStore(seed: Record<string, string> = {}): RemovableStorage & {
   data: Map<string, string>;
@@ -16,11 +17,11 @@ function fakeStore(seed: Record<string, string> = {}): RemovableStorage & {
 }
 
 describe("OWNED_STORAGE_KEYS", () => {
-  it("lists exactly the three keys the app persists, sourced from their owners", () => {
+  it("lists exactly the four keys the app persists, sourced from their owners", () => {
     // If a persisted key were forgotten here, a reset would silently leave state
     // behind — so pin the set explicitly.
     expect(new Set(OWNED_STORAGE_KEYS)).toEqual(
-      new Set([REVIEW_STORAGE_KEY, CURSOR_STORAGE_KEY, LESSON_SCHEDULE_KEY]),
+      new Set([REVIEW_STORAGE_KEY, CURSOR_STORAGE_KEY, LESSON_SCHEDULE_KEY, LANGUAGE_STORAGE_KEY]),
     );
   });
 });
@@ -31,6 +32,7 @@ describe("clearProgress", () => {
       [REVIEW_STORAGE_KEY]: "r",
       [CURSOR_STORAGE_KEY]: "c",
       [LESSON_SCHEDULE_KEY]: "l",
+      [LANGUAGE_STORAGE_KEY]: "g",
     });
     clearProgress(store);
     expect(store.data.size).toBe(0);

--- a/code/programs/typescript/language-ladder/tests/scriptintro.test.ts
+++ b/code/programs/typescript/language-ladder/tests/scriptintro.test.ts
@@ -27,6 +27,8 @@ describe("scriptOf / LANGUAGE_SCRIPT", () => {
     expect(scriptOf("tamil")).toBe("tamil");
     expect(scriptOf("spanish")).toBe("latin");
     expect(scriptOf("german")).toBe("latin");
+    expect(scriptOf("persian")).toBe("perso-arabic");
+    expect(scriptOf("urdu")).toBe("urdu-nastaliq");
   });
 
   it("an unknown / off-chain language is treated as Latin (no intro)", () => {
@@ -34,8 +36,7 @@ describe("scriptOf / LANGUAGE_SCRIPT", () => {
   });
 
   it("every chain language has a mapping", () => {
-    // all ten chain entries present
-    expect(Object.keys(LANGUAGE_SCRIPT).length).toBe(10);
+    expect(Object.keys(LANGUAGE_SCRIPT).length).toBe(20);
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/sequence.test.ts
+++ b/code/programs/typescript/language-ladder/tests/sequence.test.ts
@@ -9,6 +9,7 @@ import {
   teachingSweep,
   sweepableConcepts,
   spineProgress,
+  resolveActiveLanguages,
   type ChainLanguage,
 } from "../src/sequence";
 
@@ -29,23 +30,27 @@ function L(language: string, concept: string, chapter: number, id?: string): Les
     romanization: "x",
     script: language,
     etymologyHook: "",
+    body: "",
+    estMinutes: 5,
   };
 }
 
 const langsOf = (stops: { language: ChainLanguage }[]) => stops.map((s) => s.language);
 
 describe("the language chain", () => {
-  it("is ten distinct languages in the fixed order", () => {
+  it("contains every registered language in the authored default order", () => {
     expect(LANGUAGE_CHAIN).toEqual([
       "spanish", "latin", "french", "german", "arabic",
       "hindi", "tamil", "kannada", "telugu", "malayalam",
+      "italian", "portuguese", "marathi", "punjabi", "bengali",
+      "gujarati", "russian", "sanskrit", "persian", "urdu",
     ]);
-    expect(new Set(LANGUAGE_CHAIN).size).toBe(10);
+    expect(new Set(LANGUAGE_CHAIN).size).toBe(20);
   });
 
   it("chainIndex and isChainLanguage locate a language, or reject a non-chain one", () => {
     expect(chainIndex("spanish")).toBe(0);
-    expect(chainIndex("malayalam")).toBe(9);
+    expect(chainIndex("urdu")).toBe(19);
     expect(chainIndex("klingon")).toBe(-1);
     expect(isChainLanguage("hindi")).toBe(true);
     expect(isChainLanguage("klingon")).toBe(false);
@@ -56,6 +61,11 @@ describe("the language chain", () => {
     expect(activeChain(3)).toEqual(["spanish", "latin", "french"]);
     expect(activeChain(99)).toEqual([...LANGUAGE_CHAIN]);
     expect(activeChain(-5)).toEqual([]);
+  });
+
+  it("normalizes an explicit language mix into registry order", () => {
+    expect(resolveActiveLanguages(["urdu", "unknown", "spanish", "urdu"]))
+      .toEqual(["spanish", "urdu"]);
   });
 });
 
@@ -108,9 +118,9 @@ describe("teachingSweep", () => {
 describe("teachingSweep against the real curriculum", () => {
   const lessons = loadLessons();
 
-  it("GREETING-HELLO sweeps all ten languages in exact chain order when all are active", () => {
-    const sweep = teachingSweep("GREETING-HELLO", lessons, activeChain(10));
-    expect(langsOf(sweep)).toEqual([...LANGUAGE_CHAIN]); // all ten, chain-ordered
+  it("GREETING-HELLO sweeps all registered languages in exact chain order", () => {
+    const sweep = teachingSweep("GREETING-HELLO", lessons, activeChain(99));
+    expect(langsOf(sweep)).toEqual([...LANGUAGE_CHAIN]);
     for (const stop of sweep) expect(stop.lessons.length).toBeGreaterThan(0);
   });
 

--- a/code/programs/typescript/language-ladder/tests/session.test.ts
+++ b/code/programs/typescript/language-ladder/tests/session.test.ts
@@ -20,6 +20,8 @@ function L(language: string, concept: string, roots: string[], chapter = 1): Les
     romanization: "x",
     script: language,
     etymologyHook: "",
+    body: "",
+    estMinutes: 5,
   };
 }
 
@@ -48,17 +50,17 @@ describe("buildSession", () => {
     const lessons = [
       L("spanish", "C", ["r1"]),
       L("french", "C", ["r1"]),
-      L("italian" /* not on chain — dropped by the sweep */, "C", ["r1"]),
+      L("italian", "C", ["r1"]),
       L("hindi", "C", ["r1", "r2"]),
     ];
-    const steps = buildSession("C", lessons, 10);
-    // italian is not a chain language, so it never appears.
-    expect(langs(steps)).toEqual(["spanish", "french", "hindi"]);
+    const steps = buildSession("C", lessons, 20);
+    expect(langs(steps)).toEqual(["spanish", "french", "hindi", "italian"]);
     // hindi shares r1 with both spanish and french (in chain order).
     expect(steps[2].connections).toEqual([
       { to: "spanish", sharedRoots: ["r1"] },
       { to: "french", sharedRoots: ["r1"] },
     ]);
+    expect(steps[3].connections.length).toBe(3);
   });
 
   it("reports multiple shared roots between a pair, sorted", () => {

--- a/code/programs/typescript/language-ladder/tests/sessionplan.test.ts
+++ b/code/programs/typescript/language-ladder/tests/sessionplan.test.ts
@@ -8,7 +8,7 @@ function L(language: string, concept: string, id: string, roots: string[] = []):
   return {
     id, language, headword: `${language}:${concept}`, gloss: concept, type: "word",
     chapter: 1, concept, prerequisites: [], reviewsOf: [], roots,
-    romanization: "x", script: language, etymologyHook: "",
+    romanization: "x", script: language, etymologyHook: "", body: "", estMinutes: 5,
   };
 }
 
@@ -37,6 +37,12 @@ describe("planSession — assembling the two passes", () => {
   it("an un-covered concept never enters the review grid", () => {
     const plan = planSession("THANKS", ["THANKS"], lessons, 10); // HELLO not covered
     expect(new Set(plan.reviewGrid.map((c) => c.concept))).toEqual(new Set(["THANKS"]));
+  });
+
+  it("teaches and reviews only an explicit selected-language mix", () => {
+    const plan = planSession("THANKS", ["THANKS", "HELLO"], lessons, ["french"]);
+    expect(plan.teaching.map((step) => step.language)).toEqual(["french"]);
+    expect(new Set(plan.reviewGrid.map((cell) => cell.language))).toEqual(new Set(["french"]));
   });
 });
 

--- a/code/scripts/build_human_language_book_catalog.py
+++ b/code/scripts/build_human_language_book_catalog.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Build a static download catalog for compiled human-language books."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+
+def load_registry(path: Path) -> dict[str, dict[str, Any]]:
+    """Load language metadata keyed by its stable curriculum identifier."""
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return {language["id"]: language for language in payload["languages"]}
+
+
+def build_catalog(
+    pdf_dir: Path,
+    registry: dict[str, dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Describe the PDFs that actually exist, in registry order."""
+
+    pdfs = {path.stem: path for path in pdf_dir.glob("*.pdf") if path.is_file()}
+    ordered_ids = [language_id for language_id in registry if language_id in pdfs]
+    ordered_ids.extend(
+        sorted(language_id for language_id in pdfs if language_id not in registry)
+    )
+
+    entries: list[dict[str, str]] = []
+    for language_id in ordered_ids:
+        metadata = registry.get(language_id, {})
+        pdf = pdfs[language_id]
+        entries.append(
+            {
+                "id": language_id,
+                "name": str(metadata.get("name", language_id.replace("-", " ").title())),
+                "family": str(metadata.get("family", "Unclassified")),
+                "script": str(metadata.get("script", "Unknown")),
+                "file": pdf.name,
+            }
+        )
+    return entries
+
+
+def render_html(entries: list[dict[str, str]]) -> str:
+    """Render an accessible, dependency-free GitHub Pages catalog."""
+
+    book_word = "book" if len(entries) == 1 else "books"
+    cards = []
+    for entry in entries:
+        name = html.escape(entry["name"])
+        family = html.escape(entry["family"])
+        script = html.escape(entry["script"])
+        href = quote(entry["file"])
+        cards.append(
+            f"""      <article class="book">
+        <div>
+          <h2>{name}</h2>
+          <p>{family} family · {script} script</p>
+        </div>
+        <a href="{href}" download>Download PDF</a>
+      </article>"""
+        )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Free downloadable language-learning books from Coding Adventures.">
+  <title>Human Languages Books · Coding Adventures</title>
+  <style>
+    :root {{ color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }}
+    body {{ margin: 0; background: #f6f3ed; color: #20251f; }}
+    main {{ width: min(52rem, calc(100% - 2rem)); margin: 0 auto; padding: 4rem 0; }}
+    h1 {{ margin-bottom: .5rem; font-family: Georgia, serif; font-size: clamp(2rem, 7vw, 4rem); }}
+    .intro {{ max-width: 42rem; color: #4b5448; font-size: 1.08rem; line-height: 1.6; }}
+    .catalog {{ display: grid; gap: .8rem; margin-top: 2.5rem; }}
+    .book {{ display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 1rem 1.2rem; border: 1px solid #ccd2c7; border-radius: .7rem; background: #fff; }}
+    .book h2 {{ margin: 0 0 .25rem; font-family: Georgia, serif; font-size: 1.25rem; }}
+    .book p {{ margin: 0; color: #596255; }}
+    a {{ color: #fff; background: #275d45; border-radius: .45rem; padding: .65rem .85rem; font-weight: 700; text-decoration: none; white-space: nowrap; }}
+    a:hover, a:focus-visible {{ background: #153e2c; text-decoration: underline; }}
+    footer {{ margin-top: 2.5rem; color: #596255; font-size: .9rem; }}
+    @media (prefers-color-scheme: dark) {{
+      body {{ background: #151914; color: #f2f4ee; }}
+      .intro, .book p, footer {{ color: #c1c8bd; }}
+      .book {{ background: #20271f; border-color: #465044; }}
+      a {{ background: #69a985; color: #101812; }}
+    }}
+    @media (max-width: 34rem) {{ .book {{ align-items: stretch; flex-direction: column; }} a {{ text-align: center; }} }}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <p>Coding Adventures</p>
+      <h1>Human Languages Books</h1>
+      <p class="intro">{len(entries)} free, etymology-first language {book_word}, built from the latest curriculum on the main branch. Each PDF introduces vocabulary, grammar, and script gradually.</p>
+    </header>
+    <section class="catalog" aria-label="Available books">
+{chr(10).join(cards)}
+    </section>
+    <footer>Licensed CC BY-SA 4.0. New editions are published automatically as the curriculum grows.</footer>
+  </main>
+</body>
+</html>
+"""
+
+
+def write_catalog(
+    pdf_dir: Path,
+    registry_path: Path,
+    output_dir: Path,
+) -> list[dict[str, str]]:
+    """Write the HTML and machine-readable catalogs, returning their entries."""
+
+    entries = build_catalog(pdf_dir, load_registry(registry_path))
+    if not entries:
+        raise ValueError(f"no PDF books found in {pdf_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "index.html").write_text(render_html(entries), encoding="utf-8")
+    (output_dir / "catalog.json").write_text(
+        json.dumps({"version": 1, "books": entries}, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return entries
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pdf-dir", type=Path, required=True)
+    parser.add_argument("--registry", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    entries = write_catalog(args.pdf_dir, args.registry, args.output_dir)
+    print(f"Wrote a public catalog for {len(entries)} books to {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/tests/test_build_human_language_book_catalog.py
+++ b/code/scripts/tests/test_build_human_language_book_catalog.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+books = importlib.import_module("build_human_language_book_catalog")
+
+
+class HumanLanguageBookCatalogTests(unittest.TestCase):
+    def test_writes_catalog_for_pdfs_that_exist(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pdf_dir = root / "pdfs"
+            output_dir = root / "site"
+            pdf_dir.mkdir()
+            (pdf_dir / "spanish.pdf").write_bytes(b"%PDF-test")
+            registry = root / "languages.json"
+            registry.write_text(
+                json.dumps(
+                    {
+                        "languages": [
+                            {
+                                "id": "spanish",
+                                "name": "Spanish",
+                                "family": "Romance",
+                                "script": "latin",
+                            },
+                            {
+                                "id": "persian",
+                                "name": "Persian",
+                                "family": "Iranian",
+                                "script": "perso-arabic",
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            entries = books.write_catalog(pdf_dir, registry, output_dir)
+
+            self.assertEqual([entry["id"] for entry in entries], ["spanish"])
+            catalog = json.loads(
+                (output_dir / "catalog.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(catalog["books"][0]["family"], "Romance")
+            page = (output_dir / "index.html").read_text(encoding="utf-8")
+            self.assertIn("1 free, etymology-first language book", page)
+            self.assertIn('href="spanish.pdf" download', page)
+            self.assertNotIn("Persian", page)
+
+    def test_rejects_an_empty_pdf_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pdf_dir = root / "pdfs"
+            pdf_dir.mkdir()
+            registry = root / "languages.json"
+            registry.write_text('{"languages": []}', encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "no PDF books found"):
+                books.write_catalog(pdf_dir, registry, root / "site")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/HL00-human-language-curriculum-framework.md
+++ b/code/specs/HL00-human-language-curriculum-framework.md
@@ -15,7 +15,10 @@ from this repo's standard software-package process. Later specs build on it:
 [`HL01`](./HL01-concept-taxonomy-and-data-layer.md) defines the cross-language
 **concept taxonomy** and the machine-readable **data layer** derived from these
 lessons; [`HL02`](./HL02-companion-practice-app.md) defines the **companion
-practice app** and the learning-science method behind it. (An earlier draft
+practice app** and the learning-science method behind it; and
+[`HL04`](./HL04-shared-spine-and-content-pipeline.md) defines the ordered shared
+spine, strict sub-five-minute and knowledge-closure contracts, language-specific
+extensions, and the one-source book/app/practice pipeline. (An earlier draft
 reserved `HL01`+ for per-language notes; those never materialized and the
 numbers are repurposed here — nothing is released, so this is a free change.)
 

--- a/code/specs/HL03-unified-language-learning-app.md
+++ b/code/specs/HL03-unified-language-learning-app.md
@@ -23,6 +23,12 @@ remains the substrate. What is new here is the **unification** around the
 curriculum, the **language-chain / spiral** sequencing, the **as-needed**
 introduction of scripts and grammar, and a **mistakes** layer.
 
+[`HL04`](./HL04-shared-spine-and-content-pipeline.md) tightens this design after
+the first shipped corpus audit: the chain becomes learner-selected, each language
+gets its own authored spine realization and knowledge closure, new material receives
+focused acquisition before mixed review, and the full lesson body becomes the one
+source for book and app delivery.
+
 ## The learner's model — a spiral with cumulative concept-sweeps
 
 HL02 stated the pattern in miniature (Spanish → French → German). The real model

--- a/code/specs/HL04-shared-spine-and-content-pipeline.md
+++ b/code/specs/HL04-shared-spine-and-content-pipeline.md
@@ -1,0 +1,458 @@
+# HL04 — Shared Spine, Lesson Contract, and Content Pipeline
+
+## Status and purpose
+
+This spec turns the Human Languages curriculum into one progressively disclosed
+course system that can produce books, app lessons, audio scripts, and mixed-language
+practice without maintaining four copies of the teaching content.
+
+It extends [HL00](./HL00-human-language-curriculum-framework.md),
+[HL01](./HL01-concept-taxonomy-and-data-layer.md), and
+[HL03](./HL03-unified-language-learning-app.md). Where those specs describe an
+aspiration that the current implementation does not satisfy, this spec defines the
+migration target and the executable checks that decide when it is satisfied.
+
+The design requirements are:
+
+1. Most languages follow a shared, ordered **can-do spine**.
+2. A language may insert, replace, delay, or omit spine material when its grammar,
+   script, register system, or culture requires it.
+3. Every lesson is strictly shorter than five minutes and assumes only knowledge
+   established by earlier lessons in that language.
+4. The canonical lesson content feeds the book, app, audio delivery, and practice
+   compiler.
+5. Learners choose which languages to mix. Cross-language practice never bypasses
+   either language's own prerequisites.
+6. Persian and Urdu are first-class tracks, not variants of Arabic or Hindi.
+7. Etymology remains the signature memory aid, but it is paired with communicative
+   use, graded input, output, fluency work, and cultural pragmatics.
+
+## Evidence boundary
+
+This is a benchmark of **methods and publicly documented features**, not a claim to
+have enumerated every language-learning book and not a reconstruction of copyrighted
+text. The project adopts transferable pedagogical patterns and writes original
+lessons, examples, stories, explanations, and exercises. Publisher descriptions,
+open courses, proficiency frameworks, and research establish the design rationale;
+they are not source text for the corpus.
+
+## Representative method benchmark
+
+No single course tradition covers the whole target. The useful design is a synthesis.
+
+| Tradition or framework | Transferable strength | What HL adopts |
+|---|---|---|
+| McGraw-Hill *Easy Spanish Step-by-Step* | Grammar is ordered so later structures build on earlier ones. | An explicit dependency graph and cumulative practice, but grammar is one strand rather than the entire syllabus. |
+| Assimil | Short, graded dialogues; notes at the point of need; an input-heavy phase followed by active production; periodic consolidation. | Every new form appears first in understandable input, then in guided output. Reviews revisit a small run of prior lessons. |
+| Pimsleur | Anticipation, spoken production, core vocabulary, and graduated recall. | Audio-ready prompts require an answer before reveal; successful items move to expanding intervals. Long sessions are compiled from independent sub-five-minute lessons. |
+| *Lingua Latina per se illustrata* | Carefully controlled input grows from transparent sentences into sustained reading. | Recurring micro-stories and dialogues use only known material plus the lesson's declared introduction budget. Complexity grows through text, not only explanation. |
+| Routledge Colloquial courses | Contemporary dialogues, jargon-free grammar, all four skills, native audio, answer keys, and interval reviews. | Present-day usage, explicit self-study answers, periodic mastery checks, and a four-skill coverage report. |
+| *Genki* | Everyday dialogue, plain grammar notes, varied practice, and a coordinated reading/writing progression. | Script and grammar extensions attach to the communicative lesson that needs them; neither becomes a disconnected front-loaded gate. |
+| *Integrated Chinese* | Coordinated listening, speaking, reading, and writing; real-life situations; culture; interpretive, interpersonal, and presentational modes. | Every spine cluster declares communicative outcomes and mode coverage, not just vocabulary inventory. |
+| *Alif Baa* / Al-Kitaab | Sounds, connected script, production from the beginning, and explicit spoken/formal variety choices. | Script is learned through usable language; variety and register are structured metadata rather than silently mixed forms. |
+| Modern Persian beginner courses | Spoken Persian from the outset, a clear script ramp, concise grammar, audio dialogues, and four-skill exercises. | Persian distinguishes colloquial and formal forms, introduces connected letters in real words, and progressively fades transliteration. |
+| Modern Urdu and open Urdu-script courses | Nastaliq taught through shape families, contextual forms, real-world examples, and cumulative reading/writing practice. | Urdu receives Nastaliq-aware typography and script lessons, not generic Arabic glyph presentation. Hindi–Urdu connections are enrichment and practice bridges, never assumed prerequisites. |
+| CEFR Companion Volume | Action-oriented can-do goals; reception, production, interaction, mediation; plurilingual and pluricultural competence. | The shared spine is made of communicative abilities. Mixed-language tasks include comparison and mediation without pretending languages are structurally identical. |
+| ACTFL Proficiency Guidelines 2024 | Interpretive, interpersonal, and presentational communication across modalities. | Coverage is reported by mode and skill. Book knowledge alone cannot mark a stage complete. |
+| Nation's Four Strands | A balanced course includes meaning-focused input, meaning-focused output, language-focused learning, and fluency development. | Rolling curriculum windows report all four strands; etymology and grammar cannot crowd out input, output, or fluency. |
+| Retrieval and spacing research | Retrieval improves delayed retention; distributed practice beats massed restudy. | Practice records attempts, gives corrective feedback, and schedules later retrieval rather than counting exposure as mastery. |
+| Recent L2 interleaving research | Interleaving supports discrimination, but immediate interleaving can overload initial acquisition; a focused-to-mixed progression is safer. | New material receives a short focused acquisition phase. It joins mixed-language review only after an initial success criterion. |
+
+## Current coverage and gaps
+
+The 2026-08 audit of `origin/main` found 18 tracks and 963 lesson files. The
+foundation is real, but the governing promises are not yet enforceable.
+
+| Requirement | Current coverage | Migration gap |
+|---|---|---|
+| One atomic lesson | Strong: most content lessons teach one word or phrase. | Some lessons are long enough to contain several independent teaching steps. |
+| Strictly less than five minutes | Not enforced: 364 lessons declare 5 minutes and 104 declare 6. | Add a computed duration budget and split every lesson at or above 300 seconds. |
+| Etymology and morphology | Strong prose tradition and root metadata. | Normalize etymons, record sources/confidence, and deliver the full explanation to the app. |
+| Inline grammar | Present in Markdown prose. | Grammar has almost no structured metadata, cannot be ordered or practised by the app, and cannot be closure-checked. |
+| Inline script | Writing lessons and script JSON exist. | Writing lessons do not participate in the concept sweep; the app gives a one-time script signature rather than a cumulative reading path. |
+| Shared cross-language concepts | 42 concepts are shared by two or more languages. | The shared layer is mostly greetings and A0 vocabulary; 385 concepts remain language-namespaced. |
+| Safe progression | Lesson-id prerequisites have no cycles or unknown ids. | Sixty lessons have no prerequisites, including 42 later-chapter lessons; assumed vocabulary, grammar, sounds, and glyphs are not represented. |
+| Single content source | Claimed by HL00. | The Markdown body is discarded by the parser, LaTeX chapters are handwritten copies, and the app consumes frontmatter summaries only. |
+| Four skills and communicative use | Audio-script cues and guided prompts exist. | There is no structured listening, interaction, writing, or can-do coverage model, and no audio asset contract. |
+| Graded input and sustained reading | Isolated example sentences occur. | There is no controlled micro-story/dialogue corpus or known-token validation. |
+| Mixed-language practice | Concept sweeps, cumulative review, and mixed-script drills exist. | Learn mode hard-codes 10 languages, learners cannot choose a set, and a concept can expose a late lesson early in another language. |
+| Register, dialect, and culture | Often explained in lesson prose. | These distinctions are not typed, so the app can silently compare non-equivalent registers or varieties. |
+| Proficiency target | Roadmaps generally point toward B1. | No CEFR/ACTFL-aligned outcome matrix shows which reception, production, interaction, or mediation abilities are covered. |
+
+### First implementation slice
+
+The first implementation slice establishes, without replacing existing books or
+tracks:
+
+- `core/languages.json`, containing all 20 current tracks in one registry;
+- `core/spine.json`, giving all 45 current canonical concepts an explicit first
+  shared-spine order;
+- Persian and Urdu starter tracks, each with five dependency-ordered, under-five-
+  minute lessons and language-specific script metadata;
+- lossless Markdown bodies and lossless discovery of all 17 existing LaTeX books
+  in `human-language-data`, with chapter-to-lesson alignment validation;
+- a registry-driven app language picker, the structured spine in Learn mode,
+  rendered authored lesson bodies, and fail-closed declared prerequisites.
+
+This slice does not claim the full acceptance criteria below. Per-track spine
+maps, typed body blocks, computed duration, book generation, independently gated
+focused-to-mixed retrieval, a true Nastaliq font, and B1 corpus expansion remain
+explicit migration work.
+
+## The curriculum model
+
+The curriculum has four different kinds of object. Keeping them separate prevents
+the flat `concept_tag` vocabulary from being asked to do incompatible jobs.
+
+1. **Spine node** — a language-independent communicative ability, such as
+   “exchange names politely” or “describe where a familiar object is.”
+2. **Knowledge atom** — a lexeme, construction, morpheme, sound contrast,
+   grapheme, pragmatic convention, cultural fact, or etymon.
+3. **Language realization** — how one language teaches a spine node, including
+   its ordered lessons and required extensions.
+4. **Activity** — an authored or compiled act of reception, production,
+   interaction, mediation, language-focused study, or fluency practice.
+
+`concept_tag` remains the join key for comparable meanings. It is not the spine
+order and it is not a grammar syllabus.
+
+### Shared spine
+
+The shared spine is an ordered directed acyclic graph. Nodes use stable semantic
+ids, never ordinal ids:
+
+```jsonc
+{
+  "id": "SPINE-INTRO-EXCHANGE-NAMES",
+  "stage": "pre-A1",
+  "canDo": "I can ask someone's name and give my own in a neutral setting.",
+  "prerequisites": ["SPINE-GREETING-MEET"],
+  "modes": ["interpretive", "interpersonal", "presentational"],
+  "strands": ["meaning-input", "meaning-output", "language-focus", "fluency"],
+  "core": true,
+  "extensionPoints": ["script", "register", "copula", "pronouns"]
+}
+```
+
+The canonical stages are `pre-A1`, `A1`, `A2`, and `B1`. They are curriculum
+planning labels, not claims that lesson completion alone proves external exam
+proficiency.
+
+The first shared-spine families are:
+
+1. meet, greet, thank, apologize, and take leave;
+2. exchange identity and basic personal information;
+3. understand and make simple requests;
+4. locate, possess, and describe familiar people and objects;
+5. talk about daily actions, preferences, ability, obligation, and plans;
+6. narrate simple past events and contrast background with completed actions;
+7. compare, explain a reason, give an opinion, and connect clauses;
+8. manage common transactions, travel, health, time, and social situations;
+9. understand and produce short connected texts;
+10. mediate a simple meaning between English and one or more learned languages.
+
+This order moves from immediately useful formulae through generative sentence
+building into connected discourse. Individual languages may realize the functions
+with radically different structures.
+
+### Per-language plan and extensions
+
+Each track gains a `curriculum.json` that maps spine nodes to an ordered local
+path:
+
+```jsonc
+{
+  "language": "urdu",
+  "spine": {
+    "SPINE-INTRO-EXCHANGE-NAMES": {
+      "lessons": ["UR-C02-aap", "UR-C02-naam", "UR-C02-mera-naam"],
+      "before": ["UR-SCRIPT-BE-FAMILY", "UR-GRAMMAR-POSSESSIVE-AGREEMENT"],
+      "after": ["UR-REGISTER-TUM-AAP"],
+      "omits": []
+    }
+  }
+}
+```
+
+An extension may be **required**, **supporting**, **reference**, or explicitly
+**not applicable**. No tool infers order from the minimum chapter number found in
+another language. The shared node orders abilities; each `curriculum.json` orders
+the realization.
+
+## Canonical lesson contract
+
+Markdown remains the authoring format, but both frontmatter and body become typed.
+The parser must preserve the body as a lesson AST instead of discarding it.
+
+```yaml
+---
+schema_version: 2
+id: ES-C01-gracias
+spine_node: SPINE-COURTESY-THANK
+sequence: 40
+type: word
+headword: gracias
+gloss: thank you
+concept_tag: COURTESY-THANKS
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-SOUND-G, ES-LEX-GRACIAS-RECEPTIVE]
+introduces:
+  knowledge: [ES-LEX-GRACIAS-PRODUCTIVE, ETYMON-LATIN-GRATIA]
+practises:
+  knowledge: [SPINE-GREETING-MEET]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+sources: [rae-gracias, dle-gracia, de-vries-gratia]
+---
+```
+
+The body is parsed into stable, named blocks: `warmup`, `input`, `notice`,
+`pronunciation`, `script`, `etymology`, `grammar`, `culture-pragmatics`,
+`guided-production`, `comprehension`, `fluency`, and `recall`. A block may declare
+prompts, accepted answers, feedback, and response time. The app and book render the
+same block; medium-specific presentation belongs in renderers, not a second copy.
+
+### Knowledge closure
+
+Before a lesson begins, every atom in `requires.knowledge` must have been
+introduced by a transitive prerequisite. During the lesson, assessed material may
+use only previously introduced atoms, atoms introduced earlier in this lesson, and
+transparent English instructions.
+
+The validator computes this set at every block boundary. Unknown atoms, cycles,
+forward references, and assessed undeclared forms are errors. Runtime scheduling
+fails closed and reports a curriculum defect; it never unlocks everything as a
+fallback.
+
+### Five-minute contract
+
+`max_seconds` must be `1..299`. CI independently estimates delivery time from
+spoken word count, explicit pauses, repeat count and audio duration, a learner-
+response budget for every prompt, and a safety margin. The greater of the declared
+and computed values is used. A lesson at 300 seconds or more fails validation.
+
+One session may chain several lessons, but each lesson is independently resumable.
+A lesson has one primary outcome. The default introduction budget is one lexical
+item or fixed phrase, one grammatical contrast, or one script pattern. A track may
+raise the atom count only for transparent decompositions and must still satisfy
+knowledge closure and duration.
+
+## How grammar, vocabulary, and script grow
+
+### Grammar
+
+Grammar is introduced function-first: understand a meaningful example, notice the
+contrast, explain it in plain English, optionally name the conventional term,
+manipulate one variable, use it in a tiny communicative task, and retrieve it later
+in a different context. Full paradigms are reference views assembled from already
+encountered cells, not lesson-sized information dumps.
+
+### Vocabulary and graded input
+
+Vocabulary selection records frequency band, communicative utility, register,
+variety, concreteness, and root connections. Frequency informs the choice; it does
+not override a high-value communicative need.
+
+Every spine cluster includes a recurring dialogue or micro-story. Each installment
+uses known language plus the current lesson's explicit introduction budget. This
+creates the graded reading/listening ramp missing from isolated word lessons.
+
+### Script and transliteration
+
+The target script is visible from first contact. Transliteration is temporary:
+
+- show target script and audio together;
+- teach letters by shape family, sound, joining behavior, and position in real words;
+- record contextual forms, ligatures, marks, and non-joining rules;
+- fade transliteration per learner after successful script retrieval;
+- retain an on-demand pronunciation aid for accessibility;
+- test directionality, Unicode normalization, font shaping, and cursor behavior;
+- never present a generic script font as culturally equivalent when a language's
+  conventional typography differs.
+
+## Etymology contract
+
+Etymology is an elaborative memory hook, not a substitute for current meaning and
+usage. Every claim records a canonical etymon id, source language and script,
+transliteration, gloss, change chain, relation type, confidence, traceable sources,
+semantic change, and false-cognate boundaries.
+
+The app joins canonical etymon ids, not raw root strings. A lesson first establishes
+what an expression means and how it is used, then uses the root web to strengthen
+memory.
+
+## Balanced skill and proficiency coverage
+
+Over each rolling spine cluster, the coverage report expects meaningful activity
+in all four of Nation's strands: meaning-focused input, meaning-focused output,
+language-focused learning, and fluency development with known material. The target
+is approximate balance, reported as a range rather than a false exact 25 percent.
+
+The same report tracks listening, speaking, reading, writing; interpretive,
+interpersonal, and presentational communication; CEFR reception, production,
+interaction, and mediation; cultural/pragmatic competence; and controlled versus
+fluent use.
+
+Stage completion requires original performance tasks with transparent rubrics. A
+multiple-choice recognition score alone cannot complete a can-do node.
+
+## Mixed-language learning and practice
+
+The learner selects any active language subset and may reorder it. Progress and
+knowledge closure remain per language. Each new `(knowledge atom, language)` moves
+through:
+
+1. **encounter** — understandable input;
+2. **focused acquisition** — a small block of same-language supported practice;
+3. **initial retrieval** — correct production or comprehension without reveal;
+4. **eligible for interleaving** — mixed with established items;
+5. **fluency and transfer** — faster or less scaffolded use in new contexts.
+
+Supported directions include meaning → target language, target language → meaning,
+audio → meaning or form, dictation, language A → language B through a shared
+concept, same-etymon comparison, contrastive grammar/pragmatics, and simple
+mediation.
+
+Language A → language B becomes eligible only when both realizations independently
+pass initial retrieval. The scheduler respects each realization's local spine
+position. A cross-language answer never grants mastery to an unseen local lesson.
+Wrong answers record the chosen language/form so contrastive feedback can distinguish
+a memory lapse from cross-language confusion.
+
+## Persian and Urdu onboarding
+
+Persian and Urdu share ancestry and many shapes with the Arabic script, but they
+must not reuse an undifferentiated `arabic` course identity. Script data gains
+inheritance or composition:
+
+```text
+arabic-script-core
+├── arabic-orthography
+└── perso-arabic-core
+    ├── persian-orthography
+    └── urdu-nastaliq-orthography
+```
+
+### Persian
+
+The first extension path covers right-to-left flow, joining and non-joining letters,
+Persian additions, omitted short vowels, contextual forms, common orthographic
+ambiguities, and transliteration fading. Formal written Persian and colloquial
+Iranian Persian are typed varieties; Dari and Tajik are future related varieties,
+not silent synonyms. Arabic loans preserve historically informative spellings while
+receiving Persian pronunciation and usage notes.
+
+### Urdu
+
+Urdu renders and tests with a suitable Nastaliq font and layout. Its extension path
+covers shape families, positional forms, non-joiners, short-vowel omission, Urdu
+additions for Indic sounds, aspiration and retroflexion, nasalization, and common
+ligatures. Naskh may appear as comparison or accessibility fallback, but not as the
+normal printed Urdu experience.
+
+Hindi and Urdu may share communicative spine nodes and selected Hindustani grammar
+atoms. Their scripts, register distributions, literary vocabulary, and cultural
+pragmatics remain distinct. Cross-language practice starts only after both sides
+are learned.
+
+## One-source content pipeline
+
+```text
+spine.json + per-track curriculum.json + lessons/*.md + source registry
+                              │
+                       validated lesson AST
+              ┌───────────────┼───────────────┬──────────────┐
+              ▼               ▼               ▼              ▼
+         LaTeX/HTML book   app teaching UI   exercise bank   audio script
+```
+
+Required changes:
+
+1. `human-language-data` preserves and parses every Markdown body block.
+2. Book chapters are rendered from the lesson AST. Handwritten LaTeX supplies
+   templates and front/back matter, not duplicate explanations.
+3. The app renders the same blocks and compiles exercises from their prompt/answer
+   contracts.
+4. Generated outputs embed a source hash. CI rebuilds when lessons, spine, taxonomy,
+   source registry, renderer, or templates change and rejects drift.
+5. Audio uses the same blocks plus pronunciation metadata; recordings and synthesized
+   audio carry provenance and variety labels.
+6. Linguistic and etymological citations use stable ids in a source registry.
+
+Book and app may arrange the same blocks differently; they may not silently teach
+different facts or prerequisite order.
+
+## Validation gates
+
+Tracks migrate independently. `schema_version: 1` produces migration warnings;
+once a track declares version 2, these are hard errors:
+
+1. shared and local curriculum graphs contain no cycles or unknown ids;
+2. every lesson and body block is reachable in one authored order;
+3. every required or assessed knowledge atom is known at its point of use;
+4. computed lesson duration is below 300 seconds;
+5. exercises have resolvable prompts, answers, accepted variants, and feedback;
+6. script glyphs, forms, marks, direction, normalization, and font shaping resolve;
+7. variety and register are explicit where they affect appropriateness;
+8. etymological claims have canonical relations, confidence, and sources;
+9. every spine cluster reports strand, skill, mode, and can-do coverage;
+10. book and app lesson hashes match the canonical AST;
+11. mixed practice includes only independently unlocked realizations;
+12. stage assessment tests production or interaction as well as recognition.
+
+The validator emits human-readable and JSON gap reports so corpus expansion is
+measurable.
+
+## Migration order
+
+1. **Contract and parser** — add spine, knowledge-atom, body-AST, source, and
+   duration types while preserving version-1 compatibility.
+2. **Spanish vertical slice** — migrate Chapters 1–3, render book and app, and
+   prove strict duration plus closed-world progression.
+3. **Mixed-practice correction** — add learner-selected languages, per-language
+   cursors, focused-before-interleaved eligibility, and fail-closed scheduling.
+4. **Persian and Urdu pilots** — build script composition and the first three spine
+   clusters in each language with appropriate typography and variety metadata.
+5. **Existing-track migration** — map every track onto the spine, insert extensions,
+   normalize etymons, and eliminate handwritten book copies.
+6. **Corpus expansion** — grow through B1 while coverage reports select the next
+   missing can-do, skill, mode, register, or language realization.
+
+## First milestone acceptance criteria
+
+The first vertical slice is complete when every migrated lesson computes to 299
+seconds or less; no assessed word, construction, sound, or glyph appears early;
+book and app display the same lesson facts from the same AST; a learner can select
+two or more languages without exposing a later local lesson; new items receive
+focused retrieval before mixed review; progress is per language, atom, skill, and
+prompt direction; Persian and Urdu can extend the spine without pretending their
+scripts or registers are Arabic or Hindi; and CI reports gaps across the full corpus.
+
+## Sources
+
+These sources support the benchmark and design rationale. They are not licenses to
+copy lesson content.
+
+- McGraw Hill, [*Easy Spanish Step-by-Step*](https://www.mheducation.com/highered/mhp/product/easy-spanish-step-step.html)
+- Assimil, [The Assimil method](https://www.assimil.com/en/articles/5-the-assimil-method)
+- Pimsleur, [The Pimsleur Method](https://www.pimsleur.com/the-pimsleur-method/)
+- Schola Latina, [*Lingua Latina per se illustrata*: method](https://scholalatina.it/en/latine-discere-aude-our-method/)
+- Routledge, [Colloquial Series](https://www.routledge.com/Colloquial-Series/book-series/SE0069)
+- Japan Times Publishing, [What is *Genki*?](https://genki3.japantimes.co.jp/en/intro/index.html)
+- Cheng & Tsui, [*Integrated Chinese*](https://www.cheng-tsui.com/browse/integrated-chinese-3rd-edition)
+- Georgetown University Press, [*Alif Baa*](https://press.georgetown.edu/Book/Alif-Baa-with-Website)
+- Routledge, [*Colloquial Persian*](https://www.routledge.com/Colloquial-Persian-The-Complete-Course-for-Beginners/Rafiee/p/book/9781032356730)
+- Routledge, [*Colloquial Urdu*](https://www.routledge.com/Colloquial-Urdu-The-Complete-Course-for-Beginners-2nd-Edition/Bhatia-Koul/p/book/9781315649672)
+- University of Texas at Austin, [Persian Online](https://sites.la.utexas.edu/persian_online_resources/)
+- Northwestern University, [*Zer o Zabar*](https://openbooks.library.northwestern.edu/zerozabar/)
+- Council of Europe, [CEFR Companion Volume](https://book.coe.int/en/education-and-modern-languages/8150-common-european-framework-of-reference-for-languages-learning-teaching-assessment-companion-volume.html)
+- ACTFL, [Proficiency Guidelines 2024](https://www.actfl.org/uploads/files/general/Resources-Publications/ACTFL_Proficiency_Guidelines_2024.pdf)
+- Nation and Yamamoto, [Applying the Four Strands](https://www.wgtn.ac.nz/lals/resources/paul-nations-resources/paul-nations-publications/publications/documents/yamamoto-four-strands.pdf)
+- Roediger and Karpicke, [Test-enhanced learning](https://doi.org/10.1111/j.1467-9280.2006.01693.x)
+- Cepeda et al., [Distributed practice](https://pubmed.ncbi.nlm.nih.gov/16719566/)
+- Hwang, [Initial blocked practice and interleaving in L2 vocabulary](https://onlinelibrary.wiley.com/doi/full/10.1111/lang.12659)


### PR DESCRIPTION
## Summary

- establish a machine-readable, 20-language curriculum registry and a 45-concept shared spine that each language can extend
- add Persian and Urdu starter tracks with five prerequisite-safe, sub-five-minute lessons apiece and inline right-to-left script teaching
- make the human-language data package preserve complete Markdown lesson bodies and load all 17 existing LaTeX books (105 chapters) alongside the shared curriculum
- update Language Ladder so learners can select, persist, mix, and practise across all registered languages, including RTL lesson presentation
- document the pedagogical benchmark, gentle complexity ramp, content pipeline, validation rules, and explicit migration debt in HL04

## Public book downloads

- use one workflow job for all books: check out once, install TeX Live once, then compile every discovered `book/` directory sequentially
- stage all 17 stable language-named PDFs, generate the HTML + JSON catalog, and retain one complete 30-day publication artifact on pull requests
- after merge to `main`, publish that already-validated bundle under:
  https://adhithyan15.github.io/coding-adventures/human-languages/books/
- preserve the other GitHub Pages deployments while refreshing only `human-languages/books/`

Tracks without a long-form `book/` directory are intentionally omitted from the catalog. Persian, Urdu, and Russian therefore remain curriculum tracks whose LaTeX editions are follow-up authoring work, rather than empty downloads.

## Validation

- `@coding-adventures/human-language-data`: 42 tests passed; TypeScript build passed
- `language-ladder`: 274 tests passed; Vite production build passed
- public catalog generator: 2 unit tests passed
- workflow YAML parses as exactly one job with no matrix or artifact fan-in
- the consolidated Bash build step passes syntax validation and discovers 17 unique book output names
- Ruff, JSON parsing, workflow YAML parsing, and `git diff --check` passed
- in-app browser validation covered all 20 language choices, persisted filtering, Persian/Urdu RTL layout, expanded lesson content, Naskh font loading, and a Devanagari script introduction with no console errors

## Known migration boundaries

- existing lessons remain source material while the corpus is gradually split into strict sub-five-minute spine units
- Persian and Urdu currently contain starter lessons, not complete books
- Urdu uses the vendored Noto Naskh Arabic fallback until a suitable static Nastaliq font is vendored
- the app build retains its existing large-chunk warning; it is non-failing and separate from this curriculum change
