### PR TITLE
feat(human-languages): split Telugu lessons into micro-steps

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the German duration
-tranche: 20 registered tracks, 1,002 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Telugu duration
+tranche: 20 registered tracks, 1,003 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -57,7 +57,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01H | Complete in the Portuguese duration PR | Remove all twenty-three sub-five-minute violations from the Portuguese track. | The report measures zero Portuguese violations; five new prerequisite-ordered micro-lessons preserve the register, suppletion, grammar-choice, and etymology content from the five computed violations. |
 | HL-D01I | Complete in the French duration PR | Remove all twenty-five sub-five-minute violations from the French track. | The report measures zero French violations; three new prerequisite-ordered micro-lessons preserve register, suppletion, and pronominal-agreement depth. |
 | HL-D01J | Complete in the German duration PR | Remove all twenty-seven sub-five-minute violations from the German track. | The report measures zero German violations; five new prerequisite-ordered micro-lessons preserve register, practice, areal-history, agreement, and etymology depth. |
-| HL-D01K | Next | Remove all thirty-six sub-five-minute violations from the Telugu track. | Telugu is now the smallest remaining set: thirty-five declaration-only lessons and one genuinely computed violation, with a 360-second maximum. |
+| HL-D01K | Complete in the Telugu duration PR | Remove all thirty-six sub-five-minute violations from the Telugu track. | The report measures zero Telugu violations; one new prerequisite-ordered micro-lesson separates phrase formation from register and source-evidence judgment. |
+| HL-D01L | Next | Remove all thirty-seven sub-five-minute violations from the Kannada track. | Kannada is now the smallest remaining set: thirty-six declaration-only lessons and one genuinely computed violation, with a 360-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -78,7 +79,10 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B19 | Queued | Remove French's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports sixteen overfull boxes, nine underfull boxes, and six Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B20 | Queued | Publish German Chapters 17–23 from their canonical lessons rather than hand-copying seven book chapters. | The German PDF reaches Chapter 16 while canonical app content continues through Chapter 23; schema-v2 migration plus generation should close that drift safely. |
 | HL-B21 | Queued | Remove German's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports seventeen overfull boxes, eleven underfull boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
+| HL-B22 | Queued | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Telugu PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
+| HL-B23 | Queued | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, three underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and a font-shape substitution warning; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
+| HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
@@ -361,6 +365,31 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Telugu's thirty-six violations are now the smallest remaining set.
   Thirty-five are declaration-only and one genuinely computes above the limit,
   with a 360-second maximum, so HL-D01K is next.
+
+## Findings from HL-D01K
+
+- Telugu now has zero duration violations. The corpus grows from 1,002 to 1,003
+  lessons and drops from 329 to 293 violations overall; unknown prerequisites
+  remain at zero.
+- Thirty-five lessons needed only honest declared-budget corrections. The one
+  genuinely long lesson is now a prerequisite-ordered pair: build
+  **శుభ మధ్యాహ్నం** from the widened “noon” word → distinguish the two-source
+  formal-register claim from the one-source lower-frequency claim.
+- The two Chapter 31 steps compute to 152 and 193 seconds.
+  `TE-C06-dative-subject` at 285 seconds and `TE-C29-subhodayam` at 279 are the
+  tightest remaining Telugu lessons and should be watched during copy edits.
+- The Telugu PDF builds successfully at 29 pages through Chapter 5 while
+  canonical lessons continue through Chapter 31. HL-B22 records the schema-v2
+  migration and generated publication work for Chapters 6–31.
+- The build has no missing glyphs, but reports four overfull boxes, three
+  underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and a
+  font-shape substitution warning. HL-B23 records that pre-existing clean-build
+  debt.
+- The roadmap narrative stops at Chapter 6 and the authoritative session map at
+  Chapter 5. HL-M02 records the progression-metadata work through Chapter 31.
+- Kannada's thirty-seven violations are now the smallest remaining set.
+  Thirty-six are declaration-only and one genuinely computes above the limit,
+  with a 360-second maximum, so HL-D01L is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/telugu/CHANGELOG.md
+++ b/code/learning/human-languages/telugu/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Sub-five-minute lesson remediation (2026-08-02)
+
+- All thirty-six Telugu duration violations are resolved. Thirty-five lessons
+  already computed below five minutes and now declare an honest four-minute
+  budget without changing their teaching content.
+- The genuinely long Chapter 31 lesson becomes two prerequisite-ordered steps:
+  build **శుభ మధ్యాహ్నం** from the widened “noon” word shared with Kannada,
+  then distinguish the two-source formal-register claim from the one-source
+  lower-frequency claim. They compute to 152 and 193 seconds.
+- The new support lesson brings the Telugu track to 60 lessons with zero unknown
+  prerequisite ids.
+- A forced book build succeeds at 29 pages with no missing glyphs. Canonical
+  lessons continue through Chapter 31 while the book stops at Chapter 5
+  (`HL-B22`); existing layout, bookmark, duplicate-label, and font warnings are
+  tracked in `HL-B23`; roadmap and session-map drift is tracked in `HL-M02`.
+
 ## Chapter 6 — Case endings, and the sentence with no subject
 
 - **Chapter 6 authored** (`TE-C06-dative-ku`, `-dative-subject`): the track's first

