### PR TITLE
fix(build-tool): enforce Go rockspec UTF-8

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9495,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "6a59699f5ff6ee6453bfc0dd11efe210aaad7c54",
+    "revision": "cd7bc596221d1ecc47683f955d333176559b794e",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1217,
@@ -325,11 +325,11 @@
     {
       "id": "build-tool-lua-rockspec-encoding",
       "title": "Make Python build-tool Lua metadata decoding deterministic",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-pure-domain-corpus"],
       "branch": "codex/build-tool-lua-rockspec-encoding",
       "pr_number": 9495,
-      "notes": "Discovered while validating the Dart document-ast slice. The Python build tool discovers 4,763 packages, then its Lua resolver aborts before diff selection because _parse_lua_deps exposes a raw UnicodeDecodeError. This slice defines positive and adversarial language-neutral rockspec UTF-8 fixtures, normalizes the only three invalid repository rockspecs, and makes Python fail closed with METADATA_INVALID_UTF8, package/manifest identity, and CLI exit 2 without host paths or silent replacement. Ready-for-review PR #9495 is open from the dedicated parity branch; final-base local validation includes 50 focused resolver/CLI tests, 57 conformance tests plus 52 subtests, the 32-case corpus, a 4,765-package/7,100-edge full plan, strict UTF-8 across all 246 rockspecs, and a collision-clean 1,217-identity inventory."
+      "notes": "Merged PR #9495 at cd7bc596221d1ecc47683f955d333176559b794e on 2026-08-02. Discovered while validating the Dart document-ast slice, this work defines positive and adversarial language-neutral rockspec UTF-8 fixtures, normalizes the only three invalid repository rockspecs, and makes Python fail closed with METADATA_INVALID_UTF8, package/manifest identity, and CLI exit 2 without host paths or silent replacement. Final-base local validation included 50 focused resolver/CLI tests, 57 conformance tests plus 52 subtests, the 32-case corpus, a 4,765-package/7,100-edge full plan, strict UTF-8 across all 246 rockspecs, and a collision-clean 1,217-identity inventory. GitHub auto-merged the ready PR because the repository currently has no required-check gate."
     },
     {
       "id": "build-tool-rockspec-utf8-remaining-engines",
@@ -339,6 +339,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered by the Python encoding-blocker audit. Rust and Swift silently drop invalid rockspec dependencies; TypeScript replaces invalid bytes; Go, Lua, and Perl accept them; Ruby and Haskell use locale-sensitive text decoding; Elixir is position-dependent. Remediate those nine engines against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
+    },
+    {
+      "id": "build-tool-go-rockspec-utf8-conformance",
+      "title": "Make the Go build tool enforce strict UTF-8 rockspec metadata",
+      "status": "pending",
+      "depends_on": ["build-tool-lua-rockspec-encoding"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "First dependency-shaped child of build-tool-rockspec-utf8-remaining-engines. Go is prioritized because it is the intended operational oracle and currently treats arbitrary rockspec bytes as text. Bind its resolver and front door to resolution/lua-utf8 and resolution/lua-invalid-utf8, returning METADATA_INVALID_UTF8 with package and repository-relative manifest identity before dependency parsing; do not mix the other eight engine remediations into this slice."
     },
     {
       "id": "build-tool-python-haskell-language-filter",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -343,9 +343,9 @@
     {
       "id": "build-tool-go-rockspec-utf8-conformance",
       "title": "Make the Go build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-lua-rockspec-encoding"],
-      "branch": null,
+      "branch": "codex/build-tool-go-rockspec-utf8",
       "pr_number": null,
       "notes": "First dependency-shaped child of build-tool-rockspec-utf8-remaining-engines. Go is prioritized because it is the intended operational oracle and currently treats arbitrary rockspec bytes as text. Bind its resolver and front door to resolution/lua-utf8 and resolution/lua-invalid-utf8, returning METADATA_INVALID_UTF8 with package and repository-relative manifest identity before dependency parsing; do not mix the other eight engine remediations into this slice."
     },

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,7 +13,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "cd7bc596221d1ecc47683f955d333176559b794e",
+    "revision": "2140f0e5d9faba711d9bfe903804503ab9a5297d",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1217,
@@ -347,7 +347,7 @@
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": "codex/build-tool-go-rockspec-utf8",
       "pr_number": null,
-      "notes": "First dependency-shaped child of build-tool-rockspec-utf8-remaining-engines. Go is prioritized because it is the intended operational oracle and currently treats arbitrary rockspec bytes as text. Bind its resolver and front door to resolution/lua-utf8 and resolution/lua-invalid-utf8, returning METADATA_INVALID_UTF8 with package and repository-relative manifest identity before dependency parsing; do not mix the other eight engine remediations into this slice."
+      "notes": "First dependency-shaped child of build-tool-rockspec-utf8-remaining-engines. Go is prioritized because it is the intended operational oracle. The implementation binds its resolver to the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, requires the exact expected edge set, rejects invalid bytes before parsing with a typed MetadataEncodingError, emits METADATA_INVALID_UTF8 with package and repository-relative manifest identity, and returns CLI exit 2 without host paths. Validation on rebased main 2140f0e5d passed go test and race test across every package, 73.2% total coverage, go vet, trimpath build, the 57-test/52-subtest language-neutral conformance suite, a 32-case/36-file corpus check, a real 4,763-package/8,348-edge plan, collision-free parity inventory, and an exact BUILD-validator baseline comparison of 73 issues before and after. The other eight engine remediations remain outside this slice."
     },
     {
       "id": "build-tool-python-haskell-language-filter",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9504,
   "last_inventory": {
     "revision": "2140f0e5d9faba711d9bfe903804503ab9a5297d",
     "schema_version": 3,
@@ -343,11 +343,11 @@
     {
       "id": "build-tool-go-rockspec-utf8-conformance",
       "title": "Make the Go build tool enforce strict UTF-8 rockspec metadata",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": "codex/build-tool-go-rockspec-utf8",
-      "pr_number": null,
-      "notes": "First dependency-shaped child of build-tool-rockspec-utf8-remaining-engines. Go is prioritized because it is the intended operational oracle. The implementation binds its resolver to the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, requires the exact expected edge set, rejects invalid bytes before parsing with a typed MetadataEncodingError, emits METADATA_INVALID_UTF8 with package and repository-relative manifest identity, and returns CLI exit 2 without host paths. Validation on rebased main 2140f0e5d passed go test and race test across every package, 73.2% total coverage, go vet, trimpath build, the 57-test/52-subtest language-neutral conformance suite, a 32-case/36-file corpus check, a real 4,763-package/8,348-edge plan, collision-free parity inventory, and an exact BUILD-validator baseline comparison of 73 issues before and after. The other eight engine remediations remain outside this slice."
+      "pr_number": 9504,
+      "notes": "Ready PR #9504 is the first dependency-shaped child of build-tool-rockspec-utf8-remaining-engines. Go is prioritized because it is the intended operational oracle. The implementation binds its resolver to the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, requires the exact expected edge set, rejects invalid bytes before parsing with a typed MetadataEncodingError, emits METADATA_INVALID_UTF8 with package and repository-relative manifest identity, and returns CLI exit 2 without host paths. Validation on rebased main 2140f0e5d passed go test and race test across every package, 73.2% total coverage, go vet, trimpath build, the 57-test/52-subtest language-neutral conformance suite, a 32-case/36-file corpus check, a real 4,763-package/8,348-edge plan, collision-free parity inventory, and an exact BUILD-validator baseline comparison of 73 issues before and after. The other eight engine remediations remain outside this slice."
     },
     {
       "id": "build-tool-python-haskell-language-filter",

--- a/code/programs/go/build-tool/CHANGELOG.md
+++ b/code/programs/go/build-tool/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to the Go build tool will be documented in this file.
 
 ### Fixed
 
+- Lua `.rockspec` metadata is now decoded as strict UTF-8 before dependency
+  parsing. Invalid bytes fail closed with `METADATA_INVALID_UTF8`, package and
+  repository-relative manifest identity, and CLI exit code 2 without leaking
+  checkout paths.
 - Haskell dependency resolution now recognizes the plain Cabal names used by
   current packages as well as legacy `coding-adventures-*` names. The resolver
   registers directory and manifest aliases, parses every `build-depends`

--- a/code/programs/go/build-tool/README.md
+++ b/code/programs/go/build-tool/README.md
@@ -70,12 +70,22 @@ On Windows, use the compiled `.exe`:
 | `-diff-base` | origin/main | Git ref to diff against for change detection |
 | `-cache-file` | .build-cache.json | Path to the build cache file |
 
+## Metadata safety
+
+Text package metadata is decoded according to the language-neutral build-tool
+contract. In particular, Lua `.rockspec` files must be strict UTF-8. Invalid
+bytes stop resolution with `METADATA_INVALID_UTF8`, identify the package and
+repository-relative manifest, and return CLI exit code 2 without exposing the
+checkout path or silently replacing input.
+
 ## Architecture
 
 The tool is organized into seven internal packages, each responsible for one phase of the build pipeline:
 
 1. **discovery** -- Recursively walks for `BUILD` files to find packages
-2. **resolver** -- Parses `pyproject.toml`, `.gemspec`, `go.mod`, `Cargo.toml`, `package.json`, `mix.exs`, and `pubspec.yaml`
+2. **resolver** -- Parses ecosystem metadata including `pyproject.toml`,
+   `.gemspec`, `go.mod`, `Cargo.toml`, `package.json`, `mix.exs`, `.rockspec`,
+   `pubspec.yaml`, Cabal files, Gradle files, and .NET project references
 3. **hasher** -- SHA256 hashing for change detection
 4. **cache** -- JSON-based build cache (read/write with atomic saves)
 5. **executor** -- Parallel execution with goroutines + semaphore

--- a/code/programs/go/build-tool/internal/resolver/resolver.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver.go
@@ -40,15 +40,54 @@
 package resolver
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	directedgraph "github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph"
 	"github.com/adhithyan15/coding-adventures/code/programs/go/build-tool/internal/discovery"
 )
+
+const metadataInvalidUTF8 = "METADATA_INVALID_UTF8"
+
+// MetadataEncodingError reports text metadata that cannot be decoded under the
+// repository's strict UTF-8 contract. Manifest is always repository-relative so
+// diagnostics do not disclose checkout or temporary-directory paths.
+type MetadataEncodingError struct {
+	Code     string
+	Package  string
+	Manifest string
+	Encoding string
+}
+
+func (err *MetadataEncodingError) Error() string {
+	return fmt.Sprintf(
+		"%s: package=%s manifest=%s encoding=%s",
+		err.Code,
+		err.Package,
+		err.Manifest,
+		err.Encoding,
+	)
+}
+
+func repositoryManifestPath(path string) string {
+	parts := strings.Split(filepath.ToSlash(filepath.Clean(path)), "/")
+	canonicalStart := -1
+	for index := 0; index+1 < len(parts); index++ {
+		if parts[index] == "code" &&
+			(parts[index+1] == "packages" || parts[index+1] == "programs") {
+			canonicalStart = index
+		}
+	}
+	if canonicalStart >= 0 {
+		return strings.Join(parts[canonicalStart:], "/")
+	}
+	return filepath.ToSlash(filepath.Base(path))
+}
 
 // parsePythonDeps extracts internal dependencies from a Python pyproject.toml.
 //
@@ -482,11 +521,14 @@ func parseElixirDeps(pkg discovery.Package, knownNames map[string]string) []stri
 // "coding-adventures-" and map them to internal package names. Version
 // specifiers are stripped. The rockspec format uses hyphens in package names,
 // matching the Python/PyPI convention.
-func parseLuaDeps(pkg discovery.Package, knownNames map[string]string) []string {
+func parseLuaDeps(
+	pkg discovery.Package,
+	knownNames map[string]string,
+) ([]string, error) {
 	// Find .rockspec files in the package directory.
 	entries, err := os.ReadDir(pkg.Path)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
 	var rockspecPath string
@@ -497,12 +539,20 @@ func parseLuaDeps(pkg discovery.Package, knownNames map[string]string) []string 
 		}
 	}
 	if rockspecPath == "" {
-		return nil
+		return nil, nil
 	}
 
 	data, err := os.ReadFile(rockspecPath)
 	if err != nil {
-		return nil
+		return nil, nil
+	}
+	if !utf8.Valid(data) {
+		return nil, &MetadataEncodingError{
+			Code:     metadataInvalidUTF8,
+			Package:  pkg.Name,
+			Manifest: repositoryManifestPath(rockspecPath),
+			Encoding: "UTF-8",
+		}
 	}
 
 	text := string(data)
@@ -550,7 +600,7 @@ func parseLuaDeps(pkg discovery.Package, knownNames map[string]string) []string 
 		}
 	}
 
