### PR TITLE
fix(spice): validate MOS model width

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS model-card `W` values
+  before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `JS` values before
   lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `IS` values

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1975,6 +1975,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(width) = params.get("W") {
+            if !width.is_finite() || *width <= 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET W must be finite and positive",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2128,6 +2128,30 @@ fn preserves_non_negative_mosfet_model_saturation_current_density() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_widths() {
+    for width in ["0", "-1u", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model geometry NMOS(W={width})\nM1 d g s b geometry"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET W must be finite and positive"));
+    }
+}
+
+#[test]
+fn preserves_positive_mosfet_model_width() {
+    let parsed = parse_netlist(".model geometry NMOS(W=2u)\nM1 d g s b geometry").unwrap();
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+    assert_close(mosfet.params.w, 2.0e-6);
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card saturation-current-density validation.
+1. Rust Berkeley SPICE MOS model-card width validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `JS` values before
+   - Reject zero, negative, and non-finite model-card `W` values before
      lowering MOS elements into engine parameters.
-   - Preserve zero and positive saturation-current densities.
+   - Preserve positive model widths.
 
 ## Completed Slices
 
@@ -4040,6 +4040,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Zero, negative, and non-finite model-card `IS` values are rejected before
      lowering MOS elements into engine parameters.
    - Positive saturation currents remain accepted.
+
+354. Rust Berkeley SPICE MOS model-card saturation-current-density validation.
+   - Status: completed in PR 9529.
+   - Negative and non-finite model-card `JS` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive saturation-current densities remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite Level-1 MOS model-card `W` values in the Rust Berkeley SPICE parser facade
- preserve positive model widths, including engineering suffixes
- reconcile the SPICE implementation plan after saturation-current-density validation merged in #9529

## Scope
This is a Rust parser-facade boundary change. The shared Rust, Python, and TypeScript engines already enforce the same `W` behavior and diagnostic.

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser` (146 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`