### PR TITLE
fix(spice): validate MOS gate source overlap capacitance

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `CGSO` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `CBD` / `CJD` values
   before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `CBS` / `CJS` values

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1937,6 +1937,15 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(gate_source_overlap_capacitance) = params.get("CGSO") {
+            if !gate_source_overlap_capacitance.is_finite()
+                || *gate_source_overlap_capacitance < 0.0
+            {
+                return Err(NetlistParseError::new(
+                    "MOSFET CGSO must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1988,6 +1988,35 @@ fn preserves_non_negative_mosfet_model_drain_bulk_capacitance_aliases() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_gate_source_overlap_capacitance() {
+    for capacitance in ["-6p", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model overlap NMOS(CGSO={capacitance})\nM1 d g s b overlap"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET CGSO must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_gate_source_overlap_capacitance() {
+    for (capacitance, expected) in [("0", 0.0), ("6p", 6.0e-12)] {
+        let parsed = parse_netlist(&format!(
+            ".model overlap NMOS(CGSO={capacitance})\nM1 d g s b overlap"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.gate_source_overlap_capacitance, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card drain-bulk-capacitance validation.
+1. Rust Berkeley SPICE MOS model-card gate-source-overlap-capacitance validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `CBD` / `CJD` values before
+   - Reject negative and non-finite model-card `CGSO` values before
      lowering MOS elements into engine parameters.
-   - Preserve zero and positive drain-bulk capacitances across both aliases.
+   - Preserve zero and positive gate-source overlap capacitances.
 
 ## Completed Slices
 
@@ -4008,6 +4008,13 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `CBS` / `CJS` values are rejected before
      lowering MOS elements into engine parameters.
    - Zero and positive source-bulk capacitances remain accepted across both
+     aliases.
+
+349. Rust Berkeley SPICE MOS model-card drain-bulk-capacitance validation.
+   - Status: completed in PR 9508.
+   - Negative and non-finite model-card `CBD` / `CJD` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive drain-bulk capacitances remain accepted across both
      aliases.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `CGSO` values in the Rust Berkeley parser facade
- preserve zero and positive gate-source overlap capacitances, including engineering suffixes
- reconcile the SPICE implementation plan after drain-bulk validation merged

## Tests
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
Rust-only parser-facade validation. The shared Rust, Python, and TypeScript engine behavior and diagnostic are already aligned.