### PR TITLE
fix(spice): validate MOS lateral diffusion length

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject invalid Level-1 MOS model-card `LD` values that are negative,
+  non-finite, or leave a non-positive effective channel length.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `L` values
   before lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `W` values

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1989,6 +1989,20 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(lateral_diffusion_length) = params.get("LD") {
+            let length = params
+                .get("L")
+                .copied()
+                .unwrap_or_else(|| MosfetLevel1Params::default().l);
+            if !lateral_diffusion_length.is_finite()
+                || *lateral_diffusion_length < 0.0
+                || length - 2.0 * lateral_diffusion_length <= 0.0
+            {
+                return Err(NetlistParseError::new(
+                    "MOSFET LD must be finite and non-negative with L - 2*LD > 0",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2176,6 +2176,35 @@ fn preserves_positive_mosfet_model_length() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_lateral_diffusion_lengths() {
+    for params in ["LD=-1n", "LD=1e999", "L=100n LD=50n"] {
+        let error = parse_netlist(&format!(
+            ".model geometry NMOS({params})\nM1 d g s b geometry"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET LD must be finite and non-negative with L - 2*LD > 0"));
+    }
+}
+
+#[test]
+fn preserves_valid_mosfet_model_lateral_diffusion_lengths() {
+    for (lateral_diffusion_length, expected) in [("0", 0.0), ("10n", 10.0e-9)] {
+        let parsed = parse_netlist(&format!(
+            ".model geometry NMOS(L=180n LD={lateral_diffusion_length})\nM1 d g s b geometry"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.lateral_diffusion_length, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card length validation.
+1. Rust Berkeley SPICE MOS model-card lateral-diffusion-length validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite model-card `L` values before
-     lowering MOS elements into engine parameters.
-   - Preserve positive model lengths.
+   - Reject negative and non-finite model-card `LD` values, plus combinations
+     where `L - 2*LD <= 0`, before lowering MOS elements into engine parameters.
+   - Preserve valid zero and positive lateral-diffusion lengths.
 
 ## Completed Slices
 
@@ -4053,9 +4053,22 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Positive model widths remain accepted.
 
+356. Rust Berkeley SPICE MOS model-card length validation.
+   - Status: completed in PR 9538.
+   - Zero, negative, and non-finite model-card `L` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Positive model lengths remain accepted.
+
 ## Backlog
 
-1. Grammar-backed parser and app facade.
+1. Rust Berkeley SPICE MOS model-card validation follow-ups.
+   - Validate the remaining facade gaps in priority order: drain resistance
+     `RD`, source resistance `RS`, sheet resistance `RSH`, flicker-noise
+     coefficient `KF`, and flicker-noise exponent `AF`.
+   - Reuse the finite non-negative contracts and diagnostics already aligned
+     across the Rust, Python, and TypeScript engines.
+
+2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
@@ -4063,7 +4076,7 @@ the Rust, Python, and TypeScript surfaces together.
      toward packaging, WebAssembly embedding, and product integration backed by
      the same public parser contract.
 
-2. Deck compatibility follow-up.
+3. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis
      execution and stable artifact exports toward nested sweeps, raw-format
      interoperability, and remaining vendor-style output controls.
@@ -4074,7 +4087,7 @@ the Rust, Python, and TypeScript surfaces together.
      command routing, including control flow, variables, and script execution
      policy.
 
-3. Production solver core follow-up.
+4. Production solver core follow-up.
    - Sparse real/complex matrix paths now have cross-language native coverage,
      and Python real DC solves now use an optional SciPy sparse-LU backend with
      structured native fallback metadata.
@@ -4085,14 +4098,14 @@ the Rust, Python, and TypeScript surfaces together.
      damping, device limiting, tolerance policy, and additional convergence
      diagnostics for difficult transistor decks.
 
-4. Device model depth.
+5. Device model depth.
    - Audit diode, BJT, JFET, and MOS Level 1 behavior against reference decks.
    - Decide whether Level 2/3 MOS is in scope before BSIM; if BSIM lands, make
      Rust the first fast path and port stable semantics outward.
    - Expand temperature behavior, capacitance, noise, charge conservation, model
      card aliases, and error messages.
 
-5. Analysis completion.
+6. Analysis completion.
    - Generalize pole-zero beyond constrained fixture helpers.
    - Expand nonlinear distortion coverage.
    - Expand parsed `.FOUR` / `.MEASURE` integration across output plans and
@@ -4101,14 +4114,14 @@ the Rust, Python, and TypeScript surfaces together.
      Carlo trials.
    - Stabilize raw, CSV, JSON, and browser-friendly result formats.
 
-6. Mixed-signal integration.
+7. Mixed-signal integration.
    - Connect SPICE transient stepping to the hardware VM scheduler.
    - Support bidirectional analog/digital thresholds, event scheduling,
      breakpoint coordination, and VCD correlation.
    - Keep mixed-signal coupling deterministic across Python, Rust, and
      TypeScript.
 
-7. Verilog-A and custom models.
+8. Verilog-A and custom models.
    - Specify the accepted model subset and residual/Jacobian hooks.
    - Add parser or compiler support with sandboxing for TypeScript/web usage.
    - Provide a Rust-native fast path for compiled models.


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `LD` values in the Rust Berkeley SPICE parser facade
- enforce the coupled effective-channel constraint `L - 2*LD > 0`
- preserve valid zero and positive lateral-diffusion lengths
- reconcile the plan after #9538 and prioritize newly confirmed `RD`, `RS`, `RSH`, `KF`, and `AF` facade gaps

## Scope
This is a Rust parser-facade boundary change. The shared Rust, Python, and TypeScript engines already enforce the same `LD` behavior and diagnostic.

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser` (150 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`