### PR TITLE
feat(human-languages): validate Spanish schema v2 pilot

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,7 +5,7 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after PR #9478: 20 registered
+Last prioritized: 2026-08-02. Current baseline after PR #9483: 20 registered
 tracks, 973 Markdown lessons, and 20 downloadable LaTeX books. HL-V01 makes the
 remaining migration debt reproducible in both JSON and human-readable reports.
 
@@ -23,7 +23,7 @@ remaining migration debt reproducible in both JSON and human-readable reports.
 | HL-B01 | Complete (#9472) | Publish the five authored Persian lessons as a two-chapter LaTeX starter book. | XeLaTeX builds the book; CI discovers an 18th PDF; chapters map to lessons 1 and 2. |
 | HL-B02 | Complete (#9474) | Publish the five authored Urdu lessons as a two-chapter starter book. | XeLaTeX builds with correct RTL shaping; Urdu appears in the public catalog. |
 | HL-B03 | Complete (#9478) | Publish Russian's two authored chapters as a starter book. | The existing Cyrillic lessons and roadmap produce a downloadable PDF. |
-| HL-V01 | Complete in the gap-report PR | Add a machine-readable curriculum gap report and computed duration budget. | CI reports lessons at or above 300 seconds, missing prerequisites, book coverage, and track-schema status. |
+| HL-V01 | Complete (#9483) | Add a machine-readable curriculum gap report and computed duration budget. | CI reports lessons at or above 300 seconds, missing prerequisites, book coverage, and track-schema status. |
 
 The Russian publication audit found eight of its thirteen Chapter 1--2
 curriculum lessons currently declare five minutes or more, including one at six
@@ -41,8 +41,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 
 | ID | Status | Work item | Why it follows P0 |
 |---|---|---|---|
-| HL-S01 | Next | Migrate Spanish Chapters 1–3 to schema version 2 with typed body blocks and knowledge closure. | Spanish is the specified vertical slice and proves the strict contract on mature content. |
-| HL-G01 | Queued | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy only after the AST contract is proven. |
+| HL-S01 | Complete in the Spanish schema-v2 PR | Migrate Spanish Chapters 1–3 to schema version 2 with typed body blocks and knowledge closure. | The 24-lesson slice has unique order, transitive knowledge closure, typed blocks, and no effective-duration violation. |
+| HL-G01 | Next | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy now that the AST contract is executable. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The audit must exist first so the debt remains measurable throughout migration. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
@@ -57,6 +57,21 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   prior knowledge.
 - Add provenance-labelled listening and dictation activities from the same
   canonical lesson blocks.
+
+## Findings from HL-S01
+
+- Spanish Chapters 1–3 contain 24 schema-v2 lessons after three overlong
+  explanations were split into prerequisite-ordered support lessons for noun
+  gender, the Latin *qu-* question family, and the origin of *usted*.
+- The resulting snapshot has 976 lessons, 481 duration violations, and 40
+  later-chapter prerequisite roots: four and two fewer respectively than the
+  HL-V01 baseline, with the remaining debt still explicit.
+- Every migrated lesson computes below 300 seconds; the tightest current budget
+  is *buenos días* at 296 seconds, which should be watched during copy edits.
+- Schema v2 now validates canonical spine mapping, unique local sequence,
+  typed body blocks, explicit coverage metadata, same-language prerequisites,
+  and transitive knowledge closure. Block-boundary prompt/answer knowledge
+  declarations remain a later refinement; this slice does not claim them.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Chapters 1–3 — executable schema-v2 pilot
+
+- Migrated the first three chapters to the HL04 lesson contract: canonical
+  spine nodes, stable sequence values, strict sub-five-minute duration budgets,
+  explicit skill/mode/strand metadata, and declared knowledge flow.
+- Split grammatical gender, the Latin *qu-* question family, and the origin of
+  *usted* into three prerequisite-ordered support lessons. The etymology stays
+  deep while every individual lesson remains independently resumable.
+- Removed the two later-chapter prerequisite roots in Chapter 3 and made all 24
+  lessons close over knowledge introduced by their transitive prerequisites.
+- Exposed every level-two teaching section as a typed block consumed from the
+  same lossless Markdown body by downstream book and app renderers.
+
 ## The book catches up — Chapters 4–18 typeset
 
 The lessons had run ahead of the published artifact: 90 authored lessons through

--- a/code/learning/human-languages/spanish/README.md
+++ b/code/learning/human-languages/spanish/README.md
@@ -33,6 +33,10 @@ README is "how to actually use this."
 6. **Grammar from zero, contrasted with English.** Grammar concepts are
    introduced in context on the first word that needs them, explained with no
    assumed terminology.
+7. **An executable five-minute progression.** Chapters 1–3 use HL04 schema v2:
+   each lesson has a stable local sequence, a shared-spine node, declared
+   knowledge inputs and outputs, typed body blocks, and an independently checked
+   duration below 300 seconds.
 
 ## How to use this in the car
 
@@ -81,14 +85,15 @@ All built **atom-first** (word first, then assembled) with grammar introduced
 exactly where a word needs it:
 
 - **Chapter 1 — Hola and Buenos Días**: hola → bien (+ bueno/buena) → el / la
-  (**grammatical gender**, traced to Latin *ille/illa*) → día (first noun,
+  → grammatical gender (a separate short support lesson) → día (first noun,
   applies gender; + the plural rule) → buenos días (assembled, introduces
   **agreement**) → practice.
 - **Chapter 2 — The Rest of the Greetings**: tarde → buenas tardes
   (**feminine** agreement) → noche → buenas noches → practice.
 - **Chapter 3 — Introducing Yourself**: me → llamar → me llamo (**reflexive
-  verbs**) → **tú / usted** (informal vs formal "you," both roots traced) →
-  cómo → se llama → ¿cómo se llama usted? → mucho → mucho gusto → practice.
+  verbs**) → **tú / usted** (informal vs formal "you") → the *vuestra merced*
+  origin of *usted* → cómo → the Latin *qu-* question family → se llama →
+  ¿cómo se llama usted? → mucho → mucho gusto → practice.
 - **Chapter 4 — How Are You**: gracias → de nada → estar → ¿cómo está usted? →
   regular → practice.
 - **Chapter 5 — Farewells**: adiós → hasta → hasta luego / mañana / pronto.

--- a/code/learning/human-languages/spanish/lessons/ES-C01-bien.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-bien.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C01-bien
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 20
 chapter: 1
 type: word
 headword: bien
@@ -8,7 +11,19 @@ concept_tag: WORD-WELL
 prerequisites: [ES-C01-hola]
 sounds: [diphthong-ie, v-b]
 roots: [bene, bonus]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HOLA]
+introduces:
+  knowledge: [ES-LEX-BIEN, ES-MORPH-BUENO-BUENA]
+practises:
+  knowledge: [ES-LEX-HOLA, ES-LEX-BIEN, ES-MORPH-BUENO-BUENA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C01-hola]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C01-buenos-dias.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-buenos-dias.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C01-buenos-dias
+spine_node: SPINE-TIME-OF-DAY
+sequence: 60
 chapter: 1
 type: word
 headword: buenos días
@@ -8,7 +11,19 @@ concept_tag: GREETING-MORNING
 prerequisites: [ES-C01-bien, ES-C01-dia]
 sounds: [diphthong-ue, accent-i]
 roots: [bonus, dies]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-BIEN, ES-MORPH-BUENO-BUENA, ES-LEX-DIA, ES-GRAMMAR-NOUN-NUMBER]
+introduces:
+  knowledge: [ES-LEX-BUENOS-DIAS, ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL]
+practises:
+  knowledge: [ES-LEX-BUENOS-DIAS, ES-LEX-BIEN, ES-LEX-DIA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C01-bien, ES-C01-dia]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C01-dia.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-dia.md
@@ -1,14 +1,29 @@
 ---
+schema_version: 2
 id: ES-C01-dia
+spine_node: SPINE-TIME-OF-DAY
+sequence: 50
 chapter: 1
 type: word
 headword: día
 gloss: day (el día — masculine)
 concept_tag: TIME-DAY
-prerequisites: [ES-C01-el-la]
+prerequisites: [ES-C01-genero-gramatical]
 sounds: [accent-i, vowel-a, d-soft]
 roots: [dies]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER]
+introduces:
+  knowledge: [ES-LEX-DIA, ES-GRAMMAR-NOUN-NUMBER, ES-SOUND-WRITTEN-ACCENT]
+practises:
+  knowledge: [ES-LEX-DIA, ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C01-el-la]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C01-el-la.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-el-la.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C01-el-la
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 30
 chapter: 1
 type: word
 headword: el / la
@@ -8,7 +11,19 @@ concept_tag: GRAMMAR-THE
 prerequisites: [ES-C01-bien]
 sounds: [vowel-e, vowel-a]
 roots: [ille, illa]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-MORPH-BUENO-BUENA]
+introduces:
+  knowledge: [ES-GRAMMAR-DEFINITE-ARTICLES, ES-ETYMON-ILLE-ILLA]
+practises:
+  knowledge: [ES-GRAMMAR-DEFINITE-ARTICLES, ES-ETYMON-ILLE-ILLA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C01-bien]
 ---
 
