### PR TITLE
feat(human-languages): split Punjabi lessons under five minutes

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Gujarati duration
-tranche: 20 registered tracks, 982 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Punjabi duration
+tranche: 20 registered tracks, 983 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -50,13 +50,16 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01A | Complete in the Russian duration PR | Remove all nine sub-five-minute violations from the complete Russian starter track. | The report measures zero Russian violations; every changed or added lesson is below 300 effective seconds. |
 | HL-D01B | Complete in the Marathi duration PR | Remove all eight sub-five-minute violations from the Marathi track. | The report measures zero Marathi violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
 | HL-D01C | Complete in the Gujarati duration PR | Remove all nine sub-five-minute violations from the Gujarati track. | The report measures zero Gujarati violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
-| HL-D01D | Next | Remove all ten sub-five-minute violations from the Punjabi track. | Punjabi and Sanskrit tie at ten; Punjabi has the smaller genuine split at 405 computed seconds versus Sanskrit's 513, so it is the safer next tranche. |
+| HL-D01D | Complete in the Punjabi duration PR | Remove all ten sub-five-minute violations from the Punjabi track. | The report measures zero Punjabi violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
+| HL-D01E | Next | Remove all ten sub-five-minute violations from the Sanskrit track. | Sanskrit is now the smallest remaining track-sized set; nine lessons need honest budgets and the 513-second numbers lesson needs a careful multi-part split. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B05 | Queued | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | A forced build succeeds but reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and two underfull boxes; the clean-build signal is zero of each. |
 | HL-B06 | Queued | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B07 | Queued | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B08 | Queued | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-B09 | Queued | Remove Punjabi's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -182,6 +185,29 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   each with nine declaration-only lessons and one genuine split. Punjabi's long
   lesson computes at 405 seconds versus Sanskrit's 513, so HL-D01D takes Punjabi
   first as the safer bounded tranche.
+
+## Findings from HL-D01D
+
+- Punjabi now has zero duration violations. The repository snapshot contains
+  983 lessons and 445 violations overall, down from 455 before this tranche;
+  unknown prerequisites remain at zero.
+- Nine lessons already computed between 106 and 172 seconds and only needed
+  honest four-minute declared budgets. The one genuinely long lesson computed
+  at 405 seconds.
+- That lesson is now a 229-second counting-and-script core followed by a
+  241-second etymology lesson. The Gurmukhi mark distinction, Chapter 5 callback,
+  same-source *panjāh/pacās* evidence, and convergence explanation remain
+  complete and prerequisite-ordered in the Language Ladder corpus.
+- Punjabi Chapter 6 has canonical lessons but is not in the current
+  five-chapter PDF. HL-B08 records its one-source migration and generation work
+  rather than adding another manual copy.
+- A forced build of the unchanged five-chapter book succeeds with no missing
+  glyphs, but exposes one overfull box, four underfull boxes, four duplicate
+  practice labels, and 28 Unicode bookmark warnings. HL-B09 records that
+  pre-existing publication hygiene debt separately.
+- Sanskrit's ten violations are now the smallest remaining track-sized set.
+  Nine are declaration-only; its 513-second numbers lesson will require a more
+  careful split than the three preceding tranches, so HL-D01E is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/punjabi/CHANGELOG.md
+++ b/code/learning/human-languages/punjabi/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Sub-five-minute remediation — 2026-08-02
+
+- Corrected nine declared five-minute estimates whose computed durations were
+  already between 106 and 172 seconds.
+- Split the genuinely long numbers lesson into a 229-second counting/script
+  lesson and a prerequisite-ordered 241-second etymology lesson.
+- Preserved the addak/tippi distinction, Chapter 5 *panjābī* callback,
+  *panjāh/pacās* evidence, and Punjabi/Persian convergence explanation. The
+  shared report now measures zero Punjabi duration violations.
+- Updated the roadmap and session map to expose both Chapter 6 lesson boundaries.
+  Chapter 6's missing one-source book publication remains explicit in the shared
+  backlog.
+
 ## Chapter 6 — Numbers 1–5, and *panj* arriving as a number
 
 - **Chapter 6 authored** (`PA-C06-numbers-1-5`): *ikk, do, tinn, chār, panj*, in

