### PR TITLE
Split Italian curriculum into sub-five-minute lessons

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Bengali duration
-tranche: 20 registered tracks, 985 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Italian duration
+tranche: 20 registered tracks, 989 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -53,7 +53,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01D | Complete in the Punjabi duration PR | Remove all ten sub-five-minute violations from the Punjabi track. | The report measures zero Punjabi violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
 | HL-D01E | Complete in the Sanskrit duration PR | Remove all ten sub-five-minute violations from the Sanskrit track. | The report measures zero Sanskrit violations; the 513-second anchor lesson is now three prerequisite-ordered micro-lessons. |
 | HL-D01F | Complete in the Bengali duration PR | Remove all eleven sub-five-minute violations from the Bengali track. | The report measures zero Bengali violations; all eleven lesson bodies remain unchanged because their computed durations were already below 300 seconds. |
-| HL-D01G | Next | Remove all twenty sub-five-minute violations from the Italian track. | Italian is now the smallest remaining set: seventeen declaration-only lessons and three genuinely computed violations, with a 404-second maximum. |
+| HL-D01G | Complete in the Italian duration PR | Remove all twenty sub-five-minute violations from the Italian track. | The report measures zero Italian violations; four new prerequisite-ordered micro-lessons preserve the register, metaphor, suppletion, and agreement content that did not fit safely in the original lessons. |
+| HL-D01H | Next | Remove all twenty-three sub-five-minute violations from the Portuguese track. | Portuguese is now the smallest remaining set: eighteen declaration-only lessons and five genuinely computed violations, with a 565-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -66,6 +67,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B11 | Queued | Remove Sanskrit's LaTeX layout, duplicate-label, and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs but reports three overfull boxes, six underfull boxes, four duplicate practice labels, and 28 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B12 | Queued | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The duration audit confirms authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B13 | Queued | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports six missing glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 27 Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B14 | Queued | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
+| HL-B15 | Queued | Remove Italian's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds but reports one underfull box and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -256,6 +259,30 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Italian's twenty violations are now the smallest remaining track-sized set.
   Seventeen are declaration-only and three are genuinely computed, with a
   404-second maximum, so HL-D01G is next.
+
+## Findings from HL-D01G
+
+- Italian now has zero duration violations. The repository grows from 985 to
+  989 lessons and drops from 424 to 404 violations overall; unknown
+  prerequisites remain at zero.
+- Seventeen lessons needed only honest declared-budget corrections. The three
+  computed violations were replaced by prerequisite-ordered steps: informal
+  `Come stai?` → formal `Come sta?` → register-neutral `Come va?`; `essere`
+  forms → the borrowed `stato` story → `andare` → participle agreement.
+- The first attempted combined `Come sta? / Come va?` extension still measured
+  325 seconds. Splitting register from metaphor produced two independent
+  micro-lessons without deleting the cross-language or etymological depth.
+- `IT-C02-practice` at 297 computed seconds and `IT-C17-mano` at 296 are the
+  tightest remaining Italian lessons and should be watched during copy edits.
+- The Italian PDF builds successfully at 13 pages but contains only Chapter 1,
+  while canonical app lessons run through Chapter 17. HL-B14 records the
+  schema-v2 migration and generated publication work for Chapters 2–17.
+- That forced build reports no missing glyphs, overfull boxes, or duplicate
+  labels, but does expose one underfull box and three Unicode bookmark warnings.
+  HL-B15 records the pre-existing clean-build debt.
+- Portuguese's twenty-three violations are now the smallest remaining set.
+  Eighteen are declaration-only and five genuinely compute above the limit,
+  with a 565-second maximum, so HL-D01H is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Sub-five-minute remediation — 2026-08-02
+
+- Corrected seventeen declared five-minute estimates whose lesson bodies
+  already compute below 300 seconds.
+- Replaced the three computed violations with four prerequisite-ordered
+  micro-lessons: informal → formal → register-neutral wellbeing questions, then
+  *essere* forms → borrowed *stato* → *andare* → participle agreement.
+- Preserved the original etymology and cross-language comparisons while making
+  each register, metaphor, suppletive stem, and grammar rule independently
+  learnable in under five minutes. The shared report now measures zero Italian
+  duration violations.
+- `IT-C02-practice` at 297 computed seconds and `IT-C17-mano` at 296 are the
+  tightest remaining Italian lessons and should be watched during copy edits.
+
 ## Chapter 17 — The body: the pot kept whole, and a noun that breaks the rule
 
 - **Chapter 17 authored** (`IT-C17-testa`, `-mano`) — the **body**, the theme the
@@ -33,7 +47,8 @@
 
 ## Chapter 16 — *essere*, and the participle it borrowed from *stare*
 
-- **Chapter 16 authored** (`IT-C16-essere`, `-passato-prossimo-essere`).
+- **Chapter 16 authored** (`IT-C16-essere`, `-essere-stato`, `-andare`,
+  `-passato-prossimo-essere`).
   Ch. 15 taught only the *avere* half of the passato prossimo; *essere* existed
   in no lesson. This supplies it — and Italian turns out to have the most
   interesting version of the story, because **Ch. 2 already taught *stare***.
@@ -41,22 +56,20 @@
   (*Marco **è** italiano* vs *Marco **e** Anna* — one accent, two different
   words), and the *io sono* / *loro sono* collision that is one of the few places
   a pro-drop language has to keep its pronoun.
