### PR TITLE
feat(human-languages): split Kannada lessons into micro-steps

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Telugu duration
-tranche: 20 registered tracks, 1,003 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Kannada duration
+tranche: 20 registered tracks, 1,004 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -58,7 +58,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01I | Complete in the French duration PR | Remove all twenty-five sub-five-minute violations from the French track. | The report measures zero French violations; three new prerequisite-ordered micro-lessons preserve register, suppletion, and pronominal-agreement depth. |
 | HL-D01J | Complete in the German duration PR | Remove all twenty-seven sub-five-minute violations from the German track. | The report measures zero German violations; five new prerequisite-ordered micro-lessons preserve register, practice, areal-history, agreement, and etymology depth. |
 | HL-D01K | Complete in the Telugu duration PR | Remove all thirty-six sub-five-minute violations from the Telugu track. | The report measures zero Telugu violations; one new prerequisite-ordered micro-lesson separates phrase formation from register and source-evidence judgment. |
-| HL-D01L | Next | Remove all thirty-seven sub-five-minute violations from the Kannada track. | Kannada is now the smallest remaining set: thirty-six declaration-only lessons and one genuinely computed violation, with a 360-second maximum. |
+| HL-D01L | Complete in the Kannada duration PR | Remove all thirty-seven sub-five-minute violations from the Kannada track. | The report measures zero Kannada violations; one new prerequisite-ordered micro-lesson separates suffix forms and sound history from the agglutinative-versus-fusional comparison. |
+| HL-D01M | Next | Remove all thirty-seven sub-five-minute violations from the Malayalam track. | Malayalam is now the smallest remaining set: thirty-three declaration-only lessons and four genuinely computed violations, with a 360-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -81,8 +82,11 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B21 | Queued | Remove German's LaTeX layout and Unicode bookmark warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports seventeen overfull boxes, eleven underfull boxes, and three Hyperref warnings; the clean-build signal is zero of each. |
 | HL-B22 | Queued | Publish Telugu Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Telugu PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B23 | Queued | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, three underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and a font-shape substitution warning; the clean-build signal is zero of each. |
+| HL-B24 | Queued | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Kannada PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
+| HL-B25 | Queued | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, five underfull boxes, four duplicate practice labels, 30 Hyperref warnings, and undefined bold/italic Kannada font shapes; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
+| HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
@@ -390,6 +394,32 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Kannada's thirty-seven violations are now the smallest remaining set.
   Thirty-six are declaration-only and one genuinely computes above the limit,
   with a 360-second maximum, so HL-D01L is next.
+
+## Findings from HL-D01L
+
+- Kannada now has zero duration violations. The corpus grows from 1,003 to
+  1,004 lessons and drops from 293 to 256 violations overall; unknown
+  prerequisites remain at zero.
+- Thirty-six lessons needed only honest declared-budget corrections. The one
+  genuinely long lesson is now a prerequisite-ordered sequence: **-ಗೆ/-ಿಗೆ/-ಕ್ಕೆ**
+  forms and *k → g* family history → visible Dravidian stacking versus fused
+  Latin endings → the existing dative-subject application.
+- The rewritten suffix lesson computes to 205 seconds, the new stacking lesson
+  to 196, and the following dative-subject application to 281.
+  `KA-C01-namaskara` at 295 seconds and `KA-C22-hasiru-haladi` at 294 are the
+  tightest remaining Kannada lessons and should be watched during copy edits.
+- The Kannada PDF builds successfully at 29 pages through Chapter 5 while
+  canonical lessons continue through Chapter 31. HL-B24 records the schema-v2
+  migration and generated publication work for Chapters 6–31.
+- The build has no missing glyphs, but reports four overfull boxes, five
+  underfull boxes, four duplicate practice labels, 30 Hyperref warnings, and
+  undefined bold/italic Kannada font shapes. HL-B25 records that pre-existing
+  clean-build debt.
+- The roadmap narrative stops at Chapter 6 and the authoritative session map at
+  Chapter 5. HL-M03 records the progression-metadata work through Chapter 31.
+- Malayalam's thirty-seven violations are now the smallest remaining set.
+  Thirty-three are declaration-only and four genuinely compute above the limit,
+  with a 360-second maximum, so HL-D01M is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/kannada/CHANGELOG.md
+++ b/code/learning/human-languages/kannada/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
+## Sub-five-minute lesson remediation (2026-08-02)
+
+- All thirty-seven Kannada duration violations are resolved. Thirty-six lessons
+  already computed below five minutes and now declare an honest four-minute
+  budget without changing their teaching content.
+- The genuinely long Chapter 6 lesson becomes two prerequisite-ordered steps:
+  learn **-ಗೆ/-ಿಗೆ/-ಕ್ಕೆ**, **ನಾನು → ನನಗೆ**, and the family *k → g* history;
+  then contrast transparent Dravidian suffix stacking with fused Latin endings
+  before applying the dative in **ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು**.
+- The rewritten suffix lesson computes to 205 seconds and the new stacking
+  lesson to 196. The support lesson brings the Kannada track to 60 lessons with
+  zero unknown prerequisite ids.
+- A forced book build succeeds at 29 pages with no missing glyphs. Canonical
+  lessons continue through Chapter 31 while the book stops at Chapter 5
+  (`HL-B24`); existing layout, bookmark, duplicate-label, and font warnings are
+  tracked in `HL-B25`; roadmap and session-map drift is tracked in `HL-M03`.
+
 ## Chapter 6 — Case endings, and the sentence with no subject
 
