### PR TITLE
fix(venture): keep BUILD POSIX compatible

### DIFF
--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -5,6 +5,9 @@ cross-platform proving application. Items are ordered by risk and dependency.
 
 ## Prioritized discoveries
 
+- [x] **P0 regression — POSIX entry-point shell compatibility.** Keep `BUILD`
+  compatible with the repository build tool's `/bin/sh` executor while it
+  delegates the backend matrix to the Bash-specific implementation script.
 - [x] **P0 — Web Component runtime output encoding.** Encode host-controlled text
   and attribute interpolation, reject executable dynamic link schemes, and
   constrain runtime CSS widths before adding a browser interaction gate.

--- a/code/programs/mosaic/venture-browser/BUILD
+++ b/code/programs/mosaic/venture-browser/BUILD
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -euo pipefail
+set -eu
 
-script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_root="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 cd "$script_root"
 
 # Keep the package contract tests and the generated cross-platform shell matrix

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [0.1.0] - Unreleased
 
+### Fixed
+
+- Keep the authoritative POSIX `BUILD` wrapper compatible with the repository
+  build tool's `/bin/sh` executor instead of requiring Bash `pipefail` syntax.
+
 ### Added
 
 - Run the primary generated SwiftUI and WinUI direct-launch interaction tests

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -75,6 +75,9 @@ backend on the current machine:
 
 Repository package CI reaches those same scripts through `BUILD` on POSIX and
 `BUILD_windows` on Windows, after the Rust package-contract tests pass.
+The POSIX wrapper stays `/bin/sh` compatible because the repository build tool
+interprets `BUILD` contents itself; Bash-specific logic remains in
+`scripts/build-all.sh`.
 
 React and Electron run their production builds; HTML and Web Components run
 JavaScript syntax checks plus one shared package-owned jsdom interaction gate;

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -380,6 +380,12 @@ fn backend_build_scripts_cover_the_complete_matrix_and_direct_builds() {
         "POSIX BUILD must execute the generated-shell matrix"
     );
     assert!(
+        build.starts_with("#!/bin/sh\n")
+            && !build.contains("BASH_SOURCE")
+            && !build.contains("pipefail"),
+        "POSIX BUILD must remain compatible with the build tool's /bin/sh executor"
+    );
+    assert!(
         build_windows.contains("scripts\\build-all.ps1"),
         "Windows BUILD must execute the generated-shell matrix"
     );


### PR DESCRIPTION
## Summary
- make the authoritative Venture BUILD wrapper portable to the repository build tool /bin/sh executor
- keep Bash-specific matrix logic isolated in scripts/build-all.sh
- add a package contract ratchet and record the CI regression as the highest-priority completed backlog item

## CI failure repaired
Both Ubuntu runs for merged PR #9576 failed before package tests with: set: Illegal option -o pipefail

## Validation
- sh -n code/programs/mosaic/venture-browser/BUILD
- dash -n code/programs/mosaic/venture-browser/BUILD
- sh code/programs/mosaic/venture-browser/BUILD
  - Rust contracts, React/Electron, HTML/Web Component, native SwiftUI direct-launch interaction, and Flutter gates passed
- cargo fmt --manifest-path code/programs/mosaic/venture-browser/Cargo.toml -- --check
- git diff --check
- exact HTML parser audit: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 local raw / 0 missing; 7242 normalized / 0 skipped

This repairs the package entrypoint regression and does not claim full browser conformance.