### PR TITLE
fix(build-tool): reject Rust dependency self-edges

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,7 +13,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "670445d092015e82e87d7ba1df03583413c8a6bf",
+    "revision": "9302e73668017a31e38f432c31bbba4f091a56bf",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1218,
@@ -365,7 +365,7 @@
       "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-rust-self-edge-diagnostic",
       "pr_number": null,
-      "notes": "Selected from collision-clean ca91ca25 after merged PR #9510 satisfied the sole dependency and rebased cleanly onto collision-clean 670445d0. The implementation defines exact language-neutral Elixir package/program and genuine self-edge fixtures, preserves the programs identity segment, makes library aliases outrank same-basename programs, and returns DEPENDENCY_SELF_EDGE with package, dependency, and repository-relative manifest identity through CLI exit 2 without host paths. Validation passed 138 unit tests plus both real CLI integrations, strict Clippy, release build, 79.33% region and 79.51% line coverage, 17 schema tests, 40 runner tests, the valid 34-case/42-file conformance corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real 4,766-entry full plan that now exits zero and preserves both grammar_tools identities. The known 10-item Lua BUILD_windows debt remains byte-for-byte identical to untouched ca91ca25 after root normalization. A separate pending Rust language-identity-registry item owns the 212 duplicate unknown identities found by the successful full-plan audit."
+      "notes": "Selected from collision-clean ca91ca25 after merged PR #9510 satisfied the sole dependency and rebased cleanly onto collision-clean 9302e736. The implementation defines exact language-neutral Elixir package/program and genuine self-edge fixtures, preserves the programs identity segment, makes library aliases outrank same-basename programs, and returns DEPENDENCY_SELF_EDGE with package, dependency, and repository-relative manifest identity through CLI exit 2 without host paths. Validation passed 138 unit tests plus both real CLI integrations, strict Clippy, release build, 79.33% region and 79.51% line coverage, 17 schema tests, 40 runner tests, the valid 34-case/42-file conformance corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real 4,766-entry full plan that now exits zero and preserves both grammar_tools identities. The known 10-item Lua BUILD_windows debt remains byte-for-byte identical to untouched ca91ca25 after root normalization. A separate pending Rust language-identity-registry item owns the 212 duplicate unknown identities found by the successful full-plan audit."
     },
     {
       "id": "build-tool-rust-language-identity-registry",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,7 +13,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "ca91ca25cc63e785038de4ca1b7b707e17b3fefe",
+    "revision": "670445d092015e82e87d7ba1df03583413c8a6bf",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1218,
@@ -365,7 +365,7 @@
       "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-rust-self-edge-diagnostic",
       "pr_number": null,
-      "notes": "Selected from collision-clean ca91ca25 after merged PR #9510 satisfied the sole dependency. The implementation defines exact language-neutral Elixir package/program and genuine self-edge fixtures, preserves the programs identity segment, makes library aliases outrank same-basename programs, and returns DEPENDENCY_SELF_EDGE with package, dependency, and repository-relative manifest identity through CLI exit 2 without host paths. Validation passed 138 unit tests plus both real CLI integrations, strict Clippy, release build, 79.33% region and 79.51% line coverage, 17 schema tests, 40 runner tests, the valid 34-case/42-file conformance corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real 4,766-entry full plan that now exits zero and preserves both grammar_tools identities. The known 10-item Lua BUILD_windows debt remains byte-for-byte identical to untouched ca91ca25 after root normalization. A separate pending Rust language-identity-registry item owns the 212 duplicate unknown identities found by the successful full-plan audit."
+      "notes": "Selected from collision-clean ca91ca25 after merged PR #9510 satisfied the sole dependency and rebased cleanly onto collision-clean 670445d0. The implementation defines exact language-neutral Elixir package/program and genuine self-edge fixtures, preserves the programs identity segment, makes library aliases outrank same-basename programs, and returns DEPENDENCY_SELF_EDGE with package, dependency, and repository-relative manifest identity through CLI exit 2 without host paths. Validation passed 138 unit tests plus both real CLI integrations, strict Clippy, release build, 79.33% region and 79.51% line coverage, 17 schema tests, 40 runner tests, the valid 34-case/42-file conformance corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real 4,766-entry full plan that now exits zero and preserves both grammar_tools identities. The known 10-item Lua BUILD_windows debt remains byte-for-byte identical to untouched ca91ca25 after root normalization. A separate pending Rust language-identity-registry item owns the 212 duplicate unknown identities found by the successful full-plan audit."
     },
     {
       "id": "build-tool-rust-language-identity-registry",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9521,
   "last_inventory": {
     "revision": "9302e73668017a31e38f432c31bbba4f091a56bf",
     "schema_version": 3,
@@ -361,11 +361,11 @@
     {
       "id": "build-tool-rust-self-edge-diagnostic",
       "title": "Make the Rust build tool reject self-edges without panicking",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-rust-self-edge-diagnostic",
-      "pr_number": null,
-      "notes": "Selected from collision-clean ca91ca25 after merged PR #9510 satisfied the sole dependency and rebased cleanly onto collision-clean 9302e736. The implementation defines exact language-neutral Elixir package/program and genuine self-edge fixtures, preserves the programs identity segment, makes library aliases outrank same-basename programs, and returns DEPENDENCY_SELF_EDGE with package, dependency, and repository-relative manifest identity through CLI exit 2 without host paths. Validation passed 138 unit tests plus both real CLI integrations, strict Clippy, release build, 79.33% region and 79.51% line coverage, 17 schema tests, 40 runner tests, the valid 34-case/42-file conformance corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real 4,766-entry full plan that now exits zero and preserves both grammar_tools identities. The known 10-item Lua BUILD_windows debt remains byte-for-byte identical to untouched ca91ca25 after root normalization. A separate pending Rust language-identity-registry item owns the 212 duplicate unknown identities found by the successful full-plan audit."
+      "pr_number": 9521,
+      "notes": "Ready PR #9521 opened from collision-clean 9302e736. The implementation defines exact language-neutral Elixir package/program and genuine self-edge fixtures, preserves the programs identity segment, makes library aliases outrank same-basename programs, and returns DEPENDENCY_SELF_EDGE with package, dependency, and repository-relative manifest identity through CLI exit 2 without host paths. Validation passed 138 unit tests plus both real CLI integrations, strict Clippy, release build, 79.33% region and 79.51% line coverage, 17 schema tests, 40 runner tests, the valid 34-case/42-file conformance corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real 4,766-entry full plan that now exits zero and preserves both grammar_tools identities. The known 10-item Lua BUILD_windows debt remains byte-for-byte identical to untouched ca91ca25 after root normalization. A separate pending Rust language-identity-registry item owns the 212 duplicate unknown identities found by the successful full-plan audit."
     },
     {
       "id": "build-tool-rust-language-identity-registry",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9510,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "de44349bd147c9ce46ce27d2ac741f2f01fcc2de",
+    "revision": "ca91ca25cc63e785038de4ca1b7b707e17b3fefe",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1218,
@@ -352,20 +352,29 @@
     {
       "id": "build-tool-rust-rockspec-utf8-conformance",
       "title": "Make the Rust build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-go-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-rust-rockspec-utf8",
       "pr_number": 9510,
-      "notes": "Ready PR #9510 follows the a6845a83c dependency/leverage selection and is rebased on de44349bd. The implementation consumes the exact shared success and invalid-byte fixtures, requires exact edge equality, returns a typed METADATA_INVALID_UTF8 diagnostic with package and repository-relative manifest identity, exits 2 through the real CLI, and does not disclose host paths. Validation passed 136 unit plus one CLI integration test, strict Clippy, release build, 79.33% line coverage, 57 language-neutral conformance tests plus 52 subtests, the 32-case/36-file corpus, a real 258-package Lua dry-run plan across all 246 strict-UTF-8 rockspecs, collision-free parity inventory, and a zero-advisory RustSec audit. Full-repository plan validation separately reproduced untouched main's 4,766-package exit-101 panic on an elixir/grammar_tools self-edge, and BUILD validation output matched untouched main exactly; the dedicated pending self-edge and Lua BUILD_windows items own those baselines. The seven non-Rust encoding remediations remain outside this slice."
+      "notes": "Merged PR #9510 at ca91ca25cc63e785038de4ca1b7b707e17b3fefe on 2026-08-02 after all applicable CI, fixture-consumer, detection, platform-build, and CodeQL checks passed. The implementation consumes the exact shared success and invalid-byte fixtures, requires exact edge equality, returns a typed METADATA_INVALID_UTF8 diagnostic with package and repository-relative manifest identity, exits 2 through the real CLI, and does not disclose host paths. Validation passed 136 unit plus one CLI integration test, strict Clippy, release build, 79.33% line coverage, 57 language-neutral conformance tests plus 52 subtests, the 32-case/36-file corpus, a real 258-package Lua dry-run plan across all 246 strict-UTF-8 rockspecs, collision-free parity inventory, and a zero-advisory RustSec audit. Full-repository plan validation separately reproduced untouched main's 4,766-package exit-101 panic on an elixir/grammar_tools self-edge, and BUILD validation output matched untouched main exactly; the dedicated self-edge and Lua BUILD_windows items own those baselines. The seven non-Rust encoding remediations remain outside this slice."
     },
     {
       "id": "build-tool-rust-self-edge-diagnostic",
       "title": "Make the Rust build tool reject self-edges without panicking",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
+      "branch": "codex/build-tool-rust-self-edge-diagnostic",
+      "pr_number": null,
+      "notes": "Selected from collision-clean ca91ca25 after merged PR #9510 satisfied the sole dependency. The implementation defines exact language-neutral Elixir package/program and genuine self-edge fixtures, preserves the programs identity segment, makes library aliases outrank same-basename programs, and returns DEPENDENCY_SELF_EDGE with package, dependency, and repository-relative manifest identity through CLI exit 2 without host paths. Validation passed 138 unit tests plus both real CLI integrations, strict Clippy, release build, 79.33% region and 79.51% line coverage, 17 schema tests, 40 runner tests, the valid 34-case/42-file conformance corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real 4,766-entry full plan that now exits zero and preserves both grammar_tools identities. The known 10-item Lua BUILD_windows debt remains byte-for-byte identical to untouched ca91ca25 after root normalization. A separate pending Rust language-identity-registry item owns the 212 duplicate unknown identities found by the successful full-plan audit."
+    },
+    {
+      "id": "build-tool-rust-language-identity-registry",
+      "title": "Bring Rust build-tool discovery to the canonical language and identity registry",
+      "status": "pending",
+      "depends_on": ["build-tool-rust-self-edge-diagnostic"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered during the Rust UTF-8 slice's real full-repository plan. On rebased de44349bd, both untouched main and the current branch discover 4,766 packages, then exit 101 because graph.add_edge panics on elixir/grammar_tools. Define a language-neutral self-edge resolution fixture, identify the exact Elixir resolver alias collision or self-reference, and return a stable resolver diagnostic instead of aborting the process. Keep this independent of strict rockspec decoding."
+      "notes": "Discovered while validating the Rust self-edge slice on ca91ca25. The repaired full plan exits zero and emits 4,766 package entries, but only 4,384 names are unique: 212 duplicate unknown/* identities account for 382 extra entries because the Rust discovery registry omits several established and emerging language directories. Add language-neutral discovery fixtures, classify every supported lane consistently with the canonical registry, and reject any residual duplicate qualified identity with a stable diagnostic. Keep this separate from the Elixir package/program self-edge repair."
     },
     {
       "id": "build-tool-python-haskell-language-filter",

--- a/code/programs/rust/build-tool/CHANGELOG.md
+++ b/code/programs/rust/build-tool/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Rust build tool will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.3] - 2026-08-02
+
+### Fixed
+
+- Preserve a `programs` segment in discovered program identities and prefer
+  library packages when an ecosystem dependency alias is shared. This keeps
+  `code/packages/elixir/grammar_tools` distinct from its CLI program and
+  resolves the program's dependency to the library.
+- Reject genuine dependency self-edges with `DEPENDENCY_SELF_EDGE`, stable
+  package, dependency, and repository-relative manifest identities, CLI exit
+  code 2, and no checkout-path disclosure instead of panicking in the graph.
+  Resolver and CLI coverage consume the language-neutral Elixir fixtures.
+
 ## [0.2.2] - 2026-08-02
 
 ### Fixed

--- a/code/programs/rust/build-tool/README.md
+++ b/code/programs/rust/build-tool/README.md
@@ -4,7 +4,7 @@ A **Rust port** of the Go build tool for the coding-adventures monorepo. It disc
 
 ## What it does
 
-This tool discovers packages in the monorepo via recursive `BUILD` file walking, resolves inter-package dependencies, hashes source files for change detection, and only rebuilds packages whose source or dependency inputs changed. Independent packages are built in parallel. Text metadata is decoded deterministically: Lua `.rockspec` files must be strict UTF-8, and invalid bytes fail closed instead of silently deleting dependency edges.
+This tool discovers packages in the monorepo via recursive `BUILD` file walking, resolves inter-package dependencies, hashes source files for change detection, and only rebuilds packages whose source or dependency inputs changed. Independent packages are built in parallel. Programs retain a `programs` identity segment so a library and program with the same basename stay distinct. Text metadata is decoded deterministically: Lua `.rockspec` files must be strict UTF-8, and invalid bytes fail closed instead of silently deleting dependency edges.
 
 ## Building
 
@@ -111,6 +111,17 @@ METADATA_INVALID_UTF8: package=lua/pkg manifest=code/packages/lua/pkg/coding-adv
 
 The resolver and real CLI tests materialize the language-neutral
 `resolution/lua-utf8` and `resolution/lua-invalid-utf8` fixtures.
+
+A resolved dependency self-edge also fails closed with exit code `2` instead
+of reaching the embedded graph assertion:
+
+```text
+DEPENDENCY_SELF_EDGE: package=elixir/pkg manifest=code/packages/elixir/pkg/mix.exs dependency=elixir/pkg
+```
+
+The shared `resolution/elixir-program-package` fixture verifies that the
+`grammar_tools` package and program remain distinct, while
+`resolution/elixir-self-edge` verifies the stable error path.
 
 ## How it fits in the stack
 

--- a/code/programs/rust/build-tool/src/discovery.rs
+++ b/code/programs/rust/build-tool/src/discovery.rs
@@ -142,13 +142,25 @@ fn infer_language(path: &Path) -> String {
     "unknown".to_string()
 }
 
-/// Builds a qualified package name like "python/logic-gates" from the
-/// language and the directory's basename.
+/// Builds a qualified package name from the language and directory path.
+///
+/// Programs retain a `programs` identity segment so a library package and a
+/// program with the same basename remain distinct graph nodes.
 fn infer_package_name(path: &Path, language: &str) -> String {
     let dir_name = path
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_default();
+    let components: Vec<String> = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    if components
+        .windows(2)
+        .any(|pair| pair[0] == "code" && pair[1] == "programs")
+    {
+        return format!("{}/programs/{}", language, dir_name);
+    }
     format!("{}/{}", language, dir_name)
 }
 
@@ -318,6 +330,15 @@ mod tests {
     fn test_infer_package_name() {
         let path = Path::new("/repo/code/packages/python/logic-gates");
         assert_eq!(infer_package_name(path, "python"), "python/logic-gates");
+    }
+
+    #[test]
+    fn test_infer_package_name_preserves_program_identity() {
+        let path = Path::new("/repo/code/programs/elixir/grammar_tools");
+        assert_eq!(
+            infer_package_name(path, "elixir"),
+            "elixir/programs/grammar_tools"
+        );
     }
 
     #[test]

--- a/code/programs/rust/build-tool/src/resolver.rs
+++ b/code/programs/rust/build-tool/src/resolver.rs
@@ -40,6 +40,7 @@ use std::fs;
 use std::path::Path;
 
 const METADATA_INVALID_UTF8: &str = "METADATA_INVALID_UTF8";
+const DEPENDENCY_SELF_EDGE: &str = "DEPENDENCY_SELF_EDGE";
 
 /// Text metadata that violates the repository's strict UTF-8 contract.
 ///
@@ -65,6 +66,51 @@ impl fmt::Display for MetadataEncodingError {
 
 impl std::error::Error for MetadataEncodingError {}
 
+/// A package manifest that resolves the package itself as a dependency.
+#[derive(Debug, Eq, PartialEq)]
+pub struct DependencySelfEdgeError {
+    pub code: String,
+    pub package: String,
+    pub manifest: String,
+    pub dependency: String,
+}
+
+impl fmt::Display for DependencySelfEdgeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{}: package={} manifest={} dependency={}",
+            self.code, self.package, self.manifest, self.dependency
+        )
+    }
+}
+
+impl std::error::Error for DependencySelfEdgeError {}
+
+/// Stable dependency-resolution failures returned to the CLI.
+#[derive(Debug, Eq, PartialEq)]
+pub enum ResolutionError {
+    MetadataEncoding(MetadataEncodingError),
+    DependencySelfEdge(DependencySelfEdgeError),
+}
+
+impl fmt::Display for ResolutionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ResolutionError::MetadataEncoding(error) => error.fmt(formatter),
+            ResolutionError::DependencySelfEdge(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for ResolutionError {}
+
+impl From<MetadataEncodingError> for ResolutionError {
+    fn from(error: MetadataEncodingError) -> Self {
+        ResolutionError::MetadataEncoding(error)
+    }
+}
+
 fn repository_manifest_path(path: &Path) -> String {
     let parts: Vec<String> = path
         .components()
@@ -85,6 +131,46 @@ fn repository_manifest_path(path: &Path) -> String {
             .map(|name| name.to_string_lossy().into_owned())
             .unwrap_or_default(),
     }
+}
+
+fn first_manifest_with_suffix(pkg: &Package, suffixes: &[&str]) -> Option<std::path::PathBuf> {
+    let mut matches: Vec<std::path::PathBuf> = fs::read_dir(&pkg.path)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .map(|name| {
+                    let name = name.to_string_lossy();
+                    suffixes.iter().any(|suffix| name.ends_with(suffix))
+                })
+                .unwrap_or(false)
+        })
+        .collect();
+    matches.sort();
+    matches.into_iter().next()
+}
+
+fn dependency_manifest_path(pkg: &Package) -> String {
+    let manifest = match pkg.language.as_str() {
+        "python" => pkg.path.join("pyproject.toml"),
+        "go" => pkg.path.join("go.mod"),
+        "rust" | "wasm" => pkg.path.join("Cargo.toml"),
+        "elixir" => pkg.path.join("mix.exs"),
+        "perl" => pkg.path.join("Makefile.PL"),
+        "ruby" => {
+            first_manifest_with_suffix(pkg, &[".gemspec"]).unwrap_or_else(|| pkg.path.join("BUILD"))
+        }
+        "lua" => first_manifest_with_suffix(pkg, &[".rockspec"])
+            .unwrap_or_else(|| pkg.path.join("BUILD")),
+        "haskell" => {
+            first_manifest_with_suffix(pkg, &[".cabal"]).unwrap_or_else(|| pkg.path.join("BUILD"))
+        }
+        "csharp" | "fsharp" | "dotnet" => first_manifest_with_suffix(pkg, &[".csproj", ".fsproj"])
+            .unwrap_or_else(|| pkg.path.join("BUILD")),
+        _ => pkg.path.join("BUILD"),
+    };
+    repository_manifest_path(&manifest)
 }
 
 // ---------------------------------------------------------------------------
@@ -140,6 +226,17 @@ fn read_cargo_package_name(pkg: &Package) -> Option<String> {
 fn build_known_names_for_scope(packages: &[Package], scope: &str) -> HashMap<String, String> {
     let mut known = HashMap::new();
 
+    let set_known = |known: &mut HashMap<String, String>, key: String, pkg: &Package| {
+        let current_is_program = pkg.name.split('/').nth(1) == Some("programs");
+        if let Some(existing) = known.get(&key) {
+            let existing_is_program = existing.split('/').nth(1) == Some("programs");
+            if !existing_is_program && current_is_program {
+                return;
+            }
+        }
+        known.insert(key, pkg.name.clone());
+    };
+
     for pkg in packages {
         if !scope.is_empty() && !in_dependency_scope(&pkg.language, scope) {
             continue;
@@ -154,12 +251,12 @@ fn build_known_names_for_scope(packages: &[Package], scope: &str) -> HashMap<Str
             "python" => {
                 // Convert dir name to PyPI name: "logic-gates" -> "coding-adventures-logic-gates"
                 let pypi_name = format!("coding-adventures-{}", dir_name);
-                known.insert(pypi_name, pkg.name.clone());
+                set_known(&mut known, pypi_name, pkg);
             }
             "ruby" => {
                 // Convert dir name to gem name: "logic_gates" -> "coding_adventures_logic_gates"
                 let gem_name = format!("coding_adventures_{}", dir_name);
-                known.insert(gem_name, pkg.name.clone());
+                set_known(&mut known, gem_name, pkg);
             }
             "go" => {
                 // For Go, read the module path from go.mod.
@@ -167,11 +264,9 @@ fn build_known_names_for_scope(packages: &[Package], scope: &str) -> HashMap<Str
                 if let Ok(data) = fs::read_to_string(&go_mod) {
                     for line in data.lines() {
                         if line.starts_with("module ") {
-                            let module_path = line
-                                .trim_start_matches("module ")
-                                .trim()
-                                .to_lowercase();
-                            known.insert(module_path, pkg.name.clone());
+                            let module_path =
+                                line.trim_start_matches("module ").trim().to_lowercase();
+                            set_known(&mut known, module_path, pkg);
                             break;
                         }
                     }
@@ -186,39 +281,39 @@ fn build_known_names_for_scope(packages: &[Package], scope: &str) -> HashMap<Str
                         if let Some(package) = parsed.get("package") {
                             if let Some(name) = package.get("name") {
                                 if let Some(name_str) = name.as_str() {
-                                    known.insert(name_str.to_lowercase(), pkg.name.clone());
+                                    set_known(&mut known, name_str.to_lowercase(), pkg);
                                 }
                             }
                         }
                     }
                 }
                 if let Some(cargo_name) = read_cargo_package_name(pkg) {
-                    known.insert(cargo_name, pkg.name.clone());
+                    set_known(&mut known, cargo_name, pkg);
                 }
             }
             "elixir" => {
                 let app_name = format!("coding_adventures_{}", dir_name.replace('-', "_"));
-                known.insert(app_name, pkg.name.clone());
+                set_known(&mut known, app_name, pkg);
             }
             "lua" => {
                 // Convert dir name to rockspec name: "logic_gates" -> "coding-adventures-logic-gates"
                 // Lua rockspecs use hyphens with a "coding-adventures-" prefix.
                 let rock_name = format!("coding-adventures-{}", dir_name.replace('_', "-"));
-                known.insert(rock_name, pkg.name.clone());
+                set_known(&mut known, rock_name, pkg);
             }
             "perl" => {
                 // Perl CPAN dist names use hyphens: "logic-gates" -> "coding-adventures-logic-gates"
                 // This matches the Python convention exactly.
                 let cpan_name = format!("coding-adventures-{}", dir_name);
-                known.insert(cpan_name, pkg.name.clone());
+                set_known(&mut known, cpan_name, pkg);
             }
             "haskell" => {
                 // Haskell Cabal package names use hyphens.
                 let cabal_name = format!("coding-adventures-{}", dir_name);
-                known.insert(cabal_name, pkg.name.clone());
+                set_known(&mut known, cabal_name, pkg);
             }
             "csharp" | "fsharp" | "dotnet" => {
-                known.insert(dir_name, pkg.name.clone());
+                set_known(&mut known, dir_name, pkg);
             }
             _ => {}
         }
@@ -806,7 +901,7 @@ fn parse_haskell_deps(pkg: &Package, known_names: &HashMap<String, String>) -> V
 /// among the discovered packages — are silently skipped.
 ///
 /// This function is the main entry point for dependency resolution.
-pub fn resolve_dependencies(packages: &[Package]) -> Result<Graph, MetadataEncodingError> {
+pub fn resolve_dependencies(packages: &[Package]) -> Result<Graph, ResolutionError> {
     let mut graph = Graph::new();
 
     // First, add all packages as nodes. Even packages with no dependencies
@@ -835,7 +930,7 @@ pub fn resolve_dependencies(packages: &[Package]) -> Result<Graph, MetadataEncod
             "go" => parse_go_deps(pkg, known_names),
             "rust" | "wasm" => parse_rust_deps(pkg, known_names),
             "elixir" => parse_elixir_deps(pkg, known_names),
-            "lua" => parse_lua_deps(pkg, known_names)?,
+            "lua" => parse_lua_deps(pkg, known_names).map_err(ResolutionError::from)?,
             "perl" => parse_perl_deps(pkg, known_names),
             "haskell" => parse_haskell_deps(pkg, known_names),
             "csharp" | "fsharp" | "dotnet" => parse_dotnet_deps(pkg, known_names),
@@ -846,6 +941,16 @@ pub fn resolve_dependencies(packages: &[Package]) -> Result<Graph, MetadataEncod
             // Edge direction: dep -> pkg means "dep must be built before pkg".
             // This convention makes independent_groups() produce the correct
             // build order: nodes with zero in-degree (no deps) come first.
+            if dep_name == pkg.name {
+                return Err(ResolutionError::DependencySelfEdge(
+                    DependencySelfEdgeError {
+                        code: DEPENDENCY_SELF_EDGE.to_string(),
+                        package: pkg.name.clone(),
+                        manifest: dependency_manifest_path(pkg),
+                        dependency: dep_name,
+                    },
+                ));
+            }
             graph.add_edge(&dep_name, &pkg.name);
         }
     }
@@ -861,7 +966,6 @@ pub fn resolve_dependencies(packages: &[Package]) -> Result<Graph, MetadataEncod
 mod tests {
     use super::*;
     use serde::Deserialize;
-    use std::collections::HashSet;
     use std::path::{Path, PathBuf};
 
     #[derive(Debug, Deserialize)]
@@ -909,7 +1013,10 @@ mod tests {
 
     #[derive(Debug, Deserialize)]
     struct FixtureDiagnosticDetails {
-        encoding: String,
+        #[serde(default)]
+        encoding: Option<String>,
+        #[serde(default)]
+        dependency: Option<String>,
     }
 
     fn decode_base64(input: &str) -> Vec<u8> {
@@ -959,9 +1066,6 @@ mod tests {
             std::process::id()
         ));
         let _ = fs::remove_dir_all(&root);
-        let mut packages = Vec::new();
-        let mut seen_packages = HashSet::new();
-
         for file in &fixture.workspace.files {
             let path = root.join(Path::new(&file.path));
             fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -971,21 +1075,9 @@ mod tests {
                 decode_base64(&file.content_base64)
             };
             fs::write(&path, data).unwrap();
-
-            let segments: Vec<&str> = file.path.split('/').collect();
-            if segments.len() == 5 && segments[4] == "BUILD" {
-                let name = format!("{}/{}", segments[2], segments[3]);
-                if seen_packages.insert(name.clone()) {
-                    packages.push(Package {
-                        name,
-                        path: root.join(segments[..4].iter().collect::<PathBuf>()),
-                        build_commands: Vec::new(),
-                        language: segments[2].to_string(),
-                    });
-                }
-            }
         }
 
+        let packages = crate::discovery::discover_packages(&root.join("code"));
         (root, packages)
     }
 
@@ -1016,11 +1108,63 @@ mod tests {
                     Ok(_) => panic!("invalid UTF-8 fixture must fail closed"),
                     Err(error) => error,
                 };
+                let encoding_error = match error {
+                    ResolutionError::MetadataEncoding(error) => error,
+                    other => panic!("expected metadata encoding error, got {other}"),
+                };
                 let diagnostic = &fixture.expected.diagnostics[0];
-                assert_eq!(error.code, diagnostic.code);
-                assert_eq!(error.package, diagnostic.package);
-                assert_eq!(error.manifest, diagnostic.path);
-                assert_eq!(error.encoding, diagnostic.details.encoding);
+                assert_eq!(encoding_error.code, diagnostic.code);
+                assert_eq!(encoding_error.package, diagnostic.package);
+                assert_eq!(encoding_error.manifest, diagnostic.path);
+                assert_eq!(
+                    Some(encoding_error.encoding.as_str()),
+                    diagnostic.details.encoding.as_deref()
+                );
+                assert!(!encoding_error
+                    .to_string()
+                    .contains(&root.to_string_lossy().to_string()));
+            }
+
+            let _ = fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn test_elixir_resolution_conformance_fixtures() {
+        for name in [
+            "resolution-elixir-program-package.json",
+            "resolution-elixir-self-edge.json",
+        ] {
+            let fixture = load_resolution_fixture(name);
+            let (root, packages) = materialize_resolution_fixture(&fixture, name);
+            let result = resolve_dependencies(&packages);
+
+            if fixture.expected.outcome == "ok" {
+                let graph = result.expect("distinct package and program identities must resolve");
+                let mut actual_edges = Vec::new();
+                for package in &packages {
+                    for dependency in graph.predecessors(&package.name).unwrap() {
+                        actual_edges.push(vec![dependency, package.name.clone()]);
+                    }
+                }
+                actual_edges.sort();
+                let mut expected_edges = fixture.expected.result.edges.clone();
+                expected_edges.sort();
+                assert_eq!(actual_edges, expected_edges);
+            } else {
+                let error = match result {
+                    Ok(_) => panic!("dependency self-edge fixture must fail closed"),
+                    Err(error) => error,
+                };
+                let diagnostic = &fixture.expected.diagnostics[0];
+                let expected = format!(
+                    "{}: package={} manifest={} dependency={}",
+                    diagnostic.code,
+                    diagnostic.package,
+                    diagnostic.path,
+                    diagnostic.details.dependency.as_deref().unwrap()
+                );
+                assert_eq!(error.to_string(), expected);
                 assert!(!error
                     .to_string()
                     .contains(&root.to_string_lossy().to_string()));

--- a/code/programs/rust/build-tool/tests/self_edge_cli.rs
+++ b/code/programs/rust/build-tool/tests/self_edge_cli.rs
@@ -1,0 +1,98 @@
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Deserialize)]
+struct ResolutionFixture {
+    workspace: FixtureWorkspace,
+    expected: FixtureExpected,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureWorkspace {
+    files: Vec<FixtureFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureFile {
+    path: String,
+    content_utf8: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureExpected {
+    diagnostics: Vec<FixtureDiagnostic>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureDiagnostic {
+    code: String,
+    path: String,
+    package: String,
+    details: FixtureDiagnosticDetails,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureDiagnosticDetails {
+    dependency: String,
+}
+
+fn load_fixture() -> ResolutionFixture {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/fixtures/build-tool-v1/cases/resolution-elixir-self-edge.json");
+    let data = fs::read(&path)
+        .unwrap_or_else(|error| panic!("read shared fixture {}: {error}", path.display()));
+    serde_json::from_slice(&data)
+        .unwrap_or_else(|error| panic!("decode shared fixture {}: {error}", path.display()))
+}
+
+fn materialize_fixture(fixture: &ResolutionFixture) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "build_tool_rust_self_edge_cli_{}_{}",
+        std::process::id(),
+        nonce
+    ));
+
+    for file in &fixture.workspace.files {
+        let path = root.join(Path::new(&file.path));
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, file.content_utf8.as_bytes()).unwrap();
+    }
+
+    root
+}
+
+#[test]
+fn cli_fails_closed_on_shared_self_edge_fixture() {
+    let fixture = load_fixture();
+    let root = materialize_fixture(&fixture);
+    let output = Command::new(env!("CARGO_BIN_EXE_build-tool"))
+        .args([
+            "--root",
+            root.to_str().unwrap(),
+            "--force",
+            "--dry-run",
+            "--language",
+            "elixir",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let diagnostic = &fixture.expected.diagnostics[0];
+    let expected = format!(
+        "{}: package={} manifest={} dependency={}\n",
+        diagnostic.code, diagnostic.package, diagnostic.path, diagnostic.details.dependency
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert_eq!(stderr, expected);
+    assert!(!stderr.contains(&root.to_string_lossy().to_string()));
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -131,7 +131,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 32)
+        self.assertEqual(summary["case_count"], 34)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -851,7 +851,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 32)
+        self.assertEqual(summary["case_count"], 34)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -258,8 +258,13 @@ MUST:
 - recognize repository-supported legacy and current package-name aliases;
 - keep dependency scope within the implementation ecosystem unless metadata
   explicitly names another qualified package;
-- reject self-edges, ambiguous manifests, ambiguous aliases, and duplicate
-  package identities;
+- preserve the `programs` identity segment when a package and program share a
+  language and basename, so a program dependency resolves to the package
+  instead of collapsing into a self-edge;
+- reject a resolved self-edge as `DEPENDENCY_SELF_EDGE`, including the
+  repository-relative manifest path, package identity, and dependency identity;
+- reject ambiguous manifests, ambiguous aliases, and duplicate package
+  identities;
 - decode `.rockspec` text metadata as strict UTF-8 without replacement or
   locale fallback;
 - report invalid rockspec encoding as `METADATA_INVALID_UTF8`, including the

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-08-02
 
+- Added Elixir resolution cases that preserve distinct package/program
+  identities and reject genuine dependency self-edges with the stable
+  `DEPENDENCY_SELF_EDGE` diagnostic.
 - Declared strict UTF-8 as the portable metadata text contract for dependency
   resolution and reserved `METADATA_INVALID_UTF8` for deterministic failures.
 - Added positive Unicode and adversarial invalid-byte Lua rockspec cases so

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -35,11 +35,12 @@ emerging OCaml lane. It records front-door and shared-engine state but contains
 no executable commands. Every adapter is currently marked missing, so a valid
 inventory is not reported as conformance success.
 
-The 32-case bootstrap corpus covers every process-free v1 domain:
+The 34-case bootstrap corpus covers every process-free v1 domain:
 
 - canonical membership plus Windows, macOS, and Linux BUILD precedence;
-- the shared Python dependency diamond plus positive UTF-8 and fail-closed
-  invalid-UTF-8 Lua rockspec resolution;
+- the shared Python dependency diamond, distinct Elixir package/program
+  identities, fail-closed dependency self-edges, and positive UTF-8 plus
+  fail-closed invalid-UTF-8 Lua rockspec resolution;
 - deterministic diamond graph levels;
 - the build-plan distinction between `affected_packages: null` and `[]`; and
 - fail-closed rejection of a future plan version;

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-elixir-program-package.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-elixir-program-package.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "id": "resolution/elixir-program-package",
+  "domain": "resolution",
+  "summary": "An Elixir program and package with the same basename retain distinct identities.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "resolution"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/elixir/grammar_tools/BUILD",
+        "content_utf8": "mix test\n"
+      },
+      {
+        "path": "code/packages/elixir/grammar_tools/mix.exs",
+        "content_utf8": "defmodule CodingAdventures.GrammarTools.MixProject do\n  use Mix.Project\n  def project, do: [app: :coding_adventures_grammar_tools, deps: []]\nend\n"
+      },
+      {
+        "path": "code/programs/elixir/grammar_tools/BUILD",
+        "content_utf8": "mix test\n"
+      },
+      {
+        "path": "code/programs/elixir/grammar_tools/mix.exs",
+        "content_utf8": "defmodule GrammarTools.MixProject do\n  use Mix.Project\n  def project, do: [app: :grammar_tools_program, deps: deps()]\n  defp deps, do: [{:coding_adventures_grammar_tools, path: \"../../../packages/elixir/grammar_tools\"}]\nend\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "resolution",
+    "options": {
+      "code_root": "code",
+      "language": "elixir"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "resolution/elixir-program-package",
+    "domain": "resolution",
+    "outcome": "ok",
+    "result": {
+      "edges": [
+        [
+          "elixir/grammar_tools",
+          "elixir/programs/grammar_tools"
+        ]
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-elixir-self-edge.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-elixir-self-edge.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "id": "resolution/elixir-self-edge",
+  "domain": "resolution",
+  "summary": "An Elixir package that resolves itself as a dependency fails closed.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "resolution"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/elixir/pkg/BUILD",
+        "content_utf8": "mix test\n"
+      },
+      {
+        "path": "code/packages/elixir/pkg/mix.exs",
+        "content_utf8": "defmodule CodingAdventures.Pkg.MixProject do\n  use Mix.Project\n  def project, do: [app: :coding_adventures_pkg, deps: deps()]\n  defp deps, do: [{:coding_adventures_pkg, path: \"../pkg\"}]\nend\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "resolution",
+    "options": {
+      "code_root": "code",
+      "language": "elixir"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "resolution/elixir-self-edge",
+    "domain": "resolution",
+    "outcome": "error",
+    "result": {},
+    "diagnostics": [
+      {
+        "code": "DEPENDENCY_SELF_EDGE",
+        "severity": "error",
+        "path": "code/packages/elixir/pkg/mix.exs",
+        "package": "elixir/pkg",
+        "details": {
+          "dependency": "elixir/pkg"
+        }
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,10 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `670445d0` after
+working inventory was regenerated on August 2, 2026 from `9302e736` after
 merged PR #9498 added the mixed Rust Tasmota local HTTP identity. Merged PRs
-#9502, #9505, #9506, #9510, #9512, #9514, and #9515 changed existing packages
-or learning assets without creating another implementation package directory.
+#9502, #9505, #9506, #9510, #9512, #9514, #9515, and #9516 changed existing
+packages or learning assets without creating another implementation package
+directory.
 The inventory contains
 1,218 normalized implementation identities across 4,366 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
@@ -125,7 +126,7 @@ The loop must not start by attempting 10,752 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`670445d092015e82e87d7ba1df03583413c8a6bf` is collision-clean at 1,218
+`9302e73668017a31e38f432c31bbba4f091a56bf` is collision-clean at 1,218
 normalized implementation identities, 4,366 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 768 singletons, 573
 Rust singletons, zero canonical collisions, and zero unknown language buckets.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,10 +106,10 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `de44349bd` after
+working inventory was regenerated on August 2, 2026 from `ca91ca25` after
 merged PR #9498 added the mixed Rust Tasmota local HTTP identity. Merged PRs
-#9502, #9505, and #9506 changed existing packages or learning assets without
-creating another implementation package directory. The inventory contains
+#9502, #9505, #9506, and #9510 changed existing packages or learning assets
+without creating another implementation package directory. The inventory contains
 1,218 normalized implementation identities across 4,366 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
@@ -124,7 +124,7 @@ The loop must not start by attempting 10,752 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`de44349bd147c9ce46ce27d2ac741f2f01fcc2de` is collision-clean at 1,218
+`ca91ca25cc63e785038de4ca1b7b707e17b3fefe` is collision-clean at 1,218
 normalized implementation identities, 4,366 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 768 singletons, 573
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
@@ -190,7 +190,7 @@ The August 2 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 981 | 0 | 100% |
+| Rust | 983 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -226,6 +226,12 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
 - make the Rust build tool reject resolver self-edges with a stable diagnostic.
   A real 4,766-package plan reproduced the untouched-main exit-101 panic on
   `elixir/grammar_tools`; this is tracked separately from UTF-8 decoding;
+- bring Rust build-tool discovery to the complete canonical language and
+  identity registry. The self-edge repair makes the full plan exit zero and
+  distinguishes package/program basenames, but a follow-up audit found 212
+  remaining duplicate `unknown/*` identities (382 extra discovered entries)
+  because several established and emerging language directories are not yet
+  classified by the Rust front door;
 - expose Haskell through the Python build tool's `--language` filter. Haskell
   is already in its resolver and canonical language registry but is missing
   from the native CLI choices;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,10 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `ca91ca25` after
+working inventory was regenerated on August 2, 2026 from `670445d0` after
 merged PR #9498 added the mixed Rust Tasmota local HTTP identity. Merged PRs
-#9502, #9505, #9506, and #9510 changed existing packages or learning assets
-without creating another implementation package directory. The inventory contains
+#9502, #9505, #9506, #9510, #9512, #9514, and #9515 changed existing packages
+or learning assets without creating another implementation package directory.
+The inventory contains
 1,218 normalized implementation identities across 4,366 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
@@ -124,7 +125,7 @@ The loop must not start by attempting 10,752 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`ca91ca25cc63e785038de4ca1b7b707e17b3fefe` is collision-clean at 1,218
+`670445d092015e82e87d7ba1df03583413c8a6bf` is collision-clean at 1,218
 normalized implementation identities, 4,366 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 768 singletons, 573
 Rust singletons, zero canonical collisions, and zero unknown language buckets.


### PR DESCRIPTION
## Summary

- preserve the `programs` identity segment so an Elixir library and program with the same basename remain distinct
- make library ecosystem aliases outrank same-basename programs during Rust build-tool dependency resolution
- reject a genuine resolved dependency self-edge with stable `DEPENDENCY_SELF_EDGE` output and CLI exit code 2
- extend the language-neutral build-tool corpus with package/program and self-edge fixtures, then update the shared spec, Rust docs, changelogs, parity roadmap, and durable loop state

## Root cause

Rust discovery named both `code/packages/elixir/grammar_tools` and `code/programs/elixir/grammar_tools` as `elixir/grammar_tools`. The program legitimately depends on the library alias `coding_adventures_grammar_tools`, so the resolver collapsed that edge into a graph self-loop and reached an internal assertion. The Go reference keeps program identities distinct and prefers the library alias; this change brings the Rust implementation to that contract.

## Validation

- `cargo test -- --nocapture`: 138 unit tests plus the invalid-UTF-8 and self-edge real CLI integrations pass
- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo build --release`: pass
- `cargo llvm-cov --all-targets --summary-only`: 79.33% regions, 79.51% lines; resolver 64.00% lines; discovery 99.26% lines
- `cargo audit`: 56 dependencies, zero advisories
- `python code/scripts/build_tool_conformance.py validate-corpus`: valid 34-case, 42-file corpus across 15 established languages and 16 implementations
- conformance schema tests: 17 pass
- conformance runner tests: 40 pass
- `python code/scripts/package_parity_report.py --root . --format json --fail-on-collisions`: 1,218 established implementation identities, 4,366 slots, zero collisions, zero unknown language buckets
- release binary full-repository `--force --dry-run --emit-plan`: exit 0; 4,766 entries, 4,384 unique names; both `elixir/grammar_tools` and `elixir/programs/grammar_tools` preserved
- `git diff --check`: pass

## Known baselines and follow-up

- the existing 10 Lua `BUILD_windows` validation findings are unchanged from the untouched base after checkout-root normalization and remain owned by their existing backlog item
- the successful full plan exposed 212 duplicate `unknown/*` identities (382 extra entries) caused by incomplete Rust language classification; this is logged as the separate pending `build-tool-rust-language-identity-registry` dependency-shaped work item
