### PR TITLE
fix(build-tool): make TypeScript gitdiff portable on Windows

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -352,11 +352,11 @@
     {
       "id": "build-tool-typescript-windows-gitdiff-portability",
       "title": "Make TypeScript build-tool git-diff tests portable on Windows",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-typescript-windows-gitdiff",
       "pr_number": null,
-      "notes": "Discovered while running the full TypeScript build-tool suite for the strict rockspec UTF-8 slice. On Windows, gitdiff.test.ts hardcodes /bin/sh for two git commits and uses /repo POSIX fake roots for path-mapping tests, producing two spawnSync /bin/sh ENOENT failures plus five empty affected-package sets. The failure is pre-existing and unrelated to metadata decoding. Add platform-native command invocation and temporary-directory path fixtures in a separate small slice, then require the full package suite and coverage on Windows."
+      "notes": "Selected after merged PR #9589 and the collision-clean 3918b1d9 inventory because these seven failures are the sole remaining blocker to a fully green TypeScript build-tool suite on Windows and fixing them strengthens every later parity validation. Keep the slice test-portability-only: replace two /bin/sh-dependent git commits with platform-native process invocation and replace five POSIX-only /repo path fixtures with temporary-directory-native paths, without widening runtime behavior."
     },
     {
       "id": "build-tool-typescript-language-identity-registry",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9592,
   "last_inventory": {
-    "revision": "3918b1d9c24c765363069107ba49be573e09a2b4",
+    "revision": "b70e9b7dd03198973ceadbc4d5d272f101d99afa",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1222,
@@ -352,11 +352,11 @@
     {
       "id": "build-tool-typescript-windows-gitdiff-portability",
       "title": "Make TypeScript build-tool git-diff tests portable on Windows",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-typescript-windows-gitdiff",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9589 and the collision-clean 3918b1d9 inventory because these seven failures are the sole remaining blocker to a fully green TypeScript build-tool suite on Windows and fixing them strengthens every later parity validation. Keep the slice test-portability-only: replace two /bin/sh-dependent git commits with platform-native process invocation and replace five POSIX-only /repo path fixtures with temporary-directory-native paths, without widening runtime behavior."
+      "pr_number": 9592,
+      "notes": "Ready PR #9592 is the sole active parity PR. It replaces two /bin/sh-dependent fixture commits with direct git argument vectors, uses native temporary-directory package roots, and normalizes path.relative package roots to Git's forward-slash repository paths without changing diff-selection semantics. The red Windows baseline was 275 passing plus the exact seven owned failures; exact-head validation after a conflict-free rebase onto b70e9b7dd passed all 282 tests, 96.77% gitdiff line and 95% branch coverage, 89.36%/82.06% full-suite line/branch coverage, production bundling, 17 schema plus 40 runner tests, the valid 37-case/56-file corpus, and zero-advisory npm audit. The real plan contains 4,768 packages, 4,768 unique names, zero duplicate groups, 7,243 edges, and zero backslash paths. The collision-checked parity inventory remains 1,222 identities/4,370 slots with zero collisions or unknown inventory buckets; BUILD validation reproduced only the exact ten owned Lua BUILD_windows debts."
     },
     {
       "id": "build-tool-typescript-language-identity-registry",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9589,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "3f8eb7b8a94db122c05ec4ffe1de59e0a052f515",
+    "revision": "3918b1d9c24c765363069107ba49be573e09a2b4",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1222,
@@ -370,11 +370,11 @@
     {
       "id": "build-tool-typescript-windows-plan-rel-path-portability",
       "title": "Emit portable TypeScript build-plan package paths on Windows",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-typescript-language-identity-registry"],
       "branch": "codex/build-tool-typescript-windows-plan-rel-path",
       "pr_number": 9589,
-      "notes": "Ready PR #9589 is the sole active parity PR. It adds the language-neutral plan/portable-package-path plan_v1_write fixture, consumes it through a real TypeScript CLI subprocess with exact emitted-plan equality, and normalizes only serialized package rel_path values to forward slashes. Exact-head validation after a conflict-free rebase onto 0ef57c15 passed 18 plan tests, 272 unaffected tests, 100% plan line/statement/function and 88.88% branch coverage, production bundling, 17 schema plus 40 runner tests, the valid 37-case/56-file corpus, zero-advisory npm audit, and a real 4,768-record/7,243-edge full plan with 4,768 unique names, zero duplicate groups, and zero backslash paths. The collision-checked parity inventory remains 1,222 identities/4,370 slots with zero collisions or unknown inventory buckets. Full local Windows testing separately reproduced only the exact seven owned gitdiff portability failures, and BUILD validation reproduced only the exact ten owned Lua BUILD_windows debts."
+      "notes": "Merged PR #9589 at 3c9fe557ea8e060064eff9c0bcf16b29baafa848 on 2026-08-02 after both detection runs, both fixture-consumer runs, both Ubuntu builds, macOS, Windows, CodeQL language detection, and JavaScript/TypeScript analysis passed; irrelevant CodeQL lanes skipped and the aggregate CodeQL result was neutral. It adds the language-neutral plan/portable-package-path plan_v1_write fixture, consumes it through a real TypeScript CLI subprocess with exact emitted-plan equality, and normalizes only serialized package rel_path values to forward slashes. Exact-head validation passed 18 plan tests, 272 unaffected tests, 100% plan line/statement/function and 88.88% branch coverage, production bundling, 17 schema plus 40 runner tests, the valid 37-case/56-file corpus, zero-advisory npm audit, and a real 4,768-record/7,243-edge full plan with 4,768 unique names, zero duplicate groups, and zero backslash paths. The post-merge collision-checked inventory remains 1,222 identities/4,370 slots with zero collisions or unknown inventory buckets. Full local Windows testing separately reproduced only the exact seven owned gitdiff portability failures, and BUILD validation reproduced only the exact ten owned Lua BUILD_windows debts."
     },
     {
       "id": "build-tool-go-rockspec-utf8-conformance",

--- a/code/programs/typescript/build-tool/CHANGELOG.md
+++ b/code/programs/typescript/build-tool/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the TypeScript build tool will be documented in this file
 
 ### Fixed
 
+- Normalize Git-diff package roots to repository-relative forward-slash paths
+  and make the Git integration fixtures shell-independent on Windows.
 - Emit build-plan package `rel_path` values with portable forward slashes on
   Windows, backed by the shared plan fixture and a real CLI subprocess test.
 - Classify languages only from the canonical package/program bucket, preserve

--- a/code/programs/typescript/build-tool/README.md
+++ b/code/programs/typescript/build-tool/README.md
@@ -54,6 +54,11 @@ Emitted build plans use repository-relative forward-slash package paths on
 every platform, including Windows, so downstream jobs receive the same logical
 plan regardless of the producer host.
 
+Git-diff package matching uses the same repository-relative forward-slash
+paths on every platform. Its integration tests create native temporary Git
+repositories and invoke Git with direct argument vectors, so the package suite
+runs without a POSIX shell on Windows.
+
 ## Platform-specific BUILD files
 
 The discovery system supports platform-specific BUILD files with the following priority:

--- a/code/programs/typescript/build-tool/src/gitdiff.ts
+++ b/code/programs/typescript/build-tool/src/gitdiff.ts
@@ -144,7 +144,9 @@ export function mapFilesToPackages(
   // Convert package paths to relative strings for prefix matching.
   const relativePkgPaths = new Map<string, string>();
   for (const [name, absPath] of packagePaths) {
-    const relPath = path.relative(repoRoot, absPath);
+    // Git reports repository-relative paths with forward slashes on every
+    // platform, while path.relative() uses the host separator on Windows.
+    const relPath = path.relative(repoRoot, absPath).split(path.sep).join("/");
     relativePkgPaths.set(name, relPath);
   }
 

--- a/code/programs/typescript/build-tool/tests/gitdiff.test.ts
+++ b/code/programs/typescript/build-tool/tests/gitdiff.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 import { getChangedFiles, mapFilesToPackages } from "../src/gitdiff.js";
 
@@ -11,18 +11,21 @@ import { getChangedFiles, mapFilesToPackages } from "../src/gitdiff.js";
 // root path; the caller is responsible for cleaning it up.
 function makeRepo(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "gitdiff-test-"));
-  execSync("git init -q -b main", { cwd: root });
-  execSync("git config user.email a@b", { cwd: root });
-  execSync("git config user.name x", { cwd: root });
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "a@b"], { cwd: root });
+  execFileSync("git", ["config", "user.name", "x"], { cwd: root });
+  execFileSync("git", ["config", "core.autocrlf", "false"], { cwd: root });
   fs.writeFileSync(path.join(root, "base.txt"), "base\n");
-  execSync("git add base.txt && git commit -q -m base", { cwd: root, shell: "/bin/sh" });
+  execFileSync("git", ["add", "base.txt"], { cwd: root });
+  execFileSync("git", ["commit", "-q", "-m", "base"], { cwd: root });
   // Tag the base commit so we have a stable ref to diff against.
-  execSync("git tag base", { cwd: root });
+  execFileSync("git", ["tag", "base"], { cwd: root });
   fs.writeFileSync(path.join(root, "changed.txt"), "changed\n");
   fs.mkdirSync(path.join(root, "code/packages/python/foo/src"), { recursive: true });
   fs.writeFileSync(path.join(root, "code/packages/python/foo/src/gates.py"), "x = 1\n");
   fs.writeFileSync(path.join(root, "code/packages/python/foo/README.md"), "# foo\n");
-  execSync("git add -A && git commit -q -m changes", { cwd: root, shell: "/bin/sh" });
+  execFileSync("git", ["add", "-A"], { cwd: root });
+  execFileSync("git", ["commit", "-q", "-m", "changes"], { cwd: root });
   return root;
 }
 
@@ -60,11 +63,15 @@ describe("getChangedFiles", () => {
 
 describe("mapFilesToPackages", () => {
   // Common setup used by the variants below.
-  const repoRoot = "/repo";
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gitdiff-map-test-"));
   const pkgPaths = new Map([
-    ["python/foo", "/repo/code/packages/python/foo"],
-    ["python/bar", "/repo/code/packages/python/bar"],
+    ["python/foo", path.join(repoRoot, "code", "packages", "python", "foo")],
+    ["python/bar", path.join(repoRoot, "code", "packages", "python", "bar")],
   ]);
+
+  afterAll(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
 
   it("maps a file under a package directory to that package", () => {
     const out = mapFilesToPackages(

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -240,8 +240,9 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
-  POSIX-only `/repo` path fixtures; this is tracked as a separate test-
-  portability slice rather than widening the metadata decoder change;
+  POSIX-only `/repo` path fixtures. This is the selected next slice because
+  these seven failures are the sole blocker to a fully green Windows package
+  suite; keep it test-portability-only rather than widening runtime behavior;
 - align TypeScript build-tool discovery with the canonical language and identity
   registry. Merged PR #9582 consumes the shared registry and duplicate-
   identity fixtures, preserves package/program identity, excludes spec fixtures,

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -250,7 +250,7 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   from 655 unknown records and 217 duplicate groups;
 - make TypeScript build-plan package paths portable on Windows. The identity-
   registry validation found that `rel_path` values still use host backslashes;
-  ready PR #9589 is the selected fixture-driven slice because every one of the
+  merged PR #9589 is the fixture-driven slice because every one of the
   real plan's 4,768 package records is affected on Windows. Normalize serialized
   repository-relative paths without widening discovery behavior;
 - make Swift build-tool file options recognize Windows drive-letter absolute

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -240,9 +240,10 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
-  POSIX-only `/repo` path fixtures. This is the selected next slice because
-  these seven failures are the sole blocker to a fully green Windows package
-  suite; keep it test-portability-only rather than widening runtime behavior;
+  POSIX-only `/repo` path fixtures. Ready PR #9592 is the selected slice: it
+  uses direct Git argument vectors and native temporary roots, and normalizes
+  relative package paths at the Git boundary without changing selection
+  semantics. Its exact Windows suite is green at 282/282 tests;
 - align TypeScript build-tool discovery with the canonical language and identity
   registry. Merged PR #9582 consumes the shared registry and duplicate-
   identity fixtures, preserves package/program identity, excludes spec fixtures,


### PR DESCRIPTION
## Summary
- normalize TypeScript git-diff package roots to repository-relative forward-slash paths so Git output maps correctly on Windows
- replace POSIX-shell test setup with direct `git` argument vectors and native temporary-directory package roots
- keep change detection semantics unchanged while closing the exact seven pre-existing Windows failures
- reconcile merged parity PR #9589 and record this dependency-shaped selection in the durable parity state

## Validation
- red baseline: 275 passed / exact 7 failed (2 `/bin/sh` ENOENT, 5 path-mapping failures)
- focused `tests/gitdiff.test.ts`: 10 passed
- full TypeScript package suite and coverage: 282 passed; 89.36% lines / 82.06% branches overall; `gitdiff.ts` 96.77% lines / 95% branches
- real full plan: 4,768 packages, 4,768 unique names, 0 duplicate groups, 7,243 edges, 0 backslash paths
- build-tool schema tests: 17 passed
- build-tool runner tests: 40 passed
- conformance corpus: 37 cases / 56 files, 15 established languages, 16 implementations
- collision-checked parity inventory: 1,222 implementation identities / 4,370 slots; 0 collisions; 0 unknown inventory buckets
- production esbuild bundle and bundled `--help`
- `npm audit`: 0 vulnerabilities
- Lua BUILD validation: exact existing 10-package `BUILD_windows` debt set only
- JSON parsing, `git diff --check`, exact-head rebase onto `b70e9b7dd`, and secret-like diff scan