### PR TITLE
Split Hindi lessons into sub-five-minute micro-steps

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Arabic duration
-tranche: 20 registered tracks, 1,012 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Hindi duration
+tranche: 20 registered tracks, 1,025 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -61,7 +61,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01L | Complete in the Kannada duration PR | Remove all thirty-seven sub-five-minute violations from the Kannada track. | The report measures zero Kannada violations; one new prerequisite-ordered micro-lesson separates suffix forms and sound history from the agglutinative-versus-fusional comparison. |
 | HL-D01M | Complete in the Malayalam duration PR | Remove all thirty-seven sub-five-minute violations from the Malayalam track. | The report measures zero Malayalam violations; four new prerequisite-ordered micro-lessons separate vocabulary from etymology, register, and cross-language comparison. |
 | HL-D01N | Complete in the Arabic duration PR | Remove all thirty-nine sub-five-minute violations from the Arabic track. | The report measures zero Arabic violations; four new prerequisite-ordered writing steps preserve the abjad, joining, whole-word assembly, and hamza content. |
-| HL-D01O | Next | Remove all forty sub-five-minute violations from the Hindi track. | Hindi is now the smallest remaining set: twenty-nine declaration-only lessons and eleven genuinely computed violations, with a 501-second maximum. |
+| HL-D01O | Complete in the Hindi duration PR | Remove all forty sub-five-minute violations from the Hindi track. | The report measures zero Hindi violations; thirteen new prerequisite-ordered lessons preserve its script, etymology, grammar, and register depth. |
+| HL-D01P | Next | Remove all forty-two sub-five-minute violations from the Tamil track. | Tamil is now the smallest remaining set: twenty-two declaration-only lessons and twenty genuinely computed violations, with a 441-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -90,11 +91,14 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B27 | Queued | Remove Malayalam's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports seven overfull boxes, eight underfull boxes, four duplicate practice labels, 28 Hyperref warnings, and undefined bold/italic Malayalam font shapes; the clean-build signal is zero of each. |
 | HL-B28 | Queued | Publish Arabic Chapters 3–27 and its writing companions from canonical lessons rather than hand-copying another twenty-five book chapters. | The Arabic PDF stops after Chapter 2 while canonical app content continues through Chapter 27 and sixteen dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
 | HL-B29 | Queued | Remove Arabic's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, one duplicate practice label, 14 Hyperref warnings, and undefined bold/italic Arabic font shapes; the clean-build signal is zero of each. |
+| HL-B30 | Queued | Publish Hindi Chapters 6–33 and its writing companions from canonical lessons rather than hand-copying another twenty-eight book chapters. | The Hindi PDF stops after Chapter 5 while canonical app content continues through Chapter 33 and eleven dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
+| HL-B31 | Queued | Remove Hindi's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports two overfull boxes, five underfull boxes, three duplicate practice labels, 29 Hyperref warnings, undefined bold/italic Devanagari font shapes, and a visibly colliding final-page running header; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
 | HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
 | HL-M05 | Queued | Reconcile Arabic's roadmap and authoritative session map with canonical Chapters 1–27 and the sixteen-step writing sequence. | The roadmap details only Chapters 1–4 and still calls Chapter 5+ planned; the session map stops at Chapter 2 even though prerequisite-ordered canonical lessons continue through Chapter 27. |
+| HL-M06 | Queued | Reconcile Hindi's roadmap and authoritative session map with canonical Chapters 1–33 and the eleven-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 6 planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 33. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
@@ -482,6 +486,35 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Hindi's forty violations are now the smallest remaining set. Twenty-nine are
   declaration-only and eleven genuinely compute above the limit, with a
   501-second maximum, so HL-D01O is next.
+
+## Findings from HL-D01O
+
+- Hindi now has zero duration violations. The corpus grows from 1,012 to 1,025
+  lessons and drops from 180 to 140 violations overall; unknown prerequisites
+  remain at zero.
+- Twenty-nine lessons already computed below five minutes and needed only
+  honest four-minute declared budgets. Eleven genuinely long lessons become
+  thirteen new prerequisite-ordered steps: six script companions, two history
+  supports for one-to-five, and focused lessons for age grammar, later-number
+  sound changes, cat history, yellow-word evidence, and evening register.
+- The 24 new or rewritten steps compute between 114 and 293 seconds.
+  `HI-W02-abugida-ka-ta` at 293 seconds and `HI-W04-ra-sa-mera-naam` at 278 are
+  the tightest remaining Hindi lessons and should be watched during copy edits.
+- The Hindi PDF builds successfully at 29 pages with no missing glyphs, but it
+  contains only Chapters 1–5 while canonical lessons continue through Chapter
+  33 alongside eleven writing steps. HL-B30 records the schema-v2 migration and
+  generated publication work for the missing content.
+- The build reports two overfull boxes, five underfull boxes, three duplicate
+  practice labels, 29 Hyperref warnings, and undefined bold/italic Devanagari
+  font shapes. Visual inspection also finds the final running header colliding
+  with the page number. HL-B31 records that pre-existing clean-build debt.
+- The roadmap describes only Chapters 1–6 and still labels Chapter 6 as planned;
+  the authoritative session map stops at Chapter 5. HL-M06 records the
+  progression-metadata reconciliation through Chapter 33 and the expanded
+  writing sequence.
+- Tamil's forty-two violations are now the smallest remaining set. Twenty-two
+  are declaration-only and twenty genuinely compute above the limit, with a
+  441-second maximum, so HL-D01P is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/hindi/CHANGELOG.md
+++ b/code/learning/human-languages/hindi/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Sub-five-minute canonical sequence
+
+- All 40 Hindi duration violations are resolved without removing vocabulary,
+  grammar, script, register, source qualification, or etymology content.
+  Twenty-nine lessons already computed below the limit and now declare honest
+  four-minute budgets.
+- Five long writing lessons became eleven prerequisite-ordered steps through
+  `HI-W01-na-ma`, `HI-W02-ka-ta-mouth-order`, `HI-W03-preposed-i`,
+  `HI-W04-write-mera-naam`, `HI-W05-conjuncts`, and
+  `HI-W05-write-namaste`. The progression now separates the head-line from its
+  first letter bodies, inherent vowel from mouth-order writing, basic mātrās
+  from preposed **ि**, letter history from phrase assembly, and virama from
+  conjuncts and whole-word writing.
+- Seven other long lessons gained focused supports:
+  `HI-C06-tin-char-history`, `HI-C06-paanch-nasal`,
+  `HI-C19-age-grammar`, `HI-C21-six-nine-ten-history`,
+  `HI-C23-billi-history`, `HI-C24-pila-history`, and
+  `HI-C32-evening-register`.
+- Downstream prerequisites and reviews now pass through the immediately
+  preceding skill. The 24 rewritten or new lessons compute between 114 and 293
+  seconds, and the full corpus still has zero unknown prerequisite ids.
+
 ## Chapter 6 — Numbers 1–5, and Sanskrit wearing down
 
 - **Chapter 6 authored** (`HI-C06-numbers-1-5`): *ek, do, tīn, chār, pāṁch*.

--- a/code/learning/human-languages/hindi/lessons/HI-C01-dhanyavad.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-dhanyavad.md
@@ -8,7 +8,7 @@ concept_tag: COURTESY-THANKS
 prerequisites: [HI-C01-namaskar]
 sounds: [devanagari-inherent-a, matra-aa, halant-conjunct]
 roots: [dhanya, vaada]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C01-namaste, HI-C01-namaskar]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C01-namaste.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-namaste.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [devanagari-inherent-a, matra-e, halant-conjunct]
 roots: [nam]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C01-shukriya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-shukriya.md
@@ -8,7 +8,7 @@ concept_tag: COURTESY-THANKS-CASUAL
 prerequisites: [HI-C01-dhanyavad]
 sounds: [devanagari-inherent-a, matra-i, matra-aa, halant-conjunct]
 roots: [shukr]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C01-dhanyavad]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C02-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [HI-C02-mera-naam-hai, HI-C02-aapka-naam-kya-hai, HI-C02-khushi]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C02-naam, HI-C02-meraa, HI-C02-hai, HI-C02-mera-naam-hai, HI-C02-aap-tum, HI-C02-kya, HI-C02-aapka-naam-kya-hai, HI-C02-khushi]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C03-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [HI-C03-aap-kaise-hain, HI-C03-thik, HI-C03-aapka-swagat-hai]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C03-kaise, HI-C03-aap-kaise-hain, HI-C03-main, HI-C03-hun, HI-C03-thik, HI-C03-aapka-swagat-hai]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C04-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [HI-C04-phir-milenge, HI-C04-kal-milte-hain, HI-C04-chalta-hun]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C01-alvida, HI-C04-phir, HI-C04-milenge, HI-C04-phir-milenge, HI-C04-kal-milte-hain, HI-C04-chalta-hun]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C05-karna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-karna.md
@@ -8,7 +8,7 @@ concept_tag: HI-VERB-KARNA
 prerequisites: [HI-C05-bolna]
 sounds: [matra-a]
 roots: [kr-do]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C05-bolna, HI-C05-rahna]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C05-main-hindi-bolta-hun.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-main-hindi-bolta-hun.md
@@ -8,7 +8,7 @@ concept_tag: HI-WORD-HINDI
 prerequisites: [HI-C05-bolna, HI-C03-main, HI-C03-hun]
 sounds: [anusvara, matra-i]
 roots: [sindhu-river]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C05-bolna, HI-C03-main, HI-C03-hun]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C05-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [HI-C05-bolna, HI-C05-main-hindi-bolta-hun, HI-C05-rahna, HI-C05-karna]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C05-bolna, HI-C05-main-hindi-bolta-hun, HI-C05-rahna, HI-C05-karna, HI-C03-hun, HI-C03-main]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C06-numbers-1-5.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C06-numbers-1-5.md
@@ -3,17 +3,17 @@ id: HI-C06-numbers-1-5
 chapter: 6
 type: word
 headword: एक दो तीन चार पाँच
-gloss: one to five — Sanskrit worn smooth by two thousand years
+gloss: one to five, with familiar Devanagari pieces and the chandrabindu in पाँच
 concept_tag: HI-NUMBERS-1-5
 prerequisites: [HI-C01-namaste]
 sounds: [matra-aa, matra-i, chandrabindu]
 roots: [sanskrit-eka, sanskrit-dvi, sanskrit-panca]
-etymology_hook: "each Hindi number is its Sanskrit ancestor worn down through the PRAKRITS, and three and four come from the NEUTER forms — trīṇi → tiṇṇi → तीन tīn, catvāri → cattāri → चार chār — the same erosion that turned Latin into Spanish, running on the other side of the world at the same time (quattuor → cuatro beside catvāri → chār)"
-est_minutes: 5
+etymology_hook: "पाँच pāṁch preserves Sanskrit's nasal consonant inside the vowel, written with the chandrabindu or moon-dot"
+est_minutes: 4
 reviews_of: [HI-C01-namaste, HI-W03-matras-naam]
 ---
 
-# एक, दो, तीन, चार, पाँच — one to five
+# एक, दो, तीन, चार, पाँच — the five forms
 
 ## Warm-up
 
@@ -39,81 +39,16 @@ writing track reaches them.
 The **ँ** over *pāṁch* is a *chandrabindu*, "moon-dot" — it nasalises the vowel,
 the way French does in *bon*.
 