@@ -16,10 +31,9 @@ reviews_of: [ES-C01-bien]
 
 ## Warm-up
 
-[PAUSE 2s] Before your first noun, meet the two smallest, most frequent words
-in Spanish: *el* and *la*, both meaning "the." They look trivial. They are
-not — they're *how Spanish carries gender*, so you have to understand them
-before nouns can make sense.
+[PAUSE 2s] Before your first noun, meet two of the smallest, most frequent
+words in Spanish: *el* and *la*. Both mean "the." Your job here is simply to
+recognize the pair and connect each form to its label.
 
 ## You'll want to know first
 
@@ -34,7 +48,7 @@ before nouns can make sense.
 ## The word, taken apart
 
 **el** — "the" (masculine). **la** — "the" (feminine). English has one word,
-"the"; Spanish has two, because "the" must **match the gender** of its noun.
+"the"; Spanish makes this two-way distinction.
 
 **Where they come from.** Both are worn-down Latin **demonstratives** — words
 that meant "**that one (over there)**":
@@ -53,33 +67,20 @@ the pronoun *él* ("he") are twins from one Latin parent — told apart only by
 the accent. (English "the," by contrast, is Germanic and *unrelated* — a
 shared job, not a shared root.)
 
-## Grammar Lens: grammatical gender, and where it comes from
+## What you've built
 
-Every Spanish noun belongs to one of two **genders** — masculine or feminine.
-This is a grammatical *class*, not a claim about biological sex; it's just how
-the language sorts its nouns. It comes straight from **Latin**, which sorted
-nouns into *three* genders (masculine, feminine, and neuter). Spanish
-simplified to *two*, folding most old neuter nouns into the masculine pile.
-
-*el* and *la* are how that gender shows up in the open: a masculine noun takes
-*el*, a feminine noun takes *la* — *el día* ("the day"), *la noche* ("the
-night"). From here on you'll always learn a noun **with its article**, because
-a noun's gender can't be reliably guessed — you have to know it.
-
-> Part of speech: *el*/*la* are **articles** (little words marking "the"), not
-> to be confused with their accented twins *él*/*ella*, the **pronouns**
-> "he/she." Same Latin parent, different jobs.
+*el* and *la* are **articles**: little words that mark "the." Keep them apart
+from their accented relatives *él* and *ella*, the pronouns "he" and "she."
+The next micro-lesson explains why Spanish needs two article forms.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "el" then "la" — the two "the"s]
-- [YOU SAY: "el día" (masculine) then "la noche" (feminine)]
 - [YOU SAY: which article goes with a masculine noun? with a feminine one?]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] *el* and *la* both come from a Latin word meaning what? ("That
-one" — the demonstratives *ille* / *illa*.) How many genders did Latin have,
-and how many did Spanish keep? (Three → two.) What accented twins share their
-root? (*él* / *ella*, "he / she.")
+[PAUSE 3s] Which form is labelled masculine? (*el*.) Which is labelled
+feminine? (*la*.) Both come from Latin words meaning what? ("That one" —
+*ille* / *illa*.) What accented twins share their root? (*él* / *ella*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C01-genero-gramatical.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-genero-gramatical.md
@@ -1,0 +1,64 @@
+---
+schema_version: 2
+id: ES-C01-genero-gramatical
+spine_node: SPINE-DEFINITE-REFERENCE
+sequence: 40
+chapter: 1
+type: grammar
+headword: el / la + noun
+gloss: Spanish grammatical gender
+prerequisites: [ES-C01-el-la]
+sounds: []
+roots: [genus]
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-GRAMMAR-DEFINITE-ARTICLES]
+introduces:
+  knowledge: [ES-GRAMMAR-NOUN-GENDER]
+practises:
+  knowledge: [ES-GRAMMAR-DEFINITE-ARTICLES, ES-GRAMMAR-NOUN-GENDER]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C01-el-la]
+---
+
+# Grammatical gender — the two noun classes behind *el* and *la*
+
+## Warm-up
+
+[PAUSE 2s] You know that *el* and *la* both mean "the." Now give their two
+labels: *el* is masculine; *la* is feminine.
+
+## You'll want to know first
+
+- [el / la](./ES-C01-el-la.md) — the two definite articles.
+
+## Grammar Lens: grammatical gender
+
+Every Spanish noun belongs to one of two **grammatical classes**, traditionally
+called masculine and feminine. This is not a claim about biological sex. It is
+a matching system: a masculine noun uses *el*; a feminine noun uses *la*.
+
+Latin had masculine, feminine, and neuter classes. Spanish reduced that
+three-way system to two, with most old neuter nouns joining the masculine
+class. The word *gender* itself comes through Latin *genus*, "kind" or "class."
+
+You cannot always predict a noun's class from its ending. Learn each new noun
+with its article, as one small unit: *el + noun* or *la + noun*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the article for a noun labelled masculine]
+- [YOU SAY: the article for a noun labelled feminine]
+- [YOU SAY: what grammatical gender classifies — nouns, not people]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How many noun classes did Latin have? (Three.) How many does
+Spanish keep? (Two.) What should travel with every new noun you learn? (Its
+article, *el* or *la*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C01-hola.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-hola.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C01-hola
+spine_node: SPINE-MEET-GREET
+sequence: 10
 chapter: 1
 type: word
 headword: hola
@@ -8,7 +11,19 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [silent-h, vowel-o, vowel-a, inverted-marks]
 roots: []
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ES-LEX-HOLA, ES-SOUND-H-SILENT]
+practises:
+  knowledge: [ES-LEX-HOLA, ES-SOUND-H-SILENT]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C01-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C01-practice
+spine_node: SPINE-MEET-GREET
+sequence: 70
 chapter: 1
 type: practice-mix
 headword: (practice)
@@ -8,7 +11,19 @@ concept_tag: CH1-PRACTICE
 prerequisites: [ES-C01-hola, ES-C01-bien, ES-C01-dia, ES-C01-buenos-dias]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HOLA, ES-LEX-BIEN, ES-LEX-DIA, ES-LEX-BUENOS-DIAS]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [ES-LEX-HOLA, ES-LEX-BIEN, ES-LEX-DIA, ES-LEX-BUENOS-DIAS]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus, fluency]
+register: neutral
+variety: general
 reviews_of: [ES-C01-hola, ES-C01-bien, ES-C01-dia, ES-C01-buenos-dias]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C02-buenas-noches.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-buenas-noches.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C02-buenas-noches
+spine_node: SPINE-TIME-OF-DAY
+sequence: 110
 chapter: 2
 type: word
 headword: buenas noches
@@ -8,7 +11,19 @@ concept_tag: GREETING-GOODNIGHT
 prerequisites: [ES-C02-buenas-tardes, ES-C02-noche]
 sounds: [diphthong-ue, soft-c]
 roots: [bonus, nox]
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-BUENAS-TARDES, ES-LEX-NOCHE]
+introduces:
+  knowledge: [ES-LEX-BUENAS-NOCHES]
+practises:
+  knowledge: [ES-LEX-BUENAS-TARDES, ES-LEX-NOCHE, ES-LEX-BUENAS-NOCHES]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C01-bien, ES-C02-noche]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C02-buenas-tardes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-buenas-tardes.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C02-buenas-tardes
+spine_node: SPINE-TIME-OF-DAY
+sequence: 90
 chapter: 2
 type: word
 headword: buenas tardes
@@ -8,7 +11,19 @@ concept_tag: GREETING-AFTERNOON
 prerequisites: [ES-C01-bien, ES-C02-tarde]
 sounds: [diphthong-ue, stress-default-vowel-ns]
 roots: [bonus, tardus]
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-MORPH-BUENO-BUENA, ES-LEX-TARDE, ES-GRAMMAR-NOUN-GENDER]
+introduces:
+  knowledge: [ES-LEX-BUENAS-TARDES, ES-GRAMMAR-AGREEMENT-FEMININE-PLURAL]
+practises:
+  knowledge: [ES-LEX-BUENAS-TARDES, ES-LEX-BUENOS-DIAS]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C01-bien, ES-C01-buenos-dias, ES-C02-tarde]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C02-noche.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-noche.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C02-noche
+spine_node: SPINE-TIME-OF-DAY
+sequence: 100
 chapter: 2
 type: word
 headword: la noche
@@ -8,7 +11,19 @@ concept_tag: TIME-NIGHT
 prerequisites: [ES-C02-tarde]
 sounds: [soft-c, stress-default-vowel-ns]
 roots: [nox]
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-TARDE, ES-GRAMMAR-NOUN-GENDER]
+introduces:
+  knowledge: [ES-LEX-NOCHE, ES-SOUND-LATIN-CLUSTER-TO-CH]
+practises:
+  knowledge: [ES-LEX-TARDE, ES-LEX-NOCHE, ES-GRAMMAR-NOUN-GENDER]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C02-tarde, ES-C02-buenas-tardes]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C02-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C02-practice
+spine_node: SPINE-TIME-OF-DAY
+sequence: 120
 chapter: 2
 type: practice-mix
 headword: (practice)
