### PR TITLE
Split Latin lessons into sub-five-minute micro-steps

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,8 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Tamil duration
-tranche: 20 registered tracks, 1,045 Markdown lessons, and 20 downloadable LaTeX
+Last prioritized: 2026-08-02. Current baseline after the Latin duration
+tranche: 20 registered tracks, 1,051 Markdown lessons, and 20 downloadable LaTeX
 books. HL-V01 makes the remaining migration debt reproducible in both JSON and
 human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
 lessons, and the HL-D01 tranches prove duration remediation without discarding
@@ -63,7 +63,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01N | Complete in the Arabic duration PR | Remove all thirty-nine sub-five-minute violations from the Arabic track. | The report measures zero Arabic violations; four new prerequisite-ordered writing steps preserve the abjad, joining, whole-word assembly, and hamza content. |
 | HL-D01O | Complete in the Hindi duration PR | Remove all forty sub-five-minute violations from the Hindi track. | The report measures zero Hindi violations; thirteen new prerequisite-ordered lessons preserve its script, etymology, grammar, and register depth. |
 | HL-D01P | Complete in this PR | Remove all forty-two sub-five-minute violations from the Tamil track. | The report measures zero Tamil violations; twenty new prerequisite-ordered lessons preserve its script, etymology, grammar, register, and source-evidence depth. |
-| HL-D01Q | Next | Remove all forty-three sub-five-minute violations from the Latin track. | Latin is now the smallest remaining set: thirty-seven declaration-only lessons and six genuinely computed violations, with a 370-second maximum. |
+| HL-D01Q | Complete in this PR | Remove all forty-three sub-five-minute violations from the Latin track. | The report measures zero Latin violations; six new prerequisite-ordered lessons preserve its grammar, etymology, usage, and attestation depth. |
+| HL-D01R | Next | Remove all fifty-five remaining sub-five-minute violations from the Spanish track. | Spanish is the final track with duration debt: forty-one declaration-only lessons and fourteen genuinely computed violations, with a 731-second maximum; schema-v2 lessons require closure-aware splits. |
 | HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
 | HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -96,6 +97,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B31 | Queued | Remove Hindi's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports two overfull boxes, five underfull boxes, three duplicate practice labels, 29 Hyperref warnings, undefined bold/italic Devanagari font shapes, and a visibly colliding final-page running header; the clean-build signal is zero of each. |
 | HL-B32 | Queued | Publish Tamil Chapters 6–31 and its writing companions from canonical lessons rather than hand-copying another twenty-six book chapters. | The Tamil PDF stops after Chapter 5 while canonical app content continues through Chapter 31 and eight dependency-ordered writing lessons; schema-v2 migration plus generation should close that drift safely. |
 | HL-B33 | Queued | Remove Tamil's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports six overfull boxes, six underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and undefined bold/italic Tamil font shapes; the clean-build signal is zero of each. |
+| HL-B34 | Queued | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | The Latin PDF contains only Chapter 1 while canonical app content continues through Chapter 36; schema-v2 migration plus generation should close that drift safely. |
+| HL-B35 | Queued | Remove Latin's remaining LaTeX layout and font warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports one underfull box and a small-caps font-shape substitution; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
@@ -103,6 +106,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-M05 | Queued | Reconcile Arabic's roadmap and authoritative session map with canonical Chapters 1–27 and the sixteen-step writing sequence. | The roadmap details only Chapters 1–4 and still calls Chapter 5+ planned; the session map stops at Chapter 2 even though prerequisite-ordered canonical lessons continue through Chapter 27. |
 | HL-M06 | Queued | Reconcile Hindi's roadmap and authoritative session map with canonical Chapters 1–33 and the eleven-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 6 planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 33. |
 | HL-M07 | Queued | Reconcile Tamil's roadmap and authoritative session map with canonical Chapters 1–31 and the eight-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 7+ planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 31. |
+| HL-M08 | Queued | Reconcile Latin's roadmap and authoritative session map with canonical Chapters 1–36. | Both files stop at Chapter 1 and describe Chapter 2+ as planned even though prerequisite-ordered canonical lessons continue through Chapter 36. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
@@ -549,6 +553,37 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 - Latin's forty-three violations are now the smallest remaining set.
   Thirty-seven are declaration-only and six genuinely compute above the limit,
   with a 370-second maximum, so HL-D01Q is next.
+
+## Findings from HL-D01Q
+
+- Latin now has zero duration violations. The corpus grows from 1,045 to 1,051
+  lessons and drops from 98 to 55 violations overall; unknown prerequisites
+  remain at zero.
+- Thirty-seven lessons already computed between 143 and 297 seconds and needed
+  only honest four-minute declared budgets. Six genuinely long lessons become
+  prerequisite-ordered pairs: weather-word history → impersonal weather verbs;
+  wellbeing questions → the `valeō/valē` family; dative possession → authorial
+  name-case variation; the Plautine meeting phrase → its usage limits;
+  `vesper`/west → Greek and Romance afterlives; and the missing afternoon
+  formula → time-independent `salvē`.
+- The twelve rewritten or new split steps compute between 153 and 295 seconds.
+  `LA-C19-quid-agis` at 295 seconds and `LA-C17-canis-feles-cattus` at 297 are
+  the tightest remaining Latin lessons and should be watched during copy edits.
+- The Latin PDF builds successfully at 12 pages with no missing glyphs,
+  overfull boxes, duplicate labels, or Hyperref warnings, but it contains only
+  Chapter 1 while canonical lessons continue through Chapter 36. HL-B34 records
+  the schema-v2 migration and generated publication work for the missing
+  content.
+- The build reports one underfull box and a small-caps font-shape substitution.
+  Visual inspection of the cover, reference page, and final page finds no
+  clipping or collision. HL-B35 records that pre-existing clean-build debt.
+- The roadmap and authoritative session map stop at Chapter 1 and still call
+  Chapter 2+ planned. HL-M08 records the progression-metadata reconciliation
+  through Chapter 36.
+- Spanish's fifty-five violations are the only duration debt left in the
+  corpus. Forty-one are declaration-only and fourteen genuinely compute above
+  the limit, led by a 731-second subjunctive lesson; HL-D01R is the final
+  duration tranche.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/latin/CHANGELOG.md
+++ b/code/learning/human-languages/latin/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Sub-five-minute lesson remediation — 43 violations to zero
+
+- Corrects thirty-seven declared budgets whose lesson bodies already compute
+  below five minutes.
+- Splits six genuinely long lessons into prerequisite-ordered pairs, adding
+  focused companions rather than deleting grammar, etymology, usage, or
+  attestation depth.
+- Separates weather-word history from weather verbs, wellbeing questions from
+  the `valeō/valē` family, dative possession from authorial case variation,
+  Plautine wording from its usage limits, `vesper` from its daughter-language
+  afterlives, and the absent afternoon formula from time-independent `salvē`.
+- Leaves every affected step below 300 effective seconds and keeps all
+  prerequisite references resolvable for the shared app/book corpus.
+
 ## Chapter 1 — Greetings (taproot track)
 
 - New Latin track on the HL00 framework — Italic/Indo-European, Latin script

--- a/code/learning/human-languages/latin/lessons/LA-C01-gratias.md
+++ b/code/learning/human-languages/latin/lessons/LA-C01-gratias.md
@@ -8,7 +8,7 @@ concept_tag: COURTESY-THANKS
 prerequisites: [LA-C01-vale]
 sounds: [hard-c-t, macron-long-vowel]
 roots: [gratia, gratus, ago]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C01-ave]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C01-ita-non.md
+++ b/code/learning/human-languages/latin/lessons/LA-C01-ita-non.md
@@ -8,7 +8,7 @@ concept_tag: RESPONSE-YESNO
 prerequisites: [LA-C01-gratias]
 sounds: [macron-long-vowel]
 roots: [ita, sic, non, ne-negative]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C01-salve]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C01-practice.md
+++ b/code/learning/human-languages/latin/lessons/LA-C01-practice.md
@@ -8,7 +8,7 @@ concept_tag: REVIEW
 prerequisites: [LA-C01-salve, LA-C01-ave, LA-C01-vale, LA-C01-gratias, LA-C01-ita-non]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C01-salve, LA-C01-ave, LA-C01-vale, LA-C01-gratias, LA-C01-ita-non]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C01-salve.md
+++ b/code/learning/human-languages/latin/lessons/LA-C01-salve.md
@@ -8,7 +8,7 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [macron-long-vowel, v-as-w]
 roots: [salvus, salvere]
-est_minutes: 5
+est_minutes: 4
 reviews_of: []
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C01-vale.md
+++ b/code/learning/human-languages/latin/lessons/LA-C01-vale.md
@@ -8,7 +8,7 @@ concept_tag: FAREWELL
 prerequisites: [LA-C01-ave]
 sounds: [v-as-w, macron-long-vowel]
 roots: [valere]
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C01-salve]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C02-numbers-1-5.md
+++ b/code/learning/human-languages/latin/lessons/LA-C02-numbers-1-5.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C01-salve]
 sounds: [macron-long-vowel, qu-as-kw, v-as-w]
 roots: [unus, duo, tres, quattuor, quinque]
 etymology_hook: "the ancestors the Spanish and French tracks point back to — quattuor is the source of both quatre and cuatro"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C01-salve]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C02-numbers-6-10.md
+++ b/code/learning/human-languages/latin/lessons/LA-C02-numbers-6-10.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C02-numbers-1-5]
 sounds: [macron-long-vowel, x-as-ks, c-as-k]
 roots: [sex, septem, octo, novem, decem]
 etymology_hook: "September–December still count 7–10 — Rome's year began in March, so the month names ended up two places short"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C02-numbers-1-5, LA-C01-salve]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C05-dies-lunae-veneris.md