--- a/code/learning/human-languages/punjabi/README.md
+++ b/code/learning/human-languages/punjabi/README.md
@@ -37,6 +37,13 @@ book.
 - **Chapter 5 — First Verbs** ([`lessons/PA-C05-*`](./lessons/)): bolṇā, **maiṁ
   panjābī boldā hāṁ** (*panj* "five" + *āb* "river"), rahiṇā, kamm karnā, practice.
   The gendered present habitual. In the book.
+- **Chapter 6 — Numbers 1–5** ([`lessons/PA-C06-*`](./lessons/)): a short
+  counting-and-Gurmukhi lesson followed by a prerequisite-ordered explanation
+  of why native Punjabi *panj* and Persian *panj* are convergence, not borrowing.
+
+Chapters 1–5 are in the book. Chapter 6 is canonical app-ready lesson content;
+its one-source book publication remains explicitly tracked in the shared
+backlog.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C01-practice.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [PA-C01-sat-sri-akal, PA-C01-namaste, PA-C01-dhanvaad, PA-C01-shukriya, PA-C01-han-nahin]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PA-C01-sat-sri-akal, PA-C01-namaste, PA-C01-dhanvaad, PA-C01-shukriya, PA-C01-han-nahin]
 ---
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C01-sat-sri-akal.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C01-sat-sri-akal.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-FORMAL
 prerequisites: []
 sounds: [inherent-a, vowel-sign, vowel-carrier]
 roots: [satya, sri, akala]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C01-shukriya.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C01-shukriya.md
@@ -8,7 +8,7 @@ concept_tag: COURTESY-THANKS-CASUAL
 prerequisites: [PA-C01-dhanvaad]
 sounds: [pair-bindi, vowel-sign]
 roots: [shukr]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PA-C01-dhanvaad]
 ---
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-practice.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [PA-C02-mera-naam-hai, PA-C02-tuhada-naam-ki-hai, PA-C02-khushi]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PA-C02-naam, PA-C02-mera, PA-C02-hai, PA-C02-mera-naam-hai, PA-C02-tu-tusi, PA-C02-ki, PA-C02-tuhada-naam-ki-hai, PA-C02-khushi]
 ---
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C03-practice.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [PA-C03-tusi-kivein-ho, PA-C03-thik, PA-C03-koi-gall-nahin]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PA-C03-kivein, PA-C03-tusi-kivein-ho, PA-C03-main, PA-C03-thik, PA-C03-koi-gall-nahin]
 ---
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C04-practice.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [PA-C04-phir-milaange, PA-C04-rab-raakha]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PA-C01-sat-sri-akal, PA-C04-phir, PA-C04-milaange, PA-C04-phir-milaange, PA-C04-rab-raakha]
 ---
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C05-kamm-karna.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C05-kamm-karna.md
@@ -8,7 +8,7 @@ concept_tag: PA-VERB-KARNA
 prerequisites: [PA-C05-bolna]
 sounds: [tippi-nasal, double-mm]
 roots: [kr-do]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PA-C05-bolna, PA-C05-rahna]
 ---
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C05-main-punjabi-bolda-han.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C05-main-punjabi-bolda-han.md
@@ -8,7 +8,7 @@ concept_tag: PA-WORD-PUNJABI
 prerequisites: [PA-C05-bolna, PA-C03-main]
 sounds: [tippi-nasal, kanna-aa]
 roots: [panj-persian, aab-persian]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PA-C05-bolna, PA-C03-main]
 ---
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C05-practice.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [PA-C05-bolna, PA-C05-main-punjabi-bolda-han, PA-C05-rahna, PA-C05-kamm-karna]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PA-C05-bolna, PA-C05-main-punjabi-bolda-han, PA-C05-rahna, PA-C05-kamm-karna, PA-C03-main]
 ---
 

--- a/code/learning/human-languages/punjabi/lessons/PA-C06-numbers-1-5.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C06-numbers-1-5.md
@@ -8,8 +8,8 @@ concept_tag: PA-NUMBERS-1-5
 prerequisites: [PA-C01-sat-sri-akal, PA-C05-main-punjabi-bolda-han]
 sounds: [sihari-i, tippi-nasal, kanna-aa]
 roots: [sanskrit-panca, persian-panj]
