### PR TITLE
feat(human-languages): split Marathi lessons under five minutes

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,11 +5,11 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Russian duration
-tranche: 20 registered tracks, 980 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Marathi duration
+tranche: 20 registered tracks, 981 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
-lessons, and HL-D01A proves track-sized duration remediation without discarding
+lessons, and the HL-D01 tranches prove duration remediation without discarding
 deep content.
 
 ## Priority rules
@@ -48,9 +48,12 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-G01 | Complete in the canonical-generation PR | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy now that the AST contract is executable. |
 | HL-G02 | Complete in the Chapters 2–3 generation PR | Generate Spanish Chapters 2–3 from their canonical schema-v2 lesson AST. | Extends the proven one-source path across the rest of the migrated pilot before broad corpus work. |
 | HL-D01A | Complete in the Russian duration PR | Remove all nine sub-five-minute violations from the complete Russian starter track. | The report measures zero Russian violations; every changed or added lesson is below 300 effective seconds. |
-| HL-D01B | Next | Remove all eight sub-five-minute violations from the Marathi track. | Marathi is now the smallest remaining track-sized tranche; the gap report supplies the exact bounded lesson set. |
+| HL-D01B | Complete in the Marathi duration PR | Remove all eight sub-five-minute violations from the Marathi track. | The report measures zero Marathi violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
+| HL-D01C | Next | Remove all nine sub-five-minute violations from the Gujarati track. | Gujarati is now the smallest remaining track-sized tranche; the gap report supplies the exact bounded lesson set. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
+| HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-B05 | Queued | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | A forced build succeeds but reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and two underfull boxes; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -129,6 +132,29 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Marathi's eight violations are the smallest remaining track-sized set, ahead
   of Gujarati's nine and Punjabi's and Sanskrit's ten each. HL-D01B is therefore
   the next bounded duration tranche after this PR merges.
+
+## Findings from HL-D01B
+
+- Marathi now has zero duration violations. The repository snapshot contains
+  981 lessons and 464 violations overall, down from 472 before this tranche;
+  unknown prerequisites remain at zero.
+- Seven lessons already computed between 126 and 171 seconds and only needed
+  honest four-minute declared budgets. The one genuinely long lesson computed
+  at 321 seconds.
+- That counting lesson is now a 163-second core followed by a 240-second
+  etymology lesson. The analogy and retention explanations remain complete and
+  prerequisite-ordered in the canonical corpus consumed by Language Ladder.
+- The audit also made a publication boundary explicit: Marathi Chapter 6 has
+  canonical lessons but is not in the current five-chapter PDF. HL-B04 records
+  the one-source migration and generation work instead of adding another manual
+  copy.
+- A forced build of the unchanged five-chapter book still succeeds with zero
+  overfull boxes, but exposes four duplicate practice labels, 32 Unicode
+  bookmark warnings, and two underfull boxes. HL-B05 records that pre-existing
+  publication hygiene debt separately from the lesson remediation.
+- Gujarati's nine violations are now the smallest remaining track-sized set,
+  ahead of Punjabi's and Sanskrit's ten each. HL-D01C is therefore next after
+  this PR merges.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/marathi/CHANGELOG.md
+++ b/code/learning/human-languages/marathi/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Sub-five-minute remediation — 2026-08-02
+
+- Corrected seven declared five-minute estimates whose computed durations were
+  already between 126 and 171 seconds.
+- Split the genuinely long numbers lesson into a 163-second counting lesson and
+  a prerequisite-ordered 240-second etymology lesson.
+- Preserved the complete *don / tīn* analogy, *pāch / pāṁch* retention contrast,
+  English *four / five* analogy, and Marathi *chār / tsār* sound shift. The
+  shared report now measures zero Marathi duration violations.
+- Updated the roadmap and session map to expose both Chapter 6 lesson boundaries.
+  Chapter 6's missing one-source book publication remains explicit in the shared
+  backlog.
+
 ## Chapter 6 — Numbers 1–5, and what "conservative" actually means
 
 - **Chapter 6 authored** (`MR-C06-numbers-1-5`): *ek, don, tīn, chār, pāch* —

