### PR TITLE
feat(adj): bind provenance bundles to input bytes

### DIFF
--- a/code/scripts/adj_stdlib_manifest.py
+++ b/code/scripts/adj_stdlib_manifest.py
@@ -79,6 +79,16 @@ def load_provenance_bundles(
             digest: adj_stdlib_provenance._json_object(cas, digest, "provenance_bundle")
             for digest in manifest["bundle_hashes"]
         }
+        for digest, bundle in bundles.items():
+            library_path = root / bundle["library"]
+            library_bytes = adj_stdlib_provenance._read_regular_file(library_path)
+            if (
+                adj_stdlib_provenance.sha256_bytes(library_bytes)
+                != bundle["input"]["raw_source_sha256"]
+            ):
+                raise adj_stdlib_provenance.ProvenanceError(
+                    f"bundle {digest} input bytes disagree with {bundle['library']}"
+                )
     except (
         OSError,
         UnicodeDecodeError,

--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -30,6 +30,7 @@ MAX_OBJECT_BYTES = 64 * 1024 * 1024
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 OBJECT_KINDS = {
     "fetch_receipt",
+    "input_receipt",
     "provenance_bundle",
     "raw_source",
     "rendered_text",
@@ -344,6 +345,46 @@ def build_fetch_receipt(
     }
 
 
+def _require_repo_path(value: Any, field: str) -> str:
+    repo_path = _require_nonempty(value, field)
+    path = PurePosixPath(repo_path)
+    if path.is_absolute() or ".." in path.parts or path.as_posix() != repo_path:
+        raise ProvenanceError(f"{field} must be a normalized repository-relative path")
+    return repo_path
+
+
+def git_blob_sha1(data: bytes) -> str:
+    header = f"blob {len(data)}\0".encode("ascii")
+    return hashlib.sha1(header + data, usedforsecurity=False).hexdigest()
+
+
+def build_input_receipt(
+    *,
+    repo_path: str,
+    captured_at: str,
+    body_sha256: str,
+    body_size: int,
+    body_git_sha1: str,
+) -> dict[str, Any]:
+    _require_repo_path(repo_path, "receipt.repo_path")
+    _require_utc_timestamp(captured_at, "receipt.captured_at")
+    _require_hash(body_sha256, "receipt.body_sha256")
+    if not _is_integer(body_size) or body_size < 0 or body_size > MAX_OBJECT_BYTES:
+        raise ProvenanceError("receipt.body_size is outside the supported range")
+    if not isinstance(body_git_sha1, str) or not re.fullmatch(
+        r"[0-9a-f]{40}", body_git_sha1
+    ):
+        raise ProvenanceError("receipt.body_git_sha1 must be a lowercase Git SHA-1")
+    return {
+        "body_git_sha1": body_git_sha1,
+        "body_sha256": body_sha256,
+        "body_size": body_size,
+        "captured_at": captured_at,
+        "kind": "input_receipt",
+        "repo_path": repo_path,
+    }
+
+
 def _validate_claim(
     claim: Any, source: bytes, segment_start: int, segment_end: int
 ) -> None:
@@ -645,6 +686,7 @@ def _validate_cas_schemas(schema_path: Path, cas: Cas) -> None:
     definitions = schema.get("$defs", {})
     schema_kinds = {
         "fetch_receipt",
+        "input_receipt",
         "provenance_bundle",
         "source_ir",
         "text_transform",
@@ -732,29 +774,50 @@ def _validate_source_entry(
     if cas.index[raw_hash]["links"]:
         raise ProvenanceError(f"{prefix} raw source must not carry graph links")
     raw = _read_regular_file(cas.object_path(raw_hash))
-    receipt = _json_object(cas, receipt_hash, "fetch_receipt")
-    normalized_receipt = build_fetch_receipt(
-        locator=receipt.get("locator"),
-        final_locator=receipt.get("final_locator"),
-        retrieved_at=receipt.get("retrieved_at"),
-        status=receipt.get("status"),
-        media_type=receipt.get("media_type"),
-        body_sha256=receipt.get("body_sha256"),
-        body_size=receipt.get("body_size"),
-        headers=receipt.get("headers"),
-    )
+    receipt_kinds = set(cas.index.get(receipt_hash, {}).get("kinds", []))
+    if "fetch_receipt" in receipt_kinds:
+        receipt = _json_object(cas, receipt_hash, "fetch_receipt")
+        normalized_receipt = build_fetch_receipt(
+            locator=receipt.get("locator"),
+            final_locator=receipt.get("final_locator"),
+            retrieved_at=receipt.get("retrieved_at"),
+            status=receipt.get("status"),
+            media_type=receipt.get("media_type"),
+            body_sha256=receipt.get("body_sha256"),
+            body_size=receipt.get("body_size"),
+            headers=receipt.get("headers"),
+        )
+        if not 200 <= receipt["status"] <= 299:
+            raise ProvenanceError(
+                f"{prefix} unsuccessful receipt cannot ground a bundle"
+            )
+        is_external_authority = True
+    elif "input_receipt" in receipt_kinds:
+        receipt = _json_object(cas, receipt_hash, "input_receipt")
+        normalized_receipt = build_input_receipt(
+            repo_path=receipt.get("repo_path"),
+            captured_at=receipt.get("captured_at"),
+            body_sha256=receipt.get("body_sha256"),
+            body_size=receipt.get("body_size"),
+            body_git_sha1=receipt.get("body_git_sha1"),
+        )
+        if receipt["body_git_sha1"] != git_blob_sha1(raw):
+            raise ProvenanceError(
+                f"{prefix} input receipt has the wrong Git blob SHA-1"
+            )
+        is_external_authority = False
+    else:
+        raise ProvenanceError(f"{prefix} receipt has an unsupported kind")
     if receipt != normalized_receipt:
         raise ProvenanceError(f"{prefix} receipt has unknown or inconsistent fields")
     if receipt["body_sha256"] != raw_hash or receipt["body_size"] != len(raw):
         raise ProvenanceError(f"{prefix} receipt does not identify its exact raw bytes")
-    if not 200 <= receipt["status"] <= 299:
-        raise ProvenanceError(f"{prefix} unsuccessful receipt cannot ground a bundle")
     if cas.index[receipt_hash]["links"] != [raw_hash]:
         raise ProvenanceError(f"{prefix} receipt must link only to its raw bytes")
     raw_ir = _validate_source_ir(cas, ir_hash, raw_hash)
     raw_claims = _claims_by_id(raw_ir)
     claims = {ir_hash: raw_claims}
-    authorities = {raw_hash: (raw_hash, receipt_hash)}
+    authorities = {raw_hash: (raw_hash, receipt_hash)} if is_external_authority else {}
     links = {raw_hash, receipt_hash, ir_hash}
     representations = source["representations"]
     if not isinstance(representations, list):
@@ -837,7 +900,8 @@ def _validate_source_entry(
                     f"{item_prefix} transform leaves claim {claim_id} bytes unmapped"
                 )
         claims[text_ir_hash] = text_claims
-        authorities[text_hash] = (raw_hash, receipt_hash)
+        if is_external_authority:
+            authorities[text_hash] = (raw_hash, receipt_hash)
         links.update((text_hash, text_ir_hash, transform_hash))
     return links, claims, authorities
 
@@ -850,6 +914,7 @@ def _validate_bundle(
     validated: set[str],
     snapshots: set[str],
     bundle_claims: dict[str, set[str]],
+    bundle_inputs: dict[str, str],
 ) -> None:
     if digest in validated:
         return
@@ -861,6 +926,7 @@ def _validate_bundle(
         "bundle_id",
         "clauses",
         "dependencies",
+        "input",
         "kind",
         "library",
         "sources",
@@ -882,6 +948,7 @@ def _validate_bundle(
             validated=validated,
             snapshots=snapshots,
             bundle_claims=bundle_claims,
+            bundle_inputs=bundle_inputs,
         )
     sources = bundle["sources"]
     if not isinstance(sources, list) or not sources:
@@ -889,11 +956,20 @@ def _validate_bundle(
     expected_links: set[str] = set(dependencies)
     claims: dict[str, dict[str, dict[str, Any]]] = {}
     authorities: dict[str, tuple[str, str]] = {}
+    source_identities: set[tuple[str, str, str]] = set()
+    source_by_identity: dict[tuple[str, str, str], dict[str, Any]] = {}
     for index, source in enumerate(sources):
         links, source_claims, source_authorities = _validate_source_entry(
             cas, source, f"bundle.sources[{index}]"
         )
         expected_links.update(links)
+        identity = (
+            source["raw_source_sha256"],
+            source["receipt_sha256"],
+            source["source_ir_sha256"],
+        )
+        source_identities.add(identity)
+        source_by_identity[identity] = source
         for ir_hash, ir_claims in source_claims.items():
             if ir_hash in claims:
                 raise ProvenanceError(f"bundle {digest} repeats source IR {ir_hash}")
@@ -904,6 +980,40 @@ def _validate_bundle(
                     f"bundle {digest} gives snapshot {snapshot_hash} conflicting authorities"
                 )
             authorities[snapshot_hash] = authority
+    input_binding = bundle["input"]
+    if not isinstance(input_binding, dict) or set(input_binding) != {
+        "raw_source_sha256",
+        "receipt_sha256",
+        "source_ir_sha256",
+    }:
+        raise ProvenanceError(f"bundle {digest} input must have the exact schema")
+    input_identity = (
+        _require_hash(
+            input_binding["raw_source_sha256"], "bundle.input.raw_source_sha256"
+        ),
+        _require_hash(input_binding["receipt_sha256"], "bundle.input.receipt_sha256"),
+        _require_hash(
+            input_binding["source_ir_sha256"], "bundle.input.source_ir_sha256"
+        ),
+    )
+    if input_identity not in source_identities:
+        raise ProvenanceError(f"bundle {digest} input is absent from its source graph")
+    if source_by_identity[input_identity]["representations"]:
+        raise ProvenanceError(f"bundle {digest} input must use its exact raw bytes")
+    input_raw_hash, input_receipt_hash, input_ir_hash = input_identity
+    input_receipt = _json_object(cas, input_receipt_hash, "input_receipt")
+    if input_receipt["repo_path"] != bundle["library"]:
+        raise ProvenanceError(f"bundle {digest} input path disagrees with its library")
+    if cas.index[input_ir_hash]["links"] != [input_raw_hash]:
+        raise ProvenanceError(
+            f"bundle {digest} input IR does not describe its input bytes"
+        )
+    prior_input = bundle_inputs.get(bundle["library"])
+    if prior_input is not None and prior_input != input_raw_hash:
+        raise ProvenanceError(
+            f"bundles disagree on input bytes for {bundle['library']}"
+        )
+    bundle_inputs[bundle["library"]] = input_raw_hash
     clauses = bundle["clauses"]
     if not isinstance(clauses, list) or not clauses:
         raise ProvenanceError(f"bundle {digest} must contain clauses")
@@ -913,6 +1023,7 @@ def _validate_bundle(
         if not isinstance(clause, dict) or set(clause) != {
             "claim_id",
             "end",
+            "input_claim",
             "quote",
             "quote_sha256",
             "resolution",
@@ -940,6 +1051,24 @@ def _validate_bundle(
         }
         if expected_claim != clause_claim:
             raise ProvenanceError(f"{prefix} disagrees with its byte-verified IR claim")
+        input_claim = clause["input_claim"]
+        if not isinstance(input_claim, dict) or set(input_claim) != {
+            "end",
+            "quote",
+            "quote_sha256",
+            "start",
+        }:
+            raise ProvenanceError(f"{prefix}.input_claim has the wrong schema")
+        expected_input_claim = claims.get(input_ir_hash, {}).get(claim_id)
+        normalized_input_claim = (
+            {key: expected_input_claim[key] for key in input_claim}
+            if expected_input_claim is not None
+            else None
+        )
+        if input_claim != normalized_input_claim:
+            raise ProvenanceError(
+                f"{prefix} input claim disagrees with the decomposed ADJ bytes"
+            )
         resolution = clause["resolution"]
         if not isinstance(resolution, dict):
             raise ProvenanceError(f"{prefix}.resolution must be an object")
@@ -1011,7 +1140,10 @@ def _validate_bundle(
 
 
 def validate_repository(
-    cas_root: Path, manifest_path: Path, schema_path: Path | None = None
+    cas_root: Path,
+    manifest_path: Path,
+    schema_path: Path | None = None,
+    workspace_root: Path | None = None,
 ) -> dict[str, Any]:
     cas = Cas(cas_root)
     cas.load()
@@ -1036,6 +1168,7 @@ def validate_repository(
     snapshots: set[str] = set()
     validated: set[str] = set()
     bundle_claims: dict[str, set[str]] = {}
+    bundle_inputs: dict[str, str] = {}
     for bundle in bundles:
         _validate_bundle(
             cas,
@@ -1044,7 +1177,17 @@ def validate_repository(
             validated=validated,
             snapshots=snapshots,
             bundle_claims=bundle_claims,
+            bundle_inputs=bundle_inputs,
         )
+    effective_workspace_root = workspace_root or manifest_path.parent
+    for repo_path, expected_hash in sorted(bundle_inputs.items()):
+        input_bytes = _read_regular_file(
+            effective_workspace_root / PurePosixPath(repo_path)
+        )
+        if sha256_bytes(input_bytes) != expected_hash:
+            raise ProvenanceError(
+                f"workspace input bytes disagree with bundle for {repo_path}"
+            )
     reachable = _reachable(cas, bundles)
     unreferenced = sorted(set(cas.index) - reachable)
     if unreferenced:
@@ -1063,8 +1206,11 @@ def project_snapshots(
     manifest_path: Path,
     output: Path,
     schema_path: Path | None = None,
+    workspace_root: Path | None = None,
 ) -> dict[str, Any]:
-    result = validate_repository(cas_root, manifest_path, schema_path)
+    result = validate_repository(
+        cas_root, manifest_path, schema_path, workspace_root=workspace_root
+    )
     cas = Cas(cas_root)
     cas.load()
     _ensure_real_directory(output)
@@ -1156,6 +1302,13 @@ def main() -> int:
     capture_parser.add_argument("--headers", type=Path)
     capture_parser.add_argument("--label", required=True)
 
+    input_parser = subparsers.add_parser("capture-input")
+    input_parser.add_argument("--cas", type=Path, default=DEFAULT_ROOT)
+    input_parser.add_argument("--body", type=Path, required=True)
+    input_parser.add_argument("--repo-path", required=True)
+    input_parser.add_argument("--captured-at", required=True)
+    input_parser.add_argument("--label", required=True)
+
     rendered_parser = subparsers.add_parser("put-rendered")
     rendered_parser.add_argument("--cas", type=Path, default=DEFAULT_ROOT)
     rendered_parser.add_argument("--source", required=True)
@@ -1188,6 +1341,7 @@ def main() -> int:
                 _resolve(repo_root, args.cas),
                 _resolve(repo_root, args.manifest),
                 _resolve(repo_root, args.schema),
+                workspace_root=repo_root,
             )
         elif args.command == "project":
             result = project_snapshots(
@@ -1195,6 +1349,7 @@ def main() -> int:
                 _resolve(repo_root, args.manifest),
                 _resolve(repo_root, args.output),
                 _resolve(repo_root, args.schema),
+                workspace_root=repo_root,
             )
         elif args.command == "capture":
             cas = Cas(_resolve(repo_root, args.cas))
@@ -1219,6 +1374,33 @@ def main() -> int:
                 receipt,
                 kind="fetch_receipt",
                 label=f"fetch receipt: {args.label}",
+                links=[raw_hash],
+            )
+            cas.write_index()
+            result = {"raw_source_sha256": raw_hash, "receipt_sha256": receipt_hash}
+        elif args.command == "capture-input":
+            cas = Cas(_resolve(repo_root, args.cas))
+            cas.load()
+            repo_path = _require_repo_path(args.repo_path, "receipt.repo_path")
+            body_path = _resolve(repo_root, args.body)
+            expected_path = repo_root / PurePosixPath(repo_path)
+            if os.path.abspath(body_path) != os.path.abspath(expected_path):
+                raise ProvenanceError(
+                    "capture-input body must be the file named by --repo-path"
+                )
+            body = _read_regular_file(body_path)
+            raw_hash = cas.put(body, kind="raw_source", label=args.label)
+            receipt = build_input_receipt(
+                repo_path=repo_path,
+                captured_at=args.captured_at,
+                body_sha256=raw_hash,
+                body_size=len(body),
+                body_git_sha1=git_blob_sha1(body),
+            )
+            receipt_hash = cas.put_json(
+                receipt,
+                kind="input_receipt",
+                label=f"input receipt: {args.label}",
                 links=[raw_hash],
             )
             cas.write_index()

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -132,6 +132,56 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             label="fixture text transform",
             links=[raw_hash, rendered_hash],
         )
+        input_body = b"formula sum(a, b) = a + b\n"
+        input_path = root / "code/example/arithmetic.adj"
+        input_path.parent.mkdir(parents=True)
+        input_path.write_bytes(input_body)
+        input_hash = cas.put(input_body, kind="raw_source", label="fixture ADJ input")
+        input_receipt = provenance.build_input_receipt(
+            repo_path="code/example/arithmetic.adj",
+            captured_at="2026-08-02T12:00:00Z",
+            body_sha256=input_hash,
+            body_size=len(input_body),
+            body_git_sha1=provenance.git_blob_sha1(input_body),
+        )
+        input_receipt_hash = cas.put_json(
+            input_receipt,
+            kind="input_receipt",
+            label="fixture input receipt",
+            links=[input_hash],
+        )
+        input_ir = provenance.build_source_ir(
+            source_sha256=input_hash,
+            source=input_body,
+            segments=[
+                {
+                    "claims": [
+                        {
+                            "claim_id": claim_id,
+                            "end": len(input_body),
+                            "quote": input_body.decode("utf-8"),
+                            "quote_sha256": provenance.sha256_bytes(input_body),
+                            "start": 0,
+                        }
+                    ],
+                    "disposition": "represented",
+                    "end": len(input_body),
+                    "start": 0,
+                }
+            ],
+        )
+        input_ir_hash = cas.put_json(
+            input_ir,
+            kind="source_ir",
+            label="fixture input IR",
+            links=[input_hash],
+        )
+        input_source_entry = {
+            "raw_source_sha256": input_hash,
+            "receipt_sha256": input_receipt_hash,
+            "representations": [],
+            "source_ir_sha256": input_ir_hash,
+        }
         source_entry = {
             "raw_source_sha256": raw_hash,
             "receipt_sha256": receipt_hash,
@@ -147,6 +197,12 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         clause = {
             "claim_id": claim_id,
             "end": len(rendered),
+            "input_claim": {
+                "end": len(input_body),
+                "quote": input_body.decode("utf-8"),
+                "quote_sha256": provenance.sha256_bytes(input_body),
+                "start": 0,
+            },
             "quote": rendered.decode("utf-8"),
             "quote_sha256": provenance.sha256_bytes(rendered),
             "resolution": {
@@ -164,9 +220,14 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             "bundle_id": "test.arithmetic.v1",
             "clauses": [clause],
             "dependencies": [],
+            "input": {
+                "raw_source_sha256": input_hash,
+                "receipt_sha256": input_receipt_hash,
+                "source_ir_sha256": input_ir_hash,
+            },
             "kind": "provenance_bundle",
-            "library": "arithmetic.adj",
-            "sources": [source_entry],
+            "library": "code/example/arithmetic.adj",
+            "sources": [source_entry, input_source_entry],
         }
         bundle_hash = cas.put_json(
             bundle,
@@ -191,6 +252,9 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 "rendered_ir": rendered_ir_hash,
                 "receipt": receipt_hash,
                 "ir": ir_hash,
+                "input": input_hash,
+                "input_ir": input_ir_hash,
+                "input_receipt": input_receipt_hash,
                 "bundle": bundle_hash,
                 "transform": transform_hash,
                 "snapshot": rendered_hash,
@@ -233,7 +297,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             )
 
             self.assertEqual(result["bundles"], 1)
-            self.assertEqual(result["objects"], 7)
+            self.assertEqual(result["objects"], 10)
             self.assertEqual(result["snapshots"], 1)
             self.assertTrue(result["valid"])
             self.assertEqual(projected["projected"], 1)
@@ -530,6 +594,25 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 headers={"Set-Cookie": "secret=1"},
             )
 
+    def test_input_receipt_pins_repo_path_and_git_blob(self) -> None:
+        body = b"formula sum(a, b) = a + b\n"
+        receipt = provenance.build_input_receipt(
+            repo_path="code/example.adj",
+            captured_at="2026-08-02T12:00:00Z",
+            body_sha256=provenance.sha256_bytes(body),
+            body_size=len(body),
+            body_git_sha1=provenance.git_blob_sha1(body),
+        )
+        self.assertEqual(receipt["body_git_sha1"], provenance.git_blob_sha1(body))
+        with self.assertRaisesRegex(provenance.ProvenanceError, "repository-relative"):
+            provenance.build_input_receipt(
+                repo_path="../outside.adj",
+                captured_at="2026-08-02T12:00:00Z",
+                body_sha256=provenance.sha256_bytes(body),
+                body_size=len(body),
+                body_git_sha1=provenance.git_blob_sha1(body),
+            )
+
     def test_receipt_and_ir_must_link_the_same_raw_bytes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -542,6 +625,41 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             with self.assertRaisesRegex(
                 provenance.ProvenanceError, "receipt must link"
             ):
+                provenance.validate_repository(cas_root, manifest_path)
+
+    def test_bundle_requires_matching_decomposed_input_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, _ = self.build_repository(root)
+
+            def mutate(bundle: dict[str, object], cas: provenance.Cas) -> None:
+                source = bundle["sources"][1]
+                input_hash = source["raw_source_sha256"]
+                body = provenance._read_regular_file(cas.object_path(input_hash))
+                empty_ir = provenance.build_source_ir(
+                    source_sha256=input_hash,
+                    source=body,
+                    segments=[
+                        {
+                            "disposition": "discarded",
+                            "end": len(body),
+                            "reason": "incorrectly omitted code claim",
+                            "start": 0,
+                        }
+                    ],
+                )
+                empty_ir_hash = cas.put_json(
+                    empty_ir,
+                    kind="source_ir",
+                    label="empty input IR",
+                    links=[input_hash],
+                )
+                source["source_ir_sha256"] = empty_ir_hash
+                bundle["input"]["source_ir_sha256"] = empty_ir_hash
+
+            self.replace_bundle(cas_root, manifest_path, mutate)
+
+            with self.assertRaisesRegex(provenance.ProvenanceError, "input claim"):
                 provenance.validate_repository(cas_root, manifest_path)
 
     def test_unreferenced_objects_fail_complete_graph_accounting(self) -> None:

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -260,6 +260,9 @@ option mapping, or judge/evaluation failure.
    metadata. CI rehashes every object and checks bundle reachability, exact claim
    slices and quote hashes, deterministic text transforms, and complete
    represented/discarded byte partitions.
+7a. **Complete:** add first-class repository-input receipts and require every
+    provenance bundle clause to bind its decomposed ADJ source bytes as well as
+    its external grounding bytes. Code is evidence and must not bypass IR.
 8. Replace the dead MathWorld `PercentageChange` locator before migrating
    `percent.adj`; a source returning 404 cannot ground that clause.
 

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -11,6 +11,9 @@ It starts empty and grows only through reviewed source migrations.
 - A `fetch_receipt` is a content-addressed object, not mutable metadata. It binds
   an HTTPS locator, retrieval time, status, media type, safe response headers,
   and exact response-body hash.
+- An `input_receipt` binds a normalized repository path to exact SHA-256 and Git
+  blob identities. The input bytes receive the same complete source IR as any
+  fetched source.
 - A `source_ir` partitions every source byte contiguously. Each represented claim
   records its exact byte range, UTF-8 quote, and quote hash; every discarded range
   has a non-empty reason.
@@ -22,6 +25,8 @@ It starts empty and grows only through reviewed source migrations.
   Dependency decisions name the exact exported claim. Accepted roots classify
   the terminal fact, law, definition, or measurement and pin its raw source and
   successful receipt.
+  Every clause must also exist in the bundle's designated ADJ input IR, so code
+  cannot bypass decomposition while its external citations are checked.
 - `manifest.json` pins bundle hashes. Only snapshots reachable from verified
   bundle clauses may be projected for `adj-verify`.
 
@@ -30,6 +35,7 @@ to a file and passes that file plus its receipt facts to the offline CAS tool:
 
 ```text
 python code/scripts/adj_stdlib_provenance.py capture ...
+python code/scripts/adj_stdlib_provenance.py capture-input ...
 python code/scripts/adj_stdlib_provenance.py put-rendered ...
 python code/scripts/adj_stdlib_provenance.py put-ir ...
 python code/scripts/adj_stdlib_provenance.py put-transform ...

--- a/code/specs/data/adj-stdlib-provenance/manifest.schema.json
+++ b/code/specs/data/adj-stdlib-provenance/manifest.schema.json
@@ -17,6 +17,17 @@
       "properties": {
         "claim_id": { "minLength": 1, "type": "string" },
         "end": { "minimum": 1, "type": "integer" },
+        "input_claim": {
+          "additionalProperties": false,
+          "properties": {
+            "end": { "minimum": 1, "type": "integer" },
+            "quote": { "minLength": 1, "type": "string" },
+            "quote_sha256": { "$ref": "#/$defs/hash" },
+            "start": { "minimum": 0, "type": "integer" }
+          },
+          "required": ["end", "quote", "quote_sha256", "start"],
+          "type": "object"
+        },
         "quote": { "minLength": 1, "type": "string" },
         "quote_sha256": { "$ref": "#/$defs/hash" },
         "resolution": {
@@ -49,7 +60,7 @@
         "source_ir_sha256": { "$ref": "#/$defs/hash" },
         "start": { "minimum": 0, "type": "integer" }
       },
-      "required": ["claim_id", "end", "quote", "quote_sha256", "resolution", "snapshot_sha256", "source_ir_sha256", "start"],
+      "required": ["claim_id", "end", "input_claim", "quote", "quote_sha256", "resolution", "snapshot_sha256", "source_ir_sha256", "start"],
       "type": "object"
     },
     "fetch_receipt": {
@@ -69,6 +80,19 @@
       "type": "object"
     },
     "hash": { "pattern": "^[0-9a-f]{64}$", "type": "string" },
+    "input_receipt": {
+      "additionalProperties": false,
+      "properties": {
+        "body_git_sha1": { "pattern": "^[0-9a-f]{40}$", "type": "string" },
+        "body_sha256": { "$ref": "#/$defs/hash" },
+        "body_size": { "maximum": 67108864, "minimum": 0, "type": "integer" },
+        "captured_at": { "format": "date-time", "type": "string" },
+        "kind": { "const": "input_receipt" },
+        "repo_path": { "minLength": 1, "type": "string" }
+      },
+      "required": ["body_git_sha1", "body_sha256", "body_size", "captured_at", "kind", "repo_path"],
+      "type": "object"
+    },
     "operation": {
       "additionalProperties": false,
       "properties": {
@@ -87,11 +111,12 @@
         "bundle_id": { "minLength": 1, "type": "string" },
         "clauses": { "items": { "$ref": "#/$defs/clause" }, "minItems": 1, "type": "array" },
         "dependencies": { "items": { "$ref": "#/$defs/hash" }, "type": "array", "uniqueItems": true },
+        "input": { "$ref": "#/$defs/source_binding" },
         "kind": { "const": "provenance_bundle" },
         "library": { "minLength": 1, "type": "string" },
         "sources": { "items": { "$ref": "#/$defs/source" }, "minItems": 1, "type": "array" }
       },
-      "required": ["bundle_id", "clauses", "dependencies", "kind", "library", "sources"],
+      "required": ["bundle_id", "clauses", "dependencies", "input", "kind", "library", "sources"],
       "type": "object"
     },
     "representation": {
@@ -139,6 +164,16 @@
         "source_ir_sha256": { "$ref": "#/$defs/hash" }
       },
       "required": ["raw_source_sha256", "receipt_sha256", "representations", "source_ir_sha256"],
+      "type": "object"
+    },
+    "source_binding": {
+      "additionalProperties": false,
+      "properties": {
+        "raw_source_sha256": { "$ref": "#/$defs/hash" },
+        "receipt_sha256": { "$ref": "#/$defs/hash" },
+        "source_ir_sha256": { "$ref": "#/$defs/hash" }
+      },
+      "required": ["raw_source_sha256", "receipt_sha256", "source_ir_sha256"],
       "type": "object"
     },
     "source_ir": {


### PR DESCRIPTION
## Summary
- add content-addressed repository-input receipts with normalized paths, SHA-256, size, and Git blob identity
- require every provenance bundle to designate exact raw ADJ input bytes and a complete input IR
- bind each externally grounded clause to an exact code-side quote, byte range, and quote hash
- make offline verification reread the checked-out library and reject path/body substitution

## Validation
- provenance tests: 24 passed, 1 symlink test skipped on Windows
- curriculum manifest tests: 9 passed
- reporter tests: 8 passed
- offline provenance and curriculum validators passed
- Ruff and `git diff --check` passed

## Review
An independent adversarial review found no remaining P1/P2 substitution blocker after the workspace-byte and exact input-claim checks were added.