### PR TITLE
Add runnable queries for every ADJ stdlib library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/stdlib_worked_queries_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/stdlib_worked_queries_e2e.rs
@@ -1,0 +1,103 @@
+//! Executes the checked-in consumers for every stdlib library that previously
+//! lacked a worked query. These are runnable artifacts, not documentation-only
+//! examples: each expected answer and its provenance cross the CLI boundary.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn data_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data")
+        .canonicalize()
+        .expect("spec data root must exist")
+}
+
+#[test]
+fn missing_stdlib_worked_queries_execute_with_provenance() {
+    let cases: &[(&str, &[&str])] = &[
+        (
+            "adj-formula-stdlib/arithmetic/average.query.adj",
+            &[
+                "\"name\":\"mean_two\"",
+                "\"value\":5",
+                "ArithmeticMean.html",
+            ],
+        ),
+        (
+            "adj-formula-stdlib/arithmetic/percent.query.adj",
+            &["\"name\":\"percent\"", "\"value\":75", "Percent.html"],
+        ),
+        (
+            "adj-formula-stdlib/clinical/bmi.query.adj",
+            &["\"name\":\"bmi\"", "22.857142857142858", "who.int"],
+        ),
+        (
+            "adj-formula-stdlib/clinical/bmi_category.query.adj",
+            &["\"hypothesis\":\"obese\"", "0.9999910000809994", "who.int"],
+        ),
+        (
+            "adj-formula-stdlib/cockcroft_gault.query.adj",
+            &["\"name\":\"cockcroft_gault\"", "\"value\":80", "NBK555956"],
+        ),
+        (
+            "mycin-2026/recall/anemia-recall.query.adj",
+            &["\"Class\":\"microcytic\"", "NBK560876"],
+        ),
+        (
+            "mycin-2026/recall/coag-recall.query.adj",
+            &["\"Factor\":\"factor_viii\"", "\"trust\":\"authoritative\""],
+        ),
+        (
+            "mycin-2026/recall/endocrine-recall.query.adj",
+            &[
+                "\"Gland\":\"pancreatic_beta_cells\"",
+                "\"trust\":\"authoritative\"",
+            ],
+        ),
+        (
+            "mycin-2026/recall/iem-recall.query.adj",
+            &[
+                "\"Enzyme\":\"hexosaminidase_a\"",
+                "\"trust\":\"authoritative\"",
+            ],
+        ),
+        (
+            "mycin-2026/recall/vitamin-recall.query.adj",
+            &["\"Disease\":\"beriberi\"", "\"trust\":\"authoritative\""],
+        ),
+    ];
+
+    for (relative, expected) in cases {
+        let program = data_root().join(relative);
+        let output = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+            .arg(&program)
+            .output()
+            .unwrap_or_else(|error| panic!("run {}: {error}", program.display()));
+        let stdout = String::from_utf8(output.stdout).expect("CLI output must be UTF-8");
+
+        assert!(
+            output.status.success(),
+            "{} exited non-zero: {stdout}",
+            program.display()
+        );
+        assert!(
+            !stdout.contains("\"error\""),
+            "{} returned an ADJ error: {stdout}",
+            program.display()
+        );
+        for provenance_field in ["\"source\":", "\"locator\":", "\"trust\":\"authoritative\""] {
+            assert!(
+                stdout.contains(provenance_field),
+                "{} omitted provenance field {provenance_field:?}: {stdout}",
+                program.display()
+            );
+        }
+        for needle in *expected {
+            assert!(
+                stdout.contains(needle),
+                "{} did not contain {needle:?}: {stdout}",
+                program.display()
+            );
+        }
+    }
+}

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -234,7 +234,8 @@ option mapping, or judge/evaluation failure.
 5. **Partial:** CI now gates manifest integrity, JSON Schema validity, validator
    tests, and test references. Complete the source-envelope and
    `--require-byte-pins` gates as those migrations reach zero debt.
-6. Close the ten current worked-query gaps.
+6. [complete] Close the ten current worked-query gaps with executable consumers
+   and a CLI integration test over their answers and provenance.
 
 ### Wave 1: prove the full provenance path
 

--- a/code/specs/data/adj-formula-stdlib/arithmetic/average.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/average.query.adj
@@ -1,0 +1,7 @@
+% Worked consumer for the arithmetic-mean library.
+import "average.adj"
+
+observe value_one(4)
+observe value_two(6)
+
+? mean_two(value_one, value_two)  % expect 5

