### PR TITLE
Split Arabic lessons into sub-five-minute micro-steps

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Malayalam duration
-tranche: 20 registered tracks, 1,008 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Arabic duration
+tranche: 20 registered tracks, 1,012 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -60,7 +60,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01K | Complete in the Telugu duration PR | Remove all thirty-six sub-five-minute violations from the Telugu track. | The report measures zero Telugu violations; one new prerequisite-ordered micro-lesson separates phrase formation from register and source-evidence judgment. |
 | HL-D01L | Complete in the Kannada duration PR | Remove all thirty-seven sub-five-minute violations from the Kannada track. | The report measures zero Kannada violations; one new prerequisite-ordered micro-lesson separates suffix forms and sound history from the agglutinative-versus-fusional comparison. |
 | HL-D01M | Complete in the Malayalam duration PR | Remove all thirty-seven sub-five-minute violations from the Malayalam track. | The report measures zero Malayalam violations; four new prerequisite-ordered micro-lessons separate vocabulary from etymology, register, and cross-language comparison. |
-| HL-D01N | Next | Remove all thirty-nine sub-five-minute violations from the Arabic track. | Arabic is now the smallest remaining set: thirty-five declaration-only lessons and four genuinely computed violations, with a 360-second maximum. |
+| HL-D01N | Complete in the Arabic duration PR | Remove all thirty-nine sub-five-minute violations from the Arabic track. | The report measures zero Arabic violations; four new prerequisite-ordered writing steps preserve the abjad, joining, whole-word assembly, and hamza content. |
+| HL-D01O | Next | Remove all forty sub-five-minute violations from the Hindi track. | Hindi is now the smallest remaining set: twenty-nine declaration-only lessons and eleven genuinely computed violations, with a 501-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -87,10 +88,13 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B25 | Queued | Remove Kannada's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports four overfull boxes, five underfull boxes, four duplicate practice labels, 30 Hyperref warnings, and undefined bold/italic Kannada font shapes; the clean-build signal is zero of each. |
 | HL-B26 | Queued | Publish Malayalam Chapters 6–31 from their canonical lessons rather than hand-copying twenty-six book chapters. | The Malayalam PDF reaches Chapter 5 while canonical app content continues through Chapter 31; schema-v2 migration plus generation should close that drift safely. |
 | HL-B27 | Queued | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports seven overfull boxes, eight underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and undefined bold/italic Malayalam font shapes; the clean-build signal is zero of each. |
+| HL-B28 | Queued | Publish Arabic Chapters 3–27 and its writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | The Arabic PDF stops after Chapter 2 while canonical app content continues through Chapter 27 and sixteen dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
+| HL-B29 | Queued | Remove Arabic's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, one duplicate practice label, 14 Hyperref warnings, and undefined bold/italic Arabic font shapes; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
 | HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
+| HL-M05 | Queued | Reconcile Arabic's roadmap and authoritative session map with canonical Chapters 1–27 and the sixteen-step writing sequence. | The roadmap details only Chapters 1–4 and still calls Chapter 5+ planned; the session map stops at Chapter 2 even though prerequisite-ordered canonical lessons continue through Chapter 27. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
@@ -450,6 +454,34 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Arabic's thirty-nine violations are now the smallest remaining set.
   Thirty-five are declaration-only and four genuinely compute above the limit,
   with a 360-second maximum, so HL-D01N is next.
+
+## Findings from HL-D01N
+
+- Arabic now has zero duration violations. The corpus grows from 1,008 to 1,012
+  lessons and drops from 219 to 180 violations overall; unknown prerequisites
+  remain at zero.
+- Thirty-five lessons already computed below five minutes and needed only
+  honest four-minute declared budgets. Four longer writing lessons are now
+  prerequisite-ordered pairs: direction and *alif* → hidden short vowels;
+  positional shapes → **سل/لا** joining; the dot family → writing **سلام**; and
+  short-vowel marks → hamza.
+- The eight new or rewritten writing steps compute between 135 and 279 seconds.
+  `AR-C16-al-saa` at 299 seconds and `AR-C14-ashhur` at 298 are the tightest
+  remaining Arabic lessons and should be watched during later copy edits.
+- The Arabic PDF builds successfully at 18 pages with no missing glyphs, but it
+  contains only Chapters 1–2 while canonical lessons continue through Chapter
+  27 alongside sixteen writing steps. HL-B28 records the schema-v2 migration
+  and generated publication work for the missing content.
+- The build reports one overfull box, four underfull boxes, one duplicate
+  practice label, 14 Hyperref warnings, and undefined bold/italic Arabic font
+  shapes. HL-B29 records that pre-existing clean-build debt.
+- The roadmap details only Chapters 1–4 and still labels Chapter 5+ as planned;
+  the authoritative session map stops at Chapter 2. HL-M05 records the
+  progression-metadata reconciliation through Chapter 27 and the expanded
+  writing sequence.
+- Hindi's forty violations are now the smallest remaining set. Twenty-nine are
+  declaration-only and eleven genuinely compute above the limit, with a
+  501-second maximum, so HL-D01O is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Sub-five-minute writing sequence
+
+- All 39 Arabic duration violations are resolved without removing vocabulary,
+  grammar, script, or etymology content. Thirty-five lessons already computed
+  below the limit and now declare honest four-minute budgets.
+- Four longer writing lessons became eight prerequisite-ordered micro-lessons:
+  `AR-W01-direction-and-alif` → `AR-W01-abjad-short-vowels`,
+  `AR-W02-joining-sin-lam` → `AR-W02-lam-alif-joins`,
+  `AR-W03-dots-mim-ba-salam` → `AR-W03-write-salam`, and
+  `AR-W06-harakat-and-hamza` → `AR-W06-hamza`.
+- The seams follow the script itself: direction and the first *alif* stroke
+  precede the abjad's hidden short vowels; positional shapes precede joined
+  **سل** and obligatory **لا**; the dot family precedes assembling **سلام**;
+  and short-vowel marks precede hamza as its own consonant sign.
+- Downstream writing lessons now depend on and review the immediately preceding
+  skill. All eight changed or added writing steps compute between 135 and 279
+  seconds, and the full corpus still has zero unknown prerequisite ids.
+
 ## Chapter 4 — Farewells (and the root that closes the circle)
 
 - **Chapter 4 authored** (`AR-C04-maa-with`, `-al-salama`, `-maa-salama`,

--- a/code/learning/human-languages/arabic/lessons/AR-C01-as-salamu-alaykum.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-as-salamu-alaykum.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-FORMAL
 prerequisites: [AR-C01-salam, AR-C01-al]
 sounds: [ayn, ya, kaf]
 roots: [s-l-m]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C01-salam, AR-C01-al, AR-C01-marhaba]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C01-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [AR-C01-salam, AR-C01-marhaba, AR-C01-al, AR-C01-as-salamu-alaykum, AR-C01-sabah-al-khayr, AR-C01-masa-al-khayr, AR-C01-shukran]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C01-salam, AR-C01-marhaba, AR-C01-al, AR-C01-as-salamu-alaykum, AR-C01-sabah-al-khayr, AR-C01-masa-al-khayr, AR-C01-shukran]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C01-sabah-al-khayr.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-sabah-al-khayr.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-MORNING
 prerequisites: [AR-C01-al]
 sounds: [sad-emphatic, kha]
 roots: [ṣ-b-ḥ, kh-y-r]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C01-al, AR-C01-salam]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C01-salam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-salam.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-PEACE
 prerequisites: []
 sounds: [rtl, alif-lam-mim-sin, long-vowel-alif]
 roots: [s-l-m]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C02-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [AR-C02-ismii, AR-C02-maa-ismuka, AR-C02-tasharrafna]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C02-ism, AR-C02-ii-my, AR-C02-ismii, AR-C02-anta-anti, AR-C02-maa, AR-C02-maa-ismuka, AR-C02-tasharrafna]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C03-al-hamdu-lillah.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C03-al-hamdu-lillah.md
