### PR TITLE
Split Portuguese curriculum into sub-five-minute lessons

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Italian duration
-tranche: 20 registered tracks, 989 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Portuguese duration
+tranche: 20 registered tracks, 994 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -54,7 +54,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01E | Complete in the Sanskrit duration PR | Remove all ten sub-five-minute violations from the Sanskrit track. | The report measures zero Sanskrit violations; the 513-second anchor lesson is now three prerequisite-ordered micro-lessons. |
 | HL-D01F | Complete in the Bengali duration PR | Remove all eleven sub-five-minute violations from the Bengali track. | The report measures zero Bengali violations; all eleven lesson bodies remain unchanged because their computed durations were already below 300 seconds. |
 | HL-D01G | Complete in the Italian duration PR | Remove all twenty sub-five-minute violations from the Italian track. | The report measures zero Italian violations; four new prerequisite-ordered micro-lessons preserve the register, metaphor, suppletion, and agreement content that did not fit safely in the original lessons. |
-| HL-D01H | Next | Remove all twenty-three sub-five-minute violations from the Portuguese track. | Portuguese is now the smallest remaining set: eighteen declaration-only lessons and five genuinely computed violations, with a 565-second maximum. |
+| HL-D01H | Complete in the Portuguese duration PR | Remove all twenty-three sub-five-minute violations from the Portuguese track. | The report measures zero Portuguese violations; five new prerequisite-ordered micro-lessons preserve the register, suppletion, grammar-choice, and etymology content from the five computed violations. |
+| HL-D01I | Next | Remove all twenty-five sub-five-minute violations from the French track. | French is now the smallest remaining set: twenty-two declaration-only lessons and three genuinely computed violations, with a 489-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -69,6 +70,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B13 | Queued | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | A forced build succeeds but reports six missing glyphs, one overfull box, four underfull boxes, four duplicate practice labels, and 27 Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B14 | Queued | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Italian has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B15 | Queued | Remove Italian's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds but reports one underfull box and three Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B16 | Queued | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
+| HL-B17 | Queued | Remove Portuguese's LaTeX layout warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports three underfull boxes; the clean-build signal is zero. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -283,6 +286,29 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Portuguese's twenty-three violations are now the smallest remaining set.
   Eighteen are declaration-only and five genuinely compute above the limit,
   with a 565-second maximum, so HL-D01H is next.
+
+## Findings from HL-D01H
+
+- Portuguese now has zero duration violations. The corpus grows from 989 to 994
+  lessons and drops from 404 to 381 violations overall; unknown prerequisites
+  remain at zero.
+- Eighteen lessons needed only honest declared-budget corrections. Five new
+  prerequisite-ordered lessons preserve all of the longer content: verb-free
+  `Tudo bem?` → `Como vai? / Como está?` → casual practice → formal practice;
+  `ser` forms → its two-verb, three-stem history → the core `ser/estar` choice →
+  adjective meaning shifts; `cabeça` pronunciation → the `caput` doublet map.
+- The new and rewritten lessons compute between 143 and 236 seconds.
+  `PT-C17-mao` is the tightest remaining Portuguese lesson at 293 seconds and
+  should be watched during later copy edits.
+- The Portuguese PDF builds successfully at 13 pages but contains only Chapter
+  1 while canonical lessons run through Chapter 17. HL-B16 records the
+  schema-v2 migration and generated publication work for Chapters 2–17.
+- The build has no missing glyphs, overfull boxes, duplicate labels, or Hyperref
+  warnings, but reports three underfull boxes. HL-B17 records that pre-existing
+  clean-build debt.
+- French's twenty-five violations are now the smallest remaining set.
+  Twenty-two are declaration-only and three genuinely compute above the limit,
+  with a 489-second maximum, so HL-D01I is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,10 +1,23 @@
 # Changelog
 
+## Sub-five-minute remediation — 2026-08-02
+
+- Corrected eighteen declared five-minute estimates whose lesson bodies already
+  compute below 300 seconds.
+- Replaced five computed violations with five prerequisite-ordered support
+  lessons spanning question register, *ser* suppletion, *ser/estar* meaning,
+  and the inherited/re-borrowed *caput* pair.
+- Preserved the full vocabulary, grammar, etymology, and cross-language depth.
+  The shared report now measures zero Portuguese duration violations.
+- `PT-C17-mao` at 293 computed seconds is the tightest remaining Portuguese
+  lesson and should be watched during copy edits.
+
 ## Chapter 17 — The body: the head that stayed a head, and the *n* that dissolved
 
-- **Chapter 17 authored** (`PT-C17-cabeca`, `-mao`) — the **body**, the theme the
+- **Chapter 17 authored** (`PT-C17-cabeca`, `-cabeca-caput`, `-mao`) — the **body**, the theme the
   parallel-track roadmaps name next.
-- **a cabeça** (`PT-C17-cabeca`): the chapter's role in the four-way set is that
+- **a cabeça / the *caput* map** (`PT-C17-cabeca`, `-cabeca-caput`): the
+  chapter's role in the four-way set is that
   **Portuguese kept the Latin word**. *Cabeça* ← Late Latin *capitia* ← ***caput***,
   where French and Italian replaced "head" with a **pot** (*testa*) and German
   with a **cup** (*Kopf*) — independently of each other. The five-language table
@@ -34,10 +47,12 @@
 
 ## Chapter 16 — *ser* and *estar*: sitting against standing
 
-- **Chapter 16 authored** (`PT-C16-ser`, `-ser-vs-estar`). Portuguese had **no
+- **Chapter 16 authored** (`PT-C16-ser`, `-ser-roots`, `-ser-vs-estar`,
+  `-ser-estar-meaning`). Portuguese had **no
   "to be" lesson at all** — no *ser*, and *estar* only overheard inside Ch. 2's
   *Como está?*. This is the largest single gap in the track, now closed.
-- **ser** (`PT-C16-ser`): present, preterite and imperfect, and then why *sou*,
+- **ser / its roots** (`PT-C16-ser`, `-ser-roots`): present, preterite and
+  imperfect, and then why *sou*,
   *fui* and *era* have nothing in common — **two Latin verbs but three stems**:
   *esse* (for *sou/é/são* and for *era*), *esse*'s **own** ancient perfect
   ***fuī*** (PIE \**bʰuH-*, the root of English **be** and German **bin/bist**),
@@ -55,7 +70,8 @@
     way.) Framed as a **gift to the learner**: *ir*'s preterite needs no separate
     lesson — which is also why this chapter closes the set **without** the
     motion-verb lesson French and German required.
-- **ser vs estar** (`PT-C16-ser-vs-estar`): *estar*'s forms named at last, with
+- **ser vs estar / meaning shifts** (`PT-C16-ser-vs-estar`,
+  `-ser-estar-meaning`): *estar*'s forms named at last, with
   the spoken reductions (*tou bem*, *tá bem*) flagged as recognise-don't-write,
   and *tá bom* labelled as characteristically **Brazilian** (*tá bem* is heard in
   both) rather than left to imply that an otherwise European-leaning lesson says
