### PR TITLE
feat(venture): add Flutter chrome interaction acceptance

### DIFF
--- a/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
@@ -5,6 +5,16 @@ this file.
 
 ## [Unreleased]
 
+### Fixed - native form state and generated-shell interaction acceptance
+
+Slot-backed `HostButton.disabled` and `HostInput.read-only` values now reach
+Flutter's native `onPressed` and `readOnly` contracts, while `HostInput`
+`onCommit` dispatches from `TextField.onSubmitted`. Direct `Row` inputs are
+wrapped in `Expanded` so generated toolbars have a finite width and can render.
+Generated `MosaicApp` shells also accept an injected `MosaicHost`, allowing
+widget tests to exercise initial props, native input, event envelopes, and
+host-driven prop refresh without replacing the generated component.
+
 ### Fixed - project-shell widget-slot hydration
 
 Generated Flutter shells now accept a host-provided `Widget` in the props map

--- a/code/packages/rust/mosaic-emit-flutter/README.md
+++ b/code/packages/rust/mosaic-emit-flutter/README.md
@@ -115,6 +115,12 @@ optional `MosaicHost` props map. This is the composition seam used by Venture's
 browser content surface; scalar props remain normalized by the existing typed
 helpers.
 
+`HostButton.disabled`, `HostInput.read-only`, and `HostInput.onCommit` lower to
+Flutter's native button and text-field contracts. Project shells expose a
+`MosaicApp(mosaicHost: ...)` injection seam so direct widget acceptance can
+drive those controls and verify host response hydration against the exact
+generated component.
+
 ## What works in v0.1 / what's deferred
 
 See `CHANGELOG.md` for the full feature matrix. The headline:

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -343,20 +343,21 @@ fn build_main_dart(component_name: &str, slots: &[SlotDecl]) -> String {
             "import '{component_name}.dart';\n",
             "import 'mosaic_host.dart';\n\n",
             "void main() {{\n",
-            "  runApp(const _MosaicApp());\n",
+            "  runApp(const MosaicApp());\n",
             "}}\n\n",
-            "class _MosaicApp extends StatefulWidget {{\n",
-            "  const _MosaicApp();\n\n",
+            "class MosaicApp extends StatefulWidget {{\n",
+            "  const MosaicApp({{super.key, this.mosaicHost}});\n\n",
+            "  final MosaicHost? mosaicHost;\n\n",
             "  @override\n",
-            "  State<_MosaicApp> createState() => _MosaicAppState();\n",
+            "  State<MosaicApp> createState() => _MosaicAppState();\n",
             "}}\n\n",
-            "class _MosaicAppState extends State<_MosaicApp> {{\n",
+            "class _MosaicAppState extends State<MosaicApp> {{\n",
             "  late final MosaicHost? _mosaicHost;\n",
             "  Map<String, Object?> _hostProps = const <String, Object?>{{}};\n\n",
             "  @override\n",
             "  void initState() {{\n",
             "    super.initState();\n",
-            "    _mosaicHost = MosaicHost.load();\n",
+            "    _mosaicHost = widget.mosaicHost ?? MosaicHost.load();\n",
             "    _queueMosaicResponse(_mosaicHost?.props());\n",
             "  }}\n\n",
             "  @override\n",
@@ -856,6 +857,10 @@ struct TableCtx<'a> {
     sheet_text_color: Option<&'a str>,
     sheet_font_family: Option<&'a str>,
     sheet_font_size: Option<&'a str>,
+    /// True only while emitting a widget that is a direct child of a
+    /// `Row`. Flutter text fields require a finite horizontal constraint,
+    /// so direct row inputs lower through `Expanded`.
+    direct_row_child: bool,
 }
 
 /// Scan a `HostTable`'s children for the