@@ -10,7 +10,7 @@ prerequisites: [AR-C03-bi-khayr, AR-C01-al]
 sounds: [rtl-known-letters, deep-h]
 roots: [h-m-d]
 etymology_hook: "root ḥ-m-d 'to praise' also produces the name Muḥammad ('the much-praised one') and Aḥmad — the commonest given name on earth and the commonest phrase in the language, from three shared consonants; lillāh = li- ('to') + allāh (al- + ilāh, 'the god'), cousin of Hebrew El/Elohim"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C03-bi-khayr, AR-C01-al, AR-C01-salam, AR-C02-ism]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C03-kayfa-haluka.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C03-kayfa-haluka.md
@@ -10,7 +10,7 @@ prerequisites: [AR-C03-hal, AR-C02-ii-my, AR-C02-anta-anti]
 sounds: [rtl-known-letters, harakat]
 roots: [h-w-l, k-y-f]
 etymology_hook: "the -ka/-ki 'your' suffix is the SAME gender split as anta/anti, attached the SAME way as the -ī 'my' suffix — so kayfa ḥāluka is assembled entirely from Chapter 2 machinery, with zero copula: 'how your-state?'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C03-hal, AR-C03-kayfa, AR-C02-ii-my, AR-C02-anta-anti, AR-C02-ismii]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C03-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [AR-C03-kayfa-haluka, AR-C03-bi-khayr, AR-C03-al-hamdu-lillah]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C03-kayfa, AR-C03-hal, AR-C03-kayfa-haluka, AR-C03-bi-khayr, AR-C03-al-hamdu-lillah, AR-C02-ismii, AR-C01-as-salamu-alaykum]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C04-ila-liqaa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C04-ila-liqaa.md
@@ -11,7 +11,7 @@ sounds: [hamza, alif-maqsura]
 roots: [semitic-l-q-y]
 etymology_hook: "'until the meeting' is exactly the Spanish hasta luego / hasta mañana shape — and hasta ITSELF is an Arabic loan (ḥattā), so Spanish borrowed the very word that builds this kind of farewell; liqāʾ ← root l-q-y 'to meet'"
 est_minutes: 4
-reviews_of: [AR-C04-maa-salama, AR-C01-al, AR-W06-harakat-and-hamza]
+reviews_of: [AR-C04-maa-salama, AR-C01-al, AR-W06-hamza, AR-W06-harakat-and-hamza]
 ---
 
 # إلى اللقاء (ilā l-liqāʾ) — "see you"