+++ b/code/learning/human-languages/latin/lessons/LA-C05-dies-lunae-veneris.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C02-numbers-6-10]
 sounds: [macron-long-vowel, ae-diphthong]
 roots: [dies-latin, planet-gods]
 etymology_hook: "Latin's own week names are the FULL 'diēs [planet]' phrase that Spanish and French later wore down to lunes/lundi, martes/mardi…"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C02-numbers-6-10]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C05-saturni-solis.md
+++ b/code/learning/human-languages/latin/lessons/LA-C05-saturni-solis.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C05-dies-lunae-veneris]
 sounds: [macron-long-vowel]
 roots: [saturnus-latin, sol-latin, sabbatum-latin, dominus-latin]
 etymology_hook: "Latin ORIGINALLY said diēs Saturnī and diēs Sōlis — English Saturday/Sunday kept these pagan names directly, while Spanish/French later swapped in the Christian Sabbatum/Dominica"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C05-dies-lunae-veneris]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C06-niger-albus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C06-niger-albus.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C05-saturni-solis]
 sounds: [macron-long-vowel]
 roots: [niger-latin, albus-latin, ater-latin, candidus-latin]
 etymology_hook: "niger and albus each had a brightness-twin — ater 'dull black' vs niger 'gleaming black', albus 'dull white' vs candidus 'shining white' — a distinction Romance mostly dropped"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C05-saturni-solis, LA-C05-dies-lunae-veneris]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C06-ruber-caeruleus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C06-ruber-caeruleus.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C06-niger-albus]
 sounds: [ae-diphthong, macron-long-vowel]
 roots: [pie-rewdh, caeruleus-latin]
 etymology_hook: "ruber is a rock-solid PIE-rooted red, ancestor of BOTH Spanish rojo (via russus) and French rouge (via rubeus) — but Latin's closest word for 'blue', caeruleus, was never a clean single color the way ruber was"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C06-niger-albus]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C07-frater-soror.md
+++ b/code/learning/human-languages/latin/lessons/LA-C07-frater-soror.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C07-pater-mater]
 sounds: [macron-long-vowel]
 roots: [pie-bhrater, pie-swesor]
 etymology_hook: "frater and English brother are cousins via PIE *bhreh2ter (Grimm's Law bh→b); soror and English sister are cousins via PIE *swesor, NOT soror turning into sister — Latin simplified sw- to s-, Germanic kept it"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C07-pater-mater]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C07-pater-mater.md
+++ b/code/learning/human-languages/latin/lessons/LA-C07-pater-mater.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C06-ruber-caeruleus]
 sounds: [macron-long-vowel]
 roots: [pie-pater, pie-mater]
 etymology_hook: "pater and English father are COUSINS, not parent-and-child — both descend independently from PIE *ph2ter, with Latin keeping the p and Germanic shifting it to f via Grimm's Law"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C06-ruber-caeruleus, LA-C06-niger-albus]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C08-caput.md
+++ b/code/learning/human-languages/latin/lessons/LA-C08-caput.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C07-frater-soror]
 sounds: [macron-long-vowel]
 roots: [pie-kaput]
 etymology_hook: "caput 'head' gives English captain/capital/decapitate/capitulate and Spanish cabeza (via capitia) — but French quietly REPLACED it with testa, 'pot,' Roman soldiers' slang for the skull"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C07-frater-soror, LA-C07-pater-mater]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C08-manus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C08-manus.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C08-caput]
 sounds: [macron-long-vowel]
 roots: [pie-man]
 etymology_hook: "manus is feminine despite belonging to the 4th declension, a group of -us nouns that runs mostly MASCULINE (fructus, exercitus, senatus) — manus is one of only a handful of exceptions, and Spanish's mano inherited that oddity intact"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C08-caput]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C09-anni-tempora.md
+++ b/code/learning/human-languages/latin/lessons/LA-C09-anni-tempora.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C08-manus, LA-C08-caput]
 sounds: [macron-long-vowel, ae-diphthong]
 roots: [ver-latin, aestas-latin, autumnus-latin, hiems-latin]
 etymology_hook: "vēr, aestās, autumnus, hiems are Latin's own four season-nouns — but Spanish/French didn't always keep the plain nouns; for spring and winter, they built new words from ADJECTIVE phrases instead (prīma vēra 'first spring,' hībernum tempus 'wintry time')"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C08-manus, LA-C08-caput]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C10-aqua-vinum.md
+++ b/code/learning/human-languages/latin/lessons/LA-C10-aqua-vinum.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C09-anni-tempora]
 sounds: [macron-long-vowel, qu-as-kw]
 roots: [aqua-latin, vinum-latin]
 etymology_hook: "aqua survived nearly whole into Spanish agua and Italian acqua — but French wore it all the way down to a bare 'eau'; vīnum, by contrast, barely changed ANYWHERE, surviving into every Romance daughter and into Germanic English as 'wine'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C09-anni-tempora, LA-C08-manus]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C11-menses.md
+++ b/code/learning/human-languages/latin/lessons/LA-C11-menses.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C10-panis, LA-C10-aqua-vinum]
 sounds: [macron-long-vowel, qu-as-kw]
 roots: [ianus-latin, mars-latin, numbering-months]
 etymology_hook: "Quintilis and Sextilis, 'the 5th and 6th months,' were later RENAMED Iulius and Augustus in honor of Caesar and the emperor — Rome didn't add two new months, it just relabeled two old ones"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C10-panis, LA-C10-aqua-vinum]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C12-medius-dies-nox.md
+++ b/code/learning/human-languages/latin/lessons/LA-C12-medius-dies-nox.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C11-menses]
 sounds: [macron-long-vowel]
 roots: [medius-latin, dies-latin, nox-latin]
 etymology_hook: "medius diēs 'mid-day' and media nox 'mid-night' survived at wildly different rates: Spanish kept both halves fully alive, French kept nox/nuit but wore diēs/-di to a fossil, and English's OWN word for noon isn't even this phrase — it's nōna hōra, 'the ninth hour,' which drifted from 3pm to midday"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C11-menses]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C13-hora.md
+++ b/code/learning/human-languages/latin/lessons/LA-C13-hora.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C12-medius-dies-nox]
 sounds: [macron-long-vowel, h-aspirate]
 roots: [hora-greek]
 etymology_hook: "hōra, borrowed from Greek hṓrā ('a season, a time of day'), is the source of Spanish hora, French heure, German's later-borrowed Uhr, and English hour — but the Roman hōra itself wasn't a fixed 60 minutes: it was 1/12 of THAT DAY'S sunrise-to-sunset span, so it stretched and shrank with the seasons"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C12-medius-dies-nox]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C14-annos-natus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C14-annos-natus.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C13-hora]
 sounds: [macron-long-vowel, accusative-duration]
 roots: [nascor-natus-born, annus-latin]
 etymology_hook: "vīgintī annōs nātus sum, 'I am twenty years [having been] born' — Classical Latin's age construction used nātus ('born') + the ACCUSATIVE of duration, not habēre ('have'); the Romance 'I HAVE my years' pattern (Spanish tengo, French j'ai) is a LATER Vulgar Latin innovation, not inherited from Classical Latin itself"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C13-hora]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C15-tempestas-pluit.md
+++ b/code/learning/human-languages/latin/lessons/LA-C15-tempestas-pluit.md
@@ -2,18 +2,18 @@
 id: LA-C15-tempestas-pluit
 chapter: 15
 type: phrase
-headword: tempestās, pluit
-gloss: "storm/weather" and "it rains" — tempestās is a DERIVATIVE of tempus that specialized for weather in Classical Latin, while tempus itself meant only "time"; later, WITHIN LATIN ITSELF (before Spanish/French/Italian split apart), tempus re-widened to also mean "weather," while tempestās narrowed further to just "storm" and survives in Spanish as its own separate word, tempestad
+headword: tempestās
+gloss: weather or storm — a derivative of tempus that specialized for weather in Classical Latin, while tempus itself meant only time; later tempus widened to weather and tempestās narrowed to storm
 concept_tag: LA-WEATHER
 prerequisites: [LA-C14-annos-natus]
-sounds: [macron-long-vowel, impersonal-verb-3rd-singular]
-roots: [tempus-latin, tempestas-latin, calor-latin, sol-latin, pluere-latin]
-etymology_hook: "tempestās ('weather, storm') is a DERIVATIVE noun built on tempus ('time') that specialized in Classical Latin to mean weather/storm specifically — but Latin ITSELF later re-widened tempus to also mean 'weather' (shared by French temps, Italian tempo too, not a Spanish-only innovation), while tempestās narrowed to just 'storm' and survives in Spanish as its own word, tempestad; pluit ('it rains'), calor, and sol are the direct sources of Spanish's llueve/calor/sol"
-est_minutes: 6
+sounds: [macron-long-vowel]
+roots: [tempus-latin, tempestas-latin]
+etymology_hook: "tempestās ('weather, storm') is a derivative noun built on tempus ('time') that specialized in Classical Latin; later tempus itself widened to also mean weather, while tempestās narrowed to storm and survives as Spanish tempestad"
+est_minutes: 4
 reviews_of: [LA-C14-annos-natus]
 ---
 
-# tempestās, pluit — one Latin word widened, its own derivative narrowed
+# tempestās — one Latin word widened, its own derivative narrowed
 
 ## Warm-up
 