-  - **The chapter's centrepiece**: Latin's *esse* and *stāre* both survived into
-    Italian as separate living verbs — but *essere*'s own participle did not, so
-    Italian filled the gap with ***stare*'s**. Both verbs' participle is
-    **stato**, and ***sono stato*** therefore means both "I have **been**" and "I
-    have **stayed**", separable only by context.
-  - Set against the sisters in one table: **Spanish** split the pair fully (*ser*
-    / *estar*), **French** kept *esse* as *être* and absorbed *stāre*'s whole
-    *ét-* limb (*été*, *étant*, *étais*; *stāre* survives elsewhere in French too
-    — *rester*, *coûter* — just not as a separate "to be"), **Italian** kept both
-    but let them **overlap**. Italian sits
-    exactly between the other two — a genuinely new comparative row rather than a
-    restatement of the French lesson.
-- **passato prossimo with essere** (`IT-C16-passato-prossimo-essere`): opens with
-  **`sono stato`** so the first *essere*-past costs **no new vocabulary**, then
-  introduces ***andare*** explicitly as a new verb (`vado/vai/va/andiamo/andate/
-  vanno`) rather than smuggling it in — it is itself suppletive, shown as a
+- **borrowed *stato*** (`IT-C16-essere-stato`) holds the chapter's centrepiece:
+  Latin's *esse* and *stāre* both survived into Italian as separate living verbs
+  — but *essere*'s own participle did not, so Italian filled the gap with
+  ***stare*'s**. Both verbs' participle is **stato**, and ***sono stato***
+  therefore means both "I have **been**" and "I have **stayed**", separable only
+  by context.
+- Set against the sisters in one table: **Spanish** split the pair fully (*ser*
+  / *estar*), **French** kept *esse* as *être* and absorbed *stāre*'s whole
+  *ét-* limb (*été*, *étant*, *étais*; *stāre* survives elsewhere in French too
+  — *rester*, *coûter* — just not as a separate "to be"), **Italian** kept both
+  but let them **overlap**. Italian sits exactly between the other two.
+- **andare** (`IT-C16-andare`) is introduced explicitly as a new verb
+  (`vado/vai/va/andiamo/andate/vanno`) rather than smuggled into the past. It is
+  itself suppletive, shown as a
   stem table rather than prose so no form is left unaccounted for: **vad-**
   (*vado, vai, va, **vanno*** ← *vādere* "to stride") against **and-**
   (*andiamo, andate, andare, andato*, origin genuinely disputed, most likely
@@ -64,6 +77,9 @@
   second, plus the infinitive and participle. The lesson flags that ***vanno*
   files with *vado***, so the split is *not* singular-versus-plural — the same two-stem trick as *essere*, and the
   one behind Spanish *voy* vs *andar*.
+- **passato prossimo with essere** (`IT-C16-passato-prossimo-essere`): after the
+  dedicated atoms, opens with **`sono stato`** so the first *essere*-past costs
+  **no new vocabulary**.
   - The **subject agreement** in all four endings (*andato / -a / -i / -e*), with
     the note that a woman says *sono andat**a***; explained via the same
     adjective fossil as French (*Anna è andata* ← "Anna **is** gone-away",
@@ -300,7 +316,8 @@
 ## Chapter 2 — "Come stai?" (the how-are-you chapter)
 
 - **Chapter 2 authored** (`IT-C02-prego`, `-come`, `-stare`, `-come-stai`,
-  `-cosi-cosi`, `-practice`): the "how are you?" exchange, atom-first, reviewing
+  `-come-sta`, `-come-va`, `-cosi-cosi`, `-practice`): the "how are you?"
+  exchange, atom-first, reviewing
   Chapter 1. Fourth track in the PR's cross-language how-are-you set, reusing the
   canonical concepts `STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`, `WORD-SOSO`.
   Register (tu/Lei) and the question word (come) are introduced inline, since the

--- a/code/learning/human-languages/italian/lessons/IT-C01-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [IT-C01-ciao, IT-C01-buongiorno, IT-C01-sera, IT-C01-notte, IT-C01-grazie]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C01-ciao, IT-C01-buono, IT-C01-il-la-lo, IT-C01-giorno, IT-C01-buongiorno, IT-C01-sera, IT-C01-notte, IT-C01-grazie]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C02-come-sta.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-come-sta.md
@@ -1,0 +1,56 @@
+---
+id: IT-C02-come-sta
+chapter: 2
+type: phrase
+headword: Come sta?
+gloss: formal “how are you?”
+concept_tag: IT-STATE-FORMAL
+prerequisites: [IT-C02-come-stai]
+sounds: [open-a]
+roots: [stare-latin]
+etymology_hook: "Come sta? keeps the standing metaphor of Come stai? but changes the social register"
+est_minutes: 4
+reviews_of: [IT-C02-come-stai, IT-C02-stare]
+---
+
+# Come sta? — the formal question
+
+## Warm-up
+
+[PAUSE 2s] You can ask a friend **Come stai?** Change one ending when you speak
+to a stranger or elder.
+
+## From stai to sta
+
+> **Come sta?** = “How are you?” (formal)
+
+Italian uses **Lei** — literally “she,” often capitalized — as a polite “you.”
+Its verb therefore uses the third-person form **sta**, not informal **stai**:
+
+| listener | question |
+|---|---|
+| a friend (*tu*) | **Come stai?** |
+| a stranger or elder (*Lei*) | **Come sta?** |
+
+The politeness pattern has cousins in Spanish *usted* and German *Sie*, but you
+only need one Italian contrast here: **stai** for a friend, **sta** for formal
+respect.
+
+An answer can return the formal pronoun:
+
+> **Bene, grazie. E Lei?** — “Well, thank you. And you?”
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: to a friend — “Come stai?”]
+- [YOU SAY: to a stranger — “Come sta?”]
+- [YOU SAY: “Bene, grazie. E Lei?”]
+
+[REPEAT x2] “Stai — friend. Sta — formal.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which ending marks a friend? (**-i: stai**.) Which form is formal?
+(**Sta**.) What polite pronoun can follow *e*, “and”? (**Lei**.) Next: keep the
+meaning but switch the picture from “stand” to “go.”

--- a/code/learning/human-languages/italian/lessons/IT-C02-come-stai.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-come-stai.md
@@ -3,65 +3,55 @@ id: IT-C02-come-stai
 chapter: 2
 type: phrase
 headword: Come stai?
-gloss: how are you? (informal); formal Come sta?; also Come va?
+gloss: how are you? (informal)
 concept_tag: STATE-HOW-ARE-YOU
 prerequisites: [IT-C02-stare, IT-C02-come]
 sounds: [ai-glide]
-roots: [stare-latin, andare-latin]
-etymology_hook: "come (← quōmodo) + stai (stare 'to stand'); or Come va? — va from andare 'to go'"
+roots: [stare-latin]
+etymology_hook: "come (← quōmodo) + stai (stare 'to stand'): Italian literally asks 'how do you stand?'"
 est_minutes: 4
 reviews_of: [IT-C02-stare, IT-C02-come]
 ---
 
-# Come stai? — "how are you?"
+# Come stai? — “how are you?”
 
 ## Warm-up
 
