### PR TITLE
fix(build-tool): enforce UTF-8 Lua rockspec metadata

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9592,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "b70e9b7dd03198973ceadbc4d5d272f101d99afa",
+    "revision": "5042eadeb84f9f992634a160590938e4453dba2d",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1222,
@@ -338,7 +338,16 @@
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered by the Python encoding-blocker audit. Go was remediated in merged PR #9504 and Rust in merged PR #9510. Of the seven engines that remain, Swift silently drops invalid rockspec dependencies; TypeScript replaces invalid bytes; Lua and Perl accept them; Ruby and Haskell use locale-sensitive text decoding; and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
+      "notes": "Discovered by the Python encoding-blocker audit. Go, Rust, Swift, and TypeScript were remediated in merged PRs #9504, #9510, #9537, and #9572. Five engines remain: Lua and Perl accept malformed bytes, Ruby and Haskell use locale-sensitive text decoding, and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity. The Lua engine is materialized as the next pending child because its raw byte-string boundary is narrow and its local toolchain is available."
+    },
+    {
+      "id": "build-tool-lua-engine-rockspec-utf8-conformance",
+      "title": "Make the Lua build tool enforce strict UTF-8 rockspec metadata",
+      "status": "pending",
+      "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized in the post-#9592 prioritization pass as the first of five remaining engine children. Consume the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, validate raw rockspec bytes before pattern parsing, preserve the exact success edge set, fail closed with METADATA_INVALID_UTF8 plus package and repository-relative manifest identity, and exercise the real Lua CLI exit contract without disclosing the checkout root."
     },
     {
       "id": "build-tool-typescript-rockspec-utf8-conformance",
@@ -352,11 +361,11 @@
     {
       "id": "build-tool-typescript-windows-gitdiff-portability",
       "title": "Make TypeScript build-tool git-diff tests portable on Windows",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-typescript-windows-gitdiff",
       "pr_number": 9592,
-      "notes": "Ready PR #9592 is the sole active parity PR. It replaces two /bin/sh-dependent fixture commits with direct git argument vectors, uses native temporary-directory package roots, and normalizes path.relative package roots to Git's forward-slash repository paths without changing diff-selection semantics. The red Windows baseline was 275 passing plus the exact seven owned failures; exact-head validation after a conflict-free rebase onto b70e9b7dd passed all 282 tests, 96.77% gitdiff line and 95% branch coverage, 89.36%/82.06% full-suite line/branch coverage, production bundling, 17 schema plus 40 runner tests, the valid 37-case/56-file corpus, and zero-advisory npm audit. The real plan contains 4,768 packages, 4,768 unique names, zero duplicate groups, 7,243 edges, and zero backslash paths. The collision-checked parity inventory remains 1,222 identities/4,370 slots with zero collisions or unknown inventory buckets; BUILD validation reproduced only the exact ten owned Lua BUILD_windows debts."
+      "notes": "Merged PR #9592 at 5042eadeb84f9f992634a160590938e4453dba2d on 2026-08-02 after both detection runs, both fixture-consumer runs, both Ubuntu builds, macOS, Windows, CodeQL language detection, and JavaScript/TypeScript analysis passed; irrelevant CodeQL lanes skipped. It replaces two /bin/sh-dependent fixture commits with direct git argument vectors, uses native temporary-directory package roots, and normalizes path.relative package roots to Git's forward-slash repository paths without changing diff-selection semantics. The red Windows baseline was 275 passing plus the exact seven owned failures; exact-head validation passed all 282 tests, 96.77% gitdiff line and 95% branch coverage, 89.36%/82.06% full-suite line/branch coverage, production bundling, 17 schema plus 40 runner tests, the valid 37-case/56-file corpus, and zero-advisory npm audit. The real plan contains 4,768 packages, 4,768 unique names, zero duplicate groups, 7,243 edges, and zero backslash paths. The post-merge collision-checked inventory remains 1,222 identities/4,370 slots with zero collisions or unknown inventory buckets; BUILD validation reproduced only the exact ten owned Lua BUILD_windows debts."
     },
     {
       "id": "build-tool-typescript-language-identity-registry",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -343,11 +343,11 @@
     {
       "id": "build-tool-lua-engine-rockspec-utf8-conformance",
       "title": "Make the Lua build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-lua-rockspec-utf8",
       "pr_number": null,
-      "notes": "Materialized in the post-#9592 prioritization pass as the first of five remaining engine children. Consume the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, validate raw rockspec bytes before pattern parsing, preserve the exact success edge set, fail closed with METADATA_INVALID_UTF8 plus package and repository-relative manifest identity, and exercise the real Lua CLI exit contract without disclosing the checkout root."
+      "notes": "Selected after merged PR #9592 and the collision-clean 5042eade inventory as the highest-leverage unblocked engine child: the shared fixtures and four reference remediations are already merged, Lua's raw byte-string parser boundary is narrow, and Lua 5.4 plus LuaRocks are locally available. Consume the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, validate raw rockspec bytes before pattern parsing, preserve the exact success edge set, fail closed with METADATA_INVALID_UTF8 plus package and repository-relative manifest identity, and exercise the real Lua CLI exit contract without disclosing the checkout root."
     },
     {
       "id": "build-tool-typescript-rockspec-utf8-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 9603,
   "last_inventory": {
     "revision": "5042eadeb84f9f992634a160590938e4453dba2d",
     "schema_version": 3,
@@ -338,16 +338,16 @@
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered by the Python encoding-blocker audit. Go, Rust, Swift, and TypeScript were remediated in merged PRs #9504, #9510, #9537, and #9572. Five engines remain: Lua and Perl accept malformed bytes, Ruby and Haskell use locale-sensitive text decoding, and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity. The Lua engine is materialized as the next pending child because its raw byte-string boundary is narrow and its local toolchain is available."
+      "notes": "Discovered by the Python encoding-blocker audit. Go, Rust, Swift, and TypeScript were remediated in merged PRs #9504, #9510, #9537, and #9572. PR #9603 is the active Lua remediation. Four engines remain after it: Perl accepts malformed bytes, Ruby and Haskell use locale-sensitive text decoding, and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
     },
     {
       "id": "build-tool-lua-engine-rockspec-utf8-conformance",
       "title": "Make the Lua build tool enforce strict UTF-8 rockspec metadata",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-lua-rockspec-utf8",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9592 and the collision-clean 5042eade inventory as the highest-leverage unblocked engine child: the shared fixtures and four reference remediations are already merged, Lua's raw byte-string parser boundary is narrow, and Lua 5.4 plus LuaRocks are locally available. Consume the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 fixtures, validate raw rockspec bytes before pattern parsing, preserve the exact success edge set, fail closed with METADATA_INVALID_UTF8 plus package and repository-relative manifest identity, and exercise the real Lua CLI exit contract without disclosing the checkout root."
+      "pr_number": 9603,
+      "notes": "Ready-for-review PR #9603 opened from codex/build-tool-lua-rockspec-utf8 after rebasing onto f52f1000c. The resolver validates raw rockspec bytes as strict UTF-8 before pattern parsing, preserves the exact shared-fixture success edge, throws typed METADATA_INVALID_UTF8 with package and repository-relative manifest identity, accepts literal U+FFFD, rejects overlong, truncated, surrogate, bad-continuation, and out-of-range sequences, and maps the real CLI failure to exit 2 without disclosing the checkout root. Validation: 61 Lua tests; 56.88% resolver and 44.93% aggregate LuaCov coverage including dependencies; changed-file luacheck and all-file luac syntax clean; real 4,770-package/258-Lua-package dry run with eight levels; 57 conformance tests plus 52 subtests; valid 37-case/56-file corpus; collision-clean 1,222-identity/4,370-slot inventory; diff and secret-pattern scans clean. The build-file validator reports only the exact 10 already-backlogged Lua BUILD_windows sibling-install debts, and whole-package lint reports only 11 pre-existing warnings in untouched files."
     },
     {
       "id": "build-tool-typescript-rockspec-utf8-conformance",

--- a/code/programs/lua/build-tool/CHANGELOG.md
+++ b/code/programs/lua/build-tool/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Lua `.rockspec` dependency metadata now follows the shared strict UTF-8
+  contract. Invalid bytes fail closed with the stable
+  `METADATA_INVALID_UTF8` diagnostic and CLI exit code 2 without leaking host
+  checkout paths.
+
 ## 0.1.0 — 2026-03-23
 
 ### Added

--- a/code/programs/lua/build-tool/README.md
+++ b/code/programs/lua/build-tool/README.md
@@ -51,6 +51,14 @@ lua build.lua --force                  # Rebuild everything
 - **Metatables for OOP**: DirectedGraph uses the standard `__index`
   metatable pattern for method dispatch.
 
+## Metadata Safety
+
+Lua `.rockspec` package metadata is decoded as strict UTF-8 before dependency
+resolution. Invalid bytes fail closed with `METADATA_INVALID_UTF8`, identify
+the package and repository-relative manifest, and make the CLI exit with code
+2. Diagnostics never expose the checkout path or silently replace invalid
+input bytes; a well-formed literal Unicode replacement character remains valid.
+
 ## Dependencies
 
 - Lua 5.4 (for native integers and bitwise operators)

--- a/code/programs/lua/build-tool/build.lua
+++ b/code/programs/lua/build-tool/build.lua
@@ -162,7 +162,15 @@ local function main()
 
     -- Step 3: Resolve dependencies.
     print("Resolving dependencies...")
-    local graph = Resolver.resolve_dependencies(packages)
+    local resolution_ok, graph = pcall(Resolver.resolve_dependencies, packages)
+    if not resolution_ok then
+        if Resolver.is_metadata_encoding_error(graph) then
+            io.stderr:write(tostring(graph) .. "\n")
+            os.exit(2)
+        end
+        io.stderr:write("Error: " .. tostring(graph) .. "\n")
+        os.exit(1)
+    end
 
     -- Step 4: Compute build levels.
     local ok, groups = pcall(function()

--- a/code/programs/lua/build-tool/lib/build_tool/resolver.lua
+++ b/code/programs/lua/build-tool/lib/build_tool/resolver.lua
@@ -22,9 +22,38 @@
 -- External dependencies are silently skipped.
 
 local DirectedGraph = require("build_tool.directed_graph")
-local Discovery = require("build_tool.discovery")
 
 local Resolver = {}
+
+local MetadataEncodingError = {}
+MetadataEncodingError.__index = MetadataEncodingError
+
+function MetadataEncodingError.new(pkg, manifest)
+    return setmetatable({
+        code = "METADATA_INVALID_UTF8",
+        package = pkg.name,
+        manifest = manifest,
+        encoding = "UTF-8",
+    }, MetadataEncodingError)
+end
+
+function MetadataEncodingError:__tostring()
+    return string.format(
+        "%s: package=%s manifest=%s encoding=%s",
+        self.code,
+        self.package,
+        self.manifest,
+        self.encoding
+    )
+end
+
+--- Return whether a caught error is the stable metadata encoding error.
+---
+--- @param value any A value returned by pcall.
+--- @return boolean True when value is a MetadataEncodingError.
+function Resolver.is_metadata_encoding_error(value)
+    return getmetatable(value) == MetadataEncodingError
+end
 
 -- =========================================================================
 -- Helper: read a file's contents as a string.
@@ -70,6 +99,90 @@ local function normalize_path(path)
         return joined == "" and (prefix .. "/") or (prefix .. "/" .. joined)
     end
     return joined
+end
+
+local function repository_relative_manifest(path)
+    local normalized = normalize_path(path)
+    if normalized:sub(1, 5) == "code/" then
+        return normalized
+    end
+
+    local marker = normalized:find("/code/", 1, true)
+    if marker then
+        return normalized:sub(marker + 1)
+    end
+
+    return normalized:match("([^/]+)$") or normalized
+end
+
+local function is_continuation(byte)
+    return byte and byte >= 0x80 and byte <= 0xbf
+end
+
+--- Validate one byte string as strict UTF-8.
+---
+--- This rejects truncated sequences, continuation bytes in leading position,
+--- overlong forms, UTF-16 surrogate code points, and values above U+10FFFF.
+--- A literal U+FFFD remains valid because it is ordinary well-formed UTF-8.
+---
+--- @param text string Raw file bytes.
+--- @return boolean True when every byte belongs to a valid UTF-8 sequence.
+local function is_valid_utf8(text)
+    local index = 1
+    while index <= #text do
+        local first = text:byte(index)
+
+        if first <= 0x7f then
+            index = index + 1
+        elseif first >= 0xc2 and first <= 0xdf then
+            if not is_continuation(text:byte(index + 1)) then return false end
+            index = index + 2
+        elseif first >= 0xe0 and first <= 0xef then
+            local second = text:byte(index + 1)
+            local third = text:byte(index + 2)
+            if first == 0xe0 then
+                if not second or second < 0xa0 or second > 0xbf then return false end
+            elseif first == 0xed then
+                if not second or second < 0x80 or second > 0x9f then return false end
+            elseif not is_continuation(second) then
+                return false
+            end
+            if not is_continuation(third) then return false end
+            index = index + 3
+        elseif first >= 0xf0 and first <= 0xf4 then
+            local second = text:byte(index + 1)
+            local third = text:byte(index + 2)
+            local fourth = text:byte(index + 3)
+            if first == 0xf0 then
+                if not second or second < 0x90 or second > 0xbf then return false end
+            elseif first == 0xf4 then
+                if not second or second < 0x80 or second > 0x8f then return false end
+            elseif not is_continuation(second) then
+                return false
+            end
+            if not is_continuation(third) or not is_continuation(fourth) then
+                return false
+            end
+            index = index + 4
+        else
+            return false
+        end
+    end
+
+    return true
+end
+
+local function read_lua_metadata(path, pkg)
+    local file = io.open(path, "rb")
+    if not file then return nil end
+    local content = file:read("*a")
+    file:close()
+
+    if not is_valid_utf8(content) then
+        error(MetadataEncodingError.new(pkg, repository_relative_manifest(path)), 0)
+    end
+
+    return content
 end
 
 -- =========================================================================
@@ -438,7 +551,7 @@ local function parse_lua_deps(pkg, known_names)
     local rockspec_path = find_file_by_extension(pkg.path, "rockspec")
     if not rockspec_path then return {} end
 
-    local text = read_file(rockspec_path)
+    local text = read_lua_metadata(rockspec_path, pkg)
     if not text then return {} end
 
     local deps = {}

--- a/code/programs/lua/build-tool/tests/test_resolution_utf8.lua
+++ b/code/programs/lua/build-tool/tests/test_resolution_utf8.lua
@@ -1,0 +1,258 @@
+-- Shared build-tool resolution contract tests for Lua rockspec metadata.
+
+-- Add lib/ to the module search path.
+package.path = "../lib/?.lua;" .. "../lib/?/init.lua;" .. package.path
+
+local json = require("dkjson")
+local lfs = require("lfs")
+local Discovery = require("build_tool.discovery")
+local Resolver = require("build_tool.resolver")
+
+local fixture_dir = "../../../../specs/fixtures/build-tool-v1/cases"
+local temporary_roots = {}
+
+local function read_file(path)
+    local file = assert(io.open(path, "rb"))
+    local contents = file:read("*a")
+    file:close()
+    return contents
+end
+
+local function write_file(path, contents)
+    local file = assert(io.open(path, "wb"))
+    file:write(contents)
+    file:close()
+end
+
+local function ensure_directory(path)
+    local normalized = path:gsub("\\", "/")
+    local current = ""
+
+    if normalized:match("^[A-Za-z]:/") then
+        current = normalized:sub(1, 3)
+        normalized = normalized:sub(4)
+    elseif normalized:sub(1, 1) == "/" then
+        current = "/"
+        normalized = normalized:sub(2)
+    end
+
+    for segment in normalized:gmatch("[^/]+") do
+        if current == "" then
+            current = segment
+        elseif current == "/" or current:match("^[A-Za-z]:/$") then
+            current = current .. segment
+        else
+            current = current .. "/" .. segment
+        end
+        lfs.mkdir(current)
+    end
+end
+
+local function remove_tree(path)
+    local attributes = lfs.attributes(path)
+    if not attributes then return end
+    if attributes.mode ~= "directory" then
+        os.remove(path)
+        return
+    end
+
+    for name in lfs.dir(path) do
+        if name ~= "." and name ~= ".." then
+            remove_tree(path .. "/" .. name)
+        end
+    end
+    lfs.rmdir(path)
+end
+
+local function new_temporary_root()
+    local root = os.tmpname()
+    os.remove(root)
+    ensure_directory(root)
+    temporary_roots[#temporary_roots + 1] = root
+    return root
+end
+
+local base64_values = {}
+do
+    local alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    for index = 1, #alphabet do
+        base64_values[alphabet:sub(index, index)] = index - 1
+    end
+end
+
+local function decode_base64(encoded)
+    local clean = encoded:gsub("%s", "")
+    local decoded = {}
+
+    for offset = 1, #clean, 4 do
+        local first = assert(base64_values[clean:sub(offset, offset)])
+        local second = assert(base64_values[clean:sub(offset + 1, offset + 1)])
+        local third_char = clean:sub(offset + 2, offset + 2)
+        local fourth_char = clean:sub(offset + 3, offset + 3)
+        local third = third_char == "=" and 0 or assert(base64_values[third_char])
+        local fourth = fourth_char == "=" and 0 or assert(base64_values[fourth_char])
+        local value = (first << 18) | (second << 12) | (third << 6) | fourth
+
+        decoded[#decoded + 1] = string.char((value >> 16) & 0xff)
+        if third_char ~= "=" then
+            decoded[#decoded + 1] = string.char((value >> 8) & 0xff)
+        end
+        if fourth_char ~= "=" then
+            decoded[#decoded + 1] = string.char(value & 0xff)
+        end
+    end
+
+    return table.concat(decoded)
+end
+
+local function load_fixture(filename)
+    local fixture_text = read_file(fixture_dir .. "/" .. filename)
+    local fixture, _, decode_error = json.decode(fixture_text)
+    assert.is_nil(decode_error)
+    return fixture
+end
+
+local function materialize_fixture(filename)
+    local fixture = load_fixture(filename)
+    local root = new_temporary_root()
+
+    for _, entry in ipairs(fixture.workspace.files) do
+        local path = root .. "/" .. entry.path
+        local parent = path:gsub("\\", "/"):match("^(.*)/[^/]+$")
+        ensure_directory(parent)
+        local contents = entry.content_utf8 or decode_base64(entry.content_base64)
+        write_file(path, contents)
+    end
+
+    return fixture, root
+end
+
+local function graph_edges(graph)
+    local edges = {}
+    for _, source in ipairs(graph:nodes()) do
+        for _, target in ipairs(graph:successors(source)) do
+            edges[#edges + 1] = {source, target}
+        end
+    end
+    table.sort(edges, function(left, right)
+        return table.concat(left, "\0") < table.concat(right, "\0")
+    end)
+    return edges
+end
+
+local function shell_quote(value)
+    return '"' .. value:gsub('"', '\\"') .. '"'
+end
+
+describe("Lua rockspec UTF-8 resolution contract", function()
+    after_each(function()
+        for _, root in ipairs(temporary_roots) do
+            remove_tree(root)
+        end
+        temporary_roots = {}
+    end)
+
+    it("matches the shared UTF-8 resolution fixture exactly", function()
+        local fixture, root = materialize_fixture("resolution-lua-utf8.json")
+        local packages = Discovery.discover_packages(root .. "/code")
+        local graph = Resolver.resolve_dependencies(packages)
+
+        assert.are.same(fixture.expected.result.edges, graph_edges(graph))
+    end)
+
+    it("fails closed with the shared diagnostic for invalid UTF-8", function()
+        local fixture, root = materialize_fixture("resolution-lua-invalid-utf8.json")
+        local packages = Discovery.discover_packages(root .. "/code")
+        local ok, resolution_error = pcall(Resolver.resolve_dependencies, packages)
+        local diagnostic = fixture.expected.diagnostics[1]
+
+        assert.is_false(ok)
+        assert.is_true(Resolver.is_metadata_encoding_error(resolution_error))
+        assert.are.equal(diagnostic.code, resolution_error.code)
+        assert.are.equal(diagnostic.package, resolution_error.package)
+        assert.are.equal(diagnostic.path, resolution_error.manifest)
+        assert.are.equal(diagnostic.details.encoding, resolution_error.encoding)
+        assert.are.equal(
+            "METADATA_INVALID_UTF8: package=lua/pkg " ..
+                "manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec " ..
+                "encoding=UTF-8",
+            tostring(resolution_error)
+        )
+        assert.is_nil(tostring(resolution_error):find(root, 1, true))
+    end)
+
+    it("accepts a valid literal replacement character", function()
+        local _, root = materialize_fixture("resolution-lua-utf8.json")
+        local rockspec = root ..
+            "/code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec"
+        local contents = read_file(rockspec)
+        write_file(rockspec, contents .. "-- valid literal: \239\191\189\n")
+
+        local packages = Discovery.discover_packages(root .. "/code")
+        local graph = Resolver.resolve_dependencies(packages)
+        assert.are.same({{"lua/other", "lua/pkg"}}, graph_edges(graph))
+    end)
+
+    it("rejects malformed, overlong, surrogate, and out-of-range sequences", function()
+        local invalid_sequences = {
+            {"overlong two-byte form", string.char(0xc0, 0xaf)},
+            {"overlong three-byte form", string.char(0xe0, 0x80, 0x80)},
+            {"UTF-16 surrogate", string.char(0xed, 0xa0, 0x80)},
+            {"overlong four-byte form", string.char(0xf0, 0x80, 0x80, 0x80)},
+            {"code point above U+10FFFF", string.char(0xf4, 0x90, 0x80, 0x80)},
+            {"truncated sequence", string.char(0xe2, 0x82)},
+            {"non-continuation tail", string.char(0xf1, 0x80, 0x80, 0x41)},
+        }
+
+        for _, case in ipairs(invalid_sequences) do
+            local root = new_temporary_root()
+            local package_dir = root .. "/code/packages/lua/pkg"
+            ensure_directory(package_dir)
+            write_file(package_dir .. "/BUILD", "echo building\n")
+            write_file(
+                package_dir .. "/coding-adventures-pkg-0.1.0-1.rockspec",
+                "package = \"coding-adventures-pkg\"\n-- " .. case[1] .. ": " .. case[2]
+            )
+
+            local packages = Discovery.discover_packages(root .. "/code")
+            local ok, resolution_error = pcall(Resolver.resolve_dependencies, packages)
+            assert.is_false(ok, case[1] .. " must fail closed")
+            assert.is_true(
+                Resolver.is_metadata_encoding_error(resolution_error),
+                case[1] .. " must return MetadataEncodingError"
+            )
+        end
+    end)
+
+    it("returns exit 2 and only the stable diagnostic from the real CLI", function()
+        local _, root = materialize_fixture("resolution-lua-invalid-utf8.json")
+        local stdout_path = root .. "/stdout.txt"
+        local stderr_path = root .. "/stderr.txt"
+        local command = table.concat({
+            "lua",
+            shell_quote("../build.lua"),
+            "--root",
+            shell_quote(root),
+            "--force",
+            "--dry-run",
+            "--language",
+            "lua",
+            "1>" .. shell_quote(stdout_path),
+            "2>" .. shell_quote(stderr_path),
+        }, " ")
+
+        local success, _, exit_code = os.execute(command)
+        if success then exit_code = 0 end
+
+        assert.are.equal(2, exit_code)
+        local stderr = read_file(stderr_path)
+        local portable_stderr = stderr:gsub("\r\n", "\n")
+        assert.are.equal(
+            "METADATA_INVALID_UTF8: package=lua/pkg " ..
+                "manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec " ..
+                "encoding=UTF-8\n",
+            portable_stderr
+        )
+        assert.is_nil(stderr:find(root, 1, true))
+    end)
+end)

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -229,7 +229,7 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   #9495 normalized the three CP1252 metadata bytes, added positive and invalid-
   UTF-8 fixtures, and returns `METADATA_INVALID_UTF8`; its refreshed full scan
   succeeds across 4,765 packages and 7,100 edges;
-- bring the remaining TypeScript, Lua, Perl, Ruby, Elixir, and Haskell
+- bring the remaining Lua, Perl, Ruby, Elixir, and Haskell
   build-tool resolvers to the shared strict-UTF-8 rockspec contract.
   Their current byte, replacement, silent-drop, and locale-sensitive behavior
   is tracked separately from the Python full-scan blocker. Merged PR #9504
@@ -237,10 +237,12 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   Rust. Merged PR #9537 completed Swift with exact shared success and invalid-
   byte fixtures plus real CLI exit-2 coverage. Merged PR #9572 completed
   TypeScript with strict decoding, exact shared-fixture coverage, and green
-  Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks;
+  Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks. The Lua
+  engine is now materialized as the next pending child because its raw-byte
+  parser boundary is narrow and the local Lua 5.4 toolchain is available;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
-  POSIX-only `/repo` path fixtures. Ready PR #9592 is the selected slice: it
+  POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it
   uses direct Git argument vectors and native temporary roots, and normalizes
   relative package paths at the Git boundary without changing selection
   semantics. Its exact Windows suite is green at 282/282 tests;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -229,7 +229,7 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   #9495 normalized the three CP1252 metadata bytes, added positive and invalid-
   UTF-8 fixtures, and returns `METADATA_INVALID_UTF8`; its refreshed full scan
   succeeds across 4,765 packages and 7,100 edges;
-- bring the remaining Lua, Perl, Ruby, Elixir, and Haskell
+- bring the remaining Perl, Ruby, Elixir, and Haskell
   build-tool resolvers to the shared strict-UTF-8 rockspec contract.
   Their current byte, replacement, silent-drop, and locale-sensitive behavior
   is tracked separately from the Python full-scan blocker. Merged PR #9504
@@ -237,9 +237,10 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   Rust. Merged PR #9537 completed Swift with exact shared success and invalid-
   byte fixtures plus real CLI exit-2 coverage. Merged PR #9572 completed
   TypeScript with strict decoding, exact shared-fixture coverage, and green
-  Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks. The Lua
-  engine is the selected next child because its raw-byte parser boundary is
-  narrow and the local Lua 5.4 toolchain is available;
+  Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks. Ready PR
+  #9603 is the active Lua child: it validates raw rockspec bytes strictly,
+  consumes both shared fixtures, returns the stable repository-relative
+  diagnostic with real CLI exit code 2, and covers malformed Unicode classes;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -238,8 +238,8 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   byte fixtures plus real CLI exit-2 coverage. Merged PR #9572 completed
   TypeScript with strict decoding, exact shared-fixture coverage, and green
   Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks. The Lua
-  engine is now materialized as the next pending child because its raw-byte
-  parser boundary is narrow and the local Lua 5.4 toolchain is available;
+  engine is the selected next child because its raw-byte parser boundary is
+  narrow and the local Lua 5.4 toolchain is available;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it


### PR DESCRIPTION
## Summary
- validate Lua `.rockspec` files as strict UTF-8 before dependency parsing
- return the stable `METADATA_INVALID_UTF8` diagnostic with package and repository-relative manifest identity
- map metadata input failures to CLI exit code 2 without leaking checkout paths
- consume the shared valid/invalid resolution fixtures and cover malformed Unicode edge cases on the real CLI

## Validation
- `busted`: 61 passed on Windows (including shared fixtures and real CLI)
- LuaCov: resolver 56.88%; aggregate 44.93% including Busted/LuaRocks internals
- `luacheck` on changed Lua files: 0 warnings / 0 errors
- whole-package `luacheck`: only 11 pre-existing warnings in untouched executor/validator/legacy-test files
- `luac -p`: every Lua build-tool source and test file passed
- real repository dry run: 4,770 packages discovered; 258 Lua packages; 8 dependency levels
- build-file validation: only the exact 10 already-backlogged Lua `BUILD_windows` sibling-install debts
- conformance schema/runner: 57 passed, 52 subtests passed
- shared corpus: 37 cases / 56 files valid
- package parity inventory: 1,255 reported identities; 1,222 implementation identities; 4,370 slots; 172 high-consensus; 0 collisions; 0 unknown buckets
- `git diff --check` and changed-diff secret-pattern scan passed