### PR TITLE
fix(spice): validate MOS flicker noise exponent

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite Level-1 MOS model-card `AF` values before
+  lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `KF` values before
   lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `RSH` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2031,6 +2031,13 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(flicker_noise_exponent) = params.get("AF") {
+            if !flicker_noise_exponent.is_finite() || *flicker_noise_exponent < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET AF must be finite and non-negative",
+                ));
+            }
+        }
     }
     Ok(ModelCard {
         name: fields[1].clone(),

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2321,6 +2321,35 @@ fn preserves_non_negative_mosfet_model_flicker_noise_coefficient() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_flicker_noise_exponents() {
+    for exponent in ["-1", "1e999"] {
+        let error = parse_netlist(&format!(
+            ".model noise NMOS(AF={exponent})\nM1 d g s b noise"
+        ))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("MOSFET AF must be finite and non-negative"));
+    }
+}
+
+#[test]
+fn preserves_non_negative_mosfet_model_flicker_noise_exponent() {
+    for (exponent, expected) in [("0", 0.0), ("1.2", 1.2)] {
+        let parsed = parse_netlist(&format!(
+            ".model noise NMOS(AF={exponent})\nM1 d g s b noise"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.flicker_noise_exponent, expected);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card flicker-noise-coefficient validation.
+1. Rust Berkeley SPICE MOS model-card flicker-noise-exponent validation.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite model-card `KF` values before lowering MOS
+   - Reject negative and non-finite model-card `AF` values before lowering MOS
      elements into engine parameters.
-   - Preserve zero and positive flicker-noise coefficients.
+   - Preserve zero and positive flicker-noise exponents.
 
 ## Completed Slices
 
@@ -4083,12 +4083,19 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Zero and positive sheet resistances remain accepted.
 
+361. Rust Berkeley SPICE MOS model-card flicker-noise-coefficient validation.
+   - Status: completed in PR 9554.
+   - Negative and non-finite model-card `KF` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Zero and positive flicker-noise coefficients remain accepted.
+
 ## Backlog
 
-1. Rust Berkeley SPICE MOS model-card validation follow-ups.
-   - Validate the remaining flicker-noise-exponent facade gap for `AF`.
-   - Reuse the finite non-negative contracts and diagnostics already aligned
-     across the Rust, Python, and TypeScript engines.
+1. Rust Berkeley SPICE MOS model-card validation audit.
+   - Re-audit supported model-card parameters after the `AF` facade gap lands,
+     recording any newly confirmed gaps here before selecting another slice.
+   - Reuse contracts and diagnostics already aligned across the Rust, Python,
+     and TypeScript engines whenever the missing behavior is facade-only.
 
 2. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `AF` values in the Rust Berkeley SPICE parser facade
- preserve zero and positive flicker-noise exponents
- reconcile the plan after #9554 and schedule a fresh supported-parameter audit after this queue completes

## Scope
This is a Rust parser-facade boundary change. The shared Rust, Python, and TypeScript engines already enforce the same `AF` behavior and diagnostic.

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser` (160 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`