-[PAUSE 2s] Both pieces are ready: **come** ("how") and **stare / stai** ("to
-be," from *stand*). Assemble Italian's everyday check-in — and meet its formal
-partner and a "go" cousin.
+[PAUSE 2s] Both pieces are ready: **come** (“how”) and **stare / stai** (“to
+be,” from *stand*). Assemble Italian’s everyday question for a friend.
 
 ## The phrase, taken apart
 
-> **Come stai?** = "How are you?" (informal)
-> literally: **"How do you stand?"**
+> **Come stai?** = “How are you?” (informal)
+> literally: **“How do you stand?”**
 
-- **come** = "how" · **stai** = "you are/stand" (the *tu* form of *stare*).
+- **come** = “how”
+- **stai** = “you are / stand,” the *tu* form of *stare*
 
-Italian, like Spanish, splits formal from informal — and here it also offers a
-"go" version, so you get **three** everyday forms:
+The subject **tu** (“you”) is already carried by **stai**, so Italian normally
+leaves it unspoken. Say **Come stai?**, not *Come tu stai?*, unless you need to
+stress “you.” This is the same pro-drop habit you will use in later verb lessons.
 
-| register | question | verb → picture |
-|---|---|---|
-| **informal** (friend) | **Come stai?** | *stare* → "how do you **stand**?" |
-| **formal** (stranger, elder) | **Come sta?** | *stare*, *Lei* form |
-| **either, very common** | **Come va?** | *andare* → "how does it **go**?" |
+An everyday answer reuses the same verb:
 
-- **Lei** is the formal "you" — literally "she" (capitalized), a politeness that
-  addresses you in the third person, cousin to Spanish *usted* and German *Sie*.
-- **Come va?** uses **va**, from **andare** ("to go") — so Italian can ask it
-  *both* ways: standing (*stai*) **and** going (*va*). It sits right between the
-  Spanish "stand" and the French/German "go."
+> **Come stai? — Sto bene, grazie.**
+> “How are you? — I’m well, thanks.”
 
-## Where the five tracks land
-
-You've now seen the whole spread — same question, two metaphors:
-
-- **Stand:** Spanish *¿cómo estás?* · Italian *come stai?*
-- **Go:** French *comment ça va?* · German *wie geht's?* · Italian *come va?* (both!)
+**Sto** means “I am / stand.” The pair **stai / sto** lets the ending do the
+pronoun’s work: “you” in *-ai*, “I” in *-o*.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "Come stai?" — informal, for a friend]
-- [YOU SAY: "Come sta?" — formal, for a stranger (Lei)]
-- [YOU SAY: "Come va?" — the "how's it going?" version]
+- [YOU SAY: “Come stai?” — informal, for a friend]
+- [YOU SAY: “Sto bene, grazie.”]
+- [YOU SAY: the two-part exchange — “Come stai? — Sto bene.”]
 
-[REPEAT x2] "Come stai? — Sto bene, grazie." ("How are you? — I'm well, thanks.")
+[REPEAT x2] “Come stai? — Sto bene, grazie.”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] *Come stai?* literally asks what? ("How do you **stand**?") What's the
-formal form, and what pronoun does it use? (*Come sta?*, with *Lei*, "she" as
-politeness.) Which verb is *Come va?* built on, and what does it mean? (*andare*,
-"to go" — "how does it go?") Next: the shrug — **così così**.
+[PAUSE 3s] *Come stai?* literally asks what? (“How do you **stand**?”) Which word
+means “how”? (**Come**.) Which form answers “I am”? (**Sto**.) Give the whole
+exchange: **Come stai? — Sto bene, grazie.** Next: formal speech and the “go”
+version.

--- a/code/learning/human-languages/italian/lessons/IT-C02-come-va.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-come-va.md
@@ -1,0 +1,56 @@
+---
+id: IT-C02-come-va
+chapter: 2
+type: phrase
+headword: Come va?
+gloss: how is it going?
+concept_tag: IT-STATE-GOING
+prerequisites: [IT-C02-come-sta]
+sounds: [open-a]
+roots: [andare-latin]
+etymology_hook: "Come va? changes the wellbeing metaphor from stare, 'stand', to andare, 'go'"
+est_minutes: 4
+reviews_of: [IT-C02-come-stai, IT-C02-come-sta]
+---
+
+# Come va? — “how is it going?”
+
+## Warm-up
+
+[PAUSE 2s] **Come stai?** pictures wellbeing as standing. Italian also has the
+same “going” picture as English.
+
+> **Come va?** = “How’s it going?”
+
+**Va** comes from **andare**, “to go.” Unlike *stai / sta*, this question does
+not force you to choose an informal or formal ending, so it is useful in either
+setting.
+
+## Two pictures
+
+- **Come stai?** — “How do you **stand**?”
+- **Come va?** — “How does it **go**?”
+
+Spanish also uses the “stand” picture in *¿cómo estás?*; French and German use a
+“go” picture. Italian keeps **both**, which makes it a bridge between them. The
+comparison is only a memory aid: in Italian, simply connect **stai** with
+*stare* and **va** with *andare*.
+
+You will learn all six forms of *andare* much later. For now, **va** is one
+ready-made piece inside this question.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the standing question — “Come stai?”]
+- [YOU SAY: the going question — “Come va?”]
+- [YOU SAY: “Come va? — Bene, grazie.”]
+
+[REPEAT x2] “Come stai? — Come va?”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which question uses “stand”? (**Come stai?**) Which uses “go”?
+(**Come va?**) What infinitive owns **va**? (**Andare**.) Must *Come va?* choose
+between *tu* and *Lei*? (**No**.) Next: answer with the original Italian
+“so-so.”

--- a/code/learning/human-languages/italian/lessons/IT-C02-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-practice.md
@@ -5,11 +5,11 @@ type: practice-mix
 headword: (practice)
 gloss: the full "Come stai?" exchange, formal and informal
 concept_tag: CH2-PRACTICE
-prerequisites: [IT-C02-prego, IT-C02-come, IT-C02-stare, IT-C02-come-stai, IT-C02-cosi-cosi]
+prerequisites: [IT-C02-prego, IT-C02-come, IT-C02-stare, IT-C02-come-stai, IT-C02-come-sta, IT-C02-come-va, IT-C02-cosi-cosi]
 sounds: []
 roots: []
