### PR TITLE
feat(human-languages): split German lessons into micro-steps

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the French duration
-tranche: 20 registered tracks, 997 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the German duration
+tranche: 20 registered tracks, 1,002 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -56,7 +56,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01G | Complete in the Italian duration PR | Remove all twenty sub-five-minute violations from the Italian track. | The report measures zero Italian violations; four new prerequisite-ordered micro-lessons preserve the register, metaphor, suppletion, and agreement content that did not fit safely in the original lessons. |
 | HL-D01H | Complete in the Portuguese duration PR | Remove all twenty-three sub-five-minute violations from the Portuguese track. | The report measures zero Portuguese violations; five new prerequisite-ordered micro-lessons preserve the register, suppletion, grammar-choice, and etymology content from the five computed violations. |
 | HL-D01I | Complete in the French duration PR | Remove all twenty-five sub-five-minute violations from the French track. | The report measures zero French violations; three new prerequisite-ordered micro-lessons preserve register, suppletion, and pronominal-agreement depth. |
-| HL-D01J | Next | Remove all twenty-seven sub-five-minute violations from the German track. | German is now the smallest remaining set: twenty-two declaration-only lessons and five genuinely computed violations, with a 360-second maximum. |
+| HL-D01J | Complete in the German duration PR | Remove all twenty-seven sub-five-minute violations from the German track. | The report measures zero German violations; five new prerequisite-ordered micro-lessons preserve register, practice, areal-history, agreement, and etymology depth. |
+| HL-D01K | Next | Remove all thirty-six sub-five-minute violations from the Telugu track. | Telugu is now the smallest remaining set: thirty-five declaration-only lessons and one genuinely computed violation, with a 360-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -75,6 +76,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B17 | Queued | Remove Portuguese's LaTeX layout warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports three underfull boxes; the clean-build signal is zero. |
 | HL-B18 | Queued | Publish French Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The French PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
 | HL-B19 | Queued | Remove French's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B20 | Queued | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The German PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
+| HL-B21 | Queued | Remove German's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports seventeen overfull boxes, eleven underfull boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
@@ -334,6 +337,30 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - German's twenty-seven violations are now the smallest remaining set.
   Twenty-two are declaration-only and five genuinely compute above the limit,
   with a 360-second maximum, so HL-D01J is next.
+
+## Findings from HL-D01J
+
+- German now has zero duration violations. The corpus grows from 997 to 1,002
+  lessons and drops from 356 to 329 violations overall; unknown prerequisites
+  remain at zero.
+- Twenty-two lessons needed only honest declared-budget corrections. Five new
+  prerequisite-ordered lessons preserve the longer content: informal wellbeing
+  language → formal *Ihnen* register → casual practice → formal practice;
+  Präteritum forms → north/south areal history; *sein*-perfect auxiliaries → the
+  French/German agreement contrast; *Kopf* as cup → inherited *Haupt* and the
+  Grimm's-law/container comparison.
+- The new and rewritten lessons compute between 147 and 244 seconds.
+  `GE-C16-sein` at 287 seconds and `GE-W03-capitalization` at 285 are the
+  tightest remaining German lessons and should be watched during copy edits.
+- The German PDF builds successfully at 84 pages through Chapter 16 while
+  canonical lessons continue through Chapter 23. HL-B20 records the schema-v2
+  migration and generated publication work for Chapters 17–23.
+- The build has no missing glyphs or duplicate labels, but reports seventeen
+  overfull boxes, eleven underfull boxes, and three Hyperref warnings. HL-B21
+  records that pre-existing clean-build debt.
+- Telugu's thirty-six violations are now the smallest remaining set.
+  Thirty-five are declaration-only and one genuinely computes above the limit,
+  with a 360-second maximum, so HL-D01K is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Sub-five-minute lesson remediation (2026-08-02)
+
+- All twenty-seven German duration violations are resolved. Twenty-two lessons
+  already computed below five minutes and now declare an honest four-minute
+  budget without changing their teaching content.
+- Five lessons that genuinely exceeded the limit become prerequisite-ordered
+  micro-sequences: informal wellbeing → formal *Ihnen* register → separate
+  casual/formal practice; Präteritum forms → its north/south areal map; the
+  *sein*-perfect auxiliary family → French/German agreement; *Kopf* as cup →
+  inherited *Haupt* and the Grimm's-law/container comparison.
+- The five new support lessons bring the German track to 86 lessons. Every new
+  or rewritten step computes between 147 and 244 seconds, with zero unknown
+  prerequisite ids.
+- A forced build still succeeds at 84 pages with no missing glyphs or duplicate
+  labels. Its existing seventeen overfull boxes, eleven underfull boxes, and
+  three Hyperref warnings are recorded separately in `HL-B21`; publishing the
+  canonical Chapters 17–23 is recorded in `HL-B20`.
+
 ## The book catches up -- Chapters 3-16 typeset
 
 The lessons had run ahead of the published artifact: 61 authored lessons through
@@ -36,7 +54,7 @@ superscripts all render correctly.
 
 ## Chapter 17 — The body: a cup for a head, and a hand with no Latin cousin
 
-- **Chapter 17 authored** (`GE-C17-kopf`, `-hand`) — the **body**, the theme the
+- **Chapter 17 authored** (`GE-C17-kopf`, `-kopf-haupt`, `-hand`) — the **body**, the theme the
   parallel-track roadmaps name next.
 - **der Kopf** (`GE-C17-kopf`): *Kopf* did not originally mean "head." It meant a
   **cup or bowl** — the same word as English **cup**, both early borrowings of
@@ -70,7 +88,8 @@ superscripts all render correctly.
 
 ## Chapter 16 — *sein*: three ancient verbs wearing one infinitive
 
-- **Chapter 16 authored** (`GE-C16-sein`, `-perfekt-sein`). Ch. 15 taught only
+- **Chapter 16 authored** (`GE-C16-sein`, `-perfekt-sein`,
+  `-perfekt-sein-agreement`). Ch. 15 taught only
   the *haben* half of the Perfekt because *sein* had never been taught. Fixed.
 - **sein** (`GE-C16-sein`): the present, plus *war/waren*, and then the reason
   they look unrelated — they **are** unrelated. *sein* is assembled from **three
@@ -108,7 +127,8 @@ superscripts all render correctly.
 
 ## Chapter 15 — The Perfekt, and the tense it pushed aside
 
-- **Chapter 15 authored** (`GE-C15-perfekt`, `-praeteritum`): the everyday past,
+- **Chapter 15 authored** (`GE-C15-perfekt`, `-praeteritum`,
+  `-praeteritum-map`): the everyday past,
   built on Ch.14's *haben* — reviewing Ch.5/14 via `reviews_of`.
 - **Perfekt** (`GE-C15-perfekt`): *haben* + past participle (*ich habe gesagt*),
   with two things German does that English can't. First, the weak participle is
@@ -345,7 +365,8 @@ superscripts all render correctly.
 ## Chapter 3 — "Wie geht's?" (completes the how-are-you trilogy)
 
 - **Chapter 3 authored** (`GE-C03-danke`, `-bitte`, `-gehen`, `-wie-geht-es`,
-  `-es-geht`, `-practice`): the "how are you?" exchange, atom-first, reviewing
+  `-wie-geht-register`, `-es-geht`, `-practice`, `-formal-practice`): the
+  "how are you?" exchange, atom-first, reviewing
   Chapter 2. Third of a deliberate cross-language trilogy in this PR (Spanish
   Ch.4 / French Ch.3 / German Ch.3), all sharing the canonical concepts
   `STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`, `WORD-SOSO`.

