### PR TITLE
Split Tamil lessons into sub-five-minute micro-steps

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Hindi duration
-tranche: 20 registered tracks, 1,025 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Tamil duration
+tranche: 20 registered tracks, 1,045 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -62,7 +62,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01M | Complete in the Malayalam duration PR | Remove all thirty-seven sub-five-minute violations from the Malayalam track. | The report measures zero Malayalam violations; four new prerequisite-ordered micro-lessons separate vocabulary from etymology, register, and cross-language comparison. |
 | HL-D01N | Complete in the Arabic duration PR | Remove all thirty-nine sub-five-minute violations from the Arabic track. | The report measures zero Arabic violations; four new prerequisite-ordered writing steps preserve the abjad, joining, whole-word assembly, and hamza content. |
 | HL-D01O | Complete in the Hindi duration PR | Remove all forty sub-five-minute violations from the Hindi track. | The report measures zero Hindi violations; thirteen new prerequisite-ordered lessons preserve its script, etymology, grammar, and register depth. |
-| HL-D01P | Next | Remove all forty-two sub-five-minute violations from the Tamil track. | Tamil is now the smallest remaining set: twenty-two declaration-only lessons and twenty genuinely computed violations, with a 441-second maximum. |
+| HL-D01P | Complete in this PR | Remove all forty-two sub-five-minute violations from the Tamil track. | The report measures zero Tamil violations; twenty new prerequisite-ordered lessons preserve its script, etymology, grammar, register, and source-evidence depth. |
+| HL-D01Q | Next | Remove all forty-three sub-five-minute violations from the Latin track. | Latin is now the smallest remaining set: thirty-seven declaration-only lessons and six genuinely computed violations, with a 370-second maximum. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -93,12 +94,15 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B29 | Queued | Remove Arabic's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports one overfull box, four underfull boxes, one duplicate practice label, 14 Hyperref warnings, and undefined bold/italic Arabic font shapes; the clean-build signal is zero of each. |
 | HL-B30 | Queued | Publish Hindi Chapters 6–33 and its writing companions from canonical lessons rather than hand-copying another twenty-eight book chapters. | The Hindi PDF stops after Chapter 5 while canonical app content continues through Chapter 33 and eleven dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
 | HL-B31 | Queued | Remove Hindi's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports two overfull boxes, five underfull boxes, three duplicate practice labels, 29 Hyperref warnings, undefined bold/italic Devanagari font shapes, and a visibly colliding final-page running header; the clean-build signal is zero of each. |
+| HL-B32 | Queued | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | The Tamil PDF stops after Chapter 5 while canonical app content continues through Chapter 31 and eight dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
+| HL-B33 | Queued | Remove Tamil's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports six overfull boxes, six underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and undefined bold/italic Tamil font shapes; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
 | HL-M04 | Queued | Extend Malayalam's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the four new support steps, needs a scheduled place. |
 | HL-M05 | Queued | Reconcile Arabic's roadmap and authoritative session map with canonical Chapters 1–27 and the sixteen-step writing sequence. | The roadmap details only Chapters 1–4 and still calls Chapter 5+ planned; the session map stops at Chapter 2 even though prerequisite-ordered canonical lessons continue through Chapter 27. |
 | HL-M06 | Queued | Reconcile Hindi's roadmap and authoritative session map with canonical Chapters 1–33 and the eleven-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 6 planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 33. |
+| HL-M07 | Queued | Reconcile Tamil's roadmap and authoritative session map with canonical Chapters 1–31 and the eight-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 7+ planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 31. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
@@ -515,6 +519,36 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Tamil's forty-two violations are now the smallest remaining set. Twenty-two
   are declaration-only and twenty genuinely compute above the limit, with a
   441-second maximum, so HL-D01P is next.
+
+## Findings from HL-D01P
+
+- Tamil now has zero duration violations. The corpus grows from 1,025 to 1,045
+  lessons and drops from 140 to 98 violations overall; unknown prerequisites
+  remain at zero.
+- Twenty-two lessons already computed between 107 and 285 seconds and needed
+  only honest four-minute declared budgets. Twenty genuinely long lessons are
+  now prerequisite-ordered pairs, adding focused script, etymology, grammar,
+  register, family-comparison, and source-evidence steps without discarding the
+  original depth.
+- The forty rewritten or new split steps compute between 127 and 296 seconds.
+  `TA-W02-ma-retroflex-na` at 296 seconds and `TA-C06-dative-subject` at 294 are
+  the tightest remaining Tamil lessons and should be watched during copy edits.
+- The Tamil PDF builds successfully at 29 pages with no missing glyphs, but it
+  contains only Chapters 1–5 while canonical lessons continue through Chapter
+  31 alongside eight writing steps. HL-B32 records the schema-v2 migration and
+  generated publication work for the missing content.
+- The build reports six overfull boxes, six underfull boxes, four duplicate
+  practice labels, 27 Hyperref warnings, and undefined bold/italic Tamil font
+  shapes. Visual inspection of the cover, middle, and final pages finds no
+  additional clipping or collision. HL-B33 records that pre-existing
+  clean-build debt.
+- The roadmap details only Chapters 1–6 and still labels Chapter 7+ as planned;
+  the authoritative session map stops at Chapter 5. HL-M07 records the
+  progression-metadata reconciliation through Chapter 31 and the expanded
+  writing sequence.
+- Latin's forty-three violations are now the smallest remaining set.
+  Thirty-seven are declaration-only and six genuinely compute above the limit,
+  with a 370-second maximum, so HL-D01Q is next.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Sub-five-minute lesson remediation — 42 violations to zero
+
+- Corrects twenty-two declared budgets whose lesson bodies already compute
+  below five minutes.
+- Splits twenty genuinely long lessons into prerequisite-ordered pairs, adding
+  twenty focused companions rather than deleting script, etymology, grammar,
+  register, family-comparison, or source-evidence depth.
+- Expands the writing strand from four long topics to eight gentle steps:
+  curves → abugida, retroflex **ṇ** → the three-n map, visible puḷḷi → whole-word
+  **வணக்கம்**, and letter bodies → the **ி** sign and whole-word **நன்றி**.
+- Leaves every affected step below 300 effective seconds and keeps all
+  prerequisite references resolvable for the shared app/book corpus.
+
 ## Writing track W01–W04 — the first handwriting lessons for any Dravidian language
 
 Four tracks — Tamil, Telugu, Kannada, Malayalam — had reached Chapter 6 with

--- a/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
@@ -5,11 +5,11 @@ type: word
 headword: ஆம்
 gloss: yes (ām)
 concept_tag: RESPONSE-YES
-prerequisites: [TA-C01-vanakkam]
+prerequisites: [TA-C01-vanakkam-family-register]
 sounds: [independent-vowel-aa, matra-vs-independent]
 roots: [ām]
 est_minutes: 3
-reviews_of: [TA-C01-vanakkam, TA-C01-nandri]
+reviews_of: [TA-C01-vanakkam-family-register, TA-C01-vanakkam, TA-C01-nandri]
 ---
 
 # ஆம் (ām) — "yes"

--- a/code/learning/human-languages/tamil/lessons/TA-C01-nandri-family-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-nandri-family-register.md
@@ -1,0 +1,55 @@
+---
+id: TA-C01-nandri-family-register
+chapter: 1
+type: etymology
+headword: நன்றி / നന്ദി
+gloss: Tamil and Malayalam kept the native goodness-word while explicit thanks can sound marked among intimates
+prerequisites: [TA-C01-nandri]
+sounds: [tamil-nasal-r-cluster]
+roots: [nal, dravidian-nandi]
+est_minutes: 4
+reviews_of: [TA-C01-nandri, TA-C01-vanakkam-family-register]
+---
+
+# நன்றி — a native family word with a register edge
+
+## Warm-up
+
+[PAUSE 2s] *Naṉṟi* literally names goodness. Its family distribution mirrors
+the greeting split you just saw.
+
+## Across the family
+
+| Language | "Thanks" | Source |
+|---|---|---|
+| **Tamil** | *naṉṟi* | native *nal*, "good" |
+| Malayalam | *nandi* | the **same Dravidian word** |
+| Kannada | *dhanyavāda* | Sanskrit |
+| Telugu | *dhanyavādamulu* | Sanskrit |
+| Hindi | *dhanyavād / shukriyā* | Sanskrit / Perso-Arabic |
+
+Tamil and its closest sister Malayalam kept the native word. Kannada and
+Telugu borrowed Sanskrit *dhanyavāda*, repeating the split seen with "hello."
+
+## Where explicit thanks fits
+
+Spoken *naṉṟi* can feel a little formal. Everyday warmth may live in a smile or
+nod; among close family an explicit thank-you can sound oddly distant. Use
+**romba naṉṟi**, "many thanks," when you want to mark gratitude strongly.
+
+This is a register tendency, not a ban: the relationship and moment determine
+whether naming the gratitude feels warm or ceremonious.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: Tamil *naṉṟi* · Malayalam *nandi*]
+- [YOU SAY: "romba naṉṟi" — many thanks]
+- [YOU CHOOSE: close-family routine favor → warmth may be nonverbal]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which sister shares Tamil's native gratitude word? (**Malayalam**.)
+What did Kannada and Telugu borrow? (Sanskrit ***dhanyavāda***.) Why can explicit
+*naṉṟi* sound marked? (Among intimates, gratitude may be assumed; the word can
+feel **formal**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C01-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-nandri.md
@@ -5,11 +5,11 @@ type: word
 headword: நன்றி
 gloss: thank you (naṉṟi — "goodness, gratitude")
 concept_tag: COURTESY-THANKS
-prerequisites: [TA-C01-vanakkam]
+prerequisites: [TA-C01-vanakkam-family-register]
 sounds: [dental-vs-alveolar-vs-retroflex-n, matra-i]
 roots: [nal]
-est_minutes: 5
-reviews_of: [TA-C01-vanakkam]
+est_minutes: 4
+reviews_of: [TA-C01-vanakkam-family-register, TA-C01-vanakkam]
 ---
 
 # நன்றி (naṉṟi) — "thank you," literally "goodness"
@@ -60,39 +60,17 @@ they **change meaning** — so learning to hear them is learning to read. Don't
 drill the whole set now; just know the differences are real and will return
 word by word.
 
-## Across the family — the same idea, five ways
-
-| Language | "Thanks" | Note |
-|---|---|---|
-| **Tamil** | *naṉṟi* (நன்றி) | native (*nal*, "good") |
-| Malayalam | *nandi* (നന്ദി) | the **same** Dravidian word as Tamil *naṉṟi* |
-| Kannada | *dhanyavāda* (ಧನ್ಯವಾದ) | Sanskrit (*dhanya* + *vāda*) |
-| Telugu | *dhanyavādamulu* (ధన్యవాదములు) | Sanskrit |
-| Hindi | *dhanyavād* / *shukriyā* | Sanskrit / Perso-Arabic |
-
-Malayalam, Tamil's closest sister, kept the native *nandi*; Kannada and Telugu
-took the Sanskrit *dhanyavāda*. The family splits the same way it did over
-"hello."
-
-## Why it's said this way
-
-Spoken *naṉṟi* is a touch formal — in warm, everyday Tamil people often thank
-with a smile, a nod, or *romba nandri* ("many thanks"), and among close family
-saying it can even feel oddly stiff, as if you were treating kin like
-strangers. Warmth is assumed; the explicit word is for when you want to mark
-the gratitude.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: na · ṉ · ṟi → "naṉṟi"]
 - [YOU SAY: the three *n*'s — ந (teeth), ன (ridge), ண (curled back)]
-- [YOU SAY: "romba naṉṟi" — "many thanks"]
+- [YOU SAY: "nal — good; naṉṟi — the good you did"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Read **நன்றி**. What does it literally mean, and from what root?
 ("Goodness," from *nal* "good.") How many distinct *n*-sounds does Tamil write,
 and what tells them apart? (Three — dental, alveolar, retroflex — by tongue
-position.) Which language shares Tamil's native word for thanks? (Malayalam,
-*nandi*.)
+position.) Next: compare the gratitude word across the family and choose its
+register.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-practice.md
@@ -5,11 +5,11 @@ type: practice
 headword: (recap)
 gloss: Chapter 1 recap + the Tamil farewell
 concept_tag: REVIEW
-prerequisites: [TA-C01-vanakkam, TA-C01-nandri, TA-C01-aam, TA-C01-illai, TA-C01-sari]
+prerequisites: [TA-C01-vanakkam-family-register, TA-C01-nandri-family-register, TA-C01-aam, TA-C01-illai, TA-C01-sari]
 sounds: []
 roots: []
-est_minutes: 5
-reviews_of: [TA-C01-vanakkam, TA-C01-nandri, TA-C01-aam, TA-C01-illai, TA-C01-sari]
+est_minutes: 4
+reviews_of: [TA-C01-vanakkam-family-register, TA-C01-nandri-family-register, TA-C01-vanakkam, TA-C01-nandri, TA-C01-aam, TA-C01-illai, TA-C01-sari]
 ---
 
 # Chapter 1 — recap, and how Tamil says goodbye

--- a/code/learning/human-languages/tamil/lessons/TA-C01-vanakkam-family-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-vanakkam-family-register.md
@@ -1,0 +1,53 @@
+---
+id: TA-C01-vanakkam-family-register
+chapter: 1
+type: etymology
+headword: வணக்கம் / நமஸ்காரம்
+gloss: Tamil kept a native bow-word where its neighbors borrowed Sanskrit, and uses it across settings
+prerequisites: [TA-C01-vanakkam]
+sounds: [tamil-retroflex-n]
+roots: [vaṇaṅku, sanskrit-namas]
+est_minutes: 4
+reviews_of: [TA-C01-vanakkam]
+---
+
+# வணக்கம் — one bow, two lexical loyalties
+
+## Warm-up
+
+[PAUSE 2s] *Vaṇakkam* names a bow. Neighboring languages name the same gesture
+with a different inherited or borrowed root.
+
+## Across the family
+
+| Language | "Hello" | Source |
+|---|---|---|
+| **Tamil** | *vaṇakkam* | **native Dravidian** *vaṇaṅku* |
+| Kannada | *namaskāra* | Sanskrit |
+| Telugu | *namaskāram* | Sanskrit |
+| Malayalam | *namaskāram* | Sanskrit |
+| Hindi | *namaste* | Sanskrit |
+| English | *hello* | Germanic hailing-call |
+
+Four tracks use Sanskrit *namas-*, "bow." Tamil kept its own verb. The gesture
+and social meaning match; the lexical loyalty differs.
+
+## Where the word fits
+
+Say *vaṇakkam* with pressed palms or a small head-bow: the gesture is the word.
+It works as **hello and goodbye**, at any time, to almost anyone. It is respectful
+without being stiff; cinema and formal speech can also use it as a ringing
+one-word salutation to a whole room.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vaṇakkam" with a small bow]
+- [YOU CONTRAST: Tamil *vaṇaṅku* · neighbors Sanskrit *namas-*]
+- [YOU CHOOSE: greeting or parting → **வணக்கம்** works]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which Dravidian language kept its native bow-word? (**Tamil**.) What
+did the neighbors borrow? (Sanskrit ***namas-***.) Can *vaṇakkam* greet and part?
+(**Yes** — it is an all-day respectful salutation.)

--- a/code/learning/human-languages/tamil/lessons/TA-C01-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-vanakkam.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [tamil-inherent-a, pulli-virama, retroflex-n]
 roots: [vaṇaṅku]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 
@@ -54,40 +54,17 @@ That last point is the whole personality of Tamil: it is an old language proud
 of its own word-stock, and it often keeps a home-grown word where its
 neighbours reached for Sanskrit.
 
-## Across the family — the same idea, five ways
-
-Watch "hello" split the Dravidian family in two:
-
-| Language | "Hello" | Source |
-|---|---|---|
-| **Tamil** | *vaṇakkam* (வணக்கம்) | **native Dravidian** (*vaṇaṅku*, "to bow") |
-| Kannada | *namaskāra* (ನಮಸ್ಕಾರ) | Sanskrit |
-| Telugu | *namaskāram* (నమస్కారం) | Sanskrit |
-| Malayalam | *namaskāram* (നമസ്കാരം) | Sanskrit |
-| Hindi | *namaste* (नमस्ते) | Sanskrit |
-| English | *hello* | Germanic hailing-call |
-
-Four of the five borrowed the Sanskrit *namas-* ("bow"); Tamil alone kept its
-own. Same gesture, same meaning — different loyalties.
-
-## Why it's said this way
-
-*vaṇakkam* is said with the palms pressed together, a small bow of the head —
-the gesture *is* the word. It works as **hello and goodbye**, at any time of
-day, to almost anyone, and it is respectful without being stiff. In Tamil
-cinema and formal speech you'll hear the fuller **வணக்கம்!** ring out as a
-one-word salutation to a whole room.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: read it left to right — va · ṇa · k · ka · m → "vaṇakkam"]
 - [YOU SAY: what the *puḷḷi* dot on க் does (kills its vowel: ka → k)]
-- [YOU SAY: "vaṇakkam," with a small bow — you are offering respect]
+- [YOU SAY: "vaṇaṅku — to bow; vaṇakkam — an act of reverence"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Read **வணக்கம்**. What verb is it built from, and what does that
 verb mean? (*vaṇaṅku*, "to bow / pay homage.") What does a **puḷḷi** do to a
-consonant? (Removes its built-in *a*.) Which Dravidian language kept a native
-word for "hello" while its neighbours borrowed Sanskrit? (Tamil.)
+consonant? (Removes its built-in *a*.) Is the root borrowed from Sanskrit?
+(**No** — it is native Tamil.) Next: compare that native greeting across the
+family and learn where it fits.

--- a/code/learning/human-languages/tamil/lessons/TA-C02-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [TA-C02-en-peyar, TA-C02-ungal-peyar-enna, TA-C02-magizhcci]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C02-peyar, TA-C02-en, TA-C02-en-peyar, TA-C02-nii-niingal, TA-C02-enna, TA-C02-ungal-peyar-enna, TA-C02-magizhcci]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C03-eppadi-irukkirirgal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-eppadi-irukkirirgal.md
@@ -8,7 +8,7 @@ concept_tag: STATE-HOW-ARE-YOU
 prerequisites: [TA-C03-eppadi, TA-C02-nii-niingal]
 sounds: [retroflex-kk, iir-gal]
 roots: [iru-be]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C02-nii-niingal, TA-C03-eppadi]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C03-paravayillai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-paravayillai.md
@@ -5,11 +5,11 @@ type: phrase
 headword: பரவாயில்லை
 gloss: it's okay / no problem / you're welcome
 concept_tag: COURTESY-YOUREWELCOME
-prerequisites: [TA-C01-illai, TA-C01-nandri]
+prerequisites: [TA-C01-illai, TA-C01-nandri-family-register]
 sounds: [illai-negative]
 roots: [illai-not-dravidian]
 est_minutes: 4
-reviews_of: [TA-C01-illai, TA-C01-nandri]
+reviews_of: [TA-C01-illai, TA-C01-nandri-family-register, TA-C01-nandri]
 ---
 
 # பரவாயில்லை (paravāyillai) — "no problem"

