### PR TITLE
Align SPICE parser MOS LEVEL validation

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject non-finite and non-Level-1 MOS model-card `LEVEL` values while
+  preserving explicit and implicit Level 1 cards.
 - Parse `.save`, scoped or global `.probe`, and `.measure` / `.meas` cards,
   and expose `select_outputs()` / `measure_results()` helpers plus matching
   `ParsedNetlist` methods for analysis-plan results.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1878,7 +1878,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         params_text = " ".join(fields[3:]).strip()
         if params_text.startswith("(") and params_text.endswith(")"):
             params_text = params_text[1:-1]
-    return ModelCard(name=name, kind=kind, params=_parse_model_params(params_text))
+    params = _parse_model_params(params_text)
+    if kind in {"NMOS", "PMOS"} and "LEVEL" in params:
+        level = params["LEVEL"]
+        if not math.isfinite(level) or abs(level - 1.0) > 1.0e-12:
+            raise NetlistParseError("only MOS LEVEL=1 model cards are supported")
+    return ModelCard(name=name, kind=kind, params=params)
 
 
 def _parse_model_params(params_text: str) -> dict[str, float]:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1376,6 +1376,22 @@ M1 d g s b nfast W
         )
 
 
+@pytest.mark.parametrize("level", ["0", "2", "1.000000000002", "1e999"])
+def test_rejects_unsupported_mosfet_model_levels(level: str) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="only MOS LEVEL=1 model cards are supported",
+    ):
+        parse_netlist(f".model nfast NMOS(LEVEL={level})\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("parameters", ["LEVEL=1", "LEVEL=1.0000000000005", ""])
+def test_preserves_supported_and_implicit_mosfet_model_level_one(parameters: str) -> None:
+    parsed = parse_netlist(f".model nfast NMOS({parameters})\nM1 d g s b nfast\n")
+
+    assert isinstance(parsed.circuit.elements[0], Mosfet)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject non-finite and non-Level-1 MOS model-card `LEVEL` values while
+  preserving explicit and implicit Level 1 cards.
 - Parse `.save`, scoped or global `.probe`, and `.measure` / `.meas` cards,
   and expose `selectOutputs()` / `measureResults()` helpers plus matching
   `ParsedNetlist` methods for analysis-plan results.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1145,10 +1145,20 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   if (paramsText.startsWith("(") && paramsText.endsWith(")")) {
     paramsText = paramsText.slice(1, -1);
   }
+  const kind = match[1].toUpperCase();
+  const params = parseModelParams(paramsText);
+  const level = params.get("LEVEL");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    level !== undefined &&
+    (!Number.isFinite(level) || Math.abs(level - 1.0) > 1.0e-12)
+  ) {
+    throw new NetlistParseError("only MOS LEVEL=1 model cards are supported");
+  }
   return {
     name: fields[1],
-    kind: match[1].toUpperCase(),
-    params: parseModelParams(paramsText),
+    kind,
+    params,
   };
 }
 

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1289,6 +1289,23 @@ Xright c d load
     );
   });
 
+  it.each(["0", "2", "1.000000000002", "1e999"])(
+    "rejects unsupported MOSFET model LEVEL=%s",
+    (level) => {
+      expect(() => parseNetlist(`.model nfast NMOS(LEVEL=${level})\nM1 d g s b nfast\n`)).toThrow(
+        "only MOS LEVEL=1 model cards are supported",
+      );
+    },
+  );
+
+  it.each(["LEVEL=1", "LEVEL=1.0000000000005", ""])(
+    "preserves supported MOSFET model parameters %s",
+    (parameters) => {
+      const parsed = parseNetlist(`.model nfast NMOS(${parameters})\nM1 d g s b nfast\n`);
+      expect(parsed.circuit.elements()[0].kind).toBe("mosfet");
+    },
+  );
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE MOS model-card electrostatic-default lowering parity.
+1. Python and TypeScript Berkeley SPICE MOS model-card level validation parity.
    - Status: current PR completion candidate.
-   - Validate `NSS` and `TPG` before lowering MOS elements into engine
-     parameters.
-   - Reuse shared engine semantics for `N_SUB` / `TOX` derived `VT0`, `GAMMA`,
-     and `PHI` defaults instead of silently dropping supported inputs.
+   - Reject non-finite and non-Level-1 model-card `LEVEL` values with the same
+     tolerance and diagnostic already used by Rust and the shared engines.
+   - Preserve explicit `LEVEL=1` model cards and cards that omit `LEVEL`.
 
 ## Completed Slices
 
@@ -4114,20 +4113,30 @@ the Rust, Python, and TypeScript surfaces together.
      lowering MOS elements into engine parameters.
    - Explicit `LEVEL=1` model cards and cards that omit `LEVEL` remain accepted.
 
+366. Rust Berkeley SPICE MOS model-card electrostatic-default lowering parity.
+   - Status: completed in PR 9577.
+   - `NSS` and `TPG` values are validated before lowering MOS elements.
+   - `N_SUB` / `TOX` derived `VT0`, `GAMMA`, and `PHI` defaults reuse shared
+     engine semantics instead of silently dropping supported inputs.
+
+367. Rust Berkeley SPICE MOS model-card supported-parameter and lowering audit.
+   - Status: completed during post-PR 9577 reconciliation.
+   - Every shared Level-1 alias is now validated and either directly lowered or
+     handled by the shared electrostatic-default path.
+   - No remaining Rust netlist-facade model-card gap was confirmed.
+
 ## Backlog
 
-1. Rust Berkeley SPICE MOS model-card electrostatic-default lowering parity.
-   - Validate `NSS` and `TPG` before lowering MOS elements into engine
-     parameters.
-   - Reuse shared engine semantics for `N_SUB` / `TOX` derived `VT0`, `GAMMA`,
-     and `PHI` defaults instead of silently dropping supported inputs.
+1. Python and TypeScript Berkeley SPICE MOS model-card level validation parity.
+   - Reject non-finite and non-Level-1 model-card `LEVEL` values with the same
+     tolerance and diagnostic already used by Rust and the shared engines.
+   - Preserve explicit `LEVEL=1` model cards and cards that omit `LEVEL`.
 
-2. Rust Berkeley SPICE MOS model-card validation audit.
-   - Re-audit supported model-card parameters after the electrostatic-default
-     facade gap lands, recording any newly confirmed gaps here before selecting
-     another slice.
-   - Reuse contracts and diagnostics already aligned across the Rust, Python,
-     and TypeScript engines whenever the missing behavior is facade-only.
+2. Python and TypeScript Berkeley SPICE Level-1 model-card lowering parity.
+   - Audit and close supported parameter, alias, validation, and derived-default
+     gaps against the completed Rust facade and shared engines.
+   - Keep each follow-up slice small while preserving identical diagnostics and
+     lowering semantics across all three languages.
 
 3. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust


### PR DESCRIPTION
## Summary
- reject non-finite and unsupported MOS model-card LEVEL values in the Python and TypeScript parsers
- preserve implicit and tolerance-equivalent Level 1 cards with mirrored tests
- record the completed Rust audit and prioritize the broader Python/TypeScript lowering parity follow-up

## Verification
- Python spice-netlist-parser: 80 tests passed, 87.81% coverage
- Python ruff: passed
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed, 79 tests passed
- TypeScript spice-netlist-parser coverage: 82.88% statements, 83.52% lines
- git diff --check: passed

## Note
- A standalone mypy run still reports the existing origin/main type errors; mypy is not part of this package BUILD gate and this change adds none.