### PR TITLE
feat(adj): expose formula source byte spans

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.70.0] - 2026-08-02 - parser-backed formula source maps
+
+- `formula_source_map` inventories every parsed formulabook entry in source order and returns
+  the real typed `FormulaDef` beside exact half-open UTF-8 byte spans for its declaration and
+  final executable body.
+- The mapper pairs generic grammar-tree nodes with typed adapter output and fails closed on
+  formula-boundary, order, count, or name disagreement, so provenance tooling never falls back
+  to regex discovery.
+- Span recovery handles Unicode prefixes, multi-step formula bodies, and escaped quoted math
+  without normalizing or re-encoding the caller's bytes.
+
 ## [0.69.0] - 2026-08-02 - byte-grounded observed inputs
 
 - `observe` declarations now accept the standard provenance annotations, including exact

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.69.0"
+version = "0.70.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/README.md
+++ b/code/packages/rust/adj-lang/README.md
@@ -81,6 +81,16 @@ The frontend parses the string with the repo's LaTeX `MathFrontend` and lowers
 the supported arithmetic subset into the same expression tree as ASCII ADJ.
 Unsupported math is a compile error, not a guessed rewrite.
 
+### Parser-backed formula source maps
+
+Provenance tooling can call `formula_source_map(source)` to inventory every formula with the
+same grammar and typed adapter used for execution. Each entry carries its `FormulaDef` plus
+half-open UTF-8 byte spans for the complete declaration and final executable body. Multi-step
+formulas point at the final expression, quoted math retains its exact source spelling, and any
+formula-boundary, order, count, or name disagreement is an error rather than a best-effort match.
+The source map is structural: import resolution, lowering, derivation replay, and execution
+coverage remain separate gates.
+
 ### Constraints — `symbol` / `constrain` / `solve` / `check` (v0.7)
 
 The model extracts the policy's **unknowns and constraints**; the engine solves

--- a/code/packages/rust/adj-lang/src/lib.rs
+++ b/code/packages/rust/adj-lang/src/lib.rs
@@ -54,8 +54,9 @@ mod _lexer_grammar;
 mod _parser_grammar;
 
 use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::{Token, TokenType};
 use logic_engine::Differential;
-use parser::grammar_parser::{GrammarParseError, GrammarParser};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode, GrammarParseError, GrammarParser};
 
 pub use adapter::{adapt_program, AdapterError};
 pub use ast::{Annotation, Define, DefineKind, OptDir, Program, RelOp, Statement, Term as AstTerm};
@@ -77,6 +78,39 @@ pub enum CompileError {
     Parse(GrammarParseError),
     Adapt(AdapterError),
     Lower(LowerError),
+}
+
+/// A half-open UTF-8 byte range in the exact source passed to [`parse`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// One formula as both the real typed AST and its exact source-byte envelope.
+///
+/// This is the parser-backed bridge used by provenance tooling. It avoids
+/// rediscovering formulas with regular expressions and pairs each typed formula
+/// with the parse-tree node that supplied its source envelope.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FormulaSource {
+    pub formulabook: String,
+    pub formula: ast::FormulaDef,
+    pub declaration_span: SourceSpan,
+    pub body_span: SourceSpan,
+}
+
+/// Failure to construct a trustworthy formula source map.
+#[derive(Debug)]
+pub enum FormulaSourceMapError {
+    Compile(CompileError),
+    Inconsistent(String),
+}
+
+impl From<CompileError> for FormulaSourceMapError {
+    fn from(error: CompileError) -> Self {
+        Self::Compile(error)
+    }
 }
 
 /// Recursion-depth cap for the adj-lang [`GrammarParser`] — see
