### PR TITLE
fix(spice): validate MOS model threshold voltage

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values before
+  lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `KP` values
   before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `U0` / `UO` values

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1845,6 +1845,14 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        for threshold_voltage in [params.get("VT0"), params.get("VTO"), params.get("VTH")]
+            .into_iter()
+            .flatten()
+        {
+            if !threshold_voltage.is_finite() {
+                return Err(NetlistParseError::new("MOSFET VT0 must be finite"));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1631,6 +1631,33 @@ fn preserves_explicit_positive_mosfet_model_transconductance() {
 }
 
 #[test]
+fn rejects_non_finite_mosfet_model_threshold_aliases() {
+    for alias in ["VT0", "VTO", "VTH"] {
+        let error = parse_netlist(&format!(
+            ".model threshold NMOS({alias}=1e999)\nM1 d g s b threshold"
+        ))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("MOSFET VT0 must be finite"));
+    }
+}
+
+#[test]
+fn preserves_finite_mosfet_model_threshold_aliases() {
+    for (alias, threshold_voltage) in [("VT0", "-0.7"), ("VTO", "0"), ("VTH", "0.7")] {
+        let parsed = parse_netlist(&format!(
+            ".model threshold NMOS({alias}={threshold_voltage})\nM1 d g s b threshold"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.vt0, threshold_voltage.parse().unwrap());
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card transconductance validation.
+1. Rust Berkeley SPICE MOS model-card threshold-voltage validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite model-card `KP` values before
+   - Reject non-finite model-card `VT0` / `VTO` / `VTH` values before
      lowering MOS elements into engine parameters.
-   - Preserve positive explicit transconductance and its precedence over
-     mobility-derived values.
+   - Preserve arbitrary finite NMOS and PMOS threshold voltages across all
+     accepted aliases.
 
 ## Completed Slices
 
@@ -3933,6 +3933,13 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Zero and positive surface mobility remain accepted, including the `UO`
      alias.
+
+337. Rust Berkeley SPICE MOS model-card transconductance validation.
+   - Status: completed in PR 9464.
+   - Zero, negative, and non-finite model-card `KP` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Positive explicit transconductance remains accepted and takes precedence
+     over mobility-derived values.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-finite MOS model-card `VT0`, `VTO`, and `VTH` values in the Rust Berkeley parser facade
- preserve arbitrary finite thresholds across all accepted aliases
- reconcile the SPICE completion plan after PR #9464

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's threshold-voltage semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.