--- a/code/learning/human-languages/arabic/lessons/AR-C04-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [AR-C04-maa-salama, AR-C04-ila-liqaa]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C04-maa-with, AR-C04-al-salama, AR-C04-maa-salama, AR-C04-ila-liqaa, AR-C03-practice, AR-C02-practice, AR-C01-practice]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C08-al-ahad-al-khamis.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C08-al-ahad-al-khamis.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C07-asif]
 sounds: [arabic-rtl, hamza-variants, definite-article-al]
 roots: [ahad-wahid, ithnayn, thalatha, arbaa, khamsa]
 etymology_hook: "Arabic weekdays are literally ordinal numbers — al-aḥad 'the first,' al-ithnayn 'the second' — a genuinely different system from Rome's planet-week"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C07-asif]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C08-al-jumua-as-sabt.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C08-al-jumua-as-sabt.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C08-al-ahad-al-khamis]
 sounds: [arabic-rtl, ayn-sound, teh-marbuta]
 roots: [jamaa-gather, sabt-semitic]
 etymology_hook: "as-sabt is a Semitic COUSIN of Hebrew shabbat (same family, shared root) — unlike Latin's Sabbatum, which BORROWED the word across a language-family line"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C08-al-ahad-al-khamis]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C09-aswad-abyad.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C09-aswad-abyad.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C08-al-jumua-as-sabt]
 sounds: [hamza-variants, feminine-alif-hamza-ending, arabic-rtl]
 roots: [sawad-black, bayad-white]
 etymology_hook: "أسود aswad / سوداء sawdaa' (black) and أبيض abyad / بيضاء baydaa' (white) share ONE grammatical template — masc. أ...   fem. ...اء — that Arabic reserves for colors and physical traits"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C08-al-jumua-as-sabt, AR-C07-asif]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C10-ab-umm.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C10-ab-umm.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C09-ahmar-azraq]
 sounds: [hamza-variants, arabic-rtl]
 roots: [semitic-ab, semitic-umm]
 etymology_hook: "أب ab 'father' and أم umm 'mother' are ancient Semitic roots, cousins of Hebrew av and em — the same roots behind Aramaic abba ('Abba, Father') and the honorific naming pattern Umm [child]"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C09-ahmar-azraq]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C12-al-fusul.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C12-al-fusul.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C11-yad]
 sounds: [ayn-sound, hamza-final, arabic-rtl]
 roots: [rabii-spring, sayf-summer, khariif-autumn, shitaa-winter]
 etymology_hook: "ربيع rabii' 'spring' is also the name of two Islamic calendar months (Rabi' al-Awwal, Rabi' al-Thani) — the season-word and the month-names share one root, a reminder that the lunar Islamic calendar and the solar seasons are two separate systems"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C11-yad]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C14-ashhur.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C14-ashhur.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C13-maa-khubz]
 sounds: [arabic-rtl, long-vowels]
 roots: [latin-months-borrowed]
 etymology_hook: "yanaayir, maaris, uktuubar... are simply Latin month-names in Arabic dress, borrowed for everyday/civil use — while the Islamic Hijri calendar keeps its OWN, entirely different 12 lunar months (Muharram, Rabi' al-Awwal...) for religious life, both running side by side"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [AR-C13-maa-khubz]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C15-ad-duhr-muntasaf-al-layl.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C15-ad-duhr-muntasaf-al-layl.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C14-ashhur]
 sounds: [arabic-rtl, emphatic-zaa]
 roots: [zahara-appear, nisf-half]
 etymology_hook: "الظهر (adh-dhuhr) 'noon' is also the name of the midday prayer, salat al-zuhr — Arabic's word for noon is bound up with the daily prayer schedule, not a neutral clock-time word; منتصف الليل (muntasaf al-layl) 'the half of the night' is fully transparent, from nisf 'half'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C14-ashhur]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C16-al-saa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C16-al-saa.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C15-ad-duhr-muntasaf-al-layl]
 sounds: [arabic-ain, teh-marbuta]
 roots: [aramaic-shaata-hour]
 etymology_hook: "ساعة (sāʿa, 'hour') is a loanword from Aramaic شָׁעְתָא/ܫܳܥܬܳܐ (šāʿəṯā) — the same Semitic root behind Hebrew's שָׁעָה (šāʿā), borrowed into Arabic long before Islam; ساعة does triple duty for 'hour,' 'clock,' and 'a while, a moment'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C15-ad-duhr-muntasaf-al-layl]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C17-kam-umruka.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C17-kam-umruka.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C16-al-saa]
 sounds: [arabic-ain, possessive-suffix-ka-ki]
 roots: [arabic-umr-life]
 etymology_hook: "كم عمرك؟ (kam ʿumruka?, 'how old are you?') is literally 'how much [is] your ʿumr' — ʿumr (life, lifetime, age) from root ع-م-ر, the same root behind the name ʿUmar; Arabic asks age with a NOUN + possessive suffix, no verb at all — a FOURTH shape, after Romance's 'have', Germanic's 'be', and Latin's 'born + accusative of duration'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C16-al-saa]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C18-al-taqs.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C18-al-taqs.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C17-kam-umruka]
 sounds: [arabic-emphatic-taa, arabic-feminine-dummy-pronoun]
 roots: [arabic-taqs-weather-rite]
 etymology_hook: "الطقس (aṭ-ṭaqs, 'weather') shares its root ط-ق-س with طقوس (ṭuqūs), 'rites, religious ceremonies' — weather and ritual sharing one root; الجو حار/بارد ('it's hot/cold') are verbless, like كم عمرك, but rain gets its OWN personal verb: إنها تمطر, 'she/it is raining'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C17-kam-umruka]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C19-wahid-khamsa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C19-wahid-khamsa.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C18-al-taqs]
 sounds: [arabic-hamza, arabic-teh-marbuta]
 roots: [arabic-semitic-numerals]
 etymology_hook: "واحد، اثنان، ثلاثة، أربعة، خمسة (wāḥid, ithnān, thalātha, arbaʿa, khamsa) are the Arabic WORDS for 1-5 — genuinely different from 'Arabic numerals' (the written digit shapes 0-9), which actually originated in India and reached Europe via Arabic mathematicians like al-Khwārizmī, not from these words at all"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C18-al-taqs]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C20-ahada-ashar-ishrun.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C20-ahada-ashar-ishrun.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C19-wahid-khamsa]
 sounds: [arabic-ain-shiin, arabic-teh-marbuta]
 roots: [arabic-ashar-ten, arabic-ishrun-twenty]
 etymology_hook: "أحد عشر through خمسة عشر (11-15) are plain 'X and ten' compounds, X + عشر (ʿashar, 'ten') — but عشرون (ʿishrūn, 'twenty') is NOT 'two-ten'; it's its OWN distinct plural-like form built directly on the 'ten' root, the same root behind Hebrew's eser and English's own '-teen'"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [AR-C19-wahid-khamsa]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C21-kalb-qitt.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C21-kalb-qitt.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C20-ahada-ashar-ishrun]
 sounds: [arabic-qaf, arabic-geminate-tt]
 roots: [semitic-kalb-dog, afroasiatic-qitt-cat]
 etymology_hook: "كلب (kalb, 'dog') is Proto-Semitic *kalb-, cousin of Hebrew's own כֶּלֶב (kelev) — a solid, well-attested root, no mystery here; قط (qiṭṭ, 'cat/tomcat') is widely compared to the same ancient Afro-Asiatic root behind Latin's cattus (and so Spanish's gato, French's chat, German's Katze) — some linguists argue for a shared ancestor, though the exact relationship and even the direction of borrowing are still genuinely debated"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [AR-C20-ahada-ashar-ishrun]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C22-akhdar-asfar.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C22-akhdar-asfar.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C21-kalb-qitt]
 sounds: [arabic-dad, arabic-sad]
 roots: [semitic-khadara-green, semitic-safara-empty]
 etymology_hook: "أخضر (akhḍar, 'green') is from root خ-ض-ر (kh-ḍ-r, 'to be green') — the same root behind خضار (khuḍār, 'vegetables'), echoing English's own 'greens' for vegetables, and the name of the Quranic figure al-Khiḍr, 'the Green One'; أصفر (aṣfar, 'yellow') shares its root, ص-ف-ر (ṣ-f-r), with صفر (ṣifr, 'zero, empty') — the very word behind English 'zero' and 'cipher'"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [AR-C21-kalb-qitt]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C23-afwan.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C23-afwan.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C01-shukran]
 sounds: [ayn, tanwin-fath]
 roots: [ayn-f-w]
 etymology_hook: "عفوا (ʿafwan), root ʿ-f-w, 'to erase, obliterate' → 'to pardon, forgive' (forgiving as metaphorically erasing an offense) — the same root behind العفو (al-ʿAfuww, 'The Supreme Pardoner,' one of the 99 names of Allah); grammatically, ʿafwan carries the exact same indefinite-accusative ending (tanwīn fatḥ, the '-an' sound) as شكرا (shukran) itself — both are fixed, idiomatic accusative forms, not full sentences"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C01-shukran]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C24-ila-al-ghad.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C24-ila-al-ghad.md