@@ -41,29 +41,12 @@ Meanwhile *tempestās* kept going too, narrowing further to mean specifically
 **tempestad** ("storm, tempest"), sitting right alongside *tiempo*. So it's
 one word (*tempus*) widening back out, not two words fusing into one.
 
-## pluit — Latin's own impersonal "it rains"
-
-Latin states weather with **dedicated impersonal verbs**, no subject at all:
-**pluit** ("**it rains**"), **ningit** ("it snows"), **tonat** ("it thunders").
-**pluit** is the direct ancestor of Spanish's **llueve** — the same **pl- →
-ll-** shift you've now met repeatedly (*clāmāre → llamar*, *clāvem → llave*,
-*flamma → llama*, *plovere → llover*). Latin's impersonal-verb pattern for
-weather is actually closer to English's own "it **rains**" than to Spanish's
-*hacer*-based "**hace** calor" — Spanish only kept the dedicated-verb pattern
-for rain, and invented the *hacer* periphrasis fresh for heat, cold, and sun.
-
-## calor and sol — carried straight through, unchanged
-
-**calor** ("heat") and **sol** ("sun") are the exact same words in Latin and
-Spanish — no sound change at all, just carried straight through.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "tempestās" — weather/storm, a derivative of tempus, "time,"
   narrowed today to Spanish's "tempestad"]
-- [YOU SAY: "pluit" — it rains, ancestor of Spanish's llueve]
-- [YOU SAY: "calor," "sol" — unchanged in both languages]
+- [YOU SAY: "tempus" — time, later widened inside Latin to weather too]
 
 ## Wrap-up Recall
 
@@ -72,8 +55,4 @@ Spanish — no sound change at all, just carried straight through.
 while *tempus* stayed strictly "time.") Did Spanish merge these two words back
 together? (**No** — *tempus* itself re-widened to cover "weather" already
 within Latin's own history, shared by French/Italian too; *tempestās* kept
-narrowing and survives separately as Spanish *tempestad*.) How does Latin
-state "it rains," and what does it become in Spanish? (**pluit** → *llueve*,
-via the same *pl- → ll-* shift as *llamar*.) Does Latin's weather grammar look
-more like Spanish's *hacer* pattern or English's dedicated verbs? (**English's**
-— Latin uses dedicated impersonal verbs like *pluit*, *ningit*, *tonat*.)
+narrowing and survives separately as Spanish *tempestad*.)

--- a/code/learning/human-languages/latin/lessons/LA-C15-weather-verbs.md
+++ b/code/learning/human-languages/latin/lessons/LA-C15-weather-verbs.md
@@ -1,0 +1,56 @@
+---
+id: LA-C15-weather-verbs
+chapter: 15
+type: grammar
+headword: pluit, calor, sol
+gloss: it rains, heat, and sun — Latin uses a subjectless weather verb, while Spanish keeps that pattern for rain but uses hacer with heat and sun
+prerequisites: [LA-C15-tempestas-pluit]
+sounds: [impersonal-verb-3rd-singular]
+roots: [calor-latin, sol-latin, pluere-latin]
+etymology_hook: "pluit ('it rains') becomes Spanish llueve through the familiar pl- to ll- shift, while calor and sol pass into Spanish unchanged"
+est_minutes: 4
+reviews_of: [LA-C15-tempestas-pluit]
+---
+
+# pluit, calor, sol — three pieces of weather language
+
+## Warm-up
+
+[PAUSE 2s] You know the history of **tempestās**. Now learn how Latin
+actually states rain, heat, and sun.
+
+## pluit — a subjectless weather verb
+
+Latin uses dedicated impersonal verbs with no subject at all:
+
+- **pluit** — it rains
+- **ningit** — it snows
+- **tonat** — it thunders
+
+**Pluit** is the ancestor of Spanish **llueve**. Its opening follows the
+same **pl- → ll-** path as *plovere → llover*, *clāmāre → llamar*, and
+*flamma → llama*.
+
+This verb pattern resembles English "it rains" more closely than Spanish
+**hace calor**. Spanish kept the dedicated verb for rain but built a new
+**hacer** expression for heat, cold, and sun.
+
+## calor and sol — carried straight through
+
+Latin **calor** ("heat") and **sol** ("sun") are also Spanish **calor** and
+**sol**. These words needed no visible sound change at all.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pluit" — it rains; ancestor of Spanish llueve]
+- [YOU SAY: "calor" — heat, unchanged in Spanish]
+- [YOU SAY: "sol" — sun, unchanged in Spanish]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Latin say "it rains"? (**Pluit**, with no subject.)
+What sound path connects it to Spanish **llueve**? (**pl- → ll-**.) Which
+two weather nouns pass into Spanish unchanged? (**Calor** and **sol**.)
+Does Latin use a counterpart of Spanish **hacer** for all three ideas?
+(**No** — it uses dedicated impersonal weather verbs.)

--- a/code/learning/human-languages/latin/lessons/LA-C16-undecim-viginti.md
+++ b/code/learning/human-languages/latin/lessons/LA-C16-undecim-viginti.md
@@ -5,12 +5,12 @@ type: word
 headword: ūndecim — vīgintī
 gloss: 11-20, the source numbers themselves — including Latin's own genuine oddity, SUBTRACTIVE 18 and 19, which Spanish quietly regularized away
 concept_tag: LA-NUM-11-20
-prerequisites: [LA-C15-tempestas-pluit]
+prerequisites: [LA-C15-weather-verbs]
 sounds: [macron-long-vowel, prefix-un-duo]
 roots: [latin-decim-ten, latin-viginti-twenty]
 etymology_hook: "ūndecim through quīndecim (11-15) are simple 'X-ten' compounds, the direct source of Spanish's fused once-quince; but 18 and 19 are the genuinely odd ones — duodēvīgintī ('two FROM twenty') and ūndēvīgintī ('one FROM twenty'), SUBTRACTIVE counting that Spanish did NOT inherit, replacing it with plain addition instead"
-est_minutes: 6
-reviews_of: [LA-C15-tempestas-pluit]
+est_minutes: 4
+reviews_of: [LA-C15-weather-verbs, LA-C15-tempestas-pluit]
 ---
 
 # ūndecim, vīgintī — the source numbers, including a genuine oddity

--- a/code/learning/human-languages/latin/lessons/LA-C17-canis-feles-cattus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C17-canis-feles-cattus.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C16-undecim-viginti]
 sounds: [macron-long-vowel, consonant-cluster-tt]
 roots: [latin-canis-dog, latin-feles-cat, latin-cattus-afroasiatic]
 etymology_hook: "canis ('dog') is the source of English canine, French chien, Italian cane — and the word Spanish's perro mysteriously displaced, surviving there only as archaic can; fēlēs was Classical Latin's OWN word for 'cat' (source of the scientific Felis), later pushed out within Latin itself by the newcomer cattus, probably an Afro-Asiatic loanword that traveled with the cat itself out of Egypt"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C16-undecim-viginti]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C18-viridis-flavus.md
+++ b/code/learning/human-languages/latin/lessons/LA-C18-viridis-flavus.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C17-canis-feles-cattus]
 sounds: [macron-long-vowel, consonant-v]
 roots: [latin-virere-flourish, pie-bhleh3w-shine]
 etymology_hook: "viridis ('green'), from virēre, 'to flourish,' is the direct source of Spanish's verde; flāvus ('yellow, golden, blond'), from PIE *bhleh₃w-, is Latin's OWN real word for yellow — but Spanish/Portuguese reinvented amarillo/amarelo from 'bitter,' while French's jaune, Italian's giallo, and Romanian's galben ALL independently converge on a different shared Latin word instead, galbinus, 'light GREEN,' not yellow at all; flavus survives mainly in Roman names like Flavius"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C17-canis-feles-cattus]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C19-quid-agis.md
+++ b/code/learning/human-languages/latin/lessons/LA-C19-quid-agis.md
@@ -3,13 +3,13 @@ id: LA-C19-quid-agis
 chapter: 19
 type: phrase
 headword: quid agis? / ut valēs?
-gloss: how are you? — both genuinely attested in Plautus and Terence's comedies; the reply, valeō ("I fare well"), is the very same verb already hiding inside valē, the "goodbye" you learned in Chapter 1
+gloss: how are you? — two colloquial questions genuinely attested in Plautus and Terence, unlike a popular modern spoken-Latin alternative
 concept_tag: STATE-HOW-ARE-YOU
 prerequisites: [LA-C01-vale, LA-C01-ita-non]
 sounds: [macron-long-vowel, qu-kw-sound]
-roots: [valere-latin, agere-latin]
-etymology_hook: "quid agis?, literally 'what are you doing?', and ut valēs?, literally 'how do you fare?', are both genuinely attested in Plautus and Terence's comedies — colloquial, everyday Latin, not literary invention; the reply valeō ('I fare well'), sometimes intensified as Plautus's valeō rēctē or valeō et salvōs sum rēctē, is the exact same verb, valēre, already hiding inside valē, the farewell from Chapter 1 (itself literally an imperative, 'be well!')"
-est_minutes: 6
+roots: [agere-latin, valere-latin]
+etymology_hook: "quid agis?, literally 'what are you doing?', and ut valēs?, literally 'how do you fare?', are both attested in Plautus and Terence; quōmodo tē habēs? is grammatical modern spoken Latin but is not found in surviving classical texts"
+est_minutes: 4
 reviews_of: [LA-C01-vale]
 ---
 
@@ -17,9 +17,8 @@ reviews_of: [LA-C01-vale]
 
 ## Warm-up
 
