### PR TITLE
Report duplicate HTML shell start tags

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Duplicate `html`, `head`, and `body` start tags now emit tree-construction
+  diagnostics while retaining the Standard's attribute-merge recovery for
+  `html` and `body`, closing 28 previously silent malformed corpus cases.
 - Full-document parsing now emits a `missing-doctype` tree-construction
   diagnostic when the initial insertion mode sees a non-whitespace,
   non-comment, non-processing-instruction token before a doctype, closing 783
@@ -325,8 +328,9 @@ documented in this file.
 - Nested `form` start tags are now ignored with a parser diagnostic while an
   outer form remains open, keeping form-associated content in the existing form
   instead of creating nested form DOMs.
-- Duplicate open `html` and `head` start tags now merge missing attributes into
-  the existing shell elements instead of creating nested shell DOMs.
+- Duplicate open `html` start tags merge missing attributes into the existing
+  document element, while duplicate `head` start tags are ignored instead of
+  creating nested shell DOMs.
 - Late `head` start tags after body content has already started are ignored
   with a parser diagnostic.
 - Self-closing flags on non-void HTML start tags are now ignored with a parser

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -25,8 +25,8 @@ The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
 all 6,806 html5lib tokenizer cases with zero missing signatures and zero
 normalized skips. DOM output is complete, but diagnostic coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the initial-mode missing-doctype slice, 1,389 of those cases emit at
-least one lexer or parser diagnostic and 794 remain uncovered. Another 139
+After the duplicate document-shell start-tag slice, 1,417 of those cases emit
+at least one lexer or parser diagnostic and 766 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -36,7 +36,7 @@ Prioritized work items:
 
 1. **Document shell insertion modes.** Emit the remaining parse errors around
    explicit and implied `html`, `head`, and `body` creation. Missing-doctype
-   handling in the initial mode is complete.
+   handling and duplicate shell start-tag diagnostics are complete.
 2. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
    recovery, formatting reconstruction, and stray start/end tags.
 3. **Table, select, and template insertion modes.** Cover foster parenting,

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -198,6 +198,9 @@ identify missing diagnostic coverage while DOM output remains independently
 checked. Full-document parsing follows the Standard's initial insertion mode:
 whitespace, comments, and processing instructions may precede a doctype, while
 any other token first emits `missing-doctype` and enters quirks handling.
+Repeated `html`, `head`, and `body` start tags also emit shell diagnostics;
+`html` and `body` retain the Standard's missing-attribute merge behavior while
+a repeated `head` token is ignored.
 
 For sharper parser regression reporting, the generated
 `tests/fixtures/whatwg-tree-insertion-audit.json` fixture indexes the

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4758,6 +4758,7 @@ impl HtmlParser {
             ));
             name = "img".to_string();
         }
+        let body_element_existed_before_start_tag = self.document_has_body_element();
         if name == "body" {
             self.explicit_body_start_seen = true;
         }
@@ -5275,6 +5276,13 @@ impl HtmlParser {
             return;
         }
 
+        if !in_foreign_content && name == "html" && self.has_document_element() {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-html-start-tag",
+                "html start tag was recovered against the existing document element",
+            ));
+        }
+
         if !in_foreign_content
             && name == "html"
             && self.merge_attributes_into_open_element("html", &attributes)
@@ -5292,16 +5300,11 @@ impl HtmlParser {
             return;
         }
 
-        if !in_foreign_content
-            && name == "head"
-            && self.has_open_element("head")
-            && !self.current_element_is("head")
-        {
-            return;
-        }
-
         if !in_foreign_content && name == "head" && self.has_open_element("head") {
-            self.merge_attributes_into_open_element("head", &attributes);
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-head-start-tag",
+                "duplicate head start tag was ignored",
+            ));
             return;
         }
 
@@ -5328,6 +5331,17 @@ impl HtmlParser {
 
         if !in_foreign_content && name == "body" && self.has_open_element("template") {
             return;
+        }
+
+        if !in_foreign_content
+            && name == "body"
+            && body_element_existed_before_start_tag
+            && self.has_open_element("body")
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-body-start-tag",
+                "body start tag was recovered against the existing body element",
+            ));
         }
 
         if !in_foreign_content
@@ -32722,20 +32736,55 @@ mod tests {
     }
 
     #[test]
-    fn merges_duplicate_html_and_head_start_tags_without_nesting() {
-        let document = parse_html(
-            "<html lang=en><html data-app=venture lang=ignored><head id=main><head data-h=yes><title>T</title><body><p>x</p>",
+    fn reports_and_recovers_duplicate_html_and_head_start_tags() {
+        let output = parse_html_with_diagnostics(
+            "<!doctype html><html lang=en><html data-app=venture lang=ignored><head id=main><head data-h=yes><title>T</title><body><p>x</p>",
         )
         .unwrap();
+        let document = output.document;
 
         assert_eq!(html(&document).attribute("lang"), Some("en"));
         assert_eq!(html(&document).attribute("data-app"), Some("venture"));
         assert_eq!(head(&document).attribute("id"), Some("main"));
-        assert_eq!(head(&document).attribute("data-h"), Some("yes"));
+        assert_eq!(head(&document).attribute("data-h"), None);
         assert_eq!(head(&document).children.len(), 1);
         assert_eq!(element(&head(&document).children[0]).name, "title");
         assert_eq!(body(&document).children.len(), 1);
         assert_eq!(element(&body(&document).children[0]).name, "p");
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![
+                ParserDiagnostic::new(
+                    "unexpected-html-start-tag",
+                    "html start tag was recovered against the existing document element"
+                ),
+                ParserDiagnostic::new(
+                    "unexpected-head-start-tag",
+                    "duplicate head start tag was ignored"
+                )
+            ]
+        );
+    }
+
+    #[test]
+    fn reports_and_recovers_duplicate_body_start_tags() {
+        let output = parse_html_with_diagnostics(
+            "<!doctype html><body class=first><body data-app=venture class=ignored><p>x",
+        )
+        .unwrap();
+
+        assert_eq!(body(&output.document).attribute("class"), Some("first"));
+        assert_eq!(
+            body(&output.document).attribute("data-app"),
+            Some("venture")
+        );
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-body-start-tag",
+                "body start tag was recovered against the existing body element"
+            )]
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 794);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1389);
+    assert_eq!(missing_diagnostic_cases, 766);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1417);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- emit parser diagnostics for duplicate `html`, `head`, and `body` start tags
- retain WHATWG attribute recovery for repeated `html` and `body`, while ignoring repeated `head` attributes
- ratchet malformed tree cases with diagnostics from 1,389 to 1,417, leaving 766 uncovered

## Evidence
- [WHATWG in-body `html` and `body` start-tag rules](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody)
- [WHATWG in-head and after-head rules](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhead)
- all 2,637 checked tree-construction DOM outputs remain unchanged
- current upstream tree/tokenizer signature coverage remains complete with zero skips

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture checks and README inventory check
- `git diff --check`