@@ -8,7 +11,19 @@ concept_tag: CH2-PRACTICE
 prerequisites: [ES-C01-hola, ES-C01-buenos-dias, ES-C02-buenas-tardes, ES-C02-buenas-noches]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-BUENAS-TARDES, ES-LEX-BUENAS-NOCHES]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-BUENAS-TARDES, ES-LEX-BUENAS-NOCHES]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus, fluency]
+register: neutral
+variety: general
 reviews_of: [ES-C01-hola, ES-C01-buenos-dias, ES-C02-buenas-tardes, ES-C02-buenas-noches]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C02-tarde.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-tarde.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C02-tarde
+spine_node: SPINE-TIME-OF-DAY
+sequence: 80
 chapter: 2
 type: word
 headword: la tarde
@@ -8,7 +11,19 @@ concept_tag: TIME-AFTERNOON
 prerequisites: [ES-C01-dia, ES-C01-buenos-dias]
 sounds: [vowel-a, stress-default-vowel-ns]
 roots: [tardus]
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-DIA, ES-LEX-BUENOS-DIAS]
+introduces:
+  knowledge: [ES-LEX-TARDE]
+practises:
+  knowledge: [ES-LEX-DIA, ES-LEX-BUENOS-DIAS, ES-LEX-TARDE]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C01-buenos-dias]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C03-como-se-llama.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-como-se-llama.md
@@ -1,14 +1,29 @@
 ---
+schema_version: 2
 id: ES-C03-como-se-llama
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 210
 chapter: 3
 type: word
 headword: ¿cómo se llama usted?
 gloss: what's your name? (formal)
 concept_tag: INTRO-WHATS-YOUR-NAME
-prerequisites: [ES-C03-como, ES-C03-se-llama, ES-C03-tu-usted]
+prerequisites: [ES-C03-como, ES-C03-familia-qu, ES-C03-se-llama, ES-C03-tu-usted]
 sounds: [inverted-marks, accent-mark]
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-COMO, ES-SCRIPT-INVERTED-QUESTION, ES-LEX-SE-LLAMA, ES-LEX-USTED]
+introduces:
+  knowledge: [ES-LEX-COMO-SE-LLAMA]
+practises:
+  knowledge: [ES-LEX-COMO, ES-LEX-SE-LLAMA, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C03-me-llamo, ES-C03-como, ES-C03-se-llama]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C03-como.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-como.md
@@ -1,15 +1,30 @@
 ---
+schema_version: 2
 id: ES-C03-como
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 180
 chapter: 3
 type: word
 headword: cómo
 gloss: how
 concept_tag: QUESTION-HOW
-prerequisites: []
+prerequisites: [ES-C02-practice]
 sounds: [accent-mark, soft-c, inverted-marks]
 roots: [quomodo]
-est_minutes: 3
-reviews_of: [ES-C03-tu-usted]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-SOUND-WRITTEN-ACCENT]
+introduces:
+  knowledge: [ES-LEX-COMO, ES-SCRIPT-INVERTED-QUESTION, ES-GRAMMAR-QUESTION-ACCENT, ES-ETYMON-QUOMODO]
+practises:
+  knowledge: [ES-LEX-COMO, ES-SCRIPT-INVERTED-QUESTION, ES-GRAMMAR-QUESTION-ACCENT]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C01-dia]
 ---
 
 # cómo — "how," your first question word
@@ -51,23 +66,6 @@ river. The same erosion gave Italian *come*, Portuguese *como*, French
 *comme*. The accent in *cómo* is the one late addition: Spanish stamps it on
 to mark the question (vs. accent-less *como*, "like / as").
 
-**The whole question family is worn-down Latin *qu-*.** Once you see *cómo ←
-quomodo*, the rest fall into place — nearly every Spanish question word is an
-eroded Latin *qu-* interrogative:
-
-| Spanish | ← Latin | meaning |
-|---|---|---|
-| qué | *quid* | what |
-| quién | *quem* | who |
-| cuál | *qualis* | which |
-| cuándo | *quando* | when |
-| cuánto | *quantus* | how much |
-| **cómo** | *quomodo* | how |
-
-Learn one derivation and you've cracked the pattern behind all of them.
-(*dónde*, "where," is the odd one out — from *de unde*, "from where," not the
-*qu-* stem.)
-
 ## Grammar Lens: the accent that marks a question
 
 Watch the accent mark do real work. **cómo** (with the accent) = "how?", the
@@ -90,5 +88,5 @@ puts a visible flag on the question word. Every question word you'll learn
 ## Wrap-up Recall
 
 [PAUSE 3s] Walk the erosion: *quomodo* → ? → *cómo* (*quomo* → *como*, then
-the question-accent). And what single Latin stem gives *qué, quién, cuándo,
-cómo*? (The question-stem *qu-*.)
+the question-accent). What changes when the accent disappears? (*como* is no
+longer the question word "how.")

--- a/code/learning/human-languages/spanish/lessons/ES-C03-familia-qu.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-familia-qu.md
@@ -1,0 +1,69 @@
+---
+schema_version: 2
+id: ES-C03-familia-qu
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 190
+chapter: 3
+type: etymology
+headword: qu-
+gloss: the Latin question family inside Spanish
+prerequisites: [ES-C03-como]
+sounds: []
+roots: [quomodo, quid, quem, qualis, quando, quantus]
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-COMO, ES-ETYMON-QUOMODO, ES-GRAMMAR-QUESTION-ACCENT]
+introduces:
+  knowledge: [ES-ETYMON-QUESTION-QU]
+practises:
+  knowledge: [ES-LEX-COMO, ES-ETYMON-QUOMODO, ES-ETYMON-QUESTION-QU]
+skills: [listening, speaking, reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C03-como]
+---
+
+# The *qu-* question family — one ancient pattern, many clues
+
+## Warm-up
+
+[PAUSE 2s] You traced *cómo* back to Latin *quomodo*. Focus now on its first
+piece, *qu-*, without trying to use a whole set of new question words yet.
+
+## You'll want to know first
+
+- [cómo](./ES-C03-como.md) — "how," from Latin *quomodo*.
+
+## The word, taken apart
+
+Latin used a recurring *qu-* stem in questions. Spanish preserves that family,
+although centuries of sound change gave the modern forms different shapes:
+
+| Spanish clue | ← Latin | future meaning |
+|---|---|---|
+| *qué* | *quid* | what |
+| *quién* | *quem* | who |
+| *cuál* | *qualis* | which |
+| *cuándo* | *quando* | when |
+| *cuánto* | *quantus* | how much |
+| **cómo** | *quomodo* | how |
+
+These are previews, not vocabulary to produce today. For now, use the family
+only as an etymological clue: a question form beginning *qu-* or *cu-* may
+continue the same Latin pattern. *Dónde*, "where," is an exception from Latin
+*de unde*, "from where."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the Latin source of *cómo*]
+- [YOU SAY: the recurring Latin question stem]
+- [YOU SAY: whether the table is today's production list or a preview]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which old stem connects *qué, quién, cuándo,* and *cómo*? (*qu-*.)
+Which word in the preview is the exception? (*Dónde*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C03-gusto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-gusto.md
@@ -1,14 +1,29 @@
 ---
+schema_version: 2
 id: ES-C03-gusto
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 230
 chapter: 3
 type: word
 headword: mucho gusto
 gloss: pleased to meet you (literally "much pleasure")
 concept_tag: INTRO-NICE-TO-MEET-YOU
-prerequisites: [ES-C03-mucho]
+prerequisites: [ES-C03-mucho, ES-C03-como-se-llama]
 sounds: [vowel-o, stress-default-vowel-ns]
 roots: [gustus, multus]
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-MUCHO, ES-LEX-COMO-SE-LLAMA]
+introduces:
+  knowledge: [ES-LEX-MUCHO-GUSTO]
+practises:
+  knowledge: [ES-LEX-MUCHO, ES-LEX-MUCHO-GUSTO, ES-LEX-COMO-SE-LLAMA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C03-como-se-llama, ES-C03-mucho]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C03-llamar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-llamar.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C03-llamar
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 140
 chapter: 3
 type: word
 headword: llamo
@@ -8,7 +11,19 @@ concept_tag: ES-VERB-LLAMAR
 prerequisites: [ES-C03-me]
 sounds: [ll-y, vowel-o]
 roots: [clamare]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-ME, ES-GRAMMAR-OBJECT-PRONOUN]
+introduces:
+  knowledge: [ES-LEX-LLAMO, ES-GRAMMAR-FIRST-PERSON-VERB]
+practises:
+  knowledge: [ES-LEX-ME, ES-LEX-LLAMO, ES-GRAMMAR-FIRST-PERSON-VERB]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C03-me]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C03-me-llamo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-me-llamo.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C03-me-llamo
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 150
 chapter: 3
 type: word
 headword: me llamo
@@ -8,7 +11,19 @@ concept_tag: INTRO-MY-NAME-IS
 prerequisites: [ES-C03-me, ES-C03-llamar]
 sounds: [ll-y]
 roots: [clamare]
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-ME, ES-LEX-LLAMO]
+introduces:
+  knowledge: [ES-LEX-ME-LLAMO, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON]
+practises:
+  knowledge: [ES-LEX-ME, ES-LEX-LLAMO, ES-LEX-ME-LLAMO]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C03-me, ES-C03-llamar]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C03-me.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-me.md
@@ -1,14 +1,29 @@
 ---
