### PR TITLE
feat(human-languages): split Gujarati lessons under five minutes

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Marathi duration
-tranche: 20 registered tracks, 981 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Gujarati duration
+tranche: 20 registered tracks, 982 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -49,11 +49,14 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-G02 | Complete in the Chapters 2–3 generation PR | Generate Spanish Chapters 2–3 from their canonical schema-v2 lesson AST. | Extends the proven one-source path across the rest of the migrated pilot before broad corpus work. |
 | HL-D01A | Complete in the Russian duration PR | Remove all nine sub-five-minute violations from the complete Russian starter track. | The report measures zero Russian violations; every changed or added lesson is below 300 effective seconds. |
 | HL-D01B | Complete in the Marathi duration PR | Remove all eight sub-five-minute violations from the Marathi track. | The report measures zero Marathi violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
-| HL-D01C | Next | Remove all nine sub-five-minute violations from the Gujarati track. | Gujarati is now the smallest remaining track-sized tranche; the gap report supplies the exact bounded lesson set. |
+| HL-D01C | Complete in the Gujarati duration PR | Remove all nine sub-five-minute violations from the Gujarati track. | The report measures zero Gujarati violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
+| HL-D01D | Next | Remove all ten sub-five-minute violations from the Punjabi track. | Punjabi and Sanskrit tie at ten; Punjabi has the smaller genuine split at 405 computed seconds versus Sanskrit's 513, so it is the safer next tranche. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B05 | Queued | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | A forced build succeeds but reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and two underfull boxes; the clean-build signal is zero of each. |
+| HL-B06 | Queued | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-B07 | Queued | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -155,6 +158,30 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Gujarati's nine violations are now the smallest remaining track-sized set,
   ahead of Punjabi's and Sanskrit's ten each. HL-D01C is therefore next after
   this PR merges.
+
+## Findings from HL-D01C
+
+- Gujarati now has zero duration violations. The repository snapshot contains
+  982 lessons and 455 violations overall, down from 464 before this tranche;
+  unknown prerequisites remain at zero.
+- Eight lessons already computed between 110 and 184 seconds and only needed
+  honest four-minute declared budgets. The one genuinely long lesson computed
+  at 370 seconds.
+- That counting lesson is now a 174-second core followed by a 253-second
+  etymology lesson. The *dvé → be* inheritance, cross-Indic comparison, and
+  restored *r* in *traṇ* remain complete and prerequisite-ordered in the
+  canonical corpus consumed by Language Ladder.
+- Gujarati Chapter 6 has canonical lessons but is not in the current
+  five-chapter PDF. HL-B06 records its one-source migration and generation work
+  instead of adding another manual copy.
+- A forced build of the unchanged five-chapter book succeeds, but exposes four
+  missing punctuation glyphs, one overfull box, four underfull boxes, four
+  duplicate practice labels, and 28 Unicode bookmark warnings. HL-B07 records
+  that pre-existing publication hygiene debt separately.
+- Punjabi and Sanskrit tie for the smallest remaining set at ten violations,
+  each with nine declaration-only lessons and one genuine split. Punjabi's long
+  lesson computes at 405 seconds versus Sanskrit's 513, so HL-D01D takes Punjabi
+  first as the safer bounded tranche.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/gujarati/CHANGELOG.md
+++ b/code/learning/human-languages/gujarati/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Sub-five-minute remediation — 2026-08-02
+
+- Corrected eight declared five-minute estimates whose computed durations were
+  already between 110 and 184 seconds.
+- Split the genuinely long numbers lesson into a 174-second counting lesson and
+  a prerequisite-ordered 253-second etymology lesson.
+- Preserved the complete *dvé → be* assimilation history, the comparison across
+  Hindi, Marathi, and Bengali, and the restored *r* in *traṇ*. The shared report
+  now measures zero Gujarati duration violations.
+- Updated the roadmap and session map to expose both Chapter 6 lesson boundaries.
+  Chapter 6's missing one-source book publication remains explicit in the shared
+  backlog.
+
 ## Chapter 6 — Numbers 1–5, and two different inheritances
 
 - **Chapter 6 authored** (`GU-C06-numbers-1-5`): *ek, be, traṇ, chār, pā̃ch* —