--- a/code/learning/human-languages/tamil/lessons/TA-C03-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [TA-C03-eppadi-irukkirirgal, TA-C03-nalam, TA-C03-paravayillai]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C03-eppadi, TA-C03-eppadi-irukkirirgal, TA-C03-naan, TA-C03-nalam, TA-C03-paravayillai]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C04-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [TA-C04-poy-varugiren, TA-C04-naalai, TA-C04-mindum-sandippom]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C04-po, TA-C04-poy-varugiren, TA-C04-naalai, TA-C04-mindum-sandippom]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C05-naan-tamizh-pesugiren.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-naan-tamizh-pesugiren.md
@@ -8,7 +8,7 @@ concept_tag: TA-WORD-TAMIZH
 prerequisites: [TA-C05-pesu, TA-C03-naan]
 sounds: [zh-retroflex]
 roots: [tamizh]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C05-pesu, TA-C03-naan]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C05-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [TA-C05-pesu, TA-C05-naan-tamizh-pesugiren, TA-C05-vaazh, TA-C05-velai-sey]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C05-pesu, TA-C05-naan-tamizh-pesugiren, TA-C05-vaazh, TA-C05-velai-sey, TA-C03-naan]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C05-velai-sey.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-velai-sey.md
@@ -8,7 +8,7 @@ concept_tag: TA-VERB-SEY
 prerequisites: [TA-C05-pesu]
 sounds: [long-e, ai-sign]
 roots: [sey-do-dravidian, velai-work-dravidian]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C05-pesu, TA-C05-vaazh]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-stacking.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-stacking.md
@@ -1,0 +1,50 @@
+---
+id: TA-C06-dative-stacking
+chapter: 6
+type: grammar
+headword: பெயர் + உக்கு
+gloss: Tamil stacks a visible one-purpose dative suffix where Latin fuses several meanings
+romanization: "peyar + ukku"
+prerequisites: [TA-C06-dative-ukku]
+sounds: [gemination-kk]
+roots: [dravidian-agglutination, latin-fusion]
+est_minutes: 4
+reviews_of: [TA-C06-dative-ukku]
+---
+
+# -உக்கு — one carriage in a suffix train
+
+## Warm-up
+
+[PAUSE 2s] You can point to *peyar* and *-ukku* separately. That visible seam is
+the structural lesson.
+
+## Stacking versus fusion
+
+| | Tamil **-ukku** | Latin **-īs** |
+|---|---|---|
+| fixes the case? | **dative**, always | dative **or** ablative |
+| carries number? | no; another suffix can | plural is baked in |
+| carries declension? | no | first/second class is baked in |
+| visible seam? | **peyar + ukku** | one fused ending |
+
+Tamil **stacks**. Each suffix contributes one meaning in a fixed order, like a
+train carriage. Latin **fuses** case, number, and class into an indivisible
+ending, and *-īs* does not even identify one case by itself.
+
+This is **agglutinative** structure: long words remain buildable because their
+pieces stay legible. The comparison is not about simplicity; it is about where
+the grammatical information lives.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SEGMENT: *peyar + ukku*]
+- [YOU SAY: "one suffix, one meaning, visible seam"]
+- [YOU CONTRAST: Tamil stacks · Latin fuses]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *-ukku* contribute? (**Dative to/for**, one meaning.) What
+does Latin *-īs* fuse? (**Case, plural number, and declension class**.) Which
+system leaves the seam visible? (**Tamil's agglutinative stack**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject-family.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject-family.md
@@ -1,0 +1,49 @@
+---
+id: TA-C06-dative-subject-family
+chapter: 6
+type: grammar
+headword: எனக்கு / నాకు / ನನಗೆ / എനിക്ക്
+gloss: all four Dravidian sisters put the experiencer in visibly related dative forms
+prerequisites: [TA-C06-dative-subject]
+sounds: [dravidian-dative-cognates]
+roots: [dravidian-dative-ku]
+est_minutes: 4
+reviews_of: [TA-C06-dative-subject, TA-C06-dative-stacking]
+---
+
+# -ukku, -ku, -ge, -ikku — the family shows its bones
+
+## Warm-up
+
+[PAUSE 2s] Tamil says knowing happens **to** you. Its three closest sisters make
+the same grammatical choice.
+
+## Four sentences, one construction
+
+| language | "I know [the language]" | dative |
+|---|---|---|
+| Tamil | *enakku tamiḻ teriyum* | **-ukku** |
+| Telugu | *nāku telugu vaccu* | **-ku** |
+| Kannada | *nanage kannaḍa gottu* | **-ge** |
+| Malayalam | *enikku malayāḷam aṟiyām* | **-ikku** |
+
+The verbs differ, but the experiencer sits in a dative whose forms visibly
+belong together: *-ukku / -ku / -ge / -ikku*. This is family evidence, just as
+*blanc/bianco/branco* exposes Romance kinship.
+
+The comparison also makes cross-language practice useful: once you recognize
+"to me," you can search for the known or apparent thing rather than forcing an
+English subject onto the sentence.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "-ukku · -ku · -ge · -ikku"]
+- [YOU POINT: the experiencer in each sentence]
+- [YOU PARAPHRASE: "the language is known to me"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Do the four sisters agree on dative experiencers? (**Yes**.) Which
+four suffix shapes reveal the relationship? (***-ukku, -ku, -ge, -ikku***.)
+What stays plain in the sentence? (The thing **known or experienced**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject.md
@@ -6,12 +6,12 @@ headword: எனக்குத் தமிழ் தெரியும்
 gloss: "'I know Tamil' — built with no subject, because knowing happens TO you"
 romanization: enakkut tamiḻ teriyum
 concept_tag: TA-DATIVE-SUBJECT
-prerequisites: [TA-C06-dative-ukku, TA-C05-naan-tamizh-pesugiren]
+prerequisites: [TA-C06-dative-stacking, TA-C05-naan-tamizh-pesugiren]
 sounds: [gemination-kk]
 roots: [dravidian-dative-ku]
 etymology_hook: "Dravidian puts the EXPERIENCER in the dative: knowing, liking, wanting and being cold all happen TO you rather than being done BY you — so 'I know Tamil' has no nominative 'I' at all, the person sitting in the dative instead (a 'dative subject'), and the same construction runs through Telugu, Kannada and Malayalam"
-est_minutes: 5
-reviews_of: [TA-C06-dative-ukku, TA-C05-naan-tamizh-pesugiren, TA-C03-naan]
+est_minutes: 4
+reviews_of: [TA-C06-dative-stacking, TA-C06-dative-ukku, TA-C05-naan-tamizh-pesugiren, TA-C03-naan]
 ---
 
 # எனக்குத் தமிழ் தெரியும் — "I know Tamil"
@@ -65,26 +65,12 @@ person in the **dative**.
 English does this occasionally and archaically — "**methinks**" is exactly it
 (*me* is dative: "it seems **to me**"). Tamil made it a rule.
 
-## All four sisters do it
-
-| language | "I know [the language]" | the dative |
-|---|---|---|
-| Tamil | *enakku tamiḻ teriyum* | **-ukku** |
-| Telugu | *nāku telugu vaccu* | **-ku** |
-| Kannada | *nanage kannaḍa gottu* | **-ge** |
-| Malayalam | *enikku malayāḷam aṟiyām* | **-ikku** |
-
-Four languages, one construction, and four suffixes that are visibly the **same
-suffix** — *-ukku / -ku / -ge / -ikku*. This is the Dravidian family showing its
-bones, exactly as *blanc/bianco/branco* did for Romance.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "*enakku tamiḻ teriyum*"]
 - [YOU SAY: the contrast — "*nāṉ tamiḻ pēsugiṟēṉ*" (I speak) … "*enakku tamiḻ teriyum*" (known to me)]
 - [YOU SAY: the literal — "to-me Tamil is-known"]
-- [YOU SAY: the four cousins — "*-ukku · -ku · -ge · -ikku*"]
 
 ## Wrap-up Recall
 
@@ -93,5 +79,5 @@ bones, exactly as *blanc/bianco/branco* did for Romance.
 "**I**" — *nāṉ* is replaced by the dative *enakku*.) Why does Tamil use the dative
 here? (Because knowing
 **happens to** you; you don't **do** it.) Which English word preserves the same
-idea? (**Methinks** — "it seems **to me**".) Do the sister languages agree? (**Yes**
-— all four, with cousin suffixes *-ukku/-ku/-ge/-ikku*.)
+idea? (**Methinks** — "it seems **to me**".) Next: watch all four Dravidian
+sisters use the same experiencer shape.

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-ukku.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-ukku.md
@@ -3,7 +3,7 @@ id: TA-C06-dative-ukku
 chapter: 6
 type: word
 headword: -உக்கு
-gloss: "the dative suffix -ukku, 'to / for' — and the idea of stacking"
+gloss: "the dative suffix -ukku, 'to / for,' including its two surface forms and irregular enakku"
 romanization: -ukku
 concept_tag: TA-CASE-DATIVE
 prerequisites: [TA-C05-practice, TA-C03-naan, TA-C02-peyar]
@@ -42,33 +42,12 @@ constantly:
 The pronoun changes its body (*nāṉ* → *en-*) before the suffix lands. Nouns don't
 — they just take the ending.
 
-## Why this matters
-
-Look at what the suffix does, and what it **doesn't** do:
-
-| | Tamil **-ukku** | a Latin ending like **-īs** |
-|---|---|---|
-| pins down the case? | **yes** — dative, always | **no** — *-īs* is dative **or** ablative |
-| carries number? | **no** — a separate suffix does | yes — plural, baked in |
-| carries declension class? | **no** | yes — 1st/2nd only |
-| can you see the seam? | **yes**: *peyar* + *ukku* | no — it's one fused lump |
-
-Tamil **stacks**. Each suffix means **one** thing and sits in a fixed order, so a
-long Tamil word can be read like a train of carriages — you can point at each
-piece. Latin **fuses**: *-īs* is case *and* plural *and* declension all at once,
-indivisible — and it doesn't even settle *which* case, since dative and ablative
-share the form. Tamil's *-ukku* is never ambiguous.
-
-This is what "**agglutinative**" means, and it's why Tamil words get long without
-getting hard: they're built, not memorised.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "*peyar* … *peyarukku*"]
 - [YOU SAY: "*nāṉ* … *enakku*" — "I" … "to me"]
 - [YOU SAY: "*vēlaikku*" — "for work," from Ch. 5's வேலை]
-- [YOU SAY: the principle — "one suffix, one meaning, visible seam"]
 
 ## Wrap-up Recall
 
@@ -76,7 +55,5 @@ getting hard: they're built, not memorised.
 (**On the end** of the noun — Tamil adds, it doesn't put a word in front.) What is
 "to me"? (**எனக்கு** *enakku* — the pronoun's body changes to *en-* first.) Why does
 the suffix show up as *-ukku* and *-kku*? (**One case, two shapes**, chosen by the
-noun's ending.) What's the difference from a Latin case ending? (Latin **fuses**
-case+number+declension into one lump — and *-īs* doesn't even fix *which* case;
-Tamil's suffix carries **one** meaning, unambiguously, with the **seam visible**.)
-Next: the sentence where Tamil puts "I" in the dative — and has no subject at all.
+noun's ending.) Next: compare that visible one-purpose suffix with a fused Latin
+ending.

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5-family.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5-family.md
@@ -1,0 +1,53 @@
+---
+id: TA-C07-numbers-1-5-family
+chapter: 7
+type: etymology
+headword: இரண்டு மூன்று நான்கு ஐந்து
+gloss: two through five remain visible cousins across the Dravidian family while one is less tidy
+prerequisites: [TA-C07-numbers-1-5]
+sounds: [alveolar-n-r-cluster]
+roots: [proto-dravidian-numbers]
+est_minutes: 4
+reviews_of: [TA-C07-numbers-1-5, TA-C01-vanakkam-family-register]
+---
+
+# Two to five — one family in four regional coats
+
+## Warm-up
+
+[PAUSE 2s] Hindi's number forms are Sanskrit worn smooth. Tamil's are native
+Dravidian, so their sister-language shapes reveal the family directly.
+
+## The cousin table
+
+| | Tamil | Kannada | Telugu | Malayalam |
+|---|---|---|---|---|
+| 2 | *iraṇṭu* | *eraḍu* | *reṇḍu* | *raṇṭu* |
+| 3 | *mūṉṟu* | *mūru* | *mūḍu* | *mūnnu* |
+| 4 | *nāṉku* | *nālku* | *nālugu* | *nālu* |
+| 5 | *aintu* | *aidu* | *aidu* | *añcu* |
+
+Each row is one word in four regional coats. That shared skeleton is why one
+Dravidian language gives you a running start on another.
+
+**One** is less tidy: Tamil *oṉṟu*, Kannada *ondu*, and Malayalam *onnu* share
+old *oṉ-*, while Telugu uses the separate formation *okaṭi*. The family agrees
+more neatly on 2–5 than on 1.
+
+## Hear the Tamil cluster
+
+In *oṉṟu* and *mūṉṟu*, **ன்ற** is alveolar *n* running into hard *ṟ*, almost one
+knock: *on-ru, muun-ru*. Puḷḷi on **ன்** removes its vowel before the cluster.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "iraṇṭu · eraḍu · reṇḍu · raṇṭu"]
+- [YOU SAY: *oṉṟu* and *mūṉṟu*, holding **ன்ற** together]
+- [YOU IDENTIFY: Telugu *okaṭi* as the different "one"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are these forms borrowed? (**No**, native Dravidian.) Which numbers
+stay tidiest across the family? (**Two through five**.) Which language forms
+"one" differently? (**Telugu**, *okaṭi*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C01-vanakkam]
 sounds: [tamil-inherent-a, pulli-virama, alveolar-rra, retroflex-nn]
 roots: [proto-dravidian-numbers]
 etymology_hook: "Tamil's numbers are native Dravidian, not borrowed — and 2–5 stay visibly cousin across Tamil, Kannada, Telugu, Malayalam"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C01-vanakkam]
 ---
 
@@ -40,49 +40,16 @@ and **ன** (the *n*-family), **ற** the hard *r* inside *mūṉṟu*, and the 
 dot that stacks *ன்ற* into the single cluster you hear in **ஒன்று** and
 **மூன்று**.
 
-## Where they come from — the family stays together
-
-Hindi's numbers are **Sanskrit worn smooth** (*eka → ek*). Tamil's are not
-borrowed at all: they are **native Dravidian**, the same instinct that kept
-*vaṇakkam* where the north reached for *namaste*. And because they're the
-family's own, they stay visibly **cousin** across the four Dravidian languages:
-
-| | Tamil | Kannada | Telugu | Malayalam |
-|---|---|---|---|---|
-| 2 | *iraṇṭu* | *eraḍu* | *reṇḍu* | *raṇṭu* |
-| 3 | *mūṉṟu* | *mūru* | *mūḍu* | *mūnnu* |
-| 4 | *nāṉku* | *nālku* | *nālugu* | *nālu* |
-| 5 | *aintu* | *aidu* | *aidu* | *añcu* |
-
-Read down any column and you can see one word wearing four regional coats —
-*iraṇṭu / eraḍu / reṇḍu / raṇṭu* is unmistakably **one** number, four ways.
-That shared skeleton is the whole reason learning one Dravidian language gives
-you a running start on the next.
-
-**One** is the odd one out. Tamil *oṉṟu*, Kannada *ondu* and Malayalam *onnu*
-are cousins (from an old *oṉ-*), but **Telugu** breaks ranks with *okaṭi* — a
-different formation entirely. A useful thing to know early: the family agrees
-on 2–5 far more tidily than on 1.
-
-## A sound to notice
-
-**ஏ**... not yet — that's next lesson. For now, the one to feel is the cluster
-**ன்ற** in *oṉṟu* and *mūṉṟu*: an alveolar *n* running straight into the hard
-*ṟ*, said almost as a single knock — *on-ru*, *muun-ru*. It's a very Tamil
-sound, and the puḷḷi dot on **ன்** is what tells you the two letters fuse.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "oṉṟu, iraṇṭu, mūṉṟu, nāṉku, aintu"]
-- [YOU SAY: the cousins — "iraṇṭu … eraḍu … reṇḍu … raṇṭu": one number, four coats]
 - [YOU SAY: read the digits aloud — ௧ ௨ ௩ ௪ ௫]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Count to five in Tamil. (*Oṉṟu, iraṇṭu, mūṉṟu, nāṉku, aintu*.) Are
 Tamil's numbers borrowed from Sanskrit, like Hindi's? (**No** — they're native
-Dravidian.) Which number does **Telugu** form differently from its cousins?
-(**One** — *okaṭi*, where Tamil/Kannada/Malayalam share *oṉṟu / ondu / onnu*.)
-What does the puḷḷi on **ன்** do inside *oṉṟu*? (Fuses *ன்* + *ற* into one
-cluster.) Next: six to ten.
+Dravidian.) Which two writing systems sit side by side? (Spelled-out **words**
+and Tamil's own **numerals**.) Next: compare these native forms across the
+family.

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10-family.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10-family.md
@@ -1,0 +1,50 @@
+---
+id: TA-C07-numbers-6-10-family
+chapter: 7
+type: etymology
+headword: ஆறு ஏழு பத்து
+gloss: six, seven, and ten stay family cousins while Kannada regularly softens p to h
+prerequisites: [TA-C07-numbers-6-10]
+sounds: [kannada-p-to-h, tamil-retroflex-liquid]
+roots: [proto-dravidian-numbers]
+est_minutes: 4
+reviews_of: [TA-C07-numbers-6-10, TA-C07-numbers-1-5-family]
+---
+
+# Six to ten — family resemblances and one Kannada shift
+
+## Warm-up
+
+[PAUSE 2s] The Tamil forms are learned. Now use their sister shapes as evidence
+for inheritance and regular sound change.
+
+## The stable cousins
+
+Six and seven remain close: Tamil *āṟu*, Kannada *āru*, Malayalam *āṟu*;
+Tamil *ēḻu*, Kannada *ēḷu*, Malayalam *ēḻu*. Tamil and Malayalam also keep
+eight and nine nearly identical: *eṭṭu* and *oṉpatu/onpatu*.
+
+Telugu wanders on eight and nine with *enimidi* and *tommidi*, so those forms
+are less reliable as family-wide recognition anchors.
+
+## pattu → hattu
+
+Tamil and Malayalam say **pattu**, while Kannada says **hattu**. The initial
+*p → h* is a regular Kannada shift, not a random replacement. Compare Tamil
+*pāl*, "milk," with Kannada *hālu*.
+
+A correspondence lets differences prove relationship: repeated *p/h* pairs
+are stronger evidence than one accidental resemblance.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: Tamil *pattu* · Kannada *hattu*]
+- [YOU SAY: Tamil *pāl* · Kannada *hālu*]
+- [YOU IDENTIFY: *ēḻu / ēḷu / ēḻu* as one inherited seven]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What happens to Tamil *pattu* in Kannada? (*P* regularly softens to
+***h***: *hattu*.) Which second pair confirms the pattern? (*Pāl / hālu*,
+"milk.") Which language diverges most on eight and nine? (**Telugu**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10.md
@@ -5,12 +5,12 @@ type: word
 headword: ஆறு ஏழு எட்டு ஒன்பது பத்து
 gloss: six to ten — and the number that carries Tamil's own letter
 concept_tag: TA-NUMBERS-6-10
-prerequisites: [TA-C07-numbers-1-5]
+prerequisites: [TA-C07-numbers-1-5-family]
 sounds: [tamil-inherent-a, pulli-virama, tamil-zha-llla]
 roots: [proto-dravidian-numbers]
 etymology_hook: "seven ஏழு ēḻu carries ழ — the letter and sound in the name Tamiḻ itself; and nine is oṉ (one) + patu (ten)"
-est_minutes: 5
-reviews_of: [TA-C07-numbers-1-5, TA-C01-vanakkam]
+est_minutes: 4
+reviews_of: [TA-C07-numbers-1-5-family, TA-C07-numbers-1-5, TA-C01-vanakkam]
 ---
 
 # ஆறு, ஏழு, எட்டு, ஒன்பது, பத்து — six to ten
@@ -55,17 +55,6 @@ And ten itself is **பத்து** (*pattu*). Say *oṉpatu* then *pattu* and
 nine leaning on ten. That is a common Dravidian habit — nine described as
 one-away-from-ten rather than named outright.
 
-## The family, still together (mostly)
-
-Six, seven and ten stay clear cousins across the Dravidian languages — Tamil
-*āṟu*, Kannada *āru*, Malayalam *āṟu*; Tamil *ēḻu*, Kannada *ēḷu*, Malayalam
-*ēḻu*. Ten is a nice one to watch: Tamil **pattu**, Malayalam **pattu**, but
-Kannada softens the *p‑* to *h‑* → **hattu** — a regular Kannada sound-shift
-you'll see again (Tamil *pāl* "milk" ↔ Kannada *hālu*). Tamil and Malayalam even
-keep **eight** and **nine** nearly identical (*eṭṭu*, *oṉpatu* / *onpatu*); it's
-**Telugu** that wanders off there (*enimidi*, *tommidi*) — so those two are the
-least reliable as family-wide cousins.
-
 ## Guided Practice
 
 [PAUSE 1s]
@@ -79,6 +68,5 @@ least reliable as family-wide cousins.
 [PAUSE 3s] Count six to ten in Tamil. (*Āṟu, ēḻu, eṭṭu, oṉpatu, pattu*.) Which
 number is written with **ழ**, and where else does that letter appear? (**Seven**,
 *ēḻu* — the same letter that ends *Tamiḻ*.) How is **nine** built? (*Oṉ* "one" +
-*patu* "ten" → *oṉpatu*, one short of ten.) What happens to Tamil *pattu* when you
-cross into Kannada? (The *p‑* softens to *h‑*: *hattu*.) Next chapter builds on
-these to ask *how many?* and *how old are you?*
+*patu* "ten" → *oṉpatu*, one short of ten.) Next: follow these forms across the
+family and hear Kannada *p* soften to *h*.

--- a/code/learning/human-languages/tamil/lessons/TA-C08-please-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C08-please-register.md
@@ -1,0 +1,49 @@
+---
+id: TA-C08-please-register
+chapter: 8
+type: grammar
+headword: தயவுசெய்து / -உங்கள்
+gloss: standalone please is emphatic while everyday courtesy often lives in the respectful verb ending
+prerequisites: [TA-C08-tayavuseytu]
+sounds: [tamil-vowel-sign-e, pulli-virama]
+roots: [tamil-respectful-imperative]
+est_minutes: 4
+reviews_of: [TA-C08-tayavuseytu]
+---
+
+# தயவுசெய்து or -உங்கள்? — politeness in phrase or verb
+
+## Warm-up
+
+[PAUSE 2s] Tamil has a phrase meaning "do the kindness," but everyday courtesy
+often sits somewhere English speakers do not expect: inside the verb.
+
+## Choose by emphasis
+
+A standalone **தயவுசெய்து** is more emphatic and formal than English "please."
+Ordinary polite commands use respectful **-உங்கள்** (*-uṅgaḷ*):
+
+- **உட்காருங்கள்** *uṭkāruṅgaḷ* — please sit
+- **சொல்லுங்கள்** *solluṅgaḷ* — please tell me
+
+Use *tayavu seytu* to mark "please, do me the kindness" warmly or formally. Let
+the verb ending carry routine courtesy.
+
+## Read the join in செய்து
+
+**செ** is *ca* with the **ெ** sign for *e*. **ய்** is *ya* shut off by puḷḷi,
+a bare *y*, before **து** *tu*. The same dot that built numbers now makes the
+consonant seam in *seytu* visible.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU CHOOSE: emphatic request → **தயவுசெய்து**]
+- [YOU CHOOSE: ordinary "please sit" → **உட்காருங்கள்**]
+- [YOU SEGMENT: செ + ய் + து → செய்து]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What carries everyday "please"? (The respectful verb ending
+***-uṅgaḷ***.) When is *tayavu seytu* especially useful? (A **markedly polite or
+emphatic** request.) What silences *y* in **ய்**? (The **puḷḷi**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C08-tayavuseytu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C08-tayavuseytu.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C01-aam]
 sounds: [tamil-vowel-sign-u, pulli-virama, tamil-vowel-sign-e]
 roots: [daya-compassion]
 etymology_hook: "தயவுசெய்து = 'do the kindness' — Tamil asks please by naming daya 'compassion', like Arabic faḍl and Hindi kṛpā"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C01-aam]
 ---
 
@@ -50,31 +50,11 @@ light verb "do / place / become":
 
 One idea, four scripts. Learn one and you can almost read the others.
 
-## Be honest about how it's used
-
-Here is the honest part. A standalone "please" word is more **emphatic and
-formal** in Tamil than in English. In ordinary speech, politeness usually lives
-**in the verb** — the respectful command ending **‑உங்கள்** (*-uṅgaḷ*):
-**உட்காருங்கள்** (*uṭkāruṅgaḷ*) "please sit," **சொல்லுங்கள்** (*sollungaḷ*) "please
-tell me." That *-uṅgaḷ* already carries the "please."
-
-So reach for **தயவுசெய்து** when you want to be markedly, warmly polite —
-"*please*, do me the kindness" — and lean on the **‑உங்கள்** verb ending for
-everyday courtesy.
-
-## Sound & structure point
-
-Notice the join in **செய்து**: **செ** is *ca* wearing the **‑ெ** sign for *e*,
-then **ய்** is *ya* shut off by the **புள்ளி** (*puḷḷi*, the virama dot) — a bare
-consonant *y* — before **து** *tu*. That dot, silencing a vowel, is the same tool
-you met building the numbers.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "tayavu" — the kindness — then "seytu," having done]
 - [YOU SAY: the whole phrase — "tayavu seytu" = please, do the kindness]
