### PR TITLE
Publish the human-language curriculum gap report

### DIFF
--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -14,12 +14,14 @@ on:
     branches: [main]
     paths:
       - "code/learning/human-languages/**"
+      - "code/packages/typescript/human-language-data/**"
       - "code/scripts/build_human_language_book_catalog.py"
       - ".github/workflows/human-languages-books.yml"
   pull_request:
     branches: [main]
     paths:
       - "code/learning/human-languages/**"
+      - "code/packages/typescript/human-language-data/**"
       - "code/scripts/build_human_language_book_catalog.py"
       - ".github/workflows/human-languages-books.yml"
   workflow_dispatch:
@@ -37,6 +39,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Build curriculum gap report
+        working-directory: code/packages/typescript/human-language-data
+        run: |
+          npm ci
+          npm run build
+          mkdir -p "$GITHUB_WORKSPACE/dist/human-languages/books"
+          npm run --silent report -- --format json \
+            > "$GITHUB_WORKSPACE/dist/human-languages/books/curriculum-gaps.json"
+          npm run --silent report -- --format text \
+            > "$GITHUB_WORKSPACE/dist/human-languages/books/curriculum-gaps.txt"
+          cat "$GITHUB_WORKSPACE/dist/human-languages/books/curriculum-gaps.txt"
 
       # Install the COMPLETE TeX Live distribution rather than a hand-picked
       # list of texlive-* sub-packages. The earlier granular approach broke
@@ -92,6 +106,9 @@ jobs:
         run: |
           test -s dist/human-languages/books/index.html
           test -s dist/human-languages/books/catalog.json
+          test -s dist/human-languages/books/curriculum-gaps.json
+          test -s dist/human-languages/books/curriculum-gaps.txt
+          python -m json.tool dist/human-languages/books/curriculum-gaps.json >/dev/null
           test -n "$(find dist/human-languages/books -maxdepth 1 -name '*.pdf' -print -quit)"
 
       - name: Upload complete publication bundle

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,9 +5,9 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after PR #9474: 20 registered
-tracks, 973 Markdown lessons, and 19 downloadable LaTeX books. The Russian item
-below adds the twentieth book without adding a parallel publication workflow.
+Last prioritized: 2026-08-02. Current baseline after PR #9478: 20 registered
+tracks, 973 Markdown lessons, and 20 downloadable LaTeX books. HL-V01 makes the
+remaining migration debt reproducible in both JSON and human-readable reports.
 
 ## Priority rules
 
