### PR TITLE
fix(spice): validate MOS saturation current

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS model-card `IS` values
+  before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `CGBO` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `CGDO` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1961,6 +1961,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(saturation_current) = params.get("IS") {
+            if !saturation_current.is_finite() || *saturation_current <= 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET IS must be finite and positive",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2075,6 +2075,30 @@ fn preserves_non_negative_mosfet_model_gate_bulk_overlap_capacitance() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_saturation_current() {
+    for saturation_current in ["0", "-1p", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model leakage NMOS(IS={saturation_current})\nM1 d g s b leakage"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET IS must be finite and positive"));
+    }
+}
+
+#[test]
+fn preserves_positive_mosfet_model_saturation_current() {
+    let parsed = parse_netlist(".model leakage NMOS(IS=1p)\nM1 d g s b leakage").unwrap();
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+    assert_close(mosfet.params.saturation_current, 1.0e-12);
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card gate-bulk-overlap-capacitance validation.
+1. Rust Berkeley SPICE MOS model-card saturation-current validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `CGBO` values before
+   - Reject zero, negative, and non-finite model-card `IS` values before
      lowering MOS elements into engine parameters.
-   - Preserve zero and positive gate-bulk overlap capacitances.
+   - Preserve positive saturation currents.
 
 ## Completed Slices
 
@@ -4028,6 +4028,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `CGDO` values are rejected before
      lowering MOS elements into engine parameters.
    - Zero and positive gate-drain overlap capacitances remain accepted.
+
+352. Rust Berkeley SPICE MOS model-card gate-bulk-overlap-capacitance validation.
+   - Status: completed in PR 9522.
+   - Negative and non-finite model-card `CGBO` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive gate-bulk overlap capacitances remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite Level-1 MOS model-card `IS` values in the Rust Berkeley parser facade
- preserve positive saturation currents, including engineering suffixes
- reconcile the SPICE implementation plan after `CGBO` validation merged

## Tests
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`

## Scope
Rust-only parser-facade validation. The shared Rust, Python, and TypeScript engine behavior and diagnostic are already aligned.