-- **Chapter 6 authored** (`KA-C06-dative-ge`, `-dative-subject`): the track's first
+- **Chapter 6 authored** (`KA-C06-dative-ge`, `-dative-stacking`,
+  `-dative-subject`): the track's first
   **case ending** — reviewing Ch.2/3/5 via `reviews_of`.
 - **-ಗೆ** (`KA-C06-dative-ge`): the dative "to/for," taught as the doorway to
   **agglutination**. Kannada **adds** a suffix carrying **one** meaning with the
@@ -13,6 +31,9 @@
   sisters kept the hard consonant — while the
   *-kke* form (*kelasakke*) preserves the original hard doubled consonant. Includes
   *nānu* → **ನನಗೆ** *nanage*.
+- **Stacking** (`KA-C06-dative-stacking`): the visible Kannada noun-plus-case
+  seam and one-suffix/one-job principle now get their own micro-lesson before
+  the contrast with Latin *-īs*, which fuses case, number, and declension.
 - **ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು** (`KA-C06-dative-subject`): "I know Kannada" — literally
   "**to-me Kannada known**," with **no nominative subject** (contrast Ch.5's *nānu
   kannaḍa mātanāḍuttēne*), and with the further observation that ***gottu* isn't an

--- a/code/learning/human-languages/kannada/lessons/KA-C01-namaskara.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-namaskara.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [kannada-inherent-a, virama, ottakshara-conjunct]
 roots: [namas, kṛ]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C01-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [KA-C01-namaskara, KA-C01-dhanyavada, KA-C01-haudu, KA-C01-illa, KA-C01-sari]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C01-namaskara, KA-C01-dhanyavada, KA-C01-haudu, KA-C01-illa, KA-C01-sari]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C02-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [KA-C02-nanna-hesaru, KA-C02-nimma-hesaru-enu, KA-C02-santosha]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C02-hesaru, KA-C02-nanna, KA-C02-nanna-hesaru, KA-C02-niinu-niivu, KA-C02-enu, KA-C02-nimma-hesaru-enu, KA-C02-santosha]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C03-niivu-hegiddiira.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-niivu-hegiddiira.md
@@ -8,7 +8,7 @@ concept_tag: STATE-HOW-ARE-YOU
 prerequisites: [KA-C03-hege, KA-C02-niinu-niivu]
 sounds: [double-dd, long-ii]
 roots: [iru-be-dravidian]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C02-niinu-niivu, KA-C03-hege]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C03-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [KA-C03-niivu-hegiddiira, KA-C03-cennaagi, KA-C03-paravaagilla]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C03-hege, KA-C03-niivu-hegiddiira, KA-C03-naanu, KA-C03-cennaagi, KA-C03-paravaagilla]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C04-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [KA-C04-hoogi-baruttene, KA-C04-naale-sigona, KA-C04-matte-sigona]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C04-hoogu, KA-C04-hoogi-baruttene, KA-C04-naale-sigona, KA-C04-matte-sigona]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C05-kelasa-maadu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-kelasa-maadu.md
@@ -8,7 +8,7 @@ concept_tag: KA-VERB-MAADU
 prerequisites: [KA-C05-maatanaadu]
 sounds: [long-aa]
 roots: [maadu-do-dravidian, kelasa-work-dravidian]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C05-maatanaadu, KA-C05-iru]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C05-naanu-kannada-maatanaaduttene.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-naanu-kannada-maatanaaduttene.md
@@ -8,7 +8,7 @@ concept_tag: KA-WORD-KANNADA
 prerequisites: [KA-C05-maatanaadu, KA-C03-naanu]
 sounds: [double-nn]
 roots: [kannada]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C05-maatanaadu, KA-C03-naanu]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C05-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [KA-C05-maatanaadu, KA-C05-naanu-kannada-maatanaaduttene, KA-C05-iru, KA-C05-kelasa-maadu]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C05-maatanaadu, KA-C05-naanu-kannada-maatanaaduttene, KA-C05-iru, KA-C05-kelasa-maadu, KA-C03-naanu]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C06-dative-ge.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C06-dative-ge.md
@@ -3,13 +3,13 @@ id: KA-C06-dative-ge
 chapter: 6
 type: word
 headword: -ಗೆ
-gloss: "the dative suffix -ge, 'to / for' — and the idea of stacking"
+gloss: "the dative suffix -ge, 'to / for,' and its family sound history"
 romanization: -ge
 concept_tag: KA-CASE-DATIVE
 prerequisites: [KA-C05-practice, KA-C03-naanu, KA-C02-hesaru]
 sounds: [voiced-g]
 roots: [dravidian-dative-ku]
