### PR TITLE
fix(build-tool): enforce Rust rockspec UTF-8

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,16 +13,16 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "a6845a83c8e2667d8cf35a9e80a0c51a1d74698e",
+    "revision": "de44349bd147c9ce46ce27d2ac741f2f01fcc2de",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1217,
-    "implementation_package_slots": 4365,
+    "implementation_identities": 1218,
+    "implementation_package_slots": 4366,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 767,
-    "singleton_missing_slots": 10738,
-    "rust_singletons": 572,
+    "singleton_packages": 768,
+    "singleton_missing_slots": 10752,
+    "rust_singletons": 573,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -356,7 +356,16 @@
       "depends_on": ["build-tool-go-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-rust-rockspec-utf8",
       "pr_number": null,
-      "notes": "Selected after the a6845a83c dependency/leverage pass because Rust currently converts fs::read_to_string failure into an empty dependency list, silently erasing edges, while merged Go provides the operational-oracle behavior. Bind the Rust resolver and CLI to the exact shared success and invalid-byte fixtures, preserve METADATA_INVALID_UTF8 with package and repository-relative manifest identity, return exit 2 without host paths, and leave the seven non-Rust engine remediations outside this slice."
+      "notes": "Selected after the a6845a83c dependency/leverage pass because Rust silently erased dependency edges on fs::read_to_string failure while merged Go provides the operational-oracle behavior. The implementation now consumes the exact shared success and invalid-byte fixtures, requires exact edge equality, returns a typed METADATA_INVALID_UTF8 diagnostic with package and repository-relative manifest identity, exits 2 through the real CLI, and does not disclose host paths. Validation passed 136 unit plus one CLI integration test, strict Clippy, release build, 79.33% line coverage, 57 language-neutral conformance tests plus 52 subtests, the 32-case/36-file corpus, a real 258-package Lua dry-run plan across all 246 strict-UTF-8 rockspecs, collision-free parity inventory, and a zero-advisory RustSec audit. After rebasing onto de44349bd, full-repository plan validation separately reproduced untouched main's 4,766-package exit-101 panic on an elixir/grammar_tools self-edge, and BUILD validation output matched untouched main exactly; the dedicated pending self-edge and Lua BUILD_windows items own those baselines. The seven non-Rust encoding remediations remain outside this slice."
+    },
+    {
+      "id": "build-tool-rust-self-edge-diagnostic",
+      "title": "Make the Rust build tool reject self-edges without panicking",
+      "status": "pending",
+      "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the Rust UTF-8 slice's real full-repository plan. On rebased de44349bd, both untouched main and the current branch discover 4,766 packages, then exit 101 because graph.add_edge panics on elixir/grammar_tools. Define a language-neutral self-edge resolution fixture, identify the exact Elixir resolver alias collision or self-reference, and return a stable resolver diagnostic instead of aborting the process. Keep this independent of strict rockspec decoding."
     },
     {
       "id": "build-tool-python-haskell-language-filter",
@@ -1142,6 +1151,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Share the XOR codec, bounded JSON/status validation, device and identity normalization, state/capability projection, stable errors, command planning, and verification fixtures. Network, time, and runtime authority are excluded."
+    },
+    {
+      "id": "smart-home-tasmota-portable-core-extraction-and-conformance",
+      "title": "Extract and port the portable Tasmota local HTTP core",
+      "status": "pending",
+      "depends_on": ["smart-home-switch-entity-command-contract"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after merged PR #9498 added the Rust-only Tasmota local HTTP host. Share bounded Status 0 JSON validation, relay/light/sensor normalization, stable identities and errors, state/capability projection, command planning, color conversion, and verification fixtures. mDNS, DNS/TCP, plaintext LAN HTTP execution, credentials and Vault, trusted time, console I/O, authorization, and runtime mutation are excluded native-host responsibilities."
     },
     {
       "id": "smart-home-reolink-portable-core-extraction-and-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9510,
   "last_inventory": {
     "revision": "de44349bd147c9ce46ce27d2ac741f2f01fcc2de",
     "schema_version": 3,
@@ -352,11 +352,11 @@
     {
       "id": "build-tool-rust-rockspec-utf8-conformance",
       "title": "Make the Rust build tool enforce strict UTF-8 rockspec metadata",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-go-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-rust-rockspec-utf8",
-      "pr_number": null,
-      "notes": "Selected after the a6845a83c dependency/leverage pass because Rust silently erased dependency edges on fs::read_to_string failure while merged Go provides the operational-oracle behavior. The implementation now consumes the exact shared success and invalid-byte fixtures, requires exact edge equality, returns a typed METADATA_INVALID_UTF8 diagnostic with package and repository-relative manifest identity, exits 2 through the real CLI, and does not disclose host paths. Validation passed 136 unit plus one CLI integration test, strict Clippy, release build, 79.33% line coverage, 57 language-neutral conformance tests plus 52 subtests, the 32-case/36-file corpus, a real 258-package Lua dry-run plan across all 246 strict-UTF-8 rockspecs, collision-free parity inventory, and a zero-advisory RustSec audit. After rebasing onto de44349bd, full-repository plan validation separately reproduced untouched main's 4,766-package exit-101 panic on an elixir/grammar_tools self-edge, and BUILD validation output matched untouched main exactly; the dedicated pending self-edge and Lua BUILD_windows items own those baselines. The seven non-Rust encoding remediations remain outside this slice."
+      "pr_number": 9510,
+      "notes": "Ready PR #9510 follows the a6845a83c dependency/leverage selection and is rebased on de44349bd. The implementation consumes the exact shared success and invalid-byte fixtures, requires exact edge equality, returns a typed METADATA_INVALID_UTF8 diagnostic with package and repository-relative manifest identity, exits 2 through the real CLI, and does not disclose host paths. Validation passed 136 unit plus one CLI integration test, strict Clippy, release build, 79.33% line coverage, 57 language-neutral conformance tests plus 52 subtests, the 32-case/36-file corpus, a real 258-package Lua dry-run plan across all 246 strict-UTF-8 rockspecs, collision-free parity inventory, and a zero-advisory RustSec audit. Full-repository plan validation separately reproduced untouched main's 4,766-package exit-101 panic on an elixir/grammar_tools self-edge, and BUILD validation output matched untouched main exactly; the dedicated pending self-edge and Lua BUILD_windows items own those baselines. The seven non-Rust encoding remediations remain outside this slice."
     },
     {
       "id": "build-tool-rust-self-edge-diagnostic",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -352,11 +352,11 @@
     {
       "id": "build-tool-rust-rockspec-utf8-conformance",
       "title": "Make the Rust build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-go-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-rust-rockspec-utf8",
       "pr_number": null,
-      "notes": "Materialized from build-tool-rockspec-utf8-remaining-engines after Go established the operational-oracle behavior. Rust currently converts fs::read_to_string failure into an empty dependency list, so invalid rockspec bytes silently erase edges. Bind the Rust resolver and CLI to the exact shared success and invalid-byte fixtures, preserve METADATA_INVALID_UTF8 with package and repository-relative manifest identity, return exit 2 without host paths, and leave the seven non-Rust engine remediations outside this slice."
+      "notes": "Selected after the a6845a83c dependency/leverage pass because Rust currently converts fs::read_to_string failure into an empty dependency list, silently erasing edges, while merged Go provides the operational-oracle behavior. Bind the Rust resolver and CLI to the exact shared success and invalid-byte fixtures, preserve METADATA_INVALID_UTF8 with package and repository-relative manifest identity, return exit 2 without host paths, and leave the seven non-Rust engine remediations outside this slice."
     },
     {
       "id": "build-tool-python-haskell-language-filter",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9504,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "2140f0e5d9faba711d9bfe903804503ab9a5297d",
+    "revision": "a6845a83c8e2667d8cf35a9e80a0c51a1d74698e",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1217,
@@ -338,16 +338,25 @@
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered by the Python encoding-blocker audit. Rust and Swift silently drop invalid rockspec dependencies; TypeScript replaces invalid bytes; Go, Lua, and Perl accept them; Ruby and Haskell use locale-sensitive text decoding; Elixir is position-dependent. Remediate those nine engines against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
+      "notes": "Discovered by the Python encoding-blocker audit. Go was remediated in merged PR #9504. Of the eight remaining engines, Rust and Swift silently drop invalid rockspec dependencies; TypeScript replaces invalid bytes; Lua and Perl accept them; Ruby and Haskell use locale-sensitive text decoding; and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
     },
     {
       "id": "build-tool-go-rockspec-utf8-conformance",
       "title": "Make the Go build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": "codex/build-tool-go-rockspec-utf8",
       "pr_number": 9504,
-      "notes": "Ready PR #9504 is the first dependency-shaped child of build-tool-rockspec-utf8-remaining-engines. Go is prioritized because it is the intended operational oracle. The implementation binds its resolver to the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, requires the exact expected edge set, rejects invalid bytes before parsing with a typed MetadataEncodingError, emits METADATA_INVALID_UTF8 with package and repository-relative manifest identity, and returns CLI exit 2 without host paths. Validation on rebased main 2140f0e5d passed go test and race test across every package, 73.2% total coverage, go vet, trimpath build, the 57-test/52-subtest language-neutral conformance suite, a 32-case/36-file corpus check, a real 4,763-package/8,348-edge plan, collision-free parity inventory, and an exact BUILD-validator baseline comparison of 73 issues before and after. The other eight engine remediations remain outside this slice."
+      "notes": "Merged PR #9504 at 3776a290063d40042e05c81a0979fc58ff258581 on 2026-08-02. This first dependency-shaped child of build-tool-rockspec-utf8-remaining-engines binds the Go resolver to the exact success and invalid-byte fixtures, requires the exact expected edge set, rejects invalid bytes before parsing with a typed MetadataEncodingError, emits METADATA_INVALID_UTF8 with package and repository-relative manifest identity, and returns CLI exit 2 without host paths. Final-base local validation passed Go tests and race tests, 73.2% total coverage, vet, trimpath build, language-neutral conformance and corpus gates, a real full-repository plan, collision-free inventory, and an exact 73-to-73 BUILD-validator baseline comparison. Post-merge Ubuntu, macOS, Windows, fixture-consumer, detection, and Go CodeQL checks all passed; irrelevant language CodeQL jobs were skipped."
+    },
+    {
+      "id": "build-tool-rust-rockspec-utf8-conformance",
+      "title": "Make the Rust build tool enforce strict UTF-8 rockspec metadata",
+      "status": "pending",
+      "depends_on": ["build-tool-go-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized from build-tool-rockspec-utf8-remaining-engines after Go established the operational-oracle behavior. Rust currently converts fs::read_to_string failure into an empty dependency list, so invalid rockspec bytes silently erase edges. Bind the Rust resolver and CLI to the exact shared success and invalid-byte fixtures, preserve METADATA_INVALID_UTF8 with package and repository-relative manifest identity, return exit 2 without host paths, and leave the seven non-Rust engine remediations outside this slice."
     },
     {
       "id": "build-tool-python-haskell-language-filter",

--- a/code/programs/rust/build-tool/CHANGELOG.md
+++ b/code/programs/rust/build-tool/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the Rust build tool will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.2] - 2026-08-02
+
+### Fixed
+
+- Decode Lua `.rockspec` metadata as strict UTF-8 before parsing dependencies.
+  Invalid bytes now fail closed with `METADATA_INVALID_UTF8`, stable package and
+  repository-relative manifest identity, CLI exit code 2, and no checkout-path
+  disclosure. Resolver and CLI coverage consume the shared positive and
+  invalid-byte conformance fixtures and require the exact expected edge set.
+
 ## [0.2.1] - 2026-07-12
 
 ### Fixed

--- a/code/programs/rust/build-tool/README.md
+++ b/code/programs/rust/build-tool/README.md
@@ -4,7 +4,7 @@ A **Rust port** of the Go build tool for the coding-adventures monorepo. It disc
 
 ## What it does
 
-This tool discovers packages in the monorepo via recursive `BUILD` file walking, resolves inter-package dependencies, hashes source files for change detection, and only rebuilds packages whose source or dependency inputs changed. Independent packages are built in parallel.
+This tool discovers packages in the monorepo via recursive `BUILD` file walking, resolves inter-package dependencies, hashes source files for change detection, and only rebuilds packages whose source or dependency inputs changed. Independent packages are built in parallel. Text metadata is decoded deterministically: Lua `.rockspec` files must be strict UTF-8, and invalid bytes fail closed instead of silently deleting dependency edges.
 
 ## Building
 
@@ -52,7 +52,7 @@ The release binary is at `target/release/build-tool` (or `build-tool.exe` on Win
 | `--force` | false | Rebuild everything regardless of cache |
 | `--dry-run` | false | Show what would build without executing |
 | `--jobs` | CPU count | Maximum parallel build jobs |
-| `--language` | all | Filter to: python, ruby, go, rust, or all |
+| `--language` | all | Filter to one supported implementation language or use `all` |
 | `--cache-file` | .build-cache.json | Path to the build cache file |
 
 ## Architecture
@@ -61,7 +61,7 @@ The tool is organized into eight modules, each responsible for one aspect of the
 
 1. **graph** — Directed graph data structure with topological sort and affected-node queries
 2. **discovery** — Recursively walks for `BUILD` files to find packages
-3. **resolver** — Parses pyproject.toml, .gemspec, go.mod, Cargo.toml for dependencies
+3. **resolver** — Parses supported package metadata, including strict UTF-8 Lua rockspecs, into dependency edges
 4. **hasher** — SHA256 hashing for change detection
 5. **cache** — JSON-based build cache (read/write with atomic saves)
 6. **executor** — Parallel execution with Rayon thread pool
@@ -98,6 +98,19 @@ This is equivalent to the Go implementation's goroutine + semaphore pattern, but
 ```bash
 cargo test -- --nocapture
 ```
+
+## Metadata diagnostics
+
+Lua `.rockspec` metadata is decoded as strict UTF-8 before dependency parsing.
+Invalid bytes stop resolution, return exit code `2`, and emit a stable diagnostic
+without the checkout root:
+
+```text
+METADATA_INVALID_UTF8: package=lua/pkg manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec encoding=UTF-8
+```
+
+The resolver and real CLI tests materialize the language-neutral
+`resolution/lua-utf8` and `resolution/lua-invalid-utf8` fixtures.
 
 ## How it fits in the stack
 

--- a/code/programs/rust/build-tool/src/main.rs
+++ b/code/programs/rust/build-tool/src/main.rs
@@ -284,7 +284,13 @@ fn run() -> i32 {
     println!("Discovered {} packages", packages.len());
 
     // Step 4: Resolve dependencies.
-    let graph = resolver::resolve_dependencies(&packages);
+    let graph = match resolver::resolve_dependencies(&packages) {
+        Ok(graph) => graph,
+        Err(error) => {
+            eprintln!("{}", error);
+            return 2;
+        }
+    };
 
     // Step 5: Git-diff change detection (default mode).
     // Git is the source of truth — no cache file needed for primary workflow.

--- a/code/programs/rust/build-tool/src/resolver.rs
+++ b/code/programs/rust/build-tool/src/resolver.rs
@@ -32,10 +32,60 @@
 // A -> B. This convention means "A must be built before B", and
 // independent_groups() naturally produces the correct build order.
 
-use std::collections::HashMap;
-use std::fs;
 use crate::discovery::Package;
 use crate::graph::Graph;
+use std::collections::HashMap;
+use std::fmt;
+use std::fs;
+use std::path::Path;
+
+const METADATA_INVALID_UTF8: &str = "METADATA_INVALID_UTF8";
+
+/// Text metadata that violates the repository's strict UTF-8 contract.
+///
+/// `manifest` is always repository-relative so diagnostics cannot disclose a
+/// checkout root or temporary-directory path.
+#[derive(Debug, Eq, PartialEq)]
+pub struct MetadataEncodingError {
+    pub code: String,
+    pub package: String,
+    pub manifest: String,
+    pub encoding: String,
+}
+
+impl fmt::Display for MetadataEncodingError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{}: package={} manifest={} encoding={}",
+            self.code, self.package, self.manifest, self.encoding
+        )
+    }
+}
+
+impl std::error::Error for MetadataEncodingError {}
+
+fn repository_manifest_path(path: &Path) -> String {
+    let parts: Vec<String> = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    let mut canonical_start = None;
+    for index in 0..parts.len().saturating_sub(1) {
+        if parts[index] == "code"
+            && (parts[index + 1] == "packages" || parts[index + 1] == "programs")
+        {
+            canonical_start = Some(index);
+        }
+    }
+    match canonical_start {
+        Some(index) => parts[index..].join("/"),
+        None => path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Known-name mapping
@@ -519,11 +569,14 @@ fn parse_elixir_deps(pkg: &Package, known_names: &HashMap<String, String>) -> Ve
 /// We scan for quoted strings inside the `dependencies = { ... }` block,
 /// strip version specifiers (>=, <=, ==, etc.), and look them up in
 /// known_names. Only internal monorepo dependencies are returned.
-fn parse_lua_deps(pkg: &Package, known_names: &HashMap<String, String>) -> Vec<String> {
+fn parse_lua_deps(
+    pkg: &Package,
+    known_names: &HashMap<String, String>,
+) -> Result<Vec<String>, MetadataEncodingError> {
     // Find .rockspec files in the package directory.
     let entries = match fs::read_dir(&pkg.path) {
         Ok(e) => e,
-        Err(_) => return Vec::new(),
+        Err(_) => return Ok(Vec::new()),
     };
 
     let mut rockspec_path = None;
@@ -537,12 +590,23 @@ fn parse_lua_deps(pkg: &Package, known_names: &HashMap<String, String>) -> Vec<S
 
     let rockspec_path = match rockspec_path {
         Some(p) => p,
-        None => return Vec::new(),
+        None => return Ok(Vec::new()),
     };
 
-    let data = match fs::read_to_string(&rockspec_path) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
+    let raw = match fs::read(&rockspec_path) {
+        Ok(data) => data,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let data = match String::from_utf8(raw) {
+        Ok(text) => text,
+        Err(_) => {
+            return Err(MetadataEncodingError {
+                code: METADATA_INVALID_UTF8.to_string(),
+                package: pkg.name.clone(),
+                manifest: repository_manifest_path(&rockspec_path),
+                encoding: "UTF-8".to_string(),
+            });
+        }
     };
 
     let mut internal_deps = Vec::new();
@@ -573,7 +637,7 @@ fn parse_lua_deps(pkg: &Package, known_names: &HashMap<String, String>) -> Vec<S
         extract_lua_dep(trimmed, known_names, &mut internal_deps);
     }
 
-    internal_deps
+    Ok(internal_deps)
 }
 
 /// Extracts a single dependency name from a quoted string in a Lua
@@ -742,7 +806,7 @@ fn parse_haskell_deps(pkg: &Package, known_names: &HashMap<String, String>) -> V
 /// among the discovered packages — are silently skipped.
 ///
 /// This function is the main entry point for dependency resolution.
-pub fn resolve_dependencies(packages: &[Package]) -> Graph {
+pub fn resolve_dependencies(packages: &[Package]) -> Result<Graph, MetadataEncodingError> {
     let mut graph = Graph::new();
 
     // First, add all packages as nodes. Even packages with no dependencies
@@ -771,7 +835,7 @@ pub fn resolve_dependencies(packages: &[Package]) -> Graph {
             "go" => parse_go_deps(pkg, known_names),
             "rust" | "wasm" => parse_rust_deps(pkg, known_names),
             "elixir" => parse_elixir_deps(pkg, known_names),
-            "lua" => parse_lua_deps(pkg, known_names),
+            "lua" => parse_lua_deps(pkg, known_names)?,
             "perl" => parse_perl_deps(pkg, known_names),
             "haskell" => parse_haskell_deps(pkg, known_names),
             "csharp" | "fsharp" | "dotnet" => parse_dotnet_deps(pkg, known_names),
@@ -786,7 +850,7 @@ pub fn resolve_dependencies(packages: &[Package]) -> Graph {
         }
     }
 
-    graph
+    Ok(graph)
 }
 
 // ---------------------------------------------------------------------------
@@ -796,7 +860,191 @@ pub fn resolve_dependencies(packages: &[Package]) -> Graph {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use serde::Deserialize;
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+
+    #[derive(Debug, Deserialize)]
+    struct ResolutionFixture {
+        workspace: FixtureWorkspace,
+        expected: FixtureExpected,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureWorkspace {
+        files: Vec<FixtureFile>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureFile {
+        path: String,
+        #[serde(default)]
+        content_utf8: String,
+        #[serde(default)]
+        content_base64: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureExpected {
+        outcome: String,
+        #[serde(default)]
+        result: FixtureResult,
+        #[serde(default)]
+        diagnostics: Vec<FixtureDiagnostic>,
+    }
+
+    #[derive(Debug, Default, Deserialize)]
+    struct FixtureResult {
+        #[serde(default)]
+        edges: Vec<Vec<String>>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureDiagnostic {
+        code: String,
+        path: String,
+        package: String,
+        details: FixtureDiagnosticDetails,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureDiagnosticDetails {
+        encoding: String,
+    }
+
+    fn decode_base64(input: &str) -> Vec<u8> {
+        let mut output = Vec::new();
+        let mut accumulator = 0u32;
+        let mut bits = 0u8;
+
+        for byte in input.bytes() {
+            let value = match byte {
+                b'A'..=b'Z' => byte - b'A',
+                b'a'..=b'z' => byte - b'a' + 26,
+                b'0'..=b'9' => byte - b'0' + 52,
+                b'+' => 62,
+                b'/' => 63,
+                b'=' => break,
+                b'\r' | b'\n' | b'\t' | b' ' => continue,
+                _ => panic!("invalid base64 fixture byte: {byte}"),
+            };
+            accumulator = (accumulator << 6) | u32::from(value);
+            bits += 6;
+            if bits >= 8 {
+                bits -= 8;
+                output.push((accumulator >> bits) as u8);
+                accumulator &= (1 << bits) - 1;
+            }
+        }
+
+        output
+    }
+
+    fn load_resolution_fixture(name: &str) -> ResolutionFixture {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../specs/fixtures/build-tool-v1/cases")
+            .join(name);
+        let data = fs::read(&path)
+            .unwrap_or_else(|error| panic!("read shared fixture {}: {error}", path.display()));
+        serde_json::from_slice(&data)
+            .unwrap_or_else(|error| panic!("decode shared fixture {}: {error}", path.display()))
+    }
+
+    fn materialize_resolution_fixture(
+        fixture: &ResolutionFixture,
+        case_name: &str,
+    ) -> (PathBuf, Vec<Package>) {
+        let root = std::env::temp_dir().join(format!(
+            "build_tool_rust_resolution_{case_name}_{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let mut packages = Vec::new();
+        let mut seen_packages = HashSet::new();
+
+        for file in &fixture.workspace.files {
+            let path = root.join(Path::new(&file.path));
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let data = if file.content_base64.is_empty() {
+                file.content_utf8.as_bytes().to_vec()
+            } else {
+                decode_base64(&file.content_base64)
+            };
+            fs::write(&path, data).unwrap();
+
+            let segments: Vec<&str> = file.path.split('/').collect();
+            if segments.len() == 5 && segments[4] == "BUILD" {
+                let name = format!("{}/{}", segments[2], segments[3]);
+                if seen_packages.insert(name.clone()) {
+                    packages.push(Package {
+                        name,
+                        path: root.join(segments[..4].iter().collect::<PathBuf>()),
+                        build_commands: Vec::new(),
+                        language: segments[2].to_string(),
+                    });
+                }
+            }
+        }
+
+        (root, packages)
+    }
+
+    #[test]
+    fn test_lua_resolution_conformance_fixtures() {
+        for name in [
+            "resolution-lua-utf8.json",
+            "resolution-lua-invalid-utf8.json",
+        ] {
+            let fixture = load_resolution_fixture(name);
+            let (root, packages) = materialize_resolution_fixture(&fixture, name);
+            let result = resolve_dependencies(&packages);
+
+            if fixture.expected.outcome == "ok" {
+                let graph = result.expect("valid UTF-8 fixture must resolve");
+                let mut actual_edges = Vec::new();
+                for package in &packages {
+                    for dependency in graph.predecessors(&package.name).unwrap() {
+                        actual_edges.push(vec![dependency, package.name.clone()]);
+                    }
+                }
+                actual_edges.sort();
+                let mut expected_edges = fixture.expected.result.edges.clone();
+                expected_edges.sort();
+                assert_eq!(actual_edges, expected_edges);
+            } else {
+                let error = match result {
+                    Ok(_) => panic!("invalid UTF-8 fixture must fail closed"),
+                    Err(error) => error,
+                };
+                let diagnostic = &fixture.expected.diagnostics[0];
+                assert_eq!(error.code, diagnostic.code);
+                assert_eq!(error.package, diagnostic.package);
+                assert_eq!(error.manifest, diagnostic.path);
+                assert_eq!(error.encoding, diagnostic.details.encoding);
+                assert!(!error
+                    .to_string()
+                    .contains(&root.to_string_lossy().to_string()));
+            }
+
+            let _ = fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn test_repository_manifest_path_uses_final_canonical_boundary() {
+        let host_path = PathBuf::from("private")
+            .join("code")
+            .join("checkout")
+            .join("code")
+            .join("packages")
+            .join("lua")
+            .join("pkg")
+            .join("pkg.rockspec");
+        assert_eq!(
+            repository_manifest_path(&host_path),
+            "code/packages/lua/pkg/pkg.rockspec"
+        );
+    }
 
     #[test]
     fn test_build_known_names_python() {
@@ -961,7 +1209,7 @@ dependencies = [
             },
         ];
 
-        let graph = resolve_dependencies(&packages);
+        let graph = resolve_dependencies(&packages).unwrap();
 
         // Verify the graph has both nodes and the correct edge.
         assert!(graph.has_node("python/logic-gates"));

--- a/code/programs/rust/build-tool/tests/rockspec_utf8_cli.rs
+++ b/code/programs/rust/build-tool/tests/rockspec_utf8_cli.rs
@@ -1,0 +1,135 @@
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Deserialize)]
+struct ResolutionFixture {
+    workspace: FixtureWorkspace,
+    expected: FixtureExpected,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureWorkspace {
+    files: Vec<FixtureFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureFile {
+    path: String,
+    #[serde(default)]
+    content_utf8: String,
+    #[serde(default)]
+    content_base64: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureExpected {
+    diagnostics: Vec<FixtureDiagnostic>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureDiagnostic {
+    code: String,
+    path: String,
+    package: String,
+    details: FixtureDiagnosticDetails,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureDiagnosticDetails {
+    encoding: String,
+}
+
+fn decode_base64(input: &str) -> Vec<u8> {
+    let mut output = Vec::new();
+    let mut accumulator = 0u32;
+    let mut bits = 0u8;
+
+    for byte in input.bytes() {
+        let value = match byte {
+            b'A'..=b'Z' => byte - b'A',
+            b'a'..=b'z' => byte - b'a' + 26,
+            b'0'..=b'9' => byte - b'0' + 52,
+            b'+' => 62,
+            b'/' => 63,
+            b'=' => break,
+            b'\r' | b'\n' | b'\t' | b' ' => continue,
+            _ => panic!("invalid base64 fixture byte: {byte}"),
+        };
+        accumulator = (accumulator << 6) | u32::from(value);
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            output.push((accumulator >> bits) as u8);
+            accumulator &= (1 << bits) - 1;
+        }
+    }
+
+    output
+}
+
+fn load_fixture(name: &str) -> ResolutionFixture {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/fixtures/build-tool-v1/cases")
+        .join(name);
+    let data = fs::read(&path)
+        .unwrap_or_else(|error| panic!("read shared fixture {}: {error}", path.display()));
+    serde_json::from_slice(&data)
+        .unwrap_or_else(|error| panic!("decode shared fixture {}: {error}", path.display()))
+}
+
+fn materialize_fixture(fixture: &ResolutionFixture) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "build_tool_rust_cli_{}_{}",
+        std::process::id(),
+        nonce
+    ));
+
+    for file in &fixture.workspace.files {
+        let path = root.join(Path::new(&file.path));
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let data = if file.content_base64.is_empty() {
+            file.content_utf8.as_bytes().to_vec()
+        } else {
+            decode_base64(&file.content_base64)
+        };
+        fs::write(path, data).unwrap();
+    }
+
+    root
+}
+
+#[test]
+fn cli_fails_closed_on_shared_invalid_utf8_fixture() {
+    let fixture = load_fixture("resolution-lua-invalid-utf8.json");
+    let root = materialize_fixture(&fixture);
+    let output = Command::new(env!("CARGO_BIN_EXE_build-tool"))
+        .args([
+            "--root",
+            root.to_str().unwrap(),
+            "--force",
+            "--dry-run",
+            "--language",
+            "lua",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let diagnostic = &fixture.expected.diagnostics[0];
+    let expected = format!(
+        "{}: package={} manifest={} encoding={}\n",
+        diagnostic.code, diagnostic.package, diagnostic.path, diagnostic.details.encoding
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert_eq!(stderr, expected);
+    assert!(!stderr.contains(&root.to_string_lossy().to_string()));
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,10 +106,13 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `2140f0e5d` after
-merged PRs #9477 and #9485 added the three Dart ML leaves and Dart
-`document-ast`, following the serial Rust smart-home additions through Sonos
-(#9461), Nanoleaf (#9486), and the Rust SPICE model validation chain. It contains
+working inventory was regenerated on August 2, 2026 from `a6845a83c` after
+merged PR #9504 added the Go rockspec UTF-8 conformance slice and #9501 added
+Venture acceptance coverage without creating implementation package directories.
+The inventory therefore remains unchanged from the prior regeneration after
+the three Dart ML leaves, Dart `document-ast`, the serial Rust smart-home
+additions through Sonos (#9461) and Nanoleaf (#9486), and the Rust SPICE model
+validation chain. It contains
 1,217 normalized implementation identities across 4,365 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
@@ -124,7 +127,7 @@ The loop must not start by attempting 10,738 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`2140f0e5d9faba711d9bfe903804503ab9a5297d` is collision-clean at 1,217
+`a6845a83c8e2667d8cf35a9e80a0c51a1d74698e` is collision-clean at 1,217
 normalized implementation identities, 4,365 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 767 singletons, 572
 Rust singletons, zero canonical collisions, and zero unknown language buckets.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,14 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `a6845a83c` after
-merged PR #9504 added the Go rockspec UTF-8 conformance slice and #9501 added
-Venture acceptance coverage without creating implementation package directories.
-The inventory therefore remains unchanged from the prior regeneration after
-the three Dart ML leaves, Dart `document-ast`, the serial Rust smart-home
-additions through Sonos (#9461) and Nanoleaf (#9486), and the Rust SPICE model
-validation chain. It contains
-1,217 normalized implementation identities across 4,365 established-lane
+working inventory was regenerated on August 2, 2026 from `de44349bd` after
+merged PR #9498 added the mixed Rust Tasmota local HTTP identity. Merged PRs
+#9502, #9505, and #9506 changed existing packages or learning assets without
+creating another implementation package directory. The inventory contains
+1,218 normalized implementation identities across 4,366 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -121,23 +118,24 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 767 | 10,738 |
+| Present in one language | 768 | 10,752 |
 
-The loop must not start by attempting 10,738 singleton ports. It should finish
+The loop must not start by attempting 10,752 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`a6845a83c8e2667d8cf35a9e80a0c51a1d74698e` is collision-clean at 1,217
-normalized implementation identities, 4,365 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 767 singletons, 572
+`de44349bd147c9ce46ce27d2ac741f2f01fcc2de` is collision-clean at 1,218
+normalized implementation identities, 4,366 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 768 singletons, 573
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The twelve newest mixed Rust identities are `smart-home-camera-media`,
+The thirteen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
 `smart-home-wled-integration`, `smart-home-govee-lan-integration`,
 `smart-home-lifx-lan-integration`, `smart-home-kasa-lan-integration`,
 `smart-home-reolink-integration`, `smart-home-roku-ecp-integration`,
-`smart-home-wemo-upnp-integration`, `smart-home-sonos-upnp-integration`, and
-`smart-home-nanoleaf-local-integration`. All are
+`smart-home-wemo-upnp-integration`, `smart-home-sonos-upnp-integration`,
+`smart-home-nanoleaf-local-integration`, and
+`smart-home-tasmota-local-integration`. All are
 mixed splits rather than blind parity ports: camera grant policy,
 generation-bound lease state, quotas, and redacted audit are portable, while
 authenticated host context and media delivery remain native mediation; ONVIF
@@ -151,9 +149,10 @@ WLED DTO validation, master/segment projection, capability-bit interpretation,
 state normalization, and command planning are portable, while mDNS, DNS/TCP,
 plaintext LAN HTTP, trusted time, console I/O, pairing/origin policy, runtime
 effects, and capability profiles remain native. Govee, LIFX, Kasa, Reolink,
-Roku, Wemo, Sonos, and Nanoleaf contribute deterministic codecs, bounded parsers
-and DTO validation, normalization, projection, stable identities/errors, command
-planning, and language-neutral fixtures to the parity backlog. Wemo specifically
+Roku, Wemo, Sonos, Nanoleaf, and Tasmota contribute deterministic codecs,
+bounded parsers and DTO validation, normalization, projection, stable
+identities/errors, command planning, and language-neutral fixtures to the
+parity backlog. Wemo specifically
 contributes SSDP header parsing, bounded setup/SOAP XML, service/device
 normalization, and switch/light command planning. Sonos additionally contributes
 credential-free URL/control-path validation, AVTransport, RenderingControl,
@@ -161,7 +160,10 @@ DIDL metadata normalization, deterministic inspection planning, and
 protocol-neutral media-player projection. Nanoleaf adds credential syntax and
 origin-configuration validation, bounded snapshot/state validation, stable
 identity and capability projection, RGB/HSV and mirek conversion, command
-planning, and verification. UDP multicast, DNS/TCP, LAN HTTP
+planning, and verification. Tasmota adds bounded Status 0 JSON validation,
+relay/light/sensor normalization,
+state and capability projection, command planning, color conversion, and
+verification fixtures. UDP multicast, DNS/TCP, LAN HTTP
 execution, timeouts, endpoint approval, CLI I/O, authorization, and runtime
 mutation remain native-host responsibilities.
 
@@ -216,11 +218,14 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   #9495 normalized the three CP1252 metadata bytes, added positive and invalid-
   UTF-8 fixtures, and returns `METADATA_INVALID_UTF8`; its refreshed full scan
   succeeds across 4,765 packages and 7,100 edges;
-- bring the remaining Go, Rust, Swift, TypeScript, Lua, Perl, Ruby, Elixir, and
+- bring the remaining Rust, Swift, TypeScript, Lua, Perl, Ruby, Elixir, and
   Haskell build-tool resolvers to the shared strict-UTF-8 rockspec contract.
   Their current byte, replacement, silent-drop, and locale-sensitive behavior
-  is tracked separately from the Python full-scan blocker. The Go resolver is
-  the first prioritized child because it is the intended operational oracle;
+  is tracked separately from the Python full-scan blocker. Merged PR #9504
+  completed the Go operational-oracle child, and the Rust child is next;
+- make the Rust build tool reject resolver self-edges with a stable diagnostic.
+  A real 4,766-package plan reproduced the untouched-main exit-101 panic on
+  `elixir/grammar_tools`; this is tracked separately from UTF-8 decoding;
 - expose Haskell through the Python build tool's `--language` filter. Haskell
   is already in its resolver and canonical language registry but is missing
   from the native CLI choices;


### PR DESCRIPTION
## Summary
- make the Rust build-tool resolver reject non-UTF-8 Lua rockspec metadata before parsing
- consume the exact shared `resolution/lua-utf8` and `resolution/lua-invalid-utf8` fixtures and require exact dependency-edge equality
- return the stable `METADATA_INVALID_UTF8` diagnostic with package and repository-relative manifest identity, CLI exit 2, and no checkout-path disclosure
- propagate the fallible resolver result through the real Rust front door and document the contract
- refresh the collision-checked inventory after merged Tasmota work and log its portable-core parity item

## Scope
This is the second dependency-shaped child of `build-tool-rockspec-utf8-remaining-engines`, following the merged Go operational-oracle slice. Seven non-Rust encoding remediations remain separate.

## Validation
- test-first compile failure at the new fallible resolver, typed error, and path helper seams
- `cargo test -- --nocapture`: 136 unit tests plus 1 real CLI integration test
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo llvm-cov --all-targets --summary-only`: 79.33% line coverage; resolver 61.61%
- `cargo audit`: zero RustSec advisories across 56 locked dependencies
- language-neutral conformance: 57 tests plus 52 subtests
- shared corpus: 32 cases / 36 files / 15 established languages / 16 implementations
- real Lua release-binary plan: 258 packages / 258 unique plan entries / schema v1
- strict UTF-8 check: all 246 repository rockspecs valid
- package parity inventory: 1,218 identities / 4,366 slots / zero collisions / zero unknown buckets
- current versus untouched-main BUILD validator: exit 1 on both, exact output match
- `rustfmt --check` for the new integration target
- `git diff --check`

## Baseline notes and discovered work
A real full-repository plan discovers 4,766 packages and then both this branch and untouched main exit 101 on the same `elixir/grammar_tools` self-edge panic. That defect is now a separate pending `build-tool-rust-self-edge-diagnostic` backlog item; this UTF-8 slice does not hide or expand into it. The existing Lua `BUILD_windows` validation wave remains separately owned as well.

The post-rebase inventory also added the Rust-only Tasmota local HTTP identity. Its deterministic Status 0 parsing, relay/light/sensor normalization, projection, command planning, color conversion, and verification are now backlogged for language-neutral fixtures and ports; native mDNS/network/HTTP/Vault/runtime effects remain excluded.