### PR TITLE
feat(human-languages): split Russian lessons under five minutes

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,10 +5,12 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after PR #9497: 20 registered
-tracks, 976 Markdown lessons, and 20 downloadable LaTeX books. HL-V01 makes the
-remaining migration debt reproducible in both JSON and human-readable reports;
-HL-S01 proves the strict schema on the first 24 Spanish lessons.
+Last prioritized: 2026-08-02. Current baseline after the Russian duration
+tranche: 20 registered tracks, 980 Markdown lessons, and 20 downloadable LaTeX
+books. HL-V01 makes the remaining migration debt reproducible in both JSON and
+human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
+lessons, and HL-D01A proves track-sized duration remediation without discarding
+deep content.
 
 ## Priority rules
 
@@ -45,7 +47,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-S01 | Complete (#9497) | Migrate Spanish Chapters 1–3 to schema version 2 with typed body blocks and knowledge closure. | The 24-lesson slice has unique order, transitive knowledge closure, typed blocks, and no effective-duration violation. |
 | HL-G01 | Complete in the canonical-generation PR | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy now that the AST contract is executable. |
 | HL-G02 | Complete in the Chapters 2–3 generation PR | Generate Spanish Chapters 2–3 from their canonical schema-v2 lesson AST. | Extends the proven one-source path across the rest of the migrated pilot before broad corpus work. |
-| HL-D01A | Next | Remove all nine sub-five-minute violations from the complete Russian starter track. | A bounded first duration tranche covers both declaration-only and genuinely overlong lessons without skipping an existing language. |
+| HL-D01A | Complete in the Russian duration PR | Remove all nine sub-five-minute violations from the complete Russian starter track. | The report measures zero Russian violations; every changed or added lesson is below 300 effective seconds. |
+| HL-D01B | Next | Remove all eight sub-five-minute violations from the Marathi track. | Marathi is now the smallest remaining track-sized tranche; the gap report supplies the exact bounded lesson set. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
@@ -109,6 +112,23 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   smallest complete existing track with measurable debt: nine violations, of
   which five are computed at 312–405 seconds and four only need honest declared
   budgets below the cap. HL-D01A is therefore the next bounded tranche.
+
+## Findings from HL-D01A
+
+- Russian now has zero duration violations. The repository snapshot contains
+  980 lessons and 472 violations overall, down from 481 before this tranche;
+  unknown prerequisites remain at zero.
+- Four lessons already computed below five minutes and only needed their
+  declared estimates corrected. The five genuinely long lessons were shortened
+  through de-duplication or split into four prerequisite-ordered support and
+  practice lessons.
+- The cross-language formality comparison, naming-as-action comparison, person
+  shapes, and precise zero-copula explanation remain in the canonical corpus.
+  The tightest changed lesson is `RU-C01-privet` at 293 computed seconds; every
+  other changed or new lesson has a larger buffer.
+- Marathi's eight violations are the smallest remaining track-sized set, ahead
+  of Gujarati's nine and Punjabi's and Sanskrit's ten each. HL-D01B is therefore
+  the next bounded duration tranche after this PR merges.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/russian/CHANGELOG.md
+++ b/code/learning/human-languages/russian/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — Russian track
 
+## 0.4.0 — 2026-08-02
+
+- Corrected four honest four-minute estimates that had been rounded up to five
+  even though the shared duration model already placed them below that boundary.
+- Split the genuinely long Chapter 2 material into prerequisite-ordered support
+  lessons: *why вы is polite* and *why Russian asks how rather than what*.
+- Replaced the long cumulative recap with three focused practices for the
+  formal/informal exchange, subject/object person shapes, and the precise scope
+  of the zero copula.
+- Preserved the complete etymological and cross-language content while making
+  each individual lesson independently doable in under five minutes. Updated
+  the roadmap and session map to distinguish lesson duration from a commute
+  session that intentionally combines several lessons.
+
 ## 0.3.0 — 2026-08-02
 
 - Added the first downloadable LaTeX edition.

--- a/code/learning/human-languages/russian/README.md
+++ b/code/learning/human-languages/russian/README.md
@@ -33,9 +33,11 @@ grammar introduced only when a word needs it.
   нет (no) → пожалуйста (please / you're welcome), plus a practice recap. Six
   words, and enough Cyrillic to read them all cold.
 - **Chapter 2 — Introducing yourself** ([`lessons/RU-C02-*`](./lessons/)):
-  я → ты / вы → меня зовут… → как вас зовут? → очень приятно, plus cumulative
-  formal and informal practice. Case appears only through the forms the exchange
-  needs.
+  я → ты / вы → why вы is polite → меня зовут… → как вас зовут? → why Russian
+  asks “how” → очень приятно, followed by three focused practices for the
+  exchange, person shapes, and zero copula. Case appears only through the forms
+  the exchange needs. Every lesson is prerequisite-ordered and below five
+  minutes, while the cross-language and etymological depth remains intact.
 
 See [`roadmap.md`](./roadmap.md) for the plan toward B1 and
 [`session-map.md`](./session-map.md) for how the lessons compose into commute

--- a/code/learning/human-languages/russian/lessons/RU-C01-pozhaluysta.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-pozhaluysta.md
@@ -10,7 +10,7 @@ prerequisites: [RU-C01-spasibo]
 sounds: [zh-sound, syllable-drop, o-reduction]
 roots: [zhalovat]
 etymology_hook: "пожалуйста ← пожалуй 'grant / do favour' + -ста; also the reply to spasibo ('you're welcome')"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [RU-C01-spasibo, RU-C01-net]
 ---
 

--- a/code/learning/human-languages/russian/lessons/RU-C01-practice.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH1-PRACTICE
 prerequisites: [RU-C01-privet, RU-C01-zdravstvuyte, RU-C01-spasibo, RU-C01-da, RU-C01-net, RU-C01-pozhaluysta]
 sounds: [cyrillic-false-friends]
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [RU-C01-privet, RU-C01-zdravstvuyte, RU-C01-spasibo, RU-C01-da, RU-C01-net, RU-C01-pozhaluysta]
 ---
 

--- a/code/learning/human-languages/russian/lessons/RU-C01-privet.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-privet.md
@@ -10,7 +10,7 @@ prerequisites: []
 sounds: [cyrillic-false-friends, stress-unmarked, e-ye]
 roots: [pri, vet]
 etymology_hook: "привет ← при- + root вет- 'to speak' → same root as sovet 'council' → Soviet"
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 
@@ -18,9 +18,8 @@ reviews_of: []
 
 ## Warm-up
 
-[PAUSE 2s] Your first Russian word — and your first Cyrillic letters. Cyrillic
-looks familiar, and that is exactly the trap: several letters are **false
-friends** that look Latin but sound nothing like it. We'll meet them head-on.
+[PAUSE 2s] Your first Russian word and Cyrillic letters. Several shapes are
+**false friends** that look Latin but sound different; meet them head-on.
 
 ## The letters in this word
 
@@ -61,19 +60,11 @@ already know in English:
 So *привet* is a cousin of **Soviet** — the same "speak" root, one a friendly
 hello, the other the most famous Russian word in English.
 
-## Across the family — "hi" without the formality
+## Across the family
 
-| Language | informal "hi" | note |
-|---|---|---|
-| **Russian** | *privét* (привет) | to friends, family, peers |
-| Spanish | *hola* | |
-| French | *salut* | also informal-only |
-| German | *hallo* | |
-| English | *hi / hey* | |
-
-Every language keeps a *casual* greeting separate from the formal one. In
-Russian that line is sharp — use *привет* with friends, and the next lesson's
-*здравствуйте* with everyone else.
+Russian *privét*, Spanish *hola*, French *salut*, German *hallo*, and English
+*hi* fill the casual slot. Russian draws the line sharply: use *привет* with
+friends and the next lesson's formal greeting with everyone else.
 
 ## Why it's said this way
 

--- a/code/learning/human-languages/russian/lessons/RU-C01-spasibo.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-spasibo.md
@@ -10,7 +10,7 @@ prerequisites: [RU-C01-privet]
 sounds: [cyrillic-false-friends, b-vs-v, o-reduction]
 roots: [spasti, bog]
 etymology_hook: "спасибо ← спаси Бог 'God save [you]' — like adiós (a Dios), goodbye (God be with ye)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [RU-C01-privet, RU-C01-zdravstvuyte]
 ---
 

--- a/code/learning/human-languages/russian/lessons/RU-C01-zdravstvuyte.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-zdravstvuyte.md
@@ -10,7 +10,7 @@ prerequisites: [RU-C01-privet]
 sounds: [cyrillic-false-friends, silent-v, stress-unmarked]
 roots: [zdorov]
 etymology_hook: "здравствуйте ← здоровье 'health' → literally 'be healthy!'"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [RU-C01-privet]
 ---
 
@@ -60,19 +60,6 @@ English *health* — they come from different roots (English *health/whole/hale*
 is Germanic). The *idea* is the shared one: many languages greet by wishing
 **health** (Latin *salve* = "be well," the ancestor of Spanish *hola*'s cousin
 *salud*) or **peace** (Arabic *salām*, Hebrew *shalom*). Russian picked health.
-
-## Across the family — greetings that wish something
-
-| Language | formal greeting | literally wishes… |
-|---|---|---|
-| **Russian** | *zdravstvuyte* (здравствуйте) | **health** |
-| Latin | *salvē* | "be well" (health) |
-| Arabic | *as-salāmu ʿalaykum* | **peace** upon you |
-| Hebrew | *shalom* | **peace** |
-| English | *hello* | (nothing — just a call) |
-
-English *hello* is unusual: it wishes nothing at all, it just gets attention.
-Most languages greet by handing over health or peace.
 
 ## Grammar Lens — Russian's formal *you* is plural
 

--- a/code/learning/human-languages/russian/lessons/RU-C02-kak-cross-language.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-kak-cross-language.md
@@ -1,0 +1,51 @@
+---
+id: RU-C02-kak-cross-language
+chapter: 2
+type: grammar
+headword: как / comment / cómo
+gloss: naming as an action across Russian, French, and Spanish
+romanization: kak / comment / como
+prerequisites: [RU-C02-kak-vas-zovut]
+sounds: [stress-unmarked]
+roots: [slavic-kako]
+etymology_hook: "Russian, French, and Spanish ask how people call you; English asks what your name is"
+est_minutes: 3
+reviews_of: [RU-C02-kak-vas-zovut, RU-C02-menya-zovut]
+---
+
+# Why Russian asks *how*, not *what*
+
+## Warm-up
+
+[PAUSE 2s] In *Как вас зовут?*, which word means "how"? (*Как*.)
+
+## One question, two ways to organize it
+
+English asks **what** your name is, treating the name as a thing you have.
+Russian asks **how** people call you, treating naming as something people do.
+
+English is the odd one out in this small comparison:
+
+| Language | question frame |
+|---|---|
+| Russian | *Как вас зовут?* — **how** |
+| French | *Comment vous appelez-vous ?* — **how** |
+| Spanish | *¿Cómo se llama?* — **how** |
+| English | ***What*** is your name? — **what** |
+
+Three languages organize the question around an **action**; English organizes
+it around a **possession**. The answer is the same social fact, but the route to
+it differs.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the three action words — *как*, *comment*, *cómo*]
+- [YOU SAY: Russian literally asks — "how do they call you?"]
+- [YOU SAY: English asks about — a thing you have]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which three languages ask "how"? (Russian, French, Spanish.) Which
+asks "what"? (English.) What is the underlying contrast? (Naming as an action
+versus a name as a possession.)

--- a/code/learning/human-languages/russian/lessons/RU-C02-kak-vas-zovut.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-kak-vas-zovut.md
@@ -6,7 +6,7 @@ headword: как вас зовут?
 gloss: "what's your name? — literally 'HOW do they call you?', not 'what'"
 concept_tag: INTRO-WHATS-YOUR-NAME
 romanization: kak vas zovút
-prerequisites: [RU-C02-menya-zovut, RU-C02-ty-vy]
+prerequisites: [RU-C02-menya-zovut]
 sounds: [cyrillic-false-friends, stress-unmarked]
 roots: [slavic-kako, slavic-zvati]
 etymology_hook: "Russian asks HOW they call you, not WHAT — как вас зовут, matching French comment vous appelez-vous and Spanish cómo se llama; English is the odd one out with 'what', because it asks about a possession while the others ask about an action"
@@ -36,23 +36,6 @@ Taken apart:
 
 So: **"How do they call you?"**
 
-## Not "what" — "how"
-
-English asks *what* is your name, treating the name as a **thing you have**.
-Russian asks *how* people call you, treating it as **something people do**.
-
-And Russian is not the odd one here — English is:
-
-| | |
-|---|---|
-| Russian | *Как* вас зовут? — **how** |
-| French | *Comment* vous appelez-vous ? — **how** |
-| Spanish | ¿*Cómo* se llama? — **how** |
-| **English** | ***What*** is your name? — **what** |
-
-Three languages ask about an **action**; English asks about a **possession**.
-Once you have heard it in one of them, the others stop feeling strange.
-
 ## The object forms again
 
 Last lesson's *меня* has partners, and they follow the same logic — the person
@@ -72,13 +55,11 @@ You now have a matched pair: **Как вас зовут?** — **Меня зов
 - [YOU SAY: "Как вас зовут?" — formal]
 - [YOU SAY: "Как тебя зовут?" — informal]
 - [YOU SAY: the whole exchange — "Как вас зовут?" · "Меня зовут…"]
-- [YOU SAY: the odd one out — "**how**, **how**, **how** … *what*"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Ask a stranger's name. (*Как вас зовут?*) And a friend's? (*Как тебя
 зовут?*) What does *как* mean, and why does it matter? (**How** — Russian asks
 *how they call you*, about an **action**, where English asks *what*, about a
-**possession**.) Which languages agree with Russian here? (**French** *comment*
-and **Spanish** *cómo* — English is the odd one out.) Give the three object
-forms. (*Меня, тебя, вас*.) Next: "pleased to meet you."
+**possession**.) Give the three object forms. (*Меня, тебя, вас*.) Next: compare
+how several languages frame the same question.

--- a/code/learning/human-languages/russian/lessons/RU-C02-menya-zovut.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-menya-zovut.md
@@ -6,11 +6,11 @@ headword: меня зовут…
 gloss: "my name is… — literally 'they call me', with no word for 'my' and no word for 'name'"
 concept_tag: INTRO-MY-NAME-IS
 romanization: menyá zovút
-prerequisites: [RU-C02-ty-vy]
+prerequisites: [RU-C02-vy-formality]
 sounds: [cyrillic-false-friends, stress-unmarked]
 roots: [slavic-zvati]
 etymology_hook: "меня зовут is literally '[they] CALL me' — an unnamed 'they' doing the naming, so the sentence contains no word for 'my' and none for 'name'; and меня is not я plus an ending but a SUPPLETIVE form from a different PIE stem, the first case FORM in the course"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [RU-C02-ty-vy, RU-C01-privet]
 ---
 

--- a/code/learning/human-languages/russian/lessons/RU-C02-ochen-priyatno.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-ochen-priyatno.md
@@ -6,7 +6,7 @@ headword: очень приятно
 gloss: "pleased to meet you — literally 'very pleasant', and a cousin of English FRIEND"
 concept_tag: INTRO-NICE-TO-MEET-YOU
 romanization: óchen priyátno
-prerequisites: [RU-C02-kak-vas-zovut]
+prerequisites: [RU-C02-kak-cross-language]
 sounds: [cyrillic-false-friends, stress-unmarked]
 roots: [pie-preyh]
 etymology_hook: "приятно 'pleasant' comes from Slavic prijati 'to favour, be well-disposed' ← PIE *preyH- 'to love, please' — the same root that gave Germanic its word for FRIEND (one who is dear) and, most likely, FREE (originally 'belonging to the beloved household, not a slave')"

--- a/code/learning/human-languages/russian/lessons/RU-C02-practice-cases.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-practice-cases.md
@@ -1,0 +1,54 @@
+---
+id: RU-C02-practice-cases
+chapter: 2
+type: practice-mix
+headword: "Chapter 2 practice: person shapes"
+gloss: "subject and object forms for I, informal you, and formal you"
+prerequisites: [RU-C02-practice]
+sounds: [cyrillic-false-friends, stress-unmarked]
+roots: []
+est_minutes: 3
+reviews_of: [RU-C02-ya, RU-C02-ty-vy, RU-C02-menya-zovut, RU-C02-kak-vas-zovut]
+---
+
+# Chapter 2 practice — the two person shapes
+
+## Warm-up
+
+[PAUSE 2s] Russian changes a pronoun's shape when the action lands on that
+person. English still shows the same idea in *I → me*.
+
+## Cover and retrieve
+
+Cover the right column, then give the acted-on form:
+
+| doing the action | action lands here | meaning |
+|---|---|---|
+| **я** | **меня** | I / me |
+| **ты** | **тебя** | you / you, informal |
+| **вы** | **вас** | you / you, formal or plural |
+
+Russian has six cases, but none of that system is due yet. Learn these three
+pairs because the naming exchange needs them.
+
+## Put each shape in the frame
+
+- **Меня** зовут… — people call **me**…
+- Как **тебя** зовут? — how do people call **you**, one friend?
+- Как **вас** зовут? — how do people call **you**, formally?
+
+The verb stays **зовут**; the person changes shape.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: *я → меня*]
+- [YOU SAY: *ты → тебя*]
+- [YOU SAY: *вы → вас*]
+- [YOU SAY: one verb, three object forms]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the three pairs. Which shape answers "who receives the
+calling"? (The object form.) Do you need the six-case table yet? (No — only
+these earned pairs.)