@@ -10,7 +10,7 @@ prerequisites: [AR-C04-ila-liqaa]
 sounds: [ghayn, sun-letter-assimilation]
 roots: [gh-d-w]
 etymology_hook: "إلى الغد (ilā l-ghad), 'until tomorrow,' reuses إلى (ilā, 'until') from ilā l-liqāʾ; الغد (al-ghad, 'tomorrow') is root gh-d-w, whose core sense is 'to go out at dawn, early morning' — the same 'morning becomes tomorrow' shift already seen in Latin's māne→mañana/demain, an honest cross-language echo, not a coincidence unique to Romance"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C04-ila-liqaa]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C25-yawm.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C25-yawm.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C08-al-ahad-al-khamis]
 sounds: [waw-glide, meem]
 roots: [y-w-m]
 etymology_hook: "يوم (yawm, 'day') ← Proto-Semitic *yawm-, a genuine Common Semitic word shared with Hebrew יוֹם (yōm, as in Yom Kippur), Akkadian ūmum, and Aramaic yawmā; further back, some scholars connect it to Proto-Afroasiatic *yam- ('day'), possibly related to Egyptian ỉmy ('sun, as an eye') — a speculative but genuinely proposed deep link, not settled fact"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C08-al-ahad-al-khamis]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C26-layl.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C26-layl.md
@@ -9,7 +9,7 @@ prerequisites: [AR-C15-ad-duhr-muntasaf-al-layl, AR-C25-yawm]
 sounds: [lam-yeh-lam, long-i-glide]
 roots: [l-y-l]
 etymology_hook: "ليل (layl, 'night') ← Proto-Semitic *layl-, cognate with Hebrew לילה (layla/laylah — as in the Passover question 'mah nishtana ha-layla ha-zeh,' 'why is this NIGHT different'), Aramaic/Syriac lēlyā, and Akkadian līliātum; scholars genuinely debate whether Proto-Semitic had this simple triradical *layl- or a reduplicated *laylay- form — an open question, not settled"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C15-ad-duhr-muntasaf-al-layl, AR-C25-yawm]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-C27-tusbih-ala-khayr.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C27-tusbih-ala-khayr.md
@@ -10,7 +10,7 @@ prerequisites: [AR-C01-sabah-al-khayr, AR-C01-masa-al-khayr, AR-C26-layl]
 sounds: [sad-emphatic, kha]
 roots: [ṣ-b-ḥ, kh-y-r]
 etymology_hook: "تصبح على خير (tuṣbiḥ ʿalā khayr), the everyday Arabic 'good night,' literally means 'may you WAKE UP into goodness' — tuṣbiḥ is the ordinary imperfect of aṣbaḥa ('to become morning'), used performatively as a blessing (no special subjunctive/jussive marking), the same ṣ-b-ḥ root as ṣabāḥ al-khayr ('good morning'), plus khayr ('goodness') already met in masāʾ al-khayr; unlike every other language in this arc, Arabic's night-parting phrase points FORWARD to the morning, not to the night itself"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-C01-sabah-al-khayr, AR-C01-masa-al-khayr, AR-C26-layl]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-W01-abjad-short-vowels.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W01-abjad-short-vowels.md
@@ -1,0 +1,49 @@
+---
+id: AR-W01-abjad-short-vowels
+chapter: 1
+type: writing
+headword: الحركات
+gloss: Arabic letters normally show consonants while short a, i, and u stay hidden
+romanization: al-ḥarakāt
+prerequisites: [AR-W01-direction-and-alif]
+sounds: [arabic-harakat]
+roots: [abjad-vowels]
+est_minutes: 4
+reviews_of: [AR-W01-direction-and-alif, AR-C01-salam]
+---
+
+# The abjad — short vowels hiding in plain sight
+
+## Warm-up
+
+[PAUSE 2s] You can move right to left and draw **ا**. Now notice why Arabic
+words often contain fewer written marks than their romanization suggests.
+
+## Consonant skeletons
+
+Look again at **سلام** (*salām*): the consonant skeleton is *s-l-m*, while the
+short *a* is not written as a full letter. Arabic is an **abjad**. Its letters
+primarily record consonants, and the short vowels *a, i, u* are normally left
+out—rather like still recognizing “bld a hs” as “build a house.”
+
+The name *abjad* recites the old first four letters, *a-b-j-d*, just as “ABC”
+names an alphabet. *Alphabet* itself performs the same trick with Greek
+*alpha-beta*.
+
+Beginner texts can add tiny **ḥarakāt**, small marks above or below a consonant,
+to show the short vowels. Everyday text usually omits them because readers
+supply the word from grammar and context. A later lesson will teach those marks
+one at a time; for now, expect to write the consonant skeleton.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: *abjad* — a consonant-first writing system]
+- [YOU POINT: **سلام** — *s-l-m* visible, short *a* supplied]
+- [YOU SAY: *ḥarakāt* — optional marks that can reveal short vowels]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does an abjad normally leave out? (**Short vowels.**) Are they
+impossible to mark? (**No.** Beginner texts can add *ḥarakāt*.) What do you
+learn to recognize first? (**The consonant skeleton.**)

--- a/code/learning/human-languages/arabic/lessons/AR-W01-direction-and-alif.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W01-direction-and-alif.md
@@ -3,7 +3,7 @@ id: AR-W01-direction-and-alif
 chapter: 1
 type: writing
 headword: "ا"
-gloss: two surprises before the first stroke — Arabic runs right-to-left and hides its short vowels — then writing alif (ā)
+gloss: Arabic runs right-to-left; then one clean downstroke writes alif
 romanization: "alif"
 prerequisites: [AR-C01-salam]
 sounds: [arabic-alif, long-a]
@@ -12,16 +12,16 @@ est_minutes: 4
 reviews_of: [AR-C01-salam, AR-C01-marhaba]
 ---
 
-# ا (alif) — the first stroke, and two rules that change everything
+# ا (alif) — right to left, then the first stroke
 
 ## Warm-up
 
-[PAUSE 2s] Before you draw a single line, two facts about Arabic will feel
-strange — and both are freeing once you know them. You have already **read**
+[PAUSE 2s] Before you draw a single line, Arabic's direction will feel
+strange—and freeing once you know it. You have already **read**
 Arabic in *سلام* (*salām*, "peace") and *مرحبا* (*marḥaban*, "hello"); now you
 learn to **write** it, one piece at a time.
 
-## Surprise 1 — Arabic runs right-to-left
+## Arabic runs right-to-left
 
 English marches **left → right**. Arabic marches **right → left**. The pen
 starts on the **right edge** of the word and moves **toward the left**. So in
