### PR TITLE
Split French curriculum into sub-five-minute lessons

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Portuguese duration
-tranche: 20 registered tracks, 994 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the French duration
+tranche: 20 registered tracks, 997 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -55,7 +55,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01F | Complete in the Bengali duration PR | Remove all eleven sub-five-minute violations from the Bengali track. | The report measures zero Bengali violations; all eleven lesson bodies remain unchanged because their computed durations were already below 300 seconds. |
 | HL-D01G | Complete in the Italian duration PR | Remove all twenty sub-five-minute violations from the Italian track. | The report measures zero Italian violations; four new prerequisite-ordered micro-lessons preserve the register, metaphor, suppletion, and agreement content that did not fit safely in the original lessons. |
 | HL-D01H | Complete in the Portuguese duration PR | Remove all twenty-three sub-five-minute violations from the Portuguese track. | The report measures zero Portuguese violations; five new prerequisite-ordered micro-lessons preserve the register, suppletion, grammar-choice, and etymology content from the five computed violations. |
-| HL-D01I | Next | Remove all twenty-five sub-five-minute violations from the French track. | French is now the smallest remaining set: twenty-two declaration-only lessons and three genuinely computed violations, with a 489-second maximum. |
+| HL-D01I | Complete in the French duration PR | Remove all twenty-five sub-five-minute violations from the French track. | The report measures zero French violations; three new prerequisite-ordered micro-lessons preserve register, suppletion, and pronominal-agreement depth. |
+| HL-D01J | Next | Remove all twenty-seven sub-five-minute violations from the German track. | German is now the smallest remaining set: twenty-two declaration-only lessons and five genuinely computed violations, with a 360-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -72,6 +73,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B15 | Queued | Remove Italian's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds but reports one underfull box and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B16 | Queued | Publish Portuguese Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Portuguese has canonical app content through Chapter 17, but its downloadable PDF contains only Chapter 1; schema-v2 migration plus generation should close that drift safely. |
 | HL-B17 | Queued | Remove Portuguese's LaTeX layout warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports three underfull boxes; the clean-build signal is zero. |
+| HL-B18 | Queued | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The French PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
+| HL-B19 | Queued | Remove French's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -309,6 +312,28 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - French's twenty-five violations are now the smallest remaining set.
   Twenty-two are declaration-only and three genuinely compute above the limit,
   with a 489-second maximum, so HL-D01I is next.
+
+## Findings from HL-D01I
+
+- French now has zero duration violations. The corpus grows from 994 to 997
+  lessons and drops from 381 to 356 violations overall; unknown prerequisites
+  remain at zero.
+- Twenty-two lessons needed only honest declared-budget corrections. Three new
+  prerequisite-ordered lessons preserve the longer content: neutral `Ça va?` →
+  explicit `tu/vous` register and liaison; `être` forms → its `es-/fu-/ét-`
+  roots; motion/change agreement → pronominal direct-object agreement.
+- The new and rewritten lessons compute between 147 and 244 seconds.
+  `FR-C03-practice` at 293 seconds and `FR-C15-passe-simple` at 291 are the
+  tightest remaining French lessons and should be watched during copy edits.
+- The French PDF builds successfully at 79 pages through Chapter 16 while
+  canonical lessons continue through Chapter 23. HL-B18 records the schema-v2
+  migration and generated publication work for Chapters 17–23.
+- The build has no missing glyphs or duplicate labels, but reports sixteen
+  overfull boxes, nine underfull boxes, and six Hyperref warnings. HL-B19 records
+  that pre-existing clean-build debt.
+- German's twenty-seven violations are now the smallest remaining set.
+  Twenty-two are declaration-only and five genuinely compute above the limit,
+  with a 360-second maximum, so HL-D01J is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Sub-five-minute remediation — 2026-08-02
+
+- Corrected twenty-two declared five- or six-minute estimates whose lesson
+  bodies already compute below 300 seconds.
+- Replaced three computed violations with three prerequisite-ordered support
+  lessons for explicit register/liaison, *être* suppletion, and pronominal past
+  agreement.
+- Preserved the vocabulary, grammar, etymology, exceptions, and cross-language
+  depth. The shared report now measures zero French duration violations.
+- `FR-C03-practice` at 293 computed seconds and `FR-C15-passe-simple` at 291 are
+  the tightest remaining French lessons and should be watched during copy edits.
+
 ## The book catches up -- Chapters 3-16 typeset
 
 The lessons had run ahead of the published artifact: 61 authored lessons through
@@ -64,11 +76,12 @@ English form (the Norse cognate is Tyr), so it now reads "the Germanic war-god"
 
 ## Chapter 16 — *être*, and the half of the past Chapter 15 couldn't reach
 
-- **Chapter 16 authored** (`FR-C16-etre`, `-passe-compose-etre`). Chapter 15
+- **Chapter 16 authored** (`FR-C16-etre`, `-etre-roots`,
+  `-passe-compose-etre`, `-pronominal-past`). Chapter 15
   could only teach the *avoir* half of the compound past, because ***être* was
   taught in no lesson of any track**. This chapter supplies it and closes the
   other half.
-- **être** (`FR-C16-etre`): the six present forms, presented honestly as
+- **être / its roots** (`FR-C16-etre`, `-etre-roots`): the six present forms, presented honestly as
   unpatternable, and then explained. *être* is **suppletive across three stems**:
   - *es-* — *suis/es/est/sommes/êtes/sont* **and the infinitive** *être*
     (← \**essere*), all from Latin ***esse***
@@ -86,7 +99,8 @@ English form (the Norse cognate is Tyr), so it now reads "the Germanic war-god"
     *être* (*rester* ← *re-stāre*, *coûter* ← *constāre*) — what it didn't do is
     survive as a **separate** "to be" the way *estar* did. Anchored to English
     *go/went* so "suppletion" names something the learner already does.
-- **passé composé with être** (`FR-C16-passe-compose-etre`): verbs of **motion
+- **passé composé with être / pronominal agreement**
+  (`FR-C16-passe-compose-etre`, `-pronominal-past`): verbs of **motion
   and change of state** take *être* — taught as a **shape** (going, coming, being
   born, dying) rather than a list to memorise — built on *aller* from Ch. 3,
   **plus all pronominal verbs**. Then the visible part: the participle **agrees