+schema_version: 2
 id: ES-C03-me
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 130
 chapter: 3
 type: word
 headword: me
 gloss: me / myself
 concept_tag: PRONOUN-ME
-prerequisites: []
+prerequisites: [ES-C02-practice]
 sounds: [vowel-e]
 roots: [me-latin]
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-HOLA]
+introduces:
+  knowledge: [ES-LEX-ME, ES-GRAMMAR-OBJECT-PRONOUN]
+practises:
+  knowledge: [ES-LEX-ME, ES-GRAMMAR-OBJECT-PRONOUN]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C03-mucho.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-mucho.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C03-mucho
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 220
 chapter: 3
 type: word
 headword: mucho
@@ -8,7 +11,19 @@ concept_tag: ES-WORD-MUCHO
 prerequisites: [ES-C02-noche]
 sounds: [soft-c, vowel-o]
 roots: [multus]
-est_minutes: 3
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-NOCHE]
+introduces:
+  knowledge: [ES-LEX-MUCHO]
+practises:
+  knowledge: [ES-LEX-MUCHO]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C03-se-llama]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C03-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-practice.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C03-practice
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 240
 chapter: 3
 type: practice-mix
 headword: (practice)
@@ -8,7 +11,19 @@ concept_tag: CH3-PRACTICE
 prerequisites: [ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-como-se-llama, ES-C03-gusto]
 sounds: []
 roots: []
-est_minutes: 5
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-ME-LLAMO, ES-REGISTER-TU-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-MUCHO-GUSTO]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [ES-LEX-ME-LLAMO, ES-LEX-TU, ES-LEX-USTED, ES-LEX-COMO-SE-LLAMA, ES-LEX-MUCHO-GUSTO]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus, fluency]
+register: neutral
+variety: general
 reviews_of: [ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-como-se-llama, ES-C03-gusto]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C03-se-llama.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-se-llama.md
@@ -1,14 +1,29 @@
 ---
+schema_version: 2
 id: ES-C03-se-llama
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 200
 chapter: 3
 type: word
 headword: se llama
 gloss: he/she calls himself; you (formal) call yourself
 concept_tag: ES-SE-LLAMA
-prerequisites: [ES-C03-me-llamo, ES-C03-tu-usted]
+prerequisites: [ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-usted-origin]
 sounds: [vowel-e, ll-y]
 roots: [se-latin, clamare]
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-ME-LLAMO, ES-LEX-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-VUESTRA-MERCED]
+introduces:
+  knowledge: [ES-LEX-SE-LLAMA, ES-GRAMMAR-REFLEXIVE-THIRD-PERSON]
+practises:
+  knowledge: [ES-LEX-ME-LLAMO, ES-LEX-USTED, ES-LEX-SE-LLAMA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C03-me-llamo, ES-C03-tu-usted]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted.md
@@ -1,14 +1,29 @@
 ---
+schema_version: 2
 id: ES-C03-tu-usted
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 160
 chapter: 3
 type: word
 headword: tú / usted
 gloss: you (informal / formal)
 concept_tag: PRONOUN-YOU
-prerequisites: [ES-C03-me]
+prerequisites: [ES-C03-me-llamo]
 sounds: [vowel-u, accent-mark, d-soft]
-roots: [tu-latin, vestra, merces]
-est_minutes: 5
+roots: [tu-latin]
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-ME, ES-LEX-ME-LLAMO]
+introduces:
+  knowledge: [ES-LEX-TU, ES-LEX-USTED, ES-REGISTER-TU-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-TU-THOU]
+practises:
+  knowledge: [ES-LEX-TU, ES-LEX-USTED, ES-REGISTER-TU-USTED, ES-GRAMMAR-USTED-THIRD-PERSON]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C03-me-llamo]
 ---
 
@@ -17,9 +32,8 @@ reviews_of: [ES-C03-me-llamo]
 ## Warm-up
 
 [PAUSE 2s] English has one word for "you." Spanish has two, and picking the
-wrong one is a genuine social mistake. This lesson gives you both, and — as
-you asked — traces each back to its root, because the roots explain
-*everything* about when to use them.
+wrong one can send the wrong social signal. This lesson gives you both and
+shows the everyday choice. The remarkable history of *usted* comes next.
 
 ## The two words
 
@@ -35,17 +49,6 @@ you're on easy terms with.
 **usted** — "you," **formal**. For strangers, elders, officials, customers,
 anyone you're showing respect or keeping distance with.
 
