### PR TITLE
feat(human-languages): split Sanskrit lessons under five minutes

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Punjabi duration
-tranche: 20 registered tracks, 983 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Sanskrit duration
+tranche: 20 registered tracks, 985 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -51,7 +51,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01B | Complete in the Marathi duration PR | Remove all eight sub-five-minute violations from the Marathi track. | The report measures zero Marathi violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
 | HL-D01C | Complete in the Gujarati duration PR | Remove all nine sub-five-minute violations from the Gujarati track. | The report measures zero Gujarati violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
 | HL-D01D | Complete in the Punjabi duration PR | Remove all ten sub-five-minute violations from the Punjabi track. | The report measures zero Punjabi violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
-| HL-D01E | Next | Remove all ten sub-five-minute violations from the Sanskrit track. | Sanskrit is now the smallest remaining track-sized set; nine lessons need honest budgets and the 513-second numbers lesson needs a careful multi-part split. |
+| HL-D01E | Complete in the Sanskrit duration PR | Remove all ten sub-five-minute violations from the Sanskrit track. | The report measures zero Sanskrit violations; the 513-second anchor lesson is now three prerequisite-ordered micro-lessons. |
+| HL-D01F | Next | Remove all eleven sub-five-minute violations from the Bengali track. | Bengali is now the smallest remaining track-sized set, and all eleven already compute below five minutes; this is a bounded declared-budget correction. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -60,6 +61,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B07 | Queued | Remove Gujarati's missing punctuation glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports four missing punctuation glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B08 | Queued | Publish Punjabi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B09 | Queued | Remove Punjabi's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B10 | Queued | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-B11 | Queued | Remove Sanskrit's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports three overfull boxes, six underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -208,6 +211,29 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Sanskrit's ten violations are now the smallest remaining track-sized set.
   Nine are declaration-only; its 513-second numbers lesson will require a more
   careful split than the three preceding tranches, so HL-D01E is next.
+
+## Findings from HL-D01E
+
+- Sanskrit now has zero duration violations. The repository snapshot contains
+  985 lessons and 435 violations overall, down from 445 before this tranche;
+  unknown prerequisites remain at zero.
+- Nine lessons already computed between 107 and 186 seconds and only needed
+  honest four-minute declared budgets. The anchor numbers lesson computed at
+  513 seconds and required two new support lessons rather than one.
+- Chapter 6 is now a 232-second forms/grammar core, a 240-second east-west
+  cognate and sound-law lesson, and a 180-second *pañca* travel lesson. The dual,
+  gendered daughter forms, PIE outcomes, Grimm's law, analogy, and qualified
+  lexical histories remain complete and prerequisite-ordered in Language Ladder.
+- Sanskrit Chapter 6 has canonical lessons but is not in the current
+  five-chapter PDF. HL-B10 records its one-source migration and generation work
+  rather than adding another manual copy.
+- A forced build of the unchanged five-chapter book succeeds with no missing
+  glyphs, but exposes three overfull boxes, six underfull boxes, four duplicate
+  practice labels, and 28 Unicode bookmark warnings. HL-B11 records that
+  pre-existing publication hygiene debt separately.
+- Bengali's eleven violations are now the smallest remaining track-sized set.
+  All eleven already compute below 300 seconds (maximum 290), so HL-D01F is a
+  bounded honest-budget correction with no content split required.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/sanskrit/CHANGELOG.md
+++ b/code/learning/human-languages/sanskrit/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Sub-five-minute remediation — 2026-08-02
+
+- Corrected nine declared five-minute estimates whose computed durations were
+  already between 107 and 186 seconds.
+- Split the 513-second numbers lesson into a 232-second forms/grammar lesson, a
+  240-second cognate-and-sound-law lesson, and a 180-second *pañca* travel lesson.
+- Preserved the masculine/neuter table, dual, east-west cognate map, PIE *kʷ*
+  outcomes, Grimm's law, analogical *four*, and the qualified *punch* etymology.
+  The shared report now measures zero Sanskrit duration violations.
+- Updated the roadmap and session map to expose all three Chapter 6 lesson
+  boundaries. Chapter 6's missing one-source book publication remains explicit
+  in the shared backlog.
+
 ## Chapter 6 — Numbers 1–5, the anchor for the whole Indo-Aryan group
 
 - **Chapter 6 authored** (`SA-C06-numbers-1-5`) — the first chapter past 5 in any

