### PR TITLE
fix(spice): validate MOS drain resistance

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `RD` values before
+  lowering netlist elements into the engine.
 - Reject invalid Level-1 MOS model-card `LD` values that are negative,
   non-finite, or leave a non-positive effective channel length.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `L` values

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2003,6 +2003,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(drain_resistance) = params.get("RD") {
+            if !drain_resistance.is_finite() || *drain_resistance < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET RD must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2205,6 +2205,35 @@ fn preserves_valid_mosfet_model_lateral_diffusion_lengths() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_drain_resistances() {
+    for resistance in ["-1", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model parasitic NMOS(RD={resistance})\nM1 d g s b parasitic"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET RD must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_drain_resistance() {
+    for (resistance, expected) in [("0", 0.0), ("10", 10.0)] {
+        let parsed = parse_netlist(&format!(
+            ".model parasitic NMOS(RD={resistance})\nM1 d g s b parasitic"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.drain_resistance, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card lateral-diffusion-length validation.
+1. Rust Berkeley SPICE MOS model-card drain-resistance validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `LD` values, plus combinations
-     where `L - 2*LD <= 0`, before lowering MOS elements into engine parameters.
-   - Preserve valid zero and positive lateral-diffusion lengths.
+   - Reject negative and non-finite model-card `RD` values before lowering MOS
+     elements into engine parameters.
+   - Preserve zero and positive drain resistances.
 
 ## Completed Slices
 
@@ -4059,12 +4059,18 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Positive model lengths remain accepted.
 
+357. Rust Berkeley SPICE MOS model-card lateral-diffusion-length validation.
+   - Status: completed in PR 9541.
+   - Negative and non-finite model-card `LD` values, plus combinations where
+     `L - 2*LD <= 0`, are rejected before lowering MOS elements.
+   - Valid zero and positive lateral-diffusion lengths remain accepted.
+
 ## Backlog
 
 1. Rust Berkeley SPICE MOS model-card validation follow-ups.
-   - Validate the remaining facade gaps in priority order: drain resistance
-     `RD`, source resistance `RS`, sheet resistance `RSH`, flicker-noise
-     coefficient `KF`, and flicker-noise exponent `AF`.
+   - Validate the remaining facade gaps in priority order: source resistance
+     `RS`, sheet resistance `RSH`, flicker-noise coefficient `KF`, and
+     flicker-noise exponent `AF`.
    - Reuse the finite non-negative contracts and diagnostics already aligned
      across the Rust, Python, and TypeScript engines.
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `RD` values in the Rust Berkeley SPICE parser facade
- preserve zero and positive drain resistances
- reconcile the plan after #9541 and advance the prioritized facade backlog to `RS`

## Scope
This is a Rust parser-facade boundary change. The shared Rust, Python, and TypeScript engines already enforce the same `RD` behavior and diagnostic.

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser` (152 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`