### PR TITLE
fix(spice): lower MOS electrostatic defaults

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate Level-1 MOS model-card `NSS` and `TPG` values, then lower `N_SUB` /
+  `TOX` electrostatic defaults through the shared engine model-card semantics.
 - Reject non-finite and non-Level-1 MOS model-card `LEVEL` values before
   lowering netlist elements into the engine.
 - Reject zero, negative, and non-finite Level-1 MOS model-card `T_NOM` / `TNOM`

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -4,12 +4,12 @@ use std::{
 };
 
 use spice_engine::{
-    ac_sweep, dc_op_with_options, dc_sweep, transient_with_method, AcPoint,
-    AdaptiveTransientOptions, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, Complex,
-    CurrentSource, DcOpOptions, DcResult, DcSweepPoint, Diode, Element, ExpWaveform, Inductor,
-    Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, MutualInductor, PulseWaveform,
-    PwlWaveform, Resistor, SinWaveform, SpiceError, TransientMethod, TransientPoint,
-    TransmissionLine, Vccs, Vcvs, VoltageSource, Waveform,
+    ac_sweep, dc_op_with_options, dc_sweep, mosfet_from_model_card, normalize_model_card,
+    transient_with_method, AcPoint, AdaptiveTransientOptions, Bjt, BjtPolarity, Capacitor, Cccs,
+    Ccvs, Circuit, Complex, CurrentSource, DcOpOptions, DcResult, DcSweepPoint, Diode, Element,
+    ExpWaveform, Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType,
+    MutualInductor, PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError, TransientMethod,
+    TransientPoint, TransmissionLine, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
@@ -1831,6 +1831,18 @@ fn parse_model_card(fields: &[String]) -> Result<ModelCard, NetlistParseError> {
                 ));
             }
         }
