### PR TITLE
fix(build-tool): enforce TypeScript rockspec UTF-8

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9553,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "0455cea8e0c0ddc078040ea109ea59dbaf8403fa",
+    "revision": "0cbae0ca3799671ca7db79e92c5f38b957c2c27e",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1222,
@@ -341,6 +341,15 @@
       "notes": "Discovered by the Python encoding-blocker audit. Go was remediated in merged PR #9504 and Rust in merged PR #9510. Of the seven engines that remain, Swift silently drops invalid rockspec dependencies; TypeScript replaces invalid bytes; Lua and Perl accept them; Ruby and Haskell use locale-sensitive text decoding; and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
     },
     {
+      "id": "build-tool-typescript-rockspec-utf8-conformance",
+      "title": "Make the TypeScript build tool enforce strict UTF-8 rockspec metadata",
+      "status": "pending",
+      "depends_on": ["build-tool-lua-rockspec-encoding"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized from the remaining-engine UTF-8 umbrella after merged PR #9553. TypeScript's current TextDecoder replacement behavior cannot distinguish malformed rockspec bytes from valid replacement characters. Bind the resolver and real CLI to the shared resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, preserve the exact expected edges, reject malformed bytes before parsing with METADATA_INVALID_UTF8, package identity, repository-relative manifest path, and exit 2, and keep the slice separate from other engine ports."
+    },
+    {
       "id": "build-tool-go-rockspec-utf8-conformance",
       "title": "Make the Go build tool enforce strict UTF-8 rockspec metadata",
       "status": "merged",
@@ -379,11 +388,11 @@
     {
       "id": "build-tool-swift-language-identity-registry",
       "title": "Bring Swift build-tool discovery to the canonical language and identity registry",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-swift-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-swift-language-identity-registry",
       "pr_number": 9553,
-      "notes": "Ready-for-review PR #9553 opened from the sole active parity branch after exact-base validation. Selected after merged PR #9537 and the collision-clean 80612eb7 inventory because the dependency is now satisfied and the prior real Swift full plan measured broad identity corruption: 4,768 package entries but only 4,594 unique names, with 143 identity groups containing 317 entries and 397 entries across 228 names classified as unknown. The implementation consumes the shared discovery-language-registry and discovery-duplicate-identity fixtures, recognizes established, emerging, execution-target, domain, and build-language buckets only at the exact packages/programs boundary, preserves package/program identities, excludes spec fixtures, and fails closed on residual duplicate qualified names. Exact-base validation on 0455cea8 passes 25 Swift tests, release build, 55.56% overall and 91.33% Discovery.swift line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, and a real 4,768-package/7,471-edge full plan with 4,768 unique identities, zero duplicate groups, and only intentional unknown/blog. The refreshed inventory is collision-clean at 1,222 identities and 4,370 slots with 172 high-consensus packages, 271 high-consensus gaps, 772 singletons, 10,808 singleton gaps, 577 Rust singletons, and zero collisions/unknown buckets. Security validation found zero external Swift dependencies and zero secret-like diff hits; diff checks pass. Build-file validation reproduces only the same 10 separately owned Lua BUILD_windows debt items. Repository Swift formatting has no checked-in configuration and strict recursive lint still reports broad pre-existing violations, so this slice does not reformat the engine. The rebase also logged the new AirGradient portable telemetry core as pending without changing selection. Keep this separate from metadata decoding and Windows file-option handling."
+      "notes": "Merged PR #9553 at 5008040ef0ba64bdfdf7891111c724a9027093c2 on 2026-08-02 after all exact-head checks passed: fixture consumers, detection, macOS, Ubuntu, Windows, Swift apps, and Swift CodeQL. The implementation consumes the shared discovery-language-registry and discovery-duplicate-identity fixtures, recognizes established, emerging, execution-target, domain, and build-language buckets only at the exact packages/programs boundary, preserves package/program identities, excludes spec fixtures, and fails closed on residual duplicate qualified names. Exact-base validation on 0455cea8 passed 25 Swift tests, release build, 55.56% overall and 91.33% Discovery.swift line coverage, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, and a real 4,768-package/7,471-edge full plan with 4,768 unique identities, zero duplicate groups, and only intentional unknown/blog. The post-merge 0cbae0ca inventory remains collision-clean at 1,222 identities and 4,370 slots with 172 high-consensus packages, 271 high-consensus gaps, 772 singletons, 10,808 singleton gaps, 577 Rust singletons, and zero collisions/unknown buckets. Security validation found zero external Swift dependencies and zero secret-like diff hits; diff checks passed. Build-file validation reproduced only the same 10 separately owned Lua BUILD_windows debt items. Repository Swift formatting has no checked-in configuration and strict recursive lint reports broad pre-existing violations, so the slice did not reformat the engine. The rebase also logged the AirGradient portable telemetry core as pending. Metadata decoding and Windows file-option handling remain separate."
     },
     {
       "id": "build-tool-rust-self-edge-diagnostic",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -343,9 +343,9 @@
     {
       "id": "build-tool-typescript-rockspec-utf8-conformance",
       "title": "Make the TypeScript build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-lua-rockspec-encoding"],
-      "branch": null,
+      "branch": "codex/build-tool-typescript-rockspec-utf8",
       "pr_number": null,
       "notes": "Materialized from the remaining-engine UTF-8 umbrella after merged PR #9553. TypeScript's current TextDecoder replacement behavior cannot distinguish malformed rockspec bytes from valid replacement characters. Bind the resolver and real CLI to the shared resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, preserve the exact expected edges, reject malformed bytes before parsing with METADATA_INVALID_UTF8, package identity, repository-relative manifest path, and exit 2, and keep the slice separate from other engine ports."
     },

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,7 +13,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "0cbae0ca3799671ca7db79e92c5f38b957c2c27e",
+    "revision": "6384e2cf4e5a812f1b8fc9782c661bf5ade9bdd9",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1222,
@@ -347,7 +347,7 @@
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": "codex/build-tool-typescript-rockspec-utf8",
       "pr_number": null,
-      "notes": "Materialized from the remaining-engine UTF-8 umbrella after merged PR #9553. TypeScript's current TextDecoder replacement behavior cannot distinguish malformed rockspec bytes from valid replacement characters. Bind the resolver and real CLI to the shared resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, preserve the exact expected edges, reject malformed bytes before parsing with METADATA_INVALID_UTF8, package identity, repository-relative manifest path, and exit 2, and keep the slice separate from other engine ports."
+      "notes": "Materialized from the remaining-engine UTF-8 umbrella after merged PR #9553. TypeScript's replacement decoder could not distinguish malformed rockspec bytes from valid replacement characters. The implementation now consumes the exact shared positive and invalid-byte fixtures, requires the exact edge set, rejects malformed bytes before parsing with typed METADATA_INVALID_UTF8 package and repository-relative manifest identity, accepts valid literal U+FFFD, and returns exit 2 through a real tsx CLI subprocess. Rebased validation on origin/main 6384e2cf passed 47 resolver tests, 266 unaffected package tests, 85.40% resolver line coverage, esbuild production bundling, 17 schema and 40 runner tests, the valid 36-case/55-file corpus, a 258-package Lua dry run, a 4,770-record/7,623-edge full plan, collision-clean 1,222-identity/4,370-slot parity inventory, JSON/diff/secret checks, and zero npm advisories. The full Windows suite separately reproduces seven pre-existing gitdiff portability failures, now logged as its own pending child; BUILD validation reproduces only the same 10 owned Lua BUILD_windows debt items."
     },
     {
       "id": "build-tool-typescript-windows-gitdiff-portability",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9572,
   "last_inventory": {
     "revision": "6384e2cf4e5a812f1b8fc9782c661bf5ade9bdd9",
     "schema_version": 3,
@@ -343,11 +343,11 @@
     {
       "id": "build-tool-typescript-rockspec-utf8-conformance",
       "title": "Make the TypeScript build tool enforce strict UTF-8 rockspec metadata",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": "codex/build-tool-typescript-rockspec-utf8",
-      "pr_number": null,
-      "notes": "Materialized from the remaining-engine UTF-8 umbrella after merged PR #9553. TypeScript's replacement decoder could not distinguish malformed rockspec bytes from valid replacement characters. The implementation now consumes the exact shared positive and invalid-byte fixtures, requires the exact edge set, rejects malformed bytes before parsing with typed METADATA_INVALID_UTF8 package and repository-relative manifest identity, accepts valid literal U+FFFD, and returns exit 2 through a real tsx CLI subprocess. Rebased validation on origin/main 6384e2cf passed 47 resolver tests, 266 unaffected package tests, 85.40% resolver line coverage, esbuild production bundling, 17 schema and 40 runner tests, the valid 36-case/55-file corpus, a 258-package Lua dry run, a 4,770-record/7,623-edge full plan, collision-clean 1,222-identity/4,370-slot parity inventory, JSON/diff/secret checks, and zero npm advisories. The full Windows suite separately reproduces seven pre-existing gitdiff portability failures, now logged as its own pending child; BUILD validation reproduces only the same 10 owned Lua BUILD_windows debt items."
+      "pr_number": 9572,
+      "notes": "Ready-for-review PR #9572 is the sole active parity PR. Materialized from the remaining-engine UTF-8 umbrella after merged PR #9553. TypeScript's replacement decoder could not distinguish malformed rockspec bytes from valid replacement characters. The implementation now consumes the exact shared positive and invalid-byte fixtures, requires the exact edge set, rejects malformed bytes before parsing with typed METADATA_INVALID_UTF8 package and repository-relative manifest identity, accepts valid literal U+FFFD, and returns exit 2 through a real tsx CLI subprocess. Rebased validation on origin/main 6384e2cf passed 47 resolver tests, 266 unaffected package tests, 85.40% resolver line coverage, esbuild production bundling, 17 schema and 40 runner tests, the valid 36-case/55-file corpus, a 258-package Lua dry run, a 4,770-record/7,623-edge full plan, collision-clean 1,222-identity/4,370-slot parity inventory, JSON/diff/secret checks, and zero npm advisories. The full Windows suite separately reproduces seven pre-existing gitdiff portability failures, now logged as its own pending child; BUILD validation reproduces only the same 10 owned Lua BUILD_windows debt items."
     },
     {
       "id": "build-tool-typescript-windows-gitdiff-portability",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -350,6 +350,24 @@
       "notes": "Materialized from the remaining-engine UTF-8 umbrella after merged PR #9553. TypeScript's current TextDecoder replacement behavior cannot distinguish malformed rockspec bytes from valid replacement characters. Bind the resolver and real CLI to the shared resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, preserve the exact expected edges, reject malformed bytes before parsing with METADATA_INVALID_UTF8, package identity, repository-relative manifest path, and exit 2, and keep the slice separate from other engine ports."
     },
     {
+      "id": "build-tool-typescript-windows-gitdiff-portability",
+      "title": "Make TypeScript build-tool git-diff tests portable on Windows",
+      "status": "pending",
+      "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while running the full TypeScript build-tool suite for the strict rockspec UTF-8 slice. On Windows, gitdiff.test.ts hardcodes /bin/sh for two git commits and uses /repo POSIX fake roots for path-mapping tests, producing two spawnSync /bin/sh ENOENT failures plus five empty affected-package sets. The failure is pre-existing and unrelated to metadata decoding. Add platform-native command invocation and temporary-directory path fixtures in a separate small slice, then require the full package suite and coverage on Windows."
+    },
+    {
+      "id": "build-tool-typescript-language-identity-registry",
+      "title": "Bring TypeScript build-tool discovery to the canonical language and identity registry",
+      "status": "pending",
+      "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered by the real full-repository plan during the TypeScript UTF-8 slice. The engine emits 4,770 package records but only 4,383 unique names, including 655 unknown-language records and 217 duplicate identity groups; common C, C++, Dart, Java, and Kotlin packages collapse together under unknown/<basename>. Consume the shared discovery language-registry and duplicate-identity fixtures, classify exact package/program lane boundaries, preserve package versus program identity, exclude spec fixtures, and fail closed on residual duplicate qualified names in a separate focused slice."
+    },
+    {
       "id": "build-tool-go-rockspec-utf8-conformance",
       "title": "Make the Go build tool enforce strict UTF-8 rockspec metadata",
       "status": "merged",

--- a/code/programs/typescript/build-tool/CHANGELOG.md
+++ b/code/programs/typescript/build-tool/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the TypeScript build tool will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Decode Lua rockspec metadata as strict UTF-8 and fail closed with the portable
+  `METADATA_INVALID_UTF8` diagnostic and CLI exit code 2 for malformed input.
+- Consume the shared positive and invalid UTF-8 resolver fixtures, including a
+  real CLI subprocess test and a regression guard for valid literal U+FFFD text.
+
 ## [1.1.0] - 2026-03-22
 
 ### Added

--- a/code/programs/typescript/build-tool/README.md
+++ b/code/programs/typescript/build-tool/README.md
@@ -25,7 +25,8 @@ This is one of several build tool implementations in the monorepo (Python, Ruby,
 
 ## Supported languages
 
-The resolver can parse dependencies for all 6 languages in the monorepo:
+The resolver parses package-manager metadata for the established monorepo lanes,
+including:
 
 - **Python**: `pyproject.toml` (`coding-adventures-*` prefix)
 - **Ruby**: `.gemspec` (`coding_adventures_*` prefix)
@@ -33,6 +34,14 @@ The resolver can parse dependencies for all 6 languages in the monorepo:
 - **TypeScript**: `package.json` (`@coding-adventures/*` scoped names)
 - **Rust**: `Cargo.toml` (crate names with path dependencies)
 - **Elixir**: `mix.exs` (`coding_adventures_*` atom names)
+- **Lua**: `.rockspec` files (`coding-adventures-*` rock names)
+- **Perl**: `Makefile.PL` / `cpanfile` package references
+- **Haskell**: Cabal package dependencies
+- **.NET**: C# and F# project references
+
+Lua rockspecs are decoded as strict UTF-8. Malformed metadata fails closed with
+the stable `METADATA_INVALID_UTF8` diagnostic and CLI exit code 2; a valid
+literal U+FFFD replacement character remains valid UTF-8.
 
 ## Platform-specific BUILD files
 
@@ -69,8 +78,8 @@ npx tsx src/index.ts --language python
 ## Development
 
 ```bash
-# Install dependencies
-npm install
+# Install pinned development dependencies
+npm ci
 
 # Run tests
 npx vitest run
@@ -82,6 +91,7 @@ npx vitest run --coverage
 ## Design decisions
 
 - **Zero runtime dependencies**: Only uses Node.js built-in modules (`node:fs`, `node:path`, `node:crypto`, `node:child_process`, `node:os`, `node:util`).
+- **Portable metadata diagnostics**: Strict-decoding failures use repository-relative paths and never expose checkout-specific host paths.
 - **Inline directed graph**: Rather than importing an external graph library, the resolver includes a minimal DirectedGraph implementation.
 - **ESM-only**: Uses ES modules throughout (`"type": "module"` in package.json).
 - **Literate programming**: All source files include extensive comments explaining concepts, algorithms, and design decisions.

--- a/code/programs/typescript/build-tool/package-lock.json
+++ b/code/programs/typescript/build-tool/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",
+        "tsx": "^4.23.5",
         "vitest": "^4.1.0"
       }
     },
@@ -101,6 +102,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -626,6 +1069,48 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1237,6 +1722,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.16",

--- a/code/programs/typescript/build-tool/package.json
+++ b/code/programs/typescript/build-tool/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.0",
+    "tsx": "^4.23.5",
     "vitest": "^4.1.0"
   }
 }

--- a/code/programs/typescript/build-tool/src/index.ts
+++ b/code/programs/typescript/build-tool/src/index.ts
@@ -40,7 +40,7 @@ import {
   analyzeCIWorkflowChanges,
   sortedToolchains,
 } from "./ci-workflow.js";
-import { resolveDependencies } from "./resolver.js";
+import { MetadataEncodingError, resolveDependencies } from "./resolver.js";
 import { getChangedFiles, mapFilesToPackages } from "./gitdiff.js";
 import { hashPackage, hashDeps } from "./hasher.js";
 import { BuildCache } from "./cache.js";
@@ -404,4 +404,12 @@ Options:
 // Run the CLI.
 main().then((code) => {
   process.exit(code);
+}).catch((error: unknown) => {
+  if (error instanceof MetadataEncodingError) {
+    console.error(error.message);
+    process.exit(2);
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Error: ${message}`);
+  process.exit(1);
 });

--- a/code/programs/typescript/build-tool/src/resolver.ts
+++ b/code/programs/typescript/build-tool/src/resolver.ts
@@ -58,6 +58,30 @@ import * as fs from "node:fs";
 import * as nodePath from "node:path";
 import type { Package } from "./discovery.js";
 
+/** Stable diagnostic for metadata that is not valid UTF-8. */
+export class MetadataEncodingError extends Error {
+  readonly code: string;
+  readonly package: string;
+  readonly manifest: string;
+  readonly encoding: string;
+
+  constructor(
+    code: string,
+    packageName: string,
+    manifest: string,
+    encoding: string,
+  ) {
+    super(
+      `${code}: package=${packageName} manifest=${manifest} encoding=${encoding}`,
+    );
+    this.name = "MetadataEncodingError";
+    this.code = code;
+    this.package = packageName;
+    this.manifest = manifest;
+    this.encoding = encoding;
+  }
+}
+
 // ===========================================================================
 // DirectedGraph -- Inline Minimal Implementation
 // ===========================================================================
@@ -694,12 +718,28 @@ function parseLuaDeps(
     return [];
   }
 
-  const rockspecFile = entries.find((e) => e.endsWith(".rockspec"));
+  const rockspecFile = entries.filter((e) => e.endsWith(".rockspec")).sort()[0];
   if (!rockspecFile) {
     return [];
   }
 
-  const text = fs.readFileSync(nodePath.join(pkg.path, rockspecFile), "utf-8");
+  const rockspecPath = nodePath.join(pkg.path, rockspecFile);
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(
+      fs.readFileSync(rockspecPath),
+    );
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new MetadataEncodingError(
+        "METADATA_INVALID_UTF8",
+        pkg.name,
+        repositoryManifestPath(rockspecPath),
+        "UTF-8",
+      );
+    }
+    throw error;
+  }
   const internalDeps: string[] = [];
 
   // Strategy: scan line by line for the dependencies block,
