### PR TITLE
fix(venture): repair cross-platform native acceptance

### DIFF
--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -14,13 +14,14 @@ use std::{cell::RefCell, rc::Rc};
 use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 use venture_browser_core::{
     BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
-    BrowserScrollCommand, BrowserScrollMetrics, BrowserSession,
+    BrowserScrollCommand, BrowserSession,
 };
 use window_core::{ElementState, Key, NamedKey, PointerButton, WindowError, WindowEvent};
 
 #[cfg(target_vendor = "apple")]
 use venture_browser_core::{
-    BrowserChromeController, BrowserChromeEvent, BrowserChromeProps, HttpBrowserFetcher,
+    BrowserChromeController, BrowserChromeEvent, BrowserChromeProps, BrowserScrollMetrics,
+    HttpBrowserFetcher,
 };
 
 pub const VERSION: &str = "0.1.0";

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Repair cross-platform acceptance discovered after native scrollbar
+  projection: keep the scroll-metrics type import Apple-only, and reset the
+  WinUI viewport to document start before hover/click link acceptance.
 - Add shared viewport-metric projection and native NSScroller/WinUI ScrollBar
   bindings inside the generated HostSurface adapters, including direct app
   interaction acceptance.

--- a/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/venture-browser/host/xaml/MosaicHost.cs
@@ -1029,15 +1029,15 @@ public static class MosaicHost
         internal bool RunPointerAcceptance()
         {
             _ = Focus(FocusState.Programmatic);
-            return HandleKey(VirtualKey.Home, false, false, out var changed)
-                && changed
-                && ActivateSurfacePoint(new Windows.Foundation.Point(32, 26));
+            return ActivateSurfacePoint(new Windows.Foundation.Point(32, 26));
         }
 
         internal bool RunHoverAcceptance(string linkUrl)
         {
             _ = Focus(FocusState.Programmatic);
-            return UpdateHoverAt(new Windows.Foundation.Point(32, 26))
+            return HandleKey(VirtualKey.Home, false, false, out var changed)
+                && changed
+                && UpdateHoverAt(new Windows.Foundation.Point(32, 26))
                 && hoverUsesHandCursor
                 && string.Equals(component.StatusText, linkUrl, StringComparison.Ordinal);
         }

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -203,6 +203,26 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     ] {
         assert!(host.contains(symbol), "XAML host omits {symbol}");
     }
+    let hover_acceptance = host
+        .split("internal bool RunHoverAcceptance(string linkUrl)")
+        .nth(1)
+        .and_then(|source| source.split("internal async").next())
+        .expect("extract WinUI hover acceptance");
+    assert!(
+        hover_acceptance.contains("HandleKey(VirtualKey.Home")
+            && hover_acceptance.contains("UpdateHoverAt"),
+        "WinUI must reset the shared viewport before checking the top-of-document link"
+    );
+    let pointer_acceptance = host
+        .split("internal bool RunPointerAcceptance()")
+        .nth(1)
+        .and_then(|source| source.split("internal bool RunHoverAcceptance").next())
+        .expect("extract WinUI pointer acceptance");
+    assert!(
+        pointer_acceptance.contains("ActivateSurfacePoint")
+            && !pointer_acceptance.contains("HandleKey(VirtualKey.Home"),
+        "WinUI click acceptance must reuse the viewport position established by hover"
+    );
     let swift_host = read_package_file("host/swiftui/MosaicHost.swift");
     let xaml_host = read_package_file("host/xaml/MosaicHost.cs");
     for command in venture_browser_core::VENTURE_SCROLL_COMMAND_NAMES {


### PR DESCRIPTION
## Summary
- keep `BrowserScrollMetrics` behind the Apple cfg so Ubuntu strict-clippy builds stay warning-free
- reset the WinUI document viewport before hover acceptance, then reuse that position for pointer activation
- ratchet the generated-host source contract around the hover/click sequence

## Validation
- `cargo test -p venture-browser-macos -p venture-browser-windows --tests`
- `cargo clippy -p venture-browser-macos -p venture-browser-windows --all-targets -- -D warnings`
- Venture `cargo test --test package_compiles` (3 passed)
- exact parser audit: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 local raw / 0 missing; normalized 7242 / 0 skipped

This repairs regressions observed in the post-merge checks for #9550. It does not claim full browser conformance.