+        if let Some(surface_state_density) = params.get("NSS") {
+            if !surface_state_density.is_finite() || *surface_state_density < 0.0 {
+                return Err(NetlistParseError::new(
+                    "MOSFET NSS must be finite and non-negative",
+                ));
+            }
+        }
+        if let Some(gate_material_type) = params.get("TPG") {
+            if !matches!(*gate_material_type, -1.0 | 0.0 | 1.0) {
+                return Err(NetlistParseError::new("MOSFET TPG must be -1, 0, or 1"));
+            }
+        }
         if let Some(oxide_thickness) = params.get("TOX") {
             if !oxide_thickness.is_finite() || *oxide_thickness <= 0.0 {
                 return Err(NetlistParseError::new(
@@ -2140,9 +2152,13 @@ fn parse_element_params(
 fn build_mosfet_params(
     model: &ModelCard,
     instance_params: &HashMap<String, f64>,
-) -> MosfetLevel1Params {
+) -> Result<MosfetLevel1Params, NetlistParseError> {
     let mut params = MosfetLevel1Params::default();
-    for (name, value) in model.params.iter().chain(instance_params.iter()) {
+    for (name, value) in &model.params {
+        apply_mosfet_param(&mut params, name, *value);
+    }
+    apply_mosfet_electrostatic_defaults(model, &mut params)?;
+    for (name, value) in instance_params {
         apply_mosfet_param(&mut params, name, *value);
     }
     if !model.params.contains_key("KP") && !instance_params.contains_key("KP") {
@@ -2168,7 +2184,44 @@ fn build_mosfet_params(
     if let Some(value) = instance_params.get("PS") {
         params.source_perimeter = *value;
     }
-    params
+    Ok(params)
+}
+
+fn apply_mosfet_electrostatic_defaults(
+    model: &ModelCard,
+    params: &mut MosfetLevel1Params,
+) -> Result<(), NetlistParseError> {
+    let has_substrate_doping = ["N_SUB", "NSUB", "N"]
+        .iter()
+        .any(|name| model.params.contains_key(*name));
+    if !has_substrate_doping || !model.params.contains_key("TOX") {
+        return Ok(());
+    }
+
+    let mut parameters = Vec::new();
+    for (canonical, aliases) in [
+        ("VT0", &["VT0", "VTO", "VTH"][..]),
+        ("GAMMA", &["GAMMA"][..]),
+        ("PHI", &["PHI"][..]),
+        ("TOX", &["TOX"][..]),
+        ("N_SUB", &["N_SUB", "NSUB", "N"][..]),
+        ("T_NOM", &["T_NOM", "TNOM"][..]),
+        ("NSS", &["NSS"][..]),
+        ("TPG", &["TPG"][..]),
+    ] {
+        if let Some(value) = aliases.iter().find_map(|alias| model.params.get(*alias)) {
+            parameters.push((canonical, *value));
+        }
+    }
+
+    let normalized = normalize_model_card(&model.name, &model.kind, &parameters)
+        .map_err(|error| NetlistParseError::new(error.to_string()))?;
+    let derived = mosfet_from_model_card("M", "d", "g", "s", "b", &normalized)
+        .map_err(|error| NetlistParseError::new(error.to_string()))?;
+    params.vt0 = derived.params.vt0;
+    params.gamma = derived.params.gamma;
+    params.phi = derived.params.phi;
+    Ok(())
 }
 
 fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
@@ -2520,7 +2573,7 @@ fn parse_element(
                 &fields[3],
                 &fields[4],
                 mosfet_type,
-                build_mosfet_params(model, &instance_params),
+                build_mosfet_params(model, &instance_params)?,
             )))
         }
         'G' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1,6 +1,7 @@
 use spice_engine::{
-    ac_sweep, dc_op, dc_op_with_options, mc_dc, noise_ac, sens_dc, tf, transient_adaptive,
-    BjtPolarity, Element, JfetPolarity, McDistribution, McOptions, MosfetType, TransientMethod,
+    ac_sweep, dc_op, dc_op_with_options, mc_dc, mosfet_from_model_card, noise_ac,
+    normalize_model_card, sens_dc, tf, transient_adaptive, BjtPolarity, Element, JfetPolarity,
+    McDistribution, McOptions, MosfetType, TransientMethod,
 };
 use spice_netlist_parser::{
     berkeley_app_package_manifest, berkeley_app_package_manifest_json, build_analysis_plan,
@@ -1482,7 +1483,7 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u UO=500 LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n LD=10n TOX=20n RD=10 RS=20 RSH=250 IS=4p JS=2m NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u PB=0.9 MJ=0.45 MJSW=0.25 FC=0.4 KF=1p AF=1.2)
+.model nch NMOS(VTO=0.45 KP=250u UO=500 LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n LD=10n TOX=20n RD=10 RS=20 RSH=250 IS=4p JS=2m NSUB=1.5e16 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u PB=0.9 MJ=0.45 MJSW=0.25 FC=0.4 KF=1p AF=1.2)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
 M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n PD=6u PS=7u
@@ -1537,7 +1538,7 @@ Rload out 0 1k
     assert_close(mosfet.params.forward_bias_depletion_coefficient, 0.4);
     assert_close(mosfet.params.flicker_noise_coefficient, 1.0e-12);
     assert_close(mosfet.params.flicker_noise_exponent, 1.2);
-    assert_close(mosfet.params.n_sub, 1.5);
+    assert_close(mosfet.params.n_sub, 1.5e16);
     assert_close(mosfet.params.t_nom, 300.0);
     assert_close(mosfet.params.gate_source_overlap_capacitance, 3.0e-12);
     assert_close(mosfet.params.gate_drain_overlap_capacitance, 4.0e-12);
@@ -2435,6 +2436,64 @@ fn preserves_supported_and_implicit_mosfet_model_level_one() {
 
         assert!(matches!(parsed.circuit.elements()[0], Element::Mosfet(_)));
     }
+}
+
+#[test]
+fn rejects_invalid_mosfet_model_electrostatic_default_inputs() {
+    for (parameter, reason) in [
+        ("NSS=-1", "MOSFET NSS must be finite and non-negative"),
+        ("NSS=1e999", "MOSFET NSS must be finite and non-negative"),
+        ("TPG=0.5", "MOSFET TPG must be -1, 0, or 1"),
+        ("TPG=1e999", "MOSFET TPG must be -1, 0, or 1"),
+    ] {
+        let error = parse_netlist(&format!(
+            ".model electrostatic NMOS({parameter})\nM1 d g s b electrostatic"
+        ))
+        .unwrap_err();
+
+        assert!(error.to_string().contains(reason));
+    }
+}
+
+#[test]
+fn rejects_mosfet_model_substrate_doping_below_intrinsic_density_with_oxide() {
+    let error =
+        parse_netlist(".model electrostatic NMOS(NSUB=1e9 TOX=20n)\nM1 d g s b electrostatic")
+            .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("MOSFET NSUB must exceed the intrinsic carrier density"));
+}
+
+#[test]
+fn lowers_mosfet_model_electrostatic_defaults_through_shared_engine_semantics() {
+    let parsed = parse_netlist(
+        ".model electrostatic NMOS(NSUB=1e16 TOX=20n TNOM=325 NSS=1e11 TPG=-1)\n\
+         M1 d g s b electrostatic",
+    )
+    .unwrap();
+    let Element::Mosfet(actual) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+
+    let normalized = normalize_model_card(
+        "electrostatic",
+        "NMOS",
+        &[
+            ("NSUB", 1.0e16),
+            ("TOX", 20.0e-9),
+            ("TNOM", 325.0),
+            ("NSS", 1.0e11),
+            ("TPG", -1.0),
+        ],
+    )
+    .unwrap();
+    let expected = mosfet_from_model_card("M1", "d", "g", "s", "b", &normalized).unwrap();
+
+    assert_close(actual.params.vt0, expected.params.vt0);
+    assert_close(actual.params.gamma, expected.params.gamma);
+    assert_close(actual.params.phi, expected.params.phi);
 }
 
 #[test]

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card level validation.
+1. Rust Berkeley SPICE MOS model-card electrostatic-default lowering parity.
    - Status: current PR completion candidate.
-   - Reject non-finite and non-Level-1 model-card `LEVEL` values before lowering
-     MOS elements into engine parameters.
-   - Preserve explicit `LEVEL=1` model cards and cards that omit `LEVEL`.
+   - Validate `NSS` and `TPG` before lowering MOS elements into engine
+     parameters.
+   - Reuse shared engine semantics for `N_SUB` / `TOX` derived `VT0`, `GAMMA`,
+     and `PHI` defaults instead of silently dropping supported inputs.
 
 ## Completed Slices
 
@@ -4107,17 +4108,24 @@ the Rust, Python, and TypeScript surfaces together.
      rejected before lowering MOS elements into engine parameters.
    - Positive nominal temperatures remain accepted across both aliases.
 
+365. Rust Berkeley SPICE MOS model-card level validation.
+   - Status: completed in PR 9570.
+   - Non-finite and non-Level-1 model-card `LEVEL` values are rejected before
+     lowering MOS elements into engine parameters.
+   - Explicit `LEVEL=1` model cards and cards that omit `LEVEL` remain accepted.
+
 ## Backlog
 
-1. Rust Berkeley SPICE MOS model-card level validation.
-   - Reject non-finite and non-Level-1 model-card `LEVEL` values before lowering
-     MOS elements into engine parameters.
-   - Preserve explicit `LEVEL=1` model cards and cards that omit `LEVEL`.
+1. Rust Berkeley SPICE MOS model-card electrostatic-default lowering parity.
+   - Validate `NSS` and `TPG` before lowering MOS elements into engine
+     parameters.
+   - Reuse shared engine semantics for `N_SUB` / `TOX` derived `VT0`, `GAMMA`,
+     and `PHI` defaults instead of silently dropping supported inputs.
 
 2. Rust Berkeley SPICE MOS model-card validation audit.
-   - Re-audit supported model-card parameters after the `LEVEL` facade gap
-     lands, recording any newly confirmed gaps here before selecting another
-     slice.
+   - Re-audit supported model-card parameters after the electrostatic-default
+     facade gap lands, recording any newly confirmed gaps here before selecting
+     another slice.
    - Reuse contracts and diagnostics already aligned across the Rust, Python,
      and TypeScript engines whenever the missing behavior is facade-only.
 


### PR DESCRIPTION
## Summary
- validate Level-1 MOS model-card `NSS` and `TPG` values in the Rust netlist facade
- lower `N_SUB` / `TOX` electrostatic defaults through the shared engine model-card semantics
- preserve explicit model values and deterministic instance overrides
- reject substrate doping below intrinsic density when oxide-based derivation applies
- record the newly discovered parity work before broader backlog items

## Verification
- `cargo fmt --package spice-netlist-parser -- --check`
- `cargo test -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`

Python and TypeScript already implement the same electrostatic derivation; this closes the Rust netlist-facade lowering gap by reusing the Rust engine path.