### PR TITLE
fix(spice): validate MOS nominal temperature

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite Level-1 MOS model-card `T_NOM` / `TNOM`
+  values before lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `N_SUB` / `NSUB`
   / `N` values before lowering netlist elements into the engine.
 - Reject negative and non-finite Level-1 MOS model-card `AF` values before

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1985,6 +1985,16 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        for nominal_temperature in [params.get("T_NOM"), params.get("TNOM")]
+            .into_iter()
+            .flatten()
+        {
+            if !nominal_temperature.is_finite() || *nominal_temperature <= 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET T_NOM must be finite and positive",
+                ));
+            }
+        }
         if let Some(width) = params.get("W") {
             if !width.is_finite() || *width <= 0.0 {
                 return Err(NetlistParseError::new(

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2381,6 +2381,37 @@ fn preserves_positive_mosfet_model_substrate_doping_aliases() {
 }
 
 #[test]
+fn rejects_invalid_mosfet_model_nominal_temperatures() {
+    for alias in ["T_NOM", "TNOM"] {
+        for temperature in ["0", "-1", "1e999"] {
+            let error = parse_netlist(&format!(
+                ".model temperature NMOS({alias}={temperature})\nM1 d g s b temperature"
+            ))
+            .unwrap_err();
+
+            assert!(error
+                .to_string()
+                .contains("MOSFET T_NOM must be finite and positive"));
+        }
+    }
+}
+
+#[test]
+fn preserves_positive_mosfet_model_nominal_temperature_aliases() {
+    for alias in ["T_NOM", "TNOM"] {
+        let parsed = parse_netlist(&format!(
+            ".model temperature NMOS({alias}=325)\nM1 d g s b temperature"
+        ))
+        .unwrap();
+
+        let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+            panic!("expected MOSFET");
+        };
+        assert_close(mosfet.params.t_nom, 325.0);
+    }
+}
+
+#[test]
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card substrate-doping validation.
+1. Rust Berkeley SPICE MOS model-card nominal-temperature validation.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite model-card `N_SUB` / `NSUB` / `N`
-     values before lowering MOS elements into engine parameters.
-   - Preserve positive substrate-doping values across all supported aliases.
+   - Reject zero, negative, and non-finite model-card `T_NOM` / `TNOM` values
+     before lowering MOS elements into engine parameters.
+   - Preserve positive nominal temperatures across both supported aliases.
 
 ## Completed Slices
 
@@ -4095,31 +4095,32 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Zero and positive flicker-noise exponents remain accepted.
 
+363. Rust Berkeley SPICE MOS model-card substrate-doping validation.
+   - Status: completed in PR 9562.
+   - Zero, negative, and non-finite model-card `N_SUB` / `NSUB` / `N` values
+     are rejected before lowering MOS elements into engine parameters.
+   - Positive substrate-doping values remain accepted across all aliases.
+
 ## Backlog
 
-1. Rust Berkeley SPICE MOS model-card substrate-doping validation.
-   - Reject zero, negative, and non-finite model-card `N_SUB` / `NSUB` / `N`
-     values before lowering MOS elements into engine parameters.
-   - Preserve positive substrate-doping values across all supported aliases.
-
-2. Rust Berkeley SPICE MOS model-card nominal-temperature validation.
+1. Rust Berkeley SPICE MOS model-card nominal-temperature validation.
    - Reject zero, negative, and non-finite model-card `T_NOM` / `TNOM` values
      before lowering MOS elements into engine parameters.
    - Preserve positive nominal temperatures across both supported aliases.
 
-3. Rust Berkeley SPICE MOS model-card level validation.
+2. Rust Berkeley SPICE MOS model-card level validation.
    - Reject non-finite and non-Level-1 model-card `LEVEL` values before lowering
      MOS elements into engine parameters.
    - Preserve explicit `LEVEL=1` model cards and cards that omit `LEVEL`.
 
-4. Rust Berkeley SPICE MOS model-card validation audit.
+3. Rust Berkeley SPICE MOS model-card validation audit.
    - Re-audit supported model-card parameters after the `LEVEL` facade gap
      lands, recording any newly confirmed gaps here before selecting another
      slice.
    - Reuse contracts and diagnostics already aligned across the Rust, Python,
      and TypeScript engines whenever the missing behavior is facade-only.
 
-5. Grammar-backed parser and app facade.
+4. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
@@ -4127,7 +4128,7 @@ the Rust, Python, and TypeScript surfaces together.
      toward packaging, WebAssembly embedding, and product integration backed by
      the same public parser contract.
 
-6. Deck compatibility follow-up.
+5. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis
      execution and stable artifact exports toward nested sweeps, raw-format
      interoperability, and remaining vendor-style output controls.
@@ -4138,7 +4139,7 @@ the Rust, Python, and TypeScript surfaces together.
      command routing, including control flow, variables, and script execution
      policy.
 
-7. Production solver core follow-up.
+6. Production solver core follow-up.
    - Sparse real/complex matrix paths now have cross-language native coverage,
      and Python real DC solves now use an optional SciPy sparse-LU backend with
      structured native fallback metadata.
@@ -4149,14 +4150,14 @@ the Rust, Python, and TypeScript surfaces together.
      damping, device limiting, tolerance policy, and additional convergence
      diagnostics for difficult transistor decks.
 
-8. Device model depth.
+7. Device model depth.
    - Audit diode, BJT, JFET, and MOS Level 1 behavior against reference decks.
    - Decide whether Level 2/3 MOS is in scope before BSIM; if BSIM lands, make
      Rust the first fast path and port stable semantics outward.
    - Expand temperature behavior, capacitance, noise, charge conservation, model
      card aliases, and error messages.
 
-9. Analysis completion.
+8. Analysis completion.
    - Generalize pole-zero beyond constrained fixture helpers.
    - Expand nonlinear distortion coverage.
    - Expand parsed `.FOUR` / `.MEASURE` integration across output plans and
@@ -4165,14 +4166,14 @@ the Rust, Python, and TypeScript surfaces together.
      Carlo trials.
    - Stabilize raw, CSV, JSON, and browser-friendly result formats.
 
-10. Mixed-signal integration.
+9. Mixed-signal integration.
    - Connect SPICE transient stepping to the hardware VM scheduler.
    - Support bidirectional analog/digital thresholds, event scheduling,
      breakpoint coordination, and VCD correlation.
    - Keep mixed-signal coupling deterministic across Python, Rust, and
      TypeScript.
 
-11. Verilog-A and custom models.
+10. Verilog-A and custom models.
    - Specify the accepted model subset and residual/Jacobian hooks.
    - Add parser or compiler support with sandboxing for TypeScript/web usage.
    - Provide a Rust-native fast path for compiled models.


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite Level-1 MOS model-card nominal temperatures across `T_NOM` and `TNOM`
- preserve positive nominal temperatures across both aliases
- advance the SPICE plan after the merged substrate-doping slice

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`

Rust parser-facade only: the Rust, Python, and TypeScript engines already share the positive `T_NOM` contract, so no cross-language engine behavior changes are needed.