### PR TITLE
Lower SPICE parser MOS oxide thickness

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower MOS model-card `TOX` into Level-1 oxide thickness instead
+  of silently discarding it.
 - Reject non-finite and non-Level-1 MOS model-card `LEVEL` values while
   preserving explicit and implicit Level 1 cards.
 - Parse `.save`, scoped or global `.probe`, and `.measure` / `.meas` cards,

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1879,10 +1879,13 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         if params_text.startswith("(") and params_text.endswith(")"):
             params_text = params_text[1:-1]
     params = _parse_model_params(params_text)
-    if kind in {"NMOS", "PMOS"} and "LEVEL" in params:
-        level = params["LEVEL"]
-        if not math.isfinite(level) or abs(level - 1.0) > 1.0e-12:
-            raise NetlistParseError("only MOS LEVEL=1 model cards are supported")
+    if kind in {"NMOS", "PMOS"}:
+        if "LEVEL" in params:
+            level = params["LEVEL"]
+            if not math.isfinite(level) or abs(level - 1.0) > 1.0e-12:
+                raise NetlistParseError("only MOS LEVEL=1 model cards are supported")
+        if "TOX" in params and (not math.isfinite(params["TOX"]) or params["TOX"] <= 0.0):
+            raise NetlistParseError("MOSFET TOX must be finite and positive")
     return ModelCard(name=name, kind=kind, params=params)
 
 
@@ -1920,7 +1923,6 @@ _LEVEL1_PARAM_ALIASES = {
     "NSUB": "N_SUB",
     "N": "N_SUB",
     "TNOM": "T_NOM",
-    "TOX": "T_OX",
     "VTO": "VT0",
 }
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1392,6 +1392,23 @@ def test_preserves_supported_and_implicit_mosfet_model_level_one(parameters: str
     assert isinstance(parsed.circuit.elements[0], Mosfet)
 
 
+@pytest.mark.parametrize("oxide_thickness", ["0", "-1n", "1e999"])
+def test_rejects_invalid_mosfet_model_oxide_thickness(oxide_thickness: str) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET TOX must be finite and positive",
+    ):
+        parse_netlist(f".model nfast NMOS(TOX={oxide_thickness})\nM1 d g s b nfast\n")
+
+
+def test_lowers_mosfet_model_oxide_thickness() -> None:
+    parsed = parse_netlist(".model nfast NMOS(TOX=7n)\nM1 d g s b nfast\n")
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.TOX, 7.0e-9)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower MOS model-card `TOX` into Level-1 oxide thickness instead
+  of silently discarding it.
 - Reject non-finite and non-Level-1 MOS model-card `LEVEL` values while
   preserving explicit and implicit Level 1 cards.
 - Parse `.save`, scoped or global `.probe`, and `.measure` / `.meas` cards,

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1155,6 +1155,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("only MOS LEVEL=1 model cards are supported");
   }
+  const oxideThickness = params.get("TOX");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    oxideThickness !== undefined &&
+    (!Number.isFinite(oxideThickness) || oxideThickness <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET TOX must be finite and positive");
+  }
   return {
     name: fields[1],
     kind,
@@ -1223,6 +1231,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "PHI",
     "W",
     "L",
+    "TOX",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1306,6 +1306,25 @@ Xright c d load
     },
   );
 
