### PR TITLE
feat(human-languages): generate Spanish chapter from lessons

### DIFF
--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           npm ci
           npm run build
+          npm run check:books
           mkdir -p "$GITHUB_WORKSPACE/dist/human-languages/books"
           npm run --silent report -- --format json \
             > "$GITHUB_WORKSPACE/dist/human-languages/books/curriculum-gaps.json"

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,9 +5,10 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after PR #9483: 20 registered
-tracks, 973 Markdown lessons, and 20 downloadable LaTeX books. HL-V01 makes the
-remaining migration debt reproducible in both JSON and human-readable reports.
+Last prioritized: 2026-08-02. Current baseline after PR #9497: 20 registered
+tracks, 976 Markdown lessons, and 20 downloadable LaTeX books. HL-V01 makes the
+remaining migration debt reproducible in both JSON and human-readable reports;
+HL-S01 proves the strict schema on the first 24 Spanish lessons.
 
 ## Priority rules
 
@@ -41,8 +42,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 
 | ID | Status | Work item | Why it follows P0 |
 |---|---|---|---|
-| HL-S01 | Complete in the Spanish schema-v2 PR | Migrate Spanish Chapters 1–3 to schema version 2 with typed body blocks and knowledge closure. | The 24-lesson slice has unique order, transitive knowledge closure, typed blocks, and no effective-duration violation. |
-| HL-G01 | Next | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy now that the AST contract is executable. |
+| HL-S01 | Complete (#9497) | Migrate Spanish Chapters 1–3 to schema version 2 with typed body blocks and knowledge closure. | The 24-lesson slice has unique order, transitive knowledge closure, typed blocks, and no effective-duration violation. |
+| HL-G01 | Complete in the canonical-generation PR | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy now that the AST contract is executable. |
+| HL-G02 | Next | Generate Spanish Chapters 2–3 from their canonical schema-v2 lesson AST. | Extends the proven one-source path across the rest of the migrated pilot before broad corpus work. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The audit must exist first so the debt remains measurable throughout migration. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
@@ -72,6 +74,22 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   typed body blocks, explicit coverage metadata, same-language prerequisites,
   and transitive knowledge closure. Block-boundary prompt/answer knowledge
   declarations remain a later refinement; this slice does not claim them.
+
+## Findings from HL-G01
+
+- Spanish Chapter 1 is generated deterministically from seven canonical
+  schema-v2 lessons in authored `sequence` order; the 18-book source is now 122
+  rendered pages with no generated-chapter overfull boxes.
+- The generated chapter and Language Ladder independently combine the same
+  per-lesson FNV-1a fingerprints. The app exposes `book synced` only when its
+  loaded Chapter 1 lesson AST matches the committed manifest.
+- The unified book job now fails when generated TeX or the hash manifest is
+  missing or stale. The fingerprint is a deterministic drift signal, not a
+  cryptographic integrity claim.
+- Chapter 1 is the first one-source slice. Spanish Chapters 2–18 remain
+  handwritten LaTeX until their lessons are migrated and configured; HL-G02
+  deliberately limits the next expansion to the already-schema-v2 Chapters
+  2–3.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "targets": [
+    {
+      "language": "spanish",
+      "chapter": 1,
+      "title": "Hola and Buenos Días",
+      "label": "ch:first-words",
+      "output": "spanish/book/chapters/ch01-first-words.tex"
+    }
+  ]
+}

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "algorithm": "fnv1a64",
+  "chapters": [
+    {
+      "language": "spanish",
+      "chapter": 1,
+      "sourceHash": "fnv1a64:746d660c5f9ec3cd",
+      "lessonIds": [
+        "ES-C01-hola",
+        "ES-C01-bien",
+        "ES-C01-el-la",
+        "ES-C01-genero-gramatical",
+        "ES-C01-dia",
+        "ES-C01-buenos-dias",
+        "ES-C01-practice"
+      ],
+      "tex": "spanish/book/chapters/ch01-first-words.tex"
+    }
+  ]
+}

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Chapter 1 — canonical book generation
+
+- Replaced the handwritten first chapter with deterministic LaTeX rendered
+  from its seven schema-v2 lesson ASTs in prerequisite-safe sequence order.
+- Added a committed FNV-1a source fingerprint manifest shared with Language
+  Ladder, plus a CI drift check that rejects stale generated TeX.
+- Built the 122-page XeLaTeX book and visually checked the generated opener,
+  grammar, culture, guided-practice, and recall layouts.
+
 ## Chapters 1–3 — executable schema-v2 pilot
 
 - Migrated the first three chapters to the HL04 lesson contract: canonical

--- a/code/learning/human-languages/spanish/README.md
+++ b/code/learning/human-languages/spanish/README.md
@@ -71,9 +71,12 @@ Requires a LaTeX distribution with `xelatex`/`latexmk` on PATH (MiKTeX or
 TeX Live). The compiled PDF isn't committed — it's regenerated from source,
 same as build artifacts elsewhere in this repo.
 
-The book and `units/` are two views of the same content, not independently
-maintained — the book is the continuous read, the units are the same
-material sliced into car-sized practice pieces.
+Chapter 1 is generated from the same seven canonical lesson ASTs consumed by
+Language Ladder. Run `npm run build && npm run generate:books` from
+`code/packages/typescript/human-language-data` after editing those lessons; CI
+rejects stale generated TeX or source-hash metadata. Chapters 2–18 are still
+handwritten LaTeX during the staged one-source migration. `units/` is legacy
+source material, not a second canonical copy.
 
 ## Progress
 
