### PR TITLE
refactor(venture): share native host state

### DIFF
--- a/code/packages/rust/venture-browser-core/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a host-neutral `BrowserHostController` that keeps Mosaic event handling,
+  transactional chrome/status synchronization, scrolling, link activation,
+  and hover projection identical across native platform adapters.
 - Add target-neutral `BrowserScrollMetrics` and shared-session absolute offset
   control for generated native scrollbar projection.
 - Add non-mutating shared-session link hover lookup for native status and

--- a/code/packages/rust/venture-browser-core/src/lib.rs
+++ b/code/packages/rust/venture-browser-core/src/lib.rs
@@ -577,6 +577,167 @@ impl BrowserChromeController {
     }
 }
 
+/// Shared host state behind Venture's native Mosaic adapters.
+///
+/// Platform crates remain responsible for constructing their native text and
+/// paint pipeline. This controller owns the behavior that must not drift
+/// between those adapters: Mosaic event reduction, transactional status and
+/// chrome synchronization, scrolling, absolute scrollbar projection, link
+/// activation, and hover status.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BrowserHostController {
+    session: BrowserSession,
+    chrome: BrowserChromeController,
+    status_text: String,
+    hovered_link_url: Option<String>,
+}
+
+impl BrowserHostController {
+    pub fn new(session: BrowserSession) -> Self {
+        let chrome = BrowserChromeController::new(&session);
+        Self {
+            session,
+            chrome,
+            status_text: "Ready".to_string(),
+            hovered_link_url: None,
+        }
+    }
+
+    pub fn session(&self) -> &BrowserSession {
+        &self.session
+    }
+
+    /// Mutable session access for the platform-owned reflow and paint seam.
+    pub fn session_mut(&mut self) -> &mut BrowserSession {
+        &mut self.session
+    }
+
+    pub fn props(&self) -> BrowserChromeProps {
+        self.chrome.props(
+            &self.session,
+            self.hovered_link_url
+                .clone()
+                .unwrap_or_else(|| self.status_text.clone()),
+            false,
+        )
+    }
+
+    /// Reduce a Mosaic event and execute any resulting navigation through the
+    /// platform's native page-composition pipeline.
+    pub fn handle_event<F>(
+        &mut self,
+        event: BrowserChromeEvent,
+        execute: F,
+    ) -> Result<bool, BrowserLoadError>
+    where
+        F: FnOnce(&mut BrowserSession, BrowserNavigation) -> Result<bool, BrowserLoadError>,
+    {
+        self.hovered_link_url = None;
+        let Some(navigation) = self.chrome.handle_event(event, &self.session, false) else {
+            return Ok(false);
+        };
+        self.execute_navigation(navigation, execute)
+    }
+
+    pub fn scroll_by(&mut self, delta_y: f64) -> bool {
+        self.hovered_link_url = None;
+        let Some(viewport) = self.session.viewport_mut() else {
+            return false;
+        };
+        let before = viewport.scroll_state().offset_y();
+        viewport.scroll_by(delta_y);
+        viewport.scroll_state().offset_y() != before
+    }
+
+    pub fn scroll_command(&mut self, command: BrowserScrollCommand) -> bool {
+        self.hovered_link_url = None;
+        let Some(viewport) = self.session.viewport_mut() else {
+            return false;
+        };
+        let before = viewport.scroll_state().offset_y();
+        viewport.scroll_command(command);
+        viewport.scroll_state().offset_y() != before
+    }
+
+    pub fn scroll_metrics(&self) -> Option<BrowserScrollMetrics> {
+        self.session.scroll_metrics()
+    }
+
+    pub fn scroll_to(&mut self, offset_y: f64) -> bool {
+        self.hovered_link_url = None;
+        let before = self
+            .session
+            .scroll_metrics()
+            .map(|metrics| metrics.offset_y);
+        let after = self.session.set_scroll_offset_y(offset_y);
+        before
+            .zip(after)
+            .is_some_and(|(before, after)| before != after)
+    }
+
+    /// Activate the shared-session link under a native surface coordinate and
+    /// execute it through the same platform navigation closure as chrome.
+    pub fn activate_link<F>(
+        &mut self,
+        viewport_x: f64,
+        viewport_y: f64,
+        execute: F,
+    ) -> Result<bool, BrowserLoadError>
+    where
+        F: FnOnce(&mut BrowserSession, BrowserNavigation) -> Result<bool, BrowserLoadError>,
+    {
+        self.hovered_link_url = None;
+        let Some(url) = self
+            .session
+            .hovered_link_url(viewport_x, viewport_y)
+            .map(str::to_owned)
+        else {
+            return Ok(false);
+        };
+        self.execute_navigation(BrowserNavigation::Navigate(url), execute)
+    }
+
+    pub fn update_hover(&mut self, viewport_x: f64, viewport_y: f64) -> bool {
+        self.hovered_link_url = if viewport_x.is_finite() && viewport_y.is_finite() {
+            self.session
+                .hovered_link_url(viewport_x, viewport_y)
+                .map(str::to_owned)
+        } else {
+            None
+        };
+        self.hovered_link_url.is_some()
+    }
+
+    /// Clear transient hover projection before a platform-owned resize.
+    pub fn clear_hover(&mut self) {
+        self.hovered_link_url = None;
+    }
+
+    fn execute_navigation<F>(
+        &mut self,
+        navigation: BrowserNavigation,
+        execute: F,
+    ) -> Result<bool, BrowserLoadError>
+    where
+        F: FnOnce(&mut BrowserSession, BrowserNavigation) -> Result<bool, BrowserLoadError>,
+    {
+        self.status_text = "Loading".to_string();
+        match execute(&mut self.session, navigation) {
+            Ok(changed) => {
+                if changed {
+                    self.chrome.synchronize(&self.session);
+                }
+                self.status_text = "Ready".to_string();
+                Ok(changed)
+            }
+            Err(error) => {
+                self.status_text = format!("Load failed: {error}");
+                Err(error)
+            }
+        }
+    }
+}
+
 /// Host-neutral browser state spanning navigation, loading, and the viewport.
 ///
 /// Navigation is transactional: a failed page load leaves both history and the
