### PR TITLE
fix(spice): validate MOS source bulk capacitance

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `CBS` / `CJS` values
+  before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `CJSW` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `CJ` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1922,6 +1922,14 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        for source_bulk_capacitance in [params.get("CBS"), params.get("CJS")].into_iter().flatten()
+        {
+            if !source_bulk_capacitance.is_finite() || *source_bulk_capacitance < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET CBS must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1922,6 +1922,39 @@ fn preserves_non_negative_mosfet_model_sidewall_junction_capacitance() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_source_bulk_capacitance_aliases() {
+    for alias in ["CBS", "CJS"] {
+        for capacitance in ["-4p", "1e999"] {
+            let error = parse_netlist(&format!(
+                ".model source NMOS({alias}={capacitance})\nM1 d g s b source"
+            ))
+            .unwrap_err();
+
+            assert!(error
+                .to_string()
+                .contains("MOSFET CBS must be finite and non-negative"));
+        }
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_source_bulk_capacitance_aliases() {
+    for alias in ["CBS", "CJS"] {
+        for (capacitance, expected) in [("0", 0.0), ("4p", 4.0e-12)] {
+            let parsed = parse_netlist(&format!(
+                ".model source NMOS({alias}={capacitance})\nM1 d g s b source"
+            ))
+            .unwrap();
+
+            let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+                panic!("expected MOSFET");
+            };
+            assert_close(mosfet.params.source_bulk_capacitance, expected);
+        }
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card sidewall-junction-capacitance validation.
+1. Rust Berkeley SPICE MOS model-card source-bulk-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `CJSW` values before
+   - Reject negative and non-finite model-card `CBS` / `CJS` values before
      lowering MOS elements into engine parameters.
-   - Preserve zero and positive sidewall-junction capacitances.
+   - Preserve zero and positive source-bulk capacitances across both aliases.
 
 ## Completed Slices
 
@@ -3996,6 +3996,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `CJ` values are rejected before
      lowering MOS elements into engine parameters.
    - Zero and positive bottom-junction capacitances remain accepted.
+
+347. Rust Berkeley SPICE MOS model-card sidewall-junction-capacitance validation.
+   - Status: completed in PR 9502.
+   - Negative and non-finite model-card `CJSW` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive sidewall-junction capacitances remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CBS` / `CJS` values in the Rust Berkeley parser facade
- preserve zero and positive source-bulk capacitances across both aliases
- reconcile the SPICE implementation plan after `CJSW` validation merged

## Tests
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
Rust-only parser-facade validation. The shared Rust, Python, and TypeScript engine behavior and diagnostic are already aligned.