### PR TITLE
fix(spice): validate MOS bottom junction capacitance

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `CJ` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `MJSW` values before
   lowering netlist elements into the engine.
 - Reject non-finite Level-1 MOS model-card `FC` values outside `[0, 1)` before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1908,6 +1908,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(bottom_junction_capacitance) = params.get("CJ") {
+            if !bottom_junction_capacitance.is_finite() || *bottom_junction_capacitance < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET CJ must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1864,6 +1864,35 @@ fn preserves_non_negative_mosfet_model_sidewall_grading_coefficient() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_bottom_junction_capacitance() {
+    for capacitance in ["-2p", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model junction NMOS(CJ={capacitance})\nM1 d g s b junction"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET CJ must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_bottom_junction_capacitance() {
+    for (capacitance, expected) in [("0", 0.0), ("2p", 2.0e-12)] {
+        let parsed = parse_netlist(&format!(
+            ".model junction NMOS(CJ={capacitance})\nM1 d g s b junction"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.bottom_junction_capacitance, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card sidewall-junction-grading validation.
+1. Rust Berkeley SPICE MOS model-card bottom-junction-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `MJSW` values before
+   - Reject negative and non-finite model-card `CJ` values before
      lowering MOS elements into engine parameters.
-   - Preserve zero and positive sidewall-junction grading coefficients.
+   - Preserve zero and positive bottom-junction capacitances.
 
 ## Completed Slices
 
@@ -3984,6 +3984,12 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Values at the inclusive lower boundary and below the exclusive upper
      boundary remain accepted.
+
+345. Rust Berkeley SPICE MOS model-card sidewall-junction-grading validation.
+   - Status: completed in PR 9492.
+   - Negative and non-finite model-card `MJSW` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive sidewall-junction grading coefficients remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CJ` values in the Rust Berkeley parser facade
- preserve zero and positive bottom-junction capacitances, including engineering suffixes
- reconcile the SPICE implementation plan after MJSW validation merged

## Tests
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
Rust-only parser-facade validation. The shared Rust, Python, and TypeScript engine behavior and diagnostic are already aligned.