### PR TITLE
fix(spice): validate MOS depletion coefficient

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject non-finite Level-1 MOS model-card `FC` values outside `[0, 1)` before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `MJ` values before
   lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `PB` values

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1891,6 +1891,16 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(depletion_coefficient) = params.get("FC") {
+            if !depletion_coefficient.is_finite()
+                || *depletion_coefficient < 0.0
+                || *depletion_coefficient >= 1.0
+            {
+                return Err(NetlistParseError::new(
+                    "MOSFET FC must be finite and in [0, 1)",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1800,6 +1800,38 @@ fn preserves_non_negative_mosfet_model_bulk_junction_grading_coefficient() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_depletion_coefficient() {
+    for depletion_coefficient in ["-0.1", "1", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model depletion NMOS(FC={depletion_coefficient})\nM1 d g s b depletion"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET FC must be finite and in [0, 1)"));
+    }
+}
+
+#[test]
+fn preserves_mosfet_model_depletion_coefficient_in_range() {
+    for depletion_coefficient in ["0", "0.4", "0.999"] {
+        let parsed = parse_netlist(&format!(
+            ".model depletion NMOS(FC={depletion_coefficient})\nM1 d g s b depletion"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(
+            mosfet.params.forward_bias_depletion_coefficient,
+            depletion_coefficient.parse().unwrap(),
+        );
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card bulk-junction-grading validation.
+1. Rust Berkeley SPICE MOS model-card depletion-coefficient validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `MJ` values before
+   - Reject non-finite model-card `FC` values outside `[0, 1)` before
      lowering MOS elements into engine parameters.
-   - Preserve zero and positive bulk-junction grading coefficients.
+   - Preserve values at the inclusive lower boundary and below the exclusive
+     upper boundary.
 
 ## Completed Slices
 
@@ -3971,6 +3972,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Zero, negative, and non-finite model-card `PB` values are rejected before
      lowering MOS elements into engine parameters.
    - Positive explicit bulk-junction potentials remain accepted.
+
+343. Rust Berkeley SPICE MOS model-card bulk-junction-grading validation.
+   - Status: completed in PR 9487.
+   - Negative and non-finite model-card `MJ` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive bulk-junction grading coefficients remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-finite MOS model-card `FC` values outside `[0, 1)` in the Rust Berkeley parser facade
- preserve values at the inclusive lower and below the exclusive upper boundary
- reconcile the SPICE completion plan after PR #9487

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's depletion-coefficient semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.