--- a/code/learning/human-languages/german/lessons/GE-C02-practice.md
+++ b/code/learning/human-languages/german/lessons/GE-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [GE-C02-ich-heisse, GE-C02-wie-heissen-sie, GE-C02-freut-mich]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C02-ich, GE-C02-heissen, GE-C02-ich-heisse, GE-C02-du-sie, GE-C02-wie, GE-C02-wie-heissen-sie, GE-C02-freut-mich]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C03-formal-practice.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-formal-practice.md
@@ -1,0 +1,43 @@
+---
+id: GE-C03-formal-practice
+chapter: 3
+type: practice-mix
+headword: Wie geht es Ihnen?
+gloss: the formal wellbeing exchange
+concept_tag: GE-CH3-FORMAL-PRACTICE
+prerequisites: [GE-C03-practice, GE-C03-wie-geht-register]
+sounds: []
+roots: []
+est_minutes: 4
+reviews_of: [GE-C03-practice, GE-C03-wie-geht-register]
+---
+
+# Formal practice — Wie geht es Ihnen?
+
+## Warm-up
+
+[PAUSE 2s] Keep the casual exchange’s structure and replace *dir* with formal
+**Ihnen**.
+
+> — Guten Tag. **Wie geht es Ihnen?**
+> — **Danke, gut. Und Ihnen?**
+> — **Es geht.**
+> — [after a favour] Danke! — **Bitte.**
+
+The capital letter matters: **Ihnen** belongs to respectful **Sie**. The verb
+phrase does not change; only the dative listener word does.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the formal exchange, both voices]
+- [YOU SAY: “Wie geht es Ihnen? — Danke, gut.”]
+- [YOU SAY: “Und Ihnen? — Es geht.”]
+
+[REPEAT x2] “Wie geht es Ihnen? — Danke, gut. Und Ihnen?”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which greeting opens the formal exchange? (**Guten Tag**.) Which
+dative pronoun appears twice? (**Ihnen**.) What changes from the casual version?
+(**Dir → Ihnen**.) You can now run the Chapter 3 exchange in either register.

--- a/code/learning/human-languages/german/lessons/GE-C03-practice.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-practice.md
@@ -3,66 +3,48 @@ id: GE-C03-practice
 chapter: 3
 type: practice-mix
 headword: (practice)
-gloss: the full "Wie geht's?" exchange, formal and informal
+gloss: the casual Wie geht's? exchange
 concept_tag: CH3-PRACTICE
-prerequisites: [GE-C03-danke, GE-C03-bitte, GE-C03-gehen, GE-C03-wie-geht-es, GE-C03-es-geht]
+prerequisites: [GE-C03-danke, GE-C03-bitte, GE-C03-gehen, GE-C03-wie-geht-es, GE-C03-wie-geht-register, GE-C03-es-geht]
 sounds: []
 roots: []
-est_minutes: 5
-reviews_of: [GE-C03-danke, GE-C03-bitte, GE-C03-wie-geht-es, GE-C03-es-geht, GE-C02-practice]
+est_minutes: 4
+reviews_of: [GE-C03-danke, GE-C03-bitte, GE-C03-wie-geht-es, GE-C03-wie-geht-register, GE-C03-es-geht, GE-C02-practice]
 ---
 
-# Practice — "Wie geht's?", start to finish
+# Practice — Wie geht’s?, casually
 
 ## Warm-up
 
-[PAUSE 2s] No new words. This chapter's atoms — *danke, bitte, gehen, wie geht's,
-es geht* — assemble into a real exchange, formal and informal. It picks up right
-where the Chapter 2 introduction left off.
+[PAUSE 2s] Assemble the chapter’s atoms into one exchange with a friend. No new
+words.
 
-## The exchange
-
-**Formal** (a stranger, an elder):
-
-> — Guten Tag. **Wie geht es Ihnen?**
-> — **Danke, gut.** Und Ihnen?
-> — **Es geht.**
-> — [after a small favour] — Danke! — **Bitte.**
-
-**Informal** (a friend):
-
-> — Hallo! **Wie geht's?**
+> — Hallo! **Wie geht’s?**
 > — **Gut, danke, und dir?**
-> — So lala.
+> — **Es geht.**
+> — [after a favour] Danke! — **Bitte.**
 
-The glue is **und dir? / und Ihnen?** — "and you?" (*und* = "and," cognate of
-English *and*), the German twin of Spanish *¿y tú?* and French *et toi?*. Note it
-takes the **dative** (*dir / Ihnen*), because it's short for "how goes it *to
-you*?"
+The dative **dir** remains because the full question means “How goes it **to
+you**?” The shortened **und dir?** keeps that same grammar.
 
-## What you've built this chapter
+## What you are retrieving
 