--- a/code/learning/human-languages/gujarati/README.md
+++ b/code/learning/human-languages/gujarati/README.md
@@ -36,8 +36,13 @@ root, script taught inline, a publishable LaTeX book.
   "pāchhā maḷīshũ", kāle.
 - **Chapter 5 — The First Verbs** ([`lessons/GU-C05-*`](./lessons/)): bolvũ,
   "hũ gujarātī bolũ chhũ", rahevũ, kām karvũ.
+- **Chapter 6 — Numbers 1–5** ([`lessons/GU-C06-*`](./lessons/)): a short
+  counting lesson followed by a prerequisite-ordered history of why *be*
+  continues Sanskrit *dvé* and why *traṇ* regained an *r* after Prakrit lost it.
 
-All five chapters are in the book.
+Chapters 1–5 are in the book. Chapter 6 is canonical app-ready lesson content;
+its one-source book publication remains explicitly tracked in the shared
+backlog.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C01-namaste.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C01-namaste.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [inherent-a, no-top-line, st-conjunct]
 roots: [namas, te]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C01-practice.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [GU-C01-namaste, GU-C01-aabhaar, GU-C01-haa-naa, GU-C01-saarun, GU-C01-aavjo]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GU-C01-namaste, GU-C01-aabhaar, GU-C01-haa-naa, GU-C01-saarun, GU-C01-aavjo]
 ---
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C02-practice.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [GU-C02-maarun-naam-chhe, GU-C02-tamarun-naam-shun-chhe, GU-C02-anand]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GU-C02-naam, GU-C02-maarun, GU-C02-chhe, GU-C02-maarun-naam-chhe, GU-C02-tu-tame, GU-C02-shun, GU-C02-tamarun-naam-shun-chhe, GU-C02-anand]
 ---
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C03-practice.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [GU-C03-tame-kem-chho, GU-C03-majaa, GU-C03-vandho-nahi]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GU-C03-kem, GU-C03-tame-kem-chho, GU-C03-hun, GU-C03-majaa, GU-C03-vandho-nahi]
 ---
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C04-practice.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [GU-C04-pachha-malishun, GU-C04-kaale]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GU-C01-aavjo, GU-C04-pachha, GU-C04-malishun, GU-C04-pachha-malishun, GU-C04-kaale]
 ---
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C05-hun-gujarati-bolun-chhun.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C05-hun-gujarati-bolun-chhun.md
@@ -8,7 +8,7 @@ concept_tag: GU-WORD-GUJARATI
 prerequisites: [GU-C05-bolvun, GU-C03-hun]
 sounds: [long-aa, u-nasal]
 roots: [gurjar]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GU-C05-bolvun, GU-C03-hun]
 ---
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C05-kaam-karvun.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C05-kaam-karvun.md
@@ -8,7 +8,7 @@ concept_tag: GU-VERB-KARVU
 prerequisites: [GU-C05-bolvun]
 sounds: [long-aa, u-nasal]
 roots: [kr-do, karya-work]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GU-C05-bolvun, GU-C05-rahevun]
 ---
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C05-practice.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [GU-C05-bolvun, GU-C05-hun-gujarati-bolun-chhun, GU-C05-rahevun, GU-C05-kaam-karvun]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GU-C05-bolvun, GU-C05-hun-gujarati-bolun-chhun, GU-C05-rahevun, GU-C05-kaam-karvun, GU-C03-hun]
 ---
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C06-number-histories.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C06-number-histories.md
@@ -1,0 +1,75 @@
+---
+id: GU-C06-number-histories
+chapter: 6
+type: etymology
+headword: બે · ત્રણ
+gloss: why Gujarati two begins with b and why three regained an r
+prerequisites: [GU-C06-numbers-1-5]
+sounds: [e-sign, inherent-a]
+roots: [sanskrit-dvi, sanskrit-tri]
+etymology_hook: "Gujarati be continues Sanskrit feminine/neuter dve through dv to bb to b; tran's r was restored after Prakrit tiṇṇi had already lost it"
+est_minutes: 4
+reviews_of: [GU-C06-numbers-1-5]
+---
+
+# Two number histories: *be* and *traṇ*
+
+## Warm-up
+
+[PAUSE 2s] Count once: *ek, be, traṇ, chār, pā̃ch*. Which two forms look least
+like Hindi or Marathi? (*Be* and *traṇ*.)
+
+## બે — a different ancestor
+
+Sanskrit had gendered forms of “two,” and its daughters selected different
+parts of that paradigm:
+
+| language | “two” | route |
+|---|---|---|
+| Sanskrit | *dváu* (masc.) · *dvé* (fem. and neut.) | — |
+| Hindi | *do* | masculine side |
+| Marathi | *don* | masculine side, plus an analogical *-n* |
+| Bengali | *dui* | disyllabic Prakrit *duve* |
+| **Gujarati** | ***be*** | feminine/neuter *dvé* side |
+
+Gujarati **બે** is not a corruption of *do*. It is a **different inheritance**
+from the same Sanskrit paradigm.
+
+The initial cluster changed too. In *dv-*, the dental *d* adopted the **labial
+place** of the following *v*: *dv* → *bb* → *b*. The first consonant was remade
+in the shape of its neighbour, then the double simplified.
+
+## ત્રણ — the *r* that came back
+
+| stage | “three” |
+|---|---|
+| Sanskrit neuter | *trī́ṇi* |
+| Prakrit | *tiṇṇi*: *r* already gone |
+| Hindi | *tīn* |
+| **Gujarati** | ***traṇ***: *r* present again |
+
+The shared **ṇ** shows that Hindi and Gujarati both descend from neuter
+*trī́ṇi* through Prakrit *tiṇṇi*. By that stage, the *r* was gone and its weight
+had moved into doubled *ṇṇ*. Hindi later simplified the double and lengthened
+the vowel.
+
+Gujarati's *tr-* is generally treated as **restored from Sanskrit**, not carried
+through unbroken. Sanskrit remained a literary language and continued to reshape
+its descendants. *Traṇ* looks older than *tīn*, but it is closer because speakers
+put the *r* back.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: Gujarati's selected form — feminine/neuter *dvé*]
+- [YOU SAY: the sound path — *dv → bb → b*]
+- [YOU SAY: the *r* path — *trī́ṇi → tiṇṇi → traṇ*]
+- [YOU SAY: inherited continuously or restored — restored]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does Gujarati say *be* while Hindi says *do*? (They continue
+different forms of Sanskrit “two.”) What happened in *dv → b*? (*D* assimilated
+to labial *v*, then the double simplified.) Did Gujarati *traṇ* preserve *r*
+continuously? (No: Prakrit had lost it; Sanskrit influence restored it.) Why can
+a newer form look older? (Learned influence can put an ancestral sound back.)