@@ -328,7 +344,8 @@
 ## Chapter 2 — "Tudo bem?" (the how-are-you chapter)
 
 - **Chapter 2 authored** (`PT-C02-de-nada`, `-como`, `-tudo`, `-tudo-bem`,
-  `-mais-ou-menos`, `-practice`): the "how are you?" exchange, atom-first,
+  `-como-vai-esta`, `-mais-ou-menos`, `-practice`, `-formal-practice`): the
+  "how are you?" exchange, atom-first,
   reviewing Chapter 1. Fifth and final track in the PR's cross-language
   how-are-you set, reusing `STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`,
   `WORD-SOSO`. Reordered ahead of introductions to widen the set (register

--- a/code/learning/human-languages/portuguese/lessons/PT-C01-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [PT-C01-ola, PT-C01-bom-dia, PT-C01-tarde, PT-C01-noite, PT-C01-obrigado]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C01-ola, PT-C01-bom, PT-C01-o-a, PT-C01-dia, PT-C01-bom-dia, PT-C01-tarde, PT-C01-noite, PT-C01-obrigado]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-como-vai-esta.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-como-vai-esta.md
@@ -1,0 +1,55 @@
+---
+id: PT-C02-como-vai-esta
+chapter: 2
+type: phrase
+headword: Como vai? / Como está?
+gloss: how are you? — the “go” and “stand” versions
+concept_tag: PT-STATE-GO-AND-STAND
+prerequisites: [PT-C02-tudo-bem, PT-C02-como]
+sounds: [open-a]
+roots: [ire-latin, stare-latin]
+etymology_hook: "Como vai? pictures wellbeing as going; Como está? pictures it as standing"
+est_minutes: 4
+reviews_of: [PT-C02-tudo-bem, PT-C02-como]
+---
+
+# Como vai? / Como está? — go and stand
+
+## Warm-up
+
+[PAUSE 2s] **Tudo bem?** needs no verb. Portuguese also offers two familiar
+metaphors, using the **como** (“how”) you already know.
+
+| question | literally | verb |
+|---|---|---|
+| **Como vai?** | “How does it **go**?” | *ir*, to go |
+| **Como está?** | “How do you **stand**?” | *estar*, to be / stand |
+
+**Vai** comes from *ir*, whose Latin ancestor *īre* also sits inside English
+*exit* and *transit*. **Está** comes from Latin *stāre*, “to stand.”
+
+Portuguese therefore keeps both pictures:
+
+- the “go” family, like French and German;
+- the “stand” family, like Spanish and Italian.
+
+Italian also keeps both. You do not need those languages to speak Portuguese;
+the map simply makes the two metaphors memorable.
+
+**Tudo bem?** remains the easiest default because it skips the verb and register
+choice altogether.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the verb-free question — “Tudo bem?”]
+- [YOU SAY: the “go” question — “Como vai?”]
+- [YOU SAY: the “stand” question — “Como está?”]
+
+[REPEAT x2] “Tudo bem? — Como vai? — Como está?”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which question has no verb? (**Tudo bem?**) Which uses “go”?
+(**Como vai?**, from *ir*.) Which uses “stand”? (**Como está?**, from *estar*.)
+Portuguese keeps how many metaphors? (**Both**.) Next: the “more or less” answer.

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-formal-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-formal-practice.md
@@ -1,0 +1,49 @@
+---
+id: PT-C02-formal-practice
+chapter: 2
+type: practice-mix
+headword: Como está o senhor?
+gloss: a respectful how-are-you exchange
+concept_tag: PT-CH2-FORMAL-PRACTICE
+prerequisites: [PT-C02-practice, PT-C02-como-vai-esta]
+sounds: []
+roots: [senior-latin]
+est_minutes: 4
+reviews_of: [PT-C02-practice, PT-C02-como-vai-esta]
+---
+
+# Formal practice — Como está o senhor?
+
+## Warm-up
+
+[PAUSE 2s] The casual exchange is secure. Now replace ordinary *você* with the
+respectful title **o senhor** or **a senhora**.
+
+## The exchange
+
+> — Bom dia. **Como está o senhor?**
+> — **Bem, obrigado. E o senhor?**
+> — Tudo bem.
+
+For a woman, use **a senhora**. The words continue Latin *senior*, “older,” the
+same root as English **senior** and Spanish *señor*.
+
+The verb stays **está** because the title is grammatically third person: “How is
+the gentleman/lady?” That respectful grammar is already packed into the phrase;
+do not switch it to informal second-person *estás* here.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: to a man — “Como está o senhor?”]
+- [YOU SAY: to a woman — “Como está a senhora?”]
+- [YOU SAY: “Bem, obrigado. E o senhor?”]
+
+[REPEAT x2] “Como está o senhor? — Bem, obrigado.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which titles mean a respectful “you”? (**O senhor / a senhora**.)
+Which verb form follows them? (**Está**, third person.) Where does *senhor* come
+from? (Latin ***senior***, “older.”) You can now run the Chapter 2 exchange
+casually or formally.

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-practice.md
@@ -3,63 +3,51 @@ id: PT-C02-practice
 chapter: 2
 type: practice-mix
 headword: (practice)
-gloss: the full "Tudo bem?" exchange, casual and formal
+gloss: the casual Tudo bem? exchange
 concept_tag: CH2-PRACTICE
-prerequisites: [PT-C02-de-nada, PT-C02-como, PT-C02-tudo, PT-C02-tudo-bem, PT-C02-mais-ou-menos]
+prerequisites: [PT-C02-de-nada, PT-C02-como, PT-C02-tudo, PT-C02-tudo-bem, PT-C02-como-vai-esta, PT-C02-mais-ou-menos]
 sounds: []
 roots: []
-est_minutes: 5
-reviews_of: [PT-C02-de-nada, PT-C02-tudo-bem, PT-C02-mais-ou-menos, PT-C01-practice]
+est_minutes: 4
+reviews_of: [PT-C02-de-nada, PT-C02-tudo-bem, PT-C02-como-vai-esta, PT-C02-mais-ou-menos, PT-C01-practice]
 ---
 
-# Practice — "Tudo bem?", start to finish
+# Practice — Tudo bem?, start to finish
 
 ## Warm-up
 
-[PAUSE 2s] No new words. This chapter's atoms — *de nada, como, tudo, tudo bem?,
-mais ou menos* — assemble into a real exchange. It picks up from the Chapter 1
-greetings.
+[PAUSE 2s] No new words. Assemble the chapter’s atoms into one casual exchange
+before adding the formal version.
 
 ## The exchange
-
-**Casual** (anyone — the verb-free favourite):
 
 > — Olá! **Tudo bem?**
 > — **Tudo bem, e você?**
 > — **Mais ou menos.**
-> — [after a small favour] — Obrigado! — **De nada.**
+> — [after a small favour] Obrigado! — **De nada.**
 
-**A touch more formal** (with a verb):
+The glue is **e você?**, “and you?”: **e** continues Latin *et*, while *você*
+grew from the respectful title *vossa mercê*.
 
-> — Bom dia. **Como está o senhor?**
-> — **Bem, obrigado.** E o senhor?
-> — Tudo bem.
+## What you are retrieving
 
-The glue is **e você? / e o senhor?** — "and you?" (*e* = "and," Latin *et*), the
-Portuguese twin of Spanish *¿y usted?* and Italian *e Lei?*.
-
-## What you've built this chapter
-
-- **de nada** — you're welcome (← *nāta*, "born thing" → "nothing"; = Spanish).
-- **como** — how (← *quōmodo*; sibling of *cómo* / *come* / *comment*).
-- **tudo** — everything (← *tōtus*; English *total*), the heart of *Tudo bem?*.
-- **Tudo bem? / Como vai? / Como está?** — the verb-free, the "go," and the
-  "stand" questions.
-- **mais ou menos** — so-so (twin of Spanish *más o menos*).
+- **de nada** — “of nothing,” you’re welcome;
+- **tudo bem?** — the verb-free check-in;
+- **como vai? / como está?** — “go” and “stand” alternatives;
+- **mais ou menos** — “more or less,” so-so.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: the full *casual* exchange, both voices]
-- [YOU SAY: the more formal version with *Como está o senhor?*]
-- [YOU SAY: all three questions — Tudo bem? / Como vai? / Como está?]
+- [YOU SAY: the whole exchange, both voices]
+- [YOU SAY: answer with “Tudo bem”]
+- [YOU SAY: answer with “Mais ou menos”]
 
