### PR TITLE
Correct Bengali lesson duration budgets

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,7 +5,7 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Sanskrit duration
+Last prioritized: 2026-08-02. Current baseline after the Bengali duration
 tranche: 20 registered tracks, 985 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
@@ -52,7 +52,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01C | Complete in the Gujarati duration PR | Remove all nine sub-five-minute violations from the Gujarati track. | The report measures zero Gujarati violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
 | HL-D01D | Complete in the Punjabi duration PR | Remove all ten sub-five-minute violations from the Punjabi track. | The report measures zero Punjabi violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
 | HL-D01E | Complete in the Sanskrit duration PR | Remove all ten sub-five-minute violations from the Sanskrit track. | The report measures zero Sanskrit violations; the 513-second anchor lesson is now three prerequisite-ordered micro-lessons. |
-| HL-D01F | Next | Remove all eleven sub-five-minute violations from the Bengali track. | Bengali is now the smallest remaining track-sized set, and all eleven already compute below five minutes; this is a bounded declared-budget correction. |
+| HL-D01F | Complete in the Bengali duration PR | Remove all eleven sub-five-minute violations from the Bengali track. | The report measures zero Bengali violations; all eleven lesson bodies remain unchanged because their computed durations were already below 300 seconds. |
+| HL-D01G | Next | Remove all twenty sub-five-minute violations from the Italian track. | Italian is now the smallest remaining set: seventeen declaration-only lessons and three genuinely computed violations, with a 404-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -63,6 +64,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B09 | Queued | Remove Punjabi's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B10 | Queued | Publish Sanskrit Chapter 6 from its three canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B11 | Queued | Remove Sanskrit's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports three overfull boxes, six underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B12 | Queued | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The duration audit confirms authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
+| HL-B13 | Queued | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports six missing glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 27 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -234,6 +237,25 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Bengali's eleven violations are now the smallest remaining track-sized set.
   All eleven already compute below 300 seconds (maximum 290), so HL-D01F is a
   bounded honest-budget correction with no content split required.
+
+## Findings from HL-D01F
+
+- Bengali now has zero duration violations. The repository snapshot remains at
+  985 lessons and drops to 424 violations overall, down from 435 before this
+  tranche; unknown prerequisites remain at zero.
+- All eleven lessons already computed between 121 and 290 seconds, so only their
+  declared estimates changed. No canonical lesson body, prerequisite, book
+  source, or app behavior needed rewriting.
+- `BN-C06-numbers-1-5` is the tightest corrected lesson at 290 seconds and
+  should be watched during later copy edits.
+- Bengali Chapter 6 has canonical app-ready content but is not in the current
+  five-chapter PDF. HL-B12 records its one-source migration and generation work.
+- A forced build of the unchanged book succeeds, but exposes six missing glyphs,
+  one overfull box, four underfull boxes, four duplicate practice labels, and 27
+  Unicode bookmark warnings. HL-B13 records that pre-existing hygiene debt.
+- Italian's twenty violations are now the smallest remaining track-sized set.
+  Seventeen are declaration-only and three are genuinely computed, with a
+  404-second maximum, so HL-D01G is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/bengali/CHANGELOG.md
+++ b/code/learning/human-languages/bengali/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Sub-five-minute remediation — 2026-08-02
+
+- Corrected eleven declared five-minute estimates whose computed durations were
+  already between 121 and 290 seconds.
+- Preserved every lesson body unchanged; no split or content reduction was
+  necessary. The shared report now measures zero Bengali duration violations.
+- The 290-second numbers lesson is the tightest Bengali budget and should be
+  watched during later copy edits.
+
 ## Chapter 6 — Numbers 1–5, and the conservative "two"
 
 - **Chapter 6 authored** (`BN-C06-numbers-1-5`): *ek, dui, tin, chār, pā̃ch*