--- a/code/learning/human-languages/gujarati/lessons/GU-C06-numbers-1-5.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C06-numbers-1-5.md
@@ -8,8 +8,8 @@ concept_tag: GU-NUMBERS-1-5
 prerequisites: [GU-C01-namaste]
 sounds: [long-aa, nasal-aa, e-sign, inherent-a]
 roots: [sanskrit-dvi, sanskrit-tri, sanskrit-panca]
-etymology_hook: "Gujarati બે be comes from Sanskrit's FEMININE/NEUTER dvé, not the masculine dváu behind Hindi do and Marathi don — with the d taking the LABIAL place of the following v (dv → bb → b); and ત્રણ traṇ's r is generally RESTORED from Sanskrit rather than inherited, since Prakrit tiṇṇi had already lost it — so traṇ looks older than tīn without actually being so"
-est_minutes: 5
+etymology_hook: "Gujarati be and tran differ from their neighbours; learn the five forms first, then trace be to dve and tran's restored r in the next short lesson"
+est_minutes: 3
 reviews_of: [GU-C01-namaste]
 ---
 
@@ -34,71 +34,26 @@ Notice the script: Gujarati is Devanagari **without the top line**. Same letters
 same system — the shirorekhā simply isn't drawn. If you've done the Hindi writing
 track you can feel the relationship immediately.
 
-## બે — a different ancestor
+## Notice the two surprises
 
-Every neighbour says something with a *d*:
+Most neighbouring languages have a *d* in “two,” but Gujarati says **બે** *be*.
+Hindi says *tīn* for “three,” but Gujarati says **ત્રણ** *traṇ*, with an *r*.
 
