### PR TITLE
fix(spice): validate parser MOS channel modulation

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject non-finite MOS model-card `LAMBDA` / `LAM` values and lower the `LAM`
+  alias into Level-1 channel-length modulation.
 - Reject non-finite MOS model-card `VT0` / `VTO` / `VTH` values and lower the
   `VTH` alias into Level-1 threshold voltage.
 - Reject zero, negative, and non-finite explicit MOS model-card `KP` values.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1899,6 +1899,9 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         )
         if threshold_voltage is not None and not math.isfinite(threshold_voltage):
             raise NetlistParseError("MOSFET VT0 must be finite")
+        channel_modulation = params.get("LAMBDA", params.get("LAM"))
+        if channel_modulation is not None and not math.isfinite(channel_modulation):
+            raise NetlistParseError("MOSFET LAMBDA must be finite")
     return ModelCard(name=name, kind=kind, params=params)
 
 
@@ -1939,6 +1942,7 @@ _LEVEL1_PARAM_ALIASES = {
     "UO": "U0",
     "VTO": "VT0",
     "VTH": "VT0",
+    "LAM": "LAMBDA",
 }
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1470,6 +1470,21 @@ def test_lowers_finite_mosfet_model_threshold_voltage_aliases(alias: str) -> Non
     assert mosfet.model.model.params.VT0 == -0.38
 
 
+@pytest.mark.parametrize("alias", ["LAMBDA", "LAM"])
+def test_rejects_non_finite_mosfet_model_channel_modulation(alias: str) -> None:
+    with pytest.raises(NetlistParseError, match="MOSFET LAMBDA must be finite"):
+        parse_netlist(f".model nfast NMOS({alias}=1e999)\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("alias", ["LAMBDA", "LAM"])
+def test_lowers_finite_mosfet_model_channel_modulation_aliases(alias: str) -> None:
+    parsed = parse_netlist(f".model nfast NMOS({alias}=-0.02)\nM1 d g s b nfast\n")
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.LAMBDA == -0.02
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject non-finite MOS model-card `LAMBDA` / `LAM` values and lower the `LAM`
+  alias into Level-1 channel-length modulation.
 - Reject non-finite MOS model-card `VT0` / `VTO` / `VTH` values and lower the
   `VTH` alias into Level-1 threshold voltage.
 - Reject zero, negative, and non-finite explicit MOS model-card `KP` values.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1189,6 +1189,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET VT0 must be finite");
   }
+  const channelModulation = params.get("LAMBDA") ?? params.get("LAM");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    channelModulation !== undefined &&
+    !Number.isFinite(channelModulation)
+  ) {
+    throw new NetlistParseError("MOSFET LAMBDA must be finite");
+  }
   return {
     name: fields[1],
     kind,
@@ -1230,6 +1238,7 @@ function parseElementParams(tokens: readonly string[], label: string): ReadonlyM
 const MOSFET_PARAM_ALIASES = new Map<string, keyof MosfetLevel1Params>([
   ["VTO", "VT0"],
   ["VTH", "VT0"],
+  ["LAM", "LAMBDA"],
   ["NSUB", "N_SUB"],
   ["N", "N_SUB"],
   ["TNOM", "T_NOM"],

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1396,6 +1396,28 @@ Xright c d load
     },
   );
 
+  it.each(["LAMBDA", "LAM"])(
+    "rejects non-finite MOSFET model channel-modulation alias %s",
+    (alias) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(${alias}=1e999)\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET LAMBDA must be finite");
+    },
+  );
+
+  it.each(["LAMBDA", "LAM"])(
+    "lowers finite MOSFET model channel-modulation alias %s",
+    (alias) => {
+      const parsed = parseNetlist(`.model nfast NMOS(${alias}=-0.02)\nM1 d g s b nfast\n`);
+      const element = parsed.circuit.elements()[0];
+      expect(element.kind).toBe("mosfet");
+      if (element.kind !== "mosfet") {
+        throw new Error("unexpected element kind");
+      }
+      expect(element.params.LAMBDA).toBe(-0.02);
+    },
+  );
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,10 +33,10 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS threshold-voltage validation parity.
+1. Python and TypeScript Berkeley SPICE MOS channel-modulation validation parity.
    - Status: current PR completion candidate.
-   - Reject non-finite `VT0` / `VTO` / `VTH` values with the shared diagnostic.
-   - Lower finite `VTH` values through the canonical Level-1 threshold-voltage
+   - Reject non-finite `LAMBDA` / `LAM` values with the shared diagnostic.
+   - Lower finite `LAM` values through the canonical Level-1 channel-modulation
      field instead of silently discarding that alias.
 
 ## Completed Slices