@@ -343,7 +357,8 @@ English form (the Norse cognate is Tyr), so it now reads "the Germanic war-god"
 ## Chapter 3 — "Comment ça va ?" (the parallel of Spanish Ch. 4)
 
 - **Chapter 3 authored** (`FR-C03-merci`, `-de-rien`, `-aller`,
-  `-comment-ca-va`, `-comme-ci-comme-ca`, `-practice`): the "how are you?"
+  `-comment-ca-va`, `-comment-registers`, `-comme-ci-comme-ca`, `-practice`):
+  the "how are you?"
   exchange, atom-first, reviewing Chapter 2 throughout. Built deliberately as the
   cross-language mirror of the Spanish Chapter 4 shipped in the same PR — same
   canonical concepts (`STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`, `WORD-SOSO`),

--- a/code/learning/human-languages/french/lessons/FR-C02-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [FR-C02-je-mappelle, FR-C02-comment-vous-appelez-vous, FR-C02-enchante]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C02-je, FR-C02-me, FR-C02-appeler, FR-C02-je-mappelle, FR-C02-tu-vous, FR-C02-comment, FR-C02-comment-vous-appelez-vous, FR-C02-enchante]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C03-comment-ca-va.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-comment-ca-va.md
@@ -3,67 +3,54 @@ id: FR-C03-comment-ca-va
 chapter: 3
 type: phrase
 headword: comment ça va ?
-gloss: how are you? (neutral); formal Comment allez-vous?
+gloss: how are you? — the neutral everyday question
 concept_tag: STATE-HOW-ARE-YOU
-prerequisites: [FR-C03-aller, FR-C02-comment, FR-C02-tu-vous]
+prerequisites: [FR-C03-aller, FR-C02-comment]
 sounds: [nasal-an]
 roots: [quomodo-latin, ecce-hoc-latin, ambulare-latin]
-etymology_hook: "comment (← quōmodo) + ça (← ecce hoc 'behold this') + va (aller) — 'how does this go?'"
+etymology_hook: "comment + ça + va literally asks 'how does this go?'"
 est_minutes: 4
-reviews_of: [FR-C03-aller, FR-C02-comment, FR-C02-tu-vous]
+reviews_of: [FR-C03-aller, FR-C02-comment]
 ---
 
-# comment ça va ? — "how are you?"
+# Comment ça va ? — “how are you?”
 
 ## Warm-up
 
-[PAUSE 2s] All three pieces are in your hands: **comment** ("how," Chapter 2),
-the **tu / vous** choice (Chapter 2), and **aller / ça va** (last lesson).
-Assemble the single most useful question in spoken French.
+[PAUSE 2s] You know **comment**, “how,” and **ça va**, “it goes.” Assemble the
+most useful neutral check-in in spoken French.
 
-## Review first (30 seconds)
+> **Comment ça va ?** — “How are you?”
+> literally: “How does this go?”
 
-[PAUSE 2s] No peeking:
+The even shorter **Ça va ?** is extremely common. Answer with the same words:
 
-- **comment** — "how," from Latin *quōmodo* ("in what manner") — the very same
-  root as Spanish *cómo*.
-- **tu** vs **vous** — the informal vs formal (or plural) "you." *tu* to a
-  friend; *vous* to a stranger, an elder, or a group.
+> **Ça va ? — Ça va.**
+> “How’s it going? — It’s going / I’m fine.”
 
-Got them? Assemble.
+## The pieces
 
-## The phrase, three registers
+- **comment** comes from Latin *quōmodo*, “in what manner”;
+- **ça** comes from *ecce hoc*, “behold this”;
+- **va** is the third-person form of **aller**, “to go.”
 
-French has a neat three-step ladder from casual to formal:
+French pictures wellbeing as **going**. Spanish uses a “standing” verb instead;
+the comparison is a memory hook, not a prerequisite.
 
-| register | question | literally |
-|---|---|---|
-| **casual / universal** | **Comment ça va ?** (or just *Ça va ?*) | "How does **it** go?" |
-| **informal, to one friend** | **Comment vas-tu ?** | "How go **you**?" |
-| **formal / plural** | **Comment allez-vous ?** | "How go **you** (vous)?" |
-
-- **ça** = "it / this," worn down from Latin **ecce hoc**, "behold this" — the
-  same *hoc* that gives Spanish *ça*-less cousins. *Ça va?* — "It goes?" — is the
-  one everyone actually says; you can answer it with the same two words: **Ça
-  va.** ("It goes." = "I'm fine.")
-- **allez** / **vas** are just the *vous* and *tu* forms of **aller** you
-  previewed.
-
-Note *comment*'s nasal ending (`nasal-an`): *ko-**mahn***, the *t* silent —
-until **liaison** glues it onto a vowel in *Comment_allez-vous* (*ko-mahn-ta-lay-VOO*).
+Pronounce *comment* roughly *ko-mahn*: the ending is nasal and the written *t*
+is silent in this neutral phrase.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "Ça va ?" — the two-word version everybody uses]
-- [YOU SAY: "Comment allez-vous ?" — formal, hear the *t* liaison]
-- [YOU SAY: for your boss, then your best friend — *vous* or *tu*?]
+- [YOU SAY: “Comment ça va ?”]
+- [YOU SAY: the shorter question — “Ça va ?”]
+- [YOU SAY: the pair — “Ça va ? — Ça va.”]
 
-[REPEAT x2] "Ça va ? — Ça va." Question and answer, same two words.
+[REPEAT x2] “Ça va ? — Ça va.”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] What does *Comment ça va?* literally ask? ("How does it *go*?") Which
-verb is *va* from, and how does that differ from Spanish's choice? (*aller*, "to
-go" — Spanish uses *estar*, "to stand.") Which form for a stranger — *vas-tu* or
-*allez-vous*? (*allez-vous*.) Next: the "so-so" answer.
+[PAUSE 3s] What does *Comment ça va ?* literally ask? (“How does it go?”) Which
+verb owns **va**? (**Aller**.) What is the shortest version? (**Ça va ?**) How
+can you answer it? (**Ça va.**) Next: choose *tu* or *vous* explicitly.

