### PR TITLE
feat(dart): port matrix and core ML utilities

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -4,22 +4,25 @@
   "started": "2026-07-29",
   "policy": {
     "maximum_active_parity_prs": 1,
-    "merge_authority": "user",
+    "merge_authority": "auto-merge-after-required-checks",
     "reprioritize_after_every_merge": true,
-    "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
+    "ocaml_denominator_status": "emerging-until-promotion-gates-pass",
+    "delivery_scope": "portable-packages-and-build-tools-only",
+    "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
+    "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9421,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "d5f57bfdbc64ebf44d677f195380714f949b0db6",
+    "revision": "e552707d59c62c0c0749c6173a2cf82478629b48",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1209,
-    "implementation_package_slots": 4353,
+    "implementation_identities": 1215,
+    "implementation_package_slots": 4359,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 275,
-    "singleton_packages": 759,
-    "singleton_missing_slots": 10626,
-    "rust_singletons": 564,
+    "singleton_packages": 765,
+    "singleton_missing_slots": 10710,
+    "rust_singletons": 570,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -681,11 +684,11 @@
     {
       "id": "smart-home-camera-media-security-boundary-hardening",
       "title": "Replace camera endpoint redemption with a mediated single-use security boundary",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["capability-schema-category-action-constraints"],
       "branch": "codex/camera-media-security-boundary",
       "pr_number": 9421,
-      "notes": "Ready-for-review PR #9421. Selected after the post-#9413 collision-clean inventory and dependency, fixture, and security audits because its only dependency is merged and the current broker's replayable raw-URI redemption is a P0 privacy-boundary defect. The hardening installs authenticated principal, clock, nonce, and executor authority once in a host-owned service; removes bearer IDs from audits; revalidates grants; binds leases to endpoint generations; bounds global/per-principal leases, streams, pending cleanup, endpoints, snapshots, and audit; mints stream IDs outside the executor; owns stream close/expiry; retains and surfaces failed teardown for retry; rejects URL userinfo, fragments, default plaintext, and plaintext query strings; confines secure query tokens to the executor; and schema-validates an explicit authority-free manifest for the policy core. Final validation after rebasing onto d5f57bfdb covered 15 camera tests, 4 ONVIF tests, warning-free Clippy/format, 85.87% camera line coverage, 6 capability schema tests, 67 capability-cage tests, a real 21-package build-tool run plus identical post-rebase dry-run closure, zero parity collisions/unknown buckets at 1,209 identities and 4,353 slots, zero dependency vulnerabilities, diff/secret hygiene, and independent contract/fixture/security reviews with no blockers. The separately tracked ONVIF origin/credential item remains the owner for discovery correlation, device-origin allowlists, credential transport, and downgrade defenses."
+      "notes": "Merged PR #9421 at d0cd8ba4c8ddc83f5312eaca16e7c5fdbfb7c6ea. Retained as historical state only; host-security delivery is outside the portable-package/build-tool parity selection scope."
     },
     {
       "id": "smart-home-onvif-origin-credential-transport-hardening",
@@ -694,7 +697,9 @@
       "depends_on": ["capability-schema-category-action-constraints"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered in the post-#9413 security audit. WS-Discovery and device-supplied XAddr values can currently redirect fresh WS-Security digests to attacker-selected origins, plaintext downgrade is accepted, and discovery is overclassified as verified. Add explicit origin correlation and allowlist policy, secure transport requirements with loopback-only fixture exceptions, redirect and DNS rebinding defenses, bounded SOAP/media parsing, redacted failures, and hostile integration fixtures."
+      "selection_blocked": true,
+      "parity_scope": "excluded-host-hardening",
+      "notes": "Discovered in the post-#9413 security audit. This host-security item is explicitly excluded from parity-loop delivery; PR #9457 is not a package-parity PR. Only separately owned authority-free portable cores and language-neutral fixtures are eligible for parity work."
     },
     {
       "id": "smart-home-onvif-transactional-install",
@@ -774,7 +779,7 @@
       "id": "smart-home-shelly-portable-core-extraction-and-conformance",
       "title": "Extract, fixture, and expand the portable Shelly Gen2/Gen3 core",
       "status": "pending",
-      "depends_on": ["smart-home-shelly-host-security-hardening"],
+      "depends_on": ["smart-home-runtime-command-effect-lifecycle"],
       "branch": null,
       "pr_number": null,
       "notes": "Extract and fixture deterministic Gen2/Gen3 device-info and status parsing, authentication-required classification, component projection, stable identifiers, capability/state normalization, RPC envelope validation, command planning, bounds, and hostile inputs. Expand only this authority-free core through established lanes while mDNS, DNS/TCP, plaintext LAN HTTP, trusted time, console I/O, Vault access, origin allowlists, and SmartHomeRuntime effect application remain in the native Rust host."
@@ -814,7 +819,7 @@
       "id": "smart-home-wled-portable-core-extraction-and-conformance",
       "title": "Extract, fixture, and expand the portable WLED JSON core",
       "status": "pending",
-      "depends_on": ["smart-home-wled-host-security-hardening"],
+      "depends_on": ["smart-home-runtime-command-effect-lifecycle"],
       "branch": null,
       "pr_number": null,
       "notes": "Extract and fixture deterministic /json/si DTO validation, master and segment projection, stable identifiers, capability-bit interpretation, state normalization, brightness/RGB/mirek conversion, command planning, bounds, and hostile inputs. Expand only this authority-free core through established lanes while mDNS, DNS/TCP, plaintext LAN HTTP, trusted time, console I/O, origin/pairing policy, and SmartHomeRuntime effect application remain in the native Rust host."
@@ -830,12 +835,12 @@
     },
     {
       "id": "dart-current-14-of-15-matrix-family",
-      "title": "Port the matrix dependency and its immediate ML consumers to Dart",
-      "status": "pending",
+      "title": "Port matrix, loss-functions, and feature-normalization to Dart",
+      "status": "in-progress",
       "depends_on": ["dart-trig-wave", "dart-scaffold-capability-schema"],
-      "branch": null,
+      "branch": "codex/dart-matrix-ml-parity",
       "pr_number": null,
-      "notes": "Materialized from the remaining Dart-only 14-of-15 umbrella during the post-#9413 dependency pass. Deliver matrix first, then loss-functions and feature-normalization in a coherent dependency-shaped slice with shared fixtures, empty capability profiles, package-native tests, coverage, and real downstream builds. Security-critical camera work currently outranks this otherwise highest-leverage portable frontier child."
+      "notes": "Selected from the remaining Dart-only 14-of-15 frontier after correcting the loop to portable-package/build-tool scope. Deliver the three independent leaf packages in one coherent ML slice with shared reference vectors, empty capability profiles, package-native tests, coverage, and real build-tool validation."
     },
     {
       "id": "venture-browser-windows-portable-bridge-and-native-host",
@@ -1020,6 +1025,105 @@
       "branch": null,
       "pr_number": null,
       "notes": "After the urgent host boundary is hardened and the deterministic core is extracted, narrow the Rust host to WebSocket/TLS collection, Vault leases, bounded DTO conversion, artifact I/O, clock/reporting effects, and CLI orchestration without delaying security remediation on the larger refactor."
+    },
+    {
+      "id": "smart-home-runtime-command-effect-lifecycle",
+      "title": "Define a shared confirmed command-effect lifecycle for smart-home ports",
+      "status": "pending",
+      "depends_on": ["capability-schema-category-action-constraints"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Define language-neutral prepare/authorize, confirmed-or-failed effect, retry, idempotency, audit, and result fixtures. Native device I/O and runtime mutation are reviewed host exceptions."
+    },
+    {
+      "id": "smart-home-media-entity-command-contract",
+      "title": "Define protocol-neutral media entities, state, and command effects",
+      "status": "pending",
+      "depends_on": ["smart-home-runtime-command-effect-lifecycle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Define portable media-player and TV entity kinds, playback, input, app, power, and volume state plus command/result fixtures shared by Roku, Sonos, and Cast. Host I/O is excluded."
+    },
+    {
+      "id": "smart-home-govee-portable-core-extraction-and-conformance",
+      "title": "Extract, fixture, and expand the portable Govee LAN core",
+      "status": "pending",
+      "depends_on": ["smart-home-runtime-command-effect-lifecycle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Share scan/status parsing, bounds and stable errors, discovery/entity projection, identities, normalization, command planning, and verification fixtures. UDP, clock, and runtime authority are excluded."
+    },
+    {
+      "id": "smart-home-lifx-portable-core-extraction-and-conformance",
+      "title": "Extract and port the portable LIFX LAN protocol core",
+      "status": "pending",
+      "depends_on": ["smart-home-runtime-command-effect-lifecycle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Share packet codec and correlation, discovery normalization, HSBK/state/capability projection, bounds and errors, command planning, and verification fixtures. UDP, trusted identity/time, and runtime authority are excluded."
+    },
+    {
+      "id": "smart-home-kasa-portable-core-extraction-and-conformance",
+      "title": "Extract and port the portable Kasa protocol core",
+      "status": "pending",
+      "depends_on": ["smart-home-runtime-command-effect-lifecycle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Share the XOR codec, bounded JSON/status validation, device and identity normalization, state/capability projection, stable errors, command planning, and verification fixtures. Network, time, and runtime authority are excluded."
+    },
+    {
+      "id": "smart-home-reolink-portable-core-extraction-and-conformance",
+      "title": "Extract and port the portable Reolink protocol core",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Share CGI DTO validation, bounded response parsing, device/channel/motion projection, stable identities, and stable errors. DNS/TCP/TLS, Vault, trusted time, and runtime authority are excluded."
+    },
+    {
+      "id": "smart-home-roku-ecp-portable-core-extraction-and-conformance",
+      "title": "Extract, fixture, and expand the portable Roku ECP core",
+      "status": "pending",
+      "depends_on": ["smart-home-media-entity-command-contract"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Share SSDP/ECP request and response plus bounded XML fixtures, device/app normalization, identities, stable errors, and media projection. Multicast, DNS/TCP, and runtime authority are excluded."
+    },
+    {
+      "id": "spice-device-parameter-validation-shared-conformance",
+      "title": "Share SPICE device and model parameter validation fixtures across lanes",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Share a Python/Rust/TypeScript corpus for MOS W/L/NRD/NRS/AD/AS/PD/PS and TOX/U0/UO/KP/VT0/VTO/VTH validation, including aliases, case, duplicates, NaN/Infinity, and stable diagnostics. Discovered across merged PRs #9427, #9429, #9432, #9436, #9437, #9439, #9443, #9448, #9450, #9453, #9459, #9464, #9469, and #9473."
+    },
+    {
+      "id": "smart-home-switch-entity-command-contract",
+      "title": "Define protocol-neutral switch entities and command effects",
+      "status": "pending",
+      "depends_on": ["smart-home-runtime-command-effect-lifecycle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Define portable switch/outlet state, on/off authorization, confirmed results, retry/idempotency, and fixtures. Discovered from Wemo's read-only generic-outlet exception."
+    },
+    {
+      "id": "smart-home-wemo-upnp-portable-core-extraction-and-conformance",
+      "title": "Extract and port the portable Wemo UPnP core",
+      "status": "pending",
+      "depends_on": ["smart-home-switch-entity-command-contract"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Share SSDP header parsing, bounded setup/SOAP XML validation, service/device normalization, stable identities/errors, and switch/light command planning. UDP/DNS/TCP and runtime authority are excluded."
+    },
+    {
+      "id": "dart-neural-consumer-matrix-loss-migration",
+      "title": "Migrate Dart neural consumers to the shared matrix and loss packages",
+      "status": "pending",
+      "depends_on": ["dart-current-14-of-15-matrix-family"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the Dart ML parity audit. single-layer-network and two-layer-network duplicate private matrix and MSE helpers. Migrate them in a separate downstream slice after the shared packages land, preserving their public APIs and training fixtures."
     },
     {
       "id": "c-cpp-graduation",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -1126,6 +1126,15 @@
       "notes": "Discovered during the Dart ML parity audit. single-layer-network and two-layer-network duplicate private matrix and MSE helpers. Migrate them in a separate downstream slice after the shared packages land, preserving their public APIs and training fixtures."
     },
     {
+      "id": "ml01-non-finite-input-contract-conformance",
+      "title": "Define and enforce the ML01 non-finite input policy across lanes",
+      "status": "pending",
+      "depends_on": ["dart-current-14-of-15-matrix-family"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the Dart loss-functions security review. ML01 does not define whether NaN and infinity are rejected or propagated; Dart num.clamp and the Python reference can map NaN predictions to a finite cross-entropy boundary. Define language-neutral fixtures and update every established loss-functions lane together rather than adding a Dart-only divergence."
+    },
+    {
       "id": "c-cpp-graduation",
       "title": "Review C/C++ graduation and native build-tool requirements",
       "status": "pending",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9477,
   "last_inventory": {
     "revision": "e552707d59c62c0c0749c6173a2cf82478629b48",
     "schema_version": 3,
@@ -836,11 +836,11 @@
     {
       "id": "dart-current-14-of-15-matrix-family",
       "title": "Port matrix, loss-functions, and feature-normalization to Dart",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["dart-trig-wave", "dart-scaffold-capability-schema"],
       "branch": "codex/dart-matrix-ml-parity",
-      "pr_number": null,
-      "notes": "Selected from the remaining Dart-only 14-of-15 frontier after correcting the loop to portable-package/build-tool scope. Deliver the three independent leaf packages in one coherent ML slice with shared reference vectors, empty capability profiles, package-native tests, coverage, and real build-tool validation."
+      "pr_number": 9477,
+      "notes": "Ready-for-review PR #9477. Selected from the remaining Dart-only 14-of-15 frontier after correcting the loop to portable-package/build-tool scope. Delivers the independent matrix, loss-functions, and feature-normalization leaf packages with shared reference vectors, immutable ownership, validation, empty capability profiles, BUILD/BUILD_windows, docs, and metadata. Local validation passed formatter/analyzer/randomized tests, 93.65%-100% line coverage, both package build scripts, the exact three-package diff build, nearby neural-network regressions, 21 reporter/capability tests, collision-clean parity at 1,215 identities and 4,362 slots, dependency/diff hygiene, and independent security review. The repository-wide build validator still reports the separately tracked 73 pre-existing BUILD_windows prerequisite declarations outside this slice."
     },
     {
       "id": "venture-browser-windows-portable-bridge-and-native-host",

--- a/code/packages/dart/feature-normalization/.gitignore
+++ b/code/packages/dart/feature-normalization/.gitignore
@@ -1,0 +1,3 @@
+.dart_tool/
+coverage/
+pubspec.lock

--- a/code/packages/dart/feature-normalization/BUILD
+++ b/code/packages/dart/feature-normalization/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/feature-normalization/BUILD_windows
+++ b/code/packages/dart/feature-normalization/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/feature-normalization/CHANGELOG.md
+++ b/code/packages/dart/feature-normalization/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-08-02
+
+- Add immutable standard-scaler and min-max-scaler parameter objects.
+- Add fit and transform operations with constant-column handling.

--- a/code/packages/dart/feature-normalization/README.md
+++ b/code/packages/dart/feature-normalization/README.md
@@ -1,0 +1,27 @@
+# Feature Normalization (Dart)
+
+A dependency-free Dart implementation of the standard and min-max feature
+normalization contracts in
+[ML05](../../../specs/ML05-feature-normalization-and-learning-rate-sweeps.md).
+
+`fitStandardScaler` uses population variance and returns immutable means and
+standard deviations. `fitMinMaxScaler` returns immutable minima and maxima.
+Their transform functions accept any row count with a matching feature width,
+return fresh rows, and map constant columns to zero. Empty or ragged matrices
+and incompatible scaler widths throw `ArgumentError`.
+
+```dart
+import 'package:coding_adventures_feature_normalization/feature_normalization.dart';
+
+final rows = [[1.0, 10.0], [3.0, 20.0]];
+final scaler = fitStandardScaler(rows);
+final normalized = transformStandard(rows, scaler);
+```
+
+Run the package checks with:
+
+```sh
+dart pub get
+dart analyze
+dart test
+```

--- a/code/packages/dart/feature-normalization/lib/feature_normalization.dart
+++ b/code/packages/dart/feature-normalization/lib/feature_normalization.dart
@@ -1,0 +1,1 @@
+export 'src/feature_normalization.dart';

--- a/code/packages/dart/feature-normalization/lib/src/feature_normalization.dart
+++ b/code/packages/dart/feature-normalization/lib/src/feature_normalization.dart
@@ -1,0 +1,96 @@
+import 'dart:math' as math;
+
+class StandardScaler {
+  StandardScaler(List<double> means, List<double> standardDeviations)
+      : means = List<double>.unmodifiable(means),
+        standardDeviations = List<double>.unmodifiable(standardDeviations);
+
+  final List<double> means;
+  final List<double> standardDeviations;
+}
+
+class MinMaxScaler {
+  MinMaxScaler(List<double> minimums, List<double> maximums)
+      : minimums = List<double>.unmodifiable(minimums),
+        maximums = List<double>.unmodifiable(maximums);
+
+  final List<double> minimums;
+  final List<double> maximums;
+}
+
+StandardScaler fitStandardScaler(List<List<double>> rows) {
+  final width = _validateMatrix(rows);
+  final means = List.generate(
+    width,
+    (column) =>
+        rows.fold(0.0, (total, row) => total + row[column]) / rows.length,
+  );
+  final standardDeviations = List.generate(width, (column) {
+    final variance = rows.fold(0.0, (total, row) {
+          final difference = row[column] - means[column];
+          return total + difference * difference;
+        }) /
+        rows.length;
+    return math.sqrt(variance);
+  });
+  return StandardScaler(means, standardDeviations);
+}
+
+List<List<double>> transformStandard(
+  List<List<double>> rows,
+  StandardScaler scaler,
+) {
+  final width = _validateMatrix(rows);
+  if (scaler.means.length != width ||
+      scaler.standardDeviations.length != width) {
+    throw ArgumentError('matrix width must match standard scaler width');
+  }
+  return rows.map((row) {
+    return List.generate(width, (column) {
+      final standardDeviation = scaler.standardDeviations[column];
+      return standardDeviation == 0.0
+          ? 0.0
+          : (row[column] - scaler.means[column]) / standardDeviation;
+    });
+  }).toList();
+}
+
+MinMaxScaler fitMinMaxScaler(List<List<double>> rows) {
+  final width = _validateMatrix(rows);
+  final minimums = List.generate(
+    width,
+    (column) => rows.map((row) => row[column]).reduce(math.min),
+  );
+  final maximums = List.generate(
+    width,
+    (column) => rows.map((row) => row[column]).reduce(math.max),
+  );
+  return MinMaxScaler(minimums, maximums);
+}
+
+List<List<double>> transformMinMax(
+  List<List<double>> rows,
+  MinMaxScaler scaler,
+) {
+  final width = _validateMatrix(rows);
+  if (scaler.minimums.length != width || scaler.maximums.length != width) {
+    throw ArgumentError('matrix width must match min-max scaler width');
+  }
+  return rows.map((row) {
+    return List.generate(width, (column) {
+      final span = scaler.maximums[column] - scaler.minimums[column];
+      return span == 0.0 ? 0.0 : (row[column] - scaler.minimums[column]) / span;
+    });
+  }).toList();
+}
+
+int _validateMatrix(List<List<double>> rows) {
+  if (rows.isEmpty || rows.first.isEmpty) {
+    throw ArgumentError('matrix must have at least one row and one column');
+  }
+  final width = rows.first.length;
+  if (rows.any((row) => row.length != width)) {
+    throw ArgumentError('all matrix rows must have the same width');
+  }
+  return width;
+}

--- a/code/packages/dart/feature-normalization/pubspec.yaml
+++ b/code/packages/dart/feature-normalization/pubspec.yaml
@@ -1,0 +1,13 @@
+name: coding_adventures_feature_normalization
+description: Immutable standard and min-max feature normalization for Dart.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/feature-normalization/required_capabilities.json
+++ b/code/packages/dart/feature-normalization/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/feature-normalization",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, environment, or console access needed."
+}

--- a/code/packages/dart/feature-normalization/test/feature_normalization_test.dart
+++ b/code/packages/dart/feature-normalization/test/feature_normalization_test.dart
@@ -1,0 +1,89 @@
+import 'package:coding_adventures_feature_normalization/feature_normalization.dart';
+import 'package:test/test.dart';
+
+const tolerance = 1e-9;
+
+void main() {
+  final rows = <List<double>>[
+    [1000.0, 3.0, 1.0],
+    [1500.0, 4.0, 0.0],
+    [2000.0, 5.0, 1.0],
+  ];
+
+  group('shared reference vectors', () {
+    test('standard scaling centers and scales columns', () {
+      final scaler = fitStandardScaler(rows);
+      expect(scaler.means[0], equals(1500.0));
+      expect(scaler.means[1], equals(4.0));
+      final transformed = transformStandard(rows, scaler);
+      expect(transformed[0][0], closeTo(-1.224744871391589, tolerance));
+      expect(transformed[1][0], closeTo(0.0, tolerance));
+      expect(transformed[2][0], closeTo(1.224744871391589, tolerance));
+    });
+
+    test('min-max scaling maps columns to the unit range', () {
+      expect(
+        transformMinMax(rows, fitMinMaxScaler(rows)),
+        equals([
+          [0.0, 0.0, 1.0],
+          [0.5, 0.5, 0.0],
+          [1.0, 1.0, 1.0],
+        ]),
+      );
+    });
+
+    test('constant columns map to zero', () {
+      final data = <List<double>>[
+        [1.0, 7.0],
+        [2.0, 7.0],
+      ];
+      expect(
+        transformStandard(data, fitStandardScaler(data))[0][1],
+        equals(0.0),
+      );
+      expect(transformMinMax(data, fitMinMaxScaler(data))[0][1], equals(0.0));
+    });
+  });
+
+  group('validation and ownership', () {
+    test('rejects empty and ragged matrices', () {
+      expect(() => fitStandardScaler([]), throwsArgumentError);
+      expect(() => fitMinMaxScaler([<double>[]]), throwsArgumentError);
+      expect(
+        () => fitStandardScaler([
+          [1.0, 2.0],
+          [3.0],
+        ]),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects mismatched scaler widths', () {
+      expect(
+        () => transformStandard(rows, StandardScaler([0.0], [1.0])),
+        throwsArgumentError,
+      );
+      expect(
+        () => transformMinMax(rows, MinMaxScaler([0.0], [1.0])),
+        throwsArgumentError,
+      );
+    });
+
+    test('does not mutate inputs or expose mutable scaler storage', () {
+      final input = <List<double>>[
+        [1.0, 2.0],
+        [3.0, 4.0],
+      ];
+      final scaler = fitStandardScaler(input);
+      transformStandard(input, scaler)[0][0] = 99.0;
+      expect(
+        input,
+        equals([
+          [1.0, 2.0],
+          [3.0, 4.0],
+        ]),
+      );
+      expect(() => scaler.means[0] = 99.0, throwsUnsupportedError);
+    });
+  });
+}

--- a/code/packages/dart/loss-functions/.gitignore
+++ b/code/packages/dart/loss-functions/.gitignore
@@ -1,0 +1,3 @@
+.dart_tool/
+coverage/
+pubspec.lock

--- a/code/packages/dart/loss-functions/BUILD
+++ b/code/packages/dart/loss-functions/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/loss-functions/BUILD_windows
+++ b/code/packages/dart/loss-functions/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/loss-functions/CHANGELOG.md
+++ b/code/packages/dart/loss-functions/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-08-02
+
+- Add Dart implementations of MSE, MAE, binary cross-entropy, and categorical
+  cross-entropy.
+- Add analytical derivatives and cross-entropy stability clamping.

--- a/code/packages/dart/loss-functions/README.md
+++ b/code/packages/dart/loss-functions/README.md
@@ -1,0 +1,25 @@
+# Loss Functions (Dart)
+
+A dependency-free Dart implementation of the losses and analytical derivatives
+specified by [ML01](../../../specs/ML01-loss-functions.md).
+
+The canonical API provides `mse`, `mae`, `bce`, `cce`, and corresponding
+`*Derivative` functions. Descriptive binary and categorical cross-entropy
+aliases are also available. Every function requires equal, non-empty vectors;
+cross-entropy inputs are clamped to `1e-7` through `1 - 1e-7` for numerical
+stability, and inputs are never mutated.
+
+```dart
+import 'package:coding_adventures_loss_functions/loss_functions.dart';
+
+final loss = mse([1.0, 0.0], [0.9, 0.1]);
+final gradient = mseDerivative([1.0, 0.0], [0.9, 0.1]);
+```
+
+Run the package checks with:
+
+```sh
+dart pub get
+dart analyze
+dart test
+```

--- a/code/packages/dart/loss-functions/lib/loss_functions.dart
+++ b/code/packages/dart/loss-functions/lib/loss_functions.dart
@@ -1,0 +1,1 @@
+export 'src/loss_functions.dart';

--- a/code/packages/dart/loss-functions/lib/src/loss_functions.dart
+++ b/code/packages/dart/loss-functions/lib/src/loss_functions.dart
@@ -1,0 +1,95 @@
+import 'dart:math' as math;
+
+const double epsilon = 1e-7;
+
+double mse(List<double> yTrue, List<double> yPred) {
+  _validate(yTrue, yPred);
+  var total = 0.0;
+  for (var index = 0; index < yTrue.length; index++) {
+    final difference = yTrue[index] - yPred[index];
+    total += difference * difference;
+  }
+  return total / yTrue.length;
+}
+
+double mae(List<double> yTrue, List<double> yPred) {
+  _validate(yTrue, yPred);
+  var total = 0.0;
+  for (var index = 0; index < yTrue.length; index++) {
+    total += (yTrue[index] - yPred[index]).abs();
+  }
+  return total / yTrue.length;
+}
+
+double bce(List<double> yTrue, List<double> yPred) {
+  _validate(yTrue, yPred);
+  var total = 0.0;
+  for (var index = 0; index < yTrue.length; index++) {
+    final prediction = _clamp(yPred[index]);
+    total += yTrue[index] * math.log(prediction) +
+        (1.0 - yTrue[index]) * math.log(1.0 - prediction);
+  }
+  return -total / yTrue.length;
+}
+
+double cce(List<double> yTrue, List<double> yPred) {
+  _validate(yTrue, yPred);
+  var total = 0.0;
+  for (var index = 0; index < yTrue.length; index++) {
+    total += yTrue[index] * math.log(_clamp(yPred[index]));
+  }
+  return -total / yTrue.length;
+}
+
+double binaryCrossEntropy(List<double> yTrue, List<double> yPred) =>
+    bce(yTrue, yPred);
+
+double categoricalCrossEntropy(List<double> yTrue, List<double> yPred) =>
+    cce(yTrue, yPred);
+
+List<double> mseDerivative(List<double> yTrue, List<double> yPred) {
+  _validate(yTrue, yPred);
+  final scale = 2.0 / yTrue.length;
+  return List.generate(
+    yTrue.length,
+    (index) => scale * (yPred[index] - yTrue[index]),
+  );
+}
+
+List<double> maeDerivative(List<double> yTrue, List<double> yPred) {
+  _validate(yTrue, yPred);
+  final scale = 1.0 / yTrue.length;
+  return List.generate(yTrue.length, (index) {
+    final difference = yPred[index] - yTrue[index];
+    if (difference > 0) return scale;
+    if (difference < 0) return -scale;
+    return 0.0;
+  });
+}
+
+List<double> bceDerivative(List<double> yTrue, List<double> yPred) {
+  _validate(yTrue, yPred);
+  final scale = 1.0 / yTrue.length;
+  return List.generate(yTrue.length, (index) {
+    final prediction = _clamp(yPred[index]);
+    return scale *
+        ((prediction - yTrue[index]) / (prediction * (1.0 - prediction)));
+  });
+}
+
+List<double> cceDerivative(List<double> yTrue, List<double> yPred) {
+  _validate(yTrue, yPred);
+  final scale = -1.0 / yTrue.length;
+  return List.generate(
+    yTrue.length,
+    (index) => scale * (yTrue[index] / _clamp(yPred[index])),
+  );
+}
+
+double _clamp(double value) => value.clamp(epsilon, 1.0 - epsilon).toDouble();
+
+void _validate(List<double> yTrue, List<double> yPred) {
+  if (yTrue.isEmpty || yTrue.length != yPred.length) {
+    throw ArgumentError('inputs must have the same non-zero length');
+  }
+}

--- a/code/packages/dart/loss-functions/pubspec.yaml
+++ b/code/packages/dart/loss-functions/pubspec.yaml
@@ -1,0 +1,13 @@
+name: coding_adventures_loss_functions
+description: Dependency-free ML01 losses and analytical derivatives.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/loss-functions/required_capabilities.json
+++ b/code/packages/dart/loss-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/loss-functions",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, environment, or console access needed."
+}

--- a/code/packages/dart/loss-functions/test/loss_functions_test.dart
+++ b/code/packages/dart/loss-functions/test/loss_functions_test.dart
@@ -1,0 +1,87 @@
+import 'package:coding_adventures_loss_functions/loss_functions.dart';
+import 'package:test/test.dart';
+
+const tolerance = 1e-9;
+
+void main() {
+  final yTrue = [1.0, 0.0, 0.0];
+  final yPred = [0.9, 0.1, 0.2];
+
+  group('shared parity vectors', () {
+    test('regression losses match ML01', () {
+      expect(mse(yTrue, yPred), closeTo(0.02, tolerance));
+      expect(mae(yTrue, yPred), closeTo(0.1333333333, tolerance));
+    });
+
+    test('cross-entropy losses match ML01', () {
+      expect(
+        bce([1.0, 0.0, 1.0], [0.9, 0.1, 0.8]),
+        closeTo(0.1446215275, tolerance),
+      );
+      expect(
+        cce([1.0, 0.0, 0.0], [0.8, 0.1, 0.1]),
+        closeTo(0.07438118377140324, tolerance),
+      );
+      expect(
+        binaryCrossEntropy([1.0, 0.0], [0.9, 0.1]),
+        closeTo(bce([1.0, 0.0], [0.9, 0.1]), tolerance),
+      );
+      expect(
+        categoricalCrossEntropy([1.0, 0.0], [0.9, 0.1]),
+        closeTo(cce([1.0, 0.0], [0.9, 0.1]), tolerance),
+      );
+    });
+  });
+
+  group('derivatives', () {
+    test('mse and mae derivatives match the analytical vectors', () {
+      expect(mseDerivative(yTrue, yPred), everyElement(isA<double>()));
+      expect(mseDerivative(yTrue, yPred)[0], closeTo(-0.0666666667, tolerance));
+      expect(mseDerivative(yTrue, yPred)[1], closeTo(0.0666666667, tolerance));
+      expect(mseDerivative(yTrue, yPred)[2], closeTo(0.1333333333, tolerance));
+      expect(maeDerivative(yTrue, yPred), equals([-1 / 3, 1 / 3, 1 / 3]));
+    });
+
+    test('cross-entropy derivatives clamp consistently', () {
+      final bceGradient = bceDerivative([1.0, 0.0, 1.0], [0.9, 0.1, 0.8]);
+      expect(bceGradient[0], closeTo(-0.3703703704, tolerance));
+      expect(bceGradient[1], closeTo(0.3703703704, tolerance));
+      expect(bceGradient[2], closeTo(-0.4166666667, tolerance));
+      final cceGradient = cceDerivative([1.0, 0.0, 0.0], [0.8, 0.1, 0.1]);
+      expect(cceGradient[0], closeTo(-0.4166666667, tolerance));
+      expect(cceGradient[1], equals(0.0));
+      expect(cceGradient[2], equals(0.0));
+      expect(bce([1.0, 0.0], [0.0, 1.0]).isFinite, isTrue);
+      expect(cce([1.0, 0.0], [0.0, 1.0]).isFinite, isTrue);
+    });
+  });
+
+  group('validation and purity', () {
+    test('rejects empty and mismatched inputs in every family', () {
+      for (final loss in [mse, mae, bce, cce]) {
+        expect(() => loss([], []), throwsArgumentError);
+        expect(() => loss([1.0], [1.0, 2.0]), throwsArgumentError);
+      }
+      for (final derivative in [
+        mseDerivative,
+        maeDerivative,
+        bceDerivative,
+        cceDerivative,
+      ]) {
+        expect(() => derivative([], []), throwsArgumentError);
+        expect(() => derivative([1.0], [1.0, 2.0]), throwsArgumentError);
+      }
+    });
+
+    test('does not mutate inputs and returns fresh gradients', () {
+      final truth = [1.0, 0.0];
+      final predictions = [0.9, 0.1];
+      final first = mseDerivative(truth, predictions);
+      final second = mseDerivative(truth, predictions);
+      first[0] = 99.0;
+      expect(second[0], closeTo(-0.1, tolerance));
+      expect(truth, equals([1.0, 0.0]));
+      expect(predictions, equals([0.9, 0.1]));
+    });
+  });
+}

--- a/code/packages/dart/matrix/.gitignore
+++ b/code/packages/dart/matrix/.gitignore
@@ -1,0 +1,3 @@
+.dart_tool/
+coverage/
+pubspec.lock

--- a/code/packages/dart/matrix/BUILD
+++ b/code/packages/dart/matrix/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/matrix/BUILD_windows
+++ b/code/packages/dart/matrix/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/matrix/CHANGELOG.md
+++ b/code/packages/dart/matrix/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-08-02
+
+- Add an immutable Dart implementation of the ML03 matrix contracts.
+- Cover construction, arithmetic, reductions, element-wise math, shape
+  operations, slicing, and exact or tolerant comparison.

--- a/code/packages/dart/matrix/README.md
+++ b/code/packages/dart/matrix/README.md
@@ -1,0 +1,28 @@
+# Matrix (Dart)
+
+An immutable Dart implementation of the matrix contracts in
+[ML03](../../../specs/ML03-matrix.md) and
+[ML03 extensions](../../../specs/ML03-matrix-extensions.md).
+
+`Matrix` accepts a scalar, numeric row vector, or rectangular numeric grid and
+deep-copies it into immutable `double` data. The public API includes factories,
+matrix and scalar arithmetic, dot products, reductions, element-wise math,
+reshape and slice operations, and exact or tolerance-based comparison. Invalid
+shapes, dimensions, and indices throw `ArgumentError` or `RangeError`.
+
+```dart
+import 'package:coding_adventures_matrix/matrix.dart';
+
+final left = Matrix([[1, 2], [3, 4]]);
+final right = Matrix.identity(2);
+final product = left.dot(right);
+print(product.data); // [[1.0, 2.0], [3.0, 4.0]]
+```
+
+Run the package checks with:
+
+```sh
+dart pub get
+dart analyze
+dart test
+```

--- a/code/packages/dart/matrix/lib/matrix.dart
+++ b/code/packages/dart/matrix/lib/matrix.dart
@@ -1,0 +1,1 @@
+export 'src/matrix.dart';

--- a/code/packages/dart/matrix/lib/src/matrix.dart
+++ b/code/packages/dart/matrix/lib/src/matrix.dart
@@ -1,0 +1,367 @@
+import 'dart:math' as math;
+
+/// A row/column position returned by [Matrix.argmin] and [Matrix.argmax].
+class MatrixIndex {
+  const MatrixIndex(this.row, this.column);
+
+  final int row;
+  final int column;
+
+  @override
+  bool operator ==(Object other) =>
+      other is MatrixIndex && row == other.row && column == other.column;
+
+  @override
+  int get hashCode => Object.hash(row, column);
+
+  @override
+  String toString() => 'MatrixIndex($row, $column)';
+}
+
+/// An immutable rectangular matrix of double-precision values.
+///
+/// A scalar becomes a 1x1 matrix, a one-dimensional list becomes a row vector,
+/// and a nested list remains a two-dimensional grid. Construction deep-copies
+/// the input so later caller mutation cannot change the matrix.
+class Matrix {
+  Matrix(Object data) : _data = _normalize(data);
+
+  Matrix._fromRows(List<List<double>> rows) : _data = _freeze(rows);
+
+  final List<List<double>> _data;
+
+  /// Immutable row-major matrix data.
+  List<List<double>> get data => _data;
+
+  int get rows => _data.length;
+  int get cols => _data.first.length;
+
+  static Matrix zeros(int rows, int cols) {
+    _validateDimensions(rows, cols);
+    return Matrix._fromRows(
+      List.generate(rows, (_) => List<double>.filled(cols, 0.0)),
+    );
+  }
+
+  static Matrix identity(int size) {
+    _validateDimensions(size, size);
+    return Matrix._fromRows(
+      List.generate(
+        size,
+        (row) => List.generate(size, (column) => row == column ? 1.0 : 0.0),
+      ),
+    );
+  }
+
+  static Matrix fromDiagonal(List<num> values) {
+    if (values.isEmpty) {
+      throw ArgumentError.value(values, 'values', 'must not be empty');
+    }
+    return Matrix._fromRows(
+      List.generate(
+        values.length,
+        (row) => List.generate(
+          values.length,
+          (column) => row == column ? values[row].toDouble() : 0.0,
+        ),
+      ),
+    );
+  }
+
+  Matrix add(Object other) =>
+      _elementWise(other, (left, right) => left + right, 'addition');
+
+  Matrix subtract(Object other) =>
+      _elementWise(other, (left, right) => left - right, 'subtraction');
+
+  Matrix operator +(Object other) => add(other);
+  Matrix operator -(Object other) => subtract(other);
+
+  Matrix operator *(num scalar) => scale(scalar);
+
+  Matrix scale(num scalar) => map((value) => value * scalar.toDouble());
+
+  Matrix transpose() => Matrix._fromRows(
+        List.generate(
+          cols,
+          (column) => List.generate(rows, (row) => _data[row][column]),
+        ),
+      );
+
+  /// True matrix multiplication: `(M x K) dot (K x N) = M x N`.
+  Matrix dot(Matrix other) {
+    if (cols != other.rows) {
+      throw ArgumentError(
+        'dot dimension mismatch: ${rows}x$cols versus ${other.rows}x${other.cols}',
+      );
+    }
+    return Matrix._fromRows(
+      List.generate(rows, (row) {
+        return List.generate(other.cols, (column) {
+          var total = 0.0;
+          for (var inner = 0; inner < cols; inner++) {
+            total += _data[row][inner] * other._data[inner][column];
+          }
+          return total;
+        });
+      }),
+    );
+  }
+
+  double get(int row, int column) {
+    _checkIndex(row, column);
+    return _data[row][column];
+  }
+
+  Matrix set(int row, int column, num value) {
+    _checkIndex(row, column);
+    final next = _data.map((values) => values.toList()).toList();
+    next[row][column] = value.toDouble();
+    return Matrix._fromRows(next);
+  }
+
+  double sum() {
+    var total = 0.0;
+    for (final row in _data) {
+      for (final value in row) {
+        total += value;
+      }
+    }
+    return total;
+  }
+
+  Matrix sumRows() => Matrix._fromRows(
+        _data
+            .map((row) => [row.fold(0.0, (total, value) => total + value)])
+            .toList(),
+      );
+
+  Matrix sumCols() => Matrix._fromRows([
+        List.generate(
+          cols,
+          (column) => _data.fold(0.0, (total, row) => total + row[column]),
+        ),
+      ]);
+
+  double mean() => sum() / (rows * cols);
+
+  double min() => _data.expand((row) => row).reduce(math.min);
+  double max() => _data.expand((row) => row).reduce(math.max);
+
+  MatrixIndex argmin() => _argExtreme((candidate, best) => candidate < best);
+  MatrixIndex argmax() => _argExtreme((candidate, best) => candidate > best);
+
+  Matrix map(double Function(double value) transform) => Matrix._fromRows(
+        _data.map((row) => row.map(transform).toList()).toList(),
+      );
+
+  Matrix sqrt() {
+    if (_data.expand((row) => row).any((value) => value < 0.0)) {
+      throw ArgumentError(
+        'square root is undefined for negative matrix values',
+      );
+    }
+    return map(math.sqrt);
+  }
+
+  Matrix abs() => map((value) => value.abs());
+
+  Matrix pow(num exponent) =>
+      map((value) => math.pow(value, exponent).toDouble());
+
+  Matrix flatten() => Matrix._fromRows([_data.expand((row) => row).toList()]);
+
+  Matrix reshape(int rows, int cols) {
+    _validateDimensions(rows, cols);
+    if (rows * cols != this.rows * this.cols) {
+      throw ArgumentError(
+        'cannot reshape ${this.rows}x${this.cols} into ${rows}x$cols',
+      );
+    }
+    final flat = _data.expand((row) => row).toList();
+    return Matrix._fromRows(
+      List.generate(rows, (row) => flat.sublist(row * cols, (row + 1) * cols)),
+    );
+  }
+
+  Matrix row(int index) {
+    RangeError.checkValidIndex(index, _data, 'row');
+    return Matrix._fromRows([_data[index].toList()]);
+  }
+
+  Matrix col(int index) {
+    RangeError.checkValidIndex(index, _data.first, 'column');
+    return Matrix._fromRows(_data.map((row) => [row[index]]).toList());
+  }
+
+  Matrix slice(int rowStart, int rowEnd, int columnStart, int columnEnd) {
+    if (rowStart < 0 || rowEnd > rows) {
+      throw RangeError.range(
+        rowStart < 0 ? rowStart : rowEnd,
+        0,
+        rows,
+        'row range',
+      );
+    }
+    if (columnStart < 0 || columnEnd > cols) {
+      throw RangeError.range(
+        columnStart < 0 ? columnStart : columnEnd,
+        0,
+        cols,
+        'column range',
+      );
+    }
+    if (rowStart >= rowEnd || columnStart >= columnEnd) {
+      throw ArgumentError('slice ranges must be non-empty and increasing');
+    }
+    return Matrix._fromRows(
+      _data
+          .sublist(rowStart, rowEnd)
+          .map((row) => row.sublist(columnStart, columnEnd))
+          .toList(),
+    );
+  }
+
+  bool equals(Matrix other) {
+    if (rows != other.rows || cols != other.cols) return false;
+    for (var row = 0; row < rows; row++) {
+      for (var column = 0; column < cols; column++) {
+        if (_data[row][column] != other._data[row][column]) return false;
+      }
+    }
+    return true;
+  }
+
+  bool close(Matrix other, {double tolerance = 1e-9}) {
+    if (tolerance < 0 || rows != other.rows || cols != other.cols) return false;
+    for (var row = 0; row < rows; row++) {
+      for (var column = 0; column < cols; column++) {
+        final left = _data[row][column];
+        final right = other._data[row][column];
+        if (left.isNaN || right.isNaN) return false;
+        if (left == right) continue;
+        if (!left.isFinite ||
+            !right.isFinite ||
+            (left - right).abs() > tolerance) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @override
+  bool operator ==(Object other) => other is Matrix && equals(other);
+
+  @override
+  int get hashCode =>
+      Object.hash(rows, cols, Object.hashAll(_data.expand((row) => row)));
+
+  @override
+  String toString() => 'Matrix($_data)';
+
+  Matrix _elementWise(
+    Object other,
+    double Function(double left, double right) operation,
+    String name,
+  ) {
+    if (other is num) {
+      final scalar = other.toDouble();
+      return map((value) => operation(value, scalar));
+    }
+    if (other is! Matrix) {
+      throw ArgumentError.value(other, 'other', 'must be a Matrix or num');
+    }
+    if (rows != other.rows || cols != other.cols) {
+      throw ArgumentError(
+        '$name dimension mismatch: ${rows}x$cols versus ${other.rows}x${other.cols}',
+      );
+    }
+    return Matrix._fromRows(
+      List.generate(
+        rows,
+        (row) => List.generate(
+          cols,
+          (column) => operation(_data[row][column], other._data[row][column]),
+        ),
+      ),
+    );
+  }
+
+  MatrixIndex _argExtreme(
+    bool Function(double candidate, double best) isBetter,
+  ) {
+    var best = _data[0][0];
+    var bestRow = 0;
+    var bestColumn = 0;
+    for (var row = 0; row < rows; row++) {
+      for (var column = 0; column < cols; column++) {
+        final candidate = _data[row][column];
+        if (isBetter(candidate, best)) {
+          best = candidate;
+          bestRow = row;
+          bestColumn = column;
+        }
+      }
+    }
+    return MatrixIndex(bestRow, bestColumn);
+  }
+
+  void _checkIndex(int row, int column) {
+    RangeError.checkValidIndex(row, _data, 'row');
+    RangeError.checkValidIndex(column, _data.first, 'column');
+  }
+
+  static List<List<double>> _normalize(Object data) {
+    if (data is num) {
+      return _freeze([
+        [data.toDouble()],
+      ]);
+    }
+    if (data is! List || data.isEmpty) {
+      throw ArgumentError.value(
+        data,
+        'data',
+        'must be a scalar or non-empty numeric list',
+      );
+    }
+    if (data.every((value) => value is num)) {
+      return _freeze([
+        data.cast<num>().map((value) => value.toDouble()).toList(),
+      ]);
+    }
+    if (!data.every((value) => value is List)) {
+      throw ArgumentError.value(
+        data,
+        'data',
+        'must not mix rows and scalar values',
+      );
+    }
+    final rawRows = data.cast<List>();
+    if (rawRows.first.isEmpty) {
+      throw ArgumentError.value(data, 'data', 'rows must not be empty');
+    }
+    final width = rawRows.first.length;
+    final rows = <List<double>>[];
+    for (final row in rawRows) {
+      if (row.length != width || !row.every((value) => value is num)) {
+        throw ArgumentError.value(
+          data,
+          'data',
+          'must be a rectangular numeric grid',
+        );
+      }
+      rows.add(row.cast<num>().map((value) => value.toDouble()).toList());
+    }
+    return _freeze(rows);
+  }
+
+  static List<List<double>> _freeze(List<List<double>> rows) =>
+      List<List<double>>.unmodifiable(rows.map(List<double>.unmodifiable));
+
+  static void _validateDimensions(int rows, int cols) {
+    if (rows <= 0 || cols <= 0) {
+      throw ArgumentError('matrix dimensions must be positive');
+    }
+  }
+}

--- a/code/packages/dart/matrix/pubspec.yaml
+++ b/code/packages/dart/matrix/pubspec.yaml
@@ -1,0 +1,13 @@
+name: coding_adventures_matrix
+description: Immutable matrix arithmetic and ML03 extension operations.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/matrix/required_capabilities.json
+++ b/code/packages/dart/matrix/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/matrix",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, environment, or console access needed."
+}

--- a/code/packages/dart/matrix/test/matrix_test.dart
+++ b/code/packages/dart/matrix/test/matrix_test.dart
@@ -1,0 +1,368 @@
+import 'dart:math' as math;
+
+import 'package:coding_adventures_matrix/matrix.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('construction', () {
+    test('normalizes scalar, vector, and grid inputs', () {
+      expect(
+        Matrix(5).data,
+        equals([
+          [5.0],
+        ]),
+      );
+      expect(
+        Matrix([1, 2, 3]).data,
+        equals([
+          [1.0, 2.0, 3.0],
+        ]),
+      );
+      expect(
+        Matrix([
+          [1, 2],
+          [3, 4],
+        ]).data,
+        equals([
+          [1.0, 2.0],
+          [3.0, 4.0],
+        ]),
+      );
+    });
+
+    test('rejects empty, ragged, and unsupported inputs', () {
+      expect(() => Matrix([]), throwsArgumentError);
+      expect(() => Matrix([<num>[]]), throwsArgumentError);
+      expect(
+        () => Matrix([
+          [1, 2],
+          [3],
+        ]),
+        throwsArgumentError,
+      );
+      expect(() => Matrix('not numeric'), throwsArgumentError);
+    });
+
+    test('deep-copies inputs and exposes immutable data', () {
+      final input = <List<double>>[
+        [1.0, 2.0],
+      ];
+      final matrix = Matrix(input);
+      input[0][0] = 99.0;
+      expect(matrix.get(0, 0), equals(1.0));
+      expect(() => matrix.data.add([3.0]), throwsUnsupportedError);
+      expect(() => matrix.data[0][0] = 99.0, throwsUnsupportedError);
+    });
+
+    test('factories validate dimensions', () {
+      expect(
+        Matrix.zeros(2, 3).data,
+        equals([
+          [0.0, 0.0, 0.0],
+          [0.0, 0.0, 0.0],
+        ]),
+      );
+      expect(
+        Matrix.identity(3).data,
+        equals([
+          [1.0, 0.0, 0.0],
+          [0.0, 1.0, 0.0],
+          [0.0, 0.0, 1.0],
+        ]),
+      );
+      expect(
+        Matrix.fromDiagonal([2, 3]).data,
+        equals([
+          [2.0, 0.0],
+          [0.0, 3.0],
+        ]),
+      );
+      expect(() => Matrix.zeros(0, 2), throwsArgumentError);
+      expect(() => Matrix.identity(0), throwsArgumentError);
+      expect(() => Matrix.fromDiagonal([]), throwsArgumentError);
+    });
+  });
+
+  group('base arithmetic', () {
+    final a = Matrix([
+      [1, 2],
+      [3, 4],
+    ]);
+    final b = Matrix([
+      [5, 6],
+      [7, 8],
+    ]);
+
+    test('adds and subtracts matrices and scalars', () {
+      expect(
+        (a + b).data,
+        equals([
+          [6.0, 8.0],
+          [10.0, 12.0],
+        ]),
+      );
+      expect(
+        (b - a).data,
+        equals([
+          [4.0, 4.0],
+          [4.0, 4.0],
+        ]),
+      );
+      expect(
+        (a + 2).data,
+        equals([
+          [3.0, 4.0],
+          [5.0, 6.0],
+        ]),
+      );
+      expect(
+        (a - 1).data,
+        equals([
+          [0.0, 1.0],
+          [2.0, 3.0],
+        ]),
+      );
+      expect(() => a + Matrix([1]), throwsArgumentError);
+      expect(() => a + 'bad', throwsArgumentError);
+    });
+
+    test('scales, transposes, and multiplies matrices', () {
+      expect(
+        (a * 2).data,
+        equals([
+          [2.0, 4.0],
+          [6.0, 8.0],
+        ]),
+      );
+      expect(
+        a.scale(0.5).data,
+        equals([
+          [0.5, 1.0],
+          [1.5, 2.0],
+        ]),
+      );
+      expect(
+        a.transpose().data,
+        equals([
+          [1.0, 3.0],
+          [2.0, 4.0],
+        ]),
+      );
+      expect(
+        a.dot(b).data,
+        equals([
+          [19.0, 22.0],
+          [43.0, 50.0],
+        ]),
+      );
+      expect(() => Matrix([1, 2]).dot(Matrix([1, 2])), throwsArgumentError);
+    });
+  });
+
+  group('extensions', () {
+    final matrix = Matrix([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+
+    test('access and replacement stay immutable', () {
+      expect(matrix.get(1, 2), equals(6.0));
+      final replaced = matrix.set(0, 0, 99);
+      expect(replaced.get(0, 0), equals(99.0));
+      expect(matrix.get(0, 0), equals(1.0));
+      expect(() => matrix.get(-1, 0), throwsRangeError);
+      expect(() => matrix.set(2, 0, 1), throwsRangeError);
+    });
+
+    test('reductions match the shared vectors', () {
+      final square = Matrix([
+        [1, 2],
+        [3, 4],
+      ]);
+      expect(square.sum(), equals(10.0));
+      expect(square.mean(), equals(2.5));
+      expect(
+        square.sumRows().data,
+        equals([
+          [3.0],
+          [7.0],
+        ]),
+      );
+      expect(
+        square.sumCols().data,
+        equals([
+          [4.0, 6.0],
+        ]),
+      );
+      expect(square.min(), equals(1.0));
+      expect(square.max(), equals(4.0));
+      expect(square.argmin(), equals(const MatrixIndex(0, 0)));
+      expect(square.argmax(), equals(const MatrixIndex(1, 1)));
+    });
+
+    test('element-wise math preserves shape', () {
+      final values = Matrix([
+        [1, 4],
+        [9, 16],
+      ]);
+      expect(
+        values.map((value) => value + 1).data,
+        equals([
+          [2.0, 5.0],
+          [10.0, 17.0],
+        ]),
+      );
+      expect(
+        values.sqrt().data,
+        equals([
+          [1.0, 2.0],
+          [3.0, 4.0],
+        ]),
+      );
+      expect(
+        Matrix([
+          [-1, 2],
+          [-3, 4],
+        ]).abs().data,
+        equals([
+          [1.0, 2.0],
+          [3.0, 4.0],
+        ]),
+      );
+      expect(
+        Matrix([
+          [1, 2],
+          [3, 4],
+        ]).pow(2).data,
+        equals([
+          [1.0, 4.0],
+          [9.0, 16.0],
+        ]),
+      );
+      expect(
+        () => Matrix([
+          [-1],
+        ]).sqrt(),
+        throwsArgumentError,
+      );
+    });
+
+    test('shape operations use row-major order', () {
+      expect(
+        matrix.flatten().data,
+        equals([
+          [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        ]),
+      );
+      expect(
+        matrix.reshape(3, 2).data,
+        equals([
+          [1.0, 2.0],
+          [3.0, 4.0],
+          [5.0, 6.0],
+        ]),
+      );
+      expect(
+        matrix.row(1).data,
+        equals([
+          [4.0, 5.0, 6.0],
+        ]),
+      );
+      expect(
+        matrix.col(1).data,
+        equals([
+          [2.0],
+          [5.0],
+        ]),
+      );
+      expect(
+        matrix.slice(0, 2, 1, 3).data,
+        equals([
+          [2.0, 3.0],
+          [5.0, 6.0],
+        ]),
+      );
+      expect(() => matrix.reshape(4, 2), throwsArgumentError);
+      expect(() => matrix.slice(1, 1, 0, 1), throwsArgumentError);
+      expect(() => matrix.slice(-1, 1, 0, 1), throwsRangeError);
+    });
+
+    test('exact and tolerant comparisons follow ML03', () {
+      final same = Matrix([
+        [1, 2, 3],
+        [4, 5, 6],
+      ]);
+      expect(matrix.equals(same), isTrue);
+      expect(matrix == same, isTrue);
+      expect(
+        matrix.close(
+          Matrix([
+            [1, 2, 3],
+            [4, 5, 6.0000000001],
+          ]),
+        ),
+        isTrue,
+      );
+      expect(
+        matrix.close(
+          Matrix([
+            [1, 2, 3],
+            [4, 5, 6.1],
+          ]),
+        ),
+        isFalse,
+      );
+      expect(matrix.close(same, tolerance: -1), isFalse);
+      expect(
+          Matrix([
+            [double.nan]
+          ]).close(Matrix([
+            [double.nan]
+          ])),
+          isFalse);
+      expect(
+        Matrix([
+          [double.infinity]
+        ]).close(Matrix([
+          [double.infinity]
+        ])),
+        isTrue,
+      );
+      expect(
+        Matrix([
+          [double.infinity]
+        ]).close(Matrix([
+          [double.negativeInfinity]
+        ])),
+        isFalse,
+      );
+      expect(
+        Matrix.identity(2)
+            .dot(
+              Matrix([
+                [2, 3],
+                [4, 5],
+              ]),
+            )
+            .data,
+        equals([
+          [2.0, 3.0],
+          [4.0, 5.0],
+        ]),
+      );
+      expect(
+        Matrix([
+          [1, 4],
+          [9, 16],
+        ]).sqrt().pow(2).close(
+              Matrix([
+                [1, 4],
+                [9, 16],
+              ]),
+            ),
+        isTrue,
+      );
+      expect(math.sqrt(matrix.get(0, 0)), equals(1.0));
+    });
+  });
+}

--- a/code/specs/ML01-loss-functions.md
+++ b/code/specs/ML01-loss-functions.md
@@ -60,6 +60,14 @@ func BCE_Derivative(yTrue: Array<Float>, yPred: Array<Float>) -> Array<Float>
 func CCE_Derivative(yTrue: Array<Float>, yPred: Array<Float>) -> Array<Float>
 ```
 
+The Dart package is named `coding_adventures_loss_functions` and uses the
+canonical cross-lane names `mse`, `mae`, `bce`, `cce`, `mseDerivative`,
+`maeDerivative`, `bceDerivative`, and `cceDerivative`. Descriptive
+`binaryCrossEntropy` and `categoricalCrossEntropy` aliases are also provided
+without replacing the canonical names. All inputs are `List<double>` and
+derivative results are newly allocated lists. The same validation, epsilon
+clamping, formulas, and reference vectors apply.
+
 ## Data Flow & Constraints
 
 1. Inputs must be exactly the same length. Mismatched lengths should throw/raise an Error.

--- a/code/specs/ML03-matrix-extensions.md
+++ b/code/specs/ML03-matrix-extensions.md
@@ -8,9 +8,9 @@ These operations are required by ST01 (Statistics) and bring the Matrix
 closer to NumPy expressiveness while remaining a pure, dependency-free
 implementation in each language.
 
-All operations are added to the existing Matrix class/struct in each of
-the 9 language packages. This spec also creates the Swift matrix package
-(the 9th language) with full parity — both base operations and extensions.
+All operations are part of the Matrix class/struct in every established lane.
+New lanes must implement both the base operations and these extensions rather
+than claiming parity from directory presence alone.
 
 Existing methods (zeros, add, subtract, scale, transpose, dot) remain
 unchanged.
@@ -129,5 +129,6 @@ All 9 languages must produce identical results for:
 | Lua | `code/packages/lua/matrix/` | `src/coding_adventures/matrix/init.lua` |
 | Perl | `code/packages/perl/matrix/` | `lib/CodingAdventures/Matrix.pm` |
 | Swift | `code/packages/swift/matrix/` | **NEW** — full package with base + extensions |
+| Dart | `code/packages/dart/matrix/` | **NEW** — full package with base + extensions |
 
 **Dependencies:** None. Pure math only. Extends ML03.

--- a/code/specs/ML03-matrix.md
+++ b/code/specs/ML03-matrix.md
@@ -5,7 +5,9 @@ The `matrix` package is the foundational computational architecture replacing na
 Inspired heavily by MATLAB, it establishes a singular, robust `Matrix` Object (Class/Struct) that seamlessly handles mathematical operations across multiple dimensions. Every node in the network—from a single variable weight to an entire dataset of 10,000 houses—is strictly treated as a Matrix.
 
 ## 2. The Abstract Object Architecture
-To provide a universally elegant API across all 6 host languages (Python, Go, Ruby, TypeScript, Rust, Elixir), the Matrix logic encapsulates a standard private 2D Array mapping while exposing a dynamic initializer.
+To provide a universally elegant API across every established implementation
+lane, the Matrix logic encapsulates a standard private 2D array while exposing
+the closest idiomatic constructors and operators each host language supports.
 
 ### 2.1 Dynamic Instantiation
 The library dynamically standardizes memory inputs.
@@ -37,3 +39,13 @@ Where the native language allows (Python `__add__`, Ruby `+`), matrix operations
 
 ## 4. Cross-Language Parity & Safety
 By binding everything to an Object format, we ensure universal crash-safety across all environments. All environments have a standardized unit test file strictly validating dimensional collision logic (matrix dot product bounds) before the training loops are artificially spawned.
+
+### 4.1 Dart surface
+
+The Dart package is named `coding_adventures_matrix`. `Matrix(Object data)`
+accepts a scalar, a non-empty one-dimensional `List<num>`, or a non-empty
+rectangular `List<List<num>>`. It deep-copies inputs, exposes immutable `data`,
+`rows`, and `cols`, and implements `+`, `-`, and `*` for the matrix/scalar cases
+defined above. Invalid or ragged inputs and every dimension mismatch throw
+`ArgumentError`. The package also implements the complete ML03 extensions
+contract, with `(row, column)` positions represented by `MatrixIndex`.

--- a/code/specs/ML05-feature-normalization-and-learning-rate-sweeps.md
+++ b/code/specs/ML05-feature-normalization-and-learning-rate-sweeps.md
@@ -53,6 +53,14 @@ scaled[i][j] = (x[i][j] - min[j]) / (max[j] - min[j])
 
 If `max[j] == min[j]`, every transformed value in that column must be `0.0`.
 
+## Dart API
+
+The Dart package is named `coding_adventures_feature_normalization`. It exposes
+immutable `StandardScaler` and `MinMaxScaler` value objects plus
+`fitStandardScaler`, `transformStandard`, `fitMinMaxScaler`, and
+`transformMinMax`. Matrix and scaler-width validation throw `ArgumentError`;
+all returned lists are newly allocated and do not mutate caller input.
+
 ## Learning-Rate Sweep
 
 Example programs may run a short sweep before the full training run:

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -293,6 +293,10 @@ host PRs do not occupy the scoped parity slot.
 The audit also found private matrix/MSE helpers in Dart `single-layer-network`
 and `two-layer-network`; their migration to the shared packages is a separate
 downstream backlog item rather than hidden scope in this port.
+The security pass also found that ML01 does not define a shared NaN/infinity
+input policy: Dart and the Python reference can clamp NaN cross-entropy
+predictions to a finite boundary. A separate all-lane fixture and conformance
+item owns that decision instead of introducing a Dart-only behavioral fork.
 The build-tool execution critical path remains blocked on external
 immutable-runner and attester provisioning.
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,9 +106,10 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on August 1, 2026 at `d5f57bfdb` after merged PR
-#9419 and the addition of the Rust WLED integration package.
-It contains 1,209 normalized implementation identities across 4,353 established-lane package
+inventory was regenerated on August 2, 2026 at `e552707d5` after the serial
+Rust smart-home additions through Wemo (#9455) and the Rust SPICE model
+validation chain through #9473. It contains 1,215 normalized implementation
+identities across 4,359 established-lane package
 slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -116,19 +117,22 @@ slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 275 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 759 | 10,626 |
+| Present in one language | 765 | 10,710 |
 
-The loop must not start by attempting 10,626 singleton ports. It should finish
+The loop must not start by attempting 10,710 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current inventory at
-`d5f57bfdbc64ebf44d677f195380714f949b0db6` is collision-clean at 1,209
-normalized implementation identities, 4,353 implementation slots, 172
-high-consensus packages, 275 high-consensus missing slots, 759 singletons, 564
+`e552707d59c62c0c0749c6173a2cf82478629b48` is collision-clean at 1,215
+normalized implementation identities, 4,359 implementation slots, 172
+high-consensus packages, 275 high-consensus missing slots, 765 singletons, 570
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The four newest identities are Rust-only `smart-home-camera-media`,
-`smart-home-onvif-integration`, `smart-home-shelly-integration`, and
-`smart-home-wled-integration`. All are
+The ten newest mixed Rust identities are `smart-home-camera-media`,
+`smart-home-onvif-integration`, `smart-home-shelly-integration`,
+`smart-home-wled-integration`, `smart-home-govee-lan-integration`,
+`smart-home-lifx-lan-integration`, `smart-home-kasa-lan-integration`,
+`smart-home-reolink-integration`, `smart-home-roku-ecp-integration`, and
+`smart-home-wemo-upnp-integration`. All are
 mixed splits rather than blind parity ports: camera grant policy,
 generation-bound lease state, quotas, and redacted audit are portable, while
 authenticated host context and media delivery remain native mediation; ONVIF
@@ -141,12 +145,21 @@ ordering, future credentials, and capability profiles remain native.
 WLED DTO validation, master/segment projection, capability-bit interpretation,
 state normalization, and command planning are portable, while mDNS, DNS/TCP,
 plaintext LAN HTTP, trusted time, console I/O, pairing/origin policy, runtime
-effects, and capability profiles remain native.
-The security review found urgent repository-local hardening owners for raw media
-URI redemption and attacker-controlled ONVIF origins before either portable core
-is expanded.
+effects, and capability profiles remain native. Govee, LIFX, Kasa, Reolink,
+Roku, and Wemo contribute deterministic codecs, bounded parsers and DTO
+validation, normalization, projection, stable identities/errors, command
+planning, and language-neutral fixtures to the parity backlog. Wemo specifically
+contributes SSDP header parsing, bounded setup/SOAP XML, service/device
+normalization, and switch/light command planning.
 
-The August 1 lane audit is:
+This loop delivers only deterministic, authority-free package contracts and
+implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
+capability approval, runtime mutation, native executors, and host hardening are
+reviewed native-host exceptions and are not selectable parity work. ONVIF is
+excluded from this parity tranche. Mixed smart-home packages enter the backlog
+only through their portable cores and shared language-neutral fixtures.
+
+The August 2 lane audit is:
 
 | Established lane | Packages present | High-consensus gaps | Rust/Python-core coverage |
 |---|---:|---:|---:|
@@ -162,7 +175,7 @@ The August 1 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 974 | 0 | 100% |
+| Rust | 980 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -271,15 +284,15 @@ work remained tracked behind the merged square-root and wave slices rather
 than expanding either delivery.
 PR #9413 merged that repair at `458405a6e` after all 15 checks passed. The
 collision-clean `1e4956369` refresh added the two Rust-only camera identities.
-Their first security audit found that camera-media redemption returns a durable,
-replayable endpoint URI and that ONVIF can relay fresh credential digests to a
-device- or discovery-controlled origin. Those P0 boundaries outrank the ordinary
-Dart frontier while remaining split into serial, reviewable hardening tranches.
-The serial loop selected `smart-home-camera-media-security-boundary-hardening`
-first because it is dependency-ready and closes the endpoint-disclosure boundary
-without coupling that focused repair to ONVIF origin/Vault work.
-The remaining Dart ML dependency child is now explicit rather than hidden in an
-umbrella: `matrix`, then `loss-functions` and `feature-normalization`.
+PR #9421 merged the camera-media boundary repair. With no active in-scope parity
+PR at `e552707d5`, the leverage pass selected
+`dart-current-14-of-15-matrix-family`: the independent `matrix`,
+`loss-functions`, and `feature-normalization` leaf packages. The branch is
+`codex/dart-matrix-ml-parity` and the item is in progress. Open ONVIF and other
+host PRs do not occupy the scoped parity slot.
+The audit also found private matrix/MSE helpers in Dart `single-layer-network`
+and `two-layer-network`; their migration to the shared packages is a separate
+downstream backlog item rather than hidden scope in this port.
 The build-tool execution critical path remains blocked on external
 immutable-runner and attester provisioning.
 
@@ -956,10 +969,10 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 564 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 570 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30-August 1 inventories added twenty-four Rust singleton identities that now
+The July 30-August 2 inventories added thirty Rust singleton identities that now
 have explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and


### PR DESCRIPTION
## Summary

- add first-class Dart packages for `matrix`, `loss-functions`, and `feature-normalization`
- implement the complete ML03 matrix extension surface, ML01 losses and derivatives, and ML05 standard/min-max scaling contracts
- add immutable data ownership, validation, numerical edge-case handling, public barrels, build metadata, capability manifests, READMEs, and changelogs
- refresh the collision-checked parity roadmap/state, keep host-security work outside parity selection, and log newly discovered Dart-consumer and ML01 non-finite-policy follow-ups

## Parity impact

- established implementation slots: 4,359 -> 4,362
- high-consensus missing slots: 275 -> 272
- Dart packages present: 75 -> 78
- canonical collisions / unknown buckets: 0 / 0

## Validation

- Dart 3.12.2: formatter check, analyzer, and randomized tests passed for all three packages (11 matrix, 6 loss-functions, 6 feature-normalization tests)
- coverage: matrix 177/189 lines (93.65%); loss-functions 57/57 (100%); feature-normalization 52/52 (100%)
- both `BUILD` and `BUILD_windows` passed for every new package
- real diff build-tool run: 3 changed, 3 affected, 3 built, 4,757 skipped
- Dart-wide forced dry-run validated 81 Dart BUILD files/packages
- nearby Dart `single-layer-network` and `two-layer-network` analyzer/tests passed (2 and 3 tests)
- capability schema suites passed (11 tests); package-parity reporter suite passed (10 tests)
- collision-checked reporter passed: schema 3, 15 established lanes, 1,215 identities, 4,362 slots, 272 high-consensus missing slots, 765 singletons, zero collisions, zero unknown buckets
- `dart pub outdated --no-dev-dependencies` found no runtime dependency updates (all runtime dependency sets are empty)
- `git diff --check` passed; independent security/capability review found no blocker

## Existing repository debt

The repository-wide BUILD metadata validator still reports the already-tracked 73 unrelated stale `BUILD_windows` prerequisite declarations (12 Python, 3 Swift, 58 TypeScript). The Dart-only validation and the actual three-package diff build both pass; this PR does not widen into that separate backlog item.
