### PR TITLE
fix(ci): provision Venture native Linux dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,7 @@ jobs:
           components: clippy
 
       - name: Install native Paint VM dependencies
-        if: needs.detect.outputs.needs_rust == 'true' && runner.os == 'Linux'
+        if: (needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true') && runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libcairo2-dev

--- a/code/scripts/tests/test_venture_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_venture_windows_ci_acceptance.py
@@ -103,6 +103,12 @@ class VentureWindowsCIAcceptanceTests(unittest.TestCase):
             "needs.detect.outputs.needs_venture_windows == 'true'",
             workflow,
         )
+        self.assertIn(
+            "(needs.detect.outputs.needs_rust == 'true' || "
+            "needs.detect.outputs.needs_venture_windows == 'true') "
+            "&& runner.os == 'Linux'",
+            workflow,
+        )
         self.assertIn("cargo test -p venture-browser-windows", workflow)
         self.assertIn("cargo test -p venture-browser-macos", workflow)
 


### PR DESCRIPTION
## Summary
- install Cairo development headers when the Venture native-shell acceptance lane activates Rust on Linux
- ratchet the workflow contract test so Venture-only changes cannot skip the native Paint VM dependency setup

## Root cause
The Venture Mosaic package invokes `mosaic-compile`, whose Rust dependency graph reaches `cairo-sys-rs`. The PR matrix set up Rust for Venture native acceptance but installed `libcairo2-dev` only when the ordinary Rust detector flag was true, so Venture-only Ubuntu jobs failed at `pkg-config cairo`.

## Validation
- `python3 code/scripts/tests/test_venture_windows_ci_acceptance.py`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_coverage.py --check`
- `cargo test -p coding-adventures-html-parser`
- parser ratchets remain exact: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 raw / 0 missing; normalized 7242 / 0 skipped

Auto-merge will only be enabled after every required Ubuntu, macOS, and Windows build has completed successfully.