### PR TITLE
feat(adj): require explicit dependency hashes

### DIFF
--- a/code/scripts/build_adj_percent_of_provenance.py
+++ b/code/scripts/build_adj_percent_of_provenance.py
@@ -20,9 +20,6 @@ INPUT_CAPTURED_AT = "2026-08-03T00:30:00Z"
 RAW_HASH = "89ebca7f93281cae7d8791cb6dfc65ff4ff289268fc5d7f03d41bb10adeb4e5e"
 RECEIPT_HASH = "a381508533a090ccf7cfc8cf8169c9d6496fe3dd041ff11dfcd78d13f40cfe27"
 RENDERED_HASH = "ac765615e8da33fba525925ae28f392d3c9343ac7539ea54fd0a103ca18fc718"
-ARITHMETIC_BUNDLE_HASH = (
-    "1864e954aee505be00a64dd318f2571aaaed739f83d5f2d4b8e7617d423603c0"
-)
 PERCENT_OF_CLAIM = "adj.math.arithmetic.percent_of"
 QUESTION_CLAIM = "adj.question.arithmetic.percent_of.compute"
 SELECTED_TEXT = b"n% of x items is (n/100)*x."
@@ -307,9 +304,17 @@ def input_claim_payload(item: dict) -> dict:
     return {key: item[key] for key in ("end", "quote", "quote_sha256", "start")}
 
 
-def build(cas: provenance.Cas, captured_source: Path | None) -> dict[str, str]:
+def build(
+    cas: provenance.Cas,
+    captured_source: Path | None,
+    *,
+    arithmetic_bundle_sha256: str,
+) -> dict[str, str]:
+    arithmetic_bundle_sha256 = provenance._require_hash(
+        arithmetic_bundle_sha256, "arithmetic_bundle_sha256"
+    )
     arithmetic = provenance._json_object(
-        cas, ARITHMETIC_BUNDLE_HASH, "provenance_bundle"
+        cas, arithmetic_bundle_sha256, "provenance_bundle"
     )
     if arithmetic.get("bundle_id") != "adj.math.arithmetic.primitives.v1":
         raise provenance.ProvenanceError("arithmetic dependency bundle ID drifted")
@@ -373,7 +378,7 @@ def build(cas: provenance.Cas, captured_source: Path | None) -> dict[str, str]:
                 ],
             }
         ],
-        "dependencies": [ARITHMETIC_BUNDLE_HASH],
+        "dependencies": [arithmetic_bundle_sha256],
         "input": {
             key: input_source[key]
             for key in ("raw_source_sha256", "receipt_sha256", "source_ir_sha256")
@@ -440,8 +445,10 @@ def build(cas: provenance.Cas, captured_source: Path | None) -> dict[str, str]:
             (
                 disabled_start,
                 len(query_bytes),
-                "disabled edge-case example deliberately excluded from the "
-                "executable worked query",
+                (
+                    "disabled edge-case example deliberately excluded from the "
+                    "executable worked query"
+                ),
             )
         ],
     )
@@ -500,6 +507,14 @@ def main() -> None:
         type=Path,
         help="reviewed OpenStax HTML bytes for the one-time CAS bootstrap",
     )
+    parser.add_argument(
+        "--arithmetic-bundle-sha256",
+        required=True,
+        type=lambda value: provenance._require_hash(
+            value, "--arithmetic-bundle-sha256"
+        ),
+        help="verified current primitive arithmetic provenance root",
+    )
     args = parser.parse_args()
     with provenance.BundleRegistrationTransaction(
         REPO_ROOT / provenance.DEFAULT_ROOT,
@@ -508,7 +523,13 @@ def main() -> None:
         schema_path=REPO_ROOT / provenance.DEFAULT_SCHEMA,
         workspace_root=REPO_ROOT,
     ) as transaction:
-        transaction.commit(build(transaction.cas, args.captured_source))
+        transaction.commit(
+            build(
+                transaction.cas,
+                args.captured_source,
+                arithmetic_bundle_sha256=args.arithmetic_bundle_sha256,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/code/scripts/build_adj_ratio_provenance.py
+++ b/code/scripts/build_adj_ratio_provenance.py
@@ -18,9 +18,6 @@ INPUT_CAPTURED_AT = "2026-08-02T23:39:01Z"
 RAW_HASH = "8eced6f9859e60557b69ec9ef2c1cbaf31c7086cc0d9212edc7b39b52ef52baf"
 RECEIPT_HASH = "ce1dc59cf73644563ee6c202b7067d3fab290cafab8534bd958eace36826c93b"
 RENDERED_HASH = "93fd49105b8236bd47254e1da7e378388acba6468a1188a76fe4e3c22767be73"
-ARITHMETIC_BUNDLE_HASH = (
-    "1864e954aee505be00a64dd318f2571aaaed739f83d5f2d4b8e7617d423603c0"
-)
 RATIO_CLAIM = "adj.math.arithmetic.ratio"
 QUESTION_CLAIM = "adj.question.arithmetic.ratio.compute"
 SELECTED_TEXT = (
@@ -279,9 +276,17 @@ def input_claim_payload(item: dict) -> dict:
     return {key: item[key] for key in ("end", "quote", "quote_sha256", "start")}
 
 
-def build(cas: provenance.Cas, captured_source: Path | None) -> dict[str, str]:
+def build(
+    cas: provenance.Cas,
+    captured_source: Path | None,
+    *,
+    arithmetic_bundle_sha256: str,
+) -> dict[str, str]:
+    arithmetic_bundle_sha256 = provenance._require_hash(
+        arithmetic_bundle_sha256, "arithmetic_bundle_sha256"
+    )
     arithmetic = provenance._json_object(
-        cas, ARITHMETIC_BUNDLE_HASH, "provenance_bundle"
+        cas, arithmetic_bundle_sha256, "provenance_bundle"
     )
     if arithmetic.get("bundle_id") != "adj.math.arithmetic.primitives.v1":
         raise provenance.ProvenanceError("arithmetic dependency bundle ID drifted")
@@ -326,7 +331,7 @@ def build(cas: provenance.Cas, captured_source: Path | None) -> dict[str, str]:
                 "input_claim": input_claim_payload(input_claims[RATIO_CLAIM]),
                 "locator": LOCATOR,
                 "resolution": {
-                    "bundle_sha256": ARITHMETIC_BUNDLE_HASH,
+                    "bundle_sha256": arithmetic_bundle_sha256,
                     "claim_id": "adj.math.arithmetic.quotient",
                     "kind": "dependency",
                 },
@@ -336,7 +341,7 @@ def build(cas: provenance.Cas, captured_source: Path | None) -> dict[str, str]:
                 ],
             }
         ],
-        "dependencies": [ARITHMETIC_BUNDLE_HASH],
+        "dependencies": [arithmetic_bundle_sha256],
         "input": {
             key: input_source[key]
             for key in ("raw_source_sha256", "receipt_sha256", "source_ir_sha256")
@@ -451,6 +456,14 @@ def main() -> None:
         type=Path,
         help="reviewed Ratio.html bytes for the one-time CAS bootstrap",
     )
+    parser.add_argument(
+        "--arithmetic-bundle-sha256",
+        required=True,
+        type=lambda value: provenance._require_hash(
+            value, "--arithmetic-bundle-sha256"
+        ),
+        help="verified current primitive arithmetic provenance root",
+    )
     args = parser.parse_args()
     with provenance.BundleRegistrationTransaction(
         REPO_ROOT / provenance.DEFAULT_ROOT,
@@ -459,7 +472,13 @@ def main() -> None:
         schema_path=REPO_ROOT / provenance.DEFAULT_SCHEMA,
         workspace_root=REPO_ROOT,
     ) as transaction:
-        transaction.commit(build(transaction.cas, args.captured_source))
+        transaction.commit(
+            build(
+                transaction.cas,
+                args.captured_source,
+                arithmetic_bundle_sha256=args.arithmetic_bundle_sha256,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/code/scripts/tests/test_adj_stdlib_provenance.py
+++ b/code/scripts/tests/test_adj_stdlib_provenance.py
@@ -5,6 +5,7 @@ import json
 import multiprocessing
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -317,6 +318,23 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                 "snapshot": rendered_hash,
             },
         )
