### PR TITLE
fix(spice): validate parser MOS surface potential

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `PHI` values before
+  lowering Level-1 surface potential.
 - Reject negative and non-finite MOS model-card `GAMMA` values before lowering
   Level-1 body effect.
 - Reject non-finite MOS model-card `LAMBDA` / `LAM` values and lower the `LAM`

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1906,6 +1906,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["GAMMA"]) or params["GAMMA"] < 0.0
         ):
             raise NetlistParseError("MOSFET GAMMA must be finite and non-negative")
+        if "PHI" in params and (
+            not math.isfinite(params["PHI"]) or params["PHI"] <= 0.0
+        ):
+            raise NetlistParseError("MOSFET PHI must be finite and positive")
     return ModelCard(name=name, kind=kind, params=params)
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1503,6 +1503,27 @@ def test_lowers_valid_mosfet_model_body_effect(body_effect: str) -> None:
     assert float(body_effect) == mosfet.model.model.params.GAMMA
 
 
+@pytest.mark.parametrize("surface_potential", ["0", "-0.01", "1e999"])
+def test_rejects_invalid_mosfet_model_surface_potential(
+    surface_potential: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET PHI must be finite and positive",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(PHI={surface_potential})\nM1 d g s b nfast\n"
+        )
+
+
+def test_lowers_positive_mosfet_model_surface_potential() -> None:
+    parsed = parse_netlist(".model nfast NMOS(PHI=0.65)\nM1 d g s b nfast\n")
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.PHI == 0.65
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `PHI` values before
+  lowering Level-1 surface potential.
 - Reject negative and non-finite MOS model-card `GAMMA` values before lowering
   Level-1 body effect.
 - Reject non-finite MOS model-card `LAMBDA` / `LAM` values and lower the `LAM`

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1205,6 +1205,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET GAMMA must be finite and non-negative");
   }
+  const surfacePotential = params.get("PHI");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    surfacePotential !== undefined &&
+    (!Number.isFinite(surfacePotential) || surfacePotential <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET PHI must be finite and positive");
+  }
   return {
     name: fields[1],
     kind,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1436,6 +1436,25 @@ Xright c d load
     expect(element.params.GAMMA).toBe(Number(bodyEffect));
   });
 
+  it.each(["0", "-0.01", "1e999"])(
+    "rejects invalid MOSFET model PHI=%s",
+    (surfacePotential) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(PHI=${surfacePotential})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET PHI must be finite and positive");
+    },
+  );
+
+  it("lowers positive MOSFET model surface potential", () => {
+    const parsed = parseNetlist(".model nfast NMOS(PHI=0.65)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.params.PHI).toBe(0.65);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS body-effect validation parity.
+1. Python and TypeScript Berkeley SPICE MOS surface-potential validation parity.
    - Status: current PR completion candidate.
-   - Reject negative and non-finite `GAMMA` values with the shared diagnostic.
-   - Preserve zero and positive body-effect coefficients through canonical
-     Level-1 lowering.
+   - Reject zero, negative, and non-finite `PHI` values with the shared
+     diagnostic.
+   - Preserve positive surface potentials through canonical Level-1 lowering.
 
 ## Completed Slices
 
@@ -4161,11 +4161,18 @@ the Rust, Python, and TypeScript surfaces together.
    - Non-finite `LAMBDA` / `LAM` values are rejected with the shared diagnostic.
    - Finite `LAM` values lower into canonical Level-1 channel modulation.
 
+374. Python and TypeScript Berkeley SPICE MOS body-effect validation parity.
+   - Status: completed in PR 9608.
+   - Negative and non-finite `GAMMA` values are rejected with the shared
+     diagnostic.
+   - Zero and positive body-effect coefficients lower into canonical Level-1
+     parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
-   - Apply Rust-aligned domains and diagnostics to already lowered `PHI`, `W`,
-     `L`, `IS`, and nominal-temperature fields.
+   - Apply Rust-aligned domains and diagnostics to already lowered `W`, `L`,
+     `IS`, and nominal-temperature fields.
 
 2. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
    - Lower missing canonical resistance, geometry, capacitance, junction, and


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite MOS model-card `PHI` values in Python and TypeScript parsers
- preserve positive surface potentials through Level-1 lowering
- add cross-language regression coverage, changelogs, and advance the SPICE implementation plan

## Verification
- Python spice-netlist-parser: 111 tests passed, 88.08% coverage
- Python Ruff: passed
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed; 110 tests passed; 83.4% statement / 84.05% line coverage
- `git diff --check origin/main...HEAD`