### PR TITLE
feat(learning): make training lowering inspectable

### DIFF
--- a/code/learning/COVERAGE.md
+++ b/code/learning/COVERAGE.md
@@ -10,7 +10,7 @@ mention provides a complete lesson.
 
 | Concepts | Documents | Dedicated | Related | Index only | Missing |
 | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1250 | 1183 | 98 | 60 | 8 | 1084 |
+| 1251 | 1187 | 98 | 60 | 8 | 1085 |
 
 ## Method
 
@@ -27,7 +27,7 @@ mention provides a complete lesson.
 | P0 | 86 | 25 | 6 | 55 |
 | P1 | 9 | 22 | 0 | 90 |
 | P2 | 1 | 3 | 1 | 152 |
-| P3 | 2 | 10 | 1 | 787 |
+| P3 | 2 | 10 | 1 | 788 |
 
 ## P0 Backlog
 
@@ -1203,6 +1203,7 @@ mention provides a complete lesson.
 | `smart-home-runtime` | 1 | missing |
 | `smart-home-runtime-store` | 1 | missing |
 | `smart-home-sonos-upnp-integration` | 1 | missing |
+| `smart-home-tasmota-local-integration` | 1 | missing |
 | `smart-home-testkit` | 1 | missing |
 | `smart-home-wemo-upnp-integration` | 1 | missing |
 | `smart-home-wled-integration` | 1 | missing |

--- a/code/learning/machine-learning/README.md
+++ b/code/learning/machine-learning/README.md
@@ -46,13 +46,14 @@ larger network:
 26. [Dynamic Autograd and Saved Values, by Hand](./dynamic-autograd-and-saved-values-by-hand.md)
 27. [Gradient Accumulation and Zeroing, by Hand](./gradient-accumulation-and-zeroing-by-hand.md)
 28. [Forward Graph Lowering, by Hand](./forward-graph-lowering-by-hand.md)
-29. [Matrix Math](../matrix-math.md)
-30. [Loss Functions](../loss-functions.md)
-31. [Gradient Descent](../gradient-descent.md)
-32. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
-33. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
-34. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
-35. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
+29. [Backward and Optimizer Lowering, by Hand](./backward-and-optimizer-lowering-by-hand.md)
+30. [Matrix Math](../matrix-math.md)
+31. [Loss Functions](../loss-functions.md)
+32. [Gradient Descent](../gradient-descent.md)
+33. [Single-Layer, Multi-Output Networks](../ml-single-layer-multi-output.md)
+34. [Feature Normalization and Learning-Rate Sweeps](../ml-feature-normalization-and-rate-sweeps.md)
+35. [Hidden Layers with XOR](../ml-hidden-layers-xor.md)
+36. [Hidden-Layer Example Suite](../ml-hidden-layer-example-suite.md)
 
 The [delivery roadmap](./ROADMAP.md) tracks implementation progress. The
 [full curriculum](./curriculum.md) continues from these foundations through
@@ -62,7 +63,7 @@ networks.
 ## Interactive Lab
 
 The TypeScript [ML Learning Visualizer](../../programs/typescript/ml-learning-visualizer/README.md)
-has sixteen complementary views:
+has seventeen complementary views:
 
 - **Training microscope:** pause one update and reveal multiplication, bias,
   activation, loss, chain-rule gradients, and parameter movement one phase at a
@@ -146,7 +147,11 @@ has sixteen complementary views:
   deterministic NN00 NeuralIR instructions, then open the six-operation NN01
   MatrixIR plan and inspect exactly which weight loads, products, and addition
   fuse together. Run one row or two while direct graph, scalar NeuralIR, and
-  matrix-plan outputs remain in parity.
+  matrix-plan outputs remain in parity. Continue into backward and optimizer
+  lowering: keep the production forward compiler for saved values, inspect six
+  reverse instructions and four separate SGD instructions, then follow ten
+  matrix-training operations as one or two row gradients reduce into shared
+  parameter state.
 
 ## Language-Neutral Corpus
 
@@ -272,6 +277,12 @@ topological scheduling, exact NeuralIR value allocation, matrix fusion with
 source-instruction and graph-edge provenance, one hand-calculable row, one
 two-row batch, and direct/NeuralIR/MatrixIR parity.
 
+NN30 adds `code/specs/fixtures/backward-optimizer-lowering-v1`, including saved
+forward values, exact backward and optimizer streams, stable row-order gradient
+reduction, one-row and two-row mean-SGD cases, explicit nonzero-buffer carry,
+matrix-training provenance, and independent finite-difference audits of each
+current batch contribution.
+
 Validate the bootstrap corpus with:
 
 ```text
@@ -302,6 +313,7 @@ python code/scripts/validate_tensor_broadcasting_labs.py
 python code/scripts/validate_dynamic_autograd_labs.py
 python code/scripts/validate_gradient_accumulation_labs.py
 python code/scripts/validate_forward_graph_lowering_labs.py
+python code/scripts/validate_backward_optimizer_lowering_labs.py
 ```
 
 The first NN03 labs cover a weighted forward pass, Celsius regression, a
@@ -357,6 +369,10 @@ next batch.
 The first NN29 lab turns a six-node weighted-ReLU graph into twelve scalar
 instructions and six fused matrix operations, retaining every source ID while
 all three execution paths reproduce `6` and `[6, 13]`.
+The first NN30 lab saves `prediction` and `residual`, lowers six reverse-mode
+instructions and four non-clearing SGD instructions, then proves that a
+  ten-operation matrix plan reduces row gradients `[2, 2]` to `4`, applies the
+explicit mean `2`, and updates `w` to `0.8`.
 
 ## How to Study a Model
 

--- a/code/learning/machine-learning/ROADMAP.md
+++ b/code/learning/machine-learning/ROADMAP.md
@@ -59,7 +59,7 @@ trace, and tests.
   - [x] Gradient accumulation and zeroing behavior.
 - [ ] Compilation and performance bridge
   - [x] Forward graph lowering to NeuralIR and MatrixIR.
-  - [ ] Backward and optimizer graph lowering.
+  - [x] Backward and optimizer graph lowering.
   - [ ] CPU, Rust core, and accelerated-backend parity.
   - [ ] Precision, quantization, and buffer-residency experiments.
 - [ ] Cross-language consumers

--- a/code/learning/machine-learning/backward-and-optimizer-lowering-by-hand.md
+++ b/code/learning/machine-learning/backward-and-optimizer-lowering-by-hand.md
@@ -1,0 +1,313 @@
+# Backward and Optimizer Lowering, by Hand
+
+Forward lowering turned a graph into an ordered program. Training needs two
+more programs:
+
+1. a **backward program** that turns a loss gradient into parameter and input
+   gradients; and
+2. an **optimizer program** that turns a parameter gradient into new parameter
+   state.
+
+Keeping those programs separate matters. Backward answers, "What gradient did
+the model produce?" The optimizer answers, "What should we do with it?" An SGD
+step, Adam step, gradient clip, skipped update, or accumulated micro-batch can
+all consume the same backward result.
+
+This lesson uses one trainable scalar:
+
+```text
+prediction = w * x
+residual   = prediction - target
+loss       = 0.5 * residual^2
+```
+
+There is nowhere for the arithmetic to hide, but the same saved-value,
+reverse-order, reduction, and update rules appear in large networks.
+
+## 1. One row on paper
+
+Use:
+
+```text
+w = 0.5
+x = 2
+target = 0
+learning rate = 0.1
+```
+
+The forward pass saves:
+
+```text
+prediction = 0.5 * 2 = 1
+residual   = 1 - 0 = 1
+loss       = 0.5 * 1^2 = 0.5
+```
+
+Backward starts with the statement "change in loss per change in loss is 1":
+
+```text
+d_loss = 1
+```
+
+The half-squared-error derivative is the residual:
+
+```text
+d_residual = residual * d_loss = 1 * 1 = 1
+```
+
+Subtraction passes that gradient to the prediction:
+
+```text
+d_prediction = d_residual = 1
+```
+
+The multiplication `w * x` has two local derivatives:
+
+```text
+d_w = x * d_prediction = 2 * 1 = 2
+d_x = w * d_prediction = 0.5 * 1 = 0.5
+```
+
+SGD reads `d_w` and moves against it:
+
+```text
+applied_gradient = d_w / divisor = 2 / 1 = 2
+parameter_delta  = -0.1 * 2 = -0.2
+w_next           = 0.5 + (-0.2) = 0.3
+```
+
+The optimizer step does **not** clear the gradient buffer. After the step,
+`grad_w` is still `2` until an explicit zero operation runs.
+
+## 2. Why backward needs saved values
+
+The local rule for `w * x` needs the values of both `w` and `x`. The loss rule
+needs the residual. Recomputing those values is sometimes possible, but it is
+not automatically free or safe. Randomness, mutation, control flow, and
+expensive operations can make recomputation different or costly.
+
+The tiny program therefore makes its saved-value contract explicit:
+
+```text
+saved: x, w, prediction, residual
+```
+
+A compiler may later choose to keep, move, compress, or recompute a value, but
+that is a separate optimization. The mathematical backward program first says
+which value it needs.
+
+## 3. Lower the backward graph
+
+The NN30 backward instruction stream is:
+
+| ID | Operation | Reads | Writes |
+|---|---|---|---|
+| `b0` | `SEED_LOSS_GRAD` | nothing | `d_loss` |
+| `b1` | `HALF_SQUARED_ERROR_GRAD` | `residual`, `d_loss` | `d_residual` |
+| `b2` | `PROPAGATE_GRAD` | `d_residual` | `d_prediction` |
+| `b3` | `PARAMETER_LOCAL_GRAD` | `x`, `d_prediction` | `local_d_w` |
+| `b4` | `ACCUMULATE_GRAD` | `grad_w`, `local_d_w` | `grad_w` |
+| `b5` | `INPUT_GRAD` | `w`, `d_prediction` | `d_x` |
+
+`b3` computes one row's contribution. `b4` owns the stateful addition into the
+parameter gradient buffer. Keeping those separate exposes why shared
+parameters and micro-batches add contributions instead of overwriting them.
+
+## 4. Lower the optimizer separately
+
+The optimizer instruction stream is:
+
+| ID | Operation | Reads | Writes |
+|---|---|---|---|
+| `o0` | `READ_GRAD_BUFFER` | `grad_w` | `total_d_w` |
+| `o1` | `DIVIDE_GRAD` | `total_d_w`, scenario divisor | `applied_d_w` |
+| `o2` | `SGD_UPDATE` | `w`, `applied_d_w`, learning rate | `w_next` |
+| `o3` | `KEEP_GRAD_BUFFER` | `grad_w` | `grad_w_after_step` |
+
+The divisor is runtime policy, not an inferred compiler constant. A two-row
+mean uses `2`; a summed gradient or one-row update uses `1`. A portable runtime
+must receive that choice explicitly.
+
+## 5. The same program over two rows
+
+Now use:
+
+```text
+w = 1
+learning rate = 0.1
+
+row 0: x =  2, target = 1
+row 1: x = -1, target = 1
+divisor = 2
+```
+
+Forward values:
+
+| Row | Prediction | Residual | Loss |
+|---:|---:|---:|---:|
+| 0 | `2` | `1` | `0.5` |
+| 1 | `-1` | `-2` | `2` |
+
+Backward values:
+
+| Row | `d_prediction` | Local `d_w = x * d_prediction` | `d_x = w * d_prediction` |
+|---:|---:|---:|---:|
+| 0 | `1` | `2` | `1` |
+| 1 | `-2` | `2` | `-2` |
+
+The stable row-order reduction is:
+
+```text
+grad_w = 0 + 2 + 2 = 4
+```
+
+The optimizer applies the mean:
+
+```text
+applied_gradient = 4 / 2 = 2
+w_next = 1 - 0.1 * 2 = 0.8
+```
+
+The instruction identifiers did not change. Only the columns grew from one row
+to two and the explicit divisor changed.
+
+## 6. Matrix training lowering
+
+The matrix plan keeps per-row values as columns:
+
+```text
+x column          -> [ 2, -1]
+residual column   -> [ 1, -2]
+d_prediction      -> [ 1, -2]
+local d_w column  -> [ 2,  2]
+d_x column        -> [ 1, -2]
+```
+
+Then it crosses from row-parallel work to shared state:
+
+```text
+REDUCE_SUM_GRAD         [2, 2] -> batch_d_w = 4
+ACCUMULATE_GRAD_BUFFER  0 + 4  -> grad_w = 4
+DIVIDE_GRAD             4 / 2  -> 2
+SGD_UPDATE              1 - 0.1 * 2 -> 0.8
+```
+
+The reduction order is part of the contract. Floating-point addition is not
+mathematically associative, so implementations that require reproducibility
+must use the fixture's ascending row order rather than whatever order worker
+threads happen to finish.
+
+### Prove that the buffer really persists
+
+A fresh buffer can hide an overwrite bug because both "replace with `2`" and
+"add `2` to `0`" produce `2`. The third fixture scenario therefore enters
+backward with `grad_w = 3`. Its new row contributes `2`:
+
+```text
+batch_d_w = 2
+grad_w    = 3 + 2 = 5
+w_next    = 0.5 - 0.1 * (5 / 1) = 0
+```
+
+The optimizer leaves the buffer at `5`. The finite-difference audit still
+compares the current batch contribution `2` with the current batch loss slope
+`2`; the carried `3` came from an earlier execution and is not part of that
+loss function.
+
+## 7. Check the gradient independently
+
+For a batch loss `L(w)`, central finite differences estimate:
+
+```text
+dL/dw ~= (L(w + epsilon) - L(w - epsilon)) / (2 * epsilon)
+```
+
+With `epsilon = 0.00001`, the one-row estimate is approximately `2` and the
+two-row summed-loss estimate is approximately `4`. The audit compares the new
+batch contribution, not any gradient already in the persistent buffer. It does
+not reuse the backward program, so agreement catches missing factors, wrong
+signs, and accidental averaging.
+
+Finite differences are an audit, not the runtime algorithm. They cost two
+extra forward executions per checked parameter and become expensive in large
+models.
+
+## 8. Three kinds of state
+
+Training becomes easier to reason about when state is named:
+
+- **saved forward values** belong to one forward/backward execution;
+- **gradient buffers** belong to parameters and may span several backward
+  executions; and
+- **optimizer state** belongs to the optimizer and may span many steps.
+
+Plain SGD has no momentum tensor, but it still owns learning-rate and divisor
+policy. Adam would add first- and second-moment buffers plus a step counter.
+Those are optimizer inputs and outputs, not secret backward side effects.
+
+## 9. Rust-core boundary
+
+A future Rust bridge can translate NN30 matrix operations into MX01 tensor
+operations:
+
+- column multiplication becomes `Mul`;
+- gradient addition becomes `Add`;
+- stable batch reduction becomes `ReduceSum`; and
+- scalar scaling becomes multiplication by explicit constants.
+
+The host must still own semantic decisions:
+
+- which tensor is parameter `w`;
+- which saved value belongs to which execution;
+- whether the reduction is a sum or mean;
+- when an optimizer step runs;
+- when a gradient buffer is cleared; and
+- which optimizer state is retained.
+
+An FFI should pass opaque handles or caller-provided typed buffers with explicit
+lengths, shapes, dtypes, and ownership. Rust must not retain pointers to
+garbage-collected host objects or silently clear host-owned gradient state.
+
+## 10. A language-neutral implementation recipe
+
+Every consumer can reproduce the lab without sharing TypeScript objects:
+
+1. strictly parse and validate the NN30 JSON fixture;
+2. execute the canonical production forward graph and save named values;
+3. emit the six backward instructions in canonical order;
+4. emit the four optimizer instructions separately;
+5. lower row-parallel rules into matrix column operations;
+6. reduce the current batch's contributions in ascending row order;
+7. add that batch sum to the incoming parameter gradient buffer;
+8. apply the explicit divisor and learning rate;
+9. keep the gradient buffer populated after the optimizer step;
+10. compare direct, scalar-IR, and matrix-plan results; and
+11. audit the current batch contribution with central finite differences.
+
+The fixture owns all values, identifiers, and expected traces. Ports should not
+copy numbers from this prose.
+
+## 11. What lowering does not decide yet
+
+This tranche does not choose:
+
+- CPU, GPU, WebGPU, or accelerator placement;
+- mixed-precision accumulation;
+- quantization;
+- buffer reuse or residency;
+- distributed reduction order; or
+- momentum and adaptive optimizer layouts.
+
+Those belong to later roadmap tranches because they add new observable choices.
+
+## Exercises
+
+1. Change the one-row target from `0` to `1`. Which backward values become zero?
+2. Use divisor `1` for the two-row batch. What update does summed SGD apply?
+3. Reverse the row records. Why should a deterministic runtime still reduce in
+   canonical row order?
+4. Insert gradient clipping between `o1` and `o2`. Which program owns it?
+5. Sketch the additional optimizer state needed for momentum.
+
+The useful mental model is: forward saves evidence, backward produces
+gradients, and the optimizer consumes those gradients under explicit policy.