--- a/code/learning/human-languages/telugu/lessons/TE-C01-namaskaram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-namaskaram.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [telugu-inherent-a, virama-conjunct, anusvara]
 roots: [namas, kṛ]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C01-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [TE-C01-namaskaram, TE-C01-dhanyavadamulu, TE-C01-avunu, TE-C01-ledu, TE-C01-sare]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C01-namaskaram, TE-C01-dhanyavadamulu, TE-C01-avunu, TE-C01-ledu, TE-C01-sare]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C02-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [TE-C02-naa-peru, TE-C02-mii-peru-emiti, TE-C02-santosham]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C02-peru, TE-C02-naa, TE-C02-naa-peru, TE-C02-nuvvu-miiru, TE-C02-emiti, TE-C02-mii-peru-emiti, TE-C02-santosham]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C03-miiru-elaa-unnaaru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-miiru-elaa-unnaaru.md
@@ -8,7 +8,7 @@ concept_tag: STATE-HOW-ARE-YOU
 prerequisites: [TE-C03-elaa, TE-C02-nuvvu-miiru]
 sounds: [double-nn, retroflex]
 roots: [undu-be-dravidian]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C02-nuvvu-miiru, TE-C03-elaa]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C03-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [TE-C03-miiru-elaa-unnaaru, TE-C03-baagaa, TE-C03-paravaaledu]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C03-elaa, TE-C03-miiru-elaa-unnaaru, TE-C03-nenu, TE-C03-baagaa, TE-C03-paravaaledu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C04-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [TE-C04-velli-vastaanu, TE-C04-reepu-kaluddaam, TE-C04-malli-kaluddaam]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C04-vellu, TE-C04-velli-vastaanu, TE-C04-reepu-kaluddaam, TE-C04-malli-kaluddaam]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C05-nenu-telugu-maatlaadataanu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-nenu-telugu-maatlaadataanu.md
@@ -8,7 +8,7 @@ concept_tag: TE-WORD-TELUGU
 prerequisites: [TE-C05-maatlaadu, TE-C03-nenu]
 sounds: [long-u]
 roots: [telugu]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C05-maatlaadu, TE-C03-nenu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C05-pani-ceyu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-pani-ceyu.md
@@ -8,7 +8,7 @@ concept_tag: TE-VERB-CEYU
 prerequisites: [TE-C05-maatlaadu]
 sounds: [long-e]
 roots: [ceyu-do-dravidian, pani-work-dravidian]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C05-maatlaadu, TE-C05-undu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C05-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [TE-C05-maatlaadu, TE-C05-nenu-telugu-maatlaadataanu, TE-C05-undu, TE-C05-pani-ceyu]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C05-maatlaadu, TE-C05-nenu-telugu-maatlaadataanu, TE-C05-undu, TE-C05-pani-ceyu, TE-C03-nenu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C06-dative-subject.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C06-dative-subject.md