-- **danke** — thanks (← *denken*, "to think"; English *thank* = *think*).
-- **bitte** — please / you're welcome (← *bitten*, "to ask/pray"; English *bid*,
-  *bead*).
-- **gehen / geht** — "to go," the state-verb (= English *go*; like French, unlike
-  Spanish *estar*).
-- **Wie geht es dir? / Ihnen?** — how are you, informal / formal.
-- **gut / es geht / so lala / nicht so gut** — the answer ladder.
+- **danke** — thanks, related to *denken*, “think”;
+- **bitte** — please / you’re welcome, from *bitten*, “ask”;
+- **wie geht’s?** — how are you?;
+- **gut / es geht** — well / so-so.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: the full *formal* exchange, both voices]
-- [YOU SAY: the same *informally* — *Ihnen → dir*, *Wie geht es → Wie geht's*]
-- [YOU SAY: chain Chapter 2 + 3 — "Ich heiße … Wie geht es Ihnen?"]
+- [YOU SAY: the whole exchange, both voices]
+- [YOU SAY: “Wie geht’s? — Gut, danke.”]
+- [YOU SAY: “Und dir? — Es geht.”]
 
-[REPEAT x2] "Wie geht's? — Gut, danke, und dir?" until it's reflex.
+[REPEAT x2] “Wie geht’s? — Gut, danke, und dir?”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Which verb carries German "how are you?", and what English word is it?
-(*gehen* = *go*.) What does *danke* literally mean, and *bitte*? ("I *think* of
-you"; "I *ask*" → please/you're-welcome.) Which two of our three tracks use "to
-go," and which uses "to stand"? (Go: German, French; stand: Spanish.) Next
-chapter: **farewells** — auf Wiedersehen, tschüss, bis bald.
+[PAUSE 3s] Run the casual exchange without looking. Which answer is neutral or
+so-so? (**Es geht**.) Which word answers thanks? (**Bitte**.) Why *dir*? (The
+question is literally “How goes it **to you**?”) Next: perform the formal version.

--- a/code/learning/human-languages/german/lessons/GE-C03-wie-geht-es.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-wie-geht-es.md
@@ -3,72 +3,53 @@ id: GE-C03-wie-geht-es
 chapter: 3
 type: phrase
 headword: Wie geht es dir?
-gloss: how are you? (informal); formal Wie geht es Ihnen?
+gloss: how are you? — informal and everyday
 concept_tag: STATE-HOW-ARE-YOU
-prerequisites: [GE-C03-gehen, GE-C02-wie, GE-C02-du-sie]
+prerequisites: [GE-C03-gehen, GE-C02-wie]
 sounds: [w-is-v, ie-long-ee]
 roots: [gehen-german]
-etymology_hook: "Wie (how) + geht (goes) + es (it) + dir (to you) — 'how goes it to you?'"
+etymology_hook: "Wie + geht + es + dir literally asks 'how goes it to you?'"
 est_minutes: 4
-reviews_of: [GE-C03-gehen, GE-C02-wie, GE-C02-du-sie]
+reviews_of: [GE-C03-gehen, GE-C02-wie]
 ---
 
-# Wie geht es dir? — "how are you?"
+# Wie geht es dir? — “how are you?”
 
 ## Warm-up
 
-[PAUSE 2s] Every piece is already yours: **wie** ("how," Chapter 2), the **du /
-Sie** choice (Chapter 2), and **gehen / geht** ("to go," last lesson). Snap them
-together into the question Germans actually ask.
+[PAUSE 2s] Combine **wie**, “how,” and **gehen**, “to go,” into the everyday
+question for a friend.
 
-## Review first (30 seconds)
+> **Wie geht es dir?** — “How are you?”
+> literally: “How goes it to you?”
 
-[PAUSE 2s] No peeking:
+- **wie** = how;
+- **geht** = goes;
+- **es** = it;
+- **dir** = to you, the dative form paired with *du*.
 
-- **wie** — "how." (*w* says *v*: *vee*.) Cognate with English *how*'s cousin;
-  used for manner and degree.
-- **du** vs **Sie** — informal vs formal "you." *du* to a friend; capital-S
-  *Sie* to a stranger or elder (it's literally "they," borrowed as respect).
+In speech, **geht es** contracts to **geht’s**. The short **Wie geht’s?** is the
+most useful neutral-sounding everyday form.
 
-## The phrase, taken apart
+Answer with the **gut** you already know:
 
-> **Wie geht es dir?** = "How are you?" (informal)
-> literally: **"How goes it to you?"**
+> **Wie geht’s? — Danke, gut!**
 
-- **wie** = "how" · **geht** = "goes" · **es** = "it" · **dir** = "to you"
-  (the dative of *du* — the *mir* → *dir* pair from last lesson).
-
-Two registers, and only the "you" changes — the same move as the *du/Sie* split:
-
-| register | question |
-|---|---|
-| **informal** (friend, family) | **Wie geht es dir?** (spoken: **Wie geht's dir?** / just **Wie geht's?**) |
-| **formal** (stranger, elder) | **Wie geht es Ihnen?** |
-
-*es* + *dir* often crush together in speech into **geht's** — *Wie geht's?* is
-the everyday form, and you can answer it with the **gut** you already know:
-*Danke, gut!* ("Thanks, well!").
-
-Compare the three tracks in this PR — same question, three metaphors:
-
-| | verb | literal |
-|---|---|---|
-| **German** | *gehen* (go) | "how **goes** it to you?" |
-| **French** | *aller* (go) | "how does it **go**?" |
-| **Spanish** | *estar* (stand) | "how are you **standing**?" |
+German pictures wellbeing as **going**, like English “how’s it going?” French
+uses the same metaphor; Spanish often uses a “standing” verb. The comparison is
+a memory aid, not required knowledge.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "Wie geht's?" — the everyday short form]
-- [YOU SAY: "Wie geht es Ihnen?" — formal, for a stranger]
-- [YOU SAY: "Danke, gut! Und dir?" — answer + bounce it back]
+- [YOU SAY: “Wie geht es dir?”]
+- [YOU SAY: the contraction — “Wie geht’s?”]
+- [YOU SAY: “Danke, gut! Und dir?”]
 
-[REPEAT x2] "Wie geht's? — Danke, gut!" until it's automatic.
+[REPEAT x2] “Wie geht’s? — Danke, gut!”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] What does *Wie geht es dir?* literally ask? ("How goes it *to* you?")
-Which form of "you" for a stranger — *dir* or *Ihnen*? (*Ihnen*.) All three
-languages here use one of two metaphors for "how are you" — which two? (To *go*:
-German/French; to *stand*: Spanish.) Next: the "so-so" answer, **es geht**.
+[PAUSE 3s] What does the question literally ask? (“How goes it **to you**?”)
+Which word means “to you”? (**Dir**.) What is the short form? (**Wie geht’s?**)
+How can you answer? (**Danke, gut.**) Next: switch from *dir* to formal *Ihnen*.

--- a/code/learning/human-languages/german/lessons/GE-C03-wie-geht-register.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-wie-geht-register.md
@@ -1,0 +1,53 @@
+---
+id: GE-C03-wie-geht-register
+chapter: 3
+type: grammar
+headword: Wie geht es Ihnen?
+gloss: formal how are you?
+concept_tag: GE-STATE-FORMAL
+prerequisites: [GE-C03-wie-geht-es, GE-C02-du-sie]
+sounds: [w-is-v, ie-long-ee]
+roots: [gehen-german]
+etymology_hook: "the question keeps its go metaphor and changes only dative dir to formal Ihnen"
+est_minutes: 4
+reviews_of: [GE-C03-wie-geht-es, GE-C02-du-sie]
+---
+
+# Wie geht es Ihnen? — formal “how are you?”
+
+## Warm-up
+
+[PAUSE 2s] The informal question ends in **dir**, “to you.” For a stranger or
+elder, keep the whole sentence and change only that listener word.
+
+| listener | question |
+|---|---|
+| friend or family | **Wie geht es dir?** |
+| stranger or elder | **Wie geht es Ihnen?** |
+
+Capitalised **Ihnen** is the dative form that belongs with formal **Sie**. The
+question still means “How goes it **to you**?”; German changes register inside
+the dative pronoun rather than changing the metaphor.
+
+Bounce the question back with the same contrast:
+
+- informal: **Und dir?** — and you?
+- formal: **Und Ihnen?** — and you?
+
+The short **Wie geht’s?** avoids the final pronoun and can be useful when the
+relationship is already clear.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: to a friend — “Wie geht es dir?”]
+- [YOU SAY: to a stranger — “Wie geht es Ihnen?”]
+- [YOU SAY: “Danke, gut. Und Ihnen?”]
+
+[REPEAT x2] “Dir — informal. Ihnen — formal.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which word means informal “to you”? (**Dir**.) Which is formal?
+(**Ihnen**, capitalised.) What stays the same? (**Wie geht es** and the “go”
+metaphor.) Next: practise the casual exchange before the formal one.

--- a/code/learning/human-languages/german/lessons/GE-C04-practice.md
+++ b/code/learning/human-languages/german/lessons/GE-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH4-PRACTICE
 prerequisites: [GE-C04-auf-wiedersehen, GE-C04-tschuss, GE-C04-bis-bald, GE-C04-bis-morgen]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C04-auf-wiedersehen, GE-C04-tschuss, GE-C04-bis-bald, GE-C04-bis-morgen, GE-C03-practice]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C05-practice.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH5-PRACTICE
 prerequisites: [GE-C05-wohnen, GE-C05-machen, GE-C05-lernen, GE-C05-ich-lerne-deutsch]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C05-wohnen, GE-C05-machen, GE-C05-lernen, GE-C05-ich-lerne-deutsch, GE-C03-practice]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C05-wohnen.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-wohnen.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C02-ich, GE-C02-du-sie]
 sounds: [w-is-v, h-pronounced]
 roots: [wonen-ohg]
 etymology_hook: "wohnen ← Old High German wonēn 'to dwell, be accustomed' → English 'wont' (accustomed), archaic 'won'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C03-wie-geht-es, GE-C02-practice]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C06-zahlen-1-5.md
+++ b/code/learning/human-languages/german/lessons/GE-C06-zahlen-1-5.md
@@ -9,7 +9,7 @@ prerequisites: []
 sounds: [diphthong-ei, umlaut-ue]
 roots: [germanic-numerals, grimms-law]
 etymology_hook: "eins/zwei/drei/vier/fünf are Germanic twins of English one/two/three/four/five — NOT borrowed from Latin, but cousins of it through Grimm's Law"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C05-practice]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C06-zahlen-6-10.md
+++ b/code/learning/human-languages/german/lessons/GE-C06-zahlen-6-10.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C06-zahlen-1-5]
 sounds: [ch-ach, diphthong-eu]
 roots: [germanic-numerals, grimms-law]
 etymology_hook: "sechs/sieben/acht/neun/zehn are Germanic twins of six/seven/eight/nine/ten; zehn↔ten↔decem shows Grimm's d→t; acht↔eight↔Nacht/night the -cht-"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C06-zahlen-1-5]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C07-wochentage-1.md
+++ b/code/learning/human-languages/german/lessons/GE-C07-wochentage-1.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C06-zahlen-6-10]
 sounds: [diphthong-ei, ch-ach]
 roots: [germanic-gods, planet-gods]
 etymology_hook: "German weekdays are Germanic gods — twins of the English days (Donnerstag = Thor's day = Thursday), not Latin planets — except Mittwoch 'mid-week', which the Church substituted for Woden's day"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C06-zahlen-6-10]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C08-uhr.md