@@ -1059,6 +1220,77 @@ mod tests {
             events.map(|event| event.mosaic_name()),
             VENTURE_CHROME_EVENT_NAMES
         );
+    }
+
+    #[test]
+    fn shared_host_controller_keeps_native_adapter_behavior_in_one_state_machine() {
+        let home_url = "http://example.test/";
+        let next_url = "http://example.test/next";
+        let fetcher = |url: &str| match url {
+            "http://example.test/" => Ok(BrowserFetchResponse::new(
+                url,
+                200,
+                Some("text/html".into()),
+                b"<title>Home</title><p><a href='/next'>Next</a></p>".to_vec(),
+            )),
+            "http://example.test/next" => Ok(BrowserFetchResponse::new(
+                url,
+                200,
+                Some("text/html".into()),
+                format!(
+                    "<title>Next</title>{}",
+                    (0..40)
+                        .map(|index| format!("<p>Scrollable row {index}</p>"))
+                        .collect::<String>()
+                )
+                .into_bytes(),
+            )),
+            _ => Err("offline".to_string()),
+        };
+        let theme = mosaic_html_theme();
+        let pipeline = BrowserPagePipeline::new(
+            &theme,
+            HtmlPaintViewport::new(220.0, 80.0, 1.0),
+            &MonoMeasurer,
+            &FakeShaper,
+            &FakeMetrics,
+            &FakeResolver,
+        );
+        let mut session = BrowserSession::new(home_url, 40.0);
+        session
+            .execute(BrowserNavigation::Home, &pipeline, &fetcher)
+            .expect("home should load");
+        let mut host = BrowserHostController::new(session);
+
+        assert_eq!(host.props().page_title, "Home");
+        let link = host.session().viewport().unwrap().page().paint.links[0].clone();
+        assert!(host.update_hover(link.x + 1.0, link.y + 1.0));
+        assert_eq!(host.props().status_text, next_url);
+        assert!(host
+            .activate_link(link.x + 1.0, link.y + 1.0, |session, navigation| {
+                Ok(session.execute(navigation, &pipeline, &fetcher)?.is_some())
+            })
+            .expect("link should load"));
+        assert_eq!(host.props().page_title, "Next");
+        assert_eq!(host.props().address, next_url);
+        assert!(host.scroll_by(40.0));
+        assert!(host.scroll_metrics().unwrap().offset_y > 0.0);
+
+        assert!(!host
+            .handle_event(
+                BrowserChromeEvent::AddressChange("http://missing.test/".into()),
+                |_, _| unreachable!("address edits do not execute navigation"),
+            )
+            .unwrap());
+        let error = host
+            .handle_event(BrowserChromeEvent::Navigate, |session, navigation| {
+                Ok(session.execute(navigation, &pipeline, &fetcher)?.is_some())
+            })
+            .expect_err("missing page should fail transactionally");
+        assert!(matches!(error, BrowserLoadError::Fetch { .. }));
+        assert_eq!(host.session().history().current_url(), Some(next_url));
+        assert_eq!(host.props().address, "http://missing.test/");
+        assert!(host.props().status_text.starts_with("Load failed:"));
     }
 
     #[test]

