### PR TITLE
test(venture): exercise generated surface keyboard

### DIFF
--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exercise the generated SwiftUI content surface's End-key path against a
+  scrollable live page and require the shared Rust viewport to change.
+
 - Wire normalized AppKit wheel events into the shared `BrowserSession` scroll
   model and repaint the translated viewport through Metal.
 - Activate viewport links from primary-button input, update the native title,

--- a/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
+++ b/code/packages/rust/venture-browser-macos/tests/swiftui_project_launch.rs
@@ -58,7 +58,10 @@ fn serve_html_sequence(titles: Vec<&'static str>) -> String {
             let (mut stream, _) = listener.accept().expect("accept Venture request");
             let mut request = [0_u8; 1024];
             let _ = stream.read(&mut request);
-            let body = format!("<!doctype html><title>{title}</title><main>Ready</main>");
+            let body = format!(
+                "<!doctype html><title>{title}</title><main>{}</main>",
+                "<p>Scrollable Venture acceptance content</p>".repeat(120)
+            );
             write!(
                 stream,
                 "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -183,6 +186,7 @@ fn package_owned_swiftui_project_launches_renders_and_interacts() {
         "SwiftUI interaction failed: {interaction}"
     );
     assert!(interaction.contains("\"controls\":\"back-forward-reload-home\""));
+    assert!(interaction.contains("\"surfaceKeyboard\":\"document-end\""));
     assert!(interaction.contains("\"reloadTitle\":\"Venture reload acceptance\""));
     assert!(
         interaction.contains(&start_url) || interaction.contains(&start_url.replace('/', "\\/"))

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exercise the generated WinUI content surface's End-key mapping against a
+  scrollable live page and require the shared Rust viewport to change.
+
 - Add the native Venture session bridge used by the Mosaic-generated WinUI
   shell, including shared chrome props/events, Direct2D pixel rendering,
   scrolling, and link activation.

--- a/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
+++ b/code/packages/rust/venture-browser-windows/tests/xaml_project_build.rs
@@ -55,7 +55,10 @@ fn serve_html_sequence(titles: Vec<&'static str>) -> String {
             let (mut stream, _) = listener.accept().expect("accept Venture request");
             let mut request = [0_u8; 1024];
             let _ = stream.read(&mut request);
-            let body = format!("<!doctype html><title>{title}</title><main>Ready</main>");
+            let body = format!(
+                "<!doctype html><title>{title}</title><main>{}</main>",
+                "<p>Scrollable Venture acceptance content</p>".repeat(120)
+            );
             write!(
                 stream,
                 "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -248,6 +251,7 @@ fn package_owned_xaml_project_builds_launches_and_interacts() {
         "WinUI interaction failed: {interaction}"
     );
     assert!(interaction.contains("\"controls\":\"back-forward-reload-home\""));
+    assert!(interaction.contains("\"surfaceKeyboard\":\"document-end\""));
     assert!(interaction.contains("\"reloadTitle\":\"Venture reload acceptance\""));
     assert!(
         interaction.contains(&start_url) || interaction.contains(&start_url.replace('/', "\\/"))

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Extend generated SwiftUI and WinUI launch acceptance through the native
+  content surface's End-key mapping and require the shared Rust viewport to
+  report a real scroll-state change.
 - Mosaic-authored Venture browser chrome with light and dark themes.
 - Typed slots for the address, page title, status, and disabled controls.
 - Typed dispatch events for Back, Forward, Home, Reload, address edits, and

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -104,8 +104,10 @@ cargo test -p venture-browser-windows
 
 These gates launch the generated window, render the host surface, edit and
 navigate the native address control, and invoke the Mosaic-authored Back,
-Forward, Reload, and Home controls. They require every transition to update the
-shared Rust browser session before the generated shell reports success.
+Forward, Reload, and Home controls. They then focus the emitted native content
+surface and require an End-key command to scroll the shared Rust viewport.
+Every transition must update the shared browser session before the generated
+shell reports success.
 
 This package is a browser-wiring milestone, not a claim of complete Venture or
 HTML conformance.

--- a/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
@@ -99,6 +99,7 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
   private var propsChangedHandler: (() -> Void)?
   private var acceptanceReported = false
   private var interactionAcceptanceStarted = false
+  private var lastSurfaceKeyboardCommand: String?
 
   required override init() {
     let native = VentureNativeLibrary()
@@ -369,13 +370,16 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
     let address = props?["address"] as? String ?? ""
     let pageTitle = props?["page-title"] as? String ?? ""
     if address == startURL, pageTitle == "Venture launch acceptance" {
-      writeInteractionResult(
-        [
-          "backend": "swiftui", "status": "interacted",
-          "controls": "back-forward-reload-home", "reloadTitle": "Venture reload acceptance",
-          "homeAddress": address, "targetAddress": targetURL, "pageTitle": pageTitle,
-        ],
-        to: markerPath)
+      guard performNativeSurfaceKey(keyCode: 119) else {
+        writeInteractionResult(
+          ["backend": "swiftui", "status": "error", "error": "content surface unavailable"],
+          to: markerPath)
+        return
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+        self?.verifySurfaceKeyboard(
+          startURL: startURL, targetURL: targetURL, markerPath: markerPath)
+      }
       return
     }
     guard remaining > 0 else {
@@ -392,6 +396,30 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
         startURL: startURL, targetURL: targetURL, markerPath: markerPath,
         remaining: remaining - 1)
     }
+  }
+
+  private func verifySurfaceKeyboard(
+    startURL: String, targetURL: String, markerPath: String
+  ) {
+    guard lastSurfaceKeyboardCommand == "document-end" else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error",
+          "error": "native End key did not scroll the shared viewport",
+        ],
+        to: markerPath)
+      return
+    }
+    let response = applyProps()
+    let props = response?["props"] as? NSDictionary
+    writeInteractionResult(
+      [
+        "backend": "swiftui", "status": "interacted",
+        "controls": "back-forward-reload-home", "surfaceKeyboard": "document-end",
+        "reloadTitle": "Venture reload acceptance", "homeAddress": startURL,
+        "targetAddress": targetURL, "pageTitle": props?["page-title"] as? String ?? "",
+      ],
+      to: markerPath)
   }
 
   private func findEditableTextField(
@@ -432,6 +460,26 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
         y: addressFrame.midY),
       to: nil)
     sendPrimaryClick(at: windowPoint, to: window)