--- a/code/learning/human-languages/sanskrit/README.md
+++ b/code/learning/human-languages/sanskrit/README.md
@@ -36,6 +36,14 @@ book.
 - **Chapter 5 — First Verbs** ([`lessons/SA-C05-*`](./lessons/)): vadāmi (the
   **dual** *vadāvaḥ*), **ahaṁ saṁskṛtaṁ vadāmi**, vasāmi (← *vas* → *was*),
   karomi (← √kṛ), practice. In the book.
+- **Chapter 6 — Numbers 1–5** ([`lessons/SA-C06-*`](./lessons/)): the gendered
+  forms first, then an east-west sound-law map, then *pañca* in *Punjab*,
+  *pentagon*, and the qualified history of *punch*—three prerequisite-ordered
+  micro-lessons.
+
+Chapters 1–5 are in the book. Chapter 6 is canonical app-ready lesson content;
+its one-source book publication remains explicitly tracked in the shared
+backlog.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-namaste.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-namaste.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [inherent-a, halant-conjunct]
 roots: [namas, te]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [SA-C01-namaste, SA-C01-namaskara, SA-C01-dhanyavada, SA-C01-svagatam, SA-C01-am-na]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [SA-C01-namaste, SA-C01-namaskara, SA-C01-dhanyavada, SA-C01-svagatam, SA-C01-am-na]
 ---
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-svagatam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-svagatam.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-WELCOME
 prerequisites: [SA-C01-dhanyavada]
 sounds: [sva-conjunct, halant]
 roots: [su-good, gam-come]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [SA-C01-namaskara]
 ---
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [SA-C03-bhavan-katham-asti, SA-C03-kushalam, SA-C03-na-cinta]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [SA-C03-katham, SA-C03-bhavan-katham-asti, SA-C03-aham, SA-C03-kushalam, SA-C03-na-cinta]
 ---
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [SA-C04-gacchami, SA-C04-punar-darshanaya, SA-C04-shvah]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [SA-C04-gacchami, SA-C04-punah, SA-C04-punar-darshanaya, SA-C04-shvah]
 ---
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-aham-samskritam-vadami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-aham-samskritam-vadami.md
@@ -8,7 +8,7 @@ concept_tag: SA-WORD-SAMSKRITA
 prerequisites: [SA-C05-vadami, SA-C03-aham]
 sounds: [anusvara, kr-vocalic]
 roots: [samskrita, sam-kr]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [SA-C05-vadami, SA-C03-aham]
 ---
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-karomi.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-karomi.md
@@ -8,7 +8,7 @@ concept_tag: SA-VERB-KR
 prerequisites: [SA-C05-vadami]
 sounds: [inherent-a, long-o]
 roots: [kr-do]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [SA-C05-vadami, SA-C05-vasami]
 ---
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [SA-C05-vadami, SA-C05-aham-samskritam-vadami, SA-C05-vasami, SA-C05-karomi]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [SA-C05-vadami, SA-C05-aham-samskritam-vadami, SA-C05-vasami, SA-C05-karomi, SA-C03-aham]
 ---
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-vadami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-vadami.md
@@ -8,7 +8,7 @@ concept_tag: SA-VERB-VAD
 prerequisites: [SA-C03-aham]
 sounds: [inherent-a, long-aa]
 roots: [vad-speak]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C06-number-cognates.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C06-number-cognates.md