-## Watch them wear down
-
-Put them beside their Sanskrit ancestors:
-
-| Sanskrit | → Prakrit → | Hindi |
-|---|---|---|
-| *éka-* | *ekka* | **ek** |
-| *dvá-* | *do* | **do** |
-| **neuter *trī́ṇi*** | *tiṇṇi* | **tīn** |
-| **neuter *catvā́ri*** | *cattāri* | **chār** |
-| *páñca* | *pañca* | **pāṁch** |
-
-Two things to notice.
-
-**The middle column matters.** These didn't jump straight from Sanskrit to Hindi.
-They passed through the **Prakrits**, the everyday spoken descendants of Sanskrit
-— which is where most of the wearing-down actually happened.
-
-**Three and four come from the neuter forms.** Sanskrit had *tráyaḥ* (masculine)
-and *trī́ṇi* (neuter); Hindi's *tīn* continues **the neuter**. Same for
-*catvā́ri* → *chār*. That's why the anchor lesson made you look at the neuter
-column.
-
-The mechanism is visible in *tīn*, and it runs in two steps:
-
-1. ***trī́ṇi* → *tiṇṇi***. The *r* is lost and the **ṇ doubles** to make up the
-   weight. The long *ī* shortens at the same time, because Prakrit won't have a
-   long vowel sitting in front of a double consonant — a syllable can be heavy
-   one way or the other, not both at once.
-2. ***tiṇṇi* → *tīn***. The double simplifies, and now the **vowel lengthens** to
-   make up the weight instead.
-
-Each step trades one kind of heaviness for another — and the vowel ends up long
-again, having been short in between.
-
-*Ek* shows only the **second** half of that. *Éka-* had no cluster to lose, so
-Prakrit *ekka* doubled for reasons of its own; but *ekka* → *ek* is the same
-step 2, the double giving way.
-
-This is not decay in any bad sense — it's what heavy use does to words over two
-thousand years. And it is **exactly the process the Spanish and French tracks
-keep describing**, running on the other side of the world at the same time:
-
-| | ancient | modern |
-|---|---|---|
-| **Latin → Spanish** | *quattuor* | *cuatro* |
-| **Sanskrit → Hindi** | *catvā́ri* | *chār* |
-
-Same PIE word, two continents, two thousand years of erosion each.
-
-## The nasal that stayed
-
-*Pañca* → *pāṁch* is the interesting one. The **n** didn't vanish; it moved
-**into the vowel**. Sanskrit's *ñ* consonant became Hindi's nasalised *ā* — which
-is what that chandrabindu records.
-
-Say *pāṁch* and *pañca* one after the other and you can hear the nasal migrating
-backwards.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "ek, do, tīn, chār, pāṁch"]
-- [YOU SAY: the erosion — "catvā́ri … cattāri … **chār**"]
-- [YOU SAY: the parallel — "quattuor → cuatro … catvā́ri → chār"]
-- [YOU SAY: the two-step — "trī́ṇi … ti**ṇṇ**i … t**ī**n"]
+- [YOU POINT: the familiar क, त, न, र and ा inside the five words]
+- [YOU TRACE: the **ँ** moon-dot over *pāṁch*]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Count to five in Hindi. (*Ek, do, tīn, chār, pāṁch*.) Which Sanskrit
-forms do *tīn* and *chār* come from — masculine or neuter? (**Neuter** — *trī́ṇi*
-and *catvā́ri*, not *tráyaḥ*/*catvā́raḥ*.) What sat between Sanskrit and Hindi?
-(**The Prakrits** — that's where most of the wearing-down happened.) In *trī́ṇi*
-→ *tiṇṇi* → *tīn*, what is traded for what? (The **r** is lost and the **ṇ
-doubles**; then the double simplifies and the **vowel lengthens**.) What European
-change is this the twin of? (**Latin → Spanish** — *quattuor* → *cuatro*.) What
-is the **ँ** in *pāṁch*? (A **chandrabindu** — Sanskrit's *ñ* moved **into** the
-vowel.) Next: six to ten.
+[PAUSE 3s] Count to five in Hindi. (*Ek, do, tīn, chār, pāṁch*.) Which mark
+nasalises the vowel in **पाँच**? (The **chandrabindu**, "moon-dot.") Do you need
+to draw every unfamiliar letter today? (**No** — read them now and draw them
+when their stroke lessons arrive.) Next: watch the Sanskrit forms wear smooth.

--- a/code/learning/human-languages/hindi/lessons/HI-C06-paanch-nasal.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C06-paanch-nasal.md
@@ -1,0 +1,43 @@
+---
+id: HI-C06-paanch-nasal
+chapter: 6
+type: etymology
+headword: पाँच
+gloss: Sanskrit's nasal consonant survives inside the Hindi vowel
+romanization: "pāṁch"
+prerequisites: [HI-C06-tin-char-history]
+sounds: [chandrabindu, vowel-nasalization]
+roots: [sanskrit-panca]
+etymology_hook: "pañca → pāṁch keeps the nasal by moving it from a consonant into the vowel; the chandrabindu makes that migration visible"
+est_minutes: 4
+reviews_of: [HI-C06-tin-char-history, HI-C06-numbers-1-5]
+---
+
+# पाँच — the nasal moved into the vowel
+
+## Warm-up
+
+[PAUSE 2s] *Tīn* moved weight between consonants and vowels. *Pāṁch* moves a
+whole nasal sound into the vowel itself.
+
+## The nasal that stayed
+
+Sanskrit ***pañca*** → Hindi ***pāṁch***. The **n** did not vanish; Sanskrit's
+*ñ* consonant became Hindi's nasalised *ā*. The **ँ** chandrabindu records that
+nasality above the word.
+
+Say *pāṁch* and *pañca* one after the other. You can hear the nasal migrating
+backward from its own consonant into the vowel.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pañca … pāṁch"]
+- [YOU HUM: hold the nasal through the vowel in *pāṁch*]
+- [YOU POINT: **ँ**, the moon-dot that records it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Did the nasal in *pañca* disappear? (**No** — it moved into the
+vowel.) What records it in **पाँच**? (The **chandrabindu**.) Count one to five
+once more. (*Ek, do, tīn, chār, pāṁch*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C06-tin-char-history.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C06-tin-char-history.md
@@ -1,0 +1,70 @@
+---
+id: HI-C06-tin-char-history
+chapter: 6
+type: etymology
+headword: तीन, चार
+gloss: three and four descend from Sanskrit neuter forms through Prakrit weight trades
+prerequisites: [HI-C06-numbers-1-5]
+sounds: [prakrit-gemination, compensatory-lengthening]
+roots: [sanskrit-trini, sanskrit-catvari, pie-number-four]
+etymology_hook: "trīṇi → tiṇṇi → tīn trades r for a doubled consonant and then the double for a long vowel; catvāri → cattāri → chār follows the same Prakrit path beside Latin quattuor → Spanish cuatro"
+est_minutes: 4
+reviews_of: [HI-C06-numbers-1-5]
+---
+
+# तीन and चार — weight moves from consonants to vowels
+
+## Warm-up
+
+[PAUSE 2s] The five modern forms did not jump straight from Sanskrit. The
+Prakrits did most of the wearing-down in between.
+
+## Put the stages side by side
+
+| Sanskrit | → Prakrit → | Hindi |
+|---|---|---|
+| *éka-* | *ekka* | **ek** |
+| *dvá-* | *do* | **do** |
+| **neuter *trī́ṇi*** | *tiṇṇi* | **tīn** |
+| **neuter *catvā́ri*** | *cattāri* | **chār** |
+| *páñca* | *pañca* | **pāṁch** |
+
+Three and four come from the **neuter** forms. Sanskrit also had masculine
+*tráyaḥ*, but Hindi *tīn* continues *trī́ṇi*. The same choice gives
+*catvā́ri* → *chār*.
+
+## The two-step weight trade
+
+1. ***trī́ṇi* → *tiṇṇi***: *r* is lost and **ṇ doubles** to make up the weight.
+   Long *ī* shortens because the doubled consonant already makes the syllable
+   heavy.
+2. ***tiṇṇi* → *tīn***: the double simplifies and the **vowel lengthens** to
+   pay for the lost consonant weight.
+
+The vowel ends long again after being short in the middle. *Ekka* → *ek* shows
+the second half of the same trade.
+
+This is not decay in a bad sense; it is what heavy use does over two thousand
+years. The same ancient number wore down on another continent:
+
+| | ancient | modern |
+|---|---|---|
+| **Latin → Spanish** | *quattuor* | *cuatro* |
+| **Sanskrit → Hindi** | *catvā́ri* | *chār* |
+
+Same PIE word, two continents, two ordinary histories.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "trī́ṇi … ti**ṇṇ**i … t**ī**n"]
+- [YOU SAY: "catvā́ri … cattāri … **chār**"]
+- [YOU COMPARE: "quattuor → cuatro · catvā́ri → chār"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which Sanskrit forms underlie *tīn* and *chār*? (**Neuter**
+*trī́ṇi* and *catvā́ri*.) What sits between Sanskrit and Hindi? (The
+**Prakrits**.) In *trī́ṇi* → *tiṇṇi* → *tīn*, what trades places? (The lost *r*
+is paid for by a **double consonant**, then the simplified double by a **long
+vowel**.) Next: follow the nasal that stayed inside *pāṁch*.

--- a/code/learning/human-languages/hindi/lessons/HI-C10-somavaar-shukravaar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C10-somavaar-shukravaar.md
@@ -5,12 +5,12 @@ type: word
 headword: सोमवार मंगलवार बुधवार गुरुवार शुक्रवार
 gloss: Monday–Friday — Hindi's own planet-week, independent of Rome's
 concept_tag: HI-DAYS-WEEKDAYS
-prerequisites: [HI-C06-numbers-1-5]
+prerequisites: [HI-C06-paanch-nasal]
 sounds: [devanagari-conjunct-kra, anusvara]
 roots: [vara-sanskrit, navagraha]
 etymology_hook: "सोमवार somavār 'Moon's day' and its four siblings are India's OWN planet-week — the same seven-body idea as Rome's, likely both downstream of a shared Babylonian source, not one copying the other"
-est_minutes: 5
-reviews_of: [HI-C06-numbers-1-5]
+est_minutes: 4
+reviews_of: [HI-C06-paanch-nasal, HI-C06-numbers-1-5]
 ---
 
 # सोमवार to शुक्रवार — Hindi's own planet-week

--- a/code/learning/human-languages/hindi/lessons/HI-C11-kaalaa-safed.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C11-kaalaa-safed.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C10-shanivaar-ravivaar]
 sounds: [devanagari-long-aa, nukta-f]
 roots: [kala-sanskrit, safed-persian]
 etymology_hook: "काला kālā 'black' is traditionally linked to काल kāla, Sanskrit for 'time' and 'death' — the same word underlies Kali and Yama's title Kaala, though whether the two senses truly share one root is still debated; सफ़ेद safed is a Persian loan"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C10-shanivaar-ravivaar]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C11-laal-niila.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C11-laal-niila.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C11-kaalaa-safed]
 sounds: [devanagari-long-aa, retroflex-la-vs-dental]
 roots: [laal-persian, nila-sanskrit]
 etymology_hook: "लाल laal 'red' comes from a Persian word for a RUBY; नीला niilaa 'blue' is Sanskrit for the indigo plant — and India's indigo trade is why English says 'indigo' at all"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C11-kaalaa-safed]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C12-bhaai-bahin.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C12-bhaai-bahin.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C12-pitaa-maataa]
 sounds: [devanagari-long-ii, aspirated-bha]
 roots: [pie-bhrater, bhaga-sanskrit]
 etymology_hook: "भाई bhāī IS the PIE cousin of English 'brother' — but बहन bahin is NOT the cousin of 'sister'; Sanskrit's PIE-cognate word for sister (svasṛ) faded, replaced by bhaginī, 'the one who shares,' the ancestor of bahin"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C12-pitaa-maataa]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C12-pitaa-maataa.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C12-pitaa-maataa.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C11-laal-niila]
 sounds: [devanagari-long-aa, retroflex-vs-dental-ta]
 roots: [pie-pater, pie-mater]
 etymology_hook: "पिता pitā and माता mātā are Sanskrit cousins of Latin pater/mater and English father/mother; बाप bāp and माँ māṁ are ALSO Sanskrit-descended, just via a different root (vaptṛ) and a Prakrit doublet, not uncertain outliers"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C11-laal-niila]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C14-ritu.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C14-ritu.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C13-haath]
 sounds: [devanagari-conjunct-shma, anusvara]
 roots: [ritu-sanskrit-six-season-system]
 etymology_hook: "Hindi's traditional calendar recognizes SIX ऋतु (ṛtu) 'seasons', not four — vasant, grishma, varsha (monsoon), sharad, hemant, shishir — a genuinely different structure, not just extra vocabulary"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [HI-C13-haath]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C15-paani-roti.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C15-paani-roti.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C14-ritu]
 sounds: [devanagari-long-ii, retroflex-tta]
 roots: [paaniiya-sanskrit-drink, roti-uncertain]
 etymology_hook: "पानी paanii doesn't come from Sanskrit's ancient water-words (ap, jala) — it's from पानीय paaniiya, 'the drinkable thing,' from पा paa 'to drink' — water named for what you DO with it, not what it IS"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C14-ritu]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C16-mahine.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C16-mahine.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C15-paani-roti]
 sounds: [nukta-f, devanagari-long-ii]
 roots: [gregorian-months-borrowed, vikrama-samvat-sanskrit]
 etymology_hook: "janvarii, maarch, agast... are borrowed English/international month-names for everyday civil use — Hindu tradition keeps a SEPARATE calendar, Vikram Samvat, whose months (Chaitra, Vaishaakh...) map onto the SIX ritu from the seasons lesson, not four Western seasons"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [HI-C15-paani-roti]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C17-dopahar-aadhi-raat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C17-dopahar-aadhi-raat.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C16-mahine]
 sounds: [devanagari-vowel-sign-o, devanagari-long-ii]
 roots: [do-two, pahar-traditional-watch, aadhi-half, raat-night]
 etymology_hook: "दोपहर (dopahar) 'noon' is literally 'two pahars' — pahar being a traditional ~3-hour time-unit, with noon falling at the end of the second pahar after sunrise; आधी रात (aadhi raat) 'half night' is fully transparent, just like Latin's media nox"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C16-mahine]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C18-ghanta.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C18-ghanta.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C17-dopahar-aadhi-raat]
 sounds: [devanagari-anusvara, devanagari-conjunct-none]
 roots: [sanskrit-ghanta-bell]
 etymology_hook: "घंटा (ghanṭā, 'hour') comes from Sanskrit घण्टा (ghaṇṭā), 'bell, gong' — the SAME word Hindi still uses for an actual bell, because clocks and towns once marked the hour by striking one; telling time uses बजना (bajnā), 'to strike/toll,' the same imagery"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C17-dopahar-aadhi-raat]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C19-age-grammar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C19-age-grammar.md
@@ -1,0 +1,49 @@
+---
+id: HI-C19-age-grammar
+chapter: 19
+type: grammar
+headword: कितने साल के हो?
+gloss: Hindi tells age as belonging to a number of years, a fifth cross-language shape
+romanization: "kitne sāl ke ho?"
+prerequisites: [HI-C19-umr]
+sounds: [hindi-genitive-ke-ka]
+roots: [hindi-genitive-possession, hindi-hona]
+est_minutes: 4
+reviews_of: [HI-C19-umr, HI-C02-aap-tum, HI-C03-hun]
+---
+
+# कितने साल के हो? — belonging to so many years
+
+## Warm-up
+
+[PAUSE 2s] Languages do not agree on whether age is something you have, are,
+were born with, or state without a verb. Hindi gives the idea a fifth shape.
+
+## The two sentences
+
+> **तुम कितने साल के हो?** — "How old are you?" (informal), literally "you,
+> **of how many years, are**?" (*tum kitne sāl ke ho?*)
+
+> **मैं बीस साल का हूँ।** — "I am twenty years old," literally "I [am one]
+> **belonging to twenty years**." (*maiṅ bīs sāl kā hūṅ.*)
+
+**के/का** (*ke/kā*) is Hindi's **genitive postposition**, "of, belonging to."
+The same marker family handles possession elsewhere: *merā ghar*, "my house."
+
+So Hindi does not copy Romance's "I **have** years," Germanic's simple "I
+**am** [a number]," Latin's "**born** + N years," or Arabic's verbless "my age
+[is] N." It says "I am [one] **belonging to** N years," with a genitive marker
+plus **होना** (*honā*, "to be").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tum kitne sāl ke ho?" — how old are you?]
+- [YOU SAY: "maiṅ bīs sāl kā hūṅ" — I belong to twenty years]
+- [YOU POINT: **ke/kā** — the genitive, "of/belonging to"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **के/का** mark? (A **genitive/possessive** relationship.)
+Does Hindi use Romance "have," simple Germanic "be," Latin "born," or Arabic's
+verbless sentence? (**None**: it says "belonging to N years" + *honā*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C19-umr.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C19-umr.md
@@ -3,23 +3,22 @@ id: HI-C19-umr
 chapter: 19
 type: phrase
 headword: उम्र
-gloss: age — the SAME word as Arabic's ʿumr, borrowed via Persian; telling age uses a "belonging to N years" construction, a fifth shape distinct from Romance/Germanic/Latin/Arabic
+gloss: age — the same word as Arabic's ʿumr, borrowed through Persian, beside formal Sanskrit āyu
 concept_tag: HI-AGE
 prerequisites: [HI-C18-ghanta]
 sounds: [devanagari-conjunct-mra, devanagari-independent-vowel]
 roots: [arabic-umr-life, sanskrit-aayu-lifespan]
 etymology_hook: "उम्र (umr, 'age') is the SAME Arabic ʿumr you just met, borrowed into Hindi/Urdu via Persian — everyday Hindi uses this Perso-Arabic loan, while more formal/shuddh Hindi uses the native Sanskrit आयु (āyu) instead; telling age uses 'kitne saal ke ho,' literally 'of how many years are you,' a genitive-possessive shape distinct from Romance's 'have,' Germanic's 'be,' Latin's 'born + duration,' or Arabic's no-verb noun sentence"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [HI-C18-ghanta]
 ---
 
-# उम्र — the same word as Arabic, and a fifth grammatical shape
+# उम्र — the same word as Arabic
 
 ## Warm-up
 
 [PAUSE 2s] You just met Arabic's *ʿumr*. Hindi's everyday word for "age" is the
-**exact same word** — and its age-telling grammar is a fifth distinct pattern
-you haven't seen yet.
+**exact same word**, carried through Persian.
 
 ## उम्र — a Perso-Arabic loan, and a native alternative
 
@@ -31,36 +30,15 @@ now seen several times (compare Kannada's Sanskrit-tatsama *madhyāhna* vs.
 Tamil's native words for the same concepts, just flipped here: the **borrowed**
 word is the everyday one, the **native** word is the formal one).
 
-## Grammar Lens: "kitne sāl ke ho?" — a fifth shape
-
-> **तुम कितने साल के हो?** — "How old are you?" (informal) — literally "**you,
-  of how many years, are**?" (*tum kitne sāl ke ho?*)
-> **मैं बीस साल का हूँ।** — "I am twenty years old." — literally "**I [am one]
-  belonging to twenty years**." (*maiṅ bīs sāl kā hūṅ.*)
-
-Look closely at **के** / **का** (*ke*/*kā*) here — this is Hindi's **genitive
-postposition**, "of, belonging to," the same word that marks possession
-elsewhere in Hindi (*merā ghar*, "my house" uses the same family of markers).
-So the construction is genuinely a **fifth** shape for this concept: not
-Romance's "I **have** years," not Germanic's simple "I **am** [a number],"
-not Latin's "**born** + N years [of duration]," not Arabic's verbless "my age
-[is] a number" — but "I am [one] **belonging to** that many years," using a
-possessive/genitive marker plus **होना** (*honā*, "to be").
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "umr" — age, same word as Arabic's ʿumr]
-- [YOU SAY: "tum kitne sāl ke ho?" — how old are you?]
-- [YOU SAY: "maiṅ bīs sāl kā hūṅ" — I am twenty years old, literally
-  "belonging to twenty years"]
+- [YOU CONTRAST: everyday *umr* · formal/literary *āyu*]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What language does Hindi's **उम्र** come from, and what's the native
 Sanskrit alternative? (**Arabic** *ʿumr*, via Persian; native alternative is
-**आयु**, *āyu*.) What does **के**/**का** mark in "*bīs sāl kā hūṅ*"? (A
-**genitive/possessive** relationship — "belonging to.") Is Hindi's age
-construction the same as Romance's "have," Germanic's "be," Latin's "born +
-duration," or Arabic's verbless noun sentence? (**No** — it's a **fifth**
-shape: "belonging to N years" + *honā*, "to be.")
+**आयु**, *āyu*.) Which one is ordinary conversational Hindi? (**Umr**.) Next:
+use a genitive marker to say how many years someone belongs to.

--- a/code/learning/human-languages/hindi/lessons/HI-C20-mausam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C20-mausam.md
@@ -5,12 +5,12 @@ type: phrase
 headword: मौसम
 gloss: weather — the SAME root as English "monsoon"; rain has TWO words that sound alike but are NOT related, a real false-friend trap
 concept_tag: HI-WEATHER
-prerequisites: [HI-C19-umr]
+prerequisites: [HI-C19-age-grammar]
 sounds: [devanagari-vowel-sign-au, devanagari-conjunct-rsha]
 roots: [arabic-mawsim-season, sanskrit-varsha-rain, persian-baarish-rain]
 etymology_hook: "मौसम (mausam, 'weather') is ANOTHER Arabic loan via Persian (mawsim, 'season'), like umr — and the SAME root as English 'monsoon' (via Portuguese/Dutch traders, 1580s, not the later British Raj); be careful, though: बारिश (baarish, 'rain,' from Persian bāriš) and वर्षा (varṣā, native Sanskrit 'rain,' PIE cousin of Greek hérsē 'dew') sound alike but are flagged by dictionaries as PROBABLY unrelated — a likely false-friend trap, not a confirmed doublet"
-est_minutes: 6
-reviews_of: [HI-C19-umr]
+est_minutes: 4
+reviews_of: [HI-C19-age-grammar, HI-C19-umr]
 ---
 
 # मौसम — another Perso-Arabic loan, and a false-friend trap

--- a/code/learning/human-languages/hindi/lessons/HI-C21-numbers-6-10.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C21-numbers-6-10.md
@@ -3,14 +3,14 @@ id: HI-C21-numbers-6-10
 chapter: 21
 type: word
 headword: छह सात आठ नौ दस
-gloss: six to ten — the SAME cluster-simplifies/vowel-lengthens erosion as three and four, twice more
+gloss: six to ten, with seven and eight repeating the same Prakrit weight trade as three
 concept_tag: HI-NUMBERS-6-10
-prerequisites: [HI-C06-numbers-1-5]
+prerequisites: [HI-C06-paanch-nasal]
 sounds: [matra-au, retroflex-tha]
 roots: [sanskrit-sas, sanskrit-sapta, sanskrit-ashta, sanskrit-nava, sanskrit-dasa]
 etymology_hook: "sapta → satta → सात sāt and aṣṭa → aṭṭha → आठ āṭh repeat EXACTLY the trīṇi→tiṇṇi→tīn mechanism from lesson 6 — a consonant cluster simplifies to a geminate, then the geminate simplifies again and the vowel lengthens to pay for it; nau (nine) shows a different fate entirely, an intervocalic -v- dissolving into a diphthong"
-est_minutes: 5
-reviews_of: [HI-C06-numbers-1-5]
+est_minutes: 4
+reviews_of: [HI-C06-paanch-nasal, HI-C06-tin-char-history, HI-C06-numbers-1-5]
 ---
 
 # छह, सात, आठ, नौ, दस — six to ten, the same erosion twice more
@@ -51,44 +51,17 @@ Same trade, same reason, two more numbers. This is exactly what the anchor
 lesson meant by "not decay in any bad sense" — it's the standard Prakrit
 weight-conservation move, and by now you've seen it three times.
 
-## ṣaṣ → chhah — a different consonant story
-
-**छह** (*chhah*) continues Sanskrit **ṣaṣ** ("six") — here the retroflex
-sibilant **ṣ** shifted forward into Hindi's **छ** (*ch*), a separate sound
-change from the cluster-simplification story above, but still the same
-overall picture: two thousand years of ordinary use reshaping a Sanskrit
-word into its modern Hindi descendant.
-
-## nava → nau — the consonant that dissolved
-
-**नौ** (*nau*) continues Sanskrit **nava** ("nine") differently again: the
-**v** between the two vowels didn't survive at all — it weakened and
-disappeared, and the two vowels either side of it **contracted into one
-diphthong**, *-ava-* → *-au-*. Compare this to *pāṁch*'s nasal-migration
-story from lesson 6: different mechanism, same underlying truth — consonants
-between vowels are exactly where Prakrit did its heaviest wearing-down.
-
-## दस — the simple one
-
-**दस** (*das*) continues Sanskrit **daśa** ("ten") the plainest way of all —
-just the final vowel dropping, no cluster to simplify, no consonant to lose.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "chhah, sāt, āṭh, nau, das"]
 - [YOU SAY: the repeated mechanism — "saptá … satta … **sāt**" and "aṣṭá …
   aṭṭha … **āṭh**"]
-- [YOU SAY: the different one — "nava … **nau**," a **v** dissolving between
-  vowels]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Count six to ten in Hindi. (*Chhah, sāt, āṭh, nau, das*.) What
 mechanism do *sāt* and *āṭh* share with lesson 6's *tīn*? (**Cluster
 simplifies to a geminate, then the geminate simplifies again and the vowel
-lengthens** — the same weight-conservation move, three numbers running.) What
-happened to the **v** in *nava* on its way to *nau*? (It **dissolved between
-the vowels**, which then contracted into one diphthong.) Which of these five
-numbers changed the least from Sanskrit? (**दस**, *das* — just the final
-vowel dropped.)
+lengthens** — the same weight-conservation move, three numbers running.) Next:
+compare the three different histories inside six, nine, and ten.

--- a/code/learning/human-languages/hindi/lessons/HI-C21-six-nine-ten-history.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C21-six-nine-ten-history.md
@@ -1,0 +1,52 @@
+---
+id: HI-C21-six-nine-ten-history
+chapter: 21
+type: etymology
+headword: छह, नौ, दस
+gloss: six shifts a sibilant, nine dissolves intervocalic v, and ten only drops a vowel
+prerequisites: [HI-C21-numbers-6-10]
+sounds: [retroflex-sibilant-shift, intervocalic-v-loss, diphthong-au]
+roots: [sanskrit-sas, sanskrit-nava, sanskrit-dasa]
+etymology_hook: "ṣaṣ → chhah shifts a retroflex sibilant; nava → nau dissolves intervocalic v into a diphthong; daśa → das only drops the final vowel"
+est_minutes: 4
+reviews_of: [HI-C21-numbers-6-10, HI-C06-paanch-nasal]
+---
+
+# छह, नौ, दस — three different paths
+
+## Warm-up
+
+[PAUSE 2s] Seven and eight repeated a familiar weight trade. Six, nine, and ten
+show that not every number took the same road.
+
+## ṣaṣ → chhah — a sibilant moves forward
+
+**छह** (*chhah*) continues Sanskrit **ṣaṣ**, "six." The retroflex sibilant **ṣ**
+shifted forward into Hindi **छ** (*ch*). This is separate from cluster
+simplification, but it is still two thousand years of ordinary speech reshaping
+a Sanskrit word.
+
+## nava → nau — a consonant dissolves
+
+**नौ** (*nau*) continues Sanskrit **nava**. The **v** between vowels weakened
+and disappeared; the vowels on either side contracted into the diphthong
+*-ava-* → *-au-*. Compare *pāṁch*: there a nasal moved into the vowel; here an
+intervocalic consonant dissolved between two vowels.
+
+## daśa → das — the quiet path
+
+**दस** (*das*) continues Sanskrit **daśa** most plainly: the final vowel drops.
+There is no cluster to simplify and no middle consonant to lose.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ṣaṣ … chhah" — the sibilant shifts]
+- [YOU SAY: "nava … nau" — *v* dissolves into a diphthong]
+- [YOU SAY: "daśa … das" — only the final vowel drops]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What happened to **v** in *nava* → *nau*? (It **dissolved between
+vowels**, which contracted.) Which form changed least? (**Das** — only the final
+vowel dropped.) Count six to ten once more. (*Chhah, sāt, āṭh, nau, das*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C22-gyarah-bees.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C22-gyarah-bees.md
@@ -5,12 +5,12 @@ type: word
 headword: ग्यारह — बीस
 gloss: 11-20 — genuinely irregular, must be memorized individually; but उन्नीस (19) most likely preserves Sanskrit's OWN subtractive naming, the same logic as Latin's ūndēvīgintī
 concept_tag: HI-NUMBERS-11-20
-prerequisites: [HI-C21-numbers-6-10]
+prerequisites: [HI-C21-six-nine-ten-history]
 sounds: [conjunct-gya, vowel-sign-ii]
 roots: [sanskrit-ekadasha-vimshati, sanskrit-una-subtractive]
 etymology_hook: "ग्यारह-अठारह (11-18) are each opaque, individually-eroded Sanskrit descendants that must be memorized, unlike Spanish's transparent teens — but उन्नीस (unnīs, 19) most likely continues Sanskrit's OWN subtractive ūnaviṃśati ('one less than twenty,' the later, eka-less form of the fuller Vedic ekonaviṃśati), the SAME logic as Latin's ūndēvīgintī from the Latin numbers lesson — two unrelated language families independently naming 19 as 'twenty minus one'"
-est_minutes: 6
-reviews_of: [HI-C21-numbers-6-10]
+est_minutes: 4
+reviews_of: [HI-C21-six-nine-ten-history, HI-C21-numbers-6-10]
 ---
 
 # ग्यारह, बीस — genuinely irregular, and one honest exception

--- a/code/learning/human-languages/hindi/lessons/HI-C23-billi-history.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C23-billi-history.md
@@ -1,0 +1,50 @@
+---
+id: HI-C23-billi-history
+chapter: 23
+type: etymology
+headword: बिल्ली
+gloss: cat — probably a Dravidian loan into Sanskrit, but the deeper origin remains disputed
+romanization: "billī"
+prerequisites: [HI-C23-kutta-billi]
+sounds: [conjunct-lli]
+roots: [dravidian-bidala-cat]
+etymology_hook: "billī traces through Prakrit to Sanskrit biḍāla; most linguists treat biḍāla as a Dravidian loan, though serious alternatives make this a probable rather than certain fourth cat-word family"
+est_minutes: 4
+reviews_of: [HI-C23-kutta-billi]
+---
+
+# बिल्ली — a probable fourth cat-word family
+
+## Warm-up
+
+[PAUSE 2s] Hindi's dog-word joined three mysteries. Its cat-word probably opens
+a family separate from the widespread *qiṭṭ/cattus/gato/chat/Katze* story.
+
+## The route into Hindi
+
+**बिल्ली** (*billī*, "cat") traces through Sauraseni Prakrit to Sanskrit
+**बिडालिका** (*biḍālikā*), a diminutive of **बिडाल** (*biḍāla*, "cat").
+
+Be honest about the deeper step: most linguists consider *biḍāla* a loanword
+**into Sanskrit from Dravidian**, but this is not universal. Some scholars are
+skeptical of the comparison; another serious proposal derives it from an
+unattested native compound, ***vidāla**, "that which tears apart small birds."
+
+If the leading Dravidian account is right, *billī* belongs to a probable fourth
+cat-word family. Arabic *qiṭṭ*, Latin *cattus*, Spanish *gato*, French *chat*,
+and German *Katze* are usually linked to one Afro-Asiatic source; Hindi's word
+would instead descend from a word Sanskrit borrowed from Dravidian.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "billī" — cat]
+- [YOU TRACE: *biḍāla* → *biḍālikā* → Prakrit → *billī*]
+- [YOU QUALIFY: "probably Dravidian, not proven"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does **बिल्ली** most likely come from? (**Dravidian**, via
+Sanskrit *biḍāla*.) Is that universally agreed? (**No** — it is the leading
+account with serious alternatives.) Why is this a new cat-word family? (It is
+probably separate from the *qiṭṭ/cattus* family.)

--- a/code/learning/human-languages/hindi/lessons/HI-C23-kutta-billi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C23-kutta-billi.md
@@ -2,25 +2,23 @@
 id: HI-C23-kutta-billi
 chapter: 23
 type: word
-headword: कुत्ता, बिल्ली
-gloss: dog and cat — kutta is a THIRD instance of a genuinely-uncertain-origin word displacing the PIE-inherited word for dog (echoing perro/can and dog/hound); billi most likely traces to Sanskrit's own loan from DRAVIDIAN — a probable fourth, separate "cat word" family in this course
+headword: कुत्ता
+gloss: dog — a third uncertain-origin everyday word displacing an inherited PIE dog-word
 concept_tag: HI-ANIMALS
 prerequisites: [HI-C22-gyarah-bees]
 sounds: [conjunct-tta, conjunct-lli]
 roots: [uncertain-kutta, dravidian-bidala-cat]
 etymology_hook: "कुत्ता (kuttā, 'dog') is of genuinely UNCERTAIN origin — either onomatopoeic or non-Indo-Aryan, linguists disagree — and it displaced Sanskrit's own PIE-inherited word for dog, श्वान (śvān, cognate with Latin canis, English hound/German Hund), the SAME shape of mystery-word-displaces-inherited-word as Spanish's perro and English's dog; बिल्ली (billī, 'cat') most likely traces to Sanskrit बिडाल (biḍāla), itself most likely (though not universally agreed) a loan from Dravidian — a probable fourth, separate cat-word family, distinct from the Afro-Asiatic cattus/qitt story"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [HI-C22-gyarah-bees]
 ---
 
-# कुत्ता, बिल्ली — a third mystery dog-word, and a fourth cat-word family
+# कुत्ता — a third mystery dog-word
 
 ## Warm-up
 
-[PAUSE 2s] You've now met a mystery dog-word in Spanish, and another one in
-English/German. Hindi genuinely gives you a **third** — and its cat-word
-opens up a completely separate story, tracing all the way back to the
-Dravidian languages you already know from elsewhere in this course.
+[PAUSE 2s] You have met a mystery dog-word in Spanish and another in
+English/German. Hindi genuinely gives you a **third**.
 
 ## कुत्ता — a third mystery, displacing Sanskrit's own PIE word
 
@@ -39,30 +37,12 @@ Spanish's *perro* displacing *can*, and English's *dog* displacing *hound*.
 Three unrelated language families, three mystery words, all crowding out the
 same inherited PIE word for "dog."
 
-## बिल्ली — most likely Sanskrit's own loan from Dravidian
-
-**बिल्ली** (*billī*, "**cat**") traces through Sauraseni Prakrit to Sanskrit
-**बिडालिका** (*biḍālikā*), a diminutive of **बिडाल** (*biḍāla*, "cat"). Be
-honest that *biḍāla*'s own origin isn't fully settled: most linguists
-consider it most likely a loanword **into** Sanskrit **from Dravidian**, but
-this isn't universal — some (notably Mayrhofer) are skeptical of the
-Dravidian comparison, and at least one serious alternative derives it from
-an unattested native Sanskrit compound instead, ***vidāla**, "that which
-tears apart [small birds]." If the Dravidian derivation holds, this opens up
-a probable **fourth** cat-word story in this course: unlike Arabic's *qiṭṭ*,
-Latin's *cattus*, Spanish's *gato*, French's *chat*, and German's *Katze* —
-all most likely cousins of the same Afro-Asiatic root — Hindi's *billī*
-would come from a **completely separate** word family, one that started in
-the Dravidian languages themselves before Sanskrit borrowed it.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "kuttā" — dog, genuinely uncertain origin, displacing
   Sanskrit's own śvān]
 - [YOU SAY: "śvān" — the PIE-inherited word, now rare and formal]
-- [YOU SAY: "billī" — cat, most likely from Sanskrit's own Dravidian
-  loanword]
 
 ## Wrap-up Recall
 
@@ -71,7 +51,5 @@ family does it belong to? (**श्वान**, *śvān* — same PIE root as La
 *canis*, English *hound*, German *Hund*.) Does everyday Hindi use *śvān*?
 (**No** — *kuttā* displaced it, echoing Spanish's *perro* and English's
 *dog*.) Is *kuttā*'s own origin settled? (**No** — genuinely disputed
-between an onomatopoeic origin and a non-Indo-Aryan substrate word.) Where
-does **बिल्ली** most likely come from? (**Dravidian** — via Sanskrit
-*biḍāla*, though this isn't universally agreed — a probable cat-word family
-distinct from Arabic's *qiṭṭ* or Latin's *cattus*.)
+between an onomatopoeic origin and a non-Indo-Aryan substrate word.) Next:
+follow Hindi's cat-word into a probable fourth family.

--- a/code/learning/human-languages/hindi/lessons/HI-C24-hara-pila.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C24-hara-pila.md
@@ -2,24 +2,23 @@
 id: HI-C24-hara-pila
 chapter: 24
 type: word
-headword: हरा, पीला
-gloss: green and yellow — harā traces to Sanskrit's own descendant of the same ancient root behind French's jaune and German's gelb, so Hindi's word for GREEN turns out to be a deep cousin of other languages' words for YELLOW; pīlā comes from a Sanskrit word that also literally means "drunk," though nobody is fully sure why
+headword: हरा
+gloss: green — a deep cousin of German gelb and English yellow from an ancient shining-color root
 concept_tag: HI-COLOUR-GREEN-YELLOW
-prerequisites: [HI-C23-kutta-billi]
+prerequisites: [HI-C23-billi-history]
 sounds: [retroflex-l, vowel-length-aa]
 roots: [pie-ghelh3-shine, sanskrit-pita-drunk]
 etymology_hook: "हरा (harā, 'green') ← Sanskrit हरित (harita, 'green, yellowish, tawny'), from Proto-Indo-European *ǵʰelh₃-, 'to shine' — the SAME confirmed ancient root behind German's gelb, meaning Hindi's word for GREEN is a genuine cousin of German's word for YELLOW (French's jaune is usually traced to this same family too, via Latin galbinus, though that particular link is less secure than the others); पीला (pīlā, 'yellow') ← Prakrit पीअल (pīala) ← Sanskrit पीतल (pītala), from पीत (pīta) — which also literally means 'drunk, quaffed' — though the exact semantic chain connecting 'drink' to 'yellow' is explicitly flagged by sources as uncertain"
-est_minutes: 6
-reviews_of: [HI-C23-kutta-billi]
+est_minutes: 4
+reviews_of: [HI-C23-billi-history, HI-C23-kutta-billi]
 ---
 
-# हरा, पीला — a cousin hiding in plain sight, and a word that also means "drunk"
+# हरा — a color cousin hiding in plain sight
 
 ## Warm-up
 
-[PAUSE 2s] Hindi's green word turns out to share deep roots with words other
-languages use for yellow. Hindi's yellow word hides something even stranger —
-it comes from a word that also means "drunk."
+[PAUSE 2s] Hindi's green word shares deep roots with words other languages use
+for yellow.
 
 ## हरा — a hidden cousin of jaune and gelb
 
@@ -40,34 +39,18 @@ pieces of it. Sanskrit *harita* itself kept some of that blur, historically
 covering shades from green through yellowish and tawny, before Hindi's
 *harā* settled specifically on "green."
 
-## पीला — literally "drunk"
-
-**पीला** (**pīlā**, "**yellow**") traces through **Prakrit** **पीअल**
-(**pīala**) back to **Sanskrit** **पीतल** (**pītala**), built on **पीत**
-(**pīta**) — which means "**yellow**," but **also, literally, "drunk,
-quaffed,"** from a root meaning "to drink." Why would "yellow" and "drunk"
-share a word? Here's the honest answer: the connecting chain is **not
-settled**. One proposed path runs "to drink" → "to become full, swell" →
-"the color of fat" → "yellow" — but sources explicitly flag this specific
-semantic mechanism as **uncertain**, not established fact. What **is** solid
-is the plain sound history: *pīta* → *pītala* → *pīala* → *pīlā*, an entirely
-ordinary chain of yellow-word ancestors ending in Hindi's *pīlā* today.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "हरा" — green, a hidden PIE cousin of German's gelb]
-- [YOU SAY: "पीला" — yellow, literally built on a word meaning "drunk"]
-- [YOU SAY: the contrast — harā's root is SHARED with German's yellow word;
-  pīlā's root carries an unsolved semantic mystery]
+- [YOU SAY: "*ǵʰelh₃-* — shine, then a yellow-to-green color zone"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What ancient Proto-Indo-European root connects **harā** to
 German's *gelb*? (***\*ǵʰelh₃-***, "to shine" — Hindi's GREEN word is a
 genuine cousin of German's YELLOW word; French's *jaune* is usually placed
-in this family too, though that link is less secure.) What does
-**पीत** (*pīta*), the root behind **pīlā**, also literally mean? ("**Drunk,
-quaffed**.") Is the "drink → yellow" semantic connection settled fact?
-(**No** — sources explicitly flag it as uncertain; only the sound-history
-chain *pīta* → *pītala* → *pīala* → *pīlā* is solid.)
+in this family too, though that link is less secure.) Why can one root yield
+green and yellow words? (It once covered a broader **shining yellow-to-green
+zone**.) Next: the yellow word whose sound history is clear but meaning history
+is not.

--- a/code/learning/human-languages/hindi/lessons/HI-C24-pila-history.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C24-pila-history.md
@@ -1,0 +1,51 @@
+---
+id: HI-C24-pila-history
+chapter: 24
+type: etymology
+headword: पीला
+gloss: yellow — a clear sound-history chain built on a Sanskrit word that also means drunk
+romanization: "pīlā"
+prerequisites: [HI-C24-hara-pila]
+sounds: [retroflex-l, vowel-length-i]
+roots: [sanskrit-pita-drunk]
+etymology_hook: "pīta → pītala → pīala → pīlā is secure sound history; why pīta means both yellow and drunk remains explicitly uncertain"
+est_minutes: 4
+reviews_of: [HI-C24-hara-pila]
+---
+
+# पीला — clear sounds, uncertain meaning
+
+## Warm-up
+
+[PAUSE 2s] *Harā* gave a secure ancient color family. Hindi's yellow word gives
+a secure sound chain wrapped around an unsolved semantic mystery.
+
+## The chain
+
+**पीला** (*pīlā*, "yellow") traces through Prakrit **पीअल** (*pīala*) to
+Sanskrit **पीतल** (*pītala*), built on **पीत** (*pīta*).
+
+*Pīta* means "yellow," but also literally **"drunk, quaffed,"** from a root
+meaning "to drink." Why do "yellow" and "drunk" share a word? The connection is
+**not settled**. One proposed path runs "drink" → "become full or swell" → "the
+color of fat" → "yellow," but sources flag that mechanism as uncertain.
+
+What is solid is the ordinary sound history:
+
+> ***pīta* → *pītala* → *pīala* → *pīlā***
+
+Keep the evidence levels separate: trust the forms; label the semantic bridge a
+hypothesis.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pīlā" — yellow]
+- [YOU TRACE: "pīta · pītala · pīala · pīlā"]
+- [YOU QUALIFY: "drink → yellow is uncertain"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **pīta** also mean? (**Drunk, quaffed**.) Is the bridge
+from drinking to yellow settled? (**No**.) What part is secure? (The sound chain
+*pīta* → *pītala* → *pīala* → *pīlā*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C25-din.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C25-din.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C17-dopahar-aadhi-raat]
 sounds: [devanagari-short-i, devanagari-na]
 roots: [sanskrit-dina, pie-dyew-shine]
 etymology_hook: "दिन (din, 'day') ← Sanskrit दिन (dina) ← Proto-Indo-Iranian *dinám ← a SUFFIXED formation on Proto-Indo-European *dyew-/*dyēws- ('to shine, sky') — the same ultimate root as Latin's diēs (*dyēws-, same root at a different ablaut grade), but a SEPARATE derivational branch: din patterns with Lithuanian diena and Proto-Slavic *dьnь, not directly with diēs; Sanskrit's own द्यु (dyu) and दिव् (div) are the unsuffixed root-nouns, actually closer, more direct cousins of diēs than din itself is"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C17-dopahar-aadhi-raat]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C26-raat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C26-raat.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C17-dopahar-aadhi-raat, HI-C25-din]
 sounds: [devanagari-long-aa, devanagari-ta]
 roots: [sanskrit-ratri, pie-h1reh1-rest]
 etymology_hook: "रात (raat, 'night') ← Prakrit रत्ति (ratti) ← Sanskrit रात्रि (rātri) ← Proto-Indo-Iranian *HráHtriH ← Proto-Indo-European *h₁reh₁-trih₂ ('rest' + a feminine suffix); despite both being Indo-European 'night' words, this is a COMPLETELY DIFFERENT PIE root from Latin's nox (*nókʷts) — a genuine false cousin, not a true cognate, unlike Hindi's din/Latin's diēs pair"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C17-dopahar-aadhi-raat, HI-C25-din]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C27-shubh-raatri.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C27-shubh-raatri.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C26-raat]
 sounds: [devanagari-sha, devanagari-bha]
 roots: [sanskrit-shubh-shine, sanskrit-ratri]
 etymology_hook: "शुभ रात्रि (śubh rātri), 'good night,' literally 'auspicious night' — रात्रि here is the FORMAL, literary Sanskrit-derived (tatsama) doublet of the everyday, eroded रात (rāt, tadbhava) from last lesson; शुभ ('auspicious, good') comes from Sanskrit root शुभ् (śubh), 'to be beautiful, splendid,' from a well-sourced PIE root *ḱewbʰ- ('to be beautiful') — a further, more speculative link to *(s)kewh₁-/*ḱew- ('to shine') has also been proposed, but that deeper connection, not *ḱewbʰ- itself, is the genuinely uncertain part"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C26-raat]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C28-subah.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C28-subah.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C25-din, HI-C26-raat]
 sounds: [hindi-ba, hindi-ha]
 roots: [arabic-sbh-dawn]
 etymology_hook: "सुबह (subah, 'morning') is genuinely borrowed — Persian صبح (subh) ← Arabic صبح (ṣubḥ), from the triliteral root ص-ب-ح (ṣ-b-ḥ, 'dawn, to become morning') — the SAME Arabic root already met in this course's Arabic arc, inside تصبح على خير (tuṣbiḥ ʿalā khayr, 'good night,' literally 'may you wake into goodness,' AR-C27); unlike दिन/din and रात/raat (both Sanskrit tatsama, HI-C25/26), Hindi's everyday word for 'morning' isn't Sanskrit at all — a genuine break from the pattern the last two lessons set"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [HI-C25-din, HI-C26-raat]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C29-shaam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C29-shaam.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C28-subah]
 sounds: [hindi-sha, hindi-anusvara]
 roots: [persian-sham-evening]
 etymology_hook: "शाम (shaam, 'evening') is, like सुबह last lesson, a genuine Persian loanword — from Persian شام (šām) ← Proto-Iranian *xšáfnyah ← Proto-Indo-Iranian *kšápā ('night'); be careful here: it LOOKS like it should connect to Sanskrit श्यामा (śyāmā, 'dark, night-colored'), and the resemblance is tempting, but these are NOT related — two separate roots that happened to converge on similar sounds and meanings, a genuine false cognate, not a shared one"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [HI-C28-subah]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C30-dopahar-widened.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C30-dopahar-widened.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C17-dopahar-aadhi-raat, HI-C29-shaam]
 sounds: [devanagari-vowel-sign-o, devanagari-aspirated-pa]
 roots: [do-two, pahar-traditional-watch]
 etymology_hook: "दोपहर (dopahar) is the SAME word already met in HI-C17 meaning precisely 'noon' ('two pahars,' a traditional ~3-hour Indian time-unit, counted from sunrise) — but in modern everyday Hindi, its meaning has genuinely WIDENED: दोपहर now covers the whole afternoon stretch, roughly noon through late afternoon (a meeting 'दोपहर में,' 'in the dopahar,' could mean anywhere from 1pm to 4pm), not just the precise midday instant its etymology points to"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [HI-C17-dopahar-aadhi-raat, HI-C29-shaam]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C31-suprabhat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C31-suprabhat.md
@@ -9,7 +9,7 @@ prerequisites: [HI-C28-subah]
 sounds: [devanagari-conjunct-pra, devanagari-bha]
 roots: [su-good, prabhata-dawn-sanskrit]
 etymology_hook: "सुप्रभात (suprabhāt, 'good morning') = सु ('good') + प्रभात (prabhāta, native Sanskrit 'dawn, daybreak,' from प्रभा/prabhā, 'light, splendour,' itself from भा, 'to shine,' + preverb प्र-, 'forth' + suffix -त) — a COMPLETELY DIFFERENT root from सुबह (subah, HI-C28's Persian/Arabic loan for the everyday noun 'morning'); be honest about its actual register, though: sources describe सुप्रभात as skewing FORMAL and WRITTEN (speeches, radio, greeting-card/WhatsApp-forward culture) rather than casual spoken Hindi, where नमस्ते commonly covers mornings too — this is a genuine formal/everyday split, though there's no strong evidence सुप्रभात itself is being routinely code-switched to English the way some sources (thinly) suggested for other languages' night greetings in this arc"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [HI-C28-subah]
 ---
 

--- a/code/learning/human-languages/hindi/lessons/HI-C32-evening-register.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C32-evening-register.md
@@ -1,0 +1,48 @@
+---
+id: HI-C32-evening-register
+chapter: 32
+type: grammar
+headword: शुभ संध्या / नमस्ते
+gloss: good evening leans written and greeting-card formal while namaste covers casual evenings
+romanization: "shubh sandhyā / namaste"
+prerequisites: [HI-C32-shubh-sandhya]
+sounds: [hindi-formal-register]
+roots: [sandhya-written-greeting, namaste-all-day]
+est_minutes: 4
+reviews_of: [HI-C32-shubh-sandhya, HI-C31-suprabhat, HI-C01-namaste]
+---
+
+# शुभ संध्या or नमस्ते? — choose by setting
+
+## Warm-up
+
+[PAUSE 2s] *Shubh sandhyā* is structurally transparent. The final question is
+where Hindi speakers actually reach for it.
+
+## Written warmth and casual speech
+
+Like **सुप्रभात**, **शुभ संध्या** appears heavily in **written and social
+greeting-card culture**: greeting poetry, WhatsApp messages, and evening
+well-wishes. It is less likely to open an ordinary mid-conversation exchange.
+
+**नमस्ते** works at any time of day, evenings included, and is more common in
+casual conversation than either *shubh prabhāt* or *shubh sandhyā*. The native
+language has divided the jobs: a Sanskrit "good ___" phrase for formal or
+written warmth, and another native greeting for everyday speech.
+
+This is not English displacing a Hindi greeting. It is Hindi choosing between
+two of its own expressions by register and medium.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU CHOOSE: a WhatsApp evening card → **शुभ संध्या**]
+- [YOU CHOOSE: greeting someone casually at 7 p.m. → **नमस्ते**]
+- [YOU SAY: "formal/written is a tendency, not an absolute ban"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does **शुभ संध्या** especially thrive? (**Written and social
+greeting-card culture**.) Does **नमस्ते** genuinely work in the evening?
+(**Yes** — it works at any time and is common casually.) Is the distinction
+Hindi versus English? (**No** — it is a native register/medium choice.)

--- a/code/learning/human-languages/hindi/lessons/HI-C32-shubh-sandhya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C32-shubh-sandhya.md
@@ -3,13 +3,13 @@ id: HI-C32-shubh-sandhya
 chapter: 32
 type: phrase
 headword: शुभ संध्या
-gloss: "good evening" (shubh sandhya) — संध्या is native Sanskrit, "the junction of day and night," with its own tadbhava doublet साँझ; like सुप्रभात, this leans toward written/greeting-card use, with नमस्ते covering evenings casually too
+gloss: "good evening" — sandhyā is the Sanskrit junction of day and night, with the register-crossing doublet sāñjh
 concept_tag: GREETING-EVENING
 prerequisites: [HI-C29-shaam, HI-C31-suprabhat, HI-C27-shubh-raatri]
 sounds: [devanagari-anusvara, devanagari-conjunct-dhya]
 roots: [su-good, sandhya-junction-sanskrit]
 etymology_hook: "शुभ संध्या (shubh sandhyā, 'good evening') pairs शुभ ('good') with संध्या (sandhyā, native Sanskrit, from सम् + धा, 'to hold together' — literally 'the junction of day and night,' i.e. twilight); संध्या has its own Hindi tadbhava doublet, साँझ (sāñjh, evolved via Prakrit) — but unlike रात्रि/राat's tatsama/tadbhava split (HI-C26/27), साँझ isn't simply the eroded-casual counterpart: sources describe it as used across BOTH literary/poetic and everyday registers, not confined to one; शुभ संध्या itself, like सुप्रभात, shows up heavily in written/greeting-card and social-media culture, with नमस्ते — confirmed usable at any time of day, including evening — covering the casual spoken gap"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [HI-C29-shaam, HI-C31-suprabhat]
 ---
 
@@ -41,28 +41,13 @@ and the tatsama stayed formal, sources describe **साँझ** as used across
 "the casual one." The doublet exists; the clean formal/casual split
 doesn't carry over as neatly this time.
 
-## Be honest: written greeting-card culture, and नमस्ते again
-
-Like सुप्रभात last lesson, **शुभ संध्या** shows up heavily in **written
-and social greeting-card culture** — shayari (Hindi greeting-poetry),
-WhatsApp messages, evening well-wishes — more than as something reached
-for mid-conversation. And, confirmed independently this time:
-**नमस्ते** genuinely does work "at any time of day," evenings included,
-and is described as the more commonly used greeting in **casual**
-conversation than either शुभ प्रभात or शुभ संध्या. The same honest
-pattern from last lesson holds: a Sanskrit "good ___" phrase skewing
-formal/written, with नमस्ते filling the everyday spoken gap — not
-English displacing it, just a different native word doing the casual
-work.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "shubh sandhyā" — "good evening," su + sandhyā]
 - [YOU SAY: sandhyā's own meaning — "holding together," the junction of
   day and night]
-- [YOU SAY: the honest note — शुभ संध्या leans written/greeting-card;
-  नमस्ते covers casual evenings too]
+- [YOU CONTRAST: tatsama *sandhyā* · evolved doublet *sāñjh*]
 
 ## Wrap-up Recall
 
@@ -70,6 +55,5 @@ work.
 ("**Holding together**" — सम् + धा — i.e. the junction of day and
 night.) Does साँझ work the same way रात्रि/राat's tatsama/tadbhava split
 did — one strictly formal, one strictly casual? (**No** — साँझ is used
-across both literary and everyday registers, not confined to one.) Does
-नमस्ते genuinely work for evenings too? (**Yes** — confirmed usable at
-any time of day, and more common in casual speech than शुभ संध्या.)
+across both literary and everyday registers, not confined to one.) Next:
+choose between the written greeting and the casual all-day greeting.

--- a/code/learning/human-languages/hindi/lessons/HI-C33-shubh-dopahar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C33-shubh-dopahar.md
@@ -5,12 +5,12 @@ type: phrase
 headword: शुभ दोपहर
 gloss: "good afternoon" (shubh dopahar) — uses दोपहर in its modern, widened "afternoon" sense (HI-C30), not the narrow etymological "noon"; the rarest of this arc's three शुभ+noun greetings in actual casual use, with नमस्ते/नमस्कार covering the afternoon in practice
 concept_tag: GREETING-AFTERNOON
-prerequisites: [HI-C30-dopahar-widened, HI-C32-shubh-sandhya]
+prerequisites: [HI-C30-dopahar-widened, HI-C32-evening-register]
 sounds: [devanagari-vowel-sign-o, devanagari-aspirated-pa]
 roots: [su-good, do-two, pahar-traditional-watch]
 etymology_hook: "शुभ दोपहर (shubh dopahar, 'good afternoon') pairs शुभ with दोपहर IN ITS WIDENED MODERN SENSE (HI-C30's 'the whole afternoon,' not the narrow etymological 'exactly noon') — but of this arc's three शुभ+timeword greetings, this is the one described as most clearly rare/uncommon in actual spoken use, more so than सुप्रभात or शुभ संध्या; sources describe it as formal/written only, with casual alternatives like आपका दोपहर शुभ हो ('may your afternoon be good') existing but still uncommon, and नमस्ते/नमस्कार doing the real everyday work, all day including afternoon"
-est_minutes: 5
-reviews_of: [HI-C30-dopahar-widened, HI-C32-shubh-sandhya]
+est_minutes: 4
+reviews_of: [HI-C30-dopahar-widened, HI-C32-evening-register, HI-C32-shubh-sandhya]
 ---
 
 # शुभ दोपहर (shubh dopahar) — "good afternoon," this arc's rarest greeting

--- a/code/learning/human-languages/hindi/lessons/HI-W01-na-ma.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W01-na-ma.md
@@ -1,0 +1,61 @@
+---
+id: HI-W01-na-ma
+chapter: 1
+type: writing
+headword: "न, म"
+gloss: the first two Devanagari letters, sharing a right spine and a top bar
+romanization: "na, ma"
+prerequisites: [HI-W01-shirorekha-na-ma]
+sounds: [devanagari-top-bar, devanagari-spine]
+roots: [devanagari-spine-family]
+est_minutes: 4
+reviews_of: [HI-W01-shirorekha-na-ma, HI-C01-namaste, HI-C01-namaskar]
+---
+
+# न and म — two bodies under one head-line
+
+## Warm-up
+
+[PAUSE 2s] You know the bar is usually drawn last. Now give it two letter
+bodies to cap.
+
+## न — "na"
+
+Three pieces:
+
+1. **a left bowl** — a rounded scoop on the left.
+2. **a right spine** — a vertical downstroke on the right.
+3. **the top bar** — capping both. *Last.*
+
+## म — "ma"
+
+Four pieces — the same spine, with two loops instead of a bowl:
+
+1. **a lower loop**
+2. **an upper loop**, sitting above it
+3. **the right spine**
+4. **the top bar** — last, again.
+
+## The shared frame
+
+Both letters have a **vertical spine on the right**, with the distinguishing
+shape hanging to its left. This is Devanagari's commonest skeleton: **spine on
+the right, character on the left, bar across the top**. Learn the frame once
+and many new letters are only a new left-hand part.
+
+"Commonest," not "only" — a minority of letters (**द** and **र** among them)
+have **no** right-hand spine at all. You will meet them as they come.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: न — "bowl, spine, **bar last**"]
+- [YOU WRITE: म — "lower loop, upper loop, spine, **bar last**"]
+- [YOU WRITE: न and म side by side, then **one single bar across both**]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Draw **न** — its three pieces? (Bowl, spine, bar.) Draw **म** — what
+makes it different? (**Two loops** where न has one bowl.) Where does the spine
+sit in both? (**On the right** — though a minority of letters have none.) Next:
+the vowel already hiding inside each consonant.

--- a/code/learning/human-languages/hindi/lessons/HI-W01-shirorekha-na-ma.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W01-shirorekha-na-ma.md
@@ -2,9 +2,9 @@
 id: HI-W01-shirorekha-na-ma
 chapter: 1
 type: writing
-headword: "न, म"
-gloss: the shirorekhā (the line Devanagari hangs from) and your first two letters, न (na) and म (ma)
-romanization: "na, ma"
+headword: "शिरोरेखा"
+gloss: the head-line that Devanagari letters hang from, including its usual stroke-order convention
+romanization: "shirorekhā"
 prerequisites: [HI-C01-namaste]
 sounds: [devanagari-top-bar, devanagari-spine]
 roots: [sanskrit-shiras, sanskrit-rekha]
@@ -13,7 +13,7 @@ est_minutes: 4
 reviews_of: [HI-C01-namaste, HI-C01-namaskar]
 ---
 
-# The line on top — and न, म
+# The line on top — Devanagari's head-line
 
 ## Warm-up
 
@@ -53,49 +53,17 @@ for. Read the word; don't try to draw it. This track only asks you to hand-write
 letters whose stroke data actually exists, and it will say so every time that gap
 shows up.
 
-## न — "na"
-
-Three pieces:
-
-1. **a left bowl** — a rounded scoop on the left.
-2. **a right spine** — a vertical downstroke on the right.
-3. **the top bar** — capping both. *Last.*
-
-## म — "ma"
-
-Four pieces — the same spine, with two loops instead of a bowl:
-
-1. **a lower loop**
-2. **an upper loop**, sitting above it
-3. **the right spine**
-4. **the top bar** — last, again.
-
-## The pattern you should already be noticing
-
-Both letters end with *the top bar*. And both have a **vertical spine on the
-right**, with the letter's distinguishing shape hanging off to the left of it.
-
-That is the commonest Devanagari skeleton: **spine on the right, character on the
-left, bar across the top.** Learn the frame once and many new letters are only
-the left-hand part.
-
-"Commonest," not "only" — a minority of letters (**द** and **र** among them)
-have **no** right-hand spine at all. You'll meet them as they come.
-
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU WRITE: न — "bowl, spine, **bar last**"]
-- [YOU WRITE: म — "lower loop, upper loop, spine, **bar last**"]
-- [YOU WRITE: न and म side by side, then **one single bar across both**]
+- [YOU TRACE: the bar across **नमस्ते**, from left edge to right edge]
+- [YOU GESTURE: write letter bodies first, then cap the whole word]
 - [YOU SAY: "शिरोरेखा — the **head-line**"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What is the line across the top called, and what does the word
 literally mean? (**Shirorekhā** — "**head-line**".) When is it usually drawn?
-(**Last** — and as **one** line across the whole word. Usually: it's the common
-convention, not a rule.) Draw **न** — its
-three pieces? (Bowl, spine, bar.) Draw **म** — what makes it different from न?
-(**Two loops** where न has one bowl.) Where does the spine sit in both? (**On the
-right** — though a minority of letters have none at all.) Next: the surprise hiding inside every Devanagari consonant.
+(**Last** — and as **one** line across the whole word. Usually: it is the common
+convention, not a rule.) What ancient root sits inside *śiras*, "head"? (PIE
+***ḱerh₂-***, also behind **horn**.) Next: hang your first two letters from it.

--- a/code/learning/human-languages/hindi/lessons/HI-W02-abugida-ka-ta.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W02-abugida-ka-ta.md
@@ -2,18 +2,18 @@
 id: HI-W02-abugida-ka-ta
 chapter: 1
 type: writing
-headword: "क, त"
-gloss: "the inherent vowel — क is not 'k' but 'ka' — plus the letters क and त"
-romanization: "ka, ta"
-prerequisites: [HI-W01-shirorekha-na-ma]
+headword: "अ"
+gloss: "the inherent vowel — every Devanagari consonant arrives with a built-in a"
+romanization: "a"
+prerequisites: [HI-W01-na-ma]
 sounds: [devanagari-inherent-vowel, devanagari-spine]
 roots: [ethiopic-abugida]
 etymology_hook: "a script whose consonants carry a built-in vowel is called an ABUGIDA — a name coined from Ge'ez, and cleverly built: ʾä-bu-gi-da names the first four consonants of the old SEMITIC letter order AND the first four VOWEL series at once, so the word demonstrates the very consonant-plus-vowel system it names"
-est_minutes: 5
-reviews_of: [HI-W01-shirorekha-na-ma, HI-C01-namaste]
+est_minutes: 4
+reviews_of: [HI-W01-na-ma, HI-W01-shirorekha-na-ma, HI-C01-namaste]
 ---
 
-# The vowel that's already there — and क, त
+# The vowel that is already there — the abugida
 
 ## Warm-up
 
@@ -64,52 +64,12 @@ consonant plus vowel, four times over. A term that performs its own definition.
 *abugida* is a scholar's coinage drawing on the inherited Semitic order, not the
 Ethiopian schoolroom one.)
 
-## क — "ka"
-
-1. **a left loop**
-2. **a vertical spine** on the right
-3. **the top bar** — last.
-
-## त — "ta"
-
-1. **a small left curl**
-2. **a tall spine**
-3. **the top bar** — last.
-
-Same frame as before: spine right, shape left, bar on top. Only the left-hand
-part changes.
-
-## Why the letters are in the order they're in
-
-One more thing worth knowing, because it makes the whole script feel less
-arbitrary. The heart of the Devanagari consonant order is not historical accident
-like A-B-C. The stops are grouped into five families (*vargas*), **sorted by
-where in your mouth the closure happens** — starting at the soft palate and
-walking forward to the lips:
-
-**क** (soft palate) → **च** (hard palate) → **ट** (roof, tongue curled back) →
-**त** (teeth) → **प** (lips)
-
-Say those five in order and feel the closure travel forward. Indian phoneticians
-organised the sounds this way well over two thousand years ago — Pāṇini's work is
-roughly 4th century BCE — producing a phonetics chart memorised as an alphabet,
-long before anyone in Europe attempted the same analysis.
-
-Two honest footnotes. The tidy front-to-back walk describes the **five stop
-families**, not the whole letter list — the vowels come first, and ह sits at the
-very end after the labials. And of those five sample letters, **ट is not yet in
-this curriculum's Devanagari data**: read it here, and you'll draw it when its
-entry is written. This track only asks you to hand-write letters whose stroke
-data actually exists.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "क is **ka**, not k"]
-- [YOU WRITE: क — "loop, spine, bar last"]
-- [YOU WRITE: त — "curl, spine, bar last"]
 - [YOU WRITE: नम — two letters, **one bar across both** — "nama"]
-- [YOU SAY: the mouth-walk — "ka … ca … ṭa … ta … pa", back to front]
+- [YOU SAY: "abugida — a consonant plus its built-in vowel"]
 
 ## Wrap-up Recall
 
@@ -118,6 +78,4 @@ is that vowel called? (The **inherent vowel**.) What kind of script is this, and
 where does the word come from? (An **abugida** — *ʾä-bu-gi-da*, from Ge'ez,
 naming four **consonants** of the old Semitic order **and** four **vowel series**
 at once, so the word performs its own definition.) Write **नम** — what does it
-say? (*Nama*.) What orders the five stop families? (**Place of articulation** —
-soft palate forward to the lips.) Next: how to get rid of the inherent vowel
-and put a different one in.
+say? (*Nama*.) Next: two more letters, and the sound-map that orders them.

--- a/code/learning/human-languages/hindi/lessons/HI-W02-ka-ta-mouth-order.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W02-ka-ta-mouth-order.md
@@ -1,0 +1,66 @@
+---
+id: HI-W02-ka-ta-mouth-order
+chapter: 1
+type: writing
+headword: "क, त"
+gloss: write ka and ta, then feel why Devanagari's stop families follow a mouth-map
+romanization: "ka, ta"
+prerequisites: [HI-W02-abugida-ka-ta]
+sounds: [devanagari-inherent-vowel, devanagari-spine]
+roots: [sanskrit-varga, panini-phonetics]
+est_minutes: 4
+reviews_of: [HI-W02-abugida-ka-ta, HI-W01-na-ma]
+---
+
+# क and त — two letters on a map of the mouth
+
+## Warm-up
+
+[PAUSE 2s] The built-in vowel means these are **ka** and **ta**, not bare *k*
+and *t*. Their shapes share the frame you already know.
+
+## क — "ka"
+
+1. **a left loop**
+2. **a vertical spine** on the right
+3. **the top bar** — last.
+
+## त — "ta"
+
+1. **a small left curl**
+2. **a tall spine**
+3. **the top bar** — last.
+
+Same frame as before: spine right, shape left, bar on top. Only the left-hand
+part changes.
+
+## Why the letters are in this order
+
+The heart of the Devanagari consonant order is not a historical accident like
+A-B-C. Its five stop families (*vargas*) are sorted by **where in your mouth the
+closure happens**, starting at the soft palate and walking forward to the lips:
+
+**क** (soft palate) → **च** (hard palate) → **ट** (roof, tongue curled back) →
+**त** (teeth) → **प** (lips)
+
+Say those five and feel the closure travel forward. Indian phoneticians
+organised sounds this way well over two thousand years ago — Pāṇini's work is
+roughly fourth century BCE — producing a phonetics chart memorised as an
+alphabet long before Europe attempted the same analysis.
+
+Two honest footnotes: this walk describes the **five stop families**, not the
+whole list; and **ट** is not yet in this curriculum's stroke data. Read it here
+and draw it only after its entry is authored.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: क — "loop, spine, bar last"]
+- [YOU WRITE: त — "curl, spine, bar last"]
+- [YOU SAY: "ka … ca … ṭa … ta … pa", back to front]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do **क** and **त** say alone? (**Ka**, **ta** — each has an
+inherent vowel.) What orders the five stop families? (**Place of articulation**,
+from the soft palate forward to the lips.) Next: replace that built-in vowel.

--- a/code/learning/human-languages/hindi/lessons/HI-W03-matras-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W03-matras-naam.md
@@ -2,15 +2,15 @@
 id: HI-W03-matras-naam
 chapter: 2
 type: writing
-headword: "ा, े, ि"
-gloss: "mātrās — the vowel signs that replace the inherent 'a', including the one written before the letter it follows; writing नाम"
-romanization: "ā, e, i"
-prerequisites: [HI-W02-abugida-ka-ta, HI-W01-shirorekha-na-ma]
+headword: "ा, े"
+gloss: "mātrās — vowel signs that replace the inherent a — and writing नाम"
+romanization: "ā, e"
+prerequisites: [HI-W02-ka-ta-mouth-order, HI-W01-na-ma]
 sounds: [devanagari-matra, devanagari-inherent-vowel]
 roots: [sanskrit-matra, pie-meh1]
 etymology_hook: "mātrā मात्रा means 'a MEASURE' — from mā- 'to measure', PIE *meh₁-, the root behind English METER, MEASURE, and even MONTH (the moon being the old measurer of time); the vowel signs are literally the measures of the syllable"
-est_minutes: 5
-reviews_of: [HI-W02-abugida-ka-ta, HI-C02-naam]
+est_minutes: 4
+reviews_of: [HI-W02-ka-ta-mouth-order, HI-W02-abugida-ka-ta, HI-C02-naam]
 ---
 
 # Mātrās — swapping the built-in vowel
@@ -53,28 +53,6 @@ You have न, ा, म. That is enough for the Hindi word for "name" (Chapter 2)
 
 Write the three characters, then draw **one bar** across all of them.
 
-## The famous one
-
-Mātrās can attach almost anywhere — right, above, below. And one of them goes
-somewhere that will feel wrong for a while:
-
-**ि** — the vowel **i** — is written **BEFORE** the consonant, to its **left**,
-but pronounced **AFTER** it.
-
-> श + ि → **शि**, and that says ***śi***, not *iś*.
-
-Read it aloud in the order you'd guess and you get the wrong word. The mark
-*leans left* on the page and *lands right* in the mouth.
-
-There is no satisfying reason for it. It is an inherited quirk — the placement
-comes down from the script's Brahmi ancestry, and it simply stuck. Don't look for
-logic; your eye will learn it faster than your intuition will.
-
-The rule to carry away:
-
-> **A mātrā replaces the inherent vowel. And one of them — ि, the only one in
-> Hindi that does this — is written before the consonant it follows.**
-
 ## Guided Practice
 
 [PAUSE 1s]
@@ -82,7 +60,6 @@ The rule to carry away:
 - [YOU WRITE: मे — "ma, then the stroke above" — *me*]
 - [YOU WRITE: **नाम** — three characters, **one bar**, "nām"]
 - [YOU SAY: "**मात्रा** = a **measure**"]
-- [YOU SAY: the warning — "शि is ***śi***, not *iś*"]
 
 ## Wrap-up Recall
 
@@ -90,6 +67,4 @@ The rule to carry away:
 adds to it.) What does the word *mātrā* mean, and what English words share its
 root? ("**Measure**" — *meter*, *measure*, *month*.) Where does **ा** attach, and
 where does **े**? (Right; above the bar.) Write **नाम** — what does it mean?
-("**Name**".) And the trap: **शि** — is that *śi* or *iś*? (***Śi*** — the ि is
-written **before** but pronounced **after**.) Next: र and स, and your own name
-sentence.
+("**Name**".) Next: the one mātrā whose position tries to fool your eye.

--- a/code/learning/human-languages/hindi/lessons/HI-W03-preposed-i.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W03-preposed-i.md
@@ -1,0 +1,53 @@
+---
+id: HI-W03-preposed-i
+chapter: 2
+type: writing
+headword: "ि"
+gloss: the i mātrā is written before the consonant it is pronounced after
+romanization: "i"
+prerequisites: [HI-W03-matras-naam]
+sounds: [devanagari-matra, devanagari-preposed-i]
+roots: [brahmi-vowel-signs]
+est_minutes: 4
+reviews_of: [HI-W03-matras-naam, HI-W02-abugida-ka-ta]
+---
+
+# ि — left on the page, right in the mouth
+
+## Warm-up
+
+[PAUSE 2s] **ा** sits to the right and **े** above. One Hindi vowel sign goes
+somewhere that will feel wrong for a while.
+
+## The famous mātrā
+
+**ि** — the vowel **i** — is written **before** the consonant, to its **left**,
+but pronounced **after** it:
+
+> श + ि → **शि**, and that says ***śi***, not *iś*.
+
+Read it aloud in the order you might guess and you get the wrong word. The mark
+*leans left* on the page and *lands right* in the mouth.
+
+There is no satisfying modern logic behind the placement. It comes down from
+the script's Brahmi ancestry and simply stuck. Your eye will learn it faster
+than your intuition will.
+
+The rule to carry away:
+
+> **A mātrā replaces the inherent vowel. And ि — the only Hindi mātrā that does
+> this — is written before the consonant it follows.**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU TRACE: ि + श as the visual order in **शि**]
+- [YOU SAY: "śi — the mark leans left and lands right"]
+- [YOU CONTRAST: **ना** *nā* · **मे** *me* · **शि** *śi*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] **शि** — *śi* or *iś*? (***Śi***.) Where is ि written, and where is
+it pronounced? (**Before** the consonant on the page, **after** it in speech.)
+Does it add to the inherent vowel? (**No** — it replaces it.) Next: र and स,
+then your own name phrase.

--- a/code/learning/human-languages/hindi/lessons/HI-W04-ra-sa-mera-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W04-ra-sa-mera-naam.md
@@ -3,22 +3,21 @@ id: HI-W04-ra-sa-mera-naam
 chapter: 2
 type: writing
 headword: "र, स"
-gloss: "र (ra) and स (sa) — your first spineless letter — and hand-writing मेरा नाम"
+gloss: "र (ra) and स (sa), including your first spineless letter and a carefully qualified distant cousin"
 romanization: "ra, sa"
-prerequisites: [HI-W03-matras-naam, HI-W01-shirorekha-na-ma]
+prerequisites: [HI-W03-preposed-i, HI-W01-na-ma]
 sounds: [devanagari-spine, devanagari-matra]
 roots: [sanskrit-sa, greek-sigma]
 etymology_hook: "Greek SIGMA and Latin S descend from the Phoenician letter šin — and on the leading (though not universally accepted) account, Brahmi, Devanagari's ancestor, came from the same Semitic family by way of Aramaic; if that is right, स and S are very distant cousins that stopped looking alike thousands of years ago"
-est_minutes: 5
-reviews_of: [HI-W03-matras-naam, HI-C02-meraa, HI-C02-mera-naam-hai]
+est_minutes: 4
+reviews_of: [HI-W03-preposed-i, HI-W03-matras-naam, HI-C02-meraa, HI-C02-mera-naam-hai]
 ---
 
-# र and स — and writing "my name"
+# र and स — a spineless letter and a possible cousin
 
 ## Warm-up
 
-[PAUSE 2s] Two more letters, and then you can hand-write a whole phrase from
-Chapter 2.
+[PAUSE 2s] Two more letters put every consonant in "my name" within reach.
 
 ## र — "ra", your first spineless letter
 
@@ -62,33 +61,11 @@ So: if the mainstream account holds, स and S share a great-great-grandparent s
 three thousand years back, with no family resemblance left at all. Say "probably
 cousins," not "cousins."
 
-## Write the phrase
-
-You now have every piece of *merā nām* — "my name" (Chapter 2):
-
-| | |
-|---|---|
-| **मेरा** | म + े + र + ा — *merā*, "my" |
-| **नाम** | न + ा + म — *nām*, "name" |
-
-> **मेरा नाम**
-
-Two words, so **two bars**. Modern Hindi separates words with an ordinary space,
-exactly like English — and because the shirorekhā is drawn over each word, the
-space shows up as a **break in the line**. The gap in the bar is the *result* of
-the space, not a substitute for it.
-
-(Worth knowing why that needs saying: classical Sanskrit manuscripts often ran
-words together with no spaces at all, so the bar really was continuous across a
-whole line. Modern Hindi doesn't do that.)
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU WRITE: र — "shoulder, downstroke, bar" — **no spine**]
 - [YOU WRITE: स — "curl, body, spine, bar"]
-- [YOU WRITE: **मेरा** — four pieces, one bar]
-- [YOU WRITE: **मेरा नाम** — two words, **two separate bars**]
 - [YOU SAY: the probable cousins — "Σ · S from *šin* … and **probably** स too"]
 
 ## Wrap-up Recall
@@ -98,7 +75,5 @@ right-hand spine** — just a shoulder and a downstroke.) Is it the only spinele
 letter? (**No** — **द** is one too, and there are a few others.) Draw **स** — four pieces? (Curl, body,
 spine, bar.) Which English letter might स be related to, and how sure are we?
 (**S** — certainly *šin* → Σ → S going west; the eastern leg through Aramaic to
-**Brahmi** is the **leading view, not settled**.) Write **मेरा नाम** — how many
-bars, and why? (**Two** — Hindi uses an ordinary **space**, and the bar breaks
-because of it.) Next: the mark that
-kills a vowel, and you'll write *namaste*.
+**Brahmi** is the **leading view, not settled**.) Next: assemble those letters
+into "my name" and let the word boundary break the head-line.

--- a/code/learning/human-languages/hindi/lessons/HI-W04-write-mera-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W04-write-mera-naam.md
@@ -1,0 +1,52 @@
+---
+id: HI-W04-write-mera-naam
+chapter: 2
+type: writing
+headword: "मेरा नाम"
+gloss: assemble my name from known letters and show word spacing as two head-lines
+romanization: "merā nām"
+prerequisites: [HI-W04-ra-sa-mera-naam, HI-W03-matras-naam]
+sounds: [devanagari-spine, devanagari-matra, devanagari-top-bar]
+roots: [hindi-word-spacing]
+est_minutes: 4
+reviews_of: [HI-W04-ra-sa-mera-naam, HI-W03-matras-naam, HI-C02-meraa, HI-C02-mera-naam-hai]
+---
+
+# मेरा नाम — two words, two head-lines
+
+## Warm-up
+
+[PAUSE 2s] You now know every piece of *merā nām*, "my name." This lesson only
+asks you to assemble them and make the word boundary visible.
+
+## Build the phrase
+
+| | |
+|---|---|
+| **मेरा** | म + े + र + ा — *merā*, "my" |
+| **नाम** | न + ा + म — *nām*, "name" |
+
+> **मेरा नाम**
+
+Two words means **two bars**. Modern Hindi separates words with an ordinary
+space, exactly like English. Because the shirorekhā is drawn over each word,
+that space appears as a **break in the line**. The gap in the bar is the result
+of the space, not a substitute for it.
+
+Classical Sanskrit manuscripts often ran words together without spaces, so the
+bar could continue across a whole line. Modern Hindi does not ask you to copy
+that manuscript habit.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **मेरा** — four pieces, one bar]
+- [YOU WRITE: **नाम** — three pieces, one bar]
+- [YOU WRITE: **मेरा नाम** — two words, **two separate bars**]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Write **मेरा नाम**. How many bars, and why? (**Two** — Hindi uses an
+ordinary **space**, and the bar breaks because of it.) Is the gap itself the
+space? (**No** — it is the visible result of the space.) Next: stop an inherent
+vowel, then use that power inside *namaste*.

--- a/code/learning/human-languages/hindi/lessons/HI-W05-conjuncts.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W05-conjuncts.md
@@ -1,0 +1,56 @@
+---
+id: HI-W05-conjuncts
+chapter: 2
+type: writing
+headword: "स्त"
+gloss: a vowel-less consonant usually fuses with the next consonant into a conjunct
+romanization: "sta"
+prerequisites: [HI-W05-virama-namaste, HI-W04-ra-sa-mera-naam]
+sounds: [devanagari-virama, devanagari-conjunct]
+roots: [devanagari-conjunct-formation]
+est_minutes: 4
+reviews_of: [HI-W05-virama-namaste, HI-W04-ra-sa-mera-naam]
+---
+
+# स्त — two consonants squeezed together
+
+## Warm-up
+
+[PAUSE 2s] A visible virama can stop a vowel. In ordinary writing, the stopped
+consonant often goes one step further and fuses with the consonant after it.
+
+## The usual squeeze
+
+The fused shape is a **conjunct**:
+
+> स् + त → **स्त** (*sta*)
+
+Look at स. It loses its right-hand spine, shrinks, and leans into त. For
+**spine-bearing** letters this is the usual move: **the first consonant gives up
+its spine and hands the syllable to the second**.
+
+## Spineless and irregular shapes
+
+र has no spine to give up, so it behaves differently: as a hook above a later
+letter (र् + क → **र्क**) or as a small stroke under an earlier one
+(क + ्र → **क्र**). Other spineless letters, **द** among them, stack or take
+special shapes. A few common conjuncts — **क्ष**, **त्र**, **ज्ञ** — are
+irregular and must be learned whole.
+
+This is why Devanagari seems to have so many shapes: it is not only 40-odd
+letters, but also the ligatures they form when they collide. Do not memorise
+every conjunct as a separate character. Learn to recognise the *squeeze*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: स् — स with the vowel stopped]
+- [YOU WRITE: स्त — watch स **lose its spine** and lean into त]
+- [YOU TRACE: र्क and क्र — two special jobs for spineless र]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What usually happens instead of leaving a virama visible? (The first
+consonant **fuses** with the next into a **conjunct**.) In **स्त**, what does स
+give up? (**Its spine**.) Why does र need different forms? (**It has no spine to
+give up.**) Next: use **स्त** inside the first greeting you learned.

--- a/code/learning/human-languages/hindi/lessons/HI-W05-virama-namaste.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W05-virama-namaste.md
@@ -3,25 +3,22 @@ id: HI-W05-virama-namaste
 chapter: 2
 type: writing
 headword: "्"
-gloss: "the virama — the mark that kills the inherent vowel — conjuncts, and hand-writing नमस्ते"
+gloss: "the virama or halant — the mark that stops a consonant's inherent vowel"
 romanization: "(vowel killer)"
-prerequisites: [HI-W04-ra-sa-mera-naam, HI-W03-matras-naam, HI-W02-abugida-ka-ta]
+prerequisites: [HI-W04-write-mera-naam, HI-W03-preposed-i, HI-W02-ka-ta-mouth-order]
 sounds: [devanagari-virama, devanagari-conjunct]
 roots: [sanskrit-virama, sanskrit-namas]
 etymology_hook: "virāma विराम means 'a STOPPING, a cessation' (vi- + ram- 'to rest') — the same word that grades Hindi's punctuation, pūrṇ virām 'complete stop' = full stop, alp virām 'slight stop' = comma; and namaste = namas 'a bow' + te 'to you', so the first word of the course is literally 'a bowing to you', from nam- 'to bend'"
-est_minutes: 5
-reviews_of: [HI-W04-ra-sa-mera-naam, HI-W02-abugida-ka-ta, HI-C01-namaste]
+est_minutes: 4
+reviews_of: [HI-W04-write-mera-naam, HI-W02-abugida-ka-ta, HI-C01-namaste]
 ---
 
-# The vowel killer — and नमस्ते at last
+# The vowel killer — virama and halant
 
 ## Warm-up
 
-[PAUSE 2s] One problem remains. Every consonant carries a free "a". Mātrās can
-**replace** that vowel with a different one. But what if you want **no vowel at
-all** — a bare consonant clamped onto the next?
-
-That is the last piece, and then you can write the first word you ever learned.
+[PAUSE 2s] Every consonant carries a free "a." Mātrās replace it. But what if
+you need **no vowel at all** — just a bare consonant?
 
 ## The virama ्
 
@@ -42,78 +39,17 @@ A naming note: *virāma* is the Sanskrit term, and the one Unicode uses. In
 everyday Hindi the mark is usually called the **हलंत** (*halant*). Same mark,
 two names — you'll meet both.
 
-## What actually happens when you write it
-
-Here is the twist. In careful print you *can* leave the virama sitting there —
-but in ordinary writing, a vowel-less consonant doesn't stand alone. It **fuses
-with the consonant that follows**, and the two are written as one squeezed
-character called a **conjunct**:
-
-> स् + त → **स्त** (*sta*)
-
-Look at what happened to स. It lost its right-hand spine, shrank, and leaned into
-त. For **spine-bearing** letters that is the usual move: **the first consonant
-gives up its spine and hands the syllable over to the second.**
-
-It is not the *only* move, though — and the counterexample is a letter you learned
-last lesson. **र has no spine to give up**, so it forms conjuncts differently: as
-a hook riding above a later letter (र् + क → **र्क**) or as a small stroke
-underneath an earlier one (क + ्र → **क्र**). Other spineless letters, **द**
-among them, stack or take special shapes instead. And a handful of very common
-conjuncts — **क्ष**, **त्र**, **ज्ञ** — are simply irregular and have to be
-learned whole.
-
-This is why Devanagari has so many shapes: it isn't only 40-odd letters, it's
-those letters plus the ligatures they form when they collide. You don't need to
-memorise conjuncts as separate characters. You need to recognise the *squeeze*.
-
-## Assemble नमस्ते
-
-You have every piece:
-
-| piece | | |
-|---|---|---|
-| **न** | *na* | Lesson 1 |
-| **म** | *ma* | Lesson 1 |
-| **स्** | *s* — स with its vowel killed | this lesson |
-| **ते** | *te* — त + the े mātrā | Lessons 2 and 3 |
-
-> **न · म · स् · ते → नमस्ते**
-
-Write it, then draw **one bar** across the whole word.
-
-## What you have been writing all along
-
-**नमस्ते** is two words fused: **namas** + **te**.
-
-- **namas** — "a bow, an obeisance," from the verb *nam-*, "**to bend**."
-- **te** — "to you."
-
-So *namaste* is, literally, **"a bowing to you."** Not "hello" — a described
-physical gesture, which is why the word and the folded hands go together. The
-greeting *is* the bow, said aloud.
-
-And *namaskār* (Lesson 1 of Chapter 1) is the same *namas* with *kāra*, "making":
-"**making** a bow." One root, two greetings.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU WRITE: क् — "क with the stroke below" — the vowel is dead]
-- [YOU WRITE: स्त — watch स **lose its spine** and lean in]
-- [YOU WRITE: ते — त plus the stroke above]
-- [YOU WRITE: **नमस्ते** — one bar across all of it]
-- [YOU SAY: "*namas* = a **bow**, *te* = **to you**"]
+- [YOU SAY: "virāma — stopping; halant — the everyday Hindi name"]
+- [YOU CONTRAST: क *ka* → क् *k*]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What does the virama **्** do, and what does its name mean? (Kills the
 **inherent vowel**; *virāma* = "a **stopping**" — and a full stop in Hindi is
 **पूर्ण विराम**, a "complete stop".) What is the mark usually called in everyday
-Hindi? (The **halant**.) What usually happens instead of leaving it visible? (The
-consonant **fuses** with the next into a **conjunct** — स् + त → स्त.) What does
-a **spine-bearing** first consonant give up? (**Its spine** — but र, having none,
-uses a hook above or a stroke below instead.) Write **नमस्ते** — how many bars? (**One** —
-it's one word.) What does it literally mean? ("**A bowing to you**" — *namas*
-from *nam-*, "to bend," + *te*, "to you.") And *namaskār*? (The same *namas* +
-*kāra*, "**making** a bow.")
+Hindi? (The **halant**.) Next: watch a stopped consonant squeeze into the one
+that follows.

--- a/code/learning/human-languages/hindi/lessons/HI-W05-write-namaste.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W05-write-namaste.md
@@ -1,0 +1,61 @@
+---
+id: HI-W05-write-namaste
+chapter: 2
+type: writing
+headword: "नमस्ते"
+gloss: assemble namaste, then uncover the bowing gesture inside the greeting
+romanization: "namaste"
+prerequisites: [HI-W05-conjuncts, HI-W03-matras-naam, HI-W01-na-ma]
+sounds: [devanagari-conjunct, devanagari-matra, devanagari-top-bar]
+roots: [sanskrit-namas, sanskrit-nam-bend]
+est_minutes: 4
+reviews_of: [HI-W05-conjuncts, HI-C01-namaste, HI-C01-namaskar]
+---
+
+# नमस्ते — assemble the greeting at last
+
+## Warm-up
+
+[PAUSE 2s] You have learned every piece separately. Now the writing track pays
+off in the first word of the course.
+
+## Assemble नमस्ते
+
+| piece | | |
+|---|---|---|
+| **न** | *na* | Lesson 1 |
+| **म** | *ma* | Lesson 1 |
+| **स्** | *s* — स with its vowel killed | last lesson |
+| **ते** | *te* — त + the े mātrā | Lessons 2 and 3 |
+
+> **न · म · स् · ते → नमस्ते**
+
+Write it, then draw **one bar** across the whole word.
+
+## What you have been writing all along
+
+**नमस्ते** joins **namas** + **te**:
+
+- **namas** — "a bow, an obeisance," from *nam-*, "**to bend**"
+- **te** — "to you"
+
+So *namaste* is literally **"a bowing to you."** It describes the physical
+gesture, which is why the word and folded hands go together. The greeting is
+the bow said aloud.
+
+*Namaskār* is the same *namas* with *kāra*, "making": "**making** a bow." One
+root, two greetings.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: स्त — the conjunct at the center]
+- [YOU WRITE: ते — त plus the stroke above]
+- [YOU WRITE: **नमस्ते** — one bar across all of it]
+- [YOU SAY: "*namas* = a **bow**, *te* = **to you**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Write **नमस्ते**. How many bars? (**One** — it is one word.) What
+does it literally mean? (**A bowing to you**: *namas*, "bow," + *te*, "to
+you.") And *namaskār*? (The same *namas* + *kāra*, "**making** a bow.")

--- a/code/learning/human-languages/hindi/roadmap.md
+++ b/code/learning/human-languages/hindi/roadmap.md
@@ -32,9 +32,10 @@ reading course.
   Hindi; *hindī* ← *sindhu*) → rahnā (to live; postposition *meṁ*) → karnā (to
   do; ← √kṛ, the root of *karma/namaskār/Sanskrit*) → practice. The present
   habitual (stem + *-tā/-tī/-te* + *honā*), verb-last, gender agreement.
-- **Writing track W01–W05 — hand-writing Devanagari.** A parallel spine, the
+- **Writing track W01–W05 — eleven hand-writing micro-lessons.** A parallel spine, the
   Hindi counterpart of Arabic AR-W01–12 and Russian RU-W01–05, ending on the
-  first word of the course. **W01** the **shirorekhā** (शिरोरेखा = "head-line";
+  first word of the course. Each numbered cluster is split at one script seam so
+  no step reaches five minutes. **W01** the **shirorekhā** (शिरोरेखा = "head-line";
   *śiras* ← PIE \**ḱerh₂-*, the root of Latin *cornu*/*cerebrum* and English
   **horn**) — drawn **last**, and as **one** bar across a whole word, so Hindi
   hangs *from* a line where Latin sits *on* one (flagged as the **common


### PR DESCRIPTION
## Summary

- correct 29 Hindi lesson declarations whose computed duration already fits the sub-five-minute contract
- split 11 genuinely long lessons into 13 prerequisite-ordered supports covering Devanagari, number history, age grammar, animal/color etymology, and evening register
- preserve source qualification and cross-language comparisons while making each lesson depend only on already-learned material
- record Hindi book-generation, PDF-warning, and progression-map follow-ups in the prioritized backlog

The corpus grows from 1,012 to 1,025 lessons, Hindi drops from 40 duration violations to zero, the repository drops from 180 to 140, and unknown prerequisites remain at zero.

## Validation

- `npm run test:coverage` (human-language-data: 68 tests, 93.60% line coverage)
- `npm run build` (human-language-data)
- `npm run validate` (9 integration tests)
- `npm run check:books`
- `npm run report` (20 tracks, 1,025 lessons, 140 duration violations, 0 unknown prerequisites)
- `npm run test:coverage` (Language Ladder: 278 tests, 98.37% line coverage)
- `npm run build` (Language Ladder)
- `latexmk -g -xelatex -interaction=nonstopmode -halt-on-error book.tex` (unchanged Hindi book: 29 pages, zero missing glyphs; publication and warning debt recorded separately)
- visual PDF inspection of cover, Chapter 2 opener, and final page