-- [YOU SAY: the everyday way — the verb ending: "uṭkāruṅgaḷ" = please sit]
 
 ## Wrap-up Recall
 
@@ -82,5 +62,5 @@ you met building the numbers.
 What do its two pieces mean? ("**Kindness**" *tayavu* + "**having done**" *seytu*
 — *do the kindness*.) Which languages ask the same way? (**Kannada, Telugu,
 Malayalam** with *daya*, and further off **Arabic** *faḍl* and **Hindi** *kṛpā*.)
-And what carries "please" in ordinary speech? (**The verb ending ‑உங்கள்**
-*-uṅgaḷ*.)
+Next: decide when the standalone phrase is natural and when the verb carries
+the courtesy.

--- a/code/learning/human-languages/tamil/lessons/TA-C09-mannikkavum.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C09-mannikkavum.md
@@ -5,12 +5,12 @@ type: phrase
 headword: மன்னிக்கவும்
 gloss: please forgive (maṉṉikkavum — a formal/written polite request, from மன்னி maṉṉi "to forgive")
 concept_tag: COURTESY-SORRY
-prerequisites: [TA-C08-tayavuseytu]
+prerequisites: [TA-C08-please-register]
 sounds: [tamil-double-nnna, pulli-virama]
 roots: [manni-tamil]
 etymology_hook: "மன்னிக்கவும் maṉṉikkavum is built on மன்னி maṉṉi 'to forgive' — Tamil's OWN native word, unlike its Dravidian cousins' Sanskrit kṣamā"
-est_minutes: 5
-reviews_of: [TA-C08-tayavuseytu]
+est_minutes: 4
+reviews_of: [TA-C08-please-register, TA-C08-tayavuseytu]
 ---
 
 # மன்னிக்கவும் (maṉṉikkavum) — please forgive
@@ -51,22 +51,6 @@ Where "please" showed the whole family sharing one Sanskrit-derived idea
 (*daya*), "sorry" shows the opposite: Tamil kept its own word while its
 cousins borrowed the same Sanskrit one.
 
-## Be honest about register
-
-**மன்னிக்கவும்** leans formal — the kind of "please forgive" you'd read on a
-notice or offer in a considered apology. Everyday spoken Tamil often reaches
-for something shorter and more local depending on region, or simply borrows
-the English word "sorry." (This is one for a Tamil speaker to sharpen further
-— regional colloquial Tamil varies more than a single lesson can capture.)
-
-## Sound & structure point
-
-Notice **ன்னி**: the alveolar **ன** (*ṉ* — a third "n," distinct from dental
-ந and retroflex ண) is silenced by the **புள்ளி** (*puḷḷi*, virama dot) and
-then **doubled** before the vowel — the same gemination-by-repetition device
-you saw building numbers, here holding the *ṉ* consonant twice across the
-syllable boundary.
-
 ## Guided Practice
 
 [PAUSE 1s]
@@ -80,6 +64,5 @@ syllable boundary.
 (**"Please forgive"** — *maṉṉi* "to forgive" + *‑kkavum*, a formal request
 ending.) What's different about Tamil's forgiveness-word compared to Kannada,
 Telugu, and Malayalam? (**It's Tamil's own native root** — the other three
-borrow Sanskrit *kṣamā* instead.) Is மன்னிக்கவும் the everyday spoken word?
-(**Not necessarily** — it leans formal/written; everyday speech varies by
-region or may just borrow English "sorry.")
+borrow Sanskrit *kṣamā* instead.) Next: place the word in its real register and
+read the doubled alveolar n.

--- a/code/learning/human-languages/tamil/lessons/TA-C09-sorry-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C09-sorry-register.md
@@ -1,0 +1,50 @@
+---
+id: TA-C09-sorry-register
+chapter: 9
+type: grammar
+headword: மன்னிக்கவும் / sorry
+gloss: the native forgiveness request leans formal while colloquial apologies vary by region
+prerequisites: [TA-C09-mannikkavum]
+sounds: [tamil-double-alveolar-n, pulli-virama]
+roots: [manni-tamil]
+est_minutes: 4
+reviews_of: [TA-C09-mannikkavum, TA-C08-please-register]
+---
+
+# மன்னிக்கவும் — formal forgiveness and a doubled n
+
+## Warm-up
+
+[PAUSE 2s] The root is native Tamil. Its everyday conversational fit is less
+simple than a one-to-one dictionary entry suggests.
+
+## Register first
+
+**மன்னிக்கவும்** leans formal: a "please forgive" on a notice or in a considered
+apology. Spoken Tamil may use shorter regional forms or borrow English "sorry."
+Colloquial variation is real, so treat formal/written as a reliable center, not
+a claim that one casual form covers every region.
+
+## Read ன்னி
+
+In **ன்னி**, alveolar **ன** is first silenced by puḷḷi and then repeated before
+the vowel. The spelling holds the consonant across the syllable boundary:
+
+> **ன் + னி → ன்னி** — *ṉ-ṉi*
+
+This is the same gemination-by-repetition principle used elsewhere in Tamil;
+the sound is doubled without inventing a new ligature.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "maṉ-ṉi-kkavum," holding both doubled consonants]
+- [YOU CHOOSE: considered/formal apology → **மன்னிக்கவும்**]
+- [YOU QUALIFY: casual alternatives vary by region]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the reliable register center of *maṉṉikkavum*?
+(**Formal/written or considered apology**.) Must every region use it casually?
+(**No**.) How does **ன்னி** show a doubled *ṉ*? (Puḷḷi stops the first **ன்**,
+then full **னி** follows.)

--- a/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
@@ -5,12 +5,12 @@ type: word
 headword: திங்கள் செவ்வாய் புதன் வியாழன் வெள்ளி சனி ஞாயிறு
 gloss: the seven weekdays — a mix of Tamil's OWN planet-words and Sanskrit borrowings
 concept_tag: TA-DAYS-WEEK
-prerequisites: [TA-C09-mannikkavum]
+prerequisites: [TA-C09-sorry-register]
 sounds: [tamil-alveolar-rra, pulli-virama, tamil-nya]
 roots: [dravidian-native-planet-words, sanskrit-planet-words]
 etymology_hook: "Tamil names its week with கிழமை kizhamai 'day' — a native Dravidian word, not Sanskrit vāra — and four of its seven planet-names (moon, Mars, Venus, sun) are Tamil's own, not borrowed"
-est_minutes: 6
-reviews_of: [TA-C09-mannikkavum]
+est_minutes: 4
+reviews_of: [TA-C09-sorry-register, TA-C09-mannikkavum]
 ---
 
 # திங்கள் to ஞாயிறு — the week, home-grown and borrowed together

--- a/code/learning/human-languages/tamil/lessons/TA-C11-nirangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C11-nirangal.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C10-vaara-kizhamai]
 sounds: [tamil-double-lla, pulli-virama]
 roots: [dravidian-native-colors, sanskrit-nila]
 etymology_hook: "கருப்பு, வெள்ளை, சிவப்பு (black/white/red) are Tamil's OWN native words; நீலம் (blue) is a Sanskrit loan — the same 'blue arrives late' pattern Latin's caeruleus showed"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [TA-C10-vaara-kizhamai]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C11-nirangal]
 sounds: [tamil-double-nna-retroflex, pulli-virama]
 roots: [dravidian-appa-amma, dravidian-age-graded-siblings]
 etymology_hook: "அப்பா appā/அம்மா ammā (native, baby-talk-type words found worldwide) are just the start — Tamil has FOUR sibling words, split by the sibling's AGE relative to you, not just their gender"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TA-C11-nirangal]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C14-kaalangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C14-kaalangal.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C13-udal-uruppugal]
 sounds: [tamil-vowel-sign-ai, tamil-retroflex-lla]
 roots: [dravidian-kodai-mazhai-kulir, sanskrit-vasantha]
 etymology_hook: "கோடை kodai (summer heat) and குளிர் kulir (cold) are native Tamil words; வசந்தம் vasantham (spring) is a Sanskrit loan — but the season that actually shapes life in Tamil Nadu is மழைக்காலம், the RAINS, not any of the four Western ones"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TA-C13-udal-uruppugal]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C15-thanneer-arisi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C15-thanneer-arisi.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C14-kaalangal]
 sounds: [tamil-retroflex-nna-double, tamil-vowel-sign-ii]
 roots: [thann-cool-nir-water, arisi-rice-dravidian]
 etymology_hook: "அரிசி arisi (uncooked rice) may be the ULTIMATE source of the English word 'rice' itself, via Greek oryza — a widely cited hypothesis, though etymologists don't all agree on the exact chain"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TA-C14-kaalangal]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C16-thamizh-maadangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C16-thamizh-maadangal.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C15-thanneer-arisi]
 sounds: [tamil-vowel-sign-ai, tamil-retroflex-lla]
 roots: [tamil-solar-calendar-nakshatra]
 etymology_hook: "The Tamil solar calendar's twelve months are named for nakshatras (lunar-mansion star groups) the MOON sits near on the full-moon day within that month — a THIRD calendar system, alongside the Gregorian and the pan-Indian Hindu lunisolar calendar, still governing Tamil New Year and Pongal today"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TA-C15-thanneer-arisi]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C17-nanpakal-nalliravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C17-nanpakal-nalliravu.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C16-thamizh-maadangal]
 sounds: [tamil-retroflex-lla, tamil-vowel-sign-u]
 roots: [tamil-nal-middle-proto-dravidian, tamil-naTu-middle]
 etymology_hook: "நண்பகல் (naṇpakal, noon) and நள்ளிரவு (naḷḷiravu, midnight) both trace to நள் (naḷ, 'middle'), a documented Proto-Dravidian root that survives today mainly in literary compounds like நள்ளிருள் ('thick darkness') — but Tamil ALSO keeps fully transparent synonyms, நடுப்பகல்/நடு இரவு, built directly on நடு (naṭu), the everyday colloquial word for 'middle'"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TA-C16-thamizh-maadangal]
 ---
 
@@ -42,37 +42,17 @@ with **பகல்** (*pakal*, "**daytime**") — but here it surfaces as
 following ப. Same root, two different faces, depending on what it's fused
 to.
 
-## The genuinely interesting part: Tamil ALSO kept the transparent version
-
-Here's what makes Tamil's case different from the Latin *medius diēs*
-story you saw earlier — where **different daughter languages** (Spanish,
-French, English) each inherited **one** fate for the phrase. Tamil kept
-**both fates in the very same language**, as living synonyms:
-
-- **நடுப்பகல்** (*naṭuppakal*) — dictionary-listed as a synonym of
-  *naṇpakal* — built directly on **நடு** (*naṭu*, "**middle**"), a word
-  every Tamil speaker still uses today (as in *naḍuvē*, "in the middle").
-- **நடு இரவு** (*naṭu iravu*) — the fully transparent synonym of
-  *naḷḷiravu*, again built directly on *naṭu*.
-
-So Tamil didn't have to choose between "erode it" and "keep it
-transparent" the way Latin's daughters did — it simply kept **both**,
-side by side, as everyday synonyms.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "naḷ" — an old word for "middle" — then "naḷḷiravu," midnight]
 - [YOU SAY: "naṇpakal" — noon, the same naḷ root, resurfacing as naṇ-]
-- [YOU SAY: the everyday synonyms — "naṭuppakal," "naṭu iravu," built on
-  naṭu, the "middle" word you already know]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What old Proto-Dravidian root do நண்பகல் and நள்ளிரவு both trace
 back to, and what does it mean? (**நள்** *naḷ*, "middle" — surviving mainly
-in literary compounds like *naḷḷiruḷ*, "thick darkness.") What fully
-transparent, everyday synonyms does Tamil ALSO keep for the same meanings?
-(**நடுப்பகல்** and **நடு இரவு**, built on the everyday word **நடு**,
-"middle.") Does Tamil reach for a Sanskrit word here, the way Kannada and
-Telugu do? (**No** — every piece here is native Tamil.)
+in literary compounds like *naḷḷiruḷ*, "thick darkness.") Why does it surface
+as **naṇ-** in *naṇpakal*? (A sandhi change before following **p**.) Does Tamil
+reach for Sanskrit here? (**No**.) Next: meet the transparent *naṭu* synonyms
+Tamil kept beside these older compounds.