-	return internalDeps
+	return internalDeps, nil
 }
 
 // mapLuaDep strips version specifiers from a Lua dependency string and maps it
@@ -1166,7 +1216,7 @@ func readCabalPackageName(pkgPath string) string {
 // among the discovered packages — are silently skipped.
 //
 // This function is the main entry point for dependency resolution.
-func ResolveDependencies(packages []discovery.Package) *directedgraph.Graph {
+func ResolveDependencies(packages []discovery.Package) (*directedgraph.Graph, error) {
 	graph := directedgraph.New()
 
 	// First, add all packages as nodes. Even packages with no dependencies
@@ -1207,7 +1257,11 @@ func ResolveDependencies(packages []discovery.Package) *directedgraph.Graph {
 		case "elixir":
 			deps = parseElixirDeps(pkg, knownNames)
 		case "lua":
-			deps = parseLuaDeps(pkg, knownNames)
+			var err error
+			deps, err = parseLuaDeps(pkg, knownNames)
+			if err != nil {
+				return nil, err
+			}
 		case "perl":
 			deps = parsePerlDeps(pkg, knownNames)
 		case "swift":
@@ -1229,7 +1283,7 @@ func ResolveDependencies(packages []discovery.Package) *directedgraph.Graph {
 		}
 	}
 
-	return graph
+	return graph, nil
 }
 
 // BuildKnownNames is exported for testing. It delegates to buildKnownNames.

--- a/code/programs/go/build-tool/internal/resolver/resolver_test.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver_test.go
@@ -1,10 +1,16 @@
 package resolver
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
+	directedgraph "github.com/adhithyan15/coding-adventures/code/packages/go/directed-graph"
 	"github.com/adhithyan15/coding-adventures/code/programs/go/build-tool/internal/discovery"
 )
 
@@ -22,6 +28,163 @@ func makeFixture(t *testing.T, tree map[string]string) string {
 		}
 	}
 	return root
