### PR TITLE
fix(spice): validate MOS sidewall junction capacitance

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `CJSW` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `CJ` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `MJSW` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1915,6 +1915,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(sidewall_junction_capacitance) = params.get("CJSW") {
+            if !sidewall_junction_capacitance.is_finite() || *sidewall_junction_capacitance < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET CJSW must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1893,6 +1893,35 @@ fn preserves_non_negative_mosfet_model_bottom_junction_capacitance() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_sidewall_junction_capacitance() {
+    for capacitance in ["-3p", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model sidewall NMOS(CJSW={capacitance})\nM1 d g s b sidewall"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET CJSW must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_sidewall_junction_capacitance() {
+    for (capacitance, expected) in [("0", 0.0), ("3p", 3.0e-12)] {
+        let parsed = parse_netlist(&format!(
+            ".model sidewall NMOS(CJSW={capacitance})\nM1 d g s b sidewall"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.sidewall_junction_capacitance, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card bottom-junction-capacitance validation.
+1. Rust Berkeley SPICE MOS model-card sidewall-junction-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `CJ` values before
+   - Reject negative and non-finite model-card `CJSW` values before
      lowering MOS elements into engine parameters.
-   - Preserve zero and positive bottom-junction capacitances.
+   - Preserve zero and positive sidewall-junction capacitances.
 
 ## Completed Slices
 
@@ -3990,6 +3990,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `MJSW` values are rejected before
      lowering MOS elements into engine parameters.
    - Zero and positive sidewall-junction grading coefficients remain accepted.
+
+346. Rust Berkeley SPICE MOS model-card bottom-junction-capacitance validation.
+   - Status: completed in PR 9496.
+   - Negative and non-finite model-card `CJ` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive bottom-junction capacitances remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CJSW` values in the Rust Berkeley parser facade
- preserve zero and positive sidewall-junction capacitances, including engineering suffixes
- reconcile the SPICE implementation plan after `CJ` validation merged

## Tests
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
Rust-only parser-facade validation. The shared Rust, Python, and TypeScript engine behavior and diagnostic are already aligned.