### PR TITLE
fix(build-tool): reject invalid Swift rockspec bytes

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -361,11 +361,11 @@
     {
       "id": "build-tool-swift-rockspec-utf8-conformance",
       "title": "Make the Swift build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-swift-rockspec-utf8",
       "pr_number": null,
-      "notes": "Materialized after merged PR #9527 and the eabfc1a3 collision-clean reprioritization. The Swift build tool currently converts a failed UTF-8 decode into an empty Lua dependency list. Bind the engine to the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, require exact success edges, and fail closed with METADATA_INVALID_UTF8, package identity, repository-relative manifest path, real CLI exit 2, and no host-path disclosure. This slice changes only the Swift engine; TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate children."
+      "notes": "Selected after merged PR #9527 and the eabfc1a3 collision-clean reprioritization because this is the highest-severity remaining fail-open engine and one bounded child of the shared UTF-8 contract. The Swift build tool currently converts a failed UTF-8 decode into an empty Lua dependency list. Bind the engine to the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, require exact success edges, and fail closed with METADATA_INVALID_UTF8, package identity, repository-relative manifest path, real CLI exit 2, and no host-path disclosure. This slice changes only the Swift engine; TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate children."
     },
     {
       "id": "build-tool-rust-self-edge-diagnostic",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9537,
   "last_inventory": {
     "revision": "613717e22fe7b65c37eebb35a84a5b440a55ddb1",
     "schema_version": 3,
@@ -361,11 +361,11 @@
     {
       "id": "build-tool-swift-rockspec-utf8-conformance",
       "title": "Make the Swift build tool enforce strict UTF-8 rockspec metadata",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-swift-rockspec-utf8",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9527 because this is the highest-severity remaining fail-open engine and one bounded child of the shared UTF-8 contract. The implementation decodes Lua rockspec bytes strictly before parsing, propagates a typed METADATA_INVALID_UTF8 error with package and repository-relative manifest identity, writes a platform-stable diagnostic without the checkout root, and returns CLI exit 2. Shared positive and invalid-byte fixtures require the exact success edge set and are exercised through the resolver, CLI entry point, and a real subprocess. Exact-base validation on 613717e2 passed 22 Swift tests, production build, measured 39.74% overall and 42.94% resolver line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, a 258-package/382-edge Lua plan, a 4,768-package/7,458-edge full plan, collision-clean 1,220-identity parity inventory, JSON/diff/secret checks, and an exact 10-to-10 Lua BUILD_windows debt comparison with untouched main. The full-plan audit separately logged Swift absolute file-option and language/identity-registry children, and the post-rebase inventory logged the new HomeWizard portable telemetry core. TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate encoding children."
+      "pr_number": 9537,
+      "notes": "Ready PR #9537. Selected after merged PR #9527 because this is the highest-severity remaining fail-open engine and one bounded child of the shared UTF-8 contract. The implementation decodes Lua rockspec bytes strictly before parsing, propagates a typed METADATA_INVALID_UTF8 error with package and repository-relative manifest identity, writes a platform-stable diagnostic without the checkout root, and returns CLI exit 2. Shared positive and invalid-byte fixtures require the exact success edge set and are exercised through the resolver, CLI entry point, and a real subprocess. Exact-base validation on 613717e2 passed 22 Swift tests, production build, measured 39.74% overall and 42.94% resolver line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, a 258-package/382-edge Lua plan, a 4,768-package/7,458-edge full plan, collision-clean 1,220-identity parity inventory, JSON/diff/secret checks, and an exact 10-to-10 Lua BUILD_windows debt comparison with untouched main. The full-plan audit separately logged Swift absolute file-option and language/identity-registry children, and the post-rebase inventory logged the new HomeWizard portable telemetry core. TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate encoding children."
     },
     {
       "id": "build-tool-swift-windows-absolute-file-options",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9527,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "4d0a98e02bec862a5b852329426d01c8996a19c6",
+    "revision": "eabfc1a3f60571f3b0f2e01d0861a695a418a9cb",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1219,
@@ -338,7 +338,7 @@
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered by the Python encoding-blocker audit. Go was remediated in merged PR #9504. Of the eight remaining engines, Rust and Swift silently drop invalid rockspec dependencies; TypeScript replaces invalid bytes; Lua and Perl accept them; Ruby and Haskell use locale-sensitive text decoding; and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
+      "notes": "Discovered by the Python encoding-blocker audit. Go was remediated in merged PR #9504 and Rust in merged PR #9510. Of the seven engines that remain, Swift silently drops invalid rockspec dependencies; TypeScript replaces invalid bytes; Lua and Perl accept them; Ruby and Haskell use locale-sensitive text decoding; and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
     },
     {
       "id": "build-tool-go-rockspec-utf8-conformance",
@@ -359,6 +359,15 @@
       "notes": "Merged PR #9510 at ca91ca25cc63e785038de4ca1b7b707e17b3fefe on 2026-08-02 after all applicable CI, fixture-consumer, detection, platform-build, and CodeQL checks passed. The implementation consumes the exact shared success and invalid-byte fixtures, requires exact edge equality, returns a typed METADATA_INVALID_UTF8 diagnostic with package and repository-relative manifest identity, exits 2 through the real CLI, and does not disclose host paths. Validation passed 136 unit plus one CLI integration test, strict Clippy, release build, 79.33% line coverage, 57 language-neutral conformance tests plus 52 subtests, the 32-case/36-file corpus, a real 258-package Lua dry-run plan across all 246 strict-UTF-8 rockspecs, collision-free parity inventory, and a zero-advisory RustSec audit. Full-repository plan validation separately reproduced untouched main's 4,766-package exit-101 panic on an elixir/grammar_tools self-edge, and BUILD validation output matched untouched main exactly; the dedicated self-edge and Lua BUILD_windows items own those baselines. The seven non-Rust encoding remediations remain outside this slice."
     },
     {
+      "id": "build-tool-swift-rockspec-utf8-conformance",
+      "title": "Make the Swift build tool enforce strict UTF-8 rockspec metadata",
+      "status": "pending",
+      "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized after merged PR #9527 and the eabfc1a3 collision-clean reprioritization. The Swift build tool currently converts a failed UTF-8 decode into an empty Lua dependency list. Bind the engine to the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, require exact success edges, and fail closed with METADATA_INVALID_UTF8, package identity, repository-relative manifest path, real CLI exit 2, and no host-path disclosure. This slice changes only the Swift engine; TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate children."
+    },
+    {
       "id": "build-tool-rust-self-edge-diagnostic",
       "title": "Make the Rust build tool reject self-edges without panicking",
       "status": "merged",
@@ -370,11 +379,11 @@
     {
       "id": "build-tool-rust-language-identity-registry",
       "title": "Bring Rust build-tool discovery to the canonical language and identity registry",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-rust-self-edge-diagnostic"],
       "branch": "codex/build-tool-rust-language-identity-registry",
       "pr_number": 9527,
-      "notes": "Ready PR #9527 opened from collision-clean 4d0a98e0. The implementation adds language-neutral canonical-registry and duplicate-identity discovery fixtures, classifies every established, emerging, execution-target, domain, and build-language bucket plus the shared dotnet program host, skips specification fixture trees, and rejects any residual duplicate qualified name with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, CLI exit 2, and no host-path disclosure. Validation passed 140 unit tests plus three real CLI integrations, strict Clippy, release build, 79.39% region and 79.49% line coverage with 94.03% discovery lines, 17 schema tests, 40 runner tests, the valid 36-case/55-file corpus, a zero-advisory RustSec audit, collision-clean 1,219-identity parity inventory, and a real full plan that now exits zero with 4,765 entries, 4,765 unique names, zero duplicates, the new Fronius package, and only the intentional unknown/blog site package. The known 10-item Lua BUILD_windows debt remains unchanged and separately owned."
+      "notes": "Merged PR #9527 at 14602f3e2353af304564f61bc5caebcb33160f6d on 2026-08-02 after all applicable detection, fixture-consumer, CodeQL, Ubuntu, macOS, and Windows checks passed. The implementation adds language-neutral canonical-registry and duplicate-identity discovery fixtures, classifies every established, emerging, execution-target, domain, and build-language bucket plus the shared dotnet program host, skips specification fixture trees, and rejects any residual duplicate qualified name with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, CLI exit 2, and no host-path disclosure. Validation passed 140 unit tests plus three real CLI integrations, strict Clippy, release build, 79.39% region and 79.49% line coverage with 94.03% discovery lines, 17 schema tests, 40 runner tests, the valid 36-case/55-file corpus, a zero-advisory RustSec audit, collision-clean 1,219-identity parity inventory, and a real full plan with 4,765 unique entries, zero duplicates, the Fronius package, and only the intentional unknown/blog site package. The known 10-item Lua BUILD_windows debt remains unchanged and separately owned."
     },
     {
       "id": "build-tool-python-haskell-language-filter",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -368,6 +368,24 @@
       "notes": "Selected after merged PR #9527 and the eabfc1a3 collision-clean reprioritization because this is the highest-severity remaining fail-open engine and one bounded child of the shared UTF-8 contract. The Swift build tool currently converts a failed UTF-8 decode into an empty Lua dependency list. Bind the engine to the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, require exact success edges, and fail closed with METADATA_INVALID_UTF8, package identity, repository-relative manifest path, real CLI exit 2, and no host-path disclosure. This slice changes only the Swift engine; TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate children."
     },
     {
+      "id": "build-tool-swift-windows-absolute-file-options",
+      "title": "Recognize Windows absolute paths in Swift build-tool file options",
+      "status": "pending",
+      "depends_on": ["build-tool-fixtures"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while validating the Swift UTF-8 slice on Windows. --emit-plan with an absolute drive-letter path reaches package discovery and resolution but absolutePath treats the value as repository-relative because it only recognizes a leading slash, producing an invalid filename. Add Windows and POSIX path fixtures, then use platform-correct absolute-path detection consistently for emit-plan, plan-file, and cache-file without widening the current metadata-only slice."
+    },
+    {
+      "id": "build-tool-swift-language-identity-registry",
+      "title": "Bring Swift build-tool discovery to the canonical language and identity registry",
+      "status": "pending",
+      "depends_on": ["build-tool-swift-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered by the full-repository release-plan audit in the Swift UTF-8 slice. The Swift engine emits 4,767 package entries but only 4,593 unique names: 143 identity groups contain 317 entries, and 397 entries across 228 names are classified as unknown. Reuse the shared discovery-language-registry and discovery-duplicate-identity fixtures to recognize established, emerging, execution-target, domain, and build-language buckets from the exact packages/programs boundary, preserve package/program identities, exclude spec fixtures, and fail closed on residual duplicate qualified names. Keep this separate from metadata decoding."
+    },
+    {
       "id": "build-tool-rust-self-edge-diagnostic",
       "title": "Make the Rust build tool reject self-edges without panicking",
       "status": "merged",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,16 +13,16 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "eabfc1a3f60571f3b0f2e01d0861a695a418a9cb",
+    "revision": "613717e22fe7b65c37eebb35a84a5b440a55ddb1",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1219,
     "implementation_package_slots": 4367,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 769,
-    "singleton_missing_slots": 10766,
-    "rust_singletons": 574,
+    "singleton_packages": 770,
+    "singleton_missing_slots": 10780,
+    "rust_singletons": 575,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -365,7 +365,7 @@
       "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-swift-rockspec-utf8",
       "pr_number": null,
-      "notes": "Selected after merged PR #9527 and the eabfc1a3 collision-clean reprioritization because this is the highest-severity remaining fail-open engine and one bounded child of the shared UTF-8 contract. The Swift build tool currently converts a failed UTF-8 decode into an empty Lua dependency list. Bind the engine to the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, require exact success edges, and fail closed with METADATA_INVALID_UTF8, package identity, repository-relative manifest path, real CLI exit 2, and no host-path disclosure. This slice changes only the Swift engine; TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate children."
+      "notes": "Selected after merged PR #9527 because this is the highest-severity remaining fail-open engine and one bounded child of the shared UTF-8 contract. The implementation decodes Lua rockspec bytes strictly before parsing, propagates a typed METADATA_INVALID_UTF8 error with package and repository-relative manifest identity, writes a platform-stable diagnostic without the checkout root, and returns CLI exit 2. Shared positive and invalid-byte fixtures require the exact success edge set and are exercised through the resolver, CLI entry point, and a real subprocess. Exact-base validation on 613717e2 passed 22 Swift tests, production build, measured 39.74% overall and 42.94% resolver line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, a 258-package/382-edge Lua plan, a 4,768-package/7,458-edge full plan, collision-clean 1,220-identity parity inventory, JSON/diff/secret checks, and an exact 10-to-10 Lua BUILD_windows debt comparison with untouched main. The full-plan audit separately logged Swift absolute file-option and language/identity-registry children, and the post-rebase inventory logged the new HomeWizard portable telemetry core. TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate encoding children."
     },
     {
       "id": "build-tool-swift-windows-absolute-file-options",
@@ -383,7 +383,7 @@
       "depends_on": ["build-tool-swift-rockspec-utf8-conformance"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered by the full-repository release-plan audit in the Swift UTF-8 slice. The Swift engine emits 4,767 package entries but only 4,593 unique names: 143 identity groups contain 317 entries, and 397 entries across 228 names are classified as unknown. Reuse the shared discovery-language-registry and discovery-duplicate-identity fixtures to recognize established, emerging, execution-target, domain, and build-language buckets from the exact packages/programs boundary, preserve package/program identities, exclude spec fixtures, and fail closed on residual duplicate qualified names. Keep this separate from metadata decoding."
+      "notes": "Discovered by the full-repository release-plan audit in the Swift UTF-8 slice and refreshed after rebasing onto 613717e2. The Swift engine emits 4,768 package entries but only 4,594 unique names: 143 identity groups contain 317 entries, and 397 entries across 228 names are classified as unknown. Reuse the shared discovery-language-registry and discovery-duplicate-identity fixtures to recognize established, emerging, execution-target, domain, and build-language buckets from the exact packages/programs boundary, preserve package/program identities, exclude spec fixtures, and fail closed on residual duplicate qualified names. Keep this separate from metadata decoding."
     },
     {
       "id": "build-tool-rust-self-edge-diagnostic",
@@ -1205,6 +1205,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered after merged PR #9513 added the Rust-only Fronius Solar API v1 host. Share bounded Power Flow response and API-status validation, site and inverter measurement normalization, stable identities and errors, deterministic entity projection, and language-neutral telemetry fixtures. mDNS, DNS/TCP, plaintext LAN HTTP execution, endpoint authorization, trusted time, console I/O, and runtime mutation are excluded native-host responsibilities."
+    },
+    {
+      "id": "smart-home-homewizard-energy-portable-core-extraction-and-conformance",
+      "title": "Extract and port the portable HomeWizard Energy telemetry core",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after merged PR #9526 added the Rust-only HomeWizard Energy API v1 host. Share bounded device-information and measurement response validation, API-version checks, device and external-meter normalization, units, stable identities and errors, deterministic sensor projection, and language-neutral telemetry fixtures. mDNS, DNS/TCP, plaintext LAN HTTP execution, endpoint authorization, trusted time, console I/O, and runtime mutation are excluded native-host responsibilities."
     },
     {
       "id": "smart-home-reolink-portable-core-extraction-and-conformance",

--- a/code/programs/swift/build-tool/CHANGELOG.md
+++ b/code/programs/swift/build-tool/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Decode Lua `.rockspec` metadata as strict UTF-8 before dependency parsing.
+  Invalid bytes now fail closed with `METADATA_INVALID_UTF8`, stable package
+  and repository-relative manifest identity, CLI exit code `2`, and no
+  checkout-path disclosure. Resolver and CLI coverage consume the shared
+  positive and invalid-byte conformance fixtures and require the exact
+  expected edge set.
+
 ## 0.1.0
 
 - Added a full Swift port of the monorepo build tool.

--- a/code/programs/swift/build-tool/README.md
+++ b/code/programs/swift/build-tool/README.md
@@ -15,6 +15,20 @@ This port mirrors the other build-tool implementations in the repo:
 7. Emits and consumes JSON build plans for CI
 8. Validates the CI full-build toolchain contract
 
+## Metadata safety
+
+Lua `.rockspec` files are decoded as strict UTF-8 before dependency parsing.
+Invalid bytes stop resolution, return CLI exit code `2`, and emit a stable
+diagnostic with package and repository-relative manifest identity:
+
+```text
+METADATA_INVALID_UTF8: package=lua/pkg manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec encoding=UTF-8
+```
+
+The resolver tests consume the language-neutral `resolution/lua-utf8` and
+`resolution/lua-invalid-utf8` fixtures, require the exact success edge set,
+and verify that diagnostics never expose the checkout root.
+
 ## Usage
 
 ```bash

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/BuildTool.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/BuildTool.swift
@@ -20,6 +20,9 @@ public enum BuildTool {
             }
 
             return try runNormalFlow(options: options, repoRoot: repoRoot)
+        } catch let error as MetadataEncodingError {
+            FileHandle.standardError.write(Data((error.localizedDescription + "\n").utf8))
+            return 2
         } catch {
             fputs("Error: \(error.localizedDescription)\n", stderr)
             return 1
@@ -91,7 +94,7 @@ public enum BuildTool {
         }
 
         print("Discovered \(packages.count) packages")
-        let graph = Resolver.resolveDependencies(packages: packages)
+        let graph = try Resolver.resolveDependencies(packages: packages)
 
         var force = options.force
         var affectedSet: Set<String>? = nil

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
@@ -23,6 +23,24 @@ public enum BuildToolError: Error, LocalizedError {
     }
 }
 
+public struct MetadataEncodingError: Error, LocalizedError, Equatable {
+    public let code: String
+    public let package: String
+    public let manifest: String
+    public let encoding: String
+
+    public init(code: String, package: String, manifest: String, encoding: String) {
+        self.code = code
+        self.package = package
+        self.manifest = manifest
+        self.encoding = encoding
+    }
+
+    public var errorDescription: String? {
+        "\(code): package=\(package) manifest=\(manifest) encoding=\(encoding)"
+    }
+}
+
 public enum BuildStatus: String, Codable {
     case built
     case failed

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Resolver.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Resolver.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum Resolver {
-    public static func resolveDependencies(packages: [BuildPackage]) -> DirectedGraph {
+    public static func resolveDependencies(packages: [BuildPackage]) throws -> DirectedGraph {
         let graph = DirectedGraph()
         for package in packages {
             graph.addNode(package.name)
@@ -32,7 +32,7 @@ public enum Resolver {
             case "elixir":
                 deps = parseElixirDeps(package: package, knownNames: knownNames)
             case "lua":
-                deps = parseLuaDeps(package: package, knownNames: knownNames)
+                deps = try parseLuaDeps(package: package, knownNames: knownNames)
             case "perl":
                 deps = parsePerlDeps(package: package, knownNames: knownNames)
             case "swift":
@@ -322,10 +322,18 @@ public enum Resolver {
             .compactMap { knownNames[$0.lowercased()] }
     }
 
-    private static func parseLuaDeps(package: BuildPackage, knownNames: [String: String]) -> [String] {
+    private static func parseLuaDeps(package: BuildPackage, knownNames: [String: String]) throws -> [String] {
         guard let rockspecPath = firstFile(in: package.path, suffix: ".rockspec"),
-              let content = try? String(contentsOfFile: rockspecPath, encoding: .utf8) else {
+              let data = try? Data(contentsOf: URL(fileURLWithPath: rockspecPath)) else {
             return []
+        }
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw MetadataEncodingError(
+                code: "METADATA_INVALID_UTF8",
+                package: package.name,
+                manifest: repositoryManifestPath(rockspecPath),
+                encoding: "UTF-8"
+            )
         }
 
         var dependencies: [String] = []
@@ -443,6 +451,22 @@ public enum Resolver {
 
     private static func normalizePath(_ path: String) -> String {
         path.replacingOccurrences(of: "\\", with: "/").lowercased()
+    }
+
+    private static func repositoryManifestPath(_ path: String) -> String {
+        let normalized = path.replacingOccurrences(of: "\\", with: "/")
+        let parts = normalized.split(separator: "/")
+        var canonicalStart: Int?
+        if parts.count >= 2 {
+            for index in 0 ..< (parts.count - 1) where
+                parts[index] == "code" && (parts[index + 1] == "packages" || parts[index + 1] == "programs") {
+                canonicalStart = index
+            }
+        }
+        if let canonicalStart {
+            return parts[canonicalStart...].joined(separator: "/")
+        }
+        return URL(fileURLWithPath: path).lastPathComponent
     }
 
     private static func firstFile(in directory: String, suffix: String) -> String? {

--- a/code/programs/swift/build-tool/Tests/BuildToolCoreTests/ResolverTests.swift
+++ b/code/programs/swift/build-tool/Tests/BuildToolCoreTests/ResolverTests.swift
@@ -54,7 +54,7 @@ struct ResolverTests {
             """
         )
 
-        let graph = Resolver.resolveDependencies(
+        let graph = try Resolver.resolveDependencies(
             packages: [
                 BuildPackage(name: "swift/trig", path: trigPath, language: "swift"),
                 BuildPackage(name: "swift/arc2d", path: arcPath, language: "swift"),
@@ -63,5 +63,92 @@ struct ResolverTests {
 
         #expect(graph.successors(of: "swift/trig") == ["swift/arc2d"])
         #expect(graph.predecessors(of: "swift/arc2d") == ["swift/trig"])
+    }
+
+    @Test
+    func luaResolutionConsumesSharedUTF8Fixtures() throws {
+        for name in ["resolution-lua-utf8.json", "resolution-lua-invalid-utf8.json"] {
+            let fixture = try loadSharedResolutionFixture(name)
+            let materialized = try materializeSharedResolutionFixture(fixture, label: "resolver_fixture")
+            defer { try? FileManager.default.removeItem(atPath: materialized.root) }
+
+            if fixture.expected.outcome == "ok" {
+                let graph = try Resolver.resolveDependencies(packages: materialized.packages)
+                let actualEdges = graph.edges()
+                    .map { [$0.0, $0.1] }
+                    .sorted { $0.joined(separator: "\0") < $1.joined(separator: "\0") }
+                let expectedEdges = (fixture.expected.result.edges ?? [])
+                    .sorted { $0.joined(separator: "\0") < $1.joined(separator: "\0") }
+                #expect(actualEdges == expectedEdges)
+                continue
+            }
+
+            do {
+                _ = try Resolver.resolveDependencies(packages: materialized.packages)
+                Issue.record("invalid UTF-8 metadata must fail closed")
+            } catch let error as MetadataEncodingError {
+                let diagnostic = try #require(fixture.expected.diagnostics.first)
+                #expect(error.code == diagnostic.code)
+                #expect(error.package == diagnostic.package)
+                #expect(error.manifest == diagnostic.path)
+                #expect(error.encoding == diagnostic.details.encoding)
+                #expect(
+                    error.localizedDescription ==
+                        "\(diagnostic.code): package=\(diagnostic.package) manifest=\(diagnostic.path) encoding=\(diagnostic.details.encoding)"
+                )
+                #expect(!error.localizedDescription.contains(materialized.root))
+            } catch {
+                Issue.record("expected MetadataEncodingError, got \(error)")
+            }
+        }
+    }
+
+    @Test
+    func cliReturnsExitTwoForInvalidUTF8Metadata() throws {
+        let fixture = try loadSharedResolutionFixture("resolution-lua-invalid-utf8.json")
+        let materialized = try materializeSharedResolutionFixture(fixture, label: "resolver_cli")
+        defer { try? FileManager.default.removeItem(atPath: materialized.root) }
+
+        let exitCode = BuildTool.run(
+            arguments: [
+                "--root", materialized.root,
+                "--force",
+                "--dry-run",
+                "--language", "lua",
+            ]
+        )
+
+        #expect(exitCode == 2)
+    }
+
+    @Test
+    func realCLIFailsClosedOnSharedInvalidUTF8Fixture() throws {
+        let fixture = try loadSharedResolutionFixture("resolution-lua-invalid-utf8.json")
+        let materialized = try materializeSharedResolutionFixture(fixture, label: "resolver_real_cli")
+        defer { try? FileManager.default.removeItem(atPath: materialized.root) }
+
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = try buildToolExecutableURL()
+        process.arguments = [
+            "--root", materialized.root,
+            "--force",
+            "--dry-run",
+            "--language", "lua",
+        ]
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+
+        let diagnostic = try #require(fixture.expected.diagnostics.first)
+        let expected =
+            "\(diagnostic.code): package=\(diagnostic.package) manifest=\(diagnostic.path) encoding=\(diagnostic.details.encoding)\n"
+        let actualStderr = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+
+        #expect(process.terminationStatus == 2)
+        #expect(actualStderr == expected)
+        #expect(!actualStderr.contains(materialized.root))
     }
 }

--- a/code/programs/swift/build-tool/Tests/BuildToolCoreTests/TestSupport.swift
+++ b/code/programs/swift/build-tool/Tests/BuildToolCoreTests/TestSupport.swift
@@ -1,3 +1,4 @@
+import BuildToolCore
 import Foundation
 
 func makeTempDirectory(label: String = "build_tool_swift") throws -> String {
@@ -11,4 +12,108 @@ func writeFile(_ path: String, _ contents: String) throws {
     let url = URL(fileURLWithPath: path)
     try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
     try contents.write(to: url, atomically: true, encoding: .utf8)
+}
+
+func writeData(_ path: String, _ contents: Data) throws {
+    let url = URL(fileURLWithPath: path)
+    try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try contents.write(to: url, options: .atomic)
+}
+
+struct SharedResolutionFixture: Decodable {
+    struct Workspace: Decodable {
+        let files: [File]
+    }
+
+    struct File: Decodable {
+        let path: String
+        let contentUTF8: String?
+        let contentBase64: String?
+
+        enum CodingKeys: String, CodingKey {
+            case path
+            case contentUTF8 = "content_utf8"
+            case contentBase64 = "content_base64"
+        }
+
+        func data() throws -> Data {
+            if let contentBase64 {
+                guard let decoded = Data(base64Encoded: contentBase64) else {
+                    throw CocoaError(.fileReadCorruptFile)
+                }
+                return decoded
+            }
+            return Data((contentUTF8 ?? "").utf8)
+        }
+    }
+
+    struct Expected: Decodable {
+        struct Result: Decodable {
+            let edges: [[String]]?
+        }
+
+        struct Diagnostic: Decodable {
+            struct Details: Decodable {
+                let encoding: String
+            }
+
+            let code: String
+            let path: String
+            let package: String
+            let details: Details
+        }
+
+        let outcome: String
+        let result: Result
+        let diagnostics: [Diagnostic]
+    }
+
+    let workspace: Workspace
+    let expected: Expected
+}
+
+func loadSharedResolutionFixture(_ name: String) throws -> SharedResolutionFixture {
+    let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let fixtureURL = packageRoot
+        .appendingPathComponent("../../../specs/fixtures/build-tool-v1/cases")
+        .appendingPathComponent(name)
+        .standardizedFileURL
+    return try JSONDecoder().decode(SharedResolutionFixture.self, from: Data(contentsOf: fixtureURL))
+}
+
+func materializeSharedResolutionFixture(
+    _ fixture: SharedResolutionFixture,
+    label: String
+) throws -> (root: String, packages: [BuildPackage]) {
+    let root = try makeTempDirectory(label: label)
+    try FileManager.default.createDirectory(
+        atPath: (root as NSString).appendingPathComponent(".git"),
+        withIntermediateDirectories: false
+    )
+    for file in fixture.workspace.files {
+        try writeData((root as NSString).appendingPathComponent(file.path), file.data())
+    }
+    let codeRoot = (root as NSString).appendingPathComponent("code")
+    return (root, Discovery.discoverPackages(root: codeRoot))
+}
+
+func buildToolExecutableURL() throws -> URL {
+    #if os(Windows)
+    let executableName = "build-tool.exe"
+    #else
+    let executableName = "build-tool"
+    #endif
+
+    var directory = URL(fileURLWithPath: CommandLine.arguments[0]).deletingLastPathComponent()
+    for _ in 0 ..< 8 {
+        let candidate = directory.appendingPathComponent(executableName)
+        if FileManager.default.isExecutableFile(atPath: candidate.path) {
+            return candidate
+        }
+        directory.deleteLastPathComponent()
+    }
+    throw CocoaError(.fileNoSuchFile)
 }

--- a/code/programs/swift/build-tool/Tests/BuildToolCoreTests/TestSupport.swift
+++ b/code/programs/swift/build-tool/Tests/BuildToolCoreTests/TestSupport.swift
@@ -107,13 +107,39 @@ func buildToolExecutableURL() throws -> URL {
     let executableName = "build-tool"
     #endif
 
-    var directory = URL(fileURLWithPath: CommandLine.arguments[0]).deletingLastPathComponent()
-    for _ in 0 ..< 8 {
-        let candidate = directory.appendingPathComponent(executableName)
-        if FileManager.default.isExecutableFile(atPath: candidate.path) {
-            return candidate
+    let fileManager = FileManager.default
+    let testExecutables = [
+        Bundle.main.executableURL,
+        URL(fileURLWithPath: CommandLine.arguments[0]),
+    ].compactMap { $0 }
+
+    for testExecutable in testExecutables {
+        var directory = testExecutable.deletingLastPathComponent()
+        for _ in 0 ..< 8 {
+            let candidate = directory.appendingPathComponent(executableName)
+            if fileManager.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+            directory.deleteLastPathComponent()
         }
-        directory.deleteLastPathComponent()
+    }
+
+    // SwiftPM can copy the test bundle away from the package build directory
+    // on macOS. Fall back to the package-local scratch tree in that case.
+    let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    if let enumerator = fileManager.enumerator(
+        at: packageRoot.appendingPathComponent(".build"),
+        includingPropertiesForKeys: [.isRegularFileKey, .isExecutableKey]
+    ) {
+        for case let candidate as URL in enumerator where candidate.lastPathComponent == executableName {
+            let values = try candidate.resourceValues(forKeys: [.isRegularFileKey, .isExecutableKey])
+            if values.isRegularFile == true, values.isExecutable == true {
+                return candidate
+            }
+        }
     }
     throw CocoaError(.fileNoSuchFile)
 }

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -229,6 +229,15 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   completed the Go operational-oracle child, and merged PR #9510 completed
   Rust. The next dependency-shaped child is the Swift engine, whose failed
   UTF-8 decode currently becomes an empty Lua dependency list;
+- make Swift build-tool file options recognize Windows drive-letter absolute
+  paths. The UTF-8 validation run discovered that `--emit-plan` reaches
+  resolution but then joins an absolute Windows path under the repository;
+  cover `--emit-plan`, `--plan-file`, and `--cache-file` in a separate slice;
+- align Swift build-tool discovery with the canonical language and identity
+  registry. Its full release plan currently emits 4,767 entries but only 4,593
+  unique names, including 143 duplicate identity groups and 397 `unknown`
+  entries; consume the shared registry and duplicate-identity fixtures in a
+  separate post-UTF-8 slice;
 - merged PR #9521 makes the Rust build tool reject resolver self-edges with a
   stable diagnostic and preserves distinct package/program identities for
   `elixir/grammar_tools`;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -222,18 +222,20 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   #9495 normalized the three CP1252 metadata bytes, added positive and invalid-
   UTF-8 fixtures, and returns `METADATA_INVALID_UTF8`; its refreshed full scan
   succeeds across 4,765 packages and 7,100 edges;
-- bring the remaining Rust, Swift, TypeScript, Lua, Perl, Ruby, Elixir, and
-  Haskell build-tool resolvers to the shared strict-UTF-8 rockspec contract.
+- bring the remaining Swift, TypeScript, Lua, Perl, Ruby, Elixir, and Haskell
+  build-tool resolvers to the shared strict-UTF-8 rockspec contract.
   Their current byte, replacement, silent-drop, and locale-sensitive behavior
   is tracked separately from the Python full-scan blocker. Merged PR #9504
-  completed the Go operational-oracle child, and the Rust child is next;
+  completed the Go operational-oracle child, and merged PR #9510 completed
+  Rust. The next dependency-shaped child is the Swift engine, whose failed
+  UTF-8 decode currently becomes an empty Lua dependency list;
 - merged PR #9521 makes the Rust build tool reject resolver self-edges with a
   stable diagnostic and preserves distinct package/program identities for
   `elixir/grammar_tools`;
 - bring Rust build-tool discovery to the complete canonical language and
-  identity registry. The active slice classifies every repository bucket,
+  identity registry. Merged PR #9527 classifies every repository bucket,
   excludes specification fixture trees, and rejects residual duplicate names;
-  its real full plan exits zero with 4,764 entries, 4,764 unique identities,
+  its real full plan exits zero with 4,765 entries, 4,765 unique identities,
   and only the intentional language-neutral `code/sites/blog` package;
 - expose Haskell through the Python build tool's `--language` filter. Haskell
   is already in its resolver and canonical language registry but is missing

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -120,17 +120,17 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 769 | 10,766 |
+| Present in one language | 770 | 10,780 |
 
-The loop must not start by attempting 10,766 singleton ports. It should finish
+The loop must not start by attempting 10,780 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`4d0a98e02bec862a5b852329426d01c8996a19c6` is collision-clean at 1,219
-normalized implementation identities, 4,367 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 769 singletons, 574
+`613717e22fe7b65c37eebb35a84a5b440a55ddb1` is collision-clean at 1,220
+normalized implementation identities, 4,368 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 770 singletons, 575
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The fourteen newest mixed Rust identities are `smart-home-camera-media`,
+The fifteen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
 `smart-home-wled-integration`, `smart-home-govee-lan-integration`,
 `smart-home-lifx-lan-integration`, `smart-home-kasa-lan-integration`,
@@ -138,7 +138,8 @@ The fourteen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-wemo-upnp-integration`, `smart-home-sonos-upnp-integration`,
 `smart-home-nanoleaf-local-integration`,
 `smart-home-tasmota-local-integration`, and
-`smart-home-fronius-local-integration`. All are
+`smart-home-fronius-local-integration`, plus
+`smart-home-homewizard-energy-integration`. All are
 mixed splits rather than blind parity ports: camera grant policy,
 generation-bound lease state, quotas, and redacted audit are portable, while
 authenticated host context and media delivery remain native mediation; ONVIF
@@ -152,10 +153,11 @@ WLED DTO validation, master/segment projection, capability-bit interpretation,
 state normalization, and command planning are portable, while mDNS, DNS/TCP,
 plaintext LAN HTTP, trusted time, console I/O, pairing/origin policy, runtime
 effects, and capability profiles remain native. Govee, LIFX, Kasa, Reolink,
-Roku, Wemo, Sonos, Nanoleaf, Tasmota, and Fronius contribute deterministic
-codecs, bounded parsers and DTO validation, normalization, projection, stable
-identities/errors, command planning, and language-neutral fixtures to the
-parity backlog. Wemo specifically contributes SSDP header parsing, bounded
+Roku, Wemo, Sonos, Nanoleaf, Tasmota, Fronius, and HomeWizard contribute
+deterministic codecs, bounded parsers and DTO validation, normalization,
+projection, stable identities/errors, command planning, and language-neutral
+fixtures to the parity backlog. Wemo specifically contributes SSDP header
+parsing, bounded
 setup/SOAP XML, service/device
 normalization, and switch/light command planning. Sonos additionally contributes
 credential-free URL/control-path validation, AVTransport, RenderingControl,
@@ -234,7 +236,7 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   resolution but then joins an absolute Windows path under the repository;
   cover `--emit-plan`, `--plan-file`, and `--cache-file` in a separate slice;
 - align Swift build-tool discovery with the canonical language and identity
-  registry. Its full release plan currently emits 4,767 entries but only 4,593
+  registry. Its full release plan currently emits 4,768 entries but only 4,594
   unique names, including 143 duplicate identity groups and 397 `unknown`
   entries; consume the shared registry and duplicate-identity fixtures in a
   separate post-UTF-8 slice;


### PR DESCRIPTION
## Summary

- decode Lua `.rockspec` bytes as strict UTF-8 in the Swift build tool before dependency parsing
- fail closed with typed `METADATA_INVALID_UTF8`, package identity, repository-relative manifest identity, platform-stable stderr, and CLI exit code 2
- consume the shared positive and invalid-byte resolution fixtures through resolver, CLI-entry, and real subprocess tests
- refresh the collision-checked parity inventory and log separately scoped Swift path/identity and HomeWizard portable-core follow-ups

## Validation

- `swift test` — 22 tests passed, including exact fixture edges and a real invalid-byte CLI subprocess
- `swift build -c release` — passed with the existing Swift 6 concurrency warnings unchanged
- `swift test --enable-code-coverage` — passed; measured 39.74% overall line coverage, 42.94% for `Resolver.swift`, 76.60% for `Models.swift`, and 27.60% for `BuildTool.swift`
- shared build-tool corpus — 17 schema tests and 40 runner tests passed; 36 cases / 55 files validated across 15 established languages and 16 implementations
- release CLI Lua plan — 258 packages / 382 dependency edges
- release CLI full plan — 4,768 packages / 7,458 dependency edges
- package parity report — 1,220 identities / 4,368 slots, 0 canonical collisions, 0 unknown language buckets
- JSON parse, `git diff --check`, and changed-diff credential scan — passed
- Python BUILD validator — exactly the same 10 pre-existing Lua `BUILD_windows` findings as untouched `origin/main`; no delta from this PR

## Follow-ups discovered

- Swift drive-letter absolute paths in `--emit-plan`, `--plan-file`, and `--cache-file`
- Swift canonical discovery/language registry and duplicate-identity rejection
- HomeWizard Energy deterministic telemetry parsing, normalization, identity, error, and sensor-projection conformance

Each follow-up is recorded as a pending package-parity backlog item and is intentionally outside this metadata-only slice.
