### PR TITLE
fix(adj): make provenance registration transactional

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/arithmetic_provenance_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/arithmetic_provenance_e2e.rs
@@ -1,6 +1,7 @@
 //! End-to-end CAS projection and verification for the arithmetic stdlib root.
 
 use std::collections::BTreeSet;
+use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -29,7 +30,20 @@ fn read_cas_object(root: &Path, digest: &str) -> Vec<u8> {
     bytes
 }
 
+fn lock_cas(root: &Path) -> File {
+    let lock_path = root.join("code/specs/data/adj-stdlib-provenance/cas/lock");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .unwrap_or_else(|error| panic!("open CAS lock {}: {error}", lock_path.display()));
+    file.lock()
+        .unwrap_or_else(|error| panic!("acquire CAS lock {}: {error}", lock_path.display()));
+    file
+}
+
 fn project_manifest_snapshots(root: &Path, snapshots: &Path) -> usize {
+    let _cas_lock = lock_cas(root);
     std::fs::create_dir_all(snapshots).expect("create snapshot directory");
     let manifest_path = root.join("code/specs/data/adj-stdlib-provenance/manifest.json");
     let manifest: serde_json::Value =
@@ -57,6 +71,22 @@ fn project_manifest_snapshots(root: &Path, snapshots: &Path) -> usize {
             .expect("project CAS snapshot");
     }
     snapshot_hashes.len()
+}
+
+#[test]
+fn rust_reader_uses_the_repository_cas_lock() {
+    let root = repo_root();
+    let _guard = lock_cas(&root);
+    let lock_path = root.join("code/specs/data/adj-stdlib-provenance/cas/lock");
+    let contender = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .expect("open competing CAS lock handle");
+    let error = contender
+        .try_lock()
+        .expect_err("a second reader must not bypass the CAS lock");
+    assert!(matches!(error, std::fs::TryLockError::WouldBlock));
 }
 
 #[test]