+++ b/code/learning/human-languages/german/lessons/GE-C08-uhr.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C06-zahlen-1-5]
 sounds: [vowel-u-long, r-final]
 roots: [hora-latin]
 etymology_hook: "Uhr ← Latin hōra 'hour' — a LATIN LOANWORD, unlike German's native numbers and day-gods; the same hōra behind French heure and English hour"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C06-zahlen-1-5, GE-C07-wochentage-2]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C09-monate.md
+++ b/code/learning/human-languages/german/lessons/GE-C09-monate.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C06-zahlen-6-10, GE-C08-uhr]
 sounds: [vowel-ae, ch-none]
 roots: [latin-months]
 etymology_hook: "German's months are Latin loans (Januar←Janus, März←Mars, like mardi!) — the same reach-for-Rome that gave it Uhr, while its numbers and seasons stay native"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C06-zahlen-6-10, GE-C07-wochentage-1, GE-C08-uhr]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C10-eltern.md
+++ b/code/learning/human-languages/german/lessons/GE-C10-eltern.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C09-jahreszeiten, GE-C01-hallo]
 sounds: [v-as-f, umlaut-u]
 roots: [pie-pater, pie-mater, grimms-law]
 etymology_hook: "Vater/Mutter aren't borrowed from Latin like the German months — they're inherited Germanic cousins of English father/mother, and Grimm's law (p→f, t→th→d) is written right on their faces"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C09-jahreszeiten, GE-C01-hallo]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C11-brot.md
+++ b/code/learning/human-languages/german/lessons/GE-C11-brot.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C10-geschwister, GE-C01-hallo]
 sounds: [long-o, r-uvular]
 roots: [germanic-braudam]
 etymology_hook: "Brot is INHERITED Germanic (← *braudam), the direct twin of English bread — NOT the Latin pānis the Romance sisters use; and it introduces the third gender, das (neuter)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C10-geschwister, GE-C01-hallo]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C11-wasser-wein.md
+++ b/code/learning/human-languages/german/lessons/GE-C11-wasser-wein.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C11-brot]
 sounds: [w-as-v, ai-as-eye]
 roots: [germanic-watar, vinum-latin]
 etymology_hook: "Wasser is INHERITED Germanic (Grimm's-law twin of English water); but Wein — like English wine — is an ANCIENT Latin loan (vīnum), borrowed when Rome brought the vine north; native vs borrowed, side by side"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C11-brot, GE-C10-eltern]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C12-elf-zwoelf.md
+++ b/code/learning/human-languages/german/lessons/GE-C12-elf-zwoelf.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C06-zahlen-6-10, GE-C11-wasser-wein]
 sounds: [umlaut-oe, f-final]
 roots: [germanic-ainlif, germanic-twalif]
 etymology_hook: "elf ← ainlif, zwölf ← twalif — the -lif is 'leave/remain', so they mean 'ONE left [over ten]' and 'TWO left'; English eleven/twelve are the same words, same meaning — you counted ten fingers and had one left"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C06-zahlen-6-10, GE-C11-wasser-wein]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C12-zahlen-13-20.md
+++ b/code/learning/human-languages/german/lessons/GE-C12-zahlen-13-20.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C12-elf-zwoelf]
 sounds: [zehn-ts, ig-final]
 roots: [germanic-tehun, germanic-twaintig]
 etymology_hook: "dreizehn…neunzehn = digit + zehn, the exact mirror of English thir-teen…nine-teen (-teen IS ten); zwanzig ← twaintig 'two-tens' = English twenty; German never breaks the pattern, unlike the Romance sisters"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C12-elf-zwoelf, GE-C06-zahlen-6-10]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C13-rot-blau.md
+++ b/code/learning/human-languages/german/lessons/GE-C13-rot-blau.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C13-schwarz-weiss]
 sounds: [long-o, diphthong-au]
 roots: [pie-rewdh, germanic-blao]
 etymology_hook: "rot ← *raudaz ← PIE *h₁rewdʰ-, the same root as Latin ruber → French rouge — genuine cousins; and blau, like blank, was borrowed INTO Romance (bleu, blu), then English took blue back from French"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C13-schwarz-weiss, GE-C12-zahlen-13-20]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C13-schwarz-weiss.md
+++ b/code/learning/human-languages/german/lessons/GE-C13-schwarz-weiss.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C12-zahlen-13-20]
 sounds: [schw-cluster, eszett]
 roots: [germanic-swartaz, germanic-hweit]
 etymology_hook: "schwarz ← *swartaz (English 'swarthy'; cousin of Latin sordēs 'dirt' → sordid); weiß ← *hwītaz = English white — and German's own blank ('shiny') is the word French/Italian/Portuguese BORROWED for 'white'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C12-zahlen-13-20, GE-C11-brot-wasser]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C14-haben.md
+++ b/code/learning/human-languages/german/lessons/GE-C14-haben.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C13-rot-blau, GE-C05-machen]
 sounds: [long-a, final-t]
 roots: [germanic-habjana]
 etymology_hook: "haben ← Germanic *habjaną (= English have), from PIE *kap- 'to seize' — the SAME root as Latin capere (capture/captive). Latin habēre only LOOKS like it: it descends from *gʰabʰ-, whose English child is GIVE. A textbook false cognate — same sound, same meaning, opposite ancestry"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C13-rot-blau, GE-C05-machen, GE-C10-geschwister]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C15-perfekt.md
+++ b/code/learning/human-languages/german/lessons/GE-C15-perfekt.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C14-haben, GE-C05-machen]
 sounds: [ge-prefix, final-t]
 roots: [germanic-ga-perfective]
 etymology_hook: "the ge- of gesagt ← Germanic *ga-, a prefix meaning 'completely, together' that marked an action as FINISHED — English dropped it, but it survives fossilised inside enough (Old English genōg) and archaic yclept; German still wraps its participle in it"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C14-haben, GE-C05-machen, GE-C05-lernen]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C15-praeteritum-map.md
+++ b/code/learning/human-languages/german/lessons/GE-C15-praeteritum-map.md
@@ -1,0 +1,57 @@
+---
+id: GE-C15-praeteritum-map
+chapter: 15
+type: etymology
+headword: Präteritum north and south
+gloss: the regional and cross-language retreat of the simple past
+concept_tag: GE-PAST-AREAL-CHANGE
+prerequisites: [GE-C15-praeteritum]
+sounds: []
+roots: [germanic-dental-preterite, areal-contact]
+etymology_hook: "the simple past is weakest in southern German, beside the French and northern Italian regions where compound pasts also displaced it"
+est_minutes: 4
+reviews_of: [GE-C15-praeteritum, GE-C15-perfekt]
+---
+
+# The simple past’s regional retreat
+
+## Warm-up
+
+[PAUSE 2s] In speech, German’s *Perfekt* often replaced the *Präteritum*. The
+geography lines up with neighbouring French and Italian changes.
+
+| language | inherited simple past | compound replacement in speech |
+|---|---|---|
+| German | *Präteritum* | *Perfekt* |
+| French | *passé simple* | *passé composé* |
+| Italian | *passato remoto* | *passato prossimo* |
+
+These are not one inherited rule: Germanic and Romance built their tenses from
+different material. The similar retreat spread through a connected region as
+speakers interacted across language boundaries. Linguists call such a shared
+regional development an **areal change**.
+
+The internal German map supports that story:
+
+- strongest compound preference in the **south**, nearest France and northern
+  Italy;
+- better survival of the simple past in the **north**;
+- standard *Präteritum* throughout narrative writing.
+
+Spanish and Portuguese, farther west, kept their simple pasts more fully in
+speech. Geography did not dictate every sentence, but it helps explain why a
+Germanic language and two Romance neighbours moved in parallel.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “south — more Perfekt; north — more Präteritum”]
+- [YOU SAY: “German, French, Italian: parallel retreat”]
+- [YOU SAY: “areal change — spread by contact”]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where is spoken *Präteritum* weakest? (The German-speaking **south**.)
+Which neighbouring languages show a similar retreat? (**French and Italian**.)
+Did German inherit that from Latin? (**No**.) What kind of change is it?
+(An **areal** change spreading through contact.)