@@ -10,7 +10,7 @@ prerequisites: [TE-C06-dative-ku, TE-C05-nenu-telugu-maatlaadataanu]
 sounds: [gemination-cc]
 roots: [dravidian-dative-ku]
 etymology_hook: "Telugu says knowing a language literally as 'to me it COMES' (vaccu, the verb already taught for 'come') — the experiencer goes in the dative because knowing happens TO you; the same dative-subject construction runs through Tamil, Kannada and Malayalam"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C06-dative-ku, TE-C05-nenu-telugu-maatlaadataanu, TE-C04-vellu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C07-numbers-1-5.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C07-numbers-1-5.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C01-namaskaram]
 sounds: [telugu-inherent-a, retroflex-series, telugu-u-ending]
 roots: [proto-dravidian-numbers]
 etymology_hook: "Telugu shares the family's 2–5 (iraṇṭu ↔ reṇḍu) but strikes out alone on ONE — okaṭi, not oṉṟu/ondu/onnu"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C01-namaskaram]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C07-numbers-6-10.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C07-numbers-6-10.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C07-numbers-1-5]
 sounds: [telugu-inherent-a, retroflex-da, telugu-u-ending]
 roots: [proto-dravidian-numbers]
 etymology_hook: "eight and nine — enimidi, tommidi — you can't derive from Tamil's eṭṭu/oṉpatu; seven ēḍu shows Telugu's ḻ→ḍ"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C07-numbers-1-5]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C08-dayachesi.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C08-dayachesi.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C01-avunu]
 sounds: [telugu-vowel-sign-ee, telugu-vowel-sign-i, telugu-ca]
 roots: [daya-compassion]
 etymology_hook: "దయచేసి = 'having done compassion' — Telugu asks please with daya, like Tamil, Kannada, Arabic faḍl and Hindi kṛpā"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C01-avunu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C09-kshaminchandi.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C09-kshaminchandi.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C08-dayachesi]
 sounds: [telugu-conjunct-kssa, telugu-anusvara]
 roots: [kshama-sanskrit]
 etymology_hook: "క్షమించండి kṣamin̄caṇḍi ← Sanskrit kṣamā 'forgiveness' + Telugu verb-making -in̄cu + the SAME respectful -aṇḍi ending from దయచేసి...ండి"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C08-dayachesi]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C10-vaaram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C10-vaaram.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C09-kshaminchandi]
 sounds: [telugu-anusvara, telugu-conjunct-kra]
 roots: [sanskrit-planet-words]
 etymology_hook: "Telugu's week is Sanskritic like Hindi's, but Sunday is Ādivāram — 'the FIRST day' (Sanskrit ādi 'beginning'), not a sun-name at all"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C09-kshaminchandi]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C11-rangulu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C11-rangulu.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C10-vaaram]
 sounds: [telugu-anusvara, telugu-short-vowels]
 roots: [dravidian-native-colors, sanskrit-nila]
 etymology_hook: "నలుపు/తెలుపు/ఎరుపు (black/white/red) are native Dravidian, matching a pattern across all four languages — నీలం (blue) closes the set as the one shared Sanskrit loan, everywhere"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C10-vaaram]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C12-kutumbam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C12-kutumbam.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C11-rangulu]
 sounds: [telugu-retroflex-dda, telugu-geminate-nna]
 roots: [dravidian-appa-amma, dravidian-age-graded-siblings]
 etymology_hook: "నాన్న naanna (father) and చెల్లి chelli (younger sister) are Telugu's OWN forms, unlike Tamil/Kannada's appa/tangi — but the age-before-gender sibling system is the same across the family"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C11-rangulu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C14-rutuvulu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C14-rutuvulu.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C13-sharira-bhagalu]
 sounds: [telugu-vocalic-r, telugu-anusvara]
 roots: [dravidian-vesavi-vaana, sanskrit-vasanta-rutu]
 etymology_hook: "వేసవి vesavi (summer) is native Dravidian, cousin of Kannada's besige — వసంత ఋతువు vasanta rutuvu (spring) borrows both vasanta AND rutu from Sanskrit, like Kannada, not just Tamil/Malayalam's single vasantham loan"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C13-sharira-bhagalu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C15-neellu-biyyam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C15-neellu-biyyam.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C14-rutuvulu]
 sounds: [telugu-geminate-lla, telugu-anusvara]
 roots: [neellu-water-dravidian, biyyam-rice-dravidian]
 etymology_hook: "నీళ్ళు neellu (water) matches Tamil/Kannada's neer/niiru, completing the 3-against-1 pattern against Malayalam's vellam; బియ్యం biyyam (raw rice) is Telugu's own word, unlike Tamil/Kannada/Malayalam's shared ari/arisi/akki"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C14-rutuvulu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C16-nelalu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C16-nelalu.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C15-neellu-biyyam]
 sounds: [telugu-conjunct-shtha, telugu-anusvara]
 roots: [sanskrit-lunisolar-chaitra-system]
 etymology_hook: "Telugu shares the same pan-Indian Sanskritic lunisolar calendar as Kannada and Hindi (Ugadi falls the SAME day, Chaitra Shudda Padyami) — completing a clean split: Tamil and Malayalam built their OWN solar calendars, Kannada and Telugu share the pan-Indian one"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C15-neellu-biyyam]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C17-madhyaahnam-ardharaatri.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C17-madhyaahnam-ardharaatri.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C16-nelalu]
 sounds: [telugu-conjunct-rdha, telugu-anusvara]
 roots: [sanskrit-madhya-middle, sanskrit-ardha-half]
 etymology_hook: "Telugu's మధ్యాహ్నం (madhyāhnam, noon) matches Kannada's madhya ('middle') root exactly — but its midnight word, అర్ధరాత్రి (ardharātri), switches to a DIFFERENT Sanskrit root, ardha ('half'), echoing Hindi's colloquial 'half night' pattern instead of Kannada's 'middle night'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C16-nelalu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C18-ganta.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C18-ganta.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri]
 sounds: [telugu-anusvara, telugu-retroflex-tta]
 roots: [sanskrit-ghanta-bell]
 etymology_hook: "గంట (ganṭa, 'hour') is the same Sanskrit ghaṇṭā ('bell') word as Kannada's gaṇṭe and Hindi's ghanṭā — Telugu completes a clean 3-way match on this concept, contrasting with Tamil's most-likely-native maṇi (Malayalam's cognate mani, interestingly, traces to a DIFFERENT Sanskrit word, maṇi 'gem,' per its own dictionaries)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C17-madhyaahnam-ardharaatri]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C19-vayasu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C19-vayasu.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C18-ganta]
 sounds: [telugu-anusvara, telugu-vowel-sandhi]
 roots: [sanskrit-vayas-vigor-age]
 etymology_hook: "వయస్సు (vayasu, 'age') is the same Sanskrit वयस् (vayas, 'vigor, age') as Kannada's vayassu — PIE cousin of Latin vīs — and Telugu asks it the same simple, verbless way: 'నీ వయసెంత?' (nī vayasenta?, 'your age how-much?'), where వయస్సు+ఎంత fuse into vayas-enta by regular vowel sandhi"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C18-ganta]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C20-padakondu-iravai.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C20-padakondu-iravai.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C19-vayasu]
 sounds: [telugu-vowel-sign-ai, telugu-geminate-none]
 roots: [dravidian-padi-ten, dravidian-rendu-two]
 etymology_hook: "పదకొండు-పందొమ్మిది (11-19) echo పది (padi, 'ten') + a digit — ఇరవై (iravai, 'twenty') most likely continues the same pan-Dravidian *iru-/*renḍu ('two') + *pad- ('ten') pattern as Kannada's transparent ippattu, but centuries of erosion have worn iravai down further, so it doesn't visibly split into 'two' + 'ten' on the surface the way Kannada's does today"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TE-C19-vayasu]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C20-vatavaranam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C20-vatavaranam.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C18-ganta]
 sounds: [telugu-anusvara, telugu-compound-word]
 roots: [sanskrit-vata-wind, sanskrit-avarana-covering]
 etymology_hook: "వాతావరణం (vātāvaraṇam, 'weather, atmosphere') is a PURE Sanskrit compound — వాత (vāta, 'wind, air') + ఆవరణ (āvaraṇa, 'covering, layer') — literally 'the covering of air,' unlike Kannada's Persian+Sanskrit hybrid havāmāna for the same concept"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C18-ganta]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C21-kukka-pilli.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C21-kukka-pilli.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C20-padakondu-iravai]
 sounds: [telugu-geminate-kk, telugu-geminate-ll]
 roots: [uncertain-kukka, dravidian-pillu-cat]
 etymology_hook: "కుక్క (kukka, 'dog') genuinely breaks from Kannada/Malayalam/Tamil's shared naayi root — debated between an onomatopoeic origin (imitating a bark) and a Sanskrit loan (कुक्कुर, kukkura); పిల్లి (pilli, 'cat') is Proto-Dravidian *pillV, and most likely closes this WHOLE arc's cat-word loop — the probable Dravidian source Sanskrit borrowed as बिडाल (biḍāla), giving Hindi's बिल्ली (billī)"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TE-C20-padakondu-iravai]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C22-pacha-pasupu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C22-pacha-pasupu.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C11-rangulu, TE-C21-kukka-pilli]
 sounds: [telugu-short-vowels, telugu-virama-geminate]
 roots: [proto-dravidian-pac-green]
 etymology_hook: "పచ్చ (pacca, 'green') and పసుపు (pasupu, 'yellow, turmeric') are both descendants of the SAME Proto-Dravidian root, *pac- — true doublets of each other, not two separate word families; పచ్చ also shares that root with Tamil's பச்சை (paccai) and Kannada's ಹಸಿರು (hasiru), while Tamil's பசுப்பு (pacuppu) is a direct cognate of పసుపు itself"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TE-C21-kukka-pilli]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C23-roju.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C23-roju.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri]
 sounds: [telugu-vowel-sign-oo, telugu-ja]
 roots: [persian-roz-day, sanskrit-dinamu]
 etymology_hook: "రోజు (rōju, 'day') is genuinely borrowed from Classical Persian روز (rōz), itself from PIE *lewk- ('bright') — a completely different route and root from Latin diēs/Hindi din/Kannada dina's *dyew- family, though both ultimately trace to 'shining, bright' senses independently; దినము (dinamu) is the Sanskrit tatsama word (same root as Kannada's dina), but here it's the more FORMAL alternate — Telugu's everyday/formal split runs the OPPOSITE way from Kannada's"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TE-C17-madhyaahnam-ardharaatri]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C24-ratri.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C24-ratri.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
 sounds: [telugu-conjunct-tra, telugu-vowel-sign-i]
 roots: [sanskrit-ratri, telugu-native-reyi-maapu]
 etymology_hook: "రాత్రి (rātri, 'night') is a Sanskrit tatsama word, already hiding inside అర్ధరాత్రి (ardharātri, 'midnight'), and — unlike rōju's genuine Persian surprise last lesson — it really is Telugu's everyday word for night; genuine native Telugu words exist too — రేయి (rēyi, most sources treat it as inherited Dravidian, though some grammars link it to rātri itself), మాపు (māpu, whose primary sense is actually 'evening/dusk,' as in రేపుమాపు, 'morning and evening'), and ఇరులు (irulu, cognate with Kannada's ಇರುಳು/iruḷu, primarily 'darkness') — a messier, three-way version of Kannada's cleaner two-word replacement story, not a tidy mirror of it"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C25-shubha-ratri.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C25-shubha-ratri.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C24-ratri]
 sounds: [telugu-sha, telugu-bha]
 roots: [sanskrit-shubha-beautiful, sanskrit-ratri]
 etymology_hook: "శుభ రాత్రి (śubha rātri), 'good night,' literally 'auspicious night' — both pieces Sanskrit tatsama: రాత్రి (already met last lesson) plus శుభ (śubha, 'auspicious,' from root śubh, 'to be beautiful,' PIE *ḱewbʰ-); some sources describe modern Telugu speakers often code-switching to English 'good night' in casual conversation instead of saying śubha rātri aloud — though this same code-switching pattern for farewells plausibly shows up across other South Asian languages too, so it's honestly unclear whether this is Telugu-specific or just where the available sources happened to comment on it"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TE-C24-ratri]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C26-udayam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C26-udayam.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
 sounds: [telugu-anusvara, telugu-da]
 roots: [sanskrit-udaya-rise]
 etymology_hook: "ఉదయం (udayam, 'morning') is a Sanskrit tatsama — from ఉదయ (udaya, 'rise, appearance') + Telugu's own -ము (-mu) suffix — and it's genuinely Telugu's most common, general everyday word for 'morning'; be honest, though: it doesn't have the field entirely to itself — పొద్దు/పొద్దున (poddu/podduna), genuine Proto-Dravidian vocabulary cognate with Tamil pozhudu and Kannada hottu, does real everyday work too, and వేకువ (vēkuva, 'dawn, early morning') is labeled colloquial, not archaic; be honest also about the contrast with Kannada: Kannada has this exact Sanskrit root (udaya), but only inside its GREETING, ಶುಭೋದಯ (śubhōdaya) — Kannada's everyday morning noun is the unrelated native ಬೆಳಗ್ಗೆ; Telugu's ఉదయం, by contrast, covers BOTH the everyday-noun and greeting-root jobs at once — no such twist here, unlike the Persian-loan surprise already found for Telugu's 'day' word (rōju, TE-C23)"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TE-C17-madhyaahnam-ardharaatri, TE-C23-roju]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C27-sayantram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C27-sayantram.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C26-udayam]
 sounds: [telugu-anusvara, telugu-conjunct-tra]
 roots: [sanskrit-sayam-evening]
 etymology_hook: "సాయంత్రం (sāyantram, 'evening') is a Sanskrit tatsama — from సాయం (sāyam, 'in the evening') plus a Sanskrit '-tana' suffix that turns time-adverbs into adjectives (cf. divātana, 'of the day'; sanātana, 'eternal'); సాయం itself, per Wiktionary, traces to PIE *seh₁- ('long, lasting') — and Wiktionary explicitly states this root is 'distantly related to Latin sērus,' independently confirmed on sērus's own Wiktionary page (Proto-Italic *sēros ← PIE *seh₁-, 'to be long, lasting, slow'); sērus is already established in this course as the root of French soir and Italian sera (LA-C33-vesper) — meaning Telugu's everyday evening word and the Romance family's everyday evening word are genuine, if very distant, cognates, one route through Sanskrit tatsama borrowing, one through Vulgar Latin erosion"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TE-C26-udayam]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C28-madhyahnam-widened.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C28-madhyahnam-widened.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C17-madhyaahnam-ardharaatri, TE-C27-sayantram]
 sounds: [telugu-conjunct-dhya, telugu-vowel-sign-aa]
 roots: [sanskrit-madhya-middle]
 etymology_hook: "మధ్యాహ్నం (madhyāhnam) is the SAME word already met in TE-C17 meaning precisely 'noon' ('middle' + 'day') — but a directly-fetched source confirms it also covers 'the time between noon and evening' in modern usage, the same kind of widening already found for Hindi's दोपहर (well-confirmed) and Kannada's మధ్యాహ్న (more thinly hedged); a separate, more precise word for 'later afternoon' specifically, అపరాహ్నం (aparāhnam, from the same classical five-part Sanskrit day division as Kannada's అపరాహ్న), also exists; thin, informal evidence (native-speaker forum discussion, dictionary usage notes) converges on మధ్యాహ్నం winning colloquially while అపరాహ్నం stays the formally precise term — a hedged, KA-C28-style parallel, not a fully settled comparison"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TE-C17-madhyaahnam-ardharaatri, TE-C27-sayantram]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C29-subhodayam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C29-subhodayam.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C26-udayam]
 sounds: [telugu-sha, telugu-conjunct-bha]
 roots: [su-good, sanskrit-udaya-rise]
 etymology_hook: "శుభోదయం (śubhōdayam, 'good morning') = శుభ ('good') + ఉదయం (already met, TE-C26); be honest about sourcing here: one directly-fetched source — a Telugu-learning content blog, the SAME low-authority genre already found overstated for Hindi's सुप्रभात and Kannada's ಶುಭೋದಯ — claims this is OUT OF TREND, displaced by ENGLISH 'good morning,' with children taught the English phrase from preschool; treat this with real skepticism, since a directly-fetched page isn't automatically an authoritative source; the same page also calls a SEPARATE alternative, సుప్రభాతం (suprabhātam, built on ప్రభాత/prabhāta — a genuinely DIFFERENT Sanskrit root from ఉదయ/udaya, NOT the same root as Kannada's ಶುಭೋದಯ, which itself uses udaya) 'archaic'; a third option, ప్రొద్దుటి వందనాలు ('morning greetings,' built on పొద్దు, TE-C26's genuine native competitor), also exists but isn't confirmed common; నమస్కారం is the safer everyday-greeting bet, matching the నమస్కార/नमस्ते pattern already found for Kannada and Hindi"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TE-C26-udayam]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C30-subha-sayantram.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C30-subha-sayantram.md