-est_minutes: 5
-reviews_of: [IT-C02-prego, IT-C02-come-stai, IT-C02-cosi-cosi, IT-C01-practice]
+est_minutes: 4
+reviews_of: [IT-C02-prego, IT-C02-come-stai, IT-C02-come-sta, IT-C02-come-va, IT-C02-cosi-cosi, IT-C01-practice]
 ---
 
 # Practice — "Come stai?", start to finish

--- a/code/learning/human-languages/italian/lessons/IT-C05-parlare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C05-parlare.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C03-io, IT-C02-come]
 sounds: [r-tap, vowel-a-open]
 roots: [parabolare-latin]
 etymology_hook: "parlare ← Late Latin parabolāre 'to tell parables' (← parabola) → English parable, parole; = French parler"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C03-practice, IT-C04-practice]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C05-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH5-PRACTICE
 prerequisites: [IT-C05-parlare, IT-C05-abitare, IT-C05-lavorare, IT-C05-parlo-italiano]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C05-parlare, IT-C05-abitare, IT-C05-lavorare, IT-C05-parlo-italiano, IT-C03-practice]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C07-giorni-1.md
+++ b/code/learning/human-languages/italian/lessons/IT-C07-giorni-1.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C06-numeri-6-10]
 sounds: [final-stress-i, c-before-i]
 roots: [dies-latin, planet-gods]
 etymology_hook: "lunedì/martedì… = [planet] + dì (← diēs 'day'); same Roman planet-week as French, with the accented -dì kept audible; Spanish twins lunes/martes"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C06-numeri-6-10]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C08-ora.md
+++ b/code/learning/human-languages/italian/lessons/IT-C08-ora.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C06-numeri-1-5]
 sounds: [open-o, r-single]
 roots: [hora-latin, hora-greek]
 etymology_hook: "ora ← Latin hōra ← Greek hṓrā → hour; time is told with the feminine article: 'sono le due' = 'it is the two [hours]'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C06-numeri-1-5, IT-C07-giorni-2]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C09-mesi.md
+++ b/code/learning/human-languages/italian/lessons/IT-C09-mesi.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C06-numeri-6-10, IT-C07-giorni-1]
 sounds: [double-gg, c-before-i]
 roots: [latin-months, roman-gods]
 etymology_hook: "Italy kept the months closest to Latin: gennaio←Januarius, marzo←Mars (= martedì!), settembre–dicembre = the Latin 7–10 you learned as numbers"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C06-numeri-6-10, IT-C07-giorni-1]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C10-genitori.md
+++ b/code/learning/human-languages/italian/lessons/IT-C10-genitori.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C09-stagioni, IT-C01-ciao]
 sounds: [d-single, r-tap]
 roots: [pater-latin, mater-latin]
 etymology_hook: "padre/madre sit closest of the sisters to Latin pater/mater; padre is the very word English borrowed as 'padre'; genitori 'parents' ← genitor 'begetter' (→ genital, progenitor, genesis)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C09-stagioni, IT-C01-ciao]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C11-acqua-vino.md
+++ b/code/learning/human-languages/italian/lessons/IT-C11-acqua-vino.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C11-pane]
 sounds: [double-cq, v-clear]
 roots: [aqua-latin, vinum-latin]
 etymology_hook: "acqua kept Latin aqua almost whole (the -cq- doubles the sound) — the loud original French wore down to eau; vino ← vīnum → wine/vine/vinegar/vintage"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C11-pane, IT-C10-genitori]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C12-numeri-11-16.md
+++ b/code/learning/human-languages/italian/lessons/IT-C12-numeri-11-16.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C06-numeri-6-10, IT-C11-acqua-vino]
 sounds: [c-soft-dici, double-consonant]
 roots: [latin-decim]
 etymology_hook: "undici…sedici ← ūndecim…sēdecim, with -dici still visibly Latin decem ('ten') — clearer than French's worn-down -ze; and dieci (10) sits right there beside it"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C06-numeri-6-10, IT-C11-acqua-vino]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C12-numeri-17-20.md
+++ b/code/learning/human-languages/italian/lessons/IT-C12-numeri-17-20.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C12-numeri-11-16]
 sounds: [double-ss, c-soft-dici]
 roots: [latin-decim, viginti-latin]
 etymology_hook: "at 17 Italian reverses itself — sedici is 'six-ten' but diciassette is 'ten-and-seven' (dici + e + sette); the same ten, moved to the front, mid-count; venti ← vīgintī"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C12-numeri-11-16, IT-C06-numeri-6-10]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C13-nero-bianco.md
+++ b/code/learning/human-languages/italian/lessons/IT-C13-nero-bianco.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C12-numeri-17-20]
 sounds: [open-e, palatal-bi]
 roots: [latin-niger, germanic-blank]
 etymology_hook: "nero ← niger, but bianco ← Germanic *blank 'shining' — brought by the Lombards and displacing Latin albus, which survives in alba ('dawn') and albume"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C12-numeri-17-20, IT-C11-pane-acqua]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C13-rosso-blu.md
+++ b/code/learning/human-languages/italian/lessons/IT-C13-rosso-blu.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C13-nero-bianco]
 sounds: [double-s, final-stress-u]
 roots: [pie-rewdh, germanic-blao, arabic-lazaward]
 etymology_hook: "rosso ← russus ← PIE *h₁rewdʰ-, cousin of English red and German rot; blu is a SECOND Germanic loan, while azzurro ← Arabic lāzaward 'lapis lazuli' → English azure — the colour Italy's teams are named for"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C13-nero-bianco, IT-C12-numeri-17-20]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C14-avere.md
+++ b/code/learning/human-languages/italian/lessons/IT-C14-avere.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C13-rosso-blu, IT-C05-parlare]
 sounds: [silent-h, double-n]
 roots: [latin-habere]
 etymology_hook: "avere ← habēre (→ habit/inhabit/exhibit/prohibit). Italian dropped the Latin h everywhere EXCEPT here: ho/hai/ha/hanno keep a silent h purely to distinguish them from o 'or', ai 'to the', a 'to', anno 'YEAR' — spelling doing a job sound can't"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C13-rosso-blu, IT-C05-parlare, IT-C11-acqua-vino]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C15-passato-prossimo.md
