### PR TITLE
feat(smart-home): add authorized HEOS media controls

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Added explicit labels and argument conversion for D23 media playback,
+  volume, grouping, and queue commands.
 - Added `udp_multicast` discovery, `lan_udp` transport, and LAN UDP topology
   labels to Chief catalog filters and serialized runtime reports.
 - Added `camera`, `onvif`, and `ws_discovery` labels to Chief catalog filters

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -26,7 +26,8 @@ use smart_home_core::{
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
     CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device, DeviceCommand,
     DeviceEvent, DeviceEventType, DeviceId, EntityId, EntityKind, EventId, Health,
-    IntegrationCatalogSummary, IntegrationId, Metadata, PrivilegeTier, ProtocolFamily,
+    IntegrationCatalogSummary, IntegrationId, MediaCommandType, Metadata, PrivilegeTier,
+    ProtocolFamily,
     ProtocolIdentifier, RuntimeKind, Scene, SceneAction, SceneId, SceneScope,
     SmartHomeToolCatalogSummary, StateConfidence, StateDelta, StateSnapshot, StateSource, Value,
     VaultRef,
@@ -89719,18 +89720,26 @@ fn json_to_smart_value_for_command(
     value: &JsonValue,
 ) -> Result<Value, ToolCallError> {
     match command_type {
-        CommandType::TurnOn | CommandType::TurnOff | CommandType::RecallScene => Ok(Value::Null),
-        CommandType::SetBrightness => match json_to_smart_value(value)? {
-            Value::Integer(value) if (0..=100).contains(&value) => {
-                Ok(Value::Percentage(value as u8))
+        CommandType::TurnOn
+        | CommandType::TurnOff
+        | CommandType::RecallScene
+        | CommandType::Media(MediaCommandType::PlayNext)
+        | CommandType::Media(MediaCommandType::PlayPrevious)
+        | CommandType::Media(MediaCommandType::ClearQueue) => Ok(Value::Null),
+        CommandType::SetBrightness | CommandType::Media(MediaCommandType::SetVolume) => {
+            match json_to_smart_value(value)? {
+                Value::Integer(value) if (0..=100).contains(&value) => {
+                    Ok(Value::Percentage(value as u8))
+                }
+                Value::Percentage(value) => Ok(Value::Percentage(value)),
+                other => Ok(other),
             }
-            Value::Percentage(value) => Ok(Value::Percentage(value)),
-            other => Ok(other),
-        },
+        }
         CommandType::SetColor
         | CommandType::SetColorTemperature
         | CommandType::SetLock
-        | CommandType::SetThermostatSetpoint => json_to_smart_value(value),
+        | CommandType::SetThermostatSetpoint
+        | CommandType::Media(_) => json_to_smart_value(value),
     }
 }
 
@@ -90122,6 +90131,16 @@ fn parse_command_type(label: &str) -> Result<CommandType, ToolCallError> {
         "recall_scene" => Ok(CommandType::RecallScene),
         "set_lock" => Ok(CommandType::SetLock),
         "set_thermostat_setpoint" => Ok(CommandType::SetThermostatSetpoint),
+        "media_set_playback_state" => Ok(CommandType::Media(MediaCommandType::SetPlaybackState)),
+        "media_play_next" => Ok(CommandType::Media(MediaCommandType::PlayNext)),
+        "media_play_previous" => Ok(CommandType::Media(MediaCommandType::PlayPrevious)),
+        "media_set_volume" => Ok(CommandType::Media(MediaCommandType::SetVolume)),
+        "media_set_mute" => Ok(CommandType::Media(MediaCommandType::SetMute)),
+        "media_set_group" => Ok(CommandType::Media(MediaCommandType::SetGroup)),
+        "media_clear_queue" => Ok(CommandType::Media(MediaCommandType::ClearQueue)),
+        "media_play_queue_item" => Ok(CommandType::Media(MediaCommandType::PlayQueueItem)),
+        "media_remove_queue_item" => Ok(CommandType::Media(MediaCommandType::RemoveQueueItem)),
+        "media_move_queue_item" => Ok(CommandType::Media(MediaCommandType::MoveQueueItem)),
         _ => Err(validation_error(format!("unknown command_type `{label}`"))),
     }
 }
@@ -92488,6 +92507,16 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         CommandType::RecallScene => "recall_scene",
         CommandType::SetLock => "set_lock",
         CommandType::SetThermostatSetpoint => "set_thermostat_setpoint",
+        CommandType::Media(MediaCommandType::SetPlaybackState) => "media_set_playback_state",
+        CommandType::Media(MediaCommandType::PlayNext) => "media_play_next",
+        CommandType::Media(MediaCommandType::PlayPrevious) => "media_play_previous",
+        CommandType::Media(MediaCommandType::SetVolume) => "media_set_volume",
+        CommandType::Media(MediaCommandType::SetMute) => "media_set_mute",
+        CommandType::Media(MediaCommandType::SetGroup) => "media_set_group",
+        CommandType::Media(MediaCommandType::ClearQueue) => "media_clear_queue",
+        CommandType::Media(MediaCommandType::PlayQueueItem) => "media_play_queue_item",
+        CommandType::Media(MediaCommandType::RemoveQueueItem) => "media_remove_queue_item",
+        CommandType::Media(MediaCommandType::MoveQueueItem) => "media_move_queue_item",
     }
 }
 
@@ -121368,5 +121397,26 @@ mod tests {
             return None;
         };
         Some(*value)
+    }
+
+    #[test]
+    fn media_command_labels_round_trip_through_the_chief_boundary() {
+        let commands = [
+            ("media_set_playback_state", MediaCommandType::SetPlaybackState),
+            ("media_play_next", MediaCommandType::PlayNext),
+            ("media_play_previous", MediaCommandType::PlayPrevious),
+            ("media_set_volume", MediaCommandType::SetVolume),
+            ("media_set_mute", MediaCommandType::SetMute),
+            ("media_set_group", MediaCommandType::SetGroup),
+            ("media_clear_queue", MediaCommandType::ClearQueue),
+            ("media_play_queue_item", MediaCommandType::PlayQueueItem),
+            ("media_remove_queue_item", MediaCommandType::RemoveQueueItem),
+            ("media_move_queue_item", MediaCommandType::MoveQueueItem),
+        ];
+        for (label, media_command) in commands {
+            let command = CommandType::Media(media_command);
+            assert_eq!(parse_command_type(label).unwrap(), command);
+            assert_eq!(command_type_label(command), label);
+        }
     }
 }

