### PR TITLE
fix(spice): validate MOS model body effect

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `GAMMA` values before
+  lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `PHI` values
   before lowering netlist elements into the engine.
 - Reject non-finite Level-1 MOS model-card `LAMBDA` / `LAM` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1868,6 +1868,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(body_effect_coefficient) = params.get("GAMMA") {
+            if !body_effect_coefficient.is_finite() || *body_effect_coefficient < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET GAMMA must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1712,6 +1712,38 @@ fn preserves_positive_mosfet_model_bulk_potential() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_body_effect_coefficient() {
+    for body_effect_coefficient in ["-0.3", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model body NMOS(GAMMA={body_effect_coefficient})\nM1 d g s b body"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET GAMMA must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_body_effect_coefficient() {
+    for body_effect_coefficient in ["0", "0.3"] {
+        let parsed = parse_netlist(&format!(
+            ".model body NMOS(GAMMA={body_effect_coefficient})\nM1 d g s b body"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(
+            mosfet.params.gamma,
+            body_effect_coefficient.parse().unwrap(),
+        );
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card bulk-potential validation.
+1. Rust Berkeley SPICE MOS model-card body-effect-coefficient validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite model-card `PHI` values before
+   - Reject negative and non-finite model-card `GAMMA` values before
      lowering MOS elements into engine parameters.
-   - Preserve positive explicit bulk-potential values.
+   - Preserve zero and positive explicit body-effect coefficients.
 
 ## Completed Slices
 
@@ -3953,6 +3953,12 @@ the Rust, Python, and TypeScript surfaces together.
      MOS elements into engine parameters.
    - Arbitrary finite channel-length-modulation values remain accepted across
      both aliases.
+
+340. Rust Berkeley SPICE MOS model-card bulk-potential validation.
+   - Status: completed in PR 9475.
+   - Zero, negative, and non-finite model-card `PHI` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Positive explicit bulk-potential values remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `GAMMA` values in the Rust Berkeley parser facade
- preserve zero and positive explicit body-effect coefficients
- reconcile the SPICE completion plan after PR #9475

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's body-effect semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.