-etymology_hook: "Ch.5 took panjābī apart as Persian panj 'five' + āb 'water'; here panj arrives as an ordinary Punjabi NUMBER — and the twist is that Punjabi's panj is NOT the Persian word but its own inherited descendant of pañca, voiced after the nasal exactly as Persian independently voiced its own; the match is CONVERGENCE, which is why the Persian place-name sits so comfortably in Punjabi"
-est_minutes: 5
+etymology_hook: "Chapter 5 introduced panj inside panjabi; learn it as the ordinary number five here, then trace Punjabi and Persian panj as convergence in the next short lesson"
+est_minutes: 3
 reviews_of: [PA-C01-sat-sri-akal, PA-C05-main-punjabi-bolda-han]
 ---
 
@@ -41,7 +41,7 @@ Two marks worth telling apart, because they look similar and do different jobs:
 (So *tinn*'s double *n* is not the addak's doing — that word is spelled with a
 nasal mark, and the doubling is in the pronunciation.)
 
-## ਪੰਜ — the word you already knew
+## ਪੰਜ — a word you already know
 
 Chapter 5 took the name **ਪੰਜਾਬੀ** (*panjābī*) apart for you: Persian **ਪੰਜ**
 *panj*, "five," plus **ਆਬ** *āb*, "water" — the language **of the five rivers**.
@@ -49,47 +49,8 @@ Chapter 5 took the name **ਪੰਜਾਬੀ** (*panjābī*) apart for you: Pers
 You learned *panj* there as a piece of a place-name. Here it arrives as what it
 actually is: **the number five**, an ordinary word you will count with.
 
-That's the whole point of this lesson. Compare the family:
-
-| | 5 |
-|---|---|
-| Sanskrit | *pañca* |
-| Hindi | *pāṁch* |
-| Bengali | *pā̃ch* |
-| Gujarati | *pā̃ch* |
-| **Punjabi** | ***panj*** |
-
-Every neighbour has a *pā̃ch* shape ending in a **-ch**. Punjabi's ends in
-**-j** — matching the **Persian** *panj* that Chapter 5 said the province was
-named for.
-
-Here is the twist, and it is better than the obvious story.
-
-**Punjabi's *panj* is not the Persian word.** It is Punjabi's own inherited
-descendant of Sanskrit *pañca*. North-western Indo-Aryan regularly **voiced a
-stop after a nasal**, turning *-ñc-* into *-nj-*, which is why Punjabi also has
-**panjāh** "fifty" (← *pañcāśat*) where **Hindi has *pacās***, with no *j* at all.
-That contrast is the proof: same Sanskrit source, and only the north-western
-language voices it.
-
-Persian, quite separately, voiced its own *č* to *j* on the way from Old to
-Middle Persian.
-
-So two branches of Indo-Iranian **arrived at the same shape independently**:
-
-| | 5 | how it got there |
-|---|---|---|
-| Sanskrit | *pañca* | — |
-| Hindi / Bengali / Gujarati | *pāṁch* etc. | kept the *ch* |
-| **Persian** | *panj* | voiced its own *č* |
-| **Punjabi** | ***panj*** | voiced *-ñc-* after the nasal, on its own |
-
-Not borrowing. **Convergence** — which is exactly why the Persian name *Punjab*
-sits so comfortably in Punjabi that you would never guess it was Persian. The
-foreign word and the native word had already grown into the same shape.
-
-(The place-name *is* Persian, because Persian was the region's administrative
-language for centuries. It's the **numeral** that's homegrown.)
+The next prerequisite-ordered lesson explains an important twist: Punjabi's
+numeral and the Persian word reached the same *panj* shape independently.
 
 ## Guided Practice
 
@@ -97,7 +58,6 @@ language for centuries. It's the **numeral** that's homegrown.)
 - [YOU SAY: "ikk, do, tinn, chār, panj"]
 - [YOU SAY: the two marks — "**addak** doubles, **tippi** nasalises"]
 - [YOU SAY: the Ch. 5 callback — "**panj** + **āb** = five rivers"]
-- [YOU SAY: the family — "pañca … pa**nj**āh … pa**nj**", all homegrown]
 
 ## Wrap-up Recall
 
@@ -106,8 +66,4 @@ this? (**Gurmukhi** — related to Devanagari, and it has a top line too.) What 
 **ੱ** and **ੰ** each do? (**Addak** doubles the following consonant; **tippi**
 marks a nasal.) Chapter 5 told you *panjābī* means "of the five rivers." What has
 changed now? (***Panj* is a number you can count with**, not just a piece of a
-name.) Is Punjabi's *panj* borrowed from Persian? (**No** — it is Punjabi's own
-*pañca*, voiced after the nasal, like *panjāh* "fifty". Persian voiced its own
-separately: the match is **convergence**.) Why does the Persian place-name feel
-native, then? (Because **the two words had already grown into the same shape**.)
-Next: six to ten.
+name.) Next: learn why Punjabi and Persian both say *panj*.

