### PR TITLE
fix(spice): validate parser MOS body effect

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `GAMMA` values before lowering
+  Level-1 body effect.
 - Reject non-finite MOS model-card `LAMBDA` / `LAM` values and lower the `LAM`
   alias into Level-1 channel-length modulation.
 - Reject non-finite MOS model-card `VT0` / `VTO` / `VTH` values and lower the

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1902,6 +1902,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         channel_modulation = params.get("LAMBDA", params.get("LAM"))
         if channel_modulation is not None and not math.isfinite(channel_modulation):
             raise NetlistParseError("MOSFET LAMBDA must be finite")
+        if "GAMMA" in params and (
+            not math.isfinite(params["GAMMA"]) or params["GAMMA"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET GAMMA must be finite and non-negative")
     return ModelCard(name=name, kind=kind, params=params)
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1485,6 +1485,24 @@ def test_lowers_finite_mosfet_model_channel_modulation_aliases(alias: str) -> No
     assert mosfet.model.model.params.LAMBDA == -0.02
 
 
+@pytest.mark.parametrize("body_effect", ["-0.01", "1e999"])
+def test_rejects_invalid_mosfet_model_body_effect(body_effect: str) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET GAMMA must be finite and non-negative",
+    ):
+        parse_netlist(f".model nfast NMOS(GAMMA={body_effect})\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("body_effect", ["0", "0.45"])
+def test_lowers_valid_mosfet_model_body_effect(body_effect: str) -> None:
+    parsed = parse_netlist(f".model nfast NMOS(GAMMA={body_effect})\nM1 d g s b nfast\n")
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert float(body_effect) == mosfet.model.model.params.GAMMA
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `GAMMA` values before lowering
+  Level-1 body effect.
 - Reject non-finite MOS model-card `LAMBDA` / `LAM` values and lower the `LAM`
   alias into Level-1 channel-length modulation.
 - Reject non-finite MOS model-card `VT0` / `VTO` / `VTH` values and lower the

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1197,6 +1197,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET LAMBDA must be finite");
   }
+  const bodyEffect = params.get("GAMMA");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    bodyEffect !== undefined &&
+    (!Number.isFinite(bodyEffect) || bodyEffect < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET GAMMA must be finite and non-negative");
+  }
   return {
     name: fields[1],
     kind,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1418,6 +1418,24 @@ Xright c d load
     },
   );
 
+  it.each(["-0.01", "1e999"])("rejects invalid MOSFET model GAMMA=%s", (bodyEffect) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(GAMMA=${bodyEffect})\nM1 d g s b nfast\n`),
+    ).toThrow("MOSFET GAMMA must be finite and non-negative");
+  });
+
+  it.each(["0", "0.45"])("lowers valid MOSFET model GAMMA=%s", (bodyEffect) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(GAMMA=${bodyEffect})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.params.GAMMA).toBe(Number(bodyEffect));
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS channel-modulation validation parity.
+1. Python and TypeScript Berkeley SPICE MOS body-effect validation parity.
    - Status: current PR completion candidate.
-   - Reject non-finite `LAMBDA` / `LAM` values with the shared diagnostic.
-   - Lower finite `LAM` values through the canonical Level-1 channel-modulation
-     field instead of silently discarding that alias.
+   - Reject negative and non-finite `GAMMA` values with the shared diagnostic.
+   - Preserve zero and positive body-effect coefficients through canonical
+     Level-1 lowering.
 
 ## Completed Slices
 
@@ -4156,11 +4156,16 @@ the Rust, Python, and TypeScript surfaces together.
      diagnostic.
    - Finite `VTH` values lower into canonical Level-1 threshold voltage.
 
+373. Python and TypeScript Berkeley SPICE MOS channel-modulation validation parity.
+   - Status: completed in PR 9600.
+   - Non-finite `LAMBDA` / `LAM` values are rejected with the shared diagnostic.
+   - Finite `LAM` values lower into canonical Level-1 channel modulation.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
-   - Apply Rust-aligned domains and diagnostics to already lowered `GAMMA`,
-     `PHI`, `W`, `L`, `IS`, and nominal-temperature fields.
+   - Apply Rust-aligned domains and diagnostics to already lowered `PHI`, `W`,
+     `L`, `IS`, and nominal-temperature fields.
 
 2. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
    - Lower missing canonical resistance, geometry, capacitance, junction, and


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `GAMMA` values in Python and TypeScript parsers
- preserve zero and positive body-effect coefficients through Level-1 lowering
- add cross-language regression coverage, changelogs, and advance the SPICE implementation plan

## Verification
- Python spice-netlist-parser: 107 tests passed, 88.06% coverage
- Python Ruff: passed
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed; 106 tests passed; 83.35% statement / 84% line coverage
- `git diff --check origin/main...HEAD`