@@ -9,7 +9,7 @@ prerequisites: [TE-C27-sayantram]
 sounds: [telugu-sha, telugu-anusvara]
 roots: [su-good, sanskrit-sayam-evening]
 etymology_hook: "శుభ సాయంత్రం (śubha sāyantram, 'good evening') pairs శుభ with సాయంత్రం (TE-C27's word with the striking distant cognate to Latin sērus/French soir); unlike GREETING-MORNING's శుభోదయం, which rested on ONE dramatic, low-authority source claiming displacement by English, TWO independently fetched sources here agree it's genuinely, commonly used in BOTH formal and informal contexts — a real difference in evidence quality, worth noting explicitly rather than treating every 'good ___' greeting in this arc the same way; నమస్కారం remains confirmed as a time-independent, any-occasion alternative rather than something that has displaced this specific greeting"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TE-C27-sayantram]
 ---
 

--- a/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam-register.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam-register.md
@@ -1,0 +1,58 @@
+---
+id: TE-C31-subha-madhyahnam-register
+chapter: 31
+type: culture
+headword: శుభ మధ్యాహ్నం — register
+gloss: a real formal or workplace greeting, less secure as an everyday default
+concept_tag: TE-GREETING-AFTERNOON-REGISTER
+prerequisites: [TE-C31-subha-madhyahnam]
+sounds: []
+roots: []
+etymology_hook: "source claims must stay separate: two sources support the formal timing, while only one ranks the greeting as less common"
+est_minutes: 4
+reviews_of: [TE-C29-subhodayam, TE-C30-subha-sayantram, TE-C31-subha-madhyahnam]
+---
+
+# శుభ మధ్యాహ్నం — register and evidence
+
+## Warm-up
+
+[PAUSE 2s] You can now build **శుభ మధ్యాహ్నం**. The next question is when it
+sounds natural—and how strongly the available evidence answers that question.
+
+## Real and formal; frequency is a narrower claim
+
+Two independently fetched language-learning sources confirm that
+**శుభ మధ్యాహ్నం** is a real, correctly formed greeting for **formal or
+workplace** use around noon and early afternoon.
+
+Keep the claims separate, though. Talkpal explicitly ranks the greeting as
+**less common** in everyday conversation than morning or evening greetings.
+Preply independently supports its timing and formal register, but does not make
+that frequency comparison. So there are two sources for “real and formal,” but
+only one for “less common.” A second source must not be counted as evidence for
+a claim it never made.
+
+## The honest three-way greeting map
+
+- **శుభోదయం** — the morning lesson found one low-authority claim of
+  displacement by English; treat that dramatic claim skeptically.
+- **శుభ సాయంత్రం** — two sources supported common formal and informal use.
+- **శుభ మధ్యాహ్నం** — real and workplace-timed, with narrower support for its
+  lower everyday frequency.
+
+The three phrases do not need one uniform usage story. For a time-independent
+everyday greeting, **నమస్కారం** remains the safer choice.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the two-source claim — real, formal, and workplace-timed]
+- [YOU SAY: the one-source claim — less common than morning or evening]
+- [YOU SAY: నమస్కారం — the time-independent everyday alternative]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Do both sources rank శుభ మధ్యాహ్నం as less common? (**No.** Both
+support its formal use; only Talkpal makes the frequency comparison.) What is
+the safer all-day greeting? (**నమస్కారం**.)