+    return true
+  }
+
+  private func performNativeSurfaceKey(keyCode: UInt16) -> Bool {
+    guard let contentView, let window = contentView.window else { return false }
+    NSApp.activate(ignoringOtherApps: true)
+    guard window.makeFirstResponder(contentView),
+      let event = NSEvent.keyEvent(
+        with: .keyDown,
+        location: .zero,
+        modifierFlags: [],
+        timestamp: ProcessInfo.processInfo.systemUptime,
+        windowNumber: window.windowNumber,
+        context: nil,
+        characters: "",
+        charactersIgnoringModifiers: "",
+        isARepeat: false,
+        keyCode: keyCode)
+    else { return false }
+    NSApp.sendEvent(event)
     return true
   }
 
@@ -495,6 +543,7 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
     guard let native, let browser else { return }
     let changed = command.withCString { native.scrollCommand(browser, $0) }
     guard changed != 0 else { return }
+    lastSurfaceKeyboardCommand = command
     contentView?.renderPage()
   }
 

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -300,11 +300,23 @@ public static class MosaicHost
                     return;
                 }
 
+                if (contentSurface is null || !contentSurface.RunKeyboardAcceptance())
+                {
+                    WriteInteractionResult(markerPath, new
+                    {
+                        backend = "xaml",
+                        status = "error",
+                        error = "native End key did not scroll the shared viewport",
+                    });
+                    return;
+                }
+
                 WriteInteractionResult(markerPath, new
                 {
                     backend = "xaml",
                     status = "interacted",
                     controls = "back-forward-reload-home",
+                    surfaceKeyboard = "document-end",
                     reloadTitle = "Venture reload acceptance",
                     homeAddress = component.Address,
                     targetAddress = targetUrl,
@@ -547,9 +559,30 @@ public static class MosaicHost
 
         private void OnKeyDown(object sender, KeyRoutedEventArgs e)
         {
-            if (e.KeyStatus.IsMenuKeyDown)
+            var shift = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift)
+                & CoreVirtualKeyStates.Down) != 0;
+            if (HandleKey(e.Key, e.KeyStatus.IsMenuKeyDown, shift, out _))
             {
-                var historyEvent = e.Key switch
+                e.Handled = true;
+            }
+        }
+
+        internal bool RunKeyboardAcceptance()
+        {
+            _ = Focus(FocusState.Programmatic);
+            return HandleKey(VirtualKey.End, false, false, out var changed) && changed;
+        }
+
+        private bool HandleKey(
+            VirtualKey key,
+            bool menuKeyDown,
+            bool shift,
+            out bool changed)
+        {
+            changed = false;
+            if (menuKeyDown)
+            {
+                var historyEvent = key switch
                 {
                     VirtualKey.Left => "onBack",
                     VirtualKey.Right => "onForward",
@@ -561,14 +594,12 @@ public static class MosaicHost
                         component,
                         Native.Decode(Native.HandleEvent(browser, historyEvent, null)));
                     Refresh();
-                    e.Handled = true;
-                    return;
+                    changed = true;
+                    return true;
                 }
             }
 