--- a/code/packages/rust/venture-browser-macos/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-macos/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Delegate generated-host browser state and interaction behavior to the shared
+  `venture-browser-core::BrowserHostController`, retaining only native page
+  composition and Metal presentation in this adapter.
 - Bind a generated-host `NSScroller` to shared Rust viewport metrics and
   absolute offset control, with direct app acceptance.
 - Project shared link-hover URLs into Mosaic status and drive the generated

--- a/code/packages/rust/venture-browser-macos/src/lib.rs
+++ b/code/packages/rust/venture-browser-macos/src/lib.rs
@@ -20,7 +20,7 @@ use window_core::{ElementState, Key, NamedKey, PointerButton, WindowError, Windo
 
 #[cfg(target_vendor = "apple")]
 use venture_browser_core::{
-    BrowserChromeController, BrowserChromeEvent, BrowserChromeProps, BrowserScrollMetrics,
+    BrowserChromeEvent, BrowserChromeProps, BrowserHostController, BrowserScrollMetrics,
     HttpBrowserFetcher,
 };
 
@@ -399,13 +399,10 @@ impl BrowserResourceFetcher for OwnedFetcher {
 
 #[cfg(target_vendor = "apple")]
 pub struct MacBrowserHost {
-    session: BrowserSession,
-    chrome: BrowserChromeController,
+    controller: BrowserHostController,
     fetcher: OwnedFetcher,
     width: f64,
     height: f64,
-    status_text: String,
-    hovered_link_url: Option<String>,
 }
 
 #[cfg(target_vendor = "apple")]
@@ -427,122 +424,61 @@ impl MacBrowserHost {
     ) -> Result<Self, BrowserLoadError> {
         let fetcher = OwnedFetcher(fetcher);
         let session = load_initial_session(start_url, width, height, &fetcher)?;
-        let chrome = BrowserChromeController::new(&session);
         Ok(Self {
-            session,
-            chrome,
+            controller: BrowserHostController::new(session),
             fetcher,
             width,
             height,
-            status_text: "Ready".to_string(),
-            hovered_link_url: None,
         })
     }
 
     pub fn props(&self) -> BrowserChromeProps {
-        self.chrome.props(
-            &self.session,
-            self.hovered_link_url
-                .clone()
-                .unwrap_or_else(|| self.status_text.clone()),
-            false,
-        )
+        self.controller.props()
     }
 
     pub fn handle_event(&mut self, event: BrowserChromeEvent) -> Result<bool, BrowserLoadError> {
-        self.hovered_link_url = None;
-        let Some(navigation) = self.chrome.handle_event(event, &self.session, false) else {
-            return Ok(false);
-        };
-        self.status_text = "Loading".to_string();
-        match navigate_session(
-            &mut self.session,
-            navigation,
-            self.width,
-            self.height,
-            &self.fetcher,
-        ) {
-            Ok(changed) => {
-                if changed {
-                    self.chrome.synchronize(&self.session);
-                }
-                self.status_text = "Ready".to_string();
-                Ok(changed)
-            }
-            Err(error) => {
-                self.status_text = format!("Load failed: {error}");
-                Err(error)
-            }
-        }
+        let width = self.width;
+        let height = self.height;
+        let fetcher = &self.fetcher;
+        self.controller.handle_event(event, |session, navigation| {
+            navigate_session(session, navigation, width, height, fetcher)
+        })
     }
 
     pub fn scroll_by(&mut self, delta_y: f64) -> bool {
-        self.hovered_link_url = None;
-        let Some(viewport) = self.session.viewport_mut() else {
-            return false;
-        };
-        let before = viewport.scroll_state().offset_y();
-        viewport.scroll_by(delta_y);
-        viewport.scroll_state().offset_y() != before
+        self.controller.scroll_by(delta_y)
     }
 
     pub fn scroll_command(&mut self, command: BrowserScrollCommand) -> bool {
-        self.hovered_link_url = None;
-        let Some(viewport) = self.session.viewport_mut() else {
-            return false;
-        };
-        let before = viewport.scroll_state().offset_y();
-        viewport.scroll_command(command);
-        viewport.scroll_state().offset_y() != before
+        self.controller.scroll_command(command)
     }
 
     pub fn scroll_metrics(&self) -> Option<BrowserScrollMetrics> {
-        self.session.scroll_metrics()
+        self.controller.scroll_metrics()
     }
 
     pub fn scroll_to(&mut self, offset_y: f64) -> bool {
-        self.hovered_link_url = None;
-        let before = self
-            .session
-            .scroll_metrics()
-            .map(|metrics| metrics.offset_y);
-        let after = self.session.set_scroll_offset_y(offset_y);
-        before
-            .zip(after)
-            .is_some_and(|(before, after)| before != after)
+        self.controller.scroll_to(offset_y)
     }
 
     pub fn activate_link(&mut self, x: f64, y: f64) -> Result<bool, BrowserLoadError> {
-        self.hovered_link_url = None;
-        let changed = activate_link_at(
-            &mut self.session,
-            x,
-            y,
-            self.width,
-            self.height,
-            &self.fetcher,
-        )?;
-        if changed {
-            self.chrome.synchronize(&self.session);
-            self.status_text = "Ready".to_string();
-        }
-        Ok(changed)
+        let width = self.width;
+        let height = self.height;
+        let fetcher = &self.fetcher;
+        self.controller.activate_link(x, y, |session, navigation| {
+            navigate_session(session, navigation, width, height, fetcher)
+        })
     }
 
     pub fn update_hover(&mut self, x: f64, y: f64) -> bool {
-        self.hovered_link_url = if x.is_finite() && y.is_finite() {
-            self.session.hovered_link_url(x, y).map(str::to_owned)
-        } else {
-            None
-        };
-        self.hovered_link_url.is_some()
+        self.controller.update_hover(x, y)
     }
 
     /// Reflow the retained page for a new logical content-surface size.
     /// The HTML document and navigation history stay in the shared session;
     /// only layout, paint, image placement, and scroll bounds are recomputed.
     pub fn resize(&mut self, width: f64, height: f64) -> bool {
-        self.hovered_link_url = None;
+        self.controller.clear_hover();
         let width = finite_positive_or(width, self.width);
         let height = finite_positive_or(height, self.height);
         if self.width == width && self.height == height {
@@ -563,7 +499,8 @@ impl MacBrowserHost {
             &resolver,
         );
         let reflowed = self
-            .session
+            .controller
+            .session_mut()
             .reflow(&pipeline, &self.fetcher, height)
             .is_some();
         self.width = width;
@@ -573,7 +510,8 @@ impl MacBrowserHost {
 
     pub fn render_to_layer(&self, layer: objc_bridge::Id) -> Result<(), MacBrowserError> {
         let viewport = self
-            .session
+            .controller
+            .session()
             .viewport()
             .ok_or(MacBrowserError::MissingViewport)?;
         paint_metal::render_to_metal_layer(&viewport.viewport_scene(), layer)
@@ -1269,7 +1207,15 @@ mod tests {
         .expect("Mosaic host should load the initial page");
 
         assert_eq!(host.props().page_title, "Start");
-        let link = host.session.viewport().unwrap().page().paint.links[0].clone();
+        let link = host
+            .controller
+            .session()
+            .viewport()
+            .unwrap()
+            .page()
+            .paint
+            .links[0]
+            .clone();
         assert!(host.update_hover(link.x + link.width / 2.0, link.y + link.height / 2.0));
         assert_eq!(host.props().status_text, "http://example.test/next.html");
         assert!(!host.update_hover(f64::NAN, f64::NAN));
@@ -1288,7 +1234,8 @@ mod tests {
         assert_eq!(props.status_text, "Ready");
         assert!(!props.back_disabled);
         let scene = host
-            .session
+            .controller
+            .session()
             .viewport()
             .expect("host should retain a live native viewport")
             .viewport_scene();
@@ -1338,11 +1285,20 @@ mod tests {
         );
 
         assert_eq!(
-            host.session.viewport().unwrap().viewport_scene().width,
+            host.controller
+                .session()
+                .viewport()
+                .unwrap()
+                .viewport_scene()
+                .width,
             320.0
         );
         assert!(host.resize(144.0, 96.0));
-        let viewport = host.session.viewport().expect("viewport remains loaded");
+        let viewport = host
+            .controller
+            .session()
+            .viewport()
+            .expect("viewport remains loaded");
         assert_eq!(viewport.viewport_scene().width, 144.0);
         assert_eq!(viewport.viewport_scene().height, 96.0);
         assert_eq!(fetches.get(), 1, "resize must not refetch page HTML");

--- a/code/packages/rust/venture-browser-windows/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-windows/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Delegate generated-host browser state and interaction behavior to the shared
+  `venture-browser-core::BrowserHostController`, retaining only native page
+  composition and Direct2D presentation in this adapter.
 - Bind a generated-host WinUI `ScrollBar` to shared Rust viewport metrics and
   absolute offset control, with direct app acceptance.
 - Project shared link-hover URLs into Mosaic status and drive the generated

--- a/code/packages/rust/venture-browser-windows/src/lib.rs
+++ b/code/packages/rust/venture-browser-windows/src/lib.rs
@@ -9,7 +9,7 @@ use html_to_paint::HtmlPaintViewport;
 use layout_text_measure_native::NativeMeasurer;
 use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 use venture_browser_core::{
-    BrowserChromeController, BrowserChromeEvent, BrowserChromeProps, BrowserFetchResponse,
+    BrowserChromeEvent, BrowserChromeProps, BrowserFetchResponse, BrowserHostController,
     BrowserLoadError, BrowserNavigation, BrowserPagePipeline, BrowserResourceFetcher,
     BrowserScrollCommand, BrowserScrollMetrics, BrowserSession, HttpBrowserFetcher,
 };
@@ -45,33 +45,6 @@ where
     Ok(session.execute(navigation, &pipeline, fetcher)?.is_some())
 }
 
-fn activate_link<F>(
-    session: &mut BrowserSession,
-    x: f64,
-    y: f64,
-    width: f64,
-    height: f64,
-    fetcher: &F,
-) -> Result<bool, BrowserLoadError>
-where
-    F: BrowserResourceFetcher,
-{
-    let theme = mosaic_html_theme();
-    let measurer = NativeMeasurer::new();
-    let shaper = NativeShaper::new();
-    let metrics = NativeMetrics::new();
-    let resolver = NativeResolver::new();
-    let pipeline = BrowserPagePipeline::new(
-        &theme,
-        HtmlPaintViewport::new(width, height, 1.0),
-        &measurer,
-        &shaper,
-        &metrics,
-        &resolver,
-    );
-    Ok(session.activate_link(x, y, &pipeline, fetcher)?.is_some())
-}
-
 struct OwnedFetcher(Box<dyn BrowserResourceFetcher>);
 
 impl BrowserResourceFetcher for OwnedFetcher {
@@ -82,13 +55,10 @@ impl BrowserResourceFetcher for OwnedFetcher {
 
 /// One browser session shared by generated chrome and the Direct2D surface.
 pub struct WindowsBrowserHost {
-    session: BrowserSession,
-    chrome: BrowserChromeController,
+    controller: BrowserHostController,
     fetcher: OwnedFetcher,
     width: f64,
     height: f64,
-    status_text: String,
-    hovered_link_url: Option<String>,
 }
 
 impl WindowsBrowserHost {
@@ -116,120 +86,59 @@ impl WindowsBrowserHost {
             height,
             &fetcher,
         )?;
-        let chrome = BrowserChromeController::new(&session);
         Ok(Self {
-            session,
-            chrome,
+            controller: BrowserHostController::new(session),
             fetcher,
             width,
             height,
-            status_text: "Ready".to_string(),
-            hovered_link_url: None,
         })
     }
 
     pub fn props(&self) -> BrowserChromeProps {
-        self.chrome.props(
-            &self.session,
-            self.hovered_link_url
-                .clone()
-                .unwrap_or_else(|| self.status_text.clone()),
-            false,
-        )
+        self.controller.props()
     }
 
     pub fn handle_event(&mut self, event: BrowserChromeEvent) -> Result<bool, BrowserLoadError> {
-        self.hovered_link_url = None;
-        let Some(navigation) = self.chrome.handle_event(event, &self.session, false) else {
-            return Ok(false);
-        };
-        self.status_text = "Loading".to_string();
-        match execute_navigation(
-            &mut self.session,
-            navigation,
-            self.width,
-            self.height,
-            &self.fetcher,
-        ) {
-            Ok(changed) => {
-                if changed {
-                    self.chrome.synchronize(&self.session);
-                }
-                self.status_text = "Ready".to_string();
-                Ok(changed)
-            }
-            Err(error) => {
-                self.status_text = format!("Load failed: {error}");
-                Err(error)
-            }
-        }
+        let width = self.width;
+        let height = self.height;
+        let fetcher = &self.fetcher;
+        self.controller.handle_event(event, |session, navigation| {
+            execute_navigation(session, navigation, width, height, fetcher)
+        })
     }
 
     pub fn scroll_by(&mut self, delta_y: f64) -> bool {
-        self.hovered_link_url = None;
-        let Some(viewport) = self.session.viewport_mut() else {
-            return false;
-        };
-        let before = viewport.scroll_state().offset_y();
-        viewport.scroll_by(delta_y);
-        viewport.scroll_state().offset_y() != before
+        self.controller.scroll_by(delta_y)
     }
 
     pub fn scroll_command(&mut self, command: BrowserScrollCommand) -> bool {
-        self.hovered_link_url = None;
-        let Some(viewport) = self.session.viewport_mut() else {
-            return false;
-        };
-        let before = viewport.scroll_state().offset_y();
-        viewport.scroll_command(command);
-        viewport.scroll_state().offset_y() != before
+        self.controller.scroll_command(command)
     }
 
     pub fn scroll_metrics(&self) -> Option<BrowserScrollMetrics> {
-        self.session.scroll_metrics()
+        self.controller.scroll_metrics()
     }
 
     pub fn scroll_to(&mut self, offset_y: f64) -> bool {
-        self.hovered_link_url = None;
-        let before = self
-            .session
-            .scroll_metrics()
-            .map(|metrics| metrics.offset_y);
-        let after = self.session.set_scroll_offset_y(offset_y);
-        before
-            .zip(after)
-            .is_some_and(|(before, after)| before != after)
+        self.controller.scroll_to(offset_y)
     }
 
     pub fn activate_link(&mut self, x: f64, y: f64) -> Result<bool, BrowserLoadError> {
-        self.hovered_link_url = None;
-        let changed = activate_link(
-            &mut self.session,
-            x,
-            y,
-            self.width,
-            self.height,
-            &self.fetcher,
-        )?;
-        if changed {
-            self.chrome.synchronize(&self.session);
-            self.status_text = "Ready".to_string();
-        }
-        Ok(changed)
+        let width = self.width;
+        let height = self.height;
+        let fetcher = &self.fetcher;
+        self.controller.activate_link(x, y, |session, navigation| {
+            execute_navigation(session, navigation, width, height, fetcher)
+        })
     }
 
     pub fn update_hover(&mut self, x: f64, y: f64) -> bool {
-        self.hovered_link_url = if x.is_finite() && y.is_finite() {
-            self.session.hovered_link_url(x, y).map(str::to_owned)
-        } else {
-            None
-        };
-        self.hovered_link_url.is_some()
+        self.controller.update_hover(x, y)
     }
 
     /// Reflow the retained page for a new logical content-surface size.
     pub fn resize(&mut self, width: f64, height: f64) -> bool {
-        self.hovered_link_url = None;
+        self.controller.clear_hover();
         let width = finite_positive_or(width, self.width);
         let height = finite_positive_or(height, self.height);
         if self.width == width && self.height == height {
@@ -250,7 +159,8 @@ impl WindowsBrowserHost {
             &resolver,
         );
         let reflowed = self
-            .session
+            .controller
+            .session_mut()
             .reflow(&pipeline, &self.fetcher, height)
             .is_some();
         self.width = width;
@@ -260,7 +170,7 @@ impl WindowsBrowserHost {
 
     #[cfg(target_os = "windows")]
     fn render_bgra(&self) -> Option<(u32, u32, Vec<u8>)> {
-        let scene = self.session.viewport()?.viewport_scene();
+        let scene = self.controller.session().viewport()?.viewport_scene();
         let mut pixels = paint_vm_direct2d::render(&scene);
         for pixel in pixels.data.chunks_exact_mut(4) {
             pixel.swap(0, 2);
@@ -581,7 +491,15 @@ mod tests {
         .expect("initial page loads");
 
         assert_eq!(host.props().page_title, "Home");
-        let link = host.session.viewport().unwrap().page().paint.links[0].clone();
+        let link = host
+            .controller
+            .session()
+            .viewport()
+            .unwrap()
+            .page()
+            .paint
+            .links[0]
+            .clone();
         assert!(host.update_hover(link.x + link.width / 2.0, link.y + link.height / 2.0));
         assert_eq!(host.props().status_text, "http://example.test/next");
         assert!(!host.update_hover(f64::NAN, f64::NAN));
@@ -658,11 +576,20 @@ mod tests {
         );
 
         assert_eq!(
-            host.session.viewport().unwrap().viewport_scene().width,
+            host.controller
+                .session()
+                .viewport()
+                .unwrap()
+                .viewport_scene()
+                .width,
             320.0
         );
         assert!(host.resize(144.0, 96.0));
-        let viewport = host.session.viewport().expect("viewport remains loaded");
+        let viewport = host
+            .controller
+            .session()
+            .viewport()
+            .expect("viewport remains loaded");
         assert_eq!(viewport.viewport_scene().width, 144.0);
         assert_eq!(viewport.viewport_scene().height, 96.0);
         assert_eq!(fetches.get(), 1, "resize must not refetch page HTML");

--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -5,6 +5,15 @@ cross-platform proving application. Items are ordered by risk and dependency.
 
 ## Prioritized discoveries
 
+- [x] **P0 architecture — shared native host controller.** Move Mosaic event
+  reduction, status/chrome synchronization, scrolling, scrollbar projection,
+  link activation, and hover state into one host-neutral Rust controller used
+  by both the SwiftUI/Metal and WinUI/Direct2D adapters.
+- [ ] **P1 — live page bridges for the remaining generated hosts.** Replace the
+  recording-only content hosts in Qt, Flutter, and Compose acceptance with
+  adapters backed by the shared Venture session and page renderer, starting
+  with Qt on Linux and reusing the same controller rather than introducing
+  backend-specific browser behavior.
 - [x] **P0 regression — POSIX entry-point shell compatibility.** Keep `BUILD`
   compatible with the repository build tool's `/bin/sh` executor while it
   delegates the backend matrix to the Bash-specific implementation script.

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -20,6 +20,11 @@ recreating the surrounding chrome in backend-specific UI code.
 - Emits carry Back, Forward, Home, Reload, address edits, and Navigate.
 - `venture-browser-core::BrowserChromeController` is the shared reducer and
   slot projection for that exact contract.
+- `venture-browser-core::BrowserHostController` owns the native-host state
+  machine around that reducer: load status, transactional synchronization,
+  scrolling, native scrollbar offsets, link activation, and hover projection
+  are shared by the macOS and Windows bridges. Platform crates supply only
+  their text/page composition and final paint backends.
 - Both themes expose the same parts and interaction states.
 - `tests/package_compiles.rs` guards the package contract; the package artifact
   builder compiles these exact sources, emits project shells, and verifies a


### PR DESCRIPTION
## Summary
- add a host-neutral `BrowserHostController` for Mosaic event/status synchronization, scroll state, native scrollbar offsets, link activation, and hover projection
- migrate the macOS Metal and Windows Direct2D adapters to that single controller while retaining their native page composition/rendering seams
- record and prioritize the remaining live Qt/Flutter/Compose page-bridge work in Venture's acceptance backlog

## Validation
- `cargo test -p venture-browser-core -p venture-browser-macos -p venture-browser-windows`
- `cargo clippy -p venture-browser-core -p venture-browser-macos -p venture-browser-windows --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test`

The parser coverage gate remains exact: tree 1934 upstream / 2637 local / 0 missing; tokenizer 6806 upstream / 7015 local raw / 0 missing; 7242 normalized / 0 skipped. This is a browser-wiring foundation, not a full browser-conformance claim.