--- a/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C31-subha-madhyahnam.md
@@ -3,59 +3,34 @@ id: TE-C31-subha-madhyahnam
 chapter: 31
 type: phrase
 headword: శుభ మధ్యాహ్నం
-gloss: "good afternoon" (śubha madhyāhnam) — built on మధ్యాహ్నం (TE-C17/TE-C28), NOT అపరాహ్నం, matching Kannada's exact same choice (KA-C31); one directly-fetched source (talkpal.ai) explicitly ranks it less common than morning/evening greetings; a second (preply.com) independently confirms it's real and formal/workplace-timed but does NOT itself make the frequency comparison
+gloss: "good afternoon" (śubha madhyāhnam), built on the widened "noon" word rather than the classical later-afternoon term
 concept_tag: GREETING-AFTERNOON
 prerequisites: [TE-C28-madhyahnam-widened, TE-C29-subhodayam, TE-C30-subha-sayantram]
 sounds: [telugu-conjunct-dhya, telugu-anusvara]
 roots: [su-good, sanskrit-madhya-middle]
-etymology_hook: "శుభ మధ్యాహ్నం (śubha madhyāhnam, 'good afternoon') pairs శుభ with మధ్యాహ్నం (TE-C17/TE-C28's word — literally 'noon,' widened to also cover the afternoon stretch), NOT with అపరాహ్నం, the more formally precise classical word for later afternoon — this is the EXACT SAME choice already found for Kannada's ಶುಭ ಮಧ್ಯಾಹ್ನ (KA-C31), a genuine cross-language parallel; two independently-fetched sources (talkpal.ai, preply.com) both confirm this greeting is real, correctly formed, and formal/workplace-timed — but only talkpal.ai explicitly ranks it LESS common in everyday speech than the morning/evening greetings; preply.com confirms the timing/register but doesn't itself make that frequency comparison, so it isn't double-counted as a second source for the ranking — a third, more even-keeled register than either TE-C29's morning greeting (contested displacement claim) or TE-C30's evening greeting (confirmed common, both registers)"
-est_minutes: 6
+etymology_hook: "శుభ మధ్యాహ్నం pairs శుభ with the widened modern మధ్యాహ్నం, not the more classically precise అపరాహ్నం, exactly as Kannada does"
+est_minutes: 4
 reviews_of: [TE-C28-madhyahnam-widened, TE-C29-subhodayam, TE-C30-subha-sayantram]
 ---
 