--- a/code/specs/data/adj-formula-stdlib/arithmetic/percent.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/percent.query.adj
@@ -1,0 +1,10 @@
+% Worked consumer for percentage and percentage-change formulas.
+import "percent.adj"
+
+observe part(30)
+observe whole(40)
+? percent(part, whole)  % expect 75
+
+observe old_amount(200)
+observe new_amount(250)
+? percent_change(old_amount, new_amount)  % expect 25

--- a/code/specs/data/adj-formula-stdlib/clinical/bmi.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/bmi.query.adj
@@ -1,0 +1,7 @@
+% Worked consumer for body mass index.
+import "bmi.adj"
+
+observe body_mass(70)
+observe height(1.75)
+
+? bmi(body_mass, height)  % expect 22.857142857142858

--- a/code/specs/data/adj-formula-stdlib/clinical/bmi_category.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/bmi_category.query.adj
@@ -1,0 +1,7 @@
+% Worked consumer for a rule that branches on a computed BMI.
+import "bmi_category.adj"
+
+observe body_mass(100)
+observe height(1.7)
+
+? obese  % expect a near-certain posterior because BMI is at least 30

--- a/code/specs/data/adj-formula-stdlib/cockcroft_gault.query.adj
+++ b/code/specs/data/adj-formula-stdlib/cockcroft_gault.query.adj
@@ -1,0 +1,10 @@
+% This entry program stays at the stdlib root so the clinical library's
+% cross-directory arithmetic import remains inside the import root.
+import "clinical/cockcroft_gault.adj"
+
+observe age(60)
+observe weight(72)
+observe creatinine(1)
+observe sex_factor(1)
+
+? cockcroft_gault(age, weight, creatinine, sex_factor)  % expect 80

--- a/code/specs/data/adj-stdlib-coverage/COVERAGE.md
+++ b/code/specs/data/adj-stdlib-coverage/COVERAGE.md
@@ -11,8 +11,8 @@ exists. Semantic coverage is tracked in `code/specs/ADJ-STDLIB-COVERAGE.md`.
 | Collection | Content libraries | Clauses | Query companions | Test references | Source envelopes | Byte-pinned |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
 | facts | 141 | 142 | 141 (100.0%) | 141 (100.0%) | 141 (100.0%) | 0 (0.0%) |
-| formulas | 155 | 387 | 150 (96.8%) | 155 (100.0%) | 155 (100.0%) | 0 (0.0%) |
-| medical-recall | 63 | 634 | 58 (92.1%) | 63 (100.0%) | 60 (95.2%) | 0 (0.0%) |
+| formulas | 155 | 387 | 155 (100.0%) | 155 (100.0%) | 155 (100.0%) | 0 (0.0%) |
+| medical-recall | 63 | 634 | 63 (100.0%) | 63 (100.0%) | 60 (95.2%) | 0 (0.0%) |
 
 A complete source envelope means every grounded clause has `source`,
 `locator`, and `trust`. Byte-pinned additionally requires every clause to
@@ -45,29 +45,20 @@ lets `adj-verify --snapshots` check the exact bytes rather than trust a label.
 | `facts/optics` | 1 | 1 | 1 | 1 | 1 | 0 |
 | `facts/physics` | 19 | 19 | 19 | 19 | 19 | 0 |
 | `facts/transportation` | 1 | 1 | 1 | 1 | 1 | 0 |
-| `formulas/arithmetic` | 10 | 20 | 8 | 10 | 10 | 0 |
+| `formulas/arithmetic` | 10 | 20 | 10 | 10 | 10 | 0 |
 | `formulas/chemistry` | 7 | 26 | 7 | 7 | 7 | 0 |
-| `formulas/clinical` | 84 | 263 | 81 | 84 | 84 | 0 |
+| `formulas/clinical` | 84 | 263 | 84 | 84 | 84 | 0 |
 | `formulas/mathematics` | 1 | 4 | 1 | 1 | 1 | 0 |
 | `formulas/metrology` | 1 | 3 | 1 | 1 | 1 | 0 |
 | `formulas/physics` | 13 | 32 | 13 | 13 | 13 | 0 |
 | `formulas/reference` | 39 | 39 | 39 | 39 | 39 | 0 |
