### PR TITLE
fix(qr-code): synchronize generator cache

### DIFF
--- a/code/packages/go/qr-code/CHANGELOG.md
+++ b/code/packages/go/qr-code/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — qr-code (Go)
 
+## Unreleased
+
+### Fixed
+
+- Made the Reed-Solomon generator cache safe for concurrent QR encodes.
+
 ## [0.1.0] — 2026-04-24
 
 ### Added

--- a/code/packages/go/qr-code/qr_code.go
+++ b/code/packages/go/qr-code/qr_code.go
@@ -40,6 +40,7 @@ package qrcode
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"unicode/utf8"
 
 	barcode2d "github.com/adhithyan15/coding-adventures/code/packages/go/barcode-2d"
@@ -430,15 +431,16 @@ func rsEncode(data []byte, generator []byte) []byte {
 
 // generatorCache caches pre-built generators by ECC count to avoid rebuilding
 // the same polynomial repeatedly (each generator for a given n is always the same).
-var generatorCache = map[int][]byte{}
+var generatorCache sync.Map
 
 func getGenerator(n int) []byte {
-	if g, ok := generatorCache[n]; ok {
-		return g
+	if cached, ok := generatorCache.Load(n); ok {
+		return cached.([]byte)
 	}
-	g := buildQRGenerator(n)
-	generatorCache[n] = g
-	return g
+
+	generated := buildQRGenerator(n)
+	actual, _ := generatorCache.LoadOrStore(n, generated)
+	return actual.([]byte)
 }
 
 // ============================================================================

--- a/code/packages/go/qr-code/qr_code_test.go
+++ b/code/packages/go/qr-code/qr_code_test.go
@@ -13,7 +13,9 @@
 package qrcode
 
 import (
+	"bytes"
 	"fmt"
+	"sync"
 	"testing"
 
 	barcode2d "github.com/adhithyan15/coding-adventures/code/packages/go/barcode-2d"
@@ -82,6 +84,36 @@ func TestBuildQRGeneratorDegree10(t *testing.T) {
 		if gen[i] != w {
 			t.Errorf("gen[%d] = %d, want %d", i, gen[i], w)
 		}
+	}
+}
+
+// TestGetGeneratorConcurrentCache verifies that the shared generator cache is
+// safe when independent QR encodes request Reed-Solomon polynomials in parallel.
+func TestGetGeneratorConcurrentCache(t *testing.T) {
+	t.Parallel()
+
+	degrees := []int{7, 10, 13, 16, 17, 18, 20, 22, 24, 26, 28, 30}
+	var wg sync.WaitGroup
+	errors := make(chan string, 32*len(degrees))
+
+	for worker := 0; worker < 32; worker++ {
+		for _, degree := range degrees {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				got := getGenerator(degree)
+				want := buildQRGenerator(degree)
+				if !bytes.Equal(got, want) {
+					errors <- fmt.Sprintf("degree %d generator = %v, want %v", degree, got, want)
+				}
+			}()
+		}
+	}
+
+	wg.Wait()
+	close(errors)
+	for message := range errors {
+		t.Error(message)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the unsynchronized Reed-Solomon generator map with a concurrency-safe cache
- return the canonical cached generator when simultaneous callers build the same degree
- add a high-contention regression test and changelog entry

## Broken-main evidence
CodeQL run 30785404530 failed while building affected Go packages with `fatal error: concurrent map writes` in `qr-code.getGenerator`.

## Validation
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go test -count=20 ./...`