### PR TITLE
feat(human-languages): split Malayalam lessons into micro-steps

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Kannada duration
-tranche: 20 registered tracks, 1,004 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Malayalam duration
+tranche: 20 registered tracks, 1,008 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -59,7 +59,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01J | Complete in the German duration PR | Remove all twenty-seven sub-five-minute violations from the German track. | The report measures zero German violations; five new prerequisite-ordered micro-lessons preserve register, practice, areal-history, agreement, and etymology depth. |
 | HL-D01K | Complete in the Telugu duration PR | Remove all thirty-six sub-five-minute violations from the Telugu track. | The report measures zero Telugu violations; one new prerequisite-ordered micro-lesson separates phrase formation from register and source-evidence judgment. |
 | HL-D01L | Complete in the Kannada duration PR | Remove all thirty-seven sub-five-minute violations from the Kannada track. | The report measures zero Kannada violations; one new prerequisite-ordered micro-lesson separates suffix forms and sound history from the agglutinative-versus-fusional comparison. |
-| HL-D01M | Next | Remove all thirty-seven sub-five-minute violations from the Malayalam track. | Malayalam is now the smallest remaining set: thirty-three declaration-only lessons and four genuinely computed violations, with a 360-second maximum. |
+| HL-D01M | Complete in the Malayalam duration PR | Remove all thirty-seven sub-five-minute violations from the Malayalam track. | The report measures zero Malayalam violations; four new prerequisite-ordered micro-lessons separate vocabulary from etymology, register, and cross-language comparison. |
+| HL-D01N | Next | Remove all thirty-nine sub-five-minute violations from the Arabic track. | Arabic is now the smallest remaining set: thirty-five declaration-only lessons and four genuinely computed violations, with a 360-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -84,9 +85,12 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B23 | Queued | Remove Telugu's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, three underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and a font-shape substitution warning; the clean-build signal is zero of each. |
 | HL-B24 | Queued | Publish Kannada Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Kannada PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B25 | Queued | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, five underfull boxes, four duplicate practice labels, 30 Hyperref warnings, and undefined bold/italic Kannada font shapes; the clean-build signal is zero of each. |
+| HL-B26 | Queued | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Malayalam PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
+| HL-B27 | Queued | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports seven overfull boxes, eight underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and undefined bold/italic Malayalam font shapes; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
+| HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
@@ -420,6 +424,32 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Malayalam's thirty-seven violations are now the smallest remaining set.
   Thirty-three are declaration-only and four genuinely compute above the limit,
   with a 360-second maximum, so HL-D01M is next.
+
+## Findings from HL-D01M
+
+- Malayalam now has zero duration violations. The corpus grows from 1,004 to
+  1,008 lessons and drops from 256 to 219 violations overall; unknown
+  prerequisites remain at zero.
+- Thirty-three lessons needed only honest declared-budget corrections. Four
+  genuinely long lessons become prerequisite-ordered pairs: **ഉച്ച** “peak” noon
+  → **പാതിരാ** half-night; Sanskrit *divasam/dinam* → surviving native **നാൾ**;
+  Sanskrit **രാത്രി** and its PIE history → native *iravŭ/iruḷ* register split;
+  formal **ശുഭ മധ്യാഹ്നം** → the Malayalam/Kannada/Telugu convergence map.
+- The eight new or rewritten steps compute between 141 and 235 seconds.
+  `ML-C26-raavile` at 299 seconds and `ML-C06-dative-subject` at 294 are the
+  tightest remaining Malayalam lessons and should be watched during copy edits.
+- The Malayalam PDF builds successfully at 31 pages through Chapter 5 while
+  canonical lessons continue through Chapter 31. HL-B26 records the schema-v2
+  migration and generated publication work for Chapters 6–31.
+- The build has no missing glyphs, but reports seven overfull boxes, eight
+  underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and
+  undefined bold/italic Malayalam font shapes. HL-B27 records that pre-existing
+  clean-build debt.
+- The roadmap narrative stops at Chapter 6 and the authoritative session map at
+  Chapter 5. HL-M04 records the progression-metadata work through Chapter 31.
+- Arabic's thirty-nine violations are now the smallest remaining set.
+  Thirty-five are declaration-only and four genuinely compute above the limit,
+  with a 360-second maximum, so HL-D01N is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/malayalam/CHANGELOG.md
+++ b/code/learning/human-languages/malayalam/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Sub-five-minute lesson remediation (2026-08-02)
+
+- All thirty-seven Malayalam duration violations are resolved. Thirty-three
+  lessons already computed below five minutes and now declare an honest
+  four-minute budget without changing their teaching content.
+- Four long lessons become gentle prerequisite pairs: **ഉച്ച** noon →
+  **പാതിരാ** midnight; Sanskrit *divasam/dinam* → native **നാൾ**; Sanskrit
+  **രാത്രി** → native *iravŭ/iruḷ*; formal **ശുഭ മധ്യാഹ്നം** → the three-language
+  convergence map. The eight steps compute between 141 and 235 seconds.
+- The four support lessons bring the Malayalam track to 64 lessons with zero
+  unknown prerequisite ids; downstream lessons now require the moved concept
+  before using it.
+- A forced book build succeeds at 31 pages with no missing glyphs. Canonical
+  lessons continue through Chapter 31 while the book stops at Chapter 5
+  (`HL-B26`); existing layout, bookmark, duplicate-label, and font warnings are
+  tracked in `HL-B27`; roadmap and session-map drift is tracked in `HL-M04`.
+
 ## Chapter 6 — Case endings, and the sentence with no subject
 
 - **Chapter 6 authored** (`ML-C06-dative-ikku`, `-dative-subject`): the track's

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-namaskaram.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-namaskaram.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [malayalam-inherent-a, chandrakkala, conjunct, anusvara]
 roots: [namas, kṛ]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [ML-C01-namaskaram, ML-C01-nandi, ML-C01-athe, ML-C01-illa, ML-C01-sari]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C01-namaskaram, ML-C01-nandi, ML-C01-athe, ML-C01-illa, ML-C01-sari]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [ML-C02-enre-peru-aanu, ML-C02-ninre-peru-entaanu, ML-C02-santosham]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C02-peru, ML-C02-enre, ML-C02-aanu, ML-C02-enre-peru-aanu, ML-C02-nii-ningal, ML-C02-entu, ML-C02-ninre-peru-entaanu, ML-C02-santosham]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C03-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [ML-C03-sukhamaano, ML-C03-sukham, ML-C03-saaramilla]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C03-engane, ML-C03-sukhamaano, ML-C03-njaan, ML-C03-sukham, ML-C03-saaramilla]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C03-sukhamaano.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C03-sukhamaano.md
@@ -8,7 +8,7 @@ concept_tag: STATE-HOW-ARE-YOU
 prerequisites: [ML-C02-aanu, ML-C03-engane]
 sounds: [question-o]
 roots: [sukha-sanskrit, aaka-dravidian]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C02-aanu]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C04-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [ML-C04-poyi-varaam, ML-C04-naale-kaanaam, ML-C04-veendum-kaanaam]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C04-pokuka, ML-C04-poyi-varaam, ML-C04-naale-kaanaam, ML-C04-veendum-kaanaam]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C05-joli-ceyyuka.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C05-joli-ceyyuka.md
@@ -8,7 +8,7 @@ concept_tag: ML-VERB-CEYYUKA
 prerequisites: [ML-C05-samsaarikkuka]
 sounds: [double-yy]
 roots: [cey-do-dravidian, joli-work]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C05-samsaarikkuka, ML-C05-taamasikkuka]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C05-njaan-malayalam-samsaarikkunnu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C05-njaan-malayalam-samsaarikkunnu.md
@@ -8,7 +8,7 @@ concept_tag: ML-WORD-MALAYALAM
 prerequisites: [ML-C05-samsaarikkuka, ML-C03-njaan]
 sounds: [retroflex-l, long-aa]
 roots: [mala-mountain-dravidian, alam-place-dravidian]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C05-samsaarikkuka, ML-C03-njaan]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C05-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [ML-C05-samsaarikkuka, ML-C05-njaan-malayalam-samsaarikkunnu, ML-C05-taamasikkuka, ML-C05-joli-ceyyuka]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C05-samsaarikkuka, ML-C05-njaan-malayalam-samsaarikkunnu, ML-C05-taamasikkuka, ML-C05-joli-ceyyuka, ML-C03-njaan]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C05-samsaarikkuka.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C05-samsaarikkuka.md