@@ -118,7 +121,8 @@ exactly where a word needs it:
   not-yet-real).
 
 Every noun carries its gender (*el*/*la*) and plural; every pronoun is traced
-to its root. **All 18 chapters are authored and in the book (114 pages).**
+to its root. **All 18 chapters are authored and in the book (122 pages); Chapter
+1 is generated from canonical lessons.**
 Lessons are named by **slug** (e.g. `ES-C01-dia`), not numbered — order lives
 in the book (which LaTeX auto-numbers) and in `session-map.md`, so inserting a
 lesson never renumbers anything.

--- a/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
@@ -1,163 +1,358 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:746d660c5f9ec3cd
+% canonical-lessons: ES-C01-hola, ES-C01-bien, ES-C01-el-la, ES-C01-genero-gramatical, ES-C01-dia, ES-C01-buenos-dias, ES-C01-practice
+
 \chapter{Hola and Buenos Días}
 \label{ch:first-words}
 
-We start with a single casual greeting, then build a second one \emph{from
-its pieces} --- a word for ``good,'' a word for ``day,'' and the first two
-rules of Spanish grammar picked up exactly where they're needed. By the end
-you can greet two ways and you'll understand why the words take the shapes
-they do. \emph{Practice lessons: \texttt{lessons/ES-C01-*.md}.}
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section{\emph{hola} --- hello}
-\label{lesson:hola}
+\section[hola]{hola — hello}
 
-\begin{sounds}
-The \textbf{h} is silent: \emph{hola} is said \emph{OH-la}, never
-\emph{HOH-la}. True of every Spanish \emph{h}.
-\end{sounds}
+\label{lesson:ES-C01-hola}
 
-\emph{hola} is the informal ``hi'' --- for friends, children, familiar faces.
-It carries no time of day and no deference, which is why warmer or
-first-meeting situations reach instead for \emph{buenos d\'{i}as}, which we
-build over the next three lessons.
 
-\begin{cousinweb}
-\emph{hola}'s origin is genuinely \textbf{unsettled} --- an old hailing call,
-and firm evidence stops about there. Its resemblance to English \emph{hello}
-is a \textbf{false friend}: \emph{hello} is Germanic (\emph{hail},
-\emph{holler}), a different family entirely. They sound alike by coincidence.
-Enjoy \emph{hola}, but don't file it next to \emph{hello} --- a fake
-connection is worse than none.
-\end{cousinweb}
 
-\section{\emph{bien} --- ``well,'' a whole answer in one word}
-\label{lesson:bien}
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The very first word, and the easiest to say — but there's already one trap hiding in it, and one small mystery.
+\end{quote}
 
 \begin{sounds}
-\textbf{ie} is a quick \emph{YEH}: \emph{bien} is \emph{byen}, one syllable.
-The \textbf{b} is soft, halfway to a \emph{v}.
+\begin{itemize}
+  \item \texttt{silent-h} — the \textbf{h is silent}. \emph{hola} is said \emph{OH-la}, never \emph{HOH-la}. The letter is written but makes no sound at all. This is true of every Spanish \emph{h} you'll ever meet. $\to$ pronunciation reference
+  \item \texttt{vowel-o}, \texttt{vowel-a} — two pure vowels: \emph{OH}, \emph{AH}. No glide, no drift.
+\end{itemize}
 \end{sounds}
 
 \begin{cousinweb}
-\textbf{bien} $\leftarrow$ Latin \emph{bene} (``well'') --- the piece hiding
-in a shelf of English words, all about something being good or well:
-\textbf{bene}fit (``to do well''), \textbf{bene}volent (``wishing well''),
-\textbf{bene}diction (``speaking well,'' a blessing), \textbf{bene}factor,
-be\textbf{nign}.
+\textbf{hola} — hello / hi.
+
+This one is a genuine mystery, and honesty matters more than a tidy story: \emph{hola}'s origin is \textbf{not settled}. It's an old interjection — a hailing call — and that's about as far as the evidence firmly goes. You'll see it confidently linked to English \emph{hello}, or to Arabic \emph{wallāh} ("by God"), or to a nautical shout. Treat all of those as \textbf{folk etymology}: plausible- sounding, not established.
+
+In particular, the resemblance to English \emph{hello} is a \textbf{false friend}. English \emph{hello} comes from a Germanic hailing root (\emph{hail}, \emph{holler}, \emph{hollo}) — a completely different family from anything Spanish. The two words sound alike by pure coincidence, not shared ancestry.
+
+\begin{quote}
+Why flag this so hard? Because the whole method of this book is building on real family resemblances between Spanish and English. A \emph{fake} one is worse than none — it teaches a connection your brain then has to unlearn. So: enjoy \emph{hola}, but don't file it next to \emph{hello} in your head. They're strangers who happen to look alike.
+\end{quote}
 \end{cousinweb}
 
-\emph{bien} is a complete answer on its own: ``\emph{\textquestiondown C\'{o}mo
-est\'{a}s?}'' $\to$ ``\textbf{Bien.}'' (``Well / I'm good.''); as agreement,
-``\textbf{Bien.}'' (``Okay, fine.''); intensified, ``\textbf{muy bien}.''
+\begin{culture}
+\emph{hola} is \textbf{informal}. It's the "hi" you'd say to a friend, a kid, a shopkeeper you know. It carries no time of day and no deference — which is exactly why, in more formal or first-meeting situations, Spanish speakers reach past it for \emph{buenos días} and its siblings (the next lessons). Knowing \emph{when not} to use \emph{hola} is as much the lesson as the word itself.
 
-\begin{grammarlens}
-\emph{bien} is an \textbf{adverb} (``well'' --- \emph{how} something is done).
-The \textbf{adjective} ``good,'' describing a thing, is \textbf{bueno}
-(masculine) / \textbf{buena} (feminine), from Latin \emph{bonus} (\emph{bene}'s
-sibling; its English cousins are \emph{bonus}, \emph{bonanza}, \emph{bounty}).
-English splits it the same way --- \emph{well} (adverb) vs.\ \emph{good}
-(adjective) --- though English's pair is Germanic, a parallel structure
-rather than a shared root. Your handle: \textbf{bien = well, bueno/buena =
-good.}
-\end{grammarlens}
+Note the written form: an exclamation gets an \textbf{upside-down mark} at the front — \emph{¡hola!} — so you know the tone before you start reading it aloud.
+\end{culture}
 
-\section{\emph{el} and \emph{la} --- ``the,'' and the gender it carries}
-\label{lesson:el-la}
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
 
-\emph{el} (``the,'' masculine) and \emph{la} (``the,'' feminine): English has
-one word, Spanish has two, because ``the'' must \textbf{match the gender} of
-its noun. You have to meet these before nouns, because they \emph{are} how
-Spanish carries gender.
+\begin{itemize}
+  \item {[}YOU SAY: "hola" — \emph{OH-la}, silent h{]}
+  \item {[}YOU SAY: "¡hola!" to an imagined friend — light, informal{]}
+\end{itemize}
 
-\begin{cousinweb}
-Both are worn-down Latin \textbf{demonstratives} meaning ``that one'':
-\textbf{el} $\leftarrow$ \emph{ille}, \textbf{la} $\leftarrow$ \emph{illa}.
-The pointing force faded, the initial \emph{i-} dropped (\emph{ille} $\to$
-\emph{el}), and ``that one'' softened into ``the'' --- the same erosion behind
-French \emph{le/la}, Italian \emph{il/la}. The \emph{same} \emph{ille/illa}
-also became \textbf{\'{e}l} (``he'') and \textbf{ella} (``she''): the article
-\emph{el} and the pronoun \emph{\'{e}l} are twins, told apart only by the
-accent. (English ``the'' is Germanic and \emph{unrelated} --- a shared job,
-not a shared root.)
-\end{cousinweb}
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Two things to lock in: what sound does the \emph{h} make? (None.) And is \emph{hola} actually related to English \emph{hello}? (No — a coincidence, a false friend.)
+\end{tcolorbox}
+\section[bien]{bien — "well," a whole answer in one word}
 
-\begin{grammarlens}
-Every Spanish noun has a \textbf{gender} --- masculine or feminine. A
-grammatical class, not a claim about sex; it comes from \textbf{Latin}, which
-sorted nouns into \emph{three} genders (masculine, feminine, neuter). Spanish
-kept \emph{two}, folding most neuters into the masculine. \emph{el}/\emph{la}
-are how gender shows in the open --- \emph{el d\'{i}a}, \emph{la noche} --- so
-from here every noun arrives \emph{with} its article, because gender can't be
-guessed reliably. (\emph{el}/\emph{la} are \emph{articles}; their accented
-twins \emph{\'{e}l}/\emph{ella} are the \emph{pronouns} ``he/she.'')
-\end{grammarlens}
+\label{lesson:ES-C01-bien}
 
-\section{\emph{d\'{i}a} --- your first noun}
-\label{lesson:dia}
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You have \emph{hola}. Now the word that carries half of everyday small talk: \emph{bien}. It answers "how are you," it agrees to a plan, it stands completely on its own — and it opens a family of English words you already use.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+  \item hola — your first word; \emph{bien} is what you say back when someone asks how you are.
+\end{itemize}
 
 \begin{sounds}
-The accent sits on the \textbf{\'{i}}: \emph{d\'{i}a} is \emph{DEE-a}, two
-beats. The \textbf{d} between vowels is soft, toward the \emph{th} in
-\emph{this}.
+\begin{itemize}
+  \item \texttt{diphthong-ie} — \textbf{ie} is a quick \emph{YEH}: \emph{bien} is said \emph{byen}, one syllable. $\to$ reference
+  \item \texttt{v-b} — the \textbf{b} is soft, halfway to a \emph{v}.
+\end{itemize}
 \end{sounds}
 
 \begin{cousinweb}
-\textbf{el d\'{i}a} $\leftarrow$ Latin \emph{dies} (``day'') $\to$
-\textbf{di}ary, \textbf{di}urnal, \textbf{jour}nal and \textbf{jour}ney
-(French \emph{jour}, ``a day''), quoti\textbf{di}an, meri\textbf{di}an, and
-\emph{dismal} (\emph{dies mali}, ``evil days'').
+\textbf{bien} — "well." Root: Latin \textbf{bene} ("well"). That \emph{bene} is the piece hiding in a shelf of English words, every one about something being \emph{good} or \emph{well}:
+
+\begin{itemize}
+  \item \textbf{bene}fit — literally "to do \textbf{well}" (\emph{bene} + \emph{facere}).
+  \item \textbf{bene}volent — "wishing \textbf{well}" (\emph{bene} + \emph{volens}).
+  \item \textbf{bene}diction — "speaking \textbf{well}," a blessing (\emph{bene} + \emph{dicere}).
+  \item \textbf{bene}factor, \textbf{bene}ficial, be\textbf{nign}.
+\end{itemize}
+
+So \emph{bien} is the Spanish member of the \emph{bene-} family you've owned in English your whole life.
+
+\textbf{Using it on its own.} This is the useful part: \emph{bien} is a complete answer.
+
+\begin{itemize}
+  \item "\emph{¿Cómo estás?}" (how are you?) $\to$ "\textbf{Bien.}" — "Well." / "I'm good." Done.
+  \item As agreement, when someone suggests something $\to$ "\textbf{Bien.}" — "Okay / fine."
+  \item Stack it: "\textbf{muy bien}" — "very well / very good."
+\end{itemize}
 \end{cousinweb}
 
-\begin{grammarlens}
-Now apply the gender you just met. \emph{d\'{i}a} is \textbf{masculine} ---
-\emph{el d\'{i}a} --- a small surprise, since it ends in \emph{-a}, the ending
-that usually signals feminine. The exception is pure inheritance: Latin
-\emph{dies} was masculine, and \emph{d\'{i}a} took that gender whole. (Exactly
-why gender is learned \emph{with} the word, never guessed from the ending.)\\
-\textbf{Number:} a noun ending in a vowel adds \textbf{-s}: \emph{d\'{i}a}
-$\to$ \emph{d\'{i}as}. The gender matters immediately --- the next section,
-\emph{buenos d\'{i}as}, bends \emph{bueno} to match it.
+\begin{grammarlens}[title={The adjective sibling: \emph{bueno} / \emph{buena}}]
+\emph{bien} is an \textbf{adverb} — it describes \emph{how} something is done ("you speak \emph{well}"). When you want the \textbf{adjective} — to describe a \emph{thing} as "good" — Spanish uses \textbf{bueno} (for a masculine word) or \textbf{buena} (for a feminine word). These come from Latin \textbf{bonus} ("good"), \emph{bene}'s sibling: Latin split the idea of "good" into an adverb (\emph{bene}) and an adjective (\emph{bonus}), and Spanish kept both. The Latin-descended English cousins of \emph{bueno} are \emph{bonus}, \emph{bonanza}, and \emph{bounty}.
+
+\begin{quote}
+\textbf{English does the exact same split}: \emph{well} (adverb) vs. \emph{good} (adjective) — "you did \emph{well}" but "a \emph{good} job." English's pair happens to be Germanic, not Latin, so \emph{well/good} aren't blood cousins of \emph{bien/bueno} — but the \emph{structure} is identical, and that parallel is your handle: \textbf{bien = well, bueno/buena = good.}
+\end{quote}
 \end{grammarlens}
 
-\section{\emph{buenos d\'{i}as} --- assembled from two words you have}
-\label{lesson:buenos-dias}
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
 
-Two lessons now snap together: \emph{bueno} (``good,'' \S\ref{lesson:bien})
-$+$ \emph{d\'{i}as} (``days,'' \S\ref{lesson:dia}) $=$ literally ``good
-days.'' But it comes out \emph{buen\textbf{os}}, not \emph{bueno} --- and the
-reason is this lesson's one new rule.
+\begin{itemize}
+  \item {[}YOU SAY: "bien" as the answer to "how are you"{]}
+  \item {[}YOU SAY: "muy bien"{]}
+  \item {[}YOU SAY: "bueno" then "buena" — the adjective, masculine then feminine{]}
+\end{itemize}
 
-\begin{grammarlens}
-An adjective \textbf{agrees} with its noun --- it copies the noun's gender and
-number. \emph{d\'{i}as} is masculine (last lesson's exception) and plural, so
-\emph{bueno} must become masculine plural: \emph{bueno} $\to$ \emph{buenos}.
-The four shapes:\\
-\quad \textbf{bueno} (masc.\ sg.) \quad \textbf{buena} (fem.\ sg.) \quad
-\textbf{buenos} (masc.\ pl.) \quad \textbf{buenas} (fem.\ pl.)\\
-English adjectives never do this (``good'' stays ``good''); Spanish makes the
-adjective echo the noun. That echo is \emph{why} it is \emph{buenos d\'{i}as},
-not \emph{bueno d\'{i}as}.
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which is the adverb ("well") and which is the adjective ("good")? (\emph{bien} / \emph{bueno}–\emph{buena}.) And name an English \emph{bene-} cousin of \emph{bien}. (benefit, benevolent, benediction…)
+\end{tcolorbox}
+\section[el / la]{el and la — "the," and the gender it carries}
+
+\label{lesson:ES-C01-el-la}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Before your first noun, meet two of the smallest, most frequent words in Spanish: \emph{el} and \emph{la}. Both mean "the." Your job here is simply to recognize the pair and connect each form to its label.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+  \item bien / bueno — you saw \emph{bueno} change to \emph{buena}; this lesson explains the gender that made it happen.
+\end{itemize}
+
+\begin{sounds}
+\begin{itemize}
+  \item \texttt{vowel-e}, \texttt{vowel-a} — two clean vowels: \emph{el} (\emph{ehl}), \emph{la} (\emph{lah}). $\to$ reference
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{el} — "the" (masculine). \textbf{la} — "the" (feminine). English has one word, "the"; Spanish makes this two-way distinction.
+
+\textbf{Where they come from.} Both are worn-down Latin \textbf{demonstratives} — words that meant "\textbf{that one (over there)}":
+
+\begin{itemize}
+  \item \textbf{el} $\leftarrow$ Latin \textbf{ille} ("that one," masculine).
+  \item \textbf{la} $\leftarrow$ Latin \textbf{illa} ("that one," feminine).
+\end{itemize}
+
+Over centuries the pointing force faded and the initial \emph{i-} dropped: \emph{ille $\to$ el}, \emph{illa $\to$ la}. What began as "that one" softened into a plain "the." The same \emph{ille/illa} spread across the whole family — French \emph{le/la}, Italian \emph{il/la} — every Romance "the" is eroded Latin "that."
+
+\textbf{The twin thread.} Those \emph{same} Latin words, \emph{ille/illa}, also became Spanish \textbf{él} ("he") and \textbf{ella} ("she"). So the article \emph{el} ("the") and the pronoun \emph{él} ("he") are twins from one Latin parent — told apart only by the accent. (English "the," by contrast, is Germanic and \emph{unrelated} — a shared job, not a shared root.)
+\end{cousinweb}
+
+\begin{grammarlens}[title={What you've built}]
+\emph{el} and \emph{la} are \textbf{articles}: little words that mark "the." Keep them apart from their accented relatives \emph{él} and \emph{ella}, the pronouns "he" and "she." The next micro-lesson explains why Spanish needs two article forms.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+  \item {[}YOU SAY: "el" then "la" — the two "the"s{]}
+  \item {[}YOU SAY: which article goes with a masculine noun? with a feminine one?{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which form is labelled masculine? (\emph{el}.) Which is labelled feminine? (\emph{la}.) Both come from Latin words meaning what? ("That one" — \emph{ille} / \emph{illa}.) What accented twins share their root? (\emph{él} / \emph{ella}.)
+\end{tcolorbox}
+\section[el / la + noun]{Grammatical gender — the two noun classes behind \emph{el} and \emph{la}}
+
+\label{lesson:ES-C01-genero-gramatical}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You know that \emph{el} and \emph{la} both mean "the." Now give their two labels: \emph{el} is masculine; \emph{la} is feminine.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+  \item el / la — the two definite articles.
+\end{itemize}
+
+\begin{grammarlens}[title={Grammar Lens: grammatical gender}]
+Every Spanish noun belongs to one of two \textbf{grammatical classes}, traditionally called masculine and feminine. This is not a claim about biological sex. It is a matching system: a masculine noun uses \emph{el}; a feminine noun uses \emph{la}.
+
+Latin had masculine, feminine, and neuter classes. Spanish reduced that three-way system to two, with most old neuter nouns joining the masculine class. The word \emph{gender} itself comes through Latin \emph{genus}, "kind" or "class."
+
+You cannot always predict a noun's class from its ending. Learn each new noun with its article, as one small unit: \emph{el + noun} or \emph{la + noun}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+  \item {[}YOU SAY: the article for a noun labelled masculine{]}
+  \item {[}YOU SAY: the article for a noun labelled feminine{]}
+  \item {[}YOU SAY: what grammatical gender classifies — nouns, not people{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How many noun classes did Latin have? (Three.) How many does Spanish keep? (Two.) What should travel with every new noun you learn? (Its article, \emph{el} or \emph{la}.)
+\end{tcolorbox}
+\section[día]{día — your first noun}
+
+\label{lesson:ES-C01-dia}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You just learned how Spanish tags gender with \emph{el} / \emph{la}. Now put it to work on your very first noun — \emph{día}, "day."
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+  \item el / la — grammatical gender and the two "the"s; \emph{día} is where you apply them.
+\end{itemize}
+
+\begin{sounds}
+\begin{itemize}
+  \item \texttt{accent-i} — the accent sits on the \textbf{í}: \emph{día} is \emph{DEE-a}, two beats. $\to$ reference
+  \item \texttt{d-soft} — the \textbf{d} between vowels is soft, toward the \emph{th} in \emph{this}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{el día} — "the day." Root: Latin \textbf{dies} ("day"). The family fans across English, mostly through French:
+
+\begin{itemize}
+  \item \textbf{di}ary, \textbf{di}urnal ("of the day").
+  \item \textbf{jour}nal, \textbf{jour}ney — French \emph{jour}, "a day" (a \emph{journey} was once "a day's travel").
+  \item quoti\textbf{di}an ("every-day"), meri\textbf{di}an ("mid-day"), and \emph{dismal} (\emph{dies mali}, "evil days").
+\end{itemize}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Its two tags: gender and number}]
+You already know gender from the last lesson; here's how \emph{día} wears it.
+
+\textbf{Gender.} \emph{día} is \textbf{masculine} — \emph{el día} — which is a small surprise, because it ends in \emph{-a}, the ending that usually signals feminine. Why the exception? Because Latin \emph{dies} was masculine, and \emph{día} inherited that gender whole, spelling be damned. (This is exactly why gender must be learned \emph{with} the word, not guessed from the ending — and it's the first of several "\emph{-a}-but-masculine" nouns you'll meet.)
+
+\textbf{Number.} One rule for now: a noun ending in a vowel adds \textbf{-s}. \emph{día $\to$ días} ("days"). (Consonant endings take \emph{-es} — later.)
+\end{grammarlens}
+
+\begin{grammarlens}[title={Grammar Lens: why the gender matters next}]
+Gender isn't a passive label — it \emph{forces} the words around the noun to match. The very next lesson, \emph{buenos días}, turns \emph{bueno} ("good") into \emph{buen}\emph{os}\emph{} precisely because \emph{día} is masculine and plural. So the gender you just attached to \emph{día} is about to earn its keep.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+  \item {[}YOU SAY: "el día" — with its masculine "the"{]}
+  \item {[}YOU SAY: "días" — plural, vowel + \emph{-s}{]}
+  \item {[}YOU SAY: is \emph{día} masculine or feminine, and why? (masculine — from Latin \emph{dies}, despite the \emph{-a}){]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which "the" goes with \emph{día}, and why? (\emph{el} — masculine, inherited from Latin \emph{dies}, despite the \emph{-a} ending.) How do you make it plural? (\emph{días} — vowel + \emph{-s}.)
+\end{tcolorbox}
+\section[buenos días]{buenos días — assembled from two words you already have}
+
+\label{lesson:ES-C01-buenos-dias}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Now watch two lessons snap together. You have \emph{bueno} ("good," from the \emph{bien} lesson) and \emph{días} ("days," from the \emph{día} lesson). Put them side by side and you build the greeting everyone knows — and, for the first time, you'll know \emph{why it's shaped the way it is}.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+  \item bien / bueno — the adjective \emph{bueno}.
+  \item día — the noun \emph{días}, and that it's masculine.
+\end{itemize}
+
+\begin{sounds}
+\begin{itemize}
+  \item \texttt{diphthong-ue} — \textbf{ue} is a quick \emph{WEH}: \emph{bueno} is \emph{BWEH-no}.
+  \item \texttt{accent-i} — \emph{días} keeps its stress on the \emph{í}: \emph{DEE-as}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{buenos días} = \textbf{bueno} ("good") + \textbf{días} ("days") = literally \textbf{"good days."}
+
+But look closely: it's \emph{buen}\emph{os}\emph{}, not \emph{bueno}. Why? Because of the one new grammar rule of this lesson.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: agreement}]
+An adjective in Spanish \textbf{agrees} with its noun — it copies the noun's gender and number. \emph{días} is \textbf{masculine} (the \emph{día} lesson's flagged exception) and \textbf{plural} (the \emph{-s} rule from the \emph{día} lesson). So \emph{bueno} has to become \textbf{masculine plural} to match: \emph{bueno $\to$ buenos}.
+
+The adjective \emph{bueno} has four shapes, and you now understand the machine that picks between them:
+
+\begin{itemize}
+  \item \textbf{bueno} — masculine singular (\emph{un buen día} $\to$ a good day)
+  \item \textbf{buena} — feminine singular
+  \item \textbf{buenos} — masculine plural $\to$ \emph{buenos días}
+  \item \textbf{buenas} — feminine plural (you'll want this one the moment we reach \emph{tardes} and \emph{noches}, which are feminine)
+\end{itemize}
+
+English adjectives never do this — "good" is "good" whether it's one day or a hundred. Spanish makes the adjective echo the noun. That echo is \emph{why} it's \emph{buenos días} and not \emph{bueno días}.
 \end{grammarlens}
 
 \begin{culture}
-Why ``good \emph{days}'' at all? Because \emph{buenos d\'{i}as} is a fossil ---
-the worn-down stub of \emph{``Buenos d\'{i}as os d\'{e} Dios,''} ``\emph{may
-God give you good days}.'' Not one good morning, but many good days ahead. The
-plural is the last bone of that blessing, and it's why the phrase feels warm
-and a little formal where \emph{hola} is casual --- almost literally a small
-\emph{bene}diction. (Widely accepted; exact history debated.)
+So why "good \textbf{days}," plural at all? Because \emph{buenos días} is a \textbf{fossil} — the worn-down stub of a blessing: \textbf{"Buenos días os dé Dios,"} \emph{"may God give you good days."} You weren't wishing one good morning; you were asking heaven for many good days ahead. The plural is the last bone of that prayer — and it's why \emph{buenos días} feels warm and a little formal, where \emph{hola} is casual. It is, almost literally, a small \emph{bene}diction (the \emph{bien} lesson's word). \emph{(A widely-accepted account; exact history debated.)}
 \end{culture}
 
-\section{Practice --- \emph{hola} and \emph{buenos d\'{i}as}}
-\label{lesson:ch1-practice}
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
 
-No new words --- just the four you built, until they're automatic. In four
-short lessons you went from nothing to two greetings and the first two rules
-of Spanish grammar: the plural (\emph{d\'{i}a} $\to$ \emph{d\'{i}as}) and
-agreement (\emph{bueno} $\to$ \emph{buenos}). Practice building \emph{buenos
-d\'{i}as} out loud from its pieces until the ``why'' feels obvious, not
-memorized.
+\begin{itemize}
+  \item {[}YOU SAY: build it slowly — "bueno" … "días" … "buenos días"{]}
+  \item {[}YOU SAY: "hola, buenos días" — casual + warm, stacked{]}
+  \item {[}YOU SAY: why is it \emph{buenos}, not \emph{bueno}? (out loud, in your own words){]}
+\end{itemize}
 
-The next question is the one that opens a real conversation: when
-\emph{someone else} greets \emph{you} with \emph{buenos d\'{i}as}, what do you
-say back? That is the next chapter --- where these words start turning into an
-exchange.
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Two things: why is it \emph{buenos} and not \emph{bueno}? (Agreement — \emph{días} is masculine plural.) And what blessing was \emph{buenos días} shortened from? ("May God give you good days.")
+\end{tcolorbox}
+\section[Practice]{Practice — hola and buenos días}
+
+\label{lesson:ES-C01-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} End of the chapter. No new words — just the four you have, turned over until they're automatic.
+\end{quote}
+
+\begin{grammarlens}[title={What you've built}]
+In four short lessons you went from nothing to two full greetings and the first two rules of Spanish grammar:
+
+\begin{itemize}
+  \item \textbf{hola} — the casual "hi."
+  \item \textbf{bien} — "well/good," a complete answer on its own; and its adjective sibling \textbf{bueno / buena}.
+  \item \textbf{día $\to$ días} — a noun, and the plural rule (vowel + \emph{-s}).
+  \item \textbf{buenos días} — assembled from \emph{bueno} + \emph{días}, with \textbf{agreement} turning \emph{bueno} into \emph{buenos} to match.
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]} Say each out loud; don't just read.
+
+\begin{itemize}
+  \item {[}YOU SAY: greet a friend casually — \emph{hola}{]}
+  \item {[}YOU SAY: greet someone warmly in the morning — \emph{buenos días}{]}
+  \item {[}YOU SAY: stack them — \emph{hola, buenos días}{]}
+  \item {[}YOU SAY: answer "how are you" with one word — \emph{bien}; then \emph{muy bien}{]}
+  \item {[}YOU SAY: the four shapes of "good" — \emph{bueno, buena, buenos, buenas} — and for each, is it masculine/feminine, singular/plural?{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Build \emph{buenos días} from scratch, out loud: \emph{bueno} $\to$ agree with masculine-plural \emph{días} $\to$ \emph{buenos días}. Do it until the "why" feels obvious, not memorized.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} You can now greet two ways and give a one-word positive answer. The very next question is the one that opens a real conversation: when \emph{someone else} says \emph{buenos días} to you — \textbf{what do you say back?} That's the whole next chapter, and it's where these words start turning into an exchange.
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/preamble.tex
+++ b/code/learning/human-languages/spanish/book/preamble.tex
@@ -46,10 +46,10 @@
 }
 
 % Grammar Lens callout: plain-language grammar concept + English contrast.
-\newtcolorbox{grammarlens}{
+\newtcolorbox{grammarlens}[1][]{
   breakable, skin=enhanced, colback=blue!5, colframe=blue!35!black,
   boxrule=0.5pt, arc=1mm, left=6pt, right=6pt, top=4pt, bottom=4pt,
-  fonttitle=\bfseries, title={Grammar Lens}
+  fonttitle=\bfseries, title={Grammar Lens}, #1
 }
 
 % Sounds callout: the pronunciation facts a single word needs.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — canonical LaTeX chapter generation
+
+- Added deterministic lesson-AST fingerprints and a pure Markdown-block to
+  LaTeX renderer, with Spanish Chapter 1 as the first generated slice.
+- Added write/check CLI modes, a committed chapter-hash manifest, path-safety
+  validation, and a unified-book CI drift gate.
+- Exposed each parsed lesson's source hash so book and app consumers can verify
+  that they loaded the same canonical content.
+
 ### Added — schema-v2 lesson AST and strict curriculum contract
 
 - Parse one-level nested lesson frontmatter and losslessly expose level-two

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -13,7 +13,8 @@ their frontmatter and lossless typed body blocks, joins them through the canonic
 (`concepts/taxonomy.json`), and exposes the result as a queryable dataset —
 plus a **validator** that keeps the lessons and the taxonomy from drifting apart.
 It also produces the versioned migration-gap report published with every book
-bundle.
+bundle and deterministically renders configured LaTeX chapters from that same
+lesson AST.
 
 ```
 lessons/*.md frontmatter  ─┐
@@ -49,6 +50,19 @@ npm run --silent report -- --format json > curriculum-gaps.json
 npm run --silent report -- --format text > curriculum-gaps.txt
 ```
 
+Generate configured book chapters, or verify the committed output is current:
+
+```bash
+npm run build
+npm run generate:books
+npm run check:books
+```
+
+`core/book-generation.json` declares each generated chapter. The generator
+orders schema-v2 lessons by `sequence`, writes the LaTeX chapter, and records a
+stable FNV-1a fingerprint in `core/generated-book-hashes.json`. The fingerprint
+detects drift between book and app inputs; it is not a security hash.
+
 The duration estimator uses instructional word count, explicit pauses, repeat
 cues, learner-response prompts, and a safety margin. Its effective duration is
 the greater of that estimate and the lesson's declared budget. A value of 300
@@ -61,6 +75,8 @@ until the existing corpus has been split.
 |---|---|---|
 | `frontmatter.ts` | tiny zero-dep frontmatter reader with one nested-map level | ✅ |
 | `parse.ts` | frontmatter + Markdown → typed lesson AST; realizations → `Dataset` | ✅ |
+| `hash.ts` | stable canonical lesson serialization and deterministic fingerprints | ✅ |
+| `book.ts` | typed lesson AST → LaTeX chapter | ✅ |
 | `curriculum.ts` | spine, prerequisite, schema-v2 duration/block/knowledge validation | ✅ |
 | `validate.ts` | the round-trip validator (errors fail CI; warnings tolerated) | ✅ |
 | `queries.ts` | `allConcepts` / `conceptsByLanguage` / `languagesForConcept` / `coverageByLanguage` | ✅ |
@@ -68,8 +84,9 @@ until the existing corpus has been split.
 | `loader.ts` | reads the curriculum off disk | ⛔ (fs) |
 | `cli.ts` | `validate` command + report | ⛔ (fs) |
 | `report-cli.ts` | prints JSON or text for CI artifact capture | ⛔ (fs) |
+| `book-cli.ts` | writes or checks generated chapters and their hash manifest | ⛔ (fs) |
 
-Only `loader.ts`, `cli.ts`, and `report-cli.ts` touch the filesystem (declared in
+Only `loader.ts`, `cli.ts`, `report-cli.ts`, and `book-cli.ts` touch the filesystem (declared in
 `required_capabilities.json`); everything the app relies on is pure and unit-tested
 against inline fixtures.
 

--- a/code/packages/typescript/human-language-data/package.json
+++ b/code/packages/typescript/human-language-data/package.json
@@ -6,6 +6,8 @@
   "main": "src/index.ts",
   "scripts": {
     "build": "tsc",
+    "generate:books": "node dist/book-cli.js --write",
+    "check:books": "node dist/book-cli.js --check",
     "report": "node dist/report-cli.js",
     "validate": "vitest run tests/integration.test.ts",
     "test": "vitest run",

--- a/code/packages/typescript/human-language-data/required_capabilities.json
+++ b/code/packages/typescript/human-language-data/required_capabilities.json
@@ -14,7 +14,19 @@
       "action": "list",
       "target": "../../learning/human-languages/**",
       "justification": "The loader enumerates each track's lessons/ directory and data/scripts/ to discover files to parse."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "../../learning/human-languages/**/book/chapters/*.tex",
+      "justification": "The explicit generate:books command refreshes configured LaTeX chapters from the canonical lesson AST; CI normally uses the read-only check:books drift gate."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "../../learning/human-languages/core/generated-book-hashes.json",
+      "justification": "The explicit generate:books command refreshes the deterministic app/book source-hash manifest; CI normally verifies it without writing."
     }
   ],
-  "justification": "Read-only filesystem access to the Human Languages curriculum directory. The parse/build/validate/query/report core is pure; only loader-backed CLI entry points touch the filesystem. No write, network, or process access needed."
+  "justification": "Filesystem access stays in loader-backed CLI entry points. Validation/reporting are read-only; the explicit book generator writes only configured LaTeX chapters and their shared source-hash manifest. No network or process access is needed."
 }

--- a/code/packages/typescript/human-language-data/src/book-cli.ts
+++ b/code/packages/typescript/human-language-data/src/book-cli.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, normalize, relative as pathRelative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { renderBookChapter, type BookGenerationTarget } from "./book.js";
+import { defaultCurriculumRoot, loadLessons } from "./loader.js";
+
+interface BookGenerationConfig {
+  version: 1;
+  targets: BookGenerationTarget[];
+}
+
+interface GeneratedBookHashManifest {
+  version: 1;
+  algorithm: "fnv1a64";
+  chapters: Array<{
+    language: string;
+    chapter: number;
+    sourceHash: string;
+    lessonIds: string[];
+    tex: string;
+  }>;
+}
+
+const MANIFEST_PATH = "core/generated-book-hashes.json";
+
+function loadConfig(root: string): BookGenerationConfig {
+  return JSON.parse(
+    readFileSync(join(root, "core", "book-generation.json"), "utf8"),
+  ) as BookGenerationConfig;
+}
+
+function safeOutput(root: string, relative: string): string {
+  const output = resolve(root, relative);
+  const fromRoot = normalize(pathRelative(resolve(root), output)).replaceAll("\\", "/");
+  if (
+    fromRoot === "" ||
+    fromRoot === ".." ||
+    fromRoot.startsWith("../") ||
+    !fromRoot.endsWith(".tex")
+  ) {
+    throw new Error(`unsafe generated book output '${relative}'`);
+  }
+  return output;
+}
+
+export function generatedBookOutputs(root = defaultCurriculumRoot()): Map<string, string> {
+  const config = loadConfig(root);
+  if (config.version !== 1 || config.targets.length === 0) {
+    throw new Error("book-generation.json must declare version 1 and at least one target");
+  }
+  const lessons = loadLessons(root);
+  const outputs = new Map<string, string>();
+  const manifest: GeneratedBookHashManifest = { version: 1, algorithm: "fnv1a64", chapters: [] };
+  for (const target of config.targets) {
+    const generated = renderBookChapter(target, lessons);
+    safeOutput(root, target.output);
+    outputs.set(target.output, generated.tex);
+    manifest.chapters.push({
+      language: target.language,
+      chapter: target.chapter,
+      sourceHash: generated.sourceHash,
+      lessonIds: generated.lessonIds,
+      tex: target.output,
+    });
+  }
+  manifest.chapters.sort(
+    (left, right) => left.language.localeCompare(right.language) || left.chapter - right.chapter,
+  );
+  outputs.set(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+  return outputs;
+}
+
+export function runBookGeneration(
+  args = process.argv.slice(2),
+  root = defaultCurriculumRoot(),
+): number {
+  const mode = args.length === 1 ? args[0] : undefined;
+  if (mode !== "--check" && mode !== "--write") {
+    process.stderr.write("usage: book-cli (--check | --write)\n");
+    return 2;
+  }
+  let mismatch = false;
+  for (const [relative, expected] of generatedBookOutputs(root)) {
+    const output = relative === MANIFEST_PATH ? join(root, relative) : safeOutput(root, relative);
+    if (mode === "--write") {
+      mkdirSync(dirname(output), { recursive: true });
+      writeFileSync(output, expected, "utf8");
+      process.stdout.write(`generated ${relative}\n`);
+      continue;
+    }
+    const actual = existsSync(output) ? readFileSync(output, "utf8") : undefined;
+    if (actual !== expected) {
+      process.stderr.write(`${relative}: generated output is missing or stale\n`);
+      mismatch = true;
+    }
+  }
+  return mismatch ? 1 : 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  process.exit(runBookGeneration());
+}

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -1,0 +1,251 @@
+import { canonicalChapterHash } from "./hash.js";
+import type { LessonBodyBlock } from "./types.js";
+import type { ParsedLesson } from "./parse.js";
+
+export interface BookGenerationTarget {
+  language: string;
+  chapter: number;
+  title: string;
+  label: string;
+  output: string;
+}
+
+export interface GeneratedBookChapter {
+  tex: string;
+  sourceHash: string;
+  lessonIds: string[];
+}
+
+function stringValue(value: ParsedLesson["frontmatter"][string] | undefined): string {
+  return typeof value === "string" ? value : "";
+}
+
+function escapeLatexCharacter(character: string): string {
+  const escaped: Record<string, string> = {
+    "\\": "\\textbackslash{}",
+    "{": "\\{",
+    "}": "\\}",
+    "%": "\\%",
+    "$": "\\$",
+    "#": "\\#",
+    "_": "\\_",
+    "&": "\\&",
+    "~": "\\textasciitilde{}",
+    "^": "\\textasciicircum{}",
+    "[": "{[}",
+    "]": "{]}",
+    "←": "$\\leftarrow$",
+    "→": "$\\to$",
+  };
+  return escaped[character] ?? character;
+}
+
+/** Render the deliberately small inline subset used by schema-v2 lessons. */
+export function renderInlineMarkdown(markdown: string): string {
+  const output: string[] = [];
+  let cursor = 0;
+  while (cursor < markdown.length) {
+    if (markdown.startsWith("**", cursor)) {
+      const end = markdown.indexOf("**", cursor + 2);
+      if (end !== -1) {
+        output.push(`\\textbf{${renderInlineMarkdown(markdown.slice(cursor + 2, end))}}`);
+        cursor = end + 2;
+        continue;
+      }
+    }
+    if (markdown[cursor] === "*") {
+      const end = markdown.indexOf("*", cursor + 1);
+      if (end !== -1) {
+        output.push(`\\emph{${renderInlineMarkdown(markdown.slice(cursor + 1, end))}}`);
+        cursor = end + 1;
+        continue;
+      }
+    }
+    if (markdown[cursor] === "`") {
+      const end = markdown.indexOf("`", cursor + 1);
+      if (end !== -1) {
+        const literal = markdown
+          .slice(cursor + 1, end)
+          .split("")
+          .map(escapeLatexCharacter)
+          .join("");
+        output.push(`\\texttt{${literal}}`);
+        cursor = end + 1;
+        continue;
+      }
+    }
+    if (markdown[cursor] === "[") {
+      const labelEnd = markdown.indexOf("](", cursor + 1);
+      const destinationEnd = labelEnd === -1 ? -1 : markdown.indexOf(")", labelEnd + 2);
+      if (labelEnd !== -1 && destinationEnd !== -1) {
+        output.push(renderInlineMarkdown(markdown.slice(cursor + 1, labelEnd)));
+        cursor = destinationEnd + 1;
+        continue;
+      }
+    }
+    output.push(escapeLatexCharacter(markdown[cursor] ?? ""));
+    cursor += 1;
+  }
+  return output.join("");
+}
+
+function renderMarkdown(markdown: string): string {
+  const output: string[] = [];
+  const paragraph: string[] = [];
+  const quote: string[] = [];
+  let listOpen = false;
+  let listItem: string[] = [];
+
+  const flushParagraph = (): void => {
+    if (paragraph.length === 0) return;
+    output.push(renderInlineMarkdown(paragraph.join(" ")), "");
+    paragraph.length = 0;
+  };
+  const flushQuote = (): void => {
+    if (quote.length === 0) return;
+    output.push("\\begin{quote}", renderInlineMarkdown(quote.join(" ")), "\\end{quote}", "");
+    quote.length = 0;
+  };
+  const flushListItem = (): void => {
+    if (listItem.length === 0) return;
+    output.push(`  \\item ${renderInlineMarkdown(listItem.join(" "))}`);
+    listItem = [];
+  };
+  const closeList = (): void => {
+    if (!listOpen) return;
+    flushListItem();
+    output.push("\\end{itemize}", "");
+    listOpen = false;
+  };
+
+  for (const rawLine of markdown.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (line.trim() === "") {
+      flushParagraph();
+      flushQuote();
+      closeList();
+      continue;
+    }
+    if (line.startsWith("> ")) {
+      flushParagraph();
+      closeList();
+      quote.push(line.slice(2));
+      continue;
+    }
+    if (line.startsWith("- ")) {
+      flushParagraph();
+      flushQuote();
+      if (!listOpen) {
+        output.push("\\begin{itemize}");
+        listOpen = true;
+      }
+      flushListItem();
+      listItem = [line.slice(2)];
+      continue;
+    }
+    if (listOpen && /^\s+/.test(line)) {
+      listItem.push(line.trim());
+      continue;
+    }
+    if (quote.length > 0) flushQuote();
+    if (listOpen) closeList();
+    paragraph.push(line.trim());
+  }
+  flushParagraph();
+  flushQuote();
+  closeList();
+  return output.join("\n").trimEnd();
+}
+
+function renderBlock(block: LessonBodyBlock): string {
+  const content = renderMarkdown(block.markdown);
+  const title = renderInlineMarkdown(block.title);
+  if (block.type === "pronunciation") return `\\begin{sounds}\n${content}\n\\end{sounds}`;
+  if (block.type === "etymology") return `\\begin{cousinweb}\n${content}\n\\end{cousinweb}`;
+  if (block.type === "grammar" || block.type === "notice") {
+    return `\\begin{grammarlens}[title={${title}}]\n${content}\n\\end{grammarlens}`;
+  }
+  if (block.type === "culture-pragmatics") return `\\begin{culture}\n${content}\n\\end{culture}`;
+  if (block.type === "warmup") {
+    return `\\begin{quote}\n\\textbf{Warm-up.} ${content}\n\\end{quote}`;
+  }
+  if (block.type === "recall") {
+    return [
+      "\\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]",
+      content,
+      "\\end{tcolorbox}",
+    ].join("\n");
+  }
+  return `\\subsection*{${title}}\n${content}`;
+}
+
+function lessonTitle(lesson: ParsedLesson): string {
+  const firstLine = lesson.preamble.split(/\r?\n/).find((line) => line.trim() !== "") ?? "";
+  return firstLine.startsWith("# ") ? firstLine.slice(2).trim() : lesson.realization.headword;
+}
+
+function lessonSequence(lesson: ParsedLesson): number {
+  return Number(stringValue(lesson.frontmatter.sequence));
+}
+
+/** Render one configured chapter from the same typed lesson AST the app receives. */
+export function renderBookChapter(
+  target: BookGenerationTarget,
+  allLessons: ParsedLesson[],
+): GeneratedBookChapter {
+  const lessons = allLessons
+    .filter(
+      (lesson) =>
+        lesson.language === target.language && lesson.realization.chapter === target.chapter,
+    )
+    .sort(
+      (left, right) =>
+        lessonSequence(left) - lessonSequence(right) ||
+        left.realization.lessonId.localeCompare(right.realization.lessonId),
+    );
+  if (lessons.length === 0) throw new Error(`${target.language} chapter ${target.chapter}: no lessons`);
+  for (const lesson of lessons) {
+    if (stringValue(lesson.frontmatter.schema_version) !== "2") {
+      throw new Error(`${lesson.realization.lessonId}: generated books require schema version 2`);
+    }
+    if (!Number.isInteger(lessonSequence(lesson))) {
+      throw new Error(`${lesson.realization.lessonId}: generated books require an integer sequence`);
+    }
+    if (lesson.blocks.some((block) => block.type === "unknown")) {
+      throw new Error(`${lesson.realization.lessonId}: generated books require known body blocks`);
+    }
+  }
+
+  const sourceHash = canonicalChapterHash(lessons);
+  const sections = lessons.map((lesson) => {
+    const id = lesson.realization.lessonId;
+    const shortTitle = lesson.realization.type.startsWith("practice")
+      ? "Practice"
+      : lesson.realization.headword;
+    return [
+      `\\section[${renderInlineMarkdown(shortTitle)}]{${renderInlineMarkdown(lessonTitle(lesson))}}`,
+      `\\label{lesson:${id}}`,
+      "",
+      ...lesson.blocks.map(renderBlock),
+    ].join("\n\n");
+  });
+  const tex = [
+    "% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.",
+    `% canonical-source-hash: ${sourceHash}`,
+    `% canonical-lessons: ${lessons.map((lesson) => lesson.realization.lessonId).join(", ")}`,
+    "",
+    `\\chapter{${renderInlineMarkdown(target.title)}}`,
+    `\\label{${target.label}}`,
+    "",
+    "This chapter is generated from the canonical micro-lessons used by Language Ladder.",
+    "Each section stays independently resumable and preserves the authored prerequisite order.",
+    "",
+    ...sections,
+    "",
+  ].join("\n");
+  return {
+    tex,
+    sourceHash,
+    lessonIds: lessons.map((lesson) => lesson.realization.lessonId),
+  };
+}

--- a/code/packages/typescript/human-language-data/src/hash.ts
+++ b/code/packages/typescript/human-language-data/src/hash.ts
@@ -1,0 +1,63 @@
+import type { Frontmatter } from "./frontmatter.js";
+import type { ParsedLesson } from "./parse.js";
+
+export interface LessonHashEntry {
+  id: string;
+  sequence: number;
+  sourceHash: string;
+}
+
+type CanonicalLesson = Pick<
+  ParsedLesson,
+  "language" | "script" | "frontmatter" | "body" | "preamble" | "blocks"
+>;
+
+function sortedFrontmatter(frontmatter: Frontmatter): Frontmatter {
+  return Object.fromEntries(
+    Object.entries(frontmatter).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+/** Browser-safe FNV-1a over UTF-8 bytes, used only as a deterministic drift fingerprint. */
+export function fnv1a64(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of new TextEncoder().encode(value)) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return `fnv1a64:${hash.toString(16).padStart(16, "0")}`;
+}
+
+/** Stable serialization of the canonical lesson AST shared by books and the app. */
+export function canonicalLessonSource(lesson: CanonicalLesson): string {
+  return JSON.stringify({
+    language: lesson.language,
+    script: lesson.script,
+    frontmatter: sortedFrontmatter(lesson.frontmatter),
+    body: lesson.body,
+    preamble: lesson.preamble,
+    blocks: lesson.blocks,
+  });
+}
+
+export function canonicalLessonHash(lesson: CanonicalLesson): string {
+  return fnv1a64(canonicalLessonSource(lesson));
+}
+
+/** Combine independently computed lesson hashes into one authored chapter fingerprint. */
+export function combineLessonHashes(entries: LessonHashEntry[]): string {
+  const ordered = [...entries].sort(
+    (left, right) => left.sequence - right.sequence || left.id.localeCompare(right.id),
+  );
+  return fnv1a64(JSON.stringify(ordered));
+}
+
+export function canonicalChapterHash(lessons: ParsedLesson[]): string {
+  return combineLessonHashes(
+    lessons.map((lesson) => ({
+      id: lesson.realization.lessonId,
+      sequence: Number(lesson.frontmatter.sequence),
+      sourceHash: lesson.sourceHash,
+    })),
+  );
+}

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -9,6 +9,20 @@ export * from "./constants.js";
 export { splitFrontmatter, type Frontmatter } from "./frontmatter.js";
 export { parseBodyBlocks, parseLesson, buildDataset, type ParsedLesson } from "./parse.js";
 export {
+  fnv1a64,
+  canonicalLessonSource,
+  canonicalLessonHash,
+  combineLessonHashes,
+  canonicalChapterHash,
+  type LessonHashEntry,
+} from "./hash.js";
+export {
+  renderInlineMarkdown,
+  renderBookChapter,
+  type BookGenerationTarget,
+  type GeneratedBookChapter,
+} from "./book.js";
+export {
   allConcepts,
   conceptsByLanguage,
   languagesForConcept,
@@ -41,3 +55,4 @@ export {
 } from "./report.js";
 export { runValidate } from "./cli.js";
 export { runCurriculumGapReport } from "./report-cli.js";
+export { generatedBookOutputs, runBookGeneration } from "./book-cli.js";

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -5,6 +5,7 @@
 
 import { splitFrontmatter, type Frontmatter } from "./frontmatter.js";
 import { LANGUAGE_SCRIPT, CONTENT_TYPES, hasOwn } from "./constants.js";
+import { canonicalLessonHash } from "./hash.js";
 import type {
   Concept,
   Dataset,
@@ -27,6 +28,8 @@ export interface ParsedLesson {
   preamble: string;
   /** Typed, ordered body blocks for schema-v2 validation and rendering. */
   blocks: LessonBodyBlock[];
+  /** Deterministic fingerprint of the canonical frontmatter and typed body AST. */
+  sourceHash: string;
   realization: Realization;
 }
 
@@ -146,15 +149,18 @@ export function parseLesson(
     etymologyHook: str(fm.etymology_hook),
   };
   const typedBody = parseBodyBlocks(body);
-  return {
+  const parsed: ParsedLesson = {
     language,
     script: resolvedScript,
     frontmatter: fm,
     body,
     preamble: typedBody.preamble,
     blocks: typedBody.blocks,
+    sourceHash: "",
     realization,
   };
+  parsed.sourceHash = canonicalLessonHash(parsed);
+  return parsed;
 }
 
 /**

--- a/code/packages/typescript/human-language-data/tests/book-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book-cli.test.ts
@@ -1,0 +1,100 @@
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generatedBookOutputs, runBookGeneration } from "../src/book-cli.js";
+
+const roots: string[] = [];
+
+function fixture(output = "test/book/chapters/ch01-first.tex"): string {
+  const root = mkdtempSync(join(tmpdir(), "human-language-book-"));
+  roots.push(root);
+  mkdirSync(join(root, "core"), { recursive: true });
+  mkdirSync(join(root, "test", "lessons"), { recursive: true });
+  writeFileSync(
+    join(root, "core", "book-generation.json"),
+    `${JSON.stringify({
+      version: 1,
+      targets: [{ language: "test", chapter: 1, title: "Hello", label: "ch:hello", output }],
+    })}\n`,
+  );
+  writeFileSync(
+    join(root, "test", "lessons", "hello.md"),
+    `---
+schema_version: 2
+id: TEST-C01-hello
+spine_node: HELLO
+sequence: 10
+chapter: 1
+type: word
+headword: hello
+gloss: hello
+concept_tag: GREETING-HELLO
+duration:
+  max_seconds: 120
+---
+
+# hello
+
+## Warm-up
+
+Say hello.
+
+## Wrap-up Recall
+
+Say hello again.
+`,
+  );
+  return root;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("canonical book generator filesystem shell", () => {
+  it("writes and checks the generated chapter plus source-hash manifest", () => {
+    const root = fixture();
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    expect(runBookGeneration(["--write"], root)).toBe(0);
+    const chapter = join(root, "test", "book", "chapters", "ch01-first.tex");
+    const manifest = join(root, "core", "generated-book-hashes.json");
+    expect(existsSync(chapter)).toBe(true);
+    expect(readFileSync(manifest, "utf8")).toContain('"algorithm": "fnv1a64"');
+    expect(runBookGeneration(["--check"], root)).toBe(0);
+
+    writeFileSync(chapter, "stale\n");
+    expect(runBookGeneration(["--check"], root)).toBe(1);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      "test/book/chapters/ch01-first.tex: generated output is missing or stale\n",
+    );
+  });
+
+  it("rejects outputs outside the curriculum root", () => {
+    const root = fixture("../../escape.tex");
+    expect(() => generatedBookOutputs(root)).toThrow(/unsafe generated book output/);
+  });
+
+  it("rejects an empty generation config and unsupported CLI modes", () => {
+    const root = fixture();
+    writeFileSync(
+      join(root, "core", "book-generation.json"),
+      `${JSON.stringify({ version: 1, targets: [] })}\n`,
+    );
+    expect(() => generatedBookOutputs(root)).toThrow(/at least one target/);
+
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(runBookGeneration([], root)).toBe(2);
+    expect(process.stderr.write).toHaveBeenCalledWith("usage: book-cli (--check | --write)\n");
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { renderBookChapter, renderInlineMarkdown } from "../src/book.js";
+import { parseLesson } from "../src/parse.js";
+
+function source(id: string, sequence: number, word: string): string {
+  return `---
+schema_version: 2
+id: ${id}
+spine_node: HELLO
+sequence: ${sequence}
+chapter: 1
+type: word
+headword: ${word}
+gloss: ${word}
+concept_tag: GREETING-HELLO
+prerequisites: []
+duration:
+  max_seconds: 120
+requires:
+  knowledge: []
+introduces:
+  knowledge: []
+practises:
+  knowledge: []
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input]
+register: neutral
+variety: general
+---
+
+# *${word}* — lesson
+
+## Warm-up
+
+Recall **${word}**.
+
+## Guided Practice
+
+- [YOU SAY: **${word}**]
+
+## Wrap-up Recall
+
+Say *${word}*.
+`;
+}
+
+const target = {
+  language: "test",
+  chapter: 1,
+  title: "First & safest",
+  label: "ch:first",
+  output: "test/book/chapters/ch01-first.tex",
+};
+
+describe("canonical LaTeX chapter rendering", () => {
+  it("renders typed blocks in sequence and embeds the combined source hash", () => {
+    const later = parseLesson(source("B", 20, "bye"), "test");
+    const earlier = parseLesson(source("A", 10, "hello"), "test");
+    const generated = renderBookChapter(target, [later, earlier]);
+    expect(generated.lessonIds).toEqual(["A", "B"]);
+    expect(generated.tex).toContain(`% canonical-source-hash: ${generated.sourceHash}`);
+    expect(generated.tex.indexOf("lesson:A")).toBeLessThan(generated.tex.indexOf("lesson:B"));
+    expect(generated.tex).toContain("\\begin{tcolorbox}");
+    expect(generated.tex).toContain("\\item {[}YOU SAY: \\textbf{hello}{]}");
+  });
+
+  it("escapes LaTeX control characters while preserving authored emphasis", () => {
+    expect(renderInlineMarkdown("**A&B** costs $5 and uses `x_y`")).toBe(
+      "\\textbf{A\\&B} costs \\$5 and uses \\texttt{x\\_y}",
+    );
+  });
+
+  it("fails closed when a target includes a legacy lesson", () => {
+    const legacy = parseLesson(source("A", 10, "hello").replace("schema_version: 2\n", ""), "test");
+    expect(() => renderBookChapter(target, [legacy])).toThrow(/schema version 2/);
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/hash.test.ts
+++ b/code/packages/typescript/human-language-data/tests/hash.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { combineLessonHashes, fnv1a64 } from "../src/hash.js";
+
+describe("canonical source fingerprints", () => {
+  it("matches the published FNV-1a 64-bit test vectors", () => {
+    expect(fnv1a64("")).toBe("fnv1a64:cbf29ce484222325");
+    expect(fnv1a64("hello")).toBe("fnv1a64:a430d84680aabd0b");
+  });
+
+  it("combines lesson hashes by authored sequence, independent of discovery order", () => {
+    const forward = [
+      { id: "A", sequence: 10, sourceHash: fnv1a64("a") },
+      { id: "B", sequence: 20, sourceHash: fnv1a64("b") },
+    ];
+    expect(combineLessonHashes([...forward].reverse())).toBe(combineLessonHashes(forward));
+    expect(combineLessonHashes(forward)).not.toBe(
+      combineLessonHashes([{ ...forward[1]!, sequence: 5 }, forward[0]!]),
+    );
+  });
+});

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -6,6 +6,8 @@
   typed lesson AST.
 - Derive the lesson-card minute label from schema-v2 `duration.max_seconds`,
   while retaining `est_minutes` for unmigrated tracks.
+- Independently combine loaded lesson fingerprints and show `book synced` for a
+  generated chapter only when the app AST matches the committed book manifest.
 
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 

--- a/code/programs/typescript/language-ladder/src/bookhashes.ts
+++ b/code/programs/typescript/language-ladder/src/bookhashes.ts
@@ -1,0 +1,55 @@
+import manifestJson from "../../../../learning/human-languages/core/generated-book-hashes.json";
+import { combineLessonHashes } from "@coding-adventures/human-language-data/src/hash.ts";
+import type { Lesson } from "./lessons.ts";
+
+interface BookHashEntry {
+  language: string;
+  chapter: number;
+  sourceHash: string;
+  lessonIds: string[];
+  tex: string;
+}
+
+const ENTRIES = manifestJson.chapters as BookHashEntry[];
+
+export type BookHashStatus = "not-generated" | "synced" | "stale";
+
+export function expectedBookHash(language: string, chapter: number): BookHashEntry | undefined {
+  return ENTRIES.find((entry) => entry.language === language && entry.chapter === chapter);
+}
+
+export function actualChapterHash(
+  lessons: Lesson[],
+  language: string,
+  chapter: number,
+): string | undefined {
+  const chapterLessons = lessons.filter(
+    (lesson) => lesson.language === language && lesson.chapter === chapter,
+  );
+  if (
+    chapterLessons.length === 0 ||
+    chapterLessons.some(
+      (lesson) => lesson.sourceHash === undefined || lesson.sequence === undefined,
+    )
+  ) {
+    return undefined;
+  }
+  return combineLessonHashes(
+    chapterLessons.map((lesson) => ({
+      id: lesson.id,
+      sequence: lesson.sequence!,
+      sourceHash: lesson.sourceHash!,
+    })),
+  );
+}
+
+/** Compare the browser-loaded lesson AST with the hash embedded in the book. */
+export function bookHashStatus(
+  lessons: Lesson[],
+  language: string,
+  chapter: number,
+): BookHashStatus {
+  const expected = expectedBookHash(language, chapter);
+  if (!expected) return "not-generated";
+  return actualChapterHash(lessons, language, chapter) === expected.sourceHash ? "synced" : "stale";
+}

--- a/code/programs/typescript/language-ladder/src/concepts.ts
+++ b/code/programs/typescript/language-ladder/src/concepts.ts
@@ -108,6 +108,7 @@ export function datasetFromLessons(
     body: l.body,
     preamble: "",
     blocks: [],
+    sourceHash: l.sourceHash ?? "",
     realization: {
       concept: l.concept,
       language: l.language,

--- a/code/programs/typescript/language-ladder/src/lessons.ts
+++ b/code/programs/typescript/language-ladder/src/lessons.ts
@@ -65,6 +65,10 @@ export interface Lesson {
   etymologyHook: string;
   /** Lossless authored lesson Markdown, shared with the book corpus. */
   body: string;
+  /** Canonical AST fingerprint; generated books combine these in authored order. */
+  sourceHash?: string;
+  /** Explicit schema-v2 local order. Legacy lessons omit it. */
+  sequence?: number;
   /** The author's upper bound for this micro-lesson. */
   estMinutes: number;
 }
@@ -123,6 +127,11 @@ export function toLesson(parsed: ParsedLesson): Lesson | null {
     script: r.script,
     etymologyHook: r.etymologyHook,
     body: parsed.body,
+    sourceHash: parsed.sourceHash,
+    sequence:
+      typeof fm.sequence === "string" && Number.isFinite(Number(fm.sequence))
+        ? Number(fm.sequence)
+        : undefined,
     estMinutes,
   };
 }

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -72,6 +72,7 @@ import {
 import { LANGUAGE_REGISTRY, SPINE_CONCEPTS, languageName, spineNodeForConcept } from "./curriculum.ts";
 import { loadLanguages, saveLanguages } from "./languagestore.ts";
 import { lessonSections } from "./lessonbody.ts";
+import { bookHashStatus } from "./bookhashes.ts";
 import taxonomyJson from "../../../../learning/human-languages/concepts/taxonomy.json";
 import type { Taxonomy } from "@coding-adventures/human-language-data/src/types.ts";
 import {
@@ -1505,7 +1506,9 @@ function renderLessons(): HTMLElement {
 
   const lesson = LESSONS[lessonIndex]!;
   const meta = el("p", "muted");
-  meta.textContent = `${languageName(lesson.language)} · chapter ${lesson.chapter} · ${lesson.id}`;
+  const hashStatus = bookHashStatus(LESSONS, lesson.language, lesson.chapter);
+  const bookStatus = hashStatus === "not-generated" ? "" : ` · book ${hashStatus}`;
+  meta.textContent = `${languageName(lesson.language)} · chapter ${lesson.chapter} · ${lesson.id}${bookStatus}`;
   wrap.appendChild(meta);
 
   // Prompt: the headword, in its own script. Answer hidden until asked for —

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { actualChapterHash, bookHashStatus, expectedBookHash } from "../src/bookhashes.ts";
+import { loadLessons } from "../src/lessons.ts";
+
+describe("generated book source hashes", () => {
+  it("matches the browser-loaded Spanish Chapter 1 AST to the generated book", () => {
+    const lessons = loadLessons();
+    const expected = expectedBookHash("spanish", 1);
+    expect(expected?.lessonIds).toHaveLength(7);
+    expect(actualChapterHash(lessons, "spanish", 1)).toBe(expected?.sourceHash);
+    expect(bookHashStatus(lessons, "spanish", 1)).toBe("synced");
+  });
+
+  it("reports a generated chapter stale when one canonical lesson changes", () => {
+    const lessons = loadLessons();
+    const changed = lessons.map((lesson) =>
+      lesson.id === "ES-C01-hola" ? { ...lesson, sourceHash: "fnv1a64:changed" } : lesson,
+    );
+    expect(bookHashStatus(changed, "spanish", 1)).toBe("stale");
+    expect(bookHashStatus(lessons, "spanish", 2)).toBe("not-generated");
+  });
+});


### PR DESCRIPTION
## Summary

- generate Spanish Chapter 1 deterministically from its seven canonical schema-v2 lesson ASTs
- add stable per-lesson and per-chapter FNV-1a drift fingerprints plus a committed generated-book manifest
- have Language Ladder independently compare its loaded lesson AST with the book manifest and surface `book synced`
- make the unified book workflow reject stale generated TeX or hash metadata
- record HL-G01 findings and reprioritize HL-G02 as the next one-source slice

## Validation

- `human-language-data`: 11 test files / 67 tests; 93.47% line coverage; TypeScript build; generated-output check; JSON gap report
- `language-ladder`: 27 test files / 276 tests; 98.37% line coverage; production Vite build
- Spanish XeLaTeX book: 122 pages, successful build
- rendered and visually inspected the generated chapter opener, grammar, culture, guided-practice, and recall pages
- `git diff --check`