--- a/code/learning/human-languages/marathi/README.md
+++ b/code/learning/human-languages/marathi/README.md
@@ -30,8 +30,14 @@ book.
   "punhā bheṭū", "udyā bheṭū", kāḷjī ghyā.
 - **Chapter 5 — The First Verbs** ([`lessons/MR-C05-*`](./lessons/)): bolṇe, "mī
   marāṭhī bolto", rāhṇe, kām karṇe.
+- **Chapter 6 — Numbers 1–5** ([`lessons/MR-C06-*`](./lessons/)): a short
+  counting lesson followed by a prerequisite-ordered etymology lesson on why
+  *don* copied *tīn*, why Hindi retains *pāṁch*'s nasal, and why written *chār*
+  sounds nearer *tsār* in Marathi.
 
-All five chapters are in the book.
+Chapters 1–5 are in the book. Chapter 6 is canonical app-ready lesson content;
+its one-source book publication remains explicitly tracked in the shared
+backlog.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/marathi/lessons/MR-C01-namaskar.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C01-namaskar.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [inherent-a, halant-conjunct]
 roots: [namas, kara]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/marathi/lessons/MR-C01-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [MR-C01-namaskar, MR-C01-dhanyavad, MR-C01-ho, MR-C01-nahi, MR-C01-baram, MR-C01-yeto]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [MR-C01-namaskar, MR-C01-dhanyavad, MR-C01-ho, MR-C01-nahi, MR-C01-baram, MR-C01-yeto]
 ---
 

--- a/code/learning/human-languages/marathi/lessons/MR-C02-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [MR-C02-anand]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [MR-C02-naav, MR-C02-majhe, MR-C02-aahe, MR-C02-majhe-naav-aahe, MR-C02-tu-tumhi, MR-C02-kaay, MR-C02-tumche-naav-kaay-aahe, MR-C02-anand]
 ---
 

--- a/code/learning/human-languages/marathi/lessons/MR-C03-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [MR-C03-kaahi-harkat-nahi]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [MR-C03-kasa, MR-C03-tumhi-kase-aahat, MR-C03-mi, MR-C03-mi-bara-aahe, MR-C03-kaahi-harkat-nahi]
 ---
 

--- a/code/learning/human-languages/marathi/lessons/MR-C04-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [MR-C04-kalji-ghya]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [MR-C04-punha, MR-C04-bhetu, MR-C04-punha-bhetu, MR-C04-udya-bhetu, MR-C04-kalji-ghya, MR-C01-yeto]
 ---
 

--- a/code/learning/human-languages/marathi/lessons/MR-C05-mi-marathi-bolto.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C05-mi-marathi-bolto.md
@@ -8,7 +8,7 @@ concept_tag: MR-WORD-MARATHI
 prerequisites: [MR-C05-bolne, MR-C03-mi]
 sounds: [retroflex-tha]
 roots: [maharashtra]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [MR-C05-bolne, MR-C03-mi]
 ---
 

--- a/code/learning/human-languages/marathi/lessons/MR-C05-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [MR-C05-kaam-karne]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [MR-C05-bolne, MR-C05-mi-marathi-bolto, MR-C05-rahne, MR-C05-kaam-karne]
 ---
 

