### PR TITLE
Report open elements at HTML EOF

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Full-document parsing now reports the in-body EOF parse error when disallowed
+  elements remain on the stack, closing 335 previously silent malformed corpus
+  cases without changing DOM recovery or fragment diagnostics.
 - `body` and `html` end tags now report the Standard's parse error when
   disallowed elements remain on the stack of open elements, closing 7
   previously silent malformed corpus cases without changing DOM recovery.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -25,8 +25,8 @@ The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
 all 6,806 html5lib tokenizer cases with zero missing signatures and zero
 normalized skips. DOM output is complete, but diagnostic coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the document-shell end-tag slice, 1,424 of those cases emit at least one
-lexer or parser diagnostic and 759 remain uncovered. Another 139
+After the full-document in-body EOF slice, 1,759 of those cases emit at least
+one lexer or parser diagnostic and 424 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -36,22 +36,27 @@ Prioritized work items:
 
 1. **Document shell insertion modes.** Emit the remaining parse errors around
    explicit and implied `html`, `head`, and `body` creation. Missing-doctype
-   handling, duplicate shell start-tag diagnostics, and body/html end tags with
-   disallowed open elements are complete.
-2. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
+   handling, duplicate shell start-tag diagnostics, body/html end tags with
+   disallowed open elements, and full-document in-body EOF diagnostics are
+   complete.
+2. **Fragment EOF diagnostics.** Audit the current in-body EOF rule against
+   fragment parsing. Legacy fragment fixtures omit many EOF error rows, so add
+   explicit current-WHATWG evidence before extending the full-document
+   diagnostic into fragments.
+3. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
    recovery, formatting reconstruction, and stray start/end tags.
-3. **Table, select, and template insertion modes.** Cover foster parenting,
+4. **Table, select, and template insertion modes.** Cover foster parenting,
    table scopes, select recovery, and template mode-stack errors.
-4. **Adoption agency and active formatting.** Cover malformed formatting cases
+5. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
-5. **Foreign content and fragment parsing.** Cover SVG/MathML integration
+6. **Foreign content and fragment parsing.** Cover SVG/MathML integration
    boundaries and context-sensitive fragment errors.