+
+    def registered_bundle_hash(
+        self, cas_root: Path, manifest_path: Path, bundle_id: str
+    ) -> str:
+        cas = provenance.Cas(cas_root)
+        cas.load()
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        matches = [
+            digest
+            for digest in manifest["bundle_hashes"]
+            if provenance._json_object(cas, digest, "provenance_bundle").get(
+                "bundle_id"
+            )
+            == bundle_id
+        ]
+        self.assertEqual(len(matches), 1, f"expected one registered {bundle_id} root")
+        return matches[0]
 
     def replace_bundle(
         self, cas_root: Path, manifest_path: Path, mutate: object
@@ -766,7 +784,6 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             cas_root, manifest_path, hashes = self.build_repository(root)
             baseline_index = (cas_root / "index.json").read_bytes()
             baseline_manifest = manifest_path.read_bytes()
-
             with (
                 self.assertRaisesRegex(
                     provenance.ProvenanceError, "staged unreferenced new objects"
@@ -1241,7 +1258,11 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             provenance_source = repo_root / provenance.DEFAULT_ROOT.parent
             provenance_copy = workspace / provenance.DEFAULT_ROOT.parent
             provenance_copy.parent.mkdir(parents=True)
-            shutil.copytree(provenance_source, provenance_copy)
+            shutil.copytree(
+                provenance_source,
+                provenance_copy,
+                ignore=shutil.ignore_patterns("lock"),
+            )
             arithmetic_source = (
                 repo_root / "code/specs/data/adj-formula-stdlib/arithmetic"
             )
@@ -1255,6 +1276,11 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             manifest_path = workspace / provenance.DEFAULT_MANIFEST
             baseline_index = (cas_root / "index.json").read_bytes()
             baseline_manifest = manifest_path.read_bytes()
+            arithmetic_hash = self.registered_bundle_hash(
+                cas_root,
+                manifest_path,
+                "adj.math.arithmetic.primitives.v1",
+            )
             original_root = ratio_builder.REPO_ROOT
             ratio_builder.REPO_ROOT = workspace
             try:
@@ -1265,7 +1291,13 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                     schema_path=workspace / provenance.DEFAULT_SCHEMA,
                     workspace_root=workspace,
                 ) as transaction:
-                    transaction.commit(ratio_builder.build(transaction.cas, None))
+                    transaction.commit(
+                        ratio_builder.build(
+                            transaction.cas,
+                            None,
+                            arithmetic_bundle_sha256=arithmetic_hash,
+                        )
+                    )
             finally:
                 ratio_builder.REPO_ROOT = original_root
 
@@ -1282,13 +1314,11 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             }
             ratio_hash, ratio_bundle = bundles["adj.math.arithmetic.ratio.v1"]
             query_hash, query_bundle = bundles["adj.math.arithmetic.ratio.query.v1"]
-            self.assertEqual(
-                ratio_bundle["dependencies"], [ratio_builder.ARITHMETIC_BUNDLE_HASH]
-            )
+            self.assertEqual(ratio_bundle["dependencies"], [arithmetic_hash])
             self.assertEqual(
                 ratio_bundle["clauses"][0]["resolution"],
                 {
-                    "bundle_sha256": ratio_builder.ARITHMETIC_BUNDLE_HASH,
+                    "bundle_sha256": arithmetic_hash,
                     "claim_id": "adj.math.arithmetic.quotient",
                     "kind": "dependency",
                 },
@@ -1375,7 +1405,11 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                     workspace_root=workspace,
                 ) as transaction:
                     transaction.commit(
-                        ratio_builder.build(transaction.cas, captured_source)
+                        ratio_builder.build(
+                            transaction.cas,
+                            captured_source,
+                            arithmetic_bundle_sha256=arithmetic_hash,
+                        )
                     )
             finally:
                 ratio_builder.REPO_ROOT = original_root
@@ -1390,7 +1424,11 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             repo_root = percent_of_builder.REPO_ROOT
             provenance_copy = workspace / provenance.DEFAULT_ROOT.parent
             provenance_copy.parent.mkdir(parents=True)
-            shutil.copytree(repo_root / provenance.DEFAULT_ROOT.parent, provenance_copy)
+            shutil.copytree(
+                repo_root / provenance.DEFAULT_ROOT.parent,
+                provenance_copy,
+                ignore=shutil.ignore_patterns("lock"),
+            )
             arithmetic_copy = (
                 workspace / "code/specs/data/adj-formula-stdlib/arithmetic"
             )
@@ -1404,6 +1442,11 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             manifest_path = workspace / provenance.DEFAULT_MANIFEST
             baseline_index = (cas_root / "index.json").read_bytes()
             baseline_manifest = manifest_path.read_bytes()
+            arithmetic_hash = self.registered_bundle_hash(
+                cas_root,
+                manifest_path,
+                "adj.math.arithmetic.primitives.v1",
+            )
             original_root = percent_of_builder.REPO_ROOT
 
             def register(captured_source: Path | None) -> None:
@@ -1417,7 +1460,11 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
                         workspace_root=workspace,
                     ) as transaction:
                         transaction.commit(
-                            percent_of_builder.build(transaction.cas, captured_source)
+                            percent_of_builder.build(
+                                transaction.cas,
+                                captured_source,
+                                arithmetic_bundle_sha256=arithmetic_hash,
+                            )
                         )
                 finally:
                     percent_of_builder.REPO_ROOT = original_root
