### PR TITLE
Make ADJ query coverage executable

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/stdlib_worked_queries_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/stdlib_worked_queries_e2e.rs
@@ -13,8 +13,12 @@ fn data_root() -> PathBuf {
 }
 
 #[test]
-fn missing_stdlib_worked_queries_execute_with_provenance() {
+fn stdlib_worked_queries_execute_with_provenance() {
     let cases: &[(&str, &[&str])] = &[
+        (
+            "adj-formula-stdlib/arithmetic/arithmetic.query.adj",
+            &["\"name\":\"sum\"", "\"value\":12", "Sum.html"],
+        ),
         (
             "adj-formula-stdlib/arithmetic/average.query.adj",
             &[
@@ -26,6 +30,10 @@ fn missing_stdlib_worked_queries_execute_with_provenance() {
         (
             "adj-formula-stdlib/arithmetic/percent.query.adj",
             &["\"name\":\"percent\"", "\"value\":75", "Percent.html"],
+        ),
+        (
+            "adj-formula-stdlib/arithmetic/ratio.query.adj",
+            &["\"name\":\"ratio\"", "\"value\":0.75", "Ratio.html"],
         ),
         (
             "adj-formula-stdlib/clinical/bmi.query.adj",

--- a/code/scripts/adj_stdlib_report.py
+++ b/code/scripts/adj_stdlib_report.py
@@ -27,6 +27,7 @@ CLAUSE_PATTERNS = {
 SOURCE_RE = re.compile(r'(?m)^\s*source\s+"')
 LOCATOR_RE = re.compile(r'(?m)^\s*locator\s+"')
 TRUST_RE = re.compile(r"(?m)^\s*trust\s+[a-zA-Z_]")
+IMPORT_RE = re.compile(r'(?m)^\s*import\s+"([^"]+)"')
 PINNED_QUOTE_RE = re.compile(
     r'(?m)^\s*quote\s+".*?"\s+at\s+\d+\s+snapshot\s+"[0-9a-f]{64}"\s*$'
 )
@@ -76,13 +77,26 @@ def _referenced_by_test(candidates: Iterable[str], test_texts: list[str]) -> boo
     )
 
 
+def discover_query_imports(collection_root: Path) -> set[Path]:
+    """Return the normalized files directly imported by worked queries."""
+
+    imports: set[Path] = set()
+    for query in collection_root.rglob("*.query.adj"):
+        text = query.read_text(encoding="utf-8")
+        imports.update(
+            (query.parent / imported).resolve()
+            for imported in IMPORT_RE.findall(text)
+        )
+    return imports
+
+
 def inspect_library(
     root: Path,
     collection: str,
     collection_root: Path,
     path: Path,
     test_texts: list[str],
-    query_texts: list[str],
+    query_imports: set[Path],
 ) -> dict[str, Any]:
     """Return structural evidence for one shipped ADJ file."""
 
@@ -109,11 +123,7 @@ def inspect_library(
         "domain": domain,
         "path": repo_path,
         "content_library": clause_count > 0,
-        "query_companion": any(
-            candidate in query_text
-            for candidate in (repo_path, collection_path, path.name)
-            for query_text in query_texts
-        ),
+        "query_companion": path.resolve() in query_imports,
         "test_reference": _referenced_by_test(
             (repo_path, collection_path, path.name), test_texts
         ),
@@ -157,10 +167,7 @@ def build_report(root: Path) -> dict[str, Any]:
     libraries: list[dict[str, Any]] = []
     for collection, relative_root in COLLECTIONS:
         collection_root = root / relative_root
-        query_texts = [
-            path.read_text(encoding="utf-8").replace("\\", "/")
-            for path in collection_root.rglob("*.query.adj")
-        ]
+        query_imports = discover_query_imports(collection_root)
         for path in sorted(collection_root.rglob("*.adj")):
             if path.name.endswith(".query.adj"):
                 continue
@@ -171,7 +178,7 @@ def build_report(root: Path) -> dict[str, Any]:
                     collection_root,
                     path,
                     test_texts,
-                    query_texts,
+                    query_imports,
                 )
             )
 

--- a/code/scripts/tests/test_adj_stdlib_report.py
+++ b/code/scripts/tests/test_adj_stdlib_report.py
@@ -91,6 +91,29 @@ class AdjStdlibReportTests(unittest.TestCase):
             ["code/specs/data/adj-facts-stdlib/science/two.adj"],
         )
 
+    def test_query_comments_do_not_count_as_imports(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.make_root(directory)
+            library = root / "code/specs/data/adj-facts-stdlib/math/counting.adj"
+            library.parent.mkdir(parents=True, exist_ok=True)
+            library.write_text(
+                'relate counts(one, 1) source "one" trust authoritative\n',
+                encoding="utf-8",
+            )
+            (library.parent / "other.query.adj").write_text(
+                '% import "counting.adj" is only an example\n? other($Value)\n',
+                encoding="utf-8",
+            )
+
+            report = stdlib.build_report(root)
+            row = next(item for item in report["libraries"] if item["content_library"])
+
+        self.assertFalse(row["query_companion"])
+        self.assertEqual(
+            report["gaps"]["missing_query_companion"],
+            [library.relative_to(root).as_posix()],
+        )
+
     def test_excludes_consumers_from_content_gap_denominators(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = self.make_root(directory)

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -236,6 +236,9 @@ option mapping, or judge/evaluation failure.
    `--require-byte-pins` gates as those migrations reach zero debt.
 6. [complete] Close the ten current worked-query gaps with executable consumers
    and a CLI integration test over their answers and provenance.
+7. **Complete:** parse executable `import` statements when measuring worked
+   queries; filename mentions in comments are not coverage evidence. The stricter
+   audit exposed and closed two additional gaps (`arithmetic.adj`, `ratio.adj`).
 
 ### Wave 1: prove the full provenance path
 

--- a/code/specs/data/adj-formula-stdlib/arithmetic/arithmetic.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/arithmetic.query.adj
@@ -1,0 +1,18 @@
+% Worked consumers for the four elementary arithmetic primitives.
+import "arithmetic.adj"
+
+observe addend_one(7)
+observe addend_two(5)
+? sum(addend_one, addend_two)  % expect 12
+
+observe minuend(7)
+observe subtrahend(5)
+? difference(minuend, subtrahend)  % expect 2
+
+observe factor_one(6)
+observe factor_two(7)
+? product(factor_one, factor_two)  % expect 42
+
+observe dividend(20)
+observe divisor(5)
+? quotient(dividend, divisor)  % expect 4

--- a/code/specs/data/adj-formula-stdlib/arithmetic/ratio.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/ratio.query.adj
@@ -1,0 +1,7 @@
+% Worked consumer for a ratio composed from the quotient primitive.
+import "ratio.adj"
+
+observe numerator(3)
+observe denominator(4)
+
+? ratio(numerator, denominator)  % expect 0.75


### PR DESCRIPTION
## What changed
- parse direct executable imports instead of counting filename substrings in query comments
- add a regression test proving comment-only mentions do not count
- add real worked consumers for the two residual gaps exposed by the stricter audit
- extend the checked-in consumer integration test to execute both with answer and provenance checks

## Why
The previous structural metric could report a query companion from documentation text alone. This correction makes the 359/359 claim defensible and closes the two genuine gaps it reveals.

## Validation
- Ruff passes for the reporter and tests
- 5 reporter tests pass
- `cargo test -p adj-lang-cli --test stdlib_worked_queries_e2e`
- `rustfmt --check adj-lang-cli/tests/stdlib_worked_queries_e2e.rs`
- strict structural report: 359 content libraries, 359 direct query imports, 359 test references
- `git diff --check`