### PR TITLE
ci: add a "CI gate" summary check for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -841,3 +841,38 @@ jobs:
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then BT=./build-tool.exe; else BT=./build-tool; fi
           $BT -root . -plan-file build-plan.json -shard-index "${{ matrix.shard_index }}" -force -validate-build-files -clippy -language all
+
+  # ── Job 4: CI gate ─────────────────────────────────────────────
+  #
+  # A single, always-present status check that summarizes the result of
+  # every real job. The `build` job is a DYNAMIC matrix — its `build (…)`
+  # labels vary per-PR (they come from the diff-based `detect` step), so an
+  # individual label cannot be required by branch protection: a PR that does
+  # not produce that label would have the check "expected" forever and never
+  # merge. Requiring THIS job instead gives branch protection one stable
+  # context (`CI gate`) that passes only when every required job succeeded —
+  # or was legitimately skipped (e.g. an empty build matrix when nothing
+  # relevant changed). `if: always()` makes the gate itself run even when a
+  # dependency failed, so it can report the failure rather than being skipped.
+  ci-gate:
+    name: CI gate
+    needs: [detect, phy00-phy01-fixture-consumers, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs succeeded
+        shell: bash
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          PHY_RESULT: ${{ needs['phy00-phy01-fixture-consumers'].result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          echo "detect=$DETECT_RESULT phy=$PHY_RESULT build=$BUILD_RESULT"
+          fail=0
+          for r in "$DETECT_RESULT" "$PHY_RESULT" "$BUILD_RESULT"; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::a required job did not pass (result: $r)"; fail=1 ;;
+            esac
+          done
+          if [ "$fail" = "0" ]; then echo "CI gate passed"; else exit 1; fi


### PR DESCRIPTION
## What

Adds a single **`CI gate`** summary job to `ci.yml` — an always-present status
check you can require in a `main` branch-protection rule.

## Why

Your CI's `build` job is a **dynamic matrix**: the `build (<label>)` contexts are
computed per-PR from the diff-based `detect` step. Branch protection can't require
an individual `build (…)` context — a PR that doesn't produce that label would sit
"expected — waiting for status" forever and never merge. `CI gate` gives you one
stable context to require that passes only when every real job
(`detect`, `phy00-phy01-fixture-consumers`, `build`) **succeeded or was
legitimately skipped** (e.g. an empty build matrix when nothing relevant changed).

`if: always()` makes the gate run even when a dependency fails (so it reports the
failure rather than being skipped). The hyphenated `phy00-phy01-fixture-consumers`
job is referenced via `needs['…']` bracket notation (dot-notation would parse as
subtraction) and read through an env var.

## After merging — the two-step setup

1. **Settings → Branches → Add rule** (or Rulesets), pattern `main`:
   - ✅ Require status checks to pass → add **`CI gate`** (it appears in the list
     once this job has run at least once, i.e. after this PR's CI).
   - Leave approvals at 0 and admin-bypass on.
2. From then on, `gh pr merge <n> --squash --auto` **waits for `CI gate`** before
   merging — instead of merging immediately as it does today (main isn't protected
   yet).

CI-only change; no package/code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