@@ -129,9 +163,7 @@ pub enum CompileError {
 /// past any hand-written adj-lang program's real nesting.
 const MAX_RULE_DEPTH: usize = 90;
 
-/// Tokenize + parse + adapt: produce a typed [`Program`] from
-/// source text.
-pub fn parse(src: &str) -> Result<Program, CompileError> {
+fn parse_grammar_ast(src: &str) -> Result<GrammarASTNode, CompileError> {
     let token_grammar = _lexer_grammar::token_grammar();
     let mut grammar_lexer = GrammarLexer::new(src, &token_grammar);
     let tokens = grammar_lexer
@@ -140,8 +172,260 @@ pub fn parse(src: &str) -> Result<Program, CompileError> {
     let parser_grammar = _parser_grammar::parser_grammar();
     let mut grammar_parser =
         GrammarParser::new(tokens, parser_grammar).with_max_depth(MAX_RULE_DEPTH);
-    let ast = grammar_parser.parse().map_err(CompileError::Parse)?;
-    adapt_program(&ast).map_err(CompileError::Adapt)
+    grammar_parser.parse().map_err(CompileError::Parse)
+}
+
+/// Tokenize + parse + adapt: produce a typed [`Program`] from source text.
+pub fn parse(src: &str) -> Result<Program, CompileError> {
+    let tree = parse_grammar_ast(src)?;
+    adapt_program(&tree).map_err(CompileError::Adapt)
+}
+
+/// Parse one source and inventory every formula with exact UTF-8 byte spans.
+///
+/// The returned body span names only the final executable expression. For a
+/// multi-step formula it excludes the preceding `let` steps. Declaration spans
+/// include the formula's provenance annotations because those bytes are part of
+/// the authored claim. This inventory does not resolve imports, lower formulas,
+/// or prove that an external source expression is equivalent to the body; those
+/// remain separate validation stages.
+pub fn formula_source_map(src: &str) -> Result<Vec<FormulaSource>, FormulaSourceMapError> {
+    let tree = parse_grammar_ast(src)?;
+    let program = adapt_program(&tree).map_err(CompileError::Adapt)?;
+    let locator = SourceLocator::new(src);
+    let parsed_books = collect_nodes(&tree, "formulabook_decl");
+    let mut typed_books = Vec::new();
+    collect_typed_formulabooks(&program.statements, &mut typed_books);
+    if parsed_books.len() != typed_books.len() {
+        return Err(FormulaSourceMapError::Inconsistent(format!(
+            "parser found {} formulabooks but adapter produced {}",
+            parsed_books.len(),
+            typed_books.len()
+        )));
+    }
+
+    let mut inventory = Vec::new();
+    for (book_node, (book_name, formulas)) in parsed_books.into_iter().zip(typed_books) {
+        let parsed_name = direct_identifier_after(book_node, "formulabook").ok_or_else(|| {
+            FormulaSourceMapError::Inconsistent("formulabook name is absent".into())
+        })?;
+        if parsed_name != book_name {
+            return Err(FormulaSourceMapError::Inconsistent(format!(
+                "formulabook parse tree names {parsed_name} but adapter produced {book_name}"
+            )));
+        }
+        let formula_nodes = collect_nodes(book_node, "formula_decl");
+        if formula_nodes.len() != formulas.len() {
+            return Err(FormulaSourceMapError::Inconsistent(format!(
+                "formulabook {book_name} has {} parsed formulas but {} adapted formulas",
+                formula_nodes.len(),
+                formulas.len()
+            )));
+        }
+        for (formula_node, formula) in formula_nodes.into_iter().zip(formulas) {
+            let parsed_name =
+                direct_identifier_after(formula_node, "formula").ok_or_else(|| {
+                    FormulaSourceMapError::Inconsistent("formula name is absent".into())
+                })?;
+            if parsed_name != formula.name {
+                return Err(FormulaSourceMapError::Inconsistent(format!(
+                    "formula parse tree names {parsed_name} but adapter produced {}",
+                    formula.name
+                )));
+            }
+            let body_node = direct_child(formula_node, "formula_body")
+                .and_then(|body| direct_child(body, "expr"))
+                .ok_or_else(|| {
+                    FormulaSourceMapError::Inconsistent(format!(
+                        "formula {} has no final body expression",
+                        formula.name
+                    ))
+                })?;
+            inventory.push(FormulaSource {
+                formulabook: book_name.clone(),
+                formula: formula.clone(),
+                declaration_span: locator.node_span(formula_node)?,
+                body_span: locator.node_span(body_node)?,
+            });
+        }
+    }
+    Ok(inventory)
+}
+
+fn collect_nodes<'a>(node: &'a GrammarASTNode, rule_name: &str) -> Vec<&'a GrammarASTNode> {
+    let mut found = Vec::new();
+    for child in &node.children {
+        if let ASTNodeOrToken::Node(child) = child {
+            if child.rule_name == rule_name {
+                found.push(child);
+            } else {
+                found.extend(collect_nodes(child, rule_name));
+            }
+        }
+    }
+    found
+}
+
+fn collect_typed_formulabooks<'a>(
+    statements: &'a [ast::Statement],
+    found: &mut Vec<(&'a String, &'a Vec<ast::FormulaDef>)>,
+) {
+    for statement in statements {
+        match statement {
+            ast::Statement::Formulabook { name, formulas, .. } => found.push((name, formulas)),
+            ast::Statement::Rulebook { statements, .. } => {
+                collect_typed_formulabooks(statements, found);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn direct_child<'a>(node: &'a GrammarASTNode, rule_name: &str) -> Option<&'a GrammarASTNode> {
+    node.children.iter().find_map(|child| match child {
+        ASTNodeOrToken::Node(child) if child.rule_name == rule_name => Some(child),
+        _ => None,
+    })
+}
+
+fn direct_identifier_after<'a>(node: &'a GrammarASTNode, keyword: &str) -> Option<&'a str> {
+    node.children.iter().find_map(|child| match child {
+        ASTNodeOrToken::Token(token)
+            if token.type_ == TokenType::Name && token.value != keyword =>
+        {
+            Some(token.value.as_str())
+        }
+        _ => None,
+    })
+}
+
+fn first_token(node: &GrammarASTNode) -> Option<&Token> {
+    node.children.iter().find_map(|child| match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(child) => first_token(child),
+    })
+}
+
+fn last_token(node: &GrammarASTNode) -> Option<&Token> {
+    node.children.iter().rev().find_map(|child| match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(child) => last_token(child),
+    })
+}
+
+struct SourceLocator<'a> {
+    src: &'a str,
+    line_starts: Vec<usize>,
+}
+
+impl<'a> SourceLocator<'a> {
+    fn new(src: &'a str) -> Self {
+        let mut line_starts = vec![0];
+        line_starts.extend(src.match_indices('\n').map(|(offset, _)| offset + 1));
+        Self { src, line_starts }
+    }
+
+    fn node_span(&self, node: &GrammarASTNode) -> Result<SourceSpan, FormulaSourceMapError> {
+        let first = first_token(node).ok_or_else(|| {
+            FormulaSourceMapError::Inconsistent(format!("{} has no first token", node.rule_name))
+        })?;
+        let last = last_token(node).ok_or_else(|| {
+            FormulaSourceMapError::Inconsistent(format!("{} has no last token", node.rule_name))
+        })?;
+        let start = self.token_start(first)?;
+        let end = self.token_end(last)?;
+        if start >= end || end > self.src.len() {
+            return Err(FormulaSourceMapError::Inconsistent(format!(
+                "{} has invalid byte span {start}..{end}",
+                node.rule_name
+            )));
+        }
+        Ok(SourceSpan { start, end })
+    }
+
+    fn token_start(&self, token: &Token) -> Result<usize, FormulaSourceMapError> {
+        let line_index = token.line.checked_sub(1).ok_or_else(|| {
+            FormulaSourceMapError::Inconsistent("token line must be one-based".into())
+        })?;
+        let line_start = *self.line_starts.get(line_index).ok_or_else(|| {
+            FormulaSourceMapError::Inconsistent(format!(
+                "token line {} is outside the source",
+                token.line
+            ))
+        })?;
+        let line_end = self
+            .line_starts
+            .get(line_index + 1)
+            .map_or(self.src.len(), |next| next - 1);
+        let line = &self.src[line_start..line_end];
+        let column_offset = if token.column == 1 {
+            0
+        } else {
+            line.char_indices()
+                .nth(token.column - 1)
+                .map(|(offset, _)| offset)
+                .ok_or_else(|| {
+                    FormulaSourceMapError::Inconsistent(format!(
+                        "token column {} is outside source line {}",
+                        token.column, token.line
+                    ))
+                })?
+        };
+        Ok(line_start + column_offset)
+    }
+
+    fn token_end(&self, token: &Token) -> Result<usize, FormulaSourceMapError> {
+        let start = self.token_start(token)?;
+        let suffix = &self.src[start..];
+        let is_string = token.type_ == TokenType::String
+            || token
+                .type_name
+                .as_deref()
+                .is_some_and(|name| name.ends_with("STRING"));
+        if is_string {
+            return self.quoted_token_end(start);
+        }
+        if !suffix.starts_with(&token.value) {
+            return Err(FormulaSourceMapError::Inconsistent(format!(
+                "token {:?} does not match source byte {}",
+                token.value, start
+            )));
+        }
+        Ok(start + token.value.len())
+    }
+
+    fn quoted_token_end(&self, start: usize) -> Result<usize, FormulaSourceMapError> {
+        let suffix = &self.src[start..];
+        let quote = suffix
+            .chars()
+            .next()
+            .filter(|value| matches!(value, '\'' | '"'));
+        let Some(quote) = quote else {
+            return Err(FormulaSourceMapError::Inconsistent(format!(
+                "string token at byte {start} lacks a quote"
+            )));
+        };
+        let delimiter = if suffix.starts_with(&quote.to_string().repeat(3)) {
+            quote.to_string().repeat(3)
+        } else {
+            quote.to_string()
+        };
+        let mut escaped = false;
+        let mut cursor = delimiter.len();
+        while cursor < suffix.len() {
+            if !escaped && suffix[cursor..].starts_with(&delimiter) {
+                return Ok(start + cursor + delimiter.len());
+            }
+            let character = suffix[cursor..].chars().next().ok_or_else(|| {
+                FormulaSourceMapError::Inconsistent("string token ended unexpectedly".into())
+            })?;
+            cursor += character.len_utf8();
+            escaped = delimiter.len() == 1 && character == '\\' && !escaped;
+        }
+        Err(FormulaSourceMapError::Inconsistent(format!(
+            "string token at byte {start} is unterminated"
+        )))
+    }
 }
 
 /// Top-level convenience: source text → lowered program (KB +