--- a/code/learning/human-languages/german/lessons/GE-C15-praeteritum.md
+++ b/code/learning/human-languages/german/lessons/GE-C15-praeteritum.md
@@ -3,93 +3,62 @@ id: GE-C15-praeteritum
 chapter: 15
 type: word
 headword: ich sagte
-gloss: the Präteritum — the simple past, retreating in speech but alive in writing
+gloss: the Präteritum — the simple past in writing and high-frequency speech
 concept_tag: GE-PAST-SIMPLE-WRITTEN
 prerequisites: [GE-C15-perfekt]
 sounds: [final-te]
 roots: [germanic-dental-preterite]
-etymology_hook: "sagte's -te is the Germanic DENTAL preterite, the same -ed that makes English walked — a Germanic invention with no Latin equivalent; and German, French and Italian all let a have-compound push this simple past out of everyday speech"
-est_minutes: 5
+etymology_hook: "sagte's -te is the same Germanic dental past machinery as English walked"
+est_minutes: 4
 reviews_of: [GE-C15-perfekt, GE-C05-machen]
 ---
 
-# ich sagte — the simple past
+# Ich sagte — the simple past
 
 ## Warm-up
 
-[PAUSE 2s] German has a **second** past tense — and choosing between them is
-about **where you are** and **whether you're writing**, not about meaning.
+[PAUSE 2s] German has a second past tense. It usually expresses the same event
+as the *Perfekt*; register and region decide which form sounds natural.
 
-## What it looks like
-
-| | Präteritum | Perfekt |
+| meaning | Präteritum | Perfekt |
 |---|---|---|
 | I said | **ich sagte** | ich habe gesagt |
 | I made | **ich machte** | ich habe gemacht |
 | I had | **ich hatte** | ich habe gehabt |
 
-Weak verbs add **-te**. Same meaning as the *Perfekt*; different register.
+Weak verbs add **-te**. That ending is the Germanic **dental preterite**, the
+same historical machinery as English *walk-ed* and Dutch *werk-te*:
 
-## The -te is the English -ed
+> sag-**te** · walk-**ed**
 
-That **-te** is the **dental preterite** — the Germanic way of making a past
-tense by adding a *t/d* sound:
+Latin had no matching dental-past construction; Romance past endings came by a
+different route.
 
-| language | |
-|---|---|
-| German | sag → sag**te** |
-| English | walk → walk**ed** |
-| Dutch | werk → werk**te** |
+## Where you meet it
 
-This is a **Germanic invention**. Latin had nothing like it — Romance builds its
-past from inherited perfect endings instead. So *sagte* and *walked* are the same
-machinery, and *parla* / *habló* are a completely different one.
+The *Präteritum* is standard in narrative writing. Everyday speech usually
+prefers the *Perfekt*, especially in southern Germany, Austria, and Switzerland.
+It survives more in northern speech.
 
-## Who says which
+A few frequent verbs remain common in spoken *Präteritum* everywhere:
 
-| | everyday speech | writing / north |
-|---|---|---|
-| **Perfekt** | *ich habe gesagt* — dominant, especially in the **south** | |
-| **Präteritum** | rarer in speech | **standard in narrative writing** |
+- **war** — was;
+- **hatte** — had;
+- modal verbs such as **konnte** — could.
 
-In southern Germany, Austria and Switzerland the *Präteritum* has largely
-vanished from conversation. Further north it survives better. And in books, it is
-the normal past tense. A few verbs resist everywhere: *war*, *hatte*, and the
-modals stay common even in speech.
-
-## The same retreat, three times
-
-| language | simple past | replaced in speech by |
-|---|---|---|
-| **German** | *Präteritum* | **Perfekt** |
-| French | *passé simple* | *passé composé* |
-| Italian | *passato remoto* | *passato prossimo* |
-
-Two Romance languages and one **Germanic** one, doing the same thing over the
-same centuries — and **not** by coincidence. Southern Germany, France and
-northern Italy are **neighbours**, and the change spread through that connected
-block by **contact**. Linguists call this an *areal* change: it travels across
-language boundaries because the speakers do, which is why a Germanic language
-and two Romance ones line up here while Spanish and Portuguese, out at the
-**western edge**, largely kept their simple past.
-
-It also explains the map **inside** German: the *Präteritum* is weakest in the
-**south**, nearest the centre of the change, and strongest in the north.
+So produce *ich habe gesagt* in ordinary conversation, recognise *ich sagte* in
+books, and actively use high-frequency *war / hatte / konnte* when needed.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: the pair — "ich **sagte** … ich **habe gesagt**"]
-- [YOU SAY: the Germanic machinery — "sag**te** · walk**ed**"]
-- [YOU SAY: "Er machte das" — and then "Er hat das gemacht"]
-- [YOU SAY: the three retreats — "Präteritum · passé simple · passato remoto"]
+- [YOU SAY: “ich sagte; ich habe gesagt”]
+- [YOU SAY: “sagte — walked: dental past”]
+- [YOU SAY: “war, hatte, konnte”]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] How do weak verbs form the *Präteritum*? (Add **-te**.) What is that
-*-te* the same thing as? (English **-ed** — the Germanic **dental preterite**.)
-Does Latin have it? (**No** — Romance uses inherited perfect endings instead.)
-Where is the *Präteritum* still normal? (In **writing**, and better preserved in
-the **north**.) Which three languages let a compound push out their simple past?
-(**German, French, Italian**.) Next chapter: the verbs that take *sein*, not
-*haben*.
+[PAUSE 3s] How do weak verbs form the *Präteritum*? (Add **-te**.) What English
+ending is related? (**-ed**.) Where is the tense standard? (**Narrative
+writing**.) Which forms remain normal in speech? (**War, hatte, modals**.) Next:
+map why the simple past retreated differently across regions and languages.

--- a/code/learning/human-languages/german/lessons/GE-C16-perfekt-sein-agreement.md
+++ b/code/learning/human-languages/german/lessons/GE-C16-perfekt-sein-agreement.md
@@ -1,0 +1,59 @@
+---
+id: GE-C16-perfekt-sein-agreement
+chapter: 16
+type: grammar
+headword: gegangen — no agreement in the perfect
+gloss: German keeps one participle form for every subject
+concept_tag: GE-PERFECT-NO-AGREEMENT
+prerequisites: [GE-C16-perfekt-sein]
+sounds: []
+roots: [germanic-participle-agreement]
+etymology_hook: "German lost participle agreement inside the perfect even though attributive participles still take adjective endings"
+est_minutes: 4
+reviews_of: [GE-C16-perfekt-sein, GE-C16-sein]
+---
+
+# Gegangen — no agreement in the perfect
+
+## Warm-up
+
+[PAUSE 2s] German and French both split their compound past between “have” and
+“be,” but their participles behave differently.
+
+| subject | French | German |
+|---|---|---|
+| he | il est **allé** | er ist **gegangen** |
+| she | elle est **allée** | sie ist **gegangen** |
+| they | ils sont **allés** | sie sind **gegangen** |
+
+In the German perfect, **gegangen never changes** for person, number, or gender.
+French preserves adjective-like agreement; German lost it in this position.
+
+German participles still inflect when they stand before a noun as adjectives:
+
+- der angekommen**e** Zug — the arrived train;
+- die eingeschlafen**e** Katze — the fallen-asleep cat.
+
+So the participle did not lose every adjective ending everywhere. It is
+specifically the perfect construction where agreement disappeared.
+
+Old High German varied in this position. Modern German simplified it to one
+unchanging form.
+
+The *haben/sein* split is a native Germanic development, not a borrowing from
+Latin. It grew alongside neighbouring Romance systems through centuries of
+contact. The **auxiliary split** is parallel; the **agreement outcome** differs.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “er ist gegangen; sie ist gegangen”]
+- [YOU SAY: “wir sind gegangen — same participle”]
+- [YOU SAY: “der angekommene Zug — adjective ending returns”]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does the participle agree inside the German perfect? (**No**.) Where
+can it still take endings? (**Before a noun as an adjective**.) Does French
+agree? (**Yes**.) Did German inherit its split from Latin? (**No**; it developed
+in parallel.)