+++ b/code/learning/human-languages/italian/lessons/IT-C15-passato-prossimo.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C14-avere, IT-C05-parlare]
 sounds: [silent-h, double-t]
 roots: [latin-habere-participle]
 etymology_hook: "ho parlato was once literally 'I HAVE [a thing] spoken' — Latin habeō litterās scriptās, a possessive with the participle as an ADJECTIVE agreeing with the object; the agreement survives when the object comes first (le ho viste), a fossil of the lost meaning"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C14-avere, IT-C05-parlare, IT-C05-lavorare]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C15-passato-remoto.md
+++ b/code/learning/human-languages/italian/lessons/IT-C15-passato-remoto.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C15-passato-prossimo]
 sounds: [final-stress-o]
 roots: [latin-perfect]
 etymology_hook: "parlò ← Vulgar Latin perfect *parabolāvit, the same inheritance as Spanish habló and Portuguese falou — but in Italian its survival is GEOGRAPHIC: everyday speech in Sicily and much of the south, literature-only in the north"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C15-passato-prossimo, IT-C05-parlare]
 ---
 

--- a/code/learning/human-languages/italian/lessons/IT-C16-andare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C16-andare.md
@@ -1,0 +1,63 @@
+---
+id: IT-C16-andare
+chapter: 16
+type: word
+headword: andare
+gloss: to go — one verb built from two historical stems
+concept_tag: IT-VERB-ANDARE
+prerequisites: [IT-C16-essere-stato, IT-C02-come-va]
+sounds: [double-consonant, open-a]
+roots: [latin-vadere, disputed-ambitare]
+etymology_hook: "vado/vai/va/vanno continue Latin vadere, while andare/andiamo/andate/andato probably continue a different root"
+est_minutes: 4
+reviews_of: [IT-C16-essere-stato, IT-C02-come-va]
+---
+
+# andare — “to go,” on two stems
+
+## Warm-up
+
+[PAUSE 2s] Chapter 2 gave you **Come va?**, “How’s it going?” The **va** inside
+it belongs to **andare**, “to go.” Learn the whole verb before using it to build
+the past.
+
+## The forms
+
+| | |
+|---|---|
+| io **vado** | noi **andiamo** |
+| tu **vai** | voi **andate** |
+| lui/lei **va** | loro **vanno** |
+
+Past participle: **andato**.
+
+The table has a visible seam:
+
+| stem | forms | history |
+|---|---|---|
+| **vad- / va-** | vado, vai, va, **vanno** | Latin *vādere*, “to stride” |
+| **and-** | andare, andiamo, andate, andato | disputed; probably *ambitāre*, “go around” |
+
+Notice that **vanno** belongs with **vado**, not with *andiamo*. The split is not
+“singular versus plural.” It is two old verbs patched into one modern paradigm —
+another case of **suppletion**, like *essere* borrowing *stare*’s **stato**.
+
+Spanish shows the same kind of seam in *voy* beside *andar*. The comparison is
+a memory aid; the Italian forms above are the only ones you need here.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “vado, vai, va”]
+- [YOU SAY: “andiamo, andate, vanno”]
+- [YOU SAY: the infinitive and participle — “andare, andato”]
+- [YOU SAY: the Chapter 2 callback — “Come va?”]
+
+[REPEAT x2] “Vado, vai, va — andiamo, andate, vanno.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the six present forms. (**Vado, vai, va, andiamo, andate,
+vanno**.) Which plural form belongs to the *vad-* side? (**Vanno**.) What is the
+participle? (**Andato**.) Which familiar question already used *va*? (**Come
+va?**) Next: combine **essere + andato** and make the ending agree.

--- a/code/learning/human-languages/italian/lessons/IT-C16-essere-stato.md
+++ b/code/learning/human-languages/italian/lessons/IT-C16-essere-stato.md
@@ -1,0 +1,68 @@
+---
+id: IT-C16-essere-stato
+chapter: 16
+type: etymology
+headword: essere → stato
+gloss: why essere and stare share the past participle stato
+concept_tag: IT-ESSERE-STATO
+prerequisites: [IT-C16-essere]
+sounds: [double-consonant]
+roots: [latin-esse, latin-stare]
+etymology_hook: "essere borrowed stare's participle, so sono stato can mean both 'I have been' and 'I have stayed'"
+est_minutes: 4
+reviews_of: [IT-C16-essere, IT-C02-stare]
+---
+
+# essere → stato — a borrowed piece
+
+## Warm-up
+
+[PAUSE 2s] Italian kept both Latin “be” verbs as **essere** and **stare**. Now
+look at the piece they unexpectedly share.
+
+## One participle for two verbs
+
+| verb | past participle |
+|---|---|
+| **stare** | **stato** |
+| **essere** | **stato** |
+
+*Essere*’s own participle did not survive. Latin *esse* never supplied a useful
+one, so Italian filled the empty slot with *stare*’s **stato**. A verb assembled
+from historically different roots is **suppletive**, like English *go / went*.
+
+That shared piece creates a real ambiguity:
+
+> **sono stato** = “I have been” or “I have stayed”
+
+Only the surrounding sentence tells you which verb is meant.
+
+## Three Romance solutions
+
+The same Latin material took a different shape in each sister language:
+
+| language | result |
+|---|---|
+| Spanish | *ser* and *estar*: two verbs kept fully separate |
+| French | *être*: one verb with old *stāre* pieces inside its forms |
+| Italian | *essere* and *stare*: two verbs that share **stato** |
+
+Italian sits between the other two: less separated than Spanish, less fused
+than French. You do not need either sister language to use Italian; the
+comparison simply makes the borrowed piece visible.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “stare → stato”]
+- [YOU SAY: “essere → stato”]
+- [YOU SAY: “sono stato — I have been / I have stayed”]
+
+[REPEAT x2] “Two verbs, one **stato**.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is *essere*’s participle? (**Stato**, borrowed from *stare*.)
+What can *sono stato* mean? (“I have **been**” or “I have **stayed**.”) Which
+language keeps the two verbs fully separate? (**Spanish**.) Which fuses them
+most? (**French**.) Next: the two-stem verb **andare**, “to go.”

--- a/code/learning/human-languages/italian/lessons/IT-C16-essere.md
+++ b/code/learning/human-languages/italian/lessons/IT-C16-essere.md
@@ -3,25 +3,24 @@ id: IT-C16-essere
 chapter: 16
 type: word
 headword: essere