--- a/code/learning/human-languages/french/lessons/FR-C03-comment-registers.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-comment-registers.md
@@ -1,0 +1,57 @@
+---
+id: FR-C03-comment-registers
+chapter: 3
+type: grammar
+headword: Comment vas-tu ? / Comment allez-vous ?
+gloss: informal and formal how-are-you questions
+concept_tag: FR-STATE-REGISTER
+prerequisites: [FR-C03-comment-ca-va, FR-C02-tu-vous]
+sounds: [nasal-an, liaison]
+roots: [ambulare-latin]
+etymology_hook: "vas-tu and allez-vous are the tu and vous forms of aller placed around French question inversion"
+est_minutes: 4
+reviews_of: [FR-C03-comment-ca-va, FR-C02-tu-vous, FR-C03-aller]
+---
+
+# Comment vas-tu ? / Comment allez-vous ?
+
+## Warm-up
+
+[PAUSE 2s] **Comment ça va ?** avoids naming the listener. Now use the *tu /
+vous* choice you learned in Chapter 2.
+
+| listener | question |
+|---|---|
+| one friend, informal | **Comment vas-tu ?** |
+| stranger, elder, or group | **Comment allez-vous ?** |
+
+**Vas** and **allez** are forms of *aller*, “to go.” Formal writing and careful
+speech invert verb and pronoun: **allez-vous**, literally “go-you.”
+
+## Hear the liaison
+
+The final *t* of **comment** is normally silent. Before vowel-initial **allez**,
+liaison can carry it across:
+
+> **Comment allez-vous ?** — roughly *ko-mahn-ta-lay-voo*
+
+That linking sound is not an extra word; it is a normally silent consonant
+surfacing between two words.
+
+Use **Ça va ?** as the easy neutral default, **vas-tu** for a friend when you
+want explicit informality, and **allez-vous** for formal or plural address.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: to a friend — “Comment vas-tu ?”]
+- [YOU SAY: to a stranger — “Comment allez-vous ?”]
+- [YOU SAY: the neutral default — “Ça va ?”]
+
+[REPEAT x2] “Vas-tu — friend. Allez-vous — formal or plural.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which form addresses one friend? (**Comment vas-tu ?**) Which is
+formal or plural? (**Comment allez-vous ?**) What sound appears in the liaison?
+(The normally silent ***t*** of *comment*.) Next: the “so-so” answer.

--- a/code/learning/human-languages/french/lessons/FR-C03-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-practice.md
@@ -5,11 +5,11 @@ type: practice-mix
 headword: (practice)
 gloss: the full "how are you?" exchange, formal and informal
 concept_tag: CH3-PRACTICE
-prerequisites: [FR-C03-merci, FR-C03-de-rien, FR-C03-aller, FR-C03-comment-ca-va, FR-C03-comme-ci-comme-ca]
+prerequisites: [FR-C03-merci, FR-C03-de-rien, FR-C03-aller, FR-C03-comment-ca-va, FR-C03-comment-registers, FR-C03-comme-ci-comme-ca]
 sounds: []
 roots: []
-est_minutes: 5
-reviews_of: [FR-C03-merci, FR-C03-de-rien, FR-C03-comment-ca-va, FR-C03-comme-ci-comme-ca, FR-C02-practice]
+est_minutes: 4
+reviews_of: [FR-C03-merci, FR-C03-de-rien, FR-C03-comment-ca-va, FR-C03-comment-registers, FR-C03-comme-ci-comme-ca, FR-C02-practice]
 ---
 
 # Practice — "comment ça va ?", start to finish

--- a/code/learning/human-languages/french/lessons/FR-C04-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH4-PRACTICE
 prerequisites: [FR-C04-au-revoir, FR-C04-a-plus-tard, FR-C04-a-bientot, FR-C04-a-demain]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C04-au-revoir, FR-C04-a-plus-tard, FR-C04-a-bientot, FR-C04-a-demain, FR-C03-practice]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C05-parler.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-parler.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C02-je, FR-C02-tu-vous]
 sounds: [er-ending, r-uvular]
 roots: [parabolare-latin]
 etymology_hook: "parler ← Late Latin parabolāre 'to tell parables, to talk' (← parabola) → English parable, parole, palaver"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C03-comment-ca-va, FR-C02-practice]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C05-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH5-PRACTICE
 prerequisites: [FR-C05-parler, FR-C05-habiter, FR-C05-travailler, FR-C05-je-parle-francais]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C05-parler, FR-C05-habiter, FR-C05-travailler, FR-C05-je-parle-francais, FR-C03-practice]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C06-nombres-6-10.md
+++ b/code/learning/human-languages/french/lessons/FR-C06-nombres-6-10.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C06-nombres-1-5]
 sounds: [nasal-eu, final-consonant]
 roots: [sex-septem-octo-latin]
 etymology_hook: "sept/huit/neuf/dix ← septem/octō/novem/decem → septembre/octobre/novembre/décembre (= Spanish siete/ocho/nueve/diez)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C06-nombres-1-5]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C07-jours-1.md
+++ b/code/learning/human-languages/french/lessons/FR-C07-jours-1.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C06-nombres-6-10]
 sounds: [nasal-un, vowel-eu]
 roots: [dies-latin, planet-gods]
 etymology_hook: "the -di in lundi/mardi… is Latin diēs 'day'; each weekday is a Roman planet-god — lundi = lūnae diēs 'Moon's day', and English Tuesday names the SAME planet (Mars) via a Germanic god"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C06-nombres-6-10]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C08-heure.md
+++ b/code/learning/human-languages/french/lessons/FR-C08-heure.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C06-nombres-1-5]
 sounds: [silent-h, liaison-z]
 roots: [hora-latin, hora-greek]
 etymology_hook: "heure ← Latin hōra ← Greek hṓrā 'season, time of day' → English hour; 'il est deux heures' = 'it is two hours'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C06-nombres-1-5, FR-C07-jours-2]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C09-mois.md
+++ b/code/learning/human-languages/french/lessons/FR-C09-mois.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C06-nombres-6-10, FR-C07-jours-1]
 sounds: [nasal-an, silent-final]
 roots: [latin-months, roman-gods]
 etymology_hook: "the French months are Roman gods and emperors: janvier←Janus, mars←Mars (= mardi!); septembre–décembre still mean Latin 7–10 — not because Julius/Augustus added months, but because January/February were added centuries earlier"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C06-nombres-6-10, FR-C07-jours-1]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C10-parents.md