--- a/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/ml-learning-visualizer/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Add the NN30 backward/optimizer lowering workbench with production forward
+  saved values, executable reverse and SGD streams, matrix gradient reduction,
+  persistent-buffer carry, provenance, one/two-row parity, and finite-difference
+  audits of current batch contributions.
 - Add the NN29 forward-lowering workbench with graph topology, exact NeuralIR
   instructions, MatrixIR fusion provenance, scalar reads and writes, batch
   columns, and three-path execution parity.

--- a/code/programs/typescript/ml-learning-visualizer/README.md
+++ b/code/programs/typescript/ml-learning-visualizer/README.md
@@ -4,7 +4,7 @@ Interactive machine learning lab for building intuition around small models.
 
 ## What It Shows
 
-The app has sixteen workbenches that move from one arithmetic update to small
+The app has seventeen workbenches that move from one arithmetic update to small
 spatial and hidden-layer networks.
 
 ### Training-step microscope
@@ -235,6 +235,18 @@ its first-row reads and write, or open any matrix operation to reveal its exact
 source instructions, graph nodes, and edge provenance. Switch from one row to a
 two-row batch while direct graph, NeuralIR, and MatrixIR outputs remain aligned.
 
+### Backward and optimizer lowering lab
+
+The Train Lowering workbench keeps a one-parameter multiplication fixed. Its
+saved predictions come from the production neural graph compiler and VM. Open
+any of six backward instructions, four separate SGD instructions, or ten
+matrix-training operations to see reads, writes, values, attributes, and source
+provenance. Switch from one row to two, then enter with a nonzero buffer to see
+the current batch reduce separately before it accumulates into persistent
+state. The optimizer applies an explicit divisor, updates `w`, and leaves the
+buffer populated. A fresh finite-difference route audits only the current batch
+contribution.
+
 ## Lab Families
 
 - Basics: clean linear relationships such as Celsius to Fahrenheit.
@@ -368,6 +380,11 @@ NN29 under `code/specs/fixtures/forward-graph-lowering-v1` pins one stable
 topological schedule, exact NeuralIR value IDs, seven-to-one weighted-sum
 fusion, complete source provenance, and direct/NeuralIR/MatrixIR parity for one
 row and a two-row batch.
+
+NN30 under `code/specs/fixtures/backward-optimizer-lowering-v1` pins saved
+forward values, six backward instructions, four optimizer instructions, ten
+matrix-training operations, stable row reduction, explicit mean divisors,
+non-clearing optimizer steps, and numerical gradient audits.
 
 ## Development
 

--- a/code/programs/typescript/ml-learning-visualizer/src/App.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { ACTIVATIONS, activationByKind, activate, type ActivationKind } from "./activation.js";
 import { AttentionWorkbench } from "./AttentionWorkbench.js";
+import { BackwardOptimizerLoweringWorkbench } from "./BackwardOptimizerLoweringWorkbench.js";
 import { ConvolutionWorkbench } from "./ConvolutionWorkbench.js";
 import { DeepTrainingWorkbench } from "./DeepTrainingWorkbench.js";
 import { DynamicAutogradWorkbench } from "./DynamicAutogradWorkbench.js";
