### PR TITLE
fix(build-tool): enforce UTF-8 Lua metadata

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9495,
   "last_inventory": {
     "revision": "6a59699f5ff6ee6453bfc0dd11efe210aaad7c54",
     "schema_version": 3,
@@ -325,11 +325,11 @@
     {
       "id": "build-tool-lua-rockspec-encoding",
       "title": "Make Python build-tool Lua metadata decoding deterministic",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-pure-domain-corpus"],
       "branch": "codex/build-tool-lua-rockspec-encoding",
-      "pr_number": null,
-      "notes": "Discovered while validating the Dart document-ast slice. The Python build tool discovers 4,763 packages, then its Lua resolver aborts before diff selection because _parse_lua_deps exposes a raw UnicodeDecodeError. This slice defines positive and adversarial language-neutral rockspec UTF-8 fixtures, normalizes the only three invalid repository rockspecs, and makes Python fail closed with METADATA_INVALID_UTF8, package/manifest identity, and CLI exit 2 without host paths or silent replacement."
+      "pr_number": 9495,
+      "notes": "Discovered while validating the Dart document-ast slice. The Python build tool discovers 4,763 packages, then its Lua resolver aborts before diff selection because _parse_lua_deps exposes a raw UnicodeDecodeError. This slice defines positive and adversarial language-neutral rockspec UTF-8 fixtures, normalizes the only three invalid repository rockspecs, and makes Python fail closed with METADATA_INVALID_UTF8, package/manifest identity, and CLI exit 2 without host paths or silent replacement. Ready-for-review PR #9495 is open from the dedicated parity branch; final-base local validation includes 50 focused resolver/CLI tests, 57 conformance tests plus 52 subtests, the 32-case corpus, a 4,765-package/7,100-edge full plan, strict UTF-8 across all 246 rockspecs, and a collision-clean 1,217-identity inventory."
     },
     {
       "id": "build-tool-rockspec-utf8-remaining-engines",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9485,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "f42c8218afee1c63551ff987bdf1d76e007ae12e",
+    "revision": "6a59699f5ff6ee6453bfc0dd11efe210aaad7c54",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1216,
-    "implementation_package_slots": 4363,
+    "implementation_identities": 1217,
+    "implementation_package_slots": 4365,
     "high_consensus_packages": 172,
-    "high_consensus_missing_slots": 272,
-    "singleton_packages": 766,
-    "singleton_missing_slots": 10724,
-    "rust_singletons": 571,
+    "high_consensus_missing_slots": 271,
+    "singleton_packages": 767,
+    "singleton_missing_slots": 10738,
+    "rust_singletons": 572,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -311,16 +311,52 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The rebased Go oracle full dry-run currently reports 73 pre-existing validation gaps: 12 Python, 3 Swift, and 58 TypeScript. Deliver dependency-shaped waves and preserve the broader July 29 audit queue for Perl, Dart, Kotlin, and related packages."
+      "notes": "The rebased Go oracle full dry-run reports 73 pre-existing validation gaps: 12 Python, 3 Swift, and 58 TypeScript. The Python validator separately reports 10 Lua BUILD_windows gaps, now materialized as a child wave. Deliver dependency-shaped waves and preserve the broader July 29 audit queue for Perl, Dart, Kotlin, and related packages."
+    },
+    {
+      "id": "build-file-standalone-integrity-lua",
+      "title": "Repair the Lua BUILD_windows standalone prerequisite wave",
+      "status": "pending",
+      "depends_on": ["build-file-standalone-integrity"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized during Python build-tool validation after the rockspec encoding repair. Ten pre-existing Lua BUILD_windows files omit sibling installs present in BUILD: brainfuck_ir_compiler, brainfuck_wasm_compiler, correlation_vector, ir_to_wasm_compiler, ir_to_wasm_validator, json_serializer, ls00, qr-code, wasm_module_encoder, and zstd. Repair these as one dependency-shaped standalone-build wave; the current metadata-only slice does not alter BUILD files."
     },
     {
       "id": "build-tool-lua-rockspec-encoding",
       "title": "Make Python build-tool Lua metadata decoding deterministic",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-pure-domain-corpus"],
+      "branch": "codex/build-tool-lua-rockspec-encoding",
+      "pr_number": null,
+      "notes": "Discovered while validating the Dart document-ast slice. The Python build tool discovers 4,763 packages, then its Lua resolver aborts before diff selection because _parse_lua_deps exposes a raw UnicodeDecodeError. This slice defines positive and adversarial language-neutral rockspec UTF-8 fixtures, normalizes the only three invalid repository rockspecs, and makes Python fail closed with METADATA_INVALID_UTF8, package/manifest identity, and CLI exit 2 without host paths or silent replacement."
+    },
+    {
+      "id": "build-tool-rockspec-utf8-remaining-engines",
+      "title": "Make every remaining build-tool engine pass the rockspec UTF-8 contract",
+      "status": "pending",
+      "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered while validating the Dart document-ast slice. The Python build tool discovers 4,763 packages, then its Lua resolver aborts before diff selection because _parse_lua_deps unconditionally decodes repository rockspecs as UTF-8. Exactly three files contain byte 0x97: lua/block_ram and lua/tree at offset 208, and lua/trig at offset 218. Classify and normalize those metadata bytes or define a fail-closed diagnostic contract with fixtures, then repair the Python resolver without silent replacement. Targeted plan-mode validation and the package BUILD files remain green."
+      "notes": "Discovered by the Python encoding-blocker audit. Rust and Swift silently drop invalid rockspec dependencies; TypeScript replaces invalid bytes; Go, Lua, and Perl accept them; Ruby and Haskell use locale-sensitive text decoding; Elixir is position-dependent. Remediate those nine engines against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
+    },
+    {
+      "id": "build-tool-python-haskell-language-filter",
+      "title": "Expose Haskell in the Python build-tool language filter",
+      "status": "pending",
+      "depends_on": ["build-tool-lua-rockspec-encoding"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while validating the full Python build-tool scan. ALL_LANGUAGES and the resolver include Haskell, but argparse omits it from --language choices, so users cannot select the established Haskell lane even though all-language mode discovers it. Add the focused CLI contract and regression test in a separate build-tool parity slice."
+    },
+    {
+      "id": "build-tool-python-plan-atomic-overwrite-windows",
+      "title": "Make Python build-plan replacement atomic on Windows",
+      "status": "pending",
+      "depends_on": ["build-tool-lua-rockspec-encoding"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the post-rebase full-scan validation. Re-emitting to an existing plan path leaves the temporary file and fails with WinError 183 because write_plan renames instead of replacing atomically on Windows. Add a repeated-write fixture and use a portable atomic replacement primitive in a separate build-tool parity slice. A fresh unique output path succeeds with 4,764 packages and 7,093 dependency edges."
     },
     {
       "id": "build-tool-go-oracle",
@@ -679,7 +715,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 564, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 572, Python 86, and TypeScript 84; do not port blindly."
     },
     {
       "id": "rust-singletons-20260730-classification",
@@ -832,6 +868,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Extract and fixture deterministic /json/si DTO validation, master and segment projection, stable identifiers, capability-bit interpretation, state normalization, brightness/RGB/mirek conversion, command planning, bounds, and hostile inputs. Expand only this authority-free core through established lanes while mDNS, DNS/TCP, plaintext LAN HTTP, trusted time, console I/O, origin/pairing policy, and SmartHomeRuntime effect application remain in the native Rust host."
+    },
+    {
+      "id": "smart-home-nanoleaf-portable-core-extraction-and-conformance",
+      "title": "Extract, fixture, and expand the portable Nanoleaf local core",
+      "status": "pending",
+      "depends_on": ["smart-home-runtime-command-effect-lifecycle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 3f7531a8 inventory after PR #9486 added the Rust-only Nanoleaf local integration. Extract and fixture deterministic credential syntax and origin-configuration validation without exposing token material, bounded snapshot/state validation, stable identifiers, capability and state normalization, RGB/HSV and mirek conversion, command planning, verification, and hostile inputs. Expand only this authority-free core through established lanes while mDNS, DNS/TCP, LAN HTTP execution, physical-presence pairing, token and Vault handling, trusted time, endpoint approval, CLI I/O, authorization, and SmartHomeRuntime effect application remain in the native Rust host."
     },
     {
       "id": "smart-home-lan-http-native-executor-consolidation",
@@ -1155,11 +1200,11 @@
     {
       "id": "dart-current-14-of-15-document-ast",
       "title": "Port the shared Document AST model to Dart",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["dart-scaffold-capability-schema"],
       "branch": "codex/dart-document-ast-parity",
       "pr_number": 9485,
-      "notes": "Ready-for-review PR #9485. Selected after merged PR #9477 because TE00 is a zero-dependency, types-only, empty-capability foundation with 68 exact cross-repository consumers. Delivers Dart's sealed 24-node Document AST, stable discriminators, typed containment, immutable collections, structural value semantics, exhaustive tests, docs, metadata, and both build files without expanding into downstream parsers. Rebased onto f42c8218a after Sonos #9461 and SPICE #9481; refreshed inventory is collision-clean at 1,216 identities, 4,364 working slots, 271 high-consensus missing slots, 766 singletons, and 571 Rust singletons. Local validation passed format/analyze, 14 randomized tests, 100% production line coverage, no outdated dependencies, both package build files, targeted metadata-validating build-tool dry-run and real build, 21 capability/reporter tests, state/diff hygiene, and an independent no-blocker API/security audit. The separately logged Lua rockspec encoding defect blocks only the unrelated full 4,763-package Python build-tool scan."
+      "notes": "Merged PR #9485 at 892b41a559f61968b1318bea4f56eb8406d17c48 on 2026-08-02. Selected after merged PR #9477 because TE00 is a zero-dependency, types-only, empty-capability foundation with 68 exact cross-repository consumers. Delivers Dart's sealed 24-node Document AST, stable discriminators, typed containment, immutable collections, structural value semantics, exhaustive tests, docs, metadata, and both build files without expanding into downstream parsers. Rebased onto f42c8218a after Sonos #9461 and SPICE #9481; refreshed inventory is collision-clean at 1,216 identities, 4,364 slots, 271 high-consensus missing slots, 766 singletons, and 571 Rust singletons. Local validation passed format/analyze, 14 randomized tests, 100% production line coverage, no outdated dependencies, both package build files, targeted metadata-validating build-tool dry-run and real build, 21 capability/reporter tests, state/diff hygiene, and an independent no-blocker API/security audit. Final-head PR CI passed on Ubuntu, macOS, and Windows; push CI, fixture consumers, and CodeQL all passed in runs 30767408092, 30767406534, and 30767408096. The later build-tool rockspec-encoding slice removes the full-scan blocker that this PR originally discovered."
     },
     {
       "id": "dart-current-14-of-15-atbash-scytale-vigenere",

--- a/code/packages/lua/block_ram/coding-adventures-block-ram-0.1.0-1.rockspec
+++ b/code/packages/lua/block_ram/coding-adventures-block-ram-0.1.0-1.rockspec
@@ -4,7 +4,7 @@ source = {
     url = "git://github.com/adhithyan15/coding-adventures.git",
 }
 description = {
-    summary = "Block RAM memory built from logic gates — addressable read/write storage",
+    summary = "Block RAM memory built from logic gates â€” addressable read/write storage",
     license = "MIT",
 }
 dependencies = {

--- a/code/packages/lua/tree/coding-adventures-tree-0.1.0-1.rockspec
+++ b/code/packages/lua/tree/coding-adventures-tree-0.1.0-1.rockspec
@@ -4,7 +4,7 @@ source = {
     url = "git://github.com/adhithyan15/coding-adventures.git",
 }
 description = {
-    summary = "Tree data structure built on directed graphs — parent-child relationships, traversals",
+    summary = "Tree data structure built on directed graphs â€” parent-child relationships, traversals",
     license = "MIT",
 }
 dependencies = {

--- a/code/packages/lua/trig/coding-adventures-trig-0.1.0-1.rockspec
+++ b/code/packages/lua/trig/coding-adventures-trig-0.1.0-1.rockspec
@@ -4,7 +4,7 @@ source = {
     url = "git://github.com/adhithyan15/coding-adventures.git",
 }
 description = {
-    summary = "Trigonometric functions computed from first principles — sine, cosine, tangent via Taylor series",
+    summary = "Trigonometric functions computed from first principles â€” sine, cosine, tangent via Taylor series",
     license = "MIT",
 }
 dependencies = {

--- a/code/programs/python/build-tool/CHANGELOG.md
+++ b/code/programs/python/build-tool/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2026-08-02
+
+### Fixed
+
+- **Deterministic metadata decoding**: Lua rockspec dependency resolution now
+  requires UTF-8 and returns `METADATA_INVALID_UTF8` with package and manifest
+  identity instead of exposing a host-specific `UnicodeDecodeError` traceback.
+
 ## [0.3.0] - 2026-03-29
 
 ### Added

--- a/code/programs/python/build-tool/README.md
+++ b/code/programs/python/build-tool/README.md
@@ -6,7 +6,7 @@ An incremental, parallel monorepo build tool with hash-based caching.
 
 This CLI program:
 1. Discovers all packages via recursive `BUILD` file walking
-2. Resolves dependencies by parsing pyproject.toml and .gemspec files
+2. Resolves dependencies from each supported ecosystem's package metadata
 3. Builds a directed graph of dependencies
 4. Hashes all source files in each package
 5. Compares hashes against a committed cache file (.build-cache.json)
@@ -39,8 +39,12 @@ build-tool --language python
 
 This is a standalone program (not a library) that orchestrates builds across
 the entire coding-adventures monorepo. It understands the recursive `BUILD`
-discovery convention used throughout the repository and can build Python, Ruby, and Go
-packages.
+discovery convention used throughout the repository and orchestrates every
+language listed by `build-tool --help`.
+
+Lua rockspec metadata is decoded as strict UTF-8. Invalid text fails closed with
+the stable `METADATA_INVALID_UTF8` diagnostic rather than using a host locale or
+silently replacing bytes.
 
 ## Installation
 

--- a/code/programs/python/build-tool/src/build_tool/cli.py
+++ b/code/programs/python/build-tool/src/build_tool/cli.py
@@ -56,7 +56,11 @@ from build_tool.plan import (
     write_plan,
 )
 from build_tool.reporter import print_report
-from build_tool.resolver import DirectedGraph, resolve_dependencies
+from build_tool.resolver import (
+    DirectedGraph,
+    MetadataEncodingError,
+    resolve_dependencies,
+)
 from build_tool.starlark_evaluator import (
     evaluate_build_file,
     generate_commands,
@@ -337,7 +341,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Discovered {len(packages)} packages")
 
     # Step 4: Resolve dependencies
-    graph = resolve_dependencies(packages)
+    try:
+        graph = resolve_dependencies(packages)
+    except MetadataEncodingError as exc:
+        print(f"Dependency resolution failed: {exc}", file=sys.stderr)
+        return 2
 
     # Step 5: Determine which packages need building
     #

--- a/code/programs/python/build-tool/src/build_tool/resolver.py
+++ b/code/programs/python/build-tool/src/build_tool/resolver.py
@@ -50,6 +50,32 @@ from build_tool.discovery import Package
 # inline for the build tool.
 
 
+class MetadataEncodingError(ValueError):
+    """A dependency manifest is not valid UTF-8 metadata."""
+
+    code = "METADATA_INVALID_UTF8"
+
+    def __init__(self, package: str, manifest: Path) -> None:
+        self.package = package
+        self.manifest = manifest.name
+        code_index = next(
+            (
+                index
+                for index in range(len(manifest.parts) - 2, -1, -1)
+                if manifest.parts[index] == "code"
+                and manifest.parts[index + 1] in {"packages", "programs"}
+            ),
+            None,
+        )
+        if code_index is None:
+            self.path = f"{package}/{manifest.name}"
+        else:
+            self.path = "/".join(manifest.parts[code_index:])
+        super().__init__(
+            f"{self.code}: {self.path} for {package} must be encoded as UTF-8"
+        )
+
+
 class DirectedGraph:
     """A minimal directed graph for dependency resolution.
 
@@ -340,7 +366,11 @@ def _parse_lua_deps(package: Package, known_names: dict[str, str]) -> list[str]:
     if not rockspec_files:
         return []
 
-    text = rockspec_files[0].read_text(encoding="utf-8")
+    rockspec = rockspec_files[0]
+    try:
+        text = rockspec.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise MetadataEncodingError(package.name, rockspec) from exc
     internal_deps: list[str] = []
 
     # Find the dependencies = { ... } block and extract quoted strings.

--- a/code/programs/python/build-tool/tests/test_cli.py
+++ b/code/programs/python/build-tool/tests/test_cli.py
@@ -97,6 +97,27 @@ class TestMainCli:
         ])
         assert exit_code == 0
 
+    def test_invalid_lua_metadata_fails_closed(self, tmp_path, capsys):
+        pkg_dir = tmp_path / "code" / "packages" / "lua" / "pkg"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "BUILD").write_text('echo "hi"\n', encoding="utf-8")
+        (pkg_dir / "test-0.1.0-1.rockspec").write_bytes(
+            b'package = "coding-adventures-pkg"\n-- invalid byte: \x97\n'
+        )
+
+        exit_code = main([
+            "--root", str(tmp_path),
+            "--language", "lua",
+            "--dry-run",
+        ])
+
+        captured = capsys.readouterr()
+        assert exit_code == 2
+        assert "METADATA_INVALID_UTF8" in captured.err
+        assert "lua/pkg" in captured.err
+        assert "test-0.1.0-1.rockspec" in captured.err
+        assert str(tmp_path) not in captured.err
+
     def test_no_packages_found(self, tmp_path):
         """Test when no packages match the language filter."""
         code_dir = tmp_path / "code"

--- a/code/programs/python/build-tool/tests/test_resolver.py
+++ b/code/programs/python/build-tool/tests/test_resolver.py
@@ -9,6 +9,7 @@ import pytest
 from build_tool.discovery import Package, discover_packages
 from build_tool.resolver import (
     DirectedGraph,
+    MetadataEncodingError,
     _build_known_names,
     _parse_python_deps,
     _parse_ruby_deps,
@@ -289,6 +290,48 @@ class TestParseLuaDeps:
         deps = _parse_lua_deps(pkg, known)
         assert "lua/logic_gates" in deps
         assert "lua/arithmetic" in deps
+
+    def test_accepts_utf8_metadata(self, tmp_path):
+        pkg_dir = tmp_path / "pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "test-0.1.0-1.rockspec").write_text(
+            'description = { summary = "Portable metadata — UTF-8" }\n'
+            'dependencies = { "coding-adventures-other >= 0.1.0" }\n',
+            encoding="utf-8",
+        )
+        pkg = Package(name="lua/pkg", path=pkg_dir, language="lua")
+
+        assert _parse_lua_deps(
+            pkg, {"coding-adventures-other": "lua/other"}
+        ) == ["lua/other"]
+
+    def test_rejects_invalid_utf8_with_stable_metadata_error(self, tmp_path):
+        pkg_dir = (
+            tmp_path
+            / "code"
+            / "private-checkout"
+            / "code"
+            / "packages"
+            / "lua"
+            / "pkg"
+        )
+        pkg_dir.mkdir(parents=True)
+        manifest = pkg_dir / "test-0.1.0-1.rockspec"
+        manifest.write_bytes(
+            b'package = "coding-adventures-pkg"\n-- invalid byte: \x97\n'
+        )
+        pkg = Package(name="lua/pkg", path=pkg_dir, language="lua")
+
+        with pytest.raises(MetadataEncodingError) as error:
+            _parse_lua_deps(pkg, {})
+
+        assert error.value.code == "METADATA_INVALID_UTF8"
+        assert error.value.package == "lua/pkg"
+        assert error.value.manifest == "test-0.1.0-1.rockspec"
+        assert error.value.path == (
+            "code/packages/lua/pkg/test-0.1.0-1.rockspec"
+        )
+        assert str(tmp_path) not in str(error.value)
 
 
 class TestBuildKnownNamesLua:

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -131,7 +131,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 30)
+        self.assertEqual(summary["case_count"], 32)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -851,7 +851,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 30)
+        self.assertEqual(summary["case_count"], 32)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -260,6 +260,10 @@ MUST:
   explicitly names another qualified package;
 - reject self-edges, ambiguous manifests, ambiguous aliases, and duplicate
   package identities;
+- decode `.rockspec` text metadata as strict UTF-8 without replacement or
+  locale fallback;
+- report invalid rockspec encoding as `METADATA_INVALID_UTF8`, including the
+  repository-relative manifest path and package identity;
 - emit sorted, unique internal edges; and
 - report malformed metadata with stable diagnostics instead of silently
   inventing a partial graph.

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-08-02
+
+- Declared strict UTF-8 as the portable metadata text contract for dependency
+  resolution and reserved `METADATA_INVALID_UTF8` for deterministic failures.
+- Added positive Unicode and adversarial invalid-byte Lua rockspec cases so
+  every build-tool implementation has the same resolution oracle.
+
 ## 2026-07-31
 
 - Replaced pathname `lstat`/glob/reopen execution-corpus reads with one

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -35,10 +35,11 @@ emerging OCaml lane. It records front-door and shared-engine state but contains
 no executable commands. Every adapter is currently marked missing, so a valid
 inventory is not reported as conformance success.
 
-The 30-case bootstrap corpus covers every process-free v1 domain:
+The 32-case bootstrap corpus covers every process-free v1 domain:
 
 - canonical membership plus Windows, macOS, and Linux BUILD precedence;
-- the shared Python dependency diamond;
+- the shared Python dependency diamond plus positive UTF-8 and fail-closed
+  invalid-UTF-8 Lua rockspec resolution;
 - deterministic diamond graph levels;
 - the build-plan distinction between `affected_packages: null` and `[]`; and
 - fail-closed rejection of a future plan version;

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-lua-invalid-utf8.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-lua-invalid-utf8.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "id": "resolution/lua-invalid-utf8",
+  "domain": "resolution",
+  "summary": "Lua rockspec metadata with invalid UTF-8 fails closed with a stable diagnostic.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "resolution"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/lua/pkg/BUILD",
+        "content_utf8": "echo \"building pkg\"\n"
+      },
+      {
+        "path": "code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec",
+        "content_base64": "cGFja2FnZSA9ICJjb2RpbmctYWR2ZW50dXJlcy1wa2ciCnZlcnNpb24gPSAiMC4xLjAtMSIKZGVwZW5kZW5jaWVzID0gewogICAgImx1YSA+PSA1LjQiLAp9Ci0tIGludmFsaWQgYnl0ZToglwo="
+      }
+    ]
+  },
+  "input": {
+    "operation": "resolution",
+    "options": {
+      "code_root": "code",
+      "language": "lua"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "resolution/lua-invalid-utf8",
+    "domain": "resolution",
+    "outcome": "error",
+    "result": {},
+    "diagnostics": [
+      {
+        "code": "METADATA_INVALID_UTF8",
+        "severity": "error",
+        "path": "code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec",
+        "package": "lua/pkg",
+        "details": {
+          "encoding": "UTF-8"
+        }
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-lua-utf8.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-lua-utf8.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "id": "resolution/lua-utf8",
+  "domain": "resolution",
+  "summary": "Lua rockspec metadata is decoded as UTF-8 while internal dependencies are resolved.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "resolution"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/lua/pkg/BUILD",
+        "content_utf8": "echo \"building pkg\"\n"
+      },
+      {
+        "path": "code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec",
+        "content_utf8": "package = \"coding-adventures-pkg\"\nversion = \"0.1.0-1\"\ndescription = { summary = \"Portable metadata — UTF-8\" }\ndependencies = {\n    \"lua >= 5.4\",\n    \"coding-adventures-other >= 0.1.0\",\n}\n"
+      },
+      {
+        "path": "code/packages/lua/other/BUILD",
+        "content_utf8": "echo \"building other\"\n"
+      },
+      {
+        "path": "code/packages/lua/other/coding-adventures-other-0.1.0-1.rockspec",
+        "content_utf8": "package = \"coding-adventures-other\"\nversion = \"0.1.0-1\"\ndependencies = { \"lua >= 5.4\" }\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "resolution",
+    "options": {
+      "code_root": "code",
+      "language": "lua"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "resolution/lua-utf8",
+    "domain": "resolution",
+    "outcome": "ok",
+    "result": {
+      "edges": [
+        [
+          "lua/other",
+          "lua/pkg"
+        ]
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,11 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `f42c8218a` after
-merged PR #9477 added the three Dart ML leaves and this branch added Dart
+working inventory was regenerated on August 2, 2026 from `6a59699f5` after
+merged PRs #9477 and #9485 added the three Dart ML leaves and Dart
 `document-ast`, following the serial Rust smart-home additions through Sonos
-(#9461) and the Rust SPICE model validation chain through #9481. It contains
-1,216 normalized implementation identities across 4,364 established-lane
+(#9461), Nanoleaf (#9486), and the Rust SPICE model validation chain. It contains
+1,217 normalized implementation identities across 4,365 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -118,23 +118,23 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 766 | 10,724 |
+| Present in one language | 767 | 10,738 |
 
-The loop must not start by attempting 10,724 singleton ports. It should finish
+The loop must not start by attempting 10,738 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`f42c8218afee1c63551ff987bdf1d76e007ae12e` is collision-clean at 1,216
-normalized implementation identities, 4,364 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 766 singletons, 571
+`6a59699f5ff6ee6453bfc0dd11efe210aaad7c54` is collision-clean at 1,217
+normalized implementation identities, 4,365 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 767 singletons, 572
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The eleven newest mixed Rust identities are `smart-home-camera-media`,
+The twelve newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
 `smart-home-wled-integration`, `smart-home-govee-lan-integration`,
 `smart-home-lifx-lan-integration`, `smart-home-kasa-lan-integration`,
 `smart-home-reolink-integration`, `smart-home-roku-ecp-integration`,
-`smart-home-wemo-upnp-integration`, and
-`smart-home-sonos-upnp-integration`. All are
+`smart-home-wemo-upnp-integration`, `smart-home-sonos-upnp-integration`, and
+`smart-home-nanoleaf-local-integration`. All are
 mixed splits rather than blind parity ports: camera grant policy,
 generation-bound lease state, quotas, and redacted audit are portable, while
 authenticated host context and media delivery remain native mediation; ONVIF
@@ -148,14 +148,17 @@ WLED DTO validation, master/segment projection, capability-bit interpretation,
 state normalization, and command planning are portable, while mDNS, DNS/TCP,
 plaintext LAN HTTP, trusted time, console I/O, pairing/origin policy, runtime
 effects, and capability profiles remain native. Govee, LIFX, Kasa, Reolink,
-Roku, Wemo, and Sonos contribute deterministic codecs, bounded parsers and DTO
-validation, normalization, projection, stable identities/errors, command
+Roku, Wemo, Sonos, and Nanoleaf contribute deterministic codecs, bounded parsers
+and DTO validation, normalization, projection, stable identities/errors, command
 planning, and language-neutral fixtures to the parity backlog. Wemo specifically
 contributes SSDP header parsing, bounded setup/SOAP XML, service/device
 normalization, and switch/light command planning. Sonos additionally contributes
 credential-free URL/control-path validation, AVTransport, RenderingControl,
 DIDL metadata normalization, deterministic inspection planning, and
-protocol-neutral media-player projection. UDP multicast, DNS/TCP, LAN HTTP
+protocol-neutral media-player projection. Nanoleaf adds credential syntax and
+origin-configuration validation, bounded snapshot/state validation, stable
+identity and capability projection, RGB/HSV and mirek conversion, command
+planning, and verification. UDP multicast, DNS/TCP, LAN HTTP
 execution, timeouts, endpoint approval, CLI I/O, authorization, and runtime
 mutation remain native-host responsibilities.
 
@@ -203,13 +206,23 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
 
 - reconcile stale `BUILD_windows` prerequisite declarations reported by the
   build-tool validator across Python, Perl, TypeScript, Swift, Dart, Kotlin, and
-  related packages in dependency-shaped waves;
-- make the Python build tool's Lua rockspec decoding deterministic. A full
-  4,763-package dry-run currently aborts before diff selection when
-  `_parse_lua_deps` reads byte `0x97` from `lua/block_ram` and `lua/tree` at
-  offset 208 or `lua/trig` at offset 218; classify and normalize the three
-  metadata files or add a deterministic fail-closed encoding diagnostic with
-  fixtures rather than silently replacing bytes;
+  related packages in dependency-shaped waves. The Python validator now also
+  materializes a 10-file Lua wave covering the compiler, serializer, language
+  server, QR, and compression dependency chains;
+- keep the Python build tool's Lua rockspec decoding deterministic. The
+  encoding-blocker slice normalizes the three CP1252 metadata bytes, adds
+  positive and invalid-UTF-8 fixtures, and returns `METADATA_INVALID_UTF8`;
+  its refreshed full scan succeeds across 4,764 packages and 7,093 edges;
+- bring the remaining Go, Rust, Swift, TypeScript, Lua, Perl, Ruby, Elixir, and
+  Haskell build-tool resolvers to the shared strict-UTF-8 rockspec contract.
+  Their current byte, replacement, silent-drop, and locale-sensitive behavior
+  is tracked separately from the Python full-scan blocker;
+- expose Haskell through the Python build tool's `--language` filter. Haskell
+  is already in its resolver and canonical language registry but is missing
+  from the native CLI choices;
+- make Python build-plan emission replace an existing destination atomically on
+  Windows. Repeated output currently leaves the temporary path and fails with
+  `WinError 183`, while a fresh destination succeeds;
 - remove environment-specific Starlark grammar lookup so build discovery works
   from arbitrary clean worktrees;
 - add explicit applicability and maturity data before either C/C++ or OCaml
@@ -1000,10 +1013,10 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 571 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 572 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30-August 2 inventories added thirty Rust singleton identities that now
+The July 30-August 2 inventories added thirty-one Rust singleton identities that now
 have explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
@@ -1093,6 +1106,17 @@ host profiles and external Layer 5 evidence remain separate owners. A shared
 follow-up consolidates the duplicated Shelly/WLED DNS, TCP, request encoding,
 bounded response, chunked decoding, and error projection behind a native LAN-
 HTTP executor while keeping `smart-home-local-http` a pure request planner.
+
+The newest identity, `smart-home-nanoleaf-local-integration`, is another mixed
+split rather than a blind port. Credential syntax and credential-free origin
+configuration, bounded snapshot and state validation, stable identifiers,
+capability and state normalization, RGB/HSV and mirek conversion, command
+planning, verification, and hostile inputs are deterministic portable-core
+candidates. mDNS, DNS/TCP, LAN HTTP execution, physical-presence pairing, token
+and Vault handling, trusted time, endpoint approval, CLI I/O, authorization,
+and SmartHomeRuntime mutation remain native-host responsibilities. Its portable
+owner depends on the shared confirmed command-effect lifecycle so that fixtures
+describe confirmed device state rather than optimistic runtime acceptance.
 
 The fourteenth identity, `smart-home-home-assistant-migration`, is a mixed
 boundary rather than an automatic fifteen-lane port. Its deterministic export


### PR DESCRIPTION
## Summary

- define strict UTF-8 decoding for Lua `.rockspec` metadata in the language-neutral build-tool contract
- add positive Unicode and invalid-byte resolution fixtures, with stable `METADATA_INVALID_UTF8` diagnostics
- make the Python build tool fail closed with package and repository-relative manifest identity, CLI exit 2, and no traceback or host-path disclosure
- normalize the only three invalid repository rockspecs (Lua `block_ram`, `tree`, and `trig`) from CP1252 to UTF-8
- refresh the collision-clean parity inventory and log newly discovered build-tool and portable-package follow-ups without expanding this PR's implementation scope

## Validation

- Python build tool: 352 tests passed; 85.05% total coverage
- focused final-head resolver/CLI regression: 50 tests passed
- conformance schemas/runner: 57 tests and 52 subtests passed
- shared corpus: 32 cases, 36 validated files, 15 established languages, 16 implementations
- full Python build-tool plan: 4,765 packages and 7,100 dependency edges
- affected Lua packages: 308 assertions passed across `block_ram`, `tree`, and `trig`
- `luarocks lint` passed for all three normalized rockspecs
- all 246 Lua rockspecs decode as strict UTF-8
- focused mypy, critical Ruff, focused Bandit, compileall, and `pip check` passed
- parity inventory: 1,217 identities, 4,365 slots, 172 high-consensus packages, 271 high-consensus missing slots, 767 singletons, 572 Rust singletons, zero canonical collisions, zero unknown buckets
- state graph: unique IDs, allowed transitions, no missing dependencies or cycles, exactly one active item
- `git diff --check` passed
- independent final code/contract audit found no blockers

## Baseline observations

The repository-wide Ruff, mypy, Bandit, standalone BUILD validator, and optional Starlark interpreter checks continue to report already-tracked baseline findings outside this slice: 85 Ruff issues, six mypy import/type issues, existing subprocess findings, ten Lua `BUILD_windows` prerequisite gaps, and missing local `starlark_interpreter` imports. Focused changed-file checks and the full plan succeed; each newly materialized parity/build-integrity gap is recorded as a separate pending item.