@@ -8,7 +8,7 @@ concept_tag: ML-VERB-SAMSARIKKUKA
 prerequisites: [ML-C03-njaan, ML-C04-pokuka]
 sounds: [anusvara, double-kk]
 roots: [samsaara-sanskrit]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C06-dative-subject.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C06-dative-subject.md
@@ -10,7 +10,7 @@ prerequisites: [ML-C06-dative-ikku, ML-C05-njaan-malayalam-samsaarikkunnu]
 sounds: [gemination-kk, retroflex-l]
 roots: [dravidian-dative-ku]
 etymology_hook: "Dravidian puts the EXPERIENCER in the dative — knowing, liking and wanting happen TO you rather than being done BY you — so 'I know Malayalam' has no nominative 'I', the person sitting in the dative instead (a 'dative subject'); aṟiyām is aṟiy- 'know' + the able-to ending -ām, so it is literally 'is knowable'; the same construction runs through Tamil, Telugu and Kannada with cousin suffixes"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C06-dative-ikku, ML-C05-njaan-malayalam-samsaarikkunnu, ML-C03-njaan]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C07-numbers-1-5.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C07-numbers-1-5.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C01-namaskaram]
 sounds: [malayalam-inherent-a, chandrakkala, gemination]
 roots: [proto-dravidian-numbers]
 etymology_hook: "Malayalam split from Tamil ~1000 years ago — its numbers are the family's closest, and even ONE agrees (onnu ↔ oṉṟu)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C01-namaskaram]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C07-numbers-6-10.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C07-numbers-6-10.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C07-numbers-1-5]
 sounds: [malayalam-inherent-a, chandrakkala, zha-llla]
 roots: [proto-dravidian-numbers]
 etymology_hook: "seven ēḻu keeps the rare ḻ that Kannada hardened to ḷ and Telugu to ḍ — Malayalam and Tamil alone preserve it"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C07-numbers-1-5, ML-C01-namaskaram]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C08-dayavayi.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C08-dayavayi.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C01-athe]
 sounds: [malayalam-vowel-sign-aa, malayalam-vowel-sign-i, malayalam-va]
 roots: [daya-compassion]
 etymology_hook: "ദയവായി = 'as a compassion' — Malayalam asks please with daya, like Tamil, Kannada, Telugu, Arabic faḍl and Hindi kṛpā"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C01-athe]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C09-kshamikkanam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C09-kshamikkanam.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C08-dayavayi]
 sounds: [malayalam-conjunct-kssa, malayalam-geminate-kka]
 roots: [kshama-sanskrit]
 etymology_hook: "ക്ഷമിക്കണം kṣamikkaṇaṁ ← Sanskrit kṣama 'forgiveness' + Malayalam verb-making -ikkuka + the SAME necessitative -aṇaṁ noted in ദയവായി's lesson"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C08-dayavayi]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C10-azhcha.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C10-azhcha.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C09-kshamikkanam]
 sounds: [malayalam-zha, malayalam-nya]
 roots: [dravidian-native-planet-words, sanskrit-planet-words]
 etymology_hook: "Malayalam's week-word ആഴ്ച āzhcha and several planet-names (thiṅkaḷ, veḷḷi, ñāyar) are near-identical to Tamil's — the two split apart only centuries ago"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ML-C09-kshamikkanam]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C11-nirangal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C11-nirangal.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C10-azhcha]
 sounds: [malayalam-virama-final, malayalam-cha]
 roots: [dravidian-native-colors, sanskrit-nila]
 etymology_hook: "കറുപ്പ്/വെള്ള/ചുവപ്പ് (black/white/red) closely match Tamil's karuppu/vellai/sivappu; നീല (blue) is the same Sanskrit loan as Tamil's nilam"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C10-azhcha]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C12-kudumbam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C12-kudumbam.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C11-nirangal]
 sounds: [malayalam-chillu-n, malayalam-geminate-tta]
 roots: [dravidian-age-graded-siblings]
 etymology_hook: "അച്ഛൻ achan/അമ്മ amma and ചേട്ടൻ/അനിയൻ/ചേച്ചി/അനിയത്തി look less like Tamil's set than Kannada/Telugu's do — but the age-before-gender sibling system still holds"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C11-nirangal]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C14-kaalangal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C14-kaalangal.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C13-shareera-bhaagangal]
 sounds: [malayalam-chillu-l, malayalam-anusvara]
 roots: [dravidian-venal-mazha, sanskrit-vasantha]
 etymology_hook: "വേനൽ venal (summer heat) and മഴ mazha (rain) are native Dravidian, matching Tamil's kodai/mazhai closely — വസന്തം vasantham (spring) is the same Sanskrit loan Tamil uses too"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C13-shareera-bhaagangal]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C15-vellam-ari.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C15-vellam-ari.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C14-kaalangal]
 sounds: [malayalam-geminate-lla, malayalam-vowel-sign-oo]
 roots: [vellam-flood-white, ari-rice-dravidian]
 etymology_hook: "വെള്ളം vellam (water) does NOT match Tamil's neer/thanneer — it shares the veL- 'bright/white' root already met in Malayalam's word for silver/Venus, originally meaning 'flood'; അരി ari (rice) DOES match Tamil's arisi closely"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C14-kaalangal]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C16-kollavarsham-maasangal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C16-kollavarsham-maasangal.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C15-vellam-ari]
 sounds: [malayalam-anusvara, malayalam-chillu-rr]
 roots: [malayalam-solar-calendar-zodiac, kollam-era]
 etymology_hook: "Malayalam's Kollam Era calendar is ALSO solar, like Tamil's — but its months are named for the ZODIAC SIGN the sun occupies (Chingam = Leo, Kanni = Virgo...), not nakshatras — a genuinely different naming logic from its closest cousin"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ML-C15-vellam-ari]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C17-paathira.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C17-paathira.md