+++ b/code/learning/human-languages/french/lessons/FR-C10-parents.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C09-saisons, FR-C01-bonjour]
 sounds: [nasal-none, e-grave]
 roots: [pater-latin, mater-latin]
 etymology_hook: "père ← pater, mère ← mater — the same PIE *ph2tēr/*méh2tēr that split into English father/mother (Grimm's law p→f, t→th) and Latin paternal/maternal"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C09-saisons, FR-C01-bonjour]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C11-eau-vin.md
+++ b/code/learning/human-languages/french/lessons/FR-C11-eau-vin.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C11-pain]
 sounds: [o-eau, nasal-in]
 roots: [aqua-latin, vinum-latin]
 etymology_hook: "eau ← aqua — worn down so far almost nothing is left (aqua→eue→eau, just 'oh'); vin ← vīnum → wine, vine, vinegar, vintage; French drank the vowels out of aqua"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C11-pain, FR-C10-parents]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C12-nombres-11-16.md
+++ b/code/learning/human-languages/french/lessons/FR-C12-nombres-11-16.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C06-nombres-6-10, FR-C11-eau-vin]
 sounds: [nasal-on, z-voiced]
 roots: [latin-decim]
 etymology_hook: "onze…seize ← Latin ūndecim, duodecim … sēdecim — 'one-ten, two-ten … six-ten'; the -ze is a worn-down decem ('ten'), the same ten hiding in dix and décembre"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C06-nombres-6-10, FR-C11-eau-vin]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C12-nombres-17-20.md
+++ b/code/learning/human-languages/french/lessons/FR-C12-nombres-17-20.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C12-nombres-11-16]
 sounds: [liaison-t, nasal-in]
 roots: [latin-decim, viginti-latin]
 etymology_hook: "at 17 French abandons the Latin fusion and goes transparent: dix-sept = literally 'ten-seven' — you can watch the language change strategy mid-count; vingt ← vīgintī → English vigesimal"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C12-nombres-11-16, FR-C06-nombres-6-10]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C13-noir-blanc.md
+++ b/code/learning/human-languages/french/lessons/FR-C13-noir-blanc.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C12-nombres-17-20]
 sounds: [nasal-an, silent-c]
 roots: [latin-niger, germanic-blank]
 etymology_hook: "noir ← Latin niger, but blanc is NOT from Latin albus — it's Frankish *blank 'shining', borrowed INTO French, the reverse of the usual flow; albus survives only in aube ('dawn') and album"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C12-nombres-17-20, FR-C11-eau-vin]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C13-rouge-bleu.md
+++ b/code/learning/human-languages/french/lessons/FR-C13-rouge-bleu.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C13-noir-blanc]
 sounds: [uvular-r, vowel-eu]
 roots: [pie-rewdh, germanic-blao]
 etymology_hook: "rouge ← Latin rubeus, from the PIE root that also gave English red/ruby/rust — so rouge and red are cousins; bleu is a SECOND Germanic loan (*blāo), and English borrowed it back from French"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C13-noir-blanc, FR-C12-nombres-17-20]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C14-avoir.md
+++ b/code/learning/human-languages/french/lessons/FR-C14-avoir.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C13-rouge-bleu, FR-C05-habiter]
 sounds: [elision-j-ai, liaison]
 roots: [latin-habere]
 etymology_hook: "avoir ← Latin habēre — the SAME root as habiter from Ch.5 (habitāre was habēre's frequentative, 'to keep having a place'), and as English habit / inhabit / exhibit / prohibit; habeō wore all the way down to j'ai, one sound"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C13-rouge-bleu, FR-C05-habiter, FR-C05-parler]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C15-passe-compose.md
+++ b/code/learning/human-languages/french/lessons/FR-C15-passe-compose.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C14-avoir, FR-C05-parler]
 sounds: [participle-e-acute, silent-endings]
 roots: [latin-habere-participle]
 etymology_hook: "j'ai parlé was once literally 'I HAVE [a thing] spoken' — Latin habeō litterās scriptās, 'I have letters written', where the participle was an ADJECTIVE agreeing with the object; that lost meaning is exactly why the participle still agrees with a preceding object today"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C14-avoir, FR-C05-parler, FR-C05-travailler]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C15-passe-simple.md
+++ b/code/learning/human-languages/french/lessons/FR-C15-passe-simple.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C15-passe-compose]
 sounds: [silent-endings]
 roots: [latin-perfect]
 etymology_hook: "il parla ← Vulgar Latin perfect *parabolāvit — the DIRECT inheritance, exactly what Spanish habló and Portuguese falou still are in everyday speech; French, German and Italian all let a compound past push this simple past out of conversation and into literature"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C15-passe-compose, FR-C05-parler]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C16-etre-roots.md
+++ b/code/learning/human-languages/french/lessons/FR-C16-etre-roots.md
@@ -1,0 +1,59 @@
+---
+id: FR-C16-etre-roots
+chapter: 16
+type: etymology
+headword: suis / fus / étais
+gloss: three historical stems inside être
+concept_tag: FR-ETRE-SUPPLETION
+prerequisites: [FR-C16-etre]
+sounds: [circumflex]
+roots: [latin-esse, latin-stare, latin-fui]
+etymology_hook: "être uses esse in the present, fui in the passé simple, and stare 'stand' throughout its ét- forms"
+est_minutes: 4
+reviews_of: [FR-C16-etre, FR-C15-passe-simple]
+---
+
+# suis / fus / étais — three stems
+
+## Warm-up
+
+[PAUSE 2s] The present of *être* comes from Latin *esse*. Its other forms expose
+two more historical pieces.
+
+| French | source |
+|---|---|
+| **suis, es, est, sommes, êtes, sont** | Latin *esse*, “be” |
+| **fus, fut** | ancient perfect stem *fuī* |
+| **été, étant, étais, était** | Latin *stāre*, “stand” |
+
+Every *ét-* form comes from the standing verb: participle **été**, present
+participle **étant**, imperfect **étais / était**. A paradigm patched from
+different roots is **suppletive**, like English *go / went*.
+
+The *fu-* stem is related to the root of English **be**. The *ét-* limb is even
+more striking because Spanish kept the same *stāre* source as a separate verb,
+**estar**.
+
+| language | what happened to *esse* and *stāre* |
+|---|---|
+| Spanish | kept *ser* and *estar* separate |
+| French | kept *être* and absorbed a whole *ét-* limb |
+
+French also preserves *stāre* outside *être*, for example in **rester**, “stay.”
+But it no longer has a separate standing-based “to be.”
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “suis ← esse”]
+- [YOU SAY: “fus ← fuī”]
+- [YOU SAY: “été, étant, étais ← stāre”]
+
+[REPEAT x2] “Es-, fu-, ét-: three stems, one verb.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which root supplies the present? (***Esse***.) Which supplies *fus*?
+(***Fuī***.) Which supplies every *ét-* form? (***Stāre**, “stand.”*) What is
+such patching called? (**Suppletion**.) What did Spanish do differently? (Kept
+the two verbs **separate**.) Next: build the compound past with *être*.