-etymology_hook: "Dravidian marks case by ADDING a suffix that means one thing and stays visible at the seam — unlike Latin, where a fused ending like -īs carries case AND number AND declension at once and doesn't even settle which case; -ge is Kannada's form of the shared Dravidian dative *-k(k)u, cousin of Tamil -ukku, Telugu -ku, Malayalam -ikku, with the k voiced to g between vowels while the geminate -kke resisted and kept the old hard consonant"
+etymology_hook: "-ge is Kannada's form of shared Dravidian *-k(k)u: k voiced to g between vowels while doubled -kke kept the hard consonant"
 est_minutes: 4
 reviews_of: [KA-C03-naanu, KA-C02-hesaru, KA-C05-practice]
 ---
@@ -55,20 +55,6 @@ other Kannada form, ***-kke***: a **doubled** consonant resists voicing, so the
 geminate preserved the original *k*. The two Kannada shapes are the same suffix
 caught on either side of a sound change.
 
-## Why this matters
-
-| | Kannada **-ge** | a Latin ending like **-īs** |
-|---|---|---|
-| pins down the case? | **yes** — dative, always | **no** — *-īs* is dative **or** ablative |
-| carries number? | **no** — a separate suffix does | yes — plural, baked in |
-| carries declension class? | **no** | yes — 1st/2nd only |
-| can you see the seam? | **yes**: *hesar* + *ige* | no — one fused lump |
-
-Kannada **stacks**: each suffix carries one meaning and sits in a fixed order.
-Latin **fuses**: *-īs* is case *and* plural *and* declension at once, indivisible
-— and it doesn't even settle *which* case. Kannada's *-ge* is never ambiguous. That is what "**agglutinative**" means — long words that are **built**
-rather than memorised.
-
 ## Guided Practice
 
 [PAUSE 1s]
@@ -79,11 +65,7 @@ rather than memorised.
 
 ## Wrap-up Recall
 
-[PAUSE 3s] What does **-ಗೆ** mean? ("**To**" or "**for**.") Where does it go? (**On
-the end** of the noun.) What is "to me"? (**ನನಗೆ** *nanage*.) Why does Kannada have
-*g* where its sisters have *k*? (Kannada **voiced** the *k* between vowels and
-carried that into the dative; the **doubled** *-kke* resisted and kept the old hard
-form.) How does this differ from a Latin ending? (Latin **fuses**
-case+number+declension — and *-īs* doesn't even fix *which* case; Kannada's suffix
-carries **one** meaning, unambiguously, seam visible.) Next: the sentence where the
-person isn't the subject.
+[PAUSE 3s] What does **-ಗೆ** mean? ("**To**" or "**for**.") Where does it go?
+(**On the end** of the noun.) What is "to me"? (**ನನಗೆ** *nanage*.) Why does
+Kannada have *g* where its sisters have *k*? (Kannada **voiced** the *k* between
+vowels; doubled *-kke* resisted and kept the old hard form.)

--- a/code/learning/human-languages/kannada/lessons/KA-C06-dative-stacking.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C06-dative-stacking.md
@@ -1,0 +1,53 @@
+---
+id: KA-C06-dative-stacking
+chapter: 6
+type: grammar
+headword: -ಗೆ — stacking
+gloss: Kannada adds one visible suffix per job where Latin fuses several jobs into one ending
+romanization: -ge
+concept_tag: KA-AGGLUTINATIVE-STACKING
+prerequisites: [KA-C06-dative-ge]
+sounds: []
+roots: [dravidian-dative-ku]
+etymology_hook: "Kannada -ge carries one unambiguous case meaning at a visible seam; Latin -īs fuses case, number, and declension and can name two cases"
+est_minutes: 4
+reviews_of: [KA-C06-dative-ge, KA-C05-practice]
+---
+
+# -ಗೆ — one suffix, one job
+
+## Warm-up
+
+[PAUSE 2s] You can now attach **-ಗೆ** and make **ನನಗೆ** “to me.” Look at what
+that visible seam tells you about how Kannada builds longer words.
+
+## Stacking versus fusion
+
+| | Kannada **-ge** | a Latin ending like **-īs** |
+|---|---|---|
+| pins down the case? | **yes** — dative, always | **no** — dative **or** ablative |
+| carries number? | **no** — a separate suffix does | yes — plural, baked in |
+| carries declension class? | **no** | yes — first or second |
+| can you see the seam? | **yes**: *hesar* + *ige* | no — one fused lump |
+
+Kannada **stacks** suffixes. Each suffix carries one meaning and sits in a fixed
+order, so the learner can see where the noun ends and the case marker begins.
+That is what **agglutinative** means here: longer words are assembled from
+pieces whose jobs remain visible.
+
+Latin **fuses** several jobs into one ending. *-īs* carries case, plural number,
+and declension class at once—and it does not even settle whether the case is
+dative or ablative. Kannada **-ಗೆ** carries one unambiguous job: “to/for.”
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: *hesar* + *ige* — a visible noun-plus-case seam]
+- [YOU SAY: Kannada *-ge* — one job, dative]
+- [YOU SAY: Latin *-īs* — case, plural, and declension fused]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why is Kannada called agglutinative? (**It stacks visible pieces,
+each with one job.**) How many jobs can Latin *-īs* fuse? (**Case, number, and
+declension class—and its case can still be dative or ablative.**)