--- a/code/learning/human-languages/bengali/lessons/BN-C01-ashi.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C01-ashi.md
@@ -8,7 +8,7 @@ concept_tag: FAREWELL
 prerequisites: [BN-C01-achchha]
 sounds: [s-to-sh, i-sign-before]
 roots: [asa-come]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C01-hyan-na]
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C01-nomoshkar.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C01-nomoshkar.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [inherent-o, hasanta-conjunct, s-to-sh]
 roots: [namas, kara]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C01-practice.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [BN-C01-nomoshkar, BN-C01-dhonnobad, BN-C01-hyan-na, BN-C01-achchha, BN-C01-ashi]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C01-nomoshkar, BN-C01-dhonnobad, BN-C01-hyan-na, BN-C01-achchha, BN-C01-ashi]
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C02-practice.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [BN-C02-amar-naam, BN-C02-tomar-naam-ki, BN-C02-alaap]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C02-naam, BN-C02-amar, BN-C02-amar-naam, BN-C02-tumi-apni, BN-C02-ki, BN-C02-tomar-naam-ki, BN-C02-alaap]
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C03-practice.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [BN-C03-tumi-kemon-achho, BN-C03-bhalo, BN-C03-kono-bepar-na]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C03-kemon, BN-C03-tumi-kemon-achho, BN-C03-ami, BN-C03-bhalo, BN-C03-kono-bepar-na]
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C03-tumi-kemon-achho.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C03-tumi-kemon-achho.md
@@ -8,7 +8,7 @@ concept_tag: STATE-HOW-ARE-YOU
 prerequisites: [BN-C03-kemon, BN-C02-tumi-apni]
 sounds: [chh-conjunct, o-ending]
 roots: [aachha-be]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C02-tumi-apni, BN-C03-kemon]
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C04-practice.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [BN-C04-abar-dekha-hobe, BN-C04-kal-dekha-hobe]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C01-ashi, BN-C04-abar, BN-C04-dekha-hobe, BN-C04-abar-dekha-hobe, BN-C04-kal-dekha-hobe]
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C05-ami-bangla-boli.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C05-ami-bangla-boli.md
@@ -8,7 +8,7 @@ concept_tag: BN-WORD-BANGLA
 prerequisites: [BN-C05-bola, BN-C03-ami]
 sounds: [anusvara, long-aa]
 roots: [banga]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C05-bola, BN-C03-ami]
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C05-kaj-kora.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C05-kaj-kora.md
@@ -8,7 +8,7 @@ concept_tag: BN-VERB-KORA
 prerequisites: [BN-C05-bola]
 sounds: [long-aa, o-inherent]
 roots: [kr-do, karya-work]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C05-bola, BN-C05-thaka]
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C05-practice.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [BN-C05-bola, BN-C05-ami-bangla-boli, BN-C05-thaka, BN-C05-kaj-kora]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C05-bola, BN-C05-ami-bangla-boli, BN-C05-thaka, BN-C05-kaj-kora, BN-C03-ami]
 ---
 

--- a/code/learning/human-languages/bengali/lessons/BN-C06-numbers-1-5.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C06-numbers-1-5.md
@@ -9,7 +9,7 @@ prerequisites: [BN-C01-nomoshkar]
 sounds: [long-aa, chandrabindu-nasal, i-sign]
 roots: [sanskrit-dvi, sanskrit-panca]
 etymology_hook: "Bengali দুই dui keeps a trace of the vowel following the old dv- that Hindi and Marathi flattened into do/don — which is why it has two syllables where they have one; it shares this with Assamese, Odia and Nepali, and is unusual only among the four languages compared here"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [BN-C01-nomoshkar]
 ---
 


### PR DESCRIPTION
## Summary

- remove all eleven Bengali sub-five-minute duration violations by correcting their declared lesson budgets from five to four minutes
- preserve every canonical lesson body, prerequisite, book source, and app behavior because all eleven already compute below 300 seconds
- record `BN-C06-numbers-1-5` at 290 seconds as the tightest Bengali lesson to watch during copy edits
- reprioritize the next duration tranche to Italian (20 violations: 17 declaration-only and 3 computed, maximum 404 seconds)
- log Bengali's canonical Chapter 6 publication gap and pre-existing LaTeX clean-build debt

## Measured change

- Bengali duration violations: **11 → 0**
- overall duration violations: **435 → 424**
- lessons: **985 → 985**
- unknown prerequisites: **0 → 0**

## Validation

- `npm run test:coverage` — 68 tests, 93.60% line coverage
- `npm run build`
- `npm run validate` — 9 integration tests
- `npm run check:books`
- Language Ladder `npm run test:coverage` — 278 tests, 98.37% line coverage
- Language Ladder production build — 1,035 modules transformed
- forced Bengali XeLaTeX build — 25-page PDF
- `git diff --check`

## Pre-existing book warnings

The unchanged Bengali book source still builds successfully, but the forced build reports six missing glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 27 Hyperref warnings. Those are recorded separately as HL-B13; the duration-only patch does not introduce them.