### PR TITLE
Report malformed HTML shell end tags

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- `body` and `html` end tags now report the Standard's parse error when
+  disallowed elements remain on the stack of open elements, closing 7
+  previously silent malformed corpus cases without changing DOM recovery.
 - Duplicate `html`, `head`, and `body` start tags now emit tree-construction
   diagnostics while retaining the Standard's attribute-merge recovery for
   `html` and `body`, closing 28 previously silent malformed corpus cases.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -25,8 +25,8 @@ The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
 all 6,806 html5lib tokenizer cases with zero missing signatures and zero
 normalized skips. DOM output is complete, but diagnostic coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the duplicate document-shell start-tag slice, 1,417 of those cases emit
-at least one lexer or parser diagnostic and 766 remain uncovered. Another 139
+After the document-shell end-tag slice, 1,424 of those cases emit at least one
+lexer or parser diagnostic and 759 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -36,7 +36,8 @@ Prioritized work items:
 
 1. **Document shell insertion modes.** Emit the remaining parse errors around
    explicit and implied `html`, `head`, and `body` creation. Missing-doctype
-   handling and duplicate shell start-tag diagnostics are complete.
+   handling, duplicate shell start-tag diagnostics, and body/html end tags with
+   disallowed open elements are complete.
 2. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
    recovery, formatting reconstruction, and stray start/end tags.
 3. **Table, select, and template insertion modes.** Cover foster parenting,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6603,6 +6603,15 @@ impl HtmlParser {
         if name == "html" {
             self.explicit_html_end_seen = true;
         }
+        if matches!(name, "body" | "html")
+            && self.has_open_element("body")
+            && self.has_disallowed_open_element_for_body_end_tag()
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "shell-end-tag-with-unclosed-elements",
+                format!("end tag `</{name}>` was seen with disallowed open elements"),
+            ));
+        }
         match name {
             "head" if !self.has_open_element("head") && !self.has_open_element("body") => {
                 self.strip_next_leading_lf = false;
@@ -7997,6 +8006,34 @@ impl HtmlParser {
         self.open_elements
             .iter()
             .any(|path| element_at_path(&self.document, path).is_some_and(|n| n == name))
+    }
+
+    fn has_disallowed_open_element_for_body_end_tag(&self) -> bool {
+        self.open_elements.iter().any(|path| {
+            element_ref_at_path(&self.document, path).is_some_and(|element| {
+                element.namespace.is_some()
+                    || !matches!(
+                        element.name.as_str(),
+                        "dd" | "dt"
+                            | "li"
+                            | "optgroup"
+                            | "option"
+                            | "p"
+                            | "rb"
+                            | "rp"
+                            | "rt"
+                            | "rtc"
+                            | "tbody"
+                            | "td"
+                            | "tfoot"
+                            | "th"
+                            | "thead"
+                            | "tr"
+                            | "body"
+                            | "html"
+                    )
+            })
+        })
     }
 
     fn has_document_type(&self) -> bool {
@@ -32788,6 +32825,28 @@ mod tests {
     }
 
     #[test]
+    fn reports_shell_end_tags_with_disallowed_open_elements() {
+        for (source, end_tag) in [
+            ("<!doctype html><menuitem></body>", "body"),
+            ("<!doctype html><menuitem></html>", "html"),
+            ("<!doctype html><table><tbody><tr><td></body>", "body"),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "shell-end-tag-with-unclosed-elements",
+                    format!("end tag `</{end_tag}>` was seen with disallowed open elements")
+                )],
+                "source {source:?}"
+            );
+        }
+
+        let allowed = parse_html_with_diagnostics("<!doctype html><p></body>").unwrap();
+        assert!(allowed.parser_diagnostics.is_empty());
+    }
+
+    #[test]
     fn ignores_head_start_tags_after_body_content_starts() {
         let output = parse_html_with_diagnostics(
             "<!doctype html><body><p>before</p><head data-late=yes><p>after</p>",
@@ -32927,7 +32986,13 @@ mod tests {
         )
         .unwrap();
 
-        assert!(output.parser_diagnostics.is_empty());
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "shell-end-tag-with-unclosed-elements",
+                "end tag `</html>` was seen with disallowed open elements"
+            )]
+        );
         assert_eq!(element(&head(&output.document).children[0]).name, "title");
 
         let output_body = body(&output.document);

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 766);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1417);
+    assert_eq!(missing_diagnostic_cases, 759);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1424);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the current HTML Standard parse error for `</body>` and `</html>` when disallowed elements remain open
- preserve existing recovery and all 2,637 checked DOM outputs
- ratchet malformed tree diagnostic coverage from 1,417 to 1,424 cases, reducing silent cases from 766 to 759 with no increase in undeclared diagnostics
- update the conformance backlog and changelog

## Evidence
- [HTML Standard: in body insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody)
- executable corpus cases include open `menuitem` and table contexts, plus an allowed open-`p` control

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`