### PR TITLE
fix(spice): validate MOS model length

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS model-card `L` values
+  before lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `W` values
   before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `JS` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1982,6 +1982,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(length) = params.get("L") {
+            if !length.is_finite() || *length <= 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET L must be finite and positive",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2152,6 +2152,30 @@ fn preserves_positive_mosfet_model_width() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_lengths() {
+    for length in ["0", "-1u", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model geometry NMOS(L={length})\nM1 d g s b geometry"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET L must be finite and positive"));
+    }
+}
+
+#[test]
+fn preserves_positive_mosfet_model_length() {
+    let parsed = parse_netlist(".model geometry NMOS(L=180n)\nM1 d g s b geometry").unwrap();
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+    assert_close(mosfet.params.l, 180.0e-9);
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card width validation.
+1. Rust Berkeley SPICE MOS model-card length validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite model-card `W` values before
+   - Reject zero, negative, and non-finite model-card `L` values before
      lowering MOS elements into engine parameters.
-   - Preserve positive model widths.
+   - Preserve positive model lengths.
 
 ## Completed Slices
 
@@ -4046,6 +4046,12 @@ the Rust, Python, and TypeScript surfaces together.
    - Negative and non-finite model-card `JS` values are rejected before
      lowering MOS elements into engine parameters.
    - Zero and positive saturation-current densities remain accepted.
+
+355. Rust Berkeley SPICE MOS model-card width validation.
+   - Status: completed in PR 9533.
+   - Zero, negative, and non-finite model-card `W` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Positive model widths remain accepted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite Level-1 MOS model-card `L` values in the Rust Berkeley SPICE parser facade
- preserve positive model lengths, including engineering suffixes
- reconcile the SPICE implementation plan after model-width validation merged in #9533

## Scope
This is a Rust parser-facade boundary change. The shared Rust, Python, and TypeScript engines already enforce the same `L` behavior and diagnostic.

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser` (148 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`