--- a/code/learning/human-languages/tamil/lessons/TA-C17-transparent-middle-synonyms.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C17-transparent-middle-synonyms.md
@@ -1,0 +1,46 @@
+---
+id: TA-C17-transparent-middle-synonyms
+chapter: 17
+type: etymology
+headword: நடுப்பகல், நடு இரவு
+gloss: Tamil kept transparent middle-day and middle-night synonyms beside the older fused forms
+prerequisites: [TA-C17-nanpakal-nalliravu]
+sounds: [tamil-gemination]
+roots: [tamil-naTu-middle, tamil-nal-middle-proto-dravidian]
+est_minutes: 4
+reviews_of: [TA-C17-nanpakal-nalliravu]
+---
+
+# நடுப்பகல் and நடு இரவு — the transparent twins
+
+## Warm-up
+
+[PAUSE 2s] *Naṇpakal* and *naḷḷiravu* preserve an older middle-root in fused
+forms. Tamil also kept versions whose pieces remain obvious today.
+
+## The living synonyms
+
+- **நடுப்பகல்** (*naṭuppakal*) — "middle-daytime," a dictionary synonym of
+  *naṇpakal*
+- **நடு இரவு** (*naṭu iravu*) — "middle night," the transparent synonym of
+  *naḷḷiravu*
+
+Both use **நடு** (*naṭu*, "middle"), the everyday word still heard in *naṭuvē*,
+"in the middle."
+
+Latin daughter languages often inherit one fate for an old compound: eroded or
+transparent. Tamil kept **both fates inside one language**—old fused forms and
+fresh transparent synonyms side by side.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "naṇpakal · naṭuppakal" — two noon forms]
+- [YOU SAY: "naḷḷiravu · naṭu iravu" — two midnight forms]
+- [YOU POINT: *naṭu* as the visible everyday "middle"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which everyday word builds the transparent forms? (**நடு**, *naṭu*,
+"middle.") What did Tamil keep simultaneously? (**Older fused compounds and
+transparent synonyms**.) Are any pieces Sanskrit loans? (**No**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C18-mani-homophone-time.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C18-mani-homophone-time.md
@@ -1,0 +1,51 @@
+---
+id: TA-C18-mani-homophone-time
+chapter: 18
+type: etymology
+headword: மணி / மணி
+gloss: the hour-word and Sanskrit gem-word are likely homophones, then maṇi tells clock time
+prerequisites: [TA-C18-mani]
+sounds: [tamil-retroflex-nna, tamil-vowel-sign-i]
+roots: [tamil-mani-bell, sanskrit-mani-gem]
+est_minutes: 4
+reviews_of: [TA-C18-mani, TA-C07-numbers-1-5]
+---
+
+# மணி — hour or jewel? Context decides
+
+## Warm-up
+
+[PAUSE 2s] The likely native bell/hour word shares its spelling and sound with
+a clear Sanskrit loan meaning something entirely different.
+
+## The homophone trap
+
+Tamil dictionaries list a second **மணி** from Sanskrit **मणि** (*maṇi*), "gem,
+jewel." On that analysis, bell/hour and gem are **homophones**: one likely
+native, one borrowed, identical on the page. Context separates clock time from a
+jewel or personal name.
+
+Malayalam dictionaries analyze their cognate differently, treating bell/hour
+and gem as one Sanskrit-derived word. Closely related languages do not always
+settle the same etymological question in the same way.
+
+## Tell the time
+
+> **ஒரு மணி.** — one o'clock, literally "one hour/bell"
+>
+> **இரண்டு மணி.** — two o'clock
+
+The number comes first; *maṇi* supplies the clock unit.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "oru maṇi" — one o'clock]
+- [YOU SAY: "iraṇṭu maṇi" — two o'clock]
+- [YOU CHOOSE BY CONTEXT: clock → hour · jewelry/name → gem]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the homophone trap? (A likely separate Sanskrit-borrowed
+**மணி** means **gem**.) Does Malayalam analyze the same forms identically?
+(**No**.) How do you say two o'clock? (**இரண்டு மணி**, *iraṇṭu maṇi*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C18-mani.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C18-mani.md
@@ -5,12 +5,12 @@ type: word
 headword: மணி
 gloss: hour — Tamil's OWN dictionaries treat this as a native Dravidian "bell" word, most likely NOT Kannada/Telugu/Hindi's Sanskrit ghaṇṭā, and a probable homophone trap with an unrelated Sanskrit "gem" word spelled the same way
 concept_tag: TA-TIME-HOUR
-prerequisites: [TA-C17-nanpakal-nalliravu]
+prerequisites: [TA-C17-transparent-middle-synonyms]
 sounds: [tamil-retroflex-nna, tamil-vowel-sign-i]
 roots: [tamil-mani-bell]
 etymology_hook: "மணி (maṇi, 'hour') — Tamil's own dictionaries (Wiktionary) split this into a native Dravidian 'bell, gong' word (→'hour', via the same bell-strikes-the-hour logic as Sanskrit's ghaṇṭā) and a wholly separate Sanskrit loan meaning 'gem' — though even the comparative Dravidian dictionary (DEDR) flags a possible Sanskrit connection for the whole family as unresolved, so treat 'native' as the best current account, not a closed case"
-est_minutes: 6
-reviews_of: [TA-C17-nanpakal-nalliravu]
+est_minutes: 4
+reviews_of: [TA-C17-transparent-middle-synonyms, TA-C17-nanpakal-nalliravu]
 ---
 
 # மணி — Tamil's native "bell," and a real homophone trap
@@ -34,41 +34,16 @@ starting point — though even the comparative Dravidian dictionary (DEDR) flags
 possible Sanskrit connection for this whole word-family as unresolved, so hold
 "native" as the best current account rather than a settled fact.
 
-## Be careful: a likely second, separate மணி means "gem"
-
-Here's the honest trap. Tamil's dictionaries ALSO list a **second, separate**
-entry spelled and pronounced exactly the same — **மணி**, borrowed from
-**Sanskrit** **मणि** (*maṇi*, "**gem, jewel, precious stone**"), the same
-Sanskrit word behind Tamil personal names like *Maṇi*. This gem-word and the
-bell/hour-word are treated as **homophones**: identical in sound and spelling,
-but listed as separate, unrelated entries — one most likely inherited Dravidian
-vocabulary, the other a clear Sanskrit loan. Only context tells them apart
-(*maṇi* the hour vs. *maṇi* a jewel in someone's name or a piece of jewelry).
-Worth noting: Malayalam, Tamil's closest cousin, handles this exact word very
-differently — its own dictionaries treat bell/hour and gem as **one single**
-Sanskrit-derived word, not two separate homophones. Even between two closely
-related languages, this hasn't settled into one agreed story.
-
-## Grammar Lens: telling the time
-
-> **ஒரு மணி.** — "One o'clock." (*oru maṇi*, "one hour/bell")
-> **இரண்டு மணி.** — "Two o'clock." (*iraṇṭu maṇi*, "two hour/bell")
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "maṇi" — hour, also "bell" — native, NOT from Sanskrit ghaṇṭā]
-- [YOU SAY: "oru maṇi" — one o'clock]
-- [YOU SAY: the homophone trap — a completely separate maṇi, from Sanskrit, means
-  "gem"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Is Tamil's **மணி** ("hour") from the same Sanskrit root as
 Kannada/Telugu/Hindi's hour-words? (**Most likely no** — it's treated as a native
 Dravidian "bell" word that independently reached "hour" the same way, though even
-DEDR flags this as not fully settled.) What's the homophone trap here? (A likely
-**separate**, Sanskrit-borrowed மணி means "**gem, jewel**" — identical in sound
-and spelling, listed as an unrelated entry.) Does Malayalam treat its cognate the
-same way? (**No** — Malayalam's own dictionaries treat bell/hour and gem as
-**one single** Sanskrit word, not two separate homophones.)
+DEDR flags this as not fully settled.) What semantic path links the meanings?
+(A **bell announces the hour**.) Next: distinguish the likely Sanskrit gem
+homophone and tell the time.

--- a/code/learning/human-languages/tamil/lessons/TA-C19-age-register-grammar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C19-age-register-grammar.md
@@ -1,0 +1,52 @@
+---
+id: TA-C19-age-register-grammar
+chapter: 19
+type: grammar
+headword: உன் வயசு என்ன? / உனக்கு எத்தனை வயது ஆகிறது?
+gloss: casual Tamil uses a possessive age question while formal Tamil uses dative plus become
+prerequisites: [TA-C19-vayathu]
+sounds: [tamil-dative-ukku, tamil-verb-aakiradhu]
+roots: [tamil-aaku-become]
+est_minutes: 4
+reviews_of: [TA-C19-vayathu, TA-C06-dative-subject-family]
+---
+
+# Your age what? / To you how many years becomes?
+
+## Warm-up
+
+[PAUSE 2s] Tamil did not choose one age construction. Register selects between
+two shapes already visible elsewhere in the family.
+
+## Casual possessive
+
+> **உன் வயசு என்ன?** — "your age what?"
+
+Casual speech uses a plain possessive with no dative and no verb, like Kannada
+and Telugu.
+
+## Formal dative plus "become"
+
+> **உனக்கு எத்தனை வயது ஆகிறது?** — "to you how many years is becoming?"
+>
+> **எனக்கு இருபது வயது ஆகிறது.** — "to me twenty years is becoming."
+
+Formal/written Tamil uses the dative experiencer plus **ஆகிறது** (*aakirathu*,
+"is becoming," from *aaku*). Malayalam uses a similar dative shape but chooses
+"exists" instead.
+
+Do not compress these into "Tamil's one grammar." Both live in the language;
+setting and register choose between them.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "un vayasu enna?" — casual]
+- [YOU SAY: "unakku ettanai vayathu aakirathu?" — formal]
+- [YOU ANSWER: "enakku irupathu vayathu aakirathu"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which shape is casual? (**Possessive**: "your age what?") Which is
+formal? (**Dative + aakirathu**, "become.") Does Malayalam use the same verb?
+(**No** — it uses "exists.")

--- a/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
@@ -5,12 +5,12 @@ type: phrase
 headword: உனக்கு எத்தனை வயது ஆகிறது?
 gloss: how old are you? — literally "to you how many years is becoming?"; the SAME Sanskrit vayas word as Kannada/Telugu/Malayalam; Tamil actually spans BOTH grammatical shapes seen so far, from a plain possessive in casual speech to this more formal dative+verb construction
 concept_tag: TA-AGE
-prerequisites: [TA-C18-mani]
+prerequisites: [TA-C18-mani-homophone-time]
 sounds: [tamil-dative-ukku, tamil-verb-aakiradhu]
 roots: [sanskrit-vayas-vigor-age]
 etymology_hook: "வயது (vayathu, 'age') is the same Sanskrit वयस् (vayas, 'vigor, age,' PIE cousin of Latin vīs) as its Kannada/Telugu/Malayalam cousins — Tamil actually has BOTH shapes seen so far: a plain possessive in casual speech ('un vayasu enna?', matching Kannada/Telugu), and this more formal dative-subject + ஆகிறது (aakirathu, 'is becoming') construction, matching Malayalam's shape"
-est_minutes: 6
-reviews_of: [TA-C18-mani]
+est_minutes: 4
+reviews_of: [TA-C18-mani-homophone-time, TA-C18-mani]
 ---
 
 # உனக்கு எத்தனை வயது ஆகிறது? — Tamil actually has BOTH shapes
@@ -29,44 +29,15 @@ Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact
 Sanskrit word for "age" — none of them built a native alternative for this
 particular concept, unlike some others you've seen in this course.
 
-## Grammar Lens: casual possessive AND formal dative + "become"
-
-Be honest here: Tamil doesn't pick just one shape. **Casual, spoken** Tamil
-uses the exact same **plain possessive** shape as Kannada and Telugu:
-
-> **உன் வயசு என்ன?** — "How old are you?" (casual) — literally "**your age
-  what**?" (*un vayasu enna?*) — no dative, no verb, just like Kannada's
-  *ninna vayassu eṣṭu?*
-
-**Formal, written** Tamil instead uses a **dative-subject + verb** shape,
-matching Malayalam's:
-
-> **உனக்கு எத்தனை வயது ஆகிறது?** — "How old are you?" (formal) — literally
-  "**to you how many years is becoming**?" (*unakku ettanai vayathu
-  aakirathu?* — from *unakku*, "to you" [dative] + *ettanai vayathu*, "how
-  many years" + *aakirathu*, "is becoming," from *aaha*, "to become.")
-> **எனக்கு இருபது வயது ஆகிறது.** — "I am twenty years old." — literally "**to
-  me twenty years is becoming**." (*enakku irupathu vayathu aakirathu.*)
-
-Where Malayalam reaches for **ഉണ്ട്** (*uṇṭŭ*, "exists") in this formal shape,
-Tamil reaches for its own verb, **ஆகிறது** (*aakirathu*, "is becoming, is
-happening," from **ஆகு** *aaku*, "to become"). So don't treat this as "Tamil's
-one grammar" — it's the more **formal** register, existing alongside a
-perfectly ordinary casual register that looks just like Kannada's and Telugu's.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "vayathu" — age]
-- [YOU SAY: "un vayasu enna?" — how old are you? (casual, like Kannada/Telugu)]
-- [YOU SAY: "unakku ettanai vayathu aakirathu?" — how old are you? (formal,
-  like Malayalam)]
+- [YOU CONNECT: Sanskrit *vayas* · Tamil *vayathu* · Latin *vīs*]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Is Tamil's **வயது** the same Sanskrit word borrowed by all four
 Dravidian languages here? (**Yes** — none built a native alternative for this
-concept.) Does Tamil use only ONE grammatical shape for asking age? (**No** —
-casual Tamil uses Kannada/Telugu's **plain possessive** shape; formal Tamil
-uses Malayalam's **dative + verb** shape.) What verb does formal Tamil use
-instead of Malayalam's "exists"? (**ஆகிறது**, *aakirathu*, "is becoming.")
+concept.) What did *vayas* originally include besides age? (**Vigor**.) Next:
+choose between Tamil's casual possessive and formal dative-plus-become shapes.

--- a/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
@@ -5,12 +5,12 @@ type: word
 headword: பதினொன்று — இருபது
 gloss: 11-20 — additive "ten-echo" compounds for the teens, then இருபது (20), transparently "two-tens" — closing out the arc: all four Dravidian languages build twenty compositionally, unlike Sanskrit, Latin, or Arabic's opaque special words
 concept_tag: TA-NUM-11-20
-prerequisites: [TA-C19-vayathu]
+prerequisites: [TA-C19-age-register-grammar]
 sounds: [tamil-vowel-sign-o, tamil-rra-letter]
 roots: [dravidian-pathu-ten, dravidian-iru-two]
 etymology_hook: "பதினொன்று-பத்தொன்பது (11-19) echo பத்து (pathu, 'ten') + a digit — இருபது (irupathu, 'twenty') is transparently 'two-tens', இரு (iru, an older word for 'two') + பத்து (pathu, 'ten'), matching Malayalam's own irupathu almost exactly — closing the arc: all four Dravidian languages build twenty compositionally, where Sanskrit/Latin/Arabic each have their own opaque, non-compositional special word"
-est_minutes: 6
-reviews_of: [TA-C19-vayathu]
+est_minutes: 4
+reviews_of: [TA-C19-age-register-grammar, TA-C19-vayathu]
 ---
 
 # பதினொன்று, இருபது — Dravidian's shared, transparent twenty

--- a/code/learning/human-languages/tamil/lessons/TA-C20-vaanilai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-vaanilai.md
@@ -5,12 +5,12 @@ type: word
 headword: வானிலை
 gloss: weather — most likely a NATIVE Dravidian compound, unlike Kannada/Telugu/Malayalam's Sanskrit compounds: vaanam ("sky") + nilai ("state, standing")
 concept_tag: TA-WEATHER
-prerequisites: [TA-C18-mani]
+prerequisites: [TA-C18-mani-homophone-time]
 sounds: [tamil-vowel-sign-ai, tamil-compound-word]
 roots: [dravidian-vaanam-sky, dravidian-nilai-state]
 etymology_hook: "வானிலை (vāṉilai, 'weather') most likely breaks from Kannada/Telugu/Malayalam's Sanskrit compounds entirely — வானம் (vāṉam, 'sky,' likely native Dravidian, with confirmed cognates in Kannada ಬಾನು/bānu and Telugu వాన/vāna, distinct from the Sanskrit sky word ākāśa) + நிலை (nilai, 'state, standing,' from நில் nil, 'to stand,' a core native Dravidian verb) — literally 'the state/standing of the sky'"
-est_minutes: 6
-reviews_of: [TA-C18-mani]
+est_minutes: 4
+reviews_of: [TA-C18-mani-homophone-time, TA-C18-mani]
 ---
 
 # வானிலை — "the standing of the sky," most likely all native

--- a/code/learning/human-languages/tamil/lessons/TA-C21-naay-poonai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C21-naay-poonai.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C20-pathinondru-irupathu]
 sounds: [tamil-vowel-sign-ai, tamil-final-y]
 roots: [dravidian-naay-dog, dravidian-punai-cat]
 etymology_hook: "நாய் (nāy, 'dog') is a solid, undisputed native Proto-Dravidian root — the SAME root behind Kannada's naayi and Malayalam's naaya — closing this whole arc's dog-word theme on solid ground, the honest opposite of Spanish's perro, English's dog, and Hindi's kuttā, all genuine unsolved mysteries; பூனை (pūnai, 'cat') is Tamil's everyday word, matching Malayalam closely but genuinely different from Kannada's bekku and Telugu's pilli — Tamil itself even keeps rarer alternate cat-words (பில்லி, வெருகு) echoing those other roots"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TA-C20-pathinondru-irupathu]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C22-paccai-manjal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C22-paccai-manjal.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C11-nirangal, TA-C21-naay-poonai]
 sounds: [tamil-double-lla, pulli-virama]
 roots: [proto-dravidian-pac-green, dravidian-mancal-turmeric]
 etymology_hook: "பச்சை (paccai, 'green') ← Proto-Dravidian *pac-, the same root as Kannada's hasiru, Telugu's pacca, and Malayalam's paccha; மஞ்சள் (mañcaḷ, 'yellow, turmeric') is a SEPARATE native Dravidian root, matching Malayalam's മഞ്ഞ/മഞ്ഞൾ (mañña/maññaḷ) closely — modern comparative Dravidian linguistics treats it as inherited (cognates in Kannada, Kodava, Tulu), though one older Tamil dictionary source floats a Sanskrit derivation via मञ्जिष्ठा (mañjiṣṭha, a red-dye plant name) that the semantic mismatch makes unlikely; the Tamil Lexicon additionally records பசுப்பு (pacuppu, 'greenish yellow'), a genuine doublet of paccai from the *pac- root — a rarer word, but one that means Tamil quietly holds BOTH of this arc's Dravidian patterns (Telugu's one-root-doublet AND Malayalam's two-separate-roots) inside itself"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TA-C21-naay-poonai]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C23-day-family-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C23-day-family-register.md