--- a/code/learning/human-languages/french/lessons/FR-C16-etre.md
+++ b/code/learning/human-languages/french/lessons/FR-C16-etre.md
@@ -3,109 +3,60 @@ id: FR-C16-etre
 chapter: 16
 type: word
 headword: être
-gloss: to be — the most irregular verb in French, drawing on three separate Latin stems
+gloss: to be — the six present forms
 concept_tag: FR-VERB-BE
 prerequisites: [FR-C15-passe-simple, FR-C14-avoir]
 sounds: [nasal-on, circumflex]
-roots: [latin-esse, latin-stare, latin-fui]
-etymology_hook: "être is SUPPLETIVE across three stems — the present (suis/es/est) and the infinitive from Latin esse, the passé simple (je fus) from the old perfect stem fuī, and EVERY ét- form (été, étant, étais) from a different verb entirely, stāre 'to stand' — the very verb Spanish made into estar, so French absorbed a whole limb of what Spanish kept apart"
-est_minutes: 5
+roots: [latin-esse]
+etymology_hook: "the present forms of être continue Latin esse, among the oldest and most frequently worn word-shapes in French"
+est_minutes: 4
 reviews_of: [FR-C14-avoir, FR-C15-passe-simple, FR-C05-parler]
 ---
 
-# être — "to be"
+# être — “to be”
 
 ## Warm-up
 
-[PAUSE 2s] The other verb everything is built on. Chapter 14 gave you *avoir*;
-this is its partner — and it is the **most irregular verb in the language**, for
-a reason worth knowing.
+[PAUSE 2s] Chapter 14 gave you *avoir*, “to have.” Meet its partner **être**,
+the auxiliary and everyday verb “to be.”
 
-## The forms
+## The six forms
 
-| | | |
-|---|---|---|
-| je **suis** | nous **sommes** | |
-| tu **es** | vous **êtes** | |
-| il/elle **est** | ils/elles **sont** | |
-
-There is no pattern to find. Don't look for one — these are among the oldest
-word-shapes in Europe, worn smooth by three thousand years of daily use.
-
-## Three stems in a trench coat
-
-Line the forms up against Latin:
-
-| French | ← Latin |
+| | |
 |---|---|
-| je **suis** | *sum* — "I am" |
-| tu **es** | *es* |
-| il **est** | *est* |
-| nous **sommes** | *sumus* |
-| ils **sont** | *sunt* |
+| je **suis** | nous **sommes** |
+| tu **es** | vous **êtes** |
+| il/elle **est** | ils/elles **sont** |
 
-All from ***esse***, "to be" — and so is the infinitive:
+These forms are old and frequent, so sound change has worn away any neat modern
+pattern. Learn the row as a rhythm:
 
-| French | ← Latin |
-|---|---|
-| **être** | \**essere*, Vulgar Latin's remodelling of *esse* |
+> **suis, es, est — sommes, êtes, sont**
 
-Now the two pieces that come from somewhere else:
+Use the subject pronoun every time; unlike Spanish or Italian, French verb
+sounds often do not identify the person by themselves.
 
-| French | ← Latin |
-|---|---|
-| je **fus**, il **fut** (passé simple, Ch. 15) | ***fuī*** — an ancient perfect stem |
-| **été** (past participle) | ***stāre*** — "**to stand**" |
-| **étant** (present participle) | *stāre* again (*stantem*) |
-| j'**étais**, il **était** (imperfect) | *stāre* again (*stābam*) |
+Examples:
 
-*Fus* and *été* are not related to *suis* at all. The first is an ancient perfect
-stem (from PIE \**bʰuH-*, "grow, become" — the source of English **be**); the
-second is the Latin verb for **standing**.
+- **Je suis français.** — I am French.
+- **Elle est fatiguée.** — She is tired.
+- **Nous sommes prêts.** — We are ready.
 
-And look how much of *stāre* is in there. It isn't one stray form: **every
-French *être* form beginning *ét-*** comes from the standing verb — *été*,
-*étant*, *étais*, *était*. A whole limb of the verb.
-
-Three stems, then: *es-* for the present and infinitive, *fu-* for the passé
-simple, *ét-* for the participles and the imperfect. That patching is called **suppletion** — one
-verb's paradigm filled in with pieces of another, exactly like English *go /
-went* (where *went* was stolen from *wend*).
-
-## The Spanish connection
-
-***Stāre*** should look familiar. It is the verb Spanish turned into **estar**,
-its second "to be" (taught in Ch. 4 of the Spanish track, and contrasted with
-*ser* in Ch. 9). So:
-
-| | *esse* | *stāre* |
-|---|---|---|
-| Spanish | **ser** | **estar** — kept as two separate verbs |
-| French | **être** ← *esse*, having **absorbed** *stāre*'s whole *ét-* limb | |
-
-Spanish kept the two verbs **apart** and made you choose between them. French
-kept one verb and **swallowed a large piece of the other**. Same two Latin
-sources, opposite solutions.
-
-(*Stāre* also left French words outside *être* — *rester* ← *re-stāre*, "to
-stay", and *coûter* ← *constāre*. What it did **not** do is survive as a separate
-"to be" the way *estar* did.)
+The present forms continue Latin ***esse***, “to be”: *suis* beside *sum*, *est*
+beside *est*, *sommes* beside *sumus*, and *sont* beside *sunt*. Other tenses
+draw on different roots; the next micro-lesson maps those seams.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "je suis, tu es, il est, nous sommes, vous êtes, ils sont"]
-- [YOU SAY: "Je suis français" / "Je suis fatigué"]
-- [YOU SAY: the seam — "suis ← *sum* … fus ← *fuī* … **ét-** ← ***stāre***"]
-- [YOU SAY: the English parallel — "go / went"]
+- [YOU SAY: “je suis, tu es, il est”]
+- [YOU SAY: “nous sommes, vous êtes, ils sont”]
+- [YOU SAY: “Je suis français. Elle est fatiguée.”]
+
+[REPEAT x2] “Suis, es, est — sommes, êtes, sont.”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Give the six forms of *être*. (*Suis, es, est, sommes, êtes, sont*.)
-Which Latin verb are the present forms **and the infinitive** from? (***Esse***.)
-Which verb do the ***ét-*** forms come from? (***Stāre***, "to **stand**" — a
-different verb entirely.) Name three of them. (*Été*, *étant*, *étais/était*.)
-And *je fus*? (The old perfect stem ***fuī***.)
-What is that patching called? (**Suppletion** — like *go/went*.) What did Spanish
-do with *esse* and *stāre*? (Kept them **apart** as *ser* and *estar*.)
-Next: the verbs that take *être* instead of *avoir* in the past.
+[PAUSE 3s] Give the six present forms. (**Suis, es, est, sommes, êtes, sont**.)
+Which pronoun goes with *êtes*? (**Vous**.) Which Latin verb supplies this row?
+(***Esse***.) Next: find the *fu-* and *ét-* pieces inside the wider paradigm.

