### PR TITLE
fix(spice): validate MOS sheet resistance

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `RSH` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `RS` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `RD` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2017,6 +2017,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(sheet_resistance) = params.get("RSH") {
+            if !sheet_resistance.is_finite() || *sheet_resistance < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET RSH must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2263,6 +2263,35 @@ fn preserves_non_negative_mosfet_model_source_resistance() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_sheet_resistances() {
+    for resistance in ["-1", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model parasitic NMOS(RSH={resistance})\nM1 d g s b parasitic"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET RSH must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_sheet_resistance() {
+    for (resistance, expected) in [("0", 0.0), ("250", 250.0)] {
+        let parsed = parse_netlist(&format!(
+            ".model parasitic NMOS(RSH={resistance})\nM1 d g s b parasitic"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.sheet_resistance, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card source-resistance validation.
+1. Rust Berkeley SPICE MOS model-card sheet-resistance validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `RS` values before lowering MOS
+   - Reject negative and non-finite model-card `RSH` values before lowering MOS
      elements into engine parameters.
-   - Preserve zero and positive source resistances.
+   - Preserve zero and positive sheet resistances.
 
 ## Completed Slices
 
@@ -4071,11 +4071,17 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Zero and positive drain resistances remain accepted.
 
+359. Rust Berkeley SPICE MOS model-card source-resistance validation.
+   - Status: completed in PR 9547.
+   - Negative and non-finite model-card `RS` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive source resistances remain accepted.
+
 ## Backlog
 
 1. Rust Berkeley SPICE MOS model-card validation follow-ups.
-   - Validate the remaining facade gaps in priority order: sheet resistance
-     `RSH`, flicker-noise coefficient `KF`, and flicker-noise exponent `AF`.
+   - Validate the remaining facade gaps in priority order: flicker-noise
+     coefficient `KF`, then flicker-noise exponent `AF`.
    - Reuse the finite non-negative contracts and diagnostics already aligned
      across the Rust, Python, and TypeScript engines.
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `RSH` values in the Rust Berkeley SPICE parser facade
- preserve zero and positive sheet resistances
- reconcile the plan after #9547 and advance the prioritized facade backlog to `KF`

## Scope
This is a Rust parser-facade boundary change. The shared Rust, Python, and TypeScript engines already enforce the same `RSH` behavior and diagnostic.

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser` (156 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`