### PR TITLE
fix(build-tool): enforce TypeScript package identity

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9572,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "6384e2cf4e5a812f1b8fc9782c661bf5ade9bdd9",
+    "revision": "6141793a9c29cd1177b3b201565e4f8537e77585",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1222,
@@ -343,11 +343,11 @@
     {
       "id": "build-tool-typescript-rockspec-utf8-conformance",
       "title": "Make the TypeScript build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": "codex/build-tool-typescript-rockspec-utf8",
       "pr_number": 9572,
-      "notes": "Ready-for-review PR #9572 is the sole active parity PR. Materialized from the remaining-engine UTF-8 umbrella after merged PR #9553. TypeScript's replacement decoder could not distinguish malformed rockspec bytes from valid replacement characters. The implementation now consumes the exact shared positive and invalid-byte fixtures, requires the exact edge set, rejects malformed bytes before parsing with typed METADATA_INVALID_UTF8 package and repository-relative manifest identity, accepts valid literal U+FFFD, and returns exit 2 through a real tsx CLI subprocess. Rebased validation on origin/main 6384e2cf passed 47 resolver tests, 266 unaffected package tests, 85.40% resolver line coverage, esbuild production bundling, 17 schema and 40 runner tests, the valid 36-case/55-file corpus, a 258-package Lua dry run, a 4,770-record/7,623-edge full plan, collision-clean 1,222-identity/4,370-slot parity inventory, JSON/diff/secret checks, and zero npm advisories. The full Windows suite separately reproduces seven pre-existing gitdiff portability failures, now logged as its own pending child; BUILD validation reproduces only the same 10 owned Lua BUILD_windows debt items."
+      "notes": "Merged PR #9572 at 6141793a9c29cd1177b3b201565e4f8537e77585 on 2026-08-02 after both detection runs, both fixture-consumer runs, both Ubuntu builds, macOS, Windows, and JavaScript/TypeScript CodeQL passed; irrelevant CodeQL languages skipped and the aggregate CodeQL check was neutral. TypeScript now consumes the exact shared positive and invalid-byte fixtures, requires the exact edge set, rejects malformed bytes before parsing with typed METADATA_INVALID_UTF8 package and repository-relative manifest identity, accepts valid literal U+FFFD, and returns exit 2 through a real tsx CLI subprocess. Final validation passed 47 resolver tests, 266 unaffected package tests, 85.40% resolver line coverage, esbuild production bundling, 17 schema and 40 runner tests, the valid 36-case/55-file corpus, a 258-package Lua dry run, a 4,770-record/7,623-edge full plan, collision-clean 1,222-identity/4,370-slot parity inventory, JSON/diff/secret checks, and zero npm advisories. The full local Windows suite separately reproduces seven pre-existing gitdiff portability failures, logged as its own pending child; BUILD validation reproduced only the same 10 owned Lua BUILD_windows debt items."
     },
     {
       "id": "build-tool-typescript-windows-gitdiff-portability",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9582,
   "last_inventory": {
     "revision": "6141793a9c29cd1177b3b201565e4f8537e77585",
     "schema_version": 3,
@@ -361,11 +361,11 @@
     {
       "id": "build-tool-typescript-language-identity-registry",
       "title": "Bring TypeScript build-tool discovery to the canonical language and identity registry",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-typescript-language-identity-registry",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9572 and the collision-clean 6141793a inventory because the dependency is satisfied and real full-plan identity corruption affects every downstream graph consumer. The engine emits 4,770 package records but only 4,383 unique names, including 655 unknown-language records and 217 duplicate identity groups; common C, C++, Dart, Java, and Kotlin packages collapse together under unknown/<basename>. Consume the shared discovery language-registry and duplicate-identity fixtures, classify exact package/program lane boundaries, preserve package versus program identity, exclude spec fixtures, and fail closed on residual duplicate qualified names. This outranks the local-only Windows gitdiff fixture debt and the next single-engine UTF-8 child on dependency leverage."
+      "pr_number": 9582,
+      "notes": "Ready PR #9582 is the sole active parity PR. It consumes the shared discovery language-registry and duplicate-identity fixtures, classifies only exact package/program lane boundaries, preserves language/programs/name identity, excludes spec fixtures, and fails closed with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, real CLI exit 2, and no checkout-root disclosure. Exact-head validation after a conflict-free rebase onto fc27dd48 passed 37 discovery tests, 271 unaffected tests, 93.40% discovery line and 89.23% branch coverage, production bundling, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, zero-advisory npm audit, and a real 4,768-record/7,242-edge full plan with 4,768 unique names, zero duplicate groups, and only intentional unknown/blog. The collision-checked parity inventory remains 1,222 identities/4,370 slots with zero collisions or unknown inventory buckets. Full local Windows testing separately reproduced only the exact seven owned gitdiff portability failures, and BUILD validation reproduced only the exact ten owned Lua BUILD_windows debts. The newly discovered Windows plan rel_path normalization is logged as its own pending child."
     },
     {
       "id": "build-tool-typescript-windows-plan-rel-path-portability",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -368,6 +368,15 @@
       "notes": "Selected after merged PR #9572 and the collision-clean 6141793a inventory because the dependency is satisfied and real full-plan identity corruption affects every downstream graph consumer. The engine emits 4,770 package records but only 4,383 unique names, including 655 unknown-language records and 217 duplicate identity groups; common C, C++, Dart, Java, and Kotlin packages collapse together under unknown/<basename>. Consume the shared discovery language-registry and duplicate-identity fixtures, classify exact package/program lane boundaries, preserve package versus program identity, exclude spec fixtures, and fail closed on residual duplicate qualified names. This outranks the local-only Windows gitdiff fixture debt and the next single-engine UTF-8 child on dependency leverage."
     },
     {
+      "id": "build-tool-typescript-windows-plan-rel-path-portability",
+      "title": "Emit portable TypeScript build-plan package paths on Windows",
+      "status": "pending",
+      "depends_on": ["build-tool-typescript-language-identity-registry"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered by the real full-repository plan validation for the TypeScript language/identity-registry slice. On Windows, package rel_path values are emitted with backslashes because index.ts serializes path.relative directly, while the language-neutral canonical path contract requires forward slashes. Keep this separate from discovery identity: add a cross-platform plan fixture and real CLI coverage, normalize only repository-relative serialized paths, and preserve absolute destination option handling for its separately owned file-option concerns."
+    },
+    {
       "id": "build-tool-go-rockspec-utf8-conformance",
       "title": "Make the Go build tool enforce strict UTF-8 rockspec metadata",
       "status": "merged",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -361,11 +361,11 @@
     {
       "id": "build-tool-typescript-language-identity-registry",
       "title": "Bring TypeScript build-tool discovery to the canonical language and identity registry",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-typescript-language-identity-registry",
       "pr_number": null,
-      "notes": "Discovered by the real full-repository plan during the TypeScript UTF-8 slice. The engine emits 4,770 package records but only 4,383 unique names, including 655 unknown-language records and 217 duplicate identity groups; common C, C++, Dart, Java, and Kotlin packages collapse together under unknown/<basename>. Consume the shared discovery language-registry and duplicate-identity fixtures, classify exact package/program lane boundaries, preserve package versus program identity, exclude spec fixtures, and fail closed on residual duplicate qualified names in a separate focused slice."
+      "notes": "Selected after merged PR #9572 and the collision-clean 6141793a inventory because the dependency is satisfied and real full-plan identity corruption affects every downstream graph consumer. The engine emits 4,770 package records but only 4,383 unique names, including 655 unknown-language records and 217 duplicate identity groups; common C, C++, Dart, Java, and Kotlin packages collapse together under unknown/<basename>. Consume the shared discovery language-registry and duplicate-identity fixtures, classify exact package/program lane boundaries, preserve package versus program identity, exclude spec fixtures, and fail closed on residual duplicate qualified names. This outranks the local-only Windows gitdiff fixture debt and the next single-engine UTF-8 child on dependency leverage."
     },
     {
       "id": "build-tool-go-rockspec-utf8-conformance",

--- a/code/programs/typescript/build-tool/CHANGELOG.md
+++ b/code/programs/typescript/build-tool/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the TypeScript build tool will be documented in this file
 
 ### Fixed
 
+- Classify languages only from the canonical package/program bucket, preserve
+  `language/programs/name` identities, and exclude specification fixtures.
+- Reject residual duplicate qualified names with the stable
+  `DUPLICATE_PACKAGE_IDENTITY` diagnostic, sorted repository-relative paths,
+  and CLI exit code 2.
 - Decode Lua rockspec metadata as strict UTF-8 and fail closed with the portable
   `METADATA_INVALID_UTF8` diagnostic and CLI exit code 2 for malformed input.
 - Consume the shared positive and invalid UTF-8 resolver fixtures, including a

--- a/code/programs/typescript/build-tool/README.md
+++ b/code/programs/typescript/build-tool/README.md
@@ -6,6 +6,13 @@ An incremental, parallel monorepo build tool implemented in TypeScript. This is 
 
 The build tool discovers packages in the monorepo by walking the directory tree looking for BUILD files, resolves inter-package dependencies by parsing language-specific metadata files, and executes builds in parallel topological order.
 
+Discovery classifies only the exact bucket immediately below `code/packages`
+or `code/programs`. It recognizes every established and emerging implementation
+lane plus the repository's execution, domain, build-language, and shared .NET
+host buckets. Program identities use `language/programs/name`, specification
+fixtures are excluded, and residual duplicate qualified names fail closed with
+the portable `DUPLICATE_PACKAGE_IDENTITY` diagnostic and CLI exit code 2.
+
 ## How it fits in the stack
 
 This is one of several build tool implementations in the monorepo (Python, Ruby, Go, Rust, Elixir, TypeScript). All implementations share the same architecture and produce identical results. The Go implementation is the primary one used in CI; the others serve as educational implementations demonstrating the same concepts in different languages.
@@ -92,6 +99,9 @@ npx vitest run --coverage
 
 - **Zero runtime dependencies**: Only uses Node.js built-in modules (`node:fs`, `node:path`, `node:crypto`, `node:child_process`, `node:os`, `node:util`).
 - **Portable metadata diagnostics**: Strict-decoding failures use repository-relative paths and never expose checkout-specific host paths.
+- **Collision-safe discovery**: Canonical package/program identities are unique;
+  duplicate diagnostics contain sorted repository-relative paths and never
+  expose the checkout root.
 - **Inline directed graph**: Rather than importing an external graph library, the resolver includes a minimal DirectedGraph implementation.
 - **ESM-only**: Uses ES modules throughout (`"type": "module"` in package.json).
 - **Literate programming**: All source files include extensive comments explaining concepts, algorithms, and design decisions.

--- a/code/programs/typescript/build-tool/src/discovery.ts
+++ b/code/programs/typescript/build-tool/src/discovery.ts
@@ -30,10 +30,9 @@
  *
  * ## Language inference
  *
- * We infer the language from the directory path. If the path contains
- * "packages/python/X" or "programs/python/X", the language is "python".
- * Similarly for "ruby", "go", "rust", "typescript", and "elixir". The
- * package name is "{language}/{dir-name}".
+ * We infer the language only from the exact bucket immediately below
+ * `packages` or `programs`. Programs retain a `programs` identity segment so
+ * they cannot collide with a package that has the same language and basename.
  */
 
 import * as fs from "node:fs";
@@ -67,7 +66,39 @@ export const SKIP_DIRS: ReadonlySet<string> = new Set([
   "build",
   "target",
   ".claude",
+  "specs",
   "Pods",
+  ".dart_tool",
+  ".build",
+  ".gradle",
+  "gradle-build",
+]);
+
+/** Canonical repository buckets accepted by build-tool discovery. */
+export const DISCOVERY_LANGUAGES: ReadonlySet<string> = new Set([
+  "csharp",
+  "dart",
+  "elixir",
+  "fsharp",
+  "go",
+  "haskell",
+  "java",
+  "kotlin",
+  "lua",
+  "perl",
+  "python",
+  "ruby",
+  "rust",
+  "swift",
+  "typescript",
+  "c",
+  "cpp",
+  "ocaml",
+  "wasm",
+  "mosaic",
+  "twig",
+  "starlark",
+  "dotnet",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -80,19 +111,37 @@ export const SKIP_DIRS: ReadonlySet<string> = new Set([
  * Think of this as a "build target" -- it's a directory with source code
  * and a BUILD file that tells us how to build it.
  *
- * @property name - A qualified name like "python/logic-gates" or "ruby/arithmetic".
- *                  The format is always "{language}/{directory-name}".
+ * @property name - A qualified name like "python/logic-gates" or
+ *                  "go/programs/build-tool".
  * @property path - Absolute path to the package directory on disk.
  * @property buildCommands - Lines from the BUILD file (commands to execute).
  *                           Blank lines and comments are stripped out.
- * @property language - Inferred language: "python", "ruby", "go", "rust",
- *                      "typescript", "elixir", or "unknown".
+ * @property language - The canonical package/program bucket, or "unknown".
  */
 export interface Package {
   name: string;
   path: string;
   buildCommands: string[];
   language: string;
+}
+
+/** Two or more directories that normalize to one graph identity. */
+export class DuplicatePackageIdentityError extends Error {
+  readonly code = "DUPLICATE_PACKAGE_IDENTITY";
+  readonly package: string;
+  readonly paths: string[];
+
+  constructor(
+    packageName: string,
+    paths: string[],
+  ) {
+    super(
+      `DUPLICATE_PACKAGE_IDENTITY: package=${packageName} paths=${paths.join(",")}`,
+    );
+    this.name = "DuplicatePackageIdentityError";
+    this.package = packageName;
+    this.paths = paths;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -130,10 +179,9 @@ export function readLines(filepath: string): string[] {
 /**
  * Infer the programming language from the directory path.
  *
- * We look for known language directory names in the path components.
- * The pattern we look for is a parent directory named "python", "ruby",
- * "go", "rust", "typescript", or "elixir" that sits under "packages" or
- * "programs".
+ * The sole discriminator is the exact component immediately below a
+ * `packages` or `programs` component. Canonical-looking words later in the
+ * path do not change the result.
  *
  * For example:
  * - "/repo/code/packages/python/logic-gates" -> "python"
@@ -152,25 +200,12 @@ export function inferLanguage(dirPath: string): string {
   // cross-platform plan files or test fixtures).
   const parts = dirPath.split(/[/\\]/);
 
-  const knownLanguages = [
-    "python",
-    "ruby",
-    "go",
-    "rust",
-    "typescript",
-    "elixir",
-    "lua",
-    "perl",
-    "swift",
-    "haskell",
-    "wasm",
-    "csharp",
-    "fsharp",
-    "dotnet",
-  ];
-  for (const lang of knownLanguages) {
-    if (parts.includes(lang)) {
-      return lang;
+  for (let index = 0; index < parts.length; index += 1) {
+    if (parts[index] === "packages" || parts[index] === "programs") {
+      const bucket = parts[index + 1];
+      return bucket !== undefined && DISCOVERY_LANGUAGES.has(bucket)
+        ? bucket
+        : "unknown";
     }
   }
 
@@ -189,7 +224,35 @@ export function inferLanguage(dirPath: string): string {
  * @returns A qualified name string.
  */
 export function inferPackageName(dirPath: string, language: string): string {
-  return `${language}/${path.basename(dirPath)}`;
+  const parts = dirPath.split(/[/\\]/);
+  const isProgram = parts.some((part, index) =>
+    part === "programs" && index + 1 < parts.length
+  );
+  const kind = isProgram ? "programs/" : "";
+  return `${language}/${kind}${path.basename(dirPath)}`;
+}
+
+function repositoryPackagePath(root: string, packagePath: string): string {
+  const normalizedPath = packagePath.replaceAll("\\", "/");
+  const parts = normalizedPath.split("/").filter(Boolean);
+  let canonicalStart: number | null = null;
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    if (
+      parts[index] === "code" &&
+      (parts[index + 1] === "packages" || parts[index + 1] === "programs")
+    ) {
+      canonicalStart = index;
+    }
+  }
+  if (canonicalStart !== null) {
+    return parts.slice(canonicalStart).join("/");
+  }
+
+  const relative = path.relative(root, packagePath).replaceAll("\\", "/");
+  if (relative !== "" && !relative.startsWith("../")) {
+    return relative;
+  }
+  return path.basename(packagePath);
 }
 
 /**
@@ -239,7 +302,7 @@ export function getBuildFile(
     }
   }
 
-  if (platform === "win32") {
+  if (platform === "win32" || platform === "windows") {
     const windowsBuild = path.join(directory, "BUILD_windows");
     if (fs.existsSync(windowsBuild)) {
       return windowsBuild;
@@ -302,7 +365,27 @@ export function discoverPackages(
   // Sort by name for deterministic output. This ensures that the build
   // order is the same regardless of filesystem ordering (which can vary
   // between operating systems and filesystems).
-  packages.sort((a, b) => a.name.localeCompare(b.name));
+  packages.sort((a, b) =>
+    a.name.localeCompare(b.name) || a.path.localeCompare(b.path)
+  );
+
+  for (let index = 0; index < packages.length;) {
+    let end = index + 1;
+    while (
+      end < packages.length &&
+      packages[end].name === packages[index].name
+    ) {
+      end += 1;
+    }
+    if (end - index > 1) {
+      const paths = packages
+        .slice(index, end)
+        .map((pkg) => repositoryPackagePath(root, pkg.path))
+        .sort((left, right) => left.localeCompare(right));
+      throw new DuplicatePackageIdentityError(packages[index].name, paths);
+    }
+    index = end;
+  }
 
   return packages;
 }

--- a/code/programs/typescript/build-tool/src/index.ts
+++ b/code/programs/typescript/build-tool/src/index.ts
@@ -34,7 +34,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { parseArgs } from "node:util";
-import { discoverPackages } from "./discovery.js";
+import {
+  DuplicatePackageIdentityError,
+  discoverPackages,
+} from "./discovery.js";
 import {
   CI_WORKFLOW_PATH,
   analyzeCIWorkflowChanges,
@@ -405,7 +408,10 @@ Options:
 main().then((code) => {
   process.exit(code);
 }).catch((error: unknown) => {
-  if (error instanceof MetadataEncodingError) {
+  if (
+    error instanceof MetadataEncodingError ||
+    error instanceof DuplicatePackageIdentityError
+  ) {
     console.error(error.message);
     process.exit(2);
   }

--- a/code/programs/typescript/build-tool/tests/discovery.test.ts
+++ b/code/programs/typescript/build-tool/tests/discovery.test.ts
@@ -15,7 +15,10 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import {
+  DuplicatePackageIdentityError,
   discoverPackages,
   readLines,
   inferLanguage,
@@ -42,6 +45,51 @@ function rmDir(dir: string): void {
 function writeFile(filepath: string, content: string): void {
   fs.mkdirSync(path.dirname(filepath), { recursive: true });
   fs.writeFileSync(filepath, content, "utf-8");
+}
+
+interface SharedDiscoveryFixture {
+  workspace: {
+    files: Array<{ path: string; content_utf8: string }>;
+  };
+  expected: {
+    outcome: "ok" | "error";
+    result: {
+      packages?: Array<{
+        language: string;
+        name: string;
+        rel_path: string;
+      }>;
+    };
+    diagnostics: Array<{
+      code: string;
+      path: string;
+      package: string;
+      details: { paths: string[] };
+    }>;
+  };
+  limits: { wall_time_ms: number };
+}
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const sharedFixtureRoot = fileURLToPath(
+  new URL("../../../../specs/fixtures/build-tool-v1/cases/", import.meta.url),
+);
+
+function loadSharedDiscoveryFixture(name: string): SharedDiscoveryFixture {
+  return JSON.parse(
+    fs.readFileSync(path.join(sharedFixtureRoot, name), "utf-8"),
+  ) as SharedDiscoveryFixture;
+}
+
+function materializeSharedDiscoveryFixture(
+  fixture: SharedDiscoveryFixture,
+): string {
+  const root = makeTempDir();
+  fs.mkdirSync(path.join(root, ".git"));
+  for (const file of fixture.workspace.files) {
+    writeFile(path.join(root, ...file.path.split("/")), file.content_utf8);
+  }
+  return root;
 }
 
 // ---------------------------------------------------------------------------
@@ -125,9 +173,12 @@ describe("inferLanguage", () => {
   });
 
   it("should return unknown for unrecognized paths", () => {
-    expect(inferLanguage("/repo/code/packages/haskell/something")).toBe(
-      "haskell",
-    );
+    expect(inferLanguage("/repo/code/packages/custom/haskell")).toBe("unknown");
+  });
+
+  it("should classify only the exact bucket below packages or programs", () => {
+    expect(inferLanguage("/repo/code/packages/custom/go")).toBe("unknown");
+    expect(inferLanguage("/repo/code/programs/ocaml/tool")).toBe("ocaml");
   });
 });
 
@@ -145,7 +196,16 @@ describe("inferPackageName", () => {
   it("should handle nested paths", () => {
     expect(
       inferPackageName("/a/b/c/programs/go/build-tool", "go"),
+    ).toBe("go/programs/build-tool");
+  });
+
+  it("should preserve package and program identities with the same basename", () => {
+    expect(
+      inferPackageName("/repo/code/packages/go/build-tool", "go"),
     ).toBe("go/build-tool");
+    expect(
+      inferPackageName("/repo/code/programs/go/build-tool", "go"),
+    ).toBe("go/programs/build-tool");
   });
 });
 
@@ -344,6 +404,88 @@ describe("discoverPackages", () => {
       "python",
       "ruby",
     ]);
+  });
+
+  it("consumes the shared canonical language-registry fixture", () => {
+    const fixture = loadSharedDiscoveryFixture(
+      "discovery-language-registry.json",
+    );
+    const root = materializeSharedDiscoveryFixture(fixture);
+    try {
+      const packages = discoverPackages(path.join(root, "code"), "linux");
+      const actual = packages.map((pkg) => ({
+        name: pkg.name,
+        language: pkg.language,
+        rel_path: path.relative(root, pkg.path).replaceAll("\\", "/"),
+      }));
+      const expected = fixture.expected.result.packages?.map((pkg) => ({
+        name: pkg.name,
+        language: pkg.language,
+        rel_path: pkg.rel_path,
+      }));
+      expect(actual).toEqual(expected);
+    } finally {
+      rmDir(root);
+    }
+  });
+
+  it("fails closed with the shared duplicate-identity diagnostic", () => {
+    const fixture = loadSharedDiscoveryFixture(
+      "discovery-duplicate-identity.json",
+    );
+    const root = materializeSharedDiscoveryFixture(fixture);
+    try {
+      let caught: unknown;
+      try {
+        discoverPackages(path.join(root, "code"), "linux");
+      } catch (error) {
+        caught = error;
+      }
+      const diagnostic = fixture.expected.diagnostics[0];
+      expect(caught).toBeInstanceOf(DuplicatePackageIdentityError);
+      const duplicate = caught as DuplicatePackageIdentityError;
+      expect(duplicate.code).toBe(diagnostic.code);
+      expect(duplicate.package).toBe(diagnostic.package);
+      expect(duplicate.paths).toEqual(diagnostic.details.paths);
+      expect(duplicate.paths[0]).toBe(diagnostic.path);
+      expect(duplicate.message).toBe(
+        `${diagnostic.code}: package=${diagnostic.package} paths=${diagnostic.details.paths.join(",")}`,
+      );
+      expect(duplicate.message).not.toContain(root);
+    } finally {
+      rmDir(root);
+    }
+  });
+
+  it("real CLI returns exit 2 for duplicate package identity", () => {
+    const fixture = loadSharedDiscoveryFixture(
+      "discovery-duplicate-identity.json",
+    );
+    const root = materializeSharedDiscoveryFixture(fixture);
+    try {
+      const tsxCli = path.join(
+        packageRoot,
+        "node_modules",
+        "tsx",
+        "dist",
+        "cli.mjs",
+      );
+      const entrypoint = path.join(packageRoot, "src", "index.ts");
+      const result = spawnSync(
+        process.execPath,
+        [tsxCli, entrypoint, "--root", root, "--force", "--dry-run"],
+        { encoding: "utf-8", timeout: fixture.limits.wall_time_ms },
+      );
+      const diagnostic = fixture.expected.diagnostics[0];
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(2);
+      expect(result.stderr).toBe(
+        `${diagnostic.code}: package=${diagnostic.package} paths=${diagnostic.details.paths.join(",")}\n`,
+      );
+      expect(result.stderr).not.toContain(root);
+    } finally {
+      rmDir(root);
+    }
   });
 });
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -243,7 +243,7 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   POSIX-only `/repo` path fixtures; this is tracked as a separate test-
   portability slice rather than widening the metadata decoder change;
 - align TypeScript build-tool discovery with the canonical language and identity
-  registry. The in-progress slice consumes the shared registry and duplicate-
+  registry. Ready PR #9582 consumes the shared registry and duplicate-
   identity fixtures, preserves package/program identity, excludes spec fixtures,
   and fails closed on collisions. Its real Windows plan now emits 4,768 unique
   identities, zero duplicate groups, and only intentional `unknown/blog`, down

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -243,10 +243,15 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   POSIX-only `/repo` path fixtures; this is tracked as a separate test-
   portability slice rather than widening the metadata decoder change;
 - align TypeScript build-tool discovery with the canonical language and identity
-  registry. This is the selected next slice: its real full plan currently emits
-  4,770 records but only 4,383 unique names, including 655 `unknown` records and
-  217 duplicate identity groups that collapse C, C++, Dart, Java, Kotlin, and
-  other lanes by basename;
+  registry. The in-progress slice consumes the shared registry and duplicate-
+  identity fixtures, preserves package/program identity, excludes spec fixtures,
+  and fails closed on collisions. Its real Windows plan now emits 4,768 unique
+  identities, zero duplicate groups, and only intentional `unknown/blog`, down
+  from 655 unknown records and 217 duplicate groups;
+- make TypeScript build-plan package paths portable on Windows. The identity-
+  registry validation found that `rel_path` values still use host backslashes;
+  normalize serialized repository-relative paths in a separate fixture-driven
+  slice rather than widening discovery behavior;
 - make Swift build-tool file options recognize Windows drive-letter absolute
   paths. The UTF-8 validation run discovered that `--emit-plan` reaches
   resolution but then joins an absolute Windows path under the repository;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -235,17 +235,18 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   is tracked separately from the Python full-scan blocker. Merged PR #9504
   completed the Go operational-oracle child, and merged PR #9510 completed
   Rust. Merged PR #9537 completed Swift with exact shared success and invalid-
-  byte fixtures plus real CLI exit-2 coverage. TypeScript is the selected next
-  dependency-shaped child because its replacement decoder cannot report
-  malformed bytes faithfully;
+  byte fixtures plus real CLI exit-2 coverage. Merged PR #9572 completed
+  TypeScript with strict decoding, exact shared-fixture coverage, and green
+  Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures; this is tracked as a separate test-
   portability slice rather than widening the metadata decoder change;
 - align TypeScript build-tool discovery with the canonical language and identity
-  registry. Its real full plan currently emits 4,770 records but only 4,383
-  unique names, including 655 `unknown` records and 217 duplicate identity
-  groups that collapse C, C++, Dart, Java, Kotlin, and other lanes by basename;
+  registry. This is the selected next slice: its real full plan currently emits
+  4,770 records but only 4,383 unique names, including 655 `unknown` records and
+  217 duplicate identity groups that collapse C, C++, Dart, Java, Kotlin, and
+  other lanes by basename;
 - make Swift build-tool file options recognize Windows drive-letter absolute
   paths. The UTF-8 validation run discovered that `--emit-plan` reaches
   resolution but then joins an absolute Windows path under the repository;


### PR DESCRIPTION
## Summary
- classify TypeScript build-tool discovery from the canonical package/program language bucket registry
- preserve `language/programs/name` identities, skip specification fixtures, and reject residual duplicate names with `DUPLICATE_PACKAGE_IDENTITY`
- consume the shared language-registry and duplicate-identity fixtures through unit and real CLI tests
- log the separately discovered Windows build-plan `rel_path` portability gap without widening this slice

## Validation
- `npm ci --ignore-scripts`
- `npx vitest run tests/discovery.test.ts`: 37 passed
- focused coverage: 93.40% lines, 89.23% branches, 100% functions in `src/discovery.ts`
- `npx vitest run --exclude tests/gitdiff.test.ts`: 271 passed
- full local Windows suite: 274 passed; exactly 7 pre-existing `gitdiff.test.ts` portability failures remain in their existing backlog item (2 `/bin/sh` ENOENT, 5 POSIX `/repo` fixtures)
- real full plan: 4,768 packages, 4,768 unique names, 0 duplicate groups, 1 intentional unknown (`unknown/blog`), 7,242 edges
- build-tool schema tests: 17 passed plus 15 subtests
- build-tool runner tests: 40 passed plus 37 subtests
- conformance corpus: 36 cases / 55 files, 15 established languages, 16 implementations
- collision-checked package parity inventory: 1,222 implementation identities / 4,370 slots; 0 collisions; 0 unknown inventory buckets
- production esbuild bundle and bundled `--help`
- `npm audit`: 0 vulnerabilities
- Lua BUILD validation: exact existing 10-package `BUILD_windows` debt set only
- JSON parsing, `git diff --check`, exact-head rebase, and secret-like diff scan