@@ -1,0 +1,52 @@
+---
+id: TA-C23-day-family-register
+chapter: 23
+type: etymology
+headword: நாள் / தினம்
+gloss: Tamil alone keeps a native everyday day-word while Sanskrit tiṉam occupies formal compounds
+prerequisites: [TA-C23-naal]
+sounds: [tamil-retroflex-lla]
+roots: [proto-dravidian-naal-day, sanskrit-dina]
+est_minutes: 4
+reviews_of: [TA-C23-naal]
+---
+
+# நாள் and தினம் — everyday native, formal borrowed
+
+## Warm-up
+
+[PAUSE 2s] *Nāḷ* is plainly native and everyday. Put that lexical choice beside
+the other Dravidian tracks.
+
+## Four everyday day-words
+
+- Kannada **dina** — Sanskrit tatsama
+- Telugu **rōju** — Persian loan
+- Malayalam **divasam** — Sanskrit tatsama
+- Tamil **nāḷ** — native Dravidian
+
+Tamil is the only one here whose unmarked everyday counting word remains
+native.
+
+## Tamil still has தினம்
+
+**தினம்** (*tiṉam*) is the same Sanskrit *dina* as Kannada/Malayalam, ultimately
+from PIE ***dyew-***, "shine," also behind Latin *diēs*. Tamil assigns it
+formal and compound work: **சுதந்திர தினம்**, "Independence Day," and
+**தினசரி**, "daily." Casual counting remains *nāḷ*.
+
+The language did not reject the loan; it gave native and borrowed forms
+different jobs.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mūnṟu nāḷ" — three days]
+- [YOU SAY: "sutantira tiṉam" — Independence Day]
+- [YOU CLASSIFY: everyday native · formal/compound Sanskrit]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which track alone keeps a native everyday day-word? (**Tamil**.)
+Where does *tiṉam* appear? (**Formal compounds**.) Is it unrelated to Kannada
+*dina*? (**No** — it is the same Sanskrit tatsama.)

--- a/code/learning/human-languages/tamil/lessons/TA-C23-naal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C23-naal.md
@@ -5,12 +5,12 @@ type: word
 headword: நாள்
 gloss: "day" — Tamil's everyday, native Dravidian word, already met inside "tomorrow"; unlike Kannada's dina, Telugu's rōju, and Malayalam's divasam, Tamil's plain day-word is NOT a loanword at all — நாள் just is the everyday word, no Sanskrit or Persian substitute doing that job
 concept_tag: TIME-DAY
-prerequisites: [TA-C04-naalai, TA-C17-nanpakal-nalliravu]
+prerequisites: [TA-C04-naalai, TA-C17-transparent-middle-synonyms]
 sounds: [tamil-retroflex-lla, tamil-vowel-sign-aa]
 roots: [proto-dravidian-naal-day, sanskrit-dina]
 etymology_hook: "நாள் (nāḷ, 'day') is native Dravidian, from Proto-Dravidian *nāḷ, already met inside நாளை (nāḷai, 'tomorrow,' Chapter 4) — and it is genuinely Tamil's plain, everyday, unmarked word for counting a day (as in மூன்று நாள், mūnṟu nāḷ, 'three days'); this makes Tamil the odd one out among this arc's Dravidian languages so far — Kannada's ದಿನ/dina and Malayalam's ദിവസം/divasam are both Sanskrit tatsama words doing the everyday job, and Telugu's రోజు/rōju is a Persian loanword doing it — Tamil is the only one where a NATIVE word holds that plain, everyday spot, uncontested; Tamil ALSO has தினம் (tiṉam), the exact same Sanskrit tatsama as Kannada's dina/Malayalam's dinam (← Sanskrit दिन/dina ← PIE *dyew-, 'to shine'), but here it functions mainly in formal/adverbial and compound use — சுதந்திர தினம் (sutantira tiṉam, 'Independence Day') and தினசரி (tiṉacari, 'daily') — not as the plain everyday noun"
-est_minutes: 6
-reviews_of: [TA-C04-naalai, TA-C17-nanpakal-nalliravu]
+est_minutes: 4
+reviews_of: [TA-C04-naalai, TA-C17-transparent-middle-synonyms, TA-C17-nanpakal-nalliravu]
 ---
 
 # நாள் (nāḷ) — "day," the one this arc's Dravidian languages didn't lose
@@ -31,48 +31,16 @@ some native words elsewhere in this arc have been — it is simply Tamil's
 **plain, everyday, unmarked** word for counting a day, as ordinary as
 **மூன்று நாள்** (*mūnṟu nāḷ*, "**three days**").
 
-## The odd one out — every other Dravidian day-word in this arc is borrowed
-
-Look back at what this arc already found, language by language, all
-comparing the **same** everyday-day-word job:
-
-- **Kannada**: **ದಿನ** (*dina*) — a Sanskrit **tatsama**, doing the plain,
-  everyday job.
-- **Telugu**: **రోజు** (*rōju*) — a **Persian** loanword, doing the plain,
-  everyday job.
-- **Malayalam**: **ദിവസം** (*divasam*) — a Sanskrit **tatsama**, doing the
-  plain, everyday job.
-- **Tamil**: **நாள்** (*nāḷ*) — **native Dravidian**, doing the plain,
-  everyday job.
-
-Tamil is the only one of the four where a genuinely native word still
-holds that everyday spot, uncontested by a loan.
-
-## தினம் — the same Sanskrit word as Kannada's dina, here pushed to the formal side
-
-Tamil does have **தினம்** (**tiṉam**) — the **exact same** Sanskrit
-tatsama as Kannada's *dina* and Malayalam's *dinam* (← Sanskrit **दिन**,
-*dina* ← PIE ***\*dyew-***, "to shine," the root behind Latin's *diēs*
-too). But in Tamil it leans **formal and compound-forming**, rather than
-doing the plain counting work: **சுதந்திர தினம்** (*sutantira tiṉam*,
-"**Independence Day**") and **தினசரி** (*tiṉacari*, "**daily**") are where
-you meet it, not in casual "how many days" counting — that's நாள்'s job.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "nāḷ" — "day," native Dravidian, already met inside "tomorrow"]
-- [YOU SAY: the contrast — Kannada's dina, Malayalam's divasam (Sanskrit),
-  Telugu's rōju (Persian), all loans; Tamil's nāḷ, native]
-- [YOU SAY: "tiṉam" — the same Sanskrit word as Kannada's dina, here
-  formal/compound use like "Independence Day"]
+- [YOU SAY: "mūnṟu nāḷ" — three days]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Where did you already meet **நாள்** before this lesson? (Inside
 **நாளை**, *nāḷai*, "tomorrow," Chapter 4.) Is Tamil's everyday day-word a
-loanword, the way Kannada's, Telugu's, and Malayalam's are? (**No** —
-**நாள்** is native Dravidian; Tamil is the only one of the four where the
-plain everyday word isn't borrowed.) What job does **தினம்** do instead of
-competing with நாள் for everyday use? (**Formal/compound** use — "
-**சுதந்திர தினம்**," Independence Day, and "**தினசரி**," daily.)
+loanword? (**No** — **நாள்** is native Dravidian.) Is it marginal or literary?
+(**No** — it is the plain everyday counting word.) Next: compare the other
+sisters' borrowed day-words and Tamil's formal *tiṉam*.

--- a/code/learning/human-languages/tamil/lessons/TA-C24-iravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C24-iravu.md
@@ -5,12 +5,12 @@ type: word
 headword: இரவு
 gloss: "night" — native Dravidian, already used standalone inside "midnight" (naḷḷiravu); a Sanskrit loan alternative, rāttiri, also exists — and per at least one dictionary source, rāttiri may actually be the MORE common word in everyday spoken Tamil, the opposite direction from நாள்'s story last lesson
 concept_tag: TIME-NIGHT
-prerequisites: [TA-C17-nanpakal-nalliravu, TA-C23-naal]
+prerequisites: [TA-C17-transparent-middle-synonyms, TA-C23-day-family-register]
 sounds: [tamil-vowel-sign-u, tamil-retroflex-lla]
 roots: [proto-dravidian-cira-darkness, sanskrit-ratri, proto-dravidian-cirvl]
 etymology_hook: "இரவு (iravu, 'night') is native Dravidian, from Proto-Dravidian *cira ('darkness') — already used standalone inside நள்ளிரவு (naḷḷiravu, 'midnight,' Chapter 17: 'இரவு, a word every Tamil speaker still uses on its own'); Tamil also has ராத்திரி (rāttiri), a Sanskrit tatsama from रात्रि (rātri) ← PIE *h₁reh₁- ('to rest') — the SAME PIE root already confirmed, specifically, for Hindi's raat and Malayalam's rāthri in this arc (Kannada's and Telugu's rātri lessons note the Sanskrit tatsama status but don't independently make this same PIE-root/nox comparison), a completely different root from Latin nox's *nókʷts; be honest about register here, and flag it clearly for a native speaker's own read: at least one Tamil dictionary source states plainly that 'colloquially, ராத்திரி is more common,' implying இரவு leans more literary/formal — if accurate, this runs the OPPOSITE direction from நாள்'s story last lesson, where the native word was the uncontested everyday choice and no loanword competed; this claim rests on limited dictionary-level sourcing, not deep confirmation, and register judgments about Sanskrit-loan versus native-Tamil vocabulary are exactly the kind of thing a native speaker's own ear should settle, not a scraped source"
-est_minutes: 6
-reviews_of: [TA-C17-nanpakal-nalliravu, TA-C23-naal]
+est_minutes: 4
+reviews_of: [TA-C17-transparent-middle-synonyms, TA-C23-day-family-register, TA-C23-naal]
 ---
 
 # இரவு (iravu) — "night," and a register question worth a native speaker's ear
@@ -43,41 +43,12 @@ for Hindi's *raat* and Malayalam's *rāthri* earlier in this arc, now a
 third confirmation, same false-cognate pattern, same honest
 non-relationship to *nox*.
 
-## Be honest, and hedge carefully: a register claim worth your own ear
-
-Here's the twist, offered deliberately as a **flag for your own
-judgment**, not a settled fact: at least one Tamil dictionary source
-states plainly that "**colloquially, ராத்திரி is more common**" — meaning
-**இரவு** may lean more toward the **literary, written** register, while
-the **Sanskrit loanword** does more of the everyday spoken work. If
-that's accurate, it's the **opposite direction** from நாள்'s story last
-lesson, where the native word was the plain, uncontested everyday choice
-and no loanword competed for the job at all. But this rests on limited,
-dictionary-level sourcing — and register judgments about native-Tamil
-versus Sanskrit-loan vocabulary are exactly the kind of thing where a
-native speaker's own sense of actual usage matters more than a single
-scraped source. Treat this one as worth double-checking against your own
-ear, not something to take as given.
-
-## Not to be confused: இருள் means "darkness," not "night" itself
-
-One more honest note, matching what's already been established for the
-sibling Dravidian languages in this arc: **இருள்** (**iruḷ**) — from
-Proto-Dravidian ***\*cirVḷ***, cognate with Kannada's **ಇರುಳು**, Telugu's
-**ఇరులు**, and Malayalam's **ഇരുൾ** — is a **different** word, from a
-**different** Proto-Dravidian root than இரவு's *cira. It means
-specifically "**darkness**," not "night" as a stretch of time — don't let
-the similar sound and shared root-family lead you to treat them as
-interchangeable.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "iravu" — "night," native, already met inside naḷḷiravu]
 - [YOU SAY: "rāttiri" — Sanskrit loan, same PIE *h₁reh₁- already drawn for
   Hindi and Malayalam, NOT related to Latin nox]
-- [YOU SAY: the honest, hedged twist — one source says rāttiri is more
-  common in colloquial speech than iravu; worth checking against your own ear]
 
 ## Wrap-up Recall
 
@@ -85,6 +56,5 @@ interchangeable.
 **நள்ளிரவு**, *naḷḷiravu*, "midnight," Chapter 17.) Does **ராத்திரி**'s PIE
 root match Latin *nox*'s? (**No** — ***\*h₁reh₁-*** "to rest," the same
 false-cognate pattern already drawn for Hindi and Malayalam earlier in
-this arc.) Is
-**இருள்** the same word as இரவு? (**No** — a different Proto-Dravidian
-root, meaning specifically "darkness," not "night" as a time period.)
+this arc.) Next: treat the proposed register split as a hypothesis and keep
+"darkness" separate from "night."

--- a/code/learning/human-languages/tamil/lessons/TA-C24-night-register-darkness.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C24-night-register-darkness.md
@@ -1,0 +1,49 @@
+---
+id: TA-C24-night-register-darkness
+chapter: 24
+type: grammar
+headword: இரவு / ராத்திரி / இருள்
+gloss: one source prefers rāttiri colloquially, a claim to test against native usage; iruḷ means darkness
+prerequisites: [TA-C24-iravu]
+sounds: [tamil-retroflex-lla]
+roots: [proto-dravidian-cira-darkness, proto-dravidian-cirvl, sanskrit-ratri]
+est_minutes: 4
+reviews_of: [TA-C24-iravu, TA-C23-day-family-register]
+---
+
+# Night words — a register hypothesis and a semantic boundary
+
+## Warm-up
+
+[PAUSE 2s] *Iravu* is native and *rāttiri* borrowed. That alone does not tell
+you which one conversational Tamil prefers.
+
+## Hedge the register claim
+
+At least one dictionary says **ராத்திரி** is more common colloquially, implying
+native **இரவு** may lean literary/written. If accurate, this reverses the day
+story, where native *nāḷ* is uncontested everyday speech.
+
+But the evidence is limited and dictionary-level. Treat this as a prompt for a
+native speaker's ear, not settled fact. Register judgments require real usage,
+region, and setting—not a purity assumption about native versus borrowed words.
+
+## Darkness is a different word
+
+**இருள்** (*iruḷ*) means **darkness**, from Proto-Dravidian ***cirVḷ*** and
+cognate with Kannada, Telugu, and Malayalam forms. It is not *iravu* "night as a
+time period" and comes from a different reconstructed root despite the similar
+sound.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU QUALIFY: "one source says *rāttiri* is more colloquial"]
+- [YOU ASK: compare that claim with native regional usage]
+- [YOU CONTRAST: *iravu* night · *iruḷ* darkness]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is the *rāttiri* register claim settled? (**No** — limited sourcing,
+worth checking against native usage.) Is **இருள்** interchangeable with **இரவு**?
+(**No** — darkness versus a time period, from different roots.)

