### PR TITLE
fix(spice): validate MOS flicker noise coefficient

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `KF` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `RSH` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `RS` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2024,6 +2024,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(flicker_noise_coefficient) = params.get("KF") {
+            if !flicker_noise_coefficient.is_finite() || *flicker_noise_coefficient < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET KF must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2292,6 +2292,35 @@ fn preserves_non_negative_mosfet_model_sheet_resistance() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_flicker_noise_coefficients() {
+    for coefficient in ["-1p", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model noise NMOS(KF={coefficient})\nM1 d g s b noise"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET KF must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_flicker_noise_coefficient() {
+    for (coefficient, expected) in [("0", 0.0), ("1p", 1.0e-12)] {
+        let parsed = parse_netlist(&format!(
+            ".model noise NMOS(KF={coefficient})\nM1 d g s b noise"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.flicker_noise_coefficient, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card sheet-resistance validation.
+1. Rust Berkeley SPICE MOS model-card flicker-noise-coefficient validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `RSH` values before lowering MOS
+   - Reject negative and non-finite model-card `KF` values before lowering MOS
      elements into engine parameters.
-   - Preserve zero and positive sheet resistances.
+   - Preserve zero and positive flicker-noise coefficients.
 
 ## Completed Slices
 
@@ -4077,11 +4077,16 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Zero and positive source resistances remain accepted.
 
+360. Rust Berkeley SPICE MOS model-card sheet-resistance validation.
+   - Status: completed in PR 9551.
+   - Negative and non-finite model-card `RSH` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive sheet resistances remain accepted.
+
 ## Backlog
 
 1. Rust Berkeley SPICE MOS model-card validation follow-ups.
-   - Validate the remaining facade gaps in priority order: flicker-noise
-     coefficient `KF`, then flicker-noise exponent `AF`.
+   - Validate the remaining flicker-noise-exponent facade gap for `AF`.
    - Reuse the finite non-negative contracts and diagnostics already aligned
      across the Rust, Python, and TypeScript engines.
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `KF` values in the Rust Berkeley SPICE parser facade
- preserve zero and positive flicker-noise coefficients
- reconcile the plan after #9551 and advance the prioritized facade backlog to `AF`

## Scope
This is a Rust parser-facade boundary change. The shared Rust, Python, and TypeScript engines already enforce the same `KF` behavior and diagnostic.

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser` (158 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`