-            var shift = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift)
-                & CoreVirtualKeyStates.Down) != 0;
-            var command = e.Key switch
+            var command = key switch
             {
                 VirtualKey.Up => "line-up",
                 VirtualKey.Down => "line-down",
@@ -582,10 +613,11 @@ public static class MosaicHost
             };
             if (command is not null)
             {
-                _ = Native.ScrollCommand(browser, command);
+                changed = Native.ScrollCommand(browser, command) != 0;
                 Refresh();
-                e.Handled = true;
+                return true;
             }
+            return false;
         }
 
         private void OnPointerReleased(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
## Summary

- extend Venture's generated SwiftUI and WinUI launch acceptance from native browser chrome into the native content surface
- drive the SwiftUI surface with an AppKit End-key event and route the WinUI acceptance through the exact key-mapping handler used by its native surface
- require the shared Rust viewport to report a real `document-end` scroll-state change on a deterministic tall page

## Why

The package-owned adapters already mapped native keyboard input into the shared `venture-browser-core` scroll contract, but the launched generated-app gates stopped after chrome actions. This adds the next bounded acceptance slice without introducing platform-specific browser chrome or test-only Rust state.

## Validation

- `cargo test -p mosaic-emit-swiftui -p mosaic-emit-xaml -p mosaic-package-artifact-builder -p venture-browser-macos -p venture-browser-windows`
- `cargo test -p venture-browser-macos --test swiftui_project_launch -- --nocapture`
- `cargo clippy -p mosaic-emit-swiftui -p mosaic-emit-xaml -p mosaic-package-artifact-builder -p venture-browser-macos -p venture-browser-windows --all-targets -- -D warnings`
- `code/programs/mosaic/venture-browser/scripts/build-all.sh --emit-only`
- `cargo test -q -p coding-adventures-html-parser --test html5lib_coverage_audit_test`

The checked parser audit remains exactly at tree-construction missing `0`, tokenizer missing `0`, and normalized tokenizer skipped `0`. Windows generated-app compilation and interaction run on the Windows CI job. This remains a bounded browser-wiring acceptance slice, not a claim of full browser conformance.