-gloss: to be — the other "to be", and the one that shares its past participle with stare
+gloss: to be — the other Italian “to be”
 concept_tag: IT-VERB-BE
 prerequisites: [IT-C02-stare, IT-C14-avere, IT-C15-passato-prossimo]
 sounds: [double-consonant, open-e]
-roots: [latin-esse, latin-stare]
-etymology_hook: "Italian kept stāre as a living verb (stare, Ch.2) AND took its participle for essere — so essere and stare share one form, stato: 'sono stato' is both 'I have been' and 'I have stayed', and only context tells them apart"
-est_minutes: 5
+roots: [latin-esse]
+etymology_hook: "essere continues Latin esse; its six present forms also teach the crucial è/e accent contrast"
+est_minutes: 4
 reviews_of: [IT-C02-stare, IT-C14-avere, IT-C05-parlare]
 ---
 
-# essere — "to be"
+# essere — “to be”
 
 ## Warm-up
 
-[PAUSE 2s] You have known one Italian "to be" since Chapter 2: **stare**, from
-Latin *stāre*, "to stand." Here is the other one — the big one — and the way the
-two of them are tangled together is the most interesting fact in this chapter.
+[PAUSE 2s] You have known one Italian “to be” since Chapter 2: **stare**, from
+Latin *stāre*, “to stand.” Now meet **essere**, from Latin *esse*, “to be.”
 
-## The forms
+## The six forms
 
 | | |
 |---|---|
@@ -29,67 +28,43 @@ two of them are tangled together is the most interesting fact in this chapter.
 | tu **sei** | voi **siete** |
 | lui/lei **è** | loro **sono** |
 
-Note `è` with the **grave accent** — that is the verb "is." Without the accent,
-*e* is the word "and." One accent mark, two completely different words:
-*Marco **è** italiano* ("Marco **is** Italian") versus *Marco **e** Anna*
-("Marco **and** Anna"). Never drop it.
+Italian normally drops the subject pronoun because the ending identifies the
+person: **Sono italiano** means “I am Italian.” One collision needs care:
+**io sono** and **loro sono** are identical. Keep *loro* when context would not
+make “they” clear.
 
-Note also that **io sono** and **loro sono** are identical. Italian normally
-drops subject pronouns, so this is one of the few places you may need to keep
-*loro* to be clear.
+## One accent, two words
 
-## The two "to be" verbs, and the one they share
+**È** with the grave accent is the verb “is.” Plain **e** is “and”:
 
-Latin had two relevant verbs:
+- Marco **è** italiano. — Marco **is** Italian.
+- Marco **e** Anna. — Marco **and** Anna.
 
-| Latin | meaning | → Italian |
+The two words sound different enough in careful speech, but the accent makes
+the contrast unmistakable on the page. Never drop it from the verb.
+
+## Two roots, two living verbs
+
+| Latin | picture | Italian |
 |---|---|---|
-| *esse* | to be (essence) | **essere** |
-| *stāre* | to **stand** | **stare** |
+| *esse* | being or identity | **essere** |
+| *stāre* | standing or state | **stare** |
 
-Italian kept **both**, as separate living verbs. Now look at their participles:
-
-| verb | past participle |
-|---|---|
-| **stare** | **stato** |
-| **essere** | **stato** ← *borrowed from stare* |
-
-*Essere*'s own participle did not survive; Latin *esse* never had a decent one.
-So Italian filled the hole with *stare*'s. That means:
-
-> **sono stato** = "I have been" *and* "I have stayed."
-
-Same three words, two meanings, sorted only by context. This is **suppletion**
-again — a paradigm patched with parts from another verb, like English *go/went*.
-
-## What the other languages did with exactly this material
-
-Every Romance language faced the same two Latin verbs, and each solved it
-differently:
-
-| | *esse* | *stāre* | result |
-|---|---|---|---|
-| **Spanish** | ser | estar | **two verbs, you must choose** |
-| **French** | être ← *esse* | as a "to be", *stāre* survives only inside the *ét-* forms — *été*, *étant*, *étais* | **one verb** |
-| **Italian** | essere | stare (alive, but narrower) | **two verbs, sharing one participle** |
-
-Italian sits exactly between the other two. Spanish split them fully; French
-fused them fully; Italian kept both but let them overlap.
+Italian kept both verbs. The next micro-lesson shows the surprising place where
+their histories overlap.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "sono, sei, è, siamo, siete, sono"]
-- [YOU SAY: "Sono italiano" / "Marco **è** italiano" — hear the accent]
-- [YOU SAY: the shared form — "stare → stato … essere → **stato**"]
-- [YOU SAY: the three-way split — "Spanish two, French one, Italian **both**"]
+- [YOU SAY: “sono, sei, è, siamo, siete, sono”]
+- [YOU SAY: “Marco è italiano” — then “Marco e Anna”]
+- [YOU SAY: “essere — be; stare — stand/state”]
+
+[REPEAT x2] “Sono, sei, è — siamo, siete, sono.”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Give the six forms of *essere*. (*Sono, sei, è, siamo, siete, sono*.)
-What does the accent on *è* distinguish? ("**is**" from "**and**".) What is
-*essere*'s past participle? (***Stato*** — borrowed from **stare**.) So what can
-*sono stato* mean? (Both "I have **been**" and "I have **stayed**".) How does
-that compare with Spanish and French? (Spanish kept **two** verbs, French fused
-them into **one**, Italian kept two that **share a participle**.) Next: the past
-tense that runs on *essere*.
+[PAUSE 3s] Give the six forms of *essere*. (**Sono, sei, è, siamo, siete,
+sono**.) What does the accent distinguish? (**È**, “is,” from **e**, “and.”)
+Which older verbs became *essere* and *stare*? (Latin ***esse*** and ***stāre***.)
+Next: why both verbs share **stato**.

--- a/code/learning/human-languages/italian/lessons/IT-C16-passato-prossimo-essere.md
+++ b/code/learning/human-languages/italian/lessons/IT-C16-passato-prossimo-essere.md
@@ -3,119 +3,74 @@ id: IT-C16-passato-prossimo-essere
 chapter: 16
 type: phrase
 headword: sono andato