--- a/code/packages/rust/adj-lang/tests/formula_source_map.rs
+++ b/code/packages/rust/adj-lang/tests/formula_source_map.rs
@@ -1,0 +1,199 @@
+use adj_lang::ast::{ArithOp, ExprAst};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+macro_rules! span_text {
+    ($source:expr, $span:expr) => {
+        &$source[$span.start..$span.end]
+    };
+}
+
+#[test]
+fn simple_formula_maps_exact_declaration_and_body_bytes() {
+    let src = "formulabook arithmetic {\n    formula add(a, b) = a + b\n}\n";
+
+    let formulas = adj_lang::formula_source_map(src).expect("valid formula book");
+
+    assert_eq!(formulas.len(), 1);
+    let mapped = &formulas[0];
+    assert_eq!(mapped.formulabook, "arithmetic");
+    assert_eq!(mapped.formula.name, "add");
+    assert_eq!(mapped.formula.params, ["a", "b"]);
+    assert_eq!(
+        span_text!(src, mapped.declaration_span),
+        "formula add(a, b) = a + b"
+    );
+    assert_eq!(span_text!(src, mapped.body_span), "a + b");
+    assert!(matches!(
+        &mapped.formula.body,
+        ExprAst::Bin(ArithOp::Add, lhs, rhs)
+            if matches!(lhs.as_ref(), ExprAst::Ref(name) if name == "a")
+                && matches!(rhs.as_ref(), ExprAst::Ref(name) if name == "b")
+    ));
+}
+
+#[test]
+fn multiple_formulas_preserve_source_order_and_exact_spans() {
+    let src = "formulabook arithmetic {\n\
+    formula subtract(a, b) = a - b\n\
+    formula divide(numerator, denominator) = numerator / denominator\n\
+}\n";
+
+    let formulas = adj_lang::formula_source_map(src).expect("valid formula book");
+
+    assert_eq!(formulas.len(), 2);
+    assert_eq!(formulas[0].formula.name, "subtract");
+    assert_eq!(formulas[1].formula.name, "divide");
+    assert!(formulas[0].declaration_span.start < formulas[1].declaration_span.start);
+    assert_eq!(
+        span_text!(src, formulas[0].declaration_span),
+        "formula subtract(a, b) = a - b"
+    );
+    assert_eq!(span_text!(src, formulas[0].body_span), "a - b");
+    assert_eq!(
+        span_text!(src, formulas[1].declaration_span),
+        "formula divide(numerator, denominator) = numerator / denominator"
+    );
+    assert_eq!(
+        span_text!(src, formulas[1].body_span),
+        "numerator / denominator"
+    );
+}
+
+#[test]
+fn multi_step_formula_body_span_selects_only_the_final_expression() {
+    let src = "formulabook staged {\n\
+    formula scaled_sum(a, b, scale) {\n\
+        let sum = a + b\n\
+        let scaled = sum * scale\n\
+        scaled / 2\n\
+    }\n\
+}\n";
+
+    let formulas = adj_lang::formula_source_map(src).expect("valid block formula");
+
+    assert_eq!(formulas.len(), 1);
+    let mapped = &formulas[0];
+    assert_eq!(mapped.formula.steps.len(), 2);
+    assert_eq!(
+        span_text!(src, mapped.declaration_span),
+        "formula scaled_sum(a, b, scale) {\n\
+        let sum = a + b\n\
+        let scaled = sum * scale\n\
+        scaled / 2\n\
+    }"
+    );
+    assert_eq!(span_text!(src, mapped.body_span), "scaled / 2");
+    assert!(matches!(
+        &mapped.formula.body,
+        ExprAst::Bin(ArithOp::Div, lhs, rhs)
+            if matches!(lhs.as_ref(), ExprAst::Ref(name) if name == "scaled")
+                && matches!(rhs.as_ref(), ExprAst::Lit(value) if *value == 2.0)
+    ));
+}
+
+#[test]
+fn unicode_before_formula_uses_utf8_byte_offsets() {
+    let src = "formulabook unicode_offsets {\n    % pi: \u{03c0}; snowman: \u{2603}\n    formula identity(x) = x\n}\n";
+
+    let formulas = adj_lang::formula_source_map(src).expect("valid Unicode source");
+
+    let mapped = &formulas[0];
+    let expected_start = src.find("formula identity").expect("formula declaration");
+    assert_eq!(mapped.declaration_span.start, expected_start);
+    assert_eq!(
+        span_text!(src, mapped.declaration_span),
+        "formula identity(x) = x"
+    );
+    assert_eq!(span_text!(src, mapped.body_span), "x");
+}
+
+#[test]
+fn escaped_quoted_latex_body_has_an_exact_span() {
+    let src =
+        "formulabook latex_math {\n    formula product(x, y) = latex \"$x \\\\times y$\"\n}\n";
+
+    let formulas = adj_lang::formula_source_map(src).expect("valid LaTeX formula");
+
+    let mapped = &formulas[0];
+    assert_eq!(
+        span_text!(src, mapped.declaration_span),
+        "formula product(x, y) = latex \"$x \\\\times y$\""
+    );
+    assert_eq!(
+        span_text!(src, mapped.body_span),
+        "latex \"$x \\\\times y$\""
+    );
+    assert!(matches!(
+        &mapped.formula.body,
+        ExprAst::Bin(ArithOp::Mul, lhs, rhs)
+            if matches!(lhs.as_ref(), ExprAst::Ref(name) if name == "x")
+                && matches!(rhs.as_ref(), ExprAst::Ref(name) if name == "y")
+    ));
+}
+
+#[test]
+fn malformed_input_returns_an_error() {
+    let src = "formulabook broken { formula missing_body(x) = }";
+
+    assert!(adj_lang::formula_source_map(src).is_err());
+}
+
+#[test]
+fn rulebook_contained_formulabook_is_mapped_like_the_lowerer_maps_it() {
+    let src = "rulebook outer {\n\
+    formulabook nested {\n\
+        formula identity(x) = x\n\
+            source \"identity definition\"\n\
+            trust authoritative\n\
+    }\n\
+}\n";
+
+    adj_lang::compile(src).expect("nested formulabook is executable after flattening");
+    let formulas = adj_lang::formula_source_map(src).expect("nested formulabook is mapped");
+
+    assert_eq!(formulas.len(), 1);
+    assert_eq!(formulas[0].formulabook, "nested");
+    assert_eq!(formulas[0].formula.name, "identity");
+    assert_eq!(span_text!(src, formulas[0].body_span), "x");
+}
+
+#[test]
+fn shipped_formula_corpus_has_exact_nested_spans() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../specs/data/adj-formula-stdlib");
+    let mut paths = Vec::new();
+    collect_adj_files(&root, &mut paths);
+    paths.sort();
+    let mut formula_count = 0;
+
+    for path in paths {
+        let src = fs::read_to_string(&path).expect("shipped ADJ source is UTF-8");
+        let mapped = adj_lang::formula_source_map(&src)
+            .unwrap_or_else(|error| panic!("{} did not map: {error:?}", path.display()));
+        for formula in mapped {
+            formula_count += 1;
+            assert!(formula.declaration_span.start <= formula.body_span.start);
+            assert!(formula.body_span.end <= formula.declaration_span.end);
+            assert!(!span_text!(src, formula.declaration_span).is_empty());
+            assert!(!span_text!(src, formula.body_span).is_empty());
+            assert!(span_text!(src, formula.declaration_span)
+                .starts_with(&format!("formula {}(", formula.formula.name)));
+        }
+    }
+
+    assert!(
+        formula_count >= 150,
+        "expected the shipped formula corpus, found {formula_count} formulas"
+    );
+}
+
+fn collect_adj_files(directory: &Path, paths: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(directory).expect("formula stdlib directory is readable") {
+        let path = entry.expect("valid directory entry").path();
+        if path.is_dir() {
+            collect_adj_files(&path, paths);
+        } else if path.extension().is_some_and(|extension| extension == "adj") {
+            paths.push(path);
+        }
+    }
+}

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -285,6 +285,10 @@ option mapping, or judge/evaluation failure.
     transform discards source bytes, its operations must partition the selected
     source span contiguously and bind every discarded range to one claim and an
     explicit reason.
