### PR TITLE
fix(spice): validate MOS model channel modulation

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values before
+  lowering netlist elements into the engine.
 - Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values before
   lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `KP` values

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1853,6 +1853,14 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 return Err(NetlistParseError::new("MOSFET VT0 must be finite"));
             }
         }
+        for channel_length_modulation in [params.get("LAMBDA"), params.get("LAM")]
+            .into_iter()
+            .flatten()
+        {
+            if !channel_length_modulation.is_finite() {
+                return Err(NetlistParseError::new("MOSFET LAMBDA must be finite"));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1658,6 +1658,36 @@ fn preserves_finite_mosfet_model_threshold_aliases() {
 }
 
 #[test]
+fn rejects_non_finite_mosfet_model_channel_length_modulation_aliases() {
+    for alias in ["LAMBDA", "LAM"] {
+        let error = parse_netlist(&format!(
+            ".model channel NMOS({alias}=1e999)\nM1 d g s b channel"
+        ))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("MOSFET LAMBDA must be finite"));
+    }
+}
+
+#[test]
+fn preserves_finite_mosfet_model_channel_length_modulation_aliases() {
+    for (alias, channel_length_modulation) in [("LAMBDA", "-0.01"), ("LAM", "0.02")] {
+        let parsed = parse_netlist(&format!(
+            ".model channel NMOS({alias}={channel_length_modulation})\nM1 d g s b channel"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(
+            mosfet.params.lambda,
+            channel_length_modulation.parse().unwrap(),
+        );
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card threshold-voltage validation.
+1. Rust Berkeley SPICE MOS model-card channel-length-modulation validation.
    - Status: current PR completion candidate.
-   - Reject non-finite model-card `VT0` / `VTO` / `VTH` values before
+   - Reject non-finite model-card `LAMBDA` / `LAM` values before
      lowering MOS elements into engine parameters.
-   - Preserve arbitrary finite NMOS and PMOS threshold voltages across all
+   - Preserve arbitrary finite channel-length-modulation values across both
      accepted aliases.
 
 ## Completed Slices
@@ -3940,6 +3940,13 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Positive explicit transconductance remains accepted and takes precedence
      over mobility-derived values.
+
+338. Rust Berkeley SPICE MOS model-card threshold-voltage validation.
+   - Status: completed in PR 9469.
+   - Non-finite model-card `VT0` / `VTO` / `VTH` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Arbitrary finite NMOS and PMOS threshold voltages remain accepted across
+     all aliases.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-finite MOS model-card `LAMBDA` and `LAM` values in the Rust Berkeley parser facade
- preserve arbitrary finite channel-length-modulation values across both aliases
- reconcile the SPICE completion plan after PR #9469

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's channel-length-modulation semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.