### PR TITLE
Derive SPICE parser MOS transconductance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Lower and validate MOS model-card `U0` / `UO`, deriving `KP` from surface
+  mobility and `TOX` when no explicit transconductance is supplied.
 - Validate and lower MOS model-card `TOX` into Level-1 oxide thickness instead
   of silently discarding it.
 - Reject non-finite and non-Level-1 MOS model-card `LEVEL` values while

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -39,6 +39,8 @@ from spice_engine import (
     ac_sweep,
     dc_op,
     dc_sweep,
+    mosfet_from_model_card,
+    normalize_model_card,
     transient,
 )
 
@@ -1886,6 +1888,9 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
                 raise NetlistParseError("only MOS LEVEL=1 model cards are supported")
         if "TOX" in params and (not math.isfinite(params["TOX"]) or params["TOX"] <= 0.0):
             raise NetlistParseError("MOSFET TOX must be finite and positive")
+        mobility = params.get("U0", params.get("UO"))
+        if mobility is not None and (not math.isfinite(mobility) or mobility < 0.0):
+            raise NetlistParseError("MOSFET U0 must be finite and non-negative")
     return ModelCard(name=name, kind=kind, params=params)
 
 
@@ -1923,6 +1928,7 @@ _LEVEL1_PARAM_ALIASES = {
     "NSUB": "N_SUB",
     "N": "N_SUB",
     "TNOM": "T_NOM",
+    "UO": "U0",
     "VTO": "VT0",
 }
 
@@ -1939,6 +1945,13 @@ def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> 
         param_name = _LEVEL1_PARAM_ALIASES.get(name, name)
         if param_name in values and not isinstance(values[param_name], bool):
             values[param_name] = value
+    if "KP" not in params and "TOX" in model.params:
+        derivation_params = {"TOX": model.params["TOX"]}
+        if "U0" in values:
+            derivation_params["U0"] = values["U0"]
+        normalized = normalize_model_card(model.name, model.kind, derivation_params)
+        derived = mosfet_from_model_card("M", "d", "g", "s", "b", normalized)
+        values["KP"] = derived.model.model.params.KP
     return MOSFET(
         type=MosfetType[model.kind],
         model=Level1Model(Level1Params(**values)),

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1409,6 +1409,33 @@ def test_lowers_mosfet_model_oxide_thickness() -> None:
     assert isclose(mosfet.model.model.params.TOX, 7.0e-9)
 
 
+@pytest.mark.parametrize("surface_mobility", ["-1", "1e999"])
+def test_rejects_invalid_mosfet_model_surface_mobility(surface_mobility: str) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET U0 must be finite and non-negative",
+    ):
+        parse_netlist(f".model nfast NMOS(U0={surface_mobility})\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("alias", ["U0", "UO"])
+def test_lowers_mosfet_model_surface_mobility_and_derives_kp(alias: str) -> None:
+    parsed = parse_netlist(f".model nfast NMOS({alias}=450 TOX=12n)\nM1 d g s b nfast\n")
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.U0 == 450.0
+    assert isclose(mosfet.model.model.params.KP, 1.294924875e-4)
+
+
+def test_explicit_mosfet_model_kp_overrides_mobility_derivation() -> None:
+    parsed = parse_netlist(".model nfast NMOS(U0=450 TOX=12n KP=123u)\nM1 d g s b nfast\n")
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.KP, 123.0e-6)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Lower and validate MOS model-card `U0` / `UO`, deriving `KP` from surface
+  mobility and `TOX` when no explicit transconductance is supplied.
 - Validate and lower MOS model-card `TOX` into Level-1 oxide thickness instead
   of silently discarding it.
 - Reject non-finite and non-Level-1 MOS model-card `LEVEL` values while

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -18,7 +18,9 @@ import {
   inductorWithInitialCurrent,
   jfet,
   mosfet,
+  mosfetFromModelCard,
   mutualInductor,
+  normalizeModelCard,
   resistor,
   transmissionLine,
   vccs,
@@ -1163,6 +1165,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET TOX must be finite and positive");
   }