-# శుభ మధ్యాహ్నం (śubha madhyāhnam) — completing Telugu's greeting triplet
+# శుభ మధ్యాహ్నం (śubha madhyāhnam) — good afternoon
 
 ## Warm-up
 
-[PAUSE 2s] Telugu's morning greeting had a contested claim behind it.
-Its evening greeting turned out genuinely well-supported. This
-afternoon greeting lands somewhere honestly in between.
+[PAUSE 2s] You already know **శుభ** from the morning and evening greetings and
+**మధ్యాహ్నం** from the parts-of-day lessons. Put them together.
 
-## శుభ మధ్యాహ్నం — built on the SAME word Kannada chose too
+## శుభ + మధ్యాహ్నం
 
-**శుభ మధ్యాహ్నం** (**śubha madhyāhnam**) — "**good afternoon**" —
-pairs **శుభ** ("good") with **మధ్యాహ్నం** (already met, Chapters
-17 and 28 — literally "noon," confirmed to have widened to also cover
-"the time between noon and evening" in modern usage). Worth noting
-directly: this greeting is built on **మధ్యాహ్నం**, **not**
-**అపరాహ్నం** (the more formally precise classical word for later
-afternoon specifically). That's the **exact same choice** already found
-for Kannada's own afternoon greeting, ಶುಭ ಮಧ್ಯಾಹ್ನ (Chapter KA-C31) —
-a genuine cross-language parallel, not a coincidence of similar
-etymology alone, since both languages had a real choice between two
-distinct classical words and both settled on the "noon, widened" one.
+**శుభ మధ్యాహ్నం** (**śubha madhyāhnam**) means “**good afternoon**.”
+The second word originally centres on “midday” or “noon,” but you learned in
+Chapter 28 that modern use widens it into the stretch between noon and evening.
 
