### PR TITLE
fix(build-tool): canonicalize Swift discovery identities

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9553,
   "last_inventory": {
     "revision": "0455cea8e0c0ddc078040ea109ea59dbaf8403fa",
     "schema_version": 3,
@@ -379,11 +379,11 @@
     {
       "id": "build-tool-swift-language-identity-registry",
       "title": "Bring Swift build-tool discovery to the canonical language and identity registry",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-swift-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-swift-language-identity-registry",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9537 and the collision-clean 80612eb7 inventory because the dependency is now satisfied and the prior real Swift full plan measured broad identity corruption: 4,768 package entries but only 4,594 unique names, with 143 identity groups containing 317 entries and 397 entries across 228 names classified as unknown. The implementation consumes the shared discovery-language-registry and discovery-duplicate-identity fixtures, recognizes established, emerging, execution-target, domain, and build-language buckets only at the exact packages/programs boundary, preserves package/program identities, excludes spec fixtures, and fails closed on residual duplicate qualified names. Exact-base validation on 0455cea8 passes 25 Swift tests, release build, 55.56% overall and 91.33% Discovery.swift line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, and a real 4,768-package/7,471-edge full plan with 4,768 unique identities, zero duplicate groups, and only intentional unknown/blog. The refreshed inventory is collision-clean at 1,222 identities and 4,370 slots with 172 high-consensus packages, 271 high-consensus gaps, 772 singletons, 10,808 singleton gaps, 577 Rust singletons, and zero collisions/unknown buckets. Security validation found zero external Swift dependencies and zero secret-like diff hits; diff checks pass. Build-file validation reproduces only the same 10 separately owned Lua BUILD_windows debt items. Repository Swift formatting has no checked-in configuration and strict recursive lint still reports broad pre-existing violations, so this slice does not reformat the engine. The rebase also logged the new AirGradient portable telemetry core as pending without changing selection. Keep this separate from metadata decoding and Windows file-option handling."
+      "pr_number": 9553,
+      "notes": "Ready-for-review PR #9553 opened from the sole active parity branch after exact-base validation. Selected after merged PR #9537 and the collision-clean 80612eb7 inventory because the dependency is now satisfied and the prior real Swift full plan measured broad identity corruption: 4,768 package entries but only 4,594 unique names, with 143 identity groups containing 317 entries and 397 entries across 228 names classified as unknown. The implementation consumes the shared discovery-language-registry and discovery-duplicate-identity fixtures, recognizes established, emerging, execution-target, domain, and build-language buckets only at the exact packages/programs boundary, preserves package/program identities, excludes spec fixtures, and fails closed on residual duplicate qualified names. Exact-base validation on 0455cea8 passes 25 Swift tests, release build, 55.56% overall and 91.33% Discovery.swift line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, and a real 4,768-package/7,471-edge full plan with 4,768 unique identities, zero duplicate groups, and only intentional unknown/blog. The refreshed inventory is collision-clean at 1,222 identities and 4,370 slots with 172 high-consensus packages, 271 high-consensus gaps, 772 singletons, 10,808 singleton gaps, 577 Rust singletons, and zero collisions/unknown buckets. Security validation found zero external Swift dependencies and zero secret-like diff hits; diff checks pass. Build-file validation reproduces only the same 10 separately owned Lua BUILD_windows debt items. Repository Swift formatting has no checked-in configuration and strict recursive lint still reports broad pre-existing violations, so this slice does not reformat the engine. The rebase also logged the new AirGradient portable telemetry core as pending without changing selection. Keep this separate from metadata decoding and Windows file-option handling."
     },
     {
       "id": "build-tool-rust-self-edge-diagnostic",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,16 +13,16 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "80612eb7ba39d864c5ffa27f2cb3ae78e92705c1",
+    "revision": "0455cea8e0c0ddc078040ea109ea59dbaf8403fa",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1221,
-    "implementation_package_slots": 4369,
+    "implementation_identities": 1222,
+    "implementation_package_slots": 4370,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 771,
-    "singleton_missing_slots": 10794,
-    "rust_singletons": 576,
+    "singleton_packages": 772,
+    "singleton_missing_slots": 10808,
+    "rust_singletons": 577,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -383,7 +383,7 @@
       "depends_on": ["build-tool-swift-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-swift-language-identity-registry",
       "pr_number": null,
-      "notes": "Selected after merged PR #9537 and the collision-clean 80612eb7 inventory because the dependency is now satisfied and the last real Swift full plan measured broad identity corruption: 4,768 package entries but only 4,594 unique names, with 143 identity groups containing 317 entries and 397 entries across 228 names classified as unknown. Reuse the shared discovery-language-registry and discovery-duplicate-identity fixtures to recognize established, emerging, execution-target, domain, and build-language buckets from the exact packages/programs boundary, preserve package/program identities, exclude spec fixtures, and fail closed on residual duplicate qualified names. Keep this separate from metadata decoding and Windows file-option handling."
+      "notes": "Selected after merged PR #9537 and the collision-clean 80612eb7 inventory because the dependency is now satisfied and the prior real Swift full plan measured broad identity corruption: 4,768 package entries but only 4,594 unique names, with 143 identity groups containing 317 entries and 397 entries across 228 names classified as unknown. The implementation consumes the shared discovery-language-registry and discovery-duplicate-identity fixtures, recognizes established, emerging, execution-target, domain, and build-language buckets only at the exact packages/programs boundary, preserves package/program identities, excludes spec fixtures, and fails closed on residual duplicate qualified names. Exact-base validation on 0455cea8 passes 25 Swift tests, release build, 55.56% overall and 91.33% Discovery.swift line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, and a real 4,768-package/7,471-edge full plan with 4,768 unique identities, zero duplicate groups, and only intentional unknown/blog. The refreshed inventory is collision-clean at 1,222 identities and 4,370 slots with 172 high-consensus packages, 271 high-consensus gaps, 772 singletons, 10,808 singleton gaps, 577 Rust singletons, and zero collisions/unknown buckets. Security validation found zero external Swift dependencies and zero secret-like diff hits; diff checks pass. Build-file validation reproduces only the same 10 separately owned Lua BUILD_windows debt items. Repository Swift formatting has no checked-in configuration and strict recursive lint still reports broad pre-existing violations, so this slice does not reformat the engine. The rebase also logged the new AirGradient portable telemetry core as pending without changing selection. Keep this separate from metadata decoding and Windows file-option handling."
     },
     {
       "id": "build-tool-rust-self-edge-diagnostic",
@@ -1223,6 +1223,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered after merged PR #9539 added the Rust-only HEOS CLI integration. Share bounded HEOS response-envelope and command-result validation, player inventory, now-playing, volume, and mute normalization, stable identities and errors, deterministic read-only media projection, HEOS escaping, and language-neutral protocol fixtures. SSDP multicast, DNS/TCP, endpoint authorization, trusted time, console I/O, account access, playback and grouping commands, subscriptions, and runtime mutation are excluded native-host responsibilities."
+    },
+    {
+      "id": "smart-home-airgradient-portable-core-extraction-and-conformance",
+      "title": "Extract and port the portable AirGradient local telemetry core",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after merged PR #9548 added the Rust-only AirGradient local monitor integration. Share bounded /measures/current JSON validation, firmware/model/sensor normalization, environmental measurement identities and units, stable errors, deterministic read-only sensor projection, and language-neutral telemetry fixtures. mDNS, DNS/TCP, plaintext LAN HTTP execution, endpoint authorization, trusted time, console I/O, and runtime mutation are excluded native-host responsibilities."
     },
     {
       "id": "smart-home-reolink-portable-core-extraction-and-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -379,11 +379,11 @@
     {
       "id": "build-tool-swift-language-identity-registry",
       "title": "Bring Swift build-tool discovery to the canonical language and identity registry",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-swift-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-swift-language-identity-registry",
       "pr_number": null,
-      "notes": "Discovered by the full-repository release-plan audit in the Swift UTF-8 slice and refreshed after rebasing onto 613717e2. The Swift engine emits 4,768 package entries but only 4,594 unique names: 143 identity groups contain 317 entries, and 397 entries across 228 names are classified as unknown. Reuse the shared discovery-language-registry and discovery-duplicate-identity fixtures to recognize established, emerging, execution-target, domain, and build-language buckets from the exact packages/programs boundary, preserve package/program identities, exclude spec fixtures, and fail closed on residual duplicate qualified names. Keep this separate from metadata decoding."
+      "notes": "Selected after merged PR #9537 and the collision-clean 80612eb7 inventory because the dependency is now satisfied and the last real Swift full plan measured broad identity corruption: 4,768 package entries but only 4,594 unique names, with 143 identity groups containing 317 entries and 397 entries across 228 names classified as unknown. Reuse the shared discovery-language-registry and discovery-duplicate-identity fixtures to recognize established, emerging, execution-target, domain, and build-language buckets from the exact packages/programs boundary, preserve package/program identities, exclude spec fixtures, and fail closed on residual duplicate qualified names. Keep this separate from metadata decoding and Windows file-option handling."
     },
     {
       "id": "build-tool-rust-self-edge-diagnostic",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,18 +11,18 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9537,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "613717e22fe7b65c37eebb35a84a5b440a55ddb1",
+    "revision": "80612eb7ba39d864c5ffa27f2cb3ae78e92705c1",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1219,
-    "implementation_package_slots": 4367,
+    "implementation_identities": 1221,
+    "implementation_package_slots": 4369,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 770,
-    "singleton_missing_slots": 10780,
-    "rust_singletons": 575,
+    "singleton_packages": 771,
+    "singleton_missing_slots": 10794,
+    "rust_singletons": 576,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -361,11 +361,11 @@
     {
       "id": "build-tool-swift-rockspec-utf8-conformance",
       "title": "Make the Swift build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-rust-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-swift-rockspec-utf8",
       "pr_number": 9537,
-      "notes": "Ready PR #9537. Selected after merged PR #9527 because this is the highest-severity remaining fail-open engine and one bounded child of the shared UTF-8 contract. The implementation decodes Lua rockspec bytes strictly before parsing, propagates a typed METADATA_INVALID_UTF8 error with package and repository-relative manifest identity, writes a platform-stable diagnostic without the checkout root, and returns CLI exit 2. Shared positive and invalid-byte fixtures require the exact success edge set and are exercised through the resolver, CLI entry point, and a real subprocess. Exact-base validation on 613717e2 passed 22 Swift tests, production build, measured 39.74% overall and 42.94% resolver line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, a 258-package/382-edge Lua plan, a 4,768-package/7,458-edge full plan, collision-clean 1,220-identity parity inventory, JSON/diff/secret checks, and an exact 10-to-10 Lua BUILD_windows debt comparison with untouched main. The full-plan audit separately logged Swift absolute file-option and language/identity-registry children, and the post-rebase inventory logged the new HomeWizard portable telemetry core. TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate encoding children."
+      "notes": "Merged PR #9537 at 80612eb7ba39d864c5ffa27f2cb3ae78e92705c1 on 2026-08-02 after all applicable fixture-consumer, detection, Ubuntu, macOS, Windows, and Swift CodeQL checks passed. The implementation decodes Lua rockspec bytes strictly before parsing, propagates a typed METADATA_INVALID_UTF8 error with package and repository-relative manifest identity, writes a platform-stable diagnostic without the checkout root, and returns CLI exit 2. Shared positive and invalid-byte fixtures require the exact success edge set and are exercised through the resolver, CLI entry point, and a real subprocess. Exact-base validation on 613717e2 passed 22 Swift tests, production build, measured 39.74% overall and 42.94% resolver line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, a 258-package/382-edge Lua plan, a 4,768-package/7,458-edge full plan, collision-clean 1,220-identity parity inventory, JSON/diff/secret checks, and an exact 10-to-10 Lua BUILD_windows debt comparison with untouched main. The first macOS check exposed that SwiftPM can relocate its test bundle; the smallest follow-up made the real CLI locator use the bundle executable plus package-local scratch fallback, after which all 22 tests and the macOS matrix passed. The full-plan audit separately logged Swift absolute file-option and language/identity-registry children, and the post-rebase inventory logged the new HomeWizard portable telemetry core. TypeScript, Lua, Perl, Ruby, Haskell, and Elixir remain separate encoding children."
     },
     {
       "id": "build-tool-swift-windows-absolute-file-options",
@@ -1214,6 +1214,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered after merged PR #9526 added the Rust-only HomeWizard Energy API v1 host. Share bounded device-information and measurement response validation, API-version checks, device and external-meter normalization, units, stable identities and errors, deterministic sensor projection, and language-neutral telemetry fixtures. mDNS, DNS/TCP, plaintext LAN HTTP execution, endpoint authorization, trusted time, console I/O, and runtime mutation are excluded native-host responsibilities."
+    },
+    {
+      "id": "smart-home-heos-portable-core-extraction-and-conformance",
+      "title": "Extract and port the portable HEOS read-only protocol core",
+      "status": "pending",
+      "depends_on": ["smart-home-media-entity-command-contract"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after merged PR #9539 added the Rust-only HEOS CLI integration. Share bounded HEOS response-envelope and command-result validation, player inventory, now-playing, volume, and mute normalization, stable identities and errors, deterministic read-only media projection, HEOS escaping, and language-neutral protocol fixtures. SSDP multicast, DNS/TCP, endpoint authorization, trusted time, console I/O, account access, playback and grouping commands, subscriptions, and runtime mutation are excluded native-host responsibilities."
     },
     {
       "id": "smart-home-reolink-portable-core-extraction-and-conformance",

--- a/code/programs/swift/build-tool/CHANGELOG.md
+++ b/code/programs/swift/build-tool/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Classify package and program buckets with the canonical discovery language
+  registry, exclude specification fixture trees, preserve program identities,
+  and fail closed on duplicate qualified names with
+  `DUPLICATE_PACKAGE_IDENTITY`, sorted repository-relative paths, and CLI exit
+  code `2`. Shared registry and duplicate-identity fixtures now cover the API
+  and real executable.
 - Decode Lua `.rockspec` metadata as strict UTF-8 before dependency parsing.
   Invalid bytes now fail closed with `METADATA_INVALID_UTF8`, stable package
   and repository-relative manifest identity, CLI exit code `2`, and no

--- a/code/programs/swift/build-tool/README.md
+++ b/code/programs/swift/build-tool/README.md
@@ -8,7 +8,8 @@ This port mirrors the other build-tool implementations in the repo:
 
 1. Discovers packages by recursively walking `BUILD` files under `code/`
 2. Evaluates simple Starlark-style BUILD targets used in this monorepo
-3. Resolves internal dependencies across Python, Ruby, Go, TypeScript, Rust, Elixir, Lua, Perl, and Swift
+3. Resolves internal dependencies across the repository's implementation
+   languages
 4. Detects changed packages from `git diff`
 5. Hashes package sources and dependency state for cache fallback
 6. Builds independent packages in parallel by dependency level
@@ -28,6 +29,28 @@ METADATA_INVALID_UTF8: package=lua/pkg manifest=code/packages/lua/pkg/coding-adv
 The resolver tests consume the language-neutral `resolution/lua-utf8` and
 `resolution/lua-invalid-utf8` fixtures, require the exact success edge set,
 and verify that diagnostics never expose the checkout root.
+
+## Discovery identity safety
+
+Package discovery classifies the exact bucket immediately below `packages` or
+`programs` using the canonical language registry. It covers all established
+and emerging implementation lanes, the WASM target, Mosaic and Twig domain
+languages, Starlark, and the shared .NET program host. Specification fixture
+trees are excluded, programs retain a `/programs/` identity segment, and an
+unrecognized bucket remains `unknown` instead of borrowing a language name
+from a later path component.
+
+If distinct directories still collapse to one qualified name, discovery stops
+with CLI exit code `2` and a stable diagnostic containing sorted repository-
+relative paths:
+
+```text
+DUPLICATE_PACKAGE_IDENTITY: package=unknown/demo paths=code/packages/alpha/demo,code/packages/beta/demo
+```
+
+The shared `discovery/language-registry` and
+`discovery/duplicate-identity` fixtures cover this behavior through the Swift
+API and the real executable without disclosing the checkout root.
 
 ## Usage
 

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/BuildTool.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/BuildTool.swift
@@ -23,6 +23,9 @@ public enum BuildTool {
         } catch let error as MetadataEncodingError {
             FileHandle.standardError.write(Data((error.localizedDescription + "\n").utf8))
             return 2
+        } catch let error as DuplicatePackageIdentityError {
+            FileHandle.standardError.write(Data((error.localizedDescription + "\n").utf8))
+            return 2
         } catch {
             fputs("Error: \(error.localizedDescription)\n", stderr)
             return 1
@@ -76,7 +79,7 @@ public enum BuildTool {
             throw BuildToolError.io("\(codeRoot) does not exist.")
         }
 
-        var packages = Discovery.discoverPackages(root: codeRoot)
+        var packages = try Discovery.discoverPackages(root: codeRoot)
         packages = evaluateStarlarkPackages(packages: packages, repoRoot: repoRoot)
 
         if options.language != "all" {

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Discovery.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Discovery.swift
@@ -1,6 +1,32 @@
 import Foundation
 
 public enum Discovery {
+    public static let languages: Set<String> = [
+        "csharp",
+        "dart",
+        "elixir",
+        "fsharp",
+        "go",
+        "haskell",
+        "java",
+        "kotlin",
+        "lua",
+        "perl",
+        "python",
+        "ruby",
+        "rust",
+        "swift",
+        "typescript",
+        "c",
+        "cpp",
+        "ocaml",
+        "wasm",
+        "mosaic",
+        "twig",
+        "starlark",
+        "dotnet",
+    ]
+
     public static let skipDirectories: Set<String> = [
         ".git",
         ".hg",
@@ -17,14 +43,41 @@ public enum Discovery {
         "build",
         "target",
         ".claude",
+        "specs",
         "Pods",
+        ".dart_tool",
         ".build",
+        ".gradle",
+        "gradle-build",
     ]
 
-    public static func discoverPackages(root: String) -> [BuildPackage] {
+    public static func discoverPackages(root: String) throws -> [BuildPackage] {
         var packages: [BuildPackage] = []
         walk(directory: root, packages: &packages)
-        return packages.sorted { $0.name < $1.name }
+        packages.sort {
+            $0.name == $1.name ? $0.path < $1.path : $0.name < $1.name
+        }
+
+        var index = 0
+        while index < packages.count {
+            var end = index + 1
+            while end < packages.count,
+                  packages[end].name == packages[index].name {
+                end += 1
+            }
+            if end - index > 1 {
+                throw DuplicatePackageIdentityError(
+                    code: "DUPLICATE_PACKAGE_IDENTITY",
+                    package: packages[index].name,
+                    paths: packages[index ..< end].map {
+                        repositoryPackagePath(root: root, path: $0.path)
+                    }
+                )
+            }
+            index = end
+        }
+
+        return packages
     }
 
     public static func inferLanguage(path: String) -> String {
@@ -32,14 +85,24 @@ public enum Discovery {
             .replacingOccurrences(of: "\\", with: "/")
             .split(separator: "/")
             .map(String.init)
-        for language in allPackageLanguages where parts.contains(language) {
-            return language
+        for index in parts.indices
+            where parts[index] == "packages" || parts[index] == "programs" {
+            guard parts.indices.contains(index + 1) else {
+                return "unknown"
+            }
+            let language = parts[index + 1]
+            return languages.contains(language) ? language : "unknown"
         }
         return "unknown"
     }
 
     public static func inferPackageName(path: String, language: String) -> String {
-        "\(language)/\((path as NSString).lastPathComponent)"
+        let parts = path
+            .replacingOccurrences(of: "\\", with: "/")
+            .split(separator: "/")
+            .map(String.init)
+        let kind = parts.contains("programs") ? "/programs" : ""
+        return "\(language)\(kind)/\((path as NSString).lastPathComponent)"
     }
 
     public static func getBuildFile(directory: String, platformOverride: String? = nil) -> String? {
@@ -78,6 +141,28 @@ public enum Discovery {
             .split(whereSeparator: \.isNewline)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+    }
+
+    private static func repositoryPackagePath(root: String, path: String) -> String {
+        let normalizedPath = path.replacingOccurrences(of: "\\", with: "/")
+        let parts = normalizedPath.split(separator: "/").map(String.init)
+        var canonicalStart: Int?
+        if parts.count >= 2 {
+            for index in 0 ..< parts.count - 1
+                where parts[index] == "code"
+                    && (parts[index + 1] == "packages" || parts[index + 1] == "programs") {
+                canonicalStart = index
+            }
+        }
+        if let canonicalStart {
+            return parts[canonicalStart...].joined(separator: "/")
+        }
+
+        let normalizedRoot = root.replacingOccurrences(of: "\\", with: "/")
+        if normalizedPath.hasPrefix(normalizedRoot + "/") {
+            return String(normalizedPath.dropFirst(normalizedRoot.count + 1))
+        }
+        return (path as NSString).lastPathComponent
     }
 
     private static func walk(directory: String, packages: inout [BuildPackage]) {

--- a/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
+++ b/code/programs/swift/build-tool/Sources/BuildToolCore/Models.swift
@@ -41,6 +41,22 @@ public struct MetadataEncodingError: Error, LocalizedError, Equatable {
     }
 }
 
+public struct DuplicatePackageIdentityError: Error, LocalizedError, Equatable {
+    public let code: String
+    public let package: String
+    public let paths: [String]
+
+    public init(code: String, package: String, paths: [String]) {
+        self.code = code
+        self.package = package
+        self.paths = paths
+    }
+
+    public var errorDescription: String? {
+        "\(code): package=\(package) paths=\(paths.joined(separator: ","))"
+    }
+}
+
 public enum BuildStatus: String, Codable {
     case built
     case failed

--- a/code/programs/swift/build-tool/Tests/BuildToolCoreTests/DiscoveryTests.swift
+++ b/code/programs/swift/build-tool/Tests/BuildToolCoreTests/DiscoveryTests.swift
@@ -6,6 +6,13 @@ struct DiscoveryTests {
     @Test
     func inferLanguageIncludesSwift() {
         #expect(Discovery.inferLanguage(path: "/repo/code/packages/swift/trig") == "swift")
+        #expect(Discovery.inferLanguage(path: "/repo/code/packages/custom/go") == "unknown")
+        #expect(
+            Discovery.inferPackageName(
+                path: "/repo/code/programs/elixir/grammar_tools",
+                language: "elixir"
+            ) == "elixir/programs/grammar_tools"
+        )
     }
 
     @Test
@@ -26,9 +33,91 @@ struct DiscoveryTests {
             "print(\"hi\")\n"
         )
 
-        let packages = Discovery.discoverPackages(root: root)
+        let packages = try Discovery.discoverPackages(root: root)
         #expect(packages.map(\.name) == ["python/logic-gates", "swift/trig"])
         #expect(packages.last?.language == "swift")
         #expect(packages.last?.buildCommands == ["swift test"])
+    }
+
+    @Test
+    func languageRegistryConsumesSharedFixture() throws {
+        let fixture = try loadSharedDiscoveryFixture("discovery-language-registry.json")
+        let root = try materializeSharedDiscoveryFixture(fixture, label: "discovery_registry")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let packages = try Discovery.discoverPackages(
+            root: (root as NSString).appendingPathComponent("code")
+        )
+        let actual = packages.map { package in
+            [
+                package.name,
+                package.language,
+                package.path
+                    .replacingOccurrences(of: "\\", with: "/")
+                    .replacingOccurrences(
+                        of: root.replacingOccurrences(of: "\\", with: "/") + "/",
+                        with: ""
+                    ),
+            ]
+        }
+        let expected = try #require(fixture.expected.result.packages).map {
+            [$0.name, $0.language, $0.relPath]
+        }
+
+        #expect(actual == expected)
+    }
+
+    @Test
+    func duplicateIdentityConsumesSharedFixture() throws {
+        let fixture = try loadSharedDiscoveryFixture("discovery-duplicate-identity.json")
+        let root = try materializeSharedDiscoveryFixture(fixture, label: "discovery_duplicate")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        do {
+            _ = try Discovery.discoverPackages(
+                root: (root as NSString).appendingPathComponent("code")
+            )
+            Issue.record("duplicate qualified identities must fail closed")
+        } catch let error as DuplicatePackageIdentityError {
+            let diagnostic = try #require(fixture.expected.diagnostics.first)
+            #expect(error.code == diagnostic.code)
+            #expect(error.package == diagnostic.package)
+            #expect(error.paths == diagnostic.details.paths)
+            #expect(error.paths.first == diagnostic.path)
+            let expected =
+                "\(diagnostic.code): package=\(diagnostic.package) paths=\(diagnostic.details.paths.joined(separator: ","))"
+            #expect(error.localizedDescription == expected)
+            #expect(!error.localizedDescription.contains(root))
+        }
+    }
+
+    @Test
+    func realCLIFailsClosedOnSharedDuplicateIdentityFixture() throws {
+        let fixture = try loadSharedDiscoveryFixture("discovery-duplicate-identity.json")
+        let root = try materializeSharedDiscoveryFixture(fixture, label: "discovery_duplicate_cli")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = try buildToolExecutableURL()
+        process.arguments = ["--root", root, "--force", "--dry-run"]
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+
+        let diagnostic = try #require(fixture.expected.diagnostics.first)
+        let expected =
+            "\(diagnostic.code): package=\(diagnostic.package) paths=\(diagnostic.details.paths.joined(separator: ","))\n"
+        let actualStderr = String(
+            decoding: stderr.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+
+        #expect(process.terminationStatus == 2)
+        #expect(actualStderr == expected)
+        #expect(!actualStderr.contains(root))
+        #expect(stdout.fileHandleForReading.readDataToEndOfFile().isEmpty)
     }
 }

--- a/code/programs/swift/build-tool/Tests/BuildToolCoreTests/TestSupport.swift
+++ b/code/programs/swift/build-tool/Tests/BuildToolCoreTests/TestSupport.swift
@@ -10,14 +10,20 @@ func makeTempDirectory(label: String = "build_tool_swift") throws -> String {
 
 func writeFile(_ path: String, _ contents: String) throws {
     let url = URL(fileURLWithPath: path)
-    try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-    try contents.write(to: url, atomically: true, encoding: .utf8)
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try Data(contents.utf8).write(to: url)
 }
 
 func writeData(_ path: String, _ contents: Data) throws {
     let url = URL(fileURLWithPath: path)
-    try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-    try contents.write(to: url, options: .atomic)
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try contents.write(to: url)
 }
 
 struct SharedResolutionFixture: Decodable {
@@ -72,6 +78,58 @@ struct SharedResolutionFixture: Decodable {
     let expected: Expected
 }
 
+struct SharedDiscoveryFixture: Decodable {
+    struct Workspace: Decodable {
+        let files: [File]
+    }
+
+    struct File: Decodable {
+        let path: String
+        let contentUTF8: String
+
+        enum CodingKeys: String, CodingKey {
+            case path
+            case contentUTF8 = "content_utf8"
+        }
+    }
+
+    struct Expected: Decodable {
+        struct Result: Decodable {
+            struct Package: Decodable {
+                let language: String
+                let name: String
+                let relPath: String
+
+                enum CodingKeys: String, CodingKey {
+                    case language
+                    case name
+                    case relPath = "rel_path"
+                }
+            }
+
+            let packages: [Package]?
+        }
+
+        struct Diagnostic: Decodable {
+            struct Details: Decodable {
+                let paths: [String]
+            }
+
+            let code: String
+            let path: String
+            let package: String
+            let details: Details
+        }
+
+        let outcome: String
+        let result: Result
+        let diagnostics: [Diagnostic]
+    }
+
+    let workspace: Workspace
+    let expected: Expected
+}
+
 func loadSharedResolutionFixture(_ name: String) throws -> SharedResolutionFixture {
     let packageRoot = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()
@@ -81,7 +139,45 @@ func loadSharedResolutionFixture(_ name: String) throws -> SharedResolutionFixtu
         .appendingPathComponent("../../../specs/fixtures/build-tool-v1/cases")
         .appendingPathComponent(name)
         .standardizedFileURL
-    return try JSONDecoder().decode(SharedResolutionFixture.self, from: Data(contentsOf: fixtureURL))
+    return try JSONDecoder().decode(
+        SharedResolutionFixture.self,
+        from: Data(contentsOf: fixtureURL)
+    )
+}
+
+func loadSharedDiscoveryFixture(_ name: String) throws -> SharedDiscoveryFixture {
+    let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let fixtureURL = packageRoot
+        .appendingPathComponent("../../../specs/fixtures/build-tool-v1/cases")
+        .appendingPathComponent(name)
+        .standardizedFileURL
+    return try JSONDecoder().decode(
+        SharedDiscoveryFixture.self,
+        from: Data(contentsOf: fixtureURL)
+    )
+}
+
+func materializeSharedDiscoveryFixture(
+    _ fixture: SharedDiscoveryFixture,
+    label: String
+) throws -> String {
+    let root = try makeTempDirectory(label: label)
+    try FileManager.default.createDirectory(
+        atPath: (root as NSString).appendingPathComponent(".git"),
+        withIntermediateDirectories: false
+    )
+    for file in fixture.workspace.files {
+        let url = URL(fileURLWithPath: (root as NSString).appendingPathComponent(file.path))
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(file.contentUTF8.utf8).write(to: url)
+    }
+    return root
 }
 
 func materializeSharedResolutionFixture(
@@ -97,7 +193,7 @@ func materializeSharedResolutionFixture(
         try writeData((root as NSString).appendingPathComponent(file.path), file.data())
     }
     let codeRoot = (root as NSString).appendingPathComponent("code")
-    return (root, Discovery.discoverPackages(root: codeRoot))
+    return (root, try Discovery.discoverPackages(root: codeRoot))
 }
 
 func buildToolExecutableURL() throws -> URL {

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -226,13 +226,13 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   #9495 normalized the three CP1252 metadata bytes, added positive and invalid-
   UTF-8 fixtures, and returns `METADATA_INVALID_UTF8`; its refreshed full scan
   succeeds across 4,765 packages and 7,100 edges;
-- bring the remaining Swift, TypeScript, Lua, Perl, Ruby, Elixir, and Haskell
+- bring the remaining TypeScript, Lua, Perl, Ruby, Elixir, and Haskell
   build-tool resolvers to the shared strict-UTF-8 rockspec contract.
   Their current byte, replacement, silent-drop, and locale-sensitive behavior
   is tracked separately from the Python full-scan blocker. Merged PR #9504
   completed the Go operational-oracle child, and merged PR #9510 completed
-  Rust. The next dependency-shaped child is the Swift engine, whose failed
-  UTF-8 decode currently becomes an empty Lua dependency list;
+  Rust. Merged PR #9537 completed Swift with exact shared success and invalid-
+  byte fixtures plus real CLI exit-2 coverage;
 - make Swift build-tool file options recognize Windows drive-letter absolute
   paths. The UTF-8 validation run discovered that `--emit-plan` reaches
   resolution but then joins an absolute Windows path under the repository;
@@ -240,8 +240,8 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
 - align Swift build-tool discovery with the canonical language and identity
   registry. Its full release plan currently emits 4,768 entries but only 4,594
   unique names, including 143 duplicate identity groups and 397 `unknown`
-  entries; consume the shared registry and duplicate-identity fixtures in a
-  separate post-UTF-8 slice;
+  entries. This is the selected post-UTF-8 child; consume the shared registry
+  and duplicate-identity fixtures without widening into file-option handling;
 - merged PR #9521 makes the Rust build tool reject resolver self-edges with a
   stable diagnostic and preserves distinct package/program identities for
   `elixir/grammar_tools`;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,13 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `4d0a98e0` after
-merged PR #9498 added the mixed Rust Tasmota local HTTP identity. Merged PR
-#9513 added the Rust-only Fronius local integration. PRs #9517, #9520, #9522,
-#9523, and #9524 changed existing packages or learning assets without creating
-another implementation package directory.
-The inventory contains
-1,219 normalized implementation identities across 4,367 established-lane
+working inventory was regenerated on August 2, 2026 from `80612eb7` after
+merged PR #9539 added the mixed Rust HEOS read-only integration and merged PR
+#9537 completed the Swift build-tool UTF-8 slice without creating another
+implementation package directory. The inventory contains
+1,221 normalized implementation identities across 4,369 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -120,17 +118,17 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 770 | 10,780 |
+| Present in one language | 771 | 10,794 |
 
 The loop must not start by attempting 10,780 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`613717e22fe7b65c37eebb35a84a5b440a55ddb1` is collision-clean at 1,220
-normalized implementation identities, 4,368 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 770 singletons, 575
+`80612eb7ba39d864c5ffa27f2cb3ae78e92705c1` is collision-clean at 1,221
+normalized implementation identities, 4,369 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 771 singletons, 576
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The fifteen newest mixed Rust identities are `smart-home-camera-media`,
+The sixteen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
 `smart-home-wled-integration`, `smart-home-govee-lan-integration`,
 `smart-home-lifx-lan-integration`, `smart-home-kasa-lan-integration`,
@@ -139,7 +137,8 @@ The fifteen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-nanoleaf-local-integration`,
 `smart-home-tasmota-local-integration`, and
 `smart-home-fronius-local-integration`, plus
-`smart-home-homewizard-energy-integration`. All are
+`smart-home-homewizard-energy-integration`, plus
+`smart-home-heos-cli-integration`. All are
 mixed splits rather than blind parity ports: camera grant policy,
 generation-bound lease state, quotas, and redacted audit are portable, while
 authenticated host context and media delivery remain native mediation; ONVIF
@@ -153,7 +152,7 @@ WLED DTO validation, master/segment projection, capability-bit interpretation,
 state normalization, and command planning are portable, while mDNS, DNS/TCP,
 plaintext LAN HTTP, trusted time, console I/O, pairing/origin policy, runtime
 effects, and capability profiles remain native. Govee, LIFX, Kasa, Reolink,
-Roku, Wemo, Sonos, Nanoleaf, Tasmota, Fronius, and HomeWizard contribute
+Roku, Wemo, Sonos, Nanoleaf, Tasmota, Fronius, HomeWizard, and HEOS contribute
 deterministic codecs, bounded parsers and DTO validation, normalization,
 projection, stable identities/errors, command planning, and language-neutral
 fixtures to the parity backlog. Wemo specifically contributes SSDP header
@@ -169,7 +168,10 @@ planning, and verification. Tasmota adds bounded Status 0 JSON validation,
 relay/light/sensor normalization, state and capability projection, command
 planning, color conversion, and verification fixtures. Fronius adds bounded
 Power Flow and API-status validation, site/inverter measurement normalization,
-and deterministic sensor projection. UDP multicast, DNS/TCP, LAN HTTP execution,
+and deterministic sensor projection. HEOS adds bounded command-result and
+response-envelope validation, player/now-playing/volume/mute normalization,
+HEOS escaping, stable identities/errors, and deterministic read-only media
+projection. UDP multicast, DNS/TCP, LAN HTTP and HEOS TCP execution,
 timeouts, endpoint approval, CLI I/O, authorization, and runtime mutation remain
 native-host responsibilities.
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,11 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `80612eb7` after
-merged PR #9539 added the mixed Rust HEOS read-only integration and merged PR
-#9537 completed the Swift build-tool UTF-8 slice without creating another
+working inventory was regenerated on August 2, 2026 from `0455cea8` after
+merged PR #9548 added the mixed Rust AirGradient local integration and merged
+PR #9537 completed the Swift build-tool UTF-8 slice without creating another
 implementation package directory. The inventory contains
-1,221 normalized implementation identities across 4,369 established-lane
+1,222 normalized implementation identities across 4,370 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -118,17 +118,17 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 771 | 10,794 |
+| Present in one language | 772 | 10,808 |
 
 The loop must not start by attempting 10,780 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`80612eb7ba39d864c5ffa27f2cb3ae78e92705c1` is collision-clean at 1,221
-normalized implementation identities, 4,369 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 771 singletons, 576
+`0455cea8e0c0ddc078040ea109ea59dbaf8403fa` is collision-clean at 1,222
+normalized implementation identities, 4,370 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 772 singletons, 577
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
-The sixteen newest mixed Rust identities are `smart-home-camera-media`,
+The seventeen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
 `smart-home-wled-integration`, `smart-home-govee-lan-integration`,
 `smart-home-lifx-lan-integration`, `smart-home-kasa-lan-integration`,
@@ -137,8 +137,9 @@ The sixteen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-nanoleaf-local-integration`,
 `smart-home-tasmota-local-integration`, and
 `smart-home-fronius-local-integration`, plus
-`smart-home-homewizard-energy-integration`, plus
-`smart-home-heos-cli-integration`. All are
+`smart-home-homewizard-energy-integration`,
+`smart-home-heos-cli-integration`, and
+`smart-home-airgradient-local-integration`. All are
 mixed splits rather than blind parity ports: camera grant policy,
 generation-bound lease state, quotas, and redacted audit are portable, while
 authenticated host context and media delivery remain native mediation; ONVIF
@@ -171,7 +172,10 @@ Power Flow and API-status validation, site/inverter measurement normalization,
 and deterministic sensor projection. HEOS adds bounded command-result and
 response-envelope validation, player/now-playing/volume/mute normalization,
 HEOS escaping, stable identities/errors, and deterministic read-only media
-projection. UDP multicast, DNS/TCP, LAN HTTP and HEOS TCP execution,
+projection. AirGradient adds bounded `/measures/current` JSON validation,
+firmware/model/sensor normalization, environmental measurement identities and
+units, stable errors, and deterministic read-only sensor projection. UDP
+multicast, DNS/TCP, LAN HTTP and HEOS TCP execution,
 timeouts, endpoint approval, CLI I/O, authorization, and runtime mutation remain
 native-host responsibilities.
 


### PR DESCRIPTION
## Summary
- align Swift package discovery with the shared canonical language/identity registry at the exact `packages` / `programs` boundary
- preserve package/program identity, exclude specification fixture trees, and reject duplicate qualified identities with a stable typed diagnostic and CLI exit 2
- consume the shared language-registry and duplicate-identity fixtures in API and real CLI subprocess tests
- refresh the collision-checked parity inventory and log the newly discovered AirGradient portable telemetry core as pending work

## Validation
- base: `0455cea8e0c0ddc078040ea109ea59dbaf8403fa`
- `swift test`: 25 tests passed
- `swift test --enable-code-coverage`: 25 tests passed; 55.56% overall line coverage, 91.33% `Discovery.swift`
- `swift build -c release`: passed (only existing warnings in `BuildTool.swift` and `Executor.swift`)
- shared conformance schema tests: 17 passed
- shared conformance runner tests: 40 passed
- `build_tool_conformance.py validate-corpus`: valid, 36 cases / 55 files / 15 established languages / 16 implementations
- real release full plan: 4,768 packages, 4,768 unique identities, zero duplicate groups, 7,471 dependency edges, only intentional `unknown/blog`
- collision-enforced parity report: 1,222 identities / 4,370 slots / 172 high-consensus packages / 271 high-consensus gaps / 772 singletons / 10,808 singleton gaps / 577 Rust singletons / zero collisions / zero unknown buckets
- `swift package show-dependencies --format json`: zero external dependencies; Swift tools 5.9
- BUILD/CI validation: reproduces only the unchanged, separately owned 10 Lua `BUILD_windows` debt items
- exact-base secret-like diff scan: zero hits
- JSON parse, `git diff --check`, and clean-worktree checks: passed

## Known baseline
- `swift-format lint --strict --recursive Sources Tests` reports 3,821 diagnostics across the existing engine and no checked-in formatter configuration; this focused slice does not reformat unrelated files.