### PR TITLE
test(venture): gate HTML web interactions

### DIFF
--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] - keep web test assets out of production
+
+- HTML and Web Component `.test.*` / `.spec.*` host assets are copied without
+  being injected as production page modules, matching the existing React host
+  asset rule.
+
 ## [Unreleased] - runnable host-surface shell acceptance
 
 - Compose Desktop project shells now resolve `node` slots from an optional

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -634,6 +634,13 @@ fn activate_react_host_asset(backend_dir: &Path, target_rel: &Path) -> Result<()
 }
 
 fn is_html_module_asset(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if file_name.contains(".test.") || file_name.contains(".spec.") {
+        return false;
+    }
+
     matches!(
         path.extension().and_then(|extension| extension.to_str()),
         Some("js") | Some("mjs")
@@ -2950,6 +2957,13 @@ files = [
             host_at < main_at,
             "host module should load before generated main.js"
         );
+    }
+
+    #[test]
+    fn html_test_host_assets_are_copied_without_production_activation() {
+        assert!(!is_html_module_asset(Path::new("test/grid-host.test.js")));
+        assert!(!is_html_module_asset(Path::new("test/grid-host.spec.mjs")));
+        assert!(is_html_module_asset(Path::new("host/grid-host.js")));
     }
 
     #[test]

--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -8,7 +8,7 @@ cross-platform proving application. Items are ordered by risk and dependency.
 - [x] **P0 — Web Component runtime output encoding.** Encode host-controlled text
   and attribute interpolation, reject executable dynamic link schemes, and
   constrain runtime CSS widths before adding a browser interaction gate.
-- [ ] **P1 — HTML and Web Component interaction acceptance.** Drive the generated
+- [x] **P1 — HTML and Web Component interaction acceptance.** Drive the generated
   browser controls through their real DOM and Custom Element host seams,
   covering disabled controls, address editing, Return, Go, and host-driven prop
   refresh. Keep both outputs sourced from the shared Venture MIL/MLL/MSL

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Add one package-owned jsdom interaction gate shared by the generated HTML
+  and Web Component targets, covering native disabled controls, address edit,
+  Return, Go, node-slot mounting, and host-driven prop refresh.
 - Add one package-owned React/Electron DOM interaction gate for native disabled
   controls, address editing, Return and Go dispatch, and host prop refresh.
 - Add direct generated Compose Desktop interaction acceptance for native

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -74,11 +74,14 @@ backend on the current machine:
 ```
 
 React and Electron run their production builds; HTML and Web Components run
-JavaScript syntax checks; SwiftUI, Qt, XAML, Flutter, and Compose invoke their
-native toolchains. React and Electron also run the same package-owned DOM
+JavaScript syntax checks plus one shared package-owned jsdom interaction gate;
+SwiftUI, Qt, XAML, Flutter, and Compose invoke their native toolchains. React
+and Electron also run the same package-owned DOM
 interaction gate against their shared generated renderer, covering disabled
 controls, address editing, Return, Go, and host-driven prop refresh. The
-Flutter gate additionally pumps the emitted `MosaicApp`
+HTML/Web Component gate drives each target's real host runtime, including
+disabled dispatch suppression, node-slot mounting, Return, Go, and
+`mosaic-host-ready` refresh. The Flutter gate additionally pumps the emitted `MosaicApp`
 with a recording host and drives the generated native controls, including
 disabled buttons, address editing, Return, Go, and host-driven prop refresh.
 The Qt gate runs the same contract through Qt Quick Test against the emitted

--- a/code/programs/mosaic/venture-browser/host/web/VentureChromeInteraction.test.js
+++ b/code/programs/mosaic/venture-browser/host/web/VentureChromeInteraction.test.js
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import test from "node:test";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { JSDOM } from "jsdom";
+
+const backend = existsSync(resolve("VentureChrome.js")) ? "webcomponent" : "html";
+
+test(`${backend} controls cross the Mosaic host seam`, async () => {
+  const source = readFileSync(resolve("index.html"), "utf8").replace(
+    /<script\b[^>]*>[\s\S]*?<\/script>|<script\b[^>]*\/?>/gi,
+    "",
+  );
+  const dom = new JSDOM(source, {
+    url: "https://venture.test/",
+    runScripts: "dangerously",
+  });
+  const installedGlobals = installDomGlobals(dom.window);
+
+  try {
+    const calls = [];
+    const contentSurface = document.createElement("div");
+    contentSurface.dataset.ventureHostSurface = backend;
+    let props = {
+      address: "https://venture.test/initial",
+      pageTitle: "Initial page",
+      statusText: "Ready from MosaicHost",
+      backDisabled: true,
+      forwardDisabled: false,
+      navigationDisabled: true,
+      contentSurface,
+    };
+
+    window.mosaicHost = {
+      async getProps() {
+        return { props };
+      },
+      async handleEvent(request) {
+        calls.push(request.event);
+        if (request.event.type === "addressChange") {
+          props = { ...props, address: request.event.value };
+        }
+        props = {
+          ...props,
+          statusText: `Handled ${request.event.type} through MosaicHost`,
+        };
+        return { props };
+      },
+    };
+
+    if (backend === "webcomponent") {
+      await importFresh("VentureChrome.js");
+    }
+    await importFresh("main.js");
+    await settle();
+
+    const root = findRoot();
+    let controls = readControls(root);
+    assert.equal(controls.back.disabled, true);
+    assert.equal(controls.forward.disabled, false);
+    assert.equal(controls.reload.disabled, true);
+    assert.equal(controls.go.disabled, true);
+    assert.equal(controls.address.readOnly, true);
+    assert.match(renderScope(root).textContent, /Ready from MosaicHost/);
+    assert.ok(root.querySelector(`[data-venture-host-surface="${backend}"]`));
+
+    controls.back.click();
+    controls.go.click();
+    await settle();
+    assert.deepEqual(calls, [], "disabled native buttons must suppress dispatch");
+
+    props = {
+      ...props,
+      backDisabled: false,
+      navigationDisabled: false,
+      statusText: "Enabled by mosaic-host-ready",
+    };
+    window.dispatchEvent(new Event("mosaic-host-ready"));
+    await settle();
+
+    controls = readControls(root);
+    assert.equal(controls.back.disabled, false);
+    assert.equal(controls.reload.disabled, false);
+    assert.equal(controls.go.disabled, false);
+    assert.equal(controls.address.readOnly, false);
+    assert.match(renderScope(root).textContent, /Enabled by mosaic-host-ready/);
+
+    const nextAddress = "https://venture.test/next";
+    controls.address.value = nextAddress;
+    controls.address.dispatchEvent(
+      new Event(backend === "html" ? "input" : "change", { bubbles: true }),
+    );
+    await settle();
+    assert.deepEqual(calls.at(-1), { type: "addressChange", value: nextAddress });
+    assert.match(renderScope(root).textContent, /Handled addressChange through MosaicHost/);
+
+    controls = readControls(root);
+    controls.address.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    await settle();
+    assert.equal(calls.at(-1)?.type, "navigate");
+
+    controls = readControls(root);
+    controls.go.click();
+    await settle();
+    assert.equal(calls.at(-1)?.type, "navigate");
+    assert.deepEqual(
+      calls.map(event => event.type),
+      ["addressChange", "navigate", "navigate"],
+    );
+    assert.match(renderScope(root).textContent, /Handled navigate through MosaicHost/);
+  } finally {
+    restoreDomGlobals(installedGlobals);
+    dom.window.close();
+  }
+});
+
+function findRoot() {
+  const root =
+    backend === "html"
+      ? document.querySelector('[data-mosaic-html-root="VentureChrome"]')
+      : document.querySelector("mos-venture-chrome");
+  assert.ok(root, `${backend} root must exist`);
+  return root;
+}
+
+function renderScope(root) {
+  return backend === "html" ? root : root.shadowRoot;
+}
+
+function readControls(root) {
+  const scope = renderScope(root);
+  assert.ok(scope, `${backend} render scope must exist`);
+  const buttons = new Map(
+    [...scope.querySelectorAll("button")].map(button => [button.textContent.trim(), button]),
+  );
+  const address = scope.querySelector("input");
+  assert.ok(address, "address input must exist");
+  for (const label of ["Back", "Forward", "Reload", "Go"]) {
+    assert.ok(buttons.has(label), `${label} button must exist`);
+  }
+  return {
+    back: buttons.get("Back"),
+    forward: buttons.get("Forward"),
+    reload: buttons.get("Reload"),
+    go: buttons.get("Go"),
+    address,
+  };
+}
+
+async function importFresh(file) {
+  const url = pathToFileURL(resolve(file));
+  url.searchParams.set("acceptance", `${backend}-${Date.now()}-${Math.random()}`);
+  await import(url.href);
+}
+
+async function settle() {
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 0));
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 0));
+}
+
+function installDomGlobals(windowObject) {
+  const names = [
+    "window",
+    "document",
+    "Node",
+    "Element",
+    "HTMLElement",
+    "customElements",
+    "CustomEvent",
+    "Event",
+    "KeyboardEvent",
+  ];
+  const previous = new Map();
+  for (const name of names) {
+    previous.set(name, globalThis[name]);
+    globalThis[name] = windowObject[name];
+  }
+  return previous;
+}
+
+function restoreDomGlobals(previous) {
+  for (const [name, value] of previous) {
+    if (value === undefined) {
+      delete globalThis[name];
+    } else {
+      globalThis[name] = value;
+    }
+  }
+}

--- a/code/programs/mosaic/venture-browser/host/web/package.json
+++ b/code/programs/mosaic/venture-browser/host/web/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "venture-browser-mosaic-web-acceptance",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/VentureChromeInteraction.test.js"
+  },
+  "devDependencies": {
+    "jsdom": "25.0.1"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/code/programs/mosaic/venture-browser/mosaic-package.toml
+++ b/code/programs/mosaic/venture-browser/mosaic-package.toml
@@ -16,6 +16,10 @@ files = [
   { backend = "compose", source = "host/compose/VentureChromeInteractionTest.kt", target = "src/test/kotlin/VentureChromeInteractionTest.kt" },
   { backend = "react", source = "host/react/VentureChromeInteraction.test.tsx", target = "src/VentureChromeInteraction.test.tsx" },
   { backend = "electron", source = "host/react/VentureChromeInteraction.test.tsx", target = "src/VentureChromeInteraction.test.tsx" },
+  { backend = "html", source = "host/web/package.json", target = "package.json" },
+  { backend = "html", source = "host/web/VentureChromeInteraction.test.js", target = "test/VentureChromeInteraction.test.js" },
+  { backend = "webcomponent", source = "host/web/package.json", target = "package.json" },
+  { backend = "webcomponent", source = "host/web/VentureChromeInteraction.test.js", target = "test/VentureChromeInteraction.test.js" },
 ]
 
 [kernel]

--- a/code/programs/mosaic/venture-browser/scripts/build-all.ps1
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.ps1
@@ -123,6 +123,22 @@ if (Test-Command "node") {
     } finally {
         Pop-Location
     }
+
+    foreach ($backend in @("html", "webcomponent")) {
+        if (-not (Test-Command "npm")) {
+            Skip-Backend -Backend $backend -Reason "npm is not installed"
+            continue
+        }
+        Write-Host "==> Testing $backend interactions"
+        Push-Location (Join-Path $outputRoot $backend)
+        try {
+            Invoke-Checked -Command "npm" -Arguments @("install", "--ignore-scripts")
+            Invoke-Checked -Command "npm" -Arguments @("test")
+            Invoke-Checked -Command "npm" -Arguments @("audit", "--audit-level=high")
+        } finally {
+            Pop-Location
+        }
+    }
 } else {
     Skip-Backend -Backend "html" -Reason "node is not installed"
     Skip-Backend -Backend "webcomponent" -Reason "node is not installed"

--- a/code/programs/mosaic/venture-browser/scripts/build-all.sh
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.sh
@@ -120,6 +120,21 @@ build_node_project() {
 build_node_project react
 build_node_project electron
 
+test_web_project() {
+  local backend="$1"
+  if ! has_command npm; then
+    skip_backend "$backend" "npm is not installed"
+    return
+  fi
+  echo "==> Testing $backend interactions"
+  (
+    cd "$output_root/$backend"
+    npm install --ignore-scripts
+    npm test
+    npm audit --audit-level=high
+  )
+}
+
 if has_command node; then
   echo "==> Checking html"
   (cd "$output_root/html" && node --check main.js)
@@ -130,6 +145,8 @@ if has_command node; then
     node --check index.js
     node --check main.js
   )
+  test_web_project html
+  test_web_project webcomponent
 else
   skip_backend html "node is not installed"
   skip_backend webcomponent "node is not installed"

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -89,7 +89,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     let package = mosaic_package_manifest::parse(&manifest).expect("parse manifest");
     assert_eq!(package.package.name, "venture-browser");
     assert_eq!(package.components.exports, ["VentureChrome"]);
-    assert_eq!(package.host_assets.files.len(), 7);
+    assert_eq!(package.host_assets.files.len(), 11);
     assert_eq!(package.host_assets.files[0].backend, "swiftui");
     assert_eq!(
         package.host_assets.files[0].target,
@@ -140,6 +140,27 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     }
     assert_eq!(package.host_assets.files[5].backend, "react");
     assert_eq!(package.host_assets.files[6].backend, "electron");
+    for index in [7, 9] {
+        assert_eq!(
+            package.host_assets.files[index].source,
+            "host/web/package.json"
+        );
+        assert_eq!(package.host_assets.files[index].target, "package.json");
+    }
+    for index in [8, 10] {
+        assert_eq!(
+            package.host_assets.files[index].source,
+            "host/web/VentureChromeInteraction.test.js"
+        );
+        assert_eq!(
+            package.host_assets.files[index].target,
+            "test/VentureChromeInteraction.test.js"
+        );
+    }
+    assert_eq!(package.host_assets.files[7].backend, "html");
+    assert_eq!(package.host_assets.files[8].backend, "html");
+    assert_eq!(package.host_assets.files[9].backend, "webcomponent");
+    assert_eq!(package.host_assets.files[10].backend, "webcomponent");
 
     let host = read_package_file("host/swiftui/MosaicHost.swift");
     for symbol in [
@@ -275,8 +296,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         );
     }
 
-    let flutter_acceptance =
-        read_package_file("host/flutter/venture_chrome_interaction_test.dart");
+    let flutter_acceptance = read_package_file("host/flutter/venture_chrome_interaction_test.dart");
     for symbol in [
         "MosaicApp(mosaicHost: host)",
         "disabled native controls suppress Mosaic dispatch",
@@ -305,8 +325,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         );
     }
 
-    let compose_acceptance =
-        read_package_file("host/compose/VentureChromeInteractionTest.kt");
+    let compose_acceptance = read_package_file("host/compose/VentureChromeInteractionTest.kt");
     for symbol in [
         "MosaicApp(host)",
         "disabledNativeControlsSuppressMosaicDispatch",
@@ -321,8 +340,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         );
     }
 
-    let react_acceptance =
-        read_package_file("host/react/VentureChromeInteraction.test.tsx");
+    let react_acceptance = read_package_file("host/react/VentureChromeInteraction.test.tsx");
     for symbol in [
         "React and Electron renderer controls cross the Mosaic host seam",
         "button.click()",
@@ -333,6 +351,20 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         assert!(
             react_acceptance.contains(symbol),
             "React/Electron interaction acceptance omits {symbol}"
+        );
+    }
+
+    let web_acceptance = read_package_file("host/web/VentureChromeInteraction.test.js");
+    for symbol in [
+        "controls cross the Mosaic host seam",
+        "disabled native buttons must suppress dispatch",
+        "mosaic-host-ready",
+        "addressChange",
+        "Handled navigate through MosaicHost",
+    ] {
+        assert!(
+            web_acceptance.contains(symbol),
+            "HTML/Web Component interaction acceptance omits {symbol}"
         );
     }
 }
@@ -370,6 +402,7 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "--emit-project",
         "npm run build",
         "npm test",
+        "npm audit --audit-level=high",
         "node --check",
         "swift build",
         "cargo \"${bridge_args[@]}\"",
@@ -388,6 +421,7 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "--emit-project",
         "npm",
         "@(\"test\")",
+        "@(\"audit\", \"--audit-level=high\")",
         "node",
         "swift",
         "venture-browser-macos",


### PR DESCRIPTION
## Summary
- add one package-owned jsdom interaction gate shared by generated HTML and Web Component Venture chrome
- drive disabled controls, address edits, Return, Go, node-slot mounting, and `mosaic-host-ready` refresh through each real generated host runtime
- keep `.test.*` and `.spec.*` web host assets out of production page activation and mark the prioritized acceptance backlog item complete

## Validation
- `cargo test -p mosaic-package-artifact-builder` (53 passed + doc test)
- `cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml` (3 passed)
- generated HTML: npm test (1 passed), npm audit --audit-level=high (0 vulnerabilities)
- generated Web Component: npm test (1 passed), npm audit --audit-level=high (0 vulnerabilities)
- generated production index/runtime files contain no interaction-test import
- POSIX and PowerShell build scripts parse successfully
- parser ratchets: tree upstream 1934 / local 2637 / missing 0; tokenizer upstream 6806 / local raw 7015 / missing 0; normalized 7242 / skipped 0

This closes the bounded web interaction gate in the Venture acceptance backlog. It is not a claim of complete Venture or HTML conformance.