-[PAUSE 2s] You already know **valē** — "goodbye," Chapter 1. What you didn't
-know yet: that same verb comes back here, as the honest Roman answer to
-"how are you?"
+[PAUSE 2s] Modern languages often teach one fixed "how are you?" formula.
+Roman comedy gives you two ordinary questions instead.
 
 ## Two real, attested questions — not modern invention
 
@@ -39,29 +38,17 @@ grammatically perfectly sound — but it is **not** actually found in any
 surviving classical text. Be careful with this one: it's a reasonable
 modern construction, not a Roman one.
 
-## valeō — the honest answer, and the same word as "goodbye"
-
-The genuinely attested reply draws on the very same verb as the question:
-**valeō**, "**I fare well, I am strong**" — Plautus's characters intensify it
-several different ways (*valeō rēctē*, "I'm well, rightly so"; *valeō et
-salvōs sum rēctē*, "I'm well and safe and rightly so"). This is the **exact
-same verb**, *valēre*, that gives you *valē* — so "goodbye" was, this whole
-time, literally an imperative: "**be well!**" Asking *ut valēs?* and
-answering *valeō* is just that same verb moving between question,
-statement, and farewell.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "quid agis?" — literally "what are you doing?"]
 - [YOU SAY: "ut valēs?" — literally "how do you fare?"]
-- [YOU SAY: "valeō" — "I fare well" — the reply, and the same verb as valē]
+- [YOU SAY: "quōmodo tē habēs?" — grammatical today, but not classically attested]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What does **quid agis?** literally mean? ("**What are you
 doing?**") What verb connects **ut valēs?**, **valeō**, and the *valē* you
-already knew from Chapter 1? (***Valēre***, "to be strong/well" — *valē* is
-literally an imperative, "be well!") Is **quōmodo tē habēs?** genuinely
+already knew from Chapter 1? (***Valēre***, "to be strong/well.") Is **quōmodo tē habēs?** genuinely
 attested in classical Latin? (**No** — grammatically sound, but a modern
 pedagogical construction, not found in surviving Roman texts.)

--- a/code/learning/human-languages/latin/lessons/LA-C19-valeo-family.md
+++ b/code/learning/human-languages/latin/lessons/LA-C19-valeo-family.md
@@ -1,0 +1,51 @@
+---
+id: LA-C19-valeo-family
+chapter: 19
+type: etymology
+headword: valeō, valē
+gloss: I fare well and be well — one verb supplies the wellbeing answer and the Chapter 1 farewell
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [LA-C19-quid-agis]
+sounds: [macron-long-vowel]
+roots: [valere-latin]
+etymology_hook: "valeō ('I fare well') and valē ('be well!') are forms of valēre, 'to be strong or well'; Plautus also attests intensified replies such as valeō rēctē"
+est_minutes: 4
+reviews_of: [LA-C19-quid-agis, LA-C01-vale]
+---
+
+# valeō and valē — answer and farewell from one verb
+
+## Warm-up
+
+[PAUSE 2s] You can ask **ut valēs?**, "how do you fare?" Its most direct
+answer is already hiding inside the first farewell you learned.
+
+## valeō — I fare well
+
+The attested reply is **valeō**: "I fare well" or "I am strong." Plautus's
+characters can intensify it as **valeō rēctē** ("I am properly well") or
+**valeō et salvōs sum rēctē** ("I am well and safe").
+
+The dictionary verb is **valēre**, "to be strong, be well." Watch one stem
+move through the exchange:
+
+- **ut valēs?** — how do you fare?
+- **valeō** — I fare well
+- **valē!** — be well!
+
+That last imperative became the Chapter 1 goodbye. Latin's farewell is
+therefore a wish for the other person to remain well.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ut valēs?" — how do you fare?]
+- [YOU SAY: "valeō" — I fare well]
+- [YOU SAY: "valē" — be well; goodbye]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What verb unites **ut valēs?**, **valeō**, and **valē**?
+(**Valēre**, "to be strong or well.") Which form answers the question?
+(**Valeō.**) What does the farewell **valē** literally command?
+(**Be well.**)

--- a/code/learning/human-languages/latin/lessons/LA-C20-name-case-variation.md
+++ b/code/learning/human-languages/latin/lessons/LA-C20-name-case-variation.md
@@ -1,0 +1,61 @@
+---
+id: LA-C20-name-case-variation
+chapter: 20
+type: grammar
+headword: puerō nōmen est Mārcus / Mārcō
+gloss: the possessor stays dative, while classical authors vary between nominative and matching dative for the name itself
+concept_tag: INTRO-WHATS-YOUR-NAME
+prerequisites: [LA-C20-quid-tibi-nomen]
+sounds: [macron-long-vowel]
+roots: [nomen-latin, dative-possession]
+etymology_hook: "the dative possessor is stable from Plautus through Livy and Sallust, but Cicero tends to keep the personal name nominative while Livy and Sallust more often attract it into the dative"
+est_minutes: 4
+reviews_of: [LA-C20-quid-tibi-nomen]
+---
+
+# Mārcus or Mārcō? — a real classical variation
+
+## Warm-up
+
+[PAUSE 2s] The possessor in Latin's naming construction is reliably
+dative. The personal name beside **nōmen**, however, is not locked to one
+case in every author.
+
+## The stable frame
+
+The dative possessor appears across authors from Plautus through Livy and
+Sallust:
+
+> **puerō nōmen est ...** — to the boy the name is ...
+
+That **puerō** does not change. It marks the person who possesses the name.
+
+## Two habits for the personal name
+
+**Cicero** tends to keep the personal name nominative, agreeing with
+**nōmen**, the sentence's subject:
+
+> **puerō nōmen est Mārcus**
+
+**Livy** and **Sallust** more often pull the personal name into the dative
+to match the possessor:
+
+> **puerō nōmen est Mārcō**
+
+The underlying dative-of-possession construction is the same. The choice
+between **Mārcus** and **Mārcō** is authorial variation, not evidence that
+one sentence has stopped using the dative of possession.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "puerō" — to the boy; always the dative possessor]
+- [YOU SAY: "Mārcus" — Cicero's usual nominative pattern]
+- [YOU SAY: "Mārcō" — the matching dative found more often in Livy/Sallust]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which case remains constant for the possessor? (**Dative.**)
+Which author tends toward nominative **Mārcus**? (**Cicero.**) Which
+authors more often use matching dative **Mārcō**? (**Livy and Sallust.**)
+Do the two forms represent different possession constructions? (**No.**)

--- a/code/learning/human-languages/latin/lessons/LA-C20-quid-tibi-nomen.md
+++ b/code/learning/human-languages/latin/lessons/LA-C20-quid-tibi-nomen.md
@@ -3,14 +3,14 @@ id: LA-C20-quid-tibi-nomen
 chapter: 20
 type: phrase
 headword: quid tibi nōmen est? / mihi nōmen est...
-gloss: what's your name? / my name is... — a genuinely classical construction (the "dative of possession"), attested across authors from Plautus to Livy, though Cicero notably preferred keeping the name itself in the nominative rather than pulling it into the dative to match
+gloss: what's your name? / my name is... — the genuinely classical dative of possession, literally what is the name to you?
 concept_tag: INTRO-WHATS-YOUR-NAME
-prerequisites: [LA-C01-salve, LA-C19-quid-agis]
+prerequisites: [LA-C01-salve, LA-C19-valeo-family]
 sounds: [macron-long-vowel, qu-kw-sound]
 roots: [nomen-latin, dative-possession]
-etymology_hook: "quid tibi nōmen est?, literally 'what is the name TO YOU?', and its reply mihi nōmen est [X], 'the name TO ME is [X]', use Latin's 'dative of possession' — the name belongs to a person by being dative TO them, not by a possessive verb like English 'have' or German's heißen; the dative possessor itself (tibi/mihi/puerō) is attested from Plautus down through Livy and Sallust, but authors differ on the NAME's own case — Cicero preferred keeping it nominative (puerō nōmen est Mārcus, 'to-the-boy the name is Marcus'), while Livy/Sallust more often pulled it into the dative to match (puerō nōmen est Mārcō)"
-est_minutes: 6
-reviews_of: [LA-C19-quid-agis]
+etymology_hook: "quid tibi nōmen est?, literally 'what is the name to you?', and mihi nōmen est [X], 'the name to me is [X]', use the classical dative of possession instead of a verb like English have"
+est_minutes: 4
+reviews_of: [LA-C19-valeo-family, LA-C19-quid-agis]
 ---
 
 # quid tibi nōmen est?, mihi nōmen est... — "what's your name?", the dative way
@@ -36,19 +36,6 @@ possession"**: instead of a possessive verb, the possessor simply sits in
 the dative case, and the thing possessed — here, **nōmen**, "name" — stays
 in the nominative, as the sentence's real subject.
 
-## A real classical construction, with real stylistic variation
-
-This isn't a modern teaching simplification — it's a genuinely attested
-pattern, found from **Plautus**'s comedies through **Livy** and **Sallust**
-— the dative possessor itself (*puerō*, "to the boy") is the constant part.
-But be honest about a real point of variation **within** the construction:
-authors differ on what case the **name itself** takes. **Cicero** preferred
-keeping the name in the **nominative** — *puerō nōmen est Mārcus*,
-"to-the-boy the name is Marcus" — while **Livy** and **Sallust** more often
-pulled the name into the **dative** too, to match the possessor: *puerō
-nōmen est Mārcō*. Same underlying construction, genuinely different habits
-about the name's own case — not one single rigid rule.
-
 ## Guided Practice
 
 [PAUSE 1s]
@@ -61,8 +48,5 @@ about the name's own case — not one single rigid rule.
 [PAUSE 3s] What case does the possessor sit in, in **mihi nōmen est**?
 (**Dative** — *mihi*, "to me.") Does Latin use a verb like "have" or "be
 called" for this? (**No** — the name simply exists; possession is shown by
-the dative case alone.) What genuinely varied between authors — the
-possessor's case, or the name's own case? (**The name's own case**: Cicero
-kept it nominative, *puerō nōmen est Mārcus*; Livy/Sallust more often
-pulled it into the dative too, *puerō nōmen est Mārcō* — the dative
-possessor itself was constant throughout.)
+the dative case alone.) What noun remains the sentence's grammatical
+subject? (**Nōmen**, "name.")