--- a/code/learning/human-languages/french/lessons/FR-C16-passe-compose-etre.md
+++ b/code/learning/human-languages/french/lessons/FR-C16-passe-compose-etre.md
@@ -3,122 +3,72 @@ id: FR-C16-passe-compose-etre
 chapter: 16
 type: phrase
 headword: je suis allé(e)
-gloss: "the other compound past — verbs of motion and change take être, and the participle agrees with the SUBJECT"
+gloss: the compound past with être and subject agreement
 concept_tag: FR-PAST-COMPOUND-ETRE
-prerequisites: [FR-C16-etre, FR-C15-passe-compose, FR-C03-aller]
+prerequisites: [FR-C16-etre-roots, FR-C15-passe-compose, FR-C03-aller]
 sounds: [silent-agreement, nasal-on]
 roots: [latin-esse-participle]
-etymology_hook: "with être the participle agrees with the SUBJECT (elle est allée) — the same adjective fossil as Ch.15's preceding-object rule, because 'she is gone' was once literally a description of her state, not an action she performed"
-est_minutes: 5
-reviews_of: [FR-C16-etre, FR-C15-passe-compose, FR-C03-aller]
+etymology_hook: "elle est allée preserves the participle's older job as an adjective describing the subject"
+est_minutes: 4
+reviews_of: [FR-C16-etre, FR-C16-etre-roots, FR-C15-passe-compose, FR-C03-aller]
 ---
 
-# je suis allé — the past built from "be"
+# Je suis allé — the past built from “be”
 
 ## Warm-up
 
-[PAUSE 2s] Chapter 15 built the past with *avoir*: *j'ai parlé*. But a small,
-important group of verbs refuses *avoir* and takes **être** instead — and when
-they do, something visible happens to the participle.
+[PAUSE 2s] Chapter 15 built **j’ai parlé** with *avoir*. A smaller family uses
+**être**, and its participle agrees with the subject.
 
-## The rule
-
-> **Verbs of motion and change of state take *être*.**
-
-*Aller* (Ch. 3) is the headline case:
+## Start with aller
 
 | | |
 |---|---|
-| je **suis** allé | I went |
-| tu **es** allé | you went |
-| il **est** allé | he went |
-| nous **sommes** allés | we went |
-| ils **sont** allés | they went |
+| je **suis allé** | I went |
+| tu **es allé** | you went |
+| il **est allé** | he went |
+| nous **sommes allés** | we went |
+| ils **sont allés** | they went |
 
-Others in the family: *venir* (come), *partir* (leave), *arriver* (arrive),
-*entrer*, *sortir*, *monter*, *descendre*, *naître* (be born), *mourir* (die),
-*rester* (stay), *tomber* (fall). Read that list as a shape rather than a list:
-**going, coming, being born, dying** — arriving and leaving, in space or in life.
+The family centres on arriving, leaving, and changing state: *aller, venir,
+partir, arriver, entrer, sortir, naître, mourir, rester, tomber*.
 
-Plus one whole extra family: **all pronominal verbs take *être*** — *je me suis
-levé*, *elle s'est lavée*. Careful, though: they take *être* but they do **not**
-follow *être*'s agreement rule. See the warning at the end of this lesson.
+Do not interpret that as “every verb involving movement.” *Marcher, courir,
+nager,* and *danser* take **avoir**. Some verbs switch with a direct object:
+**je suis monté** (“I went up”) but **j’ai monté les valises** (“I took the
+suitcases up”).
 
-Two warnings, so the rule doesn't mislead you:
+## Agreement with the subject
 