-[REPEAT x2] "Tudo bem? — Tudo bem, e você?" until it's reflex.
+[REPEAT x2] “Tudo bem? — Tudo bem, e você?”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Why is *Tudo bem?* the easiest greeting? (No pronoun or verb — skips
-register.) *Como vai?* vs *Como está?* — which metaphors? (Go, *ir*; stand,
-*estar*.) What does *de nada* literally say, and which language shares it
-exactly? ("Of nothing"; Spanish.) Next chapter: **introducing yourself** — meu
-nome é, como se chama.
+[PAUSE 3s] Run the casual exchange without looking. Which phrase answers a
+small favour? (**De nada**.) Which answer means “so-so”? (**Mais ou menos**.)
+Which question is safest before choosing a register? (**Tudo bem?**) Next:
+rebuild the exchange with **o senhor / a senhora**.

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-tudo-bem.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-tudo-bem.md
@@ -3,66 +3,57 @@ id: PT-C02-tudo-bem
 chapter: 2
 type: phrase
 headword: Tudo bem?
-gloss: how are you? (also Como vai? / Como está?)
+gloss: everything well? — the verb-free everyday “how are you?”
 concept_tag: STATE-HOW-ARE-YOU
 prerequisites: [PT-C02-tudo, PT-C02-como]
 sounds: [nasal-em]
-roots: [totus-latin, ire-latin, stare-latin]
-etymology_hook: "Tudo bem? = 'everything well?' (no verb); Como vai? (ir 'to go') / Como está? (estar 'to stand')"
+roots: [totus-latin]
+etymology_hook: "Tudo bem? literally asks 'everything well?' and needs neither a verb nor a pronoun"
 est_minutes: 4
 reviews_of: [PT-C02-tudo, PT-C02-como]
 ---
 
-# Tudo bem? — "how are you?", three ways
+# Tudo bem? — “everything well?”
 
 ## Warm-up
 
-[PAUSE 2s] Portuguese gives you three everyday ways to ask *how are you?* — one
-with no verb at all, one on "to go," one on "to stand." All three pieces are
-already yours.
+[PAUSE 2s] You know **tudo**, “everything.” Add **bem**, “well,” and Portuguese
+gives you an everyday check-in with no verb at all.
 
-## The three forms
+> **Tudo bem?** — “Everything well?” / “How are you?”
 
-| form | literally | verb |
-|---|---|---|
-| **Tudo bem?** (also *Tudo bom?*) | "everything well?" | *(none — tudo + bem)* |
-| **Como vai?** | "how do you **go**?" | *ir*, "to go" (vai = "goes") |
-| **Como está?** | "how are you / **stand**?" | *estar*, "to be/stand" |
+The friendly answer can be identical:
 
-- **Tudo bem?** is the friendly default — **no pronoun, no verb**, so it dodges
-  the register question entirely. Answer with the same words: *Tudo bem.*
-- **Como vai?** puts Portuguese with **French and German** (state as *going* —
-  *vai* is from **ir**, "to go," ← Latin *īre*, English *exit/transit*).
-- **Como está?** puts it with **Spanish and Italian** (state as *standing* —
-  *está* is from **estar**, ← Latin *stāre*). Portuguese, like Italian, does
-  **both.**
+> **Tudo bem.** — “Everything’s well.”
 
-## Grammar Lens: the "you" you're skipping
+Because the question contains no “you” and no verb, it avoids choosing a social
+register. That simplicity is exactly why it is everywhere.
 
-When you *do* want a pronoun, everyday Portuguese uses **você** ("you," worn down
-from *vossa mercê*, "your mercy" — the very same "your grace" origin as Spanish
-*usted*!). For respect, **o senhor / a senhora** ("the gentleman / the lady").
-But *Tudo bem?* lets you greet anyone without choosing — which is exactly why
-it's everywhere.
+## Add the listener only when useful
 
-## The full five-language map (this PR)
+To bounce the question back, say:
 
-- **Stand** (*estar/stare*): Spanish, Italian, Portuguese (*Como está?*)
-- **Go** (*aller/gehen/ir*): French, German, Portuguese (*Como vai?*), Italian (*Come va?*)
-- **Neither** — just "everything well?": Portuguese *Tudo bem?*
+> **Tudo bem, e você?** — “All well, and you?”
+
+Everyday **você** comes from *vossa mercê*, “your mercy.” Centuries of fast
+speech wore a respectful title into the ordinary pronoun “you,” much as Spanish
+*usted* grew from a form meaning “your grace.” For more explicit respect,
+Portuguese can use **o senhor / a senhora**, “the gentleman / the lady.”
+
+You do not need either pronoun for the basic pair: **Tudo bem? — Tudo bem.**
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "Tudo bem?" — the no-pronoun favourite]
-- [YOU SAY: "Como vai?" (go) and "Como está?" (stand)]
-- [YOU SAY: "Tudo bem? — Tudo bem, e você?" — bounce it back with *e você?*]
+- [YOU SAY: “Tudo bem?”]
+- [YOU SAY: the answer — “Tudo bem.”]
+- [YOU SAY: “Tudo bem, e você?”]
 