--- a/code/learning/human-languages/latin/lessons/LA-C21-meeting-phrase-context.md
+++ b/code/learning/human-languages/latin/lessons/LA-C21-meeting-phrase-context.md
@@ -1,0 +1,54 @@
+---
+id: LA-C21-meeting-phrase-context
+chapter: 21
+type: culture
+headword: tē volup est convēnisse
+gloss: the attested phrase greets a chance encounter between people who already know each other, so it is useful but not an exact first-introduction formula
+concept_tag: INTRO-NICE-TO-MEET-YOU
+prerequisites: [LA-C21-volup-est-convenisse]
+sounds: [macron-long-vowel]
+roots: [volup-latin, convenire-latin]
+etymology_hook: "Plautus attests the phrase in a chance encounter between fellow slaves who already know each other; mihi pergrātum est tē convenīre is grammatical modern spoken Latin but is not attested in surviving classical texts"
+est_minutes: 4
+reviews_of: [LA-C21-volup-est-convenisse]
+---
+
+# Useful phrase, honest context
+
+## Warm-up
+
+[PAUSE 2s] **Volup est convēnisse** is genuinely Roman. Now place it in
+its scene so you know exactly what that evidence does—and does not—prove.
+
+## A chance meeting, not a first introduction
+
+In *Miles Gloriosus*, Sceledrus and Palaestrio are fellow slaves who already
+know one another. The line welcomes a **chance encounter**. It does not
+document a fixed formula that Romans always used when introduced to a
+stranger for the first time.
+
+The phrase still expresses the right sentiment: "to have met you is a
+pleasure." Use it as an attested way to do that conversational work, while
+remembering that Classical Latin has no single fixed counterpart to Spanish
+*encantado* or German *freut mich*.
+
+## A grammatical modern alternative
+
+Modern spoken-Latin guides may teach **mihi pergrātum est tē convenīre**:
+"it is very pleasing to me to meet you." Its grammar is sound, but the
+formula does not occur in surviving classical texts. It is useful modern
+Latin, not direct evidence of Roman conversational convention.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "volup est convēnisse" — classically attested]
+- [YOU SAY: its scene — a chance encounter between people already acquainted]
+- [YOU SAY: "mihi pergrātum est tē convenīre" — grammatical, but modern]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is the Plautine line a first-time introduction? (**No — it is a
+chance encounter between acquaintances.**) Is it still genuinely attested?
+(**Yes.**) Is **mihi pergrātum est tē convenīre** bad grammar? (**No.**)
+Is it classically attested? (**No — it is a modern spoken-Latin formula.**)

--- a/code/learning/human-languages/latin/lessons/LA-C21-volup-est-convenisse.md
+++ b/code/learning/human-languages/latin/lessons/LA-C21-volup-est-convenisse.md
@@ -3,14 +3,14 @@ id: LA-C21-volup-est-convenisse
 chapter: 21
 type: phrase
 headword: volup est convēnisse
-gloss: "nice to meet you" — Latin genuinely has NO fixed idiom for this the way modern languages do, but Plautus gives us a real, attested phrase that does the job, "it's a pleasure to have met you"
+gloss: "it is a pleasure to have met you" — an attested Plautine phrase that can fill a conversational slot for which Classical Latin has no single fixed idiom
 concept_tag: INTRO-NICE-TO-MEET-YOU
-prerequisites: [LA-C20-quid-tibi-nomen]
+prerequisites: [LA-C20-name-case-variation]
 sounds: [macron-long-vowel, perfect-infinitive]
 roots: [volup-latin, convenire-latin]
-etymology_hook: "Latin has no single fixed 'nice to meet you' idiom the way Spanish/French/German do; but Plautus's Miles Gloriosus gives a genuinely attested real-world phrase for the same job — 'Tē ... volup est convēnisse', literally '[to have met] you is a pleasure', built on volup ('pleasant, pleasing') + the perfect infinitive convēnisse ('to have come together, met')"
-est_minutes: 6
-reviews_of: [LA-C20-quid-tibi-nomen]
+etymology_hook: "Plautus's Miles Gloriosus supplies Tē ... volup est convēnisse, literally 'to have met you is a pleasure': volup ('pleasant') + est ('is') + the perfect infinitive convēnisse ('to have met')"
+est_minutes: 4
+reviews_of: [LA-C20-name-case-variation, LA-C20-quid-tibi-nomen]
 ---
 
 # volup est convēnisse — the phrase Latin uses instead of a fixed idiom
@@ -20,14 +20,6 @@ reviews_of: [LA-C20-quid-tibi-nomen]
 [PAUSE 2s] Every modern language in this course has one fixed phrase for
 "nice to meet you." Latin, honestly, does **not** — but it has something
 better: a real line from a Roman comedy that does the job.
-
-## No fixed idiom — an honest gap, not an oversight
-
-Unlike Spanish's *encantado* or German's *freut mich*, Classical Latin has
-**no single, fixed idiom** that means exactly "nice to meet you." This
-isn't a curriculum gap to patch over — it's a real, honest feature of the
-language: Romans simply expressed the sentiment differently depending on
-context, rather than reaching for one fixed formula.
 
 ## volup est convēnisse — a genuinely attested phrase for the job
 
@@ -43,21 +35,7 @@ literally "**you, [name], [it] is-a-pleasure to-have-met**," or naturally,
   together, to meet" — "**to have met**"
 
 Put together: "**to have met [you] is a pleasure.**" This is a genuine,
-attested line — not a modern reconstruction. One honest caveat: in the
-play, Sceledrus and Palaestrio are fellow slaves who already know each
-other; the line greets a **chance encounter**, not a first-time
-introduction to a stranger. It's repurposed here for the same
-conversational slot "nice to meet you" fills, not a perfect match in
-context.
-
-## Be careful: one popular alternative is NOT classical
-
-You may see **"mihi pergrātum est tē convenīre"** ("it is very pleasing to
-me to meet you") in modern spoken-Latin guides. It's grammatically fine —
-but it does **not** appear in any surviving classical text. Like *quōmodo
-tē habēs?* from the last lesson, this is a reasonable modern construction,
-not a genuinely Roman one. Stick with *volup est convēnisse* if you want
-the real thing.
+attested line — not a modern reconstruction.
 
 ## Guided Practice
 
@@ -65,15 +43,13 @@ the real thing.
 - [YOU SAY: "volup est convēnisse" — "it's a pleasure to have met you"]
 - [YOU SAY: the pieces — volup (pleasant) + est (is) + convēnisse
   (to have met)]
-- [YOU SAY: the honest fact — Latin has no fixed idiom here, unlike every
-  modern language in this course]
+- [YOU SAY: the grammar — convēnisse is a perfect infinitive]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Does Classical Latin have one single fixed idiom for "nice to
-meet you"? (**No** — a genuine, honest gap, unlike Spanish/French/German.)
-What real, attested phrase does the same job, and where does it come from?
+meet you"? (**No** — Romans expressed the sentiment according to context.)
+What real, attested phrase can do the job, and where does it come from?
 (**"Volup est convēnisse"**, literally "to have met [you] is a pleasure" —
-**Plautus**, *Miles Gloriosus*.) Is "mihi pergrātum est tē convenīre"
-genuinely classical? (**No** — grammatically sound, but a modern
-spoken-Latin construction with no attestation in surviving texts.)
+**Plautus**, *Miles Gloriosus*.) What kind of infinitive is **convēnisse**?
+(**Perfect** — "to have met.")

--- a/code/learning/human-languages/latin/lessons/LA-C22-tu-vos.md
+++ b/code/learning/human-languages/latin/lessons/LA-C22-tu-vos.md
@@ -5,12 +5,12 @@ type: word
 headword: tū / vōs
 gloss: you (singular) / you (plural) — a PURELY grammatical number distinction in Classical Latin, with no politeness dimension at all; the polite-vous pattern (a Late Latin innovation) is vōs's own direct descendant, unlike German's Sie, which solved the same politeness problem independently via a completely different pronoun (3rd-person plural, not 2nd)
 concept_tag: PRONOUN-YOU
-prerequisites: [LA-C20-quid-tibi-nomen]
+prerequisites: [LA-C20-name-case-variation]
 sounds: [long-vowel-u, macron-long-vowel]
 roots: [tu-pie, vos-pie]
 etymology_hook: "tū ('you,' singular) and vōs ('you,' plural) are a PURELY grammatical number distinction in Classical Latin — genuinely NO politeness dimension existed yet; the later habit of using plural vōs to address one person politely only developed in LATE Latin, after the classical period, and is the direct ancestor of French's polite vous — a genuinely separate solution from German's Sie, which independently repurposes an entirely different pronoun (3rd-person plural 'they'), not a descendant of vōs at all"
-est_minutes: 5
-reviews_of: [LA-C20-quid-tibi-nomen]
+est_minutes: 4
+reviews_of: [LA-C20-name-case-variation, LA-C20-quid-tibi-nomen]
 ---
 
 # tū, vōs — "you," before politeness got involved

