### PR TITLE
Track HTML tree diagnostic debt

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Tree-construction conformance cases now retain their declared parse-error
+  rows and ratchet diagnostic coverage, exposing 1,577 malformed cases that
+  still produce no parser or lexer diagnostic without weakening DOM checks.
 - The conformance coverage report now pins the exact upstream WPT and
   html5lib-tests commits, and the package owns an explicit prioritized backlog
   and zero-debt completion boundary for future upstream drift.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -10,6 +10,10 @@ tree-construction resources and html5lib tokenizer tests reports:
 - zero missing WPT tree-construction signatures
 - zero missing html5lib tokenizer signatures
 - zero normalized tokenizer skips
+- every tree-construction case with declared parse errors emits diagnostics
+- tree-construction cases without declared parse errors do not gain spurious
+  diagnostics unless the checked fixture intentionally omits a current WHATWG
+  error
 - all checked parser, lexer, fixture, formatting, and lint gates pass
 
 The checked `tests/fixtures/html5lib-coverage-audit.json` report records the
@@ -17,9 +21,36 @@ exact upstream commits used for the latest completed audit.
 
 ## Prioritized Queue
 
-There are no open conformance items. The 2026-08-02 audit covered all 1,934 WPT
-tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
-signatures and zero normalized skips.
+The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
+all 6,806 html5lib tokenizer cases with zero missing signatures and zero
+normalized skips. DOM output is complete, but diagnostic coverage is not:
+the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
+Only 606 of those cases currently emit any lexer or parser diagnostic; 1,577
+remain uncovered. Another 50 cases emit diagnostics despite having no legacy
+`#errors` rows; these require review rather than automatic removal because the
+current WHATWG processing-instruction cases intentionally omit some errors.
+
+Prioritized work items:
+
+1. **Initial document insertion modes.** Emit the required parse errors before
+   and around `html`, `head`, and `body` creation, including missing-doctype
+   inputs. This is the next implementation slice.
+2. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
+   recovery, formatting reconstruction, and stray start/end tags.
+3. **Table, select, and template insertion modes.** Cover foster parenting,
+   table scopes, select recovery, and template mode-stack errors.
+4. **Adoption agency and active formatting.** Cover malformed formatting cases
+   without changing their now-conforming DOM output.
+5. **Foreign content and fragment parsing.** Cover SVG/MathML integration
+   boundaries and context-sensitive fragment errors.
+6. **Diagnostic positions and error taxonomy.** Carry source positions into
+   tree construction and map diagnostics to current WHATWG concepts. Legacy
+   WPT/html5lib error labels are evidence hints, not a normative public API.
+7. **Input boundary review.** Document the Unicode-code-point parser boundary
+   and either add or explicitly separate byte decoding and encoding sniffing.
+8. **Algorithm and differential audit.** Map implemented states/modes to the
+   current HTML Standard and add deterministic differential/fuzz coverage for
+   branches not exercised by the upstream corpora.
 
 ## Intake Order
 
@@ -28,8 +59,10 @@ starting the next pull request and prioritize it in this order:
 
 1. Missing executable WPT tree-construction cases.
 2. Missing or skipped html5lib tokenizer cases.
-3. Public DOM model gaps required by an upstream case.
-4. Audit, fixture, or documentation drift that weakens reproducibility.
+3. Missing required tokenizer or tree-construction diagnostics.
+4. Public DOM model gaps required by an upstream case.
+5. Input-boundary or algorithm-coverage gaps.
+6. Audit, fixture, or documentation drift that weakens reproducibility.
 
 Keep one item per pull request. After each merge, rerun the upstream audit,
 record newly discovered items, reprioritize this queue, and select the highest

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -190,6 +190,13 @@ checked tree-construction and tokenizer fixtures.
 The prioritized completion queue and intake rules live in
 `CONFORMANCE-BACKLOG.md`.
 
+Tree-construction data also carries legacy `#errors` rows. The shared test
+loader retains those rows and the main tree-construction test ratchets whether
+each malformed case produces any lexer or parser diagnostic. Exact legacy
+error strings are not treated as a public WHATWG taxonomy; they are used to
+identify missing diagnostic coverage while DOM output remains independently
+checked.
+
 For sharper parser regression reporting, the generated
 `tests/fixtures/whatwg-tree-insertion-audit.json` fixture indexes the
 adoption-agency, table/foster-parenting, template, foreign-content fragment,

--- a/code/packages/rust/html-parser/tests/common/mod.rs
+++ b/code/packages/rust/html-parser/tests/common/mod.rs
@@ -1,6 +1,8 @@
 use coding_adventures_html_lexer::HtmlScriptingMode;
 use coding_adventures_html_parser::{
-    parse_html_fragment_for_context_with_options, parse_html_with_options, HtmlParseOptions,
+    parse_html_fragment_for_context_with_diagnostics_and_options,
+    parse_html_fragment_for_context_with_options, parse_html_with_diagnostics_and_options,
+    parse_html_with_options, HtmlParseOptions,
 };
 use dom_core::{Document, DocumentType, Element, Node};
 
@@ -10,6 +12,8 @@ pub struct TreeConstructionCase {
     pub data: String,
     pub scripting: HtmlScriptingMode,
     pub fragment_context: Option<String>,
+    #[allow(dead_code)]
+    pub expected_errors: Vec<String>,
     pub document: Vec<String>,
 }
 