-[REPEAT x2] "Tudo bem? — Tudo bem!" question and answer, same two words.
+[REPEAT x2] “Tudo bem? — Tudo bem!”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Why is *Tudo bem?* so handy? (No pronoun/verb — skips the register
-choice.) *Como vai?* and *Como está?* use which two verbs, and which metaphors?
-(*ir* = go; *estar* = stand.) Where does *você* come from? (*vossa mercê*, "your
-mercy" — like Spanish *usted*.) Next: the so-so answer, **mais ou menos**.
+[PAUSE 3s] What does *Tudo bem?* literally ask? (“Everything well?”) Why can it
+fit almost any listener? (It has **no verb and no pronoun**.) How do you bounce
+it back? (**E você?**) Where did *você* come from? (*Vossa mercê*, “your
+mercy.”) Next: two questions that do use verbs.

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-falar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-falar.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C03-eu, PT-C02-como]
 sounds: [final-r, final-a-reduces]
 roots: [fabulari-latin]
 etymology_hook: "falar ← Latin fabulārī 'to chat' (← fābula 'story' → fable); Portuguese KEPT the f- where Spanish shifted f→h"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C03-practice, PT-C04-practice]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH5-PRACTICE
 prerequisites: [PT-C05-falar, PT-C05-morar, PT-C05-trabalhar, PT-C05-falo-portugues]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C05-falar, PT-C05-morar, PT-C05-trabalhar, PT-C05-falo-portugues, PT-C03-practice]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C06-numeros-6-10.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C06-numeros-6-10.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C06-numeros-1-5]
 sounds: [diphthong-oi, open-e]
 roots: [sex-septem-octo-latin]
 etymology_hook: "sete/oito/nove/dez ← septem/octō/novem/decem → setembro/outubro/novembro/dezembro; oito shows the Portuguese ct→it shift (octō→oito, like noite/noctem)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C06-numeros-1-5]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C07-dias-1.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C07-dias-1.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C06-numeros-1-5]
 sounds: [nasal-none, open-e]
 roots: [feria-latin, ordinals-latin]
 etymology_hook: "Portuguese is the ONLY Romance language to drop the pagan planet-gods: its weekdays are numbered 'feiras' — segunda-feira '2nd feast-day', built from the ordinals of the numbers you just learned"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C06-numeros-1-5, PT-C06-numeros-6-10]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C08-hora.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C08-hora.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C06-numeros-1-5]
 sounds: [silent-h, open-o]
 roots: [hora-latin, hora-greek]
 etymology_hook: "hora ← Latin hōra ← Greek hṓrā → hour; 'são duas horas' keeps 'horas' explicit and plural"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C06-numeros-1-5, PT-C07-dias-2]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C09-meses.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C09-meses.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C06-numeros-6-10, PT-C07-dias-1]
 sounds: [nasal-none, open-e]
 roots: [latin-months, roman-gods]
 etymology_hook: "janeiro←Januarius (Janus), março←Mars, julho←Julius Caesar; setembro–dezembro still mean Latin 7–10 (the numbers you learned)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C06-numeros-6-10, PT-C07-dias-1]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C10-irmaos.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C10-irmaos.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C10-pais]
 sounds: [nasal-ao, nasal-a]
 roots: [germanus-latin]
 etymology_hook: "the Iberian surprise: irmão/irmã come NOT from frater but from Latin germanus 'genuine, of the same parents' (frater germanus 'full brother') — the same word as 'germane' and the people-name 'German'; Spanish did the identical swap (hermano/hermana)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C10-pais, PT-C09-estacoes]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C10-pais.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C10-pais.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C09-estacoes, PT-C01-ola]
 sounds: [nasal-ae, diphthong-ai]
 roots: [pater-latin, mater-latin]
 etymology_hook: "Portuguese wore pater/māter down further than any sister — to one-syllable pai and nasal mãe (the intervocalic -t- vanished, pater→pae→pai); os pais means both 'the parents' and, literally, 'the fathers'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C09-estacoes, PT-C01-ola]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C11-agua-vinho.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C11-agua-vinho.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C11-pao]
 sounds: [nasal-none, nh-palatal]
 roots: [aqua-latin, vinum-latin]
 etymology_hook: "água kept aqua's body (where French wore it to eau); vinho ← vīnum, with Portuguese's signature -nh- (= Spanish ñ, French/Italian gn) → wine/vine/vinegar"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C11-pao, PT-C10-pais]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-11-15.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-11-15.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C06-numeros-6-10, PT-C11-agua-vinho]
 sounds: [nasal-on, z-voiced]
 roots: [latin-decim]
 etymology_hook: "onze…quinze ← ūndecim…quīndecim, the -ze a worn-down decem ('ten'); Portuguese keeps only FIVE fused teens — fewer than any sister — then rebuilds from 16 on"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C06-numeros-6-10, PT-C11-agua-vinho]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-16-20.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-16-20.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C12-numeros-11-15]
 sounds: [double-ss, nasal-in]
 roots: [latin-decem, viginti-latin]
 etymology_hook: "dezesseis = dez + e + seis, literally 'TEN AND SIX' — Portuguese rebuilt its upper teens from live words, keeping the 'and' (e) visible; it breaks at 16, earlier than any sister"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C12-numeros-11-15, PT-C06-numeros-6-10]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C13-preto-branco.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C13-preto-branco.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C12-numeros-16-20]
 sounds: [closed-e, nasal-an]
 roots: [latin-pressus, latin-niger, germanic-blank]
 etymology_hook: "Portuguese keeps TWO blacks — negro ← niger and everyday preto ← Latin pressus 'pressed, dense' (dense → dark); branco is Germanic *blank 'shining', and Latin albus survives in alvorada ('dawn')"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C12-numeros-16-20, PT-C11-pao-agua]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C13-vermelho-azul.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C13-vermelho-azul.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C13-preto-branco]
 sounds: [lh-palatal, final-l]
 roots: [latin-vermiculus, arabic-lazaward]
 etymology_hook: "vermelho ← vermiculus 'little worm' — the kermes insect crushed for scarlet dye (→ English vermilion), so PT alone doesn't use the ancient red root; azul ← Arabic lāzaward 'lapis lazuli' → English azure"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C13-preto-branco, PT-C12-numeros-16-20]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C14-ter.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C14-ter.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C13-vermelho-azul, PT-C05-falar]
 sounds: [nasal-em, circumflex-tem]
 roots: [latin-tenere]
 etymology_hook: "PT and ES alone use tenēre 'to HOLD' (→ tenant/retain/tenacious) for 'have', while French/Italian kept habēre; Portuguese does have haver ← habēre, but demoted it to an auxiliary — two verbs swapped jobs on the Iberian peninsula"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C13-vermelho-azul, PT-C05-falar, PT-C10-irmaos]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C15-preterito-perfeito.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C15-preterito-perfeito.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C14-ter, PT-C05-falar]
 sounds: [final-stress-ei, nasal-aram]
 roots: [latin-perfect]
 etymology_hook: "falei ← Vulgar Latin perfect **\*fabulāvī**, the direct inheritance — the SAME tense French exiled to literature (il parla), German pushed aside (sagte) and northern Italy dropped (parlò); Portuguese and Spanish, at the western edge, simply kept using it"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C14-ter, PT-C05-falar, PT-C05-trabalhar]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C15-tenho-falado.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C15-tenho-falado.md
@@ -9,7 +9,7 @@ prerequisites: [PT-C15-preterito-perfeito, PT-C14-ter]
 sounds: [nasal-am, participle-ado]
 roots: [latin-tenere-participle]
 etymology_hook: "Portuguese built the same have+participle machine as French and Italian, then gave it a DIFFERENT job: tenho falado means 'I have been speaking (repeatedly, lately)', not 'I spoke' — because the simple past falei never vacated the slot"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [PT-C15-preterito-perfeito, PT-C14-ter, PT-C05-falar]
 ---
 

--- a/code/learning/human-languages/portuguese/lessons/PT-C16-ser-estar-meaning.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C16-ser-estar-meaning.md
@@ -1,0 +1,62 @@
+---
+id: PT-C16-ser-estar-meaning
+chapter: 16
+type: grammar
+headword: é bonita / está bonita
+gloss: how changing ser to estar changes the adjective's meaning
+concept_tag: PT-BE-MEANING-SHIFT
+prerequisites: [PT-C16-ser-vs-estar]
+sounds: []
+roots: [latin-esse, latin-stare]
+etymology_hook: "the Iberian ser/estar split turns one adjective into a defining quality or a current impression"
+est_minutes: 4
+reviews_of: [PT-C16-ser-vs-estar]
+---
+
+# é bonita / está bonita — a choice you can use
+
+## Warm-up
+
+[PAUSE 2s] *Ser* and *estar* are not competing answers where one is always a
+mistake. With many adjectives, swapping the verb deliberately changes meaning.
+
+| with ser | with estar |
+|---|---|
+| Ela **é** bonita. — She is beautiful. | Ela **está** bonita. — She looks beautiful now. |
+| A sopa **é** boa. — It is a good soup. | A sopa **está** boa. — This bowl tastes good. |
+
+**Ser** presents the quality as part of what the subject is. **Estar** presents
+the quality as the current condition or impression. Context, not a mechanical
+“permanent” rule, decides what you mean.
+
+## The wider family
+
+Portuguese and Spanish maintain this full two-verb choice. Italian keeps
+*essere* and *stare* but lets them overlap differently; French has one *être*
+that absorbed old *stāre* pieces. German *sein* is a separate Germanic cousin.
+
+| language | broad result |
+|---|---|
+| Portuguese / Spanish | two verbs, chosen by meaning |
+| Italian | two verbs with overlap |
+| French | one fused verb |
+| German | one verb built from Germanic roots |
+
+The Romance rows started with the same Latin material and reorganised it in
+three ways. That is why the Portuguese choice is systematic but not universal.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “Ela é bonita” — a quality]
+- [YOU SAY: “Ela está bonita” — right now]
+- [YOU SAY: “A sopa é boa; a sopa está boa.”]
+
+[REPEAT x2] “Ser: what it is. Estar: the condition it is in.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] What changes between *ela é bonita* and *ela está bonita*? (A
+defining quality versus a **current impression**.) Is *estar* automatically a
+mistake with *bonita*? (**No**; it says something different.) Which Romance
+languages keep the full two-verb choice? (**Portuguese and Spanish**.)

