### PR TITLE
feat(venture): add Qt chrome interaction acceptance

### DIFF
--- a/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - part-backed native control identity
+
+`HostButton` and `HostInput` now project their Mosaic part names through QML
+`objectName`, giving generated Qt shells a stable native interaction seam.
+Generated Mosaic event handlers now declare formal JavaScript parameters,
+removing Qt 6.11's deprecated implicit signal-parameter injection.
+
 ### Added - host-owned surface composition
 
 `HostSurface ( content: slot: ... )` now lowers to a styled Qt Quick

--- a/code/packages/rust/mosaic-emit-qt/README.md
+++ b/code/packages/rust/mosaic-emit-qt/README.md
@@ -32,6 +32,11 @@ string describing the component as a tree of Qt Quick elements.
 takes references to the three IRs and returns a `PipelineEmitResult` with
 the QML source string and the component's PascalCase name.
 
+Part names on native `HostButton` and `HostInput` controls also lower to QML
+`objectName` values. This preserves Mosaic's authored identity for Qt Quick
+interaction tests and host-side native control discovery without duplicating
+the chrome in C++.
+
 ## Output file structure
 
 For a component named `ProfileCard` with slots `display-name: text` and

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -1122,7 +1122,7 @@ pub fn from_pipeline(
         writeln!(out, "    signal mosaicEvent(var event)").unwrap();
         writeln!(
             out,
-            "    onMosaicEvent: applyMosaicResponse(mosaicHost ? mosaicHost.handleEvent(event) : null)"
+            "    onMosaicEvent: function(event) {{ applyMosaicResponse(mosaicHost ? mosaicHost.handleEvent(event) : null) }}"
         )
         .unwrap();
         for e in &interface.emits {
@@ -1218,16 +1218,19 @@ fn emit_mosaic_event_handler(emit: &EmitDecl) -> Result<String, PipelineEmitErro
     let handler_name = qml_signal_handler_name(&signal_name);
 
     let mut fields = vec![format!("\"event\": \"{}\"", escape_qml_string(&emit.name))];
+    let mut params = Vec::with_capacity(emit.params.len());
     for param in &emit.params {
         let field = to_camel_case_first_lower(&param.name);
         validate_safe_identifier(&field).map_err(PipelineEmitError::UnsafeEmitName)?;
+        params.push(field.clone());
         fields.push(format!("\"{field}\": {field}"));
     }
 
     let mut out = String::new();
     writeln!(
         out,
-        "    {handler_name}: mosaicEvent({{ {} }})",
+        "    {handler_name}: function({}) {{ mosaicEvent({{ {} }}) }}",
+        params.join(", "),
         fields.join(", ")
     )
     .unwrap();
@@ -1866,6 +1869,15 @@ fn emit_host_input_qml(
     };
     writeln!(out, "{pad}{control_tag} {{").unwrap();
 
+    if let Some(part) = node.part_name.as_deref() {
+        writeln!(
+            out,
+            "{inner_pad}objectName: \"{}\"",
+            escape_qml_string(part)
+        )
+        .unwrap();
+    }
+
     // When the input is a styled cell's editor (it sits inside a styled
     // `Box [cell]` whose text style is in scope), fill the cell and adopt
     // its alignment / colour / font so the in-place editor matches the
@@ -2004,6 +2016,15 @@ fn emit_host_button_qml(
     let inner_pad = "    ".repeat(depth + 1);
     let mut out = String::new();
     writeln!(out, "{pad}Button {{").unwrap();
+
+    if let Some(part) = node.part_name.as_deref() {
+        writeln!(
+            out,
+            "{inner_pad}objectName: \"{}\"",
+            escape_qml_string(part)
+        )
+        .unwrap();
+    }
 
     // text: <slot or literal> — sourced from the `label` prop.
     if let Some(line) = build_label_attribute(node) {
@@ -3919,14 +3940,14 @@ mod tests {
         assert!(
             result
                 .output
-                .contains("onNavigate: mosaicEvent({ \"event\": \"onNavigate\" })"),
+                .contains("onNavigate: function() { mosaicEvent({ \"event\": \"onNavigate\" }) }"),
             "missing generic navigate Mosaic event in:\n{}",
             result.output
         );
         assert!(
-            result
-                .output
-                .contains("onEditCommit: mosaicEvent({ \"event\": \"onEditCommit\" })"),
+            result.output.contains(
+                "onEditCommit: function() { mosaicEvent({ \"event\": \"onEditCommit\" }) }"
+            ),
             "missing generic editCommit Mosaic event in:\n{}",
             result.output
         );
@@ -3960,7 +3981,7 @@ mod tests {
         );
         assert!(
             result.output.contains(
-                "onSelect: mosaicEvent({ \"event\": \"onSelect\", \"startRow\": startRow, \"startCol\": startCol })"
+                "onSelect: function(startRow, startCol) { mosaicEvent({ \"event\": \"onSelect\", \"startRow\": startRow, \"startCol\": startCol }) }"
             ),
             "expected payload to flow into generic Mosaic event, got:\n{}",
             result.output
@@ -3989,7 +4010,7 @@ mod tests {
             .contains("signal userClickedHere(real eventRow)"));
         assert!(result
             .output
-            .contains("onUserClickedHere: mosaicEvent({ \"event\": \"onUserClickedHere\", \"eventRow\": eventRow })"));
+            .contains("onUserClickedHere: function(eventRow) { mosaicEvent({ \"event\": \"onUserClickedHere\", \"eventRow\": eventRow }) }"));
     }
 
     // -------- Test 7: Row → RowLayout, Column → ColumnLayout --------
@@ -4395,7 +4416,7 @@ mod tests {
             component_name: "X".to_string(),
             root: LayoutNode {
                 tag: "HostInput".to_string(),
-                part_name: None,
+                part_name: Some("address-input".to_string()),
                 props: vec![
                     LayoutProp {
                         name: "value".to_string(),
@@ -4413,6 +4434,11 @@ mod tests {
         assert!(
             result.output.contains("TextInput {"),
             "missing TextInput in:\n{}",
+            result.output
+        );
+        assert!(
+            result.output.contains("objectName: \"address-input\""),
+            "missing part-backed object name in:\n{}",
             result.output
         );
         assert!(
@@ -5104,6 +5130,11 @@ mod tests {
             },
         };
         let result = from_pipeline(&m, &l, &style).unwrap();
+        assert!(
+            result.output.contains("objectName: \"danger\""),
+            "missing part-backed object name in:\n{}",
+            result.output
+        );
         assert!(
             result.output.contains("palette.buttonText: \"#ffffff\""),
             "missing foreground style in:\n{}",
@@ -7686,7 +7717,7 @@ mod tests {
         );
         assert!(
             out.contains(
-                "onMosaicEvent: applyMosaicResponse(mosaicHost ? mosaicHost.handleEvent(event) : null)"
+                "onMosaicEvent: function(event) { applyMosaicResponse(mosaicHost ? mosaicHost.handleEvent(event) : null) }"
             ),
             "mosaicEvent should round-trip through the optional host:\n{out}"
         );

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Add direct generated Qt Quick interaction acceptance for host hydration,
+  disabled controls, address editing, Return, Go, and response refresh, using
+  Mosaic part names as native QML object identities.
 - Repair cross-platform acceptance discovered after native scrollbar
   projection: keep the scroll-metrics type import Apple-only, and reset the
   WinUI viewport to document start before hover/click link acceptance.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -78,6 +78,8 @@ JavaScript syntax checks; SwiftUI, Qt, XAML, Flutter, and Compose invoke their
 native toolchains. The Flutter gate additionally pumps the emitted `MosaicApp`
 with a recording host and drives the generated native controls, including
 disabled buttons, address editing, Return, Go, and host-driven prop refresh.
+The Qt gate runs the same contract through Qt Quick Test against the emitted
+part-backed native controls and its generated `mosaicHost` seam.
 Platform-exclusive builds are explicitly deferred to their
 native host; missing host-applicable toolchains are reported as skips. Pass
 `--strict` on POSIX or `-Strict` on PowerShell to reject those missing

--- a/code/programs/mosaic/venture-browser/host/qt/tst_venture_chrome.qml
+++ b/code/programs/mosaic/venture-browser/host/qt/tst_venture_chrome.qml
@@ -1,0 +1,116 @@
+import QtQuick 2.15
+import QtTest 1.3
+import ".."
+
+TestCase {
+    name: "VentureChromeInteraction"
+    width: 1100
+    height: 800
+    when: windowShown
+
+    QtObject {
+        id: recordingHost
+
+        property var events: []
+
+        function reset() {
+            events = []
+        }
+
+        function handleEvent(event) {
+            events = events.concat([event])
+            if (event.event === "onNavigate") {
+                return {
+                    "props": {
+                        "statusText": "Navigated through MosaicHost"
+                    }
+                }
+            }
+            return null
+        }
+    }
+
+    VentureChrome {
+        id: chrome
+        anchors.fill: parent
+        mosaicHost: recordingHost
+    }
+
+    function nativeControl(objectName) {
+        const control = findChild(chrome, objectName)
+        verify(control !== null, "missing native control " + objectName)
+        return control
+    }
+
+    function hydrate(disabled) {
+        chrome.applyMosaicResponse({
+            "props": {
+                "address": "http://venture.test/start",
+                "pageTitle": "Venture Qt acceptance",
+                "statusText": "Ready",
+                "backDisabled": disabled,
+                "forwardDisabled": disabled,
+                "navigationDisabled": disabled
+            }
+        })
+        wait(0)
+    }
+
+    function init() {
+        hydrate(true)
+        recordingHost.reset()
+    }
+
+    function test_host_hydration_reaches_native_controls() {
+        compare(chrome.address, "http://venture.test/start")
+        compare(chrome.pageTitle, "Venture Qt acceptance")
+        compare(chrome.statusText, "Ready")
+        verify(!nativeControl("back-button").enabled)
+        verify(!nativeControl("forward-button").enabled)
+        verify(!nativeControl("reload-button").enabled)
+        verify(nativeControl("address-input").readOnly)
+        verify(!nativeControl("go-button").enabled)
+        verify(nativeControl("mosaic-host-surface") !== null)
+    }
+
+    function test_disabled_native_controls_suppress_dispatch() {
+        mouseClick(nativeControl("back-button"))
+        mouseClick(nativeControl("forward-button"))
+        mouseClick(nativeControl("reload-button"))
+        mouseClick(nativeControl("go-button"))
+        compare(recordingHost.events.length, 0)
+    }
+
+    function test_address_return_crosses_the_mosaic_host_seam() {
+        hydrate(false)
+        recordingHost.reset()
+
+        const input = nativeControl("address-input")
+        verify(!input.readOnly)
+        input.forceActiveFocus()
+        input.text = "http://venture.test/next"
+        wait(0)
+        compare(recordingHost.events.length, 1)
+        compare(recordingHost.events[0].event, "onAddressChange")
+        compare(recordingHost.events[0].value, "http://venture.test/next")
+
+        keyClick(Qt.Key_Return)
+        wait(0)
+        compare(recordingHost.events.length, 2)
+        compare(recordingHost.events[1].event, "onNavigate")
+        compare(chrome.statusText, "Navigated through MosaicHost")
+    }
+
+    function test_go_crosses_the_mosaic_host_seam() {
+        hydrate(false)
+        recordingHost.reset()
+        const goButton = nativeControl("go-button")
+        verify(goButton.enabled)
+        goButton.forceActiveFocus()
+        keyClick(Qt.Key_Space)
+        wait(0)
+        compare(recordingHost.events.length, 1)
+        compare(recordingHost.events[0].event, "onNavigate")
+        compare(chrome.statusText, "Navigated through MosaicHost")
+    }
+}

--- a/code/programs/mosaic/venture-browser/mosaic-package.toml
+++ b/code/programs/mosaic/venture-browser/mosaic-package.toml
@@ -12,6 +12,7 @@ files = [
   { backend = "swiftui", source = "host/swiftui/MosaicHost.swift", target = "Sources/App/MosaicHost.swift" },
   { backend = "xaml", source = "host/xaml/MosaicHost.cs", target = "MosaicHost.cs" },
   { backend = "flutter", source = "host/flutter/venture_chrome_interaction_test.dart", target = "test/venture_chrome_interaction_test.dart" },
+  { backend = "qt", source = "host/qt/tst_venture_chrome.qml", target = "test/tst_venture_chrome.qml" },
 ]
 
 [kernel]

--- a/code/programs/mosaic/venture-browser/scripts/build-all.ps1
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.ps1
@@ -161,7 +161,7 @@ if ($isMacOS -and (Test-Command "swift")) {
     Skip-Backend -Backend "swiftui" -Reason "swift is not installed"
 }
 
-if (Test-Command "cmake") {
+if ((Test-Command "cmake") -and (Test-Command "qmltestrunner")) {
     Write-Host "==> Building qt"
     Push-Location (Join-Path $outputRoot "qt")
     try {
@@ -171,11 +171,15 @@ if (Test-Command "cmake") {
             Invoke-Checked -Command "cmake" -Arguments @("-S", ".", "-B", "build")
         }
         Invoke-Checked -Command "cmake" -Arguments @("--build", "build")
+        Write-Host "==> Testing qt interactions"
+        Invoke-Checked -Command "qmltestrunner" -Arguments @("-platform", "offscreen", "-style", "Basic", "-input", "test", "-import", ".")
     } finally {
         Pop-Location
     }
-} else {
+} elseif (-not (Test-Command "cmake")) {
     Skip-Backend -Backend "qt" -Reason "cmake is not installed"
+} else {
+    Skip-Backend -Backend "qt" -Reason "qmltestrunner is not installed"
 }
 
 if ($isWindows -and (Test-Command "dotnet")) {

--- a/code/programs/mosaic/venture-browser/scripts/build-all.sh
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.sh
@@ -156,15 +156,19 @@ else
   skip_backend swiftui "swift is not installed"
 fi
 
-if has_command cmake; then
+if has_command cmake && has_command qmltestrunner; then
   echo "==> Building qt"
   if has_command qt-cmake; then
     (cd "$output_root/qt" && qt-cmake -S . -B build && cmake --build build)
   else
     (cd "$output_root/qt" && cmake -S . -B build && cmake --build build)
   fi
-else
+  echo "==> Testing qt interactions"
+  (cd "$output_root/qt" && qmltestrunner -platform offscreen -style Basic -input test -import .)
+elif ! has_command cmake; then
   skip_backend qt "cmake is not installed"
+else
+  skip_backend qt "qmltestrunner is not installed"
 fi
 
 case "$host_os" in

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -89,7 +89,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     let package = mosaic_package_manifest::parse(&manifest).expect("parse manifest");
     assert_eq!(package.package.name, "venture-browser");
     assert_eq!(package.components.exports, ["VentureChrome"]);
-    assert_eq!(package.host_assets.files.len(), 3);
+    assert_eq!(package.host_assets.files.len(), 4);
     assert_eq!(package.host_assets.files[0].backend, "swiftui");
     assert_eq!(
         package.host_assets.files[0].target,
@@ -109,6 +109,15 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     assert_eq!(
         package.host_assets.files[2].target,
         "test/venture_chrome_interaction_test.dart"
+    );
+    assert_eq!(package.host_assets.files[3].backend, "qt");
+    assert_eq!(
+        package.host_assets.files[3].source,
+        "host/qt/tst_venture_chrome.qml"
+    );
+    assert_eq!(
+        package.host_assets.files[3].target,
+        "test/tst_venture_chrome.qml"
     );
 
     let host = read_package_file("host/swiftui/MosaicHost.swift");
@@ -259,6 +268,21 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
             "Flutter interaction acceptance omits {symbol}"
         );
     }
+
+    let qt_acceptance = read_package_file("host/qt/tst_venture_chrome.qml");
+    for symbol in [
+        "disabled_native_controls_suppress_dispatch",
+        "address_return_crosses_the_mosaic_host_seam",
+        "go_crosses_the_mosaic_host_seam",
+        "keyClick(Qt.Key_Return)",
+        "keyClick(Qt.Key_Space)",
+        "Navigated through MosaicHost",
+    ] {
+        assert!(
+            qt_acceptance.contains(symbol),
+            "Qt interaction acceptance omits {symbol}"
+        );
+    }
 }
 
 #[test]
@@ -298,6 +322,7 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "cargo \"${bridge_args[@]}\"",
         "libventure_browser_macos.dylib",
         "cmake --build",
+        "qmltestrunner -platform offscreen -style Basic -input test -import .",
         "dotnet build",
         "flutter build",
         "flutter test test/venture_chrome_interaction_test.dart",
@@ -317,6 +342,7 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "venture_browser_windows.dll",
         "-p:Platform=x64",
         "cmake",
+        "qmltestrunner",
         "dotnet",
         "flutter",
         "venture_chrome_interaction_test.dart",

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -120,12 +120,14 @@ complete.
    extent as target-neutral state, then bind generated native scrollbars to the
    same Mosaic-hosted content surface without recreating browser chrome in
    AppKit or Win32.
-3. **P2 — remaining generated-host interaction gates (Flutter completed).**
+3. **P2 — remaining generated-host interaction gates (Flutter and Qt completed).**
    Flutter now hydrates the emitted shell through an injected Mosaic host and
    directly drives native disabled controls, address editing, Return, Go, and
-   host-response refresh. Promote the remaining Qt, Compose, and web-family
-   build/host-object checks to direct interaction acceptance where their
-   provisioned CI toolchains can launch them.
+   host-response refresh. Qt Quick now exercises the same contract through
+   part-backed native controls and a package-owned QML test. Promote the
+   remaining Compose and web-family build/host-object checks to direct
+   interaction acceptance where their provisioned CI toolchains can launch
+   them.
 
 These are browser-wiring and acceptance items. They do not relax the exact
 zero-missing WPT tree-construction or tokenizer coverage ratchets, and they do


### PR DESCRIPTION
## Summary
- project Mosaic part names into Qt Quick `objectName` for stable native control identity
- emit formal JavaScript signal-handler parameters instead of deprecated Qt implicit injection
- install a package-owned Qt Quick interaction test that covers hydration, disabled dispatch suppression, address edits, Return, Go, and host response refresh
- run the Qt interaction test from POSIX and PowerShell build matrices and update BR01 P2 status

## Validation
- `cargo test -p mosaic-emit-qt` (118 passed)
- `cargo clippy -p mosaic-emit-qt --all-targets -- -D warnings`
- Venture `cargo test --test package_compiles` (3 passed)
- fresh generated project: `qmltestrunner -platform offscreen -style Basic -input test -import .` (6 passed)
- exact parser audit: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 local raw / 0 missing; normalized 7242 / 0 skipped

Local CMake execution was unavailable because this host has Qt/qmltestrunner but no CMake binary; the existing CI matrix remains the native CMake build gate. This completes the Qt portion of BR01 P2. Compose and web-family gates remain prioritized; it does not claim full browser conformance.