### PR TITLE
feat(adj): replay formula parser inventories in CAS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Test parity metadata contracts
         run: |
           python3 -m pip install --disable-pip-version-check --quiet jsonschema==4.26.0
+          cargo build --manifest-path code/packages/rust/adj-lang-cli/Cargo.toml --bin adj-formula-inventory
           python3 -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_haskell_required_capabilities.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_ocaml_toolchain_lock.py'
@@ -110,7 +111,9 @@ jobs:
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
           python3 code/scripts/adj_stdlib_report.py --format json --fail-on-unreferenced-tests > /tmp/adj-stdlib-report.json
           python3 code/scripts/adj_stdlib_manifest.py --validate-json-schema > /tmp/adj-stdlib-manifest.json
-          python3 code/scripts/adj_stdlib_provenance.py verify > /tmp/adj-stdlib-provenance.json
+          python3 code/scripts/adj_stdlib_provenance.py verify \
+            --formula-inventory-binary code/packages/rust/target/debug/adj-formula-inventory \
+            > /tmp/adj-stdlib-provenance.json
           (cd code/programs/go/capability-cage-generator && go test ./...)
           (cd code/packages/go/ca-capability-analyzer && go test ./...)
           (cd code/packages/go/capability-cage && go test ./...)

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.33.0] - 2026-08-02 - parser-backed formula inventory
+
+- Added `adj-formula-inventory`, which emits canonical JSON from the real Adj-Lang parser for
+  every formula in one source file.
+- Each inventory binds the exact source SHA-256 and each formula's declaration and final-body
+  half-open UTF-8 spans plus their byte hashes. Parameters, parser order, and multi-step counts
+  are structural metadata; the inventory does not claim import resolution, semantic derivation,
+  or execution.
+- Serialization and verifier pipe capture enforce the 64 MiB CAS object limit while streaming.
+  The provenance CAS can store and replay the inventory against its linked input bytes, and each
+  formula declaration must have its own enclosing input-IR claim.
+
 ## [0.32.0] - 2026-08-02 - formula-only `adj-verify`
 
 - `adj-verify` now reports every computed binding, re-evaluates its separately stored compiler

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 
@@ -16,13 +16,16 @@ path = "src/main.rs"
 name = "adj-verify"
 path = "src/bin/adj-verify.rs"
 
+[[bin]]
+name = "adj-formula-inventory"
+path = "src/bin/adj-formula-inventory.rs"
+
 [dependencies]
 adj-lang = { path = "../adj-lang" }
 adj-constraint-solver = { path = "../adj-constraint-solver" }
 logic-engine = { path = "../logic-engine" }
 logic-core = { path = "../logic-core" }
 cli-builder = { path = "../cli-builder" }
-
-[dev-dependencies]
 coding_adventures_sha256 = { path = "../sha256" }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/code/packages/rust/adj-lang-cli/README.md
+++ b/code/packages/rust/adj-lang-cli/README.md
@@ -89,6 +89,24 @@ machine-readable measure of how much of the corpus is still uncheckable.
 touches the network — it is the deep re-execution *inside* one engine artifact,
 which ADJ08's linter should call rather than reimplement.
 