--- a/code/learning/human-languages/portuguese/lessons/PT-C16-ser-roots.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C16-ser-roots.md
@@ -1,0 +1,64 @@
+---
+id: PT-C16-ser-roots
+chapter: 16
+type: etymology
+headword: sou / era / fui / ser
+gloss: two Latin verbs and three stems inside ser
+concept_tag: PT-SER-SUPPLETION
+prerequisites: [PT-C16-ser]
+sounds: [open-e]
+roots: [latin-esse, latin-sedere, latin-fui]
+etymology_hook: "ser uses esse for sou/era, sedere 'sit' for the infinitive, and esse's ancient fui perfect; ir later borrowed that whole perfect"
+est_minutes: 4
+reviews_of: [PT-C16-ser, PT-C15-preterito-perfeito]
+---
+
+# ser — two verbs, three stems
+
+## Warm-up
+
+[PAUSE 2s] **Sou, era, fui, ser** do not resemble one another because the
+modern verb preserves several older roots.
+
+| Portuguese | source |
+|---|---|
+| **sou, és, é, somos, são** | Latin *esse*, “to be” |
+| **era, éramos, eram** | *esse*’s imperfect |
+| **fui, foi, foram** | *esse*’s ancient perfect *fuī* |
+| infinitive **ser** | Latin *sedēre*, “to sit” |
+
+That is **two Latin verbs** but **three stems**: *esse* was already suppletive,
+using both its ordinary root and the older *fuī* perfect. *Sedēre* also gave
+English **sedentary** and **session**.
+
+## fui means “was” and “went”
+
+The entire preterite is shared with **ir**, “to go”:
+
+| person | ser | ir |
+|---|---|---|
+| eu | **fui** | **fui** |
+| tu | **foste** | **foste** |
+| ele | **foi** | **foi** |
+| nós | **fomos** | **fomos** |
+| eles | **foram** | **foram** |
+
+**Fui professor** means “I was a teacher”; **fui ao Brasil** means “I went to
+Brazil.” What follows disambiguates them. *Fuī* already belonged to *ser*’s
+ancestor; **ir** borrowed the row after Latin *īre*’s own perfect wore away.
+Spanish made the same Iberian choice.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “ser ← sedēre, to sit”]
+- [YOU SAY: “sou / era ← esse”]
+- [YOU SAY: “fui professor; fui ao Brasil”]
+
+[REPEAT x2] “Two verbs, three stems; *fui* has two meanings.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which Latin verb gives the infinitive? (***Sedēre**, “sit.”*) Which
+gives *sou* and *era*? (***Esse**.) What two verbs share *fui*? (**Ser** and
+**ir**.) Which borrowed it? (**Ir**.) Next: put *ser* beside *estar*.

--- a/code/learning/human-languages/portuguese/lessons/PT-C16-ser-vs-estar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C16-ser-vs-estar.md
@@ -3,25 +3,22 @@ id: PT-C16-ser-vs-estar
 chapter: 16
 type: phrase
 headword: ser vs. estar
-gloss: "the two 'to be' verbs — essence against state, with a sit/stand mnemonic alongside them"
+gloss: identity or nature against location or resulting condition
 concept_tag: PT-BE-CONTRAST
-prerequisites: [PT-C16-ser, PT-C02-tudo-bem, PT-C05-morar]
+prerequisites: [PT-C16-ser-roots, PT-C02-como-vai-esta, PT-C05-morar]
 sounds: [nasal-ao, unstressed-vowel-reduction]
 roots: [latin-sedere, latin-stare]
-etymology_hook: "the two verbs are literally SITTING and STANDING — ser ← sedēre 'to sit', estar ← stāre 'to stand' — and although the essence/state meaning actually comes from esse vs stāre rather than from sitting itself, the sit/stand image is a mnemonic that predicts the right verb remarkably often"
-est_minutes: 6
-reviews_of: [PT-C16-ser, PT-C02-tudo-bem, PT-C09-estacoes]
+etymology_hook: "ser's sit and estar's stand origins make a useful mnemonic, though esse versus stare caused the meaning split"
+est_minutes: 4
+reviews_of: [PT-C16-ser-roots, PT-C02-como-vai-esta, PT-C09-estacoes]
 ---
 
-# ser vs. estar
+# ser vs. estar — the core choice
 
 ## Warm-up
 
-[PAUSE 2s] You have heard *estar* since Chapter 2 without being told its name —
-*Como **está**?*, "How are you?" Now meet it properly, and learn the choice that
-Portuguese makes every time it says "is."
-
-## estar — the forms
+[PAUSE 2s] Chapter 2 used **Como está?** Now learn *estar*’s forms and make the
+basic choice between Portuguese’s two verbs for “to be.”
 
 | | |
 |---|---|
@@ -29,112 +26,44 @@ Portuguese makes every time it says "is."
 | tu **estás** | ~~vós **estais**~~ |
 | ele/ela/você **está** | eles/elas/vocês **estão** |
 
-Same note as last lesson: *vós estais* is struck through because *vós* is dead
-outside northern dialect and church language. Say **vocês estão**.
+Say **vocês estão** in ordinary speech. You may hear shortened *tou* and *tá*;
+recognise them, but write the full forms.
 
-In speech the first syllable often vanishes: *tou bem*, *tá bem*. Recognise it;
-write the full form. (*Tá bom* is characteristically **Brazilian**; *tá bem* is
-heard in both.)
+## What something is; how it is
 
-## The choice
-
-> ***ser*** = what something **is**.  ***estar*** = how something **is right now**.
+> **ser** = what something is
+> **estar** = its location or the condition it is in
 
 | ser | estar |
 |---|---|
 | Ele **é** médico. — He is a doctor. | Ele **está** doente. — He is ill. |
-| **Sou** português. — I'm Portuguese. | **Estou** em Lisboa. — I'm in Lisbon. |
+| **Sou** português. — I’m Portuguese. | **Estou** em Lisboa. — I’m in Lisbon. |
 | A neve **é** branca. — Snow is white. | O café **está** frio. — The coffee is cold. |
-| **É** uma hora. — It's one o'clock. | **Está** frio hoje. — It's cold today. |
 
-Identity, origin, profession, permanent qualities, telling the time → **ser**.
-Location, health, mood, weather, and anything that could be different tomorrow →
-**estar**.
+Identity, origin, profession, and defining qualities use **ser**. Location,
+health, mood, weather, and resulting conditions use **estar**.
 
-One famous counterexample, so you don't over-trust "temporary": ***ele está
-morto***, "he is dead" — *estar*, for the least temporary state there is. The
-better test is not permanence but whether you are naming **what a thing is** or
-**the condition it has ended up in**.
+Do not reduce this to “permanent versus temporary”: **ele está morto**, “he is
+dead,” uses *estar*. Death is not temporary; it is a condition someone has
+ended up in.
 
-## A metaphor that works
+## A mnemonic, not the cause
 