--- a/code/learning/human-languages/tamil/lessons/TA-C25-goodnight-alternatives.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C25-goodnight-alternatives.md
@@ -1,0 +1,49 @@
+---
+id: TA-C25-goodnight-alternatives
+chapter: 25
+type: etymology
+headword: நல்ல இரவு / இரவு வணக்கம்
+gloss: Tamil repeats its native greeting loyalty with good-night alternatives built from known roots
+prerequisites: [TA-C25-iniya-iravu]
+sounds: [tamil-geminate-lla]
+roots: [tamil-nal-good, vaṇaṅku]
+est_minutes: 4
+reviews_of: [TA-C25-iniya-iravu, TA-C01-vanakkam-family-register, TA-C01-nandri]
+---
+
+# நல்ல இரவு and இரவு வணக்கம் — old roots recombined
+
+## Warm-up
+
+[PAUSE 2s] Tamil's native "sweet night" repeats the lexical choice that opened
+the course: build greetings from its own roots rather than the shared Sanskrit
+formula.
+
+## The Chapter 1 echo
+
+**வணக்கம்** comes from native *vaṇaṅku*, "bow," while neighboring greetings use
+Sanskrit *namas-*. At the other end of the day, **இனிய இரவு** is native while
+the same neighbors share Sanskrit *śubha rātri*.
+
+Tamil also keeps two transparent alternatives:
+
+- **நல்ல இரவு** — "good night," using *nalla*, from the **nal-** "good" root
+  already inside *nalam* and *naṉṟi*
+- **இரவு வணக்கம்** — "night greetings," especially for close friends/family,
+  recombining two fully known words
+
+The learner does not memorize isolated formulas; known roots generate options.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nalla iravu" — good night]
+- [YOU SAY: "iravu vaṇakkam" — night greetings]
+- [YOU TRACE: *nal-* → *nalam / naṉṟi / nalla*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which root builds **நல்ல**? (**Nal-**, good.) What two known words
+make **இரவு வணக்கம்**? (**Night + greetings**.) What lexical pattern connects
+Chapter 1 and this chapter? (**Tamil keeps native greeting roots where neighbors
+share Sanskrit formulas**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
@@ -5,12 +5,12 @@ type: phrase
 headword: இனிய இரவு
 gloss: "good night" — fully native Dravidian, "sweet/pleasant night," unlike Hindi, Kannada, Telugu, and Malayalam's shared Sanskrit-descended śubha rātri phrase; Tamil breaks the pattern this arc found in every other language
 concept_tag: GREETING-GOODNIGHT
-prerequisites: [TA-C24-iravu]
+prerequisites: [TA-C24-night-register-darkness]
 sounds: [tamil-nnna, tamil-vowel-sign-i]
 roots: [proto-dravidian-in-sweet, tamil-nal-good, vaṇaṅku]
 etymology_hook: "இனிய இரவு (iṉiya iravu), 'good night,' literally 'sweet/pleasant night' — இனிய (iṉiya, 'sweet, pleasant, dear') is native Dravidian, from Proto-Dravidian *in- ('sweet'), the same root behind இனிப்பு (iṉippu, 'sweet, dessert'); paired with இரவு (iravu, 'night,' already met last lesson). Unlike Hindi's, Kannada's, Telugu's, and Malayalam's shared śubh(a) rātri/rāthri phrase — all four built on the same Sanskrit tatsama pair (śubh 'to be beautiful' + rātri 'night') — Tamil's standard 'good night' phrase reaches for NO Sanskrit at all; the phrasebook sources checked did not surface a Tamil śubha-rāttiri equivalent as a commonly used form. Tamil also keeps நல்ல இரவு (nalla iravu, 'good night,' literally using நல்ல/nalla, 'good,' the same nal- root already met in நலம்/nalam and நன்றி/naṉṟi), and — for close friends and family — இரவு வணக்கம் (iravu vaṇakkam, 'night greetings'), built ENTIRELY from two words already taught in this course: இரவு ('night,' last lesson) and வணக்கம் ('greetings,' Chapter 1's very first word, from வணங்கு/vaṇaṅku, 'to bow')"
-est_minutes: 6
-reviews_of: [TA-C24-iravu]
+est_minutes: 4
+reviews_of: [TA-C24-night-register-darkness, TA-C24-iravu]
 ---
 
 # இனிய இரவு (iṉiya iravu) — "good night," and Tamil breaking the pattern one more time
@@ -42,30 +42,12 @@ that — no śubha-descended "good night" turned up as a commonly used
 Tamil form in the phrasebook sources checked for this lesson. Instead,
 Tamil built its own phrase from its own vocabulary.
 
-## Echo of Chapter 1: the same loyalty, twice
-
-This is the **same story** already told in this course's very first
-lesson. **வணக்கம்** (*vaṇakkam*, "hello," Chapter 1) is native Dravidian,
-from **வணங்கு** (*vaṇaṅku*, "to bow") — while Kannada, Telugu, Malayalam,
-and Hindi all borrowed Sanskrit's *namas-* for their own "hello." Tamil
-now does it again at the **other end of the day**: a native "good night"
-where its neighbors share one Sanskrit phrase.
-
-Tamil also keeps **நல்ல இரவு** (*nalla iravu*, "good night," using
-**நல்ல**, *nalla*, "good" — the same **நல்-** root already met in
-**நலம்** and **நன்றி**), and, for close friends and family, **இரவு
-வணக்கம்** (*iravu vaṇakkam*, "night greetings") — a phrase built entirely
-from two words you already have: **இரவு** from last lesson, and
-**வணக்கம்** from Chapter 1.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "iṉiya iravu" — "good night," literally "sweet night," fully native]
 - [YOU SAY: the pattern it breaks — every other language this arc shares
   one Sanskrit śubh(a) rātri phrase; Tamil doesn't]
-- [YOU SAY: "iravu vaṇakkam" — "night greetings," built from two words
-  you already knew]
 
 ## Wrap-up Recall
 
@@ -75,5 +57,4 @@ from two words you already have: **இரவு** from last lesson, and
 phrase as Hindi, Kannada, Telugu, and Malayalam? (**No** — no such form
 turned up in the sources checked for this lesson; Tamil's standard phrase
 is fully native, breaking the pattern shared by all four other languages.)
-What two already-known words combine to make **இரவு வணக்கம்**? (**இரவு**,
-"night," from last lesson; **வணக்கம்**, "greetings," from Chapter 1.)
+Next: connect that choice back to Chapter 1 and build two native alternatives.

--- a/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
@@ -5,12 +5,12 @@ type: word
 headword: காலை
 gloss: morning (kālai) — Wiktionary itself HEDGES the etymology ("possibly from Sanskrit काल्य/kālya"), not a confirmed Dravidian root; genuinely uncertain, unlike Kannada's confidently-native or Telugu's confidently-Sanskrit morning-words; பகல் (already met, TA-C17, "daytime") is Wiktionary's own listed coordinate term; அதிகாலை ("early dawn") is a transparent ati-+kālai compound
 concept_tag: TIME-MORNING
-prerequisites: [TA-C17-nanpakal-nalliravu, TA-C24-iravu]
+prerequisites: [TA-C17-transparent-middle-synonyms, TA-C24-night-register-darkness]
 sounds: [tamil-vowel-sign-ai, tamil-long-aa]
 roots: [uncertain-etymology, sanskrit-kalya-time-possible]
 etymology_hook: "காலை (kālai, 'morning') has a genuinely UNCERTAIN etymology — Wiktionary itself hedges with 'possibly from Sanskrit काल्य (kālya),' not a confident claim, and separately notes கால் (kāl) has SIX distinct etymologies, one of which ('time,' from Sanskrit काल/kāla) may or may not be what காலை derives from as an accusative-type form; be honest that this is genuinely less settled than Kannada's ಬೆಳಗ್ಗೆ (confidently native) or Telugu's ఉదయం (confidently Sanskrit tatsama) — don't manufacture false confidence where the primary source itself hedges; Wiktionary lists பகல் (already met, TA-C17, 'daytime') as a coordinate term; அதிகாலை ('early dawn') is a transparent compound of ati- ('excessive, very') + kālai, per the Tamil Lexicon (DDSA, University of Madras)"
-est_minutes: 6
-reviews_of: [TA-C17-nanpakal-nalliravu, TA-C24-iravu]
+est_minutes: 4
+reviews_of: [TA-C17-transparent-middle-synonyms, TA-C24-night-register-darkness, TA-C17-nanpakal-nalliravu, TA-C24-iravu]
 ---
 
 # காலை (kālai) — "morning," an honestly uncertain etymology

--- a/code/learning/human-languages/tamil/lessons/TA-C27-maalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C27-maalai.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C26-kaalai]
 sounds: [tamil-vowel-sign-aa, tamil-vowel-sign-ai]
 roots: [proto-dravidian-maal, proto-dravidian-maal-darkness-possible]
 etymology_hook: "மாலை (mālai, 'evening') is a genuine HOMONYM, not one word with two meanings: Wiktionary lists it under TWO entirely separate etymologies. Etymology 1 is 'மாலை' meaning 'garland, wreath, necklace' — traced to Old Tamil, and compared to Sanskrit माला (mālā) with the note 'probably borrowed FROM Dravidian languages' (a reverse-direction loan, Dravidian-into-Sanskrit, a genuine contrast with this project's usual Sanskrit-into-Dravidian pattern). Etymology 2 is the completely separate 'மாலை' meaning 'evening' — also from Old Tamil, but compared instead to மால் (māl), which Wiktionary traces to Proto-Dravidian *mā/*māl and glosses with several senses including 'கருமை' ('blackness, darkness'), plus 'illusion/confusion' and, as a proper noun, the Hindu deity Vishnu; be honest that Wiktionary's etymology for the 'evening' sense only says 'compare māl,' not an explicit 'evening derives specifically from the darkness sense' claim — a natural, plausible connection (evening = growing dark), but not spelled out with full certainty by the source itself; still, this is confidently NATIVE Dravidian vocabulary, a genuine contrast with TA-C26's uncertain காலை"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TA-C26-kaalai]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C28-afternoon-boundary.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C28-afternoon-boundary.md
@@ -1,0 +1,49 @@
+---
+id: TA-C28-afternoon-boundary
+chapter: 28
+type: etymology
+headword: நடுப்பகல் / மதியம்
+gloss: dictionary synonymy blurs noon and afternoon while Sanskrit matiyam remains a noon-word
+prerequisites: [TA-C28-pirpakal]
+sounds: [tamil-vowel-sign-i]
+roots: [tamil-naTu-middle, sanskrit-madhya-middle]
+est_minutes: 4
+reviews_of: [TA-C28-pirpakal, TA-C17-transparent-middle-synonyms]
+---
+
+# Noon or afternoon? — let the sources keep their blur
+
+## Warm-up
+
+[PAUSE 2s] *Piṟpakal* transparently says after-daytime. Dictionaries still do
+not draw a perfectly hard semantic boundary around its synonyms.
+
+## நடுப்பகல் overlaps
+
+Wiktionary's *piṟpakal* page lists **நடுப்பகல்** as an afternoon synonym, while
+the earlier noon lesson documents the same word as a synonym of **நண்பகல்**,
+"noon." This is genuine noon/afternoon boundary blur, not an inconsistency to
+erase. Time-period categories can widen differently across speakers and sources.
+
+## மதியம் is related but distinct
+
+**மதியம்** (*matiyam*) is a Sanskrit tatsama from *madhya*, "middle," the same
+root used by Kannada and Telugu. The fetched entry gives it **noon**, a synonym
+of *naṇpakal*, not a dedicated afternoon meaning.
+
+An initial search summary claimed *matiyam* once meant "moon," but that claim is
+absent from the actual fetched page. It is therefore **not asserted**. Source
+inspection outranks a search snippet.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: *naṭuppakal* can overlap noon and afternoon]
+- [YOU SAY: *matiyam* — Sanskrit *madhya*, "middle," listed as noon]
+- [YOU LABEL: the moon claim unsupported]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does the source draw a hard noon/afternoon line? (**No**.) What is
+*matiyam*'s sourced root and sense? (Sanskrit ***madhya***, "middle," and
+**noon**.) Is "originally moon" confirmed? (**No**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C28-pirpakal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C28-pirpakal.md
@@ -5,12 +5,12 @@ type: word
 headword: பிற்பகல்
 gloss: afternoon (piṟpakal) — a transparent compound, பின் (piṉ, "after") + நண்பகல்'s own பகல் ("daytime"), with பின் surfacing as பிற்- before ப, a SIMILAR kind of consonant sandhi to the one already taught in TA-C17 (நள்→நண்) — though Wiktionary itself does not discuss the sandhi mechanism, and the two changes move in different phonetic directions (nasal→stop vs. lateral→nasal), so this is the lesson's own analysis, not a sourced claim; Wiktionary-listed formal register; a real, citable overlap worth flagging honestly: Wiktionary's OWN afternoon-word page ALSO lists நடுப்பகல் as a synonym, even though TA-C17 established நடுப்பகல் as a synonym of NOON specifically; also related but distinct: மதியம், a Sanskrit tatsama (from madhya, "middle") meaning "noon," a synonym of நண்பகல் — NOT specifically "afternoon," despite an unverified WebSearch claim that matiyam "originally meant moon," which does not appear anywhere on its actual Wiktionary page and is therefore not asserted here
 concept_tag: TIME-AFTERNOON
-prerequisites: [TA-C17-nanpakal-nalliravu]
+prerequisites: [TA-C17-transparent-middle-synonyms]
 sounds: [tamil-retroflex-rra, tamil-pulli-virama]
 roots: [tamil-pin-after, sanskrit-madhya-middle]
 etymology_hook: "பிற்பகல் (piṟpakal, 'afternoon') is, per Wiktionary, a transparent compound of பின் (piṉ, 'after') + பகல் (pakal, 'daytime,' already met inside நண்பகல், TA-C17) — with பின் surfacing as பிற்- before the following ப — a similar kind of consonant sandhi to the one already taught in TA-C17 for நள்→நண் before ப, though be honest that Wiktionary's own etymology for பிற்பகல் doesn't discuss the sandhi mechanism at all, and the two changes move in different phonetic directions (nasal→stop here, vs. lateral→nasal there) — this comparison is the lesson's own linguistic observation, not a Wiktionary-sourced equivalence claim; Wiktionary labels பிற்பகல் formal register. Be honest about a genuine citable tension: Wiktionary's OWN பிற்பகல் page lists நடுப்பகல் as ITS synonym too — even though TA-C17 established நடுப்பகல் as a synonym of நண்பகல் specifically (noon, not afternoon); this looks like the same kind of noon/afternoon boundary-blur already seen elsewhere in this arc (Malayalam's TIME-AFTERNOON widening), not a contradiction to paper over. Separately, மதியம் is a Sanskrit tatsama (from madhya, 'middle,' the SAME root Kannada and Telugu both reach for) meaning specifically 'noon,' Wiktionary-listed as a synonym of நண்பகல் — NOT 'afternoon' specifically, despite it being the closest Tamil gets to the madhya-based words seen elsewhere in this arc; an unverified claim (from a search summary, not the actual Wiktionary page) that matiyam 'originally meant moon' is deliberately NOT asserted here, since it doesn't appear on the fetched source at all"
-est_minutes: 6
-reviews_of: [TA-C17-nanpakal-nalliravu]
+est_minutes: 4
+reviews_of: [TA-C17-transparent-middle-synonyms, TA-C17-nanpakal-nalliravu]
 ---
 
 # பிற்பகல் (piṟpakal) — "afternoon," a similar sandhi trick to நண்பகல்
@@ -40,27 +40,6 @@ directions (nasal→stop here, lateral→nasal there) — this is the
 lesson's own observation, not a sourced equivalence. Wiktionary labels this word
 **formal register**.
 
-## Be honest: a real, citable overlap with TA-C17's own words
-
-Here's a genuine tension worth flagging, not smoothing over: Wiktionary's
-own பிற்பகல் page lists **நடுப்பகல்** as **its** synonym — but
-TA-C17 established நடுப்பகல் as a synonym of **நண்பகல்**
-specifically, "**noon**," not "afternoon." This looks like the same
-kind of noon/afternoon **boundary blur** already seen elsewhere in this
-arc (Malayalam's own TIME-AFTERNOON widening), not a mistake to paper
-over — dictionaries genuinely don't always draw a hard line here.
-
-## A related but distinct word: matiyam, the closest Tamil gets to madhya
-
-Separately, Tamil also has **மதியம்** — a Sanskrit **tatsama**,
-from **madhya** ("middle"), the **same** root Kannada and Telugu both
-reach for. But be precise: Wiktionary lists மதியம் meaning
-specifically "**noon**," a synonym of நண்பகல் — **not** "afternoon"
-on its own. And be honest about a claim that did NOT check out: an
-initial search summary suggested மதியம் "originally meant moon" —
-but that claim appears **nowhere** on மதியம்'s actual Wiktionary
-page, so it is deliberately **not** asserted here.
-
 ## Guided Practice
 
 [PAUSE 1s]
@@ -68,8 +47,6 @@ page, so it is deliberately **not** asserted here.
   ("daytime")]
 - [YOU SAY: the sandhi echo — piṉ surfaces as piṟ-, a similar kind
   of change to TA-C17's naḷ→naṇ, though not phonetically identical]
-- [YOU SAY: "matiyam" — Sanskrit tatsama for "noon," from madhya,
-  Tamil's closest word to Kannada/Telugu's own noon-words]
 
 ## Wrap-up Recall
 
@@ -77,10 +54,6 @@ page, so it is deliberately **not** asserted here.
 sandhi change happens to the first piece? (**பின்** "after" + பகல்
 "daytime" — பின் surfaces as பிற்-, a similar kind of sandhi to
 TA-C17's naḷ→naṇ, though the two changes move in different phonetic
-directions, not identical mechanisms.) Does Wiktionary draw a hard line between நடுப்பகல்'s
-noon-sense and பிற்பகல்'s afternoon-sense? (**No** — நடுப்பகல்
-is listed as a synonym of BOTH, a real boundary-blur, not a mistake.)
-Is மதியம் confirmed to have originally meant "moon"? (**No** —
-that claim doesn't appear on its actual Wiktionary page; only its
-Sanskrit madhya ("middle") etymology and "noon" meaning are asserted
-here.)
+directions, not identical mechanisms.) What register does the fetched page
+label? (**Formal**.) Next: inspect the real noon/afternoon boundary blur and the
+separate *matiyam* root.

--- a/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
@@ -5,12 +5,12 @@ type: phrase
 headword: காலை வணக்கம்
 gloss: good morning (kālai vaṇakkam), literally "morning greetings" — a transparent compound of காலை (already met, TA-C26) + வணக்கம் (already met, TA-C01, "reverence, homage"); confirmed via TWO independently-fetched sources as the standard, formal greeting, used from sunrise until around 11 AM; NOT a śubha-equivalent construction, breaking the pattern seen in every other language in this arc; a WebSearch summary's claim that a Sanskrit-borrowed "suprabhatham" is a casual alternative could NOT be traced to either directly-fetched source and is therefore not asserted here
 concept_tag: GREETING-MORNING
-prerequisites: [TA-C26-kaalai, TA-C01-vanakkam]
+prerequisites: [TA-C26-kaalai, TA-C01-vanakkam-family-register]
 sounds: [tamil-geminate-kka, tamil-vowel-sign-ai]
 roots: [vaṇaṅku]
 etymology_hook: "காலை வணக்கம் (kālai vaṇakkam, 'good morning'), literally 'morning greetings/salutations,' is confirmed by TWO independently-fetched sources (talkpal.ai, preply.com — practical language-learning content, not lexicographic/scholarly references like TA-C26's Wiktionary and Tamil Lexicon; worth naming that source-tier difference explicitly) as Tamil's standard greeting for this time of day — talkpal.ai glosses it directly as காலை ('morning') + வணக்கம் ('a respectful greeting, similar to hello or salutations'), and preply.com independently labels it 'formal,' 'used before noon'; both agree on timing (roughly sunrise to 11 AM). Be honest about what this ISN'T: unlike Hindi/Kannada/Telugu/Malayalam, which each build their morning greeting on a śubha-equivalent word ('good, auspicious') plus a time-word, Tamil's own greeting is entirely different in structure — it's simply its own general greeting word, வணக்கம் (already met, TA-C01, 'reverence, homage,' Tamil's everyday word for 'hello'), specified with the time-of-day word காலை (already met, TA-C26) in front of it. Also be honest about a claim that did NOT check out: an initial WebSearch summary suggested a Sanskrit-borrowed word, 'suprabhatham,' serves as a casual alternative — but this claim appears on NEITHER of the two directly-fetched pages, so it is deliberately NOT asserted here"
-est_minutes: 6
-reviews_of: [TA-C26-kaalai, TA-C01-vanakkam]
+est_minutes: 4
+reviews_of: [TA-C26-kaalai, TA-C01-vanakkam-family-register, TA-C01-vanakkam]
 ---
 
 # காலை வணக்கம் (kālai vaṇakkam) — "morning greetings," built from two words you already know

--- a/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
@@ -9,7 +9,7 @@ prerequisites: [TA-C27-maalai, TA-C29-kaalai-vanakkam]
 sounds: [tamil-vowel-sign-aa, tamil-geminate-kka]
 roots: [vaṇaṅku]
 etymology_hook: "மாலை வணக்கம் (mālai vaṇakkam, 'good evening'), literally 'evening greetings/salutations,' is confirmed by TWO independently-fetched sources (talkpal.ai, preply.com — practical language-learning content, the same source tier as TA-C29's) as a real, standard Tamil evening greeting — preply.com labels it formal and gives timing 'used after noon through evening,' while talkpal.ai independently gives 'can be used from late afternoon until nightfall'; both agree on the general afternoon-into-evening window, with some looseness in exact boundaries (unsurprising, matching the boundary-blur already seen in TA-C28's noon/afternoon overlap). Structurally, this follows the EXACT SAME compositional pattern as TA-C29's kālai vaṇakkam: மாலை (already met, TA-C27, 'evening') plus வணக்கம் (already met, TA-C01, Tamil's general greeting) — this pattern was independently re-verified here, not just assumed to automatically carry over from the morning greeting, since this whole arc has repeatedly found that greeting formation doesn't reliably generalize even within a single language"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [TA-C27-maalai, TA-C29-kaalai-vanakkam]
 ---
 

--- a/code/learning/human-languages/tamil/lessons/TA-C31-afternoon-greeting-root.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C31-afternoon-greeting-root.md
@@ -1,0 +1,56 @@
+---
+id: TA-C31-afternoon-greeting-root
+chapter: 31
+type: etymology
+headword: மதிய
+gloss: the adjective inside the afternoon greeting comes from மதியம் (noon), not from பிற்பகல் (afternoon)
+concept_tag: GREETING-AFTERNOON
+prerequisites: [TA-C31-matiya-vanakkam]
+sounds: [tamil-vowel-sign-i]
+roots: [sanskrit-madhya-middle]
+etymology_hook: "மதிய is the adjectival form of மதியம் ('noon,' from Sanskrit madhya, 'middle') and can pertain to afternoon; மதிய வணக்கம் therefore does not reuse பிற்பகல், the native compound learned for 'afternoon'"
+est_minutes: 4
+reviews_of: [TA-C31-matiya-vanakkam, TA-C28-afternoon-boundary, TA-C28-pirpakal]
+---
+
+# மதிய — the greeting takes a different root
+
+## Warm-up
+
+[PAUSE 2s] You can now say **மதிய வணக்கம்**. This final step explains
+why its first word is not the ordinary afternoon word **பிற்பகல்**.
+
+## From "middle" to noon, then afternoon
+
+The greeting begins with **மதிய** (**matiya**). It is the adjectival
+form of **மதியம்** (**matiyam**), "noon." That noun entered Tamil from
+Sanskrit **madhya**, "middle": noon is the middle of the day.
+
+The adjective **மதிய** can be glossed "of or pertaining to afternoon."
+That lets Tamil build **மதிய வணக்கம்** even though the dedicated word
+you learned for "afternoon" was **பிற்பகல்**, the native compound from
+**piṉ** (after) + **pakal** (daytime).
+
+Keep the two paths separate:
+
+- **பிற்பகல்**: after + daytime → afternoon
+- **மதிய வணக்கம்**: middle/noon adjective + greeting → good afternoon
+
+The time word and the greeting do not have to share a root. That is one
+more reason not to manufacture a greeting by translating its pieces
+from another language.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: matiyam — "noon," ultimately from Sanskrit madhya, "middle"]
+- [YOU SAY: pirpakal — "afternoon," built from "after" + "daytime"]
+- [YOU SAY: matiya vaṇakkam — the afternoon greeting, built on matiya]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **மதிய வணக்கம்** begin with **பிற்பகல்**? (**No.**)
+What noun is **மதிய** related to? (**மதியம், "noon."**) What older root
+lies behind it? (**Sanskrit madhya, "middle."**) Why should you learn
+the whole greeting rather than construct it from the time word?
+(**Tamil uses a different root in the greeting.**)