--- a/code/learning/human-languages/punjabi/lessons/PA-C06-panj-convergence.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C06-panj-convergence.md
@@ -1,0 +1,79 @@
+---
+id: PA-C06-panj-convergence
+chapter: 6
+type: etymology
+headword: ਪੰਜ · panj
+gloss: why Punjabi and Persian independently reached the same word-shape for five
+prerequisites: [PA-C06-numbers-1-5]
+sounds: [tippi-nasal]
+roots: [sanskrit-panca, persian-panj]
+etymology_hook: "Punjabi panj is inherited from Sanskrit pancha, not borrowed from Persian; both branches voiced different ancestral ch sounds to j and converged"
+est_minutes: 4
+reviews_of: [PA-C06-numbers-1-5, PA-C05-main-punjabi-bolda-han]
+---
+
+# Why two branches both arrived at *panj*
+
+## Warm-up
+
+[PAUSE 2s] Say “five” in Punjabi. (*Panj*.) Where did Chapter 5 first show that
+shape? (Inside Persian *panj + āb*, “five waters.”)
+
+## The surprising family comparison
+
+| language | “five” |
+|---|---|
+| Sanskrit | *pañca* |
+| Hindi | *pāṁch* |
+| Bengali | *pā̃ch* |
+| Gujarati | *pā̃ch* |
+| **Punjabi** | ***panj*** |
+| **Persian** | ***panj*** |
+
+The neighbours keep a **-ch** shape. Punjabi matches Persian **-j**, but the
+obvious borrowing story is wrong.
+
+## Punjabi's numeral is homegrown
+
+Punjabi *panj* is its own inherited descendant of Sanskrit *pañca*.
+North-western Indo-Aryan regularly **voiced a stop after a nasal**, turning
+*-ñc-* into *-nj-*.
+
+Punjabi **panjāh** “fifty” makes the rule visible: it descends from Sanskrit
+*pañcāśat*, while Hindi has **pacās**, with no *j*. The same Sanskrit source
+changes differently in the two languages.
+
+## Persian reached the shape separately
+
+Persian independently voiced its own ancestral *č* to *j* on the way from Old
+to Middle Persian. The two branches of Indo-Iranian therefore reached *panj*
+through separate histories:
+
+| branch | path |
+|---|---|
+| Punjabi | Sanskrit *pañca* → nasal-triggered *-nj-* |
+| Persian | Iranian *panč* → voiced *panj* |
+
+This is **convergence, not borrowing**. It explains why the Persian place-name
+*Punjab* feels native in Punjabi: the borrowed name and the homegrown numeral
+had already grown into the same shape.
+
+The **place-name** is Persian, reflecting centuries of Persian administration.
+The Punjabi **numeral** is inherited.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: Punjabi's source — Sanskrit *pañca*]
+- [YOU SAY: the same-source proof — Punjabi *panjāh*, Hindi *pacās*]
+- [YOU SAY: two independent paths, one result — *panj*]
+- [YOU SAY: borrowing or convergence — convergence]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is Punjabi *panj* borrowed from Persian? (No: it is inherited from
+*pañca*.) What sound environment produced Punjabi *-nj-*? (A stop after a nasal
+became voiced.) Which “fifty” pair demonstrates it? (*Panjāh / pacās*.) Why does
+Persian also have *panj*? (It voiced its own ancestral *č* separately.) What is
+Persian and what is native in *Punjab*? (The place-name is Persian; Punjabi's
+number is homegrown.)

--- a/code/learning/human-languages/punjabi/roadmap.md
+++ b/code/learning/human-languages/punjabi/roadmap.md
@@ -28,7 +28,8 @@ vocabularies** (Sanskritic and Perso-Arabic) and the **Gurmukhi** script, taught
 - **Ch. 5 — First Verbs**: bolṇā (to speak) → maiṁ panjābī boldā hāṁ (I speak
   Punjabi; *panj* "five" + *āb* "river") → rahiṇā (to live) → kamm karnā (to work;
   ← √kṛ) → practice. The gendered present habitual.