-Look at where the two verbs come from:
-
-| verb | ← Latin | literally |
-|---|---|---|
-| **ser** | *sedēre* (+ *esse*) | **to sit** |
-| **estar** | *stāre* | **to stand** |
-
-**Sitting** is settled, where you belong. **Standing** is a posture you are in at
-the moment — you were not standing an hour ago and may not be in a minute.
-
-When you hesitate, ask the physical question: *is this thing seated in what it
-is, or standing in a passing condition?* It gives the right answer most of the
-time.
-
-Be honest about what that is, though. It is a **mnemonic, not the cause**. The
-"essence" meaning on the *ser* side comes from ***esse***, not from sitting —
-*sedēre* mostly supplied **forms** (the infinitive, the future, the
-conditional), as the last lesson showed. What really drove the split was
-*stāre*'s own sense of *standing in a place, in a resulting condition*, pulling
-away from plain *esse*. The sit/stand picture is downstream of that, and it is
-useful precisely because it is downstream of it.
-
-## Same choice, one meaning apart
-
-Because the split is real, swapping the verb changes the sentence:
-
-| | |
-|---|---|
-| Ela **é** bonita. | She is beautiful. *(a quality she has)* |
-| Ela **está** bonita. | She looks beautiful. *(tonight, right now)* |
-| A sopa **é** boa. | The soup is good. *(this is a good soup)* |
-| A sopa **está** boa. | The soup tastes good. *(this bowl, today)* |
-
-Not a mistake to avoid — a distinction to use.
-
-## What the other three languages did
-
-You now have all four Chapter 16s, and they line up:
-
-| | verbs for "to be" | from |
-|---|---|---|
-| **Portuguese** | **ser** / **estar** — two, you choose | *sedēre* / *stāre* |
-| **Spanish** | **ser** / **estar** — two, you choose | *sedēre* / *stāre* |
-| **Italian** | **essere** / **stare** — two, but sharing the participle *stato* | *esse* / *stāre* |
-| **French** | **être** — one verb, having absorbed *stāre*'s *ét-* forms | *esse*, + a limb of *stāre* |
-| **German** | **sein** — one verb, from three PIE roots | \**h₁es-*, \**bʰuH-*, \**wes-* |
-
-Four Romance languages, **three** outcomes from the same two Latin verbs: Iberia
-**split** them, France **absorbed** one into the other, Italy kept **both and let
-them overlap**.
-
-German is a separate story: its three roots came down **directly** from
-Proto-Indo-European, not by way of Latin. Which is not to say they're strangers —
-\**h₁es-*, the root behind *ist* and *sind*, is exactly the root Latin's *esse*
-came from too. German and Latin are **cousins** here, not parent and child.
-
-What the whole row shows is that "to be" is the word every language builds out of
-spare parts.
+*Ser* contains forms from Latin *sedēre*, “sit”; *estar* continues *stāre*,
+“stand.” Picture **ser** as seated in identity and **estar** as standing in a
+condition. The history is a memory aid, not the cause: *esse* supplied *ser*’s
+identity meaning, while *stāre* pulled toward place and resulting state.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "estou, estás, está, estamos, **vocês estão**"]
-- [YOU SAY: "Sou português, mas estou em Lisboa"]
-- [YOU SAY: the mnemonic — "**ser** = to **sit**. **estar** = to **stand**."]
-- [YOU SAY: the counterexample — "ele **está** morto"]
-- [YOU SAY: the pair — "Ela **é** bonita … ela **está** bonita"]
+- [YOU SAY: “estou, estás, está, estamos, estão”]
+- [YOU SAY: “Sou português; estou em Lisboa.”]
+- [YOU SAY: “Ele é médico; ele está doente.”]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Give the present of *estar*. (*Estou, estás, está, estamos, estão* —
-*vocês estão*.) Which verb for "I'm a doctor"? (***Sou*** — a profession, an
-identity.) Which for "I'm in Lisbon"? (***Estou*** — a location.) What do the two
-verbs literally mean in Latin? (***Sedēre*** = to **sit**; ***stāre*** = to
-**stand**.) Is that the *reason* for the split? (**No — it's a mnemonic.** The
-essence sense comes from *esse*.) Which verb in "he is dead"? (***Está*** — so
-the test isn't really permanence.) What is the difference between *ela é bonita*
-and *ela está bonita*? (She **is** beautiful, versus she **looks** beautiful
-**right now**.) Which language absorbed one verb into the other? (**French** —
-*être*.) Next chapter: the **body**.
+[PAUSE 3s] Which verb names identity? (**Ser**.) Which marks location or a
+resulting condition? (**Estar**.) How do you say “I’m in Lisbon”? (**Estou em
+Lisboa**.) Why does “he is dead” use *estar*? (It is a **resulting condition**,
+so permanence is not the real test.) Next: use the choice to change meaning.

--- a/code/learning/human-languages/portuguese/lessons/PT-C16-ser.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C16-ser.md
@@ -3,25 +3,24 @@ id: PT-C16-ser
 chapter: 16
 type: word
 headword: ser
-gloss: to be (essence) — two Latin verbs and three stems, welded into one
+gloss: to be — present, imperfect, and preterite forms
 concept_tag: PT-VERB-BE
 prerequisites: [PT-C14-ter, PT-C15-preterito-perfeito]
 sounds: [nasal-ao, open-e]
-roots: [latin-esse, latin-sedere, latin-fui]
-etymology_hook: "ser draws on TWO Latin verbs — esse 'to be' (sou/é/são, era) and sedēre 'to SIT' (the infinitive ser) — plus esse's own ancient perfect stem fuī; and that perfect is shared outright with ir, so fui means both 'I was' and 'I went'"
-est_minutes: 5
+roots: [latin-esse]
+etymology_hook: "sou, era, and fui expose three historical stems inside the everyday verb ser"
+est_minutes: 4
 reviews_of: [PT-C14-ter, PT-C15-preterito-perfeito, PT-C05-falar]
 ---
 
-# ser — "to be"
+# ser — “to be”
 
 ## Warm-up
 
-[PAUSE 2s] Portuguese, like Spanish, has **two** verbs for "to be." This lesson
-is the first one, *ser*; the next lesson is the choice between them. Start with
-the forms.
+[PAUSE 2s] Portuguese has two verbs for “to be.” Begin with **ser**, used for
+identity and what something is; the choice against *estar* comes later.
 
-## The forms
+## Present
 
 | | |
 |---|---|
@@ -29,82 +28,34 @@ the forms.
 | tu **és** | ~~vós **sois**~~ |
 | ele/ela/você **é** | eles/elas/vocês **são** |
 
-*Tu és* is live European Portuguese, so learn it. **Vós** is not: outside northern
-dialect and church language it is dead in both Portugal and Brazil, and the
-living "you all" is **vocês**, which takes the *eles* form — *vocês **são***.
-This track will keep showing *vós* struck through so you can recognise it in an
-old text without practising it.
+*Tu és* is live in European Portuguese. **Vós** survives mainly in northern
+dialect and church language; everyday “you all” is **vocês**, with **são**.
 
-Preterite (Ch. 15's tense): eu **fui**, tu **foste**, ele **foi**, nós **fomos**,
-eles **foram**.
-Imperfect: eu **era**, ele **era**, nós **éramos**, eles **eram**.
+## Two past rows
 
-*Sou*, *fui*, *era* — three shapes with nothing in common. As usual, that is the
-signal that more than one source is hiding in here.
+Preterite, the completed past from Chapter 15:
 
-## Two Latin verbs, three stems
+> **fui, foste, foi, fomos, foram**
 
-| Portuguese | ← Latin |
-|---|---|
-| **sou, és, é, somos, são** | *esse* — "to be" (*sum, es, est, sumus, sunt*) |
-| **era, éramos, eram** | *esse* again, its imperfect (*eram, erat*) |
-| **fui, foi, foram** | ***fuī*** — *esse*'s own ancient perfect stem, from PIE \**bʰuH-* "grow, become" |
-| the infinitive **ser** | ***sedēre*** — "**to sit**" |
+Imperfect, for background or ongoing past:
 
-Count carefully: that is **two verbs** (*esse* and *sedēre*) but **three stems**,
-because *esse* itself was already suppletive in Latin — *sum* and *fuī* were
-different roots long before Portuguese existed.
+> **era, eras, era, éramos, eram**
 
-The infinitive is the surprise. *Ser* does not come from *esse* at all; it comes
-from the Latin verb for **sitting**. (*Sedēre* also gave English *sedentary* and
-*session*, and Portuguese *sede*, "seat, headquarters.")
-
-That \**bʰuH-* root under *fui* has relatives you may have met: it is the same
-root as English **be**, and as German **bin/bist** — one language put it in the
-past, another in the present.
-
-## fui = "I was" AND "I went"
-
-Now the fact worth remembering:
-
-| | ser | ir (to go) |
-|---|---|---|
-| eu | **fui** | **fui** |
-| tu | **foste** | **foste** |
-| ele | **foi** | **foi** |
-| nós | **fomos** | **fomos** |
-| eles | **foram** | **foram** |
-
-**Identical. The entire preterite.** *Fui ao Brasil* is "I **went** to Brazil";
-*fui professor* is "I **was** a teacher." Only what follows tells you which verb
-you heard.
-
-Why? Note that only **one** of the two verbs did any borrowing. *Fuī* was already
-*esse*'s own perfect in Latin — *ser* simply kept what it had. It was ***ir***
-that came in empty-handed: Latin *īre*'s own perfect (*iī*, *īvī*) had worn down
-to almost nothing, so *ir* took over the neighbouring verb's past wholesale.
-
-Spanish did exactly the same thing — Spanish *fui* is also both, taught in the
-Spanish track's Chapter 14 as a *pretérito fuerte*. A shared **Iberian**
-inheritance, not a Portuguese quirk.
-
-You never have to learn *ir*'s preterite. You already know it.
+The three anchors **sou — fui — era** look unrelated. That is a clue that
+several historical pieces have been welded together, which the next lesson will
+unpack. For now, retrieve each row as a usable pattern.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "sou, és, é, somos, **vocês são**"]
-- [YOU SAY: "Eu sou português" / "Ela é médica"]
-- [YOU SAY: "fui, foste, foi, fomos, foram"]
-- [YOU SAY: the double meaning — "**fui** professor … **fui** ao Brasil"]
-- [YOU SAY: the sitting verb — "ser ← ***sedēre***, to sit"]
+- [YOU SAY: “sou, és, é, somos, são”]
+- [YOU SAY: “Eu sou português. Ela é médica.”]
+- [YOU SAY: “fui, foste, foi, fomos, foram”]
+- [YOU SAY: “era, éramos, eram”]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Give the present of *ser*. (*Sou, és, é, somos, são* — and *vocês
-são*, not *vós sois*.) Which Latin verb gives the **infinitive** *ser*?
-(***Sedēre*** — "to **sit**".) Which gives *sou* and *são*? (*Esse*.) How many
-Latin **verbs**, and how many **stems**? (**Two** verbs, **three** stems — *esse*
-was already suppletive.) What two verbs share the preterite *fui*? (***Ser*** and
-***ir*** — the whole preterite is identical.) Which of them did the borrowing?
-(***Ir*** — *fuī* was *ser*'s all along.) Next: *ser* against *estar*.
+[PAUSE 3s] Give the present of *ser*. (**Sou, és, é, somos, são**.) Which form
+goes with *vocês*? (**São**.) Give the preterite row. (**Fui, foste, foi, fomos,
+foram**.) Which imperfect form means “I was”? (**Era**.) Next: why those rows
+look so different.

--- a/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca-caput.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca-caput.md
@@ -1,0 +1,62 @@
+---
+id: PT-C17-cabeca-caput
+chapter: 17
+type: etymology
+headword: cabeça / capital
+gloss: one inherited caput word and one learned re-borrowing
+concept_tag: PT-CAPUT-DOUBLETS
+prerequisites: [PT-C17-cabeca]
+sounds: [cedilla-s]
+roots: [latin-caput, latin-testa]
+etymology_hook: "cabeça inherited caput through everyday speech, while capital and capítulo later re-borrowed the same root from written Latin"
+est_minutes: 4
+reviews_of: [PT-C17-cabeca]
+---
+
+# cabeça / capital — one root, two arrivals
+
+## Warm-up
+
+[PAUSE 2s] **Cabeça** kept Latin *caput*, “head.” Other languages replaced that
+everyday word with containers, which makes the Portuguese survival visible.
+
+| language | “head” | older picture |
+|---|---|---|
+| Portuguese | **cabeça** | Latin *caput*, head |
+| Spanish | *cabeza* | Latin *caput*, head |
+| French | *tête* | Latin *testa*, pot |
+| Italian | *testa* | Latin *testa*, pot |
+| German | *Kopf* | Germanic “cup” word |
+
+French/Italian and German independently replaced “head” with a vessel. Iberian
+Romance kept *caput*. Portuguese still has **testa**, but narrowed it to
+“forehead” instead of the whole head.
+
+## The root returned in books
+
+The same *caput* later entered learned vocabulary again:
+
+- **capital** — the head city or head sum;
+- **capítulo** — a “little head” of a text;
+- **capitão** — the head of a company.
+
+Portuguese therefore holds a **doublet**: one word inherited through generations
+of speech (**cabeça**), another branch borrowed back from written Latin
+(**capital, capítulo, capitão**). One root can arrive twice and look different
+because each route changes it differently.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “cabeça — inherited”]
+- [YOU SAY: “capital — re-borrowed”]
+- [YOU SAY: “tête/testa: pot; Kopf: cup”]
+
+[REPEAT x2] “Cabeça and capital — two routes from *caput*.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which languages kept the *caput* head-word? (**Portuguese and
+Spanish**.) What did French, Italian, and German substitute? (**Container
+words**.) What is the doubling in *cabeça / capital*? (One **inherited**, one
+**re-borrowed**.) Next: the hand and the disappearing *n*.

--- a/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C17-cabeca.md
@@ -3,83 +3,57 @@ id: PT-C17-cabeca
 chapter: 17
 type: word
 headword: a cabeça
-gloss: the head — the one that kept the Latin word for head
+gloss: the head — feminine, with cedilla ç pronounced s
 concept_tag: PT-BODY-HEAD
 prerequisites: [PT-C01-o-a]
 sounds: [cedilla-s]
 roots: [latin-caput]
-etymology_hook: "where French and Italian replaced caput with a pot-word (tête, testa) and German with a cup-word (Kopf), Iberian Romance KEPT it: cabeça ← Late Latin capitia ← caput, so Portuguese and Spanish are the ones still calling the head a head"
+etymology_hook: "cabeça continues Late Latin capitia from caput, so Portuguese kept the older head-word"
 est_minutes: 4
 reviews_of: [PT-C01-o-a, PT-C09-meses]
 ---
 
-# a cabeça — "the head"
+# a cabeça — “the head”
 
 ## Warm-up
 
-[PAUSE 2s] Three of the languages in this course threw away the Latin word for
-"head" and replaced it with a **container**. Portuguese didn't.
+[PAUSE 2s] Learn one body word and one reading rule together.
 
-## The word
+> **a cabeça** — the head, feminine
 
-> **a cabeça** — the head. Feminine.
+## Read the cedilla
 
-The **ç** is the **cedilla**. It marks a *c* that is said **s** in front of *a*,
-*o* or *u* — where a plain *c* would be a hard **k**. So *cabeça* ends "-essa",
-not "-eka".
+The **ç** is a **cedilla**. It marks a *c* pronounced **s** before *a*, *o*, or
+*u*, where plain *c* would normally be hard **k**. So *cabeça* ends roughly
+“-essa,” not “-eka.”
 
-(The mark is a tiny **z** written under the letter: medieval scribes wrote *ç* as
-shorthand for *cz*. The Portuguese track has no handwriting chapters yet, so
-this is a reading note rather than something you have been taught to draw.)
+The mark began as a tiny **z** under the letter: medieval scribes used *ç* as
+shorthand for *cz*. Treat that as a recognition hook; this track has not yet
+asked you to write the mark by hand.
 
-## The word that survived
+## The inherited word
 
-**Cabeça** comes from Late Latin ***capitia***, from ***caput***, "head." So the
-Iberian languages are simply still saying the Latin word.
+**Cabeça** comes from Late Latin ***capitia***, built from ***caput***, “head.”
+Portuguese wore the word down in ordinary speech but kept the old root.
 
-Now put all five side by side, because this is the point of the chapter:
+A useful sentence is:
 
-| | "head" | from | literally |
-|---|---|---|---|
-| **Portuguese** | *cabeça* | *caput* | **head** |
-| **Spanish** | *cabeza* | *caput* | **head** |
-| French | *tête* | *testa* | a **pot** |
-| Italian | *testa* | *testa* | a **pot** |
-| German | *Kopf* | \**kuppaz* | a **cup** |
+> **Dói-me a cabeça.** — “My head hurts.” (European Portuguese)
 
-Three of the five replaced the word with a **vessel** — and French/Italian and
-German did it **independently**, from unrelated words. A head looks like a bowl
-in any language, and soldiers' slang is the same everywhere.
-
-Portuguese and Spanish didn't quite sit the joke out, though — they **narrowed** it. *Testa* is alive in Portuguese; it just means the **forehead** rather than the whole head.
-
-## caput is elsewhere too
-
-Even in Portuguese, *caput* turns up in its learned form:
-
-- **capital** (the head city, and the head sum of money)
-- **capítulo** (chapter — a "little head" of a text)
-- **capitão** (captain — the head of a company)
-
-So the same Latin root appears twice in the language: once worn down by everyday
-use into *cabeça*, and once borrowed back intact from written Latin as *capital*.
-That doubling — one inherited, one re-imported — is extremely common, and worth
-recognising when you see it.
+In Brazilian Portuguese you may hear **Minha cabeça está doendo**. Both begin
+with the same feminine noun **a cabeça**.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "a cabeça" — the **ç** is an **s**]
-- [YOU SAY: "dói-me a cabeça" — European; Brazil says "minha cabeça está doendo"]
-- [YOU SAY: the five-way — "cabeça, cabeza … tête, testa … Kopf"]
-- [YOU SAY: the doubling — "**cabeça** inherited, **capital** re-borrowed"]
+- [YOU SAY: “a cabeça” — make **ç** an **s**]
+- [YOU SAY: “Dói-me a cabeça.”]
+- [YOU SAY: “cabeça ← caput”]
+
+[REPEAT x2] “A cabeça — feminine; ç sounds s.”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Say "the head." (*A cabeça* — feminine.) What does the **ç** do?
-(Marks a **c** said as **s** before *a/o/u*.) Where is *cabeça* from? (Late Latin
-***capitia***, from ***caput*** — Portuguese kept the real word.) What did French,
-Italian and German do instead? (Replaced it with a **container** — *testa* a
-pot, *Kopf* a cup — and did so **independently**.) What is the doubling in
-*cabeça* / *capital*? (**One inherited** and worn down, **one re-borrowed**
-intact from written Latin.) Next: the hand.
+[PAUSE 3s] Say “the head.” (**A cabeça**.) What does the cedilla do? (Marks *c*
+as **s** before *a/o/u*.) What is the Latin root? (***Caput***.) Next: compare
+the head-words and find that root a second time in learned vocabulary.