+  const surfaceMobility = params.get("U0") ?? params.get("UO");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    surfaceMobility !== undefined &&
+    (!Number.isFinite(surfaceMobility) || surfaceMobility < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET U0 must be finite and non-negative");
+  }
   return {
     name: fields[1],
     kind,
@@ -1206,18 +1216,28 @@ const MOSFET_PARAM_ALIASES = new Map<string, keyof MosfetLevel1Params>([
   ["NSUB", "N_SUB"],
   ["N", "N_SUB"],
   ["TNOM", "T_NOM"],
+  ["UO", "U0"],
 ]);
 
 function mosfetParams(
-  modelParams: ReadonlyMap<string, number>,
+  model: ModelCard,
   instanceParams: ReadonlyMap<string, number>,
 ): Partial<MosfetLevel1Params> {
+  const modelParams = model.params;
   const params: Record<string, number> = {};
   for (const [name, value] of [...modelParams, ...instanceParams]) {
     const key = MOSFET_PARAM_ALIASES.get(name) ?? (name as keyof MosfetLevel1Params);
     if (isMosfetParam(key)) {
       params[key] = value;
     }
+  }
+  if (!modelParams.has("KP") && !instanceParams.has("KP") && modelParams.has("TOX")) {
+    const derivationParams: Record<string, number> = { TOX: modelParams.get("TOX")! };
+    if (params.U0 !== undefined) {
+      derivationParams.U0 = params.U0;
+    }
+    const normalized = normalizeModelCard(model.name, model.kind, derivationParams);
+    params.KP = mosfetFromModelCard("M", "d", "g", "s", "b", normalized).params.KP;
   }
   return params;
 }
@@ -1232,6 +1252,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "W",
     "L",
     "TOX",
+    "U0",
     "IS",
     "N_SUB",
     "T_NOM",
@@ -1463,7 +1484,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       fields[3],
       fields[4],
       model.kind,
-      mosfetParams(model.params, parseElementParams(fields.slice(6), "MOSFET")),
+      mosfetParams(model, parseElementParams(fields.slice(6), "MOSFET")),
     );
   }
   if (prefix === "G") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1325,6 +1325,36 @@ Xright c d load
     expect(element.params.TOX).toBeCloseTo(7.0e-9, 15);
   });
 
