### PR TITLE
fix(build-tool): canonicalize Rust discovery identities

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9521,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "9302e73668017a31e38f432c31bbba4f091a56bf",
+    "revision": "c840af78378a1597134694e1008c922f4e355f95",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1218,
@@ -361,20 +361,20 @@
     {
       "id": "build-tool-rust-self-edge-diagnostic",
       "title": "Make the Rust build tool reject self-edges without panicking",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-rust-self-edge-diagnostic",
       "pr_number": 9521,
-      "notes": "Ready PR #9521 opened from collision-clean 9302e736. The implementation defines exact language-neutral Elixir package/program and genuine self-edge fixtures, preserves the programs identity segment, makes library aliases outrank same-basename programs, and returns DEPENDENCY_SELF_EDGE with package, dependency, and repository-relative manifest identity through CLI exit 2 without host paths. Validation passed 138 unit tests plus both real CLI integrations, strict Clippy, release build, 79.33% region and 79.51% line coverage, 17 schema tests, 40 runner tests, the valid 34-case/42-file conformance corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real 4,766-entry full plan that now exits zero and preserves both grammar_tools identities. The known 10-item Lua BUILD_windows debt remains byte-for-byte identical to untouched ca91ca25 after root normalization. A separate pending Rust language-identity-registry item owns the 212 duplicate unknown identities found by the successful full-plan audit."
+      "notes": "Merged PR #9521 at c840af78378a1597134694e1008c922f4e355f95 on 2026-08-02 after all applicable detection, fixture-consumer, CodeQL, Ubuntu, macOS, and Windows checks passed. The implementation defines exact language-neutral Elixir package/program and genuine self-edge fixtures, preserves the programs identity segment, makes library aliases outrank same-basename programs, and returns DEPENDENCY_SELF_EDGE with package, dependency, and repository-relative manifest identity through CLI exit 2 without host paths. Validation passed 138 unit tests plus both real CLI integrations, strict Clippy, release build, 79.33% region and 79.51% line coverage, 17 schema tests, 40 runner tests, the valid 34-case/42-file conformance corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real 4,766-entry full plan that now exits zero and preserves both grammar_tools identities. The known 10-item Lua BUILD_windows debt remains byte-for-byte identical to untouched ca91ca25 after root normalization. The separate Rust language-identity-registry item owns the 212 duplicate unknown identities found by the successful full-plan audit."
     },
     {
       "id": "build-tool-rust-language-identity-registry",
       "title": "Bring Rust build-tool discovery to the canonical language and identity registry",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-rust-self-edge-diagnostic"],
-      "branch": null,
+      "branch": "codex/build-tool-rust-language-identity-registry",
       "pr_number": null,
-      "notes": "Discovered while validating the Rust self-edge slice on ca91ca25. The repaired full plan exits zero and emits 4,766 package entries, but only 4,384 names are unique: 212 duplicate unknown/* identities account for 382 extra entries because the Rust discovery registry omits several established and emerging language directories. Add language-neutral discovery fixtures, classify every supported lane consistently with the canonical registry, and reject any residual duplicate qualified identity with a stable diagnostic. Keep this separate from the Elixir package/program self-edge repair."
+      "notes": "Selected from collision-clean c840af78 after merged PR #9521 satisfied the sole dependency. The implementation adds language-neutral canonical-registry and duplicate-identity discovery fixtures, classifies every established, emerging, execution-target, domain, and build-language bucket plus the shared dotnet program host, skips specification fixture trees, and rejects any residual duplicate qualified name with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, CLI exit 2, and no host-path disclosure. Validation passed 140 unit tests plus three real CLI integrations, strict Clippy, release build, 79.38% region and 79.49% line coverage with 94.01% discovery lines, 17 schema tests, 40 runner tests, the valid 36-case/54-file corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real full plan that now exits zero with 4,764 entries, 4,764 unique names, zero duplicates, and only the intentional unknown/blog site package. The known 10-item Lua BUILD_windows debt remains unchanged and separately owned."
     },
     {
       "id": "build-tool-python-haskell-language-filter",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,16 +13,16 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "c840af78378a1597134694e1008c922f4e355f95",
+    "revision": "4d0a98e02bec862a5b852329426d01c8996a19c6",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1218,
-    "implementation_package_slots": 4366,
+    "implementation_identities": 1219,
+    "implementation_package_slots": 4367,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 768,
-    "singleton_missing_slots": 10752,
-    "rust_singletons": 573,
+    "singleton_packages": 769,
+    "singleton_missing_slots": 10766,
+    "rust_singletons": 574,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -374,7 +374,7 @@
       "depends_on": ["build-tool-rust-self-edge-diagnostic"],
       "branch": "codex/build-tool-rust-language-identity-registry",
       "pr_number": null,
-      "notes": "Selected from collision-clean c840af78 after merged PR #9521 satisfied the sole dependency. The implementation adds language-neutral canonical-registry and duplicate-identity discovery fixtures, classifies every established, emerging, execution-target, domain, and build-language bucket plus the shared dotnet program host, skips specification fixture trees, and rejects any residual duplicate qualified name with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, CLI exit 2, and no host-path disclosure. Validation passed 140 unit tests plus three real CLI integrations, strict Clippy, release build, 79.38% region and 79.49% line coverage with 94.01% discovery lines, 17 schema tests, 40 runner tests, the valid 36-case/54-file corpus, a zero-advisory RustSec audit, collision-clean 1,218-identity parity inventory, and a real full plan that now exits zero with 4,764 entries, 4,764 unique names, zero duplicates, and only the intentional unknown/blog site package. The known 10-item Lua BUILD_windows debt remains unchanged and separately owned."
+      "notes": "Selected after merged PR #9521 satisfied the sole dependency and rebased cleanly onto collision-clean 4d0a98e0. The implementation adds language-neutral canonical-registry and duplicate-identity discovery fixtures, classifies every established, emerging, execution-target, domain, and build-language bucket plus the shared dotnet program host, skips specification fixture trees, and rejects any residual duplicate qualified name with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, CLI exit 2, and no host-path disclosure. Validation passed 140 unit tests plus three real CLI integrations, strict Clippy, release build, 79.39% region and 79.49% line coverage with 94.03% discovery lines, 17 schema tests, 40 runner tests, the valid 36-case/55-file corpus, a zero-advisory RustSec audit, collision-clean 1,219-identity parity inventory, and a real full plan that now exits zero with 4,765 entries, 4,765 unique names, zero duplicates, the new Fronius package, and only the intentional unknown/blog site package. The known 10-item Lua BUILD_windows debt remains unchanged and separately owned."
     },
     {
       "id": "build-tool-python-haskell-language-filter",
@@ -1169,6 +1169,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered after merged PR #9498 added the Rust-only Tasmota local HTTP host. Share bounded Status 0 JSON validation, relay/light/sensor normalization, stable identities and errors, state/capability projection, command planning, color conversion, and verification fixtures. mDNS, DNS/TCP, plaintext LAN HTTP execution, credentials and Vault, trusted time, console I/O, authorization, and runtime mutation are excluded native-host responsibilities."
+    },
+    {
+      "id": "smart-home-fronius-portable-core-extraction-and-conformance",
+      "title": "Extract and port the portable Fronius Solar API telemetry core",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after merged PR #9513 added the Rust-only Fronius Solar API v1 host. Share bounded Power Flow response and API-status validation, site and inverter measurement normalization, stable identities and errors, deterministic entity projection, and language-neutral telemetry fixtures. mDNS, DNS/TCP, plaintext LAN HTTP execution, endpoint authorization, trusted time, console I/O, and runtime mutation are excluded native-host responsibilities."
     },
     {
       "id": "smart-home-reolink-portable-core-extraction-and-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9527,
   "last_inventory": {
     "revision": "4d0a98e02bec862a5b852329426d01c8996a19c6",
     "schema_version": 3,
@@ -370,11 +370,11 @@
     {
       "id": "build-tool-rust-language-identity-registry",
       "title": "Bring Rust build-tool discovery to the canonical language and identity registry",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-rust-self-edge-diagnostic"],
       "branch": "codex/build-tool-rust-language-identity-registry",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9521 satisfied the sole dependency and rebased cleanly onto collision-clean 4d0a98e0. The implementation adds language-neutral canonical-registry and duplicate-identity discovery fixtures, classifies every established, emerging, execution-target, domain, and build-language bucket plus the shared dotnet program host, skips specification fixture trees, and rejects any residual duplicate qualified name with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, CLI exit 2, and no host-path disclosure. Validation passed 140 unit tests plus three real CLI integrations, strict Clippy, release build, 79.39% region and 79.49% line coverage with 94.03% discovery lines, 17 schema tests, 40 runner tests, the valid 36-case/55-file corpus, a zero-advisory RustSec audit, collision-clean 1,219-identity parity inventory, and a real full plan that now exits zero with 4,765 entries, 4,765 unique names, zero duplicates, the new Fronius package, and only the intentional unknown/blog site package. The known 10-item Lua BUILD_windows debt remains unchanged and separately owned."
+      "pr_number": 9527,
+      "notes": "Ready PR #9527 opened from collision-clean 4d0a98e0. The implementation adds language-neutral canonical-registry and duplicate-identity discovery fixtures, classifies every established, emerging, execution-target, domain, and build-language bucket plus the shared dotnet program host, skips specification fixture trees, and rejects any residual duplicate qualified name with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, CLI exit 2, and no host-path disclosure. Validation passed 140 unit tests plus three real CLI integrations, strict Clippy, release build, 79.39% region and 79.49% line coverage with 94.03% discovery lines, 17 schema tests, 40 runner tests, the valid 36-case/55-file corpus, a zero-advisory RustSec audit, collision-clean 1,219-identity parity inventory, and a real full plan that now exits zero with 4,765 entries, 4,765 unique names, zero duplicates, the new Fronius package, and only the intentional unknown/blog site package. The known 10-item Lua BUILD_windows debt remains unchanged and separately owned."
     },
     {
       "id": "build-tool-python-haskell-language-filter",

--- a/code/programs/rust/build-tool/CHANGELOG.md
+++ b/code/programs/rust/build-tool/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Rust build tool will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.4] - 2026-08-02
+
+### Fixed
+
+- Classify every canonical established, emerging, execution-target, domain,
+  and build-language bucket during discovery while retaining the shared
+  `dotnet` program host bucket, and exclude specification fixture trees from
+  the buildable package universe.
+- Reject duplicate qualified package identities with
+  `DUPLICATE_PACKAGE_IDENTITY`, sorted repository-relative paths, CLI exit code
+  2, and no checkout-path disclosure. Unit and real CLI coverage consume the
+  language-neutral discovery fixtures.
+
 ## [0.2.3] - 2026-08-02
 
 ### Fixed

--- a/code/programs/rust/build-tool/README.md
+++ b/code/programs/rust/build-tool/README.md
@@ -4,7 +4,7 @@ A **Rust port** of the Go build tool for the coding-adventures monorepo. It disc
 
 ## What it does
 
-This tool discovers packages in the monorepo via recursive `BUILD` file walking, resolves inter-package dependencies, hashes source files for change detection, and only rebuilds packages whose source or dependency inputs changed. Independent packages are built in parallel. Programs retain a `programs` identity segment so a library and program with the same basename stay distinct. Text metadata is decoded deterministically: Lua `.rockspec` files must be strict UTF-8, and invalid bytes fail closed instead of silently deleting dependency edges.
+This tool discovers packages in the monorepo via recursive `BUILD` file walking, resolves inter-package dependencies, hashes source files for change detection, and only rebuilds packages whose source or dependency inputs changed. Independent packages are built in parallel. Discovery uses the repository's canonical language registry, and programs retain a `programs` identity segment so a library and program with the same basename stay distinct. Text metadata is decoded deterministically: Lua `.rockspec` files must be strict UTF-8, and invalid bytes fail closed instead of silently deleting dependency edges.
 
 ## Building
 
@@ -52,7 +52,7 @@ The release binary is at `target/release/build-tool` (or `build-tool.exe` on Win
 | `--force` | false | Rebuild everything regardless of cache |
 | `--dry-run` | false | Show what would build without executing |
 | `--jobs` | CPU count | Maximum parallel build jobs |
-| `--language` | all | Filter to one supported implementation language or use `all` |
+| `--language` | all | Filter to one canonical discovery language or use `all` |
 | `--cache-file` | .build-cache.json | Path to the build cache file |
 
 ## Architecture
@@ -99,7 +99,19 @@ This is equivalent to the Go implementation's goroutine + semaphore pattern, but
 cargo test -- --nocapture
 ```
 
-## Metadata diagnostics
+## Discovery and metadata diagnostics
+
+Discovery rejects any residual qualified-name collision before dependency
+resolution. The diagnostic contains the shared identity and sorted
+repository-relative paths without exposing the checkout root:
+
+```text
+DUPLICATE_PACKAGE_IDENTITY: package=unknown/demo paths=code/packages/alpha/demo,code/packages/beta/demo
+```
+
+The shared `discovery/language-registry` fixture covers the canonical buckets
+that were previously omitted, while `discovery/duplicate-identity` verifies
+the stable CLI exit-code-2 failure path.
 
 Lua `.rockspec` metadata is decoded as strict UTF-8 before dependency parsing.
 Invalid bytes stop resolution, return exit code `2`, and emit a stable diagnostic

--- a/code/programs/rust/build-tool/src/discovery.rs
+++ b/code/programs/rust/build-tool/src/discovery.rs
@@ -32,13 +32,46 @@
 //
 // # Language inference
 //
-// We infer a package's language from its directory path. If the path contains
-// "python", "ruby", "go", or "rust" as a component under "packages" or
-// "programs", that is the language. The package name is "{language}/{dirname}",
-// e.g., "python/logic-gates" or "go/directed-graph".
+// We infer a package's language from its directory path using the canonical
+// package-parity bucket registry plus the shared `dotnet` program host bucket.
+// The package name is "{language}/{dirname}", e.g., "python/logic-gates" or
+// "go/directed-graph".
 
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+const DUPLICATE_PACKAGE_IDENTITY: &str = "DUPLICATE_PACKAGE_IDENTITY";
+
+/// Canonical repository buckets understood by package discovery.
+///
+/// The parity denominator is defined in `package_parity_report.py`. Discovery
+/// additionally retains `dotnet` for programs hosted by the shared .NET engine.
+pub const DISCOVERY_LANGUAGES: &[&str] = &[
+    "csharp",
+    "dart",
+    "elixir",
+    "fsharp",
+    "go",
+    "haskell",
+    "java",
+    "kotlin",
+    "lua",
+    "perl",
+    "python",
+    "ruby",
+    "rust",
+    "swift",
+    "typescript",
+    "c",
+    "cpp",
+    "ocaml",
+    "wasm",
+    "mosaic",
+    "twig",
+    "starlark",
+    "dotnet",
+];
 
 // ---------------------------------------------------------------------------
 // Data types
@@ -55,9 +88,31 @@ pub struct Package {
     pub path: PathBuf,
     /// Lines from the BUILD file (commands to execute).
     pub build_commands: Vec<String>,
-    /// Inferred language: "python", "ruby", "go", "rust", or "unknown".
+    /// Inferred canonical discovery language, or "unknown".
     pub language: String,
 }
+
+/// Two or more package directories that normalize to one graph identity.
+#[derive(Debug, Eq, PartialEq)]
+pub struct DuplicatePackageIdentityError {
+    pub code: String,
+    pub package: String,
+    pub paths: Vec<String>,
+}
+
+impl fmt::Display for DuplicatePackageIdentityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{}: package={} paths={}",
+            self.code,
+            self.package,
+            self.paths.join(",")
+        )
+    }
+}
+
+impl std::error::Error for DuplicatePackageIdentityError {}
 
 // ---------------------------------------------------------------------------
 // Skip list
@@ -83,7 +138,12 @@ const SKIP_DIRS: &[&str] = &[
     "build",
     "target",
     ".claude",
+    "specs",
     "Pods",
+    ".dart_tool",
+    ".build",
+    ".gradle",
+    "gradle-build",
 ];
 
 // ---------------------------------------------------------------------------
@@ -109,37 +169,51 @@ pub fn read_lines(path: &Path) -> Vec<String> {
 }
 
 /// Inspects the directory path to determine the programming language.
-/// We look for known language names ("python", "ruby", "go", "rust")
-/// as path components. For example, "/repo/code/packages/python/logic-gates"
-/// yields "python".
+/// We look for canonical language names as exact path components. For example,
+/// "/repo/code/packages/python/logic-gates" yields "python".
 fn infer_language(path: &Path) -> String {
     // Convert path to forward-slash form for consistent splitting across platforms.
     let path_str = path.to_string_lossy().replace('\\', "/");
     let parts: Vec<&str> = path_str.split('/').collect();
 
-    for lang in &[
-        "python",
-        "ruby",
-        "go",
-        "rust",
-        "typescript",
-        "elixir",
-        "lua",
-        "perl",
-        "swift",
-        "haskell",
-        "wasm",
-        "csharp",
-        "fsharp",
-        "dotnet",
-    ] {
-        for part in &parts {
-            if part == lang {
-                return lang.to_string();
-            }
+    for pair in parts.windows(2) {
+        if pair[0] == "packages" || pair[0] == "programs" {
+            return if DISCOVERY_LANGUAGES.contains(&pair[1]) {
+                pair[1].to_string()
+            } else {
+                "unknown".to_string()
+            };
         }
     }
     "unknown".to_string()
+}
+
+fn repository_package_path(root: &Path, path: &Path) -> String {
+    let parts: Vec<String> = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    let mut canonical_start = None;
+    for index in 0..parts.len().saturating_sub(1) {
+        if parts[index] == "code"
+            && (parts[index + 1] == "packages" || parts[index + 1] == "programs")
+        {
+            canonical_start = Some(index);
+        }
+    }
+    if let Some(index) = canonical_start {
+        return parts[index..].join("/");
+    }
+
+    path.strip_prefix(root)
+        .ok()
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .filter(|relative| !relative.is_empty())
+        .or_else(|| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .unwrap_or_default()
 }
 
 /// Builds a qualified package name from the language and directory path.
@@ -295,11 +369,32 @@ fn walk_dirs(directory: &Path, packages: &mut Vec<Package>) {
 ///
 /// This is the main entry point for the discovery module. The root
 /// parameter should typically be the "code/" directory inside the repo.
-pub fn discover_packages(root: &Path) -> Vec<Package> {
+pub fn discover_packages(root: &Path) -> Result<Vec<Package>, DuplicatePackageIdentityError> {
     let mut packages = Vec::new();
     walk_dirs(root, &mut packages);
-    packages.sort_by(|a, b| a.name.cmp(&b.name));
-    packages
+    packages.sort_by(|a, b| a.name.cmp(&b.name).then(a.path.cmp(&b.path)));
+
+    let mut index = 0;
+    while index < packages.len() {
+        let mut end = index + 1;
+        while end < packages.len() && packages[end].name == packages[index].name {
+            end += 1;
+        }
+        if end - index > 1 {
+            let paths = packages[index..end]
+                .iter()
+                .map(|package| repository_package_path(root, &package.path))
+                .collect();
+            return Err(DuplicatePackageIdentityError {
+                code: DUPLICATE_PACKAGE_IDENTITY.to_string(),
+                package: packages[index].name.clone(),
+                paths,
+            });
+        }
+        index = end;
+    }
+
+    Ok(packages)
 }
 
 // ---------------------------------------------------------------------------
@@ -309,7 +404,81 @@ pub fn discover_packages(root: &Path) -> Vec<Package> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::Deserialize;
     use std::fs;
+
+    #[derive(Deserialize)]
+    struct DiscoveryFixture {
+        workspace: FixtureWorkspace,
+        expected: ExpectedDiscovery,
+    }
+
+    #[derive(Deserialize)]
+    struct FixtureWorkspace {
+        files: Vec<FixtureFile>,
+    }
+
+    #[derive(Deserialize)]
+    struct FixtureFile {
+        path: String,
+        content_utf8: String,
+    }
+
+    #[derive(Deserialize)]
+    struct ExpectedDiscovery {
+        result: ExpectedResult,
+        diagnostics: Vec<ExpectedDiagnostic>,
+    }
+
+    #[derive(Deserialize)]
+    struct ExpectedResult {
+        #[serde(default)]
+        packages: Vec<ExpectedPackage>,
+    }
+
+    #[derive(Deserialize)]
+    struct ExpectedPackage {
+        language: String,
+        name: String,
+        rel_path: String,
+    }
+
+    #[derive(Deserialize)]
+    struct ExpectedDiagnostic {
+        code: String,
+        path: String,
+        package: String,
+        details: ExpectedDiagnosticDetails,
+    }
+
+    #[derive(Deserialize)]
+    struct ExpectedDiagnosticDetails {
+        paths: Vec<String>,
+    }
+
+    fn load_discovery_fixture(name: &str) -> DiscoveryFixture {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../specs/fixtures/build-tool-v1/cases")
+            .join(name);
+        let data = fs::read(&path)
+            .unwrap_or_else(|error| panic!("read shared fixture {}: {error}", path.display()));
+        serde_json::from_slice(&data)
+            .unwrap_or_else(|error| panic!("decode shared fixture {}: {error}", path.display()))
+    }
+
+    fn materialize_discovery_fixture(fixture: &DiscoveryFixture, case_name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "build_tool_rust_discovery_{case_name}_{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        for file in &fixture.workspace.files {
+            let path = root.join(Path::new(&file.path));
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, &file.content_utf8).unwrap();
+        }
+        root
+    }
 
     #[test]
     fn test_infer_language() {
@@ -339,6 +508,58 @@ mod tests {
             infer_package_name(path, "elixir"),
             "elixir/programs/grammar_tools"
         );
+    }
+
+    #[test]
+    fn test_language_registry_conformance_fixture() {
+        let fixture = load_discovery_fixture("discovery-language-registry.json");
+        let root = materialize_discovery_fixture(&fixture, "language_registry");
+        let packages = discover_packages(&root.join("code"))
+            .expect("the canonical language registry fixture must discover");
+        let actual: Vec<(String, String, String)> = packages
+            .iter()
+            .map(|package| {
+                (
+                    package.name.clone(),
+                    package.language.clone(),
+                    package
+                        .path
+                        .strip_prefix(&root)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                )
+            })
+            .collect();
+        let expected: Vec<(String, String, String)> = fixture
+            .expected
+            .result
+            .packages
+            .iter()
+            .map(|package| {
+                (
+                    package.name.clone(),
+                    package.language.clone(),
+                    package.rel_path.clone(),
+                )
+            })
+            .collect();
+        assert_eq!(actual, expected);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn test_duplicate_identity_conformance_fixture() {
+        let fixture = load_discovery_fixture("discovery-duplicate-identity.json");
+        let root = materialize_discovery_fixture(&fixture, "duplicate_identity");
+        let error = discover_packages(&root.join("code"))
+            .expect_err("duplicate qualified identities must fail closed");
+        let diagnostic = &fixture.expected.diagnostics[0];
+        assert_eq!(error.code, diagnostic.code);
+        assert_eq!(error.package, diagnostic.package);
+        assert_eq!(error.paths[0], diagnostic.path);
+        assert_eq!(error.paths, diagnostic.details.paths);
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -392,7 +613,7 @@ mod tests {
         fs::create_dir_all(&git_dir).unwrap();
         fs::write(git_dir.join("BUILD"), "nope").unwrap();
 
-        let packages = discover_packages(&dir);
+        let packages = discover_packages(&dir).expect("fixture identities are unique");
         assert_eq!(packages.len(), 2);
         assert_eq!(packages[0].name, "go/directed-graph");
         assert_eq!(packages[1].name, "python/logic-gates");

--- a/code/programs/rust/build-tool/src/main.rs
+++ b/code/programs/rust/build-tool/src/main.rs
@@ -80,8 +80,7 @@ struct Args {
     #[arg(long)]
     jobs: Option<usize>,
 
-    /// Filter to language: python, ruby, go, typescript, rust, elixir, lua,
-    /// perl, swift, java, kotlin, haskell, wasm, csharp, fsharp, dotnet, or all.
+    /// Filter to a canonical discovery language or use all.
     #[arg(long, default_value = "all")]
     language: String,
 
@@ -255,7 +254,13 @@ fn run() -> i32 {
     }
 
     // Step 2: Discover packages.
-    let mut packages = discovery::discover_packages(&code_root);
+    let mut packages = match discovery::discover_packages(&code_root) {
+        Ok(packages) => packages,
+        Err(error) => {
+            eprintln!("{}", error);
+            return 2;
+        }
+    };
     if packages.is_empty() {
         eprintln!("No packages found.");
         return 0;

--- a/code/programs/rust/build-tool/src/resolver.rs
+++ b/code/programs/rust/build-tool/src/resolver.rs
@@ -1077,7 +1077,8 @@ mod tests {
             fs::write(&path, data).unwrap();
         }
 
-        let packages = crate::discovery::discover_packages(&root.join("code"));
+        let packages = crate::discovery::discover_packages(&root.join("code"))
+            .expect("resolution fixture identities must be unique");
         (root, packages)
     }
 

--- a/code/programs/rust/build-tool/tests/duplicate_identity_cli.rs
+++ b/code/programs/rust/build-tool/tests/duplicate_identity_cli.rs
@@ -1,0 +1,92 @@
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Deserialize)]
+struct DiscoveryFixture {
+    workspace: FixtureWorkspace,
+    expected: FixtureExpected,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureWorkspace {
+    files: Vec<FixtureFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureFile {
+    path: String,
+    content_utf8: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureExpected {
+    diagnostics: Vec<FixtureDiagnostic>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureDiagnostic {
+    code: String,
+    package: String,
+    details: FixtureDiagnosticDetails,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureDiagnosticDetails {
+    paths: Vec<String>,
+}
+
+fn load_fixture() -> DiscoveryFixture {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/fixtures/build-tool-v1/cases/discovery-duplicate-identity.json");
+    let data = fs::read(&path)
+        .unwrap_or_else(|error| panic!("read shared fixture {}: {error}", path.display()));
+    serde_json::from_slice(&data)
+        .unwrap_or_else(|error| panic!("decode shared fixture {}: {error}", path.display()))
+}
+
+fn materialize_fixture(fixture: &DiscoveryFixture) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "build_tool_rust_duplicate_identity_cli_{}_{}",
+        std::process::id(),
+        nonce
+    ));
+
+    for file in &fixture.workspace.files {
+        let path = root.join(Path::new(&file.path));
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, file.content_utf8.as_bytes()).unwrap();
+    }
+
+    root
+}
+
+#[test]
+fn cli_fails_closed_on_shared_duplicate_identity_fixture() {
+    let fixture = load_fixture();
+    let root = materialize_fixture(&fixture);
+    let output = Command::new(env!("CARGO_BIN_EXE_build-tool"))
+        .args(["--root", root.to_str().unwrap(), "--force", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let diagnostic = &fixture.expected.diagnostics[0];
+    let expected = format!(
+        "{}: package={} paths={}\n",
+        diagnostic.code,
+        diagnostic.package,
+        diagnostic.details.paths.join(",")
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert_eq!(stderr, expected);
+    assert!(!stderr.contains(&root.to_string_lossy().to_string()));
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -131,7 +131,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 34)
+        self.assertEqual(summary["case_count"], 36)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -851,7 +851,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 34)
+        self.assertEqual(summary["case_count"], 36)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -238,6 +238,22 @@ Required behavior:
   - macOS: `BUILD_mac`, then `BUILD_mac_and_linux`, then canonical `BUILD`;
   - Linux: `BUILD_linux`, then `BUILD_mac_and_linux`, then canonical `BUILD`.
 
+The bucket component immediately below `packages` or `programs` is the sole
+language discriminator; canonical words later in a path do not change the
+language. The canonical discovery registry classifies all established implementation
+lanes (`csharp`, `dart`, `elixir`, `fsharp`, `go`, `haskell`, `java`, `kotlin`,
+`lua`, `perl`, `python`, `ruby`, `rust`, `swift`, and `typescript`), emerging
+implementation lanes (`c`, `cpp`, and `ocaml`), the `wasm` execution target,
+the `mosaic` and `twig` domain languages, and the `starlark` build language.
+The repository also retains `dotnet` for programs hosted by the shared .NET
+engine; it is not a separate package-parity denominator. An unrecognized
+component is reported as `unknown` rather than borrowed from a substring.
+
+If two discovered directories still produce one qualified name, discovery
+fails with `DUPLICATE_PACKAGE_IDENTITY`. The diagnostic includes the duplicate
+package identity and every repository-relative package path in sorted order;
+it must not disclose the checkout root.
+
 The selected canonical `BUILD` may contain legacy shell lines or Starlark.
 Conformance v1 does not recognize `BUILD.lark` as a package marker; that name in
 older migration documents is aspirational. Implementations must not infer

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-08-02
 
+- Added discovery cases for every canonical language bucket missing from the
+  Rust registry, canonical fixture-tree exclusion, and fail-closed duplicate
+  qualified identities with the stable `DUPLICATE_PACKAGE_IDENTITY`
+  diagnostic.
 - Added Elixir resolution cases that preserve distinct package/program
   identities and reject genuine dependency self-edges with the stable
   `DEPENDENCY_SELF_EDGE` diagnostic.

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -35,9 +35,11 @@ emerging OCaml lane. It records front-door and shared-engine state but contains
 no executable commands. Every adapter is currently marked missing, so a valid
 inventory is not reported as conformance success.
 
-The 34-case bootstrap corpus covers every process-free v1 domain:
+The 36-case bootstrap corpus covers every process-free v1 domain:
 
-- canonical membership plus Windows, macOS, and Linux BUILD precedence;
+- canonical membership and language-registry classification, fixture-tree
+  exclusion, fail-closed duplicate package identities, plus Windows, macOS,
+  and Linux BUILD precedence;
 - the shared Python dependency diamond, distinct Elixir package/program
   identities, fail-closed dependency self-edges, and positive UTF-8 plus
   fail-closed invalid-UTF-8 Lua rockspec resolution;

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-duplicate-identity.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-duplicate-identity.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "id": "discovery/duplicate-identity",
+  "domain": "discovery",
+  "summary": "Two unclassified buckets that collapse to one qualified name fail closed.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "discovery"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/alpha/demo/BUILD",
+        "content_utf8": "echo alpha\n"
+      },
+      {
+        "path": "code/packages/beta/demo/BUILD",
+        "content_utf8": "echo beta\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "discovery",
+    "options": {
+      "code_root": "code",
+      "platform": "linux"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "discovery/duplicate-identity",
+    "domain": "discovery",
+    "outcome": "error",
+    "result": {},
+    "diagnostics": [
+      {
+        "code": "DUPLICATE_PACKAGE_IDENTITY",
+        "severity": "error",
+        "path": "code/packages/alpha/demo",
+        "package": "unknown/demo",
+        "details": {
+          "paths": [
+            "code/packages/alpha/demo",
+            "code/packages/beta/demo"
+          ]
+        }
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-language-registry.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-language-registry.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": 1,
+  "id": "discovery/language-registry",
+  "domain": "discovery",
+  "summary": "Every canonical non-host bucket is classified by its exact path component.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "discovery"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/c/demo-c/BUILD",
+        "content_utf8": "echo c\n"
+      },
+      {
+        "path": "code/packages/cpp/demo-cpp/BUILD",
+        "content_utf8": "echo cpp\n"
+      },
+      {
+        "path": "code/packages/custom/go/BUILD",
+        "content_utf8": "echo exact-bucket-only\n"
+      },
+      {
+        "path": "code/packages/dart/demo-dart/BUILD",
+        "content_utf8": "echo dart\n"
+      },
+      {
+        "path": "code/packages/java/demo-java/BUILD",
+        "content_utf8": "echo java\n"
+      },
+      {
+        "path": "code/packages/kotlin/demo-kotlin/BUILD",
+        "content_utf8": "echo kotlin\n"
+      },
+      {
+        "path": "code/packages/mosaic/demo-mosaic/BUILD",
+        "content_utf8": "echo mosaic\n"
+      },
+      {
+        "path": "code/packages/ocaml/demo-ocaml/BUILD",
+        "content_utf8": "echo ocaml\n"
+      },
+      {
+        "path": "code/packages/starlark/demo-starlark/BUILD",
+        "content_utf8": "echo starlark\n"
+      },
+      {
+        "path": "code/packages/twig/demo-twig/BUILD",
+        "content_utf8": "echo twig\n"
+      },
+      {
+        "path": "code/specs/fixtures/scaffold-generator/ocaml-library/BUILD",
+        "content_utf8": "echo fixture-only\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "discovery",
+    "options": {
+      "code_root": "code",
+      "platform": "linux"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "discovery/language-registry",
+    "domain": "discovery",
+    "outcome": "ok",
+    "result": {
+      "packages": [
+        {
+          "build_file": "code/packages/c/demo-c/BUILD",
+          "is_starlark": false,
+          "language": "c",
+          "name": "c/demo-c",
+          "rel_path": "code/packages/c/demo-c"
+        },
+        {
+          "build_file": "code/packages/cpp/demo-cpp/BUILD",
+          "is_starlark": false,
+          "language": "cpp",
+          "name": "cpp/demo-cpp",
+          "rel_path": "code/packages/cpp/demo-cpp"
+        },
+        {
+          "build_file": "code/packages/dart/demo-dart/BUILD",
+          "is_starlark": false,
+          "language": "dart",
+          "name": "dart/demo-dart",
+          "rel_path": "code/packages/dart/demo-dart"
+        },
+        {
+          "build_file": "code/packages/java/demo-java/BUILD",
+          "is_starlark": false,
+          "language": "java",
+          "name": "java/demo-java",
+          "rel_path": "code/packages/java/demo-java"
+        },
+        {
+          "build_file": "code/packages/kotlin/demo-kotlin/BUILD",
+          "is_starlark": false,
+          "language": "kotlin",
+          "name": "kotlin/demo-kotlin",
+          "rel_path": "code/packages/kotlin/demo-kotlin"
+        },
+        {
+          "build_file": "code/packages/mosaic/demo-mosaic/BUILD",
+          "is_starlark": false,
+          "language": "mosaic",
+          "name": "mosaic/demo-mosaic",
+          "rel_path": "code/packages/mosaic/demo-mosaic"
+        },
+        {
+          "build_file": "code/packages/ocaml/demo-ocaml/BUILD",
+          "is_starlark": false,
+          "language": "ocaml",
+          "name": "ocaml/demo-ocaml",
+          "rel_path": "code/packages/ocaml/demo-ocaml"
+        },
+        {
+          "build_file": "code/packages/starlark/demo-starlark/BUILD",
+          "is_starlark": false,
+          "language": "starlark",
+          "name": "starlark/demo-starlark",
+          "rel_path": "code/packages/starlark/demo-starlark"
+        },
+        {
+          "build_file": "code/packages/twig/demo-twig/BUILD",
+          "is_starlark": false,
+          "language": "twig",
+          "name": "twig/demo-twig",
+          "rel_path": "code/packages/twig/demo-twig"
+        },
+        {
+          "build_file": "code/packages/custom/go/BUILD",
+          "is_starlark": false,
+          "language": "unknown",
+          "name": "unknown/go",
+          "rel_path": "code/packages/custom/go"
+        }
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,13 +106,13 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `c840af78` after
-merged PR #9498 added the mixed Rust Tasmota local HTTP identity. Merged PRs
-#9502, #9505, #9506, #9510, #9512, #9514, #9515, #9516, and #9521 changed
-existing packages or learning assets without creating another implementation
-package directory.
+working inventory was regenerated on August 2, 2026 from `4d0a98e0` after
+merged PR #9498 added the mixed Rust Tasmota local HTTP identity. Merged PR
+#9513 added the Rust-only Fronius local integration. PRs #9517, #9520, #9522,
+#9523, and #9524 changed existing packages or learning assets without creating
+another implementation package directory.
 The inventory contains
-1,218 normalized implementation identities across 4,366 established-lane
+1,219 normalized implementation identities across 4,367 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -120,24 +120,25 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 768 | 10,752 |
+| Present in one language | 769 | 10,766 |
 
-The loop must not start by attempting 10,752 singleton ports. It should finish
+The loop must not start by attempting 10,766 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`c840af78378a1597134694e1008c922f4e355f95` is collision-clean at 1,218
-normalized implementation identities, 4,366 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 768 singletons, 573
+`4d0a98e02bec862a5b852329426d01c8996a19c6` is collision-clean at 1,219
+normalized implementation identities, 4,367 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 769 singletons, 574
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The thirteen newest mixed Rust identities are `smart-home-camera-media`,
+The fourteen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
 `smart-home-wled-integration`, `smart-home-govee-lan-integration`,
 `smart-home-lifx-lan-integration`, `smart-home-kasa-lan-integration`,
 `smart-home-reolink-integration`, `smart-home-roku-ecp-integration`,
 `smart-home-wemo-upnp-integration`, `smart-home-sonos-upnp-integration`,
-`smart-home-nanoleaf-local-integration`, and
-`smart-home-tasmota-local-integration`. All are
+`smart-home-nanoleaf-local-integration`,
+`smart-home-tasmota-local-integration`, and
+`smart-home-fronius-local-integration`. All are
 mixed splits rather than blind parity ports: camera grant policy,
 generation-bound lease state, quotas, and redacted audit are portable, while
 authenticated host context and media delivery remain native mediation; ONVIF
@@ -151,11 +152,11 @@ WLED DTO validation, master/segment projection, capability-bit interpretation,
 state normalization, and command planning are portable, while mDNS, DNS/TCP,
 plaintext LAN HTTP, trusted time, console I/O, pairing/origin policy, runtime
 effects, and capability profiles remain native. Govee, LIFX, Kasa, Reolink,
-Roku, Wemo, Sonos, Nanoleaf, and Tasmota contribute deterministic codecs,
-bounded parsers and DTO validation, normalization, projection, stable
+Roku, Wemo, Sonos, Nanoleaf, Tasmota, and Fronius contribute deterministic
+codecs, bounded parsers and DTO validation, normalization, projection, stable
 identities/errors, command planning, and language-neutral fixtures to the
-parity backlog. Wemo specifically
-contributes SSDP header parsing, bounded setup/SOAP XML, service/device
+parity backlog. Wemo specifically contributes SSDP header parsing, bounded
+setup/SOAP XML, service/device
 normalization, and switch/light command planning. Sonos additionally contributes
 credential-free URL/control-path validation, AVTransport, RenderingControl,
 DIDL metadata normalization, deterministic inspection planning, and
@@ -163,11 +164,12 @@ protocol-neutral media-player projection. Nanoleaf adds credential syntax and
 origin-configuration validation, bounded snapshot/state validation, stable
 identity and capability projection, RGB/HSV and mirek conversion, command
 planning, and verification. Tasmota adds bounded Status 0 JSON validation,
-relay/light/sensor normalization,
-state and capability projection, command planning, color conversion, and
-verification fixtures. UDP multicast, DNS/TCP, LAN HTTP
-execution, timeouts, endpoint approval, CLI I/O, authorization, and runtime
-mutation remain native-host responsibilities.
+relay/light/sensor normalization, state and capability projection, command
+planning, color conversion, and verification fixtures. Fronius adds bounded
+Power Flow and API-status validation, site/inverter measurement normalization,
+and deterministic sensor projection. UDP multicast, DNS/TCP, LAN HTTP execution,
+timeouts, endpoint approval, CLI I/O, authorization, and runtime mutation remain
+native-host responsibilities.
 
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,11 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `9302e736` after
+working inventory was regenerated on August 2, 2026 from `c840af78` after
 merged PR #9498 added the mixed Rust Tasmota local HTTP identity. Merged PRs
-#9502, #9505, #9506, #9510, #9512, #9514, #9515, and #9516 changed existing
-packages or learning assets without creating another implementation package
-directory.
+#9502, #9505, #9506, #9510, #9512, #9514, #9515, #9516, and #9521 changed
+existing packages or learning assets without creating another implementation
+package directory.
 The inventory contains
 1,218 normalized implementation identities across 4,366 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
@@ -126,7 +126,7 @@ The loop must not start by attempting 10,752 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`9302e73668017a31e38f432c31bbba4f091a56bf` is collision-clean at 1,218
+`c840af78378a1597134694e1008c922f4e355f95` is collision-clean at 1,218
 normalized implementation identities, 4,366 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 768 singletons, 573
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
@@ -225,15 +225,14 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   Their current byte, replacement, silent-drop, and locale-sensitive behavior
   is tracked separately from the Python full-scan blocker. Merged PR #9504
   completed the Go operational-oracle child, and the Rust child is next;
-- make the Rust build tool reject resolver self-edges with a stable diagnostic.
-  A real 4,766-package plan reproduced the untouched-main exit-101 panic on
-  `elixir/grammar_tools`; this is tracked separately from UTF-8 decoding;
+- merged PR #9521 makes the Rust build tool reject resolver self-edges with a
+  stable diagnostic and preserves distinct package/program identities for
+  `elixir/grammar_tools`;
 - bring Rust build-tool discovery to the complete canonical language and
-  identity registry. The self-edge repair makes the full plan exit zero and
-  distinguishes package/program basenames, but a follow-up audit found 212
-  remaining duplicate `unknown/*` identities (382 extra discovered entries)
-  because several established and emerging language directories are not yet
-  classified by the Rust front door;
+  identity registry. The active slice classifies every repository bucket,
+  excludes specification fixture trees, and rejects residual duplicate names;
+  its real full plan exits zero with 4,764 entries, 4,764 unique identities,
+  and only the intentional language-neutral `code/sites/blog` package;
 - expose Haskell through the Python build tool's `--language` filter. Haskell
   is already in its resolver and canonical language registry but is missing
   from the native CLI choices;


### PR DESCRIPTION
## Summary

- add language-neutral discovery fixtures for the canonical language registry, exact bucket-boundary inference, fixture-tree exclusion, and duplicate qualified identities
- classify every established, emerging, execution-target, domain, and build-language bucket in Rust while retaining the shared `dotnet` program host bucket
- reject residual duplicate package identities before graph construction with stable `DUPLICATE_PACKAGE_IDENTITY` output, sorted repository-relative paths, and CLI exit code 2
- update the Rust docs/changelog, shared conformance docs, parity inventory, roadmap, and durable loop state

## Root cause

Rust discovery omitted C, C++, Dart, Java, Kotlin, Mosaic, OCaml, Starlark, and Twig. Their packages collapsed into `unknown/<basename>` identities, so the audited pre-fix full plan contained 4,766 entries but only 4,384 distinct names. Rust also descended into `code/specs`, treating two scaffold fixtures as buildable packages, and inferred a language from any later path component instead of only the bucket immediately below `packages` or `programs`.

The repaired full plan contains 4,765 real package entries and 4,765 unique names. The sole remaining `unknown/blog` entry is the intentional language-neutral `code/sites/blog` package.

## Validation

- `cargo test -- --nocapture`: 140 unit tests plus duplicate-identity, invalid-UTF-8, and dependency-self-edge real CLI integrations pass
- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo build --release`: pass
- `cargo llvm-cov --all-targets --summary-only`: 79.39% regions, 79.49% lines; discovery 94.03% lines
- `cargo audit`: 56 dependencies, zero advisories
- `python code/scripts/build_tool_conformance.py validate-corpus`: valid 36-case, 55-file corpus across 15 established languages and 16 implementations
- conformance schema tests: 17 pass
- conformance runner tests: 40 pass
- `python code/scripts/package_parity_report.py --root . --format json --fail-on-collisions`: 1,219 established implementation identities, 4,367 slots, zero collisions, zero unknown language buckets
- release binary full-repository `--force --dry-run --emit-plan`: exit 0; 4,765 entries, 4,765 unique names, zero duplicate entries; new Fronius package included
- `rustfmt --check tests/duplicate_identity_cli.rs`: pass
- `git diff --check`: pass

## Known baseline and newly logged work

- the existing 10 Lua `BUILD_windows` validation findings remain unchanged and are owned by `build-file-standalone-integrity-lua`
- merged PR #9513 added the Rust-only Fronius Solar API v1 host; this PR records the separate pending `smart-home-fronius-portable-core-extraction-and-conformance` item for bounded telemetry validation, normalization, and deterministic projection while excluding native LAN and runtime effects