--- a/code/learning/human-languages/portuguese/lessons/PT-C17-mao.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C17-mao.md
@@ -5,12 +5,12 @@ type: word
 headword: a mão
 gloss: the hand — feminine, and a showcase of the -ão ending that swallowed three Latin endings
 concept_tag: PT-BODY-HAND
-prerequisites: [PT-C17-cabeca, PT-C01-o-a]
+prerequisites: [PT-C17-cabeca-caput, PT-C01-o-a]
 sounds: [nasal-ao, til]
 roots: [latin-manus]
 etymology_hook: "mão ← manus: the -n- between vowels DISSOLVED (a regular Portuguese change, cf. lua ← luna, boa ← bona) nasalising the vowel — nasality the til records in mão/pão but which faded again in lua/boa; and like Italian mano it stays FEMININE, because manus was a fourth-declension feminine"
-est_minutes: 5
-reviews_of: [PT-C17-cabeca, PT-C11-pao]
+est_minutes: 4
+reviews_of: [PT-C17-cabeca, PT-C17-cabeca-caput, PT-C11-pao]
 ---
 
 # a mão — "the hand"

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -16,8 +16,9 @@ French.
 - **Ch. 1 — Greetings**: olá → bom/boa → **o/a** (gender) → dia → **bom dia** →
   tarde/boa tarde → noite/boa noite → obrigado/obrigada → practice.
 - **Ch. 2 — "Tudo bem?"**: de nada (← *nāta*) → como (← *quōmodo*) → **tudo**