@@ -32,19 +32,6 @@ eye is trained on.
 This is not exotic for its own sake: Arabic, Hebrew, and the old Phoenician
 alphabet **all** ran right-to-left. It is the older habit; left-to-right (Greek,
 Latin, and everything downstream) is the newcomer that flipped direction.
-
-## Surprise 2 — the short vowels are usually invisible (an *abjad*)
-
-Look again at *سلām*: three consonants (s-l-m) and the vowels *a...a* are barely
-there. Arabic is an **abjad** — the letters are **consonants**, and the short
-vowels ("a, i, u") are normally **left out**, the way you can still read "*bld a
-hs*" as "build a house." (The word *abjad* is just the first four letters —
-*a-b-j-d* — recited in order, exactly like saying "*ABC*"; the Latin *alphabet*
-is the same trick on *alpha-beta*.) When a beginner's book *does* mark the
-vowels, it uses tiny **ḥarakāt** — small dashes above or below — but everyday
-text goes without.
-
-So the skeleton you learn to draw is the **consonants**. That's the whole word.
 
 ## ا (alif) — one clean downstroke
 
@@ -76,8 +63,7 @@ lessons from now.
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Which edge of a word does your pen start on? (The **right**.) What
-does an *abjad* leave out? (The **short vowels** — the letters are consonants.)
-Draw **alif**: how many strokes, and does it join to the next letter? (**One**
+[PAUSE 3s] Which edge of a word does your pen start on? (The **right**.) Draw
+**alif**: how many strokes, and does it join to the next letter? (**One**
 vertical; **no** — it forces a break.) You have written the first letter of the
-Arabic alphabet — and met the ox that also gave you *A*.
+Arabic alphabet—and met the ox that also gave you *A*.

--- a/code/learning/human-languages/arabic/lessons/AR-W02-joining-sin-lam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W02-joining-sin-lam.md
@@ -3,16 +3,16 @@ id: AR-W02-joining-sin-lam
 chapter: 1
 type: writing
 headword: "س، ل"
-gloss: the big idea — letters JOIN and change shape by position — taught on sin (s) and lam (l), plus the لا ligature
+gloss: letters change shape by position, taught gently on sin and lam
 romanization: "sīn, lām"
-prerequisites: [AR-W01-direction-and-alif]
+prerequisites: [AR-W01-abjad-short-vowels]
 sounds: [arabic-sin, arabic-lam]
 roots: [phoenician-shin, phoenician-lamed]
-est_minutes: 5
-reviews_of: [AR-W01-direction-and-alif, AR-C01-salam, AR-C01-as-salamu-alaykum]
+est_minutes: 4
+reviews_of: [AR-W01-abjad-short-vowels, AR-W01-direction-and-alif, AR-C01-salam, AR-C01-as-salamu-alaykum]
 ---
 
-# س and ل — how Arabic letters hold hands
+# س and ل — four shapes, one letter
 
 ## Warm-up
 
@@ -60,23 +60,11 @@ trails below the line. Break it apart — *teeth, then trailing bowl*:
 teeth. (Remember the "tooth" name; next lesson its cousin **shīn** ش will be the
 *same* teeth with **three dots** added on top.)
 
-## Joining them — the لا you will need
-
-Now watch two letters hold hands. Write **lām** then **alif** and they fuse into
-one obligatory **ligature**, **لا** — a slanted stroke crossing the upright.
-Every Arabic hand writes *lām-alif* this way; you cannot leave them apart. And
-**سل** (*sīn* reaching into *lām*) is the first joined pair of *سلام* — the
-teeth flow straight into the tall hook.
-
-- **سل** = *sīn* (initial, reaching left) + *lām*.
-- **لا** = *lām* + *alif* — the fixed ligature.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "same letter, four coats — isolated, initial, medial, final"]
 - [YOU WRITE: **ل** (tall upright + base bowl), then **س** (three teeth + bowl)]
-- [YOU WRITE: the join **سل**, then the ligature **لا** — "lām and alif always fuse"]
 - [YOU SAY: "*sīn* from *shin*, tooth; *lām* from *lāmed*, cousin of **L**"]
 
 ## Wrap-up Recall
@@ -84,6 +72,5 @@ teeth flow straight into the tall hook.
 [PAUSE 3s] How many shapes can one Arabic letter wear, and what decides which?
 (Up to **four** — its **position** in the joined run.) What Phoenician word names
 **sīn**, and what does the shape look like? (**shin** — a **tooth**; and *sīn* is
-a row of teeth.) When *lām* meets *alif*, what happens? (They **must** fuse into
-the ligature **لا**.) You can now write three of the four letters in *سلām* — one
-to go.
+a row of teeth.) Which feature changes between the four coats? (**The connectors
+at the edges; the core skeleton remains.**)

--- a/code/learning/human-languages/arabic/lessons/AR-W02-lam-alif-joins.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W02-lam-alif-joins.md
@@ -1,0 +1,50 @@
+---
+id: AR-W02-lam-alif-joins
+chapter: 1
+type: writing
+headword: "سل، لا"
+gloss: join sin to lam, then write the obligatory lam-alif ligature
+romanization: "sīn-lām, lām-alif"
+prerequisites: [AR-W02-joining-sin-lam]
+sounds: [arabic-sin, arabic-lam, arabic-alif]
+roots: [phoenician-shin, phoenician-lamed, phoenician-aleph]
+est_minutes: 4
+reviews_of: [AR-W02-joining-sin-lam, AR-W01-direction-and-alif, AR-C01-salam]
+---
+
+# سل and لا — joining the letters you know
+
+## Warm-up
+
+[PAUSE 2s] You can draw **س**, **ل**, and **ا** separately. Now let the first
+two hold hands—and learn the special shape required when *lām* meets *alif*.
+
+## س reaches into ل
+
+In **سل**, initial **س** reaches leftward into **ل**. Keep *sīn*’s three teeth,
+then flow directly into *lām*’s tall upright. The skeletons stay recognizable;
+the connector turns them into one joined run.
+
+## The obligatory لا ligature
+
+Write *lām* followed by *alif* and they fuse into **لا**, a slanted stroke
+crossing the upright. This is an obligatory **ligature**: ordinary Arabic does
+not leave the two letters as separate full shapes.
+
+- **سل** = initial *sīn* reaching into *lām*.
+- **لا** = *lām* + *alif* in their fixed ligature.
+
+Together, these are the right-hand pieces you will soon use in **سلام**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **سل** — teeth flowing into the tall hook]
+- [YOU WRITE: **لا** — the fixed *lām-alif* ligature]
+- [YOU SAY: “same skeletons, connectors added”]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What happens when **س** begins a joined run? (**It reaches left into
+the next letter.**) What happens when *lām* meets *alif*? (**They must fuse into
+لا.**)

