### PR TITLE
Pin HTML conformance audit revisions

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- The conformance coverage report now pins the exact upstream WPT and
+  html5lib-tests commits, and the package owns an explicit prioritized backlog
+  and zero-debt completion boundary for future upstream drift.
 - Browser render-tree extraction can now accept the fetched document URL as
   the fallback base, including resolution of relative authored `<base href>`
   values, so Venture can fetch relative links and inline images after HTTP

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -1,0 +1,36 @@
+# HTML Parser Conformance Backlog
+
+Last audited: 2026-08-02
+
+## Completion Boundary
+
+The parser conformance loop is complete when a fresh audit against current WPT
+tree-construction resources and html5lib tokenizer tests reports:
+
+- zero missing WPT tree-construction signatures
+- zero missing html5lib tokenizer signatures
+- zero normalized tokenizer skips
+- all checked parser, lexer, fixture, formatting, and lint gates pass
+
+The checked `tests/fixtures/html5lib-coverage-audit.json` report records the
+exact upstream commits used for the latest completed audit.
+
+## Prioritized Queue
+
+There are no open conformance items. The 2026-08-02 audit covered all 1,934 WPT
+tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
+signatures and zero normalized skips.
+
+## Intake Order
+
+When a fresh upstream audit discovers work, add each bounded item here before
+starting the next pull request and prioritize it in this order:
+
+1. Missing executable WPT tree-construction cases.
+2. Missing or skipped html5lib tokenizer cases.
+3. Public DOM model gaps required by an upstream case.
+4. Audit, fixture, or documentation drift that weakens reproducibility.
+
+Keep one item per pull request. After each merge, rerun the upstream audit,
+record newly discovered items, reprioritize this queue, and select the highest
+remaining item.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -180,10 +180,15 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
 ```
 
 The audit also owns a checked `tests/fixtures/html5lib-coverage-audit.json`
-summary. Regenerate or verify that exact report with `--write-report` or
-`--check-report`. The Rust integration tests also parse that report and compare
-its local corpus counts against the checked tree-construction and tokenizer
-fixtures.
+summary. It records the exact WPT and html5lib-tests commits alongside corpus
+counts and missing source signatures, so the evidence is reproducible even
+when upstream changes without changing a case count. Regenerate or verify that
+exact report with `--write-report` or `--check-report`. The Rust integration
+tests also parse that report and compare its local corpus counts against the
+checked tree-construction and tokenizer fixtures.
+
+The prioritized completion queue and intake rules live in
+`CONFORMANCE-BACKLOG.md`.
 
 For sharper parser regression reporting, the generated
 `tests/fixtures/whatwg-tree-insertion-audit.json` fixture indexes the

--- a/code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
+++ b/code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -96,6 +97,7 @@ def main() -> int:
     report = {
         "tree_construction": {
             "upstream_source": upstream_tree_source,
+            "upstream_revision": git_revision(upstream_tree_path),
             "upstream_cases": len(upstream_tree),
             "local_cases": len(local_tree),
             "missing": len(missing_tree),
@@ -103,6 +105,7 @@ def main() -> int:
         },
         "tokenizer": {
             "upstream_source": "html5lib-tests/tokenizer",
+            "upstream_revision": git_revision(html5lib_root),
             "upstream_cases": len(upstream_tokenizer),
             "local_raw_cases": len(local_tokenizer),
             "missing": len(missing_tokenizer),
@@ -286,6 +289,21 @@ def resolve_upstream_tree_path(
         "Current html5lib-tests no longer contains tree-construction tests. "
         "Provide WPT via --wpt-root or WPT_ROOT."
     )
+
+
+def git_revision(path: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError) as error:
+        raise SystemExit(
+            f"{path} must be inside a Git checkout so the audit can pin its revision"
+        ) from error
+    return result.stdout.strip()
 
 
 def load_tree_cases(path: Path) -> list[TreeCase]:
@@ -511,6 +529,7 @@ def print_report(
     print("")
     print("tree-construction:")
     print(f"  upstream:       {upstream_tree_path}")
+    print(f"  revision:       {tree['upstream_revision']}")
     print(f"  upstream cases: {tree['upstream_cases']}")
     print(f"  local cases:    {tree['local_cases']}")
     print(f"  missing:        {tree['missing']}")
@@ -518,6 +537,7 @@ def print_report(
     print("")
     print("tokenizer:")
     print(f"  upstream:           {upstream_tokenizer_path}")
+    print(f"  revision:           {tokenizer['upstream_revision']}")
     print(f"  upstream cases:     {tokenizer['upstream_cases']}")
     print(f"  local raw cases:    {tokenizer['local_raw_cases']}")
     print(f"  missing:            {tokenizer['missing']}")

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -6,6 +6,7 @@
     "normalized_cases": 7242,
     "normalized_skipped": 0,
     "upstream_cases": 6806,
+    "upstream_revision": "224991ec10db04f056a89eed8b0bd8695fd2950e",
     "upstream_source": "html5lib-tests/tokenizer"
   },
   "tree_construction": {
@@ -13,6 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
+    "upstream_revision": "34174a4a37b1c0b8570fd816600191aaa7a5d7f7",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/test_html_conformance_coverage_audit.py
+++ b/code/packages/rust/html-parser/tests/fixtures/test_html_conformance_coverage_audit.py
@@ -7,11 +7,31 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from subprocess import run
 
 import audit_html5lib_coverage as audit
 
 
 class HtmlConformanceCoverageAuditTest(unittest.TestCase):
+    def test_resolves_revision_from_nested_checkout_path(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="html-conformance-audit-") as temp_dir:
+            root = Path(temp_dir)
+            nested = root / "html" / "syntax" / "parsing" / "resources"
+            nested.mkdir(parents=True)
+            run(["git", "init", "--quiet", str(root)], check=True)
+            run(["git", "-C", str(root), "config", "user.name", "Audit Test"], check=True)
+            run(
+                ["git", "-C", str(root), "config", "user.email", "audit@example.com"],
+                check=True,
+            )
+            (nested / "sample.dat").write_text("#data\n\n#errors\n#document\n")
+            run(["git", "-C", str(root), "add", "."], check=True)
+            run(["git", "-C", str(root), "commit", "--quiet", "-m", "fixture"], check=True)
+
+            revision = audit.git_revision(nested)
+
+            self.assertRegex(revision, r"^[0-9a-f]{40}$")
+
     def test_resolves_current_wpt_and_html5lib_layouts(self) -> None:
         with tempfile.TemporaryDirectory(prefix="html-conformance-audit-") as temp_dir:
             root = Path(temp_dir)

--- a/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
@@ -20,6 +20,7 @@ struct CoverageAudit {
 #[derive(Debug, Deserialize)]
 struct TreeConstructionAudit {
     upstream_source: String,
+    upstream_revision: String,
     upstream_cases: usize,
     local_cases: usize,
     missing: usize,
@@ -29,6 +30,7 @@ struct TreeConstructionAudit {
 #[derive(Debug, Deserialize)]
 struct TokenizerAudit {
     upstream_source: String,
+    upstream_revision: String,
     upstream_cases: usize,
     local_raw_cases: usize,
     missing: usize,
@@ -72,6 +74,14 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
         audit.tree_construction.upstream_source,
         "wpt/html/syntax/parsing/resources"
     );
+    assert_eq!(audit.tree_construction.upstream_revision.len(), 40);
+    assert!(
+        audit
+            .tree_construction
+            .upstream_revision
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    );
     assert_eq!(audit.tree_construction.upstream_cases, 1934);
     assert_eq!(audit.tree_construction.local_cases, tree_cases.len());
     assert_eq!(audit.tree_construction.local_cases, 2637);
@@ -106,6 +116,14 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
     );
 
     assert_eq!(audit.tokenizer.upstream_source, "html5lib-tests/tokenizer");
+    assert_eq!(audit.tokenizer.upstream_revision.len(), 40);
+    assert!(
+        audit
+            .tokenizer
+            .upstream_revision
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    );
     assert_eq!(audit.tokenizer.upstream_cases, 6806);
     assert_eq!(audit.tokenizer.local_raw_cases, raw_tokenizer.tests.len());
     assert_eq!(audit.tokenizer.local_raw_cases, 7015);


### PR DESCRIPTION
## Summary

- record exact WPT and html5lib-tests commit revisions in the checked conformance report
- verify revision discovery from nested checkout paths
- add an explicit prioritized conformance backlog and zero-debt completion boundary

## Why

The checked coverage report pinned corpus counts and missing signatures but could not identify the exact upstream snapshots that produced them. Current upstream remains fully covered, so this closes the remaining audit-provenance gap and gives future unattended runs a concrete intake order and stopping condition.

## Current upstream evidence

- WPT `34174a4a37b1c0b8570fd816600191aaa7a5d7f7`: 1,934 tree-construction cases, zero missing
- html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806 tokenizer cases, zero missing
- normalized tokenizer corpus: 7,242 cases, zero skips

## Validation

- Python coverage audit unit tests and live upstream report check
- parser and lexer fixture integrity checks
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `git diff --check`