### PR TITLE
fix(spice): validate MOS junction grading

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `MJ` values before
+  lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `PB` values
   before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `GAMMA` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1882,6 +1882,15 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(bulk_junction_grading_coefficient) = params.get("MJ") {
+            if !bulk_junction_grading_coefficient.is_finite()
+                || *bulk_junction_grading_coefficient < 0.0
+            {
+                return Err(NetlistParseError::new(
+                    "MOSFET MJ must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1768,6 +1768,38 @@ fn preserves_positive_mosfet_model_bulk_junction_potential() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_bulk_junction_grading_coefficient() {
+    for grading_coefficient in ["-0.5", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model junction NMOS(MJ={grading_coefficient})\nM1 d g s b junction"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET MJ must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_bulk_junction_grading_coefficient() {
+    for grading_coefficient in ["0", "0.5"] {
+        let parsed = parse_netlist(&format!(
+            ".model junction NMOS(MJ={grading_coefficient})\nM1 d g s b junction"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(
+            mosfet.params.bulk_junction_grading_coefficient,
+            grading_coefficient.parse().unwrap(),
+        );
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card bulk-junction-potential validation.
+1. Rust Berkeley SPICE MOS model-card bulk-junction-grading validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite model-card `PB` values before
+   - Reject negative and non-finite model-card `MJ` values before
      lowering MOS elements into engine parameters.
-   - Preserve positive explicit bulk-junction potentials.
+   - Preserve zero and positive bulk-junction grading coefficients.
 
 ## Completed Slices
 
@@ -3965,6 +3965,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `GAMMA` values are rejected before
      lowering MOS elements into engine parameters.
    - Zero and positive explicit body-effect coefficients remain accepted.
+
+342. Rust Berkeley SPICE MOS model-card bulk-junction-potential validation.
+   - Status: completed in PR 9484.
+   - Zero, negative, and non-finite model-card `PB` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Positive explicit bulk-junction potentials remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `MJ` values in the Rust Berkeley parser facade
- preserve zero and positive bulk-junction grading coefficients
- reconcile the SPICE completion plan after PR #9484

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's junction-grading semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.