@@ -1,0 +1,49 @@
+---
+id: ML-C17-paathira
+chapter: 17
+type: word
+headword: പാതിരാ
+gloss: midnight, built on Malayalam paathi "half" rather than Sanskrit ardha
+concept_tag: ML-TIME-MIDNIGHT
+prerequisites: [ML-C17-ucha-paathira]
+sounds: [malayalam-vowel-sign-aa]
+roots: [dravidian-paathi-half]
+etymology_hook: "പാതിരാ and Telugu ardharātri share the half-night metaphor but use unrelated words for half"
+est_minutes: 4
+reviews_of: [ML-C17-ucha-paathira]
+---
+
+# പാതിരാ — midnight as “half-night”
+
+## Warm-up
+
+[PAUSE 2s] **ഉച്ച** named noon by the sun’s height. Malayalam builds midnight
+with a different spatial idea: cut the night in half.
+
+## പാതി + a shortened night
+
+**പാതിരാ** (*paathira*) means “**midnight**.” It is built on **പാതി**
+(*paathi*), the everyday Malayalam word for “**half**”—as in *paathi vila*,
+“half price”—fused with a shortened form of “night.”
+
+The result has the same “half-night” shape as Telugu **అర్ధరాత్రి**
+(*ardharātri*) and Hindi *ādhī rāt*. The pieces are not all cousins, though.
+Malayalam **പാതി** is a genuinely different word from Sanskrit **ardha**, the
+root behind Telugu *ardharātri* and, farther back, Hindi *ādhī*.
+
+So two languages can independently choose the same transparent construction
+while filling it with unrelated words for “half.” The metaphor matches; the
+vocabulary does not.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: *paathira* — midnight]
+- [YOU SAY: *paathi* — half]
+- [YOU SAY: Malayalam *paathi* versus Sanskrit *ardha* — same job, different roots]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **പാതിരാ** build on? (**പാതി**, “half,” plus a shortened
+night-word.) Is *paathi* the same root as Telugu *ardha*? (**No.** The two
+languages share the “half-night” logic but use unrelated half-words.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C17-ucha-paathira.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C17-ucha-paathira.md
@@ -2,18 +2,18 @@
 id: ML-C17-ucha-paathira
 chapter: 17
 type: word
-headword: ഉച്ച പാതിരാ
-gloss: noon (most likely a DIFFERENT Sanskrit root than Kannada/Telugu's madhya — height, not middle) and midnight ("half-night," from paathi, "half")
-concept_tag: ML-TIME-NOON-MIDNIGHT
+headword: ഉച്ച
+gloss: noon, most likely from a different Sanskrit metaphor than Kannada and Telugu — height rather than middle
+concept_tag: ML-TIME-NOON
 prerequisites: [ML-C16-kollavarsham-maasangal]
 sounds: [malayalam-virama-cha, malayalam-vowel-sign-aa]
-roots: [sanskrit-ucca-high, dravidian-paathi-half]
+roots: [sanskrit-ucca-high]
 etymology_hook: "ഉച്ച (ucha, noon) most likely shares its root with Tamil உச்சி and Kannada ಉಚ್ಚಿ (ucci, 'peak, crown, zenith') — and per Wiktionary, THAT family is itself a Sanskrit borrowing, from ucca, 'high,' not a native Dravidian word; so Malayalam's noon may be just as Sanskrit-derived as Kannada's madhyāhna, only from a DIFFERENT Sanskrit root (height, not middle)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ML-C16-kollavarsham-maasangal]
 ---
 
-# ഉച്ച, പാതിരാ — a different Sanskrit metaphor, not a Sanskrit-free one
+# ഉച്ച — a different Sanskrit metaphor, not a Sanskrit-free one
 
 ## Warm-up
 
@@ -39,17 +39,6 @@ same zenith-based idea you already saw in Arabic's *aẓ-ẓuhr* (from a root
 meaning "to appear, become visible/apex"), just arrived at from Sanskrit
 rather than Arabic.
 
-## പാതിരാ — "half," a different word than Telugu's ardha
-
-**പാതിരാ** (*paathira*) = "**midnight**" — built on **പാതി** (*paathi*,
-"**half**," an everyday Malayalam word — think "half price," *paathi
-vila*) fused with a shortened form of night. This lands on the same
-"half-night" shape as Telugu's *ardharātri* and Hindi's *ādhī rāt* — but
-*paathi* is a genuinely **different word** from Sanskrit's *ardha* (the
-root behind Telugu's *ardharātri* and, further back, Hindi's *ādhī*
-itself). Two languages, same "half-night" logic, two unrelated words for
-"half."
-
 ## Be honest: not "Sanskrit vs. native" — more likely "which Sanskrit root"
 
 Don't walk away thinking Malayalam dodged Sanskrit here while Kannada and
@@ -62,7 +51,6 @@ different is the **metaphor**, not necessarily the **language of origin**.
 
 [PAUSE 1s]
 - [YOU SAY: "ucha" — noon, "the peak" — compare Tamil's "ucci"]
-- [YOU SAY: "paathira" — midnight, from "paathi," half]
 - [YOU SAY: the honest contrast — Kannada/Telugu's noon word means
   "middle"; Malayalam's most likely means "peak" — both probably still
   Sanskrit, just different Sanskrit roots]
@@ -73,7 +61,4 @@ different is the **metaphor**, not necessarily the **language of origin**.
 (**No** — it most likely comes from a *different* Sanskrit root, *ucca*,
 "high/peak," not *madhya*, "middle.") Does that make ഉച്ച a native Dravidian
 word? (**Not necessarily** — its likely relatives, Tamil *ucci* and Kannada
-*ucci*, are themselves documented Sanskrit borrowings.) What does
-**പാതിരാ** literally build on, and how does that differ from Telugu's
-midnight word? (**പാതി**, *paathi*, "half" — a different word entirely from
-Sanskrit's *ardha*, behind Telugu's *ardharātri*.)
+*ucci*, are themselves documented Sanskrit borrowings.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C18-mani.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C18-mani.md
@@ -5,12 +5,12 @@ type: word
 headword: മണി
 gloss: hour — Malayalam's OWN dictionary tradition treats bell/hour/gem as ONE Sanskrit word, unlike Tamil's closely related mani, which its own dictionaries split into two unrelated homophones
 concept_tag: ML-TIME-HOUR
-prerequisites: [ML-C17-ucha-paathira]
+prerequisites: [ML-C17-paathira]
 sounds: [malayalam-retroflex-nna, malayalam-vowel-sign-i]
 roots: [sanskrit-mani-gem-bell]
 etymology_hook: "മണി (mani, 'hour, bell, gem') — Malayalam's Wiktionary entry treats ALL these senses as ONE word borrowed from Sanskrit मणि (maṇi, 'gem'); this is genuinely different from how Tamil's OWN dictionaries treat its cognate மணி, which splits into two separate, unrelated words (a native 'bell/hour' word and a separate Sanskrit 'gem' loan) — two closest-cousin languages, two different scholarly pictures of the very same word"
-est_minutes: 6
-reviews_of: [ML-C17-ucha-paathira]
+est_minutes: 4
+reviews_of: [ML-C17-paathira, ML-C17-ucha-paathira]
 ---
 
 # മണി — one word in Malayalam's dictionaries, two in Tamil's

--- a/code/learning/human-languages/malayalam/lessons/ML-C19-vayassu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C19-vayassu.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C18-mani]
 sounds: [malayalam-chillu-l, malayalam-existential-undu]
 roots: [sanskrit-vayas-vigor-age]
 etymology_hook: "വയസ്സ് (vayass, 'age') is the same Sanskrit वयस् as Kannada/Telugu's word — but Malayalam asks it differently: 'നിങ്ങൾക്ക് എത്ര വയസ്സുണ്ട്?' (ningalkku ethra vayassundu?, 'to you how much age exists?'), a DATIVE-SUBJECT + existential-verb (undu, 'exists') construction, a genuinely different grammatical shape than Kannada/Telugu's plain verbless possessive"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ML-C18-mani]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C20-kalavastha.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C20-kalavastha.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C18-mani]
 sounds: [malayalam-vowel-sign-aa, malayalam-conjunct-stha]
 roots: [sanskrit-kaala-time, sanskrit-avastha-state]
 etymology_hook: "കാലാവസ്ഥ (kālāvastha, 'weather') is a Sanskrit compound literally meaning 'state of TIME' — കാലം (kālam, 'time') + അവസ്ഥ (avastha, 'state, condition') — echoing Spanish's tiempo (which means BOTH 'time' and 'weather' in one word) but built as a compound rather than a single polysemous word"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ML-C18-mani]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C20-pathinonnu-irupathu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C20-pathinonnu-irupathu.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C19-vayassu]
 sounds: [malayalam-virama-final, malayalam-vowel-sign-i]
 roots: [dravidian-pathu-ten, dravidian-iru-two]
 etymology_hook: "പതിനൊന്ന്-പത്തൊമ്പത് (11-19) echo പത്ത് (pathu, 'ten') + a digit — ഇരുപത് (irupathu, 'twenty') is transparently 'two-tens', ഇരു (iru, an older word for 'two') + പത്ത് (pathu, 'ten') — matching Tamil's own irupathu almost exactly, both languages keeping this compound visibly transparent where Telugu's has worn down further"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ML-C19-vayassu]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C21-naaya-poocha.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C21-naaya-poocha.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C20-pathinonnu-irupathu]
 sounds: [malayalam-vowel-sign-aa, malayalam-geminate-ch]
 roots: [dravidian-naay-dog, dravidian-punai-cat]
 etymology_hook: "നായ (nāya, 'dog') continues the same solid, native Proto-Dravidian root as Kannada's naayi and Tamil's naay — no mystery, unlike every other language in this arc's dog-word; പൂച്ച (pūcha, 'cat') closely matches Tamil's everyday word pūnai, part of a family distinct from Kannada's bekku and Telugu's pilli — Dravidian genuinely splits more on 'cat' than on 'dog'"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ML-C20-pathinonnu-irupathu]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C22-paccha-manja.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C22-paccha-manja.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C11-nirangal, ML-C21-naaya-poocha]
 sounds: [malayalam-chillu-l, malayalam-virama-geminate]
 roots: [proto-dravidian-pac-green, dravidian-mancal-turmeric]
 etymology_hook: "പച്ച (paccha, 'green') ← Proto-Dravidian *pac-, matching Tamil's பச்சை (paccai) almost exactly; മഞ്ഞ (mañña, 'yellow') is a doublet of മഞ്ഞൾ (maññaḷ, 'turmeric'), from a SEPARATE native Dravidian root matching Tamil's மஞ்சள் (mañcaḷ) — unlike Telugu, where green and yellow are doublets of ONE root, Malayalam's green and yellow are two independent native Dravidian word-families that happen to sit side by side"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ML-C21-naaya-poocha]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C23-divasam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C23-divasam.md