+7h. **Complete:** expose a real-parser formula source map with the typed `ExprAst`
+    and exact half-open declaration/body byte spans. Provenance tooling can now
+    inventory parsed formula bodies without regex discovery or source normalization;
+    import resolution, lowering, semantic derivation, and execution remain separate gates.
 8. Replace the dead MathWorld `PercentageChange` locator before migrating
    `percent.adj`; a source returning 404 cannot ground that clause.
 9. Add executable formula preconditions or domain guards before migrating
@@ -297,6 +301,9 @@ option mapping, or judge/evaluation failure.
 12. Revisit `simple-interest.adj` with its variable/unit context, explicit
     rejection of contradicted page metadata, unit-bearing query facts, and a
     structured lowering from source notation to primitive operations.
+13. Add CAS `formula_derivation` and execution-witness objects on top of the
+    parser-backed source map, then enforce set equality across parsed exports,
+    replayed derivations, and fully verified query executions.
 
 ### Wave 2: complete K-8 foundations
 


### PR DESCRIPTION
## Summary
- add `formula_source_map` to pair each real parser-produced `FormulaDef` with exact half-open UTF-8 declaration and final-body byte spans
- preserve source order across top-level and rulebook-contained formulabooks, with a linear-time line index and fail-closed boundary/name checks
- exercise Unicode, escaped quoted math, multi-step bodies, malformed input, nested formulabooks, and the complete shipped formula corpus
- record the next CAS tranche: derivation objects, execution witnesses, and set equality across parsed exports, replayed derivations, and fully verified executions