--- a/code/learning/human-languages/arabic/lessons/AR-W03-dots-mim-ba-salam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W03-dots-mim-ba-salam.md
@@ -3,23 +3,21 @@ id: AR-W03-dots-mim-ba-salam
 chapter: 1
 type: writing
 headword: "م، ب"
-gloss: dots as a real piece — mim (m) and ba (b) — then assembling the whole word سلام (salām)
+gloss: dots are meaningful pieces; then learn ba and mim
 romanization: "mīm, bāʾ"
-prerequisites: [AR-W02-joining-sin-lam]
+prerequisites: [AR-W02-lam-alif-joins]
 sounds: [arabic-mim, arabic-ba]
 roots: [phoenician-mem, phoenician-bet]
-est_minutes: 5
-reviews_of: [AR-W02-joining-sin-lam, AR-W01-direction-and-alif, AR-C01-salam]
+est_minutes: 4
+reviews_of: [AR-W02-lam-alif-joins, AR-W02-joining-sin-lam, AR-W01-direction-and-alif, AR-C01-salam]
 ---
 
-# م، ب — the dots that tell letters apart, and your first whole word
+# م، ب — dots that tell letters apart
 
 ## Warm-up
 
-[PAUSE 2s] The finish line. Two more letters — **م** (m) and **ب** (b) — and then
-you assemble **سلام** (*salām*, "peace") from right to left, the same word buried
-inside the greeting *as-salāmu ʿalaykum*. Along the way, the cleverest idea in
-Arabic handwriting: **the dots are a piece you draw**.
+[PAUSE 2s] Two more letters—**م** (m) and **ب** (b)—teach the cleverest
+idea in Arabic handwriting: **the dots are a piece you draw**.
 
 ## Dots are not decoration — they *are* the letter
 
@@ -57,36 +55,17 @@ Break it apart — *round head, then tail*:
 **mīm** is from Phoenician **mem** ("water") — sibling of Greek **mu** and Latin
 **M**. Four scripts, one drop of water.
 
-## Assemble — سلام, right to left
-
-Now write the whole word. Start at the **right** and move **left**, remembering
-which letters join and which break:
-
-1. **س** (*sīn*) — three teeth, **reaching left** into…
-2. **ل** (*lām*) — the tall hook; and *lām* + *alif* **fuse** into…
-3. **لا** — the obligatory ligature (the slanted alif across the upright).
-4. **[break]** — *alif* **does not join** what follows (the rule from Lesson 1),
-   so the pen **lifts**…
-5. **م** (*mīm*) — standing free at the left end, its tail dropping below the line.
-
-Read back right-to-left: **س · ل · ا · م** = *s · l · ā · m* = **سلام**. Vowels
-unwritten, consonants doing all the work — a real Arabic word in your own hand.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU WRITE: **ب** — boat + one dot below — then say "the dot makes it *b*, not
   *n*"]
 - [YOU WRITE: **م** — round head + dropping tail]
-- [YOU WRITE: **سلام**, right to left — "teeth, hook, the لا fuse, lift, mīm"]
 - [YOU SAY: "*bēt* the house → *B*; *mem* the water → *M*; *ʾālep* the ox → *A*"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Why is the **dot** under **ب** not optional? (It is the only thing
-separating *b* from *n*, *t*, *th* — same skeleton, different dots.) In **سلام**,
-where does the pen **lift**, and why? (After **alif** — alif never joins the
-letter after it.) Name the Phoenician meanings behind **A**, **B**, and **M**.
-(**ox**, **house**, **water** — *ʾālep*, *bēt*, *mem*.) You can now hand-write
-every letter in **سلام** — and you have seen that the Arabic, Greek, and Latin
-alphabets are the same family tree wearing different clothes.
+separating *b* from *n*, *t*, *th*—same skeleton, different dots.) Name the
+Phoenician meanings behind **B** and **M**. (**house** and **water**—*bēt* and
+*mem*.)

--- a/code/learning/human-languages/arabic/lessons/AR-W03-write-salam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W03-write-salam.md
@@ -1,0 +1,44 @@
+---
+id: AR-W03-write-salam
+chapter: 1
+type: writing
+headword: "سلام"
+gloss: assemble salam from sin, lam-alif, a pen lift, and final mim
+romanization: salām
+prerequisites: [AR-W03-dots-mim-ba-salam]
+sounds: [arabic-sin, arabic-lam, arabic-alif, arabic-mim, long-a]
+roots: [semitic-s-l-m]
+est_minutes: 4
+reviews_of: [AR-W03-dots-mim-ba-salam, AR-W02-lam-alif-joins, AR-W01-abjad-short-vowels, AR-C01-salam]
+---
+
+# سلام — your first whole written word
+
+## Warm-up
+
+[PAUSE 2s] You now know every letter and connector needed for **سلام**
+(*salām*, “peace”). Assemble them slowly from right to left.
+
+## Build the word
+
+1. Start on the **right** with **س** (*sīn*), its three teeth reaching left.
+2. Flow into **ل** (*lām*), the tall hook.
+3. Fuse *lām* with *alif* as the obligatory **لا** ligature.
+4. **Lift the pen** after *alif*, because alif never joins the letter after it.
+5. Finish at the left with final **م** (*mīm*), its tail dropping below the line.
+
+Read back right to left: **س · ل · ا · م** = *s · l · ā · m* = **سلام**.
+The short vowel stays hidden, while *alif* carries the long *ā*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **سلام** — teeth, hook, **لا**, lift, *mīm*]
+- [YOU POINT: the pen lift after *alif*]
+- [YOU SAY: *salām* — peace, the word inside *as-salāmu ʿalaykum*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does the pen lift in **سلام**? (**After alif**, which cannot
+join forward.) Which two letters form **لا**? (**lām + alif**.) Read the word.
+(***salām***, “peace.”)

--- a/code/learning/human-languages/arabic/lessons/AR-W04-dots-family-nun-ta.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W04-dots-family-nun-ta.md
@@ -5,11 +5,11 @@ type: writing
 headword: "ن، ت، ث"
 gloss: the bowl skeleton finished — nūn, tāʾ, thāʾ, where only the dots differ
 romanization: "nūn, tāʾ, thāʾ"
-prerequisites: [AR-W03-dots-mim-ba-salam]
+prerequisites: [AR-W03-write-salam]
 sounds: [arabic-nun, arabic-ta, arabic-tha]
 roots: [phoenician-nun, phoenician-taw]
-est_minutes: 5
-reviews_of: [AR-W03-dots-mim-ba-salam, AR-C02-anta-anti, AR-C02-ism]
+est_minutes: 4
+reviews_of: [AR-W03-write-salam, AR-W03-dots-mim-ba-salam, AR-C02-anta-anti, AR-C02-ism]
 ---
 
 # ن، ت، ث — one bowl, four dot-patterns

--- a/code/learning/human-languages/arabic/lessons/AR-W05-ya-and-my-name.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W05-ya-and-my-name.md
@@ -8,7 +8,7 @@ romanization: "yāʾ"
 prerequisites: [AR-W04-dots-family-nun-ta]
 sounds: [arabic-ya, long-i]
 roots: [phoenician-yod]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-W04-dots-family-nun-ta, AR-C02-ism, AR-C02-ii-my]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-W06-hamza.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W06-hamza.md
