### PR TITLE
fix(mosaic): encode Web Component runtime values

### DIFF
--- a/code/packages/rust/mosaic-emit-webcomponent/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-webcomponent/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed - host-controlled shadow-DOM interpolation
+
+Generated pipeline components now encode dynamic text and quoted-attribute
+values before assigning their template to `shadowRoot.innerHTML`. Dynamic link
+targets reject executable `javascript:`, `data:`, and `vbscript:` schemes, and
+runtime column widths are constrained to finite numbers. Host props and loop
+items can no longer escape their intended text, attribute, URL, or numeric CSS
+contexts.
+
 ### Fixed - project-shell named node-slot mounting
 
 Generated Web Component shells now recognize `node` and component props from

--- a/code/packages/rust/mosaic-emit-webcomponent/README.md
+++ b/code/packages/rust/mosaic-emit-webcomponent/README.md
@@ -6,6 +6,9 @@ Generated project shells hydrate scalar slots as element properties and
 attributes. For `node` and component slots, a host-provided `Element` is mounted
 in the custom element's light DOM with the declared named-slot attribute, so a
 shadow-DOM `HostSurface` can receive live host content without stringification.
+Dynamic scalar and loop values are encoded for their text or quoted-attribute
+context before the generated component assigns `shadowRoot.innerHTML`; link
+schemes and numeric style interpolation receive additional runtime guards.
 
 ## Dependencies
 