-- **Not every motion verb qualifies.** *Marcher, courir, nager, danser, voyager*
-  all take *avoir* (*j'ai couru*). The *être* verbs are about **arriving,
-  leaving, and changing state** — not about moving your legs.
-- **Some switch when they take an object.** *Monter, descendre, sortir, rentrer,
-  passer* take *être* alone (*je suis monté*, "I went up") but *avoir* with a
-  direct object (*j'ai monté les valises*, "I took the suitcases up").
-
-## The participle agrees with the subject
-
-This is the part you can see and hear:
-
-| | |
+| subject | sentence |
 |---|---|
-| Il est **allé**. | He went. |
-| Elle est **allée**. | She went. |
-| Ils sont **allés**. | They went. |
-| Elles sont **allées**. | They (f.) went. |
+| il | Il est **allé**. |
+| elle | Elle est **allée**. |
+| ils | Ils sont **allés**. |
+| elles | Elles sont **allées**. |
 
-The participle takes the subject's gender and number — exactly like an adjective.
+The participle takes the subject’s gender and number like an adjective. That is
+its history: **elle est allée** began as “she is gone,” with *gone* describing
+her state just as *fatiguée* would.
 
-**Why?** The same fossil as Chapter 15. *Elle est allée* began as a plain
-description: "**she is** gone" — *gone* describing **her**, the way *elle est
-fatiguée* describes her. It was never an action she performed on something; it
-was a state she was in. So the participle agreed with her, and it still does.
+This connects both auxiliary systems:
 
-Compare the two halves of the system:
+- with **avoir**, agreement can follow a preceding object;
+- with **être**, agreement follows the subject.
 
-| auxiliary | participle agrees with | because it was… |
-|---|---|---|
-| **avoir** | a **preceding object** (*les lettres que j'ai écrites*) | "I have letters written" |
-| **être** | the **subject** (*elle est allée*) | "she is gone" |
-
-One rule underneath both: **the participle was an adjective, and it agrees with
-whatever it described.**
-
-## The pronominal exception
-
-Pronominal verbs take *être* — but their agreement follows the **avoir** rule,
-not the *être* one. They agree with a **preceding direct object**, which usually
-*is* the reflexive pronoun, and sometimes isn't:
-
-| | |
-|---|---|
-| Elle s'est **lavée**. | She washed *herself* — *se* is the direct object, so it agrees. |
-| Elle s'est **lavé** les mains. | She washed *her hands* — the object is *les mains*, and it **follows**, so no agreement. |
-| Elles se sont **parlé**. | They spoke *to each other* — *se* is **indirect**, so no agreement. |
-
-Which is, satisfyingly, the same rule as Ch. 15 all along. The auxiliary looks
-like *être*; the agreement behaves like *avoir*. Don't let the first mislead you
-about the second.
-
-One group in particular escapes even that. Verbs that exist **only** in pronominal form — *se
-souvenir* (remember), *s'enfuir* (flee), *s'évanouir* (faint) — have no
-non-reflexive version for the pronoun to be an object *of*, so they simply agree
-with the subject: *elles se sont **souvenues***.
+Underneath both, the participle was an adjective agreeing with what it
+described.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "je suis allé, il est allé, elle est allée"]
-- [YOU SAY: the contrast — "j'**ai** parlé … je **suis** allé"]
-- [YOU SAY: the shape of the list — "going, coming, born, dying"]
-- [YOU SAY: the reason — "**she is gone** — *gone* describes **her**"]
+- [YOU SAY: “je suis allé; elle est allée”]
+- [YOU SAY: “ils sont allés; elles sont allées”]
+- [YOU SAY: the contrast — “j’ai parlé; je suis allé”]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Which verbs take *être*? (Verbs of **motion** and **change of
-state** — going, coming, arriving, being born, dying — **plus all pronominal
-verbs**.) Does *courir* take *être*? (**No** — *j'ai couru*; moving your legs
-isn't arriving or leaving.) What happens to *monter* with an object? (It switches
-to *avoir* — *j'ai monté les valises*.) Pronominal verbs take *être* — do they
-agree with the subject? (**No** — with a **preceding direct object**, the *avoir*
-rule: *elle s'est lavé**e***, but *elle s'est lav**é** les mains*.) What does the participle
-agree with under *être*? (**The subject** — *elle est allé**e***.) And under
-*avoir*? (**A preceding object**.) What single idea explains both? (The
-participle was an **adjective**, agreeing with whatever it described.) Next chapter: the **body**.
+[PAUSE 3s] Which broad family takes *être*? (Arriving, leaving, and **change of
+state**.) Does *courir*? (**No: j’ai couru**.) What does the participle agree
+with here? (**The subject**.) Why? (It began as an **adjective**.) Next: the
+special agreement logic of pronominal verbs.

--- a/code/learning/human-languages/french/lessons/FR-C16-pronominal-past.md
+++ b/code/learning/human-languages/french/lessons/FR-C16-pronominal-past.md
@@ -1,0 +1,62 @@
+---
+id: FR-C16-pronominal-past
+chapter: 16
+type: grammar
+headword: elle s'est lavée / lavé les mains
+gloss: agreement in the compound past of pronominal verbs
+concept_tag: FR-PAST-PRONOMINAL-AGREEMENT
+prerequisites: [FR-C16-passe-compose-etre]
+sounds: [silent-agreement]
+roots: [latin-reflexive]
+etymology_hook: "pronominal verbs use être as auxiliary but agreement still follows the preceding-direct-object logic learned with avoir"
+est_minutes: 4
+reviews_of: [FR-C16-passe-compose-etre, FR-C15-passe-compose]
+---
+
+# Elle s’est lavée — pronominal past agreement
+
+## Warm-up
+
+[PAUSE 2s] All pronominal verbs use **être** in the compound past: **je me suis
+levé**, **elle s’est lavée**. Their agreement, however, follows the direct
+object rather than blindly following the subject.
+
+| sentence | why |
+|---|---|
+| Elle s’est **lavée**. | *se* means “herself,” a preceding direct object |
+| Elle s’est **lavé** les mains. | direct object *les mains* follows, so no agreement |
+| Elles se sont **parlé**. | *se* means “to each other,” an indirect object |
+
+The auxiliary looks like *être*, but the decision is the same one used with
+*avoir*: agree with a **preceding direct object**.
+
+Ask two questions:
+
+1. What received the action directly?
+2. Does that direct object come before the participle?
+
+In *elle s’est lavée*, **se** is direct and precedes, so add *-e*. In *elle
+s’est lavé les mains*, *les mains* is direct but follows, so leave *lavé*
+unchanged. In *se parler*, the person is indirect — you speak **to** someone —
+so there is no agreement.
+
+## Verbs that exist only pronominally
+
+Verbs such as *se souvenir* (remember), *s’enfuir* (flee), and *s’évanouir*
+(faint) have no ordinary non-reflexive partner. They simply agree with the
+subject: **elles se sont souvenues**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “Elle s’est lavée.”]
+- [YOU SAY: “Elle s’est lavé les mains.”]
+- [YOU SAY: “Elles se sont parlé.”]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which auxiliary do pronominal verbs take? (**Être**.) Do they always
+agree with the subject? (**No**.) What controls ordinary pronominal agreement?
+(A **preceding direct object**.) Why no agreement in *se sont parlé*? (*Se* is
+**indirect**.) How do inherently pronominal verbs behave? (They agree with the
+**subject**.)

--- a/code/learning/human-languages/french/lessons/FR-C21-le-temps.md
+++ b/code/learning/human-languages/french/lessons/FR-C21-le-temps.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C14-age]
 sounds: [nasal-en, silent-final]
 roots: [tempus-latin, pluere-latin]
 etymology_hook: "le temps means BOTH 'time' and 'weather' — the exact same Latin tempus double sense as Spanish's tiempo (this widening happened within Latin itself, shared by both languages, not a Spanish-only development); il fait chaud/froid reuse faire ('to make'), just like Spanish's hacer; il pleut ('it's raining') KEEPS Latin pluere's pl- unchanged, unlike Spanish's llueve, which underwent the pl-→ll- shift"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C14-age]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C22-chien-chat.md