@@ -1,0 +1,48 @@
+---
+id: AR-W06-hamza
+chapter: 2
+type: writing
+headword: "ء، أ"
+gloss: hamza marks the glottal catch and can ride on alif as its seat
+romanization: hamza
+prerequisites: [AR-W06-harakat-and-hamza]
+sounds: [arabic-hamza]
+roots: [abjad-vowels]
+est_minutes: 4
+reviews_of: [AR-W06-harakat-and-hamza, AR-C02-anta-anti]
+---
+
+# ء and أ — the glottal catch
+
+## Warm-up
+
+[PAUSE 2s] The marks in the last lesson supplied vowels. **Hamza** is different:
+it writes a real consonant sound.
+
+## The catch in “uh-oh”
+
+Say English “uh-oh” slowly. The little catch between the two syllables is a
+**glottal stop**. Arabic writes that consonant with **ء**, called **hamza**.
+
+Hamza often sits on a **seat**. At the start of **أنت** (*anta/anti*, “you”), it
+rides above **ا**, producing **أ**. The *alif* supplies the seat; the hamza marks
+the glottal-stop consonant.
+
+That gives *alif* two roles you must keep separate:
+
+- **ا** can carry long *ā*.
+- **أ** can be an *alif* seat bearing the consonant **ء**.
+
+Hamza is therefore not another short-vowel mark. Its sound is the catch itself.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “uh-oh” and feel the glottal catch]
+- [YOU WRITE: **ء** alone, then **أ** on its *alif* seat]
+- [YOU POINT: **أنتَ / أنتِ** — the same initial hamza in both]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is hamza a vowel mark? (**No.**) What sound does it write? (**A
+glottal stop.**) What is **أ**? (**Hamza riding on an alif seat.**)

--- a/code/learning/human-languages/arabic/lessons/AR-W06-harakat-and-hamza.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W06-harakat-and-hamza.md
@@ -3,22 +3,22 @@ id: AR-W06-harakat-and-hamza
 chapter: 2
 type: writing
 headword: "َ ِ ُ"
-gloss: the abjad's optional vowel marks (ḥarakāt) and the hamza — where one tiny mark flips anta to anti
+gloss: the abjad's optional short-vowel marks, where one tiny dash flips anta to anti
 romanization: "fatḥa, kasra, ḍamma; hamza"
 prerequisites: [AR-W05-ya-and-my-name]
 sounds: [arabic-harakat, arabic-hamza]
 roots: [abjad-vowels]
-est_minutes: 5
-reviews_of: [AR-W05-ya-and-my-name, AR-W01-direction-and-alif, AR-C02-anta-anti]
+est_minutes: 4
+reviews_of: [AR-W05-ya-and-my-name, AR-W01-abjad-short-vowels, AR-W01-direction-and-alif, AR-C02-anta-anti]
 ---
 
-# َ ِ ُ and ء — the little marks the abjad usually hides
+# َ ِ ُ — the short vowels the abjad usually hides
 
 ## Warm-up
 
-[PAUSE 2s] Way back in Lesson 1 you learned Arabic is an **abjad**: the short
+[PAUSE 2s] In the first writing cluster you learned Arabic is an **abjad**: short
 vowels are **usually left out**. This lesson shows the marks that a beginner's
-book *does* print when it wants to be clear — the **ḥarakāt** — and one of them
+book *does* print when it wants to be clear—the **ḥarakāt**—and one of them
 delivers the neatest payoff in the whole set: the difference between "you (m.)"
 and "you (f.)" is a **single dash**.
 
@@ -52,14 +52,6 @@ One dash up or down carries the whole gender distinction you learned in the
 introductions chapter. Leave the mark off — as normal Arabic does — and **أنت**
 serves both, the reader deciding from context.
 
-## The hamza — the glottal catch (ء)
-
-Look at the start of **أنت**: that little hook on top of the *alif* — **أ** — is a
-**hamza** (**ء**), the sign for a **glottal stop** (the catch in the middle of
-English "uh-oh"). It rides on a "seat," most often an *alif*, and marks a real
-consonant sound, not a vowel. So *alif* has two lives: a long "aa," or — wearing a
-hamza — a glottal-stop seat.
-
 ## Guided Practice
 
 [PAUSE 1s]
@@ -67,14 +59,11 @@ hamza — a glottal-stop seat.
   (*bu*)]
 - [YOU SAY: the flip — "أنتَ *anta* (man, slash above) vs أنتِ *anti* (woman, slash
   below)"]
-- [YOU SAY: "the hamza **ء** on **أ** = a glottal stop, the catch in 'uh-oh'"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What are the **ḥarakāt**, and does everyday text show them? (The short-
 **vowel marks** — *fatḥa/kasra/ḍamma*; normally **left off**, since Arabic is an
 abjad.) Which mark, and where, turns *anta* into *anti*? (A *kasra* — the "i"
-slash — **below** the final *tāʾ*, instead of the *fatḥa* above.) What does a
-**hamza** (**ء**) stand for? (A **glottal stop** — the catch in "uh-oh" — riding
-on a seat like *alif*.) You have now met Arabic's consonants, its joining, its
-dots, **and** its hidden vowels — the whole machine.
+slash—**below** the final *tāʾ*, instead of the *fatḥa* above.) You have now made
+one consonant skeleton say *anta* or *anti* with one tiny mark.

--- a/code/learning/human-languages/arabic/lessons/AR-W07-hook-family-ha-kha.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W07-hook-family-ha-kha.md
@@ -5,11 +5,11 @@ type: writing
 headword: "ح، خ، ج"
 gloss: a second dots-family on a new skeleton — the hook-and-tail body ḥāʾ, khāʾ, jīm
 romanization: "ḥāʾ, khāʾ, jīm"