--- a/code/learning/human-languages/kannada/lessons/KA-C06-dative-subject.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C06-dative-subject.md
@@ -6,12 +6,12 @@ headword: ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು
 gloss: "'I know Kannada' — built with no subject, because knowing happens TO you"
 romanization: nanage kannaḍa gottu
 concept_tag: KA-DATIVE-SUBJECT
-prerequisites: [KA-C06-dative-ge, KA-C05-naanu-kannada-maatanaaduttene]
+prerequisites: [KA-C06-dative-stacking, KA-C05-naanu-kannada-maatanaaduttene]
 sounds: [gemination-tt]
 roots: [dravidian-dative-ku]
 etymology_hook: "Dravidian puts the EXPERIENCER in the dative — knowing, liking, wanting all happen TO you rather than being done BY you — so 'I know Kannada' has no nominative 'I', the person sitting in the dative instead (a 'dative subject'); gottu is not even a verb but a noun-like word meaning 'known', which is why nothing in the sentence is 'doing' anything"
-est_minutes: 5
-reviews_of: [KA-C06-dative-ge, KA-C05-naanu-kannada-maatanaaduttene, KA-C03-naanu]
+est_minutes: 4
+reviews_of: [KA-C06-dative-stacking, KA-C06-dative-ge, KA-C05-naanu-kannada-maatanaaduttene, KA-C03-naanu]
 ---
 
 # ನನಗೆ ಕನ್ನಡ ಗೊತ್ತು — "I know Kannada"