@@ -737,6 +777,23 @@ function parseLuaDeps(
   }
 
   return internalDeps;
+}
+
+/** Return a stable repository-relative metadata path without host details. */
+function repositoryManifestPath(manifestPath: string): string {
+  const parts = manifestPath.replaceAll("\\", "/").split("/");
+  let canonicalStart = -1;
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    if (
+      parts[index] === "code"
+      && (parts[index + 1] === "packages" || parts[index + 1] === "programs")
+    ) {
+      canonicalStart = index;
+    }
+  }
+  return canonicalStart >= 0
+    ? parts.slice(canonicalStart).join("/")
+    : nodePath.basename(manifestPath);
 }
 
 // ===========================================================================

--- a/code/programs/typescript/build-tool/tests/resolver.test.ts
+++ b/code/programs/typescript/build-tool/tests/resolver.test.ts
@@ -15,12 +15,15 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import {
   DirectedGraph,
+  MetadataEncodingError,
   resolveDependencies,
   buildKnownNames,
 } from "../src/resolver.js";
-import type { Package } from "../src/discovery.js";
+import { discoverPackages, type Package } from "../src/discovery.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -45,6 +48,63 @@ function makePkg(
   language: string,
 ): Package {
   return { name, path: pkgPath, buildCommands: ["echo test"], language };
+}
+
+interface SharedResolutionFixture {
+  workspace: {
+    files: Array<{
+      path: string;
+      content_utf8?: string;
+      content_base64?: string;
+    }>;
+  };
+  expected: {
+    outcome: "ok" | "error";
+    result: { edges?: string[][] };
+    diagnostics: Array<{
+      code: string;
+      path: string;
+      package: string;
+      details: { encoding: string };
+    }>;
+  };
+  limits: { wall_time_ms: number };
+}
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const sharedFixtureRoot = fileURLToPath(
+  new URL("../../../../specs/fixtures/build-tool-v1/cases/", import.meta.url),
+);
+
+function loadSharedResolutionFixture(name: string): SharedResolutionFixture {
+  return JSON.parse(
+    fs.readFileSync(path.join(sharedFixtureRoot, name), "utf-8"),
+  ) as SharedResolutionFixture;
+}
+
+function materializeSharedResolutionFixture(
+  fixture: SharedResolutionFixture,
+): { root: string; packages: Package[] } {
+  const root = makeTempDir();
+  fs.mkdirSync(path.join(root, ".git"));
+  for (const file of fixture.workspace.files) {
+    const destination = path.join(root, ...file.path.split("/"));
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    const content = file.content_base64 === undefined
+      ? Buffer.from(file.content_utf8 ?? "", "utf-8")
+      : Buffer.from(file.content_base64, "base64");
+    fs.writeFileSync(destination, content);
+  }
+  return {
+    root,
+    packages: discoverPackages(path.join(root, "code")),
+  };
+}
+
+function graphEdges(graph: DirectedGraph): string[][] {
+  return graph.nodes()
+    .flatMap((from) => graph.successors(from).map((to) => [from, to]))
+    .sort((left, right) => left.join("\0").localeCompare(right.join("\0")));
 }
 
 // ---------------------------------------------------------------------------