--- a/code/learning/human-languages/marathi/lessons/MR-C06-number-differences.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C06-number-differences.md
@@ -1,0 +1,68 @@
+---
+id: MR-C06-number-differences
+chapter: 6
+type: etymology
+headword: दोन · तीन · पाच · चार
+gloss: why Marathi two rhymes with three, and why Hindi preserves a different piece of five
+prerequisites: [MR-C06-numbers-1-5]
+sounds: [matra-aa, matra-i, inherent-a]
+roots: [sanskrit-dvi, sanskrit-panca]
+etymology_hook: "Marathi don's final n is an innovation copied from tin, while Hindi paanch preserves Sanskrit pancha's nasal; neither daughter is simply older"
+est_minutes: 4
+reviews_of: [MR-C06-numbers-1-5]
+---
+
+# Why Marathi *two* rhymes with *three*
+
+## Warm-up
+
+[PAUSE 2s] Count once: *ek, don, tīn, tsār, pāch*. Which two words end in *n*?
+(*Don* and *tīn*.)
+
+## दोन — an ending borrowed from “three”
+
+The tempting guess is that Marathi **दोन** *don* kept something Hindi **दो**
+*do* lost. It did not.
+
+Sanskrit's neuter word for three, **त्रीणि** *trī́ṇi*, became Prakrit
+***tiṇṇi***. In *three*, the **ṇ** genuinely belongs to the word. The doubled
+consonant is a Prakrit trade for the lost *r*.
+
+The word for two was then reshaped to match its neighbour: Prakrit
+***doṇṇi*** copied the shape of ***tiṇṇi***. Marathi *don*'s final *n* is
+therefore an **innovation**, a rhyme borrowed from the number next door. Hindi
+*do* simply never took it.
+
+English numbers did this too: *four* acquired its initial *f-* by analogy with
+*five*. Familiar sequences pull neighbouring words toward one another.
+
+## पाच — the nasal Hindi kept
+
+Marathi **पाच** *pāch* and Hindi **पाँच** *pāṁch* tell the opposite story.
+Hindi's chandrabindu **ँ** records the nasal of Sanskrit ***pañca***; Marathi's
+spelling drops it.
+
+So neither language is simply “older.” Marathi innovated in *don*, while Hindi
+retained an older feature in *pāṁch*. Comparing both descendants reveals the
+history that either one alone could hide.
+
+## चार — a change the spelling hides
+
+Both write **चार**, but Marathi pronounces **च** before *ā* nearer **ts**:
+*tsār*. The letters stayed aligned while the sound moved.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the borrowed rhyme — *tiṇṇi … doṇṇi*]
+- [YOU SAY: innovation — Marathi *don*'s final *n*]
+- [YOU SAY: retention — Hindi *pāṁch*'s nasal]
+- [YOU SAY: same spelling, shifted sound — *chār / tsār*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Did Marathi *don* preserve an ancient ending? (No: *two* copied
+*three*.) Which language retains Sanskrit *pañca*'s nasal in writing? (Hindi.)
+Why can neither daughter be called simply older? (Each changed or retained a
+different feature.) What does Marathi change without respelling **चार**? (*Ch*
+shifts toward *ts* before *ā*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C06-numbers-1-5.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C06-numbers-1-5.md
@@ -8,8 +8,8 @@ concept_tag: MR-NUMBERS-1-5
 prerequisites: [MR-C01-namaskar]
 sounds: [matra-aa, matra-i, inherent-a]
 roots: [sanskrit-dvi, sanskrit-panca]
-etymology_hook: "Marathi दोन don's final -n is not inherited from 'two' at all — Prakrit doṇṇi borrowed its shape by ANALOGY from tiṇṇi 'three', where the ṇ genuinely belongs to the word (← neuter trīṇi, the doubling itself being a Prakrit trade for the lost r); so the number two was reshaped to rhyme with the number three, and Hindi's do simply never took that ending"
-est_minutes: 5
+etymology_hook: "Marathi don rhymes with tin, paach drops Hindi's written nasal, and chaar is pronounced nearer tsaar; the next short lesson explains why"
+est_minutes: 3
 reviews_of: [MR-C01-namaskar]
 ---
 
@@ -30,65 +30,30 @@ so their numbers look almost identical. **Almost** is where the interest is.
 | 4 | **चार** | *chār* — but see below |
 | 5 | **पाच** | *pāch* |
 
-## Two tells in the spelling
+## Three Marathi tells
 
-Set them against Hindi and two are written differently:
+Set them against Hindi. Two differences are visible and one is audible:
 
-| | Hindi | Marathi |
+| number | Hindi | Marathi |
 |---|---|---|
-| 2 | दो *do* | **दोन** *do**n*** |
-| 5 | पाँच *pāṁch* | **पाच** *pāch* — no nasal mark |
+| 2 | दो *do* | **दोन** *don*: final *n* |
+| 5 | पाँच *pāṁch* | **पाच** *pāch*: no nasal mark |
+| 4 | चार *chār* | **चार** *tsār*: same spelling, different sound |
 
-### दोन — an ending borrowed from "three"
-
-The tempting guess is that Marathi *kept* something Hindi lost. It didn't.
-
-Sanskrit's word for three, neuter **त्रीणि** *trī́ṇi*, became Prakrit ***tiṇṇi***
-— and in *three* the **ṇ genuinely belongs to the word**. (The *doubling* is a
-Prakrit development, trading the lost *r* for a heavier consonant; it's the
-**ṇ itself** that's inherited.)
-
-The word for two then got **reshaped to match**: Prakrit ***doṇṇi***, copying the
-whole shape from its neighbour in the counting sequence. In *two* the ṇ isn't
-inherited at all — it was borrowed wholesale.
-
-So Marathi's *-n* isn't an ancient survival at all. It's a **borrowed rhyme**,
-taken from the number next door — and Hindi's *do* is simply the form that never
-picked it up.
-
-Numbers do this constantly. English *four* got its *f-* from *five* the same way.
-
-### पाच — the nasal Hindi kept
-
-Here it *is* a straightforward difference of retention. Hindi writes the
-**chandrabindu** (**ँ**) on *pāṁch*, recording Sanskrit *pañca*'s nasal;
-Marathi's spelling drops it.
-
-So neither language is simply "older" — and the two cases aren't even the same
-kind of thing. One is an **innovation** Marathi adopted, the other a **retention**
-Hindi made. That's the honest version of "each kept a different piece," and the
-reason comparing two descendants tells you more than either alone.
-
-### One difference that isn't in the spelling
-
-*चार* is written identically in both, but Marathi's **च** before *ā* is
-pronounced closer to **ts** than to English "ch." Marathi says something like
-*tsār*. The letter is the same; the sound has moved.
+Do not explain all three histories yet. First make the five forms automatic;
+the next lesson earns the deeper comparison.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "ek, don, tīn, tsār, pāch"]
-- [YOU SAY: the rhyme — "ti**ṇṇi** … do**ṇṇi** — two copied three"]
-- [YOU SAY: the retention — "Hindi *pā**ṁ**ch* … Marathi *pāch*"]
+- [YOU SAY: the visible tells — *don* has *n*; *pāch* has no nasal mark]
+- [YOU SAY: the audible tell — written *chār*, Marathi *tsār*]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Count to five in Marathi. (*Ek, don, tīn, tsār, pāch*.) Where does
-**दोन**'s *-n* come from? (**From "three"** — *tiṇṇi*'s **ṇ** genuinely belongs
-to the word for three, and *doṇṇi* copied the whole shape by analogy.) So is it
-a retention?
-(**No — an innovation.** Hindi's *do* just never took it.) And *pāch* against
-*pāṁch*? (**There** Hindi is the one retaining — Sanskrit *pañca*'s nasal.) What
-differs in *चार* without differing in spelling? (Marathi's **च** is nearer **ts**
-before *ā*.) Next: six to ten.
+Marathi add a letter compared with Hindi? (**दोन**, *don*.) Which form drops a
+nasal mark? (**पाच**, *pāch*.) What differs in **चार** without differing in
+spelling? (Marathi's **च** is nearer **ts** before *ā*.) Next: explain where
+those differences came from.

--- a/code/learning/human-languages/marathi/roadmap.md
+++ b/code/learning/human-languages/marathi/roadmap.md
@@ -26,9 +26,11 @@ extra letter ळ, and a Dravidian-flavoured everyday grammar. The script is taug
 - **Ch. 5 — The First Verbs**: bolṇe → "mī marāṭhī bolto" → rāhṇe → kām karṇe →
   practice. The *-ṇe* infinitive; the gendered present (*-to/-te*); postposition
   *-āt*.
-- **Ch. 6 — Numbers 1–5** (`MR-C06-numbers-1-5`): *ek, don, tīn, chār, pāch* —
-  nearly Hindi's, and the differences are the lesson, because they are **two
-  different kinds of thing**. **दोन** *don*'s *-n* is an **innovation**: Prakrit
+- **Ch. 6 — Numbers 1–5** (`MR-C06-numbers-1-5` →
+  `MR-C06-number-differences`): first make *ek, don, tīn, chār, pāch* automatic,
+  then earn the deeper comparison in a separate sub-five-minute etymology
+  lesson. The differences are **two different kinds of thing**. **दोन** *don*'s
+  *-n* is an **innovation**: Prakrit
   *doṇṇi* took its ending **by analogy** from *tiṇṇi* "three" (where the **ṇ**
   genuinely belongs, ← neuter *trī́ṇi*, the doubling being a Prakrit trade for
   the lost *r*), so *two* was reshaped to rhyme with
@@ -43,7 +45,7 @@ extra letter ळ, and a Dravidian-flavoured everyday grammar. The script is taug
 
 | Chapter | Theme |
 |---|---|
-| 6 | Numbers 1–10 (native words + Devanagari digits १२३), counting, age |
+| 6 continuation | Numbers 6–10 (native words + Devanagari digits १२३), counting, age |
 | 7 | Family (*āī*, *bābā*, *bhāū*, *bahīṇ*) and the honorific *-jī* / *-rāv* |
 | 8 | Food and the market — where the Perso-Arabic and Portuguese loans cluster |
 | 9+ | The case-endings deepened, past and future tenses (where gender returns on the verb), everyday sentences — always with the Hindi/Dravidian contrast thread |

--- a/code/learning/human-languages/marathi/session-map.md
+++ b/code/learning/human-languages/marathi/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Marathi Chapters 1–5
+# Session Map — Marathi Chapters 1–6
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -66,7 +66,14 @@ word needs.
 | 32 | kaam-karne | काम करणे | "to work"; *karṇe* ← √*kṛ* (root of *namaskār*, *karma*) |
 | 33 | practice | (recap) | three verbs, one engine — sentences about yourself |
 
+## Chapter 6 — Numbers 1–5
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 34 | numbers-1-5 | एक, दोन, तीन, चार, पाच | retrieve the five forms; notice two written differences and one sound difference |
+| 35 | number-differences | दोन · तीन · पाच · चार | *don* copied *tīn* by analogy; Hindi retained *pāṁch*'s nasal; Marathi *chār* shifts toward *tsār* |
+
 ## Next
 
-Chapter 6 — numbers 1–10 (words + Devanagari digits १२३), then family and food,
-then the case-endings and the tenses where gender returns on the verb.
+Finish Chapter 6 with numbers 6–10 and Devanagari digits १२३, then family and
+food, then the case-endings and the tenses where gender returns on the verb.


### PR DESCRIPTION
## Summary

- remove all eight Marathi lessons at or above the five-minute boundary
- correct seven declared estimates that the shared model already measured at 126–171 seconds
- split the genuinely long numbers lesson into a 163-second counting core and a prerequisite-ordered 240-second etymology lesson
- preserve the full Marathi/Hindi analogy and retention comparison in canonical Markdown consumed by Language Ladder
- update the Marathi roadmap/session map and reprioritize the measured backlog to Gujarati's nine violations

The audit also records two distinct publication follow-ups: canonical Chapter 6 is not yet in the five-chapter PDF (`HL-B04`), and the unchanged book has existing label/bookmark warnings (`HL-B05`). Neither is hidden or conflated with this duration fix.

## Measured result

- Marathi duration violations: **8 → 0**
- repository duration violations: **472 → 464**
- canonical lessons: **980 → 981**
- unknown prerequisites: **0**
- split lesson durations: **163 seconds + 240 seconds**

## Validation

- `human-language-data`: 68 tests passed; 93.60% line coverage
- curriculum integration: 9 tests passed
- generated-book drift check: passed
- `language-ladder`: 278 tests passed; 98.37% line coverage
- Language Ladder production build: passed
- forced Marathi XeLaTeX regression build: 27 pages, zero overfull boxes
- `git diff --check`: passed

## Recorded pre-existing book debt

The unchanged Marathi book still emits four duplicate practice-label warnings, 32 Unicode PDF-string warnings, and two underfull boxes. `HL-B05` records a zero-warning cleanup target; this PR does not claim those warnings were introduced or fixed.