+## `adj-formula-inventory` - exact parser source spans
+
+```sh
+adj-formula-inventory LIBRARY.adj
+```
+
+This binary emits canonical JSON that binds the input SHA-256 to every formula
+found by the real Adj-Lang parser. Each entry carries exact half-open UTF-8 byte
+spans and SHA-256s for the declaration and final body expression, along with the
+formula name, parameters, parser order, and step count. It is a structural input
+for provenance tooling: it does not resolve imports, prove source-to-formula
+equivalence, or claim that any formula executed successfully.
+
+The ADJ provenance verifier stores this output as a `formula_parser_inventory`
+CAS object and reruns this binary against the linked CAS input. Verification
+requires exact JSON agreement and one distinct enclosing input-IR claim for each
+formula declaration.
+
 ## Where it fits
 
 ```

--- a/code/packages/rust/adj-lang-cli/src/bin/adj-formula-inventory.rs
+++ b/code/packages/rust/adj-lang-cli/src/bin/adj-formula-inventory.rs
@@ -1,0 +1,181 @@
+//! Emit a canonical, parser-backed inventory of formula source bytes.
+
+use std::env;
+use std::fs;
+use std::io::{Read, Write};
+use std::process::ExitCode;
+
+use coding_adventures_sha256::sha256_hex;
+use serde::Serialize;
+
+const MAX_SOURCE_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Serialize)]
+struct Span {
+    end: usize,
+    sha256: String,
+    start: usize,
+}
+
+#[derive(Serialize)]
+struct Formula<'a> {
+    body: Span,
+    declaration: Span,
+    formula: &'a str,
+    formulabook: &'a str,
+    parameters: &'a [String],
+    step_count: usize,
+}
+
+#[derive(Serialize)]
+struct Inventory<'a> {
+    formulas: Vec<Formula<'a>>,
+    kind: &'static str,
+    parser_contract: &'static str,
+    schema_version: u8,
+    scope: &'static str,
+    source_sha256: String,
+    source_size: usize,
+}
+
+enum Failure {
+    Input(String),
+    Usage(String),
+}
+
+struct LimitedWriter<W> {
+    inner: W,
+    remaining: usize,
+}
+
+impl<W: Write> Write for LimitedWriter<W> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if bytes.len() > self.remaining {
+            return Err(std::io::Error::other(
+                "formula inventory output exceeds byte limit",
+            ));
+        }
+        let written = self.inner.write(bytes)?;
+        self.remaining -= written;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn span(source: &[u8], value: adj_lang::SourceSpan) -> Span {
+    Span {
+        end: value.end,
+        sha256: sha256_hex(&source[value.start..value.end]),
+        start: value.start,
+    }
+}
+
+fn run() -> Result<(), Failure> {
+    let mut args = env::args_os();
+    let program = args
+        .next()
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| "adj-formula-inventory".to_string());
+    let path = args
+        .next()
+        .ok_or_else(|| Failure::Usage(format!("usage: {program} PROGRAM.adj")))?;
+    if args.next().is_some() {
+        return Err(Failure::Usage(format!("usage: {program} PROGRAM.adj")));
+    }
+
+    let file = fs::File::open(&path)
+        .map_err(|error| Failure::Usage(format!("cannot open {:?}: {error}", path)))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| Failure::Usage(format!("cannot inspect {:?}: {error}", path)))?;
+    if !metadata.is_file() {
+        return Err(Failure::Usage(format!(
+            "source is not a regular file: {:?}",
+            path
+        )));
+    }
+    if metadata.len() > MAX_SOURCE_BYTES {
+        return Err(Failure::Usage(format!(
+            "source exceeds {MAX_SOURCE_BYTES} byte limit"
+        )));
+    }
+    let mut source = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_SOURCE_BYTES + 1)
+        .read_to_end(&mut source)
+        .map_err(|error| Failure::Usage(format!("cannot read {:?}: {error}", path)))?;
+    if source.len() as u64 > MAX_SOURCE_BYTES {
+        return Err(Failure::Usage(format!(
+            "source exceeds {MAX_SOURCE_BYTES} byte limit"
+        )));
+    }
+    let text = std::str::from_utf8(&source)
+        .map_err(|error| Failure::Input(format!("source is not UTF-8: {error}")))?;
+    let inventory = adj_lang::formula_source_map(text)
+        .map_err(|error| Failure::Input(format!("formula source map failed: {error:?}")))?;
+
+    let formulas = inventory
+        .iter()
+        .map(|item| Formula {
+            body: span(&source, item.body_span),
+            declaration: span(&source, item.declaration_span),
+            formula: &item.formula.name,
+            formulabook: &item.formulabook,
+            parameters: &item.formula.params,
+            step_count: item.formula.steps.len(),
+        })
+        .collect();
+    let output = Inventory {
+        formulas,
+        kind: "formula_parser_inventory",
+        parser_contract: "adj-lang/formula_source_map/v1",
+        schema_version: 1,
+        scope: "source_file",
+        source_sha256: sha256_hex(&source),
+        source_size: source.len(),
+    };
+    let stdout = std::io::stdout();
+    let mut writer = LimitedWriter {
+        inner: stdout.lock(),
+        remaining: MAX_SOURCE_BYTES as usize,
+    };
+    serde_json::to_writer_pretty(&mut writer, &output)
+        .map_err(|error| Failure::Usage(format!("cannot serialize inventory: {error}")))?;
+    writer
+        .write_all(b"\n")
+        .and_then(|()| writer.flush())
+        .map_err(|error| Failure::Usage(format!("cannot write inventory: {error}")))?;
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(Failure::Input(error)) => {
+            eprintln!("{error}");
+            ExitCode::from(1)
+        }
+        Err(Failure::Usage(error)) => {
+            eprintln!("{error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_writer_rejects_a_chunk_past_its_limit() {
+        let mut writer = LimitedWriter {
+            inner: Vec::new(),
+            remaining: 4,
+        };
+
+        assert!(writer.write_all(b"12345").is_err());
+        assert!(writer.inner.is_empty());
+    }
+}

--- a/code/packages/rust/adj-lang-cli/tests/formula_inventory_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_inventory_e2e.rs
@@ -1,0 +1,142 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "adj_formula_inventory_{tag}_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn inventory(path: &std::path::Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_adj-formula-inventory"))
+        .arg(path)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn emits_parser_order_and_exact_byte_hashes() {
+    let dir = scratch("bytes");
+    let path = dir.join("library.adj");
+    let source = concat!(
+        "formulabook demo {\n",
+        "  formula total(a, b) = a + b source \"sum\" locator \"cas://sum\" trust authoritative\n",
+        "  formula scaled(x) {\n",
+        "    let doubled = x * 2\n",
+        "    doubled / 10\n",
+        "  } source \"scale\" locator \"cas://scale\" trust authoritative\n",
+        "}\n",
+    );
+    fs::write(&path, source).unwrap();
+
+    let output = inventory(&path);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["kind"], "formula_parser_inventory");
+    assert_eq!(value["parser_contract"], "adj-lang/formula_source_map/v1");
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["scope"], "source_file");
+    assert_eq!(value["source_size"], source.len());
+    assert_eq!(
+        value["source_sha256"],
+        coding_adventures_sha256::sha256_hex(source.as_bytes())
+    );
+
+    let formulas = value["formulas"].as_array().unwrap();
+    assert_eq!(formulas.len(), 2);
+    assert_eq!(formulas[0]["formula"], "total");
+    assert_eq!(formulas[0]["parameters"], serde_json::json!(["a", "b"]));
+    assert_eq!(formulas[0]["step_count"], 0);
+    assert_eq!(formulas[1]["formula"], "scaled");
+    assert_eq!(formulas[1]["step_count"], 1);
+
+    for formula in formulas {
+        for field in ["body", "declaration"] {
+            let span = &formula[field];
+            let start = span["start"].as_u64().unwrap() as usize;
+            let end = span["end"].as_u64().unwrap() as usize;
+            assert!(start < end && end <= source.len());
+            assert_eq!(
+                span["sha256"],
+                coding_adventures_sha256::sha256_hex(&source.as_bytes()[start..end])
+            );
+        }
+    }
+    assert_eq!(
+        &source[formulas[1]["body"]["start"].as_u64().unwrap() as usize
+            ..formulas[1]["body"]["end"].as_u64().unwrap() as usize],
+        "doubled / 10"
+    );
+}
+
+#[test]
+fn rejects_non_utf8_and_malformed_input() {
+    let dir = scratch("errors");
+    let non_utf8 = dir.join("non-utf8.adj");
+    fs::write(&non_utf8, [0xff, 0xfe]).unwrap();
+    let output = inventory(&non_utf8);
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("not UTF-8"));
+
+    let malformed = dir.join("malformed.adj");
+    fs::write(&malformed, "formulabook broken { formula nope(a) = }").unwrap();
+    let output = inventory(&malformed);
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("source map failed"));
+}
+
+#[test]
+fn preserves_unicode_crlf_bytes_and_does_not_resolve_imports() {
+    let dir = scratch("unicode");
+    let path = dir.join("library.adj");
+    let source = concat!(
+        "% pi: π\r\n",
+        "import \"absent.adj\"\r\n",
+        "formulabook local {\r\n",
+        "  formula decimal(x) = x + 0.1 source \"fixture\" locator \"cas://decimal\" trust authoritative\r\n",
+        "}\r\n",
+    );
+    fs::write(&path, source).unwrap();
+
+    let output = inventory(&path);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["scope"], "source_file");
+    assert_eq!(value["formulas"].as_array().unwrap().len(), 1);
+    let body = &value["formulas"][0]["body"];
+    let start = body["start"].as_u64().unwrap() as usize;
+    let end = body["end"].as_u64().unwrap() as usize;
+    assert_eq!(&source.as_bytes()[start..end], b"x + 0.1");
+    assert!(value["formulas"][0].get("ast").is_none());
+    let canonical = format!("{}\n", serde_json::to_string_pretty(&value).unwrap());
+    assert_eq!(output.stdout, canonical.as_bytes());
+}
+
+#[test]
+fn rejects_a_source_larger_than_the_cas_object_limit_before_reading() {
+    let dir = scratch("oversized");
+    let path = dir.join("oversized.adj");
+    fs::File::create(&path)
+        .unwrap()
+        .set_len(64 * 1024 * 1024 + 1)
+        .unwrap();
+
+    let output = inventory(&path);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("byte limit"));
+}

--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -16,9 +16,11 @@ import json
 import os
 import re
 import stat
+import subprocess
 import tempfile
+import threading
 import xml.etree.ElementTree as ET
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -31,6 +33,7 @@ MAX_OBJECT_BYTES = 64 * 1024 * 1024
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 OBJECT_KINDS = {
     "fetch_receipt",
+    "formula_parser_inventory",
     "input_receipt",
     "provenance_bundle",
     "raw_source",
@@ -652,6 +655,211 @@ def _json_object(cas: Cas, digest: str, expected_kind: str) -> dict[str, Any]:
     return value
 
 
+def _run_formula_inventory(
+    parser_command: Sequence[str], source_path: Path
+) -> dict[str, Any]:
+    if not parser_command:
+        raise ProvenanceError("formula inventory parser command must not be empty")
+    try:
+        process = subprocess.Popen(
+            [*parser_command, os.fspath(source_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as error:
+        raise ProvenanceError(
+            f"formula inventory parser failed to run: {error}"
+        ) from error
+    stdout = bytearray()
+    stderr = bytearray()
+    overflow = threading.Event()
+
+    def drain(stream: Any, output: bytearray, limit: int) -> None:
+        while True:
+            chunk = stream.read(65536)
+            if not chunk:
+                return
+            remaining = limit - len(output)
+            output.extend(chunk[:remaining])
+            if len(chunk) > remaining:
+                overflow.set()
+                process.kill()
+                return
+
+    stdout_thread = threading.Thread(
+        target=drain,
+        args=(process.stdout, stdout, MAX_OBJECT_BYTES),
+        daemon=True,
+    )
+    stderr_thread = threading.Thread(
+        target=drain,
+        args=(process.stderr, stderr, 4096),
+        daemon=True,
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+    try:
+        returncode = process.wait(timeout=60)
+    except subprocess.TimeoutExpired as error:
+        process.kill()
+        process.wait()
+        raise ProvenanceError(
+            "formula inventory parser timed out after 60 seconds"
+        ) from error
+    finally:
+        stdout_thread.join()
+        stderr_thread.join()
+        process.stdout.close()
+        process.stderr.close()
+    if overflow.is_set():
+        raise ProvenanceError("formula inventory parser output exceeds byte limit")
+    if returncode != 0:
+        detail = bytes(stderr).decode("utf-8", errors="replace").strip()
+        raise ProvenanceError(f"formula inventory parser exited {returncode}: {detail}")
+    try:
+        value = json.loads(bytes(stdout).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ProvenanceError(
+            "formula inventory parser did not emit UTF-8 JSON"
+        ) from error
+    if not isinstance(value, dict):
+        raise ProvenanceError("formula inventory parser output must be an object")
+    if bytes(stdout) != canonical_json_bytes(value):
+        raise ProvenanceError("formula inventory parser output is not canonical JSON")
+    return value
+
+
+def _validate_formula_inventory_value(
+    value: Any, source_hash: str, source: bytes
+) -> None:
+    if not isinstance(value, dict) or set(value) != {
+        "formulas",
+        "kind",
+        "parser_contract",
+        "schema_version",
+        "scope",
+        "source_sha256",
+        "source_size",
+    }:
+        raise ProvenanceError("formula parser inventory has unknown or missing fields")
+    if (
+        value["kind"] != "formula_parser_inventory"
+        or value["parser_contract"] != "adj-lang/formula_source_map/v1"
+        or not _is_integer(value["schema_version"])
+        or value["schema_version"] != 1
+        or value["scope"] != "source_file"
+        or _require_hash(
+            value["source_sha256"], "formula parser inventory source_sha256"
+        )
+        != source_hash
+        or not _is_integer(value["source_size"])
+        or value["source_size"] != len(source)
+    ):
+        raise ProvenanceError(
+            "formula parser inventory contract or source binding disagrees"
+        )
+    formulas = value["formulas"]
+    if not isinstance(formulas, list):
+        raise ProvenanceError("formula parser inventory formulas must be an array")
+    previous_end = 0
+    for index, formula in enumerate(formulas):
+        prefix = f"formula parser inventory formulas[{index}]"
+        if not isinstance(formula, dict) or set(formula) != {
+            "body",
+            "declaration",
+            "formula",
+            "formulabook",
+            "parameters",
+            "step_count",
+        }:
+            raise ProvenanceError(f"{prefix} has unknown or missing fields")
+        _require_nonempty(formula["formula"], f"{prefix}.formula")
+        _require_nonempty(formula["formulabook"], f"{prefix}.formulabook")
+        parameters = formula["parameters"]
+        if not isinstance(parameters, list) or any(
+            not isinstance(parameter, str) or not parameter for parameter in parameters
+        ):
+            raise ProvenanceError(f"{prefix}.parameters must contain non-empty strings")
+        if not _is_integer(formula["step_count"]) or formula["step_count"] < 0:
+            raise ProvenanceError(f"{prefix}.step_count must be a non-negative integer")
+        spans: dict[str, tuple[int, int]] = {}
+        for span_name in ("body", "declaration"):
+            span = formula[span_name]
+            if not isinstance(span, dict) or set(span) != {"end", "sha256", "start"}:
+                raise ProvenanceError(f"{prefix}.{span_name} has the wrong schema")
+            start = span["start"]
+            end = span["end"]
+            if (
+                not _is_integer(start)
+                or not _is_integer(end)
+                or start < 0
+                or end <= start
+                or end > len(source)
+            ):
+                raise ProvenanceError(f"{prefix}.{span_name} is outside source bytes")
+            if _require_hash(
+                span["sha256"], f"{prefix}.{span_name}.sha256"
+            ) != sha256_bytes(source[start:end]):
+                raise ProvenanceError(f"{prefix}.{span_name} byte hash disagrees")
+            spans[span_name] = (start, end)
+        body_start, body_end = spans["body"]
+        declaration_start, declaration_end = spans["declaration"]
+        if not (
+            declaration_start <= body_start
+            and body_end <= declaration_end
+            and declaration_start >= previous_end
+        ):
+            raise ProvenanceError(
+                f"{prefix} body/declaration containment or parser order disagrees"
+            )
+        previous_end = declaration_end
+
+
+def _validate_formula_inventory(
+    cas: Cas,
+    digest: str,
+    source_hash: str,
+    input_claims: dict[str, dict[str, Any]],
+    parser_command: Sequence[str] | None,
+) -> dict[str, Any]:
+    source = _read_regular_file(cas.object_path(source_hash))
+    value = _json_object(cas, digest, "formula_parser_inventory")
+    _validate_formula_inventory_value(value, source_hash, source)
+    if cas.index[digest]["links"] != [source_hash]:
+        raise ProvenanceError(
+            "formula parser inventory must link only to its source bytes"
+        )
+    if parser_command is None:
+        raise ProvenanceError(
+            "formula inventory replay requires --formula-inventory-binary"
+        )
+    replayed = _run_formula_inventory(parser_command, cas.object_path(source_hash))
+    if replayed != value:
+        raise ProvenanceError(
+            "stored formula parser inventory disagrees with parser replay"
+        )
+    selected_claims: set[str] = set()
+    for index, formula in enumerate(value["formulas"]):
+        declaration = formula["declaration"]
+        enclosing = [
+            claim_id
+            for claim_id, claim in input_claims.items()
+            if claim["start"] <= declaration["start"]
+            and declaration["end"] <= claim["end"]
+        ]
+        if len(enclosing) != 1:
+            raise ProvenanceError(
+                f"formula parser inventory formulas[{index}] declaration must be "
+                "enclosed by exactly one input IR claim"
+            )
+        if enclosing[0] in selected_claims:
+            raise ProvenanceError(
+                f"input IR claim {enclosing[0]} cannot ground more than one formula"
+            )
+        selected_claims.add(enclosing[0])
+    return value
+
+
 def _registered_manifest(
     cas: Cas,
     manifest_bytes: bytes,
@@ -879,12 +1087,14 @@ class BundleRegistrationTransaction(CasMutationTransaction):
         expected_manifest_id: str,
         schema_path: Path | None = None,
         workspace_root: Path | None = None,
+        formula_inventory_command: Sequence[str] | None = None,
     ) -> None:
         super().__init__(cas_root, blocking=False)
         self.manifest_path = manifest_path
         self.expected_manifest_id = expected_manifest_id
         self.schema_path = schema_path
         self.workspace_root = workspace_root
+        self.formula_inventory_command = formula_inventory_command
         self._baseline_manifest = b""
 
     def __enter__(self):
@@ -895,6 +1105,7 @@ class BundleRegistrationTransaction(CasMutationTransaction):
                 self.manifest_path,
                 self.schema_path,
                 workspace_root=self.workspace_root,
+                formula_inventory_command=self.formula_inventory_command,
             )
             self._baseline_manifest = _read_regular_file(self.manifest_path)
             return self
@@ -919,6 +1130,7 @@ class BundleRegistrationTransaction(CasMutationTransaction):
                 self.manifest_path,
                 self.schema_path,
                 workspace_root=self.workspace_root,
+                formula_inventory_command=self.formula_inventory_command,
             )
         except Exception:
             self._rollback()
@@ -1042,6 +1254,7 @@ def _validate_cas_schemas(schema_path: Path, cas: Cas) -> None:
     definitions = schema.get("$defs", {})
     schema_kinds = {
         "fetch_receipt",
+        "formula_parser_inventory",
         "input_receipt",
         "provenance_bundle",
         "source_ir",
@@ -1323,6 +1536,7 @@ def _validate_bundle(
     snapshots: set[str],
     bundle_claims: dict[str, set[str]],
     bundle_inputs: dict[str, str],
+    formula_inventory_command: Sequence[str] | None,
 ) -> None:
     if digest in validated:
         return
@@ -1330,7 +1544,7 @@ def _validate_bundle(
         raise ProvenanceError(f"provenance bundle dependency cycle at {digest}")
     visiting.add(digest)
     bundle = _json_object(cas, digest, "provenance_bundle")
-    if set(bundle) != {
+    required_fields = {
         "bundle_id",
         "clauses",
         "dependencies",
@@ -1338,7 +1552,11 @@ def _validate_bundle(
         "kind",
         "library",
         "sources",
-    }:
+    }
+    if set(bundle) not in (
+        required_fields,
+        required_fields | {"formula_inventory_sha256"},
+    ):
         raise ProvenanceError(f"bundle {digest} has unknown or missing fields")
     if bundle["kind"] != "provenance_bundle":
         raise ProvenanceError(f"bundle {digest} payload has the wrong kind")
@@ -1357,6 +1575,7 @@ def _validate_bundle(
             snapshots=snapshots,
             bundle_claims=bundle_claims,
             bundle_inputs=bundle_inputs,
+            formula_inventory_command=formula_inventory_command,
         )
     sources = bundle["sources"]
     if not isinstance(sources, list) or not sources:
@@ -1422,6 +1641,24 @@ def _validate_bundle(
             f"bundles disagree on input bytes for {bundle['library']}"
         )
     bundle_inputs[bundle["library"]] = input_raw_hash
+    if "formula_inventory_sha256" in bundle:
+        inventory_hash = _require_hash(
+            bundle["formula_inventory_sha256"], "bundle.formula_inventory_sha256"
+        )
+        if "formula_parser_inventory" not in cas.index.get(inventory_hash, {}).get(
+            "kinds", []
+        ):
+            raise ProvenanceError(
+                f"bundle {digest} formula inventory is missing or has the wrong kind"
+            )
+        _validate_formula_inventory(
+            cas,
+            inventory_hash,
+            input_raw_hash,
+            claims[input_ir_hash],
+            formula_inventory_command,
+        )
+        expected_links.add(inventory_hash)
     clauses = bundle["clauses"]
     if not isinstance(clauses, list) or not clauses:
         raise ProvenanceError(f"bundle {digest} must contain clauses")
@@ -1576,6 +1813,7 @@ def _validate_repository_unlocked(
     manifest_path: Path,
     schema_path: Path | None = None,
     workspace_root: Path | None = None,
+    formula_inventory_command: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     cas = Cas(cas_root)
     cas.load()
@@ -1620,6 +1858,7 @@ def _validate_repository_unlocked(
             snapshots=snapshots,
             bundle_claims=bundle_claims,
             bundle_inputs=bundle_inputs,
+            formula_inventory_command=formula_inventory_command,
         )
     effective_workspace_root = workspace_root or manifest_path.parent
     for repo_path, expected_hash in sorted(bundle_inputs.items()):
@@ -1648,6 +1887,7 @@ def validate_repository(
     manifest_path: Path,
     schema_path: Path | None = None,
     workspace_root: Path | None = None,
+    formula_inventory_command: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     with CasRootLock(cas_root):
         return _validate_repository_unlocked(
@@ -1655,6 +1895,7 @@ def validate_repository(
             manifest_path,
             schema_path,
             workspace_root=workspace_root,
+            formula_inventory_command=formula_inventory_command,
         )
 
 
@@ -1664,10 +1905,15 @@ def project_snapshots(
     output: Path,
     schema_path: Path | None = None,
     workspace_root: Path | None = None,
+    formula_inventory_command: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     with CasRootLock(cas_root):
         result = _validate_repository_unlocked(
-            cas_root, manifest_path, schema_path, workspace_root=workspace_root
+            cas_root,
+            manifest_path,
+            schema_path,
+            workspace_root=workspace_root,
+            formula_inventory_command=formula_inventory_command,
         )
         cas = Cas(cas_root)
         cas.load()
@@ -1710,6 +1956,8 @@ def _resolve(root: Path, value: Path) -> Path:
 
 def _bundle_declared_links(bundle: dict[str, Any]) -> list[str]:
     links = set(bundle.get("dependencies", []))
+    if bundle.get("formula_inventory_sha256") is not None:
+        links.add(bundle["formula_inventory_sha256"])
     for source in bundle.get("sources", []):
         links.update(
             (
@@ -1742,12 +1990,14 @@ def main() -> int:
     verify_parser.add_argument("--cas", type=Path, default=DEFAULT_ROOT)
     verify_parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     verify_parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    verify_parser.add_argument("--formula-inventory-binary", type=Path)
 
     project_parser = subparsers.add_parser("project")
     project_parser.add_argument("--cas", type=Path, default=DEFAULT_ROOT)
     project_parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     project_parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
     project_parser.add_argument("--output", type=Path, required=True)
+    project_parser.add_argument("--formula-inventory-binary", type=Path)
 
     capture_parser = subparsers.add_parser("capture")
     capture_parser.add_argument("--cas", type=Path, default=DEFAULT_ROOT)
@@ -1786,6 +2036,12 @@ def main() -> int:
     ir_parser.add_argument("--segments", type=Path, required=True)
     ir_parser.add_argument("--label", required=True)
 
+    formula_parser = subparsers.add_parser("put-formula-inventory")
+    formula_parser.add_argument("--cas", type=Path, default=DEFAULT_ROOT)
+    formula_parser.add_argument("--source", required=True)
+    formula_parser.add_argument("--formula-inventory-binary", type=Path, required=True)
+    formula_parser.add_argument("--label", required=True)
+
     bundle_parser = subparsers.add_parser("put-bundle")
     bundle_parser.add_argument("--cas", type=Path, default=DEFAULT_ROOT)
     bundle_parser.add_argument("--bundle", type=Path, required=True)
@@ -1800,6 +2056,11 @@ def main() -> int:
                 _resolve(repo_root, args.manifest),
                 _resolve(repo_root, args.schema),
                 workspace_root=repo_root,
+                formula_inventory_command=(
+                    [os.fspath(_resolve(repo_root, args.formula_inventory_binary))]
+                    if args.formula_inventory_binary is not None
+                    else None
+                ),
             )
         elif args.command == "project":
             result = project_snapshots(
@@ -1808,6 +2069,11 @@ def main() -> int:
                 _resolve(repo_root, args.output),
                 _resolve(repo_root, args.schema),
                 workspace_root=repo_root,
+                formula_inventory_command=(
+                    [os.fspath(_resolve(repo_root, args.formula_inventory_binary))]
+                    if args.formula_inventory_binary is not None
+                    else None
+                ),
             )
         elif args.command == "capture":
             with CasMutationTransaction(_resolve(repo_root, args.cas)) as transaction:
@@ -1903,6 +2169,31 @@ def main() -> int:
                 )
                 transaction.commit()
             result = {"source_ir_sha256": ir_hash}
+        elif args.command == "put-formula-inventory":
+            with CasMutationTransaction(_resolve(repo_root, args.cas)) as transaction:
+                cas = transaction.cas
+                source_hash = _require_hash(args.source, "source hash")
+                if "raw_source" not in cas.index.get(source_hash, {}).get("kinds", []):
+                    raise ProvenanceError(
+                        "formula inventory source is not raw_source bytes"
+                    )
+                inventory = _run_formula_inventory(
+                    [os.fspath(_resolve(repo_root, args.formula_inventory_binary))],
+                    cas.object_path(source_hash),
+                )
+                _validate_formula_inventory_value(
+                    inventory,
+                    source_hash,
+                    _read_regular_file(cas.object_path(source_hash)),
+                )
+                inventory_hash = cas.put_json(
+                    inventory,
+                    kind="formula_parser_inventory",
+                    label=args.label,
+                    links=[source_hash],
+                )
+                transaction.commit()
+            result = {"formula_inventory_sha256": inventory_hash}
         elif args.command == "put-transform":
             with CasMutationTransaction(_resolve(repo_root, args.cas)) as transaction:
                 cas = transaction.cas

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS_DIR))
@@ -36,7 +37,18 @@ def acquire_cas_lock_with_alternate_temp(
 
 
 class AdjStdlibProvenanceTests(unittest.TestCase):
-    def build_repository(self, root: Path) -> tuple[Path, Path, dict[str, str]]:
+    def formula_inventory_command(self) -> list[str]:
+        suffix = ".exe" if os.name == "nt" else ""
+        binary = (
+            Path(__file__).resolve().parents[2]
+            / f"packages/rust/target/debug/adj-formula-inventory{suffix}"
+        )
+        self.assertTrue(binary.is_file(), f"missing formula inventory binary: {binary}")
+        return [os.fspath(binary)]
+
+    def build_repository(
+        self, root: Path, *, with_formula_inventory: bool = False
+    ) -> tuple[Path, Path, dict[str, str]]:
         cas_root = root / "cas"
         manifest_path = root / "manifest.json"
         body = b"Header\nSum is the result of addition.\nFooter\n"
@@ -154,7 +166,12 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             links=[raw_hash, rendered_hash],
         )
         input_body = (
-            b'formula sum(a, b) = a + b\n  locator "https://example.test/sum"\n'
+            b"formulabook arithmetic {\n"
+            b"  formula sum(a, b) = a + b\n"
+            b'    source "fixture arithmetic definition"\n'
+            b'    locator "https://example.test/sum"\n'
+            b"    trust authoritative\n"
+            b"}\n"
         )
         input_path = root / "code/example/arithmetic.adj"
         input_path.parent.mkdir(parents=True)
@@ -253,6 +270,21 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             "library": "code/example/arithmetic.adj",
             "sources": [source_entry, input_source_entry],
         }
+        inventory_hash = ""
+        if with_formula_inventory:
+            inventory = provenance._run_formula_inventory(
+                self.formula_inventory_command(), cas.object_path(input_hash)
+            )
+            provenance._validate_formula_inventory_value(
+                inventory, input_hash, input_body
+            )
+            inventory_hash = cas.put_json(
+                inventory,
+                kind="formula_parser_inventory",
+                label="fixture formula parser inventory",
+                links=[input_hash],
+            )
+            bundle["formula_inventory_sha256"] = inventory_hash
         bundle_hash = cas.put_json(
             bundle,
             kind="provenance_bundle",
@@ -279,6 +311,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 "input": input_hash,
                 "input_ir": input_ir_hash,
                 "input_receipt": input_receipt_hash,
+                "formula_inventory": inventory_hash,
                 "bundle": bundle_hash,
                 "transform": transform_hash,
                 "snapshot": rendered_hash,
@@ -329,6 +362,137 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertEqual(
                 provenance.sha256_bytes(projected_bytes), hashes["snapshot"]
             )
+
+    def test_formula_inventory_is_replayed_from_exact_cas_input_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(
+                root, with_formula_inventory=True
+            )
+            schema = (
+                Path(__file__).resolve().parents[2]
+                / "specs/data/adj-stdlib-provenance/manifest.schema.json"
+            )
+
+            result = provenance.validate_repository(
+                cas_root,
+                manifest_path,
+                schema,
+                workspace_root=root,
+                formula_inventory_command=self.formula_inventory_command(),
+            )
+
+            self.assertTrue(result["valid"])
+            self.assertEqual(result["objects"], 11)
+            cas = provenance.Cas(cas_root)
+            cas.load()
+            inventory = provenance._json_object(
+                cas, hashes["formula_inventory"], "formula_parser_inventory"
+            )
+            self.assertEqual(inventory["source_sha256"], hashes["input"])
+            self.assertEqual(
+                [item["formula"] for item in inventory["formulas"]], ["sum"]
+            )
+
+    def test_formula_inventory_fails_closed_without_replay_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, _ = self.build_repository(
+                root, with_formula_inventory=True
+            )
+
+            with self.assertRaisesRegex(
+                provenance.ProvenanceError, "requires --formula-inventory-binary"
+            ):
+                provenance.validate_repository(
+                    cas_root, manifest_path, workspace_root=root
+                )
+
+    def test_formula_inventory_rejects_parser_replay_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, _ = self.build_repository(
+                root, with_formula_inventory=True
+            )
+            command = self.formula_inventory_command()
+            original = provenance._run_formula_inventory
+
+            def drifted(parser_command: object, source_path: Path) -> dict[str, object]:
+                value = original(parser_command, source_path)
+                value["formulas"][0]["step_count"] = 1
+                return value
+
+            with (
+                mock.patch.object(provenance, "_run_formula_inventory", drifted),
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError, "disagrees with parser replay"
+                ),
+            ):
+                provenance.validate_repository(
+                    cas_root,
+                    manifest_path,
+                    workspace_root=root,
+                    formula_inventory_command=command,
+                )
+
+    def test_formula_inventory_parser_output_is_bounded_while_reading(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.adj"
+            source.write_bytes(b"")
+            command = [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.buffer.write(b'x' * 2048)",
+            ]
+
+            with (
+                mock.patch.object(provenance, "MAX_OBJECT_BYTES", 1024),
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError, "output exceeds byte limit"
+                ),
+            ):
+                provenance._run_formula_inventory(command, source)
+
+    def test_one_broad_input_claim_cannot_ground_two_formulas(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = (
+                b"formulabook demo {\n"
+                b'  formula first(x) = x + 1 source "s" locator "cas://s" trust authoritative\n'
+                b'  formula second(x) = x + 2 source "s" locator "cas://s" trust authoritative\n'
+                b"}\n"
+            )
+            cas = provenance.Cas(root / "cas")
+            source_hash = cas.put(source, kind="raw_source", label="two formulas")
+            inventory = provenance._run_formula_inventory(
+                self.formula_inventory_command(), cas.object_path(source_hash)
+            )
+            inventory_hash = cas.put_json(
+                inventory,
+                kind="formula_parser_inventory",
+                label="two-formula inventory",
+                links=[source_hash],
+            )
+            broad_claim = {
+                "broad": {
+                    "claim_id": "broad",
+                    "end": len(source),
+                    "quote": source.decode("utf-8"),
+                    "quote_sha256": provenance.sha256_bytes(source),
+                    "start": 0,
+                }
+            }
+
+            with self.assertRaisesRegex(
+                provenance.ProvenanceError, "cannot ground more than one formula"
+            ):
+                provenance._validate_formula_inventory(
+                    cas,
+                    inventory_hash,
+                    source_hash,
+                    broad_claim,
+                    self.formula_inventory_command(),
+                )
 
     def test_committed_json_schema_accepts_a_complete_bundle_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -289,6 +289,9 @@ option mapping, or judge/evaluation failure.
     and exact half-open declaration/body byte spans. Provenance tooling can now
     inventory parsed formula bodies without regex discovery or source normalization;
     import resolution, lowering, semantic derivation, and execution remain separate gates.
+7i. **Complete:** expose that parser inventory as canonical JSON with the exact input,
+    declaration, and final-body SHA-256s so CAS tooling can consume a stable byte-level
+    boundary without serializing `f64` AST literals as if they preserved source exactness.
 8. Replace the dead MathWorld `PercentageChange` locator before migrating
    `percent.adj`; a source returning 404 cannot ground that clause.
 9. Add executable formula preconditions or domain guards before migrating
@@ -301,9 +304,14 @@ option mapping, or judge/evaluation failure.
 12. Revisit `simple-interest.adj` with its variable/unit context, explicit
     rejection of contradicted page metadata, unit-bearing query facts, and a
     structured lowering from source notation to primitive operations.
-13. Add CAS `formula_derivation` and execution-witness objects on top of the
-    parser-backed source map, then enforce set equality across parsed exports,
-    replayed derivations, and fully verified query executions.
+13a. **Complete:** define `formula_parser_inventory` CAS objects and an optional
+     provenance-bundle link, then replay the trusted parser binary against the exact
+     linked CAS input on every verification. Output is bounded while streaming, and
+     each formula requires its own enclosing input-IR claim. The isolated bridge is
+     schema-checked; current manifest roots remain explicitly unmigrated.
+13b. Migrate parser inventories into every formula-bearing provenance root, add
+     `formula_derivation` and execution-witness objects, then enforce set equality
+     across parsed exports, replayed derivations, and fully verified query executions.
 
 ### Wave 2: complete K-8 foundations
 

--- a/code/specs/data/adj-stdlib-provenance/manifest.schema.json
+++ b/code/specs/data/adj-stdlib-provenance/manifest.schema.json
@@ -80,6 +80,45 @@
       "required": ["body_sha256", "body_size", "final_locator", "headers", "kind", "locator", "media_type", "retrieved_at", "status"],
       "type": "object"
     },
+    "formula_parser_inventory": {
+      "additionalProperties": false,
+      "properties": {
+        "formulas": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "body": { "$ref": "#/$defs/formula_span" },
+              "declaration": { "$ref": "#/$defs/formula_span" },
+              "formula": { "minLength": 1, "type": "string" },
+              "formulabook": { "minLength": 1, "type": "string" },
+              "parameters": { "items": { "minLength": 1, "type": "string" }, "type": "array" },
+              "step_count": { "minimum": 0, "type": "integer" }
+            },
+            "required": ["body", "declaration", "formula", "formulabook", "parameters", "step_count"],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "kind": { "const": "formula_parser_inventory" },
+        "parser_contract": { "const": "adj-lang/formula_source_map/v1" },
+        "schema_version": { "const": 1 },
+        "scope": { "const": "source_file" },
+        "source_sha256": { "$ref": "#/$defs/hash" },
+        "source_size": { "maximum": 67108864, "minimum": 0, "type": "integer" }
+      },
+      "required": ["formulas", "kind", "parser_contract", "schema_version", "scope", "source_sha256", "source_size"],
+      "type": "object"
+    },
+    "formula_span": {
+      "additionalProperties": false,
+      "properties": {
+        "end": { "minimum": 1, "type": "integer" },
+        "sha256": { "$ref": "#/$defs/hash" },
+        "start": { "minimum": 0, "type": "integer" }
+      },
+      "required": ["end", "sha256", "start"],
+      "type": "object"
+    },
     "hash": { "pattern": "^[0-9a-f]{64}$", "type": "string" },
     "input_receipt": {
       "additionalProperties": false,
@@ -130,6 +169,7 @@
         "bundle_id": { "minLength": 1, "type": "string" },
         "clauses": { "items": { "$ref": "#/$defs/clause" }, "minItems": 1, "type": "array" },
         "dependencies": { "items": { "$ref": "#/$defs/hash" }, "type": "array", "uniqueItems": true },
+        "formula_inventory_sha256": { "$ref": "#/$defs/hash" },
         "input": { "$ref": "#/$defs/source_binding" },
         "kind": { "const": "provenance_bundle" },
         "library": { "minLength": 1, "type": "string" },


### PR DESCRIPTION
## Summary

- add `adj-formula-inventory`, a parse-only binary that emits canonical, bounded JSON for every formula with exact source/declaration/body SHA-256s and UTF-8 byte spans
- add optional `formula_parser_inventory` CAS objects and bundle links; verification reruns the trusted parser over the linked CAS bytes and requires exact JSON agreement
- require one distinct enclosing input-IR claim per formula, bound subprocess output while reading, and keep imports, lowering, semantic derivation, and execution outside this structural claim
- build and pass the inventory binary in the ADJ provenance CI gate

## Why

The merged Rust source-map API exposed parser-backed spans, but Python CAS had no stable machine boundary to consume or replay them. Serializing `ExprAst` would also blur source-exact numeric literals because it currently stores literals as `f64`. This PR establishes the byte-exact structural bridge without overclaiming semantic derivation.

## Validation

- full `adj-lang-cli` test suite
- `cargo clippy --all-targets -- -D warnings`
- 68 ADJ script tests (1 expected Windows skip)
- manifest JSON Schema, report, and provenance gates: 6 bundles, 69 CAS objects, 9 snapshots
- inventory sweep: 155 shipped formula files, 347 formulas
- adversarial coverage for malformed/non-UTF-8/oversized input, Unicode and CRLF spans, unresolved imports, canonical JSON, replay drift, bounded parser output, and broad-claim reuse
- independent review after fixes: no remaining P1/P2 findings

## Explicit follow-up

Current manifest roots are intentionally not migrated in this PR. `ADJ-STDLIB-COVERAGE.md` keeps corpus migration, `formula_derivation`, execution witnesses, and set-equality gates open as item 13b.