### PR TITLE
feat(adj-verify): verify computed answers from trusted plans

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -82,7 +82,7 @@ interacts_decl   = "interacts" NUMBER "when" term "and" term { "and" term } "for
 
 uncertain_decl   = "uncertain" LBRACE term { COMMA term } RBRACE "for" term { annotation } ;
 
-observe_decl     = "observe" term ;
+observe_decl     = "observe" term { annotation } ;
 
 # ----------------------------------------------------------------
 # `relate <rel>(<a>, <b>)` — a ground RELATIONAL EDGE (MYCIN-2026 REL-2),

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.32.0] - 2026-08-02 - formula-only `adj-verify`
+
+- `adj-verify` now reports every computed binding, re-evaluates its separately stored compiler
+  plan, and verifies every nested formula quote plus all observed-input quotes.
+- The summary includes computation totals and allows formula-only programs to reach
+  `fully_verified: true` only when an explicit question exists, CPU replay succeeds, and every
+  byte anchor passes.
+- Drifted formula or input bytes fail closed and identify the exact `formula_quote` or
+  `input_quote` verification pass.
+
 ## [0.31.0] — 2026-07-31 — AR-3: `--explain` narrates the WITHDRAWAL of a rebutted conclusion
 
 Completes the argument surface (`ADJ-ARGUMENT-REBUTTAL.md` §4): when a paper's rebuttal DEFEATS a

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/bin/adj-verify.rs
+++ b/code/packages/rust/adj-lang-cli/src/bin/adj-verify.rs
@@ -53,9 +53,10 @@ use adj_lang_cli::{esc, payload, query_echo, FsProvider};
 use cli_builder::types::ParserOutput;
 use cli_builder::{load_spec_from_str, Parser};
 use logic_engine::{
-    enumerate_all, recheck_narrowings, verify_proof, ContentHash, LogicFailure, LogicStatus,
-    NarrowingCheck, Proof, QuoteMiss, QuoteStatus, SnapshotStore, StepVerification,
-    TraceVerification, UnverifiedReason,
+    enumerate_all, recheck_narrowings, verify_derived, verify_proof, ComputationFailure,
+    ComputationStatus, ContentHash, DerivedVerification, LogicFailure, LogicStatus, NarrowingCheck,
+    Proof, QuoteMiss, QuoteStatus, SnapshotStore, StepVerification, TraceVerification,
+    UnverifiedReason,
 };
 
 const SPEC: &str = r#"{
@@ -197,6 +198,45 @@ fn logic_json(status: &LogicStatus) -> String {
     format!("\"{tag}\"")
 }
 
+fn computation_json(status: &ComputationStatus) -> String {
+    match status {
+        ComputationStatus::ReChecked => "{\"status\":\"rechecked\"}".to_string(),
+        ComputationStatus::Unverifiable(why) => {
+            format!("{{\"status\":\"unverifiable\",\"why\":\"{}\"}}", esc(why))
+        }
+        ComputationStatus::Failed(failure) => {
+            let detail = match failure {
+                ComputationFailure::PlanUnavailable => "\"why\":\"plan_unavailable\"".to_string(),
+                ComputationFailure::ArtifactDoesNotMatchPlan => {
+                    "\"why\":\"artifact_does_not_match_plan\"".to_string()
+                }
+                ComputationFailure::ScopeUnavailable => "\"why\":\"scope_unavailable\"".to_string(),
+                ComputationFailure::EvaluationFailed(error) => format!(
+                    "\"why\":\"evaluation_failed\",\"detail\":\"{}\"",
+                    esc(&format!("{error:?}"))
+                ),
+                ComputationFailure::ValueDiffers {
+                    recorded,
+                    recomputed,
+                } => format!(
+                    "\"why\":\"value_differs\",\"recorded\":{},\"recomputed\":{}",
+                    recorded, recomputed
+                ),
+                ComputationFailure::ExactValueDiffers => {
+                    "\"why\":\"exact_value_differs\"".to_string()
+                }
+                ComputationFailure::DimensionDiffers => "\"why\":\"dimension_differs\"".to_string(),
+                ComputationFailure::TreeDiffers => "\"why\":\"tree_differs\"".to_string(),
+                ComputationFailure::ReferencedDerivedDiffers(name) => format!(
+                    "\"why\":\"referenced_derived_differs\",\"derived\":\"{}\"",
+                    esc(name)
+                ),
+            };
+            format!("{{\"status\":\"failed\",{detail}}}")
+        }
+    }
+}
+
 /// Render a quote verdict.
 ///
 /// `byte_len` is always reported alongside a verified span. §E.3 declines to
@@ -274,6 +314,37 @@ fn step_json(s: &StepVerification) -> String {
     )
 }
 
