### PR TITLE
feat(venture): add Compose chrome interaction acceptance

### DIFF
--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -127,6 +127,7 @@ pub fn from_pipeline(
     writeln!(out, "import androidx.compose.runtime.Composable").unwrap();
     writeln!(out, "import androidx.compose.ui.Alignment").unwrap();
     writeln!(out, "import androidx.compose.ui.Modifier").unwrap();
+    writeln!(out, "import androidx.compose.ui.platform.testTag").unwrap();
     writeln!(out, "import androidx.compose.ui.graphics.Color").unwrap();
     writeln!(out, "import androidx.compose.ui.text.TextStyle").unwrap();
     writeln!(out, "import androidx.compose.ui.text.font.FontFamily").unwrap();
@@ -1962,10 +1963,8 @@ fn emit_host_input(
         .unwrap();
     }
 
-    if let Some(style) = &style {
-        if !style.modifier.is_empty() {
-            writeln!(out, "{inner}modifier = Modifier{},", style.modifier).unwrap();
-        }
+    if let Some(modifier) = host_control_modifier_expr(node, style.as_ref()) {
+        writeln!(out, "{inner}modifier = {modifier},").unwrap();
     }
     if let Some(text_style) = input_text.text_style_expr() {
         writeln!(out, "{inner}textStyle = {text_style},").unwrap();
@@ -2034,17 +2033,19 @@ fn emit_host_button(
         Some(LayoutPropValue::Expr(text)) => text.trim().to_string(),
         _ => "\"\"".to_string(),
     };
+    let enabled_expr = disabled_prop_enabled_expr(node)?;
+    let modifier_expr = host_control_modifier_expr(node, style.as_ref());
 
     let mut out = String::new();
-    if style
-        .as_ref()
-        .map(|s| !s.modifier.is_empty())
-        .unwrap_or(false)
-    {
-        let style = style.as_ref().unwrap();
+    if enabled_expr.is_some() || modifier_expr.is_some() {
         writeln!(out, "{pad}Button(").unwrap();
         writeln!(out, "{inner}onClick = {{ {on_click} }},").unwrap();
-        writeln!(out, "{inner}modifier = Modifier{},", style.modifier).unwrap();
+        if let Some(enabled) = enabled_expr {
+            writeln!(out, "{inner}enabled = {enabled},").unwrap();
+        }
+        if let Some(modifier) = modifier_expr {
+            writeln!(out, "{inner}modifier = {modifier},").unwrap();
+        }
         writeln!(out, "{pad}) {{").unwrap();
     } else {
         writeln!(out, "{pad}Button(onClick = {{ {on_click} }}) {{").unwrap();
@@ -2052,6 +2053,17 @@ fn emit_host_button(
     writeln!(out, "{inner}{}", text_call(&label, Some(&label_text))).unwrap();
     writeln!(out, "{pad}}}").unwrap();
     Ok(out)
+}
+
+fn host_control_modifier_expr(node: &LayoutNode, style: Option<&ComposeStyle>) -> Option<String> {
+    let mut modifier = String::from("Modifier");
+    if let Some(style) = style {
+        modifier.push_str(&style.modifier);
+    }
+    if let Some(part) = &node.part_name {
+        write!(modifier, ".testTag(\"{}\")", escape_kotlin_string(part)).unwrap();
+    }
+    (modifier != "Modifier").then_some(modifier)
 }
 
 fn host_button_single_payload_expr(
@@ -3220,6 +3232,63 @@ mod tests {
             "expected dispatch(BarEvent.Click), got:\n{out}"
         );
         assert!(out.contains("Text(text = \"Go\")"));
+    }
+
+    #[test]
+    fn host_button_projects_disabled_slot_and_part_to_native_control() {
+        let m = component(
+            "Bar",
+            vec![slot("navigation-disabled", SlotType::Bool, true)],
+            vec![emit_decl("onClick", vec![])],
+        );
+        let l = layout(
+            "Bar",
+            styled_node(
+                "HostButton",
+                "go-button",
+                vec![
+                    LayoutProp {
+                        name: "label".into(),
+                        value: LayoutPropValue::String("Go".into()),
+                    },
+                    slot_prop("disabled", "navigation-disabled"),
+                    LayoutProp {
+                        name: "onClick".into(),
+                        value: LayoutPropValue::EmitRef("onClick".into()),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Bar")).unwrap().output;
+        assert!(
+            out.contains("enabled = navigationDisabled != true,"),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains("modifier = Modifier.testTag(\"go-button\"),"),
+            "got:\n{out}"
+        );
+        assert!(out.contains("import androidx.compose.ui.platform.testTag"));
+    }
+
+    #[test]
+    fn host_input_projects_part_to_native_control_test_tag() {
+        let m = component("Bar", vec![slot("address", SlotType::Text, true)], vec![]);
+        let l = layout(
+            "Bar",
+            styled_node(
+                "HostInput",
+                "address-input",
+                vec![slot_prop("value", "address")],
+                vec![],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Bar")).unwrap().output;
+        assert!(
+            out.contains("modifier = Modifier.testTag(\"address-input\"),"),
+            "got:\n{out}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -1172,6 +1172,8 @@ fn build_compose_build_gradle_kts(package_name: &str) -> String {
             "}}\n\n",
             "dependencies {{\n",
             "    implementation(compose.desktop.currentOs)\n",
+            "    testImplementation(\"org.jetbrains.compose.ui:ui-test-junit4-desktop:{compose_version}\")\n",
+            "    testImplementation(kotlin(\"test\"))\n",
             "}}\n\n",
             "kotlin {{\n",
             "    jvmToolchain(21)\n",
@@ -1210,6 +1212,16 @@ fn build_compose_main_kt(component_name: &str, slots: &[SlotDecl]) -> String {
             "import androidx.compose.ui.window.application\n\n",
             "fun main() = application {{\n",
             "    val mosaicHost = remember {{ MosaicComposeHostBridge.load() }}\n",
+            "    Window(onCloseRequest = ::exitApplication, title = \"{}\") {{\n",
+            "        MosaicApp(mosaicHost)\n",
+            "    }}\n",
+            "}}\n\n",
+            "interface MosaicComposeHost {{\n",
+            "    fun props(): Map<String, Any?>?\n",
+            "    fun handleEvent(event: Map<String, Any?>): Map<String, Any?>?\n",
+            "}}\n\n",
+            "@Composable\n",
+            "fun MosaicApp(mosaicHost: MosaicComposeHost?) {{\n",
             "    var hostProps by remember {{ mutableStateOf<Map<String, Any?>>(emptyMap()) }}\n",
             "    fun applyMosaicResponse(response: Map<String, Any?>?) {{\n",
             "        if (response == null) return\n",
@@ -1222,15 +1234,13 @@ fn build_compose_main_kt(component_name: &str, slots: &[SlotDecl]) -> String {
             "    LaunchedEffect(mosaicHost) {{\n",
             "        applyMosaicResponse(mosaicHost?.props())\n",
             "    }}\n",
-            "    Window(onCloseRequest = ::exitApplication, title = \"{}\") {{\n",
-            "        MaterialTheme {{\n",
+            "    MaterialTheme {{\n",
             "{root}\n",
-            "        }}\n",
             "    }}\n",
             "}}\n\n",
-            "private class MosaicComposeHostBridge(private val instance: Any) {{\n",
-            "    fun props(): Map<String, Any?>? = invokeMap(\"props\")\n",
-            "    fun handleEvent(event: Map<String, Any?>): Map<String, Any?>? = invokeMap(\"handleEvent\", event)\n\n",
+            "private class MosaicComposeHostBridge(private val instance: Any) : MosaicComposeHost {{\n",
+            "    override fun props(): Map<String, Any?>? = invokeMap(\"props\")\n",
+            "    override fun handleEvent(event: Map<String, Any?>): Map<String, Any?>? = invokeMap(\"handleEvent\", event)\n\n",
             "    private fun invokeMap(methodName: String, vararg args: Any): Map<String, Any?>? = runCatching {{\n",
             "        val method = instance.javaClass.methods.firstOrNull {{ method ->\n",
             "            method.name == methodName && method.parameterCount == args.size\n",
@@ -4510,11 +4520,18 @@ version = "1"
         assert!(gradle.contains("id(\"org.jetbrains.compose\") version \"1.11.1\""));
         assert!(gradle.contains("id(\"org.jetbrains.kotlin.plugin.compose\") version \"2.3.21\""));
         assert!(gradle.contains("kotlin(\"jvm\") version \"2.3.21\""));
+        assert!(gradle.contains(
+            "testImplementation(\"org.jetbrains.compose.ui:ui-test-junit4-desktop:1.11.1\")"
+        ));
+        assert!(gradle.contains("testImplementation(kotlin(\"test\"))"));
         assert!(gradle.contains("mainClass = \"MainKt\""));
         assert!(gradle.contains("packageName = \"mosaic_pkg_grid\""));
         let main_kt = fs::read_to_string(dir.join("src/main/kotlin/Main.kt")).expect("Main.kt");
         assert!(main_kt.contains("fun main() = application"));
         assert!(main_kt.contains("Window(onCloseRequest = ::exitApplication, title = \"Grid\")"));
+        assert!(main_kt.contains("interface MosaicComposeHost"));
+        assert!(main_kt.contains("fun MosaicApp(mosaicHost: MosaicComposeHost?)"));
+        assert!(main_kt.contains("MosaicApp(mosaicHost)"));
         assert!(main_kt.contains("MosaicComposeHostBridge.load()"));
         assert!(main_kt.contains("var hostProps by remember"));
         assert!(main_kt.contains("applyMosaicResponse(mosaicHost?.props())"));

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Add direct generated Compose Desktop interaction acceptance for native
+  disabled controls, address editing, Return and Go dispatch, and host-driven
+  prop refresh through the package-owned Mosaic host seam.
 - Add direct generated Qt Quick interaction acceptance for host hydration,
   disabled controls, address editing, Return, Go, and response refresh, using
   Mosaic part names as native QML object identities.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -80,6 +80,9 @@ with a recording host and drives the generated native controls, including
 disabled buttons, address editing, Return, Go, and host-driven prop refresh.
 The Qt gate runs the same contract through Qt Quick Test against the emitted
 part-backed native controls and its generated `mosaicHost` seam.
+The Compose gate uses the emitted Mosaic-part test tags to drive native
+Compose controls through the generated injectable `MosaicComposeHost` seam,
+including disabled buttons, address editing, Return, Go, and host prop refresh.
 Platform-exclusive builds are explicitly deferred to their
 native host; missing host-applicable toolchains are reported as skips. Pass
 `--strict` on POSIX or `-Strict` on PowerShell to reject those missing

--- a/code/programs/mosaic/venture-browser/host/compose/VentureChromeInteractionTest.kt
+++ b/code/programs/mosaic/venture-browser/host/compose/VentureChromeInteractionTest.kt
@@ -1,0 +1,95 @@
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTextReplacement
+import kotlin.test.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+private class RecordingMosaicHost(
+    private val navigationDisabled: Boolean,
+) : MosaicComposeHost {
+    val events = mutableListOf<Map<String, Any?>>()
+    private val contentSurface: @Composable () -> Unit = { Text("Compose host surface") }
+
+    override fun props(): Map<String, Any?> = response("Ready")
+
+    override fun handleEvent(event: Map<String, Any?>): Map<String, Any?>? {
+        events += event.toMap()
+        return if (event["event"] == "onNavigate") {
+            response("Navigated through MosaicHost")
+        } else {
+            null
+        }
+    }
+
+    private fun response(status: String): Map<String, Any?> = mapOf(
+        "props" to mapOf(
+            "address" to "http://venture.test/start",
+            "page-title" to "Venture Compose Acceptance",
+            "status-text" to status,
+            "back-disabled" to navigationDisabled,
+            "forward-disabled" to navigationDisabled,
+            "navigation-disabled" to navigationDisabled,
+            "content-surface" to contentSurface,
+        ),
+    )
+}
+
+class VentureChromeInteractionTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun disabledNativeControlsSuppressMosaicDispatch() {
+        val host = RecordingMosaicHost(navigationDisabled = true)
+        rule.setContent { MosaicApp(host) }
+        rule.waitForIdle()
+
+        rule.onNodeWithText("Venture Compose Acceptance").assertExists()
+        rule.onNodeWithText("Compose host surface").assertExists()
+        for (tag in listOf("back-button", "forward-button", "reload-button", "go-button")) {
+            rule.onNodeWithTag(tag).assertIsNotEnabled().performMouseInput { click() }
+        }
+        rule.onNodeWithTag("address-input").assertIsNotEnabled()
+        rule.waitForIdle()
+        assertEquals(emptyList(), host.events)
+    }
+
+    @Test
+    fun addressReturnAndGoCrossTheMosaicHostSeam() {
+        val host = RecordingMosaicHost(navigationDisabled = false)
+        rule.setContent { MosaicApp(host) }
+        rule.waitForIdle()
+
+        val input = rule.onNodeWithTag("address-input").assertIsEnabled()
+        input.performTextReplacement("http://venture.test/next")
+        rule.waitForIdle()
+        assertEquals(
+            mapOf(
+                "event" to "onAddressChange",
+                "value" to "http://venture.test/next",
+            ),
+            host.events.last(),
+        )
+
+        input.performImeAction()
+        rule.waitForIdle()
+        assertEquals("onNavigate", host.events.last()["event"])
+        rule.onNodeWithText("Navigated through MosaicHost").assertExists()
+
+        rule.onNodeWithTag("go-button").assertIsEnabled().performClick()
+        rule.waitForIdle()
+        assertEquals(2, host.events.count { it["event"] == "onNavigate" })
+        rule.onNodeWithTag("address-input").assertTextEquals("http://venture.test/start")
+    }
+}

--- a/code/programs/mosaic/venture-browser/mosaic-package.toml
+++ b/code/programs/mosaic/venture-browser/mosaic-package.toml
@@ -13,6 +13,7 @@ files = [
   { backend = "xaml", source = "host/xaml/MosaicHost.cs", target = "MosaicHost.cs" },
   { backend = "flutter", source = "host/flutter/venture_chrome_interaction_test.dart", target = "test/venture_chrome_interaction_test.dart" },
   { backend = "qt", source = "host/qt/tst_venture_chrome.qml", target = "test/tst_venture_chrome.qml" },
+  { backend = "compose", source = "host/compose/VentureChromeInteractionTest.kt", target = "src/test/kotlin/VentureChromeInteractionTest.kt" },
 ]
 
 [kernel]

--- a/code/programs/mosaic/venture-browser/scripts/build-all.ps1
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.ps1
@@ -245,10 +245,10 @@ if (-not (Test-Command "gradle")) {
 } elseif ($null -eq $javaMajor -or $javaMajor -lt 21) {
     Skip-Backend -Backend "compose" -Reason "JDK 21 or newer is not installed"
 } else {
-    Write-Host "==> Building compose"
+    Write-Host "==> Testing and building compose"
     Push-Location (Join-Path $outputRoot "compose")
     try {
-        Invoke-Checked -Command "gradle" -Arguments @("--no-daemon", "build")
+        Invoke-Checked -Command "gradle" -Arguments @("--no-daemon", "test", "build")
     } finally {
         Pop-Location
     }

--- a/code/programs/mosaic/venture-browser/scripts/build-all.sh
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.sh
@@ -220,8 +220,8 @@ if ! has_command gradle; then
 elif [[ -z "$java_major" || "$java_major" -lt 21 ]]; then
   skip_backend compose "JDK 21 or newer is not installed"
 else
-  echo "==> Building compose"
-  (cd "$output_root/compose" && gradle --no-daemon build)
+  echo "==> Testing and building compose"
+  (cd "$output_root/compose" && gradle --no-daemon test build)
 fi
 
 echo "Built or checked $((${#backends[@]} - ${#skipped[@]} - ${#deferred[@]})) of ${#backends[@]} Venture backend projects."

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -89,7 +89,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     let package = mosaic_package_manifest::parse(&manifest).expect("parse manifest");
     assert_eq!(package.package.name, "venture-browser");
     assert_eq!(package.components.exports, ["VentureChrome"]);
-    assert_eq!(package.host_assets.files.len(), 4);
+    assert_eq!(package.host_assets.files.len(), 5);
     assert_eq!(package.host_assets.files[0].backend, "swiftui");
     assert_eq!(
         package.host_assets.files[0].target,
@@ -118,6 +118,15 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     assert_eq!(
         package.host_assets.files[3].target,
         "test/tst_venture_chrome.qml"
+    );
+    assert_eq!(package.host_assets.files[4].backend, "compose");
+    assert_eq!(
+        package.host_assets.files[4].source,
+        "host/compose/VentureChromeInteractionTest.kt"
+    );
+    assert_eq!(
+        package.host_assets.files[4].target,
+        "src/test/kotlin/VentureChromeInteractionTest.kt"
     );
 
     let host = read_package_file("host/swiftui/MosaicHost.swift");
@@ -283,6 +292,22 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
             "Qt interaction acceptance omits {symbol}"
         );
     }
+
+    let compose_acceptance =
+        read_package_file("host/compose/VentureChromeInteractionTest.kt");
+    for symbol in [
+        "MosaicApp(host)",
+        "disabledNativeControlsSuppressMosaicDispatch",
+        "addressReturnAndGoCrossTheMosaicHostSeam",
+        "performTextReplacement(\"http://venture.test/next\")",
+        "performImeAction()",
+        "Navigated through MosaicHost",
+    ] {
+        assert!(
+            compose_acceptance.contains(symbol),
+            "Compose interaction acceptance omits {symbol}"
+        );
+    }
 }
 
 #[test]
@@ -326,7 +351,7 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "dotnet build",
         "flutter build",
         "flutter test test/venture_chrome_interaction_test.dart",
-        "gradle --no-daemon build",
+        "gradle --no-daemon test build",
         "--strict",
     ] {
         assert!(shell.contains(required), "POSIX build omits {required}");
@@ -347,6 +372,7 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "flutter",
         "venture_chrome_interaction_test.dart",
         "gradle",
+        "@(\"--no-daemon\", \"test\", \"build\")",
         "$Strict",
     ] {
         assert!(


### PR DESCRIPTION
## Summary
- lower Mosaic HostButton disabled state and part identities into native Compose controls
- expose an injectable generated MosaicComposeHost boundary and package a direct Venture Compose UI test
- run Compose desktop interaction tests in the shared macOS/Windows build scripts

## Validation
- cargo test -p mosaic-emit-compose (35 passed)
- cargo test -p mosaic-package-artifact-builder (51 passed + doc test)
- cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml (3 passed)
- generated Compose: gradle --no-daemon clean test build (2 UI tests passed; build successful, JDK 21)
- parser ratchets: tree 1934/2637/0 missing; tokenizer 6806/7015/0 missing; normalized 7242/0 skipped

This is a bounded Compose project-shell and interaction-acceptance slice, not a claim of full browser conformance.