-gloss: "the passato prossimo built on essere — motion and change-of-state verbs, with the participle agreeing with the subject"
+gloss: the passato prossimo built on essere, with the participle agreeing with the subject
 concept_tag: IT-PAST-PROSSIMO-ESSERE
-prerequisites: [IT-C16-essere, IT-C15-passato-prossimo, IT-C02-stare]
+prerequisites: [IT-C16-andare, IT-C16-essere-stato, IT-C15-passato-prossimo]
 sounds: [double-consonant, final-vowel]
 roots: [latin-esse-participle, latin-andare]
-etymology_hook: "the participle agrees with the subject in gender and number — sono andato / sono andata — the same adjective-fossil as French elle est allée; Italian keeps the agreement French keeps and German lost"
-est_minutes: 6
-reviews_of: [IT-C16-essere, IT-C15-passato-prossimo, IT-C02-stare]
+etymology_hook: "sono andato / sono andata preserves the participle's older job as an adjective describing the subject"
+est_minutes: 4
+reviews_of: [IT-C16-andare, IT-C16-essere-stato, IT-C15-passato-prossimo]
 ---
 
-# sono andato — the past built on "essere"
+# sono andato — the past built on essere
 
 ## Warm-up
 
-[PAUSE 2s] Chapter 15 built the past with *avere*: *ho parlato*. One family of
-verbs takes **essere** instead — and with *essere*, the participle starts
-changing its ending.
+[PAUSE 2s] Chapter 15 built the past with *avere*: **ho parlato**. You now know
+the other auxiliary, **essere**, plus the participles **stato** and **andato**.
+Combine them, then watch the participle’s ending change.
 
-## Start with a verb you already have
-
-You met *essere*'s participle last lesson: **stato**. So the very first
-*essere*-past you can build needs **no new vocabulary at all**:
+## Start with stato
 
 | | |
 |---|---|
-| **sono stato** | I have been / I have stayed |
-| **sei stato** | you have been |
-| **è stato** | he has been |
-| **siamo stati** | we have been |
+| **sono stato** | I have been / stayed |
+| **sei stato** | you have been / stayed |
+| **è stato** | he has been / stayed |
+| **siamo stati** | we have been / stayed |
 
-Both *essere* and *stare* run on *essere*: *sono stato* covers both, exactly as
-the last lesson said.
+The plural **stati** is the first clue: with *essere*, the participle describes
+the subject and therefore agrees with it.
 
-## A new verb: andare, "to go"
+## Motion, change, and agreement
 
-The headline member of this family is **andare** — the verb Italian uses for
-"go," and one you have not met before. Learn it now:
+Many verbs of motion or change of state take **essere**: *andare* (go), *venire*
+(come), *arrivare* (arrive), *partire* (leave), *nascere* (be born), *morire*
+(die), *diventare* (become), plus *essere* and *stare*.
 
-| | |
+Use the four adjective endings you already know:
+
+| subject | sentence |
 |---|---|
-| io **vado** | noi **andiamo** |
-| tu **vai** | voi **andate** |
-| lui/lei **va** | loro **vanno** |
+| Marco | Marco è **andato**. |
+| Anna | Anna è **andata**. |
+| the boys | I ragazzi sono **andati**. |
+| the girls | Le ragazze sono **andate**. |
 
-Participle: **andato**.
+A woman therefore says **sono andata**, not *sono andato*. The ending agrees
+with the **subject**, in gender and number: *-o, -a, -i, -e*.
 
-*Andare* is itself suppletive, and you can see the seam right in that table:
+## Why agreement survives
 
-| stem | forms | from |
-|---|---|---|
-| **vad-** | vado, vai, va, **vanno** | Latin *vādere*, "to stride" |
-| **and-** | andiamo, andate, andare, andato | origin genuinely **disputed** — most likely *ambitāre*, "to go around" |
-
-Four present forms from the first stem, two from the second — plus the infinitive
-and the participle. Note that **vanno** goes with *vado*, not with *andiamo*:
-the split is **not** simply "singular versus plural."
-
-Two stems, one verb: the same trick as *essere*, in a smaller verb. Spanish does
-exactly this too — *voy* against *andar*.
-
-## The rule, and the agreement
-
-> **Verbs of motion and change of state take *essere*.**
-
-*andare* (go) · *venire* (come) · *arrivare* (arrive) · *partire* (leave) ·
-*entrare* · *uscire* (go out) · *nascere* (be born) · *morire* (die) ·
-*restare* (stay) · *diventare* (become) · *essere* · *stare*.
-
-And now the visible part:
-
-| | |
-|---|---|
-| Marco è **andato**. | Marco went. |
-| Anna è **andat*a***. | Anna went. |
-| I ragazzi sono **andat*i***. | The boys went. |
-| Le ragazze sono **andat*e***. | The girls went. |
-
-The participle takes the **subject's** gender and number — *-o, -a, -i, -e*, the
-same four endings as any Italian adjective. A woman says *sono andat**a***.
-
-**Why?** Because it *was* an adjective. *Anna è andata* began as a plain
-description — "Anna **is** gone-away," *gone* describing her state, the way
-*Anna è stanca* ("Anna is tired") describes her. It was never an action done to
-something else. So it agreed with her, and it still does.
-
-## Where the three languages landed
-
-| | auxiliary split | participle agrees? |
-|---|---|---|
-| **French** | *avoir* / *être* | **yes** — *elle est allé**e*** |
-| **Italian** | *avere* / *essere* | **yes** — *è andat**a*** |
-| **German** | *haben* / *sein* | **no** — *sie ist gegangen* |
-
-The same system, and the same motion/change-of-state line — but not all from one
-source. French and Italian **inherited** theirs together, as sisters. German
-arrived at the same line **in parallel**: a native Germanic development that grew
-up alongside the Romance ones through centuries of contact. And French and
-Italian kept the agreement; German dropped it.
+The participle began as an adjective: **Anna è andata** was “Anna is
+gone-away,” with *andata* describing Anna just as *stanca* (“tired”) would.
+French keeps the same agreement (*elle est allée*); German uses a similar
+auxiliary split but no agreement (*sie ist gegangen*). The systems developed
+alongside one another, but only the Romance sisters preserve this adjective
+fossil visibly.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "sono stato, sei stato, siamo stati"]
-- [YOU SAY: "vado, vai, va, andiamo, andate, vanno"]
-- [YOU SAY: the four endings — "andat**o**, andat**a**, andat**i**, andat**e**"]
-- [YOU SAY: the contrast — "ho parlato … **sono** andato"]
-- [YOU SAY: the reason — "**Anna is gone-away** — it describes **her**"]
+- [YOU SAY: “sono stato, sei stato, siamo stati”]
+- [YOU SAY: “sono andato” — then, as a woman, “sono andata”]
+- [YOU SAY: “andato, andata, andati, andate”]
+- [YOU SAY: the contrast — “ho parlato; sono andato”]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Which verbs take *essere*? (**Motion** and **change of state**.) Say
-"I have been." (*Sono stato*.) Give the present of *andare*. (*Vado, vai, va,
-andiamo, andate, vanno*.) A woman says "I went" — how? (*Sono andat**a***.) What
-does the participle agree with? (**The subject**, in gender and number.) Which of
-the three languages drops that agreement? (**German**.) Next chapter: describing
-what you see.
+[PAUSE 3s] Which auxiliary do many motion and change verbs take? (**Essere**.)
+What does the participle agree with? (**The subject**.) Give all four endings.
+(***-o, -a, -i, -e***.) How does a woman say “I went”? (**Sono andata**.) Why
+does agreement survive? (The participle began as an **adjective**.)

