### PR TITLE
feat(adj): account for discarded transform bytes

### DIFF
--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -553,17 +553,27 @@ def build_text_transform(
     _require_hash(result_sha256, "transform.result_sha256")
     if not isinstance(operations, list) or not operations:
         raise ProvenanceError("transform.operations must not be empty")
+    explicit_source_partition = any(
+        isinstance(operation, dict) and operation.get("operation") == "discard"
+        for operation in operations
+    )
     result_cursor = 0
     source_cursor = 0
     for index, operation in enumerate(operations):
         prefix = f"transform.operations[{index}]"
-        if not isinstance(operation, dict) or set(operation) != {
+        if not isinstance(operation, dict):
+            raise ProvenanceError(f"{prefix} must be an object")
+        operation_name = operation.get("operation")
+        expected_fields = {
             "operation",
             "result_end",
             "result_start",
             "source_end",
             "source_start",
-        }:
+        }
+        if operation_name == "discard":
+            expected_fields.update(("claim_id", "reason"))
+        if set(operation) != expected_fields:
             raise ProvenanceError(f"{prefix} must have the exact operation schema")
         source_start = operation["source_start"]
         source_end = operation["source_end"]
@@ -574,17 +584,25 @@ def build_text_transform(
             for value in (source_start, source_end, result_start, result_end)
         ):
             raise ProvenanceError(f"{prefix} byte ranges must be integers")
-        if (
+        invalid_mapping = (
             source_start < source_cursor
+            or (
+                explicit_source_partition
+                and index > 0
+                and source_start != source_cursor
+            )
             or source_end <= source_start
             or source_end > len(source)
             or result_start != result_cursor
-            or result_end <= result_start
             or result_end > len(result)
-        ):
+        )
+        if operation_name == "discard":
+            invalid_mapping = invalid_mapping or result_end != result_start
+        else:
+            invalid_mapping = invalid_mapping or result_end <= result_start
+        if invalid_mapping:
             raise ProvenanceError(f"{prefix} has a non-canonical byte mapping")
         source_slice = source[source_start:source_end]
-        operation_name = operation["operation"]
         if operation_name == "copy":
             expected = source_slice
         elif operation_name == "html_entity_decode":
@@ -594,6 +612,10 @@ def build_text_transform(
                 raise ProvenanceError(f"{prefix} source is not UTF-8") from error
         elif operation_name == "mathml_to_infix":
             expected = _mathml_to_infix(source_slice, prefix)
+        elif operation_name == "discard":
+            _require_nonempty(operation["claim_id"], f"{prefix}.claim_id")
+            _require_nonempty(operation["reason"], f"{prefix}.reason")
+            expected = b""
         else:
             raise ProvenanceError(f"{prefix}.operation is unsupported")
         if expected != result[result_start:result_end]:
@@ -1086,6 +1108,21 @@ def _range_is_represented(start: int, end: int, ir: dict[str, Any]) -> bool:
     return False
 
 
+def _transform_operations_for_claim(
+    operations: list[dict[str, Any]], claim_id: str, text_claim: dict[str, Any]
+) -> list[dict[str, Any]]:
+    return [
+        operation
+        for operation in operations
+        if (operation["operation"] == "discard" and operation["claim_id"] == claim_id)
+        or (
+            operation["operation"] != "discard"
+            and operation["result_end"] > text_claim["start"]
+            and operation["result_start"] < text_claim["end"]
+        )
+    ]
+
+
 def _validate_source_entry(
     cas: Cas, source: Any, prefix: str
 ) -> tuple[
@@ -1210,10 +1247,47 @@ def _validate_source_entry(
                 f"{item_prefix} rendered claims lack raw claims: "
                 f"{', '.join(missing_raw_claims)}"
             )
+        discard_claims = {
+            operation["claim_id"]
+            for operation in transform["operations"]
+            if operation["operation"] == "discard"
+        }
+        unknown_discard_claims = sorted(
+            discard_claims - (set(text_claims) & set(raw_claims))
+        )
+        if unknown_discard_claims:
+            raise ProvenanceError(
+                f"{item_prefix} transform discards name unknown claims: "
+                f"{', '.join(unknown_discard_claims)}"
+            )
         for claim_id, text_claim in text_claims.items():
             raw_claim = raw_claims[claim_id]
+            if discard_claims:
+                claim_operations = _transform_operations_for_claim(
+                    transform["operations"], claim_id, text_claim
+                )
+                if not claim_operations or (
+                    raw_claim["start"] != claim_operations[0]["source_start"]
+                    or raw_claim["end"] != claim_operations[-1]["source_end"]
+                ):
+                    raise ProvenanceError(
+                        f"{item_prefix} explicit transform partition does not "
+                        f"account for every raw claim byte in {claim_id}"
+                    )
             claim_cursor = text_claim["start"]
             for operation in transform["operations"]:
+                if operation["operation"] == "discard":
+                    if operation["claim_id"] != claim_id:
+                        continue
+                    if (
+                        operation["source_start"] < raw_claim["start"]
+                        or operation["source_end"] > raw_claim["end"]
+                    ):
+                        raise ProvenanceError(
+                            f"{item_prefix} transform discard for claim {claim_id} "
+                            "escapes its corresponding raw claim bytes"
+                        )
+                    continue
                 if operation["result_end"] <= claim_cursor:
                     continue
                 if (

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -940,6 +940,396 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(transform["result_size"], len(result))
 
+    def test_discard_transform_accounts_for_stripped_html_tags(self) -> None:
+        source = b"<p>A &amp; B</p>"
+        result = b"A & B"
+        transform = provenance.build_text_transform(
+            source_sha256=provenance.sha256_bytes(source),
+            source=source,
+            result_sha256=provenance.sha256_bytes(result),
+            result=result,
+            operations=[
+                {
+                    "claim_id": "claim",
+                    "operation": "discard",
+                    "reason": "opening paragraph tag is markup, not text",
+                    "result_end": 0,
+                    "result_start": 0,
+                    "source_end": 3,
+                    "source_start": 0,
+                },
+                {
+                    "operation": "copy",
+                    "result_end": 2,
+                    "result_start": 0,
+                    "source_end": 5,
+                    "source_start": 3,
+                },
+                {
+                    "operation": "html_entity_decode",
+                    "result_end": 3,
+                    "result_start": 2,
+                    "source_end": 10,
+                    "source_start": 5,
+                },
+                {
+                    "operation": "copy",
+                    "result_end": 5,
+                    "result_start": 3,
+                    "source_end": 12,
+                    "source_start": 10,
+                },
+                {
+                    "claim_id": "claim",
+                    "operation": "discard",
+                    "reason": "closing paragraph tag is markup, not text",
+                    "result_end": 5,
+                    "result_start": 5,
+                    "source_end": len(source),
+                    "source_start": 12,
+                },
+            ],
+        )
+
+        self.assertEqual(transform["result_size"], len(result))
+        self.assertEqual(
+            [operation["operation"] for operation in transform["operations"]],
+            ["discard", "copy", "html_entity_decode", "copy", "discard"],
+        )
+
+    def test_discard_transform_requires_nonempty_reason(self) -> None:
+        source = b"<p>"
+        base_operation = {
+            "claim_id": "claim",
+            "operation": "discard",
+            "result_end": 0,
+            "result_start": 0,
+            "source_end": len(source),
+            "source_start": 0,
+        }
+        cases = [
+            (base_operation, "exact operation schema"),
+            ({**base_operation, "reason": ""}, "must be a non-empty string"),
+        ]
+
+        for operation, message in cases:
+            with (
+                self.subTest(operation=operation),
+                self.assertRaisesRegex(provenance.ProvenanceError, message),
+            ):
+                provenance.build_text_transform(
+                    source_sha256=provenance.sha256_bytes(source),
+                    source=source,
+                    result_sha256=provenance.sha256_bytes(b""),
+                    result=b"",
+                    operations=[operation],
+                )
+
+    def test_discard_transform_rejects_nonzero_result_range(self) -> None:
+        source = b"<p>"
+        with self.assertRaisesRegex(
+            provenance.ProvenanceError, "non-canonical byte mapping"
+        ):
+            provenance.build_text_transform(
+                source_sha256=provenance.sha256_bytes(source),
+                source=source,
+                result_sha256=provenance.sha256_bytes(b"<"),
+                result=b"<",
+                operations=[
+                    {
+                        "claim_id": "claim",
+                        "operation": "discard",
+                        "reason": "opening paragraph tag is markup, not text",
+                        "result_end": 1,
+                        "result_start": 0,
+                        "source_end": len(source),
+                        "source_start": 0,
+                    }
+                ],
+            )
+
+    def test_discard_transform_rejects_noncanonical_source_order(self) -> None:
+        source = b"<p>A</p>"
+        result = b"A"
+        with self.assertRaisesRegex(
+            provenance.ProvenanceError, "non-canonical byte mapping"
+        ):
+            provenance.build_text_transform(
+                source_sha256=provenance.sha256_bytes(source),
+                source=source,
+                result_sha256=provenance.sha256_bytes(result),
+                result=result,
+                operations=[
+                    {
+                        "operation": "copy",
+                        "result_end": 1,
+                        "result_start": 0,
+                        "source_end": 4,
+                        "source_start": 3,
+                    },
+                    {
+                        "claim_id": "claim",
+                        "operation": "discard",
+                        "reason": "opening paragraph tag is markup, not text",
+                        "result_end": 1,
+                        "result_start": 1,
+                        "source_end": 3,
+                        "source_start": 0,
+                    },
+                ],
+            )
+
+    def test_discard_transform_rejects_an_unaccounted_source_gap(self) -> None:
+        source = b"<p> A</p>"
+        with self.assertRaisesRegex(
+            provenance.ProvenanceError, "non-canonical byte mapping"
+        ):
+            provenance.build_text_transform(
+                source_sha256=provenance.sha256_bytes(source),
+                source=source,
+                result_sha256=provenance.sha256_bytes(b"A"),
+                result=b"A",
+                operations=[
+                    {
+                        "claim_id": "claim",
+                        "operation": "discard",
+                        "reason": "opening paragraph tag is markup, not text",
+                        "result_end": 0,
+                        "result_start": 0,
+                        "source_end": 3,
+                        "source_start": 0,
+                    },
+                    {
+                        "operation": "copy",
+                        "result_end": 1,
+                        "result_start": 0,
+                        "source_end": 5,
+                        "source_start": 4,
+                    },
+                    {
+                        "claim_id": "claim",
+                        "operation": "discard",
+                        "reason": "closing paragraph tag is markup, not text",
+                        "result_end": 1,
+                        "result_start": 1,
+                        "source_end": len(source),
+                        "source_start": 5,
+                    },
+                ],
+            )
+
+    def test_discard_at_a_claim_boundary_has_one_explicit_owner(self) -> None:
+        operations = [
+            {
+                "operation": "copy",
+                "result_end": 1,
+                "result_start": 0,
+                "source_end": 1,
+                "source_start": 0,
+            },
+            {
+                "claim_id": "claim.a",
+                "operation": "discard",
+                "reason": "separator belongs to the first claim",
+                "result_end": 1,
+                "result_start": 1,
+                "source_end": 2,
+                "source_start": 1,
+            },
+            {
+                "operation": "copy",
+                "result_end": 2,
+                "result_start": 1,
+                "source_end": 3,
+                "source_start": 2,
+            },
+        ]
+
+        first = provenance._transform_operations_for_claim(
+            operations, "claim.a", {"start": 0, "end": 1}
+        )
+        second = provenance._transform_operations_for_claim(
+            operations, "claim.b", {"start": 1, "end": 2}
+        )
+
+        self.assertEqual(
+            [operation["operation"] for operation in first], ["copy", "discard"]
+        )
+        self.assertEqual([operation["operation"] for operation in second], ["copy"])
+
+    def test_schema_backed_adjacent_claim_discards_have_exact_owners(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            cas = provenance.Cas(Path(directory) / "cas")
+            raw = b"<p>A</p><p>B</p>"
+            rendered = b"AB"
+            raw_hash = cas.put(raw, kind="raw_source", label="two HTML claims")
+            rendered_hash = cas.put(
+                rendered,
+                kind="rendered_text",
+                label="two rendered claims",
+                links=[raw_hash],
+            )
+            receipt = provenance.build_fetch_receipt(
+                locator="https://example.test/two-claims",
+                final_locator="https://example.test/two-claims",
+                retrieved_at="2026-08-02T12:00:00Z",
+                status=200,
+                media_type="text/html",
+                body_sha256=raw_hash,
+                body_size=len(raw),
+            )
+            receipt_hash = cas.put_json(
+                receipt,
+                kind="fetch_receipt",
+                label="two-claim receipt",
+                links=[raw_hash],
+            )
+
+            def claim(claim_id: str, data: bytes, start: int, end: int) -> dict:
+                quote = data[start:end]
+                return {
+                    "claim_id": claim_id,
+                    "end": end,
+                    "quote": quote.decode("utf-8"),
+                    "quote_sha256": provenance.sha256_bytes(quote),
+                    "start": start,
+                }
+
+            raw_ir = provenance.build_source_ir(
+                source_sha256=raw_hash,
+                source=raw,
+                segments=[
+                    {
+                        "claims": [claim("claim.a", raw, 0, 8)],
+                        "disposition": "represented",
+                        "end": 8,
+                        "start": 0,
+                    },
+                    {
+                        "claims": [claim("claim.b", raw, 8, 16)],
+                        "disposition": "represented",
+                        "end": 16,
+                        "start": 8,
+                    },
+                ],
+            )
+            raw_ir_hash = cas.put_json(
+                raw_ir, kind="source_ir", label="two-claim raw IR", links=[raw_hash]
+            )
+            rendered_ir = provenance.build_source_ir(
+                source_sha256=rendered_hash,
+                source=rendered,
+                segments=[
+                    {
+                        "claims": [claim("claim.a", rendered, 0, 1)],
+                        "disposition": "represented",
+                        "end": 1,
+                        "start": 0,
+                    },
+                    {
+                        "claims": [claim("claim.b", rendered, 1, 2)],
+                        "disposition": "represented",
+                        "end": 2,
+                        "start": 1,
+                    },
+                ],
+            )
+            rendered_ir_hash = cas.put_json(
+                rendered_ir,
+                kind="source_ir",
+                label="two-claim rendered IR",
+                links=[rendered_hash],
+            )
+            transform = provenance.build_text_transform(
+                source_sha256=raw_hash,
+                source=raw,
+                result_sha256=rendered_hash,
+                result=rendered,
+                operations=[
+                    {
+                        "claim_id": "claim.a",
+                        "operation": "discard",
+                        "reason": "first opening tag",
+                        "result_end": 0,
+                        "result_start": 0,
+                        "source_end": 3,
+                        "source_start": 0,
+                    },
+                    {
+                        "operation": "copy",
+                        "result_end": 1,
+                        "result_start": 0,
+                        "source_end": 4,
+                        "source_start": 3,
+                    },
+                    {
+                        "claim_id": "claim.a",
+                        "operation": "discard",
+                        "reason": "first closing tag",
+                        "result_end": 1,
+                        "result_start": 1,
+                        "source_end": 8,
+                        "source_start": 4,
+                    },
+                    {
+                        "claim_id": "claim.b",
+                        "operation": "discard",
+                        "reason": "second opening tag",
+                        "result_end": 1,
+                        "result_start": 1,
+                        "source_end": 11,
+                        "source_start": 8,
+                    },
+                    {
+                        "operation": "copy",
+                        "result_end": 2,
+                        "result_start": 1,
+                        "source_end": 12,
+                        "source_start": 11,
+                    },
+                    {
+                        "claim_id": "claim.b",
+                        "operation": "discard",
+                        "reason": "second closing tag",
+                        "result_end": 2,
+                        "result_start": 2,
+                        "source_end": 16,
+                        "source_start": 12,
+                    },
+                ],
+            )
+            transform_hash = cas.put_json(
+                transform,
+                kind="text_transform",
+                label="two-claim transform",
+                links=[raw_hash, rendered_hash],
+            )
+            cas.write_index()
+            schema = (
+                Path(__file__).resolve().parents[2]
+                / "specs/data/adj-stdlib-provenance/manifest.schema.json"
+            )
+            provenance._validate_cas_schemas(schema, cas)
+            links, claims, _authorities = provenance._validate_source_entry(
+                cas,
+                {
+                    "raw_source_sha256": raw_hash,
+                    "receipt_sha256": receipt_hash,
+                    "representations": [
+                        {
+                            "rendered_text_sha256": rendered_hash,
+                            "source_ir_sha256": rendered_ir_hash,
+                            "transform_sha256": transform_hash,
+                        }
+                    ],
+                    "source_ir_sha256": raw_ir_hash,
+                },
+                "two_claim_source",
+            )
+
+            self.assertIn(transform_hash, links)
+            self.assertEqual(set(claims[rendered_ir_hash]), {"claim.a", "claim.b"})
+
     def test_mathml_transform_reproduces_canonical_infix_bytes(self) -> None:
         source = (
             b"<math><semantics><mrow><mfrac><mi>n</mi><mn>100</mn></mfrac>"
@@ -1138,6 +1528,133 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
 
             with self.assertRaisesRegex(provenance.ProvenanceError, "not represented"):
                 provenance.validate_repository(cas_root, manifest_path)
+
+    def test_discard_transform_partition_must_cover_its_raw_claim(self) -> None:
+        schema = (
+            Path(__file__).resolve().parents[2]
+            / "specs/data/adj-stdlib-provenance/manifest.schema.json"
+        )
+        for include_leading_discard in (True, False):
+            with (
+                self.subTest(include_leading_discard=include_leading_discard),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                root = Path(directory)
+                cas_root, manifest_path, _ = self.build_repository(root)
+
+                def mutate(
+                    bundle: dict[str, object],
+                    cas: provenance.Cas,
+                    include_leading_discard: bool = include_leading_discard,
+                ) -> None:
+                    source = bundle["sources"][0]
+                    raw_hash = source["raw_source_sha256"]
+                    raw = provenance._read_regular_file(cas.object_path(raw_hash))
+                    claim_id = bundle["clauses"][0]["claim_id"]
+                    raw_ir = provenance.build_source_ir(
+                        source_sha256=raw_hash,
+                        source=raw,
+                        segments=[
+                            {
+                                "claims": [
+                                    {
+                                        "claim_id": claim_id,
+                                        "end": len(raw),
+                                        "quote": raw.decode("utf-8"),
+                                        "quote_sha256": provenance.sha256_bytes(raw),
+                                        "start": 0,
+                                    }
+                                ],
+                                "disposition": "represented",
+                                "end": len(raw),
+                                "start": 0,
+                            }
+                        ],
+                    )
+                    source["source_ir_sha256"] = cas.put_json(
+                        raw_ir,
+                        kind="source_ir",
+                        label="whole raw claim IR",
+                        links=[raw_hash],
+                    )
+                    rendered_hash = bundle["clauses"][0]["snapshot_sha256"]
+                    rendered = provenance._read_regular_file(
+                        cas.object_path(rendered_hash)
+                    )
+                    start = raw.index(rendered)
+                    end = start + len(rendered)
+                    operations = []
+                    if include_leading_discard:
+                        operations.append(
+                            {
+                                "claim_id": claim_id,
+                                "operation": "discard",
+                                "reason": "header is outside the rendered definition",
+                                "result_end": 0,
+                                "result_start": 0,
+                                "source_end": start,
+                                "source_start": 0,
+                            }
+                        )
+                    operations.extend(
+                        [
+                            {
+                                "operation": "copy",
+                                "result_end": len(rendered),
+                                "result_start": 0,
+                                "source_end": end,
+                                "source_start": start,
+                            },
+                            {
+                                "claim_id": claim_id,
+                                "operation": "discard",
+                                "reason": "footer is outside the rendered definition",
+                                "result_end": len(rendered),
+                                "result_start": len(rendered),
+                                "source_end": len(raw),
+                                "source_start": end,
+                            },
+                        ]
+                    )
+                    transform = provenance.build_text_transform(
+                        source_sha256=raw_hash,
+                        source=raw,
+                        result_sha256=rendered_hash,
+                        result=rendered,
+                        operations=operations,
+                    )
+                    source["representations"][0]["transform_sha256"] = cas.put_json(
+                        transform,
+                        kind="text_transform",
+                        label="explicit source partition transform",
+                        links=[raw_hash, rendered_hash],
+                    )
+
+                self.replace_bundle(cas_root, manifest_path, mutate)
+                if include_leading_discard:
+                    cas = provenance.Cas(cas_root)
+                    cas.load()
+                    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                    reachable = provenance._reachable(cas, manifest["bundle_hashes"])
+                    for digest in sorted(set(cas.index) - reachable):
+                        cas.object_path(digest).unlink()
+                    cas.index = {
+                        digest: record
+                        for digest, record in cas.index.items()
+                        if digest in reachable
+                    }
+                    cas.write_index()
+                    self.assertTrue(
+                        provenance.validate_repository(cas_root, manifest_path, schema)[
+                            "valid"
+                        ]
+                    )
+                else:
+                    with self.assertRaisesRegex(
+                        provenance.ProvenanceError,
+                        "explicit transform partition does not account",
+                    ):
+                        provenance.validate_repository(cas_root, manifest_path, schema)
 
     def test_dependency_resolution_names_an_exported_claim(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -281,8 +281,22 @@ option mapping, or judge/evaluation failure.
     perturb an already verified consumer.
 7f. **Complete:** add a strict MathML-to-infix transform so formula bytes embedded
     in publisher markup can become readable citations without invented symbols.
+7g. **Complete:** add reasoned zero-output operations to text transforms. Once a
+    transform discards source bytes, its operations must partition the selected
+    source span contiguously and bind every discarded range to one claim and an
+    explicit reason.
 8. Replace the dead MathWorld `PercentageChange` locator before migrating
    `percent.adj`; a source returning 404 cannot ground that clause.
+9. Add executable formula preconditions or domain guards before migrating
+   `proportion.adj`; `a/b=c/x` requires nonzero `a`, `b`, and `c`, while the
+   current formula fails closed only on its final divisor.
+10. Add first-class derivation objects and execute every exported formula before
+    migrating `average.adj`; prose cannot prove its `N=2` and `N=3` specializations.
+11. Replace `powers.adj`'s `Cube.html` locator, which describes the geometric
+    solid, and ground both exported formulas in stable, domain-correct bytes.
+12. Revisit `simple-interest.adj` with its variable/unit context, explicit
+    rejection of contradicted page metadata, unit-bearing query facts, and a
+    structured lowering from source notation to primitive operations.
 
 ### Wave 2: complete K-8 foundations
 

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -18,8 +18,11 @@ It starts empty and grows only through reviewed source migrations.
   records its exact byte range, UTF-8 quote, and quote hash; every discarded range
   has a non-empty reason.
 - A `text_transform` proves how selected raw response bytes reproduce every byte
-  of a rendered-text representation. Copy, HTML-entity decoding, and a strict
-  MathML-to-infix projection are the only accepted operations.
+  of a rendered-text representation. Copy, HTML-entity decoding, a strict
+  MathML-to-infix projection, and reasoned source-byte discards are the only
+  accepted operations. Once a transform uses `discard`, its operations form a
+  contiguous source partition and each zero-output discard carries a reason and
+  the exact claim ID that owns it.
 - A `provenance_bundle` binds stable clause IDs to snapshots, byte ranges, source
   IR, receipts, and recursively checked dependency or accepted-root decisions.
   Dependency decisions name the exact exported claim. Accepted roots classify

--- a/code/specs/data/adj-stdlib-provenance/manifest.schema.json
+++ b/code/specs/data/adj-stdlib-provenance/manifest.schema.json
@@ -95,16 +95,34 @@
       "type": "object"
     },
     "operation": {
-      "additionalProperties": false,
-      "properties": {
-        "operation": { "enum": ["copy", "html_entity_decode", "mathml_to_infix"] },
-        "result_end": { "minimum": 1, "type": "integer" },
-        "result_start": { "minimum": 0, "type": "integer" },
-        "source_end": { "minimum": 1, "type": "integer" },
-        "source_start": { "minimum": 0, "type": "integer" }
-      },
-      "required": ["operation", "result_end", "result_start", "source_end", "source_start"],
-      "type": "object"
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "operation": { "enum": ["copy", "html_entity_decode", "mathml_to_infix"] },
+            "result_end": { "minimum": 1, "type": "integer" },
+            "result_start": { "minimum": 0, "type": "integer" },
+            "source_end": { "minimum": 1, "type": "integer" },
+            "source_start": { "minimum": 0, "type": "integer" }
+          },
+          "required": ["operation", "result_end", "result_start", "source_end", "source_start"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "claim_id": { "minLength": 1, "type": "string" },
+            "operation": { "const": "discard" },
+            "reason": { "minLength": 1, "type": "string" },
+            "result_end": { "minimum": 0, "type": "integer" },
+            "result_start": { "minimum": 0, "type": "integer" },
+            "source_end": { "minimum": 1, "type": "integer" },
+            "source_start": { "minimum": 0, "type": "integer" }
+          },
+          "required": ["claim_id", "operation", "reason", "result_end", "result_start", "source_end", "source_start"],
+          "type": "object"
+        }
+      ]
     },
     "provenance_bundle": {
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- add a schema-backed `discard` text-transform operation with mandatory claim ownership and a non-empty reason
- require transforms using discards to form a contiguous selected-source partition, while preserving legacy sparse transforms
- enforce exact per-claim raw-byte envelopes and half-open rendered-byte ownership at adjacent claim boundaries
- document the contract and record formula migrations blocked by domain, derivation, locator, and unit-context gaps

## Why
ADJ provenance could prove the bytes retained in rendered source text, but it could not explicitly account for bytes intentionally removed from raw source material. That prevented defensible migrations from HTML and other structured sources. This adds an auditable, claim-bound record for every discarded byte without weakening existing transforms.

No new formula root is promoted in this PR. The newly discovered blockers remain explicit in the stdlib backlog.

## Validation
- `python -m ruff format --check code/scripts/adj_stdlib_provenance.py code/scripts/tests/test_adj_stdlib_provenance.py`
- `python -m ruff check code/scripts/adj_stdlib_provenance.py code/scripts/tests/test_adj_stdlib_provenance.py`
- `PYTHONPATH=code/scripts python -m unittest discover -s code/scripts/tests -p 'test_adj_stdlib_*.py'` (63 passed, 1 expected Windows skip)
- `python code/scripts/adj_stdlib_provenance.py verify` (6 bundles, 69 objects, 9 snapshots)
- `python code/scripts/adj_stdlib_manifest.py --validate-json-schema` (10 objectives)
- `python code/scripts/adj_stdlib_report.py --format json --fail-on-unreferenced-tests`
- `git diff --check`

## Review
An independent subagent reviewed the implementation twice. After adding the schema alternative, explicit discard ownership, half-open boundary handling, and a schema-backed two-claim CAS integration fixture, it reported no remaining P1/P2 findings.