+}
+
+func mustResolveDependencies(t *testing.T, packages []discovery.Package) *directedgraph.Graph {
+	t.Helper()
+	graph, err := ResolveDependencies(packages)
+	if err != nil {
+		t.Fatalf("ResolveDependencies returned an unexpected error: %v", err)
+	}
+	return graph
+}
+
+type resolutionFixture struct {
+	Workspace struct {
+		Files []struct {
+			Path          string `json:"path"`
+			ContentUTF8   string `json:"content_utf8"`
+			ContentBase64 string `json:"content_base64"`
+		} `json:"files"`
+	} `json:"workspace"`
+	Expected struct {
+		Outcome string `json:"outcome"`
+		Result  struct {
+			Edges [][]string `json:"edges"`
+		} `json:"result"`
+		Diagnostics []struct {
+			Code    string `json:"code"`
+			Path    string `json:"path"`
+			Package string `json:"package"`
+			Details struct {
+				Encoding string `json:"encoding"`
+			} `json:"details"`
+		} `json:"diagnostics"`
+	} `json:"expected"`
+}
+
+func loadResolutionFixture(t *testing.T, name string) resolutionFixture {
+	t.Helper()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not locate resolver test source")
+	}
+	fixturePath := filepath.Join(
+		filepath.Dir(sourceFile),
+		"..", "..", "..", "..", "..",
+		"specs", "fixtures", "build-tool-v1", "cases", name,
+	)
+	data, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read shared fixture %s: %v", name, err)
+	}
+	var fixture resolutionFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatalf("decode shared fixture %s: %v", name, err)
+	}
+	return fixture
+}
+
+func materializeResolutionFixture(
+	t *testing.T,
+	fixture resolutionFixture,
+) (string, []discovery.Package) {
+	t.Helper()
+	root := t.TempDir()
+	packages := make([]discovery.Package, 0)
+	seenPackages := make(map[string]bool)
+	for _, file := range fixture.Workspace.Files {
+		var data []byte
+		var err error
+		if file.ContentBase64 != "" {
+			data, err = base64.StdEncoding.DecodeString(file.ContentBase64)
+			if err != nil {
+				t.Fatalf("decode %s: %v", file.Path, err)
+			}
+		} else {
+			data = []byte(file.ContentUTF8)
+		}
+		absolutePath := filepath.Join(root, filepath.FromSlash(file.Path))
+		if err := os.MkdirAll(filepath.Dir(absolutePath), 0755); err != nil {
+			t.Fatalf("create fixture directory for %s: %v", file.Path, err)
+		}
+		if err := os.WriteFile(absolutePath, data, 0644); err != nil {
+			t.Fatalf("write fixture file %s: %v", file.Path, err)
+		}
+
+		segments := strings.Split(filepath.ToSlash(file.Path), "/")
+		if filepath.Base(absolutePath) != "BUILD" || len(segments) != 5 {
+			continue
+		}
+		packageName := segments[2] + "/" + segments[3]
+		if seenPackages[packageName] {
+			continue
+		}
+		seenPackages[packageName] = true
+		packages = append(packages, discovery.Package{
+			Name:     packageName,
+			Path:     filepath.Join(root, filepath.FromSlash(strings.Join(segments[:4], "/"))),
+			Language: segments[2],
+		})
+	}
+	return root, packages
+}
+
+func TestLuaResolutionConformanceFixtures(t *testing.T) {
+	for _, name := range []string{
+		"resolution-lua-utf8.json",
+		"resolution-lua-invalid-utf8.json",
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := loadResolutionFixture(t, name)
+			root, packages := materializeResolutionFixture(t, fixture)
+			graph, err := ResolveDependencies(packages)
+
+			if fixture.Expected.Outcome == "ok" {
+				if err != nil {
+					t.Fatalf("ResolveDependencies returned an unexpected error: %v", err)
+				}
+				edges := graph.Edges()
+				if len(edges) != len(fixture.Expected.Result.Edges) {
+					t.Fatalf("dependency edge count = %d, want %d: %v", len(edges), len(fixture.Expected.Result.Edges), edges)
+				}
+				for _, edge := range fixture.Expected.Result.Edges {
+					if len(edge) != 2 || !graph.HasEdge(edge[0], edge[1]) {
+						t.Fatalf("missing expected dependency edge %v in %v", edge, edges)
+					}
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected invalid UTF-8 metadata to fail closed")
+			}
+			var encodingError *MetadataEncodingError
+			if !errors.As(err, &encodingError) {
+				t.Fatalf("expected MetadataEncodingError, got %T: %v", err, err)
+			}
+			diagnostic := fixture.Expected.Diagnostics[0]
+			if encodingError.Code != diagnostic.Code ||
+				encodingError.Package != diagnostic.Package ||
+				encodingError.Manifest != diagnostic.Path ||
+				encodingError.Encoding != diagnostic.Details.Encoding {
+				t.Fatalf("metadata diagnostic mismatch: got %#v, want %#v", encodingError, diagnostic)
+			}
+			if strings.Contains(encodingError.Error(), root) {
+				t.Fatalf("metadata diagnostic leaked fixture host path: %s", encodingError)
+			}
+		})
+	}
+}
+
+func TestRepositoryManifestPathUsesFinalCanonicalBoundary(t *testing.T) {
+	hostPath := filepath.Join(
+		"C:", "private", "code", "checkout", "code", "packages", "lua", "pkg", "pkg.rockspec",
+	)
+	want := "code/packages/lua/pkg/pkg.rockspec"
+	if got := repositoryManifestPath(hostPath); got != want {
+		t.Fatalf("repositoryManifestPath(%q) = %q, want %q", hostPath, got, want)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -254,7 +417,7 @@ name = "graph"
 		{Name: "rust/graph", Path: filepath.Join(root, "rust-graph"), Language: "rust"},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 	if !graph.HasEdge("rust/graph", "wasm/graph") {
 		t.Fatalf("expected rust/graph -> wasm/graph edge, got %v", graph.Edges())
 	}
@@ -275,7 +438,7 @@ func TestResolveDependenciesUsesBuildToolDepsComments(t *testing.T) {
 		},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 	if !graph.HasEdge("rust/paint-vm-direct2d-c", "swift/PaintVmDirect2DNative") {
 		t.Fatalf("expected build-tool deps comment to add Rust prerequisite, got %v", graph.Edges())
 	}
@@ -299,7 +462,7 @@ name = "avl-tree"
 		{Name: "rust/avl-tree", Path: filepath.Join(root, "rust-avl-tree"), Language: "rust"},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 	if graph.HasEdge("wasm/avl-tree", "wasm/avl-tree") {
 		t.Fatalf("did not expect wasm self-loop, got %v", graph.Edges())
 	}
@@ -346,7 +509,7 @@ func TestResolveDependenciesDotnetScopeSupportsCrossLanguageProjectReferences(t 
 		{Name: "fsharp/helpers", Path: filepath.Join(root, "fsharp-helpers"), Language: "fsharp"},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 	if !graph.HasEdge("fsharp/helpers", "csharp/graph") {
 		t.Fatalf("expected fsharp/helpers -> csharp/graph edge, got %v", graph.Edges())
 	}
@@ -374,7 +537,7 @@ func TestResolveDependenciesDotnetPrefersSameLanguageOnSharedBasename(t *testing
 		{Name: "fsharp/bitset", Path: filepath.Join(root, "fsharp", "bitset"), Language: "fsharp"},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 	if !graph.HasEdge("csharp/bitset", "csharp/graph") {
 		t.Fatalf("expected csharp/bitset -> csharp/graph edge, got %v", graph.Edges())
 	}
@@ -470,7 +633,7 @@ dependencies = []
 		{Name: "python/pkg-b", Path: filepath.Join(root, "pkg-b"), Language: "python"},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 
 	// Both nodes should exist.
 	if !graph.HasNode("python/pkg-a") || !graph.HasNode("python/pkg-b") {
@@ -501,7 +664,7 @@ dependencies = []
 		{Name: "python/pkg-b", Path: filepath.Join(root, "pkg-b"), Language: "python"},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 
 	// Edge: pkg-b → pkg-a (pkg-a depends on pkg-b).
 	if !graph.HasEdge("python/pkg-b", "python/pkg-a") {
@@ -532,7 +695,7 @@ end
 		{Name: "ruby/document_ast", Path: filepath.Join(root, "ruby/document_ast"), Language: "ruby"},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 
 	if !graph.HasEdge("elixir/document_ast", "elixir/document_ast_sanitizer") {
 		t.Fatal("expected Elixir dependency to resolve to the Elixir package")
@@ -560,7 +723,7 @@ end
 		{Name: "elixir/csv_parser", Path: filepath.Join(root, "elixir/csv_parser"), Language: "elixir"},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 
 	if !graph.HasEdge("elixir/csv_parser", "elixir/sql_csv_source") {
 		t.Fatal("expected Elixir dependency with plain app atom to resolve")
@@ -594,7 +757,7 @@ dependencies = []
 		{Name: "python/pkg-d", Path: filepath.Join(root, "pkg-d"), Language: "python"},
 	}
 
-	graph := ResolveDependencies(packages)
+	graph := mustResolveDependencies(t, packages)
 
 	// Verify edge count: d→b, d→c, b→a, c→a = 4 edges.
 	edges := graph.Edges()

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -31,6 +31,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -86,6 +87,14 @@ func findRepoRoot(start string) string {
 
 func main() {
 	os.Exit(run())
+}
+
+func formatResolverError(err error) (string, int) {
+	var encodingError *resolver.MetadataEncodingError
+	if errors.As(err, &encodingError) {
+		return encodingError.Error(), 2
+	}
+	return fmt.Sprintf("Error: %v", err), 1
 }
 
 // expandAffectedSetWithPrereqs ensures all transitive prerequisites of the
@@ -381,7 +390,12 @@ func run() int {
 		fmt.Printf("Discovered %d packages\n", len(packages))
 
 		// Step 4: Resolve dependencies.
-		graph = resolver.ResolveDependencies(packages)
+		graph, err = resolver.ResolveDependencies(packages)
+		if err != nil {
+			message, exitCode := formatResolverError(err)
+			fmt.Fprintln(os.Stderr, message)
+			return exitCode
+		}
 
 		// Step 5: Git-diff change detection (default mode).
 		// Git is the source of truth — no cache file needed for primary workflow.

--- a/code/programs/go/build-tool/resolver_error_test.go
+++ b/code/programs/go/build-tool/resolver_error_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/adhithyan15/coding-adventures/code/programs/go/build-tool/internal/resolver"
+)
+
+func TestFormatResolverErrorUsesStableMetadataDiagnostic(t *testing.T) {
+	message, exitCode := formatResolverError(&resolver.MetadataEncodingError{
+		Code:     "METADATA_INVALID_UTF8",
+		Package:  "lua/pkg",
+		Manifest: "code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec",
+		Encoding: "UTF-8",
+	})
+
+	if exitCode != 2 {
+		t.Fatalf("metadata input error exit code = %d, want 2", exitCode)
+	}
+	want := "METADATA_INVALID_UTF8: package=lua/pkg manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec encoding=UTF-8"
+	if message != want {
+		t.Fatalf("metadata diagnostic = %q, want %q", message, want)
+	}
+	if strings.Contains(message, `C:\private-checkout`) {
+		t.Fatalf("metadata diagnostic leaked a host path: %s", message)
+	}
+}
+
+func TestFormatResolverErrorKeepsOperationalFailuresDistinct(t *testing.T) {
+	message, exitCode := formatResolverError(errors.New("resolver failed"))
+	if exitCode != 1 || message != "Error: resolver failed" {
+		t.Fatalf("operational failure = (%q, %d), want (%q, 1)", message, exitCode, "Error: resolver failed")
+	}
+}
+
+func TestRunFailsClosedOnInvalidRockspecUTF8(t *testing.T) {
+	root := t.TempDir()
+	packageDir := filepath.Join(root, "code", "packages", "lua", "pkg")
+	if err := os.MkdirAll(packageDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "BUILD"), []byte("echo building\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rockspec := filepath.Join(packageDir, "coding-adventures-pkg-0.1.0-1.rockspec")
+	invalid := append([]byte("package = \"coding-adventures-pkg\"\n-- invalid: "), 0x97)
+	if err := os.WriteFile(rockspec, invalid, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalArgs := os.Args
+	originalFlags := flag.CommandLine
+	originalStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Args = originalArgs
+		flag.CommandLine = originalFlags
+		os.Stderr = originalStderr
+		reader.Close()
+		writer.Close()
+	})
+	flag.CommandLine = flag.NewFlagSet("build-tool-test", flag.ContinueOnError)
+	os.Args = []string{
+		"build-tool",
+		"-root", root,
+		"-force",
+		"-dry-run",
+		"-validate-build-files=false",
+	}
+	os.Stderr = writer
+
+	exitCode := run()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = originalStderr
+	stderr, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if exitCode != 2 {
+		t.Fatalf("run exit code = %d, want 2; stderr=%s", exitCode, stderr)
+	}
+	want := "METADATA_INVALID_UTF8: package=lua/pkg manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec encoding=UTF-8\n"
+	if string(stderr) != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if strings.Contains(string(stderr), root) {
+		t.Fatalf("front door leaked the checkout path: %s", stderr)
+	}
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,7 +106,7 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `6a59699f5` after
+working inventory was regenerated on August 2, 2026 from `cd7bc5962` after
 merged PRs #9477 and #9485 added the three Dart ML leaves and Dart
 `document-ast`, following the serial Rust smart-home additions through Sonos
 (#9461), Nanoleaf (#9486), and the Rust SPICE model validation chain. It contains
@@ -124,7 +124,7 @@ The loop must not start by attempting 10,738 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`6a59699f5ff6ee6453bfc0dd11efe210aaad7c54` is collision-clean at 1,217
+`cd7bc596221d1ecc47683f955d333176559b794e` is collision-clean at 1,217
 normalized implementation identities, 4,365 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 767 singletons, 572
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
@@ -209,14 +209,15 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   related packages in dependency-shaped waves. The Python validator now also
   materializes a 10-file Lua wave covering the compiler, serializer, language
   server, QR, and compression dependency chains;
-- keep the Python build tool's Lua rockspec decoding deterministic. The
-  encoding-blocker slice normalizes the three CP1252 metadata bytes, adds
-  positive and invalid-UTF-8 fixtures, and returns `METADATA_INVALID_UTF8`;
-  its refreshed full scan succeeds across 4,764 packages and 7,093 edges;
+- keep the Python build tool's Lua rockspec decoding deterministic. Merged PR
+  #9495 normalized the three CP1252 metadata bytes, added positive and invalid-
+  UTF-8 fixtures, and returns `METADATA_INVALID_UTF8`; its refreshed full scan
+  succeeds across 4,765 packages and 7,100 edges;
 - bring the remaining Go, Rust, Swift, TypeScript, Lua, Perl, Ruby, Elixir, and
   Haskell build-tool resolvers to the shared strict-UTF-8 rockspec contract.
   Their current byte, replacement, silent-drop, and locale-sensitive behavior
-  is tracked separately from the Python full-scan blocker;
+  is tracked separately from the Python full-scan blocker. The Go resolver is
+  the first prioritized child because it is the intended operational oracle;
 - expose Haskell through the Python build tool's `--language` filter. Haskell
   is already in its resolver and canonical language registry but is missing
   from the native CLI choices;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,7 +106,7 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `cd7bc5962` after
+working inventory was regenerated on August 2, 2026 from `2140f0e5d` after
 merged PRs #9477 and #9485 added the three Dart ML leaves and Dart
 `document-ast`, following the serial Rust smart-home additions through Sonos
 (#9461), Nanoleaf (#9486), and the Rust SPICE model validation chain. It contains
@@ -124,7 +124,7 @@ The loop must not start by attempting 10,738 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`cd7bc596221d1ecc47683f955d333176559b794e` is collision-clean at 1,217
+`2140f0e5d9faba711d9bfe903804503ab9a5297d` is collision-clean at 1,217
 normalized implementation identities, 4,365 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 767 singletons, 572
 Rust singletons, zero canonical collisions, and zero unknown language buckets.


### PR DESCRIPTION
## Summary
- make the Go build-tool resolver reject non-UTF-8 Lua rockspec metadata before parsing
- bind the implementation to the shared `resolution/lua-utf8` and `resolution/lua-invalid-utf8` fixtures, including an exact expected edge set
- report the stable `METADATA_INVALID_UTF8` code with package and repository-relative manifest identity, return CLI exit 2, and prevent checkout-path leakage
- propagate resolver failures through the Go build-tool API and document the contract

## Scope
This is the first dependency-shaped child of `build-tool-rockspec-utf8-remaining-engines`. The other eight engine remediations remain separate backlog items.

## Validation
- `go test ./...`
- `go test -race ./...`
- Go coverage: 73.2% total; resolver 86.6%
- `go vet ./...`
- `go build -trimpath ./...`
- targeted resolver and CLI integration tests using the exact shared success and invalid-byte fixtures
- language-neutral build-tool conformance: 57 tests plus 52 subtests
- shared corpus: 32 cases / 36 files / 15 established languages / 16 implementations
- real full-repository Go plan: 4,763 packages / 8,348 dependency edges / 13 affected packages / schema v1
- package parity inventory: 1,217 identities / 4,365 slots / zero collisions / zero unknown buckets
- full Go BUILD validator comparison: 73 baseline issues, 73 current issues, delta 0
- `git diff --check`
- focused `gofmt` passes for every touched Go file; the five repository-baseline unformatted files are outside this slice
- all Go module dependencies resolve through repository-local replacements
- independent read-only audit: no blockers

## Baseline notes
The full Go BUILD validation continues to report the same 73 pre-existing issues. The Go operational-oracle plan count also differs from the Python engine's existing count; both are tracked parity debt outside this encoding-focused slice.