### PR TITLE
Gate ADJ stdlib metadata in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_ocaml_toolchain_lock.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_capability_taxonomy.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_phy00_phy01_fixtures.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_adj_stdlib_report.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_adj_stdlib_manifest.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_schema.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_runner.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_schema.py'
@@ -104,6 +106,8 @@ jobs:
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
+          python3 code/scripts/adj_stdlib_report.py --format json --fail-on-unreferenced-tests > /tmp/adj-stdlib-report.json
+          python3 code/scripts/adj_stdlib_manifest.py --validate-json-schema > /tmp/adj-stdlib-manifest.json
           (cd code/programs/go/capability-cage-generator && go test ./...)
           (cd code/packages/go/ca-capability-analyzer && go test ./...)
           (cd code/packages/go/capability-cage && go test ./...)

--- a/code/scripts/adj_stdlib_manifest.py
+++ b/code/scripts/adj_stdlib_manifest.py
@@ -279,11 +279,34 @@ def validate_manifest(
     return sorted(set(errors))
 
 
+def validate_json_schema(schema: Any, manifest: Any) -> list[str]:
+    """Validate the schema and instance when the optional jsonschema tool is present."""
+
+    try:
+        from jsonschema import Draft202012Validator
+        from jsonschema.exceptions import SchemaError
+    except ImportError:
+        return ["jsonschema is required for --validate-json-schema"]
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError as error:
+        return [f"invalid manifest JSON Schema: {error.message}"]
+    validator = Draft202012Validator(schema)
+    return sorted(
+        "JSON Schema: "
+        + ".".join(str(part) for part in error.absolute_path)
+        + (": " if error.absolute_path else "")
+        + error.message
+        for error in validator.iter_errors(manifest)
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--validate-json-schema", action="store_true")
     args = parser.parse_args()
 
     root = args.root.resolve()
@@ -294,6 +317,8 @@ def main() -> int:
     errors = validate_manifest(root, manifest)
     if schema.get("$id") != "https://coding-adventures.dev/schemas/adj-stdlib-manifest-v1.json":
         errors.append("manifest schema has an unexpected $id")
+    if args.validate_json_schema:
+        errors.extend(validate_json_schema(schema, manifest))
     result = {
         "valid": not errors,
         "manifest": manifest_path.relative_to(root).as_posix(),

--- a/code/scripts/tests/test_adj_stdlib_manifest.py
+++ b/code/scripts/tests/test_adj_stdlib_manifest.py
@@ -129,6 +129,18 @@ class AdjStdlibManifestTests(unittest.TestCase):
         self.assertTrue(any("names no standards" in error for error in errors))
         self.assertTrue(any("names no benchmark_paths" in error for error in errors))
 
+    def test_json_schema_validation_reports_instance_errors(self) -> None:
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["schema_version"],
+            "properties": {"schema_version": {"const": 1}},
+        }
+
+        errors = manifest_module.validate_json_schema(schema, {"schema_version": 2})
+
+        self.assertTrue(any("1 was expected" in error for error in errors))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -231,8 +231,9 @@ option mapping, or judge/evaluation failure.
 2. **Complete:** define the curriculum-manifest schema, arithmetic seed, and validator.
 3. Import versioned Common Core, NGSS, and USMLE objective indexes into the CAS.
 4. Backfill reviewed objective mappings for the remaining 349 libraries.
-5. Add CI gates for source envelopes, test references, manifest integrity, and
-   optional `--require-byte-pins` migration progress.
+5. **Partial:** CI now gates manifest integrity, JSON Schema validity, validator
+   tests, and test references. Complete the source-envelope and
+   `--require-byte-pins` gates as those migrations reach zero debt.
 6. Close the ten current worked-query gaps.
 
 ### Wave 1: prove the full provenance path


### PR DESCRIPTION
## What changed
- run ADJ stdlib audit and manifest tests in the always-on CI contract job
- fail CI if a library loses test coverage or manifest integrity regresses
- add optional Draft 2020-12 validation to the manifest CLI
- keep known source-envelope and byte-pin debt measured rather than falsely enforced

## Why
The first two PRs made coverage measurable; this prevents those invariants from regressing before larger standards and provenance work begins.

## Validation
- Ruff passes for the changed Python files
- 11 focused tests pass
- the stdlib report passes `--fail-on-unreferenced-tests`
- the manifest passes `--validate-json-schema`
- `git diff --check` passes
- `actionlint` is unavailable locally; GitHub Actions provides the workflow parser and execution gate