### PR TITLE
fix(spice): validate MOS saturation current density

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `JS` values before
+  lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `IS` values
   before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `CGBO` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1968,6 +1968,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(saturation_current_density) = params.get("JS") {
+            if !saturation_current_density.is_finite() || *saturation_current_density < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET JS must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2099,6 +2099,35 @@ fn preserves_positive_mosfet_model_saturation_current() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_saturation_current_density() {
+    for saturation_current_density in ["-1p", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model leakage NMOS(JS={saturation_current_density})\nM1 d g s b leakage"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET JS must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_saturation_current_density() {
+    for (saturation_current_density, expected) in [("0", 0.0), ("2p", 2.0e-12)] {
+        let parsed = parse_netlist(&format!(
+            ".model leakage NMOS(JS={saturation_current_density})\nM1 d g s b leakage"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.saturation_current_density, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card saturation-current validation.
+1. Rust Berkeley SPICE MOS model-card saturation-current-density validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite model-card `IS` values before
+   - Reject negative and non-finite model-card `JS` values before
      lowering MOS elements into engine parameters.
-   - Preserve positive saturation currents.
+   - Preserve zero and positive saturation-current densities.
 
 ## Completed Slices
 
@@ -4034,6 +4034,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `CGBO` values are rejected before
      lowering MOS elements into engine parameters.
    - Zero and positive gate-bulk overlap capacitances remain accepted.
+
+353. Rust Berkeley SPICE MOS model-card saturation-current validation.
+   - Status: completed in PR 9525.
+   - Zero, negative, and non-finite model-card `IS` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Positive saturation currents remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `JS` values in the Rust Berkeley SPICE parser facade
- preserve zero and positive saturation-current densities, including engineering suffixes
- reconcile the SPICE implementation plan after saturation-current validation merged in #9525

## Scope
This is a Rust parser-facade boundary change. The shared Rust, Python, and TypeScript engines already enforce the same `JS` behavior and diagnostic.

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser` (144 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`