-6. **Diagnostic positions and error taxonomy.** Carry source positions into
+7. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.
-7. **Input boundary review.** Document the Unicode-code-point parser boundary
+8. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
-8. **Algorithm and differential audit.** Map implemented states/modes to the
+9. **Algorithm and differential audit.** Map implemented states/modes to the
    current HTML Standard and add deterministic differential/fuzz coverage for
    branches not exercised by the upstream corpora.
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4350,6 +4350,7 @@ pub struct HtmlParser {
     prunable_empty_reconstructed_formatting_paths: Vec<Vec<usize>>,
     diagnostics: Vec<ParserDiagnostic>,
     options: HtmlParseOptions,
+    is_fragment: bool,
     initial_insertion_mode: bool,
     quirks_mode: bool,
     strip_next_leading_lf: bool,
@@ -4372,6 +4373,7 @@ impl Default for HtmlParser {
             prunable_empty_reconstructed_formatting_paths: Vec::new(),
             diagnostics: Vec::new(),
             options: HtmlParseOptions::default(),
+            is_fragment: false,
             initial_insertion_mode: true,
             quirks_mode: true,
             strip_next_leading_lf: false,
@@ -4424,6 +4426,7 @@ impl HtmlParser {
             prunable_empty_reconstructed_formatting_paths: Vec::new(),
             diagnostics: Vec::new(),
             options,
+            is_fragment: true,
             initial_insertion_mode: false,
             quirks_mode: true,
             strip_next_leading_lf: false,
@@ -4448,6 +4451,7 @@ impl HtmlParser {
             prunable_empty_reconstructed_formatting_paths: Vec::new(),
             diagnostics: Vec::new(),
             options,
+            is_fragment: true,
             initial_insertion_mode: false,
             quirks_mode: true,
             strip_next_leading_lf: false,
@@ -4622,6 +4626,15 @@ impl HtmlParser {
                         }));
                     }
                     Token::Eof => {
+                        if !self.is_fragment
+                            && self.has_open_element("body")
+                            && self.has_disallowed_open_element_for_body_end_tag()
+                        {
+                            self.diagnostics.push(ParserDiagnostic::new(
+                                "eof-with-unclosed-elements",
+                                "end of file was reached with disallowed open elements",
+                            ));
+                        }
                         self.populate_selectedcontent_for_open_selects();
                         repair_table_cell_fostered_nobr_adoption(&mut self.document);
                         repair_insanely_badly_nested_table_sequence(&mut self.document.children);
@@ -30461,10 +30474,16 @@ mod tests {
 
         assert_eq!(
             output.parser_diagnostics,
-            vec![ParserDiagnostic::new(
-                "nested-form-start-tag",
-                "nested form start tag was ignored while a form element was already open"
-            )]
+            vec![
+                ParserDiagnostic::new(
+                    "nested-form-start-tag",
+                    "nested form start tag was ignored while a form element was already open"
+                ),
+                ParserDiagnostic::new(
+                    "eof-with-unclosed-elements",
+                    "end of file was reached with disallowed open elements"
+                )
+            ]
         );
 
         let body = body(&output.document);
@@ -31488,10 +31507,16 @@ mod tests {
         );
         assert_eq!(
             output.parser_diagnostics,
-            vec![ParserDiagnostic::new(
-                "non-void-html-element-self-closing",
-                "self-closing flag on non-void HTML element `<plaintext>` was ignored"
-            )]
+            vec![
+                ParserDiagnostic::new(
+                    "non-void-html-element-self-closing",
+                    "self-closing flag on non-void HTML element `<plaintext>` was ignored"
+                ),
+                ParserDiagnostic::new(
+                    "eof-with-unclosed-elements",
+                    "end of file was reached with disallowed open elements"
+                )
+            ]
         );
     }
 
@@ -32829,7 +32854,6 @@ mod tests {
         for (source, end_tag) in [
             ("<!doctype html><menuitem></body>", "body"),
             ("<!doctype html><menuitem></html>", "html"),
-            ("<!doctype html><table><tbody><tr><td></body>", "body"),
         ] {
             let output = parse_html_with_diagnostics(source).unwrap();
             assert_eq!(
@@ -32842,8 +32866,50 @@ mod tests {
             );
         }
 
+        let table = parse_html_with_diagnostics(
+            "<!doctype html><table><tbody><tr><td></body>",
+        )
+        .unwrap();
+        assert_eq!(
+            table.parser_diagnostics,
+            vec![
+                ParserDiagnostic::new(
+                    "shell-end-tag-with-unclosed-elements",
+                    "end tag `</body>` was seen with disallowed open elements"
+                ),
+                ParserDiagnostic::new(
+                    "eof-with-unclosed-elements",
+                    "end of file was reached with disallowed open elements"
+                )
+            ]
+        );
+
         let allowed = parse_html_with_diagnostics("<!doctype html><p></body>").unwrap();
         assert!(allowed.parser_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_eof_with_disallowed_open_elements() {
+        for source in [
+            "<!doctype html><menuitem>",
+            "<!doctype html><div>",
+            "<!doctype html><svg>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "eof-with-unclosed-elements",
+                    "end of file was reached with disallowed open elements"
+                )],
+                "source {source:?}"
+            );
+        }
+
+        for source in ["<!doctype html><p>", "<!doctype html><head>"] {
+            let allowed = parse_html_with_diagnostics(source).unwrap();
+            assert!(allowed.parser_diagnostics.is_empty(), "source {source:?}");
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 759);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1424);
+    assert_eq!(missing_diagnostic_cases, 424);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1759);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the current HTML Standard's in-body EOF parse error when a full document reaches EOF with disallowed open elements
- keep fragment parsing unchanged pending a dedicated current-WHATWG evidence pass, and add that work to the prioritized conformance backlog
- ratchet diagnostic coverage from 1,424 to 1,759 malformed tree-construction cases while preserving all checked DOM outputs

## Evidence
The current Standard's "in body" EOF rule requires a parse error when the stack of open elements contains an element other than `dd`, `dt`, `li`, `optgroup`, `option`, `p`, `rb`, `rp`, `rt`, `rtc`, `tbody`, `td`, `tfoot`, `th`, `thead`, `tr`, `body`, or `html`.

This closes 335 previously silent declared-error cases:
- missing diagnostic cases: 759 -> 424
- covered declared-error cases: 1,424 -> 1,759
- undeclared diagnostic cases: unchanged at 139
- checked DOM outputs: all 2,637 preserved

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`