-prerequisites: [AR-W06-harakat-and-hamza]
+prerequisites: [AR-W06-hamza]
 sounds: [arabic-ha-deep, arabic-kha, arabic-jim]
 roots: [phoenician-heth, phoenician-giml]
-est_minutes: 5
-reviews_of: [AR-W06-harakat-and-hamza, AR-W04-dots-family-nun-ta, AR-C01-sabah-al-khayr]
+est_minutes: 4
+reviews_of: [AR-W06-hamza, AR-W06-harakat-and-hamza, AR-W04-dots-family-nun-ta, AR-C01-sabah-al-khayr]
 ---
 
 # ح، خ، ج — the dots trick, on a brand-new body

--- a/code/learning/human-languages/arabic/lessons/AR-W09-khayr-bikhayr.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W09-khayr-bikhayr.md
@@ -8,7 +8,7 @@ romanization: "khayr, bi-khayr"
 prerequisites: [AR-W08-kaf-and-ra]
 sounds: [arabic-khayr]
 roots: [semitic-kh-y-r]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-W08-kaf-and-ra, AR-W07-hook-family-ha-kha, AR-C01-sabah-al-khayr]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-W10-ayn.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W10-ayn.md
@@ -8,7 +8,7 @@ romanization: "ʿayn"
 prerequisites: [AR-W09-khayr-bikhayr]
 sounds: [arabic-ayn]
 roots: [phoenician-ayin]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-W09-khayr-bikhayr, AR-W07-hook-family-ha-kha, AR-C01-as-salamu-alaykum]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-W11-ha-and-ta-marbuta.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W11-ha-and-ta-marbuta.md
@@ -8,7 +8,7 @@ romanization: "hāʾ, tāʾ marbūṭa"
 prerequisites: [AR-W10-ayn]
 sounds: [arabic-ha-light, arabic-ta-marbuta]
 roots: [phoenician-he]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [AR-W10-ayn, AR-W04-dots-family-nun-ta, AR-C02-anta-anti]
 ---
 

--- a/code/learning/human-languages/arabic/lessons/AR-W12-maa-salama.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W12-maa-salama.md
@@ -8,8 +8,8 @@ romanization: "maʿa s-salāma"
 prerequisites: [AR-W11-ha-and-ta-marbuta]
 sounds: [arabic-ayn, arabic-ta-marbuta]
 roots: [semitic-s-l-m]
-est_minutes: 5
-reviews_of: [AR-W11-ha-and-ta-marbuta, AR-W10-ayn, AR-W03-dots-mim-ba-salam]
+est_minutes: 4
+reviews_of: [AR-W11-ha-and-ta-marbuta, AR-W10-ayn, AR-W03-write-salam, AR-W03-dots-mim-ba-salam]
 ---
 
 # مع السلامة — the goodbye, and a word you already know

--- a/code/learning/human-languages/arabic/roadmap.md
+++ b/code/learning/human-languages/arabic/roadmap.md
@@ -59,21 +59,24 @@ word lessons — never as a gated reading course.
   **ق** *qāf* and **ى** *alif maqṣūra* are beyond the writing track's letter set,
   so they are read, not drawn.)
 
-- **Ch. 1 — Writing set** (`AR-W01`–`AR-W03`, `writing` type): the
+- **Ch. 1 — Writing set** (`AR-W01-*`–`AR-W03-*`, six `writing` lessons): the
   "break-it-apart-and-draw-it" companion to the greetings, rendered by the
   language-ladder app (parallel to the Cyrillic `RU-W*` set). Right-to-
-  left and *abjad* taught first, then the cursive four-coats rule, dots-as-a-piece,
-  and the assembly of a whole word — **سلام** — from *sīn/lām/alif/mīm*. Ties the
-  Arabic letters back to their Phoenician ancestors (*ʾālep/bēt/mem* = **A/B/M**).
+  left and *alif* come first, followed by the *abjad*'s hidden short vowels; the
+  cursive four-coats rule comes before joined **سل/لا**; and dots-as-a-piece
+  comes before the assembly of a whole word — **سلام** — from
+  *sīn/lām/alif/mīm*. Ties the Arabic letters back to their Phoenician ancestors
+  (*ʾālep/bēt/mem* = **A/B/M**).
 
-- **Ch. 2 — Writing set** (`AR-W04`–`AR-W06`, `writing` type): the writing
+- **Ch. 2 — Writing set** (`AR-W04`–`AR-W06-*`, four `writing` lessons): the writing
   companion to the self-introduction words. Completes the **bowl-skeleton
   dots-family** as a truth-table (ب/ن/ت/ث — one-below/one-above/two/three, + ي
   two-below), teaches **ي** (*yāʾ*: consonant *y*, long vowel *ī*, and the "-ī my"
   suffix) and assembles **اسم → اسمي** ("name" → "my name") from already-known
   letters, then pays off Ch. 1's *abjad* idea with the **ḥarakāt** (short-vowel
-  marks) and the **hamza** — the showpiece being that a single *fatḥa*/*kasra*
-  flips **أنتَ** ("you," m.) to **أنتِ** ("you," f.).
+  marks) — the showpiece being that a single *fatḥa*/*kasra* flips **أنتَ**
+  ("you," m.) to **أنتِ** ("you," f.). Hamza then follows as its own consonant
+  sign, including its familiar *alif* seat.
 
 - **Ch. 3 — Writing set** (`AR-W07`–`AR-W09`, `writing` type): builds toward the
   reply *bi-khayr* ("well"). Introduces a **second dots-family** — the


### PR DESCRIPTION
## Summary

- correct 35 Arabic lesson declarations whose computed duration already fits the sub-five-minute contract
- split four longer writing lessons into eight prerequisite-ordered steps covering direction/abjad, joining/lam-alif, dot families/whole-word writing, and vowel marks/hamza
- record Arabic book-generation, PDF-warning, and progression-map follow-ups in the prioritized backlog

The corpus grows from 1,008 to 1,012 lessons, Arabic drops from 39 duration violations to zero, the repository drops from 219 to 180, and unknown prerequisites remain at zero.

## Validation

- `npm run test:coverage` (human-language-data: 68 tests, 93.60% line coverage)
- `npm run build` (human-language-data)
- `npm run validate` (9 integration tests)
- `npm run check:books`
- `npm run report` (20 tracks, 1,012 lessons, 180 duration violations, 0 unknown prerequisites)
- `npm run test:coverage` (Language Ladder: 278 tests, 98.37% line coverage)
- `npm run build` (Language Ladder)
- `latexmk -g -xelatex -interaction=nonstopmode -halt-on-error book.tex` (unchanged Arabic book: 18 pages, zero missing glyphs; warning debt recorded separately)