### PR TITLE
fix(build-tool): emit portable TypeScript plan paths

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -370,11 +370,11 @@
     {
       "id": "build-tool-typescript-windows-plan-rel-path-portability",
       "title": "Emit portable TypeScript build-plan package paths on Windows",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-typescript-language-identity-registry"],
-      "branch": null,
+      "branch": "codex/build-tool-typescript-windows-plan-rel-path",
       "pr_number": null,
-      "notes": "Discovered by the real full-repository plan validation for the TypeScript language/identity-registry slice. On Windows, package rel_path values are emitted with backslashes because index.ts serializes path.relative directly, while the language-neutral canonical path contract requires forward slashes. Keep this separate from discovery identity: add a cross-platform plan fixture and real CLI coverage, normalize only repository-relative serialized paths, and preserve absolute destination option handling for its separately owned file-option concerns."
+      "notes": "Selected after merged PR #9582 and the collision-clean 3f8eb7b8 inventory because its dependency is satisfied and Windows corrupts all 4,768 serialized package rel_path records, affecting every downstream plan consumer. This outranks the existing gitdiff item, whose seven failures are local test-fixture portability only, and the next strict-UTF-8 child, whose leverage is confined to one engine. Add a language-neutral cross-platform plan fixture plus real TypeScript CLI coverage, normalize only repository-relative serialized package paths to forward slashes, preserve absolute destination option handling, and do not widen into the separately owned gitdiff or file-option concerns."
     },
     {
       "id": "build-tool-go-rockspec-utf8-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9589,
   "last_inventory": {
     "revision": "3f8eb7b8a94db122c05ec4ffe1de59e0a052f515",
     "schema_version": 3,
@@ -370,11 +370,11 @@
     {
       "id": "build-tool-typescript-windows-plan-rel-path-portability",
       "title": "Emit portable TypeScript build-plan package paths on Windows",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-typescript-language-identity-registry"],
       "branch": "codex/build-tool-typescript-windows-plan-rel-path",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9582 and the collision-clean 3f8eb7b8 inventory because its dependency is satisfied and Windows corrupts all 4,768 serialized package rel_path records, affecting every downstream plan consumer. This outranks the existing gitdiff item, whose seven failures are local test-fixture portability only, and the next strict-UTF-8 child, whose leverage is confined to one engine. Add a language-neutral cross-platform plan fixture plus real TypeScript CLI coverage, normalize only repository-relative serialized package paths to forward slashes, preserve absolute destination option handling, and do not widen into the separately owned gitdiff or file-option concerns."
+      "pr_number": 9589,
+      "notes": "Ready PR #9589 is the sole active parity PR. It adds the language-neutral plan/portable-package-path plan_v1_write fixture, consumes it through a real TypeScript CLI subprocess with exact emitted-plan equality, and normalizes only serialized package rel_path values to forward slashes. Exact-head validation after a conflict-free rebase onto 0ef57c15 passed 18 plan tests, 272 unaffected tests, 100% plan line/statement/function and 88.88% branch coverage, production bundling, 17 schema plus 40 runner tests, the valid 37-case/56-file corpus, zero-advisory npm audit, and a real 4,768-record/7,243-edge full plan with 4,768 unique names, zero duplicate groups, and zero backslash paths. The collision-checked parity inventory remains 1,222 identities/4,370 slots with zero collisions or unknown inventory buckets. Full local Windows testing separately reproduced only the exact seven owned gitdiff portability failures, and BUILD validation reproduced only the exact ten owned Lua BUILD_windows debts."
     },
     {
       "id": "build-tool-go-rockspec-utf8-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9582,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "6141793a9c29cd1177b3b201565e4f8537e77585",
+    "revision": "3f8eb7b8a94db122c05ec4ffe1de59e0a052f515",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1222,
@@ -361,11 +361,11 @@
     {
       "id": "build-tool-typescript-language-identity-registry",
       "title": "Bring TypeScript build-tool discovery to the canonical language and identity registry",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-typescript-language-identity-registry",
       "pr_number": 9582,
-      "notes": "Ready PR #9582 is the sole active parity PR. It consumes the shared discovery language-registry and duplicate-identity fixtures, classifies only exact package/program lane boundaries, preserves language/programs/name identity, excludes spec fixtures, and fails closed with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, real CLI exit 2, and no checkout-root disclosure. Exact-head validation after a conflict-free rebase onto fc27dd48 passed 37 discovery tests, 271 unaffected tests, 93.40% discovery line and 89.23% branch coverage, production bundling, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, zero-advisory npm audit, and a real 4,768-record/7,242-edge full plan with 4,768 unique names, zero duplicate groups, and only intentional unknown/blog. The collision-checked parity inventory remains 1,222 identities/4,370 slots with zero collisions or unknown inventory buckets. Full local Windows testing separately reproduced only the exact seven owned gitdiff portability failures, and BUILD validation reproduced only the exact ten owned Lua BUILD_windows debts. The newly discovered Windows plan rel_path normalization is logged as its own pending child."
+      "notes": "Merged PR #9582 at 3f8eb7b8a94db122c05ec4ffe1de59e0a052f515 on 2026-08-02 after both detection runs, both fixture-consumer runs, both Ubuntu builds, macOS, Windows, CodeQL language detection, and JavaScript/TypeScript analysis passed; irrelevant CodeQL lanes and the aggregate no-op skipped. It consumes the shared discovery language-registry and duplicate-identity fixtures, classifies only exact package/program lane boundaries, preserves language/programs/name identity, excludes spec fixtures, and fails closed with DUPLICATE_PACKAGE_IDENTITY, sorted repository-relative paths, real CLI exit 2, and no checkout-root disclosure. Exact-head validation passed 37 discovery tests, 271 unaffected tests, 93.40% discovery line and 89.23% branch coverage, production bundling, 17 schema plus 40 runner tests, the valid 36-case/55-file corpus, zero-advisory npm audit, and a real 4,768-record/7,242-edge full plan with 4,768 unique names, zero duplicate groups, and only intentional unknown/blog. The post-merge collision-checked inventory remains 1,222 identities/4,370 slots with zero collisions or unknown inventory buckets. Full local Windows testing separately reproduced only the exact seven owned gitdiff portability failures, and BUILD validation reproduced only the exact ten owned Lua BUILD_windows debts. The newly discovered Windows plan rel_path normalization is logged as its own pending child."
     },
     {
       "id": "build-tool-typescript-windows-plan-rel-path-portability",

--- a/code/programs/typescript/build-tool/CHANGELOG.md
+++ b/code/programs/typescript/build-tool/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the TypeScript build tool will be documented in this file
 
 ### Fixed
 
+- Emit build-plan package `rel_path` values with portable forward slashes on
+  Windows, backed by the shared plan fixture and a real CLI subprocess test.
 - Classify languages only from the canonical package/program bucket, preserve
   `language/programs/name` identities, and exclude specification fixtures.
 - Reject residual duplicate qualified names with the stable

--- a/code/programs/typescript/build-tool/README.md
+++ b/code/programs/typescript/build-tool/README.md
@@ -50,6 +50,10 @@ Lua rockspecs are decoded as strict UTF-8. Malformed metadata fails closed with
 the stable `METADATA_INVALID_UTF8` diagnostic and CLI exit code 2; a valid
 literal U+FFFD replacement character remains valid UTF-8.
 
+Emitted build plans use repository-relative forward-slash package paths on
+every platform, including Windows, so downstream jobs receive the same logical
+plan regardless of the producer host.
+
 ## Platform-specific BUILD files
 
 The discovery system supports platform-specific BUILD files with the following priority:

--- a/code/programs/typescript/build-tool/src/index.ts
+++ b/code/programs/typescript/build-tool/src/index.ts
@@ -316,7 +316,7 @@ Options:
     // Build the list of package entries for the plan.
     const planPackages: PackageEntry[] = packages.map((pkg) => ({
       name: pkg.name,
-      rel_path: path.relative(root, pkg.path),
+      rel_path: path.relative(root, pkg.path).replaceAll("\\", "/"),
       language: pkg.language,
       build_commands: pkg.buildCommands,
     }));

--- a/code/programs/typescript/build-tool/tests/plan.test.ts
+++ b/code/programs/typescript/build-tool/tests/plan.test.ts
@@ -13,6 +13,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import {
   writePlan,
   readPlan,
@@ -53,6 +55,27 @@ function makeMinimalPlan(overrides?: Partial<BuildPlan>): BuildPlan {
     languages_needed: {},
     ...overrides,
   };
+}
+
+interface SharedPlanFixture {
+  workspace: {
+    files: Array<{ path: string; content_utf8: string }>;
+  };
+  expected: {
+    result: { plan: BuildPlan };
+  };
+  limits: { wall_time_ms: number };
+}
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const sharedFixtureRoot = fileURLToPath(
+  new URL("../../../../specs/fixtures/build-tool-v1/cases/", import.meta.url),
+);
+
+function loadSharedPlanFixture(name: string): SharedPlanFixture {
+  return JSON.parse(
+    fs.readFileSync(path.join(sharedFixtureRoot, name), "utf-8"),
+  ) as SharedPlanFixture;
 }
 
 // ---------------------------------------------------------------------------
@@ -212,5 +235,46 @@ describe("writePlan file format", () => {
     expect(raw.endsWith("\n")).toBe(true);
     // Should be valid JSON.
     expect(() => JSON.parse(raw)).not.toThrow();
+  });
+});
+
+describe("real CLI plan emission", () => {
+  it("consumes the shared portable package-path fixture", () => {
+    const fixture = loadSharedPlanFixture("plan-portable-package-path.json");
+    const root = path.join(tempDir, "repo");
+    fs.mkdirSync(path.join(root, ".git"), { recursive: true });
+    for (const file of fixture.workspace.files) {
+      const destination = path.join(root, ...file.path.split("/"));
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.writeFileSync(destination, file.content_utf8, "utf-8");
+    }
+
+    const outputPath = path.join(tempDir, "emitted-plan.json");
+    const tsxCli = path.join(
+      packageRoot,
+      "node_modules",
+      "tsx",
+      "dist",
+      "cli.mjs",
+    );
+    const entrypoint = path.join(packageRoot, "src", "index.ts");
+    const result = spawnSync(
+      process.execPath,
+      [
+        tsxCli,
+        entrypoint,
+        "--root",
+        root,
+        "--force",
+        "--emit-plan",
+        "--plan-file",
+        outputPath,
+      ],
+      { encoding: "utf-8", timeout: fixture.limits.wall_time_ms },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(readPlan(outputPath)).toEqual(fixture.expected.result.plan);
   });
 });

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -131,7 +131,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 36)
+        self.assertEqual(summary["case_count"], 37)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -851,7 +851,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 36)
+        self.assertEqual(summary["case_count"], 37)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/specs/fixtures/build-tool-v1/cases/plan-portable-package-path.json
+++ b/code/specs/fixtures/build-tool-v1/cases/plan-portable-package-path.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": 1,
+  "id": "plan/portable-package-path",
+  "domain": "plan",
+  "summary": "An emitted package path uses repository-relative forward slashes on every platform.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "plan_v1_write"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/typescript/demo/BUILD",
+        "content_utf8": "echo portable\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "plan",
+    "options": {
+      "mode": "write",
+      "plan": {
+        "schema_version": 1,
+        "diff_base": "origin/main",
+        "force": true,
+        "affected_packages": null,
+        "packages": [
+          {
+            "name": "typescript/demo",
+            "rel_path": "code/packages/typescript/demo",
+            "language": "typescript",
+            "build_commands": [
+              "echo portable"
+            ]
+          }
+        ],
+        "dependency_edges": [],
+        "languages_needed": {
+          "dotnet": true,
+          "elixir": true,
+          "go": true,
+          "haskell": true,
+          "java": true,
+          "kotlin": true,
+          "lua": true,
+          "perl": true,
+          "python": true,
+          "ruby": true,
+          "rust": true,
+          "swift": true,
+          "typescript": true
+        }
+      }
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "plan/portable-package-path",
+    "domain": "plan",
+    "outcome": "ok",
+    "result": {
+      "plan": {
+        "schema_version": 1,
+        "diff_base": "origin/main",
+        "force": true,
+        "affected_packages": null,
+        "packages": [
+          {
+            "name": "typescript/demo",
+            "rel_path": "code/packages/typescript/demo",
+            "language": "typescript",
+            "build_commands": [
+              "echo portable"
+            ]
+          }
+        ],
+        "dependency_edges": [],
+        "languages_needed": {
+          "dotnet": true,
+          "elixir": true,
+          "go": true,
+          "haskell": true,
+          "java": true,
+          "kotlin": true,
+          "lua": true,
+          "perl": true,
+          "python": true,
+          "ruby": true,
+          "rust": true,
+          "swift": true,
+          "typescript": true
+        }
+      }
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -250,8 +250,9 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   from 655 unknown records and 217 duplicate groups;
 - make TypeScript build-plan package paths portable on Windows. The identity-
   registry validation found that `rel_path` values still use host backslashes;
-  normalize serialized repository-relative paths in a separate fixture-driven
-  slice rather than widening discovery behavior;
+  this is the selected next fixture-driven slice because every one of the real
+  plan's 4,768 package records is affected on Windows. Normalize serialized
+  repository-relative paths without widening discovery behavior;
 - make Swift build-tool file options recognize Windows drive-letter absolute
   paths. The UTF-8 validation run discovered that `--emit-plan` reaches
   resolution but then joins an absolute Windows path under the repository;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -250,8 +250,8 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   from 655 unknown records and 217 duplicate groups;
 - make TypeScript build-plan package paths portable on Windows. The identity-
   registry validation found that `rel_path` values still use host backslashes;
-  this is the selected next fixture-driven slice because every one of the real
-  plan's 4,768 package records is affected on Windows. Normalize serialized
+  ready PR #9589 is the selected fixture-driven slice because every one of the
+  real plan's 4,768 package records is affected on Windows. Normalize serialized
   repository-relative paths without widening discovery behavior;
 - make Swift build-tool file options recognize Windows drive-letter absolute
   paths. The UTF-8 validation run discovered that `--emit-plan` reaches

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -243,7 +243,7 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   POSIX-only `/repo` path fixtures; this is tracked as a separate test-
   portability slice rather than widening the metadata decoder change;
 - align TypeScript build-tool discovery with the canonical language and identity
-  registry. Ready PR #9582 consumes the shared registry and duplicate-
+  registry. Merged PR #9582 consumes the shared registry and duplicate-
   identity fixtures, preserves package/program identity, excludes spec fixtures,
   and fails closed on collisions. Its real Windows plan now emits 4,768 unique
   identities, zero duplicate groups, and only intentional `unknown/blog`, down


### PR DESCRIPTION
## Summary
- add a language-neutral `plan_v1_write` fixture requiring repository-relative forward-slash package paths on every platform
- consume the exact fixture through a real TypeScript CLI subprocess and exact emitted-plan comparison
- normalize only emitted package `rel_path` values at the plan boundary, preserving destination option handling and unrelated gitdiff behavior
- reconcile merged parity PR #9582 and record this dependency-shaped selection in the durable parity state

## Validation
- `npm ci --ignore-scripts`
- `npx vitest run tests/plan.test.ts`: 18 passed
- focused `src/plan.ts` coverage: 100% lines/statements/functions, 88.88% branches
- `npx vitest run --exclude tests/gitdiff.test.ts`: 272 passed
- full local Windows suite: 275 passed; exactly 7 pre-existing gitdiff fixture failures remain separately owned (2 `/bin/sh` ENOENT, 5 POSIX `/repo` fixtures)
- real full plan: 4,768 packages, 4,768 unique names, 0 duplicate groups, 7,243 edges, 0 backslash paths
- build-tool schema tests: 17 passed plus 15 subtests
- build-tool runner tests: 40 passed plus 37 subtests
- conformance corpus: 37 cases / 56 files, 15 established languages, 16 implementations
- collision-checked parity inventory: 1,222 implementation identities / 4,370 slots; 0 collisions; 0 unknown inventory buckets
- production esbuild bundle and bundled `--help`
- `npm audit`: 0 vulnerabilities
- Lua BUILD validation: exact existing 10-package `BUILD_windows` debt set only
- JSON parsing, `git diff --check`, exact-head rebase, and secret-like diff scan