### PR TITLE
Validate SPICE parser MOS threshold voltage

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject non-finite MOS model-card `VT0` / `VTO` / `VTH` values and lower the
+  `VTH` alias into Level-1 threshold voltage.
 - Reject zero, negative, and non-finite explicit MOS model-card `KP` values.
 - Lower and validate MOS model-card `U0` / `UO`, deriving `KP` from surface
   mobility and `TOX` when no explicit transconductance is supplied.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1893,6 +1893,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             raise NetlistParseError("MOSFET U0 must be finite and non-negative")
         if "KP" in params and (not math.isfinite(params["KP"]) or params["KP"] <= 0.0):
             raise NetlistParseError("MOSFET KP must be finite and positive")
+        threshold_voltage = next(
+            (params[name] for name in ("VT0", "VTO", "VTH") if name in params),
+            None,
+        )
+        if threshold_voltage is not None and not math.isfinite(threshold_voltage):
+            raise NetlistParseError("MOSFET VT0 must be finite")
     return ModelCard(name=name, kind=kind, params=params)
 
 
@@ -1932,6 +1938,7 @@ _LEVEL1_PARAM_ALIASES = {
     "TNOM": "T_NOM",
     "UO": "U0",
     "VTO": "VT0",
+    "VTH": "VT0",
 }
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1455,6 +1455,21 @@ def test_preserves_positive_explicit_mosfet_model_transconductance() -> None:
     assert isclose(mosfet.model.model.params.KP, 175.0e-6)
 
 
+@pytest.mark.parametrize("alias", ["VT0", "VTO", "VTH"])
+def test_rejects_non_finite_mosfet_model_threshold_voltage(alias: str) -> None:
+    with pytest.raises(NetlistParseError, match="MOSFET VT0 must be finite"):
+        parse_netlist(f".model nfast NMOS({alias}=1e999)\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("alias", ["VT0", "VTO", "VTH"])
+def test_lowers_finite_mosfet_model_threshold_voltage_aliases(alias: str) -> None:
+    parsed = parse_netlist(f".model nfast NMOS({alias}=-0.38)\nM1 d g s b nfast\n")
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.VT0 == -0.38
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject non-finite MOS model-card `VT0` / `VTO` / `VTH` values and lower the
+  `VTH` alias into Level-1 threshold voltage.
 - Reject zero, negative, and non-finite explicit MOS model-card `KP` values.
 - Lower and validate MOS model-card `U0` / `UO`, deriving `KP` from surface
   mobility and `TOX` when no explicit transconductance is supplied.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1181,6 +1181,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET KP must be finite and positive");
   }
+  const thresholdVoltage = params.get("VT0") ?? params.get("VTO") ?? params.get("VTH");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    thresholdVoltage !== undefined &&
+    !Number.isFinite(thresholdVoltage)
+  ) {
+    throw new NetlistParseError("MOSFET VT0 must be finite");
+  }
   return {
     name: fields[1],
     kind,
@@ -1221,6 +1229,7 @@ function parseElementParams(tokens: readonly string[], label: string): ReadonlyM
 
 const MOSFET_PARAM_ALIASES = new Map<string, keyof MosfetLevel1Params>([
   ["VTO", "VT0"],
+  ["VTH", "VT0"],
   ["NSUB", "N_SUB"],
   ["N", "N_SUB"],
   ["TNOM", "T_NOM"],

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1374,6 +1374,28 @@ Xright c d load
     expect(element.params.KP).toBeCloseTo(175.0e-6, 15);
   });
 
+  it.each(["VT0", "VTO", "VTH"])(
+    "rejects non-finite MOSFET model threshold alias %s",
+    (alias) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(${alias}=1e999)\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET VT0 must be finite");
+    },
+  );
+
+  it.each(["VT0", "VTO", "VTH"])(
+    "lowers finite MOSFET model threshold alias %s",
+    (alias) => {
+      const parsed = parseNetlist(`.model nfast NMOS(${alias}=-0.38)\nM1 d g s b nfast\n`);
+      const element = parsed.circuit.elements()[0];
+      expect(element.kind).toBe("mosfet");
+      if (element.kind !== "mosfet") {
+        throw new Error("unexpected element kind");
+      }
+      expect(element.params.VT0).toBe(-0.38);
+    },
+  );
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS model-card transconductance validation.
+1. Python and TypeScript Berkeley SPICE MOS threshold-voltage validation parity.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite explicit model-card `KP` values with
-     the shared diagnostic.
-   - Preserve positive explicit `KP` and the derived-`KP` behavior completed in
-     the preceding slice.
+   - Reject non-finite `VT0` / `VTO` / `VTH` values with the shared diagnostic.
+   - Lower finite `VTH` values through the canonical Level-1 threshold-voltage
+     field instead of silently discarding that alias.
 
 ## Completed Slices
 
@@ -4145,15 +4144,21 @@ the Rust, Python, and TypeScript surfaces together.
    - Shared engine semantics derive `KP` from surface mobility and `TOX` while
      preserving explicit `KP` precedence.
 
+371. Python and TypeScript Berkeley SPICE MOS model-card transconductance validation.
+   - Status: completed in PR 9595.
+   - Zero, negative, and non-finite explicit model-card `KP` values are rejected
+     with the shared diagnostic.
+   - Positive explicit `KP` and derived transconductance behavior remain intact.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE MOS model-card transconductance validation.
-   - Reject zero, negative, and non-finite explicit `KP` values with the shared
-     diagnostic while preserving derived transconductance behavior.
+1. Python and TypeScript Berkeley SPICE MOS threshold-voltage validation parity.
+   - Reject non-finite `VT0` / `VTO` / `VTH` values and lower all three aliases
+     into canonical Level-1 threshold voltage.
 
 2. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
-   - Apply Rust-aligned domains and diagnostics to already lowered `VT0`,
-     `LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, and nominal-temperature fields.
+   - Apply Rust-aligned domains and diagnostics to already lowered `LAMBDA`,
+     `GAMMA`, `PHI`, `W`, `L`, `IS`, and nominal-temperature fields.
 
 3. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
    - Lower missing canonical resistance, geometry, capacitance, junction, and


### PR DESCRIPTION
## Summary
- reject non-finite MOS model-card VT0, VTO, and VTH values in Python and TypeScript
- lower the previously ignored VTH alias into canonical Level-1 threshold voltage
- record PR #9595 completion and keep the remaining core validation fields prioritized

## Verification
- Python spice-netlist-parser: 99 tests passed, 88.00% coverage
- Python ruff: passed
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed, 98 tests passed
- TypeScript spice-netlist-parser coverage: 83.24% statements, 83.88% lines
- git diff --check: passed