--- a/code/learning/human-languages/russian/lessons/RU-C02-practice-zero-copula.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-practice-zero-copula.md
@@ -1,0 +1,53 @@
+---
+id: RU-C02-practice-zero-copula
+chapter: 2
+type: practice-mix
+headword: "Chapter 2 practice: what Russian leaves out"
+gloss: "notice the precise zero-copula example without overgeneralizing"
+prerequisites: [RU-C02-practice-cases]
+sounds: [stress-unmarked]
+roots: [est]
+est_minutes: 4
+reviews_of: [RU-C02-menya-zovut, RU-C02-kak-vas-zovut, RU-C02-ochen-priyatno, RU-C01-net]
+---
+
+# Chapter 2 practice — what Russian leaves out
+
+## Warm-up
+
+[PAUSE 2s] Russian often says less than the English translation. Name only the
+words that are genuinely absent; do not erase a verb that is really there.
+
+## Three phrases, three English expansions
+
+| Russian | literal reading | English adds |
+|---|---|---|
+| **Меня зовут Анна** | "they call me Anna" | *my*, *name* |
+| **Очень приятно** | "very pleasant" | *it is*, *to meet you* |
+| **Как вас зовут?** | "how do they call you?" | *what*, *your* |
+
+Only the middle sentence has **no verb at all**. In present-tense descriptions,
+Russian normally drops the linking verb: *Очень приятно* needs no spoken "is."
+
+The other two sentences do contain **зовут**, "they call." They lack "is"
+because they are not "X is Y" sentences in Russian; English simply translates
+them that way.
+
+Russian also has a present-tense **есть**. Chapter 1 already hid it inside
+**нет** = *не + есть*, "not-is." The next chapter will reuse it. So the careful
+rule is not "Russian has no *is*"; it is "Russian usually omits the linking verb
+in a present-tense description."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the one verb-free phrase — *Очень приятно*]
+- [YOU SAY: the verb inside the naming pair — *зовут*]
+- [YOU SAY: the verb hidden inside *нет* — *есть*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which sentence demonstrates the zero copula? (*Очень приятно*.) Why
+do the naming sentences not count? (They contain *зовут*.) Does Russian lack a
+present form of "be" entirely? (No: *есть* exists; the linking use is normally
+omitted here.)

--- a/code/learning/human-languages/russian/lessons/RU-C02-practice.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-practice.md
@@ -2,97 +2,56 @@
 id: RU-C02-practice
 chapter: 2
 type: practice-mix
-headword: "Chapter 2 practice"
-gloss: "the whole introduction, and two of the shapes every pronoun takes"
+headword: "Chapter 2 practice: the exchange"
+gloss: "run the introduction formally and informally"
 concept_tag: CH2-PRACTICE
-prerequisites: [RU-C02-ochen-priyatno, RU-C02-kak-vas-zovut]
+prerequisites: [RU-C02-ochen-priyatno, RU-C02-kak-cross-language]
 sounds: [cyrillic-false-friends, stress-unmarked]
 roots: []
-est_minutes: 5
-reviews_of: [RU-C02-ya, RU-C02-ty-vy, RU-C02-menya-zovut, RU-C02-kak-vas-zovut, RU-C02-ochen-priyatno]
+est_minutes: 3
+reviews_of: [RU-C02-ya, RU-C02-ty-vy, RU-C02-vy-formality, RU-C02-menya-zovut, RU-C02-kak-vas-zovut, RU-C02-ochen-priyatno]
 ---
 
-# Chapter 2 practice — a whole introduction
+# Chapter 2 practice — run the exchange
 
 ## Warm-up
 
-[PAUSE 2s] Five lessons, and they add up to a real conversation.
+[PAUSE 2s] The chapter's words now add up to a real conversation. Run it first
+with a stranger, then make the two changes that turn it informal.
 
-## Drill 1 — the exchange
+## Formal exchange
 
-Say both halves aloud, formal first:
+Say both halves aloud:
 
 | | |
 |---|---|
-| — Здравствуйте! | Hello. *(Ch. 1)* |
+| — **Здравствуйте!** | Hello. |
 | — **Как вас зовут?** | What's your name? |
 | — **Меня зовут** Анна. **А вас?** | My name is Anna. And you? |
 | — Меня зовут Иван. **Очень приятно.** | My name is Ivan. Pleased to meet you. |
 
-Then the informal version — two swaps and nothing else:
+## Informal switch
 
-| | |
+With one friend, change only two pieces:
+
+| formal | informal |
 |---|---|
-| — Привет! | Hi. *(Ch. 1)* |
-| — **Как тебя зовут?** | What's your name? |
+| **Здравствуйте!** | **Привет!** |
+| **Как вас зовут?** | **Как тебя зовут?** |
 
-Two things changed, and only two: the **greeting** (Здравствуйте → Привет) and
-the **pronoun** (вас → тебя). The **verb *зовут* never moves**.
+The greeting and object pronoun change. The verb **зовут** stays exactly where
+it was.
 
-## Drill 2 — the two shapes
+## Guided Practice
 
-Each pronoun has more than one shape. Here are **two of them** — the form that
-acts, and the form that is acted on. (Russian has six cases in all; you only need
-these for now.) Cover the right column:
-
-| doing the action | being acted on | |
-|---|---|---|
-| **я** | **меня** | I / me |
-| **ты** | **тебя** | you / you (informal) |
-| **вы** | **вас** | you / you (formal) |
-
-Now use them in the frame. *Зовут* never changes — only the person changes shape:
-
-- **Меня** зовут… — *my* name is…
-- Как **тебя** зовут? — what's *your* name? (informal)
-- Как **вас** зовут? — what's *your* name? (formal)
-
-That's the whole point of case in miniature: **one verb, three people, three
-shapes.**
-
-## Drill 3 — what Russian leaves out
-
-Russian says less than English does. For each phrase, name the missing words:
-
-| Russian | says | leaves out |
-|---|---|---|
-| Меня зовут Анна | "they call me Anna" | *my*, *name* |
-| Очень приятно | "very pleasant" | *I am*, *to meet you* |
-| Как вас зовут? | "how do they call you?" | *what*, *your* |
-
-Look at the middle row especially. ***Очень приятно*** has **no verb at all** —
-Russian normally **drops the linking verb** in the present tense, so "[it is]
-very pleasant" needs no "is". That's the habit to carry into Chapter 3.
-
-(Be careful not to over-read the other two. *Меня зовут* and *Как вас зовут* do
-have a verb — *зовут*. They lack an "is" because they aren't "X is Y" sentences
-in the first place; English just happens to translate them with one. Russian
-*does* have a present-tense **есть**, which Chapter 1 already met inside **нет**
-= *не + есть*, "not-is".)
-
-## Drill 4 — how, not what
-
-One more time, because it's the error English speakers make:
-
-- ~~Что вас зовут?~~ — no.
-- **Как** вас зовут? — **how**, because it's about an *action*.
+[PAUSE 1s]
+- [YOU SAY: the full formal exchange, both voices]
+- [YOU SAY: the same exchange informally]
+- [YOU SAY: the two pieces that change — greeting and pronoun]
+- [YOU SAY: *как*, not *что* — naming is framed as an action]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Run the whole formal exchange. (*Здравствуйте — Как вас зовут? — Меня
-зовут… А вас? — Меня зовут… Очень приятно.*) What changes between formal and
-informal? (The **greeting** and the **pronoun** — *вас* → *тебя*; the verb
-*зовут* stays.) Give
-the three object forms. (*Меня, тебя, вас*.) Which sentence has no verb at all, and why? (***Очень
-приятно*** — Russian **drops the linking verb** in the present.) *Как* or *что*? (***Как*** — "how", because naming is an **action**.)
-Next chapter: being and having.
+[PAUSE 3s] Run the formal exchange without looking. Then switch it for one
+friend. What changed? (The greeting and *вас → тебя*.) What stayed fixed?
+(*Зовут*.)

--- a/code/learning/human-languages/russian/lessons/RU-C02-ty-vy.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-ty-vy.md
@@ -10,7 +10,7 @@ prerequisites: [RU-C02-ya, RU-C01-zdravstvuyte]
 sounds: [yery-vowel, stress-unmarked]
 roots: [pie-eg, pie-tu, pie-wos]
 etymology_hook: "я and ты are cousins of Latin ego and tū, English I and thou — pronouns are the least borrowable words a language has; вы continues PIE *wos like Latin vōs, though English you and German ihr come from the paradigm's OTHER stem *yūs, so that row is only half a cognate set; and вы is formal the way French vous is, a plural used as respect"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [RU-C02-ya, RU-C01-zdravstvuyte]
 ---
 
@@ -55,42 +55,16 @@ years. *Thou* fell out of standard English through the 1600s (it survives in
 Quaker usage, northern dialect and liturgy), leaving *you* for everyone — which
 is why the ты/вы choice feels foreign to English speakers. English **had** it.
 
-## вы is the same politeness French invented
-
-Look at the third row again. *Вы* is a **plural** used for **one person** as a
-mark of respect — and that is exactly what French does with **vous**, and what
-Chapter 1's *здравствуйте* is doing.
-
-The logic is old and slightly strange: addressing someone as though they were
-several people treats them as larger than they are.
-
-Not everyone got there the same way, though. **Russian and French use the
-second-person plural** (*вы*, *vous*). **German borrows the third-person plural**
-(*Sie* — not *ihr*, which is the ordinary "you all"). And **Spanish didn't use a
-plural at all**: *usted* is worn down from *vuestra merced*, "your grace" — a
-title, not a number.
-
-Russian's *вы*-politeness is generally thought to be an **18th-century import**
-from French and German usage, rather than something Russian invented alone.
-
-**When to use which:** *вы* to a stranger, an older person, anyone at work. *ты*
-to a friend, a child, a family member. When in doubt, **вы** — the mistake costs
-nothing, and the reverse is rude.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "я" — *ya*]
 - [YOU SAY: "ты" and "вы" — hear the difference]
 - [YOU SAY: the family — "**ты** … *tū* … **thou**"]