--- a/code/learning/human-languages/latin/lessons/LA-C23-nihil-est.md
+++ b/code/learning/human-languages/latin/lessons/LA-C23-nihil-est.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C01-gratias]
 sounds: [h-aspirated, nihil-two-syllables]
 roots: [nihil-latin, est-latin]
 etymology_hook: "Classical Latin has no single fixed reply to grātiās agō the way modern languages do; nihil est ('it's nothing,' from nihil, 'nothing,' ← ne + hīlum, 'not [even] a tiny bit') is the phrase modern conversational-Latin communities reach for — the words themselves are genuinely classical, but no surviving text shows this exact phrase used specifically as a reply to thanks, so treat it as a well-grounded modern convention, not an ancient one"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C01-gratias]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C24-propediem-te-videbo.md
+++ b/code/learning/human-languages/latin/lessons/LA-C24-propediem-te-videbo.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C05-dies-lunae-veneris, LA-C01-vale, LA-C01-gratias]
 sounds: [macron-long-vowel, future-tense-bo]
 roots: [prope-latin, dies-latin, videre-latin]
 etymology_hook: "propediem tē vidēbō, 'I shall see you soon,' is genuinely attested TWICE in Cicero's own letters (Ad Familiārēs 2.12, to Caelius: 'Sed, ut spērō, propediem tē vidēbō'; and Ad Familiārēs 15.6, to Cato, in reversed order: 'Ego, ut spērō, tē propediem vidēbō'); propediem itself breaks down as prope ('near') + diem (accusative of diēs, 'day' — the same diēs from your days-of-week lessons), literally 'near the day' = 'very soon'"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C01-vale]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C25-cras-te-videbo.md
+++ b/code/learning/human-languages/latin/lessons/LA-C25-cras-te-videbo.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C24-propediem-te-videbo]
 sounds: [macron-long-vowel, future-tense-bo]
 roots: [cras-latin, videre-latin]
 etymology_hook: "crās tē vidēbō, 'I'll see you tomorrow,' combines crās ('tomorrow,' Proto-Italic *krās, deeper origin genuinely uncertain/debated) with vidēbō (future of vidēre, already met in propediem tē vidēbō) — same grammatical pattern as that attested phrase, though THIS exact combination isn't itself quoted in a surviving letter; honest cross-language twist: crās was abandoned by most major Romance languages (French demain, Italian domani, Catalan demà all rebuilt 'tomorrow' from dē māne, 'in the morning' instead) — Sardinian and Sicilian are the main holdouts that kept crās itself"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C24-propediem-te-videbo]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C26-quomodo.md
+++ b/code/learning/human-languages/latin/lessons/LA-C26-quomodo.md
@@ -5,12 +5,12 @@ type: word
 headword: quōmodo
 gloss: "how, in what way" — the genuine classical word behind Italian come, Spanish cómo, and French comment, which went one step further and double-marked "manner"
 concept_tag: QUESTION-HOW
-prerequisites: [LA-C19-quid-agis]
+prerequisites: [LA-C19-valeo-family]
 sounds: [macron-long-vowel, qu-kw-sound]
 roots: [quo-latin, modus-latin, mens-latin]
 etymology_hook: "quōmodo, 'how, in what way,' is a genuine classical word — a univerbation of quō (ablative of quis/quid, 'what') + modō (ablative of modus, 'manner, measure'), literally 'by what manner,' attested in Cicero and Seneca; it's the direct source of Italian come and Spanish cómo, but French's comment went one step further, with comme (← quōmodo) picking up its own French -ment suffix (← mēns, 'mind,' the same suffix in rapidement) — one well-attested account has it double-marking 'manner' rather than carrying it once, though the exact historical mechanism has more than one proposal"
-est_minutes: 6
-reviews_of: [LA-C19-quid-agis]
+est_minutes: 4
+reviews_of: [LA-C19-valeo-family, LA-C19-quid-agis]
 ---
 
 # quōmodo — the real word behind "how," in three Romance languages at once

--- a/code/learning/human-languages/latin/lessons/LA-C27-bene.md
+++ b/code/learning/human-languages/latin/lessons/LA-C27-bene.md
@@ -5,12 +5,12 @@ type: word
 headword: bene
 gloss: "well" — a morphologically simple inheritance: French bien and Spanish bien are just bene plus one regular sound change (the same short-e-diphthongizes-to-ie shift as mel→miel), with no extra grafted-on suffix, unlike quōmodo's more roundabout Romance history
 concept_tag: WORD-WELL
-prerequisites: [LA-C19-quid-agis]
+prerequisites: [LA-C19-valeo-family]
 sounds: [macron-none-short-e]
 roots: [bene-latin, bonus-latin]
 etymology_hook: "bene ('well') is a genuinely classical adverb, related to bonus ('good') — both from the same Old Latin ancestor duenos/duonus (found in the famous Duenos inscription, one of the oldest surviving Latin texts), ultimately from a Proto-Indo-European root with several competing proposals; French bien and Spanish bien both continue bene through one single, regular sound change (short stressed e diphthongizing to 'ie,' the same shift behind mel→miel, terra→tierra) and nothing more — no extra suffix grafted on, unlike quōmodo's more roundabout Romance history; bene is genuinely attested used alone, repeated, as a toast in Plautus's Stichus 709: 'bene vōs, bene nōs, bene tē, bene mē, bene nostram etiam Stephanium'"
-est_minutes: 5
-reviews_of: [LA-C19-quid-agis]
+est_minutes: 4
+reviews_of: [LA-C19-valeo-family, LA-C19-quid-agis]
 ---
 
 # bene — a morphologically simple inheritance

--- a/code/learning/human-languages/latin/lessons/LA-C28-dies.md
+++ b/code/learning/human-languages/latin/lessons/LA-C28-dies.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C05-dies-lunae-veneris, LA-C12-medius-dies-nox]
 sounds: [macron-long-vowel, diphthong-ie]
 roots: [dies-latin]
 etymology_hook: "diēs ('day') is the same word already hiding inside diēs Lūnae ('Monday') and medius diēs ('noon') — its derivative diurnum ('daytime, daily') gives English diurnal and, via French jour/journée/jornel, journal and journey; a SIBLING derivative, diārium ('daily allowance'), gives English diary directly, a separate path from diurnum; a genuine PIE root (*dyēws-, 'to shine, sky') also connects diēs to deus ('god') and Jupiter"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C05-dies-lunae-veneris, LA-C12-medius-dies-nox]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C29-nox.md
+++ b/code/learning/human-languages/latin/lessons/LA-C29-nox.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C12-medius-dies-nox, LA-C28-dies]
 sounds: [macron-none-short-vowel, x-ks-sound]
 roots: [nox-latin]
 etymology_hook: "nox ('night'), genitive noctis, is cognate with English 'night' itself, German Nacht, Greek nyx, Sanskrit nakta — all from Proto-Indo-European *nókʷts, one of the most solid, uncontroversial PIE reconstructions there is; its own derivative nocturnus ('of the night') was coined directly on the analogy of diēs's own diurnum, reusing its exact -urnus suffix, and gives English nocturnal/nocturne; aequus ('equal') + nox/noct- gives equinox, 'equal night'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C12-medius-dies-nox, LA-C28-dies]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C30-bonam-noctem.md
+++ b/code/learning/human-languages/latin/lessons/LA-C30-bonam-noctem.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C29-nox]
 sounds: [macron-none-short-vowel, accusative-am-em]
 roots: [bonus-latin, nox-latin]
 etymology_hook: "bonam noctem, 'good night,' uses a genuinely classical Latin grammatical principle — Latin wishes and exclamations conventionally take the ACCUSATIVE case, not the nominative (the same 'Accusative of Exclamation' construction behind Fēlīcem nātālem, 'happy birthday'); be honest, though: while the accusative-of-wishing rule is solid, this SPECIFIC fixed phrase, bonam noctem, is NOT itself attested as a Roman farewell formula in any surviving classical text — a later, post-classical convention"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [LA-C29-nox]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C31-mane.md
+++ b/code/learning/human-languages/latin/lessons/LA-C31-mane.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C25-cras-te-videbo]
 sounds: [macron-long-vowel]
 roots: [manus-good-latin-archaic]
 etymology_hook: "māne ('morning, early,' an indeclinable neuter noun/adverb — it never changes form) is the same word already hiding inside dē māne ('in the morning,' Chapter 25), the phrase French demain/Italian domani/Catalan demà independently rebuilt 'tomorrow' from — while Spanish mañana, per that same lesson, was built directly on māne alone, without the dē- (Vulgar Latin *maneāna); it derives from mānus, an archaic Latin adjective meaning 'good' — a COMPLETELY DIFFERENT word from the common manus ('hand'), despite the near-identical spelling (mānus has a long ā, manus a short a) — sharing that mānus root with mātūrus ('ripe, timely, early'), itself the source of English mature, and with mātūtīnus ('of the morning,' tied to Matūta, the Roman dawn goddess), the source, via Old French matines/matin, of English matins AND matinee — the same root splitting into 'morning prayers' and 'afternoon show' in English, a genuine semantic drift"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C25-cras-te-videbo]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C32-bonum-mane.md