-| | 2 | continues |
-|---|---|---|
-| Sanskrit | *dváu* (masc.) · *dvé* (fem. & neut.) | — |
-| Hindi | *do* | the **masculine** side |
-| Marathi | *don* | the masculine side (+ the borrowed *-n*) |
-| Bengali | *dui* | the disyllabic Prakrit *duve* |
-| **Gujarati** | ***be*** | the **feminine/neuter** side |
-
-Sanskrit had **different forms for different genders** — masculine *dváu*,
-feminine and neuter *dvé*. Hindi and Marathi continue the masculine; Gujarati
-continues the ***dvé*** side. (Bengali is a third case again: its *dui* comes
-from the two-syllable Prakrit *duve*, which is why it kept a second vowel where
-*dváu* → *do* had none to keep.)
-
-And watch what happened to the cluster. In *dv-*, the *d* took on the **place of
-articulation of the following *v*** — a dental stop pulled to the lips — giving
-*bb-*, which then simplified to a single *b*. The *d* didn't fade away; it was
-**remade in the shape of its neighbour**.
-
-Not a corruption, then — a **different inheritance**. The languages picked
-different forms out of the same paradigm and wore them down separately.
-
-## ત્રણ — the r that came back
-
-| | 3 |
-|---|---|
-| Sanskrit (neuter) | *trī́ṇi* |
-| Prakrit | *tiṇṇi* — **r gone** |
-| Hindi | *tīn* |
-| **Gujarati** | ***traṇ*** — *r* present again |
-
-Both words share the **ṇ**, and that *ṇ* is the giveaway: both descend from the
-**neuter** *trī́ṇi*, by way of Prakrit *tiṇṇi* — where the *r* had already been
-lost, its weight transferred into the doubled *ṇṇ*.
-
-Hindi then simplified that double and lengthened the vowel instead: *tīn*.
-
-Gujarati's *tr-* is the interesting case, because the *r* was gone by the Prakrit
-stage — so it is generally treated as **restored** under the influence of the
-Sanskrit form, not carried through unbroken. Sanskrit stayed a living literary
-language across all this time, and it kept reaching back into its descendants.
-
-So *traṇ* looks older than *tīn* and in a sense isn't. It's closer to the
-original because someone **put the *r* back**.
+Do not carry both histories while the count is still new. Make the five forms
+automatic first; the next prerequisite-ordered lesson explains why *be* and
+*traṇ* took those shapes.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "ek, be, traṇ, chār, pā̃ch"]
-- [YOU SAY: the odd two — "everyone says *do*-something; Gujarati says **be**"]
-- [YOU SAY: the *r* — "*trī́ṇi* … *ti**ṇṇ**i* … Gujarati *t**r**aṇ*"]
+- [YOU SAY: the odd two — Gujarati **be** and **traṇ**]
+- [YOU SAY: the script clue — Devanagari shapes without a top line]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Count to five in Gujarati. (*Ek, be, traṇ, chār, pā̃ch*.) Why doesn't
-**બે** look like *do*, *don* or *dui*? (It continues Sanskrit's **feminine/neuter
-*dvé***, where **Hindi and Marathi** continue the masculine *dváu* — and Bengali
-continues the disyllabic Prakrit *duve*.) What happened to the
-*d* in *dv-*? (It **assimilated to the *v*** — *dv* → *bb* → *b*.) Does **ત્રણ**
-preserve the *r* of *tri-*? (**Not continuously** — the *r* was already lost in
-Prakrit *tiṇṇi*; Gujarati's *tr-* is generally treated as **restored** from
-Sanskrit, which stayed a living literary language.) What is visibly missing from
-the Gujarati script? (**The top line** — the shirorekhā isn't drawn.) Next: six
-to ten.
+**બે** look unlike its neighbours? (It begins with *b*, not *d*.) What does
+**ત્રણ** contain that Hindi *tīn* does not? (*r*.) What is visibly missing from
+the Gujarati script? (The top line: the *shirorekhā* is not drawn.) Next: trace
+the two surprising number histories.

--- a/code/learning/human-languages/gujarati/roadmap.md
+++ b/code/learning/human-languages/gujarati/roadmap.md
@@ -25,8 +25,10 @@ trade layer**. The script is taught **inline**, never as a gated reading course.
   The future ending; the retroflex ળ ḷ.
 - **Ch. 5 — The First Verbs**: bolvũ → "hũ gujarātī bolũ chhũ" → rahevũ → kām
   karvũ → practice. Stem + person + copula; postposition *-mā*; the *kṛ* root.
-- **Ch. 6 — Numbers 1–5** (`GU-C06-numbers-1-5`): *ek, be, traṇ, chār, pā̃ch* —
-  **two numbers that don't match the neighbours, each for a reason**. **બે** *be*
+- **Ch. 6 — Numbers 1–5** (`GU-C06-numbers-1-5` →
+  `GU-C06-number-histories`): first make *ek, be, traṇ, chār, pā̃ch* automatic,
+  then trace **two numbers that don't match the neighbours, each for a reason**,
+  in a separate sub-five-minute etymology lesson. **બે** *be*
   continues Sanskrit's **feminine/neuter *dvé*** where **Hindi and Marathi**
   continue the masculine *dváu* (Bengali is a third case, continuing the
   disyllabic Prakrit *duve*) — a *different inheritance* from the same paradigm,
@@ -43,7 +45,7 @@ trade layer**. The script is taught **inline**, never as a gated reading course.
 
 | Chapter | Theme |
 |---|---|
-| 6 | Numbers 1–10 (native words + Gujarati digits ૧૨૩), counting, age |
+| 6 continuation | Numbers 6–10 (native words + Gujarati digits ૧૨૩), counting, age |
 | 7 | Family (*mātā*, *pitā*, *bhāī*, *ben*) and the honorific *-jī* / *-bhāī* / *-ben* |
 | 8 | Food and the market — where the Perso-Arabic and Portuguese loans cluster (*batākā* ← Portuguese *batata*) |
 | 9+ | Past and future tenses (where the three genders return on the verb), postpositions, everyday sentences |

--- a/code/learning/human-languages/gujarati/session-map.md
+++ b/code/learning/human-languages/gujarati/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Gujarati Chapters 1–5
+# Session Map — Gujarati Chapters 1–6
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -64,7 +64,14 @@ lesson introduces exactly the letters that word needs.
 | 30 | kaam-karvun | કામ કરવું | "to work"; *karvũ* ← *kṛ* (root of *namaskār*, *karma*) |
 | 31 | practice | (recap) | three verbs, one engine — sentences about yourself |
 
+## Chapter 6 — Numbers 1–5
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 32 | numbers-1-5 | એક, બે, ત્રણ, ચાર, પાંચ | retrieve the five forms and the headless-script clue; notice surprising *be* and *traṇ* |
+| 33 | number-histories | બે · ત્રણ | *be* continues *dvé* through *dv → bb → b*; *traṇ* regained an *r* after Prakrit lost it |
+
 ## Next
 
-Chapter 6 — numbers 1–10 (words + Gujarati digits ૧૨૩), then family and food,
-then the tenses where the three genders return on the verb.
+Finish Chapter 6 with numbers 6–10 and Gujarati digits ૧૨૩, then family and
+food, then the tenses where the three genders return on the verb.


### PR DESCRIPTION
## Summary

- remove all nine Gujarati lessons at or above the five-minute boundary
- correct eight declared estimates that the shared model already measured at 110–184 seconds
- split the genuinely long numbers lesson into a 174-second counting core and a prerequisite-ordered 253-second etymology lesson
- preserve the full `dvé → be` inheritance, cross-Indic comparison, and restored `r` in `traṇ` in canonical Markdown consumed by Language Ladder
- update the Gujarati roadmap/session map and select Punjabi as the next measured tranche after comparing its tied ten-violation set with Sanskrit

The audit records canonical Chapter 6 publication as `HL-B06` and pre-existing Gujarati book hygiene debt as `HL-B07`; this PR does not hand-copy or hide either item.

## Measured result

- Gujarati duration violations: **9 → 0**
- repository duration violations: **464 → 455**
- canonical lessons: **981 → 982**
- unknown prerequisites: **0**
- split lesson durations: **174 seconds + 253 seconds**

## Validation

- `human-language-data`: 68 tests passed; 93.60% line coverage
- curriculum integration: 9 tests passed after the final rebase
- generated-book drift check: passed
- `language-ladder`: 278 tests passed; 98.37% line coverage
- Language Ladder production build: passed
- forced Gujarati XeLaTeX regression build: 24 pages
- `git diff --check`: passed

## Recorded pre-existing book debt

The unchanged Gujarati PDF still emits four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice-label warnings, and 28 Unicode PDF-string warnings. `HL-B07` records a zero-warning cleanup target; none was introduced by the canonical lesson changes.