--- a/code/scripts/adj_stdlib_manifest.py
+++ b/code/scripts/adj_stdlib_manifest.py
@@ -71,26 +71,29 @@ def load_provenance_bundles(
     manifest_path = root / adj_stdlib_provenance.DEFAULT_MANIFEST
     schema_path = root / adj_stdlib_provenance.DEFAULT_SCHEMA
     try:
-        adj_stdlib_provenance.validate_repository(
-            cas_root, manifest_path, schema_path, workspace_root=root
-        )
-        manifest = _load_json(manifest_path)
-        cas = adj_stdlib_provenance.Cas(cas_root)
-        cas.load()
-        bundles = {
-            digest: adj_stdlib_provenance._json_object(cas, digest, "provenance_bundle")
-            for digest in manifest["bundle_hashes"]
-        }
-        for digest, bundle in bundles.items():
-            library_path = root / bundle["library"]
-            library_bytes = adj_stdlib_provenance._read_regular_file(library_path)
-            if (
-                adj_stdlib_provenance.sha256_bytes(library_bytes)
-                != bundle["input"]["raw_source_sha256"]
-            ):
-                raise adj_stdlib_provenance.ProvenanceError(
-                    f"bundle {digest} input bytes disagree with {bundle['library']}"
+        with adj_stdlib_provenance.CasRootLock(cas_root):
+            adj_stdlib_provenance._validate_repository_unlocked(
+                cas_root, manifest_path, schema_path, workspace_root=root
+            )
+            manifest = _load_json(manifest_path)
+            cas = adj_stdlib_provenance.Cas(cas_root)
+            cas.load()
+            bundles = {
+                digest: adj_stdlib_provenance._json_object(
+                    cas, digest, "provenance_bundle"
                 )
+                for digest in manifest["bundle_hashes"]
+            }
+            for digest, bundle in bundles.items():
+                library_path = root / bundle["library"]
+                library_bytes = adj_stdlib_provenance._read_regular_file(library_path)
+                if (
+                    adj_stdlib_provenance.sha256_bytes(library_bytes)
+                    != bundle["input"]["raw_source_sha256"]
+                ):
+                    raise adj_stdlib_provenance.ProvenanceError(
+                        f"bundle {digest} input bytes disagree with {bundle['library']}"
+                    )
     except (
         OSError,
         UnicodeDecodeError,

--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -578,6 +578,288 @@ def _json_object(cas: Cas, digest: str, expected_kind: str) -> dict[str, Any]:
     return value
 
 
+def _registered_manifest(
+    cas: Cas,
+    manifest_bytes: bytes,
+    registrations: dict[str, str],
+    expected_manifest_id: str,
+) -> tuple[dict[str, Any], list[str]]:
+    if not isinstance(registrations, dict) or not registrations:
+        raise ProvenanceError("bundle registrations must be a non-empty object")
+    try:
+        manifest = json.loads(manifest_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ProvenanceError("provenance manifest must be UTF-8 JSON") from error
+    if not isinstance(manifest, dict) or set(manifest) != {
+        "algorithm",
+        "bundle_hashes",
+        "manifest_id",
+        "schema_version",
+    }:
+        raise ProvenanceError("provenance manifest has unknown or missing fields")
+    if manifest_bytes != canonical_json_bytes(manifest):
+        raise ProvenanceError("provenance manifest is not canonical JSON")
+    if (
+        not _is_integer(manifest["schema_version"])
+        or manifest["schema_version"] != 1
+        or manifest["algorithm"] != "sha256"
+    ):
+        raise ProvenanceError("provenance manifest uses an unsupported contract")
+    manifest_id = _require_nonempty(manifest["manifest_id"], "manifest_id")
+    if manifest_id != _require_nonempty(expected_manifest_id, "expected_manifest_id"):
+        raise ProvenanceError(
+            f"provenance manifest_id {manifest_id} does not match {expected_manifest_id}"
+        )
+    roots = manifest["bundle_hashes"]
+    if not isinstance(roots, list):
+        raise ProvenanceError("bundle_hashes must be sorted and unique")
+    normalized_roots = [
+        _require_hash(value, f"bundle_hashes[{index}]")
+        for index, value in enumerate(roots)
+    ]
+    if normalized_roots != sorted(set(normalized_roots)):
+        raise ProvenanceError("bundle_hashes must be sorted and unique")
+
+    by_id: dict[str, str] = {}
+    for digest in normalized_roots:
+        bundle = _json_object(cas, digest, "provenance_bundle")
+        bundle_id = _require_nonempty(bundle.get("bundle_id"), "bundle.bundle_id")
+        previous = by_id.get(bundle_id)
+        if previous is not None and previous != digest:
+            raise ProvenanceError(
+                f"manifest registers bundle_id {bundle_id} more than once"
+            )
+        by_id[bundle_id] = digest
+
+    for expected_id, digest_value in registrations.items():
+        bundle_id = _require_nonempty(expected_id, "registration bundle_id")
+        digest = _require_hash(digest_value, f"registration {bundle_id}")
+        bundle = _json_object(cas, digest, "provenance_bundle")
+        actual_id = _require_nonempty(bundle.get("bundle_id"), "bundle.bundle_id")
+        if actual_id != bundle_id:
+            raise ProvenanceError(
+                f"registration {bundle_id} points to bundle_id {actual_id}"
+            )
+        previous = by_id.get(bundle_id)
+        if previous is not None and previous != digest:
+            raise ProvenanceError(
+                f"refusing to replace registered bundle_id {bundle_id}; "
+                "use an explicit root-replacement migration"
+            )
+        by_id[bundle_id] = digest
+
+    registered = sorted(by_id.values())
+    manifest["bundle_hashes"] = registered
+    return manifest, registered
+
+
+class CasRootLock:
+    """Cross-platform OS lock released automatically when the process exits."""
+
+    def __init__(self, cas_root: Path, *, blocking: bool = True) -> None:
+        self.path = cas_root.resolve() / "lock"
+        self.blocking = blocking
+        self.descriptor: int | None = None
+
+    def __enter__(self):
+        _ensure_real_directory(self.path.parent)
+        _reject_link_components(self.path, allow_missing_leaf=True)
+        flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_BINARY", 0)
+        descriptor = os.open(self.path, flags, 0o600)
+        try:
+            if os.fstat(descriptor).st_size == 0:
+                if os.write(descriptor, b"\0") != 1:
+                    raise ProvenanceError("CAS lock initialization was incomplete")
+                os.fsync(descriptor)
+            os.lseek(descriptor, 0, os.SEEK_SET)
+        except Exception:
+            os.close(descriptor)
+            raise
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                mode = msvcrt.LK_LOCK if self.blocking else msvcrt.LK_NBLCK
+                msvcrt.locking(descriptor, mode, 1)
+            else:
+                import fcntl
+
+                mode = fcntl.LOCK_EX
+                if not self.blocking:
+                    mode |= fcntl.LOCK_NB
+                fcntl.flock(descriptor, mode)
+        except (BlockingIOError, OSError) as error:
+            os.close(descriptor)
+            raise ProvenanceError(
+                f"another provenance operation holds the CAS lock for {self.path}"
+            ) from error
+        self.descriptor = descriptor
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+        descriptor = self.descriptor
+        self.descriptor = None
+        if descriptor is None:
+            return False
+        try:
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+        return False
+
+
+class CasMutationTransaction:
+    """Serialize one CAS mutation and remove newly materialized bytes on failure."""
+
+    def __init__(self, cas_root: Path, *, blocking: bool = True) -> None:
+        self.cas = Cas(cas_root)
+        self._lock = CasRootLock(cas_root, blocking=blocking)
+        self._baseline_index: bytes | None = None
+        self._baseline_objects: set[Path] = set()
+        self._entered = False
+        self._committed = False
+
+    def __enter__(self):
+        self._lock.__enter__()
+        try:
+            self.cas.load()
+            if self.cas.index_path.exists():
+                _validate_index(self.cas)
+                self._baseline_index = _read_regular_file(self.cas.index_path)
+            elif self.cas.index:
+                raise ProvenanceError("CAS index loaded without an index file")
+            self._baseline_objects = {
+                path.resolve() for path in self.cas.objects.rglob("*") if path.is_file()
+            }
+            self._entered = True
+            return self
+        except Exception:
+            self._lock.__exit__(None, None, None)
+            raise
+
+    def commit(self) -> None:
+        if not self._entered or self._committed:
+            raise ProvenanceError("CAS mutation transaction is not open")
+        self.cas.write_index()
+        self._committed = True
+
+    def _rollback(self) -> None:
+        if not self._entered:
+            return
+        if self._baseline_index is None:
+            if self.cas.index_path.exists():
+                _reject_link_components(self.cas.index_path)
+                self.cas.index_path.unlink()
+        else:
+            _write_atomic(self.cas.index_path, self._baseline_index)
+        if self.cas.objects.exists():
+            for path in sorted(self.cas.objects.rglob("*"), reverse=True):
+                if not path.is_file() or path.resolve() in self._baseline_objects:
+                    continue
+                data = _read_regular_file(path)
+                relative = path.relative_to(self.cas.objects)
+                if len(relative.parts) != 2:
+                    raise ProvenanceError(
+                        f"refusing rollback of non-canonical CAS path {path}"
+                    )
+                digest = relative.parts[0] + relative.parts[1]
+                if sha256_bytes(data) != digest:
+                    raise ProvenanceError(
+                        f"refusing rollback of mismatched CAS object {path}"
+                    )
+                path.unlink()
+                try:
+                    path.parent.rmdir()
+                except OSError:
+                    pass
+        self.cas.load()
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+        try:
+            if exc_type is not None or not self._committed:
+                self._rollback()
+            if exc_type is None and not self._committed:
+                raise ProvenanceError("CAS mutation transaction exited without commit")
+        finally:
+            self._lock.__exit__(exc_type, exc, traceback)
+            self._entered = False
+        return False
+
+
+class BundleRegistrationTransaction(CasMutationTransaction):
+    """Validate and publish a generator's CAS index and manifest root update."""
+
+    def __init__(
+        self,
+        cas_root: Path,
+        manifest_path: Path,
+        *,
+        expected_manifest_id: str,
+        schema_path: Path | None = None,
+        workspace_root: Path | None = None,
+    ) -> None:
+        super().__init__(cas_root, blocking=False)
+        self.manifest_path = manifest_path
+        self.expected_manifest_id = expected_manifest_id
+        self.schema_path = schema_path
+        self.workspace_root = workspace_root
+        self._baseline_manifest = b""
+
+    def __enter__(self):
+        try:
+            super().__enter__()
+            _validate_repository_unlocked(
+                self.cas.root,
+                self.manifest_path,
+                self.schema_path,
+                workspace_root=self.workspace_root,
+            )
+            self._baseline_manifest = _read_regular_file(self.manifest_path)
+            return self
+        except Exception:
+            super().__exit__(Exception, None, None)
+            raise
+
+    def commit(self, registrations: dict[str, str]) -> list[str]:
+        if not self._entered or self._committed:
+            raise ProvenanceError("registration transaction is not open")
+        manifest, registered = _registered_manifest(
+            self.cas,
+            self._baseline_manifest,
+            registrations,
+            self.expected_manifest_id,
+        )
+        try:
+            self.cas.write_index()
+            _write_atomic(self.manifest_path, canonical_json_bytes(manifest))
+            _validate_repository_unlocked(
+                self.cas.root,
+                self.manifest_path,
+                self.schema_path,
+                workspace_root=self.workspace_root,
+            )
+        except Exception:
+            self._rollback()
+            raise
+        self._committed = True
+        return registered
+
+    def _rollback(self) -> None:
+        if not self._entered:
+            return
+        if self._baseline_manifest:
+            _write_atomic(self.manifest_path, self._baseline_manifest)
+        super()._rollback()
+
+
 def _validate_index(cas: Cas) -> None:
     if not cas.index_path.exists():
         raise ProvenanceError("missing CAS index")
@@ -1163,7 +1445,7 @@ def _validate_bundle(
     validated.add(digest)
 
 
-def validate_repository(
+def _validate_repository_unlocked(
     cas_root: Path,
     manifest_path: Path,
     schema_path: Path | None = None,
@@ -1174,7 +1456,11 @@ def validate_repository(
     _validate_index(cas)
     manifest_bytes = _read_regular_file(manifest_path)
     manifest = json.loads(manifest_bytes.decode("utf-8"))
-    if not isinstance(manifest, dict) or manifest.get("schema_version") != 1:
+    if (
+        not isinstance(manifest, dict)
+        or not _is_integer(manifest.get("schema_version"))
+        or manifest.get("schema_version") != 1
+    ):
         raise ProvenanceError("provenance manifest schema_version must equal 1")
     if manifest_bytes != canonical_json_bytes(manifest):
         raise ProvenanceError("provenance manifest is not canonical JSON")
@@ -1187,13 +1473,19 @@ def validate_repository(
     if manifest["algorithm"] != "sha256":
         raise ProvenanceError("provenance manifest algorithm must equal sha256")
     bundles = manifest["bundle_hashes"]
-    if not isinstance(bundles, list) or bundles != sorted(set(bundles)):
+    if not isinstance(bundles, list):
+        raise ProvenanceError("bundle_hashes must be sorted and unique")
+    normalized_bundles = [
+        _require_hash(value, f"bundle_hashes[{index}]")
+        for index, value in enumerate(bundles)
+    ]
+    if normalized_bundles != sorted(set(normalized_bundles)):
         raise ProvenanceError("bundle_hashes must be sorted and unique")
     snapshots: set[str] = set()
     validated: set[str] = set()
     bundle_claims: dict[str, set[str]] = {}
     bundle_inputs: dict[str, str] = {}
-    for bundle in bundles:
+    for bundle in normalized_bundles:
         _validate_bundle(
             cas,
             _require_hash(bundle, "bundle hash"),
@@ -1212,7 +1504,7 @@ def validate_repository(
             raise ProvenanceError(
                 f"workspace input bytes disagree with bundle for {repo_path}"
             )
-    reachable = _reachable(cas, bundles)
+    reachable = _reachable(cas, normalized_bundles)
     unreferenced = sorted(set(cas.index) - reachable)
     if unreferenced:
         raise ProvenanceError(f"unreferenced CAS objects: {', '.join(unreferenced)}")
@@ -1225,6 +1517,21 @@ def validate_repository(
     }
 
 
+def validate_repository(
+    cas_root: Path,
+    manifest_path: Path,
+    schema_path: Path | None = None,
+    workspace_root: Path | None = None,
+) -> dict[str, Any]:
+    with CasRootLock(cas_root):
+        return _validate_repository_unlocked(
+            cas_root,
+            manifest_path,
+            schema_path,
+            workspace_root=workspace_root,
+        )
+
+
 def project_snapshots(
     cas_root: Path,
     manifest_path: Path,
@@ -1232,29 +1539,30 @@ def project_snapshots(
     schema_path: Path | None = None,
     workspace_root: Path | None = None,
 ) -> dict[str, Any]:
-    result = validate_repository(
-        cas_root, manifest_path, schema_path, workspace_root=workspace_root
-    )
-    cas = Cas(cas_root)
-    cas.load()
-    _ensure_real_directory(output)
-    for child in output.iterdir():
-        if child.name not in result["snapshot_hashes"]:
-            raise ProvenanceError(
-                f"projection directory contains unexpected entry: {child.name}"
-            )
-    for digest in result["snapshot_hashes"]:
-        destination = output / digest
-        source = cas.object_path(digest)
-        source_bytes = _read_regular_file(source)
-        _write_exclusive(destination, source_bytes)
-        if sha256_bytes(_read_regular_file(destination)) != digest:
-            raise ProvenanceError(f"projection does not rehash to {digest}")
-    return {
-        **result,
-        "output": str(output),
-        "projected": len(result["snapshot_hashes"]),
-    }
+    with CasRootLock(cas_root):
+        result = _validate_repository_unlocked(
+            cas_root, manifest_path, schema_path, workspace_root=workspace_root
+        )
+        cas = Cas(cas_root)
+        cas.load()
+        _ensure_real_directory(output)
+        for child in output.iterdir():
+            if child.name not in result["snapshot_hashes"]:
+                raise ProvenanceError(
+                    f"projection directory contains unexpected entry: {child.name}"
+                )
+        for digest in result["snapshot_hashes"]:
+            destination = output / digest
+            source = cas.object_path(digest)
+            source_bytes = _read_regular_file(source)
+            _write_exclusive(destination, source_bytes)
+            if sha256_bytes(_read_regular_file(destination)) != digest:
+                raise ProvenanceError(f"projection does not rehash to {digest}")
+        return {
+            **result,
+            "output": str(output),
+            "projected": len(result["snapshot_hashes"]),
+        }
 
 
 def _load_headers(path: Path | None) -> dict[str, str]:
@@ -1376,144 +1684,150 @@ def main() -> int:
                 workspace_root=repo_root,
             )
         elif args.command == "capture":
-            cas = Cas(_resolve(repo_root, args.cas))
-            cas.load()
-            body = _read_regular_file(_resolve(repo_root, args.body))
-            raw_hash = cas.put(body, kind="raw_source", label=args.label)
-            receipt = build_fetch_receipt(
-                locator=args.locator,
-                final_locator=args.final_locator or args.locator,
-                retrieved_at=args.retrieved_at,
-                status=args.status,
-                media_type=args.media_type,
-                body_sha256=raw_hash,
-                body_size=len(body),
-                headers=_load_headers(
-                    _resolve(repo_root, args.headers)
-                    if args.headers is not None
-                    else None
-                ),
-            )
-            receipt_hash = cas.put_json(
-                receipt,
-                kind="fetch_receipt",
-                label=f"fetch receipt: {args.label}",
-                links=[raw_hash],
-            )
-            cas.write_index()
+            with CasMutationTransaction(_resolve(repo_root, args.cas)) as transaction:
+                cas = transaction.cas
+                body = _read_regular_file(_resolve(repo_root, args.body))
+                raw_hash = cas.put(body, kind="raw_source", label=args.label)
+                receipt = build_fetch_receipt(
+                    locator=args.locator,
+                    final_locator=args.final_locator or args.locator,
+                    retrieved_at=args.retrieved_at,
+                    status=args.status,
+                    media_type=args.media_type,
+                    body_sha256=raw_hash,
+                    body_size=len(body),
+                    headers=_load_headers(
+                        _resolve(repo_root, args.headers)
+                        if args.headers is not None
+                        else None
+                    ),
+                )
+                receipt_hash = cas.put_json(
+                    receipt,
+                    kind="fetch_receipt",
+                    label=f"fetch receipt: {args.label}",
+                    links=[raw_hash],
+                )
+                transaction.commit()
             result = {"raw_source_sha256": raw_hash, "receipt_sha256": receipt_hash}
         elif args.command == "capture-input":
-            cas = Cas(_resolve(repo_root, args.cas))
-            cas.load()
-            repo_path = _require_repo_path(args.repo_path, "receipt.repo_path")
-            body_path = _resolve(repo_root, args.body)
-            expected_path = repo_root / PurePosixPath(repo_path)
-            if os.path.abspath(body_path) != os.path.abspath(expected_path):
-                raise ProvenanceError(
-                    "capture-input body must be the file named by --repo-path"
+            with CasMutationTransaction(_resolve(repo_root, args.cas)) as transaction:
+                cas = transaction.cas
+                repo_path = _require_repo_path(args.repo_path, "receipt.repo_path")
+                body_path = _resolve(repo_root, args.body)
+                expected_path = repo_root / PurePosixPath(repo_path)
+                if os.path.abspath(body_path) != os.path.abspath(expected_path):
+                    raise ProvenanceError(
+                        "capture-input body must be the file named by --repo-path"
+                    )
+                body = _read_regular_file(body_path)
+                raw_hash = cas.put(body, kind="raw_source", label=args.label)
+                receipt = build_input_receipt(
+                    repo_path=repo_path,
+                    captured_at=args.captured_at,
+                    body_sha256=raw_hash,
+                    body_size=len(body),
+                    body_git_sha1=git_blob_sha1(body),
                 )
-            body = _read_regular_file(body_path)
-            raw_hash = cas.put(body, kind="raw_source", label=args.label)
-            receipt = build_input_receipt(
-                repo_path=repo_path,
-                captured_at=args.captured_at,
-                body_sha256=raw_hash,
-                body_size=len(body),
-                body_git_sha1=git_blob_sha1(body),
-            )
-            receipt_hash = cas.put_json(
-                receipt,
-                kind="input_receipt",
-                label=f"input receipt: {args.label}",
-                links=[raw_hash],
-            )
-            cas.write_index()
+                receipt_hash = cas.put_json(
+                    receipt,
+                    kind="input_receipt",
+                    label=f"input receipt: {args.label}",
+                    links=[raw_hash],
+                )
+                transaction.commit()
             result = {"raw_source_sha256": raw_hash, "receipt_sha256": receipt_hash}
         elif args.command == "put-rendered":
-            cas = Cas(_resolve(repo_root, args.cas))
-            cas.load()
-            source_hash = _require_hash(args.source, "source hash")
-            if "raw_source" not in cas.index.get(source_hash, {}).get("kinds", []):
-                raise ProvenanceError("source hash is not a raw_source CAS object")
-            rendered = _read_regular_file(_resolve(repo_root, args.body))
-            rendered_hash = cas.put(
-                rendered,
-                kind="rendered_text",
-                label=args.label,
-                links=[source_hash],
-            )
-            cas.write_index()
+            with CasMutationTransaction(_resolve(repo_root, args.cas)) as transaction:
+                cas = transaction.cas
+                source_hash = _require_hash(args.source, "source hash")
+                if "raw_source" not in cas.index.get(source_hash, {}).get("kinds", []):
+                    raise ProvenanceError("source hash is not a raw_source CAS object")
+                rendered = _read_regular_file(_resolve(repo_root, args.body))
+                rendered_hash = cas.put(
+                    rendered,
+                    kind="rendered_text",
+                    label=args.label,
+                    links=[source_hash],
+                )
+                transaction.commit()
             result = {"rendered_text_sha256": rendered_hash}
         elif args.command == "put-ir":
-            cas = Cas(_resolve(repo_root, args.cas))
-            cas.load()
-            source_hash = _require_hash(args.source, "source hash")
-            if not {
-                "raw_source",
-                "rendered_text",
-            }.intersection(cas.index.get(source_hash, {}).get("kinds", [])):
-                raise ProvenanceError("source hash is not source bytes in the CAS")
-            segments = json.loads(
-                _read_regular_file(_resolve(repo_root, args.segments)).decode("utf-8")
-            )
-            source_bytes = _read_regular_file(cas.object_path(source_hash))
-            ir = build_source_ir(
-                source_sha256=source_hash,
-                source=source_bytes,
-                segments=segments,
-            )
-            ir_hash = cas.put_json(
-                ir, kind="source_ir", label=args.label, links=[source_hash]
-            )
-            cas.write_index()
+            with CasMutationTransaction(_resolve(repo_root, args.cas)) as transaction:
+                cas = transaction.cas
+                source_hash = _require_hash(args.source, "source hash")
+                if not {
+                    "raw_source",
+                    "rendered_text",
+                }.intersection(cas.index.get(source_hash, {}).get("kinds", [])):
+                    raise ProvenanceError("source hash is not source bytes in the CAS")
+                segments = json.loads(
+                    _read_regular_file(_resolve(repo_root, args.segments)).decode(
+                        "utf-8"
+                    )
+                )
+                source_bytes = _read_regular_file(cas.object_path(source_hash))
+                ir = build_source_ir(
+                    source_sha256=source_hash,
+                    source=source_bytes,
+                    segments=segments,
+                )
+                ir_hash = cas.put_json(
+                    ir, kind="source_ir", label=args.label, links=[source_hash]
+                )
+                transaction.commit()
             result = {"source_ir_sha256": ir_hash}
         elif args.command == "put-transform":
-            cas = Cas(_resolve(repo_root, args.cas))
-            cas.load()
-            source_hash = _require_hash(args.source, "source hash")
-            result_hash = _require_hash(args.result, "result hash")
-            if "raw_source" not in cas.index.get(source_hash, {}).get("kinds", []):
-                raise ProvenanceError("transform source is not raw_source bytes")
-            if "rendered_text" not in cas.index.get(result_hash, {}).get("kinds", []):
-                raise ProvenanceError("transform result is not rendered_text bytes")
-            operations = json.loads(
-                _read_regular_file(_resolve(repo_root, args.operations)).decode("utf-8")
-            )
-            transform = build_text_transform(
-                source_sha256=source_hash,
-                source=_read_regular_file(cas.object_path(source_hash)),
-                result_sha256=result_hash,
-                result=_read_regular_file(cas.object_path(result_hash)),
-                operations=operations,
-            )
-            transform_hash = cas.put_json(
-                transform,
-                kind="text_transform",
-                label=args.label,
-                links=[source_hash, result_hash],
-            )
-            cas.write_index()
+            with CasMutationTransaction(_resolve(repo_root, args.cas)) as transaction:
+                cas = transaction.cas
+                source_hash = _require_hash(args.source, "source hash")
+                result_hash = _require_hash(args.result, "result hash")
+                if "raw_source" not in cas.index.get(source_hash, {}).get("kinds", []):
+                    raise ProvenanceError("transform source is not raw_source bytes")
+                if "rendered_text" not in cas.index.get(result_hash, {}).get(
+                    "kinds", []
+                ):
+                    raise ProvenanceError("transform result is not rendered_text bytes")
+                operations = json.loads(
+                    _read_regular_file(_resolve(repo_root, args.operations)).decode(
+                        "utf-8"
+                    )
+                )
+                transform = build_text_transform(
+                    source_sha256=source_hash,
+                    source=_read_regular_file(cas.object_path(source_hash)),
+                    result_sha256=result_hash,
+                    result=_read_regular_file(cas.object_path(result_hash)),
+                    operations=operations,
+                )
+                transform_hash = cas.put_json(
+                    transform,
+                    kind="text_transform",
+                    label=args.label,
+                    links=[source_hash, result_hash],
+                )
+                transaction.commit()
             result = {"transform_sha256": transform_hash}
         else:
-            cas = Cas(_resolve(repo_root, args.cas))
-            cas.load()
-            bundle = json.loads(
-                _read_regular_file(_resolve(repo_root, args.bundle)).decode("utf-8")
-            )
-            if (
-                not isinstance(bundle, dict)
-                or bundle.get("kind") != "provenance_bundle"
-            ):
-                raise ProvenanceError(
-                    "bundle file must contain a provenance_bundle object"
+            with CasMutationTransaction(_resolve(repo_root, args.cas)) as transaction:
+                cas = transaction.cas
+                bundle = json.loads(
+                    _read_regular_file(_resolve(repo_root, args.bundle)).decode("utf-8")
                 )
-            bundle_hash = cas.put_json(
-                bundle,
-                kind="provenance_bundle",
-                label=args.label,
-                links=_bundle_declared_links(bundle),
-            )
-            cas.write_index()
+                if (
+                    not isinstance(bundle, dict)
+                    or bundle.get("kind") != "provenance_bundle"
+                ):
+                    raise ProvenanceError(
+                        "bundle file must contain a provenance_bundle object"
+                    )
+                bundle_hash = cas.put_json(
+                    bundle,
+                    kind="provenance_bundle",
+                    label=args.label,
+                    links=_bundle_declared_links(bundle),
+                )
+                transaction.commit()
             result = {"bundle_sha256": bundle_hash}
     except (
         OSError,

--- a/code/scripts/adj_stdlib_report.py
+++ b/code/scripts/adj_stdlib_report.py
@@ -215,30 +215,31 @@ def build_report(root: Path) -> dict[str, Any]:
     )
     provenance_error: str | None = None
     try:
-        adj_stdlib_provenance.validate_repository(
-            root / adj_stdlib_provenance.DEFAULT_ROOT,
-            root / adj_stdlib_provenance.DEFAULT_MANIFEST,
-            root / adj_stdlib_provenance.DEFAULT_SCHEMA,
-            workspace_root=root,
-        )
-        provenance_manifest = json.loads(
-            (root / adj_stdlib_provenance.DEFAULT_MANIFEST).read_text(encoding="utf-8")
-        )
-        cas = adj_stdlib_provenance.Cas(root / adj_stdlib_provenance.DEFAULT_ROOT)
-        cas.load()
-        for digest in provenance_manifest["bundle_hashes"]:
-            bundle = adj_stdlib_provenance._json_object(
-                cas, digest, "provenance_bundle"
+        cas_root = root / adj_stdlib_provenance.DEFAULT_ROOT
+        manifest_path = root / adj_stdlib_provenance.DEFAULT_MANIFEST
+        with adj_stdlib_provenance.CasRootLock(cas_root):
+            adj_stdlib_provenance._validate_repository_unlocked(
+                cas_root,
+                manifest_path,
+                root / adj_stdlib_provenance.DEFAULT_SCHEMA,
+                workspace_root=root,
             )
-            verified_libraries[bundle["library"]][digest] = {
-                (
-                    clause["quote"],
-                    clause["start"],
-                    clause["end"],
-                    clause["snapshot_sha256"],
+            provenance_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            cas = adj_stdlib_provenance.Cas(cas_root)
+            cas.load()
+            for digest in provenance_manifest["bundle_hashes"]:
+                bundle = adj_stdlib_provenance._json_object(
+                    cas, digest, "provenance_bundle"
                 )
-                for clause in bundle["clauses"]
-            }
+                verified_libraries[bundle["library"]][digest] = {
+                    (
+                        clause["quote"],
+                        clause["start"],
+                        clause["end"],
+                        clause["snapshot_sha256"],
+                    )
+                    for clause in bundle["clauses"]
+                }
     except (OSError, ValueError, json.JSONDecodeError) as error:
         provenance_error = str(error)
     libraries: list[dict[str, Any]] = []

--- a/code/scripts/build_adj_arithmetic_provenance.py
+++ b/code/scripts/build_adj_arithmetic_provenance.py
@@ -155,9 +155,7 @@ def local_source(
     )
 
 
-def main() -> None:
-    cas = provenance.Cas(REPO_ROOT / provenance.DEFAULT_ROOT)
-    cas.load()
+def build(cas: provenance.Cas) -> dict[str, str]:
     source_entries = []
     clauses = []
     for item in SOURCES:
@@ -439,23 +437,21 @@ def main() -> None:
         label="arithmetic.query.adj provenance bundle",
         links=provenance._bundle_declared_links(query_bundle),
     )
-    cas.write_index()
-    (REPO_ROOT / provenance.DEFAULT_MANIFEST).write_bytes(
-        provenance.canonical_json_bytes(
-            {
-                "algorithm": "sha256",
-                "bundle_hashes": sorted([bundle_hash, query_bundle_hash]),
-                "manifest_id": "adj.stdlib.provenance.v1",
-                "schema_version": 1,
-            }
-        )
-    )
-    provenance.validate_repository(
+    return {
+        bundle["bundle_id"]: bundle_hash,
+        query_bundle["bundle_id"]: query_bundle_hash,
+    }
+
+
+def main() -> None:
+    with provenance.BundleRegistrationTransaction(
         REPO_ROOT / provenance.DEFAULT_ROOT,
         REPO_ROOT / provenance.DEFAULT_MANIFEST,
-        REPO_ROOT / provenance.DEFAULT_SCHEMA,
+        expected_manifest_id="adj.stdlib.provenance.v1",
+        schema_path=REPO_ROOT / provenance.DEFAULT_SCHEMA,
         workspace_root=REPO_ROOT,
-    )
+    ) as transaction:
+        transaction.commit(build(transaction.cas))
 
 
 if __name__ == "__main__":

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import multiprocessing
 import os
 import sys
 import tempfile
@@ -12,6 +13,23 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 provenance = importlib.import_module("adj_stdlib_provenance")
+
+
+def acquire_cas_lock_and_exit(cas_root: str, ready: object) -> None:
+    with provenance.CasRootLock(Path(cas_root), blocking=False):
+        ready.set()
+        os._exit(0)
+
+
+def acquire_cas_lock_with_alternate_temp(
+    cas_root: str, temp_root: str, ready: object, release: object
+) -> None:
+    os.environ["TEMP"] = temp_root
+    os.environ["TMP"] = temp_root
+    os.environ["TMPDIR"] = temp_root
+    with provenance.CasRootLock(Path(cas_root), blocking=False):
+        ready.set()
+        release.wait(10)
 
 
 class AdjStdlibProvenanceTests(unittest.TestCase):
@@ -329,6 +347,202 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             second = cas.put(b"same bytes", kind="raw_source", label="different fetch")
             self.assertEqual(first, second)
             self.assertEqual(len(cas.index), 1)
+
+    def test_manifest_registration_preserves_unowned_bundle_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            with provenance.BundleRegistrationTransaction(
+                cas_root,
+                manifest_path,
+                expected_manifest_id="test.provenance.v1",
+                workspace_root=root,
+            ) as transaction:
+                original = json.loads(
+                    transaction.cas.object_path(hashes["bundle"]).read_text(
+                        encoding="utf-8"
+                    )
+                )
+                ratio = json.loads(json.dumps(original))
+                ratio["bundle_id"] = "test.ratio.v1"
+                ratio_hash = transaction.cas.put_json(
+                    ratio,
+                    kind="provenance_bundle",
+                    label="ratio fixture bundle",
+                    links=provenance._bundle_declared_links(ratio),
+                )
+                registered = transaction.commit({"test.ratio.v1": ratio_hash})
+            with provenance.BundleRegistrationTransaction(
+                cas_root,
+                manifest_path,
+                expected_manifest_id="test.provenance.v1",
+                workspace_root=root,
+            ) as transaction:
+                rerun = transaction.commit({"test.arithmetic.v1": hashes["bundle"]})
+
+            self.assertEqual(registered, sorted([hashes["bundle"], ratio_hash]))
+            self.assertEqual(rerun, registered)
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(manifest["bundle_hashes"], registered)
+
+    def test_manifest_registration_refuses_implicit_root_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            before = manifest_path.read_bytes()
+
+            with (
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError,
+                    "explicit root-replacement migration",
+                ),
+                provenance.BundleRegistrationTransaction(
+                    cas_root,
+                    manifest_path,
+                    expected_manifest_id="test.provenance.v1",
+                    workspace_root=root,
+                ) as transaction,
+            ):
+                changed = json.loads(
+                    transaction.cas.object_path(hashes["bundle"]).read_text(
+                        encoding="utf-8"
+                    )
+                )
+                changed["library"] = "code/example/corrected-arithmetic.adj"
+                changed_hash = transaction.cas.put_json(
+                    changed,
+                    kind="provenance_bundle",
+                    label="changed arithmetic fixture bundle",
+                    links=provenance._bundle_declared_links(changed),
+                )
+                changed_path = transaction.cas.object_path(changed_hash)
+                transaction.commit({"test.arithmetic.v1": changed_hash})
+
+            self.assertEqual(manifest_path.read_bytes(), before)
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertFalse(changed_path.exists())
+
+    def test_manifest_registration_rejects_malformed_contracts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, _hashes = self.build_repository(root)
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            cases = [
+                {**manifest, "schema_version": True},
+                {**manifest, "bundle_hashes": [{}]},
+            ]
+            for malformed in cases:
+                with self.subTest(manifest=malformed):
+                    manifest_path.write_bytes(
+                        provenance.canonical_json_bytes(malformed)
+                    )
+                    with (
+                        self.assertRaises(provenance.ProvenanceError),
+                        provenance.BundleRegistrationTransaction(
+                            cas_root,
+                            manifest_path,
+                            expected_manifest_id="test.provenance.v1",
+                            workspace_root=root,
+                        ),
+                    ):
+                        pass
+
+    def test_manifest_registration_lock_rejects_a_concurrent_writer(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            with provenance.BundleRegistrationTransaction(
+                cas_root,
+                manifest_path,
+                expected_manifest_id="test.provenance.v1",
+                workspace_root=root,
+            ) as transaction:
+                with (
+                    self.assertRaisesRegex(
+                        provenance.ProvenanceError,
+                        "another provenance operation",
+                    ),
+                    provenance.CasMutationTransaction(cas_root, blocking=False),
+                ):
+                    pass
+                transaction.commit({"test.arithmetic.v1": hashes["bundle"]})
+
+    def test_cas_root_lock_is_released_when_its_process_exits(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            cas_root = Path(directory) / "cas"
+            context = multiprocessing.get_context("spawn")
+            ready = context.Event()
+            process = context.Process(
+                target=acquire_cas_lock_and_exit,
+                args=(str(cas_root), ready),
+            )
+            process.start()
+            self.assertTrue(ready.wait(10), "child did not acquire the CAS lock")
+            process.join(10)
+            self.assertEqual(process.exitcode, 0)
+
+            with provenance.CasRootLock(cas_root, blocking=False):
+                pass
+
+    def test_cas_root_lock_does_not_depend_on_process_temp_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root = root / "cas"
+            alternate_temp = root / "alternate-temp"
+            alternate_temp.mkdir()
+            context = multiprocessing.get_context("spawn")
+            ready = context.Event()
+            release = context.Event()
+            process = context.Process(
+                target=acquire_cas_lock_with_alternate_temp,
+                args=(str(cas_root), str(alternate_temp), ready, release),
+            )
+            process.start()
+            try:
+                self.assertTrue(ready.wait(10), "child did not acquire the CAS lock")
+                with (
+                    self.assertRaisesRegex(
+                        provenance.ProvenanceError,
+                        "another provenance operation",
+                    ),
+                    provenance.CasRootLock(cas_root, blocking=False),
+                ):
+                    pass
+            finally:
+                release.set()
+                process.join(10)
+                if process.is_alive():
+                    process.terminate()
+                    process.join(10)
+            self.assertEqual(process.exitcode, 0)
+
+    def test_manifest_registration_rolls_back_failed_graph_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            baseline_manifest = manifest_path.read_bytes()
+            with (
+                self.assertRaisesRegex(provenance.ProvenanceError, "unreferenced"),
+                provenance.BundleRegistrationTransaction(
+                    cas_root,
+                    manifest_path,
+                    expected_manifest_id="test.provenance.v1",
+                    workspace_root=root,
+                ) as transaction,
+            ):
+                stray_hash = transaction.cas.put(
+                    b"unreachable staged bytes",
+                    kind="raw_source",
+                    label="rollback fixture",
+                )
+                stray_path = transaction.cas.object_path(stray_hash)
+                transaction.commit({"test.arithmetic.v1": hashes["bundle"]})
+
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+            self.assertFalse(stray_path.exists())
 
     def test_partition_rejects_gaps_overlaps_and_unreasoned_discards(self) -> None:
         cases = [

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -264,6 +264,15 @@ option mapping, or judge/evaluation failure.
 7a. **Complete:** add first-class repository-input receipts and require every
     provenance bundle clause to bind its decomposed ADJ source bytes as well as
     its external grounding bytes. Code is evidence and must not bypass IR.
+7b. **Complete:** make per-root generators register owned bundle IDs in a
+    validating transaction under an OS-released CAS-root lock shared by
+    authoritative readers and every CLI writer. Registration is additive and
+    idempotent, preserves unrelated roots, and rolls back newly materialized
+    objects and index changes on failure.
+7c. Add an explicit transactional root-replacement migration that validates the
+    replacement graph and prunes only objects unreachable from every new root.
+7d. Add a write-ahead recovery journal for process termination between the
+    atomic CAS-index and manifest publications.
 8. Replace the dead MathWorld `PercentageChange` locator before migrating
    `percent.adj`; a source returning 404 cannot ground that clause.
 

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -57,6 +57,17 @@ The generator checks the retained source hashes and expected source spans before
 rebuilding both provenance bundles, their IR and transform objects, the CAS
 index, and the curriculum-manifest linkage.
 
+Per-root generators register only the bundle IDs they own inside a CAS-root
+transaction protected by the tracked `cas/lock` file and an OS-released lock.
+Because the stable lock identity is inside the CAS, it cannot diverge with
+process-specific temporary-directory settings. Authoritative Python and Rust
+readers and every CLI writer participate in the same lock, so neither split
+publication nor a lost index update is externally visible. Registration
+validates both the old and proposed graphs, is additive and idempotent, and
+rolls back newly written objects on failure. A different hash for an already
+registered bundle ID fails closed until an explicit root-replacement migration
+can prune the old unreachable graph.
+
 This separation prevents an untrusted source locator from turning the verifier
 into a network or SSRF primitive. Reads are bounded and reject links and Windows
 reparse points; object writes are exclusive; index writes are atomic. Existing

--- a/code/specs/data/adj-stdlib-provenance/cas/lock
+++ b/code/specs/data/adj-stdlib-provenance/cas/lock
@@ -1,0 +1,1 @@
+ADJ provenance CAS lock


### PR DESCRIPTION
﻿## Summary

- make ADJ provenance generators register only the bundle IDs they own while preserving unrelated manifest roots
- serialize all production CAS writers and authoritative Python/Rust readers through a stable OS-released `cas/lock`
- validate the baseline and proposed graphs, fail closed on implicit root replacement, and restore exact index/manifest bytes plus newly materialized objects after failure
- document explicit root-replacement pruning and process-death journaling as the next backlog items

## Root cause

The arithmetic generator rewrote the global provenance manifest with only its own roots. Adding a second stdlib provenance family would therefore orphan that family on the next arithmetic regeneration. The initial repair also needed a shared, process-safe publication protocol so concurrent readers and writers could not observe or create split state.

## Validation

- `python -m ruff check` and `python -m ruff format --check` on all changed ADJ scripts
- `python -m unittest discover -s code/scripts/tests -p "test_adj_stdlib_*.py" -q` (48 passed, 1 Windows symlink skip)
- production arithmetic provenance generator rerun and repository verification (2 bundles, 35 objects, 5 snapshots)
- ADJ curriculum manifest validation (10 objectives)
- strict byte-pin report
- `cargo test --manifest-path code/packages/rust/Cargo.toml -p adj-lang-cli`
- independent re-review: no remaining P1/P2 findings

## Residual work

A process terminated exactly between the separate atomic index and manifest replacements can still leave split state. The coverage backlog records a write-ahead recovery journal as the explicit follow-up rather than claiming crash atomicity in this PR.
