### PR TITLE
fix(spice): validate MOS sidewall grading

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `MJSW` values before
+  lowering netlist elements into the engine.
 - Reject non-finite Level-1 MOS model-card `FC` values outside `[0, 1)` before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `MJ` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1901,6 +1901,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(sidewall_grading_coefficient) = params.get("MJSW") {
+            if !sidewall_grading_coefficient.is_finite() || *sidewall_grading_coefficient < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET MJSW must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1832,6 +1832,38 @@ fn preserves_mosfet_model_depletion_coefficient_in_range() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_sidewall_grading_coefficient() {
+    for grading_coefficient in ["-0.3", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model sidewall NMOS(MJSW={grading_coefficient})\nM1 d g s b sidewall"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET MJSW must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_sidewall_grading_coefficient() {
+    for grading_coefficient in ["0", "0.3"] {
+        let parsed = parse_netlist(&format!(
+            ".model sidewall NMOS(MJSW={grading_coefficient})\nM1 d g s b sidewall"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(
+            mosfet.params.sidewall_junction_grading_coefficient,
+            grading_coefficient.parse().unwrap(),
+        );
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card depletion-coefficient validation.
+1. Rust Berkeley SPICE MOS model-card sidewall-junction-grading validation.
    - Status: current PR completion candidate.
-   - Reject non-finite model-card `FC` values outside `[0, 1)` before
+   - Reject negative and non-finite model-card `MJSW` values before
      lowering MOS elements into engine parameters.
-   - Preserve values at the inclusive lower boundary and below the exclusive
-     upper boundary.
+   - Preserve zero and positive sidewall-junction grading coefficients.
 
 ## Completed Slices
 
@@ -3978,6 +3977,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `MJ` values are rejected before
      lowering MOS elements into engine parameters.
    - Zero and positive bulk-junction grading coefficients remain accepted.
+
+344. Rust Berkeley SPICE MOS model-card depletion-coefficient validation.
+   - Status: completed in PR 9490.
+   - Non-finite model-card `FC` values outside `[0, 1)` are rejected before
+     lowering MOS elements into engine parameters.
+   - Values at the inclusive lower boundary and below the exclusive upper
+     boundary remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `MJSW` values in the Rust Berkeley parser facade
- preserve zero and positive sidewall-junction grading coefficients
- reconcile the SPICE completion plan after PR #9490

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
This is a Rust parser-facade validation slice. The shared engine's sidewall-grading semantics and tests are already aligned across Rust, Python, and TypeScript, so no Python or TypeScript package behavior changes are required.