### PR TITLE
test(venture): gate generated shell entrypoints

### DIFF
--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -13,6 +13,9 @@ cross-platform proving application. Items are ordered by risk and dependency.
   covering disabled controls, address editing, Return, Go, and host-driven prop
   refresh. Keep both outputs sourced from the shared Venture MIL/MLL/MSL
   package.
+- [x] **P2 — CI entry-point coverage.** Route the authoritative POSIX and
+  Windows package build entry points through the shared generated-shell matrix
+  so backend interaction acceptance cannot be bypassed by package-level CI.
 
 ## Completed foundations
 

--- a/code/programs/mosaic/venture-browser/BUILD
+++ b/code/programs/mosaic/venture-browser/BUILD
@@ -1,2 +1,11 @@
-# Compile-check the shared Venture browser-chrome Mosaic package.
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_root"
+
+# Keep the package contract tests and the generated cross-platform shell matrix
+# behind the same authoritative entry point used by repository CI.
 cargo test
+./scripts/build-all.sh

--- a/code/programs/mosaic/venture-browser/BUILD_windows
+++ b/code/programs/mosaic/venture-browser/BUILD_windows
@@ -1,0 +1,2 @@
+@REM Mirror BUILD: package contract tests first, then the generated shell matrix.
+cargo test && powershell -NoProfile -ExecutionPolicy Bypass -File scripts\build-all.ps1

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Route the authoritative POSIX and Windows package build entry points through
+  the complete generated-shell acceptance matrix after Rust contract tests.
 - Add one package-owned jsdom interaction gate shared by the generated HTML
   and Web Component targets, covering native disabled controls, address edit,
   Return, Go, node-slot mounting, and host-driven prop refresh.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -73,6 +73,9 @@ backend on the current machine:
 .\scripts\build-all.ps1
 ```
 
+Repository package CI reaches those same scripts through `BUILD` on POSIX and
+`BUILD_windows` on Windows, after the Rust package-contract tests pass.
+
 React and Electron run their production builds; HTML and Web Components run
 JavaScript syntax checks plus one shared package-owned jsdom interaction gate;
 SwiftUI, Qt, XAML, Flutter, and Compose invoke their native toolchains. React

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -371,8 +371,18 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
 
 #[test]
 fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
+    let build = read_package_file("BUILD");
+    let build_windows = read_package_file("BUILD_windows");
     let shell = read_package_file("scripts/build-all.sh");
     let powershell = read_package_file("scripts/build-all.ps1");
+    assert!(
+        build.contains("./scripts/build-all.sh"),
+        "POSIX BUILD must execute the generated-shell matrix"
+    );
+    assert!(
+        build_windows.contains("scripts\\build-all.ps1"),
+        "Windows BUILD must execute the generated-shell matrix"
+    );
     let backends = [
         "react",
         "electron",


### PR DESCRIPTION
## Summary
- route the authoritative POSIX Venture package entrypoint through the shared generated-backend acceptance matrix
- add a Windows CMD entrypoint that invokes the shared PowerShell matrix
- ratchet both entrypoints in package contract tests and record the prioritized backlog item as completed

## Validation
- bash code/programs/mosaic/venture-browser/BUILD
  - Rust package contracts passed
  - React and Electron interaction tests and production builds passed
  - HTML and Web Component interaction tests and zero-high npm audits passed
  - macOS native bridge, SwiftUI, and Flutter builds/tests passed
  - XAML correctly deferred to Windows; Qt and Compose skipped because local toolchains were unavailable
- cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml
- cargo fmt --manifest-path code/programs/mosaic/venture-browser/Cargo.toml -- --check
- git diff --check
- exact HTML parser audit: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 local raw / 0 missing; 7242 normalized / 0 skipped

This is an acceptance-gate slice, not a claim of full browser conformance.