@@ -1,0 +1,75 @@
+---
+id: SA-C06-number-cognates
+chapter: 6
+type: etymology
+headword: एक · द्व · त्रि · चतुर् · पञ्च
+gloss: the Sanskrit, Latin, and English number family and the sound laws between them
+prerequisites: [SA-C06-numbers-1-5]
+sounds: [inherent-a]
+roots: [pie-oyko, pie-dwoh, pie-treyes, pie-kwetwores, pie-penkwe]
+etymology_hook: "Sanskrit catur, Latin quattuor, and English four continue one root; PIE rounded k went to Latin qu, Indo-Iranian c, and Germanic hw"
+est_minutes: 4
+reviews_of: [SA-C06-numbers-1-5]
+---
+
+# The Sanskrit numbers are English cousins
+
+## Warm-up
+
+[PAUSE 2s] Give the five stems: *eka, dva, tri, catur, pañca*.
+
+## One family, not borrowing
+
+| Sanskrit | Latin | English |
+|---|---|---|
+| *éka-* | *ūnus* | **one** |
+| *dvá-* | *duo* | **two** |
+| *tri-* | *trēs* | **three** |
+| *catúr-* | *quattuor* | **four** |
+| *páñca* | *quīnque* | **five** |
+
+Sanskrit, Latin, and English inherited these from one family. Numbers resist
+replacement, so their relationship remains audible after millennia.
+
+The first row needs one caveat: *éka-* and *ūnus/one* use the same root with
+different suffixes, PIE \**oy-ko-* versus \**óynos*. They are relatives rather
+than the same complete word. The other four rows continue the same word.
+
+## Rounded *k* goes three ways
+
+PIE \**kʷ* was a *k* with rounded lips. In \**kʷetwóres* “four,” three branches
+treated it differently:
+
+| branch | outcome | example |
+|---|---|---|
+| Latin | kept *qu-* | ***qu**attuor* |
+| Indo-Iranian | merged it with *k*, then palatalised before front vowels | ***c**atvāri* |
+| Germanic | shifted it to *hw-* | ***wh**at*, ***wh**o* |
+
+Sanskrit *c-* is therefore a regular result, not a random replacement. The same
+sequence helps explain *pañca*'s *ñc*.
+
+## Two different English *f* stories
+
+The **f-** of *five* does not come from \**kʷ*. It comes from initial \**p*,
+changed to *f* by **Grimm's law**, as in *pater → father* and *pēs → foot*.
+
+English *four* is irregular. By the sound rule it should begin *hw-* like
+*what*. Its *f-* was copied from neighbouring *five*. Counting words can reshape
+one another.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: *tri, trēs, three*]
+- [YOU SAY: rounded *k* — *quattuor, catvāri, what*]
+- [YOU SAY: initial *p → f* — *pañca/five*]
+- [YOU SAY: regular inheritance or borrowing — inheritance]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are the Latin and Sanskrit forms borrowed from one another? (No:
+they are inherited cousins.) What are the three outcomes of \**kʷ*? (Latin
+*qu-*, Indo-Iranian *c-* after merger and palatalisation, Germanic *hw-*.) Where
+does *five*'s initial *f* come from? (PIE *p* by Grimm's law.) Why does *four*
+also begin with *f*? (Analogy with neighbouring *five*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C06-numbers-1-5.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C06-numbers-1-5.md
@@ -8,8 +8,8 @@ concept_tag: SA-NUMBERS-1-5
 prerequisites: [SA-C01-namaskara]
 sounds: [inherent-a, visarga, long-aa]
 roots: [pie-oyko, pie-dwoh, pie-treyes, pie-kwetwores, pie-penkwe]
-etymology_hook: "these five are among the best-preserved words in Indo-European: pañca ← PIE *pénkʷe is the same word as Latin quinque, Greek pente and English FIVE, and catur ← *kʷetwóres is quattuor and FOUR — with PIE *kʷ kept as qu- in Latin, merged into k and then palatalised to c- in Indo-Iranian, and turned into hw- in Germanic (what, who)"
-est_minutes: 6
+etymology_hook: "Learn the five Sanskrit stems and their gendered forms first; the next two short lessons trace their Indo-European cousins and pancha's travels"
+est_minutes: 3
 reviews_of: [SA-C01-namaskara]
 ---
 
@@ -45,83 +45,23 @@ these words again in Hindi, Marathi, Bengali, Gujarati or Punjabi, they will
 mostly descend from the **neuter** forms — *trī́ṇi* and *catvā́ri*, not *tráyaḥ*
 and *catvā́raḥ*. Keep that column in view; the daughter lessons depend on it.
 
-## They are the English numbers
+## What comes next
 
-Line them up:
-
-| Sanskrit | Latin | English |
-|---|---|---|
-| *éka-* | *ūnus* | **one** |
-| *dvá-* | *duo* | **two** |
-| *tri-* | *trēs* | **three** |
-| *catúr-* | *quattuor* | **four** |
-| *páñca* | *quīnque* | **five** |
-
-These aren't borrowings in any direction. Sanskrit, Latin and English are three
-branches of one family, and numbers are among the **most stubbornly preserved**
-words a language has — you can hear the relationship four thousand years later.
-
-(One caveat on the first row: *éka-* and *ūnus*/*one* are built from the **same
-root with different suffixes** — \**oy-ko-* against \**óynos* — so they are
-relatives rather than the same word. The other four rows *are* the same word.)
-
-## The kʷ that went three ways
-
-**Four** shows it best. PIE had a sound written \**kʷ*, a *k* said with rounded
-lips, and \**kʷetwóres* is "four":
-
-| branch | outcome | example |
-|---|---|---|
-| **Latin** | kept it as *qu-* | ***qu**attuor* |
-| **Indo-Iranian** | merged \**kʷ* into *k*, then **palatalised** it before front vowels | ***c**atvāri* (*c* = "ch") |
-| **Germanic** | turned it into *hw-* | **wh**at, **wh**o |
-
-So Sanskrit's *c-* isn't a random substitution: \**kʷ* fell together with plain
-*k*, and *k* then softened to *c* in front of *e*-like vowels. Same change that
-gives *pañca* its *ñc*.
-
-**A warning about *five*, because the obvious guess is wrong.** *Five* also comes
-from \**pénkʷe*, but its **f-** has nothing to do with the \**kʷ*. That *f* is
-from the initial \**p*, turned into *f* by **Grimm's law**, the sound shift that
-also gave *pater* → *father* and *pēs* → *foot*.
-
-And English **four** is irregular: by rule it should have begun *hw-* like
-*what*. It has *f-* because it was pulled into line with *five*, its neighbour in
-the counting sequence. Numbers influence their neighbours.
-
-## पञ्च is hiding in words you know
-
-*Pañca* has travelled further than any of the others:
-
-- **Punjab** — from Persian *panj-āb*, "**five waters**," the land of five
-  rivers. Persian *panj* is an **Iranian cousin** of *pañca*, from the same PIE
-  root — Indo-Iranian split into an Indic branch and an Iranian one, and this is
-  each branch's version of the same word.
-- **punch**, the drink — most accounts trace it to Hindi *pāṁch* ← *pañca*, for
-  its **five** ingredients. (Not everyone accepts this — there's a rival
-  derivation from *puncheon*, a cask — but it is the usual story.)
-- **Pentagon**, **pentathlon** — Greek *pente*, the same word again.
-
-So a Sanskrit numeral is sitting inside a place-name spanning India and Pakistan,
-an English punchbowl, and an American office building.
+These five forms point in two directions. The next lesson lines them up with
+Latin and English and explains the sound laws. A final short lesson follows
+*pañca* into *Punjab*, *pentagon*, and the qualified history of *punch*.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "eka, dva, tri, catur, pañca"]
-- [YOU SAY: the English line — "one, two, three, four, five"]
-- [YOU SAY: the *kʷ* three ways — "**qu**attuor … **c**atvāri … **wh**at"]
-- [YOU SAY: "**pañc**a → **Panj**ab, five rivers"]
+- [YOU SAY: the exactly-two category — dual]
+- [YOU SAY: the daughter-language column — neuter]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Give one to five in Sanskrit. (*Eka, dva, tri, catur, pañca*.) Why
 does "two" look unusual? (Sanskrit has a **dual** — a form for exactly two.)
 Which column will the modern languages mostly descend from? (**The neuter** —
-*trī́ṇi*, *catvā́ri*.) Are these borrowed from Latin? (**No** — Sanskrit, Latin
-and English are **cousins**.) What happened to PIE \**kʷ*? (Latin kept ***qu-***,
-Indo-Iranian merged it into *k* and **palatalised** it to ***c-***, Germanic made
-it ***hw-*** — *what*, *who*.) So where does the **f** of *five* come from?
-(**Not** from the \**kʷ* — from the initial \**p*, by **Grimm's law**, as in
-*pater* → *father*.) What does *Punjab* mean? ("**Five waters**".) Next: what
-these five became once Sanskrit wore down.
+*trī́ṇi*, *catvā́ri*.) Which number barely changes across gender in this table?
+(*Pañca*.) Next: connect the Sanskrit forms west to Latin and English.

--- a/code/learning/human-languages/sanskrit/lessons/SA-C06-pancha-travels.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C06-pancha-travels.md
@@ -1,0 +1,55 @@
+---
+id: SA-C06-pancha-travels
+chapter: 6
+type: etymology
+headword: पञ्च
+gloss: five inside Punjab, pentagon, and the debated history of punch
+prerequisites: [SA-C06-number-cognates]
+sounds: [inherent-a]
+roots: [pie-penkwe]
+etymology_hook: "Sanskrit pancha, Persian panj, and Greek pente share a root; Punjab means five waters, while punch from five ingredients is the usual but disputed account"
+est_minutes: 3
+reviews_of: [SA-C06-numbers-1-5, SA-C06-number-cognates]
+---
+
+# *Pañca* hiding in familiar words
+
+## Warm-up
+
+[PAUSE 2s] Say Sanskrit “five.” (*Pañca*.) Give its English cousin. (*Five*.)
+
+## Five waters
+
+**Punjab** comes from Persian *panj-āb*, “five waters,” for the land of five
+rivers spanning India and Pakistan. Persian *panj* is the Iranian cousin of
+Indic *pañca*: both descend from the same Indo-Iranian and PIE number root.
+
+The place-name is Persian, not Sanskrit, but the family resemblance is real.
+
+## Greek buildings and contests
+
+Greek ***pente*** is another descendant of the same root. It appears in
+**pentagon**, a five-sided figure, and **pentathlon**, a five-event contest.
+
+## The qualified *punch* story
+
+The usual account derives **punch**, the drink, from Hindi *pāṁch* ← Sanskrit
+*pañca*, because the drink was said to contain five ingredients.
+
+That origin is not unanimous. A rival derives the word from **puncheon**, a type
+of cask. Keep the useful connection with a label: “the common five-ingredients
+account,” not an unquestioned fact.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: *panj + āb* — five waters]
+- [YOU SAY: Greek *pente* — pentagon, pentathlon]
+- [YOU SAY: *punch* — common account, not certain]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *Punjab* mean? (“Five waters.”) Is Persian *panj* borrowed
+from Sanskrit? (No: it is an Iranian cousin.) Which Greek form hides in
+*pentagon*? (*Pente*.) What caution belongs with the drink *punch*? (The
+five-ingredients derivation is common, but *puncheon* is a rival account.)

--- a/code/learning/human-languages/sanskrit/roadmap.md
+++ b/code/learning/human-languages/sanskrit/roadmap.md
@@ -34,8 +34,10 @@ where a word needs them.
   → ahaṁ saṁskṛtaṁ vadāmi (I speak Sanskrit; *saṁskṛta* = "perfected"; sandhi) →
   vasāmi (← *vas* → English **was**; the locative *-e*) → karomi (← √kṛ, the root
   of *namaskāra/karma/Sanskrit*) → practice.
-- **Ch. 6 — Numbers 1–5** (`SA-C06-numbers-1-5`): *eka, dva, tri, catur, pañca*
-  — deliberately the **anchor chapter for the whole Indo-Aryan group**, since
+- **Ch. 6 — Numbers 1–5** (`SA-C06-numbers-1-5` →
+  `SA-C06-number-cognates` → `SA-C06-pancha-travels`): *eka, dva, tri, catur,
+  pañca* form the **anchor chapter for the whole Indo-Aryan group**, now divided
+  into three prerequisite-ordered sub-five-minute lessons. These stems are
   these stems are simultaneously the **source** of every modern Indic number and
   the **cousins** of the English ones. Gives masculine **and neuter** forms
   (*ekam, dve, **trī́ṇi**, **catvā́ri***) because the modern languages mostly
@@ -54,7 +56,7 @@ where a word needs them.
 
 | Chapter | Theme |
 |---|---|
-| 6 | The eight cases, one at a time (nominative, accusative…); numbers *eka–daśa* (1–10), cognate with Latin/Greek |
+| 6 continuation | Numbers 6–10, then the eight cases one at a time (nominative, accusative…) |
 | 7+ | The declensions and the root-and-affix system; the dual deepened; sandhi — always tracing roots east and west |
 
 Note: Sanskrit's showpiece features — the **dual number**, three genders, eight

--- a/code/learning/human-languages/sanskrit/session-map.md
+++ b/code/learning/human-languages/sanskrit/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Sanskrit Chapters 1–5
+# Session Map — Sanskrit Chapters 1–6
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -63,6 +63,14 @@ and the Sanskrit-specific marks (visarga, conjuncts) — that word needs.
 | 29 | karomi | करोमि | "I do" ← √kṛ — the root of *namaskāra*, *karma*, *Sanskrit* |
 | 30 | practice | (dialogue) | three verbs, one engine, and the dual |
 
+## Chapter 6 — Numbers 1–5
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 31 | numbers-1-5 | एक, द्व, त्रि, चतुर्, पञ्च | retrieve the stems; notice dual and gender; keep the neuter daughter-language forms in view |
+| 32 | number-cognates | *eka · dva · tri · catur · pañca* | Latin and English cousins; PIE *kʷ* outcomes; Grimm's law and analogical *four* |
+| 33 | pancha-travels | पञ्च | *Punjab*, Greek *pente*, and the qualified five-ingredient account of *punch* |
+
 ## Next
 
-Chapter 6 — the eight cases, one at a time, and numbers *eka–daśa* (1–10).
+Finish Chapter 6 with numbers 6–10, then introduce the eight cases one at a time.


### PR DESCRIPTION
## Summary

- remove all ten Sanskrit lessons at or above the five-minute boundary
- correct nine declared estimates that the shared model already measured at 107–186 seconds
- split the 513-second anchor lesson into prerequisite-ordered forms/grammar, east-west cognate, and `pañca` travel lessons
- preserve the dual, gendered daughter forms, PIE `kʷ` outcomes, Grimm's law, analogical `four`, and qualified lexical histories in canonical Markdown consumed by Language Ladder
- update the Sanskrit roadmap/session map and promote Bengali's eleven declaration-only violations as the next measured tranche

The audit records canonical Chapter 6 publication as `HL-B10` and pre-existing Sanskrit book hygiene debt as `HL-B11`; this PR does not hand-copy or hide either item.

## Measured result

- Sanskrit duration violations: **10 → 0**
- repository duration violations: **445 → 435**
- canonical lessons: **983 → 985**
- unknown prerequisites: **0**
- split lesson durations: **232 seconds + 240 seconds + 180 seconds**

## Validation

- `human-language-data`: 68 tests passed; 93.60% line coverage
- curriculum integration: 9 tests passed
- generated-book drift check: passed
- `language-ladder`: 278 tests passed; 98.37% line coverage
- Language Ladder production build: passed
- forced Sanskrit XeLaTeX regression build: 29 pages, no missing glyphs
- `git diff --check`: passed

## Recorded pre-existing book debt

The unchanged Sanskrit PDF still emits three overfull boxes, six underfull boxes, four duplicate practice-label warnings, and 28 Unicode PDF-string warnings. `HL-B11` records a zero-warning cleanup target; none was introduced by the canonical lesson changes.