--- a/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
@@ -657,6 +657,35 @@ pub fn from_pipeline(
     .unwrap();
     writeln!(out).unwrap();
 
+    // Runtime slot values are host-controlled. Every value interpolated
+    // into the shadow-root template must be encoded for its HTML context
+    // before the template is assigned to `innerHTML`.
+    out.push_str(
+        r##"function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeHtmlAttribute(value) {
+  return escapeHtml(value)
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function safeHref(value) {
+  const href = String(value ?? "").trim();
+  const normalizedScheme = href.replace(/[\u0000-\u0020\u007f]+/g, "");
+  if (/^(?:javascript|data|vbscript):/i.test(normalizedScheme)) {
+    return "#";
+  }
+  return escapeHtmlAttribute(href);
+}
+
+"##,
+    );
+
     // 3. Class opener.
     writeln!(out, "class {class_name} extends HTMLElement {{").unwrap();
 
@@ -1477,7 +1506,7 @@ fn emit_host_input(node: &LayoutNode, part_styles: &HashMap<String, String>) -> 
     if let Some(slot) = find_slot_ref(node, "value") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            attrs.push_str(&format!(r#" value="${{{camel}}}""#));
+            attrs.push_str(&format!(r#" value="${{escapeHtmlAttribute({camel})}}""#));
         }
     }
 
@@ -1647,7 +1676,7 @@ fn host_button_label_body(node: &LayoutNode) -> String {
             if trimmed.is_empty() {
                 String::new()
             } else {
-                format!("${{{trimmed}}}")
+                format!("${{escapeHtml({trimmed})}}")
             }
         }
         _ => String::new(),
@@ -1657,7 +1686,7 @@ fn host_button_label_body(node: &LayoutNode) -> String {
 fn template_identifier_body(name: &str) -> String {
     let camel = to_camel_case_first_lower(name);
     if is_safe_identifier(&camel) {
-        format!("${{{camel}}}")
+        format!("${{escapeHtml({camel})}}")
     } else {
         String::new()
     }
@@ -1756,7 +1785,7 @@ fn emit_host_checkbox(node: &LayoutNode, part_styles: &HashMap<String, String>) 
     } else if let Some(slot) = find_slot_ref(node, "label") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            format!("<label>{attrs} ${{{camel}}}</label>")
+            format!("<label>{attrs} ${{escapeHtml({camel})}}</label>")
         } else {
             attrs
         }
@@ -1786,7 +1815,7 @@ fn emit_host_radio(node: &LayoutNode, part_styles: &HashMap<String, String>) -> 
     } else if let Some(slot) = find_slot_ref(node, "group") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            attrs.push_str(&format!(r#" name="${{{camel}}}""#));
+            attrs.push_str(&format!(r#" name="${{escapeHtmlAttribute({camel})}}""#));
         }
     }
 
@@ -1796,7 +1825,7 @@ fn emit_host_radio(node: &LayoutNode, part_styles: &HashMap<String, String>) -> 
     } else if let Some(slot) = find_slot_ref(node, "value") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            attrs.push_str(&format!(r#" value="${{{camel}}}""#));
+            attrs.push_str(&format!(r#" value="${{escapeHtmlAttribute({camel})}}""#));
         }
     }
 
@@ -1843,7 +1872,7 @@ fn emit_host_radio(node: &LayoutNode, part_styles: &HashMap<String, String>) -> 
     } else if let Some(slot) = find_slot_ref(node, "label") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            format!("<label>{attrs} ${{{camel}}}</label>")
+            format!("<label>{attrs} ${{escapeHtml({camel})}}</label>")
         } else {
             attrs
         }
@@ -1892,7 +1921,7 @@ fn emit_host_link(
     } else if let Some(slot) = find_slot_ref(node, "href") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            attrs.push_str(&format!(r#" href="${{{camel}}}""#));
+            attrs.push_str(&format!(r#" href="${{safeHref({camel})}}""#));
         } else {
             attrs.push_str(" href=\"#\"");
         }
@@ -1934,7 +1963,7 @@ fn emit_host_link(
     } else if let Some(slot) = find_slot_ref(node, "label") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            format!("${{{camel}}}")
+            format!("${{escapeHtml({camel})}}")
         } else {
             String::new()
         }
@@ -2015,7 +2044,7 @@ fn emit_host_tooltip(
     } else if let Some(slot) = find_slot_ref(node, "text") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            attrs.push_str(&format!(r#" title="${{{camel}}}""#));
+            attrs.push_str(&format!(r#" title="${{escapeHtmlAttribute({camel})}}""#));
         }
     }
 
@@ -2043,7 +2072,7 @@ fn emit_host_number_input(node: &LayoutNode, part_styles: &HashMap<String, Strin
     if let Some(slot) = find_slot_ref(node, "value") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            attrs.push_str(&format!(r#" value="${{{camel}}}""#));
+            attrs.push_str(&format!(r#" value="${{escapeHtmlAttribute({camel})}}""#));
         }
     } else if let Some(n) = find_number(node, "value") {
         attrs.push_str(&format!(r#" value="{n}""#));
@@ -2062,7 +2091,9 @@ fn emit_host_number_input(node: &LayoutNode, part_styles: &HashMap<String, Strin
     } else if let Some(slot) = find_slot_ref(node, "placeholder") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            attrs.push_str(&format!(r#" placeholder="${{{camel}}}""#));
+            attrs.push_str(&format!(
+                r#" placeholder="${{escapeHtmlAttribute({camel})}}""#
+            ));
         }
     }
 
@@ -2181,7 +2212,7 @@ fn emit_host_dialog(
     let title_html = if let Some(slot) = find_slot_ref(node, "title") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            format!("<h2>${{{camel}}}</h2>")
+            format!("<h2>${{escapeHtml({camel})}}</h2>")
         } else {
             String::new()
         }
@@ -2499,7 +2530,7 @@ fn build_text_content(node: &LayoutNode) -> Option<String> {
         LayoutPropValue::SlotRef(name) => {
             let camel = to_camel_case_first_lower(name);
             if is_safe_identifier(&camel) {
-                format!("${{{camel}}}")
+                format!("${{escapeHtml({camel})}}")
             } else {
                 String::new()
             }
@@ -2520,20 +2551,15 @@ fn build_text_content(node: &LayoutNode) -> Option<String> {
         // One outer layer of parens is stripped via
         // `strip_outer_parens` so `( v )` reduces to `v` in the
         // interpolation; a complex expression like `( row.cells )`
-        // survives the strip and becomes `${row.cells}` so the V8
-        // JS engine evaluates the member access against the current
-        // loop scope.  The interpolated text is *not* re-escaped
-        // here because the surrounding template literal places the
-        // result directly into `shadowRoot.innerHTML` — the same
-        // surface the legitimate `SlotRef` content path already
-        // uses (`${displayName}`).  Host code is responsible for
-        // sanitising attribute values before setting them.
+        // survives the strip and is evaluated against the current loop
+        // scope. The resulting value is HTML-encoded before it reaches
+        // `shadowRoot.innerHTML`.
         LayoutPropValue::Expr(e) => {
             let trimmed = strip_outer_parens(e.trim());
             if trimmed.is_empty() {
                 String::new()
             } else {
-                format!("${{{trimmed}}}")
+                format!("${{escapeHtml({trimmed})}}")
             }
         }
     })
@@ -2607,7 +2633,7 @@ fn build_host_table_dir_attribute(node: &LayoutNode) -> String {
     if let Some(slot) = find_slot_ref(node, "dir") {
         let camel = to_camel_case_first_lower(slot);
         if is_safe_identifier(&camel) {
-            return format!(r#" dir="${{{camel}}}""#);
+            return format!(r#" dir="${{escapeHtmlAttribute({camel})}}""#);
         }
         return String::new();
     }
@@ -2937,7 +2963,9 @@ fn build_col_width_css(node: &LayoutNode) -> Option<String> {
         }
         _ => return None,
     };
-    Some(format!("width: ${{{expr}}}px"))
+    Some(format!(
+        "width: ${{Number.isFinite(Number({expr})) ? Number({expr}) : 0}}px"
+    ))
 }
 
 /// Build the per-state CSS ternaries for a node's `state-when-*` props.
@@ -3385,7 +3413,7 @@ mod tests {
     // -------- Test 3: text slot interpolates via getAttribute in _render --------
 
     /// A slot of type `text` referenced as the content of a Text
-    /// primitive lowers to `${displayName}` inside the template literal
+    /// primitive lowers to `${escapeHtml(displayName)}` inside the template literal
     /// — and a matching `const displayName = this.getAttribute(...)`
     /// line in `_render()`.
     #[test]
@@ -3416,7 +3444,9 @@ mod tests {
             result.output
         );
         assert!(
-            result.output.contains("<span>${displayName}</span>"),
+            result
+                .output
+                .contains("<span>${escapeHtml(displayName)}</span>"),
             "missing slot interpolation in shadow DOM:\n{}",
             result.output
         );
@@ -3794,6 +3824,68 @@ mod tests {
         );
     }
 
+    /// Host-provided slot and loop values are untrusted at the point where
+    /// the generated component assigns its template to `shadowRoot.innerHTML`.
+    /// Text, quoted attributes, URLs, and numeric CSS values therefore use
+    /// distinct runtime guards instead of raw template interpolation.
+    #[test]
+    fn runtime_values_are_guarded_for_their_html_context() {
+        let m = component(
+            "Safe",
+            vec![
+                slot("content", SlotType::Text, true),
+                slot("value", SlotType::Text, true),
+                slot("href", SlotType::Text, true),
+            ],
+            vec![],
+        );
+        let l = root_layout(
+            "Safe",
+            container(
+                "Box",
+                vec![
+                    leaf_with_props(
+                        "Text",
+                        vec![LayoutProp {
+                            name: "content".to_string(),
+                            value: LayoutPropValue::SlotRef("content".to_string()),
+                        }],
+                    ),
+                    leaf_with_props(
+                        "HostInput",
+                        vec![LayoutProp {
+                            name: "value".to_string(),
+                            value: LayoutPropValue::SlotRef("value".to_string()),
+                        }],
+                    ),
+                    leaf_with_props(
+                        "HostLink",
+                        vec![
+                            LayoutProp {
+                                name: "href".to_string(),
+                                value: LayoutPropValue::SlotRef("href".to_string()),
+                            },
+                            LayoutProp {
+                                name: "label".to_string(),
+                                value: LayoutPropValue::SlotRef("content".to_string()),
+                            },
+                        ],
+                    ),
+                ],
+            ),
+        );
+        let out = from_pipeline(&m, &l, &empty_style("Safe")).unwrap().output;
+
+        assert!(out.contains("function escapeHtml(value)"));
+        assert!(out.contains("function escapeHtmlAttribute(value)"));
+        assert!(out.contains("function safeHref(value)"));
+        assert!(out.contains("<span>${escapeHtml(content)}</span>"));
+        assert!(out.contains(r#"value="${escapeHtmlAttribute(value)}""#));
+        assert!(out.contains(r#"href="${safeHref(href)}""#));
+        assert!(!out.contains("<span>${content}</span>"));
+        assert!(!out.contains(r#"href="${href}""#));
+    }
+
     // -------- Test 15: ill-formed slot name is rejected --------
 
     /// A directly-constructed `SlotDecl` whose name is not a
@@ -3928,7 +4020,8 @@ mod tests {
             r.output
         );
         assert!(
-            r.output.contains(r#"value="${value}""#),
+            r.output
+                .contains(r#"value="${escapeHtmlAttribute(value)}""#),
             "missing value interpolation, got:\n{}",
             r.output
         );
@@ -4077,7 +4170,8 @@ mod tests {
         );
         let r = from_pipeline(&m, &l, &empty_style("Btn")).unwrap();
         assert!(
-            r.output.contains("<button>${displayName}</button>"),
+            r.output
+                .contains("<button>${escapeHtml(displayName)}</button>"),
             "slot-label HostButton missing camelCase interpolation, got:\n{}",
             r.output
         );
@@ -4142,7 +4236,7 @@ mod tests {
         );
         assert!(
             r.output.contains(
-                r#"<button data-mosaic-index="${i}" onclick="this.getRootNode().host.dispatch({type:'select',index:Number(this.dataset.mosaicIndex)})">${item}</button>"#
+                r#"<button data-mosaic-index="${i}" onclick="this.getRootNode().host.dispatch({type:'select',index:Number(this.dataset.mosaicIndex)})">${escapeHtml(item)}</button>"#
             ),
             "expected HostButton to dispatch index payload and render row label, got:\n{}",
             r.output
@@ -4199,7 +4293,7 @@ mod tests {
         let r = from_pipeline(&m, &l, &empty_style("SelectMenu")).unwrap();
         assert!(
             r.output.contains(
-                r#"<button data-mosaic-payload="${encodeURIComponent(String(option ?? ""))}" onclick="this.getRootNode().host.dispatch({type:'change',value:decodeURIComponent(this.dataset.mosaicPayload||'')})">${option}</button>"#
+                r#"<button data-mosaic-payload="${encodeURIComponent(String(option ?? ""))}" onclick="this.getRootNode().host.dispatch({type:'change',value:decodeURIComponent(this.dataset.mosaicPayload||'')})">${escapeHtml(option)}</button>"#
             ),
             "expected HostButton to dispatch item payload and render row label, got:\n{}",
             r.output
@@ -4430,7 +4524,7 @@ mod tests {
         let r = from_pipeline(&m, &l, &empty_style("List")).unwrap();
         assert!(
             r.output
-                .contains("${rows.map((row, idx) => `<span>${row}</span>`).join('')}"),
+                .contains("${rows.map((row, idx) => `<span>${escapeHtml(row)}</span>`).join('')}"),
             "For did not lower to Array.map().join(''), got:\n{}",
             r.output
         );
@@ -4611,7 +4705,7 @@ mod tests {
     /// `dir: slot: layout-direction` interpolates the bound slot into
     /// the `<table>`'s `dir` attribute via the shadow-DOM template
     /// literal — slot names round-trip through `to_camel_case_first_lower`
-    /// so the source `layout-direction` lands as `${layoutDirection}`.
+    /// so the source `layout-direction` lands as an encoded interpolation.
     #[test]
     fn ui31_rtl_host_table_dir_slot_ref_emits_template_interpolation() {
         let m = component(
@@ -4631,8 +4725,9 @@ mod tests {
         let l = root_layout("T", table);
         let r = from_pipeline(&m, &l, &empty_style("T")).unwrap();
         assert!(
-            r.output.contains(r#"<table dir="${layoutDirection}">"#),
-            "Expected <table dir=\"${{layoutDirection}}\">, got:\n{}",
+            r.output
+                .contains(r#"<table dir="${escapeHtmlAttribute(layoutDirection)}">"#),
+            "Expected encoded layoutDirection interpolation, got:\n{}",
             r.output
         );
     }
@@ -4937,7 +5032,7 @@ mod tests {
     // -------- D6: title slot injects an <h2> first child --------
 
     /// `title: slot: heading` lifts the title slot's value into an
-    /// `<h2>${heading}</h2>` element that's the first child of the
+    /// `<h2>${escapeHtml(heading)}</h2>` element that's the first child of the
     /// `<dialog>` — so the dialog has a screen-reader-announced
     /// heading without the author having to wire one manually.
     #[test]
@@ -4953,8 +5048,9 @@ mod tests {
         );
         let r = from_pipeline(&m, &l, &empty_style("Confirm")).unwrap();
         assert!(
-            r.output
-                .contains(r#"<dialog id="mos-dlg-0"><h2>${heading}</h2><div></div></dialog>"#),
+            r.output.contains(
+                r#"<dialog id="mos-dlg-0"><h2>${escapeHtml(heading)}</h2><div></div></dialog>"#
+            ),
             "title slot must emit <h2> as first child, got:\n{}",
             r.output
         );
@@ -5466,7 +5562,7 @@ mod tests {
         );
         let r = from_pipeline(&m, &l, &empty_style("Nav")).unwrap();
         assert!(
-            r.output.contains(r##"<a href="#" data-mosaic-index="${i}" onclick="event.preventDefault();this.getRootNode().host.dispatch({type:'select',index:Number(this.dataset.mosaicIndex)})">${item}</a>"##),
+            r.output.contains(r##"<a href="#" data-mosaic-index="${i}" onclick="event.preventDefault();this.getRootNode().host.dispatch({type:'select',index:Number(this.dataset.mosaicIndex)})">${escapeHtml(item)}</a>"##),
             "expected HostLink to dispatch the For index and render item label, got:\n{}",
             r.output
         );
@@ -5922,7 +6018,7 @@ mod tests {
     }
 
     /// `Text ( content: ( v ) )` — where `v` is a `For`-loop binding —
-    /// interpolates as `${v}` inside the surrounding template literal.
+    /// interpolates as `${escapeHtml(v)}` inside the surrounding template literal.
     /// Before this fix the cell rendered an empty `<span></span>` and
     /// the visicalc-style grid demo would show empty cells.
     #[test]
@@ -5941,8 +6037,8 @@ mod tests {
             .unwrap()
             .output;
         assert!(
-            out.contains("${v}"),
-            "expected `${{v}}` interpolation, got:\n{out}"
+            out.contains("${escapeHtml(v)}"),
+            "expected encoded `${{v}}` interpolation, got:\n{out}"
         );
         // Empty-span regression — fail loudly if it ever returns.
         assert!(
@@ -6147,8 +6243,8 @@ mod tests {
     }
 
     /// A `Col [col] ( width: ( w ) )` inside a `For (as: w)` must emit
-    /// `<col style="width: ${w}px">` so columns get their runtime
-    /// per-column widths.
+    /// a finite-number guard around the runtime width so columns get their
+    /// runtime pixel widths without allowing style-attribute injection.
     #[test]
     fn col_emits_runtime_width_px() {
         let m = component(
@@ -6189,8 +6285,8 @@ mod tests {
             .unwrap()
             .output;
         assert!(
-            out.contains(r#"<col style="width: ${w}px">"#),
-            "Col must emit a runtime px width:\n{out}"
+            out.contains(r#"<col style="width: ${Number.isFinite(Number(w)) ? Number(w) : 0}px">"#),
+            "Col must emit a guarded runtime px width:\n{out}"
         );
     }
 

--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -1,0 +1,21 @@
+# Venture browser acceptance backlog
+
+This list tracks bounded follow-ups found while exercising Venture as Mosaic's
+cross-platform proving application. Items are ordered by risk and dependency.
+
+## Prioritized discoveries
+
+- [x] **P0 — Web Component runtime output encoding.** Encode host-controlled text
+  and attribute interpolation, reject executable dynamic link schemes, and
+  constrain runtime CSS widths before adding a browser interaction gate.
+- [ ] **P1 — HTML and Web Component interaction acceptance.** Drive the generated
+  browser controls through their real DOM and Custom Element host seams,
+  covering disabled controls, address editing, Return, Go, and host-driven prop
+  refresh. Keep both outputs sourced from the shared Venture MIL/MLL/MSL
+  package.
+
+## Completed foundations
+
+- Native SwiftUI and XAML generated-app launch and interaction acceptance.
+- Direct Flutter, Qt Quick, Compose Desktop, React, and Electron interaction
+  acceptance for the shared browser-chrome contract.


### PR DESCRIPTION
## Summary
- encode host-controlled text and quoted-attribute interpolation before generated Web Components assign `shadowRoot.innerHTML`
- reject executable dynamic link schemes and constrain runtime column widths to finite numbers
- add the prioritized Venture acceptance backlog, keeping HTML/Web Component interaction acceptance next

## Validation
- `cargo test -p mosaic-emit-webcomponent` (117 passed + doc test)
- `cargo test -p mosaic-compile -p mosaic-package-artifact-builder` (61 passed + doc test)
- `cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml` (3 passed)
- generated Venture Web Component `node --check` for component and host runtime
- generated Venture jsdom hostile-value probe: markup remains text and quoted input data
- parser ratchets: tree upstream 1934 / local 2637 / missing 0; tokenizer upstream 6806 / local raw 7015 / missing 0; normalized 7242 / skipped 0

This is a bounded Mosaic emitter hardening slice, not a claim of complete Venture or HTML conformance.