-| `medical-recall/recall` | 63 | 634 | 58 | 63 | 60 | 0 |
+| `medical-recall/recall` | 63 | 634 | 63 | 63 | 60 | 0 |
 
 ## Structural Gaps
 
-### Missing worked-query import (10)
+### Missing worked-query import (0)
 
-- `code/specs/data/adj-formula-stdlib/arithmetic/average.adj`
-- `code/specs/data/adj-formula-stdlib/arithmetic/percent.adj`
-- `code/specs/data/adj-formula-stdlib/clinical/bmi.adj`
-- `code/specs/data/adj-formula-stdlib/clinical/bmi_category.adj`
-- `code/specs/data/adj-formula-stdlib/clinical/cockcroft_gault.adj`
-- `code/specs/data/mycin-2026/recall/anemia-edges.adj`
-- `code/specs/data/mycin-2026/recall/coag-edges.adj`
-- `code/specs/data/mycin-2026/recall/endocrine-edges.adj`
-- `code/specs/data/mycin-2026/recall/iem-edges.adj`
-- `code/specs/data/mycin-2026/recall/vitamin-edges.adj`
+None.
 
 ### Not named by a repository test (0)
 

--- a/code/specs/data/mycin-2026/recall/anemia-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/anemia-recall.query.adj
@@ -1,0 +1,5 @@
+% Worked binding queries over the anemia recall library.
+import "anemia-edges.adj"
+
+? has_mcv(iron_deficiency_anemia, $Class)  % expect microcytic
+? classic_finding(b12_deficiency_anemia, $Finding)  % expect hypersegmented_neutrophils

--- a/code/specs/data/mycin-2026/recall/coag-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/coag-recall.query.adj
@@ -1,0 +1,5 @@
+% Worked binding queries over the coagulation recall library.
+import "coag-edges.adj"
+
+? factor_deficiency(hemophilia_a, $Factor)  % expect factor_viii
+? prolonged_test(factor_vii_deficiency, $Test)  % expect pt

--- a/code/specs/data/mycin-2026/recall/endocrine-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/endocrine-recall.query.adj
@@ -1,0 +1,5 @@
+% Worked binding queries over the endocrine recall library.
+import "endocrine-edges.adj"
+
+? secreted_by(insulin, $Gland)  % expect pancreatic_beta_cells
+? deficiency_syndrome(adh, $Syndrome)  % expect central_diabetes_insipidus

--- a/code/specs/data/mycin-2026/recall/iem-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/iem-recall.query.adj
@@ -1,0 +1,6 @@
+% Worked binding queries over the inherited-metabolic-disease recall library.
+import "iem-edges.adj"
+
+? deficient_in(tay_sachs, $Enzyme)  % expect hexosaminidase_a
+? accumulates(gaucher, $Substrate)  % expect glucocerebroside
+? inherited_as(lesch_nyhan, $Pattern)  % expect x_linked_recessive

--- a/code/specs/data/mycin-2026/recall/vitamin-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/vitamin-recall.query.adj
@@ -1,0 +1,5 @@
+% Worked binding queries over the vitamin recall library.
+import "vitamin-edges.adj"
+
+? deficiency_causes(thiamine, $Disease)  % expect beriberi
+? classic_finding(cobalamin, $Finding)  % expect subacute_combined_degeneration


### PR DESCRIPTION
## What changed
- add runnable consumers for the five formula and five medical-recall libraries that lacked worked queries
- execute those exact checked-in consumers through `adj-lang-cli` in an integration test
- require the expected answer plus source, locator, and authoritative trust provenance from every consumer
- regenerate the structural inventory to show 359/359 query coverage

## Why
A tested library is not yet an ergonomic model-facing standard-library entry point. These consumers close the measured gap and prove that each example crosses the real CLI boundary with provenance intact.

## Validation
- `cargo test -p adj-lang-cli --test stdlib_worked_queries_e2e`
- `rustfmt --check adj-lang-cli/tests/stdlib_worked_queries_e2e.rs`
- `python code/scripts/adj_stdlib_report.py --format json --fail-on-unreferenced-tests`
- `python -m unittest discover -s code/scripts/tests -p test_adj_stdlib_report.py`
- `git diff --check origin/main...HEAD`