@@ -4150,25 +4150,27 @@ the Rust, Python, and TypeScript surfaces together.
      with the shared diagnostic.
    - Positive explicit `KP` and derived transconductance behavior remain intact.
 
+372. Python and TypeScript Berkeley SPICE MOS threshold-voltage validation parity.
+   - Status: completed in PR 9598.
+   - Non-finite `VT0` / `VTO` / `VTH` values are rejected with the shared
+     diagnostic.
+   - Finite `VTH` values lower into canonical Level-1 threshold voltage.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE MOS threshold-voltage validation parity.
-   - Reject non-finite `VT0` / `VTO` / `VTH` values and lower all three aliases
-     into canonical Level-1 threshold voltage.
+1. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
+   - Apply Rust-aligned domains and diagnostics to already lowered `GAMMA`,
+     `PHI`, `W`, `L`, `IS`, and nominal-temperature fields.
 
-2. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
-   - Apply Rust-aligned domains and diagnostics to already lowered `LAMBDA`,
-     `GAMMA`, `PHI`, `W`, `L`, `IS`, and nominal-temperature fields.
-
-3. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
+2. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
    - Lower missing canonical resistance, geometry, capacitance, junction, and
-     noise fields, then align `VTH`, `LAM`, `CJS`, and `CJD` aliases.
+     noise fields, then align the `CJS` and `CJD` aliases.
 
-4. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
+3. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
    - Validate and consume `NSS` / `TPG`, then derive `VT0`, `GAMMA`, and `PHI`
      from `N_SUB` / `TOX` with shared engine semantics.
 
-5. Grammar-backed parser and app facade.
+4. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
@@ -4176,7 +4178,7 @@ the Rust, Python, and TypeScript surfaces together.
      toward packaging, WebAssembly embedding, and product integration backed by
      the same public parser contract.
 
-6. Deck compatibility follow-up.
+5. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis
      execution and stable artifact exports toward nested sweeps, raw-format
      interoperability, and remaining vendor-style output controls.
@@ -4187,7 +4189,7 @@ the Rust, Python, and TypeScript surfaces together.
      command routing, including control flow, variables, and script execution
      policy.
 
-7. Production solver core follow-up.
+6. Production solver core follow-up.
    - Sparse real/complex matrix paths now have cross-language native coverage,
      and Python real DC solves now use an optional SciPy sparse-LU backend with
      structured native fallback metadata.
@@ -4198,14 +4200,14 @@ the Rust, Python, and TypeScript surfaces together.
      damping, device limiting, tolerance policy, and additional convergence
      diagnostics for difficult transistor decks.
 
-8. Device model depth.
+7. Device model depth.
    - Audit diode, BJT, JFET, and MOS Level 1 behavior against reference decks.
    - Decide whether Level 2/3 MOS is in scope before BSIM; if BSIM lands, make
      Rust the first fast path and port stable semantics outward.
    - Expand temperature behavior, capacitance, noise, charge conservation, model
      card aliases, and error messages.
 
-9. Analysis completion.
+8. Analysis completion.
    - Generalize pole-zero beyond constrained fixture helpers.
    - Expand nonlinear distortion coverage.
    - Expand parsed `.FOUR` / `.MEASURE` integration across output plans and
@@ -4214,14 +4216,14 @@ the Rust, Python, and TypeScript surfaces together.
      Carlo trials.
    - Stabilize raw, CSV, JSON, and browser-friendly result formats.
 
-10. Mixed-signal integration.
+9. Mixed-signal integration.
    - Connect SPICE transient stepping to the hardware VM scheduler.
    - Support bidirectional analog/digital thresholds, event scheduling,
      breakpoint coordination, and VCD correlation.
    - Keep mixed-signal coupling deterministic across Python, Rust, and
      TypeScript.
 
-11. Verilog-A and custom models.
+10. Verilog-A and custom models.
    - Specify the accepted model subset and residual/Jacobian hooks.
    - Add parser or compiler support with sandboxing for TypeScript/web usage.
    - Provide a Rust-native fast path for compiled models.


### PR DESCRIPTION
## Summary
- reject non-finite MOS model-card `LAMBDA` and `LAM` values in Python and TypeScript parsers
- lower the Berkeley `LAM` alias into canonical Level-1 `LAMBDA`
- add cross-language regression coverage, changelogs, and advance the SPICE implementation plan

## Verification
- Python spice-netlist-parser: 103 tests passed, 88.04% coverage
- Python Ruff: passed
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed; 102 tests passed; 83.29% statement / 83.94% line coverage
- `git diff --check origin/main...HEAD`