@@ -22,8 +22,8 @@ below adds the twentieth book without adding a parallel publication workflow.
 |---|---|---|---|
 | HL-B01 | Complete (#9472) | Publish the five authored Persian lessons as a two-chapter LaTeX starter book. | XeLaTeX builds the book; CI discovers an 18th PDF; chapters map to lessons 1 and 2. |
 | HL-B02 | Complete (#9474) | Publish the five authored Urdu lessons as a two-chapter starter book. | XeLaTeX builds with correct RTL shaping; Urdu appears in the public catalog. |
-| HL-B03 | Complete in the Russian starter-book PR | Publish Russian's two authored chapters as a starter book. | The existing Cyrillic lessons and roadmap produce a downloadable PDF. |
-| HL-V01 | Next | Add a machine-readable curriculum gap report and computed duration budget. | CI reports lessons at or above 300 seconds, missing prerequisites, book coverage, and track-schema status. |
+| HL-B03 | Complete (#9478) | Publish Russian's two authored chapters as a starter book. | The existing Cyrillic lessons and roadmap produce a downloadable PDF. |
+| HL-V01 | Complete in the gap-report PR | Add a machine-readable curriculum gap report and computed duration budget. | CI reports lessons at or above 300 seconds, missing prerequisites, book coverage, and track-schema status. |
 
 The Russian publication audit found eight of its thirteen Chapter 1--2
 curriculum lessons currently declare five minutes or more, including one at six
@@ -31,16 +31,22 @@ minutes. This is concrete input to HL-V01 and HL-D01, not silently treated as
 fixed by the book: the starter edition presents shorter dependency-ordered
 micro-sections while the canonical duration split remains measurable debt.
 
+The first deterministic HL-V01 snapshot measures 485 lessons at or above 300
+effective seconds, zero unknown prerequisite ids, 42 later-chapter lessons with
+no declared prerequisite, 257 lesson chapters without a matching book chapter,
+and all 20 tracks still on the legacy lesson schema. The report is evidence for
+the next migrations; it deliberately does not fail CI on already-recorded debt.
+
 ## P1 — one-source migration
 
-| ID | Work item | Why it follows P0 |
-|---|---|---|
-| HL-S01 | Migrate Spanish Chapters 1–3 to schema version 2 with typed body blocks and knowledge closure. | Spanish is the specified vertical slice and proves the strict contract on mature content. |
-| HL-G01 | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy only after the AST contract is proven. |
-| HL-D01 | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The audit must exist first so the debt remains measurable throughout migration. |
-| HL-M01 | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
-| HL-T01 | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
-| HL-U01 | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
+| ID | Status | Work item | Why it follows P0 |
+|---|---|---|---|
+| HL-S01 | Next | Migrate Spanish Chapters 1–3 to schema version 2 with typed body blocks and knowledge closure. | Spanish is the specified vertical slice and proves the strict contract on mature content. |
+| HL-G01 | Queued | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy only after the AST contract is proven. |
+| HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The audit must exist first so the debt remains measurable throughout migration. |
+| HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
+| HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
+| HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
 ## P2 — corpus growth
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -33,6 +33,12 @@ concepts/taxonomy.json          cross-language semantic join keys
 data/scripts/*.json             writing-system inventories and teaching metadata
 ```
 
+The unified publication job also emits `curriculum-gaps.json` and
+`curriculum-gaps.txt` beside the books. They record the effective duration budget
+for every over-limit lesson, prerequisite omissions, lesson-to-book chapter
+coverage, and each track's schema-migration status. Existing migration debt is
+reported rather than hidden or treated as a new regression.
+
 The data package also loads every existing `book/book.tex` and `book/chapters/ch*.tex`
 losslessly and checks that each authored book chapter maps to its short Markdown
 lessons. This preserves the well-received book narrative while the pipeline moves

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `@coding-adventures/human-language-data` are documented here.
 
+## [Unreleased]
+
+### Added — curriculum migration gap report
+
+- Added deterministic JSON and text reports for effective lesson duration,
+  unknown and omitted prerequisites, book-chapter coverage, and per-track schema
+  migration status.
+- Added a CLI format switch so CI can publish both report forms with the unified
+  human-language book artifact without turning existing migration debt into a
+  false regression gate.
+
 ## [0.3.0] - 2026-07-18
 
 ### Added — `writing` lesson type (orthography / writing nuances)

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -12,6 +12,8 @@ The curriculum is a pile of per-language Markdown lessons. This package parses
 their frontmatter, joins them through the canonical **concept taxonomy**
 (`concepts/taxonomy.json`), and exposes the result as a queryable dataset —
 plus a **validator** that keeps the lessons and the taxonomy from drifting apart.
+It also produces the versioned migration-gap report published with every book
+bundle.
 
 ```
 lessons/*.md frontmatter  ─┐
@@ -39,6 +41,20 @@ languagesForConcept(dataset, "GREETING-HELLO");
 const issues = validate({ taxonomy, lessons, scripts });
 ```
 
+Build the JSON and readable gap reports locally with:
+
+```bash
+npm run build
+npm run --silent report -- --format json > curriculum-gaps.json
+npm run --silent report -- --format text > curriculum-gaps.txt
+```
+
+The duration estimator uses instructional word count, explicit pauses, repeat
+cues, learner-response prompts, and a safety margin. Its effective duration is
+the greater of that estimate and the lesson's declared budget. A value of 300
+seconds or more is reported as migration debt; the report remains non-blocking
+until the existing corpus has been split.
+
 ### Architecture — a pure core with a thin fs shell
 
 | Module | Role | Pure? |
@@ -47,10 +63,12 @@ const issues = validate({ taxonomy, lessons, scripts });
 | `parse.ts` | frontmatter → `Realization`; realizations → `Dataset` | ✅ |
 | `validate.ts` | the round-trip validator (errors fail CI; warnings tolerated) | ✅ |
 | `queries.ts` | `allConcepts` / `conceptsByLanguage` / `languagesForConcept` / `coverageByLanguage` | ✅ |
+| `report.ts` | deterministic duration, prerequisite, book, and schema gap report | ✅ |
 | `loader.ts` | reads the curriculum off disk | ⛔ (fs) |
 | `cli.ts` | `validate` command + report | ⛔ (fs) |
+| `report-cli.ts` | prints JSON or text for CI artifact capture | ⛔ (fs) |
 
-Only `loader.ts`/`cli.ts` touch the filesystem (declared in
+Only `loader.ts`, `cli.ts`, and `report-cli.ts` touch the filesystem (declared in
 `required_capabilities.json`); everything the app relies on is pure and unit-tested
 against inline fixtures.
 

--- a/code/packages/typescript/human-language-data/package.json
+++ b/code/packages/typescript/human-language-data/package.json
@@ -6,6 +6,7 @@
   "main": "src/index.ts",
   "scripts": {
     "build": "tsc",
+    "report": "node dist/report-cli.js",
     "validate": "vitest run tests/integration.test.ts",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/code/packages/typescript/human-language-data/required_capabilities.json
+++ b/code/packages/typescript/human-language-data/required_capabilities.json
@@ -16,5 +16,5 @@
       "justification": "The loader enumerates each track's lessons/ directory and data/scripts/ to discover files to parse."
     }
   ],
-  "justification": "Read-only filesystem access to the Human Languages curriculum directory. The parse/build/validate/query core is pure; only loader.ts and cli.ts touch the filesystem. No write, network, or process access needed."
+  "justification": "Read-only filesystem access to the Human Languages curriculum directory. The parse/build/validate/query/report core is pure; only loader-backed CLI entry points touch the filesystem. No write, network, or process access needed."
 }

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -30,4 +30,14 @@ export {
   loadScripts,
   loadEverything,
 } from "./loader.js";
+export {
+  DURATION_THRESHOLD_SECONDS,
+  estimateLessonDuration,
+  buildCurriculumGapReport,
+  renderCurriculumGapReport,
+  type DurationEstimate,
+  type CurriculumGapReport,
+  type CurriculumGapReportInput,
+} from "./report.js";
 export { runValidate } from "./cli.js";
+export { runCurriculumGapReport } from "./report-cli.js";

--- a/code/packages/typescript/human-language-data/src/report-cli.ts
+++ b/code/packages/typescript/human-language-data/src/report-cli.ts
@@ -1,0 +1,46 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { loadEverything } from "./loader.js";
+import { buildCurriculumGapReport, renderCurriculumGapReport } from "./report.js";
+
+interface ReportOptions {
+  root?: string;
+  format: "json" | "text";
+}
+
+function parseOptions(args: string[]): ReportOptions {
+  const options: ReportOptions = { format: "text" };
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    if (flag !== "--root" && flag !== "--format") {
+      throw new Error(`unknown argument '${flag}'`);
+    }
+    const value = args[index + 1];
+    if (!value) throw new Error(`${flag} requires a value`);
+    if (flag === "--root") options.root = resolve(value);
+    else if (value === "json" || value === "text") options.format = value;
+    else throw new Error(`--format must be 'json' or 'text'`);
+    index += 1;
+  }
+  return options;
+}
+
+export function runCurriculumGapReport(args = process.argv.slice(2)): number {
+  let options: ReportOptions;
+  try {
+    options = parseOptions(args);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 2;
+  }
+  const { registry, lessons, books } = loadEverything(options.root);
+  const report = buildCurriculumGapReport({ registry, lessons, books });
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  const text = renderCurriculumGapReport(report);
+  process.stdout.write(options.format === "json" ? json : text);
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  process.exit(runCurriculumGapReport());
+}

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -144,13 +144,82 @@ function stripHtmlComments(markdown: string): string {
   return parts.join("");
 }
 
+function stripMarkdownLinks(markdown: string): string {
+  type State = "text" | "label" | "destination-start" | "destination";
+  const output: string[] = [];
+  const label: string[] = [];
+  const destination: string[] = [];
+  let state: State = "text";
+  let image = false;
+
+  const reset = (): void => {
+    label.length = 0;
+    destination.length = 0;
+    image = false;
+    state = "text";
+  };
+  const flushUnclosed = (suffix = ""): void => {
+    output.push(image ? "![" : "[", ...label);
+    if (state === "destination-start" || state === "destination") output.push("]");
+    if (state === "destination") output.push("(", ...destination);
+    if (suffix !== "") output.push(suffix);
+    reset();
+  };
+
+  for (let index = 0; index < markdown.length; index += 1) {
+    const character = markdown[index];
+    if (state === "text") {
+      if (character === "!" && markdown[index + 1] === "[") {
+        image = true;
+        state = "label";
+        index += 1;
+      } else if (character === "[") {
+        state = "label";
+      } else {
+        output.push(character);
+      }
+    } else if (state === "label") {
+      if (character === "]") state = "destination-start";
+      else label.push(character);
+    } else if (state === "destination-start") {
+      if (character === "(") state = "destination";
+      else flushUnclosed(character);
+    } else if (character === ")") {
+      output.push(image ? " " : label.join(""));
+      reset();
+    } else {
+      destination.push(character);
+    }
+  }
+  if (state !== "text") flushUnclosed();
+  return output.join("");
+}
+
+function stripAngleTags(text: string): string {
+  const parts: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const start = text.indexOf("<", cursor);
+    if (start === -1) {
+      parts.push(text.slice(cursor));
+      break;
+    }
+    const end = text.indexOf(">", start + 1);
+    if (end === -1) {
+      parts.push(text.slice(cursor));
+      break;
+    }
+    parts.push(text.slice(cursor, start), " ");
+    cursor = end + 1;
+  }
+  return parts.join("");
+}
+
 function instructionalText(markdown: string): string {
-  return stripHtmlComments(markdown)
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
-    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/[`*_>#|~]/g, " ")
-    .replace(/^-{3,}\s*$/gm, " ");
+  return stripAngleTags(stripMarkdownLinks(stripHtmlComments(markdown))).replace(
+    /[`*_>#|~]/g,
+    " ",
+  );
 }
 
 function countWords(text: string): number {

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -127,9 +127,25 @@ function declaredDurationSeconds(lesson: ParsedLesson): number {
   return minutes === undefined ? 0 : Math.ceil(minutes * 60);
 }
 
+function stripHtmlComments(markdown: string): string {
+  const parts: string[] = [];
+  let cursor = 0;
+  while (cursor < markdown.length) {
+    const start = markdown.indexOf("<!--", cursor);
+    if (start === -1) {
+      parts.push(markdown.slice(cursor));
+      break;
+    }
+    parts.push(markdown.slice(cursor, start), " ");
+    const end = markdown.indexOf("-->", start + 4);
+    if (end === -1) break;
+    cursor = end + 3;
+  }
+  return parts.join("");
+}
+
 function instructionalText(markdown: string): string {
-  return markdown
-    .replace(/<!--[\s\S]*?-->/g, " ")
+  return stripHtmlComments(markdown)
     .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
     .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
     .replace(/<[^>]+>/g, " ")

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -1,0 +1,339 @@
+import type { ParsedLesson } from "./parse.js";
+import type { BookCorpus, LanguageRegistry } from "./types.js";
+
+export const DURATION_THRESHOLD_SECONDS = 300;
+
+export interface DurationEstimate {
+  lessonId: string;
+  language: string;
+  chapter: number | null;
+  declaredSeconds: number;
+  computedSeconds: number;
+  effectiveSeconds: number;
+  wordCount: number;
+  promptCount: number;
+  repeatCueCount: number;
+  explicitPauseSeconds: number;
+  authoredAudioSeconds: number;
+  reasons: Array<"declared" | "computed">;
+}
+
+export interface UnknownPrerequisite {
+  lessonId: string;
+  language: string;
+  prerequisite: string;
+}
+
+export interface PrerequisiteRoot {
+  lessonId: string;
+  language: string;
+  chapter: number | null;
+}
+
+export interface BookCoverage {
+  language: string;
+  hasBook: boolean;
+  lessonChapters: number[];
+  bookChapters: number[];
+  missingBookChapters: number[];
+  orphanBookChapters: number[];
+  coveragePercent: number;
+}
+
+export type TrackSchemaStatus = "legacy" | "mixed" | "version-2";
+
+export interface TrackSchemaCoverage {
+  language: string;
+  status: TrackSchemaStatus;
+  lessonCount: number;
+  versions: Record<string, number>;
+}
+
+export interface CurriculumGapReport {
+  schemaVersion: 1;
+  durationModel: {
+    version: 1;
+    thresholdSeconds: number;
+    spokenWordsPerMinute: number;
+    learnerResponseSecondsPerPrompt: number;
+    repeatCueSeconds: number;
+    safetyMarginPercent: number;
+    audioDuration: "max(spoken estimate, authored audio seconds)";
+    effectiveDuration: "max(declared, computed)";
+  };
+  summary: {
+    registeredTracks: number;
+    totalLessons: number;
+    authoredBooks: number;
+    durationViolations: number;
+    unknownPrerequisites: number;
+    laterChapterLessonsWithoutPrerequisites: number;
+    tracksWithoutBooks: number;
+    lessonChaptersWithoutBooks: number;
+    legacySchemaTracks: number;
+    mixedSchemaTracks: number;
+    version2SchemaTracks: number;
+  };
+  duration: {
+    violations: DurationEstimate[];
+  };
+  prerequisites: {
+    unknown: UnknownPrerequisite[];
+    roots: PrerequisiteRoot[];
+    laterChapterWithoutPrerequisites: PrerequisiteRoot[];
+  };
+  books: {
+    tracks: BookCoverage[];
+  };
+  schemas: {
+    tracks: TrackSchemaCoverage[];
+  };
+}
+
+export interface CurriculumGapReportInput {
+  registry: LanguageRegistry;
+  lessons: ParsedLesson[];
+  books: BookCorpus;
+}
+
+const SPOKEN_WORDS_PER_MINUTE = 120;
+const RESPONSE_SECONDS_PER_PROMPT = 8;
+const REPEAT_CUE_SECONDS = 4;
+const SAFETY_MARGIN = 0.15;
+
+function stringValue(value: ParsedLesson["frontmatter"][string] | undefined): string {
+  return typeof value === "string" ? value : "";
+}
+
+function stringList(value: ParsedLesson["frontmatter"][string] | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  return typeof value === "string" && value.trim() !== "" ? [value] : [];
+}
+
+function nonNegativeNumber(value: string): number | undefined {
+  if (value.trim() === "") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function declaredDurationSeconds(lesson: ParsedLesson): number {
+  // The legacy parser flattens the indented `max_seconds` member from the HL04
+  // duration block, so both spellings keep the report useful during migration.
+  const maxSeconds =
+    nonNegativeNumber(stringValue(lesson.frontmatter["duration.max_seconds"])) ??
+    nonNegativeNumber(stringValue(lesson.frontmatter.max_seconds));
+  if (maxSeconds !== undefined) return Math.ceil(maxSeconds);
+  const minutes = nonNegativeNumber(stringValue(lesson.frontmatter.est_minutes));
+  return minutes === undefined ? 0 : Math.ceil(minutes * 60);
+}
+
+function instructionalText(markdown: string): string {
+  return markdown
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/[`*_>#|~]/g, " ")
+    .replace(/^-{3,}\s*$/gm, " ");
+}
+
+function countWords(text: string): number {
+  return text.match(/[\p{L}\p{N}]+(?:['’\-][\p{L}\p{N}]+)*/gu)?.length ?? 0;
+}
+
+function countPromptLines(markdown: string): number {
+  const imperative = /^(?:say|repeat|answer|choose|write|read|translate|recall|practice|produce|ask|respond|point|cover|rebuild|listen|speak|try)\b/i;
+  let count = 0;
+  for (const rawLine of markdown.split(/\r?\n/)) {
+    const line = rawLine
+      .replace(/^\s*(?:#{1,6}|[-*+] |\d+[.)] )\s*/, "")
+      .trim();
+    if (line === "") continue;
+    if (/[?؟]/u.test(line) || imperative.test(line)) count += 1;
+  }
+  return count;
+}
+
+function explicitPauseSeconds(markdown: string): number {
+  const pattern = /\b(?:pause|wait)\s+(?:for\s+)?(\d+)\s*(?:seconds?|secs?|s)\b/giu;
+  let total = 0;
+  for (const match of markdown.matchAll(pattern)) total += Number(match[1]);
+  return total;
+}
+
+/** Estimate a lesson independently from its author-declared duration. */
+export function estimateLessonDuration(lesson: ParsedLesson): DurationEstimate {
+  const text = instructionalText(lesson.body);
+  const wordCount = countWords(text);
+  const promptCount = countPromptLines(lesson.body);
+  const repeatCueCount = text.match(/\b(?:repeat|again|twice|three\s+times)\b/giu)?.length ?? 0;
+  const pauseSeconds = explicitPauseSeconds(lesson.body);
+  const authoredAudioSeconds = Math.ceil(
+    nonNegativeNumber(stringValue(lesson.frontmatter.audio_duration_seconds)) ??
+      nonNegativeNumber(stringValue(lesson.frontmatter.audio_seconds)) ??
+      0,
+  );
+  const spokenSeconds = Math.ceil((wordCount / SPOKEN_WORDS_PER_MINUTE) * 60);
+  const responseSeconds = promptCount * RESPONSE_SECONDS_PER_PROMPT;
+  const repeatSeconds = repeatCueCount * REPEAT_CUE_SECONDS;
+  const subtotal = Math.max(spokenSeconds, authoredAudioSeconds) + responseSeconds + repeatSeconds + pauseSeconds;
+  const computedSeconds = Math.ceil(subtotal * (1 + SAFETY_MARGIN));
+  const declaredSeconds = declaredDurationSeconds(lesson);
+  const effectiveSeconds = Math.max(declaredSeconds, computedSeconds);
+  const reasons: DurationEstimate["reasons"] = [];
+  if (declaredSeconds >= DURATION_THRESHOLD_SECONDS) reasons.push("declared");
+  if (computedSeconds >= DURATION_THRESHOLD_SECONDS) reasons.push("computed");
+
+  return {
+    lessonId: lesson.realization.lessonId,
+    language: lesson.language,
+    chapter: Number.isFinite(lesson.realization.chapter) ? lesson.realization.chapter : null,
+    declaredSeconds,
+    computedSeconds,
+    effectiveSeconds,
+    wordCount,
+    promptCount,
+    repeatCueCount,
+    explicitPauseSeconds: pauseSeconds,
+    authoredAudioSeconds,
+    reasons,
+  };
+}
+
+function sortedNumbers(values: Iterable<number>): number[] {
+  return [...new Set(values)].sort((a, b) => a - b);
+}
+
+function bookCoverage(
+  language: string,
+  lessons: ParsedLesson[],
+  books: BookCorpus,
+): BookCoverage {
+  const lessonChapters = sortedNumbers(
+    lessons
+      .filter((lesson) => lesson.language === language && Number.isFinite(lesson.realization.chapter))
+      .map((lesson) => lesson.realization.chapter),
+  );
+  const book = books.books.find((candidate) => candidate.language === language);
+  const bookChapters = sortedNumbers(book?.chapters.map((chapter) => chapter.chapter) ?? []);
+  const bookSet = new Set(bookChapters);
+  const lessonSet = new Set(lessonChapters);
+  const covered = lessonChapters.filter((chapter) => bookSet.has(chapter)).length;
+  return {
+    language,
+    hasBook: book !== undefined,
+    lessonChapters,
+    bookChapters,
+    missingBookChapters: lessonChapters.filter((chapter) => !bookSet.has(chapter)),
+    orphanBookChapters: bookChapters.filter((chapter) => !lessonSet.has(chapter)),
+    coveragePercent: lessonChapters.length === 0 ? 100 : Math.round((covered / lessonChapters.length) * 100),
+  };
+}
+
+function schemaCoverage(language: string, lessons: ParsedLesson[]): TrackSchemaCoverage {
+  const trackLessons = lessons.filter((lesson) => lesson.language === language);
+  const versions: Record<string, number> = {};
+  for (const lesson of trackLessons) {
+    const authored = stringValue(lesson.frontmatter.schema_version).trim();
+    const version = authored === "" ? "1" : authored;
+    versions[version] = (versions[version] ?? 0) + 1;
+  }
+  const version2 = versions["2"] ?? 0;
+  const status: TrackSchemaStatus =
+    trackLessons.length > 0 && version2 === trackLessons.length
+      ? "version-2"
+      : version2 === 0
+        ? "legacy"
+        : "mixed";
+  return { language, status, lessonCount: trackLessons.length, versions };
+}
+
+/** Build a deterministic, machine-readable snapshot of known migration gaps. */
+export function buildCurriculumGapReport(input: CurriculumGapReportInput): CurriculumGapReport {
+  const { registry, lessons, books } = input;
+  const lessonIds = new Set(lessons.map((lesson) => lesson.realization.lessonId));
+  const durationViolations = lessons
+    .map(estimateLessonDuration)
+    .filter((estimate) => estimate.effectiveSeconds >= DURATION_THRESHOLD_SECONDS)
+    .sort((a, b) => a.language.localeCompare(b.language) || a.lessonId.localeCompare(b.lessonId));
+
+  const unknown: UnknownPrerequisite[] = [];
+  const roots: PrerequisiteRoot[] = [];
+  for (const lesson of lessons) {
+    const prerequisites = stringList(lesson.frontmatter.prerequisites);
+    const root = {
+      lessonId: lesson.realization.lessonId,
+      language: lesson.language,
+      chapter: Number.isFinite(lesson.realization.chapter) ? lesson.realization.chapter : null,
+    };
+    if (prerequisites.length === 0) roots.push(root);
+    for (const prerequisite of prerequisites) {
+      if (!lessonIds.has(prerequisite)) {
+        unknown.push({ lessonId: lesson.realization.lessonId, language: lesson.language, prerequisite });
+      }
+    }
+  }
+  roots.sort((a, b) => a.language.localeCompare(b.language) || a.lessonId.localeCompare(b.lessonId));
+  unknown.sort((a, b) => a.language.localeCompare(b.language) || a.lessonId.localeCompare(b.lessonId));
+  const laterChapterWithoutPrerequisites = roots.filter((root) => (root.chapter ?? 0) > 1);
+
+  const coverage = registry.languages.map((language) => bookCoverage(language.id, lessons, books));
+  const schemas = registry.languages.map((language) => schemaCoverage(language.id, lessons));
+
+  return {
+    schemaVersion: 1,
+    durationModel: {
+      version: 1,
+      thresholdSeconds: DURATION_THRESHOLD_SECONDS,
+      spokenWordsPerMinute: SPOKEN_WORDS_PER_MINUTE,
+      learnerResponseSecondsPerPrompt: RESPONSE_SECONDS_PER_PROMPT,
+      repeatCueSeconds: REPEAT_CUE_SECONDS,
+      safetyMarginPercent: SAFETY_MARGIN * 100,
+      audioDuration: "max(spoken estimate, authored audio seconds)",
+      effectiveDuration: "max(declared, computed)",
+    },
+    summary: {
+      registeredTracks: registry.languages.length,
+      totalLessons: lessons.length,
+      authoredBooks: books.books.length,
+      durationViolations: durationViolations.length,
+      unknownPrerequisites: unknown.length,
+      laterChapterLessonsWithoutPrerequisites: laterChapterWithoutPrerequisites.length,
+      tracksWithoutBooks: coverage.filter((track) => !track.hasBook).length,
+      lessonChaptersWithoutBooks: coverage.reduce((sum, track) => sum + track.missingBookChapters.length, 0),
+      legacySchemaTracks: schemas.filter((track) => track.status === "legacy").length,
+      mixedSchemaTracks: schemas.filter((track) => track.status === "mixed").length,
+      version2SchemaTracks: schemas.filter((track) => track.status === "version-2").length,
+    },
+    duration: { violations: durationViolations },
+    prerequisites: { unknown, roots, laterChapterWithoutPrerequisites },
+    books: { tracks: coverage },
+    schemas: { tracks: schemas },
+  };
+}
+
+/** Compact text companion for CI logs and human review. */
+export function renderCurriculumGapReport(report: CurriculumGapReport): string {
+  const summary = report.summary;
+  const lines = [
+    "Human Languages curriculum gap report",
+    "====================================",
+    `${summary.registeredTracks} tracks, ${summary.totalLessons} lessons, ${summary.authoredBooks} books`,
+    `${summary.durationViolations} lessons at or above ${report.durationModel.thresholdSeconds} effective seconds`,
+    `${summary.unknownPrerequisites} unknown prerequisites; ${summary.laterChapterLessonsWithoutPrerequisites} later-chapter lessons without prerequisites`,
+    `${summary.tracksWithoutBooks} tracks without books; ${summary.lessonChaptersWithoutBooks} lesson chapters without book chapters`,
+    `${summary.legacySchemaTracks} legacy, ${summary.mixedSchemaTracks} mixed, ${summary.version2SchemaTracks} version-2 schema tracks`,
+    "",
+    "Longest effective lessons:",
+  ];
+  for (const lesson of [...report.duration.violations]
+    .sort((a, b) => b.effectiveSeconds - a.effectiveSeconds || a.lessonId.localeCompare(b.lessonId))
+    .slice(0, 20)) {
+    lines.push(
+      `  ${lesson.lessonId}: ${lesson.effectiveSeconds}s ` +
+        `(declared ${lesson.declaredSeconds}s, computed ${lesson.computedSeconds}s; ${lesson.reasons.join("+")})`,
+    );
+  }
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}

--- a/code/packages/typescript/human-language-data/tests/cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/cli.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { runValidate } from "../src/cli.js";
+import { runCurriculumGapReport } from "../src/report-cli.js";
 
 describe("runValidate", () => {
   it("returns 0 (no errors) on the real curriculum and prints a report", () => {
@@ -12,5 +13,35 @@ describe("runValidate", () => {
     expect(printed).toMatch(/concepts, \d+ languages/);
     expect(printed).toMatch(/error\(s\)/);
     expect(printed).toContain("spanish");
+  });
+});
+
+describe("runCurriculumGapReport", () => {
+  it("prints JSON or text reports for the real curriculum", () => {
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      expect(runCurriculumGapReport(["--format", "json"])).toBe(0);
+      const json = out.mock.calls.map((call) => String(call[0])).join("");
+      expect(JSON.parse(json).summary.registeredTracks).toBe(20);
+      out.mockClear();
+      expect(runCurriculumGapReport(["--format", "text"])).toBe(0);
+      expect(out.mock.calls.map((call) => String(call[0])).join("")).toContain(
+        "Human Languages curriculum gap report",
+      );
+    } finally {
+      out.mockRestore();
+    }
+  });
+
+  it("rejects unknown or incomplete arguments", () => {
+    const err = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      expect(runCurriculumGapReport(["--wat"])).toBe(2);
+      expect(runCurriculumGapReport(["--format"])).toBe(2);
+      expect(runCurriculumGapReport(["--format", "xml"])).toBe(2);
+      expect(err.mock.calls.map((call) => String(call[0])).join("")).toContain("requires a value");
+    } finally {
+      err.mockRestore();
+    }
   });
 });

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import { loadEverything } from "../src/loader.js";
 import { validate, hasErrors } from "../src/validate.js";
 import { validateCurriculum } from "../src/curriculum.js";
+import { buildCurriculumGapReport } from "../src/report.js";
 import { languagesForConcept } from "../src/queries.js";
 
 const { taxonomy, registry, spine, books, lessons, scripts, dataset } = loadEverything();
@@ -55,6 +56,18 @@ describe("real curriculum", () => {
         ?.chapters.map((chapter) => chapter.chapter),
     ).toEqual([1, 2]);
     expect(books.books.every((book) => book.chapters.every((chapter) => chapter.tex.length > 100))).toBe(true);
+  });
+
+  it("produces a machine-readable migration gap baseline", () => {
+    const report = buildCurriculumGapReport({ registry, lessons, books });
+    expect(report.schemaVersion).toBe(1);
+    expect(report.summary.registeredTracks).toBe(20);
+    expect(report.summary.totalLessons).toBe(lessons.length);
+    expect(report.summary.authoredBooks).toBe(20);
+    expect(report.summary.durationViolations).toBeGreaterThan(0);
+    expect(report.summary.unknownPrerequisites).toBe(0);
+    expect(report.schemas.tracks).toHaveLength(20);
+    expect(report.books.tracks).toHaveLength(20);
   });
 
   it("GREETING-HELLO joins every track (the normalization payoff)", () => {

--- a/code/packages/typescript/human-language-data/tests/report.test.ts
+++ b/code/packages/typescript/human-language-data/tests/report.test.ts
@@ -64,6 +64,30 @@ describe("curriculum gap report", () => {
     expect(audio.computedSeconds).toBeGreaterThan(300);
   });
 
+  it("strips closed and adversarial unclosed HTML comments without a regex backtrack", () => {
+    const closed = estimateLessonDuration(
+      lesson({
+        id: "AL-COMMENT",
+        language: "alpha",
+        chapter: 1,
+        minutes: 1,
+        body: "visible <!-- hidden words --> shown",
+      }),
+    );
+    expect(closed.wordCount).toBe(2);
+
+    const unclosed = estimateLessonDuration(
+      lesson({
+        id: "AL-UNCLOSED",
+        language: "alpha",
+        chapter: 1,
+        minutes: 1,
+        body: `visible ${"<!--".repeat(10_000)} hidden`,
+      }),
+    );
+    expect(unclosed.wordCount).toBe(1);
+  });
+
   it("reports duration, prerequisite, book, and schema migration gaps", () => {
     const lessons = [
       lesson({ id: "AL-C01", language: "alpha", chapter: 1, minutes: 4 }),

--- a/code/packages/typescript/human-language-data/tests/report.test.ts
+++ b/code/packages/typescript/human-language-data/tests/report.test.ts
@@ -88,6 +88,30 @@ describe("curriculum gap report", () => {
     expect(unclosed.wordCount).toBe(1);
   });
 
+  it("scans Markdown links, images, and tags in linear state transitions", () => {
+    const closed = estimateLessonDuration(
+      lesson({
+        id: "AL-LINKS",
+        language: "alpha",
+        chapter: 1,
+        minutes: 1,
+        body: "visible [label](https://example.test) ![alt words](image.png) <b>shown</b>",
+      }),
+    );
+    expect(closed.wordCount).toBe(3);
+
+    const unclosed = estimateLessonDuration(
+      lesson({
+        id: "AL-UNCLOSED-LINKS",
+        language: "alpha",
+        chapter: 1,
+        minutes: 1,
+        body: `${"![".repeat(10_000)}tail`,
+      }),
+    );
+    expect(unclosed.wordCount).toBe(1);
+  });
+
   it("reports duration, prerequisite, book, and schema migration gaps", () => {
     const lessons = [
       lesson({ id: "AL-C01", language: "alpha", chapter: 1, minutes: 4 }),

--- a/code/packages/typescript/human-language-data/tests/report.test.ts
+++ b/code/packages/typescript/human-language-data/tests/report.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { parseLesson } from "../src/parse.js";
+import {
+  buildCurriculumGapReport,
+  estimateLessonDuration,
+  renderCurriculumGapReport,
+} from "../src/report.js";
+import type { BookCorpus, LanguageRegistry } from "../src/types.js";
+
+const registry: LanguageRegistry = {
+  version: 1,
+  languages: [
+    { id: "alpha", name: "Alpha", family: "Test", script: "latin", status: "active", bridges: [] },
+    { id: "beta", name: "Beta", family: "Test", script: "latin", status: "active", bridges: [] },
+  ],
+};
+
+function lesson(options: {
+  id: string;
+  language: string;
+  chapter: number;
+  minutes: number;
+  prerequisites?: string[];
+  schemaVersion?: number;
+  audioSeconds?: number;
+  body?: string;
+}) {
+  const schema = options.schemaVersion ? `schema_version: ${options.schemaVersion}\n` : "";
+  const audio = options.audioSeconds ? `audio_duration_seconds: ${options.audioSeconds}\n` : "";
+  return parseLesson(
+    `---\n${schema}${audio}id: ${options.id}\nchapter: ${options.chapter}\ntype: word\nheadword: hello\ngloss: hello\nconcept_tag: TEST-HELLO\nprerequisites: [${(options.prerequisites ?? []).join(", ")}]\nest_minutes: ${options.minutes}\n---\n\n${options.body ?? "Say hello."}\n`,
+    options.language,
+  );
+}
+
+describe("curriculum gap report", () => {
+  it("uses the greater of declared and independently computed duration", () => {
+    const declared = lesson({ id: "BE-C01", language: "beta", chapter: 1, minutes: 5 });
+    const computed = lesson({
+      id: "AL-C02",
+      language: "alpha",
+      chapter: 2,
+      minutes: 1,
+      body: `${"word ".repeat(700)}\nPause for 10 seconds. Repeat this?`,
+    });
+
+    expect(estimateLessonDuration(declared)).toMatchObject({
+      declaredSeconds: 300,
+      effectiveSeconds: 300,
+      reasons: ["declared"],
+    });
+    const computedEstimate = estimateLessonDuration(computed);
+    expect(computedEstimate.computedSeconds).toBeGreaterThan(300);
+    expect(computedEstimate.effectiveSeconds).toBe(computedEstimate.computedSeconds);
+    expect(computedEstimate.promptCount).toBe(1);
+    expect(computedEstimate.repeatCueCount).toBe(1);
+    expect(computedEstimate.explicitPauseSeconds).toBe(10);
+    expect(computedEstimate.reasons).toEqual(["computed"]);
+
+    const audio = estimateLessonDuration(
+      lesson({ id: "AU-C01", language: "alpha", chapter: 1, minutes: 1, audioSeconds: 301 }),
+    );
+    expect(audio.authoredAudioSeconds).toBe(301);
+    expect(audio.computedSeconds).toBeGreaterThan(300);
+  });
+
+  it("reports duration, prerequisite, book, and schema migration gaps", () => {
+    const lessons = [
+      lesson({ id: "AL-C01", language: "alpha", chapter: 1, minutes: 4 }),
+      lesson({
+        id: "AL-C02",
+        language: "alpha",
+        chapter: 2,
+        minutes: 1,
+        schemaVersion: 2,
+        body: "word ".repeat(700),
+      }),
+      lesson({
+        id: "BE-C01",
+        language: "beta",
+        chapter: 1,
+        minutes: 5,
+        schemaVersion: 2,
+        prerequisites: ["MISSING"],
+      }),
+    ];
+    const books: BookCorpus = {
+      books: [
+        {
+          language: "alpha",
+          entrypoint: "alpha/book/book.tex",
+          chapters: [
+            { language: "alpha", chapter: 1, slug: "one", title: "One", source: "one.tex", tex: "x" },
+          ],
+        },
+      ],
+    };
+    const report = buildCurriculumGapReport({ registry, lessons, books });
+
+    expect(report.summary).toMatchObject({
+      registeredTracks: 2,
+      totalLessons: 3,
+      authoredBooks: 1,
+      durationViolations: 2,
+      unknownPrerequisites: 1,
+      laterChapterLessonsWithoutPrerequisites: 1,
+      tracksWithoutBooks: 1,
+      lessonChaptersWithoutBooks: 2,
+      legacySchemaTracks: 0,
+      mixedSchemaTracks: 1,
+      version2SchemaTracks: 1,
+    });
+    expect(report.prerequisites.unknown).toEqual([
+      { lessonId: "BE-C01", language: "beta", prerequisite: "MISSING" },
+    ]);
+    expect(report.books.tracks.find((track) => track.language === "alpha")).toMatchObject({
+      missingBookChapters: [2],
+      coveragePercent: 50,
+    });
+    expect(report.schemas.tracks.find((track) => track.language === "alpha")).toMatchObject({
+      status: "mixed",
+      versions: { "1": 1, "2": 1 },
+    });
+    expect(renderCurriculumGapReport(report)).toContain("2 lessons at or above 300 effective seconds");
+  });
+});


### PR DESCRIPTION
## Summary

- add deterministic JSON and text curriculum-gap reports to `human-language-data`
- estimate effective duration from declared budgets plus instructional words, authored audio, pauses, repeat cues, prompts, and a safety margin
- report unknown and omitted prerequisites, lesson-to-book chapter coverage, and per-track schema migration status
- publish both reports in the existing unified human-language book artifact and print the readable summary in CI
- reprioritize the backlog from the measured baseline: 485 duration violations, 42 later-chapter prerequisite omissions, 257 uncovered lesson chapters, and 20 legacy-schema tracks

The report is intentionally non-blocking while the documented legacy debt is being migrated; existing validation errors remain hard gates.

## Validation

- clean `npm ci --quiet`
- `npm run test:coverage` (47 tests; 94.64% line coverage)
- `npm run build`
- exact JSON and text report generation with JSON parse/assertions
- `python code/scripts/tests/test_build_human_language_book_catalog.py`
- changed capability manifest validated against its JSON Schema
- workflow YAML parse
- `git diff --check`