--- a/code/learning/human-languages/tamil/lessons/TA-C31-matiya-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C31-matiya-vanakkam.md
@@ -3,25 +3,25 @@ id: TA-C31-matiya-vanakkam
 chapter: 31
 type: phrase
 headword: மதிய வணக்கம்
-gloss: good afternoon (matiya vaṇakkam), literally "afternoon-ish greetings" — confirmed via TWO independently-fetched sources (ling-app.com, talkpal.ai) as used roughly noon to 4 PM; a genuine surprise worth flagging: this greeting is built on மதிய (per Wiktionary's declension table, the adjectival form of TA-C28's noun மதியம், "noon," a Sanskrit tatsama synonym of நண்பகல் — but மதிய itself is separately Wiktionary-glossed "of or pertaining to afternoon," a semantic drift from its own parent noun's "noon" meaning), NOT on TA-C28's own native afternoon word, பிற்பகல்; a third source (preply.com) doesn't list a distinct afternoon greeting at all, treating morning and evening as bookending the day — an honest extension of TA-C28's own noon/afternoon boundary-blur into the greeting layer itself
+gloss: good afternoon (matiya vaṇakkam), confirmed by two sources for roughly noon to 4 PM, while a third source does not teach a separate afternoon greeting
 concept_tag: GREETING-AFTERNOON
-prerequisites: [TA-C28-pirpakal, TA-C29-kaalai-vanakkam]
+prerequisites: [TA-C28-afternoon-boundary, TA-C29-kaalai-vanakkam]
 sounds: [tamil-vowel-sign-i, tamil-geminate-kka]
-roots: [sanskrit-madhya-middle, vaṇaṅku]
-etymology_hook: "மதிய வணக்கம் (matiya vaṇakkam, 'good afternoon'), literally 'afternoon-ish greetings,' is confirmed by TWO independently-fetched sources (ling-app.com, talkpal.ai) as Tamil's afternoon greeting, used roughly 'noon to around 4 PM'; a THIRD source (preply.com), already used for TA-C29/TA-C30, doesn't list a distinct afternoon greeting at all — it only covers morning ('before noon') and evening ('after noon through evening'), implicitly treating the two as bookending the whole day without a separate afternoon slot; this is an honest extension of TA-C28's own established noon/afternoon boundary-blur into the greeting layer itself, not a new problem. Be honest about a genuine structural surprise: this greeting is built on மதிய — per Wiktionary's declension table for மதியம், its ADJECTIVAL form (Wiktionary: 'Adjectival of மதியம்') — and NOT on TA-C28's own dedicated afternoon word, பிற்பகல் (built from piṉ + pakal). மதியம் itself means 'noon' (a Sanskrit tatsama from madhya, already established as a synonym of நண்பகல்), but மதிய, the adjective, is separately Wiktionary-glossed 'of or pertaining to afternoon' — a genuine semantic drift between the noun and its own adjectival form. So the TIME-AFTERNOON lesson's headword and the GREETING-AFTERNOON lesson's headword don't share a root at all — a genuinely different pairing than every other language's afternoon greeting in this arc, and a fitting final honest surprise to close out the whole 6-tag arc on"
-est_minutes: 6
-reviews_of: [TA-C28-pirpakal, TA-C29-kaalai-vanakkam]
+roots: [vaṇaṅku]
+etymology_hook: "மதிய வணக்கம் (matiya vaṇakkam, 'good afternoon') is confirmed by two independently fetched sources for roughly noon to 4 PM; a third source does not list a distinct afternoon greeting, so learn the phrase while keeping the source disagreement visible"
+est_minutes: 4
+reviews_of: [TA-C28-afternoon-boundary, TA-C28-pirpakal, TA-C29-kaalai-vanakkam]
 ---
 
-# மதிய வணக்கம் (matiya vaṇakkam) — "afternoon-ish greetings," the arc's final surprise
+# மதிய வணக்கம் (matiya vaṇakkam) — a sourced afternoon greeting
 
 ## Warm-up
 
-[PAUSE 2s] This is the last lesson in the whole arc — and it saves one
-more honest surprise for the end: the afternoon greeting doesn't build
-on the afternoon word you already know.
+[PAUSE 2s] You already know that Tamil's noon and afternoon boundaries
+can blur. Now learn one afternoon greeting without pretending that all
+speakers or teaching sources divide the day in exactly the same way.
 
-## மதிய வணக்கம் — confirmed real, built on a word you half-know
+## மதிய வணக்கம் — confirmed, with a flexible boundary
 
 **மதிய வணக்கம்** (**matiya vaṇakkam**) — "**good afternoon**" —
 is confirmed, by two independently-fetched sources, as Tamil's
@@ -33,44 +33,24 @@ as bookending the whole day. This is an honest extension of TA-C28's
 own noon/afternoon boundary-blur into the greeting layer, not a new
 problem to worry about.
 
-## Be honest: the arc's final surprise — a different root entirely
-
-Here's the last honest twist of the whole arc: **மதிய வணக்கம்**
-is built on **மதிய** — per Wiktionary's declension table, the
-**adjectival form** of TA-C28's noun **மதியம்** ("noon," a Sanskrit
-tatsama from *madhya*, already established as a synonym of
-**நண்பகல்**) — **not** on TA-C28's own dedicated afternoon word,
-**பிற்பகல்** (built from *piṉ* + *pakal*). Wiktionary separately
-glosses **மதிய** itself "of or pertaining to **afternoon**" — a real
-semantic drift from its own parent noun's "noon" meaning.
-So the TIME-AFTERNOON word and the GREETING-AFTERNOON word don't share
-a root at all. A fitting way to close out this arc: even after five
-lessons of finding that greeting formation doesn't reliably generalize
-from one time-of-day to another, or from one language to another, the
-very last lesson finds one more way for it to surprise you — the
-greeting doesn't even build on its own language's dedicated word for
-the same time of day.
+Use **மதிய வணக்கம்** when that afternoon slot fits the people and
+setting around you. Treat "noon to 4" as a useful learning window, not
+as a universal clock rule.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "matiya vaṇakkam" — "good afternoon," confirmed real, used
   roughly noon to 4 PM]
-- [YOU SAY: the final surprise — built on matiya/matiyam ("noon"), NOT
-  on pirpakal (TA-C28's dedicated "afternoon" word)]
-- [YOU SAY: the honest wrap-up — greeting formation never reliably
-  generalizes, right through the very last lesson]
+- [YOU SAY: the honest qualification — one source does not teach a
+  separate afternoon greeting at all]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Is மதிய வணக்கம் built on TA-C28's dedicated afternoon
-word, பிற்பகல்? (**No** — it's built on மதிய, the adjectival
-form of மதியம், "noon," a completely different root.) Do all three
-fetched sources agree on a distinct "afternoon" greeting slot? (**No**
+[PAUSE 3s] What is one sourced Tamil greeting for "good afternoon"?
+(**மதிய வணக்கம், matiya vaṇakkam**.) Do all three fetched sources
+agree on a distinct "afternoon" greeting slot? (**No**
 — two confirm மதிய வணக்கம் directly; a third doesn't list a
 separate afternoon greeting at all, treating morning and evening as
-bookending the day.) What has this whole arc repeatedly found about
-greeting formation, confirmed one final time here? (**It doesn't
-reliably generalize** — not across languages, not across a single
-language's own greetings, and not even between a language's
-TIME-word and its own matching GREETING-word.)
+bookending the day.) What clock window is a useful guide rather than a
+universal rule? (**Roughly noon to 4 PM**.)

--- a/code/learning/human-languages/tamil/lessons/TA-W01-abugida-va-ka.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W01-abugida-va-ka.md
@@ -1,0 +1,64 @@
+---
+id: TA-W01-abugida-va-ka
+chapter: 1
+type: writing
+headword: "வ, க"
+gloss: the inherent vowel and the first two Tamil letters, including க's position-driven sounds
+romanization: "va, ka"
+prerequisites: [TA-W01-curves-va-ka]
+sounds: [tamil-inherent-a, tamil-contextual-k]
+roots: [tamil-abugida]
+est_minutes: 4
+reviews_of: [TA-W01-curves-va-ka, TA-C01-vanakkam]
+---
+
+# வ and க — the vowel inside each consonant
+
+## Warm-up
+
+[PAUSE 2s] Tamil's letters do not join and they carry many curves. Now learn the
+sound that arrives for free inside every consonant.
+
+## The vowel you get for free
+
+Tamil is an **abugida**, like Devanagari: a consonant already contains a vowel.
+
+> **க is not "k". க is "ka".**
+
+Every consonant carries a built-in **a** until a later mark removes or replaces
+it.
+
+## வ — "va"
+
+1. **a near-closed loop on the left**
+2. **a full-height arm across the top, ending in a descender on the right**
+
+## க — "ka"
+
+1. **a straight horizontal top bar**
+2. **a bowl hanging from its left end**
+3. **a short right stroke that hooks left below**
+
+## One letter, three sounds
+
+Devanagari separates क, ख, ग, घ. Tamil uses **க** across that space: *k* at the
+start of a word and when doubled (**க்க**), *g* after a nasal (**ங்க**), and a
+softer *h*-like sound between vowels. **Position**, not a new spelling, selects
+the sound.
+
+Tamil therefore needs only 18 consonant letters where Devanagari needs 33; its
+native words do not depend on those written distinctions.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: வ — "left loop, top arm, descender"]
+- [YOU WRITE: க — "top bar, left bowl, hooking right stroke"]
+- [YOU SAY: "க is **ka**, not k"]
+- [YOU CONTRAST: initial *k* · after a nasal *g* · between vowels soft *h*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **க** say alone? (**Ka** — the vowel is inherent.) What
+kind of script is this? (An **abugida**.) Which sounds can க spell? (*k*, *g*,
+and a softer *h*-like sound, chosen by **position**.) Draw **வ** and **க**.

--- a/code/learning/human-languages/tamil/lessons/TA-W01-curves-va-ka.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W01-curves-va-ka.md
@@ -2,18 +2,18 @@
 id: TA-W01-curves-va-ka
 chapter: 1
 type: writing
-headword: "வ, க"
-gloss: why Tamil is so round, the vowel already inside each letter, and your first two letters
-romanization: "va, ka"
-prerequisites: [TA-C01-vanakkam]
+headword: "தமிழ் எழுத்து"
+gloss: why Tamil writing is so round, with the palm-leaf account presented as a qualified explanation
+romanization: "tamiḻ eḻuttu"
+prerequisites: [TA-C01-vanakkam-family-register]
 sounds: [tamil-inherent-a]
 roots: [palm-leaf-stylus]
 etymology_hook: "the usual explanation for Tamil's curves is PALM LEAVES — a long straight cut runs along the leaf's fibres and can split it, so a stylus favours curves; treat it as the standard account rather than settled, since early Tamil-Brahmi was angular and the rounding came later via Vatteluttu"
-est_minutes: 5
-reviews_of: [TA-C01-vanakkam]
+est_minutes: 4
+reviews_of: [TA-C01-vanakkam-family-register, TA-C01-vanakkam]
 ---
 
-# வ and க — the curves, and the vowel inside them
+# Tamil's curves — the writing surface leaves a trace
 
 ## Warm-up
 
@@ -47,57 +47,17 @@ It is still worth carrying, because it makes the right general point: **the tool
 leaves fingerprints on the letters.** Latin's straight strokes suit a wax tablet
 and a chisel; Tamil's curves suit a stylus and a leaf.
 
-## The vowel you get for free
-
-Tamil is an **abugida**, like Devanagari: a consonant already contains a vowel.
-
-> **க is not "k". க is "ka".**
-
-Every consonant in the script carries a built-in **a** until you do something to
-remove it. That "something" is Lesson 3.
-
-## வ — "va"
-
-A plain shape, and a reasonable place for your hand to start:
-
-1. **a near-closed loop on the left**
-2. **a full-height arm across the top, ending in a descender on the right**
-
-## க — "ka"
-
-1. **a straight horizontal top bar**
-2. **a bowl hanging from its left end**
-3. **a short right stroke that hooks left below**
-
-### One letter, three sounds
-
-Here is where Tamil differs sharply from the other scripts in this course.
-Devanagari has separate letters for क, ख, ग, घ — *k*, *kh*, *g*, *gh*. **Tamil
-has one letter for all of them.**
-
-**க** is said *k* at the start of a word and when doubled (**க்க**); *g* after a
-nasal (ங்க); and a softer *h*-like sound **between vowels**. The letter doesn't
-tell you which; **position in the word does**, and you learn the rule rather
-than the spelling.
-
-That is why Tamil needs only 18 consonant letters where Devanagari needs
-33 — it declined to write a distinction its own words never depend on.
-
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU WRITE: வ — "left loop, top arm, descender"]
-- [YOU WRITE: க — "top bar, left bowl, hooking right stroke"]
-- [YOU SAY: "க is **ka**, not k"]
+- [YOU TRACE: a curve crossing the imagined grain of a palm leaf]
+- [YOU CONTRAST: angular Tamil-Brahmi · later rounded Vaṭṭeḻuttu]
 - [YOU SAY: the usual reason for the curves — "a straight line can **split the leaf**"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Why is Tamil round? (The **usual** explanation: it was incised on **palm
 leaves**, where a straight stroke along the grain can **split** them — though
-early Tamil-Brahmi was angular, so it isn't the whole story.) What does **க** say on its own?
-(**"ka"** — the vowel is already inside it.) What is that kind of script called?
-(An **abugida**.) How many sounds does க spell? (At least **three** — *k* initially and
-doubled, *g* after a nasal, a soft *h* **between vowels** — decided by
-**position**, not spelling.) Draw **வ** and **க**. Next: two
-more letters, and the retroflex.
+early Tamil-Brahmi was angular, so it is not the whole story.) What broader point
+does the account teach? (**Tools and surfaces leave fingerprints on scripts.**)
+Next: the vowel hidden inside a consonant, then வ and க.

--- a/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
@@ -3,14 +3,14 @@ id: TA-W02-ma-retroflex-na
 chapter: 1
 type: writing
 headword: "ம, ண"
-gloss: two more letters — and the retroflex sound English speakers have to be told about
+gloss: write ம and retroflex ண while training the tongue to curl back
 romanization: "ma, ṇa"
-prerequisites: [TA-W01-curves-va-ka]
+prerequisites: [TA-W01-abugida-va-ka]
 sounds: [retroflex-n]
 roots: []
 etymology_hook: "ண is a RETROFLEX n, made with the tongue curled back to the roof of the mouth — a sound English does not have and cannot hear at first; Tamil writes it with its own letter because words genuinely differ by it, which is why the script needs three separate n-letters"
-est_minutes: 5
-reviews_of: [TA-W01-curves-va-ka]
+est_minutes: 4
+reviews_of: [TA-W01-abugida-va-ka, TA-W01-curves-va-ka]
 ---
 
 # ம and ண — a loop, and a curled tongue
@@ -58,39 +58,17 @@ otherwise unrelated to each other. It's one of the features that makes South Asi
 a *linguistic area*: neighbouring languages that borrowed a sound from each other
 rather than inheriting it.
 
-## Tamil writes three different n's
-
-This is worth seeing now even though you'll only draw one of them today:
-
-| letter | sound | tongue |
-|---|---|---|
-| **ந** | *na* | against the **teeth** (dental) |
-| **ன** | *ṉa* | on the **ridge** behind the teeth (alveolar) |
-| **ண** | *ṇa* | **curled back** to the roof (retroflex) |
-
-Three letters, three positions, moving backwards through the mouth. English
-spells all three with one letter and hears them as the same sound.
-
-You'll draw ந and ன in Lesson 4, where the word for "thank you" needs them. Keep
-one thing in view until then: **ண is ன with one extra arch.** Both letters open
-the same way — top bar, loop — and both finish with the same straight vertical.
-The difference sits in the middle: **ன has one arch, ண has two.** Learn the pair
-together and neither is hard.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU WRITE: ம — "left upright, bottom, **right** arch"]
 - [YOU WRITE: ண — "top bar, left loop, **two** arches, straight vertical"]
 - [YOU SAY: plain *n*, then curl the tongue back — **ṇ**]
-- [YOU SAY: the three positions — "teeth … ridge … **curled back**"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Draw **ம** — which side is the upright on? (**The left**; the
 arch closes it on the right.) Draw **ண** — what makes it *not* ன? (**One extra arch**: ண has **two** arches where ன has one. Both end in the same straight vertical.) What does the dot in **ṇ** mean? (**Retroflex** — the tongue curls
 **back** to the roof of the mouth.) Why can't you hear it yet? (**English has no
-such sound**; the ear learns it after the hand.) How many n-letters does Tamil
-have, and what separates them? (**Three** — ந dental, ன alveolar, ண retroflex,
-moving backwards through the mouth.) Next: the dot that kills a vowel — and your
-first whole word.
+such sound**; the ear learns it after the hand.) Next: place Tamil's three n's
+along one backward walk through the mouth.

--- a/code/learning/human-languages/tamil/lessons/TA-W02-three-ns.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W02-three-ns.md
@@ -1,0 +1,53 @@
+---
+id: TA-W02-three-ns
+chapter: 1
+type: writing
+headword: "ந, ன, ண"
+gloss: Tamil writes dental, alveolar, and retroflex n with three separate letters
+romanization: "na, ṉa, ṇa"
+prerequisites: [TA-W02-ma-retroflex-na]
+sounds: [dental-n, alveolar-n, retroflex-n]
+roots: [south-asian-linguistic-area]
+est_minutes: 4
+reviews_of: [TA-W02-ma-retroflex-na]
+---
+
+# ந, ன, ண — three stops on one tongue-map
+
+## Warm-up
+
+[PAUSE 2s] English writes one *n*. Tamil keeps three tongue positions apart.
+
+## The backward walk
+
+| letter | sound | tongue |
+|---|---|---|
+| **ந** | *na* | against the **teeth** (dental) |
+| **ன** | *ṉa* | on the **ridge** behind the teeth (alveolar) |
+| **ண** | *ṇa* | **curled back** to the roof (retroflex) |
+
+Move backward: teeth → ridge → curled roof. English spells all three with one
+letter and initially hears them as the same sound; Tamil uses separate letters
+because its words depend on the contrast.
+
+You will draw ந and ன when *nandri* needs them. For now compare the last pair:
+**ண is ன with one extra arch**. Both open with a top bar and loop and finish with
+the same vertical. ன has one middle arch; ண has two.
+
+Retroflex sounds occur across unrelated South Asian language families. That
+shared geography makes the region a **linguistic area**: neighbors can borrow a
+sound pattern without inheriting it from one ancestor.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: dental ந at the teeth]
+- [YOU SAY: alveolar ன at the ridge]
+- [YOU SAY: retroflex ண with the tongue curled back]
+- [YOU TRACE: one arch in ன · two arches in ண]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How many n-letters does Tamil have? (**Three**.) What separates them?
+(Tongue position: **dental, alveolar, retroflex**.) Which two differ by one
+arch? (**ன** has one; **ண** has two.) Next: remove the vowel from a consonant.

