### PR TITLE
fix(spice): validate MOS model transconductance

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS model-card `KP` values
+  before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `U0` / `UO` values
   before lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `TOX` values

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1838,6 +1838,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(transconductance) = params.get("KP") {
+            if !transconductance.is_finite() || *transconductance <= 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET KP must be finite and positive",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1606,6 +1606,31 @@ fn accepts_zero_mosfet_model_surface_mobility_aliases() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_transconductance() {
+    for transconductance in ["0", "-1u", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model mobile NMOS(KP={transconductance})\nM1 d g s b mobile"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET KP must be finite and positive"));
+    }
+}
+
+#[test]
+fn preserves_explicit_positive_mosfet_model_transconductance() {
+    let parsed =
+        parse_netlist(".model mobile NMOS(KP=250u TOX=100n U0=500)\nM1 d g s b mobile").unwrap();
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+    assert_close(mosfet.params.kp, 250.0e-6);
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card surface-mobility validation.
+1. Rust Berkeley SPICE MOS model-card transconductance validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `U0` / `UO` values before
+   - Reject zero, negative, and non-finite model-card `KP` values before
      lowering MOS elements into engine parameters.
-   - Preserve zero and positive surface mobility, including the `UO` alias.
+   - Preserve positive explicit transconductance and its precedence over
+     mobility-derived values.
 
 ## Completed Slices
 
@@ -3925,6 +3926,13 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Positive oxide thicknesses remain accepted for mobility-derived
      transconductance.
+
+336. Rust Berkeley SPICE MOS model-card surface-mobility validation.
+   - Status: completed in PR 9459.
+   - Negative and non-finite model-card `U0` / `UO` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive surface mobility remain accepted, including the `UO`
+     alias.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite MOS model-card `KP` values in the Rust Berkeley parser facade
- preserve positive explicit `KP` and its precedence over mobility-derived transconductance
- reconcile the SPICE completion plan after PR #9459

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's transconductance semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.