### PR TITLE
fix(smart-home): serialize LAN TCP transports

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -92562,6 +92562,7 @@ impl BridgeTransportLabel for smart_home_core::BridgeTransport {
     fn as_str(self) -> &'static str {
         match self {
             smart_home_core::BridgeTransport::LanHttp => "lan_http",
+            smart_home_core::BridgeTransport::LanTcp => "lan_tcp",
             smart_home_core::BridgeTransport::LanUdp => "lan_udp",
             smart_home_core::BridgeTransport::Mdns => "mdns",
             smart_home_core::BridgeTransport::Serial => "serial",
@@ -96330,6 +96331,10 @@ mod tests {
         assert_eq!(
             smart_home_core::BridgeTransport::LanUdp.as_str(),
             "lan_udp"
+        );
+        assert_eq!(
+            smart_home_core::BridgeTransport::LanTcp.as_str(),
+            "lan_tcp"
         );
 
         let summary = RegistryTopologySummary {


### PR DESCRIPTION
## Summary
- serialize `BridgeTransport::LanTcp` as `lan_tcp` in Chief smart-home tool output
- add regression coverage alongside existing transport label assertions
- correct the post-merge macOS CI failure reported on #9548

## Validation
- `bash chief-of-staff-smart-home-tools/BUILD` (62 tests)
- `cargo clippy -p chief-of-staff-smart-home-tools --all-targets -- -D warnings`
- `git diff --check`