@@ -3,17 +3,17 @@ id: ML-C23-divasam
 chapter: 23
 type: word
 headword: ദിവസം
-gloss: "day" — the common everyday Sanskrit-tatsama word; Malayalam's own native day-word (nāḷ, already met in "tomorrow") is also still alive, echoing Kannada's hagalu — narrowed to specific uses rather than erased
+gloss: "day" — everyday Sanskrit divasam beside the more literary Sanskrit dinam
 concept_tag: TIME-DAY
-prerequisites: [ML-C04-naale-kaanaam, ML-C17-ucha-paathira]
+prerequisites: [ML-C04-naale-kaanaam, ML-C17-paathira]
 sounds: [malayalam-vowel-sign-i, malayalam-anusvara]
-roots: [sanskrit-divasa-day, sanskrit-dina, proto-dravidian-naal-day]
-etymology_hook: "ദിവസം (divasam, 'day') is a Sanskrit tatsama, borrowed whole from दिवस (divasa) ← PIE *dyew- ('to shine') via the root दिव् (div); this is the SAME ultimate PIE root as Hindi/Kannada's दिन/ದಿನ (dina) and Latin's diēs, but divasa and dina are different Sanskrit derivational formations off that root (an -asa formation vs. Sanskrit's own -nó- formation), not the same word — a repeat of the din/diēs 'hidden branching' pattern, this time inside Sanskrit itself; Malayalam ALSO has ദിനം (dinam), the very word Kannada uses plainly, but here it's the more literary/formal alternate to divasam; and Malayalam's native word നാൾ (nāḷ, Proto-Dravidian *nāḷ, already met inside നാളെ/nāḷe 'tomorrow' in Chapter 4) is also still alive today, echoing Kannada's own hagalu (Chapter 23 of that language's arc) — a native day-related word that survived not by staying the default counting word, but by narrowing to specific senses/compounds: nāḷ in the narrative phrase 'oru nāḷ' ('one day') and in the living compound പിറന്നാൾ (piṟannāḷ, 'birthday,' literally 'day of birth')"
-est_minutes: 6
-reviews_of: [ML-C04-naale-kaanaam, ML-C17-ucha-paathira]
+roots: [sanskrit-divasa-day, sanskrit-dina]
+etymology_hook: "divasam and dinam share PIE *dyew- through two different Sanskrit formations; Malayalam assigns them everyday and formal jobs"
+est_minutes: 4
+reviews_of: [ML-C04-naale-kaanaam, ML-C17-paathira, ML-C17-ucha-paathira]
 ---
 
-# ദിവസം (divasam) — "day," and a native word that refused to fade
+# ദിവസം (divasam) — the everyday Sanskrit day-word
 
 ## Warm-up
 
@@ -43,38 +43,16 @@ tatsama word as Kannada's plain, everyday *dina*. But in Malayalam,
 *janmadinam*, "birthday," the modern calque-style term) — **divasam** does
 the everyday counting work instead.
 
-## നാൾ — a native word that narrowed its job, rather than losing it
-
-Here's the honest twist of this lesson: Malayalam's own native Dravidian
-word for "day," **നാൾ** (**nāḷ**, Proto-Dravidian ***\*nāḷ***, cognate with
-Tamil's **நாள்** and Kannada's **ನಾಳು**) — the very word you already met
-inside **നാളെ** (*nāḷe*, "tomorrow," Chapter 4) — is **also still alive**
-today, in a shape that echoes Kannada's own **ಹಗಲು** (*hagalu*): a native
-word that didn't get erased by the Sanskrit loan so much as **narrowed** to
-specific uses, rather than staying the default, everyday counting word
-(that job belongs to *divasam* now). Concretely: **ഒരു നാൾ** (*oru nāḷ*,
-"one day," in the storytelling sense — "once upon a day") is still real,
-narrative-register Malayalam, and *nāḷ* stays **productive** in living
-compounds today, like **പിറന്നാൾ** (*piṟannāḷ*, "**birthday**," literally
-"day of birth") — itself considered the more **traditional** of
-Malayalam's two birthday words, next to the newer Sanskrit calque
-*janmadinam*. Three words, three honest jobs: *divasam* counts days,
-*dinam* writes formally, *nāḷ* still tells stories and marks birthdays.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "divasam" — "day," the everyday counting word]
 - [YOU SAY: "dinam" — the same Sanskrit word as Kannada's dina, but formal here]
-- [YOU SAY: "nāḷ" — the native word, still alive, from "tomorrow" and "birthday"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What PIE root does **ദിവസം** ultimately share with Hindi/Kannada's
 *dina* and Latin's *diēs*? (***\*dyew-***, "to shine" — though *divasa* and
-*dina* are different Sanskrit formations off it, not the same word.) Where
-did you already meet **നാൾ** before this lesson? (Inside **നാളെ**, *nāḷe*,
-"tomorrow," Chapter 4.) Has Malayalam's native day-word been erased by the
-Sanskrit loan? (**No** — like Kannada's *hagalu*, it's still alive, just
-narrowed to specific uses rather than staying the default counting word:
-*oru nāḷ* in storytelling, and the living compound *piṟannāḷ*, "birthday.")
+*dina* are different Sanskrit formations off it, not the same word.) Which is
+the everyday counting word? (**divasam**.) Which is more literary or formal?
+(**dinam**.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C23-naal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C23-naal.md
@@ -1,0 +1,52 @@
+---
+id: ML-C23-naal
+chapter: 23
+type: etymology
+headword: നാൾ
+gloss: the native day-word, narrowed into narrative use and living compounds rather than erased
+concept_tag: ML-TIME-DAY-NATIVE
+prerequisites: [ML-C23-divasam]
+sounds: [malayalam-vowel-sign-aa]
+roots: [proto-dravidian-naal-day]
+etymology_hook: "native നാൾ survives inside നാളെ, narrative ഒരു നാൾ, and പിറന്നാൾ even though Sanskrit divasam counts ordinary days"
+est_minutes: 4
+reviews_of: [ML-C23-divasam, ML-C04-naale-kaanaam]
+---
+
+# നാൾ — the native day-word that narrowed its job
+
+## Warm-up
+
+[PAUSE 2s] **ദിവസം** counts ordinary days and **ദിനം** writes formally. But
+Malayalam’s native day-word never disappeared—you met it long ago inside
+“tomorrow.”
+
+## From നാളെ back to നാൾ
+
+**നാൾ** (*nāḷ*) means “day” and descends from Proto-Dravidian ***\*nāḷ***,
+cognate with Tamil **நாள்** and Kannada **ನಾಳು**. Chapter 4 already gave you
+**നാളെ** (*nāḷe*, “tomorrow”), with the native day-word still visible inside.
+
+The Sanskrit loan **ദിവസം** took over ordinary counting, but **നാൾ** narrowed
+rather than vanished. **ഒരു നാൾ** (*oru nāḷ*, “one day”) remains natural in
+storytelling, and the word stays productive in **പിറന്നാൾ** (*piṟannāḷ*),
+“birthday,” literally “day of birth.” That traditional compound stands beside
+the newer Sanskrit-style **ജന്മദിനം** (*janmadinam*).
+
+Three words therefore carry three honest jobs: *divasam* counts, *dinam* is
+formal, and native *nāḷ* tells stories and marks birthdays. This echoes
+Kannada’s native *hagalu*: borrowing narrowed a native word’s domain without
+erasing it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: *nāḷe* — tomorrow, with *nāḷ* inside]
+- [YOU SAY: *oru nāḷ* — one day, narrative register]
+- [YOU SAY: *piṟannāḷ* — birthday, day of birth]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Has Sanskrit **divasam** erased native **നാൾ**? (**No.**) Where does
+*nāḷ* live now? (**Inside tomorrow, in narrative “one day,” and in the living
+compound for birthday.**)

