### PR TITLE
test(venture): verify initial SwiftUI navigation state

### DIFF
--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Strengthen generated SwiftUI direct interaction acceptance to require both
+  cold-start history controls to expose their disabled Mosaic state and
+  suppress native dispatch before the first navigation.
 - Require generated SwiftUI and WinUI interaction acceptance to navigate the
   shared browser session through the Mosaic-authored address field's native
   Return/Enter `onCommit` path while retaining the existing Go-button gate.

--- a/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/venture-browser/host/swiftui/MosaicHost.swift
@@ -185,6 +185,64 @@ final class MosaicHost: NSObject, MosaicHostBridgeObject {
         remaining: remaining)
       return
     }
+    let response = applyProps()
+    let props = response?["props"] as? NSDictionary
+    let currentAddress = props?["address"] as? String ?? ""
+    let backDisabled = props?["back-disabled"] as? Bool
+    let forwardDisabled = props?["forward-disabled"] as? Bool
+    guard currentAddress == startURL, backDisabled == true, forwardDisabled == true else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error", "address": currentAddress,
+          "error": "initial native navigation control state did not match",
+        ],
+        to: markerPath)
+      return
+    }
+    let backEventCount = chromeEventCounts["onBack", default: 0]
+    let forwardEventCount = chromeEventCounts["onForward", default: 0]
+    guard performNativeButtonClick(identifier: "back-button"),
+      performNativeButtonClick(identifier: "forward-button")
+    else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error",
+          "error": "initial native navigation controls not found",
+        ],
+        to: markerPath)
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self, weak address] in
+      self?.verifyInitialDisabledControls(
+        address: address, startURL: startURL, targetURL: targetURL, markerPath: markerPath,
+        backEventCount: backEventCount, forwardEventCount: forwardEventCount)
+    }
+  }
+
+  private func verifyInitialDisabledControls(
+    address: NSTextField?, startURL: String, targetURL: String, markerPath: String,
+    backEventCount: Int, forwardEventCount: Int
+  ) {
+    guard chromeEventCounts["onBack", default: 0] == backEventCount,
+      chromeEventCounts["onForward", default: 0] == forwardEventCount
+    else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error",
+          "error": "initial native disabled navigation control dispatched",
+        ],
+        to: markerPath)
+      return
+    }
+    guard let address else {
+      writeInteractionResult(
+        [
+          "backend": "swiftui", "status": "error",
+          "error": "address-input unavailable after initial navigation state check",
+        ],
+        to: markerPath)
+      return
+    }
     address.selectText(nil)
     guard let editor = address.currentEditor() as? NSTextView else {
       writeInteractionResult(

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -128,6 +128,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         "\"surfaceResize\": \"native-reflow\"",
         "lastSurfaceRenderSize",
         "\"surfaceRepaint\": \"resized-frame\"",
+        "initial native disabled navigation control dispatched",
         "native disabled Forward button dispatched",
         "native disabled Back button dispatched",
         "\"navigationState\": \"native-disabled-transitions\"",


### PR DESCRIPTION
## Summary

- require the generated SwiftUI host to observe both cold-start history slots as disabled
- send real AppKit clicks to the initial Back and Forward controls and fail if either dispatches
- retain the existing Mosaic-authored chrome and shared Rust session contract

## Why

WinUI already proved the initial native control state, while SwiftUI only proved disabled behavior after history transitions. This closes that direct-acceptance asymmetry without adding platform-owned chrome.

## Validation

- cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml --test package_compiles
- cargo clippy --manifest-path code/programs/mosaic/venture-browser/Cargo.toml --all-targets -- -D warnings
- cargo fmt --manifest-path code/programs/mosaic/venture-browser/Cargo.toml --check
- cargo test -p venture-browser-macos --test swiftui_project_launch package_owned_swiftui_project_launches_renders_and_interacts -- --nocapture
- HTML coverage audit: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 local raw / 0 missing; 7242 normalized / 0 skipped

This is a bounded native acceptance improvement, not a claim of complete browser conformance.