--- a/code/packages/rust/matter-core/src/lib.rs
+++ b/code/packages/rust/matter-core/src/lib.rs
@@ -672,7 +672,10 @@ pub fn matter_command_for_device_command(
             endpoint_id,
             expect_lock_command(command)?,
         )),
-        CommandType::SetColor | CommandType::RecallScene | CommandType::SetThermostatSetpoint => {
+        CommandType::SetColor
+        | CommandType::RecallScene
+        | CommandType::SetThermostatSetpoint
+        | CommandType::Media(_) => {
             Err(MatterError::UnsupportedCommand {
                 command_type: command.command_type,
             })

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Typed media playback, volume, grouping, and queue command operations plus
+  canonical command-capability mappings.
 - A first-class `LanTcp` bridge transport for local stream protocols.
 - A first-class `LanUdp` bridge transport for local UDP discovery, polling,
   and command integrations.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -33,8 +33,10 @@ Current scope:
 - capability and value typing
 - capability-surface summaries for describe-capabilities tools
 - inventory summaries for bridge/device health and entity state coverage
-- canonical capability catalog entries for light, scene, lock, climate, sensor,
-  and input families
+- canonical capability catalog entries for light, scene, lock, climate, media,
+  sensor, and input families
+- typed media playback, volume, grouping, and queue operations inside the
+  existing authorized device-command envelope
 - canonical integration descriptors for Hue, Zigbee, Z-Wave, Thread, Matter,
   and MQTT bootstrap families
 - compact integration catalog summaries for runtime, discovery, pairing, and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -295,6 +295,38 @@ impl Capability {
         .with_unit("temperature")
     }
 
+    pub fn media_playback() -> Self {
+        Self::new(
+            CapabilityId::trusted("media.playback"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Text,
+        )
+    }
+
+    pub fn media_volume() -> Self {
+        Self::new(
+            CapabilityId::trusted("media.volume"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Object,
+        )
+    }
+
+    pub fn media_grouping() -> Self {
+        Self::new(
+            CapabilityId::trusted("media.grouping"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Array,
+        )
+    }
+
+    pub fn media_queue() -> Self {
+        Self::new(
+            CapabilityId::trusted("media.queue"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Object,
+        )
+    }
+
     pub fn sensor_occupancy() -> Self {
         Self::new(
             CapabilityId::trusted("sensor.occupancy"),
@@ -365,6 +397,10 @@ pub fn canonical_capability_catalog() -> Vec<Capability> {
         Capability::scene_recall(),
         Capability::lock_state(),
         Capability::climate_setpoint(),
+        Capability::media_playback(),
+        Capability::media_volume(),
+        Capability::media_grouping(),
+        Capability::media_queue(),
         Capability::sensor_occupancy(),
         Capability::sensor_contact(),
         Capability::sensor_temperature(),
@@ -1217,6 +1253,21 @@ pub enum CommandType {
     RecallScene,
     SetLock,
     SetThermostatSetpoint,
+    Media(MediaCommandType),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MediaCommandType {
+    SetPlaybackState,
+    PlayNext,
+    PlayPrevious,
+    SetVolume,
+    SetMute,
+    SetGroup,
+    ClearQueue,
+    PlayQueueItem,
+    RemoveQueueItem,
+    MoveQueueItem,
 }
 
 impl CommandType {
@@ -1229,6 +1280,23 @@ impl CommandType {
             Self::RecallScene => Some(CapabilityId::trusted("scene.recall")),
             Self::SetLock => Some(CapabilityId::trusted("lock.state")),
             Self::SetThermostatSetpoint => Some(CapabilityId::trusted("climate.setpoint")),
+            Self::Media(command) => Some(command.canonical_capability_id()),
+        }
+    }
+}
+
+impl MediaCommandType {
+    pub fn canonical_capability_id(self) -> CapabilityId {
+        match self {
+            Self::SetPlaybackState | Self::PlayNext | Self::PlayPrevious => {
+                CapabilityId::trusted("media.playback")
+            }
+            Self::SetVolume | Self::SetMute => CapabilityId::trusted("media.volume"),
+            Self::SetGroup => CapabilityId::trusted("media.grouping"),
+            Self::ClearQueue
+            | Self::PlayQueueItem
+            | Self::RemoveQueueItem
+            | Self::MoveQueueItem => CapabilityId::trusted("media.queue"),
         }
     }
 }
@@ -1291,7 +1359,8 @@ pub fn tier_for_command(command_type: CommandType) -> PrivilegeTier {
         | CommandType::SetBrightness
         | CommandType::SetColor
         | CommandType::SetColorTemperature
-        | CommandType::RecallScene => PrivilegeTier::LowRisk,
+        | CommandType::RecallScene
+        | CommandType::Media(_) => PrivilegeTier::LowRisk,
     }
 }
 
@@ -4132,12 +4201,16 @@ mod tests {
             .map(|capability| capability.capability_id.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(catalog.len(), 14);
+        assert_eq!(catalog.len(), 18);
         assert_eq!(ids[0], "light.on_off");
         assert!(ids.contains(&"light.color"));
         assert!(ids.contains(&"scene.recall"));
         assert!(ids.contains(&"lock.state"));
         assert!(ids.contains(&"climate.setpoint"));
+        assert!(ids.contains(&"media.playback"));
+        assert!(ids.contains(&"media.volume"));
+        assert!(ids.contains(&"media.grouping"));
+        assert!(ids.contains(&"media.queue"));
         assert!(ids.contains(&"sensor.contact"));
         assert!(ids.contains(&"sensor.temperature"));
         assert!(ids.contains(&"sensor.humidity"));
@@ -4173,6 +4246,16 @@ mod tests {
             CommandType::RecallScene,
             CommandType::SetLock,
             CommandType::SetThermostatSetpoint,
+            CommandType::Media(MediaCommandType::SetPlaybackState),
+            CommandType::Media(MediaCommandType::PlayNext),
+            CommandType::Media(MediaCommandType::PlayPrevious),
+            CommandType::Media(MediaCommandType::SetVolume),
+            CommandType::Media(MediaCommandType::SetMute),
+            CommandType::Media(MediaCommandType::SetGroup),
+            CommandType::Media(MediaCommandType::ClearQueue),
+            CommandType::Media(MediaCommandType::PlayQueueItem),
+            CommandType::Media(MediaCommandType::RemoveQueueItem),
+            CommandType::Media(MediaCommandType::MoveQueueItem),
         ];
 
         for command_type in command_types {

--- a/code/packages/rust/smart-home-heos-cli-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-heos-cli-integration/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+- Add authorized HEOS playback, next/previous, volume, mute, grouping, and
+  queue mutation commands over the production TCP host.
+- Require every affected grouping entity to pass D23 command authorization
+  before transport I/O and validate command-correlated success responses.
+- Advertise explicit media playback, volume, grouping, and queue capabilities.
+
 ## 0.2.0
 
 - Add bounded HEOS change-event registration and collection over a dedicated

--- a/code/packages/rust/smart-home-heos-cli-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-heos-cli-integration/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smart-home-heos-cli-integration"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "HEOS CLI discovery, player inspection, and change events for the smart-home runtime"
+description = "HEOS CLI discovery, inspection, change events, and media control for the smart-home runtime"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/smart-home-heos-cli-integration/README.md
+++ b/code/packages/rust/smart-home-heos-cli-integration/README.md
@@ -1,6 +1,7 @@
 # smart-home-heos-cli-integration
 
-First-party HEOS CLI inspection and change-event integration for D23.
+First-party HEOS CLI inspection, change-event, and media-control integration
+for D23.
 
 It discovers Denon and Marantz HEOS systems through their documented SSDP
 search target or accepts a manual host. A bounded TCP client connects to port
@@ -13,9 +14,11 @@ events and project unsolicited player state, volume, mute, progress, repeat,
 shuffle, queue, topology, and playback-error frames into D23. Subscribe
 authorization is checked before the event socket is opened.
 
-The slice intentionally excludes HEOS account access and playback, volume,
-grouping, or queue mutation commands until D23 has explicit media command
-types and capability mappings.
+D23 media commands route playback state, next/previous, volume, mute, grouping,
+queue clearing, queue playback, removal, and reordering through the same bounded
+TCP host. Every affected group member is authorized before network I/O, and the
+host validates the command-correlated HEOS success response. Account-backed
+source browsing and queue insertion remain outside this credential-free slice.
 
 ```bash
 cargo run -p smart-home-heos-cli-integration -- discover

--- a/code/packages/rust/smart-home-heos-cli-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-heos-cli-integration/src/lib.rs
@@ -4,15 +4,16 @@
 
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use smart_home_core::{
-    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode, Device,
-    DeviceEvent, DeviceEventType, DeviceId, Entity, EntityId, EntityKind, EventId, Health,
-    IntegrationId, Metadata, ProtocolFamily, ProtocolIdentifier, SmartHomeTool, StateConfidence,
-    StateDelta, StateSnapshot, StateSource, Value, ValueKind,
+    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode,
+    CommandResult, CommandType, Device, DeviceEvent, DeviceEventType, DeviceId, Entity, EntityId,
+    EntityKind, EventId, Health, IntegrationId, MediaCommandType, Metadata, ProtocolFamily,
+    ProtocolIdentifier, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource,
+    Value, ValueKind,
 };
 use smart_home_discovery::{
     DiscoveryConfidence, DiscoveryRecord, DiscoverySource, PairingRequirement,
 };
-use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
+use smart_home_runtime::{RuntimeCommandToolRequest, RuntimeError, SmartHomeRuntime};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, BufRead, BufReader, Write};
@@ -21,7 +22,7 @@ use std::time::Duration;
 use udp_client::{send_to_and_collect, UdpDiscoveryEndpoint, UdpError, UdpOptions};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 pub const INTEGRATION_ID: &str = "heos";
 pub const PROTOCOL_ID: &str = "heos_cli";
 pub const SSDP_SEARCH_TARGET: &str = "urn:schemas-denon-com:device:ACT-Denon:1";
@@ -39,10 +40,21 @@ pub enum HeosError {
     Udp(UdpError),
     Io(String),
     Json(serde_json::Error),
-    ResponseTooLarge { limit: usize },
+    ResponseTooLarge {
+        limit: usize,
+    },
     MissingField(&'static str),
-    CommandFailed { command: String, message: String },
+    CommandFailed {
+        command: String,
+        message: String,
+    },
     NoPlayers,
+    UnknownEntity(EntityId),
+    UnsupportedCommand(CommandType),
+    InvalidCommandArguments {
+        command_type: CommandType,
+        expected: &'static str,
+    },
     Runtime(RuntimeError),
 }
 
@@ -62,6 +74,19 @@ impl fmt::Display for HeosError {
                 write!(formatter, "HEOS command {command} failed: {message}")
             }
             Self::NoPlayers => formatter.write_str("HEOS system returned no players"),
+            Self::UnknownEntity(entity_id) => {
+                write!(formatter, "HEOS player entity {entity_id} is not installed")
+            }
+            Self::UnsupportedCommand(command_type) => {
+                write!(formatter, "HEOS does not support command {command_type:?}")
+            }
+            Self::InvalidCommandArguments {
+                command_type,
+                expected,
+            } => write!(
+                formatter,
+                "HEOS command {command_type:?} expects {expected}"
+            ),
             Self::Runtime(error) => error.fmt(formatter),
         }
     }
@@ -566,11 +591,15 @@ pub struct InstalledHeosSystem {
 
 pub struct HeosRuntimeIntegration<T> {
     client: HeosClient<T>,
+    player_ids: BTreeMap<EntityId, String>,
 }
 
 impl<T: HeosTransport> HeosRuntimeIntegration<T> {
     pub fn new(client: HeosClient<T>) -> Self {
-        Self { client }
+        Self {
+            client,
+            player_ids: BTreeMap::new(),
+        }
     }
 
     pub fn inspect_and_install_authorized(
@@ -581,7 +610,53 @@ impl<T: HeosTransport> HeosRuntimeIntegration<T> {
     ) -> Result<InstalledHeosSystem, HeosError> {
         authorize_read(runtime, principal_id, observed_at_ms)?;
         let snapshot = self.client.inspect()?;
-        install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)
+        let installed = install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)?;
+        self.player_ids = snapshot
+            .players
+            .iter()
+            .zip(installed.entity_ids.iter())
+            .map(|(player, entity_id)| (entity_id.clone(), player.player.pid.clone()))
+            .collect();
+        Ok(installed)
+    }
+
+    pub fn dispatch_command_authorized(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        request: RuntimeCommandToolRequest,
+        now_ms: u64,
+    ) -> Result<CommandResult, HeosError> {
+        let plan = heos_command_plan(&self.player_ids, &request)?;
+        let result = if let CommandType::Media(MediaCommandType::SetGroup) = request.command_type {
+            let mut target_result = None;
+            for entity_id in &plan.affected_entities {
+                let mut member_request = request.clone();
+                member_request.entity_id = entity_id.clone();
+                let result =
+                    runtime.execute_command_tool(principal_id.clone(), member_request, now_ms)?;
+                if entity_id == &request.entity_id {
+                    target_result = Some(result);
+                }
+            }
+            target_result.ok_or(HeosError::InvalidCommandArguments {
+                command_type: request.command_type,
+                expected: "a group containing the target entity",
+            })?
+        } else {
+            runtime.execute_command_tool(principal_id, request, now_ms)?
+        };
+        let responses = self.client.transport.exchange(
+            &self.client.config.host,
+            self.client.config.port,
+            std::slice::from_ref(&plan.command),
+            self.client.config.timeout,
+        )?;
+        let response = responses
+            .first()
+            .ok_or(HeosError::MissingField("command response"))?;
+        successful_response(response, plan.response_command)?;
+        Ok(result)
     }
 
     pub fn collect_and_apply_change_events_authorized<E: HeosChangeEventTransport>(
@@ -608,6 +683,220 @@ impl<T: HeosTransport> HeosRuntimeIntegration<T> {
             received_at_ms,
         )
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HeosCommandPlan {
+    command: String,
+    response_command: &'static str,
+    affected_entities: Vec<EntityId>,
+}
+
+fn heos_command_plan(
+    player_ids: &BTreeMap<EntityId, String>,
+    request: &RuntimeCommandToolRequest,
+) -> Result<HeosCommandPlan, HeosError> {
+    let pid = player_ids
+        .get(&request.entity_id)
+        .ok_or_else(|| HeosError::UnknownEntity(request.entity_id.clone()))?;
+    let encoded_pid = encode_argument(pid);
+    let (command, response_command, affected_entities) = match request.command_type {
+        CommandType::Media(MediaCommandType::SetPlaybackState) => {
+            let Value::Text(state) = &request.arguments else {
+                return invalid_command_arguments(
+                    request.command_type,
+                    "play, pause, or stop text",
+                );
+            };
+            if !matches!(state.as_str(), "play" | "pause" | "stop") {
+                return invalid_command_arguments(
+                    request.command_type,
+                    "play, pause, or stop text",
+                );
+            }
+            (
+                format!("heos://player/set_play_state?pid={encoded_pid}&state={state}"),
+                "player/set_play_state",
+                vec![request.entity_id.clone()],
+            )
+        }
+        CommandType::Media(MediaCommandType::PlayNext) => {
+            require_null_arguments(request)?;
+            (
+                format!("heos://player/play_next?pid={encoded_pid}"),
+                "player/play_next",
+                vec![request.entity_id.clone()],
+            )
+        }
+        CommandType::Media(MediaCommandType::PlayPrevious) => {
+            require_null_arguments(request)?;
+            (
+                format!("heos://player/play_previous?pid={encoded_pid}"),
+                "player/play_previous",
+                vec![request.entity_id.clone()],
+            )
+        }
+        CommandType::Media(MediaCommandType::SetVolume) => {
+            let Value::Percentage(level) = request.arguments else {
+                return invalid_command_arguments(request.command_type, "a percentage volume");
+            };
+            (
+                format!("heos://player/set_volume?pid={encoded_pid}&level={level}"),
+                "player/set_volume",
+                vec![request.entity_id.clone()],
+            )
+        }
+        CommandType::Media(MediaCommandType::SetMute) => {
+            let Value::Bool(muted) = request.arguments else {
+                return invalid_command_arguments(request.command_type, "a boolean mute state");
+            };
+            let state = if muted { "on" } else { "off" };
+            (
+                format!("heos://player/set_mute?pid={encoded_pid}&state={state}"),
+                "player/set_mute",
+                vec![request.entity_id.clone()],
+            )
+        }
+        CommandType::Media(MediaCommandType::SetGroup) => {
+            let Value::Array(entity_values) = &request.arguments else {
+                return invalid_command_arguments(
+                    request.command_type,
+                    "an array of installed HEOS player entity ids",
+                );
+            };
+            let mut members = BTreeMap::new();
+            for value in entity_values {
+                let Value::Text(entity_id) = value else {
+                    return invalid_command_arguments(
+                        request.command_type,
+                        "an array of installed HEOS player entity ids",
+                    );
+                };
+                let entity_id = EntityId::new(entity_id.clone()).map_err(|_| {
+                    HeosError::InvalidCommandArguments {
+                        command_type: request.command_type,
+                        expected: "an array of installed HEOS player entity ids",
+                    }
+                })?;
+                let member_pid = player_ids
+                    .get(&entity_id)
+                    .ok_or_else(|| HeosError::UnknownEntity(entity_id.clone()))?;
+                members.insert(entity_id, member_pid.clone());
+            }
+            if members.is_empty() || !members.contains_key(&request.entity_id) {
+                return invalid_command_arguments(
+                    request.command_type,
+                    "a non-empty group containing the target entity",
+                );
+            }
+            if members.len() > DEFAULT_MAX_PLAYERS {
+                return invalid_command_arguments(
+                    request.command_type,
+                    "at most 64 installed HEOS player entity ids",
+                );
+            }
+            let pids = members
+                .values()
+                .map(|pid| encode_argument(pid))
+                .collect::<Vec<_>>()
+                .join(",");
+            (
+                format!("heos://group/set_group?pid={pids}"),
+                "group/set_group",
+                members.into_keys().collect(),
+            )
+        }
+        CommandType::Media(MediaCommandType::ClearQueue) => {
+            require_null_arguments(request)?;
+            (
+                format!("heos://player/clear_queue?pid={encoded_pid}"),
+                "player/clear_queue",
+                vec![request.entity_id.clone()],
+            )
+        }
+        CommandType::Media(MediaCommandType::PlayQueueItem) => {
+            let qid = queue_item_argument(request)?;
+            (
+                format!("heos://player/play_queue?pid={encoded_pid}&qid={qid}"),
+                "player/play_queue",
+                vec![request.entity_id.clone()],
+            )
+        }
+        CommandType::Media(MediaCommandType::RemoveQueueItem) => {
+            let qid = queue_item_argument(request)?;
+            (
+                format!("heos://player/remove_queue_item?pid={encoded_pid}&qid={qid}"),
+                "player/remove_queue_item",
+                vec![request.entity_id.clone()],
+            )
+        }
+        CommandType::Media(MediaCommandType::MoveQueueItem) => {
+            let Value::Object(arguments) = &request.arguments else {
+                return invalid_command_arguments(
+                    request.command_type,
+                    "an object with positive qid and new_qid integers",
+                );
+            };
+            let qid = positive_object_integer(arguments, "qid", request.command_type)?;
+            let new_qid = positive_object_integer(arguments, "new_qid", request.command_type)?;
+            (
+                format!(
+                    "heos://player/move_queue_item?pid={encoded_pid}&qid={qid}&new_qid={new_qid}"
+                ),
+                "player/move_queue_item",
+                vec![request.entity_id.clone()],
+            )
+        }
+        command_type => return Err(HeosError::UnsupportedCommand(command_type)),
+    };
+    Ok(HeosCommandPlan {
+        command,
+        response_command,
+        affected_entities,
+    })
+}
+
+fn require_null_arguments(request: &RuntimeCommandToolRequest) -> Result<(), HeosError> {
+    if request.arguments == Value::Null {
+        Ok(())
+    } else {
+        invalid_command_arguments(request.command_type, "null arguments")
+    }
+}
+
+fn queue_item_argument(request: &RuntimeCommandToolRequest) -> Result<i64, HeosError> {
+    match request.arguments {
+        Value::Integer(qid) if qid > 0 => Ok(qid),
+        _ => invalid_command_arguments(request.command_type, "a positive queue item integer"),
+    }
+}
+
+fn positive_object_integer(
+    arguments: &[(String, Value)],
+    field: &'static str,
+    command_type: CommandType,
+) -> Result<i64, HeosError> {
+    arguments
+        .iter()
+        .find_map(|(name, value)| (name == field).then_some(value))
+        .and_then(|value| match value {
+            Value::Integer(value) if *value > 0 => Some(*value),
+            _ => None,
+        })
+        .ok_or(HeosError::InvalidCommandArguments {
+            command_type,
+            expected: "an object with positive qid and new_qid integers",
+        })
+}
+
+fn invalid_command_arguments<T>(
+    command_type: CommandType,
+    expected: &'static str,
+) -> Result<T, HeosError> {
+    Err(HeosError::InvalidCommandArguments {
+        command_type,
+        expected,
+    })
 }
 
 fn authorize_read(
@@ -880,11 +1169,17 @@ pub fn install_snapshot(
             device_id: device_id.clone(),
             kind: EntityKind::Unknown,
             name: snapshot.player.name.clone(),
-            capabilities: vec![Capability::new(
-                CapabilityId::trusted("media.player_state"),
-                CapabilityMode::Observe,
-                ValueKind::Object,
-            )],
+            capabilities: vec![
+                Capability::new(
+                    CapabilityId::trusted("media.player_state"),
+                    CapabilityMode::Observe,
+                    ValueKind::Object,
+                ),
+                Capability::media_playback(),
+                Capability::media_volume(),
+                Capability::media_grouping(),
+                Capability::media_queue(),
+            ],
             state: Some(StateSnapshot {
                 entity_id: entity_id.clone(),
                 value: player_value(snapshot),
@@ -894,7 +1189,7 @@ pub fn install_snapshot(
                 expires_at_ms: None,
                 confidence: StateConfidence::Confirmed,
             }),
-            metadata: vec![Metadata::new("heos.control_surface", "read_only_player")],
+            metadata: vec![Metadata::new("heos.control_surface", "media_player")],
         })?;
         device_ids.push(device_id);
         entity_ids.push(entity_id);
@@ -1196,6 +1491,7 @@ fn read_line_with_timeout(
 mod tests {
     use super::*;
     use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
+    use std::collections::VecDeque;
     use std::io::Cursor;
     use std::net::{TcpListener, UdpSocket};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1432,6 +1728,22 @@ mod tests {
             entity.capabilities[0].capability_id.as_str(),
             "media.player_state"
         );
+        assert!(entity.capabilities.iter().any(|capability| {
+            capability.capability_id.as_str() == "media.playback"
+                && capability.mode == CapabilityMode::ObserveAndCommand
+        }));
+        assert!(entity
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id.as_str() == "media.volume"));
+        assert!(entity
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id.as_str() == "media.grouping"));
+        assert!(entity
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id.as_str() == "media.queue"));
         assert_eq!(
             entity.state.as_ref().unwrap().confidence,
             StateConfidence::Confirmed
@@ -1534,5 +1846,196 @@ mod tests {
             successful_response(&failed, "player/get_players"),
             Err(HeosError::CommandFailed { .. })
         ));
+    }
+
+    #[test]
+    fn loopback_authorized_media_commands_reach_the_native_tcp_host() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let commands = [
+            (
+                "heos://player/set_play_state?pid=1&state=pause",
+                "player/set_play_state",
+            ),
+            ("heos://player/play_next?pid=1", "player/play_next"),
+            ("heos://player/play_previous?pid=1", "player/play_previous"),
+            (
+                "heos://player/set_volume?pid=1&level=42",
+                "player/set_volume",
+            ),
+            ("heos://player/set_mute?pid=1&state=on", "player/set_mute"),
+            ("heos://group/set_group?pid=1", "group/set_group"),
+            ("heos://player/clear_queue?pid=1", "player/clear_queue"),
+            ("heos://player/play_queue?pid=1&qid=2", "player/play_queue"),
+            (
+                "heos://player/remove_queue_item?pid=1&qid=2",
+                "player/remove_queue_item",
+            ),
+            (
+                "heos://player/move_queue_item?pid=1&qid=2&new_qid=3",
+                "player/move_queue_item",
+            ),
+        ];
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            write_responses(stream, &[PLAYERS]);
+            let (stream, _) = listener.accept().unwrap();
+            write_responses(stream, &[STATE, MEDIA, VOLUME, MUTE]);
+            for (expected, response_command) in commands {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let mut command = String::new();
+                reader.read_line(&mut command).unwrap();
+                assert_eq!(command.trim(), expected);
+                writeln!(
+                    stream,
+                    "{{\"heos\":{{\"command\":\"{response_command}\",\"result\":\"success\",\"message\":\"\"}}}}\r"
+                )
+                .unwrap();
+            }
+        });
+
+        let config = HeosConfig::new(BridgeId::trusted("heos:controls"), "127.0.0.1")
+            .unwrap()
+            .with_port(address.port())
+            .with_timeout(Duration::from_secs(1));
+        let client = HeosClient::new(config, HeosLanTransport::default());
+        let mut integration = HeosRuntimeIntegration::new(client);
+        let mut runtime = SmartHomeRuntime::new();
+        let principal = AgentId::trusted("agent:heos-controls");
+        grant(&mut runtime, &principal);
+        let installed = integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 10)
+            .unwrap();
+        let entity_id = installed.entity_ids[0].clone();
+        let requests = [
+            RuntimeCommandToolRequest::new(
+                entity_id.clone(),
+                CommandType::Media(MediaCommandType::SetPlaybackState),
+                Value::Text("pause".to_string()),
+            ),
+            RuntimeCommandToolRequest::new(
+                entity_id.clone(),
+                CommandType::Media(MediaCommandType::PlayNext),
+                Value::Null,
+            ),
+            RuntimeCommandToolRequest::new(
+                entity_id.clone(),
+                CommandType::Media(MediaCommandType::PlayPrevious),
+                Value::Null,
+            ),
+            RuntimeCommandToolRequest::new(
+                entity_id.clone(),
+                CommandType::Media(MediaCommandType::SetVolume),
+                Value::Percentage(42),
+            ),
+            RuntimeCommandToolRequest::new(
+                entity_id.clone(),
+                CommandType::Media(MediaCommandType::SetMute),
+                Value::Bool(true),
+            ),
+            RuntimeCommandToolRequest::new(
+                entity_id.clone(),
+                CommandType::Media(MediaCommandType::SetGroup),
+                Value::Array(vec![Value::Text(entity_id.as_str().to_string())]),
+            ),
+            RuntimeCommandToolRequest::new(
+                entity_id.clone(),
+                CommandType::Media(MediaCommandType::ClearQueue),
+                Value::Null,
+            ),
+            RuntimeCommandToolRequest::new(
+                entity_id.clone(),
+                CommandType::Media(MediaCommandType::PlayQueueItem),
+                Value::Integer(2),
+            ),
+            RuntimeCommandToolRequest::new(
+                entity_id.clone(),
+                CommandType::Media(MediaCommandType::RemoveQueueItem),
+                Value::Integer(2),
+            ),
+            RuntimeCommandToolRequest::new(
+                entity_id,
+                CommandType::Media(MediaCommandType::MoveQueueItem),
+                Value::Object(vec![
+                    ("qid".to_string(), Value::Integer(2)),
+                    ("new_qid".to_string(), Value::Integer(3)),
+                ]),
+            ),
+        ];
+        for (sequence, request) in requests.into_iter().enumerate() {
+            let result = integration
+                .dispatch_command_authorized(
+                    &mut runtime,
+                    principal.clone(),
+                    request,
+                    20 + sequence as u64,
+                )
+                .unwrap();
+            assert!(result.is_accepted());
+        }
+        handle.join().unwrap();
+    }
+
+    #[derive(Debug)]
+    struct ScriptedTransport {
+        calls: Arc<AtomicUsize>,
+        responses: VecDeque<Vec<JsonValue>>,
+    }
+
+    impl HeosTransport for ScriptedTransport {
+        fn exchange(
+            &mut self,
+            _host: &str,
+            _port: u16,
+            _commands: &[String],
+            _timeout: Duration,
+        ) -> Result<Vec<JsonValue>, HeosError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.responses
+                .pop_front()
+                .ok_or_else(|| HeosError::Io("unexpected scripted transport call".to_string()))
+        }
+    }
+
+    #[test]
+    fn denied_media_command_reaches_no_transport() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let responses = VecDeque::from([
+            vec![serde_json::from_str(PLAYERS).unwrap()],
+            [STATE, MEDIA, VOLUME, MUTE]
+                .into_iter()
+                .map(|value| serde_json::from_str(value).unwrap())
+                .collect(),
+        ]);
+        let client = HeosClient::new(
+            HeosConfig::new(BridgeId::trusted("heos:denied-control"), "127.0.0.1").unwrap(),
+            ScriptedTransport {
+                calls: Arc::clone(&calls),
+                responses,
+            },
+        );
+        let mut integration = HeosRuntimeIntegration::new(client);
+        let mut runtime = SmartHomeRuntime::new();
+        let installer = AgentId::trusted("agent:heos-installer");
+        grant(&mut runtime, &installer);
+        let installed = integration
+            .inspect_and_install_authorized(&mut runtime, installer, 10)
+            .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(matches!(
+            integration.dispatch_command_authorized(
+                &mut runtime,
+                AgentId::trusted("agent:denied-control"),
+                RuntimeCommandToolRequest::new(
+                    installed.entity_ids[0].clone(),
+                    CommandType::Media(MediaCommandType::SetVolume),
+                    Value::Percentage(20),
+                ),
+                20,
+            ),
+            Err(HeosError::Runtime(_))
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## Unreleased
 
+- Upgraded HEOS runtime coverage with D23-authorized local playback, volume,
+  grouping, and queue controls over the existing TCP command host.
 - Upgraded HEOS CLI runtime coverage from polling-only inspection to local
   push through authorized, bounded change-event subscriptions.
 - Added first-party HEOS CLI runtime coverage for SSDP/manual discovery and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45143,14 +45143,14 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         base_entry(
             "heos",
             "HEOS",
-            "Local Denon and Marantz HEOS CLI player discovery, inspection, and change events.",
+            "Local Denon and Marantz HEOS CLI player discovery, inspection, change events, and media control.",
             IntegrationCategory::CameraMedia,
             ConnectivityClass::LocalPush,
             ImplementationStatus::FirstPartyRuntime,
             2,
             "heos",
         )
-        .with_capabilities(&["smart_home.read"])
+        .with_capabilities(&["smart_home.read", "smart_home.command.media"])
         .with_entities(&[EntityKind::Unknown])
         .with_discovery(&[DiscoveryMechanism::Ssdp, DiscoveryMechanism::Manual])
         .with_auth(&[AuthMode::None])
@@ -45162,11 +45162,12 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
             PrimitiveFamily::Udp,
             PrimitiveFamily::Tcp,
             PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::CommandMapping,
             PrimitiveFamily::Supervision,
             PrimitiveFamily::TestSimulator,
         ])
         .with_notes(&[
-            "Current runtime support is read-only; account access and authorized media, grouping, and queue commands remain separate work.",
+            "Account-backed source browsing remains separate work; local playback, volume, grouping, and queue controls are available without HEOS account credentials.",
         ]),
         media_entry(
             "cast",
@@ -81114,7 +81115,7 @@ mod tests {
     }
 
     #[test]
-    fn heos_entry_exposes_ssdp_and_read_only_tcp_push_runtime() {
+    fn heos_entry_exposes_ssdp_tcp_push_and_media_command_runtime() {
         let catalog = first_party_catalog();
         let heos = find_entry(&catalog, &IntegrationId::trusted("heos")).unwrap();
 
@@ -81130,13 +81131,17 @@ mod tests {
         );
         assert_eq!(
             heos.required_capabilities,
-            vec![CapabilityId::trusted("smart_home.read")]
+            vec![
+                CapabilityId::trusted("smart_home.read"),
+                CapabilityId::trusted("smart_home.command.media"),
+            ]
         );
         for primitive in [
             PrimitiveFamily::Ssdp,
             PrimitiveFamily::Udp,
             PrimitiveFamily::Tcp,
             PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::CommandMapping,
             PrimitiveFamily::TestSimulator,
         ] {
             assert!(heos.required_primitives.contains(&primitive));

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Added round-trippable local API labels for D23 media playback, volume,
+  grouping, and queue command types.
 - Added `lan_tcp` bridge transport projection and request parsing.
 - Added `lan_udp` bridge transport projection and request parsing.
 - Added camera entity labels and Home Assistant-compatible `camera` domains to

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -19,8 +19,8 @@ use smart_home_core::{
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
     CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device,
     DeviceCommand, DeviceEvent, DeviceEventType, Entity, EntityId, EntityKind, EventId, Health,
-    IntegrationId, PrivilegeTier, Scene, SceneScope, SmartHomeTool, StateConfidence, StateDelta,
-    StateSource, Value, ValueKind,
+    IntegrationId, MediaCommandType, PrivilegeTier, Scene, SceneScope, SmartHomeTool,
+    StateConfidence, StateDelta, StateSource, Value, ValueKind,
 };
 use smart_home_dashboard_core::NativeDashboardManifest;
 use smart_home_runtime::{
@@ -10258,6 +10258,16 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         CommandType::RecallScene => "recall_scene",
         CommandType::SetLock => "set_lock",
         CommandType::SetThermostatSetpoint => "set_thermostat_setpoint",
+        CommandType::Media(MediaCommandType::SetPlaybackState) => "media_set_playback_state",
+        CommandType::Media(MediaCommandType::PlayNext) => "media_play_next",
+        CommandType::Media(MediaCommandType::PlayPrevious) => "media_play_previous",
+        CommandType::Media(MediaCommandType::SetVolume) => "media_set_volume",
+        CommandType::Media(MediaCommandType::SetMute) => "media_set_mute",
+        CommandType::Media(MediaCommandType::SetGroup) => "media_set_group",
+        CommandType::Media(MediaCommandType::ClearQueue) => "media_clear_queue",
+        CommandType::Media(MediaCommandType::PlayQueueItem) => "media_play_queue_item",
+        CommandType::Media(MediaCommandType::RemoveQueueItem) => "media_remove_queue_item",
+        CommandType::Media(MediaCommandType::MoveQueueItem) => "media_move_queue_item",
     }
 }
 
@@ -10271,6 +10281,16 @@ fn command_type_from_label(command_type: &str) -> Result<CommandType, ApiError> 
         "recall_scene" => Ok(CommandType::RecallScene),
         "set_lock" => Ok(CommandType::SetLock),
         "set_thermostat_setpoint" => Ok(CommandType::SetThermostatSetpoint),
+        "media_set_playback_state" => Ok(CommandType::Media(MediaCommandType::SetPlaybackState)),
+        "media_play_next" => Ok(CommandType::Media(MediaCommandType::PlayNext)),
+        "media_play_previous" => Ok(CommandType::Media(MediaCommandType::PlayPrevious)),
+        "media_set_volume" => Ok(CommandType::Media(MediaCommandType::SetVolume)),
+        "media_set_mute" => Ok(CommandType::Media(MediaCommandType::SetMute)),
+        "media_set_group" => Ok(CommandType::Media(MediaCommandType::SetGroup)),
+        "media_clear_queue" => Ok(CommandType::Media(MediaCommandType::ClearQueue)),
+        "media_play_queue_item" => Ok(CommandType::Media(MediaCommandType::PlayQueueItem)),
+        "media_remove_queue_item" => Ok(CommandType::Media(MediaCommandType::RemoveQueueItem)),
+        "media_move_queue_item" => Ok(CommandType::Media(MediaCommandType::MoveQueueItem)),
         other => Err(ApiError::bad_request(format!(
             "unsupported command_type `{other}`"
         ))),
@@ -13726,5 +13746,26 @@ mod tests {
             bridge_transport_from_label("tcp").unwrap(),
             BridgeTransport::LanTcp
         );
+    }
+
+    #[test]
+    fn media_command_labels_round_trip_through_local_api_labels() {
+        let commands = [
+            ("media_set_playback_state", MediaCommandType::SetPlaybackState),
+            ("media_play_next", MediaCommandType::PlayNext),
+            ("media_play_previous", MediaCommandType::PlayPrevious),
+            ("media_set_volume", MediaCommandType::SetVolume),
+            ("media_set_mute", MediaCommandType::SetMute),
+            ("media_set_group", MediaCommandType::SetGroup),
+            ("media_clear_queue", MediaCommandType::ClearQueue),
+            ("media_play_queue_item", MediaCommandType::PlayQueueItem),
+            ("media_remove_queue_item", MediaCommandType::RemoveQueueItem),
+            ("media_move_queue_item", MediaCommandType::MoveQueueItem),
+        ];
+        for (label, media_command) in commands {
+            let command = CommandType::Media(media_command);
+            assert_eq!(command_type_from_label(label).unwrap(), command);
+            assert_eq!(command_type_label(command), label);
+        }
     }
 }

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Authorization and optimistic-state routing for typed D23 media commands.
 - `RuntimeDurableSnapshot` plus snapshot and restore helpers for normalized
   registry, state, history, pairing, optimistic, and desired-state data.
 - `RuntimeEventDeliverySummary` plus delivery-batch `summary()` helpers for

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -15,7 +15,8 @@ use smart_home_core::{
     CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device,
     DeviceCommand, DeviceEvent, DeviceEventType, DeviceId, Entity, EntityId, EventId, Health,
     IntegrationId, Metadata, PrivilegeTier, Scene, SceneId, SceneScope, SmartHomeError,
-    SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value, VaultRef,
+    MediaCommandType, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value,
+    VaultRef,
 };
 use smart_home_discovery::{
     run_mdns_worker_scan_plan_with_executor, DiscoveryCatalog, DiscoveryError,
@@ -6341,7 +6342,8 @@ fn command_for_desired_state(
         | CommandType::SetColor
         | CommandType::SetColorTemperature
         | CommandType::SetLock
-        | CommandType::SetThermostatSetpoint => desired.value.clone(),
+        | CommandType::SetThermostatSetpoint
+        | CommandType::Media(_) => desired.value.clone(),
         CommandType::RecallScene => Value::Null,
     };
     let command_id = CommandId::trusted(format!(
@@ -6422,8 +6424,13 @@ fn optimistic_snapshot_for_command(command: &DeviceCommand, now_ms: u64) -> Opti
         | CommandType::SetColor
         | CommandType::SetColorTemperature
         | CommandType::SetLock
-        | CommandType::SetThermostatSetpoint => command.arguments.clone(),
+        | CommandType::SetThermostatSetpoint
+        | CommandType::Media(MediaCommandType::SetPlaybackState)
+        | CommandType::Media(MediaCommandType::SetVolume)
+        | CommandType::Media(MediaCommandType::SetMute)
+        | CommandType::Media(MediaCommandType::SetGroup) => command.arguments.clone(),
         CommandType::RecallScene => return None,
+        CommandType::Media(_) => return None,
     };
 
     Some(StateSnapshot {

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -811,16 +811,34 @@ without inventing a media command model prematurely:
 - A real loopback TCP test proves registration, event framing, parsing, and D23
   runtime application over the production transport.
 
+## Current HEOS Media Control Slice
+
+This slice turns the credential-free HEOS player path into an authorized local
+control surface without borrowing command semantics from unrelated domains:
+
+- D23 now has typed media playback, volume, grouping, and queue operations in
+  the canonical device-command envelope, with explicit capability mappings and
+  low-risk policy tiers.
+- HEOS player entities advertise commandable playback, volume, grouping, and
+  queue capabilities alongside their detailed observed player state.
+- The production TCP host supports play/pause/stop, next/previous, volume,
+  mute, group membership, queue clearing, queue playback, removal, and
+  reordering with exact command-response correlation.
+- Grouping authorizes every affected installed player entity before opening a
+  socket. Invalid player references and malformed queue identifiers fail before
+  transport I/O.
+- A real loopback TCP test proves all ten native command transfers, while a
+  denial test proves unauthorized media commands never reach the transport.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-1. Add explicit D23 media command types and capability mappings, then implement
-   authorized HEOS playback, volume, grouping, and queue controls over the
-   existing production TCP host.
-2. Add authorized AirGradient local configuration, LED/display control, and CO2
+1. Add authorized AirGradient local configuration, LED/display control, and CO2
    calibration while keeping cloud-controlled configuration conflicts explicit.
+2. Add authenticated HEOS source browsing and queue insertion only after the
+   account/session and Vault-leasing prerequisites are concrete.
 3. Extend authenticated Reolink CGI support with concrete camera/NVR control,
    media, recording, and push-event operations supported by the current host.
 4. Add another vendor-specific camera or NVR integration where authenticated


### PR DESCRIPTION
## Summary
- add explicit D23 media command types and canonical playback, volume, grouping, and queue capability mappings across core, runtime, Chief tools, and the local HTTP API
- add authorized HEOS playback, volume, mute, grouping, and queue dispatch over the production TCP host with exact response validation and denial-before-I/O behavior
- advertise the HEOS command surface in the integration catalog and reprioritize the remaining Smart Home backlog, including the newly discovered authenticated source-browsing follow-up

## Validation
- `bash smart-home-core/BUILD`
- `bash smart-home-runtime/BUILD`
- `bash smart-home-heos-cli-integration/BUILD`
- `bash smart-home-integration-catalog/BUILD`
- `bash chief-of-staff-smart-home-tools/BUILD`
- `bash smart-home-platform-http/BUILD`
- `bash matter-core/BUILD`
- `cargo clippy -p smart-home-core -p smart-home-runtime -p smart-home-heos-cli-integration -p smart-home-integration-catalog -p chief-of-staff-smart-home-tools -p smart-home-platform-http -p matter-core --all-targets -- -D warnings`
- compatibility compilation across the existing Smart Home integration crates
