### PR TITLE
feat(dart): add document AST package

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9477,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "e552707d59c62c0c0749c6173a2cf82478629b48",
+    "revision": "f42c8218afee1c63551ff987bdf1d76e007ae12e",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1215,
-    "implementation_package_slots": 4359,
+    "implementation_identities": 1216,
+    "implementation_package_slots": 4363,
     "high_consensus_packages": 172,
-    "high_consensus_missing_slots": 275,
-    "singleton_packages": 765,
-    "singleton_missing_slots": 10710,
-    "rust_singletons": 570,
+    "high_consensus_missing_slots": 272,
+    "singleton_packages": 766,
+    "singleton_missing_slots": 10724,
+    "rust_singletons": 571,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -312,6 +312,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "The rebased Go oracle full dry-run currently reports 73 pre-existing validation gaps: 12 Python, 3 Swift, and 58 TypeScript. Deliver dependency-shaped waves and preserve the broader July 29 audit queue for Perl, Dart, Kotlin, and related packages."
+    },
+    {
+      "id": "build-tool-lua-rockspec-encoding",
+      "title": "Make Python build-tool Lua metadata decoding deterministic",
+      "status": "pending",
+      "depends_on": ["build-tool-pure-domain-corpus"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while validating the Dart document-ast slice. The Python build tool discovers 4,763 packages, then its Lua resolver aborts before diff selection because _parse_lua_deps unconditionally decodes repository rockspecs as UTF-8. Exactly three files contain byte 0x97: lua/block_ram and lua/tree at offset 208, and lua/trig at offset 218. Classify and normalize those metadata bytes or define a fail-closed diagnostic contract with fixtures, then repair the Python resolver without silent replacement. Targeted plan-mode validation and the package BUILD files remain green."
     },
     {
       "id": "build-tool-go-oracle",
@@ -836,11 +845,11 @@
     {
       "id": "dart-current-14-of-15-matrix-family",
       "title": "Port matrix, loss-functions, and feature-normalization to Dart",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["dart-trig-wave", "dart-scaffold-capability-schema"],
       "branch": "codex/dart-matrix-ml-parity",
       "pr_number": 9477,
-      "notes": "Ready-for-review PR #9477. Selected from the remaining Dart-only 14-of-15 frontier after correcting the loop to portable-package/build-tool scope. Delivers the independent matrix, loss-functions, and feature-normalization leaf packages with shared reference vectors, immutable ownership, validation, empty capability profiles, BUILD/BUILD_windows, docs, and metadata. Local validation passed formatter/analyzer/randomized tests, 93.65%-100% line coverage, both package build scripts, the exact three-package diff build, nearby neural-network regressions, 21 reporter/capability tests, collision-clean parity at 1,215 identities and 4,362 slots, dependency/diff hygiene, and independent security review. The repository-wide build validator still reports the separately tracked 73 pre-existing BUILD_windows prerequisite declarations outside this slice."
+      "notes": "Merged PR #9477 at 1233e31dbe4a9c665f3de7b5c4e43a0edf08b2cb on 2026-08-02. Selected from the remaining Dart-only 14-of-15 frontier after correcting the loop to portable-package/build-tool scope. Delivers the independent matrix, loss-functions, and feature-normalization leaf packages with shared reference vectors, immutable ownership, validation, empty capability profiles, BUILD/BUILD_windows, docs, and metadata. Local validation passed formatter/analyzer/randomized tests, 93.65%-100% line coverage, both package build scripts, the exact three-package diff build, nearby neural-network regressions, 21 reporter/capability tests, collision-clean parity at 1,215 identities and 4,362 slots, dependency/diff hygiene, and independent security review. Final-head push CI, PR CI, and CodeQL runs 30765719887, 30765721855, and 30765721857 all passed after GitHub auto-merged the ready PR. The repository-wide build validator still reports the separately tracked 73 pre-existing BUILD_windows prerequisite declarations outside this slice."
     },
     {
       "id": "venture-browser-windows-portable-bridge-and-native-host",
@@ -1117,6 +1126,15 @@
       "notes": "Share SSDP header parsing, bounded setup/SOAP XML validation, service/device normalization, stable identities/errors, and switch/light command planning. UDP/DNS/TCP and runtime authority are excluded."
     },
     {
+      "id": "smart-home-sonos-upnp-portable-core-extraction-and-conformance",
+      "title": "Extract, fixture, and expand the portable Sonos UPnP core",
+      "status": "pending",
+      "depends_on": ["smart-home-media-entity-command-contract"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Share SSDP request/response parsing, bounded UPnP setup and SOAP validation, AVTransport/RenderingControl/DIDL normalization, deterministic inspection planning, stable identities/errors, and protocol-neutral media-player projection through language-neutral fixtures. UDP multicast, DNS/TCP, LAN HTTP execution, timeouts, endpoint approval, CLI I/O, authorization, and SmartHomeRuntime mutation remain in the native Rust host. Discovered after rebasing the Dart document-ast slice onto merged Sonos PR #9461."
+    },
+    {
       "id": "dart-neural-consumer-matrix-loss-migration",
       "title": "Migrate Dart neural consumers to the shared matrix and loss packages",
       "status": "pending",
@@ -1133,6 +1151,69 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered during the Dart loss-functions security review. ML01 does not define whether NaN and infinity are rejected or propagated; Dart num.clamp and the Python reference can map NaN predictions to a finite cross-entropy boundary. Define language-neutral fixtures and update every established loss-functions lane together rather than adding a Dart-only divergence."
+    },
+    {
+      "id": "dart-current-14-of-15-document-ast",
+      "title": "Port the shared Document AST model to Dart",
+      "status": "in-progress",
+      "depends_on": ["dart-scaffold-capability-schema"],
+      "branch": "codex/dart-document-ast-parity",
+      "pr_number": null,
+      "notes": "Selected after merged PR #9477 and the collision-clean 1233e31db inventory. TE00 is a zero-dependency, types-only, empty-capability foundation with 68 exact cross-repository consumers across CommonMark, GFM, AsciiDoc, renderer, sanitizer, and Forme stacks, giving it more dependency leverage than the remaining cipher and data-structure leaves. Add a Dart surface contract, exhaustive discriminator/containment tests derived from TE00, package metadata, coverage, and real build-tool validation without expanding into downstream parsers."
+    },
+    {
+      "id": "dart-current-14-of-15-atbash-scytale-vigenere",
+      "title": "Port the CR01-CR03 classical cipher leaves to Dart",
+      "status": "pending",
+      "depends_on": ["dart-scaffold-capability-schema"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized from the remaining Dart-only 14-of-15 frontier after PR #9477. Deliver atbash-cipher, scytale-cipher, and vigenere-cipher as one adjacent, dependency-free, empty-capability curriculum slice using the shared CR01-CR03 behavior and edge cases."
+    },
+    {
+      "id": "dart-current-14-of-15-trie",
+      "title": "Port the DT13 trie package to Dart",
+      "status": "pending",
+      "depends_on": ["dart-scaffold-capability-schema"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized from the remaining Dart-only 14-of-15 frontier after PR #9477. Deliver the standalone generic trie contract first; migrate existing Dart LZ78 duplication separately so the foundational port remains reviewable."
+    },
+    {
+      "id": "dart-lz78-shared-trie-migration",
+      "title": "Migrate Dart LZ78 to the shared trie package",
+      "status": "pending",
+      "depends_on": ["dart-current-14-of-15-trie"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the post-#9477 dependency audit. Preserve LZ78's public API and compression fixtures while replacing its private trie logic with the shared Dart DT13 package in a separate downstream slice."
+    },
+    {
+      "id": "dart-current-14-of-15-binary-search-tree",
+      "title": "Port the DT07 binary search tree package to Dart",
+      "status": "pending",
+      "depends_on": ["dart-scaffold-capability-schema"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized from the remaining Dart-only 14-of-15 frontier after PR #9477. Reconcile the cross-lane empty min/max, invalid-rank, comparator, and conceptual tree/binary-tree prerequisite differences before implementation."
+    },
+    {
+      "id": "dart-current-14-of-15-fenwick-tree",
+      "title": "Port the DT06 Fenwick tree package to Dart",
+      "status": "pending",
+      "depends_on": ["dart-scaffold-capability-schema"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized from the remaining Dart-only 14-of-15 frontier after PR #9477. Deliver the dependency-free prefix-sum structure with shared indexing, numeric, bounds, and error fixtures."
+    },
+    {
+      "id": "dart-current-14-of-15-uuid",
+      "title": "Port the UUID package to Dart with reviewed authority boundaries",
+      "status": "pending",
+      "depends_on": ["dart-scaffold-capability-schema"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized from the remaining Dart-only 14-of-15 frontier after PR #9477. Schedule last: reuse existing Dart MD5/SHA-1 where the shared contract requires them, separate deterministic parsing/formatting from time and randomness authority, and review the truthful capability profile before delivery."
     },
     {
       "id": "c-cpp-graduation",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9485,
   "last_inventory": {
     "revision": "f42c8218afee1c63551ff987bdf1d76e007ae12e",
     "schema_version": 3,
@@ -1155,11 +1155,11 @@
     {
       "id": "dart-current-14-of-15-document-ast",
       "title": "Port the shared Document AST model to Dart",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["dart-scaffold-capability-schema"],
       "branch": "codex/dart-document-ast-parity",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9477 and the collision-clean 1233e31db inventory. TE00 is a zero-dependency, types-only, empty-capability foundation with 68 exact cross-repository consumers across CommonMark, GFM, AsciiDoc, renderer, sanitizer, and Forme stacks, giving it more dependency leverage than the remaining cipher and data-structure leaves. Add a Dart surface contract, exhaustive discriminator/containment tests derived from TE00, package metadata, coverage, and real build-tool validation without expanding into downstream parsers."
+      "pr_number": 9485,
+      "notes": "Ready-for-review PR #9485. Selected after merged PR #9477 because TE00 is a zero-dependency, types-only, empty-capability foundation with 68 exact cross-repository consumers. Delivers Dart's sealed 24-node Document AST, stable discriminators, typed containment, immutable collections, structural value semantics, exhaustive tests, docs, metadata, and both build files without expanding into downstream parsers. Rebased onto f42c8218a after Sonos #9461 and SPICE #9481; refreshed inventory is collision-clean at 1,216 identities, 4,364 working slots, 271 high-consensus missing slots, 766 singletons, and 571 Rust singletons. Local validation passed format/analyze, 14 randomized tests, 100% production line coverage, no outdated dependencies, both package build files, targeted metadata-validating build-tool dry-run and real build, 21 capability/reporter tests, state/diff hygiene, and an independent no-blocker API/security audit. The separately logged Lua rockspec encoding defect blocks only the unrelated full 4,763-package Python build-tool scan."
     },
     {
       "id": "dart-current-14-of-15-atbash-scytale-vigenere",

--- a/code/packages/dart/document-ast/.gitignore
+++ b/code/packages/dart/document-ast/.gitignore
@@ -1,0 +1,3 @@
+.dart_tool/
+coverage/
+pubspec.lock

--- a/code/packages/dart/document-ast/BUILD
+++ b/code/packages/dart/document-ast/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/document-ast/BUILD_windows
+++ b/code/packages/dart/document-ast/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/document-ast/CHANGELOG.md
+++ b/code/packages/dart/document-ast/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-08-02
+
+- Add the sealed Dart Document AST node hierarchy from TE00.
+- Cover all 24 stabilized block and inline variants, typed containment,
+  immutable collections, heading validation, and structural value semantics.

--- a/code/packages/dart/document-ast/README.md
+++ b/code/packages/dart/document-ast/README.md
@@ -1,0 +1,35 @@
+# Document AST (Dart)
+
+An immutable Dart implementation of the format-neutral document intermediate
+representation defined by [TE00](../../../specs/TE00-document-ast.md).
+
+The package exposes a sealed `Node` hierarchy with stable snake_case `type`
+discriminators. It includes the universal block and inline nodes plus the
+stabilized task-list, table, and strikethrough model shared by the established
+implementation lanes. Child lists are defensively copied and unmodifiable,
+heading levels are validated, and node equality is structural.
+
+```dart
+import 'package:coding_adventures_document_ast/document_ast.dart';
+
+final document = DocumentNode([
+  HeadingNode(1, [const TextNode('Document AST')]),
+  ParagraphNode([
+    const TextNode('Hello '),
+    EmphasisNode([const TextNode('world')]),
+  ]),
+]);
+
+print(document.type); // document
+```
+
+This package intentionally contains only data types. Parsing, rendering, I/O,
+and format-specific behavior belong in downstream packages.
+
+Run the package checks with:
+
+```sh
+dart pub get
+dart analyze
+dart test
+```

--- a/code/packages/dart/document-ast/lib/document_ast.dart
+++ b/code/packages/dart/document-ast/lib/document_ast.dart
@@ -1,0 +1,4 @@
+/// Immutable, format-neutral document syntax tree nodes.
+library;
+
+export 'src/document_ast.dart';

--- a/code/packages/dart/document-ast/lib/src/document_ast.dart
+++ b/code/packages/dart/document-ast/lib/src/document_ast.dart
@@ -1,0 +1,421 @@
+/// The horizontal alignment of a table column.
+enum TableAlignment { left, right, center }
+
+/// Base class for every Document AST node.
+///
+/// Nodes are immutable value objects. Equality and hashing are structural so
+/// independently constructed trees with the same content compare equal.
+sealed class Node {
+  const Node();
+
+  /// Stable snake_case discriminator shared by every implementation lane.
+  String get type;
+
+  List<Object?> get _fields;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other.runtimeType == runtimeType &&
+          other is Node &&
+          _deepListEquals(_fields, other._fields);
+
+  @override
+  int get hashCode => Object.hash(
+        runtimeType,
+        Object.hashAll(_fields.map(_deepHash)),
+      );
+}
+
+/// Structural nodes that form a document's block-level skeleton.
+sealed class BlockNode extends Node {
+  const BlockNode();
+}
+
+/// Character-level nodes contained by headings, paragraphs, and table cells.
+sealed class InlineNode extends Node {
+  const InlineNode();
+}
+
+/// The only node types accepted directly by a [ListNode].
+sealed class ListChildNode extends BlockNode {
+  const ListChildNode();
+}
+
+/// The root of a document.
+final class DocumentNode extends BlockNode {
+  DocumentNode(List<BlockNode> children)
+      : children = List<BlockNode>.unmodifiable(children);
+
+  @override
+  String get type => 'document';
+
+  final List<BlockNode> children;
+
+  @override
+  List<Object?> get _fields => [children];
+}
+
+/// A section heading with a level from one through six.
+final class HeadingNode extends BlockNode {
+  HeadingNode(this.level, List<InlineNode> children)
+      : children = List<InlineNode>.unmodifiable(children) {
+    if (level < 1 || level > 6) {
+      throw ArgumentError.value(level, 'level', 'must be between 1 and 6');
+    }
+  }
+
+  @override
+  String get type => 'heading';
+
+  final int level;
+  final List<InlineNode> children;
+
+  @override
+  List<Object?> get _fields => [level, children];
+}
+
+/// A paragraph of inline content.
+final class ParagraphNode extends BlockNode {
+  ParagraphNode(List<InlineNode> children)
+      : children = List<InlineNode>.unmodifiable(children);
+
+  @override
+  String get type => 'paragraph';
+
+  final List<InlineNode> children;
+
+  @override
+  List<Object?> get _fields => [children];
+}
+
+/// A block of literal code or preformatted text.
+final class CodeBlockNode extends BlockNode {
+  const CodeBlockNode({required this.language, required this.value});
+
+  @override
+  String get type => 'code_block';
+
+  final String? language;
+  final String value;
+
+  @override
+  List<Object?> get _fields => [language, value];
+}
+
+/// A quotation containing block-level content.
+final class BlockquoteNode extends BlockNode {
+  BlockquoteNode(List<BlockNode> children)
+      : children = List<BlockNode>.unmodifiable(children);
+
+  @override
+  String get type => 'blockquote';
+
+  final List<BlockNode> children;
+
+  @override
+  List<Object?> get _fields => [children];
+}
+
+/// An ordered or unordered list.
+final class ListNode extends BlockNode {
+  ListNode({
+    required this.ordered,
+    required this.start,
+    required this.tight,
+    required List<ListChildNode> children,
+  }) : children = List<ListChildNode>.unmodifiable(children);
+
+  @override
+  String get type => 'list';
+
+  final bool ordered;
+  final int? start;
+  final bool tight;
+  final List<ListChildNode> children;
+
+  @override
+  List<Object?> get _fields => [ordered, start, tight, children];
+}
+
+/// One regular item in a list.
+final class ListItemNode extends ListChildNode {
+  ListItemNode(List<BlockNode> children)
+      : children = List<BlockNode>.unmodifiable(children);
+
+  @override
+  String get type => 'list_item';
+
+  final List<BlockNode> children;
+
+  @override
+  List<Object?> get _fields => [children];
+}
+
+/// One checkbox item in a task list.
+final class TaskItemNode extends ListChildNode {
+  TaskItemNode({required this.checked, required List<BlockNode> children})
+      : children = List<BlockNode>.unmodifiable(children);
+
+  @override
+  String get type => 'task_item';
+
+  final bool checked;
+  final List<BlockNode> children;
+
+  @override
+  List<Object?> get _fields => [checked, children];
+}
+
+/// A horizontal separator.
+final class ThematicBreakNode extends BlockNode {
+  const ThematicBreakNode();
+
+  @override
+  String get type => 'thematic_break';
+
+  @override
+  List<Object?> get _fields => const [];
+}
+
+/// Format-specific block content passed through by matching renderers.
+final class RawBlockNode extends BlockNode {
+  const RawBlockNode({required this.format, required this.value});
+
+  @override
+  String get type => 'raw_block';
+
+  final String format;
+  final String value;
+
+  @override
+  List<Object?> get _fields => [format, value];
+}
+
+/// A table whose alignments correspond to its columns.
+final class TableNode extends BlockNode {
+  TableNode({
+    required List<TableAlignment?> align,
+    required List<TableRowNode> children,
+  })  : align = List<TableAlignment?>.unmodifiable(align),
+        children = List<TableRowNode>.unmodifiable(children);
+
+  @override
+  String get type => 'table';
+
+  final List<TableAlignment?> align;
+  final List<TableRowNode> children;
+
+  @override
+  List<Object?> get _fields => [align, children];
+}
+
+/// One header or body row inside a table.
+final class TableRowNode extends BlockNode {
+  TableRowNode({
+    required this.isHeader,
+    required List<TableCellNode> children,
+  }) : children = List<TableCellNode>.unmodifiable(children);
+
+  @override
+  String get type => 'table_row';
+
+  final bool isHeader;
+  final List<TableCellNode> children;
+
+  @override
+  List<Object?> get _fields => [isHeader, children];
+}
+
+/// One table cell containing inline content.
+final class TableCellNode extends BlockNode {
+  TableCellNode(List<InlineNode> children)
+      : children = List<InlineNode>.unmodifiable(children);
+
+  @override
+  String get type => 'table_cell';
+
+  final List<InlineNode> children;
+
+  @override
+  List<Object?> get _fields => [children];
+}
+
+/// Plain decoded Unicode text.
+final class TextNode extends InlineNode {
+  const TextNode(this.value);
+
+  @override
+  String get type => 'text';
+
+  final String value;
+
+  @override
+  List<Object?> get _fields => [value];
+}
+
+/// Stressed inline content.
+final class EmphasisNode extends InlineNode {
+  EmphasisNode(List<InlineNode> children)
+      : children = List<InlineNode>.unmodifiable(children);
+
+  @override
+  String get type => 'emphasis';
+
+  final List<InlineNode> children;
+
+  @override
+  List<Object?> get _fields => [children];
+}
+
+/// Strongly emphasized inline content.
+final class StrongNode extends InlineNode {
+  StrongNode(List<InlineNode> children)
+      : children = List<InlineNode>.unmodifiable(children);
+
+  @override
+  String get type => 'strong';
+
+  final List<InlineNode> children;
+
+  @override
+  List<Object?> get _fields => [children];
+}
+
+/// Inline content marked as deleted or struck through.
+final class StrikethroughNode extends InlineNode {
+  StrikethroughNode(List<InlineNode> children)
+      : children = List<InlineNode>.unmodifiable(children);
+
+  @override
+  String get type => 'strikethrough';
+
+  final List<InlineNode> children;
+
+  @override
+  List<Object?> get _fields => [children];
+}
+
+/// Literal inline code.
+final class CodeSpanNode extends InlineNode {
+  const CodeSpanNode(this.value);
+
+  @override
+  String get type => 'code_span';
+
+  final String value;
+
+  @override
+  List<Object?> get _fields => [value];
+}
+
+/// A resolved hyperlink with inline label content.
+final class LinkNode extends InlineNode {
+  LinkNode({
+    required this.destination,
+    required this.title,
+    required List<InlineNode> children,
+  }) : children = List<InlineNode>.unmodifiable(children);
+
+  @override
+  String get type => 'link';
+
+  final String destination;
+  final String? title;
+  final List<InlineNode> children;
+
+  @override
+  List<Object?> get _fields => [destination, title, children];
+}
+
+/// An image reference with resolved destination and plain-text alternative.
+final class ImageNode extends InlineNode {
+  const ImageNode({
+    required this.destination,
+    required this.title,
+    required this.alt,
+  });
+
+  @override
+  String get type => 'image';
+
+  final String destination;
+  final String? title;
+  final String alt;
+
+  @override
+  List<Object?> get _fields => [destination, title, alt];
+}
+
+/// An automatically recognized URL or email address.
+final class AutolinkNode extends InlineNode {
+  const AutolinkNode({required this.destination, required this.isEmail});
+
+  @override
+  String get type => 'autolink';
+
+  final String destination;
+  final bool isEmail;
+
+  @override
+  List<Object?> get _fields => [destination, isEmail];
+}
+
+/// Format-specific inline content passed through by matching renderers.
+final class RawInlineNode extends InlineNode {
+  const RawInlineNode({required this.format, required this.value});
+
+  @override
+  String get type => 'raw_inline';
+
+  final String format;
+  final String value;
+
+  @override
+  List<Object?> get _fields => [format, value];
+}
+
+/// A forced line break.
+final class HardBreakNode extends InlineNode {
+  const HardBreakNode();
+
+  @override
+  String get type => 'hard_break';
+
+  @override
+  List<Object?> get _fields => const [];
+}
+
+/// A source line break that a renderer may collapse to whitespace.
+final class SoftBreakNode extends InlineNode {
+  const SoftBreakNode();
+
+  @override
+  String get type => 'soft_break';
+
+  @override
+  List<Object?> get _fields => const [];
+}
+
+bool _deepListEquals(List<Object?> left, List<Object?> right) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (!_deepEquals(left[index], right[index])) return false;
+  }
+  return true;
+}
+
+bool _deepEquals(Object? left, Object? right) {
+  if (identical(left, right)) return true;
+  if (left is List<Object?> && right is List<Object?>) {
+    return _deepListEquals(left, right);
+  }
+  return left == right;
+}
+
+int _deepHash(Object? value) {
+  if (value is List<Object?>) {
+    return Object.hashAll(value.map(_deepHash));
+  }
+  return value.hashCode;
+}

--- a/code/packages/dart/document-ast/pubspec.yaml
+++ b/code/packages/dart/document-ast/pubspec.yaml
@@ -1,0 +1,13 @@
+name: coding_adventures_document_ast
+description: Immutable, format-neutral document syntax tree node types.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies: {}
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/document-ast/required_capabilities.json
+++ b/code/packages/dart/document-ast/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/document-ast",
+  "capabilities": [],
+  "justification": "Types-only package. No filesystem, network, process, environment, or console access needed."
+}

--- a/code/packages/dart/document-ast/test/document_ast_test.dart
+++ b/code/packages/dart/document-ast/test/document_ast_test.dart
@@ -1,0 +1,477 @@
+import 'package:coding_adventures_document_ast/document_ast.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('block nodes', () {
+    test('builds the core TE00 document structure', () {
+      final heading = HeadingNode(1, [TextNode('Document AST')]);
+      final paragraph = ParagraphNode([
+        TextNode('Hello '),
+        EmphasisNode([TextNode('portable')]),
+        const SoftBreakNode(),
+        StrongNode([TextNode('world')]),
+      ]);
+      final document = DocumentNode([heading, paragraph]);
+
+      expect(document.type, 'document');
+      expect(document.children, hasLength(2));
+      expect(document.children.first, same(heading));
+      expect(heading.type, 'heading');
+      expect(heading.level, 1);
+      expect(paragraph.type, 'paragraph');
+      expect(paragraph.children.map((node) => node.type), [
+        'text',
+        'emphasis',
+        'soft_break',
+        'strong',
+      ]);
+    });
+
+    test('supports all heading levels and rejects invalid levels', () {
+      for (var level = 1; level <= 6; level++) {
+        expect(HeadingNode(level, []).level, level);
+      }
+      expect(() => HeadingNode(0, []), throwsArgumentError);
+      expect(() => HeadingNode(7, []), throwsArgumentError);
+    });
+
+    test('represents literal, quotation, and raw blocks', () {
+      final code = CodeBlockNode(language: 'dart', value: 'final x = 1;\n');
+      final unlabelled = CodeBlockNode(language: null, value: 'plain\n');
+      final quote = BlockquoteNode([
+        ParagraphNode([TextNode('quoted')]),
+        BlockquoteNode([]),
+      ]);
+      final raw = RawBlockNode(format: 'latex', value: r'\textbf{bold}');
+
+      expect(code.type, 'code_block');
+      expect(code.language, 'dart');
+      expect(code.value, endsWith('\n'));
+      expect(unlabelled.language, isNull);
+      expect(quote.type, 'blockquote');
+      expect(quote.children.last.type, 'blockquote');
+      expect(raw.type, 'raw_block');
+      expect(raw.format, 'latex');
+      expect(raw.value, r'\textbf{bold}');
+      expect(const ThematicBreakNode().type, 'thematic_break');
+    });
+
+    test('represents regular and task list items', () {
+      final regular = ListItemNode([
+        ParagraphNode([TextNode('first')]),
+      ]);
+      final task = TaskItemNode(
+        checked: true,
+        children: [
+          ParagraphNode([TextNode('ship it')])
+        ],
+      );
+      final unordered = ListNode(
+        ordered: false,
+        start: null,
+        tight: true,
+        children: [regular, task],
+      );
+      final ordered = ListNode(
+        ordered: true,
+        start: 42,
+        tight: false,
+        children: [regular],
+      );
+
+      expect(unordered.type, 'list');
+      expect(unordered.children.map((node) => node.type), [
+        'list_item',
+        'task_item',
+      ]);
+      expect(unordered.start, isNull);
+      expect(unordered.tight, isTrue);
+      expect(task.checked, isTrue);
+      expect(ordered.start, 42);
+      expect(ordered.ordered, isTrue);
+    });
+
+    test('represents the stabilized table model', () {
+      final header = TableRowNode(
+        isHeader: true,
+        children: [
+          TableCellNode([TextNode('Name')])
+        ],
+      );
+      final body = TableRowNode(
+        isHeader: false,
+        children: [
+          TableCellNode([
+            StrongNode([TextNode('Ada')])
+          ]),
+        ],
+      );
+      final table = TableNode(
+        align: [TableAlignment.left],
+        children: [header, body],
+      );
+
+      expect(table.type, 'table');
+      expect(table.align, [TableAlignment.left]);
+      expect(table.children, hasLength(2));
+      expect(table.children.first.type, 'table_row');
+      expect(table.children.first.isHeader, isTrue);
+      expect(table.children.first.children.first.type, 'table_cell');
+      expect(table.children.last.children.first.children.first.type, 'strong');
+      expect(TableAlignment.values.map((value) => value.name), [
+        'left',
+        'right',
+        'center',
+      ]);
+    });
+  });
+
+  group('inline nodes', () {
+    test('represents text and nested formatting', () {
+      final text = TextNode('Hello & κόσμε');
+      final emphasis = EmphasisNode([text, CodeSpanNode('&amp;')]);
+      final strong = StrongNode([emphasis]);
+      final strike = StrikethroughNode([strong]);
+
+      expect(text.type, 'text');
+      expect(text.value, 'Hello & κόσμε');
+      expect(emphasis.type, 'emphasis');
+      expect((emphasis.children.last as CodeSpanNode).value, '&amp;');
+      expect(strong.type, 'strong');
+      expect(strike.type, 'strikethrough');
+    });
+
+    test('represents resolved links, images, and autolinks', () {
+      final link = LinkNode(
+        destination: 'https://example.com',
+        title: 'Example',
+        children: [TextNode('visit')],
+      );
+      final untitled = LinkNode(
+        destination: '/relative',
+        title: null,
+        children: [],
+      );
+      final image = ImageNode(
+        destination: 'cat.png',
+        title: null,
+        alt: 'a tabby cat',
+      );
+      final email = AutolinkNode(
+        destination: 'user@example.com',
+        isEmail: true,
+      );
+      final url = AutolinkNode(
+        destination: 'https://example.com',
+        isEmail: false,
+      );
+
+      expect(link.type, 'link');
+      expect(link.title, 'Example');
+      expect(link.children.single.type, 'text');
+      expect(untitled.title, isNull);
+      expect(image.type, 'image');
+      expect(image.alt, 'a tabby cat');
+      expect(email.type, 'autolink');
+      expect(email.isEmail, isTrue);
+      expect(url.isEmail, isFalse);
+    });
+
+    test('represents raw content and break leaves', () {
+      final raw = RawInlineNode(format: 'html', value: '<em>raw</em>');
+      const hard = HardBreakNode();
+      const soft = SoftBreakNode();
+
+      expect(raw.type, 'raw_inline');
+      expect(raw.format, 'html');
+      expect(raw.value, '<em>raw</em>');
+      expect(hard.type, 'hard_break');
+      expect(soft.type, 'soft_break');
+    });
+  });
+
+  group('sealed discriminators', () {
+    test('covers every block-node discriminator', () {
+      final nodes = <BlockNode>[
+        DocumentNode([]),
+        HeadingNode(1, []),
+        ParagraphNode([]),
+        CodeBlockNode(language: null, value: ''),
+        BlockquoteNode([]),
+        ListNode(ordered: false, start: null, tight: true, children: []),
+        ListItemNode([]),
+        TaskItemNode(checked: false, children: []),
+        const ThematicBreakNode(),
+        RawBlockNode(format: 'html', value: ''),
+        TableNode(align: [], children: []),
+        TableRowNode(isHeader: false, children: []),
+        TableCellNode([]),
+      ];
+
+      expect(nodes.map(_classify), [
+        'document',
+        'heading',
+        'paragraph',
+        'code_block',
+        'blockquote',
+        'list',
+        'list_item',
+        'task_item',
+        'thematic_break',
+        'raw_block',
+        'table',
+        'table_row',
+        'table_cell',
+      ]);
+    });
+
+    test('covers every inline-node discriminator', () {
+      final nodes = <InlineNode>[
+        TextNode(''),
+        EmphasisNode([]),
+        StrongNode([]),
+        StrikethroughNode([]),
+        CodeSpanNode(''),
+        LinkNode(destination: '/', title: null, children: []),
+        ImageNode(destination: '/', title: null, alt: ''),
+        AutolinkNode(destination: 'x@y.example', isEmail: true),
+        RawInlineNode(format: 'html', value: ''),
+        const HardBreakNode(),
+        const SoftBreakNode(),
+      ];
+
+      expect(nodes.map(_classify), [
+        'text',
+        'emphasis',
+        'strong',
+        'strikethrough',
+        'code_span',
+        'link',
+        'image',
+        'autolink',
+        'raw_inline',
+        'hard_break',
+        'soft_break',
+      ]);
+    });
+  });
+
+  group('immutability and value semantics', () {
+    test('defensively copies child and alignment lists', () {
+      final inlineChildren = <InlineNode>[TextNode('before')];
+      final paragraph = ParagraphNode(inlineChildren);
+      inlineChildren.add(TextNode('after'));
+
+      final blockChildren = <BlockNode>[paragraph];
+      final document = DocumentNode(blockChildren);
+      blockChildren.clear();
+
+      final align = <TableAlignment?>[TableAlignment.center, null];
+      final table = TableNode(align: align, children: []);
+      align[0] = TableAlignment.left;
+
+      expect(paragraph.children, hasLength(1));
+      expect(document.children, [paragraph]);
+      expect(table.align, [TableAlignment.center, null]);
+      expect(
+          () => paragraph.children.add(TextNode('no')), throwsUnsupportedError);
+      expect(() => document.children.clear(), throwsUnsupportedError);
+      expect(
+          () => table.align.add(TableAlignment.right), throwsUnsupportedError);
+    });
+
+    test('uses structural equality and stable hash codes', () {
+      final left = DocumentNode([
+        HeadingNode(2, [TextNode('Title')]),
+        ParagraphNode([TextNode('Body'), const SoftBreakNode()]),
+      ]);
+      final right = DocumentNode([
+        HeadingNode(2, [TextNode('Title')]),
+        ParagraphNode([TextNode('Body'), const SoftBreakNode()]),
+      ]);
+      final different = DocumentNode([
+        HeadingNode(3, [TextNode('Title')]),
+      ]);
+
+      expect(left, equals(right));
+      expect(left.hashCode, right.hashCode);
+      expect(left, isNot(equals(different)));
+      expect(TextNode('same'), equals(TextNode('same')));
+      expect(TextNode('same'), isNot(equals(TextNode('different'))));
+    });
+
+    test('applies value semantics to every stabilized node variant', () {
+      final pairs = <(Node, Node)>[
+        (DocumentNode([]), DocumentNode([])),
+        (HeadingNode(2, []), HeadingNode(2, [])),
+        (ParagraphNode([]), ParagraphNode([])),
+        (
+          const CodeBlockNode(language: 'dart', value: 'x\n'),
+          const CodeBlockNode(language: 'dart', value: 'x\n'),
+        ),
+        (BlockquoteNode([]), BlockquoteNode([])),
+        (
+          ListNode(
+            ordered: true,
+            start: 3,
+            tight: false,
+            children: [],
+          ),
+          ListNode(
+            ordered: true,
+            start: 3,
+            tight: false,
+            children: [],
+          ),
+        ),
+        (ListItemNode([]), ListItemNode([])),
+        (
+          TaskItemNode(checked: true, children: []),
+          TaskItemNode(checked: true, children: []),
+        ),
+        (const ThematicBreakNode(), const ThematicBreakNode()),
+        (
+          const RawBlockNode(format: 'html', value: '<hr>'),
+          const RawBlockNode(format: 'html', value: '<hr>'),
+        ),
+        (
+          TableNode(align: [TableAlignment.right, null], children: []),
+          TableNode(align: [TableAlignment.right, null], children: []),
+        ),
+        (
+          TableRowNode(isHeader: true, children: []),
+          TableRowNode(isHeader: true, children: []),
+        ),
+        (TableCellNode([]), TableCellNode([])),
+        (const TextNode('text'), const TextNode('text')),
+        (EmphasisNode([]), EmphasisNode([])),
+        (StrongNode([]), StrongNode([])),
+        (StrikethroughNode([]), StrikethroughNode([])),
+        (const CodeSpanNode('code'), const CodeSpanNode('code')),
+        (
+          LinkNode(destination: '/', title: 'home', children: []),
+          LinkNode(destination: '/', title: 'home', children: []),
+        ),
+        (
+          const ImageNode(destination: 'x.png', title: null, alt: 'x'),
+          const ImageNode(destination: 'x.png', title: null, alt: 'x'),
+        ),
+        (
+          const AutolinkNode(destination: 'x@y.test', isEmail: true),
+          const AutolinkNode(destination: 'x@y.test', isEmail: true),
+        ),
+        (
+          const RawInlineNode(format: 'html', value: '<b>x</b>'),
+          const RawInlineNode(format: 'html', value: '<b>x</b>'),
+        ),
+        (const HardBreakNode(), const HardBreakNode()),
+        (const SoftBreakNode(), const SoftBreakNode()),
+      ];
+
+      expect(pairs.map((pair) => pair.$1.type).toSet(), hasLength(24));
+      for (final (left, right) in pairs) {
+        expect(left, equals(right), reason: left.type);
+        expect(left.hashCode, right.hashCode, reason: left.type);
+      }
+    });
+  });
+
+  test('walks a nested document through typed containment', () {
+    final document = DocumentNode([
+      HeadingNode(1, [TextNode('Hello')]),
+      BlockquoteNode([
+        ListNode(
+          ordered: false,
+          start: null,
+          tight: true,
+          children: [
+            ListItemNode([
+              ParagraphNode([
+                TextNode('World'),
+                const SoftBreakNode(),
+                TextNode('!'),
+              ]),
+            ]),
+          ],
+        ),
+      ]),
+    ]);
+
+    final texts = <String>[];
+    _collectText(document, texts);
+    expect(texts, ['Hello', 'World', '!']);
+  });
+}
+
+String _classify(Node node) => switch (node) {
+      DocumentNode() => 'document',
+      HeadingNode() => 'heading',
+      ParagraphNode() => 'paragraph',
+      CodeBlockNode() => 'code_block',
+      BlockquoteNode() => 'blockquote',
+      ListNode() => 'list',
+      ListItemNode() => 'list_item',
+      TaskItemNode() => 'task_item',
+      ThematicBreakNode() => 'thematic_break',
+      RawBlockNode() => 'raw_block',
+      TableNode() => 'table',
+      TableRowNode() => 'table_row',
+      TableCellNode() => 'table_cell',
+      TextNode() => 'text',
+      EmphasisNode() => 'emphasis',
+      StrongNode() => 'strong',
+      StrikethroughNode() => 'strikethrough',
+      CodeSpanNode() => 'code_span',
+      LinkNode() => 'link',
+      ImageNode() => 'image',
+      AutolinkNode() => 'autolink',
+      RawInlineNode() => 'raw_inline',
+      HardBreakNode() => 'hard_break',
+      SoftBreakNode() => 'soft_break',
+    };
+
+void _collectText(Node node, List<String> values) {
+  switch (node) {
+    case TextNode(:final value):
+      values.add(value);
+    case DocumentNode(:final children) ||
+          BlockquoteNode(:final children) ||
+          ListItemNode(:final children) ||
+          TaskItemNode(:final children):
+      for (final child in children) {
+        _collectText(child, values);
+      }
+    case HeadingNode(:final children) ||
+          ParagraphNode(:final children) ||
+          EmphasisNode(:final children) ||
+          StrongNode(:final children) ||
+          StrikethroughNode(:final children) ||
+          LinkNode(:final children) ||
+          TableCellNode(:final children):
+      for (final child in children) {
+        _collectText(child, values);
+      }
+    case ListNode(:final children):
+      for (final child in children) {
+        _collectText(child, values);
+      }
+    case TableNode(:final children):
+      for (final child in children) {
+        _collectText(child, values);
+      }
+    case TableRowNode(:final children):
+      for (final child in children) {
+        _collectText(child, values);
+      }
+    case CodeBlockNode() ||
+          ThematicBreakNode() ||
+          RawBlockNode() ||
+          CodeSpanNode() ||
+          ImageNode() ||
+          AutolinkNode() ||
+          RawInlineNode() ||
+          HardBreakNode() ||
+          SoftBreakNode():
+      return;
+  }
+}

--- a/code/specs/TE00-document-ast.md
+++ b/code/specs/TE00-document-ast.md
@@ -876,6 +876,7 @@ same immutable, discriminated-union-style design.
 | Rust       | `coding_adventures_document_ast`                         | `code/packages/rust/document-ast/`          |
 | Elixir     | `CodingAdventures.DocumentAST`                           | `code/packages/elixir/document-ast/`        |
 | Lua        | `coding_adventures.document_ast`                         | `code/packages/lua/document-ast/`           |
+| Dart       | `coding_adventures_document_ast`                         | `code/packages/dart/document-ast/`          |
 
 ### Language-idiomatic type representations
 
@@ -901,3 +902,15 @@ atom field. All structs are frozen by convention.
 
 **Lua:** Tables with a `type` string field. No static types — the spec is the
 contract.
+
+**Dart:** A sealed `Node` hierarchy with sealed `BlockNode`, `InlineNode`, and
+`ListChildNode` branches. Each concrete node is an immutable value object with
+a stable snake-case `type` discriminator and defensively copied, unmodifiable
+child lists. Dart's `int` cannot express the `1 | ... | 6` heading-level union,
+so `HeadingNode` rejects levels outside 1 through 6 with `ArgumentError`.
+Nullable fields use Dart nullable types. The package includes the five
+stabilized GFM model nodes already present in the established cross-lane
+surface — `TaskItemNode`, `TableNode`, `TableRowNode`, `TableCellNode`, and
+`StrikethroughNode` — while `FencedBlockNode` and TE05 dialect nodes remain
+owned by their extension specs. There is no parsing, rendering, I/O, or runtime
+dependency in this package.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,33 +106,35 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on August 2, 2026 at `e552707d5` after the serial
-Rust smart-home additions through Wemo (#9455) and the Rust SPICE model
-validation chain through #9473. It contains 1,215 normalized implementation
-identities across 4,359 established-lane package
-slots and found zero canonical collisions or unknown language buckets:
+working inventory was regenerated on August 2, 2026 from `f42c8218a` after
+merged PR #9477 added the three Dart ML leaves and this branch added Dart
+`document-ast`, following the serial Rust smart-home additions through Sonos
+(#9461) and the Rust SPICE model validation chain through #9481. It contains
+1,216 normalized implementation identities across 4,364 established-lane
+package slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 275 |
+| Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 765 | 10,710 |
+| Present in one language | 766 | 10,724 |
 
-The loop must not start by attempting 10,710 singleton ports. It should finish
+The loop must not start by attempting 10,724 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
-The current inventory at
-`e552707d59c62c0c0749c6173a2cf82478629b48` is collision-clean at 1,215
-normalized implementation identities, 4,359 implementation slots, 172
-high-consensus packages, 275 high-consensus missing slots, 765 singletons, 570
+The current working inventory on
+`f42c8218afee1c63551ff987bdf1d76e007ae12e` is collision-clean at 1,216
+normalized implementation identities, 4,364 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 766 singletons, 571
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The ten newest mixed Rust identities are `smart-home-camera-media`,
+The eleven newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
 `smart-home-wled-integration`, `smart-home-govee-lan-integration`,
 `smart-home-lifx-lan-integration`, `smart-home-kasa-lan-integration`,
-`smart-home-reolink-integration`, `smart-home-roku-ecp-integration`, and
-`smart-home-wemo-upnp-integration`. All are
+`smart-home-reolink-integration`, `smart-home-roku-ecp-integration`,
+`smart-home-wemo-upnp-integration`, and
+`smart-home-sonos-upnp-integration`. All are
 mixed splits rather than blind parity ports: camera grant policy,
 generation-bound lease state, quotas, and redacted audit are portable, while
 authenticated host context and media delivery remain native mediation; ONVIF
@@ -146,11 +148,16 @@ WLED DTO validation, master/segment projection, capability-bit interpretation,
 state normalization, and command planning are portable, while mDNS, DNS/TCP,
 plaintext LAN HTTP, trusted time, console I/O, pairing/origin policy, runtime
 effects, and capability profiles remain native. Govee, LIFX, Kasa, Reolink,
-Roku, and Wemo contribute deterministic codecs, bounded parsers and DTO
+Roku, Wemo, and Sonos contribute deterministic codecs, bounded parsers and DTO
 validation, normalization, projection, stable identities/errors, command
 planning, and language-neutral fixtures to the parity backlog. Wemo specifically
 contributes SSDP header parsing, bounded setup/SOAP XML, service/device
-normalization, and switch/light command planning.
+normalization, and switch/light command planning. Sonos additionally contributes
+credential-free URL/control-path validation, AVTransport, RenderingControl,
+DIDL metadata normalization, deterministic inspection planning, and
+protocol-neutral media-player projection. UDP multicast, DNS/TCP, LAN HTTP
+execution, timeouts, endpoint approval, CLI I/O, authorization, and runtime
+mutation remain native-host responsibilities.
 
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
@@ -164,7 +171,7 @@ The August 2 lane audit is:
 | Established lane | Packages present | High-consensus gaps | Rust/Python-core coverage |
 |---|---:|---:|---:|
 | C# | 196 | 0 | 47.5% |
-| Dart | 75 | 105 | 17.6% |
+| Dart | 79 | 101 | 18.6% |
 | Elixir | 276 | 0 | 69.3% |
 | F# | 195 | 0 | 47.5% |
 | Go | 292 | 0 | 72.4% |
@@ -175,7 +182,7 @@ The August 2 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 980 | 0 | 100% |
+| Rust | 981 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -197,6 +204,12 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
 - reconcile stale `BUILD_windows` prerequisite declarations reported by the
   build-tool validator across Python, Perl, TypeScript, Swift, Dart, Kotlin, and
   related packages in dependency-shaped waves;
+- make the Python build tool's Lua rockspec decoding deterministic. A full
+  4,763-package dry-run currently aborts before diff selection when
+  `_parse_lua_deps` reads byte `0x97` from `lua/block_ram` and `lua/tree` at
+  offset 208 or `lua/trig` at offset 218; classify and normalize the three
+  metadata files or add a deterministic fail-closed encoding diagnostic with
+  fixtures rather than silently replacing bytes;
 - remove environment-specific Starlark grammar lookup so build discovery works
   from arbitrary clean worktrees;
 - add explicit applicability and maturity data before either C/C++ or OCaml
@@ -229,27 +242,37 @@ Completed in the Swift lane: `wasm-simulator`, `cli-builder`,
 
 The historical Priority 1 cohort is complete, but later Haskell work promoted
 13 packages into a new 14-of-15 frontier. Merged PR #9383 closed `trig` and
-`wave`, so the remaining 11 current gaps are Dart-only:
+`wave`, merged PR #9477 closed `matrix`, `loss-functions`, and
+`feature-normalization`, and this branch closes `document-ast`, so the remaining
+seven current gaps are Dart-only:
 
-- dependency-shaped ML: `matrix`, then `loss-functions` and
-  `feature-normalization`;
 - deterministic data structures: `binary-search-tree`, `fenwick-tree`, and
   `trie`;
 - leaf ciphers: `atbash-cipher`, `scytale-cipher`, and `vigenere-cipher`;
-- shared model and utility leaves: `document-ast` and `uuid`.
+- utility leaf: `uuid`.
 
 Merged PR #9375 closed the generator-level prerequisite found by the post-#9363
 fixture audit. Dart's native scaffold generator now emits byte-stable,
 schema-v1 empty library profiles and truthful generated-program stdout
 profiles, while declaring its own reviewed runtime authority. Existing
 nonempty Dart profiles remain owned by the legacy migration review. Close the
-remaining 11-package frontier as small coherent PRs on top of that scaffold
+remaining seven-package frontier as small coherent PRs on top of that scaffold
 contract.
 
 Merged PR #9383 completed the first child item: the zero-dependency PHY00
 `trig` leaf and its direct PHY01 `wave` consumer. This closed two Dart-only
 14-of-15 gaps while exercising the scaffold and capability contract on a real
 dependency chain.
+
+Merged PR #9477 completed the ML child item with the independent `matrix`,
+`loss-functions`, and `feature-normalization` leaves. The post-merge leverage
+pass selected `document-ast` next: its types-only TE00 model has 68 exact
+cross-repository consumers and unlocks substantially more follow-on parity work
+than the remaining cipher and data-structure leaves. This branch delivers that
+sealed, immutable 24-node model with exhaustive discriminator, containment,
+value-semantics, and coverage checks. The cipher trio, trie,
+binary-search-tree, fenwick-tree, and UUID are explicit remaining child items;
+the existing Dart LZ78 private-trie migration is tracked separately.
 
 The post-merge governance audit found no repository-verifiable Layer 5 approval
 for #9375's nonempty generator profile: GitHub reports no review decision, and
@@ -287,9 +310,13 @@ collision-clean `1e4956369` refresh added the two Rust-only camera identities.
 PR #9421 merged the camera-media boundary repair. With no active in-scope parity
 PR at `e552707d5`, the leverage pass selected
 `dart-current-14-of-15-matrix-family`: the independent `matrix`,
-`loss-functions`, and `feature-normalization` leaf packages. The branch is
-`codex/dart-matrix-ml-parity` and the item is in progress. Open ONVIF and other
-host PRs do not occupy the scoped parity slot.
+`loss-functions`, and `feature-normalization` leaf packages. PR #9477 merged
+that slice at `1233e31db` with successful final-head push CI, PR CI, and
+CodeQL. The refreshed leverage pass selected the zero-dependency TE00
+`document-ast` model next because its 68 exact consumers make it the strongest
+remaining dependency foundation. The branch is
+`codex/dart-document-ast-parity`; open ONVIF and other host PRs do not occupy
+the scoped parity slot.
 The audit also found private matrix/MSE helpers in Dart `single-layer-network`
 and `two-layer-network`; their migration to the shared packages is a separate
 downstream backlog item rather than hidden scope in this port.
@@ -973,7 +1000,7 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 570 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 571 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
 The July 30-August 2 inventories added thirty Rust singleton identities that now


### PR DESCRIPTION
## Summary

- add the Dart TE00 Document AST package with the sealed 24-node block/inline hierarchy
- enforce immutable child/alignment ownership, heading bounds, stable discriminators, and structural equality/hash semantics
- add exhaustive package tests, documentation, capability metadata, BUILD/BUILD_windows, and the Dart surface contract
- refresh the collision-checked parity inventory and materialize newly discovered Sonos portable-core and Lua-rockspec build-tool backlog items

This closes the Dart-only `document-ast` 14-of-15 gap. The working inventory is now 1,216 identities / 4,364 established slots / 271 high-consensus missing slots; `document-ast` is present in all 15 established lanes with zero collisions or unknown buckets.

## Validation

- `dart format --output=none --set-exit-if-changed lib test`
- `dart analyze`
- randomized Dart tests: 14/14
- measured production line coverage: 134/134 (100%), 95% gate enabled
- `dart pub outdated --no-dependency-overrides`
- real `BUILD` and `BUILD_windows`
- Python build-tool plan mode with metadata validation: 1 would-build, then 1 built
- capability taxonomy/scaffold tests: 11/11
- package parity reporter tests: 10/10
- collision-checked live reporter: 1,216 identities, 4,364 slots, 271 high-consensus missing, Dart present 79, zero collisions/unknown
- state graph: 120 items, no duplicate IDs or missing dependencies, one in-progress item, no open parity PR
- `git diff --check`
- independent API/parity/security audit: no blockers

## Known unrelated build-tool debt

The full 4,763-package Python build-tool scan aborts before diff selection on three pre-existing Lua rockspecs containing byte `0x97` (`block_ram`, `tree`, and `trig`). This is logged as `build-tool-lua-rockspec-encoding`; targeted validated build execution for this package is green.