@@ -181,7 +182,7 @@ function groupColor(group: string | undefined, groups: string[]): string {
 
 export function App() {
   const [workbench, setWorkbench] = useState<
-    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation" | "structured" | "deep" | "tensor" | "autograd" | "gradient-buffer" | "forward-lowering"
+    "microscope" | "optimization" | "linear" | "hidden" | "convolution" | "image-cnn" | "residual" | "recurrent" | "attention" | "representation" | "structured" | "deep" | "tensor" | "autograd" | "gradient-buffer" | "forward-lowering" | "training-lowering"
   >("microscope");
   const [selectedLabId, setSelectedLabId] = useState(LABS[0]!.id);
   const selectedLab = LABS.find((lab) => lab.id === selectedLabId) ?? LABS[0]!;
@@ -312,6 +313,8 @@ export function App() {
                 ? "Backward adds, zero clears"
               : workbench === "forward-lowering"
                 ? "One graph, two executable IRs"
+              : workbench === "training-lowering"
+                ? "Reverse and update become schedules"
               : workbench === "linear"
                 ? "100-lab foundation"
                 : "Hidden-layer playground"}
@@ -432,6 +435,13 @@ export function App() {
             >
               IR Lowering
             </button>
+            <button
+              className={workbench === "training-lowering" ? "mode-button mode-button--active" : "mode-button"}
+              type="button"
+              onClick={() => setWorkbench("training-lowering")}
+            >
+              Train Lowering
+            </button>
           </div>
           <div className="formula">
             {workbench === "microscope" ? (
@@ -462,6 +472,8 @@ export function App() {
               <>backward adds {"->"} <strong>step reads</strong> {"->"} zero clears</>
             ) : workbench === "forward-lowering" ? (
               <>graph meaning {"->"} <strong>NeuralIR schedule</strong> {"->"} MatrixIR fusion</>
+            ) : workbench === "training-lowering" ? (
+              <>saved values {"->"} <strong>backward IR</strong> {"->"} optimizer IR</>
             ) : workbench === "linear" ? (
               <>y = <strong>{formatNumber(model.weight)}</strong>x + <strong>{formatNumber(model.bias)}</strong></>
             ) : (
@@ -499,6 +511,8 @@ export function App() {
         <GradientAccumulationWorkbench />
       ) : workbench === "forward-lowering" ? (
         <ForwardLoweringWorkbench />
+      ) : workbench === "training-lowering" ? (
+        <BackwardOptimizerLoweringWorkbench />
       ) : workbench === "hidden" ? <HiddenLayerWorkbench /> : (
       <main className="workspace workspace--lab">
         <nav className="lab-rail" aria-label="ML lab examples">

--- a/code/programs/typescript/ml-learning-visualizer/src/BackwardOptimizerLoweringWorkbench.tsx
+++ b/code/programs/typescript/ml-learning-visualizer/src/BackwardOptimizerLoweringWorkbench.tsx
@@ -1,0 +1,316 @@
+import { useMemo, useState } from "react";
+import {
+  BACKWARD_OPTIMIZER_LOWERING_SCENARIOS,
+  traceBackwardOptimizerLowering,
+  type BackwardOptimizerLoweringScenarioId,
+  type BackwardOptimizerLoweringTrace,
+  type TrainingLoweringInstruction,
+  type TrainingLoweringStream,
+} from "./backward-optimizer-lowering-lab.js";
+
+type Lane = "backward" | "optimizer" | "matrix";
+
+interface Selection {
+  readonly lane: Lane;
+  readonly id: string;
+}
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-12) return "0";
+  if (Number.isInteger(value)) return String(value);
+  return Number(value.toPrecision(10)).toString();
+}
+
+function describeInstruction(item: TrainingLoweringInstruction): string {
+  switch (item.op) {
+    case "SEED_LOSS_GRAD": return "start reverse mode at 1";
+    case "HALF_SQUARED_ERROR_GRAD": return "residual x loss seed";
+    case "PROPAGATE_GRAD": return "pass through subtraction";
+    case "PARAMETER_LOCAL_GRAD": return "x x d_prediction";
+    case "ACCUMULATE_GRAD": return "add rows in stable order";
+    case "INPUT_GRAD": return "w x d_prediction";
+    case "READ_GRAD_BUFFER": return "read persistent grad_w";
+    case "DIVIDE_GRAD": return "apply explicit divisor";
+    case "SGD_UPDATE":
+    case "SGD_UPDATE_SCALAR": return "w - rate x gradient";
+    case "KEEP_GRAD_BUFFER": return "step does not clear";
+    case "LOAD_SAVED_COLUMN": return `load ${item.inputs[0]} rows`;
+    case "LOSS_GRAD_COLUMN": return "reverse loss as a column";
+    case "PARAMETER_LOCAL_GRAD_COLUMN": return "one d_w per row";
+    case "INPUT_GRAD_COLUMN": return "one d_x per row";
+    case "REDUCE_SUM_GRAD": return "row-ascending reduction";
+    case "ACCUMULATE_GRAD_BUFFER": return "add batch sum to persistent grad_w";
+    default: return item.inputs.join(", ");
+  }
+}
+
+function attributeText(item: TrainingLoweringInstruction): string {
+  const entries = Object.entries(item.attributes);
+  if (entries.length === 0) return "none";
+  return entries.map(([key, value]) => (
+    `${key}=${Array.isArray(value) ? `[${value.join(", ")}]` : String(value)}`
+  )).join("; ");
+}
+
+function streamFor(trace: BackwardOptimizerLoweringTrace, lane: Lane): TrainingLoweringStream {
+  if (lane === "backward") return trace.backwardIr;
+  if (lane === "optimizer") return trace.optimizerIr;
+  return trace.matrixTrainingIr;
+}
+
+function selectedValue(
+  trace: BackwardOptimizerLoweringTrace,
+  selection: Selection,
+): string {
+  const backwardValues: Record<string, readonly number[] | number> = {
+    b0: trace.backward.dLoss,
+    b1: trace.backward.dResidual,
+    b2: trace.backward.dPrediction,
+    b3: trace.backward.localDW,
+    b4: trace.backward.gradW,
+    b5: trace.backward.dX,
+  };
+  const optimizerValues: Record<string, number> = {
+    o0: trace.backward.gradW,
+    o1: trace.optimizer.appliedGradient,
+    o2: trace.optimizer.parameterAfter,
+    o3: trace.optimizer.gradientBufferAfterStep,
+  };
+  const matrixValues: Record<string, readonly number[] | number> = {
+    t0: trace.matrixTraining.columns.x,
+    t1: trace.matrixTraining.columns.residual,
+    t2: trace.matrixTraining.columns.dPrediction,
+    t3: trace.matrixTraining.columns.localDW,
+    t4: trace.matrixTraining.columns.dX,
+    t5: trace.matrixTraining.batchGradient,
+    t6: trace.matrixTraining.gradW,
+    t7: trace.matrixTraining.appliedGradient,
+    t8: trace.matrixTraining.parameterAfter,
+    t9: trace.matrixTraining.gradientBufferAfterStep,
+  };
+  const value = selection.lane === "backward"
+    ? backwardValues[selection.id]
+    : selection.lane === "optimizer"
+      ? optimizerValues[selection.id]
+      : matrixValues[selection.id];
+  if (typeof value === "number") return formatNumber(value);
+  return `[${(value ?? []).map(formatNumber).join(", ")}]`;
+}
+
+function IrLane({
+  lane,
+  selection,
+  setSelection,
+  stream,
+}: {
+  readonly lane: Lane;
+  readonly selection: Selection;
+  readonly setSelection: (selection: Selection) => void;
+  readonly stream: TrainingLoweringStream;
+}) {
+  const className = lane === "matrix"
+    ? "forward-lowering-matrix-lane"
+    : "forward-lowering-instruction-lane";
+  const laneName = lane === "matrix" ? "Matrix training IR" : lane === "backward" ? "Backward IR" : "Optimizer IR";
+  return (
+    <div className={className}>
+      {stream.instructions.map((item) => (
+        <button
+          aria-label={`Open ${laneName} ${item.id}, ${item.op}`}
+          aria-pressed={selection.lane === lane && selection.id === item.id}
+          key={item.id}
+          onClick={() => setSelection({ lane, id: item.id })}
+          type="button"
+        >
+          <small>{item.id}</small>
+          <strong>{item.op}</strong>
+          <code>{item.output}</code>
+          <span>{describeInstruction(item)}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function BackwardOptimizerLoweringWorkbench() {
+  const [scenarioId, setScenarioId] = useState<BackwardOptimizerLoweringScenarioId>("one_row_by_hand");
+  const [selection, setSelection] = useState<Selection>({ lane: "backward", id: "b3" });
+  const trace = useMemo(() => traceBackwardOptimizerLowering(scenarioId), [scenarioId]);
+  const selectedStream = streamFor(trace, selection.lane);
+  const selected = selectedStream.instructions.find((item) => item.id === selection.id);
+
+  return (
+    <main className="workspace workspace--forward-lowering">
+      <section className="forward-lowering-stage">
+        <header className="forward-lowering-intro">
+          <div>
+            <p className="eyebrow">NN30 - saved values -&gt; backward -&gt; optimizer</p>
+            <h2>Backward and optimizer lowering map</h2>
+            <p>
+              Keep one trainable multiplication fixed while reverse mode becomes an
+              executable schedule and SGD remains a separate state transition.
+            </p>
+          </div>
+          <span className="forward-lowering-chip">
+            {trace.backwardIr.instructions.length} backward -&gt; {trace.optimizerIr.instructions.length} optimizer -&gt; {trace.matrixTrainingIr.instructions.length} matrix ops
+          </span>
+        </header>
+
+        <section className="forward-lowering-graph" aria-label="Production forward saved values">
+          <div className="panel-heading">
+            <div>
+              <p className="eyebrow">1 - save</p>
+              <h2>The production forward pass leaves evidence</h2>
+            </div>
+            <code>max forward error {trace.forward.maxError.toExponential(1)}</code>
+          </div>
+          <div className="forward-lowering-edge-grid">
+            <div>
+              <code>NeuralIR</code>
+              <span>{trace.forward.neuralOps.join(" -> ")}</span>
+              <strong>{trace.forward.neuralIrOutputs.map(formatNumber).join(", ")}</strong>
+            </div>
+            <div>
+              <code>MatrixIR</code>
+              <span>{trace.forward.matrixOps.join(" -> ")}</span>
+              <strong>{trace.forward.matrixIrOutputs.map(formatNumber).join(", ")}</strong>
+            </div>
+            <div>
+              <code>saved contract</code>
+              <span>x, w, prediction, residual</span>
+              <strong>backward may read them</strong>
+            </div>
+          </div>
+          <div className="forward-lowering-parity-table" role="table" aria-label="Saved forward row values">
+            <div className="forward-lowering-parity-head" role="row">
+              <strong role="columnheader">row</strong>
+              <strong role="columnheader">x</strong>
+              <strong role="columnheader">target</strong>
+              <strong role="columnheader">prediction</strong>
+              <strong role="columnheader">residual</strong>
+              <strong role="columnheader">loss</strong>
+            </div>
+            {trace.savedValues.x.map((x, index) => (
+              <div key={index} role="row">
+                <strong role="cell">{index}</strong>
+                <code role="cell">{formatNumber(x)}</code>
+                <code role="cell">{formatNumber(trace.savedValues.target[index]!)}</code>
+                <code role="cell">{formatNumber(trace.savedValues.prediction[index]!)}</code>
+                <code role="cell">{formatNumber(trace.savedValues.residual[index]!)}</code>
+                <code role="cell">{formatNumber(trace.savedValues.loss[index]!)}</code>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="forward-lowering-ir" aria-label="Backward instruction stream">
+          <div className="panel-heading">
+            <div><p className="eyebrow">2 - reverse</p><h2>Backward produces gradients</h2></div>
+            <code>{trace.backwardIr.magic} v{trace.backwardIr.version}</code>
+          </div>
+          <IrLane lane="backward" selection={selection} setSelection={setSelection} stream={trace.backwardIr} />
+        </section>
+
+        <section className="forward-lowering-ir" aria-label="Optimizer instruction stream">
+          <div className="panel-heading">
+            <div><p className="eyebrow">3 - update policy</p><h2>The optimizer consumes the buffer</h2></div>
+            <code>{trace.optimizerIr.magic} v{trace.optimizerIr.version}</code>
+          </div>
+          <IrLane lane="optimizer" selection={selection} setSelection={setSelection} stream={trace.optimizerIr} />
+        </section>
+
+        <section className="forward-lowering-ir" aria-label="Matrix training operation stream">
+          <div className="panel-heading">
+            <div><p className="eyebrow">4 - batch</p><h2>Columns reduce into shared parameter state</h2></div>
+            <code>{trace.matrixTrainingIr.magic} v{trace.matrixTrainingIr.version}</code>
+          </div>
+          <IrLane lane="matrix" selection={selection} setSelection={setSelection} stream={trace.matrixTrainingIr} />
+        </section>
+
+        <section className="forward-lowering-selection" aria-label="Selected training lowering detail">
+          <div className="panel-heading">
+            <div><p className="eyebrow">selected translation</p><h2>{selected?.op}</h2></div>
+            <code>{selection.id}</code>
+          </div>
+          {selected === undefined ? null : (
+            <div className="forward-lowering-detail-grid">
+              <div><small>reads -&gt; writes</small><code>{selected.inputs.join(", ") || "none"} -&gt; {selected.output}</code></div>
+              <div><small>observed value</small><code>{selectedValue(trace, selection)}</code></div>
+              <div><small>attributes</small><code>{attributeText(selected)}</code></div>
+              <div><small>graph provenance</small><code>{[...selected.sourceNodes, ...selected.sourceEdges].join(", ") || "none"}</code></div>
+              <div><small>lowered from</small><code>{selected.sourceInstructions.join(", ") || "direct semantic rule"}</code></div>
+            </div>
+          )}
+        </section>
+
+        <section className="forward-lowering-parity" aria-label="Backward optimizer execution parity">
+          <div className="panel-heading">
+            <div><p className="eyebrow">5 - prove equivalence</p><h2>Scalar and matrix training agree</h2></div>
+            <code>max error {trace.maxPathError.toExponential(1)}</code>
+          </div>
+          <div className="forward-lowering-parity-table" role="table" aria-label="Backward row gradient values">
+            <div className="forward-lowering-parity-head" role="row">
+              <strong role="columnheader">row</strong>
+              <strong role="columnheader">x</strong>
+              <strong role="columnheader">target</strong>
+              <strong role="columnheader">d prediction</strong>
+              <strong role="columnheader">local d w</strong>
+              <strong role="columnheader">d x</strong>
+            </div>
+            {trace.backward.dPrediction.map((gradient, index) => (
+              <div key={index} role="row">
+                <strong role="cell">{index}</strong>
+                <code role="cell">{formatNumber(trace.scenario.inputs[index]!)}</code>
+                <code role="cell">{formatNumber(trace.scenario.targets[index]!)}</code>
+                <code role="cell">{formatNumber(gradient)}</code>
+                <code role="cell">{formatNumber(trace.backward.localDW[index]!)}</code>
+                <code role="cell">{formatNumber(trace.backward.dX[index]!)}</code>
+              </div>
+            ))}
+          </div>
+          <div className="forward-lowering-edge-grid">
+            <div><code>persistent accumulation</code><span>{formatNumber(trace.backward.gradientBufferBefore)} before + {trace.backward.localDW.map(formatNumber).join(" + ")}</span><strong>grad_w = {formatNumber(trace.backward.gradW)}</strong></div>
+            <div><code>explicit divisor</code><span>{formatNumber(trace.backward.gradW)} / {trace.scenario.divisor}</span><strong>applied = {formatNumber(trace.optimizer.appliedGradient)}</strong></div>
+            <div><code>SGD update</code><span>{formatNumber(trace.optimizer.parameterBefore)} - {formatNumber(trace.scenario.learningRate)} x {formatNumber(trace.optimizer.appliedGradient)}</span><strong>w_next = {formatNumber(trace.optimizer.parameterAfter)}</strong></div>
+          </div>
+        </section>
+      </section>
+
+      <aside className="forward-lowering-controls">
+        <p className="eyebrow">Run shape</p>
+        <h2>Keep the programs fixed</h2>
+        <p>Change the number of rows or enter with a nonzero buffer while the programs stay fixed.</p>
+        <div className="forward-lowering-scenario-buttons">
+          {BACKWARD_OPTIMIZER_LOWERING_SCENARIOS.map((scenario) => (
+            <button
+              aria-label={scenario.title}
+              aria-pressed={scenarioId === scenario.id}
+              key={scenario.id}
+              onClick={() => setScenarioId(scenario.id as BackwardOptimizerLoweringScenarioId)}
+              type="button"
+            >
+              <strong>{scenario.title}</strong><span>{scenario.summary}</span>
+            </button>
+          ))}
+        </div>
+        <div className="forward-lowering-equation">
+          <p className="eyebrow">Paper result</p>
+          <code>loss = 0.5(w x x - target)^2</code>
+          <code>d_w = (prediction - target) x x</code>
+          <code>grad_w = grad_w_before + sum(d_w)</code>
+          <code>w_next = w - rate x (grad_w / divisor)</code>
+        </div>
+        <div className="forward-lowering-mental-model">
+          <p className="eyebrow">Gradient audit</p>
+          <h2>Different route, same slope</h2>
+          <p>Finite difference {formatNumber(trace.gradientAudit.numerical)} vs backward {formatNumber(trace.gradientAudit.analytical)}; error {trace.gradientAudit.absoluteError.toExponential(1)}.</p>
+        </div>
+        <div className="forward-lowering-mental-model">
+          <p className="eyebrow">Rust boundary</p>
+          <h2>Tensor math, explicit policy</h2>
+          <p>Rust may accelerate multiply, add, and ReduceSum. The host still owns saved values, divisor, update timing, and zeroing.</p>
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/backward-optimizer-lowering-lab.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/backward-optimizer-lowering-lab.ts
@@ -1,0 +1,570 @@
+import {
+  addActivation,
+  addInput,
+  addOutput,
+  addWeightedSum,
+  createNeuralGraph,
+} from "@coding-adventures/neural-network";
+import {
+  compileBytecodeToMatrixPlan,
+  compileNeuralGraphToBytecode,
+  runNeuralBytecodeForwardWithTrace,
+  runNeuralMatrixForward,
+} from "@coding-adventures/neural-graph-vm";
+
+const MAX_BATCH = 8;
+const MAX_TEXT = 512;
+const MAX_ABSOLUTE_INPUT = 1e3;
+const MAX_ABSOLUTE_DERIVED = 1e12;
+const EPSILON = 1e-5;
+
+type AttributeValue = string | number | boolean | readonly string[] | readonly number[];
+
+export interface TrainingLoweringInstruction {
+  readonly id: string;
+  readonly op: string;
+  readonly output: string;
+  readonly inputs: readonly string[];
+  readonly attributes: Readonly<Record<string, AttributeValue>>;
+  readonly sourceNodes: readonly string[];
+  readonly sourceEdges: readonly string[];
+  readonly sourceInstructions: readonly string[];
+}
+
+export interface TrainingLoweringStream {
+  readonly magic: "CANB" | "CANO" | "CANM-TRAIN";
+  readonly version: 0;
+  readonly instructions: readonly TrainingLoweringInstruction[];
+}
+
+export interface BackwardOptimizerLoweringScenario {
+  readonly id: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly initialParameter: number;
+  readonly learningRate: number;
+  readonly inputs: readonly number[];
+  readonly targets: readonly number[];
+  readonly gradientBufferBefore: number;
+  readonly divisor: number;
+}
+
+export type BackwardOptimizerLoweringScenarioId =
+  | "one_row_by_hand"
+  | "two_row_mean"
+  | "persistent_buffer";
+
+export const BACKWARD_OPTIMIZER_LOWERING_SCENARIOS: readonly BackwardOptimizerLoweringScenario[] = [
+  {
+    id: "one_row_by_hand",
+    title: "One row by hand",
+    summary: "Save one forward row, reverse it, then apply one scalar SGD update.",
+    initialParameter: 0.5,
+    learningRate: 0.1,
+    inputs: [2],
+    targets: [0],
+    gradientBufferBefore: 0,
+    divisor: 1,
+  },
+  {
+    id: "two_row_mean",
+    title: "The same plan, two-row mean",
+    summary: "Keep every instruction ID fixed while two row gradients reduce and average.",
+    initialParameter: 1,
+    learningRate: 0.1,
+    inputs: [2, -1],
+    targets: [1, 1],
+    gradientBufferBefore: 0,
+    divisor: 2,
+  },
+  {
+    id: "persistent_buffer",
+    title: "Continue a persistent buffer",
+    summary: "Enter with grad_w = 3, add one new row gradient of 2, and keep 5 after SGD.",
+    initialParameter: 0.5,
+    learningRate: 0.1,
+    inputs: [2],
+    targets: [0],
+    gradientBufferBefore: 3,
+    divisor: 1,
+  },
+];
+
+export interface SavedTrainingValues {
+  readonly x: readonly number[];
+  readonly target: readonly number[];
+  readonly prediction: readonly number[];
+  readonly residual: readonly number[];
+  readonly loss: readonly number[];
+}
+
+export interface BackwardTrainingValues {
+  readonly dLoss: readonly number[];
+  readonly dResidual: readonly number[];
+  readonly dPrediction: readonly number[];
+  readonly localDW: readonly number[];
+  readonly dX: readonly number[];
+  readonly gradientBufferBefore: number;
+  readonly batchGradient: number;
+  readonly gradW: number;
+}
+
+export interface OptimizerTrainingValues {
+  readonly parameterBefore: number;
+  readonly appliedGradient: number;
+  readonly parameterDelta: number;
+  readonly parameterAfter: number;
+  readonly gradientBufferAfterStep: number;
+}
+
+export interface MatrixTrainingValues {
+  readonly columns: {
+    readonly x: readonly number[];
+    readonly residual: readonly number[];
+    readonly dPrediction: readonly number[];
+    readonly localDW: readonly number[];
+    readonly dX: readonly number[];
+  };
+  readonly gradientBufferBefore: number;
+  readonly batchGradient: number;
+  readonly gradW: number;
+  readonly appliedGradient: number;
+  readonly parameterAfter: number;
+  readonly gradientBufferAfterStep: number;
+}
+
+export interface BackwardOptimizerLoweringTrace {
+  readonly scenario: BackwardOptimizerLoweringScenario;
+  readonly forward: {
+    readonly directOutputs: readonly number[];
+    readonly neuralIrOutputs: readonly number[];
+    readonly matrixIrOutputs: readonly number[];
+    readonly neuralOps: readonly string[];
+    readonly matrixOps: readonly string[];
+    readonly maxError: number;
+  };
+  readonly savedValues: SavedTrainingValues;
+  readonly backwardIr: TrainingLoweringStream;
+  readonly optimizerIr: TrainingLoweringStream;
+  readonly matrixTrainingIr: TrainingLoweringStream;
+  readonly backward: BackwardTrainingValues;
+  readonly optimizer: OptimizerTrainingValues;
+  readonly matrixTraining: MatrixTrainingValues;
+  readonly gradientAudit: {
+    readonly analytical: number;
+    readonly numerical: number;
+    readonly absoluteError: number;
+  };
+  readonly maxPathError: number;
+}
+
+function finite(value: number, context: string, derived = true): number {
+  const limit = derived ? MAX_ABSOLUTE_DERIVED : MAX_ABSOLUTE_INPUT;
+  if (!Number.isFinite(value) || Math.abs(value) > limit) {
+    throw new Error(`${context} must be finite and bounded by ${limit}`);
+  }
+  return value;
+}
+
+function boundedString(value: unknown, context: string): string {
+  if (typeof value !== "string" || value.length < 1 || value.length > MAX_TEXT) {
+    throw new Error(`${context} must be a bounded string`);
+  }
+  return value;
+}
+
+function exactKeys(value: object, expected: readonly string[], context: string): void {
+  const keys = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (keys.length !== wanted.length || keys.some((key, index) => key !== wanted[index])) {
+    throw new Error(`${context} must contain exactly ${wanted.join(", ")}`);
+  }
+}
+
+function boundedColumn(value: unknown, context: string): number[] {
+  if (!Array.isArray(value) || value.length < 1 || value.length > MAX_BATCH) {
+    throw new Error(`${context} must contain 1 to ${MAX_BATCH} values`);
+  }
+  return value.map((item, index) => {
+    if (typeof item !== "number") throw new Error(`${context}[${index}] must be numeric`);
+    return finite(item, `${context}[${index}]`, false);
+  });
+}
+
+function validateScenario(
+  value: BackwardOptimizerLoweringScenario,
+): BackwardOptimizerLoweringScenario {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("scenario must be an object");
+  }
+  exactKeys(
+    value,
+    ["id", "title", "summary", "initialParameter", "learningRate", "inputs", "targets", "gradientBufferBefore", "divisor"],
+    "scenario",
+  );
+  const inputs = boundedColumn(value.inputs, "scenario.inputs");
+  const targets = boundedColumn(value.targets, "scenario.targets");
+  if (inputs.length !== targets.length) throw new Error("inputs and targets must have the same bounded length");
+  const divisor = value.divisor;
+  if (!Number.isInteger(divisor) || divisor < 1 || divisor > inputs.length) {
+    throw new Error("divisor must be an integer within the batch length");
+  }
+  const initialParameter = finite(value.initialParameter, "initial parameter", false);
+  const learningRate = finite(value.learningRate, "learning rate", false);
+  const gradientBufferBefore = finite(value.gradientBufferBefore, "gradient buffer before", false);
+  if (learningRate <= 0) throw new Error("learning rate must be positive");
+  return {
+    id: boundedString(value.id, "scenario.id"),
+    title: boundedString(value.title, "scenario.title"),
+    summary: boundedString(value.summary, "scenario.summary"),
+    initialParameter,
+    learningRate,
+    inputs,
+    targets,
+    gradientBufferBefore,
+    divisor,
+  };
+}
+
+function instruction(
+  id: string,
+  op: string,
+  output: string,
+  inputs: readonly string[],
+  attributes: Readonly<Record<string, AttributeValue>> = {},
+  sourceNodes: readonly string[] = [],
+  sourceEdges: readonly string[] = [],
+  sourceInstructions: readonly string[] = [],
+): TrainingLoweringInstruction {
+  return { id, op, output, inputs, attributes, sourceNodes, sourceEdges, sourceInstructions };
+}
+
+export function compileBackwardTrainingIr(): TrainingLoweringStream {
+  return {
+    magic: "CANB",
+    version: 0,
+    instructions: [
+      instruction("b0", "SEED_LOSS_GRAD", "d_loss", [], { value: 1 }, ["loss"]),
+      instruction("b1", "HALF_SQUARED_ERROR_GRAD", "d_residual", ["residual", "d_loss"], {}, ["loss", "residual"]),
+      instruction("b2", "PROPAGATE_GRAD", "d_prediction", ["d_residual"], { through: "subtract_prediction" }, ["residual", "prediction"]),
+      instruction("b3", "PARAMETER_LOCAL_GRAD", "local_d_w", ["x", "d_prediction"], { parameter_id: "w" }, ["prediction"], ["w"]),
+      instruction("b4", "ACCUMULATE_GRAD", "grad_w", ["grad_w", "local_d_w"], { parameter_id: "w", order: "row_ascending" }, [], ["w"]),
+      instruction("b5", "INPUT_GRAD", "d_x", ["w", "d_prediction"], { input_id: "x" }, ["x", "prediction"], ["w"]),
+    ],
+  };
+}
+
+export function compileOptimizerTrainingIr(): TrainingLoweringStream {
+  return {
+    magic: "CANO",
+    version: 0,
+    instructions: [
+      instruction("o0", "READ_GRAD_BUFFER", "total_d_w", ["grad_w"], { parameter_id: "w" }, [], ["w"]),
+      instruction("o1", "DIVIDE_GRAD", "applied_d_w", ["total_d_w"], { divisor_source: "scenario.divisor" }, [], ["w"], ["o0"]),
+      instruction("o2", "SGD_UPDATE", "w_next", ["w", "applied_d_w"], { learning_rate_source: "scenario.learning_rate" }, [], ["w"], ["o1"]),
+      instruction("o3", "KEEP_GRAD_BUFFER", "grad_w_after_step", ["grad_w"], { optimizer_step_zeroes_gradient: false }, [], ["w"], ["o2"]),
+    ],
+  };
+}
+
+export function compileMatrixTrainingIr(): TrainingLoweringStream {
+  return {
+    magic: "CANM-TRAIN",
+    version: 0,
+    instructions: [
+      instruction("t0", "LOAD_SAVED_COLUMN", "x_col", ["x"], { saved_value: "x" }, ["x"]),
+      instruction("t1", "LOAD_SAVED_COLUMN", "residual_col", ["residual"], { saved_value: "residual" }, ["residual"]),
+      instruction("t2", "LOSS_GRAD_COLUMN", "d_prediction_col", ["residual_col"], { loss: "half_squared_error" }, ["loss", "prediction"], [], ["b0", "b1", "b2"]),
+      instruction("t3", "PARAMETER_LOCAL_GRAD_COLUMN", "local_d_w_col", ["x_col", "d_prediction_col"], { parameter_id: "w" }, ["prediction"], ["w"], ["b3"]),
+      instruction("t4", "INPUT_GRAD_COLUMN", "d_x_col", ["d_prediction_col"], { input_id: "x", parameter_id: "w" }, ["x", "prediction"], ["w"], ["b5"]),
+      instruction("t5", "REDUCE_SUM_GRAD", "batch_d_w", ["local_d_w_col"], { order: "row_ascending", parameter_id: "w" }, [], ["w"], ["b4"]),
+      instruction("t6", "ACCUMULATE_GRAD_BUFFER", "grad_w", ["grad_w", "batch_d_w"], { parameter_id: "w" }, [], ["w"], ["b4"]),
+      instruction("t7", "DIVIDE_GRAD", "applied_d_w", ["grad_w"], { divisor_source: "scenario.divisor" }, [], ["w"], ["o0", "o1"]),
+      instruction("t8", "SGD_UPDATE_SCALAR", "w_next", ["w", "applied_d_w"], { learning_rate_source: "scenario.learning_rate" }, [], ["w"], ["o2"]),
+      instruction("t9", "KEEP_GRAD_BUFFER", "grad_w_after_step", ["grad_w"], { optimizer_step_zeroes_gradient: false }, [], ["w"], ["o3"]),
+    ],
+  };
+}
+
+function buildForwardGraph(parameter: number) {
+  const graph = createNeuralGraph("nn30_scalar_training");
+  addInput(graph, "x", "x");
+  addWeightedSum(graph, "prediction_sum", [{
+    from: "x",
+    weight: parameter,
+    edgeId: "w",
+    properties: { "nn.trainable": true },
+  }]);
+  addActivation(graph, "prediction", "prediction_sum", "none", {}, "sum_to_prediction");
+  addOutput(graph, "out", "prediction", "prediction", {}, "prediction_to_out");
+  return graph;
+}
+
+function runProductionForward(scenario: BackwardOptimizerLoweringScenario) {
+  const graph = buildForwardGraph(scenario.initialParameter);
+  const bytecode = compileNeuralGraphToBytecode(graph);
+  const matrixPlan = compileBytecodeToMatrixPlan(bytecode);
+  const neuralOutputs = scenario.inputs.map((x) => {
+    const trace = runNeuralBytecodeForwardWithTrace(bytecode, { x });
+    return finite(trace.outputs.prediction!, "NeuralIR prediction");
+  });
+  const matrixOutputs = runNeuralMatrixForward(matrixPlan, { x: scenario.inputs })
+    .outputs.prediction!.map((value) => finite(value, "MatrixIR prediction"));
+  const directOutputs = scenario.inputs.map((x) => finite(scenario.initialParameter * x, "direct prediction"));
+  return {
+    directOutputs,
+    neuralIrOutputs: neuralOutputs,
+    matrixIrOutputs: matrixOutputs,
+    neuralOps: bytecode.functions[0]!.instructions.map((item) => item.op),
+    matrixOps: matrixPlan.instructions.map((item) => item.op),
+    maxError: maxDifference([directOutputs, neuralOutputs, matrixOutputs]),
+  };
+}
+
+function savedValues(
+  scenario: BackwardOptimizerLoweringScenario,
+  predictions: readonly number[],
+): SavedTrainingValues {
+  const residual = predictions.map((prediction, index) => finite(prediction - scenario.targets[index]!, `residual ${index}`));
+  const loss = residual.map((value, index) => finite(0.5 * value * value, `loss ${index}`));
+  return {
+    x: [...scenario.inputs],
+    target: [...scenario.targets],
+    prediction: [...predictions],
+    residual,
+    loss,
+  };
+}
+
+function runBackwardProgram(
+  stream: TrainingLoweringStream,
+  saved: SavedTrainingValues,
+  parameter: number,
+  gradientBufferBefore: number,
+): BackwardTrainingValues {
+  const values = new Map<string, number | number[]>();
+  values.set("x", [...saved.x]);
+  values.set("residual", [...saved.residual]);
+  values.set("w", parameter);
+  values.set("grad_w", gradientBufferBefore);
+  for (const item of stream.instructions) {
+    switch (item.op) {
+      case "SEED_LOSS_GRAD":
+        values.set(item.output, Array(saved.x.length).fill(1));
+        break;
+      case "HALF_SQUARED_ERROR_GRAD": {
+        const residual = readColumn(values, "residual");
+        const seed = readColumn(values, "d_loss");
+        values.set(item.output, residual.map((value, index) => finite(value * seed[index]!, `d_residual ${index}`)));
+        break;
+      }
+      case "PROPAGATE_GRAD":
+        values.set(item.output, [...readColumn(values, "d_residual")]);
+        break;
+      case "PARAMETER_LOCAL_GRAD": {
+        const x = readColumn(values, "x");
+        const upstream = readColumn(values, "d_prediction");
+        values.set(item.output, x.map((value, index) => finite(value * upstream[index]!, `local_d_w ${index}`)));
+        break;
+      }
+      case "ACCUMULATE_GRAD": {
+        let gradient = readScalar(values, "grad_w");
+        for (const value of readColumn(values, "local_d_w")) gradient = finite(gradient + value, "grad_w reduction");
+        values.set(item.output, gradient);
+        break;
+      }
+      case "INPUT_GRAD":
+        values.set(item.output, readColumn(values, "d_prediction").map((value, index) => finite(parameter * value, `d_x ${index}`)));
+        break;
+      default:
+        throw new Error(`unsupported backward op: ${item.op}`);
+    }
+  }
+  const localDW = readColumn(values, "local_d_w");
+  const batchGradient = stableSum(localDW, "backward batch gradient");
+  return {
+    dLoss: readColumn(values, "d_loss"),
+    dResidual: readColumn(values, "d_residual"),
+    dPrediction: readColumn(values, "d_prediction"),
+    localDW,
+    dX: readColumn(values, "d_x"),
+    gradientBufferBefore,
+    batchGradient,
+    gradW: readScalar(values, "grad_w"),
+  };
+}
+
+function runOptimizerProgram(
+  stream: TrainingLoweringStream,
+  scenario: BackwardOptimizerLoweringScenario,
+  gradW: number,
+): OptimizerTrainingValues {
+  const values = new Map<string, number>([["w", scenario.initialParameter], ["grad_w", gradW]]);
+  for (const item of stream.instructions) {
+    switch (item.op) {
+      case "READ_GRAD_BUFFER": values.set(item.output, scalar(values, "grad_w")); break;
+      case "DIVIDE_GRAD": values.set(item.output, finite(scalar(values, "total_d_w") / scenario.divisor, "applied gradient")); break;
+      case "SGD_UPDATE": values.set(item.output, finite(scalar(values, "w") - scenario.learningRate * scalar(values, "applied_d_w"), "w_next")); break;
+      case "KEEP_GRAD_BUFFER": values.set(item.output, scalar(values, "grad_w")); break;
+      default: throw new Error(`unsupported optimizer op: ${item.op}`);
+    }
+  }
+  const appliedGradient = scalar(values, "applied_d_w");
+  const parameterAfter = scalar(values, "w_next");
+  return {
+    parameterBefore: scenario.initialParameter,
+    appliedGradient,
+    parameterDelta: finite(parameterAfter - scenario.initialParameter, "parameter delta"),
+    parameterAfter,
+    gradientBufferAfterStep: scalar(values, "grad_w_after_step"),
+  };
+}
+
+function runMatrixTrainingProgram(
+  stream: TrainingLoweringStream,
+  scenario: BackwardOptimizerLoweringScenario,
+  saved: SavedTrainingValues,
+): MatrixTrainingValues {
+  const values = new Map<string, number | number[]>([
+    ["x", [...saved.x]], ["residual", [...saved.residual]], ["w", scenario.initialParameter],
+    ["grad_w", scenario.gradientBufferBefore],
+  ]);
+  for (const item of stream.instructions) {
+    switch (item.op) {
+      case "LOAD_SAVED_COLUMN": values.set(item.output, [...readColumn(values, item.inputs[0]!)]); break;
+      case "LOSS_GRAD_COLUMN": values.set(item.output, [...readColumn(values, "residual_col")]); break;
+      case "PARAMETER_LOCAL_GRAD_COLUMN": {
+        const x = readColumn(values, "x_col");
+        const gradient = readColumn(values, "d_prediction_col");
+        values.set(item.output, x.map((value, index) => finite(value * gradient[index]!, `matrix local d_w ${index}`)));
+        break;
+      }
+      case "INPUT_GRAD_COLUMN": values.set(item.output, readColumn(values, "d_prediction_col").map((value, index) => finite(scenario.initialParameter * value, `matrix d_x ${index}`))); break;
+      case "REDUCE_SUM_GRAD": {
+        values.set(item.output, stableSum(readColumn(values, "local_d_w_col"), "matrix batch gradient"));
+        break;
+      }
+      case "ACCUMULATE_GRAD_BUFFER": values.set(item.output, finite(readScalar(values, "grad_w") + readScalar(values, "batch_d_w"), "matrix grad buffer accumulation")); break;
+      case "DIVIDE_GRAD": values.set(item.output, finite(readScalar(values, "grad_w") / scenario.divisor, "matrix applied gradient")); break;
+      case "SGD_UPDATE_SCALAR": values.set(item.output, finite(scenario.initialParameter - scenario.learningRate * readScalar(values, "applied_d_w"), "matrix w_next")); break;
+      case "KEEP_GRAD_BUFFER": values.set(item.output, readScalar(values, "grad_w")); break;
+      default: throw new Error(`unsupported matrix training op: ${item.op}`);
+    }
+  }
+  return {
+    columns: {
+      x: readColumn(values, "x_col"),
+      residual: readColumn(values, "residual_col"),
+      dPrediction: readColumn(values, "d_prediction_col"),
+      localDW: readColumn(values, "local_d_w_col"),
+      dX: readColumn(values, "d_x_col"),
+    },
+    gradientBufferBefore: scenario.gradientBufferBefore,
+    batchGradient: readScalar(values, "batch_d_w"),
+    gradW: readScalar(values, "grad_w"),
+    appliedGradient: readScalar(values, "applied_d_w"),
+    parameterAfter: readScalar(values, "w_next"),
+    gradientBufferAfterStep: readScalar(values, "grad_w_after_step"),
+  };
+}
+
+function readColumn(values: ReadonlyMap<string, number | number[]>, id: string): number[] {
+  const value = values.get(id);
+  if (!Array.isArray(value)) throw new Error(`missing column: ${id}`);
+  return [...value];
+}
+
+function readScalar(values: ReadonlyMap<string, number | number[]>, id: string): number {
+  const value = values.get(id);
+  if (typeof value !== "number") throw new Error(`missing scalar: ${id}`);
+  return value;
+}
+
+function scalar(values: ReadonlyMap<string, number>, id: string): number {
+  const value = values.get(id);
+  if (value === undefined) throw new Error(`missing scalar: ${id}`);
+  return value;
+}
+
+function stableSum(values: readonly number[], context: string): number {
+  let total = 0;
+  for (const value of values) total = finite(total + value, context);
+  return total;
+}
+
+function lossSum(parameter: number, scenario: BackwardOptimizerLoweringScenario): number {
+  let total = 0;
+  scenario.inputs.forEach((x, index) => {
+    const residual = finite(parameter * x - scenario.targets[index]!, `audit residual ${index}`);
+    total = finite(total + 0.5 * residual * residual, "audit loss sum");
+  });
+  return total;
+}
+
+function maxDifference(groups: readonly (readonly number[])[]): number {
+  let maximum = 0;
+  for (let row = 0; row < groups[0]!.length; row += 1) {
+    for (let left = 0; left < groups.length; left += 1) {
+      for (let right = left + 1; right < groups.length; right += 1) {
+        maximum = Math.max(maximum, Math.abs(groups[left]![row]! - groups[right]![row]!));
+      }
+    }
+  }
+  return finite(maximum, "parity error");
+}
+
+export function traceBackwardOptimizerLoweringProgram(
+  inputScenario: BackwardOptimizerLoweringScenario,
+): BackwardOptimizerLoweringTrace {
+  const scenario = validateScenario(inputScenario);
+  const forward = runProductionForward(scenario);
+  const saved = savedValues(scenario, forward.neuralIrOutputs);
+  const backwardIr = compileBackwardTrainingIr();
+  const optimizerIr = compileOptimizerTrainingIr();
+  const matrixTrainingIr = compileMatrixTrainingIr();
+  const backward = runBackwardProgram(
+    backwardIr,
+    saved,
+    scenario.initialParameter,
+    scenario.gradientBufferBefore,
+  );
+  const optimizer = runOptimizerProgram(optimizerIr, scenario, backward.gradW);
+  const matrixTraining = runMatrixTrainingProgram(matrixTrainingIr, scenario, saved);
+  const numerical = finite((lossSum(scenario.initialParameter + EPSILON, scenario) - lossSum(scenario.initialParameter - EPSILON, scenario)) / (2 * EPSILON), "numerical gradient");
+  const absoluteError = finite(Math.abs(backward.batchGradient - numerical), "gradient error");
+  const maxPathError = Math.max(
+    Math.abs(backward.batchGradient - matrixTraining.batchGradient),
+    Math.abs(backward.gradW - matrixTraining.gradW),
+    Math.abs(optimizer.appliedGradient - matrixTraining.appliedGradient),
+    Math.abs(optimizer.parameterAfter - matrixTraining.parameterAfter),
+    Math.abs(optimizer.gradientBufferAfterStep - matrixTraining.gradientBufferAfterStep),
+  );
+  return deepFreeze({
+    scenario,
+    forward,
+    savedValues: saved,
+    backwardIr,
+    optimizerIr,
+    matrixTrainingIr,
+    backward,
+    optimizer,
+    matrixTraining,
+    gradientAudit: { analytical: backward.batchGradient, numerical, absoluteError },
+    maxPathError: finite(maxPathError, "training path error"),
+  });
+}
+
+export function traceBackwardOptimizerLowering(
+  id: BackwardOptimizerLoweringScenarioId,
+): BackwardOptimizerLoweringTrace {
+  const scenario = BACKWARD_OPTIMIZER_LOWERING_SCENARIOS.find((candidate) => candidate.id === id);
+  if (scenario === undefined) throw new Error(`unknown backward/optimizer lowering scenario: ${id}`);
+  return traceBackwardOptimizerLoweringProgram(scenario);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  Object.values(value).forEach((child) => deepFreeze(child));
+  return value;
+}

--- a/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
+++ b/code/programs/typescript/ml-learning-visualizer/src/training.test.ts
@@ -6,6 +6,15 @@ import { activate } from "./activation.js";
 import { AttentionWorkbench } from "./AttentionWorkbench.js";
 import { AutoencoderWorkbench } from "./AutoencoderWorkbench.js";
 import { traceTwoNumberAutoencoder } from "./autoencoder-lab.js";
+import { BackwardOptimizerLoweringWorkbench } from "./BackwardOptimizerLoweringWorkbench.js";
+import {
+  compileBackwardTrainingIr,
+  compileMatrixTrainingIr,
+  compileOptimizerTrainingIr,
+  traceBackwardOptimizerLowering,
+  traceBackwardOptimizerLoweringProgram,
+  type BackwardOptimizerLoweringScenario,
+} from "./backward-optimizer-lowering-lab.js";
 import {
   decoderTrainingRow,
   traceTinyDecoderTraining,
@@ -2202,5 +2211,168 @@ describe("forward graph lowering", () => {
     expect(screen.getAllByRole("cell")).toHaveLength(12);
     expect(screen.getByLabelText("Forward lowering execution parity").textContent)
       .toMatch(/1.*8.*16.*13.*13.*13/s);
+  });
+});
+
+describe("backward and optimizer lowering", () => {
+  it("pins separate backward optimizer and matrix training streams", () => {
+    expect(compileBackwardTrainingIr().instructions.map((item) => item.op)).toEqual([
+      "SEED_LOSS_GRAD",
+      "HALF_SQUARED_ERROR_GRAD",
+      "PROPAGATE_GRAD",
+      "PARAMETER_LOCAL_GRAD",
+      "ACCUMULATE_GRAD",
+      "INPUT_GRAD",
+    ]);
+    expect(compileOptimizerTrainingIr().instructions.map((item) => item.op)).toEqual([
+      "READ_GRAD_BUFFER",
+      "DIVIDE_GRAD",
+      "SGD_UPDATE",
+      "KEEP_GRAD_BUFFER",
+    ]);
+    expect(compileMatrixTrainingIr().instructions.map((item) => item.op)).toEqual([
+      "LOAD_SAVED_COLUMN",
+      "LOAD_SAVED_COLUMN",
+      "LOSS_GRAD_COLUMN",
+      "PARAMETER_LOCAL_GRAD_COLUMN",
+      "INPUT_GRAD_COLUMN",
+      "REDUCE_SUM_GRAD",
+      "ACCUMULATE_GRAD_BUFFER",
+      "DIVIDE_GRAD",
+      "SGD_UPDATE_SCALAR",
+      "KEEP_GRAD_BUFFER",
+    ]);
+  });
+
+  it("uses the production forward compiler before lowering training", () => {
+    const trace = traceBackwardOptimizerLowering("one_row_by_hand");
+    expect(trace.forward.neuralOps).toEqual([
+      "LOAD_INPUT",
+      "LOAD_EDGE_WEIGHT",
+      "MUL",
+      "ADD",
+      "ACTIVATE",
+      "STORE_OUTPUT",
+    ]);
+    expect(trace.forward.matrixOps).toEqual([
+      "LOAD_INPUT_MATRIX",
+      "WEIGHTED_SUM_MATRIX",
+      "ACTIVATE_MATRIX",
+      "STORE_OUTPUT_MATRIX",
+    ]);
+    expect(trace.forward.directOutputs).toEqual([1]);
+    expect(trace.forward.neuralIrOutputs).toEqual([1]);
+    expect(trace.forward.matrixIrOutputs).toEqual([1]);
+    expect(trace.forward.maxError).toBe(0);
+  });
+
+  it("replays the one-row backward and SGD calculation", () => {
+    const trace = traceBackwardOptimizerLowering("one_row_by_hand");
+    expect(trace.savedValues).toEqual({
+      x: [2], target: [0], prediction: [1], residual: [1], loss: [0.5],
+    });
+    expect(trace.backward).toEqual({
+      dLoss: [1], dResidual: [1], dPrediction: [1], localDW: [2], dX: [0.5],
+      gradientBufferBefore: 0, batchGradient: 2, gradW: 2,
+    });
+    expect(trace.optimizer.appliedGradient).toBe(2);
+    expect(trace.optimizer.parameterAfter).toBeCloseTo(0.3);
+    expect(trace.optimizer.gradientBufferAfterStep).toBe(2);
+    expect(trace.maxPathError).toBe(0);
+    expect(trace.gradientAudit.numerical).toBeCloseTo(2, 8);
+  });
+
+  it("keeps IDs fixed while two row gradients reduce and average", () => {
+    const one = traceBackwardOptimizerLowering("one_row_by_hand");
+    const two = traceBackwardOptimizerLowering("two_row_mean");
+    expect(two.backwardIr.instructions.map((item) => item.id))
+      .toEqual(one.backwardIr.instructions.map((item) => item.id));
+    expect(two.optimizerIr.instructions.map((item) => item.id))
+      .toEqual(one.optimizerIr.instructions.map((item) => item.id));
+    expect(two.matrixTrainingIr.instructions.map((item) => item.id))
+      .toEqual(one.matrixTrainingIr.instructions.map((item) => item.id));
+    expect(two.backward.localDW).toEqual([2, 2]);
+    expect(two.backward.gradW).toBe(4);
+    expect(two.optimizer.appliedGradient).toBe(2);
+    expect(two.optimizer.parameterAfter).toBeCloseTo(0.8);
+    expect(two.matrixTraining.columns.dX).toEqual([1, -2]);
+    expect(two.gradientAudit.numerical).toBeCloseTo(4, 8);
+  });
+
+  it("adds a new batch contribution to a persistent gradient buffer", () => {
+    const trace = traceBackwardOptimizerLowering("persistent_buffer");
+    expect(trace.backward.gradientBufferBefore).toBe(3);
+    expect(trace.backward.batchGradient).toBe(2);
+    expect(trace.backward.gradW).toBe(5);
+    expect(trace.matrixTraining.batchGradient).toBe(2);
+    expect(trace.matrixTraining.gradW).toBe(5);
+    expect(trace.optimizer.parameterAfter).toBe(0);
+    expect(trace.optimizer.gradientBufferAfterStep).toBe(5);
+    expect(trace.gradientAudit.analytical).toBe(2);
+    expect(trace.gradientAudit.numerical).toBeCloseTo(2, 8);
+    expect(trace.maxPathError).toBe(0);
+  });
+
+  it("fails closed on hostile scenarios and snapshots caller arrays", () => {
+    const inputs = [2];
+    const scenario: BackwardOptimizerLoweringScenario = {
+      id: "custom",
+      title: "custom",
+      summary: "custom",
+      initialParameter: 0.5,
+      learningRate: 0.1,
+      inputs,
+      targets: [0],
+      gradientBufferBefore: 0,
+      divisor: 1,
+    };
+    const trace = traceBackwardOptimizerLoweringProgram(scenario);
+    inputs[0] = 999;
+    expect(trace.scenario.inputs).toEqual([2]);
+    expect(Object.isFrozen(trace.backwardIr.instructions[0])).toBe(true);
+
+    expect(() => traceBackwardOptimizerLoweringProgram({ ...scenario, targets: [0, 1] }))
+      .toThrow(/same bounded length/);
+    expect(() => traceBackwardOptimizerLoweringProgram({ ...scenario, inputs: [Number.NaN] }))
+      .toThrow(/finite and bounded/);
+    expect(() => traceBackwardOptimizerLoweringProgram({ ...scenario, divisor: 2 }))
+      .toThrow(/batch length/);
+    expect(() => traceBackwardOptimizerLoweringProgram({
+      ...scenario,
+      constructor: "hostile",
+    } as unknown as BackwardOptimizerLoweringScenario)).toThrow(/contain exactly/);
+    const hostileId = { toString: () => { throw new Error("coerced"); } } as unknown as string;
+    expect(() => traceBackwardOptimizerLoweringProgram({ ...scenario, id: hostileId }))
+      .toThrow(/bounded string/);
+  });
+
+  it("opens every training lane and the responsive parity tables", () => {
+    render(React.createElement(BackwardOptimizerLoweringWorkbench));
+    expect(screen.getByRole("heading", { name: "Backward and optimizer lowering map" })).toBeTruthy();
+    const savedTable = screen.getByRole("table", { name: "Saved forward row values" });
+    const gradientTable = screen.getByRole("table", { name: "Backward row gradient values" });
+    expect(within(savedTable).getAllByRole("columnheader")).toHaveLength(6);
+    expect(within(savedTable).getAllByRole("cell")).toHaveLength(6);
+    expect(within(gradientTable).getAllByRole("cell")).toHaveLength(6);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Backward IR b3, PARAMETER_LOCAL_GRAD" }));
+    expect(screen.getByLabelText("Selected training lowering detail").textContent)
+      .toMatch(/PARAMETER_LOCAL_GRAD.*x, d_prediction.*local_d_w.*\[2\].*parameter_id=w/s);
+    fireEvent.click(screen.getByRole("button", { name: "Open Optimizer IR o2, SGD_UPDATE" }));
+    expect(screen.getByLabelText("Selected training lowering detail").textContent)
+      .toMatch(/SGD_UPDATE.*w, applied_d_w.*w_next.*0\.3/s);
+    fireEvent.click(screen.getByRole("button", { name: "Open Matrix training IR t5, REDUCE_SUM_GRAD" }));
+    expect(screen.getByLabelText("Selected training lowering detail").textContent)
+      .toMatch(/REDUCE_SUM_GRAD.*local_d_w_col.*batch_d_w.*2.*row_ascending/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "The same plan, two-row mean" }));
+    expect(within(savedTable).getAllByRole("cell")).toHaveLength(12);
+    expect(within(gradientTable).getAllByRole("cell")).toHaveLength(12);
+    expect(screen.getByLabelText("Backward optimizer execution parity").textContent)
+      .toMatch(/0 before \+ 2 \+ 2.*grad_w = 4.*4 \/ 2.*applied = 2.*w_next = 0\.8/s);
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue a persistent buffer" }));
+    expect(screen.getByLabelText("Backward optimizer execution parity").textContent)
+      .toMatch(/3 before \+ 2.*grad_w = 5.*5 \/ 1.*applied = 5.*w_next = 0/s);
   });
 });

--- a/code/scripts/tests/test_backward_optimizer_lowering_labs.py
+++ b/code/scripts/tests/test_backward_optimizer_lowering_labs.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import copy
+import math
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "code" / "scripts"))
+
+from validate_backward_optimizer_lowering_labs import (
+    DEFAULT_FIXTURE_ROOT,
+    BackwardOptimizerLoweringValidationError,
+    _compare,
+    compile_backward_ir,
+    compile_matrix_training_ir,
+    compile_optimizer_ir,
+    execute_scenario,
+    load_json,
+    validate_document,
+    validate_fixture_root,
+)
+
+LAB_PATH = DEFAULT_FIXTURE_ROOT / "labs" / "00-scalar-sgd-training.json"
+
+
+def load_lab() -> dict[str, object]:
+    return load_json(LAB_PATH)
+
+
+def test_checked_in_corpus_and_schema_validate() -> None:
+    schema = load_json(DEFAULT_FIXTURE_ROOT / "schema.json")
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(load_lab())
+    assert validate_fixture_root(DEFAULT_FIXTURE_ROOT) == 1
+
+
+def test_exact_backward_optimizer_and_matrix_streams_are_pinned() -> None:
+    document = validate_document(load_lab())
+    backward = compile_backward_ir()
+    optimizer = compile_optimizer_ir()
+    matrix = compile_matrix_training_ir()
+
+    assert [item["id"] for item in backward["instructions"]] == [
+        f"b{index}" for index in range(6)
+    ]
+    assert [item["op"] for item in backward["instructions"]] == [
+        "SEED_LOSS_GRAD",
+        "HALF_SQUARED_ERROR_GRAD",
+        "PROPAGATE_GRAD",
+        "PARAMETER_LOCAL_GRAD",
+        "ACCUMULATE_GRAD",
+        "INPUT_GRAD",
+    ]
+    assert [item["op"] for item in optimizer["instructions"]] == [
+        "READ_GRAD_BUFFER",
+        "DIVIDE_GRAD",
+        "SGD_UPDATE",
+        "KEEP_GRAD_BUFFER",
+    ]
+    assert [item["op"] for item in matrix["instructions"]] == [
+        "LOAD_SAVED_COLUMN",
+        "LOAD_SAVED_COLUMN",
+        "LOSS_GRAD_COLUMN",
+        "PARAMETER_LOCAL_GRAD_COLUMN",
+        "INPUT_GRAD_COLUMN",
+        "REDUCE_SUM_GRAD",
+        "ACCUMULATE_GRAD_BUFFER",
+        "DIVIDE_GRAD",
+        "SGD_UPDATE_SCALAR",
+        "KEEP_GRAD_BUFFER",
+    ]
+    assert document["expected_ir"] == {
+        "backward": backward,
+        "optimizer": optimizer,
+        "matrix_training": matrix,
+    }
+
+
+def test_one_row_replays_the_hand_calculation() -> None:
+    document = validate_document(load_lab())
+    scenario = document["scenarios"][0]
+    trace = execute_scenario(scenario, document["finite_difference_epsilon"])
+
+    assert trace["saved_values"] == {
+        "x": [2],
+        "target": [0],
+        "prediction": [1],
+        "residual": [1],
+        "loss": [0.5],
+    }
+    assert trace["backward"] == {
+        "d_loss": [1],
+        "d_residual": [1],
+        "d_prediction": [1],
+        "local_d_w": [2],
+        "d_x": [0.5],
+        "gradient_buffer_before": 0,
+        "batch_gradient": 2,
+        "grad_w": 2,
+    }
+    assert trace["optimizer"]["parameter_after"] == pytest.approx(0.3)
+    assert trace["optimizer"]["gradient_buffer_after_step"] == 2
+
+
+def test_two_rows_reduce_stably_then_apply_the_explicit_mean() -> None:
+    document = validate_document(load_lab())
+    scenario = document["scenarios"][1]
+    trace = execute_scenario(scenario, document["finite_difference_epsilon"])
+
+    assert trace["saved_values"]["prediction"] == [2, -1]
+    assert trace["backward"]["d_prediction"] == [1, -2]
+    assert trace["backward"]["local_d_w"] == [2, 2]
+    assert trace["backward"]["grad_w"] == 4
+    assert trace["optimizer"]["applied_gradient"] == 2
+    assert trace["optimizer"]["parameter_after"] == pytest.approx(0.8)
+    assert trace["matrix_training"]["columns"]["d_x"] == [1, -2]
+
+
+def test_nonzero_gradient_buffer_is_accumulated_and_kept() -> None:
+    document = validate_document(load_lab())
+    scenario = document["scenarios"][2]
+    trace = execute_scenario(scenario, document["finite_difference_epsilon"])
+
+    assert trace["backward"]["gradient_buffer_before"] == 3
+    assert trace["backward"]["batch_gradient"] == 2
+    assert trace["backward"]["grad_w"] == 5
+    assert trace["matrix_training"]["batch_gradient"] == 2
+    assert trace["matrix_training"]["grad_w"] == 5
+    assert trace["optimizer"]["parameter_after"] == 0
+    assert trace["optimizer"]["gradient_buffer_after_step"] == 5
+    assert trace["gradient_audit"]["analytical"] == 2
+    assert trace["max_path_error"] == 0
+
+
+def test_every_scenario_passes_an_independent_gradient_audit() -> None:
+    document = validate_document(load_lab())
+    for scenario in document["scenarios"]:
+        trace = execute_scenario(scenario, document["finite_difference_epsilon"])
+        audit = trace["gradient_audit"]
+        assert audit["numerical"] == pytest.approx(audit["analytical"], abs=1e-8)
+        assert audit["absolute_error"] <= document["absolute_tolerance"]
+        assert trace["max_path_error"] == 0
+
+
+def test_rejects_duplicate_keys_non_finite_numbers_and_unknown_fields(
+    tmp_path: Path,
+) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version": 1, "schema_version": 1}', encoding="utf-8")
+    with pytest.raises(
+        BackwardOptimizerLoweringValidationError, match="duplicate JSON key"
+    ):
+        load_json(duplicate)
+
+    non_finite = tmp_path / "non-finite.json"
+    non_finite.write_text('{"value": Infinity}', encoding="utf-8")
+    with pytest.raises(BackwardOptimizerLoweringValidationError, match="non-finite"):
+        load_json(non_finite)
+
+    extra = load_lab()
+    extra["surprise"] = True
+    with pytest.raises(BackwardOptimizerLoweringValidationError, match="key mismatch"):
+        validate_document(extra)
+
+
+def test_rejects_noncanonical_contract_values() -> None:
+    loose = load_lab()
+    loose["absolute_tolerance"] = 1
+    with pytest.raises(BackwardOptimizerLoweringValidationError, match="canonical"):
+        validate_document(loose)
+
+    wrong_epsilon = load_lab()
+    wrong_epsilon["finite_difference_epsilon"] = 0.1
+    with pytest.raises(BackwardOptimizerLoweringValidationError, match="canonical"):
+        validate_document(wrong_epsilon)
+
+    implicit_zero = load_lab()
+    implicit_zero["training_graph"]["optimizer_step_zeroes_gradient"] = True
+    with pytest.raises(
+        BackwardOptimizerLoweringValidationError,
+        match="canonical scalar training graph",
+    ):
+        validate_document(implicit_zero)
+
+
+def test_rejects_mismatched_batches_divisors_large_values_and_roster_changes() -> None:
+    mismatch = load_lab()
+    mismatch["scenarios"][1]["targets"] = [1]
+    with pytest.raises(BackwardOptimizerLoweringValidationError, match="same length"):
+        validate_document(mismatch)
+
+    divisor = load_lab()
+    divisor["scenarios"][0]["divisor"] = 2
+    with pytest.raises(BackwardOptimizerLoweringValidationError, match="batch length"):
+        validate_document(divisor)
+
+    huge = load_lab()
+    huge["scenarios"][0]["inputs"] = [int("9" * 1000)]
+    with pytest.raises(
+        BackwardOptimizerLoweringValidationError, match="finite bounded"
+    ):
+        validate_document(huge)
+
+    reordered = load_lab()
+    reordered["scenarios"] = list(reversed(reordered["scenarios"]))
+    with pytest.raises(BackwardOptimizerLoweringValidationError, match="ids expected"):
+        validate_document(reordered)
+
+
+def test_rejects_dishonest_ir_and_expected_trace() -> None:
+    dishonest_ir = load_lab()
+    dishonest_ir["expected_ir"]["backward"]["instructions"][3]["op"] = "MAGIC"
+    with pytest.raises(
+        BackwardOptimizerLoweringValidationError, match="expected 'MAGIC'"
+    ):
+        validate_document(dishonest_ir)
+
+    dishonest_trace = load_lab()
+    dishonest_trace["scenarios"][0]["expected"]["optimizer"]["parameter_after"] = 9
+    with pytest.raises(BackwardOptimizerLoweringValidationError, match="expected 9"):
+        validate_document(dishonest_trace)
+
+
+def test_comparison_rejects_adversarial_nesting() -> None:
+    deeply_nested: object = 0
+    for _ in range(66):
+        deeply_nested = [deeply_nested]
+    with pytest.raises(
+        BackwardOptimizerLoweringValidationError, match="nesting exceeds"
+    ):
+        _compare(deeply_nested, deeply_nested, 0.0, "hostile")
+
+
+def test_all_derived_values_are_finite() -> None:
+    document = validate_document(load_lab())
+    for scenario in document["scenarios"]:
+        trace = execute_scenario(scenario, document["finite_difference_epsilon"])
+        stack: list[object] = [trace]
+        while stack:
+            value = stack.pop()
+            if isinstance(value, dict):
+                stack.extend(value.values())
+            elif isinstance(value, list):
+                stack.extend(value)
+            elif isinstance(value, (int, float)) and not isinstance(value, bool):
+                assert math.isfinite(value)
+
+
+def test_validated_document_is_a_fresh_normalized_copy() -> None:
+    source = load_lab()
+    snapshot = copy.deepcopy(source)
+    validated = validate_document(source)
+    source["scenarios"][0]["inputs"][0] = 999
+
+    assert validated["scenarios"][0]["inputs"] == snapshot["scenarios"][0]["inputs"]

--- a/code/scripts/validate_backward_optimizer_lowering_labs.py
+++ b/code/scripts/validate_backward_optimizer_lowering_labs.py
@@ -1,0 +1,739 @@
+#!/usr/bin/env python3
+"""Validate the deterministic NN30 backward/optimizer lowering corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "backward-optimizer-lowering-v1"
+)
+
+CANONICAL_ID = "backward-optimizer-lowering"
+CANONICAL_TOLERANCE = 1e-8
+CANONICAL_EPSILON = 1e-5
+CANONICAL_SCENARIOS = ["one_row_by_hand", "two_row_mean", "persistent_buffer"]
+MAX_SCENARIOS = 4
+MAX_BATCH = 8
+MAX_INSTRUCTIONS = 16
+MAX_TEXT_LENGTH = 512
+MAX_IDENTIFIER_LENGTH = 64
+MAX_ABSOLUTE_INPUT = 1e3
+MAX_ABSOLUTE_DERIVED = 1e12
+MAX_COMPARE_DEPTH = 64
+IDENTIFIER = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class BackwardOptimizerLoweringValidationError(ValueError):
+    """Raised when an NN30 fixture violates the executable contract."""
+
+
+def _duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise BackwardOptimizerLoweringValidationError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_constant(value: str) -> None:
+    raise BackwardOptimizerLoweringValidationError(f"non-finite JSON constant: {value}")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_duplicate_object,
+            parse_constant=_reject_constant,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise BackwardOptimizerLoweringValidationError(f"{path}: {error}") from error
+    if not isinstance(value, dict):
+        raise BackwardOptimizerLoweringValidationError(f"{path}: expected JSON object")
+    return value
+
+
+def _object(value: Any, keys: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise BackwardOptimizerLoweringValidationError(f"{context}: expected object")
+    if set(value) != keys:
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: key mismatch, expected {sorted(keys)}, got {sorted(value)}"
+        )
+    return value
+
+
+def _text(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not 1 <= len(value) <= MAX_TEXT_LENGTH:
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: expected non-empty string up to {MAX_TEXT_LENGTH} characters"
+        )
+    return value
+
+
+def _identifier(value: Any, context: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > MAX_IDENTIFIER_LENGTH
+        or IDENTIFIER.fullmatch(value) is None
+    ):
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: expected canonical identifier"
+        )
+    return value
+
+
+def _number(value: Any, context: str, *, derived: bool = False) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise BackwardOptimizerLoweringValidationError(f"{context}: expected number")
+    limit = MAX_ABSOLUTE_DERIVED if derived else MAX_ABSOLUTE_INPUT
+    if abs(value) > limit:
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: expected finite bounded number with abs <= {limit:g}"
+        )
+    if isinstance(value, float) and not math.isfinite(value):
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: expected finite bounded number"
+        )
+    return float(value)
+
+
+def _finite(value: float, context: str) -> float:
+    if not math.isfinite(value) or abs(value) > MAX_ABSOLUTE_DERIVED:
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: derived value must be finite with abs <= {MAX_ABSOLUTE_DERIVED:g}"
+        )
+    return value
+
+
+def _instruction(
+    instruction_id: str,
+    op: str,
+    output: str,
+    inputs: list[str],
+    *,
+    attributes: dict[str, Any] | None = None,
+    source_nodes: list[str] | None = None,
+    source_edges: list[str] | None = None,
+    source_instructions: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": instruction_id,
+        "op": op,
+        "output": output,
+        "inputs": inputs,
+        "attributes": attributes or {},
+        "source_nodes": source_nodes or [],
+        "source_edges": source_edges or [],
+        "source_instructions": source_instructions or [],
+    }
+
+
+def compile_backward_ir() -> dict[str, Any]:
+    return {
+        "magic": "CANB",
+        "version": 0,
+        "instructions": [
+            _instruction(
+                "b0",
+                "SEED_LOSS_GRAD",
+                "d_loss",
+                [],
+                attributes={"value": 1},
+                source_nodes=["loss"],
+            ),
+            _instruction(
+                "b1",
+                "HALF_SQUARED_ERROR_GRAD",
+                "d_residual",
+                ["residual", "d_loss"],
+                source_nodes=["loss", "residual"],
+            ),
+            _instruction(
+                "b2",
+                "PROPAGATE_GRAD",
+                "d_prediction",
+                ["d_residual"],
+                attributes={"through": "subtract_prediction"},
+                source_nodes=["residual", "prediction"],
+            ),
+            _instruction(
+                "b3",
+                "PARAMETER_LOCAL_GRAD",
+                "local_d_w",
+                ["x", "d_prediction"],
+                attributes={"parameter_id": "w"},
+                source_nodes=["prediction"],
+                source_edges=["w"],
+            ),
+            _instruction(
+                "b4",
+                "ACCUMULATE_GRAD",
+                "grad_w",
+                ["grad_w", "local_d_w"],
+                attributes={"parameter_id": "w", "order": "row_ascending"},
+                source_edges=["w"],
+            ),
+            _instruction(
+                "b5",
+                "INPUT_GRAD",
+                "d_x",
+                ["w", "d_prediction"],
+                attributes={"input_id": "x"},
+                source_nodes=["x", "prediction"],
+                source_edges=["w"],
+            ),
+        ],
+    }
+
+
+def compile_optimizer_ir() -> dict[str, Any]:
+    return {
+        "magic": "CANO",
+        "version": 0,
+        "instructions": [
+            _instruction(
+                "o0",
+                "READ_GRAD_BUFFER",
+                "total_d_w",
+                ["grad_w"],
+                attributes={"parameter_id": "w"},
+                source_edges=["w"],
+            ),
+            _instruction(
+                "o1",
+                "DIVIDE_GRAD",
+                "applied_d_w",
+                ["total_d_w"],
+                attributes={"divisor_source": "scenario.divisor"},
+                source_edges=["w"],
+                source_instructions=["o0"],
+            ),
+            _instruction(
+                "o2",
+                "SGD_UPDATE",
+                "w_next",
+                ["w", "applied_d_w"],
+                attributes={"learning_rate_source": "scenario.learning_rate"},
+                source_edges=["w"],
+                source_instructions=["o1"],
+            ),
+            _instruction(
+                "o3",
+                "KEEP_GRAD_BUFFER",
+                "grad_w_after_step",
+                ["grad_w"],
+                attributes={"optimizer_step_zeroes_gradient": False},
+                source_edges=["w"],
+                source_instructions=["o2"],
+            ),
+        ],
+    }
+
+
+def compile_matrix_training_ir() -> dict[str, Any]:
+    return {
+        "magic": "CANM-TRAIN",
+        "version": 0,
+        "instructions": [
+            _instruction(
+                "t0",
+                "LOAD_SAVED_COLUMN",
+                "x_col",
+                ["x"],
+                attributes={"saved_value": "x"},
+                source_nodes=["x"],
+            ),
+            _instruction(
+                "t1",
+                "LOAD_SAVED_COLUMN",
+                "residual_col",
+                ["residual"],
+                attributes={"saved_value": "residual"},
+                source_nodes=["residual"],
+            ),
+            _instruction(
+                "t2",
+                "LOSS_GRAD_COLUMN",
+                "d_prediction_col",
+                ["residual_col"],
+                attributes={"loss": "half_squared_error"},
+                source_nodes=["loss", "prediction"],
+                source_instructions=["b0", "b1", "b2"],
+            ),
+            _instruction(
+                "t3",
+                "PARAMETER_LOCAL_GRAD_COLUMN",
+                "local_d_w_col",
+                ["x_col", "d_prediction_col"],
+                attributes={"parameter_id": "w"},
+                source_nodes=["prediction"],
+                source_edges=["w"],
+                source_instructions=["b3"],
+            ),
+            _instruction(
+                "t4",
+                "INPUT_GRAD_COLUMN",
+                "d_x_col",
+                ["d_prediction_col"],
+                attributes={"input_id": "x", "parameter_id": "w"},
+                source_nodes=["x", "prediction"],
+                source_edges=["w"],
+                source_instructions=["b5"],
+            ),
+            _instruction(
+                "t5",
+                "REDUCE_SUM_GRAD",
+                "batch_d_w",
+                ["local_d_w_col"],
+                attributes={"order": "row_ascending", "parameter_id": "w"},
+                source_edges=["w"],
+                source_instructions=["b4"],
+            ),
+            _instruction(
+                "t6",
+                "ACCUMULATE_GRAD_BUFFER",
+                "grad_w",
+                ["grad_w", "batch_d_w"],
+                attributes={"parameter_id": "w"},
+                source_edges=["w"],
+                source_instructions=["b4"],
+            ),
+            _instruction(
+                "t7",
+                "DIVIDE_GRAD",
+                "applied_d_w",
+                ["grad_w"],
+                attributes={"divisor_source": "scenario.divisor"},
+                source_edges=["w"],
+                source_instructions=["o0", "o1"],
+            ),
+            _instruction(
+                "t8",
+                "SGD_UPDATE_SCALAR",
+                "w_next",
+                ["w", "applied_d_w"],
+                attributes={"learning_rate_source": "scenario.learning_rate"},
+                source_edges=["w"],
+                source_instructions=["o2"],
+            ),
+            _instruction(
+                "t9",
+                "KEEP_GRAD_BUFFER",
+                "grad_w_after_step",
+                ["grad_w"],
+                attributes={"optimizer_step_zeroes_gradient": False},
+                source_edges=["w"],
+                source_instructions=["o3"],
+            ),
+        ],
+    }
+
+
+def compile_training_ir() -> dict[str, Any]:
+    return {
+        "backward": compile_backward_ir(),
+        "optimizer": compile_optimizer_ir(),
+        "matrix_training": compile_matrix_training_ir(),
+    }
+
+
+def _number_array(value: Any, context: str) -> list[float]:
+    if not isinstance(value, list) or not 1 <= len(value) <= MAX_BATCH:
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: expected 1 to {MAX_BATCH} numbers"
+        )
+    return [_number(item, f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def _loss_sum(parameter: float, inputs: list[float], targets: list[float]) -> float:
+    total = 0.0
+    for index, (input_value, target) in enumerate(zip(inputs, targets, strict=True)):
+        prediction = _finite(parameter * input_value, f"audit row {index} prediction")
+        residual = _finite(prediction - target, f"audit row {index} residual")
+        total = _finite(total + 0.5 * residual * residual, "audit loss sum")
+    return total
+
+
+def execute_scenario(scenario: dict[str, Any], epsilon: float) -> dict[str, Any]:
+    parameter = scenario["initial_parameter"]
+    learning_rate = scenario["learning_rate"]
+    inputs = scenario["inputs"]
+    targets = scenario["targets"]
+    gradient_buffer_before = scenario["gradient_buffer_before"]
+    divisor = scenario["divisor"]
+
+    predictions: list[float] = []
+    residuals: list[float] = []
+    losses: list[float] = []
+    d_loss: list[float] = []
+    d_residual: list[float] = []
+    d_prediction: list[float] = []
+    local_d_w: list[float] = []
+    d_x: list[float] = []
+    batch_gradient = 0.0
+
+    for index, (input_value, target) in enumerate(zip(inputs, targets, strict=True)):
+        prediction = _finite(parameter * input_value, f"row {index} prediction")
+        residual = _finite(prediction - target, f"row {index} residual")
+        loss = _finite(0.5 * residual * residual, f"row {index} loss")
+        loss_seed = 1.0
+        residual_grad = _finite(residual * loss_seed, f"row {index} d_residual")
+        prediction_grad = residual_grad
+        parameter_grad = _finite(
+            input_value * prediction_grad, f"row {index} local_d_w"
+        )
+        input_grad = _finite(parameter * prediction_grad, f"row {index} d_x")
+        batch_gradient = _finite(
+            batch_gradient + parameter_grad, "batch gradient stable row reduction"
+        )
+        predictions.append(prediction)
+        residuals.append(residual)
+        losses.append(loss)
+        d_loss.append(loss_seed)
+        d_residual.append(residual_grad)
+        d_prediction.append(prediction_grad)
+        local_d_w.append(parameter_grad)
+        d_x.append(input_grad)
+
+    grad_w = _finite(
+        gradient_buffer_before + batch_gradient, "persistent grad_w accumulation"
+    )
+    applied_gradient = _finite(grad_w / divisor, "applied_gradient")
+    parameter_delta = _finite(-learning_rate * applied_gradient, "parameter_delta")
+    parameter_after = _finite(parameter + parameter_delta, "parameter_after")
+    numerical_gradient = _finite(
+        (
+            _loss_sum(parameter + epsilon, inputs, targets)
+            - _loss_sum(parameter - epsilon, inputs, targets)
+        )
+        / (2 * epsilon),
+        "numerical_gradient",
+    )
+    gradient_error = _finite(abs(batch_gradient - numerical_gradient), "gradient_error")
+
+    saved_values = {
+        "x": list(inputs),
+        "target": list(targets),
+        "prediction": predictions,
+        "residual": residuals,
+        "loss": losses,
+    }
+    backward = {
+        "d_loss": d_loss,
+        "d_residual": d_residual,
+        "d_prediction": d_prediction,
+        "local_d_w": local_d_w,
+        "d_x": d_x,
+        "gradient_buffer_before": gradient_buffer_before,
+        "batch_gradient": batch_gradient,
+        "grad_w": grad_w,
+    }
+    optimizer = {
+        "parameter_before": parameter,
+        "applied_gradient": applied_gradient,
+        "parameter_delta": parameter_delta,
+        "parameter_after": parameter_after,
+        "gradient_buffer_after_step": grad_w,
+    }
+    matrix_training = {
+        "columns": {
+            "x": list(inputs),
+            "residual": list(residuals),
+            "d_prediction": list(d_prediction),
+            "local_d_w": list(local_d_w),
+            "d_x": list(d_x),
+        },
+        "gradient_buffer_before": gradient_buffer_before,
+        "batch_gradient": batch_gradient,
+        "grad_w": grad_w,
+        "applied_gradient": applied_gradient,
+        "parameter_after": parameter_after,
+        "gradient_buffer_after_step": grad_w,
+    }
+    path_values = [
+        abs(backward["batch_gradient"] - matrix_training["batch_gradient"]),
+        abs(backward["grad_w"] - matrix_training["grad_w"]),
+        abs(optimizer["applied_gradient"] - matrix_training["applied_gradient"]),
+        abs(optimizer["parameter_after"] - matrix_training["parameter_after"]),
+        abs(
+            optimizer["gradient_buffer_after_step"]
+            - matrix_training["gradient_buffer_after_step"]
+        ),
+    ]
+    return {
+        "saved_values": saved_values,
+        "backward": backward,
+        "optimizer": optimizer,
+        "matrix_training": matrix_training,
+        "gradient_audit": {
+            "analytical": batch_gradient,
+            "numerical": numerical_gradient,
+            "absolute_error": gradient_error,
+        },
+        "max_path_error": max(path_values),
+    }
+
+
+def _compare(
+    actual: Any,
+    expected: Any,
+    tolerance: float,
+    context: str,
+    depth: int = 0,
+) -> None:
+    if depth > MAX_COMPARE_DEPTH:
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: comparison nesting exceeds {MAX_COMPARE_DEPTH}"
+        )
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict) or set(actual) != set(expected):
+            raise BackwardOptimizerLoweringValidationError(
+                f"{context}: object key mismatch"
+            )
+        for key, expected_value in expected.items():
+            _compare(
+                actual[key],
+                expected_value,
+                tolerance,
+                f"{context}.{key}",
+                depth + 1,
+            )
+        return
+    if isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            raise BackwardOptimizerLoweringValidationError(
+                f"{context}: list length mismatch"
+            )
+        for index, (left, right) in enumerate(zip(actual, expected, strict=True)):
+            _compare(left, right, tolerance, f"{context}[{index}]", depth + 1)
+        return
+    if isinstance(expected, bool) or expected is None or isinstance(expected, str):
+        if actual != expected or type(actual) is not type(expected):
+            raise BackwardOptimizerLoweringValidationError(
+                f"{context}: expected {expected!r}, got {actual!r}"
+            )
+        return
+    expected_number = _number(expected, context, derived=True)
+    actual_number = _number(actual, context, derived=True)
+    if not math.isclose(actual_number, expected_number, rel_tol=0.0, abs_tol=tolerance):
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: expected {expected_number:g}, got {actual_number:g}"
+        )
+
+
+def _validate_training_graph(value: Any) -> dict[str, Any]:
+    keys = {
+        "equation",
+        "loss",
+        "parameter_id",
+        "input_id",
+        "target_id",
+        "gradient_reduction",
+        "optimizer",
+        "optimizer_step_zeroes_gradient",
+    }
+    graph = _object(value, keys, "lab.training_graph")
+    canonical = {
+        "equation": "prediction = w * x",
+        "loss": "half_squared_error",
+        "parameter_id": "w",
+        "input_id": "x",
+        "target_id": "target",
+        "gradient_reduction": "stable_row_sum_then_explicit_divisor",
+        "optimizer": "sgd",
+        "optimizer_step_zeroes_gradient": False,
+    }
+    if graph != canonical:
+        raise BackwardOptimizerLoweringValidationError(
+            "lab.training_graph: expected canonical scalar training graph"
+        )
+    return dict(graph)
+
+
+def _validate_scenario(value: Any, context: str) -> dict[str, Any]:
+    scenario = _object(
+        value,
+        {
+            "id",
+            "title",
+            "initial_parameter",
+            "learning_rate",
+            "inputs",
+            "targets",
+            "gradient_buffer_before",
+            "divisor",
+            "expected",
+        },
+        context,
+    )
+    scenario_id = _identifier(scenario["id"], f"{context}.id")
+    title = _text(scenario["title"], f"{context}.title")
+    initial_parameter = _number(
+        scenario["initial_parameter"], f"{context}.initial_parameter"
+    )
+    learning_rate = _number(scenario["learning_rate"], f"{context}.learning_rate")
+    if learning_rate <= 0:
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}.learning_rate: expected positive value"
+        )
+    inputs = _number_array(scenario["inputs"], f"{context}.inputs")
+    targets = _number_array(scenario["targets"], f"{context}.targets")
+    gradient_buffer_before = _number(
+        scenario["gradient_buffer_before"], f"{context}.gradient_buffer_before"
+    )
+    if len(inputs) != len(targets):
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}: inputs and targets must have the same length"
+        )
+    divisor = scenario["divisor"]
+    if (
+        isinstance(divisor, bool)
+        or not isinstance(divisor, int)
+        or not 1 <= divisor <= len(inputs)
+    ):
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}.divisor: expected integer from 1 through batch length"
+        )
+    if not isinstance(scenario["expected"], dict):
+        raise BackwardOptimizerLoweringValidationError(
+            f"{context}.expected: expected object"
+        )
+    return {
+        "id": scenario_id,
+        "title": title,
+        "initial_parameter": initial_parameter,
+        "learning_rate": learning_rate,
+        "inputs": inputs,
+        "targets": targets,
+        "gradient_buffer_before": gradient_buffer_before,
+        "divisor": divisor,
+        "expected": scenario["expected"],
+    }
+
+
+def validate_document(value: Any) -> dict[str, Any]:
+    lab = _object(
+        value,
+        {
+            "schema_version",
+            "id",
+            "title",
+            "question",
+            "absolute_tolerance",
+            "finite_difference_epsilon",
+            "training_graph",
+            "expected_ir",
+            "scenarios",
+        },
+        "lab",
+    )
+    if lab["schema_version"] != 1 or isinstance(lab["schema_version"], bool):
+        raise BackwardOptimizerLoweringValidationError("lab.schema_version: expected 1")
+    if lab["id"] != CANONICAL_ID:
+        raise BackwardOptimizerLoweringValidationError(
+            f"lab.id: expected {CANONICAL_ID}"
+        )
+    title = _text(lab["title"], "lab.title")
+    question = _text(lab["question"], "lab.question")
+    tolerance = _number(lab["absolute_tolerance"], "lab.absolute_tolerance")
+    epsilon = _number(lab["finite_difference_epsilon"], "lab.finite_difference_epsilon")
+    if tolerance != CANONICAL_TOLERANCE:
+        raise BackwardOptimizerLoweringValidationError(
+            f"lab.absolute_tolerance: expected canonical {CANONICAL_TOLERANCE:g}"
+        )
+    if epsilon != CANONICAL_EPSILON:
+        raise BackwardOptimizerLoweringValidationError(
+            f"lab.finite_difference_epsilon: expected canonical {CANONICAL_EPSILON:g}"
+        )
+    graph = _validate_training_graph(lab["training_graph"])
+    compiled_ir = compile_training_ir()
+    _compare(compiled_ir, lab["expected_ir"], 0.0, "lab.expected_ir")
+    for stream_name, stream in compiled_ir.items():
+        if len(stream["instructions"]) > MAX_INSTRUCTIONS:
+            raise BackwardOptimizerLoweringValidationError(
+                f"{stream_name}: exceeds {MAX_INSTRUCTIONS} instructions"
+            )
+
+    raw_scenarios = lab["scenarios"]
+    if (
+        not isinstance(raw_scenarios, list)
+        or not 1 <= len(raw_scenarios) <= MAX_SCENARIOS
+    ):
+        raise BackwardOptimizerLoweringValidationError(
+            f"lab.scenarios: expected 1 to {MAX_SCENARIOS} scenarios"
+        )
+    scenarios = [
+        _validate_scenario(item, f"lab.scenarios[{index}]")
+        for index, item in enumerate(raw_scenarios)
+    ]
+    scenario_ids = [scenario["id"] for scenario in scenarios]
+    if scenario_ids != CANONICAL_SCENARIOS:
+        raise BackwardOptimizerLoweringValidationError(
+            f"lab.scenarios: ids expected {CANONICAL_SCENARIOS}, got {scenario_ids}"
+        )
+    for scenario in scenarios:
+        trace = execute_scenario(scenario, epsilon)
+        _compare(
+            trace,
+            scenario["expected"],
+            tolerance,
+            f"scenario {scenario['id']}.expected",
+        )
+        if trace["gradient_audit"]["absolute_error"] > tolerance:
+            raise BackwardOptimizerLoweringValidationError(
+                f"scenario {scenario['id']}: numerical gradient audit exceeds tolerance"
+            )
+        if trace["max_path_error"] > tolerance:
+            raise BackwardOptimizerLoweringValidationError(
+                f"scenario {scenario['id']}: execution paths diverge"
+            )
+
+    return {
+        "schema_version": 1,
+        "id": CANONICAL_ID,
+        "title": title,
+        "question": question,
+        "absolute_tolerance": tolerance,
+        "finite_difference_epsilon": epsilon,
+        "training_graph": graph,
+        "expected_ir": compiled_ir,
+        "scenarios": scenarios,
+    }
+
+
+def validate_fixture_root(root: Path = DEFAULT_FIXTURE_ROOT) -> int:
+    lab_paths = sorted((root / "labs").glob("*.json"))
+    if not lab_paths:
+        raise BackwardOptimizerLoweringValidationError(f"{root}: no lab JSON files")
+    if len(lab_paths) > 8:
+        raise BackwardOptimizerLoweringValidationError(f"{root}: too many lab files")
+    for path in lab_paths:
+        validate_document(load_json(path))
+    return len(lab_paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "fixture_root",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_FIXTURE_ROOT,
+    )
+    args = parser.parse_args()
+    count = validate_fixture_root(args.fixture_root)
+    print(f"validated {count} backward/optimizer lowering lab(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/specs/NN30-backward-optimizer-lowering-labs.md
+++ b/code/specs/NN30-backward-optimizer-lowering-labs.md
@@ -1,0 +1,95 @@
+# NN30: Backward and Optimizer Lowering Labs
+
+## Status
+
+Version 1 is implemented by the language-neutral fixture under
+[`fixtures/backward-optimizer-lowering-v1`](./fixtures/backward-optimizer-lowering-v1/README.md).
+
+## Purpose
+
+NN29 lowered a forward neural graph to scalar NeuralIR and a batched matrix
+plan. NN30 fixes the next contract: saved forward values lower to a backward
+program, parameter gradients reduce into persistent buffers, and a separate
+optimizer program consumes those buffers without clearing them.
+
+The canonical graph is one trainable multiplication followed by half-squared
+error. It is intentionally scalar so every value can be checked on paper.
+
+## Required IR
+
+The V1 corpus pins three normalized streams:
+
+- `CANB` backward IR with six instructions;
+- `CANO` optimizer IR with four instructions; and
+- `CANM-TRAIN` matrix training IR with ten operations.
+
+Identifiers, operation order, input/output names, attributes, and provenance
+arrays are exact. Unknown fields are rejected.
+
+Backward and optimizer functions remain separate. The optimizer receives an
+explicit gradient divisor and does not implicitly zero the gradient buffer.
+
+## Required Scenarios
+
+The V1 roster and order are fixed:
+
+1. `one_row_by_hand` uses `w=0.5`, `x=[2]`, `target=[0]`, and divisor `1`.
+   It produces `grad_w=2`, `d_x=[0.5]`, and `w_next=0.3`.
+2. `two_row_mean` uses `w=1`, `x=[2,-1]`, `target=[1,1]`, and divisor `2`.
+   Row gradients `[2,2]` reduce to `4`, mean to `2`, and update `w` to `0.8`.
+3. `persistent_buffer` enters with `grad_w=3`, adds the current row's
+   contribution `2`, updates with the resulting buffer `5`, and leaves that
+   buffer populated after the optimizer step.
+
+Every scenario checks direct arithmetic, normalized backward execution,
+normalized optimizer execution, and matrix training execution. A fresh central
+finite-difference audit checks only the current batch contribution at epsilon
+`1e-5`, so an older carried buffer cannot masquerade as a derivative of the
+current batch loss.
+
+## Determinism
+
+- Backward instruction order is fixed by reverse dependency order.
+- Optimizer instruction order is independent of backward execution.
+- Batch columns retain input row order.
+- Parameter-gradient reduction uses ascending row index.
+- The canonical absolute tolerance is `1e-8` and cannot be loosened.
+
+## Validation and Safety
+
+- Reject duplicate JSON keys, non-finite constants, unknown fields, malformed
+  identifiers, wrong schema IDs, and non-canonical rosters.
+- Cap instruction streams at sixteen operations and scenarios at four.
+- Cap batches at eight rows and text at 512 characters.
+- Bound teaching inputs before arithmetic and every derived value afterward.
+- Reject mismatched input/target lengths, non-positive divisors, and a divisor
+  larger than the batch.
+- Cap recursive expected-trace comparison depth.
+- Recompute every expected IR and trace; checked-in expected objects are never
+  trusted as execution inputs.
+
+## Production Forward and Training Boundary
+
+The TypeScript visualizer uses the production `neural-network` and
+`neural-graph-vm` packages to compile and execute the forward multiplication.
+V1 then normalizes the new training contract in the fixture. That contract is
+the portable target for future training compilers; it does not pretend the
+current NN00 forward-only bytecode already implements backward execution.
+
+## Cross-Language and Rust Direction
+
+Every language consumer should reproduce the normalized streams and traces
+from JSON. A future Rust bridge may translate matrix operations to MX01 tensor
+`Mul`, `Add`, and `ReduceSum` nodes, but the host must provide parameter IDs,
+saved-value ownership, reduction/divisor policy, update scheduling, and explicit
+gradient clearing.
+
+A stable C ABI should use opaque handles or caller-owned typed slices with
+explicit lengths, shapes, dtypes, and lifetimes. It must not retain raw
+host-object pointers or make optimizer/zeroing choices implicitly.
+
+## Versioning
+
+V1 is append-only. Changing instruction semantics, operation order, scenario
+roster, tolerance, reduction order, or optimizer-zeroing behavior requires a
+new fixture version.

--- a/code/specs/fixtures/backward-optimizer-lowering-v1/CHANGELOG.md
+++ b/code/specs/fixtures/backward-optimizer-lowering-v1/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 - 2026-08-02
+
+- Add the canonical scalar half-squared-error training graph.
+- Pin six backward, four optimizer, and ten matrix-training operations.
+- Add one-row, two-row mean-SGD, and nonzero-buffer traces with numerical
+  gradient audits of each current batch contribution.

--- a/code/specs/fixtures/backward-optimizer-lowering-v1/README.md
+++ b/code/specs/fixtures/backward-optimizer-lowering-v1/README.md
@@ -1,0 +1,33 @@
+# Backward and Optimizer Lowering Fixture V1
+
+This directory is the deterministic, language-neutral NN30 corpus.
+
+## Contents
+
+- [`schema.json`](./schema.json) describes the closed JSON shape.
+- [`labs/00-scalar-sgd-training.json`](./labs/00-scalar-sgd-training.json) pins
+  one-row, two-row, and nonzero-buffer saved values, backward IR, optimizer IR,
+  matrix training IR, gradients, and SGD updates.
+- [`CHANGELOG.md`](./CHANGELOG.md) records versioned changes.
+
+## Validation
+
+From the repository root:
+
+```text
+python code/scripts/validate_backward_optimizer_lowering_labs.py
+pytest code/scripts/tests/test_backward_optimizer_lowering_labs.py -q
+```
+
+The executable validator is stricter than schema-only validation. It derives
+the canonical instruction streams, executes every path, checks finite
+differences, enforces bounds and roster order, and compares the complete trace
+with the checked-in oracle.
+
+## Consumer Contract
+
+Consumers must parse this JSON strictly, preserve canonical IDs and row order,
+and reproduce the expected streams and traces. The current TypeScript app uses
+the production forward graph compiler, then implements this fixture's explicit
+training-lowering reference contract. Other languages should consume the JSON
+rather than copying constants from prose.

--- a/code/specs/fixtures/backward-optimizer-lowering-v1/labs/00-scalar-sgd-training.json
+++ b/code/specs/fixtures/backward-optimizer-lowering-v1/labs/00-scalar-sgd-training.json
@@ -1,0 +1,411 @@
+{
+  "schema_version": 1,
+  "id": "backward-optimizer-lowering",
+  "title": "Scalar backward and SGD lowering",
+  "question": "How do saved forward values become a backward schedule, a stable gradient reduction, and a separate optimizer update?",
+  "absolute_tolerance": 1e-8,
+  "finite_difference_epsilon": 1e-5,
+  "training_graph": {
+    "equation": "prediction = w * x",
+    "loss": "half_squared_error",
+    "parameter_id": "w",
+    "input_id": "x",
+    "target_id": "target",
+    "gradient_reduction": "stable_row_sum_then_explicit_divisor",
+    "optimizer": "sgd",
+    "optimizer_step_zeroes_gradient": false
+  },
+  "expected_ir": {
+    "backward": {
+      "magic": "CANB",
+      "version": 0,
+      "instructions": [
+        {
+          "id": "b0",
+          "op": "SEED_LOSS_GRAD",
+          "output": "d_loss",
+          "inputs": [],
+          "attributes": { "value": 1 },
+          "source_nodes": ["loss"],
+          "source_edges": [],
+          "source_instructions": []
+        },
+        {
+          "id": "b1",
+          "op": "HALF_SQUARED_ERROR_GRAD",
+          "output": "d_residual",
+          "inputs": ["residual", "d_loss"],
+          "attributes": {},
+          "source_nodes": ["loss", "residual"],
+          "source_edges": [],
+          "source_instructions": []
+        },
+        {
+          "id": "b2",
+          "op": "PROPAGATE_GRAD",
+          "output": "d_prediction",
+          "inputs": ["d_residual"],
+          "attributes": { "through": "subtract_prediction" },
+          "source_nodes": ["residual", "prediction"],
+          "source_edges": [],
+          "source_instructions": []
+        },
+        {
+          "id": "b3",
+          "op": "PARAMETER_LOCAL_GRAD",
+          "output": "local_d_w",
+          "inputs": ["x", "d_prediction"],
+          "attributes": { "parameter_id": "w" },
+          "source_nodes": ["prediction"],
+          "source_edges": ["w"],
+          "source_instructions": []
+        },
+        {
+          "id": "b4",
+          "op": "ACCUMULATE_GRAD",
+          "output": "grad_w",
+          "inputs": ["grad_w", "local_d_w"],
+          "attributes": { "parameter_id": "w", "order": "row_ascending" },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": []
+        },
+        {
+          "id": "b5",
+          "op": "INPUT_GRAD",
+          "output": "d_x",
+          "inputs": ["w", "d_prediction"],
+          "attributes": { "input_id": "x" },
+          "source_nodes": ["x", "prediction"],
+          "source_edges": ["w"],
+          "source_instructions": []
+        }
+      ]
+    },
+    "optimizer": {
+      "magic": "CANO",
+      "version": 0,
+      "instructions": [
+        {
+          "id": "o0",
+          "op": "READ_GRAD_BUFFER",
+          "output": "total_d_w",
+          "inputs": ["grad_w"],
+          "attributes": { "parameter_id": "w" },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": []
+        },
+        {
+          "id": "o1",
+          "op": "DIVIDE_GRAD",
+          "output": "applied_d_w",
+          "inputs": ["total_d_w"],
+          "attributes": { "divisor_source": "scenario.divisor" },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": ["o0"]
+        },
+        {
+          "id": "o2",
+          "op": "SGD_UPDATE",
+          "output": "w_next",
+          "inputs": ["w", "applied_d_w"],
+          "attributes": { "learning_rate_source": "scenario.learning_rate" },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": ["o1"]
+        },
+        {
+          "id": "o3",
+          "op": "KEEP_GRAD_BUFFER",
+          "output": "grad_w_after_step",
+          "inputs": ["grad_w"],
+          "attributes": { "optimizer_step_zeroes_gradient": false },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": ["o2"]
+        }
+      ]
+    },
+    "matrix_training": {
+      "magic": "CANM-TRAIN",
+      "version": 0,
+      "instructions": [
+        {
+          "id": "t0",
+          "op": "LOAD_SAVED_COLUMN",
+          "output": "x_col",
+          "inputs": ["x"],
+          "attributes": { "saved_value": "x" },
+          "source_nodes": ["x"],
+          "source_edges": [],
+          "source_instructions": []
+        },
+        {
+          "id": "t1",
+          "op": "LOAD_SAVED_COLUMN",
+          "output": "residual_col",
+          "inputs": ["residual"],
+          "attributes": { "saved_value": "residual" },
+          "source_nodes": ["residual"],
+          "source_edges": [],
+          "source_instructions": []
+        },
+        {
+          "id": "t2",
+          "op": "LOSS_GRAD_COLUMN",
+          "output": "d_prediction_col",
+          "inputs": ["residual_col"],
+          "attributes": { "loss": "half_squared_error" },
+          "source_nodes": ["loss", "prediction"],
+          "source_edges": [],
+          "source_instructions": ["b0", "b1", "b2"]
+        },
+        {
+          "id": "t3",
+          "op": "PARAMETER_LOCAL_GRAD_COLUMN",
+          "output": "local_d_w_col",
+          "inputs": ["x_col", "d_prediction_col"],
+          "attributes": { "parameter_id": "w" },
+          "source_nodes": ["prediction"],
+          "source_edges": ["w"],
+          "source_instructions": ["b3"]
+        },
+        {
+          "id": "t4",
+          "op": "INPUT_GRAD_COLUMN",
+          "output": "d_x_col",
+          "inputs": ["d_prediction_col"],
+          "attributes": { "input_id": "x", "parameter_id": "w" },
+          "source_nodes": ["x", "prediction"],
+          "source_edges": ["w"],
+          "source_instructions": ["b5"]
+        },
+        {
+          "id": "t5",
+          "op": "REDUCE_SUM_GRAD",
+          "output": "batch_d_w",
+          "inputs": ["local_d_w_col"],
+          "attributes": { "order": "row_ascending", "parameter_id": "w" },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": ["b4"]
+        },
+        {
+          "id": "t6",
+          "op": "ACCUMULATE_GRAD_BUFFER",
+          "output": "grad_w",
+          "inputs": ["grad_w", "batch_d_w"],
+          "attributes": { "parameter_id": "w" },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": ["b4"]
+        },
+        {
+          "id": "t7",
+          "op": "DIVIDE_GRAD",
+          "output": "applied_d_w",
+          "inputs": ["grad_w"],
+          "attributes": { "divisor_source": "scenario.divisor" },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": ["o0", "o1"]
+        },
+        {
+          "id": "t8",
+          "op": "SGD_UPDATE_SCALAR",
+          "output": "w_next",
+          "inputs": ["w", "applied_d_w"],
+          "attributes": { "learning_rate_source": "scenario.learning_rate" },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": ["o2"]
+        },
+        {
+          "id": "t9",
+          "op": "KEEP_GRAD_BUFFER",
+          "output": "grad_w_after_step",
+          "inputs": ["grad_w"],
+          "attributes": { "optimizer_step_zeroes_gradient": false },
+          "source_nodes": [],
+          "source_edges": ["w"],
+          "source_instructions": ["o3"]
+        }
+      ]
+    }
+  },
+  "scenarios": [
+    {
+      "id": "one_row_by_hand",
+      "title": "One row by hand",
+      "initial_parameter": 0.5,
+      "learning_rate": 0.1,
+      "inputs": [2],
+      "targets": [0],
+      "gradient_buffer_before": 0,
+      "divisor": 1,
+      "expected": {
+        "saved_values": {
+          "x": [2],
+          "target": [0],
+          "prediction": [1],
+          "residual": [1],
+          "loss": [0.5]
+        },
+        "backward": {
+          "d_loss": [1],
+          "d_residual": [1],
+          "d_prediction": [1],
+          "local_d_w": [2],
+          "d_x": [0.5],
+          "gradient_buffer_before": 0,
+          "batch_gradient": 2,
+          "grad_w": 2
+        },
+        "optimizer": {
+          "parameter_before": 0.5,
+          "applied_gradient": 2,
+          "parameter_delta": -0.2,
+          "parameter_after": 0.3,
+          "gradient_buffer_after_step": 2
+        },
+        "matrix_training": {
+          "columns": {
+            "x": [2],
+            "residual": [1],
+            "d_prediction": [1],
+            "local_d_w": [2],
+            "d_x": [0.5]
+          },
+          "gradient_buffer_before": 0,
+          "batch_gradient": 2,
+          "grad_w": 2,
+          "applied_gradient": 2,
+          "parameter_after": 0.3,
+          "gradient_buffer_after_step": 2
+        },
+        "gradient_audit": {
+          "analytical": 2,
+          "numerical": 2,
+          "absolute_error": 0
+        },
+        "max_path_error": 0
+      }
+    },
+    {
+      "id": "two_row_mean",
+      "title": "The same plan, two-row mean",
+      "initial_parameter": 1,
+      "learning_rate": 0.1,
+      "inputs": [2, -1],
+      "targets": [1, 1],
+      "gradient_buffer_before": 0,
+      "divisor": 2,
+      "expected": {
+        "saved_values": {
+          "x": [2, -1],
+          "target": [1, 1],
+          "prediction": [2, -1],
+          "residual": [1, -2],
+          "loss": [0.5, 2]
+        },
+        "backward": {
+          "d_loss": [1, 1],
+          "d_residual": [1, -2],
+          "d_prediction": [1, -2],
+          "local_d_w": [2, 2],
+          "d_x": [1, -2],
+          "gradient_buffer_before": 0,
+          "batch_gradient": 4,
+          "grad_w": 4
+        },
+        "optimizer": {
+          "parameter_before": 1,
+          "applied_gradient": 2,
+          "parameter_delta": -0.2,
+          "parameter_after": 0.8,
+          "gradient_buffer_after_step": 4
+        },
+        "matrix_training": {
+          "columns": {
+            "x": [2, -1],
+            "residual": [1, -2],
+            "d_prediction": [1, -2],
+            "local_d_w": [2, 2],
+            "d_x": [1, -2]
+          },
+          "gradient_buffer_before": 0,
+          "batch_gradient": 4,
+          "grad_w": 4,
+          "applied_gradient": 2,
+          "parameter_after": 0.8,
+          "gradient_buffer_after_step": 4
+        },
+        "gradient_audit": {
+          "analytical": 4,
+          "numerical": 4,
+          "absolute_error": 0
+        },
+        "max_path_error": 0
+      }
+    },
+    {
+      "id": "persistent_buffer",
+      "title": "Continue a persistent buffer",
+      "initial_parameter": 0.5,
+      "learning_rate": 0.1,
+      "inputs": [2],
+      "targets": [0],
+      "gradient_buffer_before": 3,
+      "divisor": 1,
+      "expected": {
+        "saved_values": {
+          "x": [2],
+          "target": [0],
+          "prediction": [1],
+          "residual": [1],
+          "loss": [0.5]
+        },
+        "backward": {
+          "d_loss": [1],
+          "d_residual": [1],
+          "d_prediction": [1],
+          "local_d_w": [2],
+          "d_x": [0.5],
+          "gradient_buffer_before": 3,
+          "batch_gradient": 2,
+          "grad_w": 5
+        },
+        "optimizer": {
+          "parameter_before": 0.5,
+          "applied_gradient": 5,
+          "parameter_delta": -0.5,
+          "parameter_after": 0,
+          "gradient_buffer_after_step": 5
+        },
+        "matrix_training": {
+          "columns": {
+            "x": [2],
+            "residual": [1],
+            "d_prediction": [1],
+            "local_d_w": [2],
+            "d_x": [0.5]
+          },
+          "gradient_buffer_before": 3,
+          "batch_gradient": 2,
+          "grad_w": 5,
+          "applied_gradient": 5,
+          "parameter_after": 0,
+          "gradient_buffer_after_step": 5
+        },
+        "gradient_audit": {
+          "analytical": 2,
+          "numerical": 2,
+          "absolute_error": 0
+        },
+        "max_path_error": 0
+      }
+    }
+  ]
+}

--- a/code/specs/fixtures/backward-optimizer-lowering-v1/schema.json
+++ b/code/specs/fixtures/backward-optimizer-lowering-v1/schema.json
@@ -1,0 +1,269 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/backward-optimizer-lowering-v1.schema.json",
+  "title": "Backward and optimizer lowering lab V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "question",
+    "absolute_tolerance",
+    "finite_difference_epsilon",
+    "training_graph",
+    "expected_ir",
+    "scenarios"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "id": { "const": "backward-optimizer-lowering" },
+    "title": { "$ref": "#/$defs/text" },
+    "question": { "$ref": "#/$defs/text" },
+    "absolute_tolerance": { "const": 1e-8 },
+    "finite_difference_epsilon": { "const": 1e-5 },
+    "training_graph": { "$ref": "#/$defs/trainingGraph" },
+    "expected_ir": { "$ref": "#/$defs/expectedIr" },
+    "scenarios": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 4,
+      "items": { "$ref": "#/$defs/scenario" }
+    }
+  },
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z][a-z0-9_]*$"
+    },
+    "text": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "number": { "type": "number" },
+    "numberArray": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": { "$ref": "#/$defs/number" }
+    },
+    "attributes": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/identifier" },
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "string", "maxLength": 512 },
+          { "type": "number" },
+          { "type": "boolean" },
+          {
+            "type": "array",
+            "maxItems": 16,
+            "items": {
+              "oneOf": [
+                { "type": "string", "maxLength": 64 },
+                { "type": "number" }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "instruction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "op",
+        "output",
+        "inputs",
+        "attributes",
+        "source_nodes",
+        "source_edges",
+        "source_instructions"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "op": { "type": "string", "pattern": "^[A-Z][A-Z0-9_-]*$", "maxLength": 64 },
+        "output": { "type": ["string", "null"], "maxLength": 64 },
+        "inputs": {
+          "type": "array",
+          "maxItems": 8,
+          "items": { "type": "string", "maxLength": 64 }
+        },
+        "attributes": { "$ref": "#/$defs/attributes" },
+        "source_nodes": {
+          "type": "array",
+          "maxItems": 8,
+          "items": { "type": "string", "maxLength": 64 }
+        },
+        "source_edges": {
+          "type": "array",
+          "maxItems": 8,
+          "items": { "type": "string", "maxLength": 64 }
+        },
+        "source_instructions": {
+          "type": "array",
+          "maxItems": 8,
+          "items": { "type": "string", "maxLength": 64 }
+        }
+      }
+    },
+    "irStream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["magic", "version", "instructions"],
+      "properties": {
+        "magic": { "type": "string", "maxLength": 16 },
+        "version": { "const": 0 },
+        "instructions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "items": { "$ref": "#/$defs/instruction" }
+        }
+      }
+    },
+    "expectedIr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["backward", "optimizer", "matrix_training"],
+      "properties": {
+        "backward": { "$ref": "#/$defs/irStream" },
+        "optimizer": { "$ref": "#/$defs/irStream" },
+        "matrix_training": { "$ref": "#/$defs/irStream" }
+      }
+    },
+    "trainingGraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "equation",
+        "loss",
+        "parameter_id",
+        "input_id",
+        "target_id",
+        "gradient_reduction",
+        "optimizer",
+        "optimizer_step_zeroes_gradient"
+      ],
+      "properties": {
+        "equation": { "const": "prediction = w * x" },
+        "loss": { "const": "half_squared_error" },
+        "parameter_id": { "const": "w" },
+        "input_id": { "const": "x" },
+        "target_id": { "const": "target" },
+        "gradient_reduction": { "const": "stable_row_sum_then_explicit_divisor" },
+        "optimizer": { "const": "sgd" },
+        "optimizer_step_zeroes_gradient": { "const": false }
+      }
+    },
+    "savedValues": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "target", "prediction", "residual", "loss"],
+      "properties": {
+        "x": { "$ref": "#/$defs/numberArray" },
+        "target": { "$ref": "#/$defs/numberArray" },
+        "prediction": { "$ref": "#/$defs/numberArray" },
+        "residual": { "$ref": "#/$defs/numberArray" },
+        "loss": { "$ref": "#/$defs/numberArray" }
+      }
+    },
+    "backwardTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["d_loss", "d_residual", "d_prediction", "local_d_w", "d_x", "gradient_buffer_before", "batch_gradient", "grad_w"],
+      "properties": {
+        "d_loss": { "$ref": "#/$defs/numberArray" },
+        "d_residual": { "$ref": "#/$defs/numberArray" },
+        "d_prediction": { "$ref": "#/$defs/numberArray" },
+        "local_d_w": { "$ref": "#/$defs/numberArray" },
+        "d_x": { "$ref": "#/$defs/numberArray" },
+        "gradient_buffer_before": { "$ref": "#/$defs/number" },
+        "batch_gradient": { "$ref": "#/$defs/number" },
+        "grad_w": { "$ref": "#/$defs/number" }
+      }
+    },
+    "optimizerTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "parameter_before",
+        "applied_gradient",
+        "parameter_delta",
+        "parameter_after",
+        "gradient_buffer_after_step"
+      ],
+      "properties": {
+        "parameter_before": { "$ref": "#/$defs/number" },
+        "applied_gradient": { "$ref": "#/$defs/number" },
+        "parameter_delta": { "$ref": "#/$defs/number" },
+        "parameter_after": { "$ref": "#/$defs/number" },
+        "gradient_buffer_after_step": { "$ref": "#/$defs/number" }
+      }
+    },
+    "matrixTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["columns", "gradient_buffer_before", "batch_gradient", "grad_w", "applied_gradient", "parameter_after", "gradient_buffer_after_step"],
+      "properties": {
+        "columns": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["x", "residual", "d_prediction", "local_d_w", "d_x"],
+          "properties": {
+            "x": { "$ref": "#/$defs/numberArray" },
+            "residual": { "$ref": "#/$defs/numberArray" },
+            "d_prediction": { "$ref": "#/$defs/numberArray" },
+            "local_d_w": { "$ref": "#/$defs/numberArray" },
+            "d_x": { "$ref": "#/$defs/numberArray" }
+          }
+        },
+        "gradient_buffer_before": { "$ref": "#/$defs/number" },
+        "batch_gradient": { "$ref": "#/$defs/number" },
+        "grad_w": { "$ref": "#/$defs/number" },
+        "applied_gradient": { "$ref": "#/$defs/number" },
+        "parameter_after": { "$ref": "#/$defs/number" },
+        "gradient_buffer_after_step": { "$ref": "#/$defs/number" }
+      }
+    },
+    "gradientAudit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["analytical", "numerical", "absolute_error"],
+      "properties": {
+        "analytical": { "$ref": "#/$defs/number" },
+        "numerical": { "$ref": "#/$defs/number" },
+        "absolute_error": { "$ref": "#/$defs/number" }
+      }
+    },
+    "expectedTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["saved_values", "backward", "optimizer", "matrix_training", "gradient_audit", "max_path_error"],
+      "properties": {
+        "saved_values": { "$ref": "#/$defs/savedValues" },
+        "backward": { "$ref": "#/$defs/backwardTrace" },
+        "optimizer": { "$ref": "#/$defs/optimizerTrace" },
+        "matrix_training": { "$ref": "#/$defs/matrixTrace" },
+        "gradient_audit": { "$ref": "#/$defs/gradientAudit" },
+        "max_path_error": { "$ref": "#/$defs/number" }
+      }
+    },
+    "scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "initial_parameter", "learning_rate", "inputs", "targets", "gradient_buffer_before", "divisor", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "title": { "$ref": "#/$defs/text" },
+        "initial_parameter": { "$ref": "#/$defs/number" },
+        "learning_rate": { "$ref": "#/$defs/number" },
+        "inputs": { "$ref": "#/$defs/numberArray" },
+        "targets": { "$ref": "#/$defs/numberArray" },
+        "gradient_buffer_before": { "$ref": "#/$defs/number" },
+        "divisor": { "type": "integer", "minimum": 1, "maximum": 8 },
+        "expected": { "$ref": "#/$defs/expectedTrace" }
+      }
+    }
+  }
+}

--- a/lessons.md
+++ b/lessons.md
@@ -48,6 +48,13 @@ A condensed quick-reference of mistakes made during development, grouped by cate
 - **Python downstream tests should not assert exact dependency versions.** Assert minimum-compatible (`__version__ >= "0.3.0"`) or capability — exact-version asserts fail when a foundational package bumps and downstream gets force-rebuilt.
 - **TypeScript `package.json` must use `"main": "src/index.ts"`** (not `dist/index.js`) because Vitest resolves `file:` deps via `main` and we don't pre-compile. Also: `"type": "module"`, `@vitest/coverage-v8` in devDeps, run real coverage gate locally before pushing. Never commit `.js`/`.d.ts` transpile outputs alongside `.ts` sources.
 - **Vite-based TS programs with `file:` deps must NOT use `tsc -b` in build script.** `tsc -b` follows imports into nested `node_modules` (npm copies, not symlinks on Windows) and fails on un-installed transitives. Use plain `vite build`; type-check via vitest.
+- **Do not label a forward-only runtime as a training compiler.** Use the real
+  runtime for saved forward evidence, then name a new language-neutral
+  backward/optimizer contract explicitly. Keep backward, gradient reduction,
+  optimizer update, and zeroing as separate observable operations until the
+  production runtime implements those contracts. Prove persistence with a
+  nonzero incoming gradient buffer: reduce the current batch separately, add it
+  to the prior buffer, and finite-difference only the current batch loss.
 - **Haskell `cabal.project` must list every transitive local package.** Cabal does not discover sibling deps from a sibling's own `cabal.project`. Single-package validation: plain `cabal test` (NOT `cabal test all`, which builds the whole universe).
 - **Haskell record accessors share the module's top-level namespace.** A field such as `requestBodyKind` creates a function with that exact name, so a private helper with the same spelling fails with `Multiple declarations`. Name decision helpers distinctly (`determineRequestBodyKind`) before compiling.
 - **HTTP/1 parity must preserve fail-closed wire grammar, not legacy parser permissiveness.** Reject TE+CL ambiguity, conflicting duplicate lengths, non-final request chunking, whitespace before a field colon, variable start-line delimiters, and unbounded heads; response framing must receive HEAD/CONNECT request context, and parse errors must not retain raw targets or field values.


### PR DESCRIPTION
## What changed
- add a hand-calculable NN30 lesson for saved values, backward IR, optimizer IR, and matrix-training lowering
- add a strict language-neutral fixture, schema, executable validator, and adversarial numerical tests
- add the interactive Train Lowering workbench with production NeuralIR/MatrixIR forward evidence, selectable reverse/update traces, and responsive parity tables
- model persistent gradient buffers explicitly: reduce the current batch, accumulate into the incoming buffer, keep the buffer after SGD, and audit only the current batch with finite differences
- document the Rust-core boundary and mark the roadmap tranche complete

## Why
Training should be inspectable as explicit programs rather than hidden framework behavior. Separating backward, reduction, persistent buffer state, divisor policy, optimizer update, and zeroing gives every language the same deterministic contract while Rust can later accelerate the tensor primitives.

## Validation
- fixture validator: 1 lab validated
- Python: 13 passed; Ruff format/check passed
- TypeScript: 158 passed; production Vite build passed
- focused strict TypeScript compile: no NN30 diagnostics (unrelated repository baseline diagnostics remain)
- desktop and mobile browser QA at 1280x720 and 390x844
- changed-Markdown link validation and git diff --check
- independent security/correctness review, including a fix and re-review of persistent-buffer semantics