--- a/code/learning/human-languages/kannada/lessons/KA-C07-numbers-1-5.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C07-numbers-1-5.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C01-namaskara]
 sounds: [kannada-inherent-a, anusvara, retroflex-series]
 roots: [proto-dravidian-numbers]
 etymology_hook: "Kannada shares Tamil's native Dravidian numbers — 2–5 the same word in a Kannada coat (iraṇṭu ↔ eraḍu)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C01-namaskara]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C07-numbers-6-10.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C07-numbers-6-10.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C07-numbers-1-5]
 sounds: [kannada-inherent-a, anusvara, retroflex-la]
 roots: [proto-dravidian-numbers]
 etymology_hook: "ten shows Kannada's signature p→h shift — Tamil pattu becomes hattu, as pāl (milk) becomes hālu"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C07-numbers-1-5]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C08-dayavittu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C08-dayavittu.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C01-dhanyavada]
 sounds: [kannada-vowel-sign-i, kannada-virama-ottu, kannada-geminate-tta]
 roots: [daya-compassion]
 etymology_hook: "ದಯವಿಟ್ಟು = 'having placed compassion' — Kannada asks please with daya, like Tamil, Arabic faḍl and Hindi kṛpā"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C01-dhanyavada]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C09-kshamisi.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C09-kshamisi.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C08-dayavittu]
 sounds: [kannada-conjunct-kssa, kannada-vowel-sign-i]
 roots: [kshama-sanskrit]
 etymology_hook: "ಕ್ಷಮಿಸಿ kṣamisi ← Sanskrit kṣamā 'patience/forgiveness' + Kannada verb-making -isu — the same trick Kannada uses to borrow Sanskrit nouns as verbs"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C08-dayavittu]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C10-vaara.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C10-vaara.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C09-kshamisi]
 sounds: [kannada-anusvara, kannada-conjunct-kra]
 roots: [sanskrit-planet-words]
 etymology_hook: "Kannada's week is fully Sanskritic like Hindi's — Somavāra, Maṅgaḷavāra… — but Sunday is Bhānuvāra ('day of light'), a different Sanskrit sun-name than Hindi's Ravivāra"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C09-kshamisi]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C11-bannagalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C11-bannagalu.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C10-vaara]
 sounds: [kannada-anusvara, kannada-virama-geminate]
 roots: [dravidian-native-colors, sanskrit-nila]
 etymology_hook: "ಕಪ್ಪು/ಬಿಳಿ/ಕೆಂಪು (black/white/red) are native Dravidian, unlike Kannada's fully-Sanskritic day-names — but ನೀಲಿ (blue) is Sanskrit, same root as Tamil/Hindi/Malayalam"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C10-vaara]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C12-kutumba.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C12-kutumba.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C11-bannagalu]
 sounds: [kannada-retroflex-nna, kannada-anusvara]
 roots: [dravidian-appa-amma, dravidian-age-graded-siblings]
 etymology_hook: "ಅಪ್ಪ appa/ಅಮ್ಮ amma and the four sibling words (ಅಣ್ಣ/ತಮ್ಮ, ಅಕ್ಕ/ತಂಗಿ) match Tamil's set almost word-for-word — Kannada splits siblings by age too"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C11-bannagalu]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C14-kaalagalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C14-kaalagalu.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C13-dehada-bhagagalu]
 sounds: [kannada-vocalic-r, kannada-anusvara]
 roots: [dravidian-besige-male-chali, sanskrit-vasanta]
 etymology_hook: "ಬೇಸಿಗೆ besige (summer) and ಮಳೆ male (rain) are native Dravidian; ವಸಂತ ಋತು vasanta rutu (spring) uses the same Sanskrit vasanta AND the Sanskrit word rutu itself, 'season' — a double Sanskrit loan where Tamil/Malayalam just say kaalam"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C13-dehada-bhagagalu]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C15-niiru-akki.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C15-niiru-akki.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C14-kaalagalu]
 sounds: [kannada-vowel-sign-ii, kannada-geminate-kka]
 roots: [niiru-water-dravidian, akki-rice-dravidian]
 etymology_hook: "ನೀರು niiru (water) matches Tamil's nir/thanneer closely — unlike Malayalam's genuinely different vellam; ಅಕ್ಕಿ akki (rice) and ಅನ್ನ anna (cooked rice) complete the same raw/cooked distinction found across the family"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C14-kaalagalu]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C16-tingalugalu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C16-tingalugalu.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C15-niiru-akki]
 sounds: [kannada-conjunct-shtha, kannada-anusvara]
 roots: [sanskrit-lunisolar-chaitra-system]
 etymology_hook: "Unlike Tamil and Malayalam, which built their OWN solar calendars, Kannada uses the same pan-Indian Sanskritic lunisolar calendar as Hindi's Vikram Samvat — Ugadi falls on Chaitra Shukla Pratipada, the SAME calendar Telugu uses too"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C15-niiru-akki]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C17-madhyaahna-madhyaraatri.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C17-madhyaahna-madhyaraatri.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C16-tingalugalu]
 sounds: [kannada-conjunct-dhya, kannada-vowel-sign-aa]
 roots: [sanskrit-madhya-middle]
 etymology_hook: "ಮಧ್ಯಾಹ್ನ (madhyāhna, noon) and ಮಧ್ಯರಾತ್ರಿ (madhyarātri, midnight) are both direct Sanskrit tatsama compounds on madhya, 'middle' — Kannada's everyday words for these times are the SAME Sanskrit-formal register that Hindi keeps as a bookish alternate to its own colloquial dopahar / aadhi raat"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C16-tingalugalu]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri]
 sounds: [kannada-anusvara, kannada-vowel-sign-e]
 roots: [sanskrit-ghanta-bell]
 etymology_hook: "ಗಂಟೆ (gaṇṭe, 'hour') is related to Sanskrit घण्टा (ghaṇṭā, 'bell') — the SAME word and the SAME bell-strikes-the-hour logic as Hindi's ghanṭā, unlike Tamil's most-likely-native maṇi"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C19-vayassu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C19-vayassu.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C18-gante]
 sounds: [kannada-anusvara, kannada-conjunct-ssu]
 roots: [sanskrit-vayas-vigor-age]
 etymology_hook: "ವಯಸ್ಸು (vayassu, 'age') is from Sanskrit वयस् (vayas, 'age, youth, vigor'), from PIE *wéyh₁os — the SAME PIE root as Latin's vīs ('force'), the very word you met in Latin's age lesson's own vocabulary family; Kannada asks age with a simple possessive, 'your age how-much,' no verb at all"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C18-gante]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C20-hannondu-ippattu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C20-hannondu-ippattu.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C19-vayassu]
 sounds: [kannada-anusvara-o, kannada-geminate-pp]
 roots: [dravidian-hattu-ten, dravidian-ir-two-bound]
 etymology_hook: "ಹನ್ನೊಂದು-ಹತ್ತೊಂಬತ್ತು (11-19) are compounds echoing ಹತ್ತು (hattu, 'ten') + a digit — ಇಪ್ಪತ್ತು (ippattu, 'twenty') traces to Proto-Dravidian *ir- ('two') + *paHtu ('ten'), a real compositional origin, but Kannada's own sound changes (gemination, and a p→h shift that only fires word-initially) mean neither modern eraḍu nor modern hattu is directly visible inside it today — unlike Sanskrit/Latin/Arabic, which have no compositional origin for 'twenty' AT ALL"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [KA-C19-vayassu]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C20-havamana.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C20-havamana.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C18-gante]
 sounds: [kannada-vowel-sign-aa, kannada-compound-word]
 roots: [persian-hava-air, sanskrit-maana-measure]
 etymology_hook: "ಹವಾಮಾನ (havāmāna, 'weather') is a genuine hybrid compound: ಹವಾ (hava, 'air') is itself a Persian/Arabic loan (havā ← Arabic hawāʾ, the SAME root behind Hindi's hawa), fused with ಮಾನ (māna, 'measure,' native Sanskrit) — literally 'air-measure'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C18-gante]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C21-naayi-bekku.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C21-naayi-bekku.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C20-hannondu-ippattu]
 sounds: [kannada-vowel-sign-e, kannada-geminate-kk]
 roots: [dravidian-naay-dog, dravidian-veruku-wildcat]
 etymology_hook: "ನಾಯಿ (nāyi, 'dog') is a solid, native Proto-Dravidian root — no mystery, unlike every dog-word you've met elsewhere in this arc; ಬೆಕ್ಕು (bekku, 'cat') is cognate with a DIFFERENT ancient Dravidian root, the same one behind Tamil/Malayalam's word for wildcat/civet cat — Kannada's everyday cat-word and Tamil's everyday cat-word (pūnai) come from two genuinely separate Dravidian roots"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [KA-C20-hannondu-ippattu]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C22-hasiru-haladi.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C22-hasiru-haladi.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C11-bannagalu, KA-C21-naayi-bekku]
 sounds: [kannada-retroflex-lla, kannada-virama-geminate]
 roots: [proto-dravidian-pac-green, sanskrit-haridra-turmeric]
 etymology_hook: "ಹಸಿರು (hasiru, 'green') ← Old Kannada ಪಸಿರ್ (pasir) ← Proto-Dravidian *pac-, 'green' — the SAME root as Tamil's பச்சை (paccai) and Telugu's పచ్చ (pacca); ಹಳದಿ (haḷadi, 'yellow') appears to be a Sanskrit/Hindi loan built on हरिद्रा (haridrā, 'turmeric'), which traces to हरि (hari, 'yellow, tawny') from Proto-Indo-European *ǵʰelh₃- — the same ancient root already behind Hindi's harā (green) and German's gelb (yellow); note that Hindi itself keeps 'turmeric' (haldi) and 'yellow' (pīlā) as two separate, unrelated words, unlike Kannada/Bengali/Odia which reuse the turmeric-word for the color"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [KA-C21-naayi-bekku]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C23-dina.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C23-dina.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri]
 sounds: [kannada-vowel-sign-i, kannada-na]
 roots: [sanskrit-dina, dravidian-hagalu-daytime]
 etymology_hook: "ದಿನ (dina, 'day') is a Sanskrit tatsama word, borrowed whole and unworn — the SAME Sanskrit दिन already behind Hindi's own दिन (din), but Hindi's din is a tadbhava form, eroded by centuries of ordinary sound change (Sanskrit dina → Prakrit → din), while Kannada's dina keeps the full, unshortened Sanskrit shape; Kannada also has a genuine native Dravidian word, ಹಗಲು (hagalu), but it specifically means 'daytime' (as opposed to night), not 'a day' as a calendar unit"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C24-ratri.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C24-ratri.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina]
 sounds: [kannada-conjunct-tra, kannada-vowel-sign-i]
 roots: [sanskrit-ratri, proto-dravidian-cirvl]
 etymology_hook: "ರಾತ್ರಿ (rātri, 'night') is a Sanskrit tatsama word, the same one already hiding inside ಮಧ್ಯರಾತ್ರಿ (madhyarātri, 'midnight'), now standing alone as Kannada's everyday word for 'night'; Kannada DOES have a genuine native Dravidian word, ಇರುಳು (iruḷu) ← Proto-Dravidian *cirVḷ, cognate with Tamil இருள், Malayalam ഇരുൾ, and Telugu ఇరులు — but unlike ಹಗಲು (hagalu, still a living word for 'daytime'), iruḷu has been pushed into archaism, surviving mainly in older poetry"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C25-shubha-ratri.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C25-shubha-ratri.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C24-ratri]
 sounds: [kannada-sha, kannada-bha]
 roots: [sanskrit-shubha-beautiful, sanskrit-ratri]
 etymology_hook: "ಶುಭ ರಾತ್ರಿ (śubha rātri), 'good night,' literally 'auspicious night' — both pieces are Sanskrit tatsama: ರಾತ್ರಿ (rātri, already met last lesson) plus ಶುಭ (śubha, 'auspicious, good'), from Sanskrit root śubh, 'to be beautiful, splendid,' from a well-sourced PIE root *ḱewbʰ-; the exact same phrase, शुभ रात्रि, is also common in Hindi — most likely shared Sanskrit vocabulary rather than one language directly borrowing the whole phrase from the other, though 'good night' as a farewell is itself a modern convention across Indian languages, so some cross-language reinforcement can't be ruled out"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [KA-C24-ratri]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C26-belagge.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C26-belagge.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina, KA-C24-ratri]
 sounds: [kannada-conjunct-gge, kannada-vowel-sign-e]
 roots: [proto-dravidian-belaku-light]
 etymology_hook: "ಬೆಳಗ್ಗೆ (beḷagge, 'morning') is native Dravidian, from ಬೆಳಗು (beḷagu, 'to shine, to become bright, to dawn') and ಬೆಳಕು (beḷaku, 'light') — unlike EVERY other everyday time-word already met in Kannada's arc, ದಿನ/dina ('day'), ರಾತ್ರಿ/ratri ('night'), and ಮಧ್ಯಾಹ್ನ/madhyāhna ('noon') — all genuine Sanskrit tatsama borrowings — ಬೆಳಗ್ಗೆ is the odd one out, Kannada's own word, no Sanskrit involved"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri, KA-C23-dina, KA-C24-ratri]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C27-sanje.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C27-sanje.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C24-ratri, KA-C26-belagge]
 sounds: [kannada-anusvara, kannada-ja]
 roots: [sanskrit-sandhya-junction]
 etymology_hook: "ಸಂಜೆ (sañje, 'evening') is borrowed — from Maharashtri Prakrit ಸಂಝಾ (sañjhā), itself from Sanskrit ಸಂಧ್ಯಾ (saṃdhyā, 'twilight, junction of day and night'); unlike dina/ratri/madhyāhna (fresh Sanskrit TATSAMA, taken whole and unworn), ಸಂಜೆ arrived already eroded, in its Prakrit-worn shape; Hindi's साँझ (sāñjh) descends from the SAME Sanskrit word, but via a DIFFERENT, sister Middle Indo-Aryan dialect, Śauraseni Prakrit — two independent erosion paths off one Sanskrit root, converging on near-identical modern forms across two different language families"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [KA-C24-ratri, KA-C26-belagge]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C28-aparahna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C28-aparahna.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri]
 sounds: [kannada-conjunct-hna, kannada-vowel-sign-aa]
 roots: [sanskrit-apara-latter, sanskrit-ahna-day]
 etymology_hook: "ಅಪರಾಹ್ನ (aparāhna, 'afternoon') is a genuine Sanskrit tatsama, distinct from ಮಧ್ಯಾಹ್ನ (madhyāhna, 'noon,' already met in Chapter 17) — both share the SAME '-ahna' suffix ('day,' related to ahan), differing only in the first piece: ಅಪರ (apara, 'latter, further') vs ಮಧ್ಯ (madhya, 'middle') — the classical five-part Sanskrit day division (prāta/saṅgava/madhyāhna/aparāhna/sāyāhna) kept this distinction sharp; in practice, though, some sources describe ಮಧ್ಯಾಹ್ನ ALSO being stretched loosely to cover the whole afternoon in casual modern speech — a MUCH more thinly sourced echo of Hindi's clearer दोपहर-widening story, worth flagging honestly rather than asserting as settled"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C29-shubhodaya.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C29-shubhodaya.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C26-belagge]
 sounds: [kannada-vowel-sign-oo, kannada-bha]
 roots: [su-good, udaya-sanskrit-rise]
 etymology_hook: "ಶುಭೋದಯ (śubhōdaya, 'good morning') = ಶುಭ (śubha, 'good, auspicious') + ಉದಯ (udaya, 'rising, sunrise,' ← Sanskrit ud- 'up' + i 'to go' — the same root behind sūryodaya, 'sunrise') — a COMPLETELY DIFFERENT root from ಬೆಳಗ್ಗೆ (beḷagge, KA-C26's native word for 'morning'); be honest about register: sources genuinely CONFLICT here — some describe ಶುಭೋದಯ as common in everyday speech, but a more careful source describes it as reserved for formal or written contexts (speeches, greeting cards, WhatsApp images) and 'not as frequently used in daily conversations' as ನಮಸ್ಕಾರ/ನಮಸ್ತೆ, with at least one native-speaker account suggesting casual spoken Kannada often reaches for English 'good morning' instead — the SAME formal/written skew pattern already found for Hindi's सुप्रभात, not a genuine cross-language contrast"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [KA-C26-belagge]
 ---
 