-- [YOU SAY: the rule — "**вы** when in doubt"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Say "I". (**Я**.) What are the two words for "you", and what splits
 them? (**Ты** informal, **вы** formal — or plural.) Why is *ты* familiar to an
 English speaker's ear? (It's the **same word as *thou***, which left standard
-English through the 1600s.) Why is *вы* polite? (It's a **plural used for one person** — like
-French *vous*. German takes a different route, the **3rd**-person plural *Sie*;
-Spanish a different one again, *usted* ← "your grace".) Which do you use when unsure?
-(**Вы**.) Next: saying your name.
+English through the 1600s.) Next: why plural *вы* became polite.

--- a/code/learning/human-languages/russian/lessons/RU-C02-vy-formality.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-vy-formality.md
@@ -1,0 +1,60 @@
+---
+id: RU-C02-vy-formality
+chapter: 2
+type: grammar
+headword: вы as polite "you"
+gloss: why a plural pronoun addresses one person respectfully
+romanization: vy
+prerequisites: [RU-C02-ty-vy]
+sounds: [yery-vowel, stress-unmarked]
+roots: [pie-wos]
+etymology_hook: "Russian вы and French vous make a plural polite; German Sie and Spanish usted reach respect differently"
+est_minutes: 4
+reviews_of: [RU-C02-ty-vy, RU-C01-zdravstvuyte]
+---
+
+# Why plural *вы* became polite
+
+## Warm-up
+
+[PAUSE 2s] Give the pair: *ты* for one familiar person; *вы* for more than one
+person — or for one person addressed respectfully.
+
+## One social job, several grammatical routes
+
+Russian **вы** is a plural used for **one person** as a mark of respect. French
+does the same job with second-person plural **vous**. Chapter 1's
+*здравствуйте* already carried the matching polite-plural ending *-те*.
+
+Other languages reached respect differently:
+
+| Language | respectful form | route |
+|---|---|---|
+| Russian | *вы* | second-person plural |
+| French | *vous* | second-person plural |
+| German | *Sie* | third-person plural, not ordinary *ihr* |
+| Spanish | *usted* | title *vuestra merced*, "your grace" |
+
+Russian's polite *вы* is generally treated as an eighteenth-century import
+from French and German social usage, not a pattern Russian invented alone.
+
+## When to use which
+
+Use *вы* with a stranger, an older person, or in a formal relationship. Use
+*ты* with a friend, child, or family member. When unsure with an adult, begin
+with **вы**; too much respect is safer than unwanted familiarity.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: one close friend — *ты*]
+- [YOU SAY: a new professor — *вы*]
+- [YOU SAY: Russian and French use which route — second-person plural]
+- [YOU SAY: Spanish *usted* came from what — "your grace"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why can *вы* address one person? (A plural became respectful.) Which
+language shares that exact route? (French *vous*.) Which two take different
+routes? (German *Sie* uses third-person plural; Spanish *usted* came from a
+title.) Which Russian form is safest when you are unsure? (*Вы*.)

--- a/code/learning/human-languages/russian/roadmap.md
+++ b/code/learning/human-languages/russian/roadmap.md
@@ -33,8 +33,9 @@ Chapter 1 words introduced — component strokes + stroke order, from the canoni
 
 **я** — one letter, PIE \**eǵh₂(om)* → Slavic \**azъ*, cousin of *ego / ich / I*;
 pronouns are the least borrowable part of a language → **ты / вы**, the split
-English threw away when *thou* left standard use in the 1600s. *Вы* is polite the
-way French *vous* is, but the routes differ: Russian and French use the
+English threw away when *thou* left standard use in the 1600s → a short support
+lesson on why ***вы* is polite**. *Вы* is polite the way French *vous* is, but
+the routes differ: Russian and French use the
 **2nd-person plural**, German the **3rd-person** (*Sie*), and Spanish **no plural
 at all** (*usted* ← "your grace") — with the *вы*/*vōs* cognate row flagged as
 only half a set, since English *you* and German *ihr* continue \**yūs*
@@ -44,18 +45,20 @@ sentence contains **no word for "my" and none for "name"**; the "they" is nobody
 but its **object form** — the course's first look at **case** → **как вас
 зовут?**, which asks **how** they call you, not *what*: Russian, French
 (*comment*) and Spanish (*cómo*) all ask about an **action** where English asks
-about a **possession** → **очень приятно**, "very pleasant", whose *приятно* ←
+about a **possession** in a separate comparison lesson → **очень приятно**,
+"very pleasant", whose *приятно* ←
 Slavic *prijati* "to favour" ← PIE \**preyH-* "to love, please" — the root behind
 Russian **приятель** "friend" *and* English **friend**, with **free** most likely
-in the same family ("belonging to the beloved household") → practice, which
-closes on the **zero copula** — scoped to ***очень приятно***, the one sentence
-with no verb at all (Russian *does* have a present-tense *есть*; it just drops
-the linking verb).
+in the same family ("belonging to the beloved household") → three short practice
+lessons: retrieve the exchange, contrast the person shapes, then close on the
+**zero copula** — scoped to ***очень приятно***, the one sentence with no verb at
+all (Russian *does* have a present-tense *есть*; it just drops the linking verb).
 
-Deliberately deferred, so the chapter stays five atoms plus practice: **это**,
-and *да/нет* revisited as full answers. New letters **я**, **ч**, **ы** and the soft sign **ь** are
-flagged read-now-draw-later — the writing track (RU-W01–W05) has taught
-в р с н б д п и е т and not yet reached them.
+Deliberately deferred, so the chapter stays five vocabulary atoms plus two
+support lessons and three focused practices: **это**, and *да/нет* revisited as
+full answers. Each lesson remains below five minutes. New letters **я**, **ч**,
+**ы** and the soft sign **ь** are flagged read-now-draw-later — the writing track
+(RU-W01–W05) has taught в р с н б д п и е т and not yet reached them.
 
 ## Chapter 3 — Being and having *(planned)*
 

--- a/code/learning/human-languages/russian/session-map.md
+++ b/code/learning/human-languages/russian/session-map.md
@@ -32,15 +32,18 @@ Chapter 1's *N+7* and *N+15* resurfacings land here, as promised above.
 | Session | New | Resurfaced | Note |
 |---|---|---|---|
 | **S6** | я | пожалуйста *(N+1)*, спасибо *(N+3)*, да *(N+3)* | **я** is a new letter — read only |
-| **S7** | ты, вы | привет *(N+15)*, я *(N+1)* | **ы**, the hardest vowel; ты/вы against Ch. 1's formality split |
-| **S8** | меня зовут… | здравствуйте *(N+15)*, я *(N+3)*, ты·вы *(N+1)* | the first **case form** (я → меня) |
-| **S9** | как вас зовут? | спасибо *(N+7)*, меня зовут *(N+1)*, ты·вы *(N+3)* | the matched pair; **ч** read only |
+| **S7** | ты, вы; why вы is polite | привет *(N+15)*, я *(N+1)* | two sub-five-minute lessons: **ы**, then the cross-language formality pattern |
+| **S8** | меня зовут… | здравствуйте *(N+15)*, я *(N+3)*, ты·вы and polite вы *(N+1)* | the first **case form** (я → меня) |
+| **S9** | как вас зовут?; why Russian asks “how” | спасибо *(N+7)*, меня зовут *(N+1)*, ты·вы *(N+3)* | two sub-five-minute lessons: the matched pair, then the cross-language comparison; **ч** read only |
 | **S10** | очень приятно | нет *(N+7)*, как вас зовут *(N+1)*, я *(N+7)* | приятно ↔ **friend** |
-| **S11** | — | all five atoms *(N+1 … N+7)* | **RU-C02-practice** (full recap) |
+| **S11** | — | all five atoms *(N+1 … N+7)* | three short practices: the exchange, person shapes, then the zero copula |
 
 ### Schedule check
 
 Chapter 2's own words follow the same *N+1 / N+3* rhythm inside the chapter;
 their *N+7 / N+15* resurfacings will land in Chapter 3. The letters **read but
 not yet written** — я, ы, ч, ь — recur in every session from their introduction
-onward, the same over-learning the four false friends get.
+onward, the same over-learning the four false friends get. The deeper formality
+and question-pattern comparisons are separate prerequisite-ordered lessons, and
+the old long recap is three focused lessons. Every individual lesson stays below
+five minutes even though each commute session deliberately combines several.


### PR DESCRIPTION
## Summary

- remove all nine Russian lessons at or above the five-minute boundary
- correct four declared estimates that the shared model already measured below five minutes
- split the genuinely long explanations into prerequisite-ordered formality, cross-language, case-shape, and zero-copula micro-lessons
- update the Russian roadmap/session map and reprioritize the measured backlog to Marathi's eight violations

The deep etymology and cross-language comparisons remain in the canonical Markdown consumed by Language Ladder. The existing Russian LaTeX book already presents the same material in dependency order, so its source did not need to diverge.

## Measured result

- Russian duration violations: **9 → 0**
- repository duration violations: **481 → 472**
- canonical lessons: **976 → 980**
- unknown prerequisites: **0**
- tightest changed lesson: `RU-C01-privet` at **293 computed seconds**

## Validation

- `human-language-data`: 68 tests passed; 93.60% line coverage
- curriculum integration: 9 tests passed
- generated-book drift check: passed
- `language-ladder`: 278 tests passed; 98.37% line coverage
- Language Ladder production build: passed
- forced Russian XeLaTeX build: 19 pages, 0 overfull boxes, 0 underfull boxes, 0 Hyperref warnings
- rendered Chapter 2 opener and lesson pages visually inspected
- `git diff --check`: passed