--- a/code/learning/human-languages/tamil/lessons/TA-W03-pulli-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W03-pulli-vanakkam.md
@@ -3,17 +3,17 @@ id: TA-W03-pulli-vanakkam
 chapter: 1
 type: writing
 headword: "்"
-gloss: "the puḷḷi — a dot that kills the vowel — and writing வணக்கம், the first word of the course"
+gloss: "the puḷḷi — a visible dot that removes the inherent vowel without creating a conjunct"
 romanization: "puḷḷi"
-prerequisites: [TA-W02-ma-retroflex-na, TA-W01-curves-va-ka]
+prerequisites: [TA-W02-three-ns, TA-W01-abugida-va-ka]
 sounds: [pulli, gemination-kk, final-m]
 roots: [tamil-pulli]
 etymology_hook: "the puḷḷi ் is literally 'the dot', and where Devanagari's virama makes two consonants FUSE into a conjunct, Tamil's dot simply sits there — both letters keep their full shape, which is why Tamil has ~247 characters to Devanagari's many hundreds of ligatures"
-est_minutes: 5
-reviews_of: [TA-W02-ma-retroflex-na, TA-C01-vanakkam]
+est_minutes: 4
+reviews_of: [TA-W02-three-ns, TA-W02-ma-retroflex-na, TA-C01-vanakkam]
 ---
 
-# ் — the dot, and வணக்கம்
+# ் — the dot that leaves both letters visible
 
 ## Warm-up
 
@@ -63,37 +63,11 @@ ligature shapes on top of its letters, each to be learned or at least recognised
 words** — **க்ஷ** *kṣa* and **ஸ்ரீ** *śrī*. They sit outside the 18 native
 consonants and outside the 247.)
 
-Tamil traded a smaller alphabet for slightly longer words, and the trade shows
-up every time you write a doubled consonant.
-
-## Now write வணக்கம்
-
-You have all four letters and the dot. Build it left to right:
-
-| piece | | |
-|---|---|---|
-| **வ** | *va* | Lesson 1 |
-| **ண** | *ṇa* | Lesson 2 |
-| **க்** | *k* — க with the dot | this lesson |
-| **க** | *ka* | Lesson 1 |
-| **ம்** | *m* — ம with the dot | this lesson |
-
-> **வ · ண · க் · க · ம் → வணக்கம்**
-
-Two things to hear as you write it. The **க்க** in the middle is a **doubled**
-consonant — hold it, *vaṇak-kam*, not *vaṇakam*; Tamil distinguishes single from
-double consonants and it changes words. And the final **ம்** is a bare *m* with
-no vowel after it, which is why the word ends closed rather than trailing off.
-
-That is the first word of your course, written by hand.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU WRITE: க் — "க, then the dot above"]
 - [YOU WRITE: க்க — two full letters, dot intact, **no fusing**]
-- [YOU WRITE: **வணக்கம்** — five pieces, left to right]
-- [YOU SAY: the doubling — "vaṇa**k-k**am"]
 
 ## Wrap-up Recall
 
@@ -101,6 +75,5 @@ That is the first word of your course, written by hand.
 **inherent vowel**; *puḷḷi* is simply "**the dot**".) What does Devanagari do
 that Tamil doesn't? (**Fuses** the letters into a **conjunct** — Tamil keeps both
 shapes and the dot.) What does Tamil get in exchange? (A **much smaller
-character set** — 247, with **almost** no ligatures: only the borrowed க்ஷ and ஸ்ரீ.) Write **வணக்கம்**.
-What's special about the middle? (**க்க** — a **doubled** consonant, held:
-*vaṇak-kam*.) Next: the vowel signs, and "thank you."
+character set** — 247, with **almost** no ligatures: only the borrowed க்ஷ and
+ஸ்ரீ.) Next: assemble that visible dot into **வணக்கம்**.

--- a/code/learning/human-languages/tamil/lessons/TA-W03-write-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W03-write-vanakkam.md
@@ -1,0 +1,52 @@
+---
+id: TA-W03-write-vanakkam
+chapter: 1
+type: writing
+headword: "வணக்கம்"
+gloss: assemble the first greeting and hold its doubled consonant
+romanization: "vaṇakkam"
+prerequisites: [TA-W03-pulli-vanakkam, TA-W02-ma-retroflex-na, TA-W01-abugida-va-ka]
+sounds: [pulli, gemination-kk, final-m]
+roots: [tamil-vananku]
+est_minutes: 4
+reviews_of: [TA-W03-pulli-vanakkam, TA-C01-vanakkam]
+---
+
+# வணக்கம் — the first whole written word
+
+## Warm-up
+
+[PAUSE 2s] You know the four letter bodies and the vowel-killing dot. Assemble
+them left to right.
+
+## Build the word
+
+| piece | | |
+|---|---|---|
+| **வ** | *va* | Lesson 1 |
+| **ண** | *ṇa* | Lesson 2 |
+| **க்** | *k* — க with the dot | last lesson |
+| **க** | *ka* | Lesson 1 |
+| **ம்** | *m* — ம with the dot | this lesson |
+
+> **வ · ண · க் · க · ம் → வணக்கம்**
+
+Hear two details. **க்க** is a **doubled** consonant: hold it, *vaṇak-kam*, not
+*vaṇakam*. Tamil distinguishes single from double consonants. Final **ம்** is a
+bare *m*, so the word closes instead of trailing into *ma*.
+
+That is the first word of the course, written by hand.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: க் — க with the dot]
+- [YOU WRITE: க்க — two full letters, dot intact]
+- [YOU WRITE: **வணக்கம்** — five pieces, left to right]
+- [YOU SAY: "vaṇa**k-k**am" — hold the middle]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Write **வணக்கம்**. What is special about **க்க**? (It is **doubled**
+and held.) Why does the word end in *m*, not *ma*? (Final **ம்** carries a
+**puḷḷi**.) Next: write the letters and vowel sign inside *nandri*.

--- a/code/learning/human-languages/tamil/lessons/TA-W04-i-sign-write-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-i-sign-write-nandri.md
@@ -1,0 +1,67 @@
+---
+id: TA-W04-i-sign-write-nandri
+chapter: 1
+type: writing
+headword: "ி, நன்றி"
+gloss: replace the inherent vowel with i, assemble நன்றி, and hear nasal-triggered voicing
+romanization: "i, naṉṟi / nandri"
+prerequisites: [TA-W04-vowel-signs-nandri, TA-W03-pulli-vanakkam]
+sounds: [matra-i, nasal-stop-voicing]
+roots: [tamil-nandri]
+est_minutes: 4
+reviews_of: [TA-W04-vowel-signs-nandri, TA-C01-nandri]
+---
+
+# ி and நன்றி — replace the vowel, then hear *ndr*
+
+## Warm-up
+
+[PAUSE 2s] A consonant can keep *a* or lose it under a puḷḷi. The third option
+is to replace it with a vowel sign.
+
+## The first vowel sign
+
+> **ற** = *ṟa* → **றி** = *ṟi*
+
+**ி** is a hook above and to the right. The consonant keeps its shape; the sign
+hangs from it. Later, **ை** (*ai*) will appear before its consonant on the page
+but after it in speech, the same eye/ear trap as Devanagari ि.
+
+## Assemble நன்றி
+
+> **ந · ன் · றி → நன்றி**
+
+| piece | | |
+|---|---|---|
+| **ந** | *na* — dental | last lesson |
+| **ன்** | *ṉ* — alveolar, with puḷḷi | Lessons 3–4 |
+| **றி** | *ṟi* — ற plus the i-sign | this lesson |
+
+## Why *nandri* has a d-sound
+
+**ன் + ற** is pronounced close to **ndr**. This follows a broader Tamil rule: a
+**nasal voices the stop after it**.
+
+| | | |
+|---|---|---|
+| ந் + த | *nd* | **வந்து** *vandu* |
+| ண் + ட | *ṇḍ* | retroflex pair |
+| ன் + ற | *ndr* | **நன்றி** |
+
+Each n-letter creates its own cluster. That payoff explains both the three
+spellings and the common English romanization **nandri**, whose *d* is heard but
+not separately written.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: றி — ற plus the hook above right]
+- [YOU WRITE: **நன்றி** — three pieces]
+- [YOU SAY: "ன் + ற = **ndr**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are a consonant's three vowel choices? (Keep inherent **a**,
+**remove** it with puḷḷi, or **replace** it with a vowel sign.) Where does **ி**
+attach? (**Above and right**.) Why is *naṉṟi* often written *nandri*? (**ன் + ற**
+is pronounced *ndr* because a nasal voices the following stop.)

--- a/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
@@ -2,18 +2,18 @@
 id: TA-W04-vowel-signs-nandri
 chapter: 1
 type: writing
-headword: "ந, ன, ற, ி"
-gloss: "the other two n's, the hard ṟ, and the first vowel sign — writing நன்றி"
-romanization: "na, ṉa, ṟa, i"
-prerequisites: [TA-W03-pulli-vanakkam]
+headword: "ந, ன, ற"
+gloss: "write the remaining two n-letters and the hard r needed for நன்றி"
+romanization: "na, ṉa, ṟa"
+prerequisites: [TA-W03-write-vanakkam]
 sounds: [dental-vs-alveolar-vs-retroflex-n, matra-i]
 roots: []
 etymology_hook: "நன்றி is spelled ந ன் றி, and ன் + ற is said 'ndr' — an instance of the general Tamil rule that a NASAL VOICES THE STOP after it (ந்த nd, ண்ட ṇḍ, ன்ற ndr); each of the three n-letters produces its own cluster, which is what the three separate letters buy you"
-est_minutes: 6
-reviews_of: [TA-W03-pulli-vanakkam, TA-C01-nandri]
+est_minutes: 4
+reviews_of: [TA-W03-write-vanakkam, TA-W03-pulli-vanakkam, TA-C01-nandri]
 ---
 
-# ந, ன, ற and the i-sign — writing நன்றி
+# ந, ன, ற — the letter bodies inside நன்றி
 
 ## Warm-up
 
@@ -58,67 +58,17 @@ and ற hangs well beneath it.
 The dot under **ṟ** marks it as the *hard* or trilled r, distinct from Tamil's
 other r. You'll meet the contrast properly later; for now, learn the shape.
 
-## The first vowel sign
-
-Consonants carry **a**. The puḷḷi removes it. The third option is to **replace**
-it — with a vowel sign:
-
-> **ற** = *ṟa*  →  **றி** = *ṟi*
-
-**ி** is a hook written **above and to the right**. The consonant keeps its
-shape; the sign hangs off it.
-
-(One vowel sign to watch for later: **ை** = *ai* is written **before** the
-consonant, to its left, but pronounced **after** it — the same eye-versus-ear
-trap Devanagari's ि sets. It's in *illai*, "no.")
-
-## Now write நன்றி
-
-> **ந · ன் · றி → நன்றி**
-
-| piece | | |
-|---|---|---|
-| **ந** | *na* — dental | this lesson |
-| **ன்** | *ṉ* — alveolar, with the puḷḷi | this lesson + Lesson 3 |
-| **றி** | *ṟi* — ற plus the i-sign | this lesson |
-
-## Why the three n's earn their keep
-
-Say it: **நன்றி** is not *nan-ri*. The **ன் + ற** pair is pronounced together as
-something close to **"ndr"** — *nandri*.
-
-That is one case of a general Tamil rule: **a nasal voices the stop that follows
-it.** Each of the three n's does it with its own partner —
-
-| | | |
-|---|---|---|
-| ந் + த | *nd* | as in **வந்து** *vandu* |
-| ண் + ட | *ṇḍ* | the retroflex pair |
-| ன் + ற | *ndr* | **நன்றி** |
-
-— so the point is not that only ன does this, but that **each n produces its own
-cluster**, and the spelling tells you which. That is the payoff for a script that
-refused to collapse its three n's into one.
-
-It is also why *naṉṟi* is so often written **nandri** in English: a **d** turns
-up in the sound that appears nowhere in the spelling.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU WRITE: ந — "top bar, **two** verticals, then the curl that sweeps left"]
 - [YOU WRITE: ன — "top bar, left loop, **one** arch, straight vertical"]
 - [YOU WRITE: ற — "two arches, then the leg that sweeps left and drops"]
-- [YOU WRITE: றி — "ற, then the hook above right"]
-- [YOU WRITE: **நன்றி** — three pieces]
-- [YOU SAY: the cluster — "ன் + ற = **ndr**"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Name Tamil's three n-letters and their tongue positions. (**ந**
 dental, **ன** alveolar, **ண** retroflex.) What are a consonant's three
-possibilities? (Keep the built-in **a**; **remove** it with the puḷḷi; or
-**replace** it with a **vowel sign**.) Where does **ி** attach? (**Above and to
-the right**.) Write **நன்றி**. Why is it often written *nandri* when Ch. 1
-romanizes it *naṉṟi*? (**ன் + ற** is said together as *ndr* — a nasal **voices
-the stop after it**, and each of the three n's does it with its own partner.) Next chapter's writing: the vowel signs in full.
+possibilities so far? (Keep the built-in **a** or **remove** it with the puḷḷi.)
+Which letter hangs below the baseline? (**ற**, the hard *ṟ*.) Next: replace the
+vowel, assemble **நன்றி**, and hear why English often writes *nandri*.

--- a/code/learning/human-languages/tamil/roadmap.md
+++ b/code/learning/human-languages/tamil/roadmap.md
@@ -59,30 +59,35 @@ The **first handwriting track for any Dravidian language**. Until now
 nothing for Tamil, Telugu, Kannada or Malayalam — so four tracks had vocabulary
 through Chapter 6 and no way to learn to read it. `tamil.json` is new here.
 
-Lessons follow **book order**, taking the letters the Chapter 1 words actually
-need, and rise one piece at a time:
+Lessons follow dependency order, taking the letters the Chapter 1 words
+actually need. The original four topics are now eight sub-five-minute steps:
 
-- **`TA-W01`** — **வ, க**. Opens on the question the whole script answers: *why
+- **`TA-W01-curves-va-ka`** — **why Tamil is round**. Opens on the question the whole script answers: *why
   is Tamil round?* The usual account is **palm leaves**: incised with a stylus,
   where a straight stroke along the grain can **split the leaf**, so strokes bend
   into curves. The lesson gives that as the standard explanation *rather than a
   settled fact* — earliest Tamil-Brahmi is angular, the rounding arrived later
   via Vaṭṭeḻuttu, and Devanagari used the same leaves without going round. The
-  durable point is that **the tool leaves fingerprints on the letters**. Then the
-  **abugida** principle (க is *ka*, not *k*), and the fact that **one letter க
+  durable point is that **the tool leaves fingerprints on the letters**.
+- **`TA-W01-abugida-va-ka`** — **வ, க** and the **abugida** principle (க is *ka*, not *k*), plus the fact that **one letter க
   spells k, g and h**, decided by position — which is why Tamil needs 18
   consonant letters where Devanagari needs 33.
-- **`TA-W02`** — **ம, ண**, and the **retroflex**: ண is said with the tongue
+- **`TA-W02-ma-retroflex-na`** — **ம, ண**, and the **retroflex**: ண is said with the tongue
   curled back, a sound English lacks and cannot hear at first. Introduces the
-  three-n table (**ந** dental · **ன** alveolar · **ண** retroflex) without yet
-  drawing the other two.
-- **`TA-W03`** — the **puḷḷi** ் ("the dot"), which removes the inherent vowel —
+  physical tongue position before comparing the full set.
+- **`TA-W02-three-ns`** — the three-n map: **ந** dental · **ன** alveolar · **ண**
+  retroflex, without yet drawing the other two.
+- **`TA-W03-pulli-vanakkam`** — the **puḷḷi** ் ("the dot"), which removes the inherent vowel —
   and the sharp divergence from Devanagari: Tamil does **not fuse** the bare
   consonant into a conjunct. Both letters keep their shape and the dot stays
   visible, which is why Tamil's whole character set is ~247 where Devanagari has
-  hundreds of ligatures. **Assembles வணக்கம்** — the first word of the course.
-- **`TA-W04`** — **ந, ன, ற** and the first vowel sign **ி**, completing the
-  three n's. **Assembles நன்றி**, and shows why the three n's earn their keep:
+  hundreds of ligatures.
+- **`TA-W03-write-vanakkam`** — assembles **வணக்கம்**, the first whole written
+  word, and holds its doubled consonant.
+- **`TA-W04-vowel-signs-nandri`** — **ந, ன, ற**, completing the letter bodies
+  needed for the second whole word.
+- **`TA-W04-i-sign-write-nandri`** — introduces the first vowel sign **ி**,
+  assembles **நன்றி**, and shows why the three n's earn their keep:
   **ன் + ற** is said together as *ndr* — one instance of the general rule that a
   **nasal voices the stop after it** (ந்த *nd* · ண்ட *ṇḍ* · ன்ற *ndr*), so each
   n produces its own cluster and the spelling tells you which. It is also why


### PR DESCRIPTION
## Summary
- remove all 42 Tamil sub-five-minute duration violations
- split 20 genuinely long lessons into 20 prerequisite-ordered companions while preserving script, etymology, grammar, register, family-comparison, and source-evidence depth
- correct 22 declaration-only budgets, update downstream prerequisite handoffs, and expand the Tamil writing strand from four long topics to eight gentle steps
- record Tamil book-generation, LaTeX-cleanup, and curriculum-map follow-ups; reprioritize Latin as the next duration tranche

## Measured result
- corpus: 1,025 -> 1,045 lessons
- duration debt: 140 -> 98 overall; Tamil: 42 -> 0
- unknown prerequisites: 0
- all 40 rewritten/new split steps: 127-296 computed seconds

## Validation
- `npm run test:coverage` (human-language-data): 68 passed, 93.60% line coverage
- `npm run build` (human-language-data)
- `npm run validate`: 9 passed
- `npm run check:books`
- `npm run report`
- `npm run test:coverage` (Language Ladder): 278 passed, 98.37% line coverage
- `npm run build` (Language Ladder): 1,095 modules transformed
- forced XeLaTeX Tamil book build: 29 pages, no missing glyphs
- rendered and visually inspected cover, middle, and final pages
- `git diff --check`