+++ b/code/learning/human-languages/latin/lessons/LA-C32-bonum-mane.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C31-mane, LA-C01-salve]
 sounds: [macron-long-vowel]
 roots: [bonus-latin, mane-latin, salus-latin]
 etymology_hook: "bonum māne, 'good morning,' is a modern, pedagogical phrase — like bonam noctem, not classically attested as a fixed Roman farewell/greeting formula; but unlike bonam noctem, its grammar is genuinely INVISIBLE rather than just uncertain: māne is neuter, and Latin neuter nouns never distinguish nominative from accusative (bonum works either way), so the Accusative-of-Exclamation rule that bonam noctem demonstrated so clearly simply can't be shown here; what Romans DID have, richly documented, was the salūtātiō (mātūtīna salūtātiō) — clients visiting their patron's house at dawn to pay respects — from salūtāre ('to greet'), itself derived from salūs ('health, safety, wholeness'), a genuine DOUBLET of salvus (the root of salvē, Chapter 1's first word) — both descend from the same PIE root, *solh₂- ('whole'); a morning greeting Romans actually had, just as an ACTION, not a phrase"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C31-mane, LA-C01-salve]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C33-vesper-afterlives.md
+++ b/code/learning/human-languages/latin/lessons/LA-C33-vesper-afterlives.md
@@ -1,0 +1,58 @@
+---
+id: LA-C33-vesper-afterlives
+chapter: 33
+type: etymology
+headword: Hesperia, víspera, vespers
+gloss: the evening root survives in Greek and English loans and narrows in Spanish, while French and Italian replace it with the root for late
+concept_tag: TIME-EVENING
+prerequisites: [LA-C33-vesper]
+sounds: [macron-none-short-vowel]
+roots: [vesper-latin, serus]
+etymology_hook: "Greek hesperos supplies Hesperus and Hesperia; English borrows vespers and vespertine; Spanish víspera narrows to the eve before an event, while French soir and Italian sera descend from sērus ('late') instead"
+est_minutes: 4
+reviews_of: [LA-C33-vesper]
+---
+
+# Hesperia, víspera, vespers — the root after Latin
+
+## Warm-up
+
+[PAUSE 2s] Latin **vesper** and English **west** share the sunset idea.
+Now follow the evening root through Greek, English, Spanish, French, and
+Italian.
+
+## Greek hesperos
+
+The Greek cognate **hesperos** gives English **Hesperus**, the evening star
+(Venus at dusk), and **Hesperia**, "land of the west." The name is relative:
+Greeks used it for Italy, west of Greece; Romans could use it for Spain,
+west of Italy.
+
+## What the daughter languages kept—or replaced
+
+English borrowed **vespers**, the evening prayer service, and
+**vespertine**, "of the evening," directly from Latin.
+
+Spanish inherited *vespera* as **víspera**, but narrowed its meaning to
+"the eve" or "the day before" an event. French **soir** and Italian
+**sera** do not descend from **vesper** at all. They rebuilt "evening" from
+Latin **sērus**, "late," through the idea of the "late day."
+
+One ordinary Latin word therefore leaves three different outcomes: a
+learned English loan, a narrowed Spanish descendant, and replacement by a
+different root in French and Italian.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Hesperia" — land of the west]
+- [YOU SAY: "víspera" — the eve or day before, narrowed from evening]
+- [YOU SAY: "soir, sera" — from sērus, "late," not from vesper]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is Hesperus? (**The evening star.**) What does Spanish
+**víspera** mean now? (**The eve or day before an event.**) Which Latin
+root supplies French **soir** and Italian **sera**? (**Sērus, "late."**)
+Name one direct English borrowing from **vesper**. (**Vespers** or
+**vespertine**.)

--- a/code/learning/human-languages/latin/lessons/LA-C33-vesper.md
+++ b/code/learning/human-languages/latin/lessons/LA-C33-vesper.md
@@ -3,13 +3,13 @@ id: LA-C33-vesper
 chapter: 33
 type: word
 headword: vesper
-gloss: "evening" — a genuine everyday classical Latin word, sharing a root with English west (via the direction of sunset) and Greek Hesperos, but largely abandoned by French and Italian, who built their own "evening" from a different Latin root, "late," instead
+gloss: evening — a genuine everyday classical word sharing a deep root with English west through the direction of sunset
 concept_tag: TIME-EVENING
 prerequisites: []
 sounds: [macron-none-short-vowel]
 roots: [vesper-latin]
-etymology_hook: "vesper/vespera ('evening') is a genuine, ordinary Classical Latin word (vespere, 'in the evening,' is common in Cicero's letters); it traces to PIE *wekero- ('evening, night'), possibly an enlarged form of a root *we- some reconstructions gloss as 'down' (the direction the sun sets, though this specific sub-root is more contested than the vesper/west link itself) — the SAME conceptual root, via a separate Germanic branch, behind English west itself; its Greek cognate, hesperos, gives Hesperus (the evening star, the planet Venus) and Hesperia ('land of the west' — the Greeks used it for Italy, the Romans for Spain, since 'west' is always relative to where you're standing); vesper gives English vespers and vespertine directly, but French soir and Italian sera did NOT come from vesper — both were rebuilt from a completely different Latin root, sērus ('late'), already the story behind French soir per that lesson; Spanish kept vespera as víspera, but its meaning narrowed to 'the eve, the day before,' not 'evening' itself anymore"
-est_minutes: 6
+etymology_hook: "vesper or vespera ('evening') is ordinary Classical Latin; it traces to PIE *wekero- ('evening, night') and shares a deep sunset-direction connection with English west, while the proposed lower root meaning 'down' is more contested"
+est_minutes: 4
 reviews_of: []
 ---
 
@@ -33,46 +33,17 @@ same conceptual root, through a completely separate **Germanic** branch,
 gives English its own word for "**west**" — evening and west, sharing
 one deep idea: the direction the sun goes down.
 
-## Hesperus, Hesperia — the Greek cognate's afterlife
-
-Vesper's Greek cognate, **hesperos**, survives directly in English as
-**Hesperus** (the evening star — the planet Venus at dusk) and
-**Hesperia** ("**land of the west**") — a name that's always relative:
-the **Greeks** called **Italy** *Hesperia*, since Italy lay west of
-Greece; the **Romans**, in turn, sometimes called **Spain** *Hesperia*,
-since Spain lay west of Italy. "West" depends entirely on where you're
-standing.
-
-## Be honest: vesper's own daughters mostly walked away from it
-
-Here's the twist: despite being a perfectly ordinary classical word,
-**vesper** was largely **abandoned** by the mainstream Romance
-daughters for their everyday "evening" word. French's **soir** and
-Italian's **sera** come from a **completely different** Latin root —
-**sērus** ("late"), via **sēra diēs** ("late day") — not from *vesper* at
-all. Spanish did keep *vespera*, as **víspera** — but its meaning
-**narrowed**: *víspera* means "**the eve, the day before**" an event
-today, not "evening" itself anymore. *Vesper* survives most directly, and
-unchanged in sense, in **English** — as **vespers** (the evening prayer
-service) and **vespertine** ("of the evening") — borrowed straight from
-Latin rather than inherited through a Romance daughter at all.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "vesper" — "evening," genuinely everyday Classical Latin]
 - [YOU SAY: the deep root — *wekero-*, shared with English "west," the
   direction of sunset]
-- [YOU SAY: the honest twist — French soir and Italian sera come from a
-  DIFFERENT root, "late," not from vesper at all]
+- [YOU SAY: the careful hedge — a lower root meaning "down" is more contested]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What English word shares vesper's deep PIE root, and what's
 the connecting idea? (**West** — both trace to the direction the sun
-sets.) What did the Greeks call Italy, and why? (**Hesperia**, "land of
-the west" — because Italy lies west of Greece.) Do French *soir* and
-Italian *sera* come from *vesper*? (**No** — a completely different Latin
-root, *sērus*, "late.") What does Spanish *víspera* mean today, and how
-does that differ from vesper's original sense? (**"Eve, the day
-before"** — narrowed from "evening" itself.)
+sets.) Is the proposed still-deeper root meaning "down" equally secure?
+(**No — that sub-root is more contested than the vesper/west link.**)

--- a/code/learning/human-languages/latin/lessons/LA-C34-bonum-vesperum.md
+++ b/code/learning/human-languages/latin/lessons/LA-C34-bonum-vesperum.md
@@ -5,12 +5,12 @@ type: phrase
 headword: bonum vesperum
 gloss: "good evening" — a modern, pedagogical phrase (not classically attested), but unlike bonum māne, this one CAN show the real Accusative-of-Exclamation grammar again, since vesper is masculine, not neuter
 concept_tag: GREETING-EVENING
-prerequisites: [LA-C33-vesper, LA-C30-bonam-noctem, LA-C32-bonum-mane]
+prerequisites: [LA-C33-vesper-afterlives, LA-C30-bonam-noctem, LA-C32-bonum-mane]
 sounds: [macron-none-short-vowel, accusative-am-em]
 roots: [bonus-latin, vesper-latin]
 etymology_hook: "bonum vesperum, 'good evening,' is a modern, pedagogical phrase — like bonam noctem and bonum māne, not attested as a fixed Roman greeting in any surviving classical text; but unlike bonum māne (where the grammar point was invisible, since māne is neuter), this one CAN show real grammar again: vesper is MASCULINE, and Latin masculine nouns DO distinguish nominative (vesper) from accusative (vesperum) — so bonum vesperum genuinely demonstrates the same Accusative-of-Exclamation rule as bonam noctem, just with a different gender's endings; a separate feminine noun, vespera, gives the alternate bonam vesperam, agreeing the SAME WAY bonam noctem does — the adjective bonam matches bonam exactly — but the noun endings themselves differ, since vespera is 1st declension (accusative -am) while nox is 3rd declension (accusative -em, noctem, NOT -am)"