## Why
The provenance framework could verify ADJ source bytes and replay computations, but it had no parser-backed inventory that tied each exported formula's typed expression to its exact authored body bytes. CAS derivation proofs would otherwise need regex discovery or normalized text, either of which can silently drift from what the engine actually parses.

This API is deliberately structural. It does not resolve imports, lower formulas, prove source-expression equivalence, or prove execution coverage; those remain separate gates in the logged next work item.

## Validation
- `cargo test --manifest-path code/packages/rust/adj-lang/Cargo.toml` (178 existing tests + 8 source-map tests)
- `cargo clippy --manifest-path code/packages/rust/adj-lang/Cargo.toml --all-targets -- -D warnings`
- targeted `rustfmt --check` with child-module traversal disabled
- `PYTHONPATH=code/scripts python -m unittest discover -s code/scripts/tests -p 'test_adj_stdlib_*.py'` (63 passed, 1 expected Windows skip)
- `python code/scripts/adj_stdlib_provenance.py verify` (6 bundles, 69 objects, 9 snapshots)
- `python code/scripts/adj_stdlib_manifest.py --validate-json-schema`
- `python code/scripts/adj_stdlib_report.py --format json --fail-on-unreferenced-tests`
- `git diff --check`

The repository-wide build-plan validator was also attempted locally. On Windows it fails on pre-existing `BUILD_windows` prerequisite debt in unrelated Python, Swift, and TypeScript packages; none of those files are changed here. GitHub's Linux detector is the authoritative build-plan gate for this PR.

## Review
An independent subagent found three P2 issues: nested rulebook formulabooks, overclaiming executable validation, and overclaiming semantic tree agreement. The implementation now traverses nested typed statements, adds an executable nested-formulabook test, and limits the contract to structural boundaries/order/count/names. Final re-review reported no remaining P1/P2 findings.