+  it.each(["-1", "1e999"])("rejects invalid MOSFET model U0=%s", (surfaceMobility) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(U0=${surfaceMobility})\nM1 d g s b nfast\n`),
+    ).toThrow("MOSFET U0 must be finite and non-negative");
+  });
+
+  it.each(["U0", "UO"])(
+    "lowers MOSFET model surface-mobility alias %s and derives KP",
+    (alias) => {
+      const parsed = parseNetlist(`.model nfast NMOS(${alias}=450 TOX=12n)\nM1 d g s b nfast\n`);
+      const element = parsed.circuit.elements()[0];
+      expect(element.kind).toBe("mosfet");
+      if (element.kind !== "mosfet") {
+        throw new Error("unexpected element kind");
+      }
+      expect(element.params.U0).toBe(450.0);
+      expect(element.params.KP).toBeCloseTo(1.294924875e-4, 15);
+    },
+  );
+
+  it("preserves explicit MOSFET model KP over mobility derivation", () => {
+    const parsed = parseNetlist(".model nfast NMOS(U0=450 TOX=12n KP=123u)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.params.KP).toBeCloseTo(123.0e-6, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS model-card oxide-thickness parity.
+1. Python and TypeScript Berkeley SPICE MOS surface-mobility and derived-`KP` parity.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite model-card `TOX` values with the
-     diagnostic already used by Rust and the shared engines.
-   - Lower valid `TOX` values into Level-1 oxide thickness instead of silently
-     discarding them.
+   - Lower `U0` / `UO` and reject negative or non-finite values with the shared
+     diagnostic.
+   - Reuse shared engine semantics to derive `KP` from surface mobility and
+     `TOX` when no explicit transconductance is supplied.
 
 ## Completed Slices
 
@@ -4132,29 +4132,31 @@ the Rust, Python, and TypeScript surfaces together.
      same tolerance and diagnostic as Rust and the shared engines.
    - Explicit `LEVEL=1` model cards and cards that omit `LEVEL` remain accepted.
 
+369. Python and TypeScript Berkeley SPICE MOS model-card oxide-thickness parity.
+   - Status: completed in PR 9586.
+   - Zero, negative, and non-finite model-card `TOX` values are rejected with
+     the shared diagnostic.
+   - Valid `TOX` values reach Level-1 oxide thickness in both facades.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE MOS model-card oxide-thickness parity.
-   - Validate and lower canonical `TOX`; Python currently aliases it to a
-     nonexistent field and TypeScript currently omits it from accepted fields.
-
-2. Python and TypeScript Berkeley SPICE MOS surface-mobility and derived-`KP` parity.
+1. Python and TypeScript Berkeley SPICE MOS surface-mobility and derived-`KP` parity.
    - Lower `U0` / `UO`, validate its finite non-negative domain, and derive `KP`
      from `U0` and `TOX` when `KP` is omitted.
 
-3. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
+2. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
    - Apply Rust-aligned domains and diagnostics to already lowered `KP`, `VT0`,
      `LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, and nominal-temperature fields.
 
-4. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
+3. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
    - Lower missing canonical resistance, geometry, capacitance, junction, and
      noise fields, then align `VTH`, `LAM`, `CJS`, and `CJD` aliases.
 
-5. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
+4. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
    - Validate and consume `NSS` / `TPG`, then derive `VT0`, `GAMMA`, and `PHI`
      from `N_SUB` / `TOX` with shared engine semantics.
 
-6. Grammar-backed parser and app facade.
+5. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
@@ -4162,7 +4164,7 @@ the Rust, Python, and TypeScript surfaces together.
      toward packaging, WebAssembly embedding, and product integration backed by
      the same public parser contract.
 
-7. Deck compatibility follow-up.
+6. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis
      execution and stable artifact exports toward nested sweeps, raw-format
      interoperability, and remaining vendor-style output controls.
@@ -4173,7 +4175,7 @@ the Rust, Python, and TypeScript surfaces together.
      command routing, including control flow, variables, and script execution
      policy.
 
-8. Production solver core follow-up.
+7. Production solver core follow-up.
    - Sparse real/complex matrix paths now have cross-language native coverage,
      and Python real DC solves now use an optional SciPy sparse-LU backend with
      structured native fallback metadata.
@@ -4184,14 +4186,14 @@ the Rust, Python, and TypeScript surfaces together.
      damping, device limiting, tolerance policy, and additional convergence
      diagnostics for difficult transistor decks.
 
-9. Device model depth.
+8. Device model depth.
    - Audit diode, BJT, JFET, and MOS Level 1 behavior against reference decks.
    - Decide whether Level 2/3 MOS is in scope before BSIM; if BSIM lands, make
      Rust the first fast path and port stable semantics outward.
    - Expand temperature behavior, capacitance, noise, charge conservation, model
      card aliases, and error messages.
 
-10. Analysis completion.
+9. Analysis completion.
    - Generalize pole-zero beyond constrained fixture helpers.
    - Expand nonlinear distortion coverage.
    - Expand parsed `.FOUR` / `.MEASURE` integration across output plans and
@@ -4200,14 +4202,14 @@ the Rust, Python, and TypeScript surfaces together.
      Carlo trials.
    - Stabilize raw, CSV, JSON, and browser-friendly result formats.
 
-11. Mixed-signal integration.
+10. Mixed-signal integration.
    - Connect SPICE transient stepping to the hardware VM scheduler.
    - Support bidirectional analog/digital thresholds, event scheduling,
      breakpoint coordination, and VCD correlation.
    - Keep mixed-signal coupling deterministic across Python, Rust, and
      TypeScript.
 
-12. Verilog-A and custom models.
+11. Verilog-A and custom models.
    - Specify the accepted model subset and residual/Jacobian hooks.
    - Add parser or compiler support with sandboxing for TypeScript/web usage.
    - Provide a Rust-native fast path for compiled models.


### PR DESCRIPTION
## Summary
- validate and lower MOS model-card U0 and UO in the Python and TypeScript parsers
- reuse shared engine model-card semantics to derive KP from surface mobility and TOX when KP is omitted
- preserve explicit KP precedence and record PR #9586 completion in the implementation plan

## Verification
- Python spice-netlist-parser: 89 tests passed, 87.95% coverage
- Python ruff: passed
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed, 88 tests passed
- TypeScript spice-netlist-parser coverage: 83.13% statements, 83.77% lines
- git diff --check: passed