-## Be honest: real, but genuinely less common than its siblings
-
-Two independently-fetched sources (not just search summaries) confirm
-**శుభ మధ్యాహ్నం** is a real, correctly-formed greeting used in
-**formal, workplace** contexts specifically (roughly noon to
-mid-afternoon) — but only ONE of the two, talkpal.ai, explicitly ranks
-it as genuinely **less common** in everyday conversation than the
-morning or evening greetings. The second source, preply.com, confirms
-the timing and formal register but makes no such frequency comparison
-itself — worth being precise about which claim each source actually
-supports, rather than treating both as independently confirming the
-same "less common" ranking. This gives this
-Telugu greeting triplet a genuinely honest, three-way spread rather
-than a single uniform story: **శుభోదయం** (morning) carried one
-shaky, low-authority displacement claim worth real skepticism;
-**శుభ సాయంత్రం** (evening) turned out confirmed common in both
-formal and informal speech by two independent sources; and this
-afternoon greeting is real but the most narrowly formal of the three —
-neither displaced nor especially casual. **నమస్కారం** remains the
-safer, time-independent bet for everyday use across all three, exactly
-as already found for Kannada and Hindi.
+Telugu could instead have built the phrase on **అపరాహ్నం**
+(*aparāhnam*), the more classically precise word for later afternoon. It did
+not. Kannada made the same choice in **ಶುಭ ಮಧ್ಯಾಹ್ನ** (*śubha madhyāhna*):
+both languages chose the everyday “noon, widened” word from two available
+classical terms.
 
 ## Guided Practice
 