@@ -1444,7 +1491,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             ]
             self.assertEqual(
                 formula_bundle["dependencies"],
-                [percent_of_builder.ARITHMETIC_BUNDLE_HASH],
+                [arithmetic_hash],
             )
             self.assertEqual(
                 formula_bundle["clauses"][0]["resolution"]["kind"],
@@ -1452,7 +1499,7 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             )
             arithmetic = provenance._json_object(
                 cas,
-                percent_of_builder.ARITHMETIC_BUNDLE_HASH,
+                arithmetic_hash,
                 "provenance_bundle",
             )
             arithmetic_raw = {
@@ -1541,6 +1588,170 @@ class AdjStdlibProvenanceTests(unittest.TestCase):
             register(captured_source)
             self.assertEqual((cas_root / "index.json").read_bytes(), baseline_index)
             self.assertEqual(manifest_path.read_bytes(), baseline_manifest)
+
+    def test_dependent_generators_reject_unverified_dependency_hashes(self) -> None:
+        cas_root = ratio_builder.REPO_ROOT / provenance.DEFAULT_ROOT
+        manifest_path = ratio_builder.REPO_ROOT / provenance.DEFAULT_MANIFEST
+        cas = provenance.Cas(cas_root)
+        cas.load()
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        arithmetic_hash = self.registered_bundle_hash(
+            cas_root,
+            manifest_path,
+            "adj.math.arithmetic.primitives.v1",
+        )
+        wrong_hash = next(
+            digest for digest in manifest["bundle_hashes"] if digest != arithmetic_hash
+        )
+        raw_source_hash = next(
+            digest
+            for digest, record in cas.index.items()
+            if "raw_source" in record["kinds"]
+            and "provenance_bundle" not in record["kinds"]
+        )
+
+        for builder in (ratio_builder, percent_of_builder):
+            with (
+                self.subTest(builder=builder.__name__, failure="absent hash"),
+                self.assertRaises(TypeError),
+            ):
+                builder.build(cas, None)
+            with (
+                self.subTest(builder=builder.__name__, failure="malformed hash"),
+                self.assertRaisesRegex(provenance.ProvenanceError, "lowercase SHA-256"),
+            ):
+                builder.build(
+                    cas,
+                    None,
+                    arithmetic_bundle_sha256="not-a-sha256",
+                )
+            with (
+                self.subTest(builder=builder.__name__, failure="wrong bundle"),
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError,
+                    "arithmetic dependency bundle ID drifted",
+                ),
+            ):
+                builder.build(
+                    cas,
+                    None,
+                    arithmetic_bundle_sha256=wrong_hash,
+                )
+            with (
+                self.subTest(builder=builder.__name__, failure="missing object"),
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError, "missing CAS object"
+                ),
+            ):
+                builder.build(
+                    cas,
+                    None,
+                    arithmetic_bundle_sha256="0" * 64,
+                )
+            with (
+                self.subTest(builder=builder.__name__, failure="non-bundle object"),
+                self.assertRaisesRegex(
+                    provenance.ProvenanceError, "must be a provenance_bundle object"
+                ),
+            ):
+                builder.build(
+                    cas,
+                    None,
+                    arithmetic_bundle_sha256=raw_source_hash,
+                )
+
+    def test_dependent_generator_clis_require_the_dependency_hash(self) -> None:
+        for builder in (ratio_builder, percent_of_builder):
+            with self.subTest(builder=builder.__name__):
+                process = subprocess.run(
+                    [sys.executable, os.fspath(Path(builder.__file__))],
+                    capture_output=True,
+                    check=False,
+                    text=True,
+                )
+                self.assertEqual(process.returncode, 2)
+                self.assertIn(
+                    "the following arguments are required: --arithmetic-bundle-sha256",
+                    process.stderr,
+                )
+
+    def test_dependent_generators_honor_alternate_same_id_dependency(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            repo_root = ratio_builder.REPO_ROOT
+            provenance_copy = workspace / provenance.DEFAULT_ROOT.parent
+            provenance_copy.parent.mkdir(parents=True)
+            shutil.copytree(
+                repo_root / provenance.DEFAULT_ROOT.parent,
+                provenance_copy,
+                ignore=shutil.ignore_patterns("lock"),
+            )
+            arithmetic_copy = (
+                workspace / "code/specs/data/adj-formula-stdlib/arithmetic"
+            )
+            arithmetic_copy.parent.mkdir(parents=True)
+            shutil.copytree(
+                repo_root / "code/specs/data/adj-formula-stdlib/arithmetic",
+                arithmetic_copy,
+            )
+            cas_root = workspace / provenance.DEFAULT_ROOT
+            manifest_path = workspace / provenance.DEFAULT_MANIFEST
+            cas = provenance.Cas(cas_root)
+            cas.load()
+            arithmetic_hash = self.registered_bundle_hash(
+                cas_root,
+                manifest_path,
+                "adj.math.arithmetic.primitives.v1",
+            )
+            alternate = provenance._json_object(
+                cas, arithmetic_hash, "provenance_bundle"
+            )
+            alternate["clauses"][0]["resolution"]["reason"] = (
+                "alternate same-ID dependency selected explicitly by the caller"
+            )
+            alternate_hash = cas.put_json(
+                alternate,
+                kind="provenance_bundle",
+                label="alternate primitive arithmetic dependency",
+                links=provenance._bundle_declared_links(alternate),
+            )
+            self.assertNotEqual(alternate_hash, arithmetic_hash)
+
+            original_ratio_root = ratio_builder.REPO_ROOT
+            original_percent_root = percent_of_builder.REPO_ROOT
+            ratio_builder.REPO_ROOT = workspace
+            percent_of_builder.REPO_ROOT = workspace
+            try:
+                ratio_roots = ratio_builder.build(
+                    cas,
+                    None,
+                    arithmetic_bundle_sha256=alternate_hash,
+                )
+                percent_roots = percent_of_builder.build(
+                    cas,
+                    None,
+                    arithmetic_bundle_sha256=alternate_hash,
+                )
+            finally:
+                ratio_builder.REPO_ROOT = original_ratio_root
+                percent_of_builder.REPO_ROOT = original_percent_root
+
+            ratio = provenance._json_object(
+                cas,
+                ratio_roots["adj.math.arithmetic.ratio.v1"],
+                "provenance_bundle",
+            )
+            percent_of = provenance._json_object(
+                cas,
+                percent_roots["adj.math.arithmetic.percent_of.v1"],
+                "provenance_bundle",
+            )
+            self.assertEqual(ratio["dependencies"], [alternate_hash])
+            self.assertEqual(
+                ratio["clauses"][0]["resolution"]["bundle_sha256"],
+                alternate_hash,
+            )
+            self.assertEqual(percent_of["dependencies"], [alternate_hash])
 
     def test_partition_rejects_gaps_overlaps_and_unreasoned_discards(self) -> None:
         cases = [

--- a/code/specs/ADJ-STDLIB-COVERAGE.md
+++ b/code/specs/ADJ-STDLIB-COVERAGE.md
@@ -311,10 +311,12 @@ option mapping, or judge/evaluation failure.
      linked CAS input on every verification. Output is bounded while streaming, and
      each formula requires its own enclosing input-IR claim. The isolated bridge is
      schema-checked; current manifest roots remain explicitly unmigrated.
-13b. Migrate parser inventories into every formula-bearing provenance root, add
-     explicit dependency-hash inputs to dependent builders, then add
-     `formula_derivation` and execution-witness objects and enforce set equality
-     across parsed exports, replayed derivations, and fully verified query executions.
+13b. **In progress:** dependent provenance builders now require an explicit,
+     syntactically valid primitive-root hash and reject roots whose bundle identity
+     is not the expected arithmetic dependency. Next migrate parser inventories into
+     every formula-bearing provenance root, add `formula_derivation` and
+     execution-witness objects, and enforce set equality across parsed exports,
+     replayed derivations, and fully verified query executions.
 
 ### Wave 2: complete K-8 foundations
 

--- a/code/specs/data/adj-stdlib-provenance/README.md
+++ b/code/specs/data/adj-stdlib-provenance/README.md
@@ -54,19 +54,21 @@ fixtures are rebuilt entirely offline from retained CAS source bodies:
 
 ```text
 python code/scripts/build_adj_arithmetic_provenance.py
-python code/scripts/build_adj_ratio_provenance.py
-python code/scripts/build_adj_percent_of_provenance.py
+python code/scripts/build_adj_ratio_provenance.py --arithmetic-bundle-sha256 <verified-current-root-sha256>
+python code/scripts/build_adj_percent_of_provenance.py --arithmetic-bundle-sha256 <verified-current-root-sha256>
 ```
 
 Each generator checks retained source hashes and expected source spans before
 rebuilding its provenance bundles, IR and transform objects, and CAS linkage.
+Dependent generators require the verified current primitive-arithmetic root hash
+explicitly; they reject malformed hashes and roots with the wrong bundle ID.
 The ratio generator's reviewed one-time bootstrap accepts captured bytes without
 opening the locator; after those exact bytes enter the CAS, ordinary reruns need
 no external file:
 
 ```text
-python code/scripts/build_adj_ratio_provenance.py --captured-source <ratio.html>
-python code/scripts/build_adj_ratio_provenance.py
+python code/scripts/build_adj_ratio_provenance.py --arithmetic-bundle-sha256 <verified-current-root-sha256> --captured-source <ratio.html>
+python code/scripts/build_adj_ratio_provenance.py --arithmetic-bundle-sha256 <verified-current-root-sha256>
 ```
 
 The percent-of bootstrap follows the same offline contract. Six controlled


### PR DESCRIPTION
## Summary

- remove the hidden primitive-arithmetic bundle digest from the ratio and percent-of provenance builders
- require a caller-supplied lowercase SHA-256 through both Python APIs and CLIs, then verify that exact CAS object has the expected primitive bundle identity
- propagate the exact caller digest into dependency edges and ratio's dependency resolution
- derive the current dependency from the validated manifest in tests and prove an alternate same-ID root is honored without historical fallback
- document the explicit offline rebuild contract and update the ADJ backlog status

## Why

A composed provenance builder must not silently retain an obsolete dependency after its prerequisite root is replaced. Making the digest an explicit, validated input exposes the migration boundary and lets the next parser-inventory migration rebuild a complete dependency closure intentionally.

This PR does not migrate any manifest roots or claim that dependency reachability proves formula execution. Derivation and execution-witness enforcement remain the next 13b work.

## Validation

- `python -W error::ResourceWarning -m unittest discover -s code/scripts/tests -p 'test_adj_stdlib_*.py'` (80 passed, 1 expected skip)
- `python -m ruff check code/scripts/build_adj_ratio_provenance.py code/scripts/build_adj_percent_of_provenance.py code/scripts/tests/test_adj_stdlib_provenance.py`
- `python -m ruff format --check code/scripts/build_adj_ratio_provenance.py code/scripts/build_adj_percent_of_provenance.py code/scripts/tests/test_adj_stdlib_provenance.py`
- `python code/scripts/adj_stdlib_manifest.py --validate-json-schema`
- `python code/scripts/adj_stdlib_provenance.py verify --formula-inventory-binary code/packages/rust/target/debug/adj-formula-inventory.exe` (6 bundles, 69 objects, 9 snapshots)
- `python code/scripts/adj_stdlib_report.py --format json --fail-on-unreferenced-tests`
- both CLIs have automated subprocess coverage proving omission exits with code 2
- independent subagent review: no P1/P2 findings