### PR TITLE
feat(human-languages): generate Spanish chapters two and three

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -44,8 +44,10 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 |---|---|---|---|
 | HL-S01 | Complete (#9497) | Migrate Spanish Chapters 1–3 to schema version 2 with typed body blocks and knowledge closure. | The 24-lesson slice has unique order, transitive knowledge closure, typed blocks, and no effective-duration violation. |
 | HL-G01 | Complete in the canonical-generation PR | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy now that the AST contract is executable. |
-| HL-G02 | Next | Generate Spanish Chapters 2–3 from their canonical schema-v2 lesson AST. | Extends the proven one-source path across the rest of the migrated pilot before broad corpus work. |
-| HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The audit must exist first so the debt remains measurable throughout migration. |
+| HL-G02 | Complete in the Chapters 2–3 generation PR | Generate Spanish Chapters 2–3 from their canonical schema-v2 lesson AST. | Extends the proven one-source path across the rest of the migrated pilot before broad corpus work. |
+| HL-D01A | Next | Remove all nine sub-five-minute violations from the complete Russian starter track. | A bounded first duration tranche covers both declaration-only and genuinely overlong lessons without skipping an existing language. |
+| HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
+| HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -86,10 +88,27 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - The unified book job now fails when generated TeX or the hash manifest is
   missing or stale. The fingerprint is a deterministic drift signal, not a
   cryptographic integrity claim.
-- Chapter 1 is the first one-source slice. Spanish Chapters 2–18 remain
-  handwritten LaTeX until their lessons are migrated and configured; HL-G02
-  deliberately limits the next expansion to the already-schema-v2 Chapters
-  2–3.
+- At the end of HL-G01, Chapter 1 was the first one-source slice and Chapters
+  2–18 remained handwritten. That finding deliberately scoped HL-G02 to the
+  already-schema-v2 Chapters 2–3 rather than skipping validation to generate
+  later chapters.
+
+## Findings from HL-G02
+
+- All 24 schema-v2 Spanish lessons in Chapters 1–3 now generate their three
+  LaTeX chapters and independently match Language Ladder's loaded AST. Chapter
+  2 combines five lesson hashes; Chapter 3 combines twelve.
+- The expanded canonical content produces a 138-page book. Rendered checks of
+  both chapter openers, grammar and etymology boxes, nested emphasis, practice
+  lists, and wrap-up recall found no generated-chapter overfull box or Hyperref
+  warning.
+- The renderer now handles nested bold-within-italic Markdown, wraps practice
+  lists ragged-right, and keeps math arrows out of bookmark/running-header
+  strings. Those fixes apply to every later generated chapter.
+- The next learner-visible promise is the sub-five-minute cap. Russian is the
+  smallest complete existing track with measurable debt: nine violations, of
+  which five are computed at 312–405 seconds and four only need honest declared
+  budgets below the cap. HL-D01A is therefore the next bounded tranche.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -7,6 +7,20 @@
       "title": "Hola and Buenos Días",
       "label": "ch:first-words",
       "output": "spanish/book/chapters/ch01-first-words.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 2,
+      "title": "The Rest of the Greetings",
+      "label": "ch:greetings",
+      "output": "spanish/book/chapters/ch02-greetings.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 3,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "output": "spanish/book/chapters/ch03-introductions.tex"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -16,6 +16,39 @@
         "ES-C01-practice"
       ],
       "tex": "spanish/book/chapters/ch01-first-words.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 2,
+      "sourceHash": "fnv1a64:25b110167a9b669e",
+      "lessonIds": [
+        "ES-C02-tarde",
+        "ES-C02-buenas-tardes",
+        "ES-C02-noche",
+        "ES-C02-buenas-noches",
+        "ES-C02-practice"
+      ],
+      "tex": "spanish/book/chapters/ch02-greetings.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 3,
+      "sourceHash": "fnv1a64:394498f9947f7389",
+      "lessonIds": [
+        "ES-C03-me",
+        "ES-C03-llamar",
+        "ES-C03-me-llamo",
+        "ES-C03-tu-usted",
+        "ES-C03-usted-origin",
+        "ES-C03-como",
+        "ES-C03-familia-qu",
+        "ES-C03-se-llama",
+        "ES-C03-como-se-llama",
+        "ES-C03-mucho",
+        "ES-C03-gusto",
+        "ES-C03-practice"
+      ],
+      "tex": "spanish/book/chapters/ch03-introductions.tex"
     }
   ]
 }

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Chapters 2–3 — complete the generated schema-v2 pilot
+
+- Added the remaining 17 migrated lessons to canonical book generation, so all
+  24 Chapter 1–3 lesson ASTs now drive both the LaTeX book and Language Ladder.
+- Extended app/book hash checks across five Chapter 2 and twelve Chapter 3
+  lessons and grew the compiled book to 138 pages.
+- Fixed nested Markdown emphasis, long practice-list wrapping, and arrow-bearing
+  bookmark titles in the shared renderer; visually checked both generated
+  chapter openers and representative grammar, etymology, practice, and recall
+  pages.
+
 ## Chapter 1 — canonical book generation
 
 - Replaced the handwritten first chapter with deterministic LaTeX rendered

--- a/code/learning/human-languages/spanish/README.md
+++ b/code/learning/human-languages/spanish/README.md
@@ -71,10 +71,10 @@ Requires a LaTeX distribution with `xelatex`/`latexmk` on PATH (MiKTeX or
 TeX Live). The compiled PDF isn't committed — it's regenerated from source,
 same as build artifacts elsewhere in this repo.
 
-Chapter 1 is generated from the same seven canonical lesson ASTs consumed by
+Chapters 1–3 are generated from the same 24 canonical lesson ASTs consumed by
 Language Ladder. Run `npm run build && npm run generate:books` from
 `code/packages/typescript/human-language-data` after editing those lessons; CI
-rejects stale generated TeX or source-hash metadata. Chapters 2–18 are still
+rejects stale generated TeX or source-hash metadata. Chapters 4–18 are still
 handwritten LaTeX during the staged one-source migration. `units/` is legacy
 source material, not a second canonical copy.
 