-  (← *tōtus* "whole") → tudo bem? / como vai? (*ir*, go) / como está? (*estar*,
-  stand) → mais ou menos → practice. **Authored** — the verb-free *Tudo bem?* is
+  (← *tōtus* "whole") → verb-free **tudo bem?** → **como vai? / como está?**
+  (*ir*, go / *estar*, stand) → mais ou menos → casual practice → formal
+  practice. **Authored** — the verb-free *Tudo bem?* is
   the distinctive Portuguese move; reordered ahead of introductions, register
   você/o senhor inline.
 - **Ch. 4 — Farewells**: adeus (← *a Deus* "to God"; twin of *adiós/adieu/addio*)
@@ -112,7 +113,8 @@ French.
   Italian, but ***falei* never vacated the plain-past slot** — with no vacancy, the
   new construction drifted into an **iterative** job instead. Same parts, same era,
   different outcome, because of what was already in the way. (This is a very common English-speaker error in Portuguese.) **Authored.**
-- **Ch. 16 — *ser*, and *ser* against *estar***: ***ser*** (`PT-C16-ser`) — **two
+- **Ch. 16 — *ser*, and *ser* against *estar***: ***ser*** (`PT-C16-ser`) → its
+  suppletive roots (`PT-C16-ser-roots`) — **two
   Latin verbs, three stems**: *sou/é/são* and *era* ← ***esse***, the preterite
   *fui* ← ***fuī*** (*esse*'s **own** ancient perfect, already suppletive in
   Latin; PIE \**bʰuH-*, the root of English **be** and German **bin**), and the
@@ -123,7 +125,8 @@ French.
   shared **Iberian** inheritance (Spanish does the same, ES-C14), so *ir*'s
   preterite costs the learner **nothing**, which is why this chapter closes the
   set without the motion-verb lesson FR and GE needed → ***ser* vs *estar***
-  (`PT-C16-ser-vs-estar`): the split learners actually struggle with, with
+  (`PT-C16-ser-vs-estar`) → adjective meaning shifts
+  (`PT-C16-ser-estar-meaning`): the split learners actually struggle with, with
   *estar*'s forms finally named after fourteen chapters of hearing *Como
   **está**?* (Ch. 2). *Sedēre* "to **sit**" against *stāre* "to **stand**" is
   taught honestly as a **mnemonic, not the cause** — the essence sense comes from
@@ -137,7 +140,8 @@ French.
   \**h₁es-* is the root Latin's *esse* came from too: cousins, not descent). Both lessons strike through ***vós***, teaching *vocês são / vocês
   estão* as the living 2pl. **Authored.**
 - **Ch. 17 — The body: the head that stayed a head, and the *n* that dissolved**:
-  ***a cabeça*** (`PT-C17-cabeca`) — the one that **kept** the Latin word, ←
+  ***a cabeça*** (`PT-C17-cabeca`) → the *caput* doublet map
+  (`PT-C17-cabeca-caput`) — the one that **kept** the Latin word, ←
   Late Latin *capitia* ← ***caput***, where French and Italian replaced it with a
   **pot** (*tête*, *testa*) and German with a **cup** (*Kopf*), independently.
   The five-way table is the point: *cabeça*/*cabeza* still call the head a head;


### PR DESCRIPTION
## Summary

- remove all twenty-three Portuguese sub-five-minute duration violations
- correct eighteen declared budgets whose lesson bodies already compute below 300 seconds
- replace the five computed violations with five prerequisite-ordered micro-lessons:
  - verb-free `Tudo bem?` → `Como vai? / Como está?` → casual practice → formal practice
  - `ser` forms → its two-verb, three-stem history → core `ser/estar` choice → adjective meaning shifts
  - `cabeça` pronunciation → the inherited/re-borrowed `caput` map
- preserve the original vocabulary, grammar, register, etymology, and cross-language comparisons
- reprioritize French as the next duration tranche and log Portuguese's one-source publication and LaTeX hygiene debt

## Measured change

- Portuguese duration violations: **23 → 0**
- overall duration violations: **404 → 381**
- lessons: **989 → 994**
- unknown prerequisites: **0 → 0**
- new/rewritten micro-lessons: **143–236 computed seconds**
- tightest remaining Portuguese lesson: `PT-C17-mao` at **293s**

## Validation

- `npm run test:coverage` — 68 package tests, 93.60% line coverage
- `npm run build`
- `npm run validate` — 9 integration tests
- `npm run check:books`
- Language Ladder `npm run test:coverage` — 278 tests, 98.37% line coverage
- Language Ladder production build — 1,044 modules transformed
- forced Portuguese XeLaTeX build — 13-page PDF
- `git diff --check`

## Pre-existing book findings

The unchanged Portuguese book builds successfully but contains only Chapter 1 while canonical app lessons run through Chapter 17. The build reports three underfull boxes and no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings. Those are recorded separately as HL-B16/HL-B17; this duration patch does not hand-copy or alter the book sources.