@@ -911,7 +916,7 @@ fn emit_widget_tree(
         return emit_host_surface(node, indent);
     }
     if node.tag == "HostInput" {
-        return emit_host_input(node, indent, part_styles, component);
+        return emit_host_input(node, indent, part_styles, component, ctx.direct_row_child);
     }
     if node.tag == "HostButton" {
         return emit_host_button(node, indent, part_styles, component, emits, ctx);
@@ -1122,6 +1127,10 @@ fn emit_container(
 ) -> Result<String, PipelineEmitError> {
     let pad = " ".repeat(indent);
     let inner_pad = " ".repeat(indent + 2);
+    let child_ctx = TableCtx {
+        direct_row_child: widget == "Row",
+        ..ctx
+    };
 
     let style_props = node
         .part_name
@@ -1142,7 +1151,15 @@ fn emit_container(
         // conditional background + text colour. See `emit_styled_box`.
         if let Some(part) = node.part_name.as_deref() {
             if part_has_decoration(style_props) || node_has_state_when(node) {
-                return emit_styled_box(node, part, indent, part_styles, component, emits, ctx);
+                return emit_styled_box(
+                    node,
+                    part,
+                    indent,
+                    part_styles,
+                    component,
+                    emits,
+                    child_ctx,
+                );
             }
         }
 
@@ -1164,7 +1181,7 @@ fn emit_container(
                 part_styles,
                 component,
                 emits,
-                ctx,
+                child_ctx,
             )?;
             let child_src = child_src.trim_end_matches('\n');
             return Ok(format!(
@@ -1178,7 +1195,7 @@ fn emit_container(
             part_styles,
             component,
             emits,
-            ctx,
+            child_ctx,
         )?;
         return Ok(format!(
             "{pad}Container(\n{pad}  child: Column(children: [\n{children}{pad}  ]){style_args}\n{pad})\n"
@@ -1196,7 +1213,7 @@ fn emit_container(
         part_styles,
         component,
         emits,
-        ctx,
+        child_ctx,
     )?;
 
     if children.is_empty() {
@@ -2042,8 +2059,14 @@ fn emit_host_input(
     indent: usize,
     _part_styles: &HashMap<String, String>,
     component: &str,
+    direct_row_child: bool,
 ) -> Result<String, PipelineEmitError> {
     let pad = " ".repeat(indent);
+    let field_pad = if direct_row_child {
+        " ".repeat(indent + 2)
+    } else {
+        pad.clone()
+    };
     // UI28-1 / U29-D1 — accept Expr in `value:` so
     // mosaic-pkg-grid v0.2.0's `HostInput ( value: ( v ) )` shape
     // reaches the TextField with the For-bound cell text. The Expr
@@ -2070,20 +2093,29 @@ fn emit_host_input(
     };
 
     let mut out = String::new();
-    writeln!(out, "{pad}TextField(").unwrap();
+    if direct_row_child {
+        writeln!(out, "{pad}Expanded(").unwrap();
+        writeln!(out, "{field_pad}child: TextField(").unwrap();
+    } else {
+        writeln!(out, "{field_pad}TextField(").unwrap();
+    }
     writeln!(
         out,
-        "{pad}  controller: TextEditingController(text: {value_expr}),"
+        "{field_pad}  controller: TextEditingController(text: {value_expr}),"
     )
     .unwrap();
 
     if let Some(p) = find_string_prop(node, "placeholder") {
         writeln!(
             out,
-            "{pad}  decoration: InputDecoration(hintText: \"{}\"),",
+            "{field_pad}  decoration: InputDecoration(hintText: \"{}\"),",
             escape_dart_string(p)
         )
         .unwrap();
+    }
+
+    if let Some(read_only) = bool_prop_expression(node, "read-only")? {
+        writeln!(out, "{field_pad}  readOnly: {read_only},").unwrap();
     }
 
     // onChange — wraps the new value in a dispatched event.
@@ -2109,11 +2141,23 @@ fn emit_host_input(
         validate_emit_name(&case)?;
         writeln!(
             out,
-            "{pad}  onChanged: (value) => dispatch({component}Event{case}(value: value)),"
+            "{field_pad}  onChanged: (value) => dispatch({component}Event{case}(value: value)),"
         )
         .unwrap();
     }
-    writeln!(out, "{pad})").unwrap();
+    if let Some(emit_name) = find_emit_ref_prop(node, "onCommit") {
+        let case = pascalize(&strip_on_prefix(emit_name));
+        validate_emit_name(&case)?;
+        writeln!(
+            out,
+            "{field_pad}  onSubmitted: (_) => dispatch({component}Event{case}()),"
+        )
+        .unwrap();
+    }
+    writeln!(out, "{field_pad})").unwrap();
+    if direct_row_child {
+        writeln!(out, "{pad})").unwrap();
+    }
     Ok(out)
 }
 
@@ -2154,10 +2198,7 @@ fn emit_host_button(
     // Current behavior: zero-payload events keep the `EventCase()`
     // shape, while single text-like/number payloads borrow the nearest
     // `For` item/index when present.
-    let disabled_is_true = matches!(find_keyword_prop(node, "disabled"), Some("true"));
-    let on_pressed_expr: String = if disabled_is_true {
-        "null".to_string()
-    } else if let Some(emit_name) =
+    let callback: String = if let Some(emit_name) =
         find_emit_ref_prop(node, "onClick").or_else(|| find_emit_ref_prop(node, "onTap"))
     {
         let case = pascalize(&strip_on_prefix(emit_name));
@@ -2171,6 +2212,11 @@ fn emit_host_button(
         format!("() => dispatch({component}Event{case}({args}))")
     } else {
         "() {}".to_string()
+    };
+    let on_pressed_expr = match bool_prop_expression(node, "disabled")?.as_deref() {
+        Some("true") => "null".to_string(),
+        Some("false") | None => callback,
+        Some(disabled) => format!("{disabled} ? null : {callback}"),
     };
 
     let style_arg = host_button_style_arg(node, part_styles);
@@ -2523,6 +2569,7 @@ fn emit_host_table(
         sheet_text_color: sheet_text_color.as_deref(),
         sheet_font_family: sheet_font_family.as_deref(),
         sheet_font_size: sheet_font_size.as_deref(),
+        direct_row_child: false,
     };
 
     // UI28-1 / U29-D1 — HostTable now walks its children (sub-tags:
@@ -3306,6 +3353,28 @@ fn find_slot_ref_prop<'a>(node: &'a LayoutNode, name: &str) -> Option<&'a str> {
     })
 }
 
+fn bool_prop_expression(
+    node: &LayoutNode,
+    name: &str,
+) -> Result<Option<String>, PipelineEmitError> {
+    let Some(value) = find_prop_value(node, name) else {
+        return Ok(None);
+    };
+    let expression = match value {
+        LayoutPropValue::SlotRef(slot) => {
+            let camel = to_camel_case_first_lower(slot);
+            validate_slot_or_field_name(&camel)?;
+            camel
+        }
+        LayoutPropValue::Keyword(keyword) if keyword == "true" || keyword == "false" => {
+            keyword.clone()
+        }
+        LayoutPropValue::Expr(expression) => expression.trim().to_string(),
+        _ => return Ok(None),
+    };
+    Ok(Some(expression))
+}
+
 fn emit_host_surface(node: &LayoutNode, indent: usize) -> Result<String, PipelineEmitError> {
     let pad = " ".repeat(indent);
     let expression = if let Some(slot) = find_slot_ref_prop(node, "content") {
@@ -3878,6 +3947,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn host_button_disabled_slot_controls_onpressed() {
+        let m = component(
+            "BrowserChrome",
+            vec![slot("back-disabled", SlotType::Bool, true)],
+            vec![emit("onBack", vec![])],
+        );
+        let l = layout(
+            "BrowserChrome",
+            node_with(
+                "HostButton",
+                vec![
+                    LayoutProp {
+                        name: "disabled".into(),
+                        value: LayoutPropValue::SlotRef("back-disabled".into()),
+                    },
+                    LayoutProp {
+                        name: "onClick".into(),
+                        value: LayoutPropValue::EmitRef("onBack".into()),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let r = from_pipeline(&m, &l, &empty_style("BrowserChrome")).unwrap();
+        assert!(
+            r.output.contains(
+                "onPressed: backDisabled ? null : () => dispatch(BrowserChromeEventBack())"
+            ),
+            "slot-backed disabled state must control the native button:\n{}",
+            r.output
+        );
+    }
+
     // ----- HostInput with placeholder + slot value ---------------------
 
     #[test]
@@ -3905,6 +4008,74 @@ mod tests {
         assert!(out.contains("TextField("));
         assert!(out.contains("TextEditingController(text: formula)"));
         assert!(out.contains("hintText: \"Type a formula\""));
+    }
+
+    #[test]
+    fn host_input_lowers_read_only_slot_and_commit_event() {
+        let m = component(
+            "BrowserChrome",
+            vec![
+                slot("address", SlotType::Text, true),
+                slot("navigation-disabled", SlotType::Bool, true),
+            ],
+            vec![emit("onNavigate", vec![])],
+        );
+        let l = layout(
+            "BrowserChrome",
+            node_with(
+                "HostInput",
+                vec![
+                    LayoutProp {
+                        name: "value".into(),
+                        value: LayoutPropValue::SlotRef("address".into()),
+                    },
+                    LayoutProp {
+                        name: "read-only".into(),
+                        value: LayoutPropValue::SlotRef("navigation-disabled".into()),
+                    },
+                    LayoutProp {
+                        name: "onCommit".into(),
+                        value: LayoutPropValue::EmitRef("onNavigate".into()),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let r = from_pipeline(&m, &l, &empty_style("BrowserChrome")).unwrap();
+        assert!(r.output.contains("readOnly: navigationDisabled"));
+        assert!(r
+            .output
+            .contains("onSubmitted: (_) => dispatch(BrowserChromeEventNavigate())"));
+    }
+
+    #[test]
+    fn host_input_directly_inside_row_receives_finite_width() {
+        let m = component(
+            "BrowserChrome",
+            vec![slot("address", SlotType::Text, true)],
+            vec![],
+        );
+        let l = layout(
+            "BrowserChrome",
+            node_with(
+                "Row",
+                vec![],
+                vec![node_with(
+                    "HostInput",
+                    vec![LayoutProp {
+                        name: "value".into(),
+                        value: LayoutPropValue::SlotRef("address".into()),
+                    }],
+                    vec![],
+                )],
+            ),
+        );
+        let r = from_pipeline(&m, &l, &empty_style("BrowserChrome")).unwrap();
+        assert!(
+            r.output.contains("Expanded(") && r.output.contains("child: TextField("),
+            "a direct Row input must be flex-constrained:\n{}",
+            r.output
+        );
     }
 
     /// Regression: `HostInput { onChange: emit: onFormulaChange }`
@@ -5049,6 +5220,17 @@ mod tests {
         assert!(
             proj.main_dart.contains("MosaicHost.load()"),
             "main.dart must load the optional Mosaic host"
+        );
+        assert!(
+            proj.main_dart
+                .contains("class MosaicApp extends StatefulWidget")
+                && proj
+                    .main_dart
+                    .contains("const MosaicApp({super.key, this.mosaicHost})")
+                && proj
+                    .main_dart
+                    .contains("widget.mosaicHost ?? MosaicHost.load()"),
+            "main.dart must expose host injection for direct shell acceptance"
         );
         assert!(
             proj.readme

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Repair cross-platform acceptance discovered after native scrollbar
   projection: keep the scroll-metrics type import Apple-only, and reset the
   WinUI viewport to document start before hover/click link acceptance.
+- Add direct generated Flutter interaction acceptance through an injectable
+  Mosaic host, covering initial prop hydration, disabled controls, address
+  editing, native Return submission, Go dispatch, and host response refresh.
 - Add shared viewport-metric projection and native NSScroller/WinUI ScrollBar
   bindings inside the generated HostSurface adapters, including direct app
   interaction acceptance.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -75,7 +75,10 @@ backend on the current machine:
 
 React and Electron run their production builds; HTML and Web Components run
 JavaScript syntax checks; SwiftUI, Qt, XAML, Flutter, and Compose invoke their
-native toolchains. Platform-exclusive builds are explicitly deferred to their
+native toolchains. The Flutter gate additionally pumps the emitted `MosaicApp`
+with a recording host and drives the generated native controls, including
+disabled buttons, address editing, Return, Go, and host-driven prop refresh.
+Platform-exclusive builds are explicitly deferred to their
 native host; missing host-applicable toolchains are reported as skips. Pass
 `--strict` on POSIX or `-Strict` on PowerShell to reject those missing
 toolchains in a provisioned macOS, Windows, or Linux build job. `--emit-only` /

--- a/code/programs/mosaic/venture-browser/host/flutter/venture_chrome_interaction_test.dart
+++ b/code/programs/mosaic/venture-browser/host/flutter/venture_chrome_interaction_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mosaic_venture_chrome/main.dart';
+import 'package:mosaic_venture_chrome/mosaic_host.dart';
+
+class RecordingMosaicHost extends MosaicHost {
+  RecordingMosaicHost({required this.navigationDisabled});
+
+  final bool navigationDisabled;
+  final List<Map<String, Object?>> events = <Map<String, Object?>>[];
+
+  @override
+  FutureOr<Map<String, Object?>?> props() => <String, Object?>{
+    'props': <String, Object?>{
+      'address': 'http://venture.test/start',
+      'page-title': 'Venture Flutter Acceptance',
+      'status-text': 'Ready',
+      'back-disabled': true,
+      'forward-disabled': true,
+      'navigation-disabled': navigationDisabled,
+      'content-surface': const Text('Flutter host surface'),
+    },
+  };
+
+  @override
+  FutureOr<Map<String, Object?>?> handleEvent(Map<String, Object?> event) {
+    events.add(Map<String, Object?>.from(event));
+    if (event['event'] == 'onNavigate') {
+      return <String, Object?>{
+        'props': <String, Object?>{
+          'address': 'http://venture.test/next',
+          'page-title': 'Venture Flutter Acceptance',
+          'status-text': 'Navigated through MosaicHost',
+          'back-disabled': false,
+          'forward-disabled': true,
+          'navigation-disabled': false,
+          'content-surface': const Text('Flutter host surface'),
+        },
+      };
+    }
+    return null;
+  }
+}
+
+Future<void> pumpVentureShell(
+  WidgetTester tester,
+  RecordingMosaicHost host,
+) async {
+  await tester.binding.setSurfaceSize(const Size(1400, 900));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(MosaicApp(mosaicHost: host));
+  await tester.pumpAndSettle();
+  expect(find.text('Venture Flutter Acceptance'), findsOneWidget);
+  expect(find.text('Flutter host surface'), findsOneWidget);
+}
+
+void main() {
+  testWidgets('disabled native controls suppress Mosaic dispatch', (
+    WidgetTester tester,
+  ) async {
+    final host = RecordingMosaicHost(navigationDisabled: true);
+    await pumpVentureShell(tester, host);
+
+    expect(tester.widget<TextField>(find.byType(TextField)).readOnly, isTrue);
+    for (final label in <String>['Back', 'Forward', 'Reload', 'Go']) {
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, label),
+      );
+      expect(button.onPressed, isNull, reason: '$label must be disabled');
+      await tester.tap(find.text(label));
+    }
+    await tester.pump();
+    expect(host.events, isEmpty);
+  });
+
+  testWidgets('address edit, Return, and Go cross the Mosaic host seam', (
+    WidgetTester tester,
+  ) async {
+    final host = RecordingMosaicHost(navigationDisabled: false);
+    await pumpVentureShell(tester, host);
+
+    final input = find.byType(TextField);
+    expect(tester.widget<TextField>(input).readOnly, isFalse);
+    await tester.enterText(input, 'http://venture.test/next');
+    await tester.pump();
+    expect(host.events.last, <String, Object?>{
+      'event': 'onAddressChange',
+      'value': 'http://venture.test/next',
+    });
+
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+    expect(host.events.last['event'], 'onNavigate');
+    expect(find.text('Navigated through MosaicHost'), findsOneWidget);
+
+    await tester.tap(find.text('Go'));
+    await tester.pumpAndSettle();
+    expect(
+      host.events.where((event) => event['event'] == 'onNavigate').length,
+      2,
+    );
+  });
+}

--- a/code/programs/mosaic/venture-browser/mosaic-package.toml
+++ b/code/programs/mosaic/venture-browser/mosaic-package.toml
@@ -11,6 +11,7 @@ exports = ["VentureChrome"]
 files = [
   { backend = "swiftui", source = "host/swiftui/MosaicHost.swift", target = "Sources/App/MosaicHost.swift" },
   { backend = "xaml", source = "host/xaml/MosaicHost.cs", target = "MosaicHost.cs" },
+  { backend = "flutter", source = "host/flutter/venture_chrome_interaction_test.dart", target = "test/venture_chrome_interaction_test.dart" },
 ]
 
 [kernel]

--- a/code/programs/mosaic/venture-browser/scripts/build-all.ps1
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.ps1
@@ -215,6 +215,7 @@ if ($null -ne $flutterPlatform -and (Test-Command "flutter")) {
     try {
         Invoke-Checked -Command "flutter" -Arguments @("pub", "get")
         Invoke-Checked -Command "flutter" -Arguments @("analyze", "lib")
+        Invoke-Checked -Command "flutter" -Arguments @("test", "test/venture_chrome_interaction_test.dart")
         if (-not (Test-Path -LiteralPath $flutterPlatform)) {
             Invoke-Checked -Command "flutter" -Arguments @("create", "--platforms=$flutterPlatform", ".")
         }

--- a/code/programs/mosaic/venture-browser/scripts/build-all.sh
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.sh
@@ -194,6 +194,7 @@ if [[ -n "$flutter_platform" ]] && has_command flutter; then
     cd "$output_root/flutter"
     flutter pub get
     flutter analyze lib
+    flutter test test/venture_chrome_interaction_test.dart
     if [[ ! -d "$flutter_platform" ]]; then
       flutter create "--platforms=$flutter_platform" .
     fi

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -89,7 +89,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     let package = mosaic_package_manifest::parse(&manifest).expect("parse manifest");
     assert_eq!(package.package.name, "venture-browser");
     assert_eq!(package.components.exports, ["VentureChrome"]);
-    assert_eq!(package.host_assets.files.len(), 2);
+    assert_eq!(package.host_assets.files.len(), 3);
     assert_eq!(package.host_assets.files[0].backend, "swiftui");
     assert_eq!(
         package.host_assets.files[0].target,
@@ -101,6 +101,15 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         "host/xaml/MosaicHost.cs"
     );
     assert_eq!(package.host_assets.files[1].target, "MosaicHost.cs");
+    assert_eq!(package.host_assets.files[2].backend, "flutter");
+    assert_eq!(
+        package.host_assets.files[2].source,
+        "host/flutter/venture_chrome_interaction_test.dart"
+    );
+    assert_eq!(
+        package.host_assets.files[2].target,
+        "test/venture_chrome_interaction_test.dart"
+    );
 
     let host = read_package_file("host/swiftui/MosaicHost.swift");
     for symbol in [
@@ -235,6 +244,21 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
             "XAML host omits shared scroll command {command}"
         );
     }
+
+    let flutter_acceptance =
+        read_package_file("host/flutter/venture_chrome_interaction_test.dart");
+    for symbol in [
+        "MosaicApp(mosaicHost: host)",
+        "disabled native controls suppress Mosaic dispatch",
+        "address edit, Return, and Go cross the Mosaic host seam",
+        "tester.testTextInput.receiveAction(TextInputAction.done)",
+        "Navigated through MosaicHost",
+    ] {
+        assert!(
+            flutter_acceptance.contains(symbol),
+            "Flutter interaction acceptance omits {symbol}"
+        );
+    }
 }
 
 #[test]
@@ -276,6 +300,7 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "cmake --build",
         "dotnet build",
         "flutter build",
+        "flutter test test/venture_chrome_interaction_test.dart",
         "gradle --no-daemon build",
         "--strict",
     ] {
@@ -294,6 +319,7 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "cmake",
         "dotnet",
         "flutter",
+        "venture_chrome_interaction_test.dart",
         "gradle",
         "$Strict",
     ] {

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -120,10 +120,12 @@ complete.
    extent as target-neutral state, then bind generated native scrollbars to the
    same Mosaic-hosted content surface without recreating browser chrome in
    AppKit or Win32.
-3. **P2 — remaining generated-host interaction gates.** Promote the existing
-   build/host-object checks for Qt, Flutter, Compose, and the web-family shells
-   to direct interaction acceptance where their provisioned CI toolchains can
-   launch them.
+3. **P2 — remaining generated-host interaction gates (Flutter completed).**
+   Flutter now hydrates the emitted shell through an injected Mosaic host and
+   directly drives native disabled controls, address editing, Return, Go, and
+   host-response refresh. Promote the remaining Qt, Compose, and web-family
+   build/host-object checks to direct interaction acceptance where their
+   provisioned CI toolchains can launch them.
 
 These are browser-wiring and acceptance items. They do not relax the exact
 zero-missing WPT tree-construction or tokenizer coverage ratchets, and they do


### PR DESCRIPTION
## Summary
- lower slot-backed disabled buttons, read-only inputs, and input commit events into native Flutter widgets
- give direct Row inputs finite width so Venture chrome lays out without Flutter unbounded-width failures
- make the generated `MosaicApp` host injectable and add Venture-owned widget acceptance for hydration, disabled controls, address editing, Return/Go navigation, and host response refresh
- run that acceptance from both cross-platform build scripts and update BR01 P2 status/backlog

## Validation
- `cargo test -p mosaic-emit-flutter` (74 passed)
- `cargo clippy -p mosaic-emit-flutter --all-targets -- -D warnings`
- Venture `cargo test --test package_compiles` (3 passed)
- fresh generated project: `flutter analyze lib test/venture_chrome_interaction_test.dart`
- fresh generated project: `flutter test test/venture_chrome_interaction_test.dart` (2 passed)
- fresh generated project: `flutter build macos`
- exact parser audit: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 local raw / 0 missing; normalized 7242 / 0 skipped

This completes the Flutter portion of BR01 P2. Qt, Compose, and web-family direct interaction gates remain prioritized; it does not claim full browser conformance.