@@ -334,6 +394,93 @@ describe("resolveDependencies", () => {
 
   afterEach(() => {
     rmDir(tmpDir);
+  });
+
+  it.each([
+    "resolution-lua-utf8.json",
+    "resolution-lua-invalid-utf8.json",
+  ])("consumes shared Lua UTF-8 fixture %s", (fixtureName) => {
+    const fixture = loadSharedResolutionFixture(fixtureName);
+    const materialized = materializeSharedResolutionFixture(fixture);
+    try {
+      if (fixture.expected.outcome === "ok") {
+        expect(graphEdges(resolveDependencies(materialized.packages))).toEqual(
+          (fixture.expected.result.edges ?? []).sort((left, right) =>
+            left.join("\0").localeCompare(right.join("\0"))
+          ),
+        );
+        return;
+      }
+
+      const diagnostic = fixture.expected.diagnostics[0];
+      let caught: unknown;
+      try {
+        resolveDependencies(materialized.packages);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(MetadataEncodingError);
+      const encodingError = caught as MetadataEncodingError;
+      expect(encodingError.code).toBe(diagnostic.code);
+      expect(encodingError.package).toBe(diagnostic.package);
+      expect(encodingError.manifest).toBe(diagnostic.path);
+      expect(encodingError.encoding).toBe(diagnostic.details.encoding);
+      expect(encodingError.message).toBe(
+        `${diagnostic.code}: package=${diagnostic.package} manifest=${diagnostic.path} encoding=${diagnostic.details.encoding}`,
+      );
+      expect(encodingError.message).not.toContain(materialized.root);
+    } finally {
+      rmDir(materialized.root);
+    }
+  });
+
+  it("accepts a valid literal replacement character in Lua metadata", () => {
+    const pkgDir = path.join(tmpDir, "code", "packages", "lua", "pkg");
+    writeFile(path.join(pkgDir, "BUILD"), "echo building\n");
+    writeFile(
+      path.join(pkgDir, "coding-adventures-pkg-0.1.0-1.rockspec"),
+      "package = \"coding-adventures-pkg\"\n-- valid literal: \uFFFD\ndependencies = {\n  \"lua >= 5.4\",\n}\n",
+    );
+
+    const graph = resolveDependencies(discoverPackages(path.join(tmpDir, "code")));
+    expect(graphEdges(graph)).toEqual([]);
+  });
+
+  it("real CLI returns exit 2 and the stable diagnostic for invalid UTF-8", () => {
+    const fixture = loadSharedResolutionFixture(
+      "resolution-lua-invalid-utf8.json",
+    );
+    const materialized = materializeSharedResolutionFixture(fixture);
+    try {
+      const tsxCli = path.join(packageRoot, "node_modules", "tsx", "dist", "cli.mjs");
+      const entrypoint = path.join(packageRoot, "src", "index.ts");
+      const result = spawnSync(
+        process.execPath,
+        [
+          tsxCli,
+          entrypoint,
+          "--root",
+          materialized.root,
+          "--force",
+          "--dry-run",
+          "--language",
+          "lua",
+        ],
+        {
+          encoding: "utf-8",
+          timeout: fixture.limits.wall_time_ms,
+        },
+      );
+      const diagnostic = fixture.expected.diagnostics[0];
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(2);
+      expect(result.stderr).toBe(
+        `${diagnostic.code}: package=${diagnostic.package} manifest=${diagnostic.path} encoding=${diagnostic.details.encoding}\n`,
+      );
+      expect(result.stderr).not.toContain(materialized.root);
+    } finally {
+      rmDir(materialized.root);
+    }
   });
 
   it("should resolve Python dependencies from pyproject.toml", () => {

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -238,6 +238,14 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   byte fixtures plus real CLI exit-2 coverage. TypeScript is the selected next
   dependency-shaped child because its replacement decoder cannot report
   malformed bytes faithfully;
+- make the TypeScript build-tool git-diff suite portable on Windows. The strict-
+  UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
+  POSIX-only `/repo` path fixtures; this is tracked as a separate test-
+  portability slice rather than widening the metadata decoder change;
+- align TypeScript build-tool discovery with the canonical language and identity
+  registry. Its real full plan currently emits 4,770 records but only 4,383
+  unique names, including 655 `unknown` records and 217 duplicate identity
+  groups that collapse C, C++, Dart, Java, Kotlin, and other lanes by basename;
 - make Swift build-tool file options recognize Windows drive-letter absolute
   paths. The UTF-8 validation run discovered that `--emit-plan` reaches
   resolution but then joins an absolute Windows path under the repository;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,10 +106,9 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `0455cea8` after
-merged PR #9548 added the mixed Rust AirGradient local integration and merged
-PR #9537 completed the Swift build-tool UTF-8 slice without creating another
-implementation package directory. The inventory contains
+working inventory was regenerated on August 2, 2026 from `0cbae0ca` after
+merged PR #9553 completed the Swift build-tool identity registry and subsequent
+merges added no implementation package directory. The inventory contains
 1,222 normalized implementation identities across 4,370 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
@@ -124,7 +123,7 @@ The loop must not start by attempting 10,780 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`0455cea8e0c0ddc078040ea109ea59dbaf8403fa` is collision-clean at 1,222
+`0cbae0ca3799671ca7db79e92c5f38b957c2c27e` is collision-clean at 1,222
 normalized implementation identities, 4,370 implementation slots, 172
 high-consensus packages, 271 high-consensus missing slots, 772 singletons, 577
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
@@ -236,16 +235,18 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   is tracked separately from the Python full-scan blocker. Merged PR #9504
   completed the Go operational-oracle child, and merged PR #9510 completed
   Rust. Merged PR #9537 completed Swift with exact shared success and invalid-
-  byte fixtures plus real CLI exit-2 coverage;
+  byte fixtures plus real CLI exit-2 coverage. TypeScript is the selected next
+  dependency-shaped child because its replacement decoder cannot report
+  malformed bytes faithfully;
 - make Swift build-tool file options recognize Windows drive-letter absolute
   paths. The UTF-8 validation run discovered that `--emit-plan` reaches
   resolution but then joins an absolute Windows path under the repository;
   cover `--emit-plan`, `--plan-file`, and `--cache-file` in a separate slice;
 - align Swift build-tool discovery with the canonical language and identity
-  registry. Its full release plan currently emits 4,768 entries but only 4,594
-  unique names, including 143 duplicate identity groups and 397 `unknown`
-  entries. This is the selected post-UTF-8 child; consume the shared registry
-  and duplicate-identity fixtures without widening into file-option handling;
+  registry. Merged PR #9553 consumes the shared registry and duplicate-identity
+  fixtures; its full release plan emits 4,768 unique identities, zero duplicate
+  groups, and only the intentional language-neutral `unknown/blog`, without
+  widening into file-option handling;
 - merged PR #9521 makes the Rust build tool reject resolver self-edges with a
   stable diagnostic and preserves distinct package/program identities for
   `elixir/grammar_tools`;


### PR DESCRIPTION
## Summary

- decode Lua rockspec metadata with fatal UTF-8 semantics before parsing
- return a typed, repository-relative `METADATA_INVALID_UTF8` diagnostic without host-path leakage
- map malformed metadata to CLI exit code 2 while accepting a valid literal U+FFFD character
- bind the resolver and a real `tsx` CLI subprocess to the shared positive and invalid-byte fixtures
- record separately discovered TypeScript Windows git-diff and discovery-identity parity gaps without widening this slice

## Validation

- `npx vitest run tests/resolver.test.ts` — 47 passed
- `npx vitest run --exclude tests/gitdiff.test.ts` — 266 passed across the other 11 files
- focused resolver coverage — 85.37% statements, 74.66% branches, 91.89% functions, 85.40% lines
- production esbuild bundle plus bundled CLI `--help` — passed
- shared schema tests — 17 passed plus 15 subtests
- shared runner tests — 40 passed plus 37 subtests
- corpus validation — 36 cases / 55 files / 15 established languages / 16 implementations, valid
- real Lua dry run — 258/258 packages, exit 0
- real full plan — 4,770 records and 7,623 dependency edges
- collision-checked parity inventory — 1,222 implementation identities, 4,370 slots, 0 collisions, 0 unknown inventory buckets
- `npm ci`, `npm audit`, and `npm audit --omit=dev` — 0 vulnerabilities
- JSON parsing, `git diff --check`, scoped diff audit, and secret-pattern scan — passed
- BUILD validation reproduced only the existing 10 separately owned Lua `BUILD_windows` debt items

## Known baseline outside this slice

The full package suite on Windows reproduces seven pre-existing `gitdiff.test.ts` portability failures: two hard-coded `/bin/sh` invocations and five POSIX-only `/repo` path fixtures. The resolver and all other package tests pass. This is logged as `build-tool-typescript-windows-gitdiff-portability` for a separate focused parity PR.

The full plan also reports 655 `unknown` records and 217 duplicate identity groups. That existing discovery-registry gap is logged separately as `build-tool-typescript-language-identity-registry`.
