### PR TITLE
fix(spice): validate MOS bulk junction potential

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS model-card `PB` values
+  before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `GAMMA` values before
   lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `PHI` values

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1875,6 +1875,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(bulk_junction_potential) = params.get("PB") {
+            if !bulk_junction_potential.is_finite() || *bulk_junction_potential <= 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET PB must be finite and positive",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1744,6 +1744,30 @@ fn preserves_non_negative_mosfet_model_body_effect_coefficient() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_bulk_junction_potential() {
+    for bulk_junction_potential in ["0", "-0.9", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model junction NMOS(PB={bulk_junction_potential})\nM1 d g s b junction"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET PB must be finite and positive"));
+    }
+}
+
+#[test]
+fn preserves_positive_mosfet_model_bulk_junction_potential() {
+    let parsed = parse_netlist(".model junction NMOS(PB=0.9)\nM1 d g s b junction").unwrap();
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+    assert_close(mosfet.params.bulk_junction_potential, 0.9);
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card body-effect-coefficient validation.
+1. Rust Berkeley SPICE MOS model-card bulk-junction-potential validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `GAMMA` values before
+   - Reject zero, negative, and non-finite model-card `PB` values before
      lowering MOS elements into engine parameters.
-   - Preserve zero and positive explicit body-effect coefficients.
+   - Preserve positive explicit bulk-junction potentials.
 
 ## Completed Slices
 
@@ -3959,6 +3959,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Zero, negative, and non-finite model-card `PHI` values are rejected before
      lowering MOS elements into engine parameters.
    - Positive explicit bulk-potential values remain accepted.
+
+341. Rust Berkeley SPICE MOS model-card body-effect-coefficient validation.
+   - Status: completed in PR 9481.
+   - Negative and non-finite model-card `GAMMA` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive explicit body-effect coefficients remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite MOS model-card `PB` values in the Rust Berkeley parser facade
- preserve positive explicit bulk-junction potentials
- reconcile the SPICE completion plan after PR #9481

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's bulk-junction-potential semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.