### PR TITLE
feat(smart-home): stream HEOS change events

### DIFF
--- a/code/packages/rust/smart-home-heos-cli-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-heos-cli-integration/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.2.0
+
+- Add bounded HEOS change-event registration and collection over a dedicated
+  production TCP connection.
+- Normalize unsolicited player state, volume, mute, progress, repeat, shuffle,
+  topology, queue, and playback-error frames into D23 events.
+- Require D23 subscribe authorization before event transport I/O and prove the
+  registration and event path with a real loopback connection.
+
 ## 0.1.0
 
 - Add verified HEOS SSDP and manual host discovery.

--- a/code/packages/rust/smart-home-heos-cli-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-heos-cli-integration/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smart-home-heos-cli-integration"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "HEOS CLI discovery and read-only player inspection for the smart-home runtime"
+description = "HEOS CLI discovery, player inspection, and change events for the smart-home runtime"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/smart-home-heos-cli-integration/README.md
+++ b/code/packages/rust/smart-home-heos-cli-integration/README.md
@@ -1,6 +1,6 @@
 # smart-home-heos-cli-integration
 
-First-party, read-only HEOS CLI integration for D23.
+First-party HEOS CLI inspection and change-event integration for D23.
 
 It discovers Denon and Marantz HEOS systems through their documented SSDP
 search target or accepts a manual host. A bounded TCP client connects to port
@@ -8,8 +8,14 @@ search target or accepts a manual host. A bounded TCP client connects to port
 and mute state for each player before installing normalized D23 devices and
 entities. Authorization is checked before any socket I/O.
 