+fn derived_json(report: &DerivedVerification) -> String {
+    let formulas = report
+        .formula_quotes
+        .iter()
+        .map(quote_json)
+        .collect::<Vec<_>>()
+        .join(",");
+    let inputs = report
+        .input_quotes
+        .iter()
+        .map(|input| {
+            format!(
+                "{{\"fact_id\":{},\"quote\":{}}}",
+                input.fact_id.0,
+                quote_json(&input.quote)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{{\"name\":\"{}\",\"query_answer\":{},\"passed\":{},\"fully_verified\":{},\"computation\":{},\"formula_quotes\":[{}],\"input_quotes\":[{}]}}",
+        esc(&report.name),
+        report.is_query_answer,
+        report.passed(),
+        report.fully_verified(),
+        computation_json(&report.computation),
+        formulas,
+        inputs
+    )
+}
+
 #[derive(Default)]
 struct Totals {
     steps: usize,
@@ -281,6 +352,11 @@ struct Totals {
     quotes_verified: usize,
     proofs: usize,
     proofs_fully_verified: usize,
+    computations: usize,
+    computations_rechecked: usize,
+    computations_fully_verified: usize,
+    query_computations: usize,
+    query_computations_fully_verified: usize,
 }
 
 impl Totals {
@@ -298,6 +374,32 @@ impl Totals {
                 self.quotes_verified += 1;
             }
         }
+    }
+
+    fn absorb_derived(&mut self, report: &DerivedVerification) {
+        self.computations += 1;
+        if matches!(report.computation, ComputationStatus::ReChecked) {
+            self.computations_rechecked += 1;
+        }
+        if report.fully_verified() {
+            self.computations_fully_verified += 1;
+        }
+        if report.is_query_answer {
+            self.query_computations += 1;
+            if report.fully_verified() {
+                self.query_computations_fully_verified += 1;
+            }
+        }
+        self.quotes_verified += report
+            .formula_quotes
+            .iter()
+            .filter(|quote| matches!(quote, QuoteStatus::Verified { .. }))
+            .count();
+        self.quotes_verified += report
+            .input_quotes
+            .iter()
+            .filter(|input| matches!(input.quote, QuoteStatus::Verified { .. }))
+            .count();
     }
 }
 
@@ -428,6 +530,56 @@ fn main() -> ExitCode {
         record("lr", &text, &r.result.dag.proofs, &mut totals);
     }
 
+    // Formula queries do not produce SLD proofs: their evidence is a CPU
+    // derivation tree plus the formula and input provenance carried by the
+    // resulting binding. Re-check that independent channel explicitly so a
+    // formula-only program can become fully verified without inventing a fake
+    // logic proof, and so tampered arithmetic localizes to the computed value.
+    let mut computation_blobs: Vec<String> = Vec::new();
+    for derived in lowered.kb.derived_bindings() {
+        let report = verify_derived(derived, &lowered.kb, store.as_ref());
+        totals.absorb_derived(&report);
+        if first_failure.is_none() && !report.passed() {
+            first_failure = Some(match &report.computation {
+                status if !matches!(status, ComputationStatus::ReChecked) => format!(
+                    "{{\"pass\":\"computation\",\"name\":\"{}\",\"computation\":{}}}",
+                    esc(&report.name),
+                    computation_json(&report.computation)
+                ),
+                _ if report
+                    .formula_quotes
+                    .iter()
+                    .any(|quote| matches!(quote, QuoteStatus::QuoteMissing(_))) =>
+                {
+                    let quote = report
+                        .formula_quotes
+                        .iter()
+                        .find(|quote| matches!(quote, QuoteStatus::QuoteMissing(_)))
+                        .expect("a failed formula quote is present");
+                    format!(
+                        "{{\"pass\":\"formula_quote\",\"name\":\"{}\",\"quote\":{}}}",
+                        esc(&report.name),
+                        quote_json(quote)
+                    )
+                }
+                _ => {
+                    let input = report
+                        .input_quotes
+                        .iter()
+                        .find(|input| matches!(input.quote, QuoteStatus::QuoteMissing(_)))
+                        .expect("a failed derived report has a localized failure");
+                    format!(
+                        "{{\"pass\":\"input_quote\",\"name\":\"{}\",\"fact_id\":{},\"quote\":{}}}",
+                        esc(&report.name),
+                        input.fact_id.0,
+                        quote_json(&input.quote)
+                    )
+                }
+            });
+        }
+        computation_blobs.push(derived_json(&report));
+    }
+
     // NUM-6 audit-exactness re-check (ADJ-NUMERIC-SUBSTRATE §4.3, §6, §7). The SLD
     // and LR passes above re-derive the *logic*; the compute derivation trees carry
     // the *arithmetic*, and every `round_to`/`round_sig`/`to_scientific`/`to_percent`/
@@ -506,11 +658,14 @@ fn main() -> ExitCode {
     // been checked. That is the fail-open shape this tool exists to catch, and
     // it is no less wrong for appearing in the tool itself.
     let fully = verified
-        && totals.proofs > 0
-        && totals.proofs_fully_verified == totals.proofs
+        && totals.proofs + totals.query_computations > 0
+        && (totals.proofs == 0 || totals.proofs_fully_verified == totals.proofs)
+        && (totals.computations == 0 || totals.computations_fully_verified == totals.computations)
+        && (totals.query_computations == 0
+            || totals.query_computations_fully_verified == totals.query_computations)
         && totals.quotes_verified > 0;
     println!(
-        "{{\"verified\":{},\"fully_verified\":{},\"totals\":{{\"proofs\":{},\"proofs_fully_verified\":{},\"steps\":{},\"rechecked\":{},\"quotes_verified\":{},\"narrowings_rechecked\":{},\"narrowings_unverifiable\":{},\"narrowings_mismatched\":{}}},\"truncated_queries\":[{}],\"narrowings\":[{}],\"first_failure\":{},\"queries\":[{}]}}",
+        "{{\"verified\":{},\"fully_verified\":{},\"totals\":{{\"proofs\":{},\"proofs_fully_verified\":{},\"steps\":{},\"rechecked\":{},\"quotes_verified\":{},\"computations\":{},\"computations_rechecked\":{},\"computations_fully_verified\":{},\"query_computations\":{},\"query_computations_fully_verified\":{},\"narrowings_rechecked\":{},\"narrowings_unverifiable\":{},\"narrowings_mismatched\":{}}},\"truncated_queries\":[{}],\"computations\":[{}],\"narrowings\":[{}],\"first_failure\":{},\"queries\":[{}]}}",
         verified,
         fully,
         totals.proofs,
@@ -518,10 +673,16 @@ fn main() -> ExitCode {
         totals.steps,
         totals.rechecked,
         totals.quotes_verified,
+        totals.computations,
+        totals.computations_rechecked,
+        totals.computations_fully_verified,
+        totals.query_computations,
+        totals.query_computations_fully_verified,
         narrowings_rechecked,
         narrowings_unverifiable,
         narrowings_mismatched,
         truncated_queries.join(","),
+        computation_blobs.join(","),
         narrowing_blobs.join(","),
         first_failure.as_deref().unwrap_or("null"),
         per_query.join(",")

--- a/code/packages/rust/adj-lang-cli/tests/formula_verify_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_verify_e2e.rs
@@ -1,0 +1,199 @@
+//! Formula-only verification through the real `adj-verify` binary.
+//!
+//! A computed answer has three independent obligations: CPU math must replay,
+//! the formula must quote its source bytes, and every numeric input must quote
+//! the bytes from which it was decomposed. This fixture exercises all three.
+
+use logic_engine::ContentHash;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const DOC: &str = "Formula: total is a plus b. Input a is 7. Input b is 5.";
+const NESTED_DOC: &str = "Outer: ratio is quotient. Inner: quotient is dividend divided by divisor. Input n is 9. Input d is 3.";
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjverify_formula_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn offset(doc: &str, quote: &str) -> usize {
+    doc.find(quote)
+        .expect("fixture quote must occur in source bytes")
+}
+
+fn write_program(dir: &Path, doc: &str) -> PathBuf {
+    let hash = ContentHash::of(doc.as_bytes()).as_hex().to_string();
+    let snapshots = dir.join("snapshots");
+    std::fs::create_dir_all(&snapshots).unwrap();
+    std::fs::write(snapshots.join(&hash), doc).unwrap();
+
+    let source = format!(
+        "formulabook demo {{\n\
+             formula total(a, b) = a + b\n\
+                 quote \"total is a plus b\" at {} snapshot \"{}\"\n\
+                 source \"formula fixture\"\n\
+                 locator \"cas://formula-source\"\n\
+                 trust authoritative\n\
+         }}\n\
+         observe a(7)\n\
+             quote \"Input a is 7\" at {} snapshot \"{}\"\n\
+             source \"input fixture\"\n\
+             locator \"cas://input\"\n\
+             trust authoritative\n\
+         observe b(5)\n\
+             quote \"Input b is 5\" at {} snapshot \"{}\"\n\
+             source \"input fixture\"\n\
+             locator \"cas://input\"\n\
+             trust authoritative\n\
+         ? total(a, b)\n",
+        offset(DOC, "total is a plus b"),
+        hash,
+        offset(DOC, "Input a is 7"),
+        hash,
+        offset(DOC, "Input b is 5"),
+        hash,
+    );
+    let program = dir.join("case.adj");
+    std::fs::write(&program, source).unwrap();
+    program
+}
+
+fn write_nested_program(dir: &Path, doc: &str) -> PathBuf {
+    let hash = ContentHash::of(doc.as_bytes()).as_hex().to_string();
+    let snapshots = dir.join("snapshots");
+    std::fs::create_dir_all(&snapshots).unwrap();
+    std::fs::write(snapshots.join(&hash), doc).unwrap();
+    let source = format!(
+        "formulabook nested {{\n\
+             formula quotient(dividend, divisor) = dividend / divisor\n\
+                 quote \"quotient is dividend divided by divisor\" at {} snapshot \"{}\"\n\
+                 source \"inner fixture\" trust authoritative\n\
+             formula ratio(numerator, denominator) = quotient(numerator, denominator)\n\
+                 quote \"ratio is quotient\" at {} snapshot \"{}\"\n\
+                 source \"outer fixture\" trust authoritative\n\
+         }}\n\
+         observe n(9)\n\
+             quote \"Input n is 9\" at {} snapshot \"{}\"\n\
+             source \"input fixture\" trust authoritative\n\
+         observe d(3)\n\
+             quote \"Input d is 3\" at {} snapshot \"{}\"\n\
+             source \"input fixture\" trust authoritative\n\
+         ? ratio(n, d)\n",
+        offset(NESTED_DOC, "quotient is dividend divided by divisor"),
+        hash,
+        offset(NESTED_DOC, "ratio is quotient"),
+        hash,
+        offset(NESTED_DOC, "Input n is 9"),
+        hash,
+        offset(NESTED_DOC, "Input d is 3"),
+        hash,
+    );
+    let program = dir.join("nested.adj");
+    std::fs::write(&program, source).unwrap();
+    program
+}
+
+fn verify(program: &Path, snapshots: &Path) -> (bool, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_adj-verify"))
+        .arg("--snapshots")
+        .arg(snapshots)
+        .arg(program)
+        .output()
+        .expect("run adj-verify");
+    (
+        output.status.success(),
+        String::from_utf8(output.stdout).unwrap(),
+    )
+}
+
+#[test]
+fn formula_math_and_all_three_quotes_are_fully_verified() {
+    let dir = scratch("pass");
+    let program = write_program(&dir, DOC);
+    let (ok, output) = verify(&program, &dir.join("snapshots"));
+
+    assert!(ok, "fully grounded formula must verify: {output}");
+    assert!(output.contains("\"verified\":true"), "{output}");
+    assert!(output.contains("\"fully_verified\":true"), "{output}");
+    assert!(output.contains("\"computations\":1"), "{output}");
+    assert!(output.contains("\"computations_rechecked\":1"), "{output}");
+    assert!(
+        output.contains("\"computations_fully_verified\":1"),
+        "{output}"
+    );
+    assert!(output.contains("\"quotes_verified\":3"), "{output}");
+    assert!(
+        output.contains("\"input_quotes\":[{\"fact_id\":0"),
+        "{output}"
+    );
+}
+
+#[test]
+fn changed_formula_source_bytes_fail_closed() {
+    let dir = scratch("drift");
+    let drifted = "Formula: total is a plus c. Input a is 7. Input b is 5.";
+    let program = write_program(&dir, drifted);
+    let (ok, output) = verify(&program, &dir.join("snapshots"));
+
+    assert!(
+        !ok,
+        "a formula quote absent from its snapshot must fail: {output}"
+    );
+    assert!(output.contains("\"verified\":false"), "{output}");
+    assert!(output.contains("\"fully_verified\":false"), "{output}");
+    assert!(output.contains("\"pass\":\"formula_quote\""), "{output}");
+    assert!(output.contains("\"status\":\"quote_missing\""), "{output}");
+}
+
+#[test]
+fn changed_input_source_bytes_fail_closed() {
+    let dir = scratch("input_drift");
+    let drifted = "Formula: total is a plus b. Input a is 8. Input b is 5.";
+    let program = write_program(&dir, drifted);
+    let (ok, output) = verify(&program, &dir.join("snapshots"));
+
+    assert!(!ok, "an input absent from its snapshot must fail: {output}");
+    assert!(output.contains("\"verified\":false"), "{output}");
+    assert!(output.contains("\"fully_verified\":false"), "{output}");
+    assert!(output.contains("\"pass\":\"input_quote\""), "{output}");
+    assert!(output.contains("\"status\":\"quote_missing\""), "{output}");
+}
+
+#[test]
+fn a_computation_without_a_question_cannot_receive_the_strongest_verdict() {
+    let dir = scratch("no_query");
+    let program = write_program(&dir, DOC);
+    let source = std::fs::read_to_string(&program).unwrap();
+    std::fs::write(&program, source.replace("? total(a, b)\n", "")).unwrap();
+    let (ok, output) = verify(&program, &dir.join("snapshots"));
+
+    assert!(ok, "the computation itself still replays: {output}");
+    assert!(output.contains("\"verified\":true"), "{output}");
+    assert!(output.contains("\"fully_verified\":false"), "{output}");
+    assert!(output.contains("\"query_computations\":0"), "{output}");
+}
+
+#[test]
+fn nested_formula_sources_are_each_byte_verified() {
+    let dir = scratch("nested");
+    let program = write_nested_program(&dir, NESTED_DOC);
+    let (ok, output) = verify(&program, &dir.join("snapshots"));
+
+    assert!(ok, "nested formula chain must replay: {output}");
+    assert!(output.contains("\"fully_verified\":true"), "{output}");
+    assert!(output.contains("\"quotes_verified\":4"), "{output}");
+}
+
+#[test]
+fn drifted_nested_formula_source_fails_closed() {
+    let dir = scratch("nested_drift");
+    let drifted = NESTED_DOC.replace("dividend divided", "dividend timesxx");
+    let program = write_nested_program(&dir, &drifted);
+    let (ok, output) = verify(&program, &dir.join("snapshots"));
+
+    assert!(!ok, "a nested formula quote must not be optional: {output}");
+    assert!(output.contains("\"pass\":\"formula_quote\""), "{output}");
+    assert!(output.contains("\"fully_verified\":false"), "{output}");
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.69.0] - 2026-08-02 - byte-grounded observed inputs
+
+- `observe` declarations now accept the standard provenance annotations, including exact
+  `quote`, byte offset, and snapshot hash pins.
+- The lowerer attaches that provenance to the emitted fact, so formula verification can trace
+  every numeric input back to the bytes from which it was decomposed.
+- Formula application keeps every nested source envelope losslessly, rather than reducing inner
+  formula pins to display-only corroborations.
+- Unannotated observations remain source-compatible and retain their previous behavior.
+
 ## [0.68.0] — 2026-07-30 — AR-3: attack edges compose INSIDE the `argument` block
 
 A paper's ATTACK edges — rebuttals and undercuts — can now live inside the pure `argument`

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.68.0"
+version = "0.69.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -142,6 +142,7 @@ pub fn parser_grammar() -> ParserGrammar {
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"observe"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
             line_number: 85,
         },

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -348,9 +348,10 @@ fn adapt_uncertain(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
 }
 
 fn adapt_observe(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
-    // observe_decl = "observe" term
+    // observe_decl = "observe" term { annotation }
     let term = expect_term_child(node, "observe_decl")?;
-    Ok(Statement::Observe { term })
+    let annotations = collect_annotations(node)?;
+    Ok(Statement::Observe { term, annotations })
 }
 
 fn adapt_relate(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
@@ -3584,7 +3585,7 @@ mod tests {
     fn round_trips_valued_observation() {
         // observe <slot>(<number>) — a valued fact the predicate reads.
         match parse_one("observe gross_income(18000)") {
-            Statement::Observe { term } => match term {
+            Statement::Observe { term, .. } => match term {
                 Term::Compound { functor, args } => {
                     assert_eq!(functor, "gross_income");
                     assert_eq!(args.len(), 1);
@@ -3599,12 +3600,31 @@ mod tests {
     }
 
     #[test]
+    fn observation_accepts_a_byte_provenance_envelope() {
+        let digest = "a".repeat(64);
+        let source = format!(
+            "observe gross_income(18000)\n  quote \"income is 18000\" at 4 snapshot \"{digest}\"\n  source \"case bytes\"\n  locator \"cas://input\"\n  trust authoritative"
+        );
+        match parse_one(&source) {
+            Statement::Observe { annotations, .. } => {
+                assert_eq!(annotations.len(), 4);
+                assert!(matches!(
+                    &annotations[0],
+                    Annotation::Quote { text, byte_offset: 4, snapshot_hex }
+                        if text == "income is 18000" && snapshot_hex == &digest
+                ));
+            }
+            other => panic!("expected annotated Observe, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn exact_high_precision_literal_parses_to_numlit_exact() {
         // A >17-digit fractional literal (π to 39 places) is preserved exactly as a NumLit::Exact
         // — the NX-2 win — while staying comfortably within the size budgets.
         let pi = "3.141592653589793238462643383279502884197";
         match parse_one(&format!("observe c({pi})")) {
-            Statement::Observe { term } => match term {
+            Statement::Observe { term, .. } => match term {
                 Term::Compound { args, .. } => match &args[0] {
                     Term::Num(NumLit::Exact(d)) => assert_eq!(d.to_string(), pi),
                     other => panic!("expected NumLit::Exact, got {other:?}"),

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -359,8 +359,11 @@ pub enum Statement {
         conclusion: Term,
         annotations: Vec<Annotation>,
     },
-    /// `observe <term>` — assert a Certain Fact.
-    Observe { term: Term },
+    /// `observe <term>` (+ annotations) — assert a Certain, byte-groundable Fact.
+    Observe {
+        term: Term,
+        annotations: Vec<Annotation>,
+    },
     /// `relate <rel>(<args>)` — assert a ground RELATIONAL EDGE (MYCIN-2026
     /// REL-2). The `edge` term's functor is the relation and its arguments are
     /// the entities (e.g. `deficient_in(tay_sachs, hexosaminidase_a)`). Lowers

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -661,8 +661,9 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                 .with_provenance(prov);
                 kb.add_joint_contribution(clause);
             }
-            Statement::Observe { term } => {
-                kb.add_fact(Fact::certain(lower_term(term)));
+            Statement::Observe { term, annotations } => {
+                let prov = annotations_to_provenance(annotations)?;
+                kb.add_fact(Fact::certain(lower_term(term)).with_provenance(prov));
             }
             Statement::Relate { edge, annotations } => {
                 // A ground relational edge → a Certain Fact carrying its citation
@@ -761,8 +762,14 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                     // `quotient`'s (a corroboration). The derivation is auditable
                     // back to every formula that produced it.
                     let primary = annotations_to_provenance(&fd.annotations)?;
-                    let prov = compose_provenance(primary, &chain);
-                    kb.add_derived(derived.with_provenance(prov));
+                    let prov = compose_provenance(primary.clone(), &chain);
+                    let mut formula_sources = vec![primary];
+                    formula_sources.extend(chain.iter().cloned());
+                    kb.add_derived(
+                        derived
+                            .with_formula_sources(prov, formula_sources)
+                            .as_query_answer(),
+                    );
                 } else {
                     // An ordinary query. Lower with a per-query variable scope so
                     // repeated `$Var`s in one goal share identity (Prolog clause-scope
@@ -872,7 +879,7 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                 // library provenance (its audit trail is the derivation tree). A
                 // `let` that applied formulas carries their composed cites.
                 let derived = match compose_chain(&chain) {
-                    Some(prov) => derived.with_provenance(prov),
+                    Some(prov) => derived.with_formula_sources(prov, chain.clone()),
                     None => derived,
                 };
                 kb.add_derived(derived);
@@ -1216,7 +1223,7 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
         // the audit trail for a fired `obese` verdict cites BOTH the WHO obesity
         // threshold (on the contribution clause) AND the BMI definition (here).
         let derived = match compose_chain(&chain) {
-            Some(prov) => derived.with_provenance(prov),
+            Some(prov) => derived.with_formula_sources(prov, chain.clone()),
             None => derived,
         };
         kb.add_derived(derived);
@@ -1477,7 +1484,7 @@ fn enforce_vocabulary<'a>(
                     check_finding(t)?;
                 }
             }
-            Statement::Observe { term } => check_finding(term)?,
+            Statement::Observe { term, .. } => check_finding(term)?,
             _ => {}
         }
     }
@@ -5576,6 +5583,14 @@ rule { head: r(a) when: x(t) }";
         assert!((d.value - 0.75).abs() < 1e-9, "3/4 = 0.75, got {}", d.value);
         let prov = d.provenance.as_ref().expect("carries composed provenance");
         assert_eq!(prov.source, "ratio def", "ratio's cite is primary");
+        assert_eq!(
+            d.formula_sources
+                .iter()
+                .map(|source| source.source.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ratio def", "quotient def"],
+            "lossless formula sources stay independently verifiable"
+        );
         // quotient's cite composes in as a corroboration — both are auditable.
         assert!(
             prov.corroborations

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.51.0] - 2026-08-02 - computed-answer verification
+
+- Added `verify_derived`, which re-evaluates a compiler-owned expression stored separately
+  from the result artifact, in the original fact and derived-binding scope. It compares the
+  fresh value, exact sidecar, dimension, and complete derivation tree.
+- Prior derived inputs are verified recursively. Coordinated operator/result forgery, omitted
+  aggregation operands, stale binding substitution, and altered narrowing sidecars fail closed.
+- Every applied formula and unique observed input keeps its lossless provenance envelope and
+  is verified against pinned bytes. Inexact narrowing remains explicitly unverifiable.
+
 ## [0.50.0] — 2026-07-30 — NUM-6v: audit re-check of the precision/format narrowings
 
 Closes the NUM-6 audit-exactness promise (`ADJ-NUMERIC-SUBSTRATE.md` §4.3, §6, §7): the

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -610,14 +610,44 @@ impl DerivationNode {
 /// [`Dimension`] the engine inferred for it (so a predicate firing over a
 /// derived value — `csf_ratio <= 0.4` — knows `csf_ratio` is a dimensionless
 /// `Scalar`, and the faithfulness gate has rejected any unit-mismatched op).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComputationScope {
+    /// Fact ids below this exclusive limit were visible when evaluation ran.
+    pub fact_limit: u64,
+    /// Derived bindings below this exclusive index were visible.
+    pub derived_limit: usize,
+}
+
+/// Stable identity assigned when a computed artifact enters a knowledge base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ComputationId(pub usize);
+
+/// Compiler-owned plan kept separately from the result artifact under audit.
+#[derive(Debug, Clone)]
+pub(crate) struct ComputationPlan {
+    pub expr: ComputeExpr,
+    pub scope: ComputationScope,
+    pub formula_sources: Vec<crate::Provenance>,
+    pub is_query_answer: bool,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Derived {
+    /// Assigned by [`KnowledgeBase::add_derived`](crate::KnowledgeBase::add_derived).
+    pub(crate) computation_id: Option<ComputationId>,
     pub name: String,
     pub value: f64,
     /// Exact value when the expression stayed inside integer/rational arithmetic.
     pub exact: Option<ExactRational>,
     pub dim: Dimension,
     pub tree: DerivationNode,
+    /// The compiler-produced expression that the verifier independently
+    /// evaluates. Replaying only `tree` would trust the very operator and
+    /// operand structure under audit.
+    pub expr: ComputeExpr,
+    /// The exact fact/derived prefix visible at the original evaluation point.
+    /// This makes latest-observation and rebinding resolution reproducible.
+    pub scope: ComputationScope,
     /// Provenance for the *formula* that produced this value, when it came from
     /// APPLYING a provenanced `formula` (ADJ-FORMULA-LIBRARIES rung-0): the
     /// formula's cited `source` / `locator` / `trust`. A plain `let` leaves this
@@ -626,6 +656,11 @@ pub struct Derived {
     /// answer carries **why** its formula is trustworthy, so an independent
     /// checker can re-verify the citation without the model.
     pub provenance: Option<crate::Provenance>,
+    /// Every formula applied to produce this value, outermost first. Unlike
+    /// display corroborations, these retain their exact quote and snapshot pins.
+    pub formula_sources: Vec<crate::Provenance>,
+    /// True only when this binding is the answer to an explicit formula query.
+    pub is_query_answer: bool,
 }
 
 impl Derived {
@@ -633,7 +668,25 @@ impl Derived {
     /// `trust`). Consumes and returns `self` so it composes with [`compute`]:
     /// `compute(name, expr, kb)?.with_provenance(prov)`.
     pub fn with_provenance(mut self, provenance: crate::Provenance) -> Self {
+        self.formula_sources = vec![provenance.clone()];
         self.provenance = Some(provenance);
+        self
+    }
+
+    /// Attach display provenance and the lossless applied-formula source chain.
+    pub fn with_formula_sources(
+        mut self,
+        provenance: crate::Provenance,
+        formula_sources: Vec<crate::Provenance>,
+    ) -> Self {
+        self.provenance = Some(provenance);
+        self.formula_sources = formula_sources;
+        self
+    }
+
+    /// Mark this derived binding as the answer to an explicit formula query.
+    pub fn as_query_answer(mut self) -> Self {
+        self.is_query_answer = true;
         self
     }
 }
@@ -702,14 +755,19 @@ pub fn compute(
     let (tree, dim, exact) = eval(expr, kb, 0)?;
     let value = tree.value();
     Ok(Derived {
+        computation_id: None,
         name: name.into(),
         value,
         exact,
         dim,
         tree,
+        expr: expr.clone(),
+        scope: kb.computation_scope(),
         // A plain `let` carries no library-formula provenance; a formula
         // application attaches it afterward via [`Derived::with_provenance`].
         provenance: None,
+        formula_sources: Vec::new(),
+        is_query_answer: false,
     })
 }
 

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -49,14 +49,14 @@ use std::collections::{HashMap, HashSet};
 
 use logic_core::{unify, LogicVar, Number, Substitution, Term};
 
-pub use compute::{
-    compute, recheck_narrowing, recheck_narrowings, ComputeError, ComputeExpr, ComputeOp,
-    DerivationNode, Derived, NarrowingCheck, RoundSpec,
-};
 /// Re-exported so consumers can name the rounding mode of a
 /// [`ComputeExpr::Round`]/[`DerivationNode::Round`] without depending on
 /// `bignum-core` directly (NUM-6a).
 pub use bignum_core::RoundingMode;
+pub use compute::{
+    compute, recheck_narrowing, recheck_narrowings, ComputationId, ComputationScope, ComputeError,
+    ComputeExpr, ComputeOp, DerivationNode, Derived, NarrowingCheck, RoundSpec,
+};
 pub use conversion::{add_or_sub, convert_value, ConvError, Conversion, ConversionTable};
 pub use datetime::{
     after, before, date_add, date_ordinal, days_between, read_date, read_duration_days,
@@ -76,7 +76,8 @@ pub use lr_aggregate::{
 pub use proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
 pub use provenance::{Citation, ContentHash, Provenance, Quote, TrustTier, VerbatimSpan};
 pub use verify::{
-    verify_proof, verify_quote, verify_step, LogicFailure, LogicStatus, MemorySnapshots,
+    verify_derived, verify_proof, verify_quote, verify_step, ComputationFailure, ComputationStatus,
+    DerivedVerification, InputQuoteVerification, LogicFailure, LogicStatus, MemorySnapshots,
     NoSnapshots, QuoteMiss, QuoteStatus, SnapshotStore, StepVerification, TraceVerification,
     UnverifiedReason,
 };
@@ -425,6 +426,9 @@ pub struct KnowledgeBase {
     /// [`observed_value`](Self::observed_value) falls back to this table so a
     /// predicate fires over a computed value exactly as over an observed one.
     derived: Vec<crate::compute::Derived>,
+    /// Trusted compiler plans, stored separately from result artifacts so the
+    /// verifier never takes an artifact's own expression as authority.
+    computation_plans: Vec<crate::compute::ComputationPlan>,
     /// LP19e + ADJ47-D: uncertainty markers attached to conclusions.
     /// Each marker carries a domain of candidate evidence terms; if
     /// none of them is observed, the aggregator emits an
@@ -952,7 +956,15 @@ impl KnowledgeBase {
     /// Bind a `let`-computed [`Derived`](crate::compute::Derived) value into the
     /// KB. A later [`observed_value`](Self::observed_value) of its name returns
     /// the computed value, and a formula can reference it by name.
-    pub fn add_derived(&mut self, derived: crate::compute::Derived) {
+    pub fn add_derived(&mut self, mut derived: crate::compute::Derived) {
+        let id = crate::compute::ComputationId(self.computation_plans.len());
+        derived.computation_id = Some(id);
+        self.computation_plans.push(crate::compute::ComputationPlan {
+            expr: derived.expr.clone(),
+            scope: derived.scope,
+            formula_sources: derived.formula_sources.clone(),
+            is_query_answer: derived.is_query_answer,
+        });
         self.derived.push(derived);
     }
 
@@ -971,6 +983,39 @@ impl KnowledgeBase {
     /// the renderer keeps the most-recent per name to mirror that rule.
     pub fn derived_bindings(&self) -> &[crate::compute::Derived] {
         &self.derived
+    }
+
+    pub(crate) fn computation_scope(&self) -> crate::compute::ComputationScope {
+        crate::compute::ComputationScope {
+            fact_limit: self.next_fact_id,
+            derived_limit: self.derived.len(),
+        }
+    }
+
+    /// Reconstruct the fact and derived prefix visible to an earlier compute.
+    pub(crate) fn at_computation_scope(
+        &self,
+        scope: crate::compute::ComputationScope,
+    ) -> Option<Self> {
+        if scope.fact_limit > self.next_fact_id || scope.derived_limit > self.derived.len() {
+            return None;
+        }
+        let mut view = self.clone();
+        for facts in view.facts.values_mut() {
+            facts.retain(|fact| fact.id.0 < scope.fact_limit);
+        }
+        view.facts.retain(|_, facts| !facts.is_empty());
+        view.derived.truncate(scope.derived_limit);
+        view.computation_plans.truncate(scope.derived_limit);
+        view.next_fact_id = scope.fact_limit;
+        Some(view)
+    }
+
+    pub(crate) fn computation_plan(
+        &self,
+        id: crate::compute::ComputationId,
+    ) -> Option<&crate::compute::ComputationPlan> {
+        self.computation_plans.get(id.0)
     }
 
     /// True iff at least one contribution (single or joint) names

--- a/code/packages/rust/logic-engine/src/verify.rs
+++ b/code/packages/rust/logic-engine/src/verify.rs
@@ -71,18 +71,18 @@
 //! layer has somewhere honest to report into; this offline pass never produces
 //! them.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use logic_core::{unify, LogicVar, Substitution, Term};
 
-use crate::compute::compute;
+use crate::compute::{compute, ComputeError, DerivationNode, Derived};
 use crate::lr_aggregate::CmpOp;
 use crate::proof_dag::{DerivationOrigin, Proof, ProofStep};
-use crate::BodyLiteral;
 use crate::provenance::{ContentHash, Provenance, Quote};
+use crate::BodyLiteral;
 use crate::{
-    enumerate_all, ContributionClauseId, FactId, JointContributionClauseId,
-    KnowledgeBase, PredicateContributionClauseId, PriorClauseId, RuleId,
+    enumerate_all, ContributionClauseId, FactId, JointContributionClauseId, KnowledgeBase,
+    PredicateContributionClauseId, PriorClauseId, RuleId,
 };
 
 /// How far two log-odds values may differ and still count as "the same
@@ -94,6 +94,72 @@ use crate::{
 /// false ones. `1e-9` is many orders of magnitude below any log-odds difference
 /// that changes a decision, and many orders above accumulated rounding.
 pub const LOGIT_TOLERANCE: f64 = 1e-9;
+
+/// The outcome of independently evaluating the original computation expression.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ComputationStatus {
+    ReChecked,
+    Unverifiable(&'static str),
+    Failed(ComputationFailure),
+}
+
+/// A localized reason a computed artifact did not reproduce.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ComputationFailure {
+    PlanUnavailable,
+    ArtifactDoesNotMatchPlan,
+    ScopeUnavailable,
+    EvaluationFailed(ComputeError),
+    ValueDiffers { recorded: f64, recomputed: f64 },
+    ExactValueDiffers,
+    DimensionDiffers,
+    TreeDiffers,
+    ReferencedDerivedDiffers(String),
+}
+
+/// One input fact's byte-verification result in a computed answer.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InputQuoteVerification {
+    pub fact_id: FactId,
+    pub quote: QuoteStatus,
+}
+
+/// Independent math and byte verification for one derived result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DerivedVerification {
+    pub name: String,
+    pub computation: ComputationStatus,
+    pub formula_quotes: Vec<QuoteStatus>,
+    pub input_quotes: Vec<InputQuoteVerification>,
+    pub is_query_answer: bool,
+}
+
+impl DerivedVerification {
+    pub fn passed(&self) -> bool {
+        matches!(self.computation, ComputationStatus::ReChecked)
+            && self
+                .formula_quotes
+                .iter()
+                .all(|quote| !matches!(quote, QuoteStatus::QuoteMissing(_)))
+            && self
+                .input_quotes
+                .iter()
+                .all(|input| !matches!(input.quote, QuoteStatus::QuoteMissing(_)))
+    }
+
+    pub fn fully_verified(&self) -> bool {
+        self.passed()
+            && !self.formula_quotes.is_empty()
+            && self
+                .formula_quotes
+                .iter()
+                .all(|quote| matches!(quote, QuoteStatus::Verified { .. }))
+            && self
+                .input_quotes
+                .iter()
+                .all(|input| matches!(input.quote, QuoteStatus::Verified { .. }))
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Snapshot access
@@ -494,6 +560,199 @@ pub fn verify_quote(prov: &Provenance, snapshots: &dyn SnapshotStore) -> QuoteSt
             byte_offset,
             byte_len,
         })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Computed-answer verification
+// ---------------------------------------------------------------------------
+
+fn same_number(left: f64, right: f64) -> bool {
+    left.to_bits() == right.to_bits()
+}
+
+fn collect_computation_dependencies(
+    node: &DerivationNode,
+    facts: &mut BTreeSet<FactId>,
+    derived_names: &mut Vec<String>,
+) {
+    match node {
+        DerivationNode::Leaf { fact_id, .. } => {
+            facts.insert(*fact_id);
+        }
+        DerivationNode::DerivedRef { name, .. } => derived_names.push(name.clone()),
+        DerivationNode::Op { operands, .. } => {
+            for operand in operands {
+                collect_computation_dependencies(operand, facts, derived_names);
+            }
+        }
+        DerivationNode::Round { operand, .. }
+        | DerivationNode::ToScientific { operand, .. }
+        | DerivationNode::ToPercent { operand, .. }
+        | DerivationNode::ToCurrency { operand, .. } => {
+            collect_computation_dependencies(operand, facts, derived_names);
+        }
+        DerivationNode::Lit { .. } => {}
+    }
+}
+
+fn has_inexact_narrowing(node: &DerivationNode) -> bool {
+    match node {
+        DerivationNode::Round {
+            operand,
+            operand_exact,
+            ..
+        }
+        | DerivationNode::ToScientific {
+            operand,
+            operand_exact,
+            ..
+        }
+        | DerivationNode::ToPercent {
+            operand,
+            operand_exact,
+            ..
+        }
+        | DerivationNode::ToCurrency {
+            operand,
+            operand_exact,
+            ..
+        } => operand_exact.is_none() || has_inexact_narrowing(operand),
+        DerivationNode::Op { operands, .. } => operands.iter().any(has_inexact_narrowing),
+        DerivationNode::Leaf { .. }
+        | DerivationNode::DerivedRef { .. }
+        | DerivationNode::Lit { .. } => false,
+    }
+}
+
+fn recheck_derived_recursive(
+    derived: &Derived,
+    kb: &KnowledgeBase,
+    visiting: &mut HashSet<usize>,
+    checked: &mut HashSet<usize>,
+    input_ids: &mut BTreeSet<FactId>,
+    formula_sources: &mut Vec<Provenance>,
+) -> ComputationStatus {
+    let Some(id) = derived.computation_id else {
+        return ComputationStatus::Failed(ComputationFailure::PlanUnavailable);
+    };
+    let Some(plan) = kb.computation_plan(id) else {
+        return ComputationStatus::Failed(ComputationFailure::PlanUnavailable);
+    };
+    if kb.derived_bindings().get(id.0) != Some(derived) {
+        return ComputationStatus::Failed(ComputationFailure::ArtifactDoesNotMatchPlan);
+    }
+    formula_sources.extend(plan.formula_sources.iter().cloned());
+    let Some(view) = kb.at_computation_scope(plan.scope) else {
+        return ComputationStatus::Failed(ComputationFailure::ScopeUnavailable);
+    };
+    let fresh = match compute(derived.name.clone(), &plan.expr, &view) {
+        Ok(fresh) => fresh,
+        Err(error) => {
+            return ComputationStatus::Failed(ComputationFailure::EvaluationFailed(error))
+        }
+    };
+    if !same_number(fresh.value, derived.value) {
+        return ComputationStatus::Failed(ComputationFailure::ValueDiffers {
+            recorded: derived.value,
+            recomputed: fresh.value,
+        });
+    }
+    if fresh.exact != derived.exact {
+        return ComputationStatus::Failed(ComputationFailure::ExactValueDiffers);
+    }
+    if fresh.dim != derived.dim {
+        return ComputationStatus::Failed(ComputationFailure::DimensionDiffers);
+    }
+    if fresh.tree != derived.tree {
+        return ComputationStatus::Failed(ComputationFailure::TreeDiffers);
+    }
+
+    let mut names = Vec::new();
+    collect_computation_dependencies(&fresh.tree, input_ids, &mut names);
+    for name in names {
+        let Some(index) = view
+            .derived_bindings()
+            .iter()
+            .rposition(|candidate| candidate.name == name)
+        else {
+            return ComputationStatus::Failed(ComputationFailure::ReferencedDerivedDiffers(name));
+        };
+        if checked.contains(&index) {
+            continue;
+        }
+        if !visiting.insert(index) {
+            return ComputationStatus::Failed(ComputationFailure::ReferencedDerivedDiffers(name));
+        }
+        let dependency = &kb.derived_bindings()[index];
+        let status = recheck_derived_recursive(
+            dependency,
+            kb,
+            visiting,
+            checked,
+            input_ids,
+            formula_sources,
+        );
+        visiting.remove(&index);
+        if !matches!(status, ComputationStatus::ReChecked) {
+            return match status {
+                ComputationStatus::Unverifiable(_) => ComputationStatus::Unverifiable(
+                    "referenced computation has an inexact narrowing source",
+                ),
+                _ => ComputationStatus::Failed(ComputationFailure::ReferencedDerivedDiffers(name)),
+            };
+        }
+        checked.insert(index);
+    }
+
+    if has_inexact_narrowing(&fresh.tree) {
+        ComputationStatus::Unverifiable("inexact narrowing source")
+    } else {
+        ComputationStatus::ReChecked
+    }
+}
+
+/// Re-evaluate the original expression in its original binding scope, then
+/// verify every transitive formula and observed-input byte span.
+pub fn verify_derived(
+    derived: &Derived,
+    kb: &KnowledgeBase,
+    snapshots: &dyn SnapshotStore,
+) -> DerivedVerification {
+    let mut input_ids = BTreeSet::new();
+    let mut formula_sources = Vec::new();
+    let computation = recheck_derived_recursive(
+        derived,
+        kb,
+        &mut HashSet::new(),
+        &mut HashSet::new(),
+        &mut input_ids,
+        &mut formula_sources,
+    );
+    let formula_quotes = formula_sources
+        .iter()
+        .map(|provenance| verify_quote(provenance, snapshots))
+        .collect();
+    let input_quotes = input_ids
+        .into_iter()
+        .map(|fact_id| InputQuoteVerification {
+            fact_id,
+            quote: kb
+                .fact(fact_id)
+                .map(|fact| verify_quote(&fact.provenance, snapshots))
+                .unwrap_or(QuoteStatus::Unverified(UnverifiedReason::NoProvenance)),
+        })
+        .collect();
+
+    DerivedVerification {
+        name: derived.name.clone(),
+        computation,
+        formula_quotes,
+        input_quotes,
+        is_query_answer: derived
+            .computation_id
+            .and_then(|id| kb.computation_plan(id))
+            .is_some_and(|plan| plan.is_query_answer),
     }
 }
 

--- a/code/packages/rust/logic-engine/tests/test_verify.rs
+++ b/code/packages/rust/logic-engine/tests/test_verify.rs
@@ -11,11 +11,12 @@
 //! from no verifier at all, and it is the one component whose bugs are
 //! invisible — a broken checker reports success.
 
-use logic_core::{atom, compound, var, Substitution, Term};
+use logic_core::{atom, compound, int, var, Substitution, Term};
 use logic_engine::{
-    enumerate_all, verify_proof, verify_quote, BodyLiteral, DerivationOrigin, Fact, FactId,
-    LogicFailure, LogicStatus, MemorySnapshots, NoSnapshots, Proof, ProofStep, Provenance,
-    QuoteMiss, QuoteStatus, Rule, RuleId, TrustTier, UnverifiedReason,
+    compute, enumerate_all, verify_derived, verify_proof, verify_quote, BodyLiteral,
+    ComputationFailure, ComputationStatus, ComputeExpr, ComputeOp, DerivationNode,
+    DerivationOrigin, Fact, FactId, LogicFailure, LogicStatus, MemorySnapshots, NoSnapshots, Proof,
+    ProofStep, Provenance, QuoteMiss, QuoteStatus, Rule, RuleId, TrustTier, UnverifiedReason,
 };
 
 /// The document every quoted fact in this file is grounded in. Short on
@@ -38,6 +39,13 @@ fn snapshots() -> MemorySnapshots {
     let mut s = MemorySnapshots::new();
     s.insert(DOC.as_bytes().to_vec());
     s
+}
+
+fn quote_from(doc: &str, text: &str) -> Provenance {
+    let offset = doc.find(text).expect("quoted test span must exist");
+    Provenance::new("computed-answer fixture", None, TrustTier::Authoritative)
+        .with_quote_in(doc, offset, text.len())
+        .expect("fixture quote must be byte-addressable")
 }
 
 // ---------------------------------------------------------------------------
@@ -778,4 +786,174 @@ fn a_consistent_multi_variable_rule_trail_still_passes() {
         "a consistent q(a),r(a) derivation of p(a) must survive: {:?}",
         report.first_failure()
     );
+}
+
+// ---------------------------------------------------------------------------
+// Computed answers: re-run the math and verify formula + input bytes.
+// ---------------------------------------------------------------------------
+
+const COMPUTE_DOC: &str = "Formula: total is a plus b. Input a is 7. Input b is 5.";
+
+fn grounded_sum() -> (
+    logic_engine::KnowledgeBase,
+    logic_engine::Derived,
+    MemorySnapshots,
+) {
+    let mut kb = logic_engine::KnowledgeBase::new();
+    kb.add_fact(
+        Fact::certain(compound("a", vec![int(7)]))
+            .with_provenance(quote_from(COMPUTE_DOC, "Input a is 7")),
+    );
+    kb.add_fact(
+        Fact::certain(compound("b", vec![int(5)]))
+            .with_provenance(quote_from(COMPUTE_DOC, "Input b is 5")),
+    );
+    let expr = ComputeExpr::Bin(
+        ComputeOp::Add,
+        Box::new(ComputeExpr::Ref("a".into())),
+        Box::new(ComputeExpr::Ref("b".into())),
+    );
+    let derived = compute("total", &expr, &kb)
+        .expect("fixture arithmetic must compute")
+        .with_provenance(quote_from(COMPUTE_DOC, "total is a plus b"));
+    kb.add_derived(derived);
+    let derived = kb.derived_for("total").unwrap().clone();
+    let mut snapshots = MemorySnapshots::new();
+    snapshots.insert(COMPUTE_DOC.as_bytes().to_vec());
+    (kb, derived, snapshots)
+}
+
+#[test]
+fn a_computed_answer_rechecks_math_formula_and_input_quotes() {
+    let (kb, derived, snapshots) = grounded_sum();
+    let report = verify_derived(&derived, &kb, &snapshots);
+
+    assert_eq!(report.computation, ComputationStatus::ReChecked);
+    assert_eq!(report.formula_quotes.len(), 1);
+    assert_eq!(report.input_quotes.len(), 2);
+    assert!(report.passed());
+    assert!(
+        report.fully_verified(),
+        "full verification requires the CPU math, formula bytes, and both input spans"
+    );
+}
+
+#[test]
+fn tampered_formula_arithmetic_fails_independent_recomputation() {
+    let (kb, mut derived, snapshots) = grounded_sum();
+    if let DerivationNode::Op { result, .. } = &mut derived.tree {
+        *result = 13.0;
+    } else {
+        panic!("fixture must be an operation");
+    }
+
+    let report = verify_derived(&derived, &kb, &snapshots);
+    assert!(matches!(
+        report.computation,
+        ComputationStatus::Failed(ComputationFailure::ArtifactDoesNotMatchPlan)
+    ));
+    assert!(!report.passed());
+    assert!(!report.fully_verified());
+}
+
+#[test]
+fn coordinated_operator_and_result_forgery_does_not_redefine_the_formula() {
+    let (kb, mut derived, snapshots) = grounded_sum();
+    if let DerivationNode::Op { op, result, .. } = &mut derived.tree {
+        *op = ComputeOp::Sub;
+        *result = 2.0;
+        derived.value = 2.0;
+    } else {
+        panic!("fixture must be an operation");
+    }
+
+    let report = verify_derived(&derived, &kb, &snapshots);
+    assert!(matches!(
+        report.computation,
+        ComputationStatus::Failed(ComputationFailure::ArtifactDoesNotMatchPlan)
+    ));
+    assert!(!report.fully_verified());
+}
+
+#[test]
+fn an_aggregation_cannot_omit_or_duplicate_observed_inputs() {
+    let mut kb = logic_engine::KnowledgeBase::new();
+    kb.add_fact(
+        Fact::certain(compound("reading", vec![int(7)]))
+            .with_provenance(quote_from(COMPUTE_DOC, "Input a is 7")),
+    );
+    kb.add_fact(
+        Fact::certain(compound("reading", vec![int(5)]))
+            .with_provenance(quote_from(COMPUTE_DOC, "Input b is 5")),
+    );
+    let derived = compute(
+        "total",
+        &ComputeExpr::Agg(ComputeOp::Sum, "reading".into()),
+        &kb,
+    )
+    .unwrap()
+    .with_provenance(quote_from(COMPUTE_DOC, "total is a plus b"));
+    kb.add_derived(derived);
+    let mut forged = kb.derived_for("total").unwrap().clone();
+    if let DerivationNode::Op {
+        operands, result, ..
+    } = &mut forged.tree
+    {
+        operands.pop();
+        *result = 7.0;
+        forged.value = 7.0;
+    }
+    let mut snapshots = MemorySnapshots::new();
+    snapshots.insert(COMPUTE_DOC.as_bytes().to_vec());
+
+    let report = verify_derived(&forged, &kb, &snapshots);
+    assert!(matches!(
+        report.computation,
+        ComputationStatus::Failed(ComputationFailure::ArtifactDoesNotMatchPlan)
+    ));
+    assert!(!report.fully_verified());
+}
+
+#[test]
+fn later_observation_cannot_substitute_for_the_original_input_scope() {
+    let (mut kb, _, snapshots) = grounded_sum();
+    kb.add_fact(
+        Fact::certain(compound("a", vec![int(99)]))
+            .with_provenance(quote_from(COMPUTE_DOC, "Input a is 7")),
+    );
+    let derived = kb.derived_for("total").unwrap();
+
+    let report = verify_derived(derived, &kb, &snapshots);
+    assert_eq!(report.computation, ComputationStatus::ReChecked);
+    assert!(report.fully_verified());
+}
+
+#[test]
+fn mutating_the_artifacts_expression_breaks_its_plan_binding() {
+    let (kb, mut derived, snapshots) = grounded_sum();
+    derived.expr = ComputeExpr::Bin(
+        ComputeOp::Sub,
+        Box::new(ComputeExpr::Ref("a".into())),
+        Box::new(ComputeExpr::Ref("b".into())),
+    );
+
+    let report = verify_derived(&derived, &kb, &snapshots);
+    assert_eq!(
+        report.computation,
+        ComputationStatus::Failed(ComputationFailure::ArtifactDoesNotMatchPlan)
+    );
+    assert!(!report.fully_verified());
+}
+
+#[test]
+fn a_computed_answer_with_unavailable_source_bytes_is_not_fully_verified() {
+    let (kb, derived, _) = grounded_sum();
+    let report = verify_derived(&derived, &kb, &NoSnapshots);
+
+    assert_eq!(report.computation, ComputationStatus::ReChecked);
+    assert!(
+        report.passed(),
+        "unavailable bytes are honest uncertainty, not a fabrication"
+    );
+    assert!(!report.fully_verified());
 }

--- a/code/specs/ADJ-REASON-MATH.md
+++ b/code/specs/ADJ-REASON-MATH.md
@@ -831,6 +831,14 @@ are **never produced by the offline pass** — they are the slots D3's adapter-r
 re-fetch reports into. Shipping the statuses ahead of the fetcher is deliberate: it
 keeps the outcome type closed, so D3 cannot quietly widen what "verified" means.
 
+**Computed-answer extension shipped.** `verify_derived` now re-evaluates the
+compiler-owned expression stored separately from the result artifact, in the exact
+fact and derived-binding prefix visible to the original computation. It compares the
+fresh value, exact sidecar, dimension, and complete tree; recursively verifies prior
+derived inputs; and checks every applied formula and observed input against pinned
+bytes. `adj-verify` includes those checks in both `verified` and `fully_verified`, so
+a formula-only answer no longer bypasses the audit path.
+
 Two verdicts that must not be conflated, and are not: `verified` (every step
 re-executed) versus `fully_verified` (every step re-executed **and** every quote
 confirmed against a snapshot, over a non-empty trace). Today's stdlib is

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -242,12 +242,23 @@ option mapping, or judge/evaluation failure.
 
 ### Wave 1: prove the full provenance path
 
+0. **Complete:** computed answers are independently verifiable. `observe` inputs
+   can carry byte pins, and `adj-verify` re-evaluates a separately stored compiler
+   plan in its original fact/binding scope plus every formula/input quote before
+   a formula-only query can become `fully_verified`.
 1. Migrate the ten arithmetic libraries first because every later layer imports
    them.
 2. Store source bytes and fetch receipts in the CAS.
 3. Add byte offsets and snapshot hashes to every grounded clause.
 4. Recursively decompose source dependencies with discarded-byte accounting.
 5. Require independent `adj-verify` success in tests.
+6. **Complete:** preserve imported and nested formula pins as first-class
+   transitive evidence. Display corroborations remain available, but
+   `adj-verify` now checks every lossless formula-source envelope independently.
+7. Add first-class fetch-receipt objects and a deterministic fanout-CAS-to-flat
+   snapshot projection instead of relying on receipt-shaped metadata.
+8. Replace the dead MathWorld `PercentageChange` locator before migrating
+   `percent.adj`; a source returning 404 cannot ground that clause.
 
 ### Wave 2: complete K-8 foundations
 


### PR DESCRIPTION
## What changed
- let observed inputs carry exact quote, offset, and snapshot provenance
- store compiler-owned computation plans separately from result artifacts
- recompute formulas in their original fact and derived-binding scope
- verify every nested formula source and observed input against pinned bytes
- require an explicit question before a computation can reach fully_verified
- fail closed on artifact/plan swaps, coordinated math forgery, omitted aggregate inputs, source drift, and inexact narrowing

## Why
Formula-only answers could carry provenance but adj-verify did not independently validate their arithmetic or input bytes. Replaying the recorded tree alone would still trust the operator and operand structure under audit, so this change recomputes from a separately stored plan instead.

## Validation
- cargo test -p logic-engine
- cargo test -p adj-lang
- cargo test -p adj-lang-cli
- cargo clippy -p logic-engine -p adj-lang -p adj-lang-cli --tests -- -D warnings
- post-rebase focused verifier, grammar, narrowing, and snapshot suites
- git diff --check origin/main...HEAD
- independent adversarial review: no remaining blocking issues