### PR TITLE
Validate SPICE parser MOS transconductance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite explicit MOS model-card `KP` values.
 - Lower and validate MOS model-card `U0` / `UO`, deriving `KP` from surface
   mobility and `TOX` when no explicit transconductance is supplied.
 - Validate and lower MOS model-card `TOX` into Level-1 oxide thickness instead

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1891,6 +1891,8 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         mobility = params.get("U0", params.get("UO"))
         if mobility is not None and (not math.isfinite(mobility) or mobility < 0.0):
             raise NetlistParseError("MOSFET U0 must be finite and non-negative")
+        if "KP" in params and (not math.isfinite(params["KP"]) or params["KP"] <= 0.0):
+            raise NetlistParseError("MOSFET KP must be finite and positive")
     return ModelCard(name=name, kind=kind, params=params)
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1436,6 +1436,25 @@ def test_explicit_mosfet_model_kp_overrides_mobility_derivation() -> None:
     assert isclose(mosfet.model.model.params.KP, 123.0e-6)
 
 
+@pytest.mark.parametrize("transconductance", ["0", "-1u", "1e999"])
+def test_rejects_invalid_explicit_mosfet_model_transconductance(
+    transconductance: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET KP must be finite and positive",
+    ):
+        parse_netlist(f".model nfast NMOS(KP={transconductance})\nM1 d g s b nfast\n")
+
+
+def test_preserves_positive_explicit_mosfet_model_transconductance() -> None:
+    parsed = parse_netlist(".model nfast NMOS(KP=175u)\nM1 d g s b nfast\n")
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.KP, 175.0e-6)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite explicit MOS model-card `KP` values.
 - Lower and validate MOS model-card `U0` / `UO`, deriving `KP` from surface
   mobility and `TOX` when no explicit transconductance is supplied.
 - Validate and lower MOS model-card `TOX` into Level-1 oxide thickness instead

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1173,6 +1173,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET U0 must be finite and non-negative");
   }
+  const transconductance = params.get("KP");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    transconductance !== undefined &&
+    (!Number.isFinite(transconductance) || transconductance <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET KP must be finite and positive");
+  }
   return {
     name: fields[1],
     kind,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1355,6 +1355,25 @@ Xright c d load
     expect(element.params.KP).toBeCloseTo(123.0e-6, 15);
   });
 
+  it.each(["0", "-1u", "1e999"])(
+    "rejects invalid explicit MOSFET model KP=%s",
+    (transconductance) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(KP=${transconductance})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET KP must be finite and positive");
+    },
+  );
+
+  it("preserves positive explicit MOSFET model transconductance", () => {
+    const parsed = parseNetlist(".model nfast NMOS(KP=175u)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.params.KP).toBeCloseTo(175.0e-6, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS surface-mobility and derived-`KP` parity.
+1. Python and TypeScript Berkeley SPICE MOS model-card transconductance validation.
    - Status: current PR completion candidate.
-   - Lower `U0` / `UO` and reject negative or non-finite values with the shared
-     diagnostic.
-   - Reuse shared engine semantics to derive `KP` from surface mobility and
-     `TOX` when no explicit transconductance is supplied.
+   - Reject zero, negative, and non-finite explicit model-card `KP` values with
+     the shared diagnostic.
+   - Preserve positive explicit `KP` and the derived-`KP` behavior completed in
+     the preceding slice.
 
 ## Completed Slices
 
@@ -4138,14 +4138,21 @@ the Rust, Python, and TypeScript surfaces together.
      the shared diagnostic.
    - Valid `TOX` values reach Level-1 oxide thickness in both facades.
 
+370. Python and TypeScript Berkeley SPICE MOS surface-mobility and derived-`KP` parity.
+   - Status: completed in PR 9591.
+   - `U0` / `UO` values are lowered and validated with the shared finite
+     non-negative domain.
+   - Shared engine semantics derive `KP` from surface mobility and `TOX` while
+     preserving explicit `KP` precedence.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE MOS surface-mobility and derived-`KP` parity.
-   - Lower `U0` / `UO`, validate its finite non-negative domain, and derive `KP`
-     from `U0` and `TOX` when `KP` is omitted.
+1. Python and TypeScript Berkeley SPICE MOS model-card transconductance validation.
+   - Reject zero, negative, and non-finite explicit `KP` values with the shared
+     diagnostic while preserving derived transconductance behavior.
 
 2. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
-   - Apply Rust-aligned domains and diagnostics to already lowered `KP`, `VT0`,
+   - Apply Rust-aligned domains and diagnostics to already lowered `VT0`,
      `LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, and nominal-temperature fields.
 
 3. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite explicit MOS model-card KP values in Python and TypeScript
- preserve positive explicit KP and the shared-engine derived-KP path
- record PR #9591 completion and keep the remaining core validation fields prioritized

## Verification
- Python spice-netlist-parser: 93 tests passed, 87.97% coverage
- Python ruff: passed
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed, 92 tests passed
- TypeScript spice-netlist-parser coverage: 83.18% statements, 83.83% lines
- git diff --check: passed