+  it.each(["0", "-1n", "1e999"])(
+    "rejects invalid MOSFET model TOX=%s",
+    (oxideThickness) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(TOX=${oxideThickness})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET TOX must be finite and positive");
+    },
+  );
+
+  it("lowers MOSFET model oxide thickness", () => {
+    const parsed = parseNetlist(".model nfast NMOS(TOX=7n)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.params.TOX).toBeCloseTo(7.0e-9, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS model-card level validation parity.
+1. Python and TypeScript Berkeley SPICE MOS model-card oxide-thickness parity.
    - Status: current PR completion candidate.
-   - Reject non-finite and non-Level-1 model-card `LEVEL` values with the same
-     tolerance and diagnostic already used by Rust and the shared engines.
-   - Preserve explicit `LEVEL=1` model cards and cards that omit `LEVEL`.
+   - Reject zero, negative, and non-finite model-card `TOX` values with the
+     diagnostic already used by Rust and the shared engines.
+   - Lower valid `TOX` values into Level-1 oxide thickness instead of silently
+     discarding them.
 
 ## Completed Slices
 
@@ -4125,20 +4126,35 @@ the Rust, Python, and TypeScript surfaces together.
      handled by the shared electrostatic-default path.
    - No remaining Rust netlist-facade model-card gap was confirmed.
 
+368. Python and TypeScript Berkeley SPICE MOS model-card level validation parity.
+   - Status: completed in PR 9583.
+   - Non-finite and non-Level-1 model-card `LEVEL` values are rejected with the
+     same tolerance and diagnostic as Rust and the shared engines.
+   - Explicit `LEVEL=1` model cards and cards that omit `LEVEL` remain accepted.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE MOS model-card level validation parity.
-   - Reject non-finite and non-Level-1 model-card `LEVEL` values with the same
-     tolerance and diagnostic already used by Rust and the shared engines.
-   - Preserve explicit `LEVEL=1` model cards and cards that omit `LEVEL`.
+1. Python and TypeScript Berkeley SPICE MOS model-card oxide-thickness parity.
+   - Validate and lower canonical `TOX`; Python currently aliases it to a
+     nonexistent field and TypeScript currently omits it from accepted fields.
 
-2. Python and TypeScript Berkeley SPICE Level-1 model-card lowering parity.
-   - Audit and close supported parameter, alias, validation, and derived-default
-     gaps against the completed Rust facade and shared engines.
-   - Keep each follow-up slice small while preserving identical diagnostics and
-     lowering semantics across all three languages.
+2. Python and TypeScript Berkeley SPICE MOS surface-mobility and derived-`KP` parity.
+   - Lower `U0` / `UO`, validate its finite non-negative domain, and derive `KP`
+     from `U0` and `TOX` when `KP` is omitted.
 
-3. Grammar-backed parser and app facade.
+3. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
+   - Apply Rust-aligned domains and diagnostics to already lowered `KP`, `VT0`,
+     `LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, and nominal-temperature fields.
+
+4. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
+   - Lower missing canonical resistance, geometry, capacitance, junction, and
+     noise fields, then align `VTH`, `LAM`, `CJS`, and `CJD` aliases.
+
+5. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
+   - Validate and consume `NSS` / `TPG`, then derive `VT0`, `GAMMA`, and `PHI`
+     from `N_SUB` / `TOX` with shared engine semantics.
+
+6. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
@@ -4146,7 +4162,7 @@ the Rust, Python, and TypeScript surfaces together.
      toward packaging, WebAssembly embedding, and product integration backed by
      the same public parser contract.
 
-4. Deck compatibility follow-up.
+7. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis
      execution and stable artifact exports toward nested sweeps, raw-format
      interoperability, and remaining vendor-style output controls.
@@ -4157,7 +4173,7 @@ the Rust, Python, and TypeScript surfaces together.
      command routing, including control flow, variables, and script execution
      policy.
 
-5. Production solver core follow-up.
+8. Production solver core follow-up.
    - Sparse real/complex matrix paths now have cross-language native coverage,
      and Python real DC solves now use an optional SciPy sparse-LU backend with
      structured native fallback metadata.
@@ -4168,14 +4184,14 @@ the Rust, Python, and TypeScript surfaces together.
      damping, device limiting, tolerance policy, and additional convergence
      diagnostics for difficult transistor decks.
 
-6. Device model depth.
+9. Device model depth.
    - Audit diode, BJT, JFET, and MOS Level 1 behavior against reference decks.
    - Decide whether Level 2/3 MOS is in scope before BSIM; if BSIM lands, make
      Rust the first fast path and port stable semantics outward.
    - Expand temperature behavior, capacitance, noise, charge conservation, model
      card aliases, and error messages.
 
-7. Analysis completion.
+10. Analysis completion.
    - Generalize pole-zero beyond constrained fixture helpers.
    - Expand nonlinear distortion coverage.
    - Expand parsed `.FOUR` / `.MEASURE` integration across output plans and
@@ -4184,14 +4200,14 @@ the Rust, Python, and TypeScript surfaces together.
      Carlo trials.
    - Stabilize raw, CSV, JSON, and browser-friendly result formats.
 
-8. Mixed-signal integration.
+11. Mixed-signal integration.
    - Connect SPICE transient stepping to the hardware VM scheduler.
    - Support bidirectional analog/digital thresholds, event scheduling,
      breakpoint coordination, and VCD correlation.
    - Keep mixed-signal coupling deterministic across Python, Rust, and
      TypeScript.
 
-9. Verilog-A and custom models.
+12. Verilog-A and custom models.
    - Specify the accepted model subset and residual/Jacobian hooks.
    - Add parser or compiler support with sandboxing for TypeScript/web usage.
    - Provide a Rust-native fast path for compiled models.


### PR DESCRIPTION
## Summary
- validate MOS model-card TOX with the Rust-aligned finite positive domain and diagnostic
- lower accepted TOX values into Python and TypeScript Level-1 engine parameters instead of silently dropping them
- record PR #9583 completion and split the fresh Python/TypeScript lowering audit into prioritized follow-up slices

## Verification
- Python spice-netlist-parser: 84 tests passed, 87.84% coverage
- Python ruff: passed
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed, 83 tests passed
- TypeScript spice-netlist-parser coverage: 82.94% statements, 83.58% lines
- git diff --check: passed