--- a/code/learning/human-languages/malayalam/lessons/ML-C24-native-night-words.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C24-native-night-words.md
@@ -1,0 +1,49 @@
+---
+id: ML-C24-native-night-words
+chapter: 24
+type: etymology
+headword: ഇരവ് / ഇരുൾ
+gloss: native literary night and everyday darkness — related ideas with different modern jobs
+concept_tag: ML-TIME-NIGHT-NATIVE
+prerequisites: [ML-C24-rathri]
+sounds: [malayalam-vowel-sign-i]
+roots: [proto-dravidian-cira-darkness, proto-dravidian-cirvl]
+etymology_hook: "iravŭ survives as literary night while related pan-Dravidian iruḷ remains current as darkness, not a plain time-period synonym"
+est_minutes: 4
+reviews_of: [ML-C24-rathri, ML-C17-paathira]
+---
+
+# ഇരവ് / ഇരുൾ — two native words, two jobs
+
+## Warm-up
+
+[PAUSE 2s] **രാത്രി** is the ordinary Sanskrit night-word. Malayalam also kept
+two native Dravidian words, but they do not compete with it in the same way.
+
+## Literary night versus everyday darkness
+
+- **ഇരവ്** (*iravŭ*) is cognate with Tamil **இரவு** (*iravu*) and is traced by
+  one source to Proto-Dravidian ***\*cira***, “darkness.” It survives mainly as
+  a **literary or classical-register** synonym for “night.” Poetry is a more
+  likely home for it than everyday conversation.
+- **ഇരുൾ** (*iruḷ*) descends from Proto-Dravidian ***\*cirVḷ*** and belongs to
+  the pan-Dravidian family Kannada **ಇರುಳು**, Tamil **இருள்**, and Telugu
+  **ఇరులు**. It remains current in modern Malayalam—a 2021 film is titled
+  *Irul*—but its ordinary sense is **darkness**, not night as a time period.
+
+This is not one native night-word simply pushed into archaism. It is two native
+words carrying different pieces of **രാത്രി**’s semantic space: one formal and
+poetic, the other common but narrower.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: *iravŭ* — literary night]
+- [YOU SAY: *iruḷ* — current darkness]
+- [YOU SAY: related ideas, different modern jobs]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are **ഇരവ്** and **ഇരുൾ** interchangeable everyday words for night?
+(**No.**) Which is literary “night”? (**iravŭ**.) Which is current “darkness”?
+(**iruḷ**.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C24-rathri.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C24-rathri.md
@@ -3,17 +3,17 @@ id: ML-C24-rathri
 chapter: 24
 type: word
 headword: രാത്രി
-gloss: "night" — the same Sanskrit tatsama word already hiding (shortened) inside pāthirā, "midnight"; native competitors exist too, but split into two different words with two different jobs, neither of them a plain synonym
+gloss: "night" — the Sanskrit tatsama already shortened inside paathira, with a different PIE root from Latin nox
 concept_tag: TIME-NIGHT
-prerequisites: [ML-C17-ucha-paathira, ML-C23-divasam]
+prerequisites: [ML-C17-paathira, ML-C23-naal]
 sounds: [malayalam-virama-ta, malayalam-vowel-sign-i]
-roots: [sanskrit-ratri, proto-dravidian-cira-darkness, proto-dravidian-cirvl]
-etymology_hook: "രാത്രി (rāthri, 'night') is a Sanskrit tatsama, likely the same word already hiding, shortened to just 'rā,' inside പാതിരാ (pāthirā, 'midnight,' Chapter 17); like Hindi's രാത്/raat, this രാത്രി traces to PIE *h₁reh₁- ('to rest'), a COMPLETELY DIFFERENT root from Latin nox's *nókʷts — a genuine false cognate, not a shared-family word; Malayalam also keeps two native words, but they split the job rather than competing head-on: ഇരവ് (iravŭ, cognate Tamil இரவு/iravu, traced by one source to Proto-Dravidian *cira, 'darkness') survives mainly as a literary/classical synonym for 'night' itself, while ഇരുൾ (iruḷ, Proto-Dravidian *cirVḷ, cognate Kannada's ಇರುಳು/Tamil's இருள்/Telugu's ఇరులు, already cited in the Kannada sibling of this arc) is still current in modern Malayalam (a 2021 film is literally titled Irul) but means specifically 'darkness,' not 'night' as a time period"
-est_minutes: 6
-reviews_of: [ML-C17-ucha-paathira, ML-C23-divasam]
+roots: [sanskrit-ratri]
+etymology_hook: "rāthri is the Sanskrit night-word shortened inside paathira; its PIE rest root differs from Latin nox"
+est_minutes: 4
+reviews_of: [ML-C17-paathira, ML-C17-ucha-paathira, ML-C23-naal, ML-C23-divasam]
 ---
 
-# രാത്രി (rāthri) — "night," already hiding inside "midnight"
+# രാത്രി (rāthri) — night, already hiding inside midnight
 
 ## Warm-up
 
@@ -41,37 +41,12 @@ Two Indo-European languages, two words for "night," that **look** like they
 might be old cousins — but genuinely **aren't**. Same false-cognate story,
 now confirmed across a second Indo-Aryan-rooted borrowing.
 
-## Two native words, two different jobs — not one clean synonym
-
-Malayalam keeps native Dravidian words here too, but be honest: they
-**split the work**, rather than one cleanly standing in for *rāthri*.
-
-- **ഇരവ്** (**iravŭ**) — cognate with Tamil's **இரவு** (*iravu*), traced by
-  at least one source to **Proto-Dravidian** ***\*cira*** ("darkness") —
-  survives today mainly as a **literary, classical-register** synonym for
-  "night" itself. You'd meet it in poetry before you'd hear it in
-  conversation.
-- **ഇരുൾ** (**iruḷ**) — Proto-Dravidian ***\*cirVḷ***, the very same
-  pan-Dravidian cognate already named in this arc's Kannada lesson
-  (matching Kannada's **ಇರುಳು**, Tamil's **இருள்**, Telugu's **ఇరులు**) —
-  is still genuinely **current** in modern Malayalam (a 2021 film is
-  titled, simply, *Irul*). But its everyday sense is specifically
-  "**darkness**," not "night" as a stretch of time — a close cousin of the
-  idea, not a plain interchangeable word for it.
-
-So it's not "one native night-word, simply pushed into archaism" the way
-Kannada's *iruḷu* was. It's **two different native words**, each carrying
-only part of *rāthri*'s job — one gone formal/poetic, one still common but
-narrower in meaning.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "rāthri" — "night," already hiding, shortened, inside pāthirā]
 - [YOU SAY: the honest PIE echo — *h₁reh₁-, "to rest," like Hindi's raat,
   NOT related to Latin's nox]
-- [YOU SAY: "iravŭ" (literary "night") vs. "iruḷ" (everyday "darkness") —
-  two native words, two different jobs]
 
 ## Wrap-up Recall
 
@@ -79,7 +54,4 @@ narrower in meaning.
 before this lesson? (Shortened to "**rā**" inside **പാതിരാ**, *pāthirā*,
 "midnight," Chapter 17.) Does *rāthri*'s PIE root match Latin *nox*'s?
 (**No** — ***\*h₁reh₁-*** "to rest," a completely different root, the same
-false-cognate pattern already seen with Hindi's *raat*.) Do Malayalam's two
-native words, *iravŭ* and *iruḷ*, mean the same thing? (**No** — *iravŭ* is
-a literary synonym for "night" itself; *iruḷ* is still common but means
-specifically "darkness.")
+false-cognate pattern already seen with Hindi's *raat*.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C25-shubha-rathri.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C25-shubha-rathri.md
@@ -5,12 +5,12 @@ type: phrase
 headword: ശുഭ രാത്രി
 gloss: "good night" — the standard Sanskrit-tatsama phrase (rāthri already met, śubha new); some sources describe modern Malayalam speakers often code-switching to English "good night" instead — the same claim already made, similarly thinly sourced, for Telugu earlier in this arc
 concept_tag: GREETING-GOODNIGHT
-prerequisites: [ML-C24-rathri]
+prerequisites: [ML-C24-native-night-words]
 sounds: [malayalam-sha, malayalam-bha]
 roots: [sanskrit-shubha-beautiful, sanskrit-ratri]
 etymology_hook: "ശുഭ രാത്രി (śubha rāthri), 'good night,' literally 'auspicious night' — both pieces Sanskrit tatsama: രാത്രി (already met last lesson) plus ശുഭ (śubha, 'auspicious,' from root śubh, 'to be beautiful,' well-sourced PIE *ḱewbʰ- — the same etymology already verified for the Hindi, Kannada, and Telugu siblings of this arc); some sources describe modern Malayalam speakers, especially casually, code-switching to English 'good night' rather than saying śubha rāthri aloud — but hedge this carefully: the SAME claim was already made, and only weakly sourced, for Telugu earlier in this arc, so this looks like a recurring pattern across South Asian languages generally (or a sourcing artifact of which languages happen to get commented on), not a Malayalam-specific discovery"
-est_minutes: 5
-reviews_of: [ML-C24-rathri]
+est_minutes: 4
+reviews_of: [ML-C24-native-night-words, ML-C24-rathri]
 ---
 
 # ശുഭ രാത്രി (śubha rāthri) — "good night," and a pattern seen before

--- a/code/learning/human-languages/malayalam/lessons/ML-C26-raavile.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C26-raavile.md
@@ -5,12 +5,12 @@ type: word
 headword: രാവിലെ
 gloss: "morning" (rāvile) — a compound of രാവ് (rāvŭ, "night," a cognate doublet of ഇരവ്/iravŭ already met in ML-C24 — same root, not literally the same word) + locative-ish suffixes -il/-e; literally built from NIGHT, not light or rising — a genuinely different strategy than Kannada's "the shining" or Telugu's Sanskrit "rise"; പ്രഭാതം (Sanskrit tatsama, same prabhāta root as Telugu's TE-C29) and പുലർച്ച (native, thinner etymology) also exist as alternatives
 concept_tag: TIME-MORNING
-prerequisites: [ML-C24-rathri]
+prerequisites: [ML-C24-native-night-words]
 sounds: [malayalam-vowel-sign-e, malayalam-virama-va]
 roots: [proto-dravidian-cira-darkness, sanskrit-prabhata-shine]
 etymology_hook: "രാവിലെ (rāvile, 'morning') is, per Wiktionary, a compound of രാവ് (rāvŭ) + -il + -e; രാവ് is confirmed cognate with Tamil ரா/இரவு and shares its Proto-Dravidian *cira ('darkness') root with ഇരവ് (iravŭ), already met in ML-C24 as a literary register synonym for 'night' — a cognate doublet, not literally the same word — meaning Malayalam's everyday 'morning' word is, transparently, built from NIGHT plus locative suffixes, not from light or rising; hedge the exact semantic mechanism (why 'at night' shifted to mean 'morning') since no source spells out the intermediate step, but the morphological composition itself is Wiktionary-confirmed; two alternatives exist too: പ്രഭാതം (prabhātaṁ), a Sanskrit tatsama sharing its root, prabhāta ('shine, become bright'), with Telugu's own సుప్రభాతం (TE-C29) — a genuine cross-language callback within this very arc — and പുലർച്ച (pulaṟcca), native Dravidian but with a thinner, less certain etymology (a Starling-database entry links it to a 'subsist/live' sense that may or may not be the same root as 'dawn,' so treat that connection as unconfirmed, not settled)"
-est_minutes: 6
-reviews_of: [ML-C24-rathri]
+est_minutes: 4
+reviews_of: [ML-C24-native-night-words, ML-C24-rathri]
 ---
 
 # രാവിലെ (rāvile) — "morning," built from "night"

--- a/code/learning/human-languages/malayalam/lessons/ML-C27-vaikunneram.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C27-vaikunneram.md
@@ -5,12 +5,12 @@ type: word
 headword: വൈകുന്നേരം
 gloss: "evening" (vaikunnēraṁ) — native Dravidian compound, Wiktionary-glossed "latening time," from വൈക് (vaikŭ, plausibly the root of വൈകുക, "to get late" — a reasonable inference, not something Wiktionary's compound entry states outright) + -ഉം (-uṁ) + നേരം (nēraṁ, "time," itself native Dravidian, not Sanskrit); Wiktionary itself ALSO lists "afternoon" as a second sense, though phrasebook sources cleanly split evening (this word) from afternoon (a separate compound built on ഉച്ച, ML-C17's "noon," plus കഴിഞ്ഞ്) — an honest source-tension worth flagging, not smoothing over
 concept_tag: TIME-EVENING
-prerequisites: [ML-C17-ucha-paathira]
+prerequisites: [ML-C17-paathira]
 sounds: [malayalam-vowel-sign-ai, malayalam-conjunct-nn]
 roots: [dravidian-vaikuka-late, dravidian-neram-time]
 etymology_hook: "വൈകുന്നേരം (vaikunnēraṁ, 'evening') is, per Wiktionary, a compound of വൈക് (vaikŭ) + -ഉം (-uṁ) + നേരം (nēraṁ, 'time') — literally 'latening time'; നേരം is itself confirmed native Proto-Dravidian (*nēram, cognate Tamil நேரம்), not a Sanskrit borrowing, so this whole compound is native Dravidian start to finish; the വൈക് root is a reasonable morphological link to the everyday verb വൈകുക (vaikuka), confirmed 'to get late' on its own separate Wiktionary page (the compound's own page doesn't state the verb link explicitly, so treat that specific connection as the author's own inference, not a directly Wiktionary-sourced one); be honest about a real source tension: Wiktionary's own entry lists BOTH 'afternoon' and 'evening' as senses of this single word, but two independently-fetched phrasebook sources (ling-app.com, talkpal.ai) cleanly separate the two — evening = വൈകുന്നേരം, afternoon = a distinct compound built on ഉച്ച (ML-C17's 'noon') + കഴിഞ്ഞ് (kazhinju, 'passed, gone by') — don't smooth over this tension by picking whichever source is convenient; note it as a genuine open question about how cleanly the afternoon/evening boundary is drawn in practice"
-est_minutes: 6
-reviews_of: [ML-C17-ucha-paathira]
+est_minutes: 4
+reviews_of: [ML-C17-paathira, ML-C17-ucha-paathira]
 ---
 
 # വൈകുന്നേരം (vaikunnēraṁ) — "evening," built from a verb meaning "to get late"

--- a/code/learning/human-languages/malayalam/lessons/ML-C28-uchakazhinju.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C28-uchakazhinju.md
@@ -5,12 +5,12 @@ type: phrase
 headword: ഉച്ചകഴിഞ്ഞ്
 gloss: "afternoon" (uchakaḻiññ) — a transparent two-word phrase, not a single dictionary headword: ഉച്ച (ML-C17's "noon") + കഴിഞ്ഞ്, the past converb form of കഴിയുക (kaḻiyuka, Wiktionary-confirmed Proto-Dravidian *kaẓi, "to be over, spent") — Wiktionary itself directly shows only the finite past tense കഴിഞ്ഞു (kaḻiññu); the converb form used in this compound is a reasonable grammatical inference, not itself the form Wiktionary lists; literally "noon having passed" — a structurally different strategy than Telugu's TE-C28, where the SAME noon-word (మధ్యాహ్నం) simply widened its own meaning rather than compounding with a second word
 concept_tag: TIME-AFTERNOON
-prerequisites: [ML-C17-ucha-paathira, ML-C27-vaikunneram]
+prerequisites: [ML-C17-paathira, ML-C27-vaikunneram]
 sounds: [malayalam-geminate-cha, malayalam-zha]
 roots: [sanskrit-ucca-high, proto-dravidian-kazi-spent]
 etymology_hook: "ഉച്ചകഴിഞ്ഞ് (uchakaḻiññ, 'afternoon') is a transparent two-word phrase, not a single lexicalized dictionary entry (no Wiktionary page exists for the compound itself) — ഉച്ച (already met, ML-C17, 'noon,' likely from Sanskrit ucca 'high') plus കഴിഞ്ഞ്, the past converb form ('having passed') of കഴിയുക (kaḻiyuka), itself Wiktionary-confirmed as inherited from Proto-Dravidian *kaẓi ('to be over, spent, finished') — note that Wiktionary's own conjugation line shows only the finite past tense കഴിഞ്ഞു (kaḻiññu), not this converb form directly; the converb is the grammatically correct choice for chaining into a compound like this one, but treat the specific written form as the author's own grammatical inference, not a directly Wiktionary-sourced citation; so this phrase literally means 'noon having passed/elapsed' — a transparent, compositional way of naming the afternoon, genuinely different in STRATEGY from Telugu's TE-C28, where the exact same noon-word (మధ్యాహ్నం) simply widened its own meaning to also cover 'afternoon' rather than reaching for a second word; Malayalam instead keeps 'noon' unwidened and builds a new phrase on top of it"
-est_minutes: 6
-reviews_of: [ML-C17-ucha-paathira, ML-C27-vaikunneram]
+est_minutes: 4
+reviews_of: [ML-C17-paathira, ML-C17-ucha-paathira, ML-C27-vaikunneram]
 ---
 
 # ഉച്ചകഴിഞ്ഞ് (uchakaḻiññ) — "noon, having passed"

--- a/code/learning/human-languages/malayalam/lessons/ML-C29-suprabhaatham.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C29-suprabhaatham.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C26-raavile]
 sounds: [malayalam-conjunct-pra, malayalam-anusvara]
 roots: [sanskrit-su-good, sanskrit-prabhata-shine]
 etymology_hook: "സുപ്രഭാതം (suprabhātaṁ, 'good morning') is Malayalam's actual, most common morning greeting — confirmed via two independently-fetched sources: talkpal.ai states it is 'used in both formal and informal situations,' and ling-app.com separately, without prompting, calls it 'the most general greeting' for good morning — genuine two-source corroboration, a stronger evidentiary footing than a single directly-fetched source alone (a distinction this arc has learned to care about, per TE-C29's own 'fetched directly is not the same as authoritative' finding); it's built from the Sanskrit prefix su- ('good') plus പ്രഭാതം (already met, ML-C26, as an alternative Malayalam word for 'morning'), NOT from ശുഭ (ML-C25's 'auspicious,' the word Malayalam's own GREETING-GOODNIGHT is built on) — a genuinely different Sanskrit 'good' morpheme, a bound prefix rather than a standalone adjective; be honest about a striking cross-language structural inversion: this is the exact SAME Sanskrit tatsama word as Telugu's own సుప్రభాతం (TE-C29) — but the two languages give it OPPOSITE roles: it's Malayalam's PRIMARY, most-used morning greeting, while in Telugu it's only a SECONDARY alternative to శుభోదయం (built on a completely different root, udaya, not ప్రభాత/prabhāta)"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ML-C26-raavile]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C30-shubha-sayaahnam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C30-shubha-sayaahnam.md
@@ -9,7 +9,7 @@ prerequisites: [ML-C25-shubha-rathri, ML-C27-vaikunneram]
 sounds: [malayalam-vowel-sign-aa, malayalam-conjunct-hna]
 roots: [sanskrit-shubha-beautiful, sanskrit-saya-end]
 etymology_hook: "ശുഭ സായാഹ്നം (śubha sāyāhnaṁ, 'good evening') is confirmed real by a directly-fetched source (preply.com), used 'from late afternoon until sunset' — built on ശുഭ (ML-C25, already verified PIE *ḱewbʰ- root, shared with Hindi/Kannada/Telugu) plus സായാഹ്നം (sāyāhnaṁ, 'evening, eventide'); be honest about a genuine surprise: this is NOT built on ML-C27's native വൈകുന്നേരം at all — സായാഹ്നം is a SEPARATE word, a Sanskrit tatsama that Wiktionary's own part-of-speech label calls 'poetic' (a real, citable register signal, not an unverifiable blog claim, that this greeting likely skews formal/literary); a Sanskrit dictionary page confirms സായാഹ്നം is a karmadhāraya compound of साय ('end') + अह्न ('day'), and Wiktionary's own separate साय entry directly confirms साय traces to PIE *seh₁- ('long, lasting'), explicitly listing सायम् (sāyam, TE-C27's own root), Latin sērus, and Gothic seiþus as cognates — meaning സായാഹ്നം's root and Telugu's TE-C27 సాయంత్రం (built on sāyam) share a genuinely, properly-verified common PIE ancestor, not just a plausible guess; a claim that ordinary Malayalis rarely say this phrase, favoring നമസ്കാരം instead, could NOT be independently verified (the pages making that claim returned 403 errors) — so it is deliberately NOT asserted here, only the Wiktionary 'poetic' register label, which IS independently verifiable"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ML-C25-shubha-rathri, ML-C27-vaikunneram]
 ---
 

--- a/code/learning/human-languages/malayalam/lessons/ML-C31-afternoon-convergence.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C31-afternoon-convergence.md
@@ -1,0 +1,58 @@
+---
+id: ML-C31-afternoon-convergence
+chapter: 31
+type: etymology
+headword: ശുഭ മധ്യാഹ്നം — three-way convergence
+gloss: Malayalam, Kannada, and Telugu converge on one formal greeting after building everyday afternoon words three different ways
+concept_tag: ML-GREETING-AFTERNOON-CONVERGENCE
+prerequisites: [ML-C31-shubha-madhyaahnam]
+sounds: []
+roots: [sanskrit-shubha-beautiful, sanskrit-madhya-middle]
+etymology_hook: "three Dravidian languages share śubha plus madhyāhna at the greeting layer even though their everyday afternoon terms diverge"
+est_minutes: 4
+reviews_of: [ML-C31-shubha-madhyaahnam, ML-C28-uchakazhinju]
+---
+
+# One greeting, three afternoon strategies
+
+## Warm-up
+
+[PAUSE 2s] Malayalam’s formal greeting uses **ശുഭ + മധ്യാഹ്നം**. Kannada and
+Telugu land on the same phrase—but their ordinary afternoon words took three
+different routes.
+
+## The greeting converges
+
+| language | formal afternoon greeting |
+|---|---|
+| Malayalam | **ശുഭ മധ്യാഹ്നം** |
+| Kannada | **ಶುಭ ಮಧ್ಯಾಹ್ನ** |
+| Telugu | **శుభ మధ్యాహ్నం** |
+
+All three share the Sanskrit **śubha + madhyāhna** structure. That shared
+greeting is striking because the languages’ everyday time words diverge:
+
+- **Telugu** widened its *madhya*-based noon-word so the same word also covers
+  afternoon.
+- **Kannada** built a separate Sanskrit tatsama, **ಅಪರಾಹ್ನ** (*aparāhna*,
+  *apara* + *ahna*), rather than widening *madhyāhna*.
+- **Malayalam** built **ഉച്ചകഴിഞ്ഞ്**, the unrelated *ucca* “noon” plus
+  “having passed.”
+
+So there are three genuinely different everyday strategies, not a simple
+two-versus-one split. At the formal greeting layer, all three converge on the
+same borrowed building blocks.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the shared greeting structure — *śubha + madhyāhna*]
+- [YOU SAY: Telugu — widening]
+- [YOU SAY: Kannada — a separate *aparāhna* word]
+- [YOU SAY: Malayalam — “noon having passed”]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Do the three languages share one ordinary afternoon-word strategy?
+(**No.**) Where do they converge? (**In the formal greeting, all using
+śubha + madhyāhna.**)

--- a/code/learning/human-languages/malayalam/lessons/ML-C31-shubha-madhyaahnam.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C31-shubha-madhyaahnam.md
@@ -3,17 +3,17 @@ id: ML-C31-shubha-madhyaahnam
 chapter: 31
 type: phrase
 headword: ശുഭ മധ്യാഹ്നം
-gloss: "good afternoon" (śubha madhyāhnaṁ) — a genuinely formal, "official/ceremonial" greeting per a directly-fetched source; built on ശുഭ (ML-C25) + മധ്യാഹ്നം (madhyāhnaṁ, Wiktionary-confirmed SYNONYM of ML-C17's ഉച്ച, "noon") — NOT on ML-C28's ഉച്ചകഴിഞ്ഞ് compound; a striking 3-way Dravidian convergence: Kannada's ಶುಭ ಮಧ್ಯಾಹ್ನ (KA-C31) and Telugu's శుభ మధ్యాహ్నం (TE-C31) use the EXACT SAME śubha+madhyāhna structure, even though all three languages' own separate TIME-AFTERNOON words diverged
+gloss: "good afternoon" (śubha madhyāhnaṁ), a formal greeting built on a noon synonym rather than the everyday afternoon compound
 concept_tag: GREETING-AFTERNOON
-prerequisites: [ML-C17-ucha-paathira, ML-C28-uchakazhinju]
+prerequisites: [ML-C17-paathira, ML-C28-uchakazhinju]
 sounds: [malayalam-conjunct-dhya, malayalam-anusvara]
 roots: [sanskrit-shubha-beautiful, sanskrit-madhya-middle]
-etymology_hook: "ശുഭ മധ്യാഹ്നം (śubha madhyāhnaṁ, 'good afternoon') is confirmed, by a directly-fetched source (talkpal.ai's 'most common greetings in Kerala'), as a genuinely formal greeting, 'mainly used in official or ceremonial settings' and 'not as commonly used in daily conversation' — a real, hedged qualitative finding, NOT the suspiciously precise 'fewer than 1%' statistic a WebSearch summary attached to this claim, which could not be traced to either directly-fetched source and is therefore deliberately excluded as an apparent confabulation; the greeting is built from ശുഭ (ML-C25) plus മധ്യാഹ്നം (madhyāhnaṁ, 'noon'), which Wiktionary confirms as a direct SYNONYM of ML-C17's ഉച്ച — meaning Malayalam has BOTH a 'high/peak' noon-word (ucca, ML-C17's primary) and a 'middle' noon-word (madhya, this lesson's) all along, it simply wasn't the one ML-C17 highlighted; notably, this greeting is NOT built on ML-C28's ഉച്ചകഴിഞ്ഞ് compound (the actual TIME-AFTERNOON phrase already taught) at all; be honest about a striking 3-way Dravidian convergence: Kannada's ಶುಭ ಮಧ್ಯಾಹ್ನ (KA-C31) and Telugu's శుభ మధ్యాహ్నం (TE-C31) use the EXACT SAME śubha+madhyāhna structure for their own afternoon greetings — even though all three languages' separate TIME-AFTERNOON words (this arc's earlier lessons) diverged completely: Telugu confirmed-widened its own madhya-based noon-word directly to also mean 'afternoon'; Kannada instead built a SEPARATE Sanskrit tatsama, ಅಪರಾಹ್ನ (aparāhna, apara+ahna, KA-C28) — not a widening of madhyāhna at all; Malayalam built an unrelated ucca+kazhinju compound — three genuinely different strategies, not two-vs-one — yet the greeting layer converges on the exact same word in all three"
-est_minutes: 6
-reviews_of: [ML-C17-ucha-paathira, ML-C28-uchakazhinju]
+etymology_hook: "the formal greeting uses Sanskrit madhyāhna, a synonym of everyday ucha, rather than Malayalam's ucha-plus-passed afternoon phrase"
+est_minutes: 4
+reviews_of: [ML-C17-paathira, ML-C17-ucha-paathira, ML-C28-uchakazhinju]
 ---
 
-# ശുഭ മധ്യാഹ്നം (śubha madhyāhnaṁ) — completing Malayalam's arc, and a 3-way convergence
+# ശുഭ മധ്യാഹ്നം (śubha madhyāhnaṁ) — formal good afternoon
 
 ## Warm-up
 
@@ -40,23 +40,6 @@ didn't highlight it, teaching **ഉച്ച** ("peak, high") instead.
 And this greeting is **not** built on ML-C28's **ഉച്ചകഴിഞ്ഞ്**
 compound (the actual TIME-AFTERNOON phrase already taught) at all.
 
-## A striking 3-way convergence, right where the TIME-words diverged
-
-Here's the honest cross-language payoff: Kannada's own afternoon
-greeting, **ಶುಭ ಮಧ್ಯಾಹ್ನ** (KA-C31), and Telugu's own,
-**శుభ మధ్యాహ్నం** (TE-C31), use the **exact same śubha + madhyāhna**
-structure as this Malayalam greeting. All three Dravidian languages
-converge here — even though, earlier in this very arc, their separate
-TIME-AFTERNOON words **diverged completely** — and in three
-genuinely different directions, not just two-vs-one: **Telugu**
-confirmed-widened its own *madhya*-based noon-word directly to also
-mean "afternoon"; **Kannada** instead built a **separate** Sanskrit
-tatsama, **ಅಪರಾಹ್ನ** (*aparāhna*, "apara" + "ahna," KA-C28) — not
-a widening of *madhyāhna* at all; **Malayalam** built an unrelated
-*ucca* + "passed" compound. Three different everyday-noun strategies —
-yet the formal greeting lands on the exact same word, in all three
-languages.
-
 ## Guided Practice
 
 [PAUSE 1s]
@@ -64,8 +47,6 @@ languages.
   ceremonial-register greeting]
 - [YOU SAY: the honest surprise — madhyāhnaṁ is a genuine synonym of
   ucca, Malayalam's own "noon" word, just not the one taught first]
-- [YOU SAY: the 3-way convergence — the exact same greeting structure
-  as Kannada and Telugu, even though their TIME-AFTERNOON words differ]
 
 ## Wrap-up Recall
 
@@ -75,7 +56,4 @@ synonym of ML-C17's ഉച്ച, not the TIME-AFTERNOON compound.) Is the
 "fewer than 1% use this" statistic something this lesson confirms?
 (**No** — it couldn't be traced to any directly-fetched source and is
 deliberately excluded; only the hedged "formal, not common in daily
-conversation" finding is asserted.) Does Malayalam's afternoon greeting
-match Kannada's and Telugu's own afternoon greetings? (**Yes** — all
-three use the exact same śubha + madhyāhna structure, even though all
-three languages' separate TIME-AFTERNOON words diverged.)
+conversation" finding is asserted.)

--- a/code/learning/human-languages/malayalam/roadmap.md
+++ b/code/learning/human-languages/malayalam/roadmap.md
@@ -11,6 +11,11 @@ Tamil-like native core and its heavy Sanskrit overlay. The Malayalam script is
 taught **inline**, never as a gated reading course; grammar is introduced piece
 by piece, on the first word that needs it.
 
+Coverage note: canonical lessons now continue through Chapter 31, while the
+narrative sequence below is complete only through Chapter 6. `HL-M04` tracks
+bringing this roadmap and the session map up to the canonical prerequisite
+order; `HL-B26` tracks publishing Chapters 6–31 from the same source.
+
 ## Authored
 
 - **Ch. 1 — Greetings**: namaskāram → nandi → athe → illa → śari → practice.

--- a/code/learning/human-languages/malayalam/session-map.md
+++ b/code/learning/human-languages/malayalam/session-map.md
@@ -4,6 +4,11 @@ Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
 authoritative order.
 
+Coverage note: this map currently stops at Chapter 5 while canonical lessons
+continue through Chapter 31. `HL-M04` records the work to schedule every later
+lesson, including the four new vocabulary → support sequences, without
+pretending this partial map is already complete.
+
 **There is no reading course.** Malayalam is learned *through* the words: each
 lesson's *"The letters in this word"* section introduces exactly the letters
 that word needs. By the end of Chapter 1 you have met the inherent vowel, the


### PR DESCRIPTION
## Summary
- remove all 37 Malayalam sub-five-minute duration violations while preserving existing lesson bodies when only the declared budget was stale
- split four genuinely long lessons into prerequisite-ordered pairs for noon/midnight, Sanskrit/native day words, Sanskrit/native night words, and the three-language afternoon-greeting convergence
- update downstream prerequisites for moved concepts and record Malayalam book, typography, roadmap, and session-map drift
- reprioritize Arabic as the next duration tranche

## Measured outcome
- Malayalam duration violations: 37 → 0
- corpus lessons: 1,004 → 1,008
- total duration violations: 256 → 219
- unknown prerequisites: 0
- eight new/reworked steps: 141–235 seconds
- tightest remaining Malayalam lessons: ML-C26-raavile at 299 seconds and ML-C06-dative-subject at 294 seconds

## Validation
- `npm run test:coverage` — 68 tests, 93.60% line coverage
- `npm run build`
- `npm run validate` — 9 integration tests
- `npm run check:books`
- `npm run report`
- Language Ladder `npm run test:coverage` — 278 tests, 98.37% line coverage
- Language Ladder `npm run build` — 1,058 modules
- forced Malayalam XeLaTeX build — 31 pages, no missing glyphs
- `git diff --check`

The unchanged Malayalam book stops at Chapter 5 while canonical lessons reach Chapter 31. It also reports 7 overfull boxes, 8 underfull boxes, 4 duplicate practice labels, 28 Hyperref warnings, and undefined bold/italic Malayalam font shapes. Those publication/layout gaps and the roadmap/session-map drift are now tracked as HL-B26, HL-B27, and HL-M04.