### PR TITLE
fix(spice): validate MOS model bulk potential

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS model-card `PHI` values
+  before lowering netlist elements into the engine.
 - Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values before
   lowering netlist elements into the engine.
 - Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1861,6 +1861,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 return Err(NetlistParseError::new("MOSFET LAMBDA must be finite"));
             }
         }
+        if let Some(bulk_potential) = params.get("PHI") {
+            if !bulk_potential.is_finite() || *bulk_potential <= 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET PHI must be finite and positive",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1688,6 +1688,30 @@ fn preserves_finite_mosfet_model_channel_length_modulation_aliases() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_bulk_potential() {
+    for bulk_potential in ["0", "-0.8", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model bulk NMOS(PHI={bulk_potential})\nM1 d g s b bulk"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET PHI must be finite and positive"));
+    }
+}
+
+#[test]
+fn preserves_positive_mosfet_model_bulk_potential() {
+    let parsed = parse_netlist(".model bulk NMOS(PHI=0.8)\nM1 d g s b bulk").unwrap();
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+    assert_close(mosfet.params.phi, 0.8);
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card channel-length-modulation validation.
+1. Rust Berkeley SPICE MOS model-card bulk-potential validation.
    - Status: current PR completion candidate.
-   - Reject non-finite model-card `LAMBDA` / `LAM` values before
+   - Reject zero, negative, and non-finite model-card `PHI` values before
      lowering MOS elements into engine parameters.
-   - Preserve arbitrary finite channel-length-modulation values across both
-     accepted aliases.
+   - Preserve positive explicit bulk-potential values.
 
 ## Completed Slices
 
@@ -3947,6 +3946,13 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Arbitrary finite NMOS and PMOS threshold voltages remain accepted across
      all aliases.
+
+339. Rust Berkeley SPICE MOS model-card channel-length-modulation validation.
+   - Status: completed in PR 9473.
+   - Non-finite model-card `LAMBDA` / `LAM` values are rejected before lowering
+     MOS elements into engine parameters.
+   - Arbitrary finite channel-length-modulation values remain accepted across
+     both aliases.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite MOS model-card `PHI` values in the Rust Berkeley parser facade
- preserve positive explicit bulk-potential values
- reconcile the SPICE completion plan after PR #9473

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's bulk-potential semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.