-The slice intentionally excludes HEOS account access, playback or volume
-commands, grouping, queue mutation, and change-event subscriptions.
+A separate bounded TCP connection can register for documented HEOS change
+events and project unsolicited player state, volume, mute, progress, repeat,
+shuffle, queue, topology, and playback-error frames into D23. Subscribe
+authorization is checked before the event socket is opened.
+
+The slice intentionally excludes HEOS account access and playback, volume,
+grouping, or queue mutation commands until D23 has explicit media command
+types and capability mappings.
 
 ```bash
 cargo run -p smart-home-heos-cli-integration -- discover

--- a/code/packages/rust/smart-home-heos-cli-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-heos-cli-integration/src/lib.rs
@@ -1,13 +1,13 @@
-//! HEOS CLI discovery and read-only player inspection for D23.
+//! HEOS CLI discovery, player inspection, and change events for D23.
 
 #![forbid(unsafe_code)]
 
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use smart_home_core::{
     AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode, Device,
-    DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId, Metadata, ProtocolFamily,
-    ProtocolIdentifier, SmartHomeTool, StateConfidence, StateSnapshot, StateSource, Value,
-    ValueKind,
+    DeviceEvent, DeviceEventType, DeviceId, Entity, EntityId, EntityKind, EventId, Health,
+    IntegrationId, Metadata, ProtocolFamily, ProtocolIdentifier, SmartHomeTool, StateConfidence,
+    StateDelta, StateSnapshot, StateSource, Value, ValueKind,
 };
 use smart_home_discovery::{
     DiscoveryConfidence, DiscoveryRecord, DiscoverySource, PairingRequirement,
@@ -21,13 +21,16 @@ use std::time::Duration;
 use udp_client::{send_to_and_collect, UdpDiscoveryEndpoint, UdpError, UdpOptions};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 pub const INTEGRATION_ID: &str = "heos";
 pub const PROTOCOL_ID: &str = "heos_cli";
 pub const SSDP_SEARCH_TARGET: &str = "urn:schemas-denon-com:device:ACT-Denon:1";
 pub const DEFAULT_PORT: u16 = 1255;
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
 pub const DEFAULT_MAX_PLAYERS: usize = 64;
+pub const DEFAULT_MAX_CHANGE_EVENTS: usize = 256;
+pub const REGISTER_CHANGE_EVENTS_COMMAND: &str =
+    "heos://system/register_for_change_events?enable=on";
 
 #[derive(Debug)]
 pub enum HeosError {
@@ -362,6 +365,122 @@ impl HeosTransport for HeosLanTransport {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeosChangeEvent {
+    pub command: String,
+    pub attributes: BTreeMap<String, String>,
+}
+
+impl HeosChangeEvent {
+    pub fn attribute(&self, name: &str) -> Option<&str> {
+        self.attributes.get(name).map(String::as_str)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeosChangeEventReport {
+    pub received_frames: usize,
+    pub applied_events: usize,
+    pub player_events: usize,
+    pub system_events: usize,
+}
+
+pub trait HeosChangeEventTransport {
+    fn register_and_collect(
+        &mut self,
+        host: &str,
+        port: u16,
+        timeout: Duration,
+        maximum_events: usize,
+    ) -> Result<Vec<JsonValue>, HeosError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct HeosLanChangeEventTransport {
+    pub maximum_response_bytes: usize,
+}
+
+impl Default for HeosLanChangeEventTransport {
+    fn default() -> Self {
+        Self {
+            maximum_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+        }
+    }
+}
+
+impl HeosLanChangeEventTransport {
+    pub fn with_maximum_response_bytes(mut self, maximum: usize) -> Self {
+        self.maximum_response_bytes = maximum.max(1);
+        self
+    }
+}
+
+impl HeosChangeEventTransport for HeosLanChangeEventTransport {
+    fn register_and_collect(
+        &mut self,
+        host: &str,
+        port: u16,
+        timeout: Duration,
+        maximum_events: usize,
+    ) -> Result<Vec<JsonValue>, HeosError> {
+        if maximum_events == 0 {
+            return Ok(Vec::new());
+        }
+        let mut stream = connect_tcp(host, port, timeout)?;
+        stream
+            .write_all(REGISTER_CHANGE_EVENTS_COMMAND.as_bytes())
+            .and_then(|_| stream.write_all(b"\r\n"))
+            .and_then(|_| stream.flush())
+            .map_err(|error| HeosError::Io(error.to_string()))?;
+
+        let mut reader = BufReader::new(stream);
+        let registration = read_bounded_line(&mut reader, self.maximum_response_bytes)?;
+        let registration_bytes = registration.len();
+        let registration: JsonValue = serde_json::from_slice(&registration)?;
+        successful_response(&registration, "system/register_for_change_events")?;
+
+        let mut remaining = self
+            .maximum_response_bytes
+            .saturating_sub(registration_bytes);
+        let mut events = Vec::with_capacity(maximum_events.min(DEFAULT_MAX_CHANGE_EVENTS));
+        while events.len() < maximum_events.min(DEFAULT_MAX_CHANGE_EVENTS) {
+            let Some(line) = read_optional_bounded_line(&mut reader, remaining)? else {
+                break;
+            };
+            remaining = remaining.saturating_sub(line.len());
+            events.push(serde_json::from_slice(&line)?);
+        }
+        Ok(events)
+    }
+}
+
+pub fn parse_change_event(value: &JsonValue) -> Result<HeosChangeEvent, HeosError> {
+    let heos = value
+        .get("heos")
+        .and_then(JsonValue::as_object)
+        .ok_or(HeosError::MissingField("heos"))?;
+    let command = required_string(heos, "command")?.trim().to_string();
+    if !command.starts_with("event/") {
+        return Err(HeosError::Validation(format!(
+            "expected HEOS change event, got {command}"
+        )));
+    }
+    let mut attributes = BTreeMap::new();
+    if let Some(message) = heos.get("message").and_then(JsonValue::as_str) {
+        for pair in message.split('&') {
+            if let Some((name, value)) = pair.split_once('=') {
+                if !name.trim().is_empty() {
+                    attributes.insert(name.trim().to_string(), decode_argument(value));
+                }
+            }
+        }
+    }
+    Ok(HeosChangeEvent {
+        command,
+        attributes,
+    })
+}
+
 pub struct HeosClient<T> {
     config: HeosConfig,
     transport: T,
@@ -464,6 +583,31 @@ impl<T: HeosTransport> HeosRuntimeIntegration<T> {
         let snapshot = self.client.inspect()?;
         install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)
     }
+
+    pub fn collect_and_apply_change_events_authorized<E: HeosChangeEventTransport>(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        event_transport: &mut E,
+        maximum_events: usize,
+        observed_at_ms: u64,
+        received_at_ms: u64,
+    ) -> Result<HeosChangeEventReport, HeosError> {
+        authorize_subscribe(runtime, principal_id, received_at_ms)?;
+        let frames = event_transport.register_and_collect(
+            &self.client.config.host,
+            self.client.config.port,
+            self.client.config.timeout,
+            maximum_events,
+        )?;
+        apply_change_event_frames(
+            runtime,
+            &self.client.config,
+            &frames,
+            observed_at_ms,
+            received_at_ms,
+        )
+    }
 }
 
 fn authorize_read(
@@ -481,6 +625,199 @@ fn authorize_read(
             tool,
             missing_capabilities: decision.missing_capabilities,
         }))
+    }
+}
+
+fn authorize_subscribe(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+) -> Result<(), HeosError> {
+    let tool = SmartHomeTool::Subscribe;
+    let decision = runtime.authorize_tool_for_principal(principal_id.clone(), tool, now_ms);
+    if decision.missing_capabilities.is_empty() {
+        Ok(())
+    } else {
+        Err(HeosError::Runtime(RuntimeError::UnauthorizedTool {
+            principal_id,
+            tool,
+            missing_capabilities: decision.missing_capabilities,
+        }))
+    }
+}
+
+pub fn apply_change_event_frames(
+    runtime: &mut SmartHomeRuntime,
+    config: &HeosConfig,
+    frames: &[JsonValue],
+    observed_at_ms: u64,
+    received_at_ms: u64,
+) -> Result<HeosChangeEventReport, HeosError> {
+    let mut report = HeosChangeEventReport {
+        received_frames: frames.len(),
+        applied_events: 0,
+        player_events: 0,
+        system_events: 0,
+    };
+    for (sequence, frame) in frames.iter().enumerate() {
+        let change = parse_change_event(frame)?;
+        let event =
+            device_event_from_change(config, &change, sequence, observed_at_ms, received_at_ms)?;
+        if event.entity_id.is_some() {
+            report.player_events += 1;
+        } else {
+            report.system_events += 1;
+        }
+        runtime.apply_device_event(event)?;
+        report.applied_events += 1;
+    }
+    Ok(report)
+}
+
+fn device_event_from_change(
+    config: &HeosConfig,
+    change: &HeosChangeEvent,
+    sequence: usize,
+    observed_at_ms: u64,
+    received_at_ms: u64,
+) -> Result<DeviceEvent, HeosError> {
+    let player_id = change.attribute("pid");
+    if change.command.starts_with("event/player_") && player_id.is_none() {
+        return Err(HeosError::MissingField("pid"));
+    }
+    let (device_id, entity_id) = if let Some(player_id) = player_id {
+        let native_id = stable_component(player_id);
+        if native_id.is_empty() {
+            return Err(HeosError::Validation(
+                "change event player id contains no stable identifier".to_string(),
+            ));
+        }
+        (
+            Some(DeviceId::trusted(format!("heos:{native_id}"))),
+            Some(EntityId::trusted(format!("heos:{native_id}:player"))),
+        )
+    } else {
+        (None, None)
+    };
+
+    let state_delta = change_event_state_delta(change)?;
+    let event_type = if change.command == "event/player_playback_error" {
+        DeviceEventType::Error
+    } else {
+        DeviceEventType::Updated
+    };
+    let mut metadata = vec![Metadata::new("heos.event_command", &change.command)];
+    for (name, value) in &change.attributes {
+        if name != "un" {
+            metadata.push(Metadata::new(format!("heos.event.{name}"), value));
+        }
+    }
+    if matches!(
+        change.command.as_str(),
+        "event/player_now_playing_changed"
+            | "event/player_queue_changed"
+            | "event/players_changed"
+            | "event/groups_changed"
+    ) {
+        metadata.push(Metadata::new("heos.refresh_required", "true"));
+    }
+
+    Ok(DeviceEvent {
+        event_id: EventId::trusted(format!(
+            "heos:{}:{observed_at_ms}:{received_at_ms}:{sequence}",
+            stable_component(&change.command)
+        )),
+        bridge_id: config.bridge_id.clone(),
+        device_id,
+        entity_id,
+        observed_at_ms,
+        received_at_ms,
+        event_type,
+        state_delta,
+        raw_ref: None,
+        correlation_id: None,
+        metadata,
+    })
+}
+
+fn change_event_state_delta(change: &HeosChangeEvent) -> Result<Option<StateDelta>, HeosError> {
+    let value = match change.command.as_str() {
+        "event/player_state_changed" => Value::Object(vec![(
+            "play_state".to_string(),
+            Value::Text(required_event_attribute(change, "state")?.to_string()),
+        )]),
+        "event/player_volume_changed" => {
+            let level = parse_event_percentage(change, "level")?;
+            Value::Object(vec![("volume".to_string(), Value::Percentage(level))])
+        }
+        "event/player_mute_changed" => Value::Object(vec![(
+            "muted".to_string(),
+            Value::Bool(parse_event_switch(change, "state")?),
+        )]),
+        "event/player_now_playing_progress" => Value::Object(vec![
+            (
+                "current_position_ms".to_string(),
+                Value::Integer(parse_event_integer(change, "cur_pos")?),
+            ),
+            (
+                "duration_ms".to_string(),
+                Value::Integer(parse_event_integer(change, "duration")?),
+            ),
+        ]),
+        "event/repeat_mode_changed" => Value::Object(vec![(
+            "repeat".to_string(),
+            Value::Text(required_event_attribute(change, "repeat")?.to_string()),
+        )]),
+        "event/shuffle_mode_changed" => Value::Object(vec![(
+            "shuffle".to_string(),
+            Value::Bool(parse_event_switch(change, "shuffle")?),
+        )]),
+        _ => return Ok(None),
+    };
+    if change.attribute("pid").is_none() {
+        return Err(HeosError::MissingField("pid"));
+    }
+    Ok(Some(StateDelta {
+        capability_id: CapabilityId::trusted("media.player_state"),
+        value,
+    }))
+}
+
+fn required_event_attribute<'a>(
+    change: &'a HeosChangeEvent,
+    name: &'static str,
+) -> Result<&'a str, HeosError> {
+    change
+        .attribute(name)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or(HeosError::MissingField(name))
+}
+
+fn parse_event_percentage(change: &HeosChangeEvent, name: &'static str) -> Result<u8, HeosError> {
+    let value = required_event_attribute(change, name)?;
+    value
+        .parse::<u8>()
+        .ok()
+        .filter(|value| *value <= 100)
+        .ok_or_else(|| HeosError::Validation(format!("invalid event {name} `{value}`")))
+}
+
+fn parse_event_integer(change: &HeosChangeEvent, name: &'static str) -> Result<i64, HeosError> {
+    let value = required_event_attribute(change, name)?;
+    value
+        .parse::<i64>()
+        .ok()
+        .filter(|value| *value >= 0)
+        .ok_or_else(|| HeosError::Validation(format!("invalid event {name} `{value}`")))
+}
+
+fn parse_event_switch(change: &HeosChangeEvent, name: &'static str) -> Result<bool, HeosError> {
+    match required_event_attribute(change, name)? {
+        "on" | "1" | "true" => Ok(true),
+        "off" | "0" | "false" => Ok(false),
+        value => Err(HeosError::Validation(format!(
+            "invalid event {name} `{value}`"
+        ))),
     }
 }
 
@@ -789,15 +1126,44 @@ fn connect_tcp(host: &str, port: u16, timeout: Duration) -> Result<TcpStream, He
 }
 
 fn read_bounded_line(reader: &mut dyn BufRead, maximum: usize) -> Result<Vec<u8>, HeosError> {
+    read_line_with_timeout(reader, maximum)?
+        .ok_or_else(|| HeosError::Io("connection closed before a complete response".to_string()))
+}
+
+fn read_optional_bounded_line(
+    reader: &mut dyn BufRead,
+    maximum: usize,
+) -> Result<Option<Vec<u8>>, HeosError> {
+    read_line_with_timeout(reader, maximum)
+}
+
+fn read_line_with_timeout(
+    reader: &mut dyn BufRead,
+    maximum: usize,
+) -> Result<Option<Vec<u8>>, HeosError> {
     let mut output = Vec::new();
     loop {
-        let available = reader
-            .fill_buf()
-            .map_err(|error| HeosError::Io(error.to_string()))?;
+        let available = match reader.fill_buf() {
+            Ok(available) => available,
+            Err(error)
+                if output.is_empty()
+                    && matches!(
+                        error.kind(),
+                        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                    ) =>
+            {
+                return Ok(None);
+            }
+            Err(error) => return Err(HeosError::Io(error.to_string())),
+        };
         if available.is_empty() {
-            return Err(HeosError::Io(
-                "connection closed before a complete response".to_string(),
-            ));
+            return if output.is_empty() {
+                Ok(None)
+            } else {
+                Err(HeosError::Io(
+                    "connection closed before a complete response".to_string(),
+                ))
+            };
         }
         let consumed = available
             .iter()
@@ -821,7 +1187,7 @@ fn read_bounded_line(reader: &mut dyn BufRead, maximum: usize) -> Result<Vec<u8>
                     "HEOS response line is empty".to_string(),
                 ));
             }
-            return Ok(output);
+            return Ok(Some(output));
         }
     }
 }
@@ -843,6 +1209,13 @@ mod tests {
         r#"{"heos":{"command":"player/get_volume","result":"success","message":"pid=1&level=27"}}"#;
     const MUTE: &str =
         r#"{"heos":{"command":"player/get_mute","result":"success","message":"pid=1&on=off"}}"#;
+    const CHANGE_EVENTS_REGISTERED: &str = r#"{"heos":{"command":"system/register_for_change_events","result":"success","message":"enable=on"}}"#;
+    const STATE_CHANGED: &str =
+        r#"{"heos":{"command":"event/player_state_changed","message":"pid=1&state=pause"}}"#;
+    const VOLUME_CHANGED: &str =
+        r#"{"heos":{"command":"event/player_volume_changed","message":"pid=1&level=42"}}"#;
+    const MUTE_CHANGED: &str =
+        r#"{"heos":{"command":"event/player_mute_changed","message":"pid=1&state=on"}}"#;
 
     fn write_responses(mut stream: TcpStream, responses: &[&str]) {
         let mut reader = BufReader::new(stream.try_clone().unwrap());
@@ -899,6 +1272,27 @@ mod tests {
     }
 
     #[test]
+    fn parses_change_events_and_normalizes_state_deltas() {
+        let volume: JsonValue = serde_json::from_str(VOLUME_CHANGED).unwrap();
+        let change = parse_change_event(&volume).unwrap();
+        assert_eq!(change.command, "event/player_volume_changed");
+        assert_eq!(change.attribute("pid"), Some("1"));
+        assert_eq!(
+            change_event_state_delta(&change).unwrap(),
+            Some(StateDelta {
+                capability_id: CapabilityId::trusted("media.player_state"),
+                value: Value::Object(vec![("volume".to_string(), Value::Percentage(42))]),
+            })
+        );
+
+        let invalid: JsonValue = serde_json::from_str(
+            r#"{"heos":{"command":"event/player_volume_changed","message":"pid=1&level=101"}}"#,
+        )
+        .unwrap();
+        assert!(change_event_state_delta(&parse_change_event(&invalid).unwrap()).is_err());
+    }
+
+    #[test]
     fn response_lines_are_bounded() {
         let mut input = Cursor::new(b"{\"ok\":true}\r\n".to_vec());
         assert_eq!(read_bounded_line(&mut input, 32).unwrap(), b"{\"ok\":true}");
@@ -925,6 +1319,22 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct CountingChangeEventTransport(Arc<AtomicUsize>);
+
+    impl HeosChangeEventTransport for CountingChangeEventTransport {
+        fn register_and_collect(
+            &mut self,
+            _host: &str,
+            _port: u16,
+            _timeout: Duration,
+            _maximum_events: usize,
+        ) -> Result<Vec<JsonValue>, HeosError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
+    }
+
     #[test]
     fn denied_read_reaches_no_transport() {
         let calls = Arc::new(AtomicUsize::new(0));
@@ -937,6 +1347,29 @@ mod tests {
             integration.inspect_and_install_authorized(
                 &mut SmartHomeRuntime::new(),
                 AgentId::trusted("agent:denied"),
+                10,
+            ),
+            Err(HeosError::Runtime(_))
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn denied_change_event_subscription_reaches_no_transport() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let client = HeosClient::new(
+            HeosConfig::new(BridgeId::trusted("heos:denied-events"), "127.0.0.1").unwrap(),
+            CountingTransport(Arc::new(AtomicUsize::new(0))),
+        );
+        let mut integration = HeosRuntimeIntegration::new(client);
+        let mut event_transport = CountingChangeEventTransport(Arc::clone(&calls));
+        assert!(matches!(
+            integration.collect_and_apply_change_events_authorized(
+                &mut SmartHomeRuntime::new(),
+                AgentId::trusted("agent:denied"),
+                &mut event_transport,
+                1,
+                10,
                 10,
             ),
             Err(HeosError::Runtime(_))
@@ -1005,6 +1438,90 @@ mod tests {
         );
         udp_handle.join().unwrap();
         tcp_handle.join().unwrap();
+    }
+
+    #[test]
+    fn loopback_change_event_subscription_updates_runtime() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut command = String::new();
+            reader.read_line(&mut command).unwrap();
+            assert_eq!(command.trim(), REGISTER_CHANGE_EVENTS_COMMAND);
+            for frame in [
+                CHANGE_EVENTS_REGISTERED,
+                STATE_CHANGED,
+                VOLUME_CHANGED,
+                MUTE_CHANGED,
+            ] {
+                write!(stream, "{frame}\r\n").unwrap();
+                stream.flush().unwrap();
+            }
+        });
+
+        let config = HeosConfig::new(BridgeId::trusted("heos:events"), "127.0.0.1")
+            .unwrap()
+            .with_port(address.port())
+            .with_timeout(Duration::from_secs(1));
+        let snapshot = HeosSnapshot {
+            players: vec![HeosPlayerSnapshot {
+                player: HeosPlayer {
+                    pid: "1".to_string(),
+                    name: "Living Room".to_string(),
+                    model: "HEOS 5".to_string(),
+                    version: "3.34.620".to_string(),
+                    network: Some("wired".to_string()),
+                    group_id: None,
+                },
+                play_state: "play".to_string(),
+                volume: 27,
+                muted: false,
+                now_playing: HeosNowPlaying::default(),
+            }],
+        };
+        let mut runtime = SmartHomeRuntime::new();
+        install_snapshot(&mut runtime, &config, &snapshot, 10).unwrap();
+        let principal = AgentId::trusted("agent:heos-events");
+        grant(&mut runtime, &principal);
+        let client = HeosClient::new(config, CountingTransport(Arc::new(AtomicUsize::new(0))));
+        let mut integration = HeosRuntimeIntegration::new(client);
+        let mut event_transport = HeosLanChangeEventTransport::default();
+        let report = integration
+            .collect_and_apply_change_events_authorized(
+                &mut runtime,
+                principal,
+                &mut event_transport,
+                3,
+                20,
+                21,
+            )
+            .unwrap();
+        assert_eq!(
+            report,
+            HeosChangeEventReport {
+                received_frames: 3,
+                applied_events: 3,
+                player_events: 3,
+                system_events: 0,
+            }
+        );
+        let events = runtime.registry().events().collect::<Vec<_>>();
+        assert_eq!(events.len(), 3);
+        assert_eq!(
+            events[0].state_delta.as_ref().unwrap().value,
+            Value::Object(vec![(
+                "play_state".to_string(),
+                Value::Text("pause".to_string())
+            )])
+        );
+        assert_eq!(events[2].event_type, DeviceEventType::Updated);
+        assert_eq!(
+            events[2].entity_id.as_ref().unwrap().as_str(),
+            "heos:1:player"
+        );
+        handle.join().unwrap();
     }
 
     #[test]

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## Unreleased
 
+- Upgraded HEOS CLI runtime coverage from polling-only inspection to local
+  push through authorized, bounded change-event subscriptions.
 - Added first-party HEOS CLI runtime coverage for SSDP/manual discovery and
   read-only player identity, playback, volume, mute, and media inspection.
 - Added a reusable TCP primitive family for bounded local stream protocols.

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45143,9 +45143,9 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         base_entry(
             "heos",
             "HEOS",
-            "Local Denon and Marantz HEOS CLI player discovery and read-only inspection.",
+            "Local Denon and Marantz HEOS CLI player discovery, inspection, and change events.",
             IntegrationCategory::CameraMedia,
-            ConnectivityClass::LocalPolling,
+            ConnectivityClass::LocalPush,
             ImplementationStatus::FirstPartyRuntime,
             2,
             "heos",
@@ -45166,7 +45166,7 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
             PrimitiveFamily::TestSimulator,
         ])
         .with_notes(&[
-            "Current runtime support is read-only; account access, media commands, grouping, queues, and change-event subscriptions remain separate work.",
+            "Current runtime support is read-only; account access and authorized media, grouping, and queue commands remain separate work.",
         ]),
         media_entry(
             "cast",
@@ -81114,7 +81114,7 @@ mod tests {
     }
 
     #[test]
-    fn heos_entry_exposes_ssdp_and_read_only_tcp_player_runtime() {
+    fn heos_entry_exposes_ssdp_and_read_only_tcp_push_runtime() {
         let catalog = first_party_catalog();
         let heos = find_entry(&catalog, &IntegrationId::trusted("heos")).unwrap();
 
@@ -81122,7 +81122,7 @@ mod tests {
             heos.implementation_status,
             ImplementationStatus::FirstPartyRuntime
         );
-        assert_eq!(heos.connectivity, ConnectivityClass::LocalPolling);
+        assert_eq!(heos.connectivity, ConnectivityClass::LocalPush);
         assert_eq!(heos.auth_modes, vec![AuthMode::None]);
         assert_eq!(
             heos.supported_protocols,

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -795,35 +795,50 @@ plugs, switches, and lights:
   over the production transport. This path accepts no cloud credentials and
   does not claim newer authenticated KLAP/Tapo devices.
 
+## Current HEOS Change Event Slice
+
+This slice upgrades the existing read-only HEOS inspection path to local push
+without inventing a media command model prematurely:
+
+- A dedicated bounded TCP connection registers through the documented
+  `system/register_for_change_events` command before collecting unsolicited
+  HEOS JSON frames.
+- Player state, volume, mute, progress, repeat, shuffle, queue, topology, and
+  playback-error events become normalized D23 device events with stable player
+  identity and refresh-required metadata where the protocol sends no payload.
+- D23 subscribe authorization is checked before the event socket opens.
+  Account usernames are excluded from event metadata.
+- A real loopback TCP test proves registration, event framing, parsing, and D23
+  runtime application over the production transport.
+
 ## Smart Home Remaining Work
 
-These items move toward retiring an existing Home Assistant install:
+The remaining backlog is ordered by the strongest executable production path
+and then by prerequisite readiness:
 
-- Continue platform integrations beyond Hue, MQTT, ONVIF, Shelly Gen2/Gen3,
-  WLED, Govee LAN, LIFX LAN, Kasa legacy LAN, authenticated Reolink CGI
-  device/channel/motion inspection, Roku ECP discovery and read-only device/app
-  inspection, Wemo UPnP discovery/state inspection/light-switch control,
-  Sonos UPnP discovery and read-only player-state inspection, Nanoleaf local
-  mDNS discovery, physical-presence token pairing, state inspection, and
-  verified light control, Tasmota native local HTTP discovery, optional
-  authenticated relay/light/sensor inspection, and verified control, Fronius
-  Solar API v1 local discovery and site/inverter power and energy telemetry,
-  HomeWizard Energy API v1 local discovery and device/utility telemetry, HEOS
-  SSDP discovery and read-only CLI player inspection, AirGradient local mDNS
-  identity and environmental telemetry, and the Z-Wave, Zigbee, and Matter
-  runtime adapters: ONVIF PullPoint camera
-  events, RTSP media transfer and recording,
-  Reolink and other vendor-specific camera/NVR media, recording, control, and
-  push-event integrations, authenticated KLAP/Tapo devices and other broader
-  device families, a production Matter
-  commissioning/secure-session/network host, a Thread border-router host, a
-  production Zigbee coordinator/join/security host, and production Z-Wave
-  inclusion and S2.
-- Prioritized follow-ups discovered while delivering the broader-device slices:
-  1. HEOS change-event subscriptions and authorized playback, volume, grouping,
-     and queue controls.
-  2. AirGradient authorized local configuration, LED/display control, and CO2
-     calibration, with cloud-controlled configuration conflicts kept explicit.
+1. Add explicit D23 media command types and capability mappings, then implement
+   authorized HEOS playback, volume, grouping, and queue controls over the
+   existing production TCP host.
+2. Add authorized AirGradient local configuration, LED/display control, and CO2
+   calibration while keeping cloud-controlled configuration conflicts explicit.
+3. Extend authenticated Reolink CGI support with concrete camera/NVR control,
+   media, recording, and push-event operations supported by the current host.
+4. Add another vendor-specific camera or NVR integration where authenticated
+   protocol and transport primitives are concrete.
+5. Add authenticated KLAP/Tapo devices and other broader-device families only
+   after their authentication and session prerequisites are concrete.
+6. Add ONVIF PullPoint events once a concrete event host and subscription
+   lifecycle exist.
+7. Add RTSP media transfer and recording once concrete media transfer and
+   recorder host primitives exist.
+8. Add a production Matter commissioning, secure-session, and network host only
+   after certificate, fabric, Interaction Model encoding, subscription, and
+   transport prerequisites exist.
+9. Add a Thread border-router host only after an actual host transport exists.
+10. Add a production Zigbee coordinator, join, and security host only after
+    concrete coordinator transport and security primitives exist.
+11. Add production Z-Wave inclusion and S2 only after concrete host transport
+    and security primitives exist.
 
 ## End-To-End Definition
 


### PR DESCRIPTION
## Summary
- add a bounded dedicated HEOS TCP event connection that registers with `system/register_for_change_events?enable=on`
- normalize player state, volume, mute, progress, repeat, shuffle, queue, topology, and playback-error frames into D23 events after subscribe authorization
- mark HEOS as local push, document the production boundary, and replace the loose remaining-work paragraph with one ordered backlog
- keep account identity out of event metadata and leave media controls pending explicit D23 media command types

Protocol reference: https://assets.denon.com/documentmaster/us/heos_cli_protocol_specification_290616.pdf

## Validation
- `bash smart-home-heos-cli-integration/BUILD` (9 tests, including real loopback TCP registration/event delivery)
- `bash smart-home-integration-catalog/BUILD` (327 tests)
- post-rebase focused HEOS BUILD and catalog HEOS test
- `cargo clippy -p smart-home-heos-cli-integration -p smart-home-integration-catalog --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`