### PR TITLE
test(venture): launch primary native shells

### DIFF
--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -16,6 +16,9 @@ cross-platform proving application. Items are ordered by risk and dependency.
 - [x] **P2 — CI entry-point coverage.** Route the authoritative POSIX and
   Windows package build entry points through the shared generated-shell matrix
   so backend interaction acceptance cannot be bypassed by package-level CI.
+- [x] **P3 — Primary native direct-launch coverage.** Run the generated SwiftUI
+  and WinUI application launch-and-interaction tests from that shared matrix,
+  rather than stopping after their projects compile.
 
 ## Completed foundations
 

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Run the primary generated SwiftUI and WinUI direct-launch interaction tests
+  from the shared backend build matrix on their native hosts.
 - Route the authoritative POSIX and Windows package build entry points through
   the complete generated-shell acceptance matrix after Rust contract tests.
 - Add one package-owned jsdom interaction gate shared by the generated HTML

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -92,6 +92,9 @@ part-backed native controls and its generated `mosaicHost` seam.
 The Compose gate uses the emitted Mosaic-part test tags to drive native
 Compose controls through the generated injectable `MosaicComposeHost` seam,
 including disabled buttons, address editing, Return, Go, and host prop refresh.
+On macOS and Windows, the matrix also runs the generated SwiftUI or WinUI
+application's direct launch-and-interaction test after compiling its emitted
+project, so package-level CI cannot stop at a shell-only build.
 Platform-exclusive builds are explicitly deferred to their
 native host; missing host-applicable toolchains are reported as skips. Pass
 `--strict` on POSIX or `-Strict` on PowerShell to reject those missing

--- a/code/programs/mosaic/venture-browser/scripts/build-all.ps1
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.ps1
@@ -223,6 +223,17 @@ if ($isWindows -and (Test-Command "dotnet")) {
     } finally {
         Pop-Location
     }
+    Write-Host "==> Testing xaml direct launch and interactions"
+    $acceptanceArgs = @("test", "-p", "venture-browser-windows", "--test", "xaml_project_build")
+    if ($Release) {
+        $acceptanceArgs += "--release"
+    }
+    Push-Location $rustWorkspace
+    try {
+        Invoke-Checked -Command "cargo" -Arguments $acceptanceArgs
+    } finally {
+        Pop-Location
+    }
 } elseif (-not $isWindows) {
     Defer-Backend -Backend "xaml" -Reason "WinUI builds require Windows"
 } else {

--- a/code/programs/mosaic/venture-browser/scripts/build-all.sh
+++ b/code/programs/mosaic/venture-browser/scripts/build-all.sh
@@ -167,6 +167,12 @@ if [[ "$host_os" == Darwin ]] && has_command swift; then
     "$output_root/swiftui/libventure_browser_macos.dylib"
   echo "==> Building swiftui"
   (cd "$output_root/swiftui" && swift build)
+  echo "==> Testing swiftui direct launch and interactions"
+  acceptance_args=(test -p venture-browser-macos --test swiftui_project_launch)
+  if ((release)); then
+    acceptance_args+=(--release)
+  fi
+  (cd "$rust_workspace" && cargo "${acceptance_args[@]}")
 elif [[ "$host_os" != Darwin ]]; then
   defer_backend swiftui "SwiftUI builds require macOS"
 else

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -383,6 +383,14 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         build_windows.contains("scripts\\build-all.ps1"),
         "Windows BUILD must execute the generated-shell matrix"
     );
+    assert!(
+        shell.contains("venture-browser-macos") && shell.contains("swiftui_project_launch"),
+        "POSIX matrix must run the primary macOS direct-launch gate"
+    );
+    assert!(
+        powershell.contains("venture-browser-windows") && powershell.contains("xaml_project_build"),
+        "Windows matrix must run the primary Windows direct-launch gate"
+    );
     let backends = [
         "react",
         "electron",

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -120,14 +120,15 @@ complete.
    extent as target-neutral state, then bind generated native scrollbars to the
    same Mosaic-hosted content surface without recreating browser chrome in
    AppKit or Win32.
-3. **P2 — remaining generated-host interaction gates (Flutter and Qt completed).**
+3. **P2 — generated-host interaction gates (completed).**
    Flutter now hydrates the emitted shell through an injected Mosaic host and
    directly drives native disabled controls, address editing, Return, Go, and
    host-response refresh. Qt Quick now exercises the same contract through
-   part-backed native controls and a package-owned QML test. Promote the
-   remaining Compose and web-family build/host-object checks to direct
-   interaction acceptance where their provisioned CI toolchains can launch
-   them.
+   part-backed native controls and a package-owned QML test. Compose,
+   React/Electron, HTML, and Web Components now drive the same shared contract
+   through their generated host seams. The authoritative package entry points
+   run that matrix and additionally launch the generated SwiftUI or WinUI app
+   on its native host.
 
 These are browser-wiring and acceptance items. They do not relax the exact
 zero-missing WPT tree-construction or tokenizer coverage ratchets, and they do


### PR DESCRIPTION
## Summary
- run the generated SwiftUI direct-launch interaction gate from Venture shared POSIX matrix
- run the matching generated WinUI direct-launch interaction gate from the Windows matrix
- ratchet both commands in package contracts and refresh the authoritative completion backlog

## Validation
- bash code/programs/mosaic/venture-browser/BUILD
  - generated SwiftUI app launched and completed its native interaction sequence
  - React/Electron, HTML/Web Component, Flutter, Rust package, and production build gates passed
  - XAML correctly deferred to Windows CI; Qt and Compose skipped because their local toolchains were unavailable
- cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml
- cargo fmt --manifest-path code/programs/mosaic/venture-browser/Cargo.toml -- --check
- git diff --check
- exact HTML parser audit: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 local raw / 0 missing; 7242 normalized / 0 skipped

This closes a package-level acceptance bypass; it is not a claim of full browser conformance.