--- a/code/learning/human-languages/kannada/lessons/KA-C30-shubha-sanje.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C30-shubha-sanje.md
@@ -10,7 +10,7 @@ sounds: [kannada-sha, kannada-anusvara]
 roots: [su-good, sanskrit-sandhya-junction]
 reviews_of: [KA-C27-sanje, KA-C29-shubhodaya]
 etymology_hook: "ಶುಭ ಸಂಜೆ (śubha sañje, 'good evening') pairs śubha with ಸಂಜೆ (sañje, 'evening,' already met in Chapter 27 as a Sanskrit tatsama borrowed via Maharashtri Prakrit — NOT native Dravidian, despite a plausible-sounding claim you might encounter elsewhere that it's a native word); register evidence here is genuinely thin — a general, leans-formal impression (with ನಮಸ್ಕಾರ or, among younger urban speakers, English 'hello,' likely covering casual use) rather than a specific, well-sourced usage-context claim; this echoes, cautiously, the same formal-skew QUESTION already raised (not settled) for Hindi's सुप्रभात and Kannada's own ಶುಭೋದಯ, without overstating either lesson's own hedged conclusion into flat fact"
-est_minutes: 6
+est_minutes: 4
 ---
 
 # ಶುಭ ಸಂಜೆ (śubha sañje) — formal, and correctly citing where ಸಂಜೆ comes from