-est_minutes: 6
-reviews_of: [LA-C33-vesper, LA-C30-bonam-noctem, LA-C32-bonum-mane]
+est_minutes: 4
+reviews_of: [LA-C33-vesper-afterlives, LA-C33-vesper, LA-C30-bonam-noctem, LA-C32-bonum-mane]
 ---
 
 # bonum vesperum — the accusative rule returns, this time visibly

--- a/code/learning/human-languages/latin/lessons/LA-C35-meridies.md
+++ b/code/learning/human-languages/latin/lessons/LA-C35-meridies.md
@@ -9,7 +9,7 @@ prerequisites: [LA-C12-medius-dies-nox, LA-C13-hora]
 sounds: [macron-long-vowel]
 roots: [medius-latin, dies-latin]
 etymology_hook: "merīdiēs ('midday, noon') is the SAME phrase as medius diēs (Chapter 12), contracted by sound dissimilation from an earlier medīdiēs into merīdiēs — a fifth-declension noun (acc. merīdiem), and the ultimate root of English meridian (via the Latin adjective merīdiānus, 'of midday'); be honest: Romans did NOT have a colloquial 'afternoon' word the way Spanish's tarde or French's après-midi do — instead, they split the whole day around merīdiēs into ante merīdiem ('before noon') and post merīdiem ('after noon'), the direct ancestors of English's own a.m./p.m., a genuinely load-bearing legal distinction under the Twelve Tables (a court case had to be argued before noon with both parties present; a magistrate could rule in absentia only after noon); Latin's tardus ('slow, late') — the very word Spanish tarde comes from, per that lesson — stayed a plain adjective in Latin itself and never meant 'afternoon' there"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [LA-C12-medius-dies-nox, LA-C13-hora]
 ---
 

--- a/code/learning/human-languages/latin/lessons/LA-C36-salve-post-meridiem.md
+++ b/code/learning/human-languages/latin/lessons/LA-C36-salve-post-meridiem.md
@@ -3,13 +3,13 @@ id: LA-C36-salve-post-meridiem
 chapter: 36
 type: phrase
 headword: salvē (post merīdiem)
-gloss: "good afternoon" — no two-word phrase for it exists the way bonum vesperum does, because Latin has no simplex noun for "afternoon"; a grammatical three-word workaround (bonum tempus pōmerīdiānum) exists but isn't attested as an actual greeting — the honest answer is that Romans just used salvē, the same everyday greeting from Chapter 1, with no time-of-day restriction
+gloss: why no two-word good-afternoon phrase exists — Latin has no simplex afternoon noun, and a grammatical three-word workaround is not attested as a greeting
 concept_tag: GREETING-AFTERNOON
 prerequisites: [LA-C35-meridies, LA-C01-salve]
 sounds: [macron-long-vowel, v-as-w]
-roots: [salvere, medius-latin, dies-latin]
-etymology_hook: "unlike bonam noctem, bonum māne, and bonum vesperum — each a modern/pedagogical two-word phrase, but grammatically real — 'good afternoon' can't take that same two-word shape, because LA-C35 already established Latin has no simplex noun for 'afternoon' the way nox/māne/vesper exist for night/morning/evening; a three-word workaround, bonum tempus pōmerīdiānum ('good afternoon time'), IS grammatically valid — pōmerīdiānus is a real, Cicero-used adjective, and tempus gives bonus a genuine neuter noun to agree with — but it's a periphrasis, not a direct parallel to the other three phrases, and isn't itself attested as a greeting formula anywhere; the honest answer is that Romans just used salvē (Chapter 1), an everyday greeting with no time-of-day restriction built into it at all, rather than inventing a dedicated afternoon phrase"
-est_minutes: 5
+roots: [medius-latin, dies-latin]
+etymology_hook: "bonum post merīdiem cannot work like bonam noctem because post merīdiem is a prepositional phrase, not a noun; bonum tempus pōmerīdiānum is grammatical but is not attested as a greeting"
+est_minutes: 4
 reviews_of: [LA-C35-meridies, LA-C01-salve]
 ---
 
@@ -39,30 +39,13 @@ agree with. A three-word workaround, **bonum tempus pōmerīdiānum**
 phrases — and it isn't itself attested anywhere as something Romans
 actually said as a greeting.
 
-## What Romans actually did instead: nothing time-specific at all
-
-Here's the real answer: Romans didn't need an afternoon-specific
-greeting, because **salvē**/**salvēte** — the very first word of this
-course, Chapter 1 — carries no time-of-day restriction at all in its own
-right; it's simply "be well," said whenever you meet someone. There was
-no gap to fill with a modern convention, because Romans never divided
-their **everyday** greetings by time of day the way "good
-morning/afternoon/evening/night" does in English. *Morning* got a real
-institution instead of a phrase (the *salūtātiō*, Chapter 32); *evening*
-and *night* got attested grammar wrapped around invented phrases. But
-*afternoon* gets neither a genuine two-word phrase nor a substitute —
-just the same timeless *salvē* you already knew.
-
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "salvē" — the same word from Chapter 1, no time-of-day
-  restriction attached]
 - [YOU SAY: why "bonum post merīdiem" doesn't work — no noun for bonus
   to agree with; why "bonum tempus pōmerīdiānum" DOES work, but isn't
   attested as a real greeting]
-- [YOU SAY: the honest takeaway — Romans never split EVERYDAY greetings
-  by time of day the way English does]
+- [YOU SAY: the grammatical adjective — pōmerīdiānum, "of the afternoon"]
 
 ## Wrap-up Recall
 
@@ -72,7 +55,6 @@ noun for "afternoon" for *bonus* to pair with.) Is there ANY grammatical
 Latin phrase at all? (**Yes** — *bonum tempus pōmerīdiānum* is real
 grammar, but a three-word periphrasis, not attested as an actual
 greeting.) What did Romans say in the afternoon instead? (**Salvē** —
-the same everyday greeting from Chapter 1, with no time-of-day
-restriction.) Why
-doesn't *bonum post merīdiem* work grammatically? (*Post merīdiem* is a
-whole prepositional phrase, not a single noun *bonus* can agree with.)
+the same everyday greeting from Chapter 1.) Why doesn't *bonum post
+merīdiem* work grammatically? (*Post merīdiem* is a whole prepositional
+phrase, not a single noun *bonus* can agree with.)

--- a/code/learning/human-languages/latin/lessons/LA-C36-timeless-salve.md
+++ b/code/learning/human-languages/latin/lessons/LA-C36-timeless-salve.md
@@ -1,0 +1,55 @@
+---
+id: LA-C36-timeless-salve
+chapter: 36
+type: culture
+headword: salvē / salvēte
+gloss: the everyday greeting works at any time of day, so Romans did not need a dedicated afternoon formula
+concept_tag: GREETING-AFTERNOON
+prerequisites: [LA-C36-salve-post-meridiem]
+sounds: [macron-long-vowel, v-as-w]
+roots: [salvere]
+etymology_hook: "salvē ('be well!') and plural salvēte are everyday greetings without a built-in time boundary; the absence of a dedicated good-afternoon formula is therefore not a conversational gap"
+est_minutes: 4
+reviews_of: [LA-C36-salve-post-meridiem, LA-C01-salve]
+---
+
+# salvē — the greeting that does not watch the clock
+
+## Warm-up
+
+[PAUSE 2s] Latin cannot build a neat two-word "good afternoon." What did
+Romans actually need in that time slot? Nothing beyond a greeting you
+already know.
+
+## One everyday greeting, any time
+
+**Salvē** to one person and **salvēte** to several people mean "be well."
+Neither form contains a morning, afternoon, or evening boundary. Romans
+could use the greeting whenever they met someone.
+
+English encourages a learner to search for four matched clock-based
+formulas. Latin everyday greetings do not divide the day that way. The
+missing afternoon formula is therefore not a hole in Roman conversation.
+
+The time-of-day arc now has three different kinds of evidence:
+
+- a real institution, the morning **salūtātiō**
+- grammatical but modern phrases such as **bonam noctem**
+- no dedicated formula at all for afternoon—just **salvē**
+
+Learning those differences is more faithful than forcing four symmetrical
+translations into Latin.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "salvē" — be well, to one person]
+- [YOU SAY: "salvēte" — be well, to several people]
+- [YOU SAY: the time restriction — none]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What can one Roman say on meeting another in the afternoon?
+(**Salvē.**) What is the plural? (**Salvēte.**) Do these words encode a
+time of day? (**No.**) Why is there no conversational gap? (**The everyday
+greeting already works whenever people meet.**)


### PR DESCRIPTION
## Summary
- remove all 43 Latin sub-five-minute duration violations
- split six genuinely long lessons into six prerequisite-ordered companions while preserving grammar, etymology, usage, and attestation depth
- correct 37 declaration-only budgets and update downstream prerequisite handoffs
- record Latin book-generation, LaTeX-cleanup, and curriculum-map follow-ups; reprioritize Spanish as the final duration tranche

## Measured result
- corpus: 1,045 -> 1,051 lessons
- duration debt: 98 -> 55 overall; Latin: 43 -> 0
- unknown prerequisites: 0
- all 12 rewritten/new split steps: 153-295 computed seconds

## Validation
- `npm run test:coverage` (human-language-data): 68 passed, 93.60% line coverage
- `npm run build` (human-language-data)
- `npm run validate`: 9 passed
- `npm run check:books`
- `npm run report`
- `npm run test:coverage` (Language Ladder): 278 passed, 98.37% line coverage
- `npm run build` (Language Ladder): 1,101 modules transformed
- forced XeLaTeX Latin book build: 12 pages, no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings
- rendered and visually inspected cover, reference, and final pages
- `git diff --check`