@@ -63,17 +38,10 @@ as already found for Kannada and Hindi.
 - [YOU SAY: "śubha madhyāhnam" — "good afternoon," śubha + madhyāhnam]
 - [YOU SAY: the word choice — built on మధ్యాహ్నం, not అపరాహ్నం, matching
   Kannada's exact same choice]
-- [YOU SAY: the honest three-way spread — morning shaky, evening
-  confirmed common, afternoon real but more narrowly formal]
+- [YOU SAY: Kannada **ಶುಭ ಮಧ್ಯಾಹ್ನ** — the same word-building choice]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Is శుభ మధ్యాహ్నం built on మధ్యాహ్నం or అపరాహ్నం?
-(**మధ్యాహ్నం** — the "noon, widened" word, not the more formal
-classical term — matching Kannada's exact same choice.) Is this
-greeting as commonly used in casual speech as శుభ సాయంత్రం?
-(**No** — talkpal.ai explicitly ranks it less common than the morning
-or evening greetings; preply.com independently confirms it's real and
-formal/workplace-timed, though it doesn't itself make that frequency
-comparison.) What's the safer, time-independent everyday greeting across
-all three? (**నమస్కారం**.)
+(**మధ్యాహ్నం** — the “noon, widened” word.) Which sister language made the
+same choice? (**Kannada**, in ಶುಭ ಮಧ್ಯಾಹ್ನ.)

--- a/code/learning/human-languages/telugu/roadmap.md
+++ b/code/learning/human-languages/telugu/roadmap.md
@@ -11,6 +11,11 @@ and its independence from its sisters (e.g. *lēdu* for "no"). The Telugu script
 is taught **inline**, never as a gated reading course; grammar is introduced
 piece by piece, on the first word that needs it.
 
+Coverage note: canonical lessons now continue through Chapter 31, while the
+narrative sequence below is complete only through Chapter 6. `HL-M02` tracks
+bringing this roadmap and the session map up to the canonical prerequisite
+order; `HL-B22` tracks publishing Chapters 6–31 from the same source.
+
 ## Authored
 
 - **Ch. 1 — Greetings**: namaskāram → dhanyavādamulu → avunu → lēdu → sarē →

--- a/code/learning/human-languages/telugu/session-map.md
+++ b/code/learning/human-languages/telugu/session-map.md
@@ -4,6 +4,11 @@ Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
 authoritative order.
 
+Coverage note: this map currently stops at Chapter 5 while canonical lessons
+continue through Chapter 31. `HL-M02` records the work to schedule every later
+lesson, including the Chapter 31 phrase → register-and-evidence pair, without
+pretending this partial map is already complete.
+
 **There is no reading course.** Telugu is learned *through* the words: each
 lesson's *"The letters in this word"* section introduces exactly the letters
 that word needs. By the end of Chapter 1 you have met the inherent vowel, the


### PR DESCRIPTION
## Summary
- remove all 36 Telugu sub-five-minute duration violations while preserving the existing lesson bodies when only the declared budget was stale
- split the one genuinely long Chapter 31 lesson into a phrase-formation step and a register/source-evidence step
- record Telugu book, layout, roadmap, and session-map drift; reprioritize Kannada as the next duration tranche

## Measured outcome
- Telugu duration violations: 36 → 0
- corpus lessons: 1,002 → 1,003
- total duration violations: 329 → 293
- unknown prerequisites: 0
- Chapter 31 split lesson duration: 152 and 193 seconds
- tightest remaining Telugu lessons: TE-C06-dative-subject at 285 seconds and TE-C29-subhodayam at 279 seconds

## Validation
- `npm run test:coverage` — 68 tests, 93.60% line coverage
- `npm run build`
- `npm run validate` — 9 integration tests
- `npm run check:books`
- `npm run report`
- Language Ladder `npm run test:coverage` — 278 tests, 98.37% line coverage
- Language Ladder `npm run build` — 1,053 modules
- forced Telugu XeLaTeX build — 29 pages, no missing glyphs

The unchanged Telugu book stops at Chapter 5 while canonical lessons reach Chapter 31. It also reports 4 overfull boxes, 3 underfull boxes, 4 duplicate practice labels, 27 Hyperref warnings, and a font-shape substitution warning. Those publication/layout gaps and the roadmap/session-map drift are now tracked as HL-B22, HL-B23, and HL-M02.