@@ -37,6 +41,7 @@ pub fn parse_tree_construction_cases(raw: &str) -> Vec<TreeConstructionCase> {
             data.push(line);
         }
 
+        let mut expected_errors = Vec::new();
         let mut scripting = HtmlScriptingMode::Enabled;
         let mut fragment_context = None;
         while let Some(line) = lines.next() {
@@ -56,6 +61,8 @@ pub fn parse_tree_construction_cases(raw: &str) -> Vec<TreeConstructionCase> {
                 scripting = HtmlScriptingMode::Disabled;
             } else if line == "#script-on" {
                 scripting = HtmlScriptingMode::Enabled;
+            } else if !line.is_empty() {
+                expected_errors.push(line.to_string());
             }
         }
 
@@ -75,11 +82,47 @@ pub fn parse_tree_construction_cases(raw: &str) -> Vec<TreeConstructionCase> {
             data: data.join("\n"),
             scripting,
             fragment_context,
+            expected_errors,
             document,
         });
     }
 
     cases
+}
+
+#[allow(dead_code)]
+pub fn actual_diagnostic_codes_for_tree_case(
+    case: &TreeConstructionCase,
+) -> Result<Vec<String>, String> {
+    let options = HtmlParseOptions {
+        scripting: case.scripting,
+        ..HtmlParseOptions::default()
+    };
+
+    let (lexer_diagnostics, parser_diagnostics) =
+        if let Some(fragment_context) = &case.fragment_context {
+            let output = parse_html_fragment_for_context_with_diagnostics_and_options(
+                &case.data,
+                fragment_context,
+                options,
+            )
+            .map_err(|error| format!("{error:?}"))?;
+            (output.lexer_diagnostics, output.parser_diagnostics)
+        } else {
+            let output = parse_html_with_diagnostics_and_options(&case.data, options)
+                .map_err(|error| format!("{error:?}"))?;
+            (output.lexer_diagnostics, output.parser_diagnostics)
+        };
+
+    Ok(lexer_diagnostics
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .chain(
+            parser_diagnostics
+                .into_iter()
+                .map(|diagnostic| diagnostic.code),
+        )
+        .collect())
 }
 
 pub fn actual_dom_dump_for_tree_case(case: &TreeConstructionCase) -> Result<Vec<String>, String> {

--- a/code/packages/rust/html-parser/tests/mathml_text_conformance_test.rs
+++ b/code/packages/rust/html-parser/tests/mathml_text_conformance_test.rs
@@ -106,6 +106,7 @@ fn tree_case(
         data: data.to_string(),
         scripting: HtmlScriptingMode::Enabled,
         fragment_context: fragment_context.map(str::to_string),
+        expected_errors: Vec::new(),
         document: document.iter().map(|line| (*line).to_string()).collect(),
     }
 }

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -1,6 +1,9 @@
 mod common;
 
-use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use common::{
+    actual_diagnostic_codes_for_tree_case, actual_dom_dump_for_tree_case,
+    parse_tree_construction_cases,
+};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 
@@ -21,4 +24,37 @@ fn html5lib_tree_construction_smoke_cases_match_dom_dump() {
             case.data
         );
     }
+}
+
+#[test]
+fn tree_construction_diagnostic_coverage_is_ratcheted() {
+    let cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE);
+    let expected_error_rows = cases
+        .iter()
+        .map(|case| case.expected_errors.len())
+        .sum::<usize>();
+    let mut expected_error_cases = 0;
+    let mut missing_diagnostic_cases = 0;
+    let mut undeclared_diagnostic_cases = 0;
+
+    for case in &cases {
+        let actual = actual_diagnostic_codes_for_tree_case(case)
+            .expect("parser should accept any HTML or HTML fragment input");
+        if case.expected_errors.is_empty() {
+            if !actual.is_empty() {
+                undeclared_diagnostic_cases += 1;
+            }
+        } else {
+            expected_error_cases += 1;
+            if actual.is_empty() {
+                missing_diagnostic_cases += 1;
+            }
+        }
+    }
+
+    assert_eq!(expected_error_rows, 6243);
+    assert_eq!(expected_error_cases, 2183);
+    assert_eq!(missing_diagnostic_cases, 1577);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 606);
+    assert_eq!(undeclared_diagnostic_cases, 50);
 }


### PR DESCRIPTION
## Summary

- retain all legacy `#errors` rows in the checked tree-construction corpus
- add an executable diagnostic-coverage ratchet alongside the existing DOM-output assertions
- define the remaining WHATWG compliance dimensions and prioritize the implementation backlog

## Evidence

The checked 2,637-case tree corpus contains 6,243 declared error rows across 2,183 malformed cases. Today, 606 of those cases emit at least one lexer or parser diagnostic and 1,577 emit none. Another 50 declared-clean cases emit diagnostics and are tracked for review because some current processing-instruction fixtures intentionally omit errors.

The legacy error strings are evidence hints rather than a normative public diagnostic taxonomy. This PR deliberately ratchets coarse coverage first without weakening the independently green DOM-output checks.

## Next work item

Implement missing diagnostics in the initial document insertion modes: missing doctype and recovery around implicit `html`, `head`, and `body` creation.

## Validation

- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- WHATWG audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`