--- a/code/learning/human-languages/italian/lessons/IT-C17-mano.md
+++ b/code/learning/human-languages/italian/lessons/IT-C17-mano.md
@@ -9,7 +9,7 @@ prerequisites: [IT-C17-testa, IT-C01-il-la-lo]
 sounds: [final-vowel, open-o]
 roots: [latin-manus]
 etymology_hook: "la mano is FEMININE while ending in -o, and plural le mani — because Latin manus was a fourth-declension feminine, a class whose nouns ended in -us like the masculines; the gender is two thousand years old and the ending is a fossil of a declension Italian no longer has"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [IT-C17-testa, IT-C01-il-la-lo]
 ---
 

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -15,8 +15,9 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
 - **Ch. 1 — Greetings**: ciao → buono → **il/la/lo** (gender) → giorno →
   **buongiorno** → sera/buonasera → notte/buonanotte → grazie → practice.
 - **Ch. 2 — "Come stai?"**: prego (← *pregare* "to pray") → come (← *quōmodo*) →
-  **stare** ("to be" from *stand* = Spanish *estar*; vs *essere*) → come stai /
-  sta / **va** (also *andare* "to go") → così così → practice. **Authored.**
+  **stare** ("to be" from *stand* = Spanish *estar*; vs *essere*) → informal
+  **come stai** → formal **come sta** → register-neutral **come va** (also
+  *andare* "to go") → così così → practice. **Authored.**
   *(Reordered ahead of introductions to widen the cross-language how-are-you set;
   register tu/Lei introduced inline.)*
 - **Ch. 4 — Farewells**: arrivederci (← *a + rivedere + ci*, "to our re-seeing";
@@ -107,16 +108,16 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   Italian's solution to the Latin *esse*/*stāre* pair is the one **between** its
   sisters: it kept **both** verbs alive (unlike French, which kept *esse* as
   *être* and absorbed *stāre*'s whole *ét-* limb) but let them **share a
-  participle** — *essere*'s own didn't survive, so
-  it borrowed **stare**'s, and ***sono stato*** means both "I have **been**" and
+  participle** — a dedicated `IT-C16-essere-stato` step shows that *essere*'s
+  own didn't survive, so it borrowed **stare**'s, and ***sono stato*** means both "I have **been**" and
   "I have **stayed**". Plus the accent that separates *è* ("is") from *e* ("and")
-  → the ***passato prossimo* with *essere*** (`IT-C16-passato-prossimo-essere`):
-  starts from **`sono stato`** — an *essere*-past needing **zero new vocabulary**
-  — then introduces ***andare*** as a named new verb (itself suppletive:
+  → ***andare*** (`IT-C16-andare`) as its own named atom (itself suppletive:
   *vado/vai/va/**vanno*** ← *vādere* "stride" against *andiamo/andate/andare/
   andato*, whose origin is genuinely disputed — most likely *ambitāre*; note
   *vanno* files with *vado*, so the split is **not** singular-vs-plural — exactly
-  the trick behind Spanish *voy* against *andar*). The participle **agrees with
+  the trick behind Spanish *voy* against *andar*) → the ***passato prossimo*
+  with *essere*** (`IT-C16-passato-prossimo-essere`), starting from **`sono
+  stato`** with no new vocabulary. The participle **agrees with
   the subject** in all four
   endings (*andato/-a/-i/-e*), same adjective fossil as French. Closes the
   three-way table: French and Italian **keep** the agreement, German **drops**


### PR DESCRIPTION
## Summary

- remove all twenty Italian sub-five-minute duration violations
- correct seventeen declared budgets whose lesson bodies already compute below 300 seconds
- replace the three computed violations with four prerequisite-ordered micro-lessons:
  - informal `Come stai?` → formal `Come sta?` → register-neutral `Come va?`
  - `essere` forms → borrowed `stato` → `andare` → participle agreement
- preserve the original vocabulary, grammar, etymology, and cross-language comparisons instead of trimming content
- reprioritize Portuguese as the next duration tranche and log Italian's one-source publication and LaTeX hygiene debt

## Measured change

- Italian duration violations: **20 → 0**
- overall duration violations: **424 → 404**
- lessons: **985 → 989**
- unknown prerequisites: **0 → 0**
- new/rewritten micro-lessons: **175–248 computed seconds**
- tightest remaining Italian lessons: `IT-C02-practice` at **297s** and `IT-C17-mano` at **296s**

## Validation

- `npm run test:coverage` — 68 package tests, 93.60% line coverage
- `npm run build`
- `npm run validate` — 9 integration tests
- `npm run check:books`
- Language Ladder `npm run test:coverage` — 278 tests, 98.37% line coverage
- Language Ladder production build — 1,039 modules transformed
- forced Italian XeLaTeX build — 13-page PDF
- `git diff --check`

## Pre-existing book findings

The unchanged Italian book builds successfully but contains only Chapter 1 while canonical app lessons run through Chapter 17. The build also reports one underfull box and three Hyperref warnings. Those are recorded separately as HL-B14/HL-B15; this duration patch does not hand-copy or alter the book sources.