+++ b/code/learning/human-languages/french/lessons/FR-C22-chien-chat.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C14-age]
 sounds: [ca-to-cha-shift, nasal-en]
 roots: [latin-canis-dog, latin-cattus-afroasiatic]
 etymology_hook: "chien is the fully REGULAR French descendant of Latin canis — the same ca- → cha- palatalization that also gives champ (← campus) and chanter (← cantāre) — unlike Spanish, which replaced canis-derived can with the still-unexplained perro; chat continues cattus, the same word (probably Afro-Asiatic, traveling with the cat out of Egypt) behind Spanish's gato and Italian's gatto"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [FR-C14-age]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-C23-vert-jaune.md
+++ b/code/learning/human-languages/french/lessons/FR-C23-vert-jaune.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C22-chien-chat]
 sounds: [nasal-en, diphthong-au]
 roots: [latin-viridis-vireo, latin-galbinus-shine]
 etymology_hook: "vert ← Latin viridis, the standard source of 'green' across nearly every Romance language (Spanish verde, Italian verde, Portuguese verde); jaune ← Latin galbinus, literally 'yellow-GREEN' — an extended form of galbus, usually traced to PIE *ghel-, 'to shine,' the same root claimed for German's gelb — though modern Latin scholarship treats galbus's origin as genuinely unknown, so treat jaune/gelb as probable, not certain, cousins"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [FR-C22-chien-chat]
 ---
 

--- a/code/learning/human-languages/french/lessons/FR-W01-accents.md
+++ b/code/learning/human-languages/french/lessons/FR-W01-accents.md
@@ -7,7 +7,7 @@ gloss: the three accents on e (aigu, grave, circonflexe) — and the circumflex'
 prerequisites: [FR-C01-bien, FR-C03-comment-ca-va]
 sounds: [vowel-e-acute, vowel-e-grave]
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [FR-C02-enchante, FR-C03-comme-ci-comme-ca]
 ---
 

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -20,8 +20,9 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   included.)
 - **Ch. 3 — "Comment ça va ?"**: merci (← *mercēs* "reward") → de rien (← *rem*
   "thing" → "nothing"; twin of Spanish *de nada*) → **aller** ("to go," the
-  state-verb — vs Spanish *estar* "to stand") → comment ça va / allez-vous /
-  vas-tu → comme ci, comme ça → practice. **Authored** — the deliberate mirror of
+  state-verb — vs Spanish *estar* "to stand") → neutral **comment ça va** →
+  explicit **vas-tu / allez-vous** register and liaison → comme ci, comme ça →
+  practice. **Authored** — the deliberate mirror of
   Spanish Ch. 4.
 - **Ch. 4 — Farewells**: au revoir (← "à le revoir", *voir* ← *vidēre*; the
   "see-again" goodbye, twin of German *auf Wiedersehen*) → à plus tard (*tard* ←
@@ -108,7 +109,7 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   let a "have" compound push the inherited simple past out of speech, while
   **Spanish and Portuguese kept theirs**. **Authored.**
 - **Ch. 16 — *être*, and the other compound past**: ***être*** (`FR-C16-etre`) —
-  the most irregular verb in the language, and **suppletive across three stems**:
+  the six present forms → its root map (`FR-C16-etre-roots`), **suppletive across three stems**:
   *es-* for the present **and the infinitive** (*suis/es/est*, *être* ←
   \**essere*, all from Latin ***esse***), *fu-* for the passé simple (*je fus* ←
   the old perfect ***fuī***), and ***ét-*** for **every form beginning *ét-***
@@ -122,8 +123,10 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   (*aller, venir, naître, mourir*) plus **all pronominal verbs** take *être*, and
   the participle **agrees with the subject** (*elle est allé**e***) — with the
   caveats the bare rule hides (*courir/marcher* take *avoir*; *monter/sortir*
-  switch when transitive; and **pronominals follow *avoir*'s** preceding-direct-
-  object agreement, *elle s'est lavé**e*** but *elle s'est lav**é** les mains*).
+  switch when transitive) → dedicated pronominal agreement
+  (`FR-C16-pronominal-past`), where **pronominals follow *avoir*'s**
+  preceding-direct-object agreement, *elle s'est lavé**e*** but *elle s'est
+  lav**é** les mains*.
   This closes Ch.15's open
   half — and both agreement rules turn out to be **one** rule, because the
   participle was an **adjective**: under *avoir* it described the object, under


### PR DESCRIPTION
## Summary

- remove all twenty-five French sub-five-minute duration violations
- correct twenty-two declared budgets whose lesson bodies already compute below 300 seconds
- replace the three computed violations with three prerequisite-ordered micro-lessons:
  - neutral `Ça va ?` → explicit `tu/vous` register and liaison
  - `être` forms → its `es-/fu-/ét-` historical roots
  - motion/change auxiliary agreement → pronominal direct-object agreement
- preserve the original vocabulary, grammar, exceptions, etymology, and cross-language comparisons
- reprioritize German as the next duration tranche and log French's Chapters 17–23 publication and LaTeX hygiene debt

## Measured change

- French duration violations: **25 → 0**
- overall duration violations: **381 → 356**
- lessons: **994 → 997**
- unknown prerequisites: **0 → 0**
- new/rewritten micro-lessons: **147–244 computed seconds**
- tightest remaining French lessons: `FR-C03-practice` at **293s** and `FR-C15-passe-simple` at **291s**

## Validation

- `npm run test:coverage` — 68 package tests, 93.60% line coverage
- `npm run build`
- `npm run validate` — 9 integration tests
- `npm run check:books`
- Language Ladder `npm run test:coverage` — 278 tests, 98.37% line coverage
- Language Ladder production build — 1,047 modules transformed
- forced French XeLaTeX build — 79-page PDF
- `git diff --check`

## Pre-existing book findings

The unchanged French book builds successfully through Chapter 16 while canonical app lessons continue through Chapter 23. The build has no missing glyphs or duplicate labels, but reports sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings. Those are recorded separately as HL-B18/HL-B19; this duration patch does not hand-copy or alter the book sources.