--- a/code/learning/human-languages/kannada/lessons/KA-C31-shubha-madhyahna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C31-shubha-madhyahna.md
@@ -9,7 +9,7 @@ prerequisites: [KA-C17-madhyaahna-madhyaraatri, KA-C28-aparahna, KA-C30-shubha-s
 sounds: [kannada-conjunct-dhya, kannada-vowel-sign-aa]
 roots: [su-good, sanskrit-madhya-middle]
 etymology_hook: "ಶುಭ ಮಧ್ಯಾಹ್ನ (śubha madhyāhna, 'good afternoon') is the standard afternoon greeting — but notice which noun it reuses: ಮಧ್ಯಾಹ್ನ (madhyāhna, 'noon,' KA-C17), NOT ಅಪರಾಹ್ನ (aparāhna, the more precisely-'afternoon' word from KA-C28) — a real-world data point for KA-C28's own hedge about whether madhyāhna has loosely widened to cover the afternoon too; be careful with the register claim here: one source, fetched directly rather than trusted from a search summary, describes ಶುಭ ಮಧ್ಯಾಹ್ನ as leaning FORMAL or semi-formal, workplaces and official meetings — but this wasn't cross-corroborated by a second source the way ನಮಸ್ಕಾರ's genuinely universal, any-time-of-day status was (confirmed independently across multiple fetched sources), so treat the workplace/formal framing as a single data point, not a settled fact"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [KA-C17-madhyaahna-madhyaraatri, KA-C28-aparahna, KA-C30-shubha-sanje]
 ---
 

--- a/code/learning/human-languages/kannada/roadmap.md
+++ b/code/learning/human-languages/kannada/roadmap.md
@@ -12,6 +12,11 @@ Kannada script is taught **inline**, inside the word lessons, never as a gated
 reading course. Grammar is introduced piece by piece, on the first word that
 needs it.
 
+Coverage note: canonical lessons now continue through Chapter 31, while the
+narrative sequence below is complete only through Chapter 6. `HL-M03` tracks
+bringing this roadmap and the session map up to the canonical prerequisite
+order; `HL-B24` tracks publishing Chapters 6–31 from the same source.
+
 ## Authored
 
 - **Ch. 1 — Greetings**: namaskāra → dhanyavāda → haudu → illa → sari →
@@ -45,7 +50,9 @@ needs it.
   Dravidian dative ***k* softened between vowels** — a change Kannada made and its
   carried **into the dative** where its sisters kept the hard consonant — while
   the **geminate** *-kke* form (*kelasakke*) resisted voicing and preserves the old hard
-  doubled consonant. Includes *nānu* → **ನನಗೆ** *nanage* ("to me") → **ನನಗೆ ಕನ್ನಡ
+  doubled consonant. The forms and sound history come first; the visible
+  stacking-versus-Latin-fusion comparison follows as its own micro-lesson.
+  Includes *nānu* → **ನನಗೆ** *nanage* ("to me") → **ನನಗೆ ಕನ್ನಡ
   ಗೊತ್ತು** (*nanage kannaḍa gottu*, "I know Kannada") — literally "**to-me Kannada
   known**," with **no nominative subject**, and where *gottu* isn't even an action
   verb, so nothing in the sentence is *doing* anything. The **dative-subject**

--- a/code/learning/human-languages/kannada/session-map.md
+++ b/code/learning/human-languages/kannada/session-map.md
@@ -4,6 +4,11 @@ Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
 authoritative order.
 
+Coverage note: this map currently stops at Chapter 5 while canonical lessons
+continue through Chapter 31. `HL-M03` records the work to schedule every later
+lesson, including the Chapter 6 suffix → stacking → dative-subject sequence,
+without pretending this partial map is already complete.
+
 **There is no reading course.** Kannada is learned *through* the words: each
 lesson's *"The letters in this word"* section introduces exactly the letters
 that word needs. By the end of Chapter 1 you have met the inherent vowel, the


### PR DESCRIPTION
## Summary
- remove all 37 Kannada sub-five-minute duration violations while preserving existing lesson bodies when only the declared budget was stale
- split the one genuinely long Chapter 6 lesson into suffix/sound-history and agglutinative-stacking steps before the existing dative-subject application
- record Kannada book, typography, roadmap, and session-map drift; reprioritize Malayalam as the next duration tranche

## Measured outcome
- Kannada duration violations: 37 → 0
- corpus lessons: 1,003 → 1,004
- total duration violations: 293 → 256
- unknown prerequisites: 0
- Chapter 6 sequence: 205 seconds → 196 seconds → 281 seconds
- tightest remaining Kannada lessons: KA-C01-namaskara at 295 seconds and KA-C22-hasiru-haladi at 294 seconds

## Validation
- `npm run test:coverage` — 68 tests, 93.60% line coverage
- `npm run build`
- `npm run validate` — 9 integration tests
- `npm run check:books`
- `npm run report`
- Language Ladder `npm run test:coverage` — 278 tests, 98.37% line coverage
- Language Ladder `npm run build` — 1,054 modules
- forced Kannada XeLaTeX build — 29 pages, no missing glyphs

The unchanged Kannada book stops at Chapter 5 while canonical lessons reach Chapter 31. It also reports 4 overfull boxes, 5 underfull boxes, 4 duplicate practice labels, 30 Hyperref warnings, and undefined bold/italic Kannada font shapes. Those publication/layout gaps and the roadmap/session-map drift are now tracked as HL-B24, HL-B25, and HL-M03.