@@ -121,8 +121,8 @@ exactly where a word needs it:
   not-yet-real).
 
 Every noun carries its gender (*el*/*la*) and plural; every pronoun is traced
-to its root. **All 18 chapters are authored and in the book (122 pages); Chapter
-1 is generated from canonical lessons.**
+to its root. **All 18 chapters are authored and in the book (138 pages); Chapters
+1–3 are generated from canonical lessons.**
 Lessons are named by **slug** (e.g. `ES-C01-dia`), not numbered — order lives
 in the book (which LaTeX auto-numbers) and in `session-map.md`, so inserting a
 lesson never renumbers anything.

--- a/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch01-first-words.tex
@@ -20,6 +20,7 @@ Each section stays independently resumable and preserves the authored prerequisi
 
 \begin{sounds}
 \begin{itemize}
+\raggedright
   \item \texttt{silent-h} — the \textbf{h is silent}. \emph{hola} is said \emph{OH-la}, never \emph{HOH-la}. The letter is written but makes no sound at all. This is true of every Spanish \emph{h} you'll ever meet. $\to$ pronunciation reference
   \item \texttt{vowel-o}, \texttt{vowel-a} — two pure vowels: \emph{OH}, \emph{AH}. No glide, no drift.
 \end{itemize}
@@ -47,6 +48,7 @@ Note the written form: an exclamation gets an \textbf{upside-down mark} at the f
 {[}PAUSE 1s{]}
 
 \begin{itemize}
+\raggedright
   \item {[}YOU SAY: "hola" — \emph{OH-la}, silent h{]}
   \item {[}YOU SAY: "¡hola!" to an imagined friend — light, informal{]}
 \end{itemize}
@@ -66,11 +68,13 @@ Note the written form: an exclamation gets an \textbf{upside-down mark} at the f
 
 \subsection*{You'll want to know first}
 \begin{itemize}
+\raggedright
   \item hola — your first word; \emph{bien} is what you say back when someone asks how you are.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
+\raggedright
   \item \texttt{diphthong-ie} — \textbf{ie} is a quick \emph{YEH}: \emph{bien} is said \emph{byen}, one syllable. $\to$ reference
   \item \texttt{v-b} — the \textbf{b} is soft, halfway to a \emph{v}.
 \end{itemize}
@@ -80,6 +84,7 @@ Note the written form: an exclamation gets an \textbf{upside-down mark} at the f
 \textbf{bien} — "well." Root: Latin \textbf{bene} ("well"). That \emph{bene} is the piece hiding in a shelf of English words, every one about something being \emph{good} or \emph{well}:
 
 \begin{itemize}
+\raggedright
   \item \textbf{bene}fit — literally "to do \textbf{well}" (\emph{bene} + \emph{facere}).
   \item \textbf{bene}volent — "wishing \textbf{well}" (\emph{bene} + \emph{volens}).
   \item \textbf{bene}diction — "speaking \textbf{well}," a blessing (\emph{bene} + \emph{dicere}).
@@ -91,6 +96,7 @@ So \emph{bien} is the Spanish member of the \emph{bene-} family you've owned in 
 \textbf{Using it on its own.} This is the useful part: \emph{bien} is a complete answer.
 
 \begin{itemize}
+\raggedright
   \item "\emph{¿Cómo estás?}" (how are you?) $\to$ "\textbf{Bien.}" — "Well." / "I'm good." Done.
   \item As agreement, when someone suggests something $\to$ "\textbf{Bien.}" — "Okay / fine."
   \item Stack it: "\textbf{muy bien}" — "very well / very good."
@@ -109,6 +115,7 @@ So \emph{bien} is the Spanish member of the \emph{bene-} family you've owned in 
 {[}PAUSE 1s{]}
 
 \begin{itemize}
+\raggedright
   \item {[}YOU SAY: "bien" as the answer to "how are you"{]}
   \item {[}YOU SAY: "muy bien"{]}
   \item {[}YOU SAY: "bueno" then "buena" — the adjective, masculine then feminine{]}
@@ -129,11 +136,13 @@ So \emph{bien} is the Spanish member of the \emph{bene-} family you've owned in 
 
 \subsection*{You'll want to know first}
 \begin{itemize}
+\raggedright
   \item bien / bueno — you saw \emph{bueno} change to \emph{buena}; this lesson explains the gender that made it happen.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
+\raggedright
   \item \texttt{vowel-e}, \texttt{vowel-a} — two clean vowels: \emph{el} (\emph{ehl}), \emph{la} (\emph{lah}). $\to$ reference
 \end{itemize}
 \end{sounds}
@@ -144,6 +153,7 @@ So \emph{bien} is the Spanish member of the \emph{bene-} family you've owned in 
 \textbf{Where they come from.} Both are worn-down Latin \textbf{demonstratives} — words that meant "\textbf{that one (over there)}":
 
 \begin{itemize}
+\raggedright
   \item \textbf{el} $\leftarrow$ Latin \textbf{ille} ("that one," masculine).
   \item \textbf{la} $\leftarrow$ Latin \textbf{illa} ("that one," feminine).
 \end{itemize}
@@ -161,6 +171,7 @@ Over centuries the pointing force faded and the initial \emph{i-} dropped: \emph
 {[}PAUSE 1s{]}
 
 \begin{itemize}
+\raggedright
   \item {[}YOU SAY: "el" then "la" — the two "the"s{]}
   \item {[}YOU SAY: which article goes with a masculine noun? with a feminine one?{]}
 \end{itemize}
@@ -180,6 +191,7 @@ Over centuries the pointing force faded and the initial \emph{i-} dropped: \emph
 
 \subsection*{You'll want to know first}
 \begin{itemize}
+\raggedright
   \item el / la — the two definite articles.
 \end{itemize}
 
@@ -195,6 +207,7 @@ You cannot always predict a noun's class from its ending. Learn each new noun wi
 {[}PAUSE 1s{]}
 
 \begin{itemize}
+\raggedright
   \item {[}YOU SAY: the article for a noun labelled masculine{]}
   \item {[}YOU SAY: the article for a noun labelled feminine{]}
   \item {[}YOU SAY: what grammatical gender classifies — nouns, not people{]}
@@ -215,11 +228,13 @@ You cannot always predict a noun's class from its ending. Learn each new noun wi
 
 \subsection*{You'll want to know first}
 \begin{itemize}
+\raggedright
   \item el / la — grammatical gender and the two "the"s; \emph{día} is where you apply them.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
+\raggedright
   \item \texttt{accent-i} — the accent sits on the \textbf{í}: \emph{día} is \emph{DEE-a}, two beats. $\to$ reference
   \item \texttt{d-soft} — the \textbf{d} between vowels is soft, toward the \emph{th} in \emph{this}.
 \end{itemize}
@@ -229,6 +244,7 @@ You cannot always predict a noun's class from its ending. Learn each new noun wi
 \textbf{el día} — "the day." Root: Latin \textbf{dies} ("day"). The family fans across English, mostly through French:
 
 \begin{itemize}
+\raggedright
   \item \textbf{di}ary, \textbf{di}urnal ("of the day").
   \item \textbf{jour}nal, \textbf{jour}ney — French \emph{jour}, "a day" (a \emph{journey} was once "a day's travel").
   \item quoti\textbf{di}an ("every-day"), meri\textbf{di}an ("mid-day"), and \emph{dismal} (\emph{dies mali}, "evil days").
@@ -244,13 +260,14 @@ You already know gender from the last lesson; here's how \emph{día} wears it.
 \end{grammarlens}
 
 \begin{grammarlens}[title={Grammar Lens: why the gender matters next}]
-Gender isn't a passive label — it \emph{forces} the words around the noun to match. The very next lesson, \emph{buenos días}, turns \emph{bueno} ("good") into \emph{buen}\emph{os}\emph{} precisely because \emph{día} is masculine and plural. So the gender you just attached to \emph{día} is about to earn its keep.
+Gender isn't a passive label — it \emph{forces} the words around the noun to match. The very next lesson, \emph{buenos días}, turns \emph{bueno} ("good") into \emph{buen\textbf{os}} precisely because \emph{día} is masculine and plural. So the gender you just attached to \emph{día} is about to earn its keep.
 \end{grammarlens}
 
 \subsection*{Guided Practice}
 {[}PAUSE 1s{]}
 
 \begin{itemize}
+\raggedright
   \item {[}YOU SAY: "el día" — with its masculine "the"{]}
   \item {[}YOU SAY: "días" — plural, vowel + \emph{-s}{]}
   \item {[}YOU SAY: is \emph{día} masculine or feminine, and why? (masculine — from Latin \emph{dies}, despite the \emph{-a}){]}
@@ -271,12 +288,14 @@ Gender isn't a passive label — it \emph{forces} the words around the noun to m
 
 \subsection*{You'll want to know first}
 \begin{itemize}
+\raggedright
   \item bien / bueno — the adjective \emph{bueno}.
   \item día — the noun \emph{días}, and that it's masculine.
 \end{itemize}
 
 \begin{sounds}
 \begin{itemize}
+\raggedright
   \item \texttt{diphthong-ue} — \textbf{ue} is a quick \emph{WEH}: \emph{bueno} is \emph{BWEH-no}.
   \item \texttt{accent-i} — \emph{días} keeps its stress on the \emph{í}: \emph{DEE-as}.
 \end{itemize}
@@ -285,7 +304,7 @@ Gender isn't a passive label — it \emph{forces} the words around the noun to m
 \begin{cousinweb}
 \textbf{buenos días} = \textbf{bueno} ("good") + \textbf{días} ("days") = literally \textbf{"good days."}
 
-But look closely: it's \emph{buen}\emph{os}\emph{}, not \emph{bueno}. Why? Because of the one new grammar rule of this lesson.
+But look closely: it's \emph{buen\textbf{os}}, not \emph{bueno}. Why? Because of the one new grammar rule of this lesson.
 \end{cousinweb}
 
 \begin{grammarlens}[title={Grammar Lens: agreement}]
@@ -294,6 +313,7 @@ An adjective in Spanish \textbf{agrees} with its noun — it copies the noun's g
 The adjective \emph{bueno} has four shapes, and you now understand the machine that picks between them:
 
 \begin{itemize}
+\raggedright
   \item \textbf{bueno} — masculine singular (\emph{un buen día} $\to$ a good day)
   \item \textbf{buena} — feminine singular
   \item \textbf{buenos} — masculine plural $\to$ \emph{buenos días}
@@ -311,6 +331,7 @@ So why "good \textbf{days}," plural at all? Because \emph{buenos días} is a \te
 {[}PAUSE 1s{]}
 
 \begin{itemize}
+\raggedright
   \item {[}YOU SAY: build it slowly — "bueno" … "días" … "buenos días"{]}
   \item {[}YOU SAY: "hola, buenos días" — casual + warm, stacked{]}
   \item {[}YOU SAY: why is it \emph{buenos}, not \emph{bueno}? (out loud, in your own words){]}
@@ -333,6 +354,7 @@ So why "good \textbf{days}," plural at all? Because \emph{buenos días} is a \te
 In four short lessons you went from nothing to two full greetings and the first two rules of Spanish grammar:
 
 \begin{itemize}
+\raggedright
   \item \textbf{hola} — the casual "hi."
   \item \textbf{bien} — "well/good," a complete answer on its own; and its adjective sibling \textbf{bueno / buena}.
   \item \textbf{día $\to$ días} — a noun, and the plural rule (vowel + \emph{-s}).
@@ -344,6 +366,7 @@ In four short lessons you went from nothing to two full greetings and the first 
 {[}PAUSE 1s{]} Say each out loud; don't just read.
 
 \begin{itemize}
+\raggedright
   \item {[}YOU SAY: greet a friend casually — \emph{hola}{]}
   \item {[}YOU SAY: greet someone warmly in the morning — \emph{buenos días}{]}
   \item {[}YOU SAY: stack them — \emph{hola, buenos días}{]}

--- a/code/learning/human-languages/spanish/book/chapters/ch02-greetings.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch02-greetings.tex
@@ -1,78 +1,241 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:25b110167a9b669e
+% canonical-lessons: ES-C02-tarde, ES-C02-buenas-tardes, ES-C02-noche, ES-C02-buenas-noches, ES-C02-practice
+
 \chapter{The Rest of the Greetings}
 \label{ch:greetings}
 
-Two more times of day, built the same way --- word first, then assembled ---
-and along the way the \emph{feminine} half of agreement, plus a Latin
-sound-change you can start spotting on your own. \emph{Practice lessons:
-\texttt{lessons/ES-C02-*.md}.}
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section{\emph{la tarde} --- ``afternoon,'' with ``late'' inside it}
-\label{lesson:tarde}
+\section[la tarde]{tarde — "afternoon," and the "late" hiding inside it}
+
+\label{lesson:ES-C02-tarde}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You built \emph{buenos días}. The afternoon greeting is coming, but first its key word on its own — \emph{tarde} — and it's secretly a word you already know from English.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item buenos días — you'll pair \emph{tarde} with \emph{buena} the same way you paired \emph{días} with \emph{bueno}.
+\end{itemize}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item Regular stress: \emph{TAR-de} — ends in a vowel, so the stress falls on the second-to-last syllable. $\to$ reference
+\end{itemize}
+
+\textbf{la tarde} (feminine) — "afternoon." Root: Latin \textbf{tardus} — which did \emph{not} mean afternoon. It meant \textbf{"slow, late."} And \emph{that} is the meaning English kept:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{tard}y — late.
+  \item re\textbf{tard} — to slow down (literally "to make late").
+  \item \textbf{tard}igrade — "slow-stepper," the real name of the little water-bear that plods under a microscope.
+\end{itemize}
+
+How did "late" become "afternoon"? Naturally — the afternoon \emph{is} the late part of the day, the day growing old. Spanish took the Latin word for "late" and let it drift to name the lateness itself. Say \emph{tarde} and you're calling it "the late hours."
+
+\textbf{Its gender:} \emph{tarde} is \textbf{feminine} — \emph{la tarde}, not \emph{el tarde}. (Contrast \emph{el día} from the last lesson: your first masculine and feminine nouns, side by side.) Learn each noun \emph{with} its \emph{el}/\emph{la}, because gender isn't reliably guessable — and it will decide the shape of every word that describes the noun, starting next lesson.
+\end{sounds}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "tarde" — \emph{TAR-de}{]}
+  \item {[}YOU SAY: "tarde" then English "tardy" — hear the shared root{]}
+  \item {[}YOU SAY: "tardes" — plural, add \emph{-s} (vowel ending), just like \emph{día $\to$ días}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What did Latin \emph{tardus} originally mean, before "afternoon"? (Slow, late — as in \emph{tardy}, \emph{retard}.) And how do you make \emph{tarde} plural? (\emph{tardes} — vowel + \emph{-s}.)
+\end{tcolorbox}
+\section[buenas tardes]{buenas tardes — assembled, and now the \emph{feminine} side of agreement}
+
+\label{lesson:ES-C02-buenas-tardes}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Same move as \emph{buenos días}: take "good" and "afternoon" and snap them together. But watch the ending — this time it comes out \emph{buen\textbf{as}}, and that difference teaches you the other half of the agreement rule.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item bien / bueno — the adjective \emph{bueno} and its four shapes.
+  \item tarde — the noun \emph{tardes}.
+\end{itemize}
 
 \begin{cousinweb}
-\textbf{la tarde} (feminine) $\leftarrow$ Latin \emph{tardus}, which meant not
-``afternoon'' but \textbf{``slow, late''} --- the meaning English kept in
-\textbf{tard}y, re\textbf{tard}, and \textbf{tard}igrade (``slow-stepper,''
-the water-bear). The afternoon \emph{is} the late part of the day; Spanish let
-the word for ``late'' drift to name the lateness. \emph{tarde} is
-\textbf{feminine} (\emph{la tarde}) --- your first feminine noun, beside
-masculine \emph{el d\'{i}a}.
+\textbf{buenas tardes} = \textbf{buena} ("good") + \textbf{tardes} ("afternoons") = literally "good afternoons."
 \end{cousinweb}
 
-\section{\emph{buenas tardes} --- the feminine side of agreement}
-\label{lesson:buenas-tardes}
+\begin{grammarlens}[title={Grammar Lens: agreement, the feminine case}]
+Back in \emph{buenos días}, \emph{bueno} became \emph{buenos} — \textbf{masculine} plural, because \emph{día} is masculine. Now: \textbf{tarde is a feminine noun} (\emph{la tarde}). So \emph{bueno} has to become \textbf{feminine} plural to match — \emph{buenas}. Same rule, other gender:
 
-\emph{buena} (``good'') $+$ \emph{tardes} (``afternoons'').
+\begin{itemize}
+\raggedright
+  \item \emph{días} (masculine, plural) $\to$ \emph{buen\textbf{os} días}
+  \item \emph{tardes} (feminine, plural) $\to$ \emph{buen\textbf{as} tardes}
+\end{itemize}
 
-\begin{grammarlens}
-In \emph{buenos d\'{i}as}, \emph{bueno} became \emph{buenos} --- masculine
-plural, because \emph{d\'{i}a} is masculine. But \emph{tarde} is
-\textbf{feminine}, so ``good'' must become feminine plural: \textbf{buenas}.
-Same rule, other gender:\\
-\quad \emph{d\'{i}as} (masc.) $\to$ \emph{buen\textbf{os}} d\'{i}as \qquad
-\emph{tardes} (fem.) $\to$ \emph{buen\textbf{as}} tardes\\
-That single \emph{o}-vs-\emph{a} is the adjective reporting the noun's gender.
-You now command all four shapes: \emph{bueno, buena, buenos, buenas}.
+That single vowel — the \emph{o} vs. \emph{a} at the end of \emph{buenos}/\emph{buenas} — is the adjective reporting the gender of the noun it's attached to. You now control all four shapes in the wild: \emph{bueno, buena, buenos, buenas}.
 \end{grammarlens}
 
 \begin{culture}
-Same fossil blessing (\emph{``Buenas tardes os d\'{e} Dios''}). The timing is
-cultural, not clock-bound: \emph{tardes} runs from after the midday meal until
-it is genuinely dark. Spanish follows the daylight, not 12:00.
+Same fossil blessing as the morning greeting: \emph{buenas tardes} is short for \emph{"Buenas tardes os dé Dios."} One cultural note on timing — \emph{tardes} runs from after the midday meal until it's genuinely dark, which in much of the Spanish-speaking world is late. Spanish follows the daylight, not the clock; there's no fixed "12:00 = afternoon" line.
 \end{culture}
 
-\section{\emph{la noche} --- ``night,'' and a sound-change to bank}
-\label{lesson:noche}
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "buenas tardes" — \emph{BWEH-nas TAR-des}{]}
+  \item {[}YOU SAY: "buenos días" then "buenas tardes" — hear the \emph{o} flip to \emph{a}{]}
+  \item {[}YOU SAY: why \emph{buenas} and not \emph{buenos}? (out loud, your own words){]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Why is it \emph{buenas tardes} but \emph{buenos días}? (\emph{tarde} is feminine, \emph{día} is masculine — the adjective agrees with each.)
+\end{tcolorbox}
+\section[la noche]{noche — "night," and a Latin sound-change you can now spot}
+
+\label{lesson:ES-C02-noche}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The last time-of-day word before the evening greeting. \emph{noche} — "night" — and it shows off a spelling pattern that will help you decode dozens of Spanish words later.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item tarde — same build ahead: word first, then \emph{buenas} + it.
+\end{itemize}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{soft-c} — the \textbf{ch} in \emph{noche} is the \emph{ch} of English \emph{church}: \emph{NO-cheh}. $\to$ reference
+\end{itemize}
+\end{sounds}
 
 \begin{cousinweb}
-\textbf{la noche} (feminine) $\leftarrow$ Latin \emph{nox}, stem \emph{noct-}
-(itself feminine in Latin, whence \emph{la noche}'s gender) $\to$
-\textbf{noct}urnal, \textbf{noct}urne, equi\textbf{nox} (``equal night'').\\[3pt]
-\textbf{Pattern to bank:} Latin \emph{noctem} $\to$ Spanish \emph{noche} ---
-the Latin \textbf{-ct-} softened to Spanish \textbf{-ch-}. It recurs:
-\emph{factum} $\to$ \emph{hecho}, \emph{lactem} $\to$ \emph{leche},
-\emph{octo} $\to$ \emph{ocho}. A Spanish \emph{-ch-} word often hides a Latin
-\emph{-ct-} root --- and its English cousin usually kept the \emph{-ct-}.
+\textbf{la noche} (feminine) — "night / evening." Root: Latin \textbf{nox}, stem \textbf{noct-} — which was itself \emph{feminine} in Latin, and \emph{la noche} inherited that gender straight down (just as \emph{el día} inherited its masculine from Latin). That \emph{noct-} runs all through English:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{noct}urnal — active at night.
+  \item \textbf{noct}urne — a piece of night-music.
+  \item equi\textbf{nox} — \emph{equi} ("equal") + \emph{nox}, the day when night and day are equal length.
+\end{itemize}
+
+\textbf{A pattern worth banking:} Latin \emph{noctem} $\to$ Spanish \emph{noche}. The Latin \textbf{-ct-} softened into Spanish \textbf{-ch-}. This happened again and again: \emph{factum} $\to$ \emph{hecho} ("done"), \emph{lactem} $\to$ \emph{leche} ("milk"), \emph{octo} $\to$ \emph{ocho} ("eight"). Once you know \emph{-ct- $\to$ -ch-}, you can often guess the Latin root (and its English cousins) behind a Spanish \emph{-ch-} word on sight.
 \end{cousinweb}
 
-\section{\emph{buenas noches} --- good evening \emph{and} goodnight}
-\label{lesson:buenas-noches}
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
 
-\emph{buena} $+$ \emph{noches}; \emph{noche} is feminine, so \textbf{buenas}
-again --- no new rule, just fluency in the agreement from two sections ago.
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "noche" — \emph{NO-cheh}{]}
+  \item {[}YOU SAY: "noche" then "nocturnal" then "equinox"{]}
+  \item {[}YOU SAY: "noches" — plural, vowel + \emph{-s}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What English word is \emph{equi-} + \emph{noche}'s root? (\emph{Equinox}, "equal night.") And what Latin sound did the \emph{-ch-} in \emph{noche} come from? (\emph{-ct-}, as in \emph{noctem $\to$ noche}.)
+\end{tcolorbox}
+\section[buenas noches]{buenas noches — good evening \emph{and} good night}
+
+\label{lesson:ES-C02-buenas-noches}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The fourth greeting, assembled the way you now expect — and it has one quirk the others don't: it works both coming and going.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item buenas tardes — feminine agreement (\emph{buenas}); \emph{noche} is feminine too, so the same shape applies.
+  \item noche — the noun \emph{noches}.
+\end{itemize}
+
+\begin{cousinweb}
+\textbf{buenas noches} = \textbf{buena} ("good") + \textbf{noches} ("nights"). \emph{noche} is \textbf{feminine} (\emph{la noche}), plural here, so — exactly like \emph{tardes} — the adjective is \textbf{buenas}. No new rule; you're now just \emph{fluent} in the agreement you learned two lessons ago: masculine \emph{días} $\to$ \emph{buenos}, feminine \emph{tardes}/\emph{noches} $\to$ \emph{buenas}.
+\end{cousinweb}
 
 \begin{culture}
-The same blessing, with a twist: \emph{buenas noches} is both a \textbf{greeting}
-and a \textbf{farewell}. Arriving at 9pm, ``good evening''; leaving at
-midnight, ``goodnight.'' English splits these in two; Spanish uses one and
-lets context point the direction.
+The same amputated blessing (\emph{"Buenas noches os dé Dios"}) — but with a twist. \emph{buenas noches} is both a \textbf{greeting} and a \textbf{farewell}:
+
+\begin{itemize}
+\raggedright
+  \item Arriving at a dinner at 9pm $\to$ \emph{buenas noches} ("good evening").
+  \item Leaving that same dinner at midnight $\to$ \emph{buenas noches} ("goodnight").
+\end{itemize}
+
+English splits these into two phrases; Spanish uses one and lets context tell you the direction. The blessing doesn't care which way you're going — you're wishing good hours either way.
 \end{culture}
 
-\section{Practice --- the four greetings}
-\label{lesson:ch2-practice}
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
 
-\emph{hola} (any time) $\cdot$ \emph{buenos d\'{i}as} (\emph{d\'{i}a} masc.\
-$\to$ \emph{buenos}) $\cdot$ \emph{buenas tardes} $\cdot$ \emph{buenas noches}
-(\emph{tarde}, \emph{noche} fem.\ $\to$ \emph{buenas}). The single thread:
-\textbf{agreement} --- ``good'' copies the gender of the time-of-day noun.
-Next, someone greets \emph{you} back, and you learn to give your name.
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "buenas noches" arriving somewhere{]}
+  \item {[}YOU SAY: "buenas noches" leaving somewhere{]}
+  \item {[}YOU SAY: all four times of day — "buenos días, buenas tardes, buenas noches" — and notice which take \emph{buenos} vs \emph{buenas} and why{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What's unusual about when you can use \emph{buenas noches}? (Both hello and goodbye.) And why \emph{buenas}, not \emph{buenos}? (\emph{noche} is feminine.)
+\end{tcolorbox}
+\section[Practice]{Practice — the four greetings}
+
+\label{lesson:ES-C02-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can now greet at any hour of the day. Let's make the choice — and the grammar behind it — automatic.
+\end{quote}
+
+\begin{grammarlens}[title={What you've built}]
+\begin{itemize}
+\raggedright
+  \item \textbf{hola} — any time, casual.
+  \item \textbf{buenos días} — morning (\emph{días} masculine $\to$ \emph{buenos}).
+  \item \textbf{buenas tardes} — afternoon (\emph{tarde} feminine $\to$ \emph{buenas}).
+  \item \textbf{buenas noches} — evening \emph{and} goodnight (\emph{noche} feminine $\to$ \emph{buenas}).
+\end{itemize}
+
+The one grammar thread running through all of them: \textbf{agreement}. The "good" word copies the gender of the time-of-day word. That's why it's \emph{buen\textbf{os} días} but \emph{buen\textbf{as} tardes} and \emph{buen\textbf{as} noches}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: greet for the actual current time of day, correctly{]}
+  \item {[}YOU SAY: all three "buenos/buenas" greetings in a row; for each, say whether the noun is masculine or feminine and why the ending fits{]}
+  \item {[}YOU SAY: "hola, buenas tardes" — casual + timed, stacked{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Run morning $\to$ afternoon $\to$ night, out loud, without hesitating on \emph{buenos} vs \emph{buenas}.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Quick: is it \emph{buenos} or \emph{buenas} noches, and why? (\emph{buenas} — \emph{noche} is feminine.) Next chapter, someone finally greets \emph{you} back — and you learn to say your name and ask for theirs.
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
@@ -1,154 +1,568 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:394498f9947f7389
+% canonical-lessons: ES-C03-me, ES-C03-llamar, ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-usted-origin, ES-C03-como, ES-C03-familia-qu, ES-C03-se-llama, ES-C03-como-se-llama, ES-C03-mucho, ES-C03-gusto, ES-C03-practice
+
 \chapter{Introducing Yourself}
 \label{ch:introductions}
 
-Your first real exchange: give your name, ask for someone else's, and say
-``pleased to meet you'' --- built atom by atom, including the two words for
-``you'' that English lost. \emph{Practice lessons: \texttt{lessons/ES-C03-*.md}.}
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section{\emph{me} --- your first pronoun, a \emph{real} English twin}
-\label{lesson:me}
+\section[me]{me — your first pronoun, and a \emph{real} English twin}
 
-\begin{cousinweb}
-\textbf{me} (``me / myself'') $\leftarrow$ Latin \emph{me}. Unlike
-\emph{hola}/\emph{hello}, this look-alike is the real thing: English \emph{me}
-(and \emph{my}, \emph{mine}) descends from the \emph{same} ancient root
-(PIE \emph{*me-}). A genuine cousin, not a coincidence.
-\end{cousinweb}
+\label{lesson:ES-C03-me}
 
-A \textbf{pronoun} stands in for a person or thing without naming them.
-\emph{me} is an \emph{object} pronoun (the person an action lands on), and in
-Spanish it sits right before the verb --- as in \emph{me llamo}, next.
 
-\section{\emph{llamo} --- ``I call,'' from a root that shouts}
-\label{lesson:llamo}
 
-\begin{cousinweb}
-\textbf{llamo} (``I call''; infinitive \emph{llamar}) $\leftarrow$ Latin
-\emph{clamare} (``to shout'') $\to$ ex\textbf{claim}, pro\textbf{claim},
-ac\textbf{claim}, \textbf{claim}, \textbf{clam}or.\\[3pt]
-\textbf{Pattern:} Latin \emph{cl-} $\to$ Spanish \emph{ll-}: \emph{clamare}
-$\to$ \emph{llamar}, \emph{clavem} $\to$ \emph{llave} (``key''), \emph{flamma}
-$\to$ \emph{llama} (``flame''). A Spanish \emph{ll-} word often hides a Latin
-\emph{cl-}/\emph{fl-}/\emph{pl-} cluster the English cousin kept.
-\end{cousinweb}
-
-\section{\emph{me llamo} --- ``I call myself''}
-\label{lesson:me-llamo}
-
-\emph{me} (``myself'') $+$ \emph{llamo} (``I call'') $=$ ``I call myself.''
-\emph{Me llamo Susana.}
-
-\begin{grammarlens}
-When the action loops back on the doer --- you call \emph{yourself} --- the
-verb is \textbf{reflexive}, and Spanish marks it with the pronoun up front.
-The pronoun changes with the person: \emph{\textbf{me} llamo} (I) $\to$
-\emph{\textbf{te} llamas} (you, informal) $\to$ \emph{\textbf{se} llama}
-(he/she/you-formal). Spanish keeps the reflexive loop visible where English
-flattens it to ``my name is.''
-\end{grammarlens}
-
-\section{\emph{t\'{u}} and \emph{usted} --- two words for ``you''}
-\label{lesson:tu-usted}
-
-\begin{cousinweb}
-\textbf{t\'{u}} (``you,'' informal) $\leftarrow$ Latin \emph{t\={u}} --- a true
-cousin of English \textbf{thou}, the intimate ``you'' English retired ~400
-years ago.\\[3pt]
-\textbf{usted} (``you,'' formal) is worn down from \textbf{vuestra merced},
-``your grace / your mercy.'' \emph{merced} $\leftarrow$ Latin \emph{merces}
-(``wages, reward, favor'') --- the \emph{merc-} family: \textbf{merc}y,
-\textbf{merc}enary, com\textbf{merce}, \textbf{merc}hant, \textbf{mar}ket, the
-god \textbf{Mercur}y. \emph{usted} literally means ``your grace'' --- a title
-so often said it collapsed into a pronoun (its old abbreviation \emph{Vd.}
-still shows the \emph{v} of \emph{vuestra}).
-\end{cousinweb}
-
-\begin{grammarlens}
-Both are subject pronouns, but they carry a layer English dropped when
-\emph{thou} died: \textbf{register}. \emph{t\'{u}} for closeness, \emph{usted}
-for respect/distance --- and a Spanish speaker must choose every time. One
-structural echo of its origin: \emph{usted} takes \emph{he/she} verb forms
-(it began as the noun ``your grace''), which is why the formal ``what's your
-name?'' uses \emph{se llama}, not \emph{te llamas}.
-\end{grammarlens}
-
-\section{\emph{c\'{o}mo} --- ``how,'' your first question word}
-\label{lesson:como}
-
-\begin{cousinweb}
-\textbf{c\'{o}mo} (``how'') $\leftarrow$ Latin \emph{quomodo}, a fused phrase
-\emph{quo modo}, ``in what \emph{manner}.'' The \emph{modo} half is English
-\textbf{mode}, \textbf{mod}al, \textbf{model}, \textbf{mod}erate.\\[3pt]
-\textbf{How it wore down:} \emph{quomodo} $\to$ \emph{quomo} $\to$ \emph{como}
---- the final \emph{-do} fell off, the middle collapsed, and \emph{qu-} (a
-\emph{kw}) flattened to \emph{k}; the accent came late, to mark the question.
-(Same erosion: Italian \emph{come}, French \emph{comme}.)\\[3pt]
-\textbf{The whole question family is worn-down Latin \emph{qu-}:} \emph{qu\'{e}}
-$\leftarrow$ \emph{quid}, \emph{qui\'{e}n} $\leftarrow$ \emph{quem},
-\emph{cu\'{a}l} $\leftarrow$ \emph{qualis}, \emph{cu\'{a}ndo} $\leftarrow$
-\emph{quando}, \emph{cu\'{a}nto} $\leftarrow$ \emph{quantus}, \emph{c\'{o}mo}
-$\leftarrow$ \emph{quomodo}. One derivation cracks them all.
-\end{cousinweb}
-
-\begin{grammarlens}
-The written accent does real work: \textbf{c\'{o}mo} (with accent) $=$ ``how?''
-(a question word); \textbf{como} (no accent) $=$ ``like/as'' or ``I eat.''
-Spanish flags the question word with an accent where English relies on word
-order. Every question word carries this accent.
-\end{grammarlens}
-
-\section{\emph{se llama} --- the reflexive that fits \emph{usted}}
-\label{lesson:se-llama}
-
-\begin{cousinweb}
-\textbf{se} (``himself/herself/yourself-formal'') $\leftarrow$ Latin \emph{s\={e}}.
-The same \emph{se-} (``self / apart'') is in \textbf{se}cede, \textbf{se}clude,
-\textbf{se}duce (``lead aside''), \textbf{se}gregate, \textbf{se}parate,
-\textbf{se}cret. All turned in on themselves or set apart --- the reflexive
-idea exactly.
-\end{cousinweb}
-
-\emph{me} llamo (I) $\cdot$ \emph{te} llamas (you, \emph{t\'{u}}) $\cdot$
-\emph{se} llama (he/she/\emph{usted}). That \emph{se} is why the polite
-``what's your name?'' is \emph{\textquestiondown c\'{o}mo se llama usted?}
-
-\section{\textquestiondown\emph{C\'{o}mo se llama usted?} --- and answering it}
-\label{lesson:como-se-llama}
-
-\emph{c\'{o}mo} $+$ \emph{se llama} $+$ \emph{usted} $=$ literally ``how do
-you call yourself?'' Spanish asks \emph{how}, not \emph{what}, for a name.
-Informally: \emph{\textquestiondown C\'{o}mo te llamas?} Answer with
-\emph{Me llamo \ldots}\ (and bounce it back: \emph{\textquestiondown Y usted?},
-``and you?'').
-
-\section{\emph{mucho} and \emph{mucho gusto}}
-\label{lesson:mucho-gusto}
-
-\begin{cousinweb}
-\textbf{mucho} (``much'') $\leftarrow$ Latin \emph{multus} $\to$ \textbf{mult}iple,
-\textbf{mult}itude, \textbf{mult}iply. Sound-change again: Latin \emph{-lt-}
-$\to$ Spanish \emph{-ch-} (\emph{multum} $\to$ \emph{mucho}), the same melt as
-\emph{noctem} $\to$ \emph{noche}.\\[3pt]
-\textbf{el gusto} (masc., ``taste; pleasure'') $\leftarrow$ Latin \emph{gustus}
-$\to$ \textbf{gust}atory, dis\textbf{gust} (``distaste''), \emph{gusto}. (A
-\emph{gust} of wind is unrelated --- Old Norse; a false friend.)
-\end{cousinweb}
-
-\emph{mucho gusto} $=$ ``much pleasure'' $=$ pleased to meet you --- Spanish
-names the pleasure where English names the person. Reply: \emph{El gusto es
-m\'{i}o} (``the pleasure is mine'').
-
-\section{Practice --- introducing yourself}
-\label{lesson:ch3-practice}
-
-\begin{quote}\itshape
---- Buenos d\'{i}as. Me llamo Susana. \textquestiondown C\'{o}mo se llama
-usted?\\
---- Me llamo David. Mucho gusto.\\
---- El gusto es m\'{i}o.
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} A tiny word doing big work. \emph{me} is your first \textbf{pronoun} — and unlike \emph{hola}, its English look-alike is the real thing: a true cousin, not a coincidence.
 \end{quote}
 
-Informally, only two words change --- and they carry the whole social
-difference: \emph{\textquestiondown C\'{o}mo te llamas?} for a friend. Next
-chapter: they answer your \emph{\textquestiondown c\'{o}mo est\'{a} usted?}
---- ``how are you?''
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{vowel-e} — one clean syllable, \emph{meh} (the \emph{e} of \emph{bed}).
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{me} — "me / myself." Root: Latin \textbf{me} (the object form of \emph{ego}, "I").
+
+Here's the satisfying part: English \textbf{me} is a \textbf{genuine cousin}, not a false friend. Spanish \emph{me} comes from Latin \emph{me}; English \emph{me} comes from Proto-Germanic — but both trace back to the \emph{same} ancient ancestor (the Proto-Indo-European root \emph{me-}, "me"). So do English \textbf{my} and \textbf{mine}. This is the opposite of the \emph{hola}/\emph{hello} trap you saw earlier: here the resemblance is real, and you can lean on it hard. Spanish \emph{me} = English \emph{me}, all the way down.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: what a pronoun is}]
+A \textbf{pronoun} is a stand-in word that points to a person or thing without naming them — \emph{I, you, he, me, it}. \emph{me} specifically is an \textbf{object} pronoun: it marks the person the action lands on ("call \emph{me}", "give \emph{me}"). In Spanish it usually sits \textbf{right before the verb} — you'll see it next lesson in \emph{me llamo}, literally "myself I-call." For now, just hold \emph{me} = "me / myself."
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "me" — \emph{meh}{]}
+  \item {[}YOU SAY: "me" then English "me", "my", "mine" — all one family{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Is Spanish \emph{me} a true cousin of English \emph{me}, or a coincidence like \emph{hola}/\emph{hello}? (A true cousin — both from the same ancient root.) What part of speech is it? (A pronoun.)
+\end{tcolorbox}
+\section[llamo]{llamo — "I call," from a root that shouts}
+
+\label{lesson:ES-C03-llamar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The verb inside "my name is." On its own it means "to call" — and its Latin root literally means \emph{to shout}, which is why it echoes through a whole family of English words.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item me — you'll bolt \emph{me} onto \emph{llamo} next lesson.
+\end{itemize}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{ll-y} — \textbf{ll} sounds like English \textbf{y}: \emph{llamo} is \emph{YA-mo}, not \emph{LA-mo}. $\to$ reference
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{llamo} — "I call." The dictionary form (the infinitive) is \textbf{llamar}, "to call." Root: Latin \textbf{clamare}, "to cry out, to shout." That \emph{clam-} shouts all through English:
+
+\begin{itemize}
+\raggedright
+  \item ex\textbf{claim}, ex\textbf{clam}ation — \emph{ex-} ("out") + \emph{clamare}: to shout \textbf{out}.
+  \item pro\textbf{claim}, pro\textbf{clam}ation — \emph{pro-} ("forth"): to call \textbf{forth}.
+  \item ac\textbf{claim} — \emph{ad-} ("toward"): to shout praise toward.
+  \item \textbf{claim}, re\textbf{claim}, dis\textbf{claim}; and \textbf{clam}or, borrowed whole.
+\end{itemize}
+
+\textbf{A sound-pattern to bank:} Latin \emph{cl-} became Spanish \emph{ll-}. \emph{clamare} $\to$ \emph{llamar}. It happened repeatedly: \emph{clavem} $\to$ \emph{llave} ("key"), \emph{flamma} $\to$ \emph{llama} ("flame"), \emph{plovere} $\to$ \emph{llover} ("to rain"). A Spanish word starting \emph{ll-} is very often a Latin \emph{cl-}/\emph{fl-}/\emph{pl-} word in disguise — and its English cousin usually kept the original cluster (\emph{clamor}, \emph{flame}, \emph{pluvial}).
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "llamo" — \emph{YA-mo}{]}
+  \item {[}YOU SAY: "llamo" then "exclaim", "proclaim", "clamor" — the shouting root{]}
+  \item {[}YOU SAY: "llamar" (to call), "llave" (key) — both from Latin \emph{cl-}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does the root \emph{clamare} mean? (To shout / cry out.) Latin \emph{cl-} becomes which two letters in Spanish? (\emph{ll-} — \emph{clamare $\to$ llamar}.)
+\end{tcolorbox}
+\section[me llamo]{me llamo — "I call myself"}
+
+\label{lesson:ES-C03-me-llamo}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Snap the last two lessons together — \emph{me} + \emph{llamo} — and you can introduce yourself. But notice Spanish doesn't say "my name is" at all.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item me · llamo
+\end{itemize}
+
+\begin{cousinweb}
+\textbf{me llamo} = \textbf{me} ("myself") + \textbf{llamo} ("I call") = literally \textbf{"I call myself."} Then the name: \emph{Me llamo Susana} — "I call myself Susan."
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: reflexive verbs}]
+When the action loops back onto the person doing it — you call \emph{yourself} — the verb is \textbf{reflexive}, and Spanish marks it with that little pronoun in front: \emph{me} ("myself"). \emph{llamo} alone is "I call {[}someone else{]}"; \emph{me llamo} is "I call \textbf{myself}." English can do this ("I call myself Sam") but usually doesn't bother, flattening it to "my name is." Spanish keeps the reflexive loop visible.
+
+This matters because the pronoun \textbf{changes with the person}: \emph{me} llamo (I call myself) $\to$ \emph{te} llamas (you-informal call yourself) $\to$ \emph{se} llama (he/she/you-formal calls himself). You'll meet \emph{te} and \emph{se} in a few lessons; for now, lock in \emph{me llamo} for yourself.
+\end{grammarlens}
+
+\begin{culture}
+Spanish presents your name not as a thing you \emph{have} ("my name is") but as what you \emph{do} — what you call yourself. It's subtly more active, and it's the completely standard, neutral way to introduce yourself.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "me llamo" + your own name{]}
+  \item {[}YOU SAY: "hola, me llamo \_\_\_" — greeting + introduction{]}
+  \item {[}YOU SAY: what does \emph{me llamo} literally mean, word for word?{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Literally, what is \emph{me llamo}? ("I call myself.") What makes it reflexive? (The \emph{me} — the action loops back on you.)
+\end{tcolorbox}
+\section[tú / usted]{tú and usted — two words for "you," and why you must choose}
+
+\label{lesson:ES-C03-tu-usted}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} English has one word for "you." Spanish has two, and picking the wrong one can send the wrong social signal. This lesson gives you both and shows the everyday choice. The remarkable history of \emph{usted} comes next.
+\end{quote}
+
+\subsection*{The two words}
+\textbf{tú} — "you," \textbf{informal}. For friends, family, children, peers, anyone you're on easy terms with.
+
+\begin{quote}
+Root: Latin \textbf{tū}. This is a \textbf{true cousin} of English \textbf{thou} — the word English used to have for exactly this job, the intimate "you" (\emph{thou/thee/thy}), before it faded out around 400 years ago. Both \emph{tú} and \emph{thou} come straight from the same ancient root (\emph{tu-}). So Spanish still uses, every day, the pronoun English quietly retired.
+\end{quote}
+
+\textbf{usted} — "you," \textbf{formal}. For strangers, elders, officials, customers, anyone you're showing respect or keeping distance with.
+
+\begin{grammarlens}[title={Grammar Lens: the choice English lost}]
+Both are \textbf{subject pronouns} — the "doer" word, like \emph{yo} ("I"). But they carry a second layer English dropped when \emph{thou} died: \textbf{social register}. Choosing \emph{tú} vs. \emph{usted} tells the listener how you see the relationship — close or respectful. English "you" is one-size-fits-all; a Spanish speaker must decide every time.
+
+One structural surprise, because it explains the next lessons: \textbf{usted takes \emph{he/she} verb forms}, not the informal "you" forms. That's why "what's your name?" formally is \emph{¿cómo \textbf{se llama} usted?} (the \emph{se llama} you'd use for "he calls himself") and not \emph{te llamas}. The next micro-lesson explains the history behind that third-person pattern.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "tú" — for a close friend{]}
+  \item {[}YOU SAY: "usted" — for someone you'd address respectfully{]}
+  \item {[}YOU SAY: "tú" then English "thou" — the retired twin{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which is formal, \emph{tú} or \emph{usted}? (\emph{usted}.) What English pronoun is the lost twin of \emph{tú}? (\emph{Thou}.) Which verb pattern does \emph{usted} take? (The same form used with "he" or "she.")
+\end{tcolorbox}
+\section[vuestra merced to usted]{\emph{vuestra merced} $\to$ \emph{usted} — respect compressed into one word}
+
+\label{lesson:ES-C03-usted-origin}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You use \emph{usted} for respectful "you," and it takes the same verb form as "he" or "she." That surprising grammar preserves the word's history.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item tú / usted — the informal and formal choices.
+\end{itemize}
+
+\begin{cousinweb}
+\emph{usted} wore down from \textbf{vuestra merced}, "your grace" or "your mercy." \emph{Vuestra} comes from Latin \emph{vestra}, "your." \emph{Merced} comes from Latin \emph{merces, mercedem}, "wages, reward, favor."
+
+The \emph{merc-} root links \textbf{mercy}, \textbf{mercenary}, \textbf{commerce}, \textbf{merchant}, and \textbf{merchandise}. A respectful title was repeated so often that two words compressed into one pronoun. Its older abbreviation \textbf{Vd.} still preserves the \emph{v} of \emph{vuestra}.
+\end{cousinweb}
+
+\begin{culture}
+A title like "your grace" refers to a respected person in the third person. That is why modern \emph{usted} still takes the he/she verb form even while it means "you." The social history remains visible in the grammar.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the two-word title that became \emph{usted}{]}
+  \item {[}YOU SAY: "usted" followed by "mercy" and "merchant" — the \emph{merc-} family{]}
+  \item {[}YOU SAY: which verb pattern \emph{usted} takes{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What did \emph{vuestra merced} mean? ("Your grace" or "your mercy.") Why does \emph{usted} take the he/she verb form? (It began as a third-person title.)
+\end{tcolorbox}
+\section[cómo]{cómo — "how," your first question word}
+
+\label{lesson:ES-C03-como}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} To ask someone's name or how they are, you need this word first. \emph{cómo} — "how" — and it carries a little word for "manner" you already own in English.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{inverted-marks} — Spanish questions open with an upside-down \textbf{¿} so you see the question coming: \emph{¿cómo…?}
+  \item \texttt{accent-mark} — the accent on \textbf{ó} marks the stress \emph{and} flags it as a question word (see below): \emph{CÓ-mo}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{cómo} — "how." Root: Latin \textbf{quomodo} — a fused little phrase, \emph{quo modo}, "in what \textbf{manner}."
+
+\textbf{The two halves, and their English cousins:}
+
+\begin{itemize}
+\raggedright
+  \item \emph{modo} ("manner, measure") $\to$ English \textbf{mode}, \textbf{mod}al, \textbf{model}, \textbf{mod}erate, \textbf{mod}ify, com\textbf{mod}ity.
+  \item \emph{quo} ("in what") is the Latin question-stem \textbf{qu-} — the seed of almost every Spanish question word (see the family below).
+\end{itemize}
+
+\textbf{How \emph{quomodo} became \emph{cómo} — the wearing-down.} Spanish didn't borrow \emph{cómo} ready-made; it \emph{eroded} out of \emph{quomodo} over centuries of everyday speech. The final \emph{-do} fell off and the middle collapsed:
+
+\begin{quote}
+\emph{quomodo} $\to$ \emph{quomo} $\to$ \textbf{como}
+\end{quote}
+
+The \emph{qu-} (a \emph{kw} sound) flattened to a plain \emph{k} (written \emph{c} before \emph{o}). What's left is \emph{quomodo} worn smooth — the way a pebble loses its edges in a river. The same erosion gave Italian \emph{come}, Portuguese \emph{como}, French \emph{comme}. The accent in \emph{cómo} is the one late addition: Spanish stamps it on to mark the question (vs. accent-less \emph{como}, "like / as").
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the accent that marks a question}]
+Watch the accent mark do real work. \textbf{cómo} (with the accent) = "how?", the question word. \textbf{como} (no accent) = "like / as," or "I eat." Same letters, and the written accent is the \emph{only} thing telling you it's a question:
+
+\begin{itemize}
+\raggedright
+  \item \emph{¿\textbf{Cómo} estás?} — "\textbf{How} are you?"
+  \item \emph{\textbf{Como} tú.} — "Like you." / \emph{Yo \textbf{como}.} — "I eat."
+\end{itemize}
+
+English has no such marker — it relies on word order and context. Spanish puts a visible flag on the question word. Every question word you'll learn (\emph{qué, dónde, cuándo, quién…}) carries this accent for the same reason.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "¿cómo?" — with question intonation{]}
+  \item {[}YOU SAY: "cómo" then English "mode", "model" — the \emph{modo} root{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Walk the erosion: \emph{quomodo} $\to$ ? $\to$ \emph{cómo} (\emph{quomo} $\to$ \emph{como}, then the question-accent). What changes when the accent disappears? (\emph{como} is no longer the question word "how.")
+\end{tcolorbox}
+\section[qu-]{The \emph{qu-} question family — one ancient pattern, many clues}
+
+\label{lesson:ES-C03-familia-qu}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You traced \emph{cómo} back to Latin \emph{quomodo}. Focus now on its first piece, \emph{qu-}, without trying to use a whole set of new question words yet.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item cómo — "how," from Latin \emph{quomodo}.
+\end{itemize}
+
+\begin{cousinweb}
+Latin used a recurring \emph{qu-} stem in questions. Spanish preserves that family, although centuries of sound change gave the modern forms different shapes:
+
+| Spanish clue | $\leftarrow$ Latin | future meaning | |---|---|---| | \emph{qué} | \emph{quid} | what | | \emph{quién} | \emph{quem} | who | | \emph{cuál} | \emph{qualis} | which | | \emph{cuándo} | \emph{quando} | when | | \emph{cuánto} | \emph{quantus} | how much | | \textbf{cómo} | \emph{quomodo} | how |
+
+These are previews, not vocabulary to produce today. For now, use the family only as an etymological clue: a question form beginning \emph{qu-} or \emph{cu-} may continue the same Latin pattern. \emph{Dónde}, "where," is an exception from Latin \emph{de unde}, "from where."
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the Latin source of \emph{cómo}{]}
+  \item {[}YOU SAY: the recurring Latin question stem{]}
+  \item {[}YOU SAY: whether the table is today's production list or a preview{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which old stem connects \emph{qué, quién, cuándo,} and \emph{cómo}? (\emph{qu-}.) Which word in the preview is the exception? (\emph{Dónde}.)
+\end{tcolorbox}
+\section[se llama]{se llama — the reflexive that fits \emph{usted}}
+
+\label{lesson:ES-C03-se-llama}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can say \emph{me llamo} ("I call myself"). To ask someone \emph{else} their name — especially formally, with \emph{usted} — you need the version that loops back on \emph{them}: \emph{se llama}.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item me llamo — the reflexive "I call myself."
+  \item tú / usted — and the key fact that \emph{usted} takes \emph{he/she} verb forms.
+\end{itemize}
+
+\begin{cousinweb}
+\textbf{se llama} = \textbf{se} ("himself / herself / yourself-formal") + \textbf{llama} ("calls"). So \emph{se llama} = "he/she calls himself," or — because \emph{usted} uses third-person forms — "\textbf{you} (formal) call yourself."
+
+\textbf{se} — the reflexive pronoun for the third person (and for \emph{usted}). Root: Latin \textbf{sē} ("himself, herself, itself"). That same \emph{se-} — carrying the sense of "self / apart / aside" — is bolted onto a shelf of English words:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{se}cede — \emph{se} + \emph{cedere} ("go apart").
+  \item \textbf{se}clude, \textbf{se}gregate ("apart from the flock"), \textbf{se}parate.
+  \item \textbf{se}duce — \emph{se} + \emph{ducere} ("lead aside").
+  \item \textbf{se}cure — \emph{se} + \emph{cura} ("free from care"), \textbf{se}cret ("set apart").
+\end{itemize}
+
+Every one is something turned in on itself or set apart — the same idea as a reflexive looping the action back on the doer.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the reflexive pronoun changes with the person}]
+The verb \emph{llamar} stays, but the little reflexive word in front shifts to match \emph{who} is doing the calling:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{me} llamo — \emph{I} call myself
+  \item \textbf{te} llamas — \emph{you (informal, tú)} call yourself
+  \item \textbf{se} llama — \emph{he / she / you (formal, usted)} calls himself/yourself
+\end{itemize}
+
+Three persons, three pronouns: \emph{me / te / se}. That \emph{se} is exactly why the formal "what's your name?" is \emph{¿cómo \textbf{se} llama usted?} — \emph{usted}, born from "your grace," politely takes the \emph{he/she} shape.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "se llama" — \emph{seh YA-ma}{]}
+  \item {[}YOU SAY: the set — "me llamo, te llamas, se llama"{]}
+  \item {[}YOU SAY: "se" then "secede", "seclude", "separate" — the set-apart root{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which reflexive goes with \emph{usted} — \emph{te} or \emph{se}? (\emph{se} — because \emph{usted} takes third-person forms.) What's the "self/apart" root inside \emph{secede} and \emph{separate}? (Latin \emph{se-}.)
+\end{tcolorbox}
+\section[¿cómo se llama usted?]{¿cómo se llama usted? — assembling the question, and answering it}
+
+\label{lesson:ES-C03-como-se-llama}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Everything you built this chapter clicks into one sentence: how to ask a stranger their name, and how to answer back. This is your first real two-way exchange.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item cómo · se llama · usted
+\end{itemize}
+
+\begin{cousinweb}
+\textbf{¿Cómo se llama usted?} = \emph{cómo} ("how") + \emph{se llama} ("do you-formal call yourself") + \emph{usted} ("you," formal).
+
+Literally: \textbf{"How do you call yourself?"} Spanish asks \emph{how}, not \emph{what}, for a name — you're asking by what name a person goes, the manner they're called.
+
+\textbf{The informal version}, for a friend, swaps the reflexive and drops the formal pronoun: \textbf{¿Cómo te llamas?} (\emph{te llamas}, from \emph{tú}). Same question, two registers — exactly the \emph{tú}/\emph{usted} choice from earlier, now live in a real sentence:
+
+\begin{itemize}
+\raggedright
+  \item To a stranger, an elder, a customer $\to$ \emph{¿Cómo se llama usted?}
+  \item To a friend, a child, a peer $\to$ \emph{¿Cómo te llamas?}
+\end{itemize}
+\end{cousinweb}
+
+\subsection*{How to answer}
+You already have the answer from the \emph{me llamo} lesson: \textbf{Me llamo \_\_\_.}
+
+\begin{quote}
+— ¿Cómo se llama usted? — \textbf{Me llamo David.} ¿Y usted?
+\end{quote}
+
+(\emph{¿Y usted?} — "And you?" — bounces the same question back; \emph{y} = "and," a whole lesson's worth of its own soon, but usable now.)
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: ask a stranger their name — \emph{¿cómo se llama usted?}{]}
+  \item {[}YOU SAY: ask a friend the same — \emph{¿cómo te llamas?}{]}
+  \item {[}YOU SAY: the whole mini-exchange — ask, then answer with \emph{me llamo \_\_\_}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Formal vs. informal "what's your name"? (\emph{¿Cómo se llama usted?} / \emph{¿Cómo te llamas?}) Does Spanish literally ask "what" or "how" is your name? ("How" — \emph{cómo}.)
+\end{tcolorbox}
+\section[mucho]{mucho — "much," and a sound-change you've already seen}
+
+\label{lesson:ES-C03-mucho}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} One more word before "pleased to meet you." \emph{mucho} — "much, a lot" — and it hides the same Latin-to-Spanish sound trick you spotted in \emph{noche}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{soft-c} — the \textbf{ch} is the \emph{ch} of \emph{church}: \emph{MOO-cho}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{mucho} — "much, a lot." Root: Latin \textbf{multus} ("much, many"). The English cousins keep the original \emph{-lt-}:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{mult}iple, \textbf{mult}itude, \textbf{mult}iply, \textbf{mult}i-purpose, \textbf{mult}imedia.
+\end{itemize}
+
+\textbf{The sound-change, again:} Latin \emph{multum} $\to$ Spanish \emph{mucho}. The Latin \textbf{-lt-} softened into Spanish \textbf{-ch-} — the very same move as \emph{noctem $\to$ noche} (\emph{-ct- $\to$ -ch-}, as in the \emph{noche} lesson). Spanish has a habit of melting these consonant clusters into \emph{ch}. So a Spanish \emph{-ch-} word very often points back to a Latin \emph{-ct-} or \emph{-lt-} root — and the English cousin usually preserves it (\emph{noct}urnal, \emph{mult}iple).
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "mucho" — \emph{MOO-cho}{]}
+  \item {[}YOU SAY: "mucho" then "multiple", "multitude" — the \emph{mult-} family{]}
+  \item {[}YOU SAY: "noche" and "mucho" — two words, same \emph{-ch-} from a melted Latin cluster{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} \emph{mucho} comes from Latin \emph{multus} — what English words keep the \emph{-lt-}? (multiple, multitude, multiply.) What Latin cluster melted into the \emph{-ch-}? (\emph{-lt-}, like \emph{-ct-} did in \emph{noche}.)
+\end{tcolorbox}
+\section[mucho gusto]{gusto $\to$ mucho gusto — "much pleasure"}
+
+\label{lesson:ES-C03-gusto}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The line you say when you shake someone's hand. First the noun \emph{gusto}, then snap \emph{mucho} onto it, and you've got it.
+\end{quote}
+
+\subsection*{You'll want to know first}
+\begin{itemize}
+\raggedright
+  \item mucho — "much," about to modify \emph{gusto}.
+\end{itemize}
+
+\begin{cousinweb}
+\textbf{el gusto} (masculine) — "taste; pleasure, liking." Root: Latin \textbf{gustus} ("a tasting, a taste"). The English cousins:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{gust}atory — to do with the sense of taste.
+  \item dis\textbf{gust} — \emph{dis-} ("not, opposite") + \emph{gust}: literally "\textbf{dis}taste."
+  \item \textbf{gusto} — borrowed whole into English, meaning zest, relish, enjoyment.
+\end{itemize}
+
+\begin{quote}
+False friend to flag: a \emph{gust} of wind is \textbf{not} related — that one's from Old Norse \emph{gustr}. Same spelling, different root. Resemblance isn't proof.
+\end{quote}
+
+\textbf{mucho gusto} = \emph{mucho} ("much") + \emph{gusto} ("pleasure") = literally \textbf{"much pleasure"} — short for "it's a great pleasure {[}to meet you{]}." \emph{gusto} is masculine (\emph{el gusto}), and \emph{mucho} is in its plain masculine form to match it: another quiet piece of the agreement you've been building.
+\end{cousinweb}
+
+\begin{culture}
+Spanish greets a new acquaintance by naming the \emph{pleasure} of it — "much pleasure" — where English names the \emph{person} ("pleased to meet \textbf{you}"). There's a stock reply that volleys it back: \textbf{"El gusto es mío"} — "the pleasure is mine."
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "gusto" then "gusto" (English), "disgust", "gustatory"{]}
+  \item {[}YOU SAY: "mucho gusto" — on meeting someone{]}
+  \item {[}YOU SAY: the reply — "el gusto es mío"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{mucho gusto} literally mean? ("Much pleasure.") Is \emph{el gusto} masculine or feminine? (Masculine.) And the English cousin of \emph{gusto} built from \emph{dis-}? (\emph{Disgust} — "distaste.")
+\end{tcolorbox}
+\section[Practice]{Practice — introducing yourself}
+
+\label{lesson:ES-C03-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Ten lessons of atoms now assemble into a real conversation. No new words — just the exchange, run both formally and informally until the \emph{tú} / \emph{usted} choice is automatic.
+\end{quote}
+
+\subsection*{The exchange}
+\textbf{Formal} (a stranger, an elder, a customer):
+
+\begin{quote}
+— Buenos días. Me llamo Susana. \textbf{¿Cómo se llama usted?} — Me llamo David. \textbf{Mucho gusto.} — El gusto es mío.
+\end{quote}
+
+\textbf{Informal} (a friend, a peer): only two words change, and they're the ones that carry the whole social difference:
+
+\begin{quote}
+— ¡Hola! Me llamo Susana. \textbf{¿Cómo te llamas?} — Me llamo David. Mucho gusto.
+\end{quote}
+
+\begin{grammarlens}[title={What you've built}]
+\begin{itemize}
+\raggedright
+  \item \textbf{me llamo} — introduce yourself ("I call myself").
+  \item \textbf{tú / usted} — the informal vs. formal "you," and \emph{why} (the retired \emph{thou}; \emph{usted} from "your grace").
+  \item \textbf{¿cómo te llamas? / ¿cómo se llama usted?} — ask a name, in either register, the pronoun (\emph{te} / \emph{se}) tracking the choice.
+  \item \textbf{mucho gusto} — "much pleasure," pleased to meet you.
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the full \emph{formal} exchange, both parts{]}
+  \item {[}YOU SAY: the same exchange \emph{informally} — catch yourself on \emph{se llama} $\to$ \emph{te llamas}{]}
+  \item {[}YOU SAY: for a police officer, then your best friend — which "you" for each, and why?{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Run the formal version start to finish without stopping.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which two words change between the formal and informal introduction? (\emph{se llama usted} $\to$ \emph{te llamas}.) Next chapter: they answer your \emph{"¿cómo está usted?"} — "how are you?" — and you learn to say how you're doing.
+\end{tcolorbox}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 ### Added — canonical LaTeX chapter generation
 
 - Added deterministic lesson-AST fingerprints and a pure Markdown-block to
-  LaTeX renderer, with Spanish Chapter 1 as the first generated slice.
+  LaTeX renderer, now covering all 24 Spanish Chapter 1–3 schema-v2 lessons.
+- Preserved nested inline emphasis, wrapped long practice lists, and emitted
+  text-safe short titles for running headers and PDF bookmarks.
 - Added write/check CLI modes, a committed chapter-hash manifest, path-safety
   validation, and a unified-book CI drift gate.
 - Exposed each parsed lesson's source hash so book and app consumers can verify

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -43,24 +43,17 @@ function escapeLatexCharacter(character: string): string {
 /** Render the deliberately small inline subset used by schema-v2 lessons. */
 export function renderInlineMarkdown(markdown: string): string {
   const output: string[] = [];
+  const emphasis: Array<"italic" | "bold"> = [];
   let cursor = 0;
+  const open = (kind: "italic" | "bold"): void => {
+    output.push(kind === "italic" ? "\\emph{" : "\\textbf{");
+    emphasis.push(kind);
+  };
+  const close = (): void => {
+    output.push("}");
+    emphasis.pop();
+  };
   while (cursor < markdown.length) {
-    if (markdown.startsWith("**", cursor)) {
-      const end = markdown.indexOf("**", cursor + 2);
-      if (end !== -1) {
-        output.push(`\\textbf{${renderInlineMarkdown(markdown.slice(cursor + 2, end))}}`);
-        cursor = end + 2;
-        continue;
-      }
-    }
-    if (markdown[cursor] === "*") {
-      const end = markdown.indexOf("*", cursor + 1);
-      if (end !== -1) {
-        output.push(`\\emph{${renderInlineMarkdown(markdown.slice(cursor + 1, end))}}`);
-        cursor = end + 1;
-        continue;
-      }
-    }
     if (markdown[cursor] === "`") {
       const end = markdown.indexOf("`", cursor + 1);
       if (end !== -1) {
@@ -83,9 +76,35 @@ export function renderInlineMarkdown(markdown: string): string {
         continue;
       }
     }
+    if (markdown.startsWith("***", cursor)) {
+      const top = emphasis.at(-1);
+      const below = emphasis.at(-2);
+      if (top && below && top !== below) {
+        close();
+        close();
+      } else {
+        open("italic");
+        open("bold");
+      }
+      cursor += 3;
+      continue;
+    }
+    if (markdown.startsWith("**", cursor)) {
+      if (emphasis.at(-1) === "bold") close();
+      else open("bold");
+      cursor += 2;
+      continue;
+    }
+    if (markdown[cursor] === "*") {
+      if (emphasis.at(-1) === "italic") close();
+      else open("italic");
+      cursor += 1;
+      continue;
+    }
     output.push(escapeLatexCharacter(markdown[cursor] ?? ""));
     cursor += 1;
   }
+  while (emphasis.length > 0) close();
   return output.join("");
 }
 
@@ -136,7 +155,7 @@ function renderMarkdown(markdown: string): string {
       flushParagraph();
       flushQuote();
       if (!listOpen) {
-        output.push("\\begin{itemize}");
+        output.push("\\begin{itemize}", "\\raggedright");
         listOpen = true;
       }
       flushListItem();
@@ -188,6 +207,15 @@ function lessonSequence(lesson: ParsedLesson): number {
   return Number(stringValue(lesson.frontmatter.sequence));
 }
 
+function sectionShortTitle(lesson: ParsedLesson): string {
+  const title = lesson.realization.type.startsWith("practice")
+    ? "Practice"
+    : lesson.realization.headword;
+  return renderInlineMarkdown(
+    title.replaceAll("←", " from ").replaceAll("→", " to ").replace(/\s+/g, " ").trim(),
+  );
+}
+
 /** Render one configured chapter from the same typed lesson AST the app receives. */
 export function renderBookChapter(
   target: BookGenerationTarget,
@@ -219,11 +247,8 @@ export function renderBookChapter(
   const sourceHash = canonicalChapterHash(lessons);
   const sections = lessons.map((lesson) => {
     const id = lesson.realization.lessonId;
-    const shortTitle = lesson.realization.type.startsWith("practice")
-      ? "Practice"
-      : lesson.realization.headword;
     return [
-      `\\section[${renderInlineMarkdown(shortTitle)}]{${renderInlineMarkdown(lessonTitle(lesson))}}`,
+      `\\section[${sectionShortTitle(lesson)}]{${renderInlineMarkdown(lessonTitle(lesson))}}`,
       `\\label{lesson:${id}}`,
       "",
       ...lesson.blocks.map(renderBlock),

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -62,12 +62,23 @@ describe("canonical LaTeX chapter rendering", () => {
     expect(generated.tex).toContain(`% canonical-source-hash: ${generated.sourceHash}`);
     expect(generated.tex.indexOf("lesson:A")).toBeLessThan(generated.tex.indexOf("lesson:B"));
     expect(generated.tex).toContain("\\begin{tcolorbox}");
+    expect(generated.tex).toContain("\\begin{itemize}\n\\raggedright");
     expect(generated.tex).toContain("\\item {[}YOU SAY: \\textbf{hello}{]}");
+  });
+
+  it("keeps arrows out of the PDF bookmark and running-header title", () => {
+    const lesson = parseLesson(source("A", 10, "vuestra merced → usted"), "test");
+    const generated = renderBookChapter(target, [lesson]);
+    expect(generated.tex).toContain("\\section[vuestra merced to usted]");
+    expect(generated.tex).toContain("$\\to$");
   });
 
   it("escapes LaTeX control characters while preserving authored emphasis", () => {
     expect(renderInlineMarkdown("**A&B** costs $5 and uses `x_y`")).toBe(
       "\\textbf{A\\&B} costs \\$5 and uses \\texttt{x\\_y}",
+    );
+    expect(renderInlineMarkdown("*buen**os*** and ***Como** tú.*")).toBe(
+      "\\emph{buen\\textbf{os}} and \\emph{\\textbf{Como} tú.}",
     );
   });
 

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Derive the lesson-card minute label from schema-v2 `duration.max_seconds`,
   while retaining `est_minutes` for unmigrated tracks.
 - Independently combine loaded lesson fingerprints and show `book synced` for a
-  generated chapter only when the app AST matches the committed book manifest.
+  generated chapter only when the app AST matches the committed book manifest;
+  Spanish Chapters 1–3 now verify all 24 migrated lessons this way.
 
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -3,12 +3,16 @@ import { actualChapterHash, bookHashStatus, expectedBookHash } from "../src/book
 import { loadLessons } from "../src/lessons.ts";
 
 describe("generated book source hashes", () => {
-  it("matches the browser-loaded Spanish Chapter 1 AST to the generated book", () => {
+  it.each([
+    [1, 7],
+    [2, 5],
+    [3, 12],
+  ])("matches the browser-loaded Spanish Chapter %i AST across %i lessons", (chapter, count) => {
     const lessons = loadLessons();
-    const expected = expectedBookHash("spanish", 1);
-    expect(expected?.lessonIds).toHaveLength(7);
-    expect(actualChapterHash(lessons, "spanish", 1)).toBe(expected?.sourceHash);
-    expect(bookHashStatus(lessons, "spanish", 1)).toBe("synced");
+    const expected = expectedBookHash("spanish", chapter);
+    expect(expected?.lessonIds).toHaveLength(count);
+    expect(actualChapterHash(lessons, "spanish", chapter)).toBe(expected?.sourceHash);
+    expect(bookHashStatus(lessons, "spanish", chapter)).toBe("synced");
   });
 
   it("reports a generated chapter stale when one canonical lesson changes", () => {
@@ -17,6 +21,6 @@ describe("generated book source hashes", () => {
       lesson.id === "ES-C01-hola" ? { ...lesson, sourceHash: "fnv1a64:changed" } : lesson,
     );
     expect(bookHashStatus(changed, "spanish", 1)).toBe("stale");
-    expect(bookHashStatus(lessons, "spanish", 2)).toBe("not-generated");
+    expect(bookHashStatus(lessons, "spanish", 4)).toBe("not-generated");
   });
 });


### PR DESCRIPTION
## Summary

- generate Spanish Chapters 2–3 from the remaining 17 schema-v2 lesson ASTs, completing the 24-lesson pilot
- extend the app/book source-hash agreement checks across all three generated chapters
- teach the shared renderer nested emphasis, text-safe short titles, and ragged-right practice-list wrapping
- record the 138-page visual QA findings and reprioritize Russian's nine duration violations as HL-D01A

## Validation

- `human-language-data`: 11 test files / 68 tests; 93.60% line coverage; TypeScript build; generated-output check; JSON gap report
- `language-ladder`: 27 test files / 278 tests; 98.37% line coverage; production Vite build
- Spanish XeLaTeX book: 138 pages, successful build
- generated Chapters 1–3 log segment has no overfull box or Hyperref warning
- rendered and visually inspected both new chapter openers plus representative etymology, grammar, nested-emphasis, guided-practice, and recall pages
- `git diff --check`