-- **Ch. 6 — Numbers 1–5** (`PA-C06-numbers-1-5`): *ikk, do, tinn, chār, panj* —
+- **Ch. 6 — Numbers 1–5** (`PA-C06-numbers-1-5` →
+  `PA-C06-panj-convergence`): first make *ikk, do, tinn, chār, panj* automatic
   in **Gurmukhi**, distinguishing the **ੱ** *addak* (doubles the following
   consonant, *ikk*) from the **ੰ** *tippi* (marks a nasal, *tinn*, *panj*). The
   chapter is built as a **payoff to Ch. 5**, which already took *panjābī* apart
@@ -38,13 +39,14 @@ vocabularies** (Sanskritic and Perso-Arabic) and the **Gurmukhi** script, taught
   voicing of a stop after a nasal (*panjāh* "fifty" against Hindi *pacās*),
   while Persian voiced its own *č* separately. **Convergence, not borrowing** —
   which is precisely why the Persian place-name sits so comfortably in Punjabi.
-  The *name* is Persian; the *numeral* is homegrown. **Authored.**
+  The *name* is Persian; the *numeral* is homegrown. The convergence history now
+  occupies its own sub-five-minute etymology lesson. **Authored.**
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 6 | Postpositions (*nū̃, tō̃, vic, te*); numbers 1–10 (Sanskritic vs. everyday) |
+| 6 continuation | Numbers 6–10, then postpositions (*nū̃, tō̃, vic, te*) |
 | 7+ | Gendered verbs deepened, family, food — with the Sanskrit/Persian thread; tone flagged where it distinguishes words |
 
 Note: Punjabi marks "you" by **register** (*tūṇ* familiar / *tusīṇ* respectful,

--- a/code/learning/human-languages/punjabi/session-map.md
+++ b/code/learning/human-languages/punjabi/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Punjabi Chapters 1–5
+# Session Map — Punjabi Chapters 1–6
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -64,6 +64,13 @@ word needs.
 | 30 | kamm-karna | ਕੰਮ ਕਰਨਾ | "to work" (noun + *karnā*) ← √kṛ, the root of *namaskār* |
 | 31 | practice | (dialogue) | three verbs, one engine |
 
+## Chapter 6 — Numbers 1–5
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 32 | numbers-1-5 | ਇੱਕ, ਦੋ, ਤਿੰਨ, ਚਾਰ, ਪੰਜ | retrieve the five forms; distinguish addak from tippi; reuse *panj* from *panjābī* |
+| 33 | panj-convergence | ਪੰਜ · *panj* | Punjabi *pañca → panj* and Persian *panč → panj* converge independently |
+
 ## Next
 
-Chapter 6 — postpositions (*nū̃, tō̃, vic, te*) and numbers 1–10.
+Finish Chapter 6 with numbers 6–10, then postpositions (*nū̃, tō̃, vic, te*).


### PR DESCRIPTION
## Summary

- remove all ten Punjabi lessons at or above the five-minute boundary
- correct nine declared estimates that the shared model already measured at 106–172 seconds
- split the genuinely long numbers lesson into a 229-second counting/script core and a prerequisite-ordered 241-second convergence lesson
- preserve the Gurmukhi addak/tippi distinction, Chapter 5 callback, `panjāh/pacās` evidence, and Punjabi/Persian etymology in canonical Markdown consumed by Language Ladder
- update the Punjabi roadmap/session map and promote Sanskrit's ten violations as the next measured tranche

The audit records canonical Chapter 6 publication as `HL-B08` and pre-existing Punjabi book hygiene debt as `HL-B09`; this PR does not hand-copy or hide either item.

## Measured result

- Punjabi duration violations: **10 → 0**
- repository duration violations: **455 → 445**
- canonical lessons: **982 → 983**
- unknown prerequisites: **0**
- split lesson durations: **229 seconds + 241 seconds**

## Validation

- `human-language-data`: 68 tests passed; 93.60% line coverage
- curriculum integration: 9 tests passed
- generated-book drift check: passed
- `language-ladder`: 278 tests passed; 98.37% line coverage
- Language Ladder production build: passed
- forced Punjabi XeLaTeX regression build: 25 pages, no missing glyphs
- `git diff --check`: passed

## Recorded pre-existing book debt

The unchanged Punjabi PDF still emits one overfull box, four underfull boxes, four duplicate practice-label warnings, and 28 Unicode PDF-string warnings. `HL-B09` records a zero-warning cleanup target; none was introduced by the canonical lesson changes.