### PR TITLE
fix(spice): validate MOS source resistance

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `RS` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `RD` values before
   lowering netlist elements into the engine.
 - Reject invalid Level-1 MOS model-card `LD` values that are negative,

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2010,6 +2010,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(source_resistance) = params.get("RS") {
+            if !source_resistance.is_finite() || *source_resistance < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET RS must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2234,6 +2234,35 @@ fn preserves_non_negative_mosfet_model_drain_resistance() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_source_resistances() {
+    for resistance in ["-1", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model parasitic NMOS(RS={resistance})\nM1 d g s b parasitic"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET RS must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_source_resistance() {
+    for (resistance, expected) in [("0", 0.0), ("20", 20.0)] {
+        let parsed = parse_netlist(&format!(
+            ".model parasitic NMOS(RS={resistance})\nM1 d g s b parasitic"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.source_resistance, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card drain-resistance validation.
+1. Rust Berkeley SPICE MOS model-card source-resistance validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `RD` values before lowering MOS
+   - Reject negative and non-finite model-card `RS` values before lowering MOS
      elements into engine parameters.
-   - Preserve zero and positive drain resistances.
+   - Preserve zero and positive source resistances.
 
 ## Completed Slices
 
@@ -4065,12 +4065,17 @@ the Rust, Python, and TypeScript surfaces together.
      `L - 2*LD <= 0`, are rejected before lowering MOS elements.
    - Valid zero and positive lateral-diffusion lengths remain accepted.
 
+358. Rust Berkeley SPICE MOS model-card drain-resistance validation.
+   - Status: completed in PR 9543.
+   - Negative and non-finite model-card `RD` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive drain resistances remain accepted.
+
 ## Backlog
 
 1. Rust Berkeley SPICE MOS model-card validation follow-ups.
-   - Validate the remaining facade gaps in priority order: source resistance
-     `RS`, sheet resistance `RSH`, flicker-noise coefficient `KF`, and
-     flicker-noise exponent `AF`.
+   - Validate the remaining facade gaps in priority order: sheet resistance
+     `RSH`, flicker-noise coefficient `KF`, and flicker-noise exponent `AF`.
    - Reuse the finite non-negative contracts and diagnostics already aligned
      across the Rust, Python, and TypeScript engines.
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `RS` values in the Rust Berkeley SPICE parser facade
- preserve zero and positive source resistances
- reconcile the plan after #9543 and advance the prioritized facade backlog to `RSH`

## Scope
This is a Rust parser-facade boundary change. The shared Rust, Python, and TypeScript engines already enforce the same `RS` behavior and diagnostic.

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser` (154 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`