### PR TITLE
feat(adj): replace provenance roots transactionally

### DIFF
--- a/code/scripts/adj_stdlib_provenance.py
+++ b/code/scripts/adj_stdlib_provenance.py
@@ -865,6 +865,10 @@ def _registered_manifest(
     manifest_bytes: bytes,
     registrations: dict[str, str],
     expected_manifest_id: str,
+    *,
+    allow_replacements: bool = False,
+    require_existing: bool = False,
+    expected_current: dict[str, str] | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
     if not isinstance(registrations, dict) or not registrations:
         raise ProvenanceError("bundle registrations must be a non-empty object")
@@ -913,6 +917,18 @@ def _registered_manifest(
             )
         by_id[bundle_id] = digest
 
+    for bundle_id, expected_digest in (expected_current or {}).items():
+        normalized_id = _require_nonempty(bundle_id, "expected bundle_id")
+        normalized_digest = _require_hash(
+            expected_digest, f"expected current root {normalized_id}"
+        )
+        actual_digest = by_id.get(normalized_id)
+        if actual_digest != normalized_digest:
+            raise ProvenanceError(
+                f"stale root replacement for {normalized_id}: expected "
+                f"{normalized_digest}, found {actual_digest or 'unregistered'}"
+            )
+
     for expected_id, digest_value in registrations.items():
         bundle_id = _require_nonempty(expected_id, "registration bundle_id")
         digest = _require_hash(digest_value, f"registration {bundle_id}")
@@ -923,7 +939,9 @@ def _registered_manifest(
                 f"registration {bundle_id} points to bundle_id {actual_id}"
             )
         previous = by_id.get(bundle_id)
-        if previous is not None and previous != digest:
+        if require_existing and previous is None:
+            raise ProvenanceError(f"cannot replace unregistered bundle_id {bundle_id}")
+        if previous is not None and previous != digest and not allow_replacements:
             raise ProvenanceError(
                 f"refusing to replace registered bundle_id {bundle_id}; "
                 "use an explicit root-replacement migration"
@@ -1144,6 +1162,163 @@ class BundleRegistrationTransaction(CasMutationTransaction):
         if self._baseline_manifest:
             _write_atomic(self.manifest_path, self._baseline_manifest)
         super()._rollback()
+
+
+class BundleRootReplacementTransaction(BundleRegistrationTransaction):
+    """Explicitly replace owned roots and prune only newly unreachable objects."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._baseline_digests: set[str] = set()
+        self._pruned_digests: list[str] = []
+        self._prune_backup: tempfile.TemporaryDirectory[str] | None = None
+
+    def __enter__(self):
+        super().__enter__()
+        self._baseline_digests = set(self.cas.index)
+        return self
+
+    def _stage_prune(self, digests: set[str]) -> None:
+        backup = tempfile.TemporaryDirectory(prefix="adj-provenance-prune-")
+        backup_root = Path(backup.name)
+        try:
+            for digest in sorted(digests):
+                data = _read_regular_file(self.cas.object_path(digest))
+                if sha256_bytes(data) != digest:
+                    raise ProvenanceError(
+                        f"refusing to prune mismatched CAS object {digest}"
+                    )
+                _write_exclusive(backup_root / digest, data)
+            for digest in sorted(digests):
+                path = self.cas.object_path(digest)
+                _reject_link_components(path)
+                self._pruned_digests.append(digest)
+                path.unlink()
+                try:
+                    path.parent.rmdir()
+                except OSError:
+                    pass
+        except Exception:
+            self._prune_backup = backup
+            self._restore_pruned()
+            raise
+        self._prune_backup = backup
+
+    def _restore_pruned(self) -> None:
+        if self._prune_backup is None:
+            return
+        backup_root = Path(self._prune_backup.name)
+        for digest in self._pruned_digests:
+            destination = self.cas.object_path(digest)
+            if destination.exists():
+                if sha256_bytes(_read_regular_file(destination)) != digest:
+                    raise ProvenanceError(
+                        f"cannot restore over mismatched CAS object {digest}"
+                    )
+                continue
+            _write_exclusive(destination, _read_regular_file(backup_root / digest))
+        self._pruned_digests.clear()
+
+    def commit(self, registrations: dict[str, str]) -> list[str]:
+        del registrations
+        raise ProvenanceError(
+            "root replacement transactions require replace_roots with expected hashes"
+        )
+
+    def replace_roots(self, replacements: dict[str, dict[str, str]]) -> dict[str, Any]:
+        if not self._entered or self._committed:
+            raise ProvenanceError("root replacement transaction is not open")
+        if not isinstance(replacements, dict) or not replacements:
+            raise ProvenanceError("root replacements must be a non-empty object")
+        expected_current: dict[str, str] = {}
+        new_roots: dict[str, str] = {}
+        for bundle_id, replacement in replacements.items():
+            normalized_id = _require_nonempty(bundle_id, "replacement bundle_id")
+            if not isinstance(replacement, dict) or set(replacement) != {
+                "expected_old_sha256",
+                "new_sha256",
+            }:
+                raise ProvenanceError(
+                    f"replacement {normalized_id} must name expected_old_sha256 "
+                    "and new_sha256"
+                )
+            expected_current[normalized_id] = _require_hash(
+                replacement["expected_old_sha256"],
+                f"replacement {normalized_id}.expected_old_sha256",
+            )
+            new_roots[normalized_id] = _require_hash(
+                replacement["new_sha256"],
+                f"replacement {normalized_id}.new_sha256",
+            )
+        manifest, registered = _registered_manifest(
+            self.cas,
+            self._baseline_manifest,
+            new_roots,
+            self.expected_manifest_id,
+            allow_replacements=True,
+            require_existing=True,
+            expected_current=expected_current,
+        )
+        try:
+            self.cas.write_index()
+            with tempfile.TemporaryDirectory(
+                prefix="adj-provenance-candidate-"
+            ) as candidate_directory:
+                candidate_manifest = Path(candidate_directory) / "manifest.json"
+                _write_exclusive(candidate_manifest, canonical_json_bytes(manifest))
+                _validate_repository_unlocked(
+                    self.cas.root,
+                    candidate_manifest,
+                    self.schema_path,
+                    workspace_root=self.workspace_root or self.manifest_path.parent,
+                    formula_inventory_command=self.formula_inventory_command,
+                    _allow_unreferenced=True,
+                )
+            reachable = _reachable(self.cas, registered)
+            unreachable = set(self.cas.index) - reachable
+            staged_strays = unreachable - self._baseline_digests
+            if staged_strays:
+                raise ProvenanceError(
+                    "root replacement staged unreferenced new objects: "
+                    + ", ".join(sorted(staged_strays))
+                )
+            self._stage_prune(unreachable)
+            self.cas.index = {
+                digest: record
+                for digest, record in self.cas.index.items()
+                if digest in reachable
+            }
+            self.cas.write_index()
+            _write_atomic(self.manifest_path, canonical_json_bytes(manifest))
+            _validate_repository_unlocked(
+                self.cas.root,
+                self.manifest_path,
+                self.schema_path,
+                workspace_root=self.workspace_root,
+                formula_inventory_command=self.formula_inventory_command,
+            )
+        except Exception:
+            self._rollback()
+            raise
+        self._committed = True
+        pruned = sorted(unreachable)
+        if self._prune_backup is not None:
+            try:
+                self._prune_backup.cleanup()
+            except OSError:
+                pass
+            self._prune_backup = None
+        return {"bundle_hashes": registered, "pruned_sha256s": pruned}
+
+    def _rollback(self) -> None:
+        self._restore_pruned()
+        super()._rollback()
+        if self._prune_backup is not None:
+            try:
+                self._prune_backup.cleanup()
+            except OSError:
+                pass
+            self._prune_backup = None
 
 
 def _validate_index(cas: Cas) -> None:
@@ -1814,6 +1989,7 @@ def _validate_repository_unlocked(
     schema_path: Path | None = None,
     workspace_root: Path | None = None,
     formula_inventory_command: Sequence[str] | None = None,
+    _allow_unreferenced: bool = False,
 ) -> dict[str, Any]:
     cas = Cas(cas_root)
     cas.load()
@@ -1871,7 +2047,7 @@ def _validate_repository_unlocked(
             )
     reachable = _reachable(cas, normalized_bundles)
     unreferenced = sorted(set(cas.index) - reachable)
-    if unreferenced:
+    if unreferenced and not _allow_unreferenced:
         raise ProvenanceError(f"unreferenced CAS objects: {', '.join(unreferenced)}")
     return {
         "bundles": len(validated),

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -590,6 +590,529 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
             self.assertFalse(changed_path.exists())
 
+    def test_explicit_root_replacement_prunes_only_superseded_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+
+            with provenance.BundleRootReplacementTransaction(
+                cas_root,
+                manifest_path,
+                expected_manifest_id="test.provenance.v1",
+                workspace_root=root,
+            ) as transaction:
+                changed = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                changed["clauses"][0]["resolution"]["reason"] = (
+                    "corrected fixture definition accepted as a primitive root"
+                )
+                changed_hash = transaction.cas.put_json(
+                    changed,
+                    kind="provenance_bundle",
+                    label="corrected arithmetic fixture bundle",
+                    links=provenance._bundle_declared_links(changed),
+                )
+                result = transaction.replace_roots(
+                    {
+                        "test.arithmetic.v1": {
+                            "expected_old_sha256": hashes["bundle"],
+                            "new_sha256": changed_hash,
+                        }
+                    }
+                )
+
+            self.assertEqual(result["bundle_hashes"], [changed_hash])
+            self.assertEqual(result["pruned_sha256s"], [hashes["bundle"]])
+            self.assertFalse(
+                provenance.Cas(cas_root).object_path(hashes["bundle"]).exists()
+            )
+            self.assertTrue(provenance.Cas(cas_root).object_path(changed_hash).exists())
+            self.assertTrue(
+                provenance.validate_repository(
+                    cas_root, manifest_path, workspace_root=root
+                )["valid"]
+            )
+
+    def test_root_replacement_preserves_old_root_reachable_as_dependency(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            with provenance.BundleRegistrationTransaction(
+                cas_root,
+                manifest_path,
+                expected_manifest_id="test.provenance.v1",
+                workspace_root=root,
+            ) as transaction:
+                consumer = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                consumer["bundle_id"] = "test.consumer.v1"
+                consumer["dependencies"] = [hashes["bundle"]]
+                consumer_hash = transaction.cas.put_json(
+                    consumer,
+                    kind="provenance_bundle",
+                    label="consumer fixture bundle",
+                    links=provenance._bundle_declared_links(consumer),
+                )
+                transaction.commit({"test.consumer.v1": consumer_hash})
+
+            with provenance.BundleRootReplacementTransaction(
+                cas_root,
+                manifest_path,
+                expected_manifest_id="test.provenance.v1",
+                workspace_root=root,
+            ) as transaction:
+                changed = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                changed["clauses"][0]["resolution"]["reason"] = "replacement root"
+                changed_hash = transaction.cas.put_json(
+                    changed,
+                    kind="provenance_bundle",
+                    label="replacement fixture bundle",
+                    links=provenance._bundle_declared_links(changed),
+                )
+                result = transaction.replace_roots(
+                    {
+                        "test.arithmetic.v1": {
+                            "expected_old_sha256": hashes["bundle"],
+                            "new_sha256": changed_hash,
+                        }
+                    }
+                )
+
+            self.assertEqual(
+                result["bundle_hashes"], sorted([changed_hash, consumer_hash])
+            )
+            self.assertEqual(result["pruned_sha256s"], [])
+            self.assertTrue(
+                provenance.Cas(cas_root).object_path(hashes["bundle"]).exists()
+            )
+
+    def test_root_replacement_updates_multiple_roots_in_one_compare_and_swap(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            with provenance.BundleRegistrationTransaction(
+                cas_root,
+                manifest_path,
+                expected_manifest_id="test.provenance.v1",
+                workspace_root=root,
+            ) as transaction:
+                second = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                second["bundle_id"] = "test.second.v1"
+                second_hash = transaction.cas.put_json(
+                    second,
+                    kind="provenance_bundle",
+                    label="second fixture bundle",
+                    links=provenance._bundle_declared_links(second),
+                )
+                transaction.commit({"test.second.v1": second_hash})
+
+            with provenance.BundleRootReplacementTransaction(
+                cas_root,
+                manifest_path,
+                expected_manifest_id="test.provenance.v1",
+                workspace_root=root,
+            ) as transaction:
+                first_new = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                first_new["clauses"][0]["resolution"]["reason"] = "first replacement"
+                first_new_hash = transaction.cas.put_json(
+                    first_new,
+                    kind="provenance_bundle",
+                    label="first replacement bundle",
+                    links=provenance._bundle_declared_links(first_new),
+                )
+                second_new = provenance._json_object(
+                    transaction.cas, second_hash, "provenance_bundle"
+                )
+                second_new["clauses"][0]["resolution"]["reason"] = "second replacement"
+                second_new_hash = transaction.cas.put_json(
+                    second_new,
+                    kind="provenance_bundle",
+                    label="second replacement bundle",
+                    links=provenance._bundle_declared_links(second_new),
+                )
+                result = transaction.replace_roots(
+                    {
+                        "test.arithmetic.v1": {
+                            "expected_old_sha256": hashes["bundle"],
+                            "new_sha256": first_new_hash,
+                        },
+                        "test.second.v1": {
+                            "expected_old_sha256": second_hash,
+                            "new_sha256": second_new_hash,
+                        },
+                    }
+                )
+
+            self.assertEqual(
+                result["bundle_hashes"], sorted([first_new_hash, second_new_hash])
+            )
+            self.assertEqual(
+                result["pruned_sha256s"], sorted([hashes["bundle"], second_hash])
+            )
+
+    def test_root_replacement_rejects_new_strays_and_restores_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            baseline_manifest = manifest_path.read_bytes()
+
+            with (
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError, "staged unreferenced new objects"
+                ),
+                provenance.BundleRootReplacementTransaction(
+                    cas_root,
+                    manifest_path,
+                    expected_manifest_id="test.provenance.v1",
+                    workspace_root=root,
+                ) as transaction,
+            ):
+                changed = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                changed["clauses"][0]["resolution"]["reason"] = "replacement root"
+                changed_hash = transaction.cas.put_json(
+                    changed,
+                    kind="provenance_bundle",
+                    label="replacement fixture bundle",
+                    links=provenance._bundle_declared_links(changed),
+                )
+                stray_hash = transaction.cas.put(
+                    b"unreachable replacement bytes",
+                    kind="raw_source",
+                    label="replacement stray",
+                )
+                transaction.replace_roots(
+                    {
+                        "test.arithmetic.v1": {
+                            "expected_old_sha256": hashes["bundle"],
+                            "new_sha256": changed_hash,
+                        }
+                    }
+                )
+
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+            cas = provenance.Cas(cas_root)
+            self.assertFalse(cas.object_path(changed_hash).exists())
+            self.assertFalse(cas.object_path(stray_hash).exists())
+
+    def test_root_replacement_cannot_add_an_unregistered_bundle_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            baseline_manifest = manifest_path.read_bytes()
+
+            with (
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError,
+                    "stale root replacement for test.new-root.v1",
+                ),
+                provenance.BundleRootReplacementTransaction(
+                    cas_root,
+                    manifest_path,
+                    expected_manifest_id="test.provenance.v1",
+                    workspace_root=root,
+                ) as transaction,
+            ):
+                added = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                added["bundle_id"] = "test.new-root.v1"
+                added_hash = transaction.cas.put_json(
+                    added,
+                    kind="provenance_bundle",
+                    label="invalid replacement addition",
+                    links=provenance._bundle_declared_links(added),
+                )
+                transaction.replace_roots(
+                    {
+                        "test.new-root.v1": {
+                            "expected_old_sha256": hashes["bundle"],
+                            "new_sha256": added_hash,
+                        }
+                    }
+                )
+
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+            self.assertFalse(provenance.Cas(cas_root).object_path(added_hash).exists())
+
+    def test_root_replacement_rejects_a_stale_expected_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            baseline_manifest = manifest_path.read_bytes()
+
+            with (
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError,
+                    "stale root replacement for test.arithmetic.v1",
+                ),
+                provenance.BundleRootReplacementTransaction(
+                    cas_root,
+                    manifest_path,
+                    expected_manifest_id="test.provenance.v1",
+                    workspace_root=root,
+                ) as transaction,
+            ):
+                changed = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                changed["clauses"][0]["resolution"]["reason"] = "stale replacement"
+                changed_hash = transaction.cas.put_json(
+                    changed,
+                    kind="provenance_bundle",
+                    label="stale replacement fixture bundle",
+                    links=provenance._bundle_declared_links(changed),
+                )
+                transaction.replace_roots(
+                    {
+                        "test.arithmetic.v1": {
+                            "expected_old_sha256": "0" * 64,
+                            "new_sha256": changed_hash,
+                        }
+                    }
+                )
+
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+            self.assertFalse(
+                provenance.Cas(cas_root).object_path(changed_hash).exists()
+            )
+
+    def test_root_replacement_restores_pruned_objects_on_final_validation_failure(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            baseline_manifest = manifest_path.read_bytes()
+            validate = provenance._validate_repository_unlocked
+            calls = 0
+
+            def fail_final_validation(
+                *args: object, **kwargs: object
+            ) -> dict[str, object]:
+                nonlocal calls
+                calls += 1
+                if calls == 3:
+                    raise provenance.ProvenanceError(
+                        "injected final validation failure"
+                    )
+                return validate(*args, **kwargs)
+
+            with (
+                mock.patch.object(
+                    provenance,
+                    "_validate_repository_unlocked",
+                    fail_final_validation,
+                ),
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError, "injected final validation failure"
+                ),
+                provenance.BundleRootReplacementTransaction(
+                    cas_root,
+                    manifest_path,
+                    expected_manifest_id="test.provenance.v1",
+                    workspace_root=root,
+                ) as transaction,
+            ):
+                changed = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                changed["clauses"][0]["resolution"]["reason"] = "replacement root"
+                changed_hash = transaction.cas.put_json(
+                    changed,
+                    kind="provenance_bundle",
+                    label="replacement fixture bundle",
+                    links=provenance._bundle_declared_links(changed),
+                )
+                transaction.replace_roots(
+                    {
+                        "test.arithmetic.v1": {
+                            "expected_old_sha256": hashes["bundle"],
+                            "new_sha256": changed_hash,
+                        }
+                    }
+                )
+
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+            self.assertTrue(
+                provenance.Cas(cas_root).object_path(hashes["bundle"]).exists()
+            )
+            self.assertFalse(
+                provenance.Cas(cas_root).object_path(changed_hash).exists()
+            )
+
+    def assert_root_replacement_publication_failure(self, failure_stage: str) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            baseline_manifest = manifest_path.read_bytes()
+            baseline_objects = {
+                path.relative_to(cas_root): path.read_bytes()
+                for path in (cas_root / "objects").rglob("*")
+                if path.is_file()
+            }
+            write_index = provenance.Cas.write_index
+            write_atomic = provenance._write_atomic
+            index_writes = 0
+            manifest_failed = False
+
+            def fail_index_publication(cas: provenance.Cas) -> None:
+                nonlocal index_writes
+                index_writes += 1
+                failing_write = 1 if failure_stage == "candidate index" else 2
+                if failure_stage != "manifest" and index_writes == failing_write:
+                    raise OSError(f"injected {failure_stage} publication failure")
+                write_index(cas)
+
+            def fail_manifest_publication(path: Path, data: bytes) -> None:
+                nonlocal manifest_failed
+                if (
+                    failure_stage == "manifest"
+                    and path == manifest_path
+                    and not manifest_failed
+                ):
+                    manifest_failed = True
+                    raise OSError("injected manifest publication failure")
+                write_atomic(path, data)
+
+            with (
+                mock.patch.object(
+                    provenance.Cas,
+                    "write_index",
+                    fail_index_publication,
+                ),
+                mock.patch.object(
+                    provenance,
+                    "_write_atomic",
+                    fail_manifest_publication,
+                ),
+                self.assertRaisesRegex(
+                    OSError, f"injected {failure_stage} publication failure"
+                ),
+                provenance.BundleRootReplacementTransaction(
+                    cas_root,
+                    manifest_path,
+                    expected_manifest_id="test.provenance.v1",
+                    workspace_root=root,
+                ) as transaction,
+            ):
+                changed = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                changed["clauses"][0]["resolution"]["reason"] = (
+                    f"replacement before {failure_stage} failure"
+                )
+                changed_hash = transaction.cas.put_json(
+                    changed,
+                    kind="provenance_bundle",
+                    label="publication failure replacement bundle",
+                    links=provenance._bundle_declared_links(changed),
+                )
+                transaction.replace_roots(
+                    {
+                        "test.arithmetic.v1": {
+                            "expected_old_sha256": hashes["bundle"],
+                            "new_sha256": changed_hash,
+                        }
+                    }
+                )
+
+            restored_objects = {
+                path.relative_to(cas_root): path.read_bytes()
+                for path in (cas_root / "objects").rglob("*")
+                if path.is_file()
+            }
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+            self.assertEqual(restored_objects, baseline_objects)
+
+    def test_root_replacement_restores_bytes_after_publication_failures(self) -> None:
+        for failure_stage in ("candidate index", "filtered index", "manifest"):
+            with self.subTest(failure_stage=failure_stage):
+                self.assert_root_replacement_publication_failure(failure_stage)
+
+    def test_root_replacement_restores_bytes_after_partial_prune_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cas_root, manifest_path, hashes = self.build_repository(root)
+            baseline_index = (cas_root / "index.json").read_bytes()
+            baseline_manifest = manifest_path.read_bytes()
+            baseline_objects = {
+                path.relative_to(cas_root): path.read_bytes()
+                for path in (cas_root / "objects").rglob("*")
+                if path.is_file()
+            }
+            old_root_path = provenance.Cas(cas_root).object_path(hashes["bundle"])
+            unlink = Path.unlink
+            prune_failed = False
+
+            def fail_after_prune(path: Path, *args: object, **kwargs: object) -> None:
+                nonlocal prune_failed
+                unlink(path, *args, **kwargs)
+                if path == old_root_path and not prune_failed:
+                    prune_failed = True
+                    raise OSError("injected partial prune failure")
+
+            with (
+                mock.patch.object(Path, "unlink", fail_after_prune),
+                self.assertRaisesRegex(OSError, "injected partial prune failure"),
+                provenance.BundleRootReplacementTransaction(
+                    cas_root,
+                    manifest_path,
+                    expected_manifest_id="test.provenance.v1",
+                    workspace_root=root,
+                ) as transaction,
+            ):
+                changed = provenance._json_object(
+                    transaction.cas, hashes["bundle"], "provenance_bundle"
+                )
+                changed["clauses"][0]["resolution"]["reason"] = (
+                    "replacement before partial prune failure"
+                )
+                changed_hash = transaction.cas.put_json(
+                    changed,
+                    kind="provenance_bundle",
+                    label="partial prune failure replacement bundle",
+                    links=provenance._bundle_declared_links(changed),
+                )
+                transaction.replace_roots(
+                    {
+                        "test.arithmetic.v1": {
+                            "expected_old_sha256": hashes["bundle"],
+                            "new_sha256": changed_hash,
+                        }
+                    }
+                )
+
+            restored_objects = {
+                path.relative_to(cas_root): path.read_bytes()
+                for path in (cas_root / "objects").rglob("*")
+                if path.is_file()
+            }
+            self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
+            self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+            self.assertEqual(restored_objects, baseline_objects)
+
     def test_manifest_registration_rejects_malformed_contracts(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -272,8 +272,10 @@ option mapping, or judge/evaluation failure.
     authoritative readers and every CLI writer. Registration is additive and
     idempotent, preserves unrelated roots, and rolls back newly materialized
     objects and index changes on failure.
-7c. Add an explicit transactional root-replacement migration that validates the
-    replacement graph and prunes only objects unreachable from every new root.
+7c. **Complete:** add an explicit transactional root-replacement migration that
+    compares each expected old root hash before publishing, validates the replacement
+    graph, rejects staged stray objects, preserves shared dependencies, and reports the
+    exact baseline objects pruned because no final root reaches them.
 7d. Add a write-ahead recovery journal for process termination between the
     atomic CAS-index and manifest publications.
 7e. **Complete:** scope native snapshot projection to a named bundle and its
@@ -310,7 +312,8 @@ option mapping, or judge/evaluation failure.
      each formula requires its own enclosing input-IR claim. The isolated bridge is
      schema-checked; current manifest roots remain explicitly unmigrated.
 13b. Migrate parser inventories into every formula-bearing provenance root, add
-     `formula_derivation` and execution-witness objects, then enforce set equality
+     explicit dependency-hash inputs to dependent builders, then add
+     `formula_derivation` and execution-witness objects and enforce set equality
      across parsed exports, replayed derivations, and fully verified query executions.
 
 ### Wave 2: complete K-8 foundations


### PR DESCRIPTION
## Summary

- add an explicit compare-and-swap transaction for replacing one or more registered ADJ provenance roots
- validate the complete candidate graph, reject newly staged unreachable objects, and prune only bytes unreachable from every final root
- preserve shared dependencies and restore the manifest, index, old CAS bytes, and newly staged objects on in-process failures
- report the exact final root set and exact pruned SHA-256 set
- record crash-recovery journaling and dependency-builder parameterization as separate follow-up work

## Why

Additive registration intentionally refuses to replace an existing bundle ID. Formula-inventory migration and future provenance corrections need a separate, auditable migration path whose ownership, expected old hashes, reachability, and byte deletion behavior are explicit.

This provides in-process transactional rollback. It does not claim process-termination atomicity; the write-ahead recovery journal remains backlog item 7d.

## Validation

- `python -W error::ResourceWarning -m unittest discover -s code/scripts/tests -p 'test_adj_stdlib_*.py'` (77 passed, 1 expected skip)
- `python -m ruff check code/scripts/adj_stdlib_provenance.py code/scripts/tests/test_adj_stdlib_provenance.py`
- `python -m ruff format --check code/scripts/adj_stdlib_provenance.py code/scripts/tests/test_adj_stdlib_provenance.py`
- `python code/scripts/adj_stdlib_manifest.py --validate-json-schema`
- `python code/scripts/adj_stdlib_provenance.py verify --formula-inventory-binary code/packages/rust/target/debug/adj-formula-inventory.exe` (6 bundles, 69 objects, 9 snapshots)
- `python code/scripts/adj_stdlib_report.py --format json --fail-on-unreferenced-tests`
- independent subagent review: no P1/P2 defects; fault injection covers partial unlink, candidate-index publication, filtered-index publication, manifest publication, and final validation failure