-> Root: this one is a beautiful compression. *usted* is worn down from
-> **vuestra merced** — "**your grace / your mercy**." *vuestra* ← Latin
-> *vestra* ("your"); *merced* ← Latin **merces, mercedem** ("wages, reward,
-> favor"). That *merc-* root — "trade, pay, favor" — is a whole English
-> family: **merc**y, **merc**iful, **merc**enary, **com**mer**ce**,
-> **merc**hant, **merc**handise, **mar**ket, even the god **Mercury**
-> (patron of commerce). So *usted* literally means "your grace" — a title of
-> deference that got said so often it collapsed into a single pronoun. You
-> can still see the ghost in its old abbreviation, **Vd.** (the *V* from
-> *vuestra*).
-
 ## Grammar Lens: the choice English lost
 
 Both are **subject pronouns** — the "doer" word, like *yo* ("I"). But they
@@ -55,10 +58,10 @@ close or respectful. English "you" is one-size-fits-all; a Spanish speaker
 must decide every time.
 
 One structural surprise, because it explains the next lessons: **usted takes
-*he/she* verb forms**, not "you" forms — because it began life as *"your
-grace"*, a third-person title. That's why "what's your name?" formally is
+*he/she* verb forms**, not the informal "you" forms. That's why "what's your name?" formally is
 *¿cómo **se llama** usted?* (the *se llama* you'd use for "he calls himself")
-and not *te llamas*. The grammar still remembers *usted* used to be a noun.
+and not *te llamas*. The next micro-lesson explains the history behind that
+third-person pattern.
 
 ## Guided Practice
 
@@ -66,10 +69,9 @@ and not *te llamas*. The grammar still remembers *usted* used to be a noun.
 - [YOU SAY: "tú" — for a close friend]
 - [YOU SAY: "usted" — for someone you'd address respectfully]
 - [YOU SAY: "tú" then English "thou" — the retired twin]
-- [YOU SAY: "usted" then "mercy", "commerce", "merchant" — the *merc-* family]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Which is formal, *tú* or *usted*? (*usted*.) What two-word phrase
-did *usted* shrink from, and what does it mean? (*Vuestra merced* — "your
-grace.") What English pronoun is the lost twin of *tú*? (*Thou*.)
+[PAUSE 3s] Which is formal, *tú* or *usted*? (*usted*.) What English pronoun
+is the lost twin of *tú*? (*Thou*.) Which verb pattern does *usted* take?
+(The same form used with "he" or "she.")

--- a/code/learning/human-languages/spanish/lessons/ES-C03-usted-origin.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-usted-origin.md
@@ -1,0 +1,67 @@
+---
+schema_version: 2
+id: ES-C03-usted-origin
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 170
+chapter: 3
+type: etymology
+headword: vuestra merced → usted
+gloss: the respectful title inside usted
+prerequisites: [ES-C03-tu-usted]
+sounds: []
+roots: [vestra, merces]
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-USTED, ES-REGISTER-TU-USTED, ES-GRAMMAR-USTED-THIRD-PERSON]
+introduces:
+  knowledge: [ES-ETYMON-VUESTRA-MERCED]
+practises:
+  knowledge: [ES-LEX-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-ETYMON-VUESTRA-MERCED]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal
+variety: general
+reviews_of: [ES-C03-tu-usted]
+---
+
+# *vuestra merced* → *usted* — respect compressed into one word
+
+## Warm-up
+
+[PAUSE 2s] You use *usted* for respectful "you," and it takes the same verb
+form as "he" or "she." That surprising grammar preserves the word's history.
+
+## You'll want to know first
+
+- [tú / usted](./ES-C03-tu-usted.md) — the informal and formal choices.
+
+## The word, taken apart
+
+*usted* wore down from **vuestra merced**, "your grace" or "your mercy."
+*Vuestra* comes from Latin *vestra*, "your." *Merced* comes from Latin
+*merces, mercedem*, "wages, reward, favor."
+
+The *merc-* root links **mercy**, **mercenary**, **commerce**, **merchant**,
+and **merchandise**. A respectful title was repeated so often that two words
+compressed into one pronoun. Its older abbreviation **Vd.** still preserves
+the *v* of *vuestra*.
+
+## Why it's said this way
+
+A title like "your grace" refers to a respected person in the third person.
+That is why modern *usted* still takes the he/she verb form even while it means
+"you." The social history remains visible in the grammar.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the two-word title that became *usted*]
+- [YOU SAY: "usted" followed by "mercy" and "merchant" — the *merc-* family]
+- [YOU SAY: which verb pattern *usted* takes]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did *vuestra merced* mean? ("Your grace" or "your mercy.")
+Why does *usted* take the he/she verb form? (It began as a third-person title.)

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — schema-v2 lesson AST and strict curriculum contract
+
+- Parse one-level nested lesson frontmatter and losslessly expose level-two
+  Markdown sections as stable typed body blocks.
+- Enforce schema-v2 spine mapping, local sequence, strict computed duration,
+  block shape, coverage metadata, same-language prerequisites, stable knowledge
+  atoms, unique introductions, and transitive knowledge closure.
+- Prove the contract on all 24 Spanish Chapter 1–3 lessons while preserving
+  schema-v1 compatibility for the rest of the corpus.
+
 ### Added — curriculum migration gap report
 
 - Added deterministic JSON and text reports for effective lesson duration,

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -9,7 +9,7 @@ consume. It implements [`HL01`](../../../specs/HL01-concept-taxonomy-and-data-la
 ## What it does
 
 The curriculum is a pile of per-language Markdown lessons. This package parses
-their frontmatter, joins them through the canonical **concept taxonomy**
+their frontmatter and lossless typed body blocks, joins them through the canonical **concept taxonomy**
 (`concepts/taxonomy.json`), and exposes the result as a queryable dataset —
 plus a **validator** that keeps the lessons and the taxonomy from drifting apart.
 It also produces the versioned migration-gap report published with every book
@@ -59,8 +59,9 @@ until the existing corpus has been split.
 
 | Module | Role | Pure? |
 |---|---|---|
-| `frontmatter.ts` | tiny zero-dep YAML-frontmatter reader | ✅ |
-| `parse.ts` | frontmatter → `Realization`; realizations → `Dataset` | ✅ |
+| `frontmatter.ts` | tiny zero-dep frontmatter reader with one nested-map level | ✅ |
+| `parse.ts` | frontmatter + Markdown → typed lesson AST; realizations → `Dataset` | ✅ |
+| `curriculum.ts` | spine, prerequisite, schema-v2 duration/block/knowledge validation | ✅ |
 | `validate.ts` | the round-trip validator (errors fail CI; warnings tolerated) | ✅ |
 | `queries.ts` | `allConcepts` / `conceptsByLanguage` / `languagesForConcept` / `coverageByLanguage` | ✅ |
 | `report.ts` | deterministic duration, prerequisite, book, and schema gap report | ✅ |
@@ -82,6 +83,12 @@ namespaced), one realization per (concept, language), required fields present,
 field shapes, script-glyph coverage (where script data exists), and core-concept
 coverage (enforced only for tracks that declare `parity: complete`). The
 integration test runs it against the real curriculum, so drift breaks CI.
+
+For a lesson declaring `schema_version: 2`, `validateCurriculum()` additionally
+enforces its canonical spine node, unique per-language sequence, 1–299 second
+declared and computed duration, stable typed body sections, explicit
+skill/mode/strand/register/variety metadata, same-language prerequisites, and
+transitive knowledge closure. Schema-v1 tracks remain readable during migration.
 
 ## Scope note
 

--- a/code/packages/typescript/human-language-data/src/constants.ts
+++ b/code/packages/typescript/human-language-data/src/constants.ts
@@ -44,12 +44,18 @@ export const CONTENT_TYPES = new Set(["word", "phrase"]);
  *   accent) and its `gloss` names it; it takes no `concept_tag`, because a mark
  *   is not a word that joins across languages. See HL00 "writing nuances" and
  *   HL02 (the app renders these for hand-writing practice).
+ *
+ * `grammar` and `etymology` are short support lessons whose progression lives
+ * in knowledge atoms rather than the cross-language vocabulary join.
  */
 export const EXEMPT_TYPES = new Set([
   "practice",
   "practice-mix",
   "review",
   "writing",
+  // Short support lessons are ordered by knowledge atoms, not concept joins.
+  "grammar",
+  "etymology",
 ]);
 
 /** A language-local concept id: two-letter lang prefix + SCREAMING-KEBAB name. */

--- a/code/packages/typescript/human-language-data/src/curriculum.ts
+++ b/code/packages/typescript/human-language-data/src/curriculum.ts
@@ -1,6 +1,7 @@
 // Pure validation for the structured HL04 language registry and shared spine.
 
 import { CONTENT_TYPES, hasOwn } from "./constants.js";
+import { DURATION_THRESHOLD_SECONDS, estimateLessonDuration } from "./report.js";
 import type {
   BookCorpus,
   CurriculumSpine,
@@ -9,6 +10,20 @@ import type {
   Taxonomy,
 } from "./types.js";
 import type { ParsedLesson } from "./parse.js";
+
+const SCHEMA_V2_SKILLS = new Set(["listening", "speaking", "reading", "writing"]);
+const SCHEMA_V2_MODES = new Set(["interpretive", "interpersonal", "presentational", "mediation"]);
+const SCHEMA_V2_STRANDS = new Set(["meaning-input", "meaning-output", "language-focus", "fluency"]);
+const KNOWLEDGE_ATOM = /^[A-Z]{2,}(?:-[A-Z0-9]+)+$/;
+
+function stringValue(value: ParsedLesson["frontmatter"][string] | undefined): string {
+  return typeof value === "string" ? value : "";
+}
+
+function stringList(value: ParsedLesson["frontmatter"][string] | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  return typeof value === "string" && value.trim() !== "" ? [value] : [];
+}
 
 export interface CurriculumValidationInput {
   registry: LanguageRegistry;
@@ -84,6 +99,10 @@ export function validateCurriculum(input: CurriculumValidationInput): Issue[] {
       warning("long-micro-lesson", `${id}: estimated at ${estimate} minutes; new spine lessons should be at most 5`, id);
     }
     if (lesson.body.trim() === "") warning("empty-lesson-body", `${id}: lesson has no authored body`, id);
+    const schemaVersion = stringValue(lesson.frontmatter.schema_version);
+    if (schemaVersion !== "" && schemaVersion !== "1" && schemaVersion !== "2") {
+      error("unknown-lesson-schema-version", `${id}: schema_version '${schemaVersion}' is not supported`);
+    }
   }
 
   const prerequisites = (lesson: ParsedLesson): string[] => {
@@ -161,6 +180,197 @@ export function validateCurriculum(input: CurriculumValidationInput): Issue[] {
     visited.add(id);
   };
   for (const id of nodeIds) visit(id);
+
+  // Schema v1 remains readable during migration. Version 2 is the strict HL04
+  // contract used by both books and apps, so every declared field is executable.
+  const schema2Lessons = lessons.filter(
+    (lesson) => stringValue(lesson.frontmatter.schema_version) === "2",
+  );
+  const sequences = new Map<string, Map<number, string>>();
+  const introducedByLesson = new Map<string, string[]>();
+  const atomOwner = new Map<string, Map<string, string>>();
+  for (const lesson of schema2Lessons) {
+    const id = lesson.realization.lessonId;
+    const fm = lesson.frontmatter;
+    const spineNode = stringValue(fm.spine_node);
+    if (!nodeIds.has(spineNode)) {
+      error("schema-v2-unknown-spine-node", `${id}: spine_node '${spineNode}' is not canonical`);
+    }
+
+    const sequence = Number(stringValue(fm.sequence));
+    if (!Number.isInteger(sequence) || sequence <= 0) {
+      error("schema-v2-invalid-sequence", `${id}: sequence must be a positive integer`);
+    } else {
+      const languageSequences = sequences.get(lesson.language) ?? new Map<number, string>();
+      const previous = languageSequences.get(sequence);
+      if (previous) {
+        error(
+          "schema-v2-duplicate-sequence",
+          `${id}: sequence ${sequence} is already used by ${previous} in ${lesson.language}`,
+        );
+      } else {
+        languageSequences.set(sequence, id);
+      }
+      sequences.set(lesson.language, languageSequences);
+    }
+
+    const declaredSeconds = Number(stringValue(fm["duration.max_seconds"]));
+    if (!Number.isInteger(declaredSeconds) || declaredSeconds < 1 || declaredSeconds >= DURATION_THRESHOLD_SECONDS) {
+      error(
+        "schema-v2-invalid-duration",
+        `${id}: duration.max_seconds must be an integer from 1 through 299`,
+      );
+    }
+    const estimate = estimateLessonDuration(lesson);
+    if (estimate.effectiveSeconds >= DURATION_THRESHOLD_SECONDS) {
+      error(
+        "schema-v2-duration-budget",
+        `${id}: effective duration is ${estimate.effectiveSeconds}s ` +
+          `(declared ${estimate.declaredSeconds}s, computed ${estimate.computedSeconds}s)`,
+      );
+    }
+
+    const requiredListFields = [
+      "requires.knowledge",
+      "introduces.knowledge",
+      "practises.knowledge",
+      "skills",
+      "modes",
+      "strands",
+    ];
+    for (const field of requiredListFields) {
+      if (!hasOwn(fm, field) || !Array.isArray(fm[field])) {
+        error("schema-v2-missing-list", `${id}: ${field} must be an authored list`);
+      }
+    }
+    for (const field of ["register", "variety"]) {
+      if (stringValue(fm[field]).trim() === "") {
+        error("schema-v2-missing-metadata", `${id}: ${field} must be explicit`);
+      }
+    }
+    for (const [field, allowed] of [
+      ["skills", SCHEMA_V2_SKILLS],
+      ["modes", SCHEMA_V2_MODES],
+      ["strands", SCHEMA_V2_STRANDS],
+    ] as const) {
+      const values = stringList(fm[field]);
+      if (values.length === 0) {
+        error("schema-v2-empty-coverage", `${id}: ${field} must contain at least one value`);
+      }
+      for (const value of values) {
+        if (!allowed.has(value)) {
+          error("schema-v2-unknown-coverage", `${id}: ${field} contains unknown value '${value}'`);
+        }
+      }
+    }
+
+    if (lesson.blocks.length === 0) {
+      error("schema-v2-empty-blocks", `${id}: body contains no typed level-two blocks`);
+    } else {
+      if (lesson.blocks[0]?.type !== "warmup") {
+        error("schema-v2-first-block", `${id}: first body block must be warmup`);
+      }
+      if (lesson.blocks.at(-1)?.type !== "recall") {
+        error("schema-v2-last-block", `${id}: last body block must be recall`);
+      }
+    }
+    for (const block of lesson.blocks) {
+      if (block.type === "unknown") {
+        error("schema-v2-unknown-block", `${id}: heading '${block.title}' has no stable block type`);
+      }
+      if (block.markdown.trim() === "") {
+        error("schema-v2-empty-block", `${id}: block '${block.title}' is empty`);
+      }
+    }
+
+    for (const prerequisite of prerequisites(lesson)) {
+      const resolved = lessonById.get(prerequisite);
+      if (resolved && resolved.language !== lesson.language) {
+        error(
+          "schema-v2-cross-language-prerequisite",
+          `${id}: prerequisite '${prerequisite}' belongs to ${resolved.language}`,
+        );
+      }
+    }
+
+    const introduced = stringList(fm["introduces.knowledge"]);
+    introducedByLesson.set(id, introduced);
+    const languageOwners = atomOwner.get(lesson.language) ?? new Map<string, string>();
+    for (const field of ["requires.knowledge", "introduces.knowledge", "practises.knowledge"]) {
+      for (const atom of stringList(fm[field])) {
+        if (!KNOWLEDGE_ATOM.test(atom)) {
+          error("schema-v2-invalid-knowledge-atom", `${id}: '${atom}' is not a stable knowledge atom id`);
+        }
+      }
+    }
+    for (const atom of introduced) {
+      const previous = languageOwners.get(atom);
+      if (previous) {
+        error(
+          "schema-v2-duplicate-knowledge-introduction",
+          `${id}: '${atom}' was already introduced by ${previous}`,
+        );
+      } else {
+        languageOwners.set(atom, id);
+      }
+    }
+    atomOwner.set(lesson.language, languageOwners);
+  }
+
+  for (const lesson of schema2Lessons) {
+    const sequence = Number(stringValue(lesson.frontmatter.sequence));
+    for (const prerequisite of prerequisites(lesson)) {
+      const resolved = lessonById.get(prerequisite);
+      if (!resolved || stringValue(resolved.frontmatter.schema_version) !== "2") continue;
+      const prerequisiteSequence = Number(stringValue(resolved.frontmatter.sequence));
+      if (Number.isFinite(sequence) && Number.isFinite(prerequisiteSequence) && prerequisiteSequence >= sequence) {
+        error(
+          "schema-v2-prerequisite-order",
+          `${lesson.realization.lessonId}: prerequisite '${prerequisite}' must have an earlier sequence`,
+        );
+      }
+    }
+  }
+
+  const prerequisiteKnowledge = (lesson: ParsedLesson): Set<string> => {
+    const known = new Set<string>();
+    const walked = new Set<string>();
+    const walk = (id: string): void => {
+      if (walked.has(id)) return;
+      walked.add(id);
+      for (const atom of introducedByLesson.get(id) ?? []) known.add(atom);
+      const resolved = lessonById.get(id);
+      if (resolved && resolved.language === lesson.language) {
+        for (const prerequisite of prerequisites(resolved)) walk(prerequisite);
+      }
+    };
+    for (const prerequisite of prerequisites(lesson)) walk(prerequisite);
+    return known;
+  };
+  for (const lesson of schema2Lessons) {
+    const id = lesson.realization.lessonId;
+    const known = prerequisiteKnowledge(lesson);
+    for (const atom of stringList(lesson.frontmatter["requires.knowledge"])) {
+      if (!known.has(atom)) {
+        error(
+          "schema-v2-knowledge-not-closed",
+          `${id}: required atom '${atom}' is not introduced by a transitive prerequisite`,
+        );
+      }
+    }
+    const available = new Set([
+      ...known,
+      ...stringList(lesson.frontmatter["introduces.knowledge"]),
+    ]);
+    for (const atom of stringList(lesson.frontmatter["practises.knowledge"])) {
+      if (!available.has(atom)) {
+        error(
+          "schema-v2-practice-before-introduction",
+          `${id}: practised atom '${atom}' is not yet available`,
+        );
+      }
+    }
+  }
 
   const spineConcepts = new Set(conceptOwner.keys());
   for (const language of registry.languages) {

--- a/code/packages/typescript/human-language-data/src/frontmatter.ts
+++ b/code/packages/typescript/human-language-data/src/frontmatter.ts
@@ -1,11 +1,9 @@
 // A deliberately tiny YAML-frontmatter reader.
 //
-// Lesson frontmatter is a flat block of `key: value` lines between two `---`
-// fences, where a value is a scalar or a simple `[a, b, c]` list. That's all the
-// schema uses, so a full YAML parser (and a third-party dependency, which this
-// repo forbids) would be overkill. This handles exactly that shape and nothing
-// more — which is a feature, not a limitation: it can't silently mis-parse
-// something clever because there's nothing clever to parse.
+// Lesson frontmatter is a block of `key: value` lines between two `---` fences,
+// where a value is a scalar or a simple `[a, b, c]` list. Schema v2 also uses
+// one level of nested maps, flattened here to dotted keys. A full YAML parser
+// (and a third-party dependency, which this repo forbids) would be overkill.
 
 export type FrontmatterValue = string | string[];
 
@@ -30,15 +28,25 @@ export function splitFrontmatter(source: string): {
 
 function parseBlock(block: string): Frontmatter {
   const out: Frontmatter = {};
+  let parent: string | undefined;
   for (const raw of block.split(/\r?\n/)) {
     const line = raw.trimEnd();
     // Skip blanks and whole-line comments.
     if (line.trim() === "" || line.trimStart().startsWith("#")) continue;
-    const colon = line.indexOf(":");
+    const trimmed = line.trimStart();
+    const colon = trimmed.indexOf(":");
     if (colon === -1) continue; // not a key: value line — ignore
-    const key = line.slice(0, colon).trim();
+    const key = trimmed.slice(0, colon).trim();
     if (key === "") continue;
-    out[key] = parseValue(line.slice(colon + 1).trim());
+    const value = trimmed.slice(colon + 1).trim();
+    const indented = trimmed.length !== line.length;
+    if (!indented && value === "") {
+      parent = key;
+      continue;
+    }
+    const resolvedKey = indented && parent ? `${parent}.${key}` : key;
+    out[resolvedKey] = parseValue(value);
+    if (!indented) parent = undefined;
   }
   return out;
 }

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -7,7 +7,7 @@
 export * from "./types.js";
 export * from "./constants.js";
 export { splitFrontmatter, type Frontmatter } from "./frontmatter.js";
-export { parseLesson, buildDataset, type ParsedLesson } from "./parse.js";
+export { parseBodyBlocks, parseLesson, buildDataset, type ParsedLesson } from "./parse.js";
 export {
   allConcepts,
   conceptsByLanguage,

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -9,6 +9,8 @@ import type {
   Concept,
   Dataset,
   Gender,
+  LessonBodyBlock,
+  LessonBlockType,
   Realization,
   Script,
   Taxonomy,
@@ -21,6 +23,10 @@ export interface ParsedLesson {
   frontmatter: Frontmatter;
   /** Lossless Markdown after the frontmatter, used by both books and apps. */
   body: string;
+  /** Markdown before the first level-two teaching block, normally the title. */
+  preamble: string;
+  /** Typed, ordered body blocks for schema-v2 validation and rendering. */
+  blocks: LessonBodyBlock[];
   realization: Realization;
 }
 
@@ -32,6 +38,62 @@ function arrayify(value: Frontmatter[string] | undefined): string[] {
 
 function str(value: Frontmatter[string] | undefined): string {
   return typeof value === "string" ? value : "";
+}
+
+function classifyBlock(title: string): LessonBlockType {
+  const normalized = title.toLowerCase();
+  if (normalized === "warm-up" || normalized === "warmup") return "warmup";
+  if (normalized.startsWith("you'll want to know")) return "input";
+  if (normalized.startsWith("sounds you'll need")) return "pronunciation";
+  if (normalized.startsWith("the word, taken apart")) return "etymology";
+  if (normalized.startsWith("why it's said this way")) return "culture-pragmatics";
+  if (
+    normalized.startsWith("grammar lens") ||
+    normalized.startsWith("the adjective sibling") ||
+    normalized.startsWith("its two tags")
+  ) return "grammar";
+  if (normalized.startsWith("guided practice") || normalized.startsWith("how to answer")) {
+    return "guided-production";
+  }
+  if (normalized.startsWith("wrap-up recall")) return "recall";
+  if (normalized.startsWith("what you've built")) return "notice";
+  if (normalized.startsWith("the exchange") || normalized.startsWith("the two words")) return "input";
+  return "unknown";
+}
+
+/** Parse level-two lesson sections into the stable HL04 body-block vocabulary. */
+export function parseBodyBlocks(body: string): {
+  preamble: string;
+  blocks: LessonBodyBlock[];
+} {
+  const lines = body.split(/\r?\n/);
+  const preamble: string[] = [];
+  const blocks: LessonBodyBlock[] = [];
+  let current: LessonBodyBlock | undefined;
+  const blockLines: string[] = [];
+  const finish = (): void => {
+    if (!current) return;
+    current.markdown = blockLines.join("\n").replace(/^\n|\n$/g, "");
+    blocks.push(current);
+    blockLines.length = 0;
+  };
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith("## ") && !trimmed.startsWith("### ")) {
+      finish();
+      const title = trimmed.slice(3).trim();
+      current = { type: classifyBlock(title), title, markdown: "" };
+    } else if (current) {
+      blockLines.push(line);
+    } else {
+      preamble.push(line);
+    }
+  }
+  finish();
+  return {
+    preamble: preamble.join("\n").replace(/^\n|\n$/g, ""),
+    blocks,
+  };
 }
 
 /** Gender: prefer an explicit field, else sniff the gloss, else none. */
@@ -83,7 +145,16 @@ export function parseLesson(
     roots: arrayify(fm.roots),
     etymologyHook: str(fm.etymology_hook),
   };
-  return { language, script: resolvedScript, frontmatter: fm, body, realization };
+  const typedBody = parseBodyBlocks(body);
+  return {
+    language,
+    script: resolvedScript,
+    frontmatter: fm,
+    body,
+    preamble: typedBody.preamble,
+    blocks: typedBody.blocks,
+    realization,
+  };
 }
 
 /**

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -117,8 +117,8 @@ function nonNegativeNumber(value: string): number | undefined {
 }
 
 function declaredDurationSeconds(lesson: ParsedLesson): number {
-  // The legacy parser flattens the indented `max_seconds` member from the HL04
-  // duration block, so both spellings keep the report useful during migration.
+  // The frontmatter parser flattens the indented `max_seconds` member from the
+  // HL04 duration block. The old spelling keeps reports useful during migration.
   const maxSeconds =
     nonNegativeNumber(stringValue(lesson.frontmatter["duration.max_seconds"])) ??
     nonNegativeNumber(stringValue(lesson.frontmatter.max_seconds));

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -133,6 +133,31 @@ export interface BookCorpus {
   books: LanguageBook[];
 }
 
+// ---- Typed lesson body (HL04 schema v2) ----------------------------------
+
+export type LessonBlockType =
+  | "warmup"
+  | "input"
+  | "notice"
+  | "pronunciation"
+  | "script"
+  | "etymology"
+  | "grammar"
+  | "culture-pragmatics"
+  | "guided-production"
+  | "comprehension"
+  | "fluency"
+  | "recall"
+  | "unknown";
+
+export interface LessonBodyBlock {
+  type: LessonBlockType;
+  /** Original level-two heading, kept for book/app presentation. */
+  title: string;
+  /** Lossless Markdown between this heading and the next typed block. */
+  markdown: string;
+}
+
 // ---- Script / character-breakdown data (data/scripts/<script>.json) ----
 //
 // Deliberately GENERAL, so one schema can teach any writing system. It has to

--- a/code/packages/typescript/human-language-data/tests/curriculum.test.ts
+++ b/code/packages/typescript/human-language-data/tests/curriculum.test.ts
@@ -31,6 +31,55 @@ reviews_of: []
 # A real body
 `;
 
+const sourceV2 = (
+  id: string,
+  sequence: number,
+  prerequisites: string[],
+  requires: string[],
+  introduces: string[],
+  practises: string[],
+) => `---
+schema_version: 2
+id: ${id}
+spine_node: HELLO
+sequence: ${sequence}
+chapter: 1
+type: word
+headword: hello
+gloss: hello
+concept_tag: GREETING-HELLO
+prerequisites: [${prerequisites.join(", ")}]
+duration:
+  max_seconds: 120
+requires:
+  knowledge: [${requires.join(", ")}]
+introduces:
+  knowledge: [${introduces.join(", ")}]
+practises:
+  knowledge: [${practises.join(", ")}]
+skills: [listening, speaking]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output]
+register: neutral
+variety: general
+reviews_of: []
+---
+
+# A real body
+
+## Warm-up
+
+Recall what you know.
+
+## Guided Practice
+
+Say hello.
+
+## Wrap-up Recall
+
+Say hello once.
+`;
+
 describe("curriculum prerequisite validation", () => {
   it("rejects an unknown lesson prerequisite", () => {
     const lessons = [parseLesson(source("A", "word", "GREETING-HELLO", ["MISSING"]), "test")];
@@ -45,5 +94,94 @@ describe("curriculum prerequisite validation", () => {
     ];
     expect(validateCurriculum({ registry, taxonomy, spine, lessons }).map((issue) => issue.code))
       .toContain("lesson-prerequisite-cycle");
+  });
+});
+
+describe("schema-v2 lesson validation", () => {
+  it("accepts a dependency-ordered transitive knowledge chain", () => {
+    const lessons = [
+      parseLesson(sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], ["TEST-LEX-HELLO"]), "test"),
+      parseLesson(
+        sourceV2(
+          "B",
+          20,
+          ["A"],
+          ["TEST-LEX-HELLO"],
+          ["TEST-GRAMMAR-GREETING"],
+          ["TEST-LEX-HELLO", "TEST-GRAMMAR-GREETING"],
+        ),
+        "test",
+      ),
+      parseLesson(
+        sourceV2(
+          "C",
+          30,
+          ["B"],
+          ["TEST-LEX-HELLO", "TEST-GRAMMAR-GREETING"],
+          [],
+          ["TEST-LEX-HELLO"],
+        ),
+        "test",
+      ),
+    ];
+    expect(validateCurriculum({ registry, taxonomy, spine, lessons }).filter((issue) => issue.level === "error"))
+      .toEqual([]);
+  });
+
+  it("rejects required and practised knowledge that is not available", () => {
+    const lessons = [
+      parseLesson(
+        sourceV2(
+          "A",
+          10,
+          [],
+          ["TEST-LEX-FUTURE"],
+          ["TEST-LEX-HELLO"],
+          ["TEST-GRAMMAR-FUTURE"],
+        ),
+        "test",
+      ),
+    ];
+    const codes = validateCurriculum({ registry, taxonomy, spine, lessons }).map((issue) => issue.code);
+    expect(codes).toContain("schema-v2-knowledge-not-closed");
+    expect(codes).toContain("schema-v2-practice-before-introduction");
+  });
+
+  it("rejects malformed duration, coverage, sequence, and body blocks", () => {
+    const malformed = sourceV2("A", 10, [], [], ["TEST-LEX-HELLO"], [])
+      .replace("sequence: 10", "sequence: 0")
+      .replace("max_seconds: 120", "max_seconds: 300")
+      .replace("skills: [listening, speaking]", "skills: [guessing]")
+      .replace("## Warm-up", "## Surprise")
+      .replace("## Wrap-up Recall", "## Guided Practice");
+    const lessons = [parseLesson(malformed, "test")];
+    const codes = validateCurriculum({ registry, taxonomy, spine, lessons }).map((issue) => issue.code);
+    expect(codes).toEqual(expect.arrayContaining([
+      "schema-v2-invalid-sequence",
+      "schema-v2-invalid-duration",
+      "schema-v2-duration-budget",
+      "schema-v2-unknown-coverage",
+      "schema-v2-first-block",
+      "schema-v2-last-block",
+      "schema-v2-unknown-block",
+    ]));
+  });
+
+  it("rejects a prerequisite that appears later in the authored sequence", () => {
+    const lessons = [
+      parseLesson(sourceV2("A", 20, ["B"], ["TEST-LEX-B"], ["TEST-LEX-A"], []), "test"),
+      parseLesson(sourceV2("B", 30, [], [], ["TEST-LEX-B"], []), "test"),
+    ];
+    expect(validateCurriculum({ registry, taxonomy, spine, lessons }).map((issue) => issue.code))
+      .toContain("schema-v2-prerequisite-order");
+  });
+
+  it("rejects an unknown authored schema version", () => {
+    const lesson = parseLesson(
+      source("A", "word", "GREETING-HELLO", []).replace("est_minutes: 4", "schema_version: 9"),
+      "test",
+    );
+    expect(validateCurriculum({ registry, taxonomy, spine, lessons: [lesson] }).map((issue) => issue.code))
+      .toContain("unknown-lesson-schema-version");
   });
 });

--- a/code/packages/typescript/human-language-data/tests/frontmatter.test.ts
+++ b/code/packages/typescript/human-language-data/tests/frontmatter.test.ts
@@ -42,6 +42,26 @@ describe("splitFrontmatter", () => {
     expect(frontmatter).toEqual({ id: "X" });
   });
 
+  it("flattens one schema-v2 nested map level to dotted keys", () => {
+    const { frontmatter } = splitFrontmatter(
+      [
+        "---",
+        "duration:",
+        "  max_seconds: 240",
+        "requires:",
+        "  knowledge: [ES-LEX-HOLA, ES-SOUND-H-SILENT]",
+        "register: neutral",
+        "---",
+        "",
+      ].join("\n"),
+    );
+    expect(frontmatter).toEqual({
+      "duration.max_seconds": "240",
+      "requires.knowledge": ["ES-LEX-HOLA", "ES-SOUND-H-SILENT"],
+      register: "neutral",
+    });
+  });
+
   it("returns null frontmatter when there is no fence", () => {
     const { frontmatter, body } = splitFrontmatter("no frontmatter here");
     expect(frontmatter).toBeNull();

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -70,6 +70,28 @@ describe("real curriculum", () => {
     expect(report.books.tracks).toHaveLength(20);
   });
 
+  it("keeps the Spanish Chapters 1-3 schema-v2 pilot closed and under five minutes", () => {
+    const report = buildCurriculumGapReport({ registry, lessons, books });
+    const pilot = lessons.filter(
+      (lesson) =>
+        lesson.language === "spanish" &&
+        lesson.realization.chapter >= 1 &&
+        lesson.realization.chapter <= 3,
+    );
+    expect(pilot).toHaveLength(24);
+    expect(pilot.every((lesson) => lesson.frontmatter.schema_version === "2")).toBe(true);
+    expect(
+      report.duration.violations.filter(
+        (lesson) => lesson.language === "spanish" && (lesson.chapter ?? 0) <= 3,
+      ),
+    ).toEqual([]);
+    expect(
+      report.prerequisites.laterChapterWithoutPrerequisites.filter(
+        (lesson) => lesson.language === "spanish" && (lesson.chapter ?? 0) <= 3,
+      ),
+    ).toEqual([]);
+  });
+
   it("GREETING-HELLO joins every track (the normalization payoff)", () => {
     // Every track realizes 'hello', so the join size tracks the track count.
     const langs = languagesForConcept(dataset, "GREETING-HELLO").map((r) => r.language);

--- a/code/packages/typescript/human-language-data/tests/parse.test.ts
+++ b/code/packages/typescript/human-language-data/tests/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseLesson, buildDataset } from "../src/parse.js";
+import { parseBodyBlocks, parseLesson, buildDataset } from "../src/parse.js";
 import type { Taxonomy } from "../src/types.js";
 
 const lesson = (fields: Record<string, string>) =>
@@ -70,6 +70,34 @@ describe("parseLesson", () => {
     );
     expect(p.script).toBe("hebrew");
     expect(p.realization.romanization).toBe("shalom");
+  });
+
+  it("preserves the preamble and parses stable typed body blocks", () => {
+    const body = [
+      "# hola — hello",
+      "",
+      "## Warm-up",
+      "Remember yesterday.",
+      "",
+      "## The word, taken apart",
+      "A root note.",
+      "",
+      "## Wrap-up Recall",
+      "Say it once.",
+    ].join("\n");
+    const parsed = parseBodyBlocks(body);
+    expect(parsed.preamble).toBe("# hola — hello");
+    expect(parsed.blocks).toEqual([
+      { type: "warmup", title: "Warm-up", markdown: "Remember yesterday." },
+      { type: "etymology", title: "The word, taken apart", markdown: "A root note." },
+      { type: "recall", title: "Wrap-up Recall", markdown: "Say it once." },
+    ]);
+  });
+
+  it("marks unregistered headings as unknown instead of discarding them", () => {
+    expect(parseBodyBlocks("## A surprising section\nKeep me.").blocks).toEqual([
+      { type: "unknown", title: "A surprising section", markdown: "Keep me." },
+    ]);
   });
 });
 

--- a/code/packages/typescript/human-language-data/tests/validate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/validate.test.ts
@@ -98,6 +98,18 @@ describe("validate", () => {
     expect(issues.some((i) => i.code === "unresolved-concept")).toBe(false);
   });
 
+  it("accepts grammar and etymology support lessons without concept tags", () => {
+    const support = ["grammar", "etymology"].map((type) =>
+      parseLesson(
+        lesson({ id: `ES-${type}`, chapter: "1", type, headword: type, gloss: `${type} support`, concept_tag: "" }),
+        "spanish",
+      ),
+    );
+    const issues = validate({ taxonomy, lessons: support });
+    expect(issues.some((i) => i.code === "unknown-type")).toBe(false);
+    expect(issues.some((i) => i.code === "missing-concept")).toBe(false);
+  });
+
   it("treats missing core coverage as info, but as error for parity-complete tracks", () => {
     const lessons = [good("spanish", "ES1", "GREETING-HELLO")]; // missing COURTESY-THANKS
     const infoIssues = validate({ taxonomy, lessons });

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased — schema-v2 lesson compatibility
+
+- Keep the browser's lightweight dataset adapter compatible with the canonical
+  typed lesson AST.
+- Derive the lesson-card minute label from schema-v2 `duration.max_seconds`,
+  while retaining `est_minutes` for unmigrated tracks.
+
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 
 - **Telugu కి, Kannada ಕಿ, Malayalam കി — side by side.** The three Dravidian

--- a/code/programs/typescript/language-ladder/src/concepts.ts
+++ b/code/programs/typescript/language-ladder/src/concepts.ts
@@ -106,6 +106,8 @@ export function datasetFromLessons(
     // an empty object is honest about that rather than reconstructing a fake.
     frontmatter: {},
     body: l.body,
+    preamble: "",
+    blocks: [],
     realization: {
       concept: l.concept,
       language: l.language,

--- a/code/programs/typescript/language-ladder/src/lessons.ts
+++ b/code/programs/typescript/language-ladder/src/lessons.ts
@@ -99,6 +99,14 @@ export function toLesson(parsed: ParsedLesson): Lesson | null {
   const r = parsed.realization;
   const arr = (v: unknown): string[] =>
     Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+  const maxSeconds =
+    typeof fm["duration.max_seconds"] === "string"
+      ? Number(fm["duration.max_seconds"])
+      : undefined;
+  const estMinutes =
+    maxSeconds !== undefined && Number.isFinite(maxSeconds)
+      ? Math.ceil(maxSeconds / 60)
+      : Number(typeof fm.est_minutes === "string" ? fm.est_minutes : 0);
 
   return {
     id,
@@ -115,7 +123,7 @@ export function toLesson(parsed: ParsedLesson): Lesson | null {
     script: r.script,
     etymologyHook: r.etymologyHook,
     body: parsed.body,
-    estMinutes: Number(typeof fm.est_minutes === "string" ? fm.est_minutes : 0),
+    estMinutes,
   };
 }
 

--- a/code/programs/typescript/language-ladder/tests/lessons.test.ts
+++ b/code/programs/typescript/language-ladder/tests/lessons.test.ts
@@ -21,6 +21,8 @@ concept_tag: ES-FUTURE
 prerequisites: [ES-C16-practice]
 reviews_of: [ES-C16-practice, ES-C06-hablar]
 roots: [futurus, esse]
+duration:
+  max_seconds: 240
 ---
 
 # body
@@ -74,6 +76,7 @@ describe("toLesson", () => {
     expect(lesson!.prerequisites).toEqual(["ES-C16-practice"]);
     expect(lesson!.reviewsOf).toEqual(["ES-C16-practice", "ES-C06-hablar"]);
     expect(lesson!.body).toContain("# body");
+    expect(lesson!.estMinutes).toBe(4);
   });
 
   it("skips a lesson with no id rather than inventing one", () => {


### PR DESCRIPTION
## Summary
- add the executable HL04 schema-v2 lesson contract: nested frontmatter, lossless typed body blocks, strict duration/coverage/order validation, and transitive knowledge closure
- migrate all 24 Spanish Chapters 1–3 lessons, splitting grammatical gender, the Latin qu- family, and the origin of usted into three prerequisite-safe support lessons
- keep Language Ladder compatible with the typed AST and schema-v2 duration labels
- record the post-slice backlog snapshot and prioritize canonical Spanish book generation next

## Measured result
- 24/24 pilot lessons use schema v2
- 0 pilot duration violations; maximum is ES-C01-buenos-dias at 296 seconds
- 0 later-chapter prerequisite roots in the pilot
- corpus snapshot: 976 lessons, 481 duration violations, 40 later-chapter roots

## Validation
- `human-language-data`: 59 tests pass; TypeScript build passes; real-curriculum validation passes (9 integration tests)
- `language-ladder`: 274 tests pass; production Vite build passes; coverage suite passes
- `git diff --check` passes