--- a/code/learning/human-languages/german/lessons/GE-C16-perfekt-sein.md
+++ b/code/learning/human-languages/german/lessons/GE-C16-perfekt-sein.md
@@ -3,96 +3,64 @@ id: GE-C16-perfekt-sein
 chapter: 16
 type: phrase
 headword: ich bin gegangen
-gloss: "the perfect built on sein — motion and change-of-state verbs, with no agreement at all"
+gloss: the perfect with sein for motion, arrival, and change of state
 concept_tag: GE-PAST-PERFEKT-SEIN
 prerequisites: [GE-C16-sein, GE-C15-perfekt, GE-C03-gehen]
 sounds: [ich-laut, ge-prefix]
 roots: [germanic-ga-participle]
-etymology_hook: "German splits its perfect between haben and sein on the same motion/change-of-state line as French — but unlike French the participle never agrees IN THE PERFECT (gegangen is gegangen for everyone), though it still inflects attributively (der angekommene Zug); and the split is a parallel Germanic development alongside Romance, not something inherited from Latin"
-est_minutes: 5
+etymology_hook: "German uses sein with a bounded motion/change family while ordinary activity verbs keep haben"
+est_minutes: 4
 reviews_of: [GE-C16-sein, GE-C15-perfekt, GE-C03-gehen]
 ---
 
-# ich bin gegangen — the perfect built on "sein"
+# Ich bin gegangen — the perfect with sein
 
 ## Warm-up
 
-[PAUSE 2s] Chapter 15 built the perfect with *haben*: *ich habe gelernt*. A
-particular family of verbs takes **sein** instead — and the line it draws will
-look familiar if you have seen the French track.
-
-## The rule
-
-> **Verbs of motion and change of state take *sein*.**
-
-*Gehen* (Ch. 3) is the model:
+[PAUSE 2s] Chapter 15 built **ich habe gelernt** with *haben*. A smaller family
+uses **sein**.
 
 | | |
 |---|---|
-| ich **bin** gegangen | I went / I have gone |
-| du **bist** gegangen | you went |
-| er **ist** gegangen | he went |
-| wir **sind** gegangen | we went |
+| ich **bin gegangen** | I went / have gone |
+| du **bist gegangen** | you went |
+| er **ist gegangen** | he went |
+| wir **sind gegangen** | we went |
 
-The rest of the family:
+## The family
 
-| verb | perfect | |
+The centre is a change of place or state with a clear result:
+
+| verb | perfect | meaning |
 |---|---|---|
-| kommen | ich **bin** gekommen | I came |
-| fahren | ich **bin** gefahren | I travelled, drove |
-| bleiben | ich **bin** geblieben | I stayed |
-| werden | ich **bin** geworden | I became |
-| **sein** itself | ich **bin** gewesen | I have been |
+| gehen | **bin gegangen** | went |
+| kommen | **bin gekommen** | came |
+| fahren | **bin gefahren** | travelled |
+| werden | **bin geworden** | became |
 
-Motion (*gehen, kommen, fahren*), change of state (*werden*) — and then a small
-set that breaks the pattern and simply has to be learned: **sein** and
-**bleiben**, which are the *opposite* of change, plus *gelingen* (succeed),
-*geschehen* / *passieren* (happen) and *begegnen* (meet).
+Ordinary activity without that result usually keeps **haben**: *ich habe
+gearbeitet*, *ich habe getanzt*.
 
-## No agreement — the German simplification
+A small learned group also takes *sein*: **sein** itself (*bin gewesen*),
+**bleiben** (*bin geblieben*), plus verbs such as *gelingen* (succeed),
+*geschehen / passieren* (happen), and *begegnen* (meet).
 
-Here is where German is *easier* than French. Compare:
+Build each perfect as:
 
-| | French | German |
-|---|---|---|
-| he went | il est **allé** | er ist **gegangen** |
-| she went | elle est **allé*e*** | sie ist **gegangen** |
-| they went | ils sont **allé*s*** | sie sind **gegangen** |
+> present form of **sein** + past participle
 
-French makes the participle agree with the subject. **In the perfect, German
-makes it agree with nothing** — *gegangen* is *gegangen* for every person and
-gender. (German participles *do* still inflect when used as adjectives in front
-of a noun — *ein geschrieben**er** Brief*, *der angekommen**e** Zug*, *die
-eingeschlafen**e** Katze*. It is specifically the perfect where the ending is
-gone.)
-
-Old High German did inflect the participle here, at least variably; German lost
-that, along with most of its other adjective-like endings in this position.
-
-And note what did **not** happen: German didn't get this from Latin. The
-*haben*-perfect and the *sein*-perfect are native Germanic developments that grew
-up **alongside** the Romance ones — neighbouring languages drifting the same way
-through centuries of contact, the same areal spread that Ch. 15 blamed for the
-simple past retreating in French, German and Italian together.
-
-Two things to carry forward: the **split** is parallel, the **agreement** is not
-shared.
+The participle stays at the end, just as it did with *haben*.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "ich bin gegangen, du bist gegangen, wir sind gegangen"]
-- [YOU SAY: the contrast — "ich **habe** gelernt … ich **bin** gegangen"]
-- [YOU SAY: the odd ones out — "**sein**, **bleiben**, **geschehen**"]
-- [YOU SAY: the comparison — "elle est allé**e** … sie ist gegangen — **no ending**"]
+- [YOU SAY: “ich bin gegangen; wir sind gegangen”]
+- [YOU SAY: “ich habe gelernt; ich bin gegangen”]
+- [YOU SAY: “bin gekommen; bin geworden; bin geblieben”]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Which verbs form the perfect with *sein*? (Verbs of **motion** and
-**change of state**.) Say "I went." (*Ich bin gegangen*.) Name two non-motion verbs that also
-take *sein*. (***Sein***, ***bleiben*** — or *geschehen*, *gelingen*.) Does the
-German participle agree with the subject **in the perfect**? (**No.** *Gegangen*
-never changes.) Where does it still inflect? (**In front of a noun** — *der
-angekommen**e** Zug*.) Does the French participle agree? (**Yes** — *elle est
-allé**e***.) Did German get this split from Latin? (**No** — it grew up
-**alongside** Romance, through contact.) Next chapter: the **body**.
+[PAUSE 3s] Which broad family takes *sein*? (Resultative **motion/change**.) Say
+“I went.” (**Ich bin gegangen**.) Name two learned exceptions. (**Sein,
+bleiben**, or *geschehen*.) Where does the participle go? (**At the end**.) Next:
+compare German agreement with French.

--- a/code/learning/human-languages/german/lessons/GE-C16-sein.md
+++ b/code/learning/human-languages/german/lessons/GE-C16-sein.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C14-haben, GE-C15-praeteritum]
 sounds: [ich-laut, final-devoicing]
 roots: [pie-h1es, pie-bhuh, pie-wes]
 etymology_hook: "sein is built from THREE roots: ist/sind ← *h₁es- (Latin est/sunt), bin/bist ← *bʰuH- 'grow, become' (the same root as English be and as Spanish fui, taught in ES-C14), and war/waren ← *wes- 'dwell, remain' (English was/were) — three verbs' worth of forms living under one infinitive"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C14-haben, GE-C15-praeteritum, GE-C05-lernen]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C17-hand.md
+++ b/code/learning/human-languages/german/lessons/GE-C17-hand.md
@@ -5,12 +5,12 @@ type: word
 headword: die Hand
 gloss: the hand — the same word as English, and unrelated to Romance manus
 concept_tag: GE-BODY-HAND
-prerequisites: [GE-C17-kopf, GE-C01-der-die-das]
+prerequisites: [GE-C17-kopf-haupt, GE-C01-der-die-das]
 sounds: [final-devoicing, vowel-a-german]
 roots: [germanic-handuz]
 etymology_hook: "die Hand IS English hand — Germanic *handuz, with no Latin relative at all; where French/Italian/Portuguese all continue manus, Germanic simply has a different word, so this is the body part where the two families do NOT meet"
 est_minutes: 4
-reviews_of: [GE-C17-kopf, GE-C01-der-die-das]
+reviews_of: [GE-C17-kopf, GE-C17-kopf-haupt, GE-C01-der-die-das]
 ---
 
 # die Hand — "the hand"

--- a/code/learning/human-languages/german/lessons/GE-C17-kopf-haupt.md
+++ b/code/learning/human-languages/german/lessons/GE-C17-kopf-haupt.md
@@ -1,0 +1,65 @@
+---
+id: GE-C17-kopf-haupt
+chapter: 17
+type: etymology
+headword: Kopf / Haupt
+gloss: the cup-word and the inherited Germanic head-word
+concept_tag: GE-HEAD-DOUBLETS
+prerequisites: [GE-C17-kopf]
+sounds: []
+roots: [latin-cuppa, germanic-haubudam, pie-kaput]
+etymology_hook: "Kopf took the everyday job while inherited Haupt, cousin of head and caput, survived in compounds"
+est_minutes: 4
+reviews_of: [GE-C17-kopf]
+---
+
+# Kopf / Haupt — two head-words
+
+## Warm-up
+
+[PAUSE 2s] **Kopf** began as “cup.” German’s inherited word for “head” is
+**Haupt**, a cousin of English *head* and Latin *caput*.
+
+| language | inherited form |
+|---|---|
+| Latin | *caput* |
+| German | **Haupt** |
+| English | **head** |
+
+The initial *k → h* relationship reflects Grimm’s law, the same systematic
+Germanic sound shift seen in Latin *pater* beside English *father*. The later
+consonants have their own history; use the initial pair as the clear signal.
+
+**Haupt** survives in compounds and formal vocabulary:
+
+- **Hauptstadt** — capital, literally “head city”;
+- **Hauptbahnhof** — main station;
+- **Hauptsache** — main thing.
+
+## Two container metaphors
+
+| language | everyday word | older picture |
+|---|---|---|
+| German | **Kopf** | *cuppa*, cup |
+| French | *tête* | *testa*, pot |
+
+Both languages independently promoted a vessel-word to “head,” while keeping
+the older head-root in words for chiefs, capitals, or main things. The
+vocabulary sources are both Latin loans, but the **metaphor** was applied
+separately: heads look like bowls in many languages.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “Kopf — everyday cup-word”]
+- [YOU SAY: “Haupt — inherited head-word”]
+- [YOU SAY: “Hauptstadt, Hauptbahnhof”]
+
+[REPEAT x2] “Kopf took the job; Haupt stayed in compounds.”
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which word is everyday “head”? (**Kopf**.) Which inherited word
+survives in compounds? (**Haupt**.) Name two compounds. (**Hauptstadt,
+Hauptbahnhof**.) What parallel metaphor did French use? (**Tête**, originally a
+pot.) Next: the hand.

--- a/code/learning/human-languages/german/lessons/GE-C17-kopf.md
+++ b/code/learning/human-languages/german/lessons/GE-C17-kopf.md
@@ -3,96 +3,63 @@ id: GE-C17-kopf
 chapter: 17
 type: word
 headword: der Kopf
-gloss: the head — from a word meaning "cup, bowl"
+gloss: the head — masculine, capitalised, with final pf
 concept_tag: GE-BODY-HEAD
 prerequisites: [GE-C01-der-die-das]
 sounds: [final-devoicing]
-roots: [latin-cuppa, germanic-haubudam]
-etymology_hook: "Kopf originally meant a CUP or bowl — the same word as English CUP, both early borrowings of Late Latin cuppa — and it displaced the inherited Haupt ← *haubudam, which is the true Germanic cognate of Latin caput; so German swapped a vessel-word in for the head word — the very same move French made with tête ← testa 'pot'"
+roots: [latin-cuppa]
+etymology_hook: "Kopf first meant cup or bowl, from the same Late Latin cuppa source as English cup"
 est_minutes: 4
 reviews_of: [GE-C01-der-die-das, GE-W03-capitalization]
 ---
 
-# der Kopf — "the head"
+# Der Kopf — “the head”
 
 ## Warm-up
 
-[PAUSE 2s] The first body part — and German did something to it that a Romance
-language did too, entirely independently.
+[PAUSE 2s] Learn the first body part with its article and its characteristic
+final sound.
 
-## The word
+> **der Kopf** — the head
 
-> **der Kopf** — the head. Masculine, and capitalised, because every German noun
-> is (Chapter W03).
+It is masculine and capitalised because every German noun begins with a capital
+letter.
 
-Note the **-pf**: a single sound, made by starting with *p* and releasing it into
-*f*. It is one of German's signature noises, and English has nothing like it.
+## Make the -pf sequence
 
-## Kopf was a drinking vessel
+At the end of **Kopf**, close for *p* and release directly into *f*. English has
+no identical native ending, so practise it slowly:
 
-**Kopf** did not originally mean "head." It meant a **cup or bowl** — and it is
-the same word as English **cup**, both of them early borrowings of Late Latin
-***cuppa***, taken separately into Old High German and Old English.
+> Ko-p-f → **Kopf**
 
-So the *word* isn't native Germanic. What **is** independent is the **move**:
-just as with *tête* in French, a vessel-word became slang for the skull, and the
-slang won.
+A useful phrase is:
 
-## So what happened to the real word?
+> **Ich habe Kopfschmerzen.** — I have a headache.
 
-German's inherited word for "head" is **das Haupt** — and it is a genuine cousin
-of Latin *caput*:
+German compounds simply place nouns together: **Kopf** (head) + **Schmerzen**
+(pains).
 
-| | |
-|---|---|
-| Latin | *caput* |
-| German | **Haupt** |
-| English | **head** |
+## The old cup
 
-All three from PIE \**kaput-*, by **Grimm's law** — the same systematic swap
-(**p→f, t→th, k→h**) that turns *pater* into *father* and *pēs* into *foot*.
-Here it is the **k→h** you can see cleanly: *caput* begins with *k*, *Haupt* and
-*head* with *h*.
+**Kopf** originally meant a **cup or bowl**. It is related to English **cup**;
+both were early borrowings of Late Latin ***cuppa***. A container word became
+slang for the skull and eventually took over the everyday job.
 
-(The consonants further in are a longer story involving a second shift, so take
-the *k*→*h* as the demonstration and leave the rest.)
-
-*Haupt* is still alive, but only in compounds and formal register:
-**Haupt**stadt (capital city — literally "head city"), **Haupt**bahnhof (main
-station), **Haupt**sache ("the main thing").
-
-So German has both words, and gave the everyday job to the cup.
-
-## Two languages, one joke
-
-This is the part worth keeping:
-
-| | everyday "head" | from | the inherited word |
-|---|---|---|---|
-| **French** | *tête* | *testa*, an earthenware **pot** | *caput* → survives in *chef* |
-| **German** | *Kopf* | *cuppa*, a **cup** | \**haubudam* → survives in *Haupt* |
-
-Two unrelated languages, both replacing "head" with a **container**, both keeping
-the old word for chiefs and capitals. Nobody coordinated this.
-
-Be precise about what's independent, though: both vessel-words happen to trace
-back to Latin (*testa*, *cuppa*). It is the **metaphor** that was invented twice,
-not the vocabulary. Heads simply look like bowls, in any language.
+German’s older inherited head-word did not disappear completely. The next
+micro-lesson follows it into compounds and compares the same container metaphor
+in French.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "der Kopf" — feel the **-pf**]
-- [YOU SAY: "Ich habe Kopfschmerzen" — "I have a headache"]
-- [YOU SAY: the vessel — "Kopf = a **cup**"]
-- [YOU SAY: the survivor — "**Haupt**stadt, **Haupt**bahnhof"]
+- [YOU SAY: “der Kopf” — release *p* into *f*]
+- [YOU SAY: “Ich habe Kopfschmerzen.”]
+- [YOU SAY: “Kopf — cup or bowl”]
+
+[REPEAT x2] “Der Kopf — masculine, capitalised.”
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Say "the head." (*Der Kopf* — masculine, capitalised.) What did *Kopf*
-originally mean? (A **cup or bowl** — the same word as English **cup**, both borrowed from Late Latin *cuppa*.) What is
-German's inherited word for head? (***Das Haupt***, a true cousin of Latin
-*caput* and English *head*, by **Grimm's law**.) Where does *Haupt* survive?
-(In compounds — *Hauptstadt*, *Hauptbahnhof*.) What did French do with the same
-idea? (***Tête*** ← *testa*, a **pot** — the identical swap, invented
-separately.) Next: the hand.
+[PAUSE 3s] Say “the head.” (**Der Kopf**.) What gender? (**Masculine**.) Why the
+capital? (It is a **noun**.) What did *Kopf* first mean? (A **cup or bowl**.)
+Which English word is related? (**Cup**.) Next: find the inherited word *Haupt*.

--- a/code/learning/human-languages/german/lessons/GE-C21-das-wetter.md
+++ b/code/learning/human-languages/german/lessons/GE-C21-das-wetter.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C14-alter]
 sounds: [w-as-v, umlaut-none]
 roots: [germanic-wetter-weather, germanic-regen-rain]
 etymology_hook: "das Wetter is a native Germanic word (Proto-Germanic *wedrą) — the SAME word as English 'weather' itself, not a Latin loan like every Romance language's tempus-based word; es regnet ('it's raining') is likewise native, from Proto-Germanic *regnōną — the SAME root as English 'rain'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [GE-C14-alter]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C22-hund-katze.md
+++ b/code/learning/human-languages/german/lessons/GE-C22-hund-katze.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C14-alter]
 sounds: [u-umlaut-none, tz-affricate]
 roots: [germanic-hund-dog, latin-cattus-afroasiatic]
 etymology_hook: "Hund is native Germanic (Proto-Indo-European *kwon-), cognate with English's OWN 'hound' — the word English ITSELF replaced with the still-unexplained 'dog,' the same shape of mystery as Spanish's perro; Katze, surprisingly, is NOT native Germanic at all — like French/Spanish/Italian, German borrowed the same Late Latin cattus, so 'cat' words are remarkably widespread across Germanic AND Romance (though NOT every European language: Romanian and much of South Slavic use their own onomatopoeic cat-words instead), while 'dog' words go their own separate ways almost everywhere"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [GE-C14-alter]
 ---
 

--- a/code/learning/human-languages/german/lessons/GE-C23-gruen-gelb.md
+++ b/code/learning/human-languages/german/lessons/GE-C23-gruen-gelb.md
@@ -9,7 +9,7 @@ prerequisites: [GE-C22-hund-katze]
 sounds: [umlaut-u, consonant-b-final]
 roots: [germanic-groeniz-grow, pie-ghel-shine]
 etymology_hook: "grün is native Germanic, the direct cousin of English's own 'green' (Proto-Germanic *grōniz, PIE *ǵʰreh₁-, 'to grow, become green') — a COMPLETELY DIFFERENT root from Latin's viridis, even though both independently mean 'grow' → 'green'; gelb is native too (Proto-Germanic *gelwaz), usually traced to the same ultimate PIE root, *ghel- ('to shine'), as French's jaune — though modern Latin scholarship treats jaune's Latin ancestor galbus as genuinely unknown in origin, so treat gelb/jaune as probable, not certain, cousins"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [GE-C22-hund-katze]
 ---
 

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -19,8 +19,9 @@ Spanish and French where a contrast helps. The recurring decoder is the
   is") → **du / Sie** → wie → **wie heißen Sie?** → freut mich → practice.
 - **Ch. 3 — "Wie geht's?"**: danke (← *denken* "think"; Eng *thank*=*think*) →
   bitte (← *bitten* "ask/pray"; Eng *bid*/*bead*) → **gehen** ("to go" = Eng
-  *go*; the state-verb, w/ a first taste of the **dative** *mir/dir*) → wie geht
-  es dir/Ihnen → es geht (so-so) → practice. **Authored** — completes the
+  *go*; the state-verb, w/ a first taste of the **dative** *mir/dir*) → informal
+  *wie geht es dir?* → formal *wie geht es Ihnen?* → es geht (so-so) → casual
+  practice → formal practice. **Authored** — completes the
   Spanish/French/German how-are-you trilogy.
 - **Ch. 4 — Farewells**: auf Wiedersehen ("on the seeing-again", *sehen* = *see*;
   twin of *au revoir*) → tschüss (← *adieu* → secretly "to God", cousin of
@@ -115,7 +116,8 @@ Spanish and French where a contrast helps. The recurring decoder is the
   south, better held in the north) but **standard in narrative writing**. The
   cross-language payoff: **German, French and Italian all** let a
   "have" compound displace their simple past, while Spanish and Portuguese kept
-  theirs. **Authored.**
+  theirs. The forms come first; the north/south register and three-language
+  areal map follow as their own micro-lesson. **Authored.**
 - **Ch. 16 — *sein*, and the Perfekt built on it**: ***sein*** (`GE-C16-sein`) —
   not one verb but **three PIE roots** under one infinitive: *ist/sind* ←
   \**h₁es-* (Latin *est/sunt*), *bin/bist* ← \**bʰuH-* "grow, become" (English
@@ -134,7 +136,8 @@ Spanish and French where a contrast helps. The recurring decoder is the
   *haben*/*sein* perfect is a native Germanic development that grew up
   **alongside** Romance by areal contact — the same Sprachbund Ch.15 blamed for
   the simple past retreating in three languages at once. Split **parallel**,
-  agreement **not shared**. **Authored.**
+  agreement **not shared**. The auxiliary family comes first and the agreement
+  contrast follows as its own micro-lesson. **Authored.**
 - **Ch. 17 — The body: a cup for a head, and a hand with no Latin cousin**:
   ***der Kopf*** (`GE-C17-kopf`) — originally a **cup or bowl**, Germanic
   \**kuppaz*, the same word as English **cup**, which displaced the inherited
@@ -149,7 +152,9 @@ Spanish and French where a contrast helps. The recurring decoder is the
   every Romance track here builds "hand" on *manus*, and \**handuz* is unrelated
   to it. The course keeps finding links; it matters to mark where the families
   genuinely diverge. *Manus* reached German only as **borrowed** vocabulary
-  (*Manuskript*, *manuell*). **Authored.**
+  (*Manuskript*, *manuell*). *Kopf* as the everyday vessel-word comes first;
+  inherited *Haupt*, Grimm's Law, and the French/German container comparison
+  follow before *Hand* as a separate support step. **Authored.**
 
 ## Planned
 


### PR DESCRIPTION
## Summary
- remove all 27 German sub-five-minute duration violations while preserving the existing lesson bodies when only the declared budget was stale
- split five genuinely long lessons into five prerequisite-ordered micro-lessons for formal register, formal practice, areal past-tense history, participle agreement, and Kopf/Haupt etymology
- record German book publication/layout follow-ups and reprioritize Telugu as the next duration tranche

## Measured outcome
- German duration violations: 27 → 0
- corpus lessons: 997 → 1,002
- total duration violations: 356 → 329
- unknown prerequisites: 0
- new/reworked lesson duration: 147–244 seconds
- tightest remaining German lessons: GE-C16-sein at 287 seconds and GE-W03-capitalization at 285 seconds

## Validation
- `npm run test:coverage` — 68 tests, 93.60% line coverage
- `npm run build`
- `npm run validate` — 9 integration tests
- `npm run check:books`
- `npm run report`
- Language Ladder `npm run test:coverage` — 278 tests, 98.37% line coverage
- Language Ladder `npm run build` — 1,052 modules
- forced German XeLaTeX build — 84 pages, no missing glyphs or duplicate labels

The unchanged German book still reports 17 overfull boxes, 11 underfull boxes, and 3 Hyperref warnings. Those pre-existing cleanup items and generated publication of canonical Chapters 17–23 are now explicitly tracked as HL-B20 and HL-B21.