### PR TITLE
feat(mini-sqlite): date/time unixepoch/julianday/auto interpretation modifiers

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.76 — date/time `unixepoch` / `julianday` / `auto` interpretation modifiers
+
+A leading `unixepoch`/`julianday`/`auto` modifier now reinterprets the raw
+numeric time value, matching SQLite:
+
+- `datetime(1234567890, 'unixepoch')` → `2009-02-13 23:31:30` (reads the number as
+  Unix epoch seconds; numeric strings, negatives, and fractions work too, and
+  further modifiers still apply: `datetime(1234567890,'unixepoch','+1 day')`).
+- `datetime(2451545.0, 'julianday')` forces the Julian-day reading; `'auto'`
+  picks Julian when the value is inside the Julian-day window, else Unix.
+- A non-numeric value (e.g. an ISO date) with one of these → NULL.
+
+`localtime`/`utc` remain unimplemented (they need a timezone database) — like any
+unknown modifier they yield NULL. Two new differential-oracle cases pin this
+against bundled real SQLite; the ledger stays empty. Spans sql-vm 0.4.45.
+
 ## 0.5.75 — `cast(…)` is case-insensitive
 
 `cast(x AS t)`, `Cast(…)`, `cAsT(…)`, and `CAST(…)` all parse now, matching

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.75"
+version = "0.5.76"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -2527,6 +2527,22 @@ const CASES: &[Case] = &[
         setup: &[],
         query: "SELECT cast(1 AS TEXT) AS a, Cast(3.9 As Integer) AS b, CAST('3.5' as real) AS c, cAsT(42 aS tExT) AS d",
     },
+    // Date/time INTERPRETATION modifiers: a leading `unixepoch`/`julianday`/`auto`
+    // reinterprets the raw numeric time value. `unixepoch` reads it as Unix
+    // seconds (number or numeric string, negative and fractional allowed; further
+    // modifiers still apply; a non-numeric value like an ISO date is NULL).
+    Case {
+        id: "datetime_unixepoch_modifier",
+        setup: &[],
+        query: "SELECT datetime(1234567890,'unixepoch') AS a, datetime('1234567890','unixepoch') AS b, date(1751328000,'unixepoch') AS c, datetime(1234567890,'unixepoch','+1 day') AS d, datetime(-100,'unixepoch') AS e, datetime('2026-07-30','unixepoch') AS f",
+    },
+    // `julianday` forces the Julian-day reading (the default for a number); `auto`
+    // picks Julian when the number is inside the Julian-day window, else Unix.
+    Case {
+        id: "datetime_julianday_auto_modifier",
+        setup: &[],
+        query: "SELECT datetime(2451545.0,'julianday') AS a, datetime(2451545.0,'auto') AS b, datetime(1234567890,'auto') AS c",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.45] - Unreleased
+
+### Added
+
+- **Date/time interpretation modifiers `unixepoch` / `julianday` / `auto`.** A
+  leading one of these reinterprets the raw numeric time value instead of the
+  default Julian-day/ISO parse: `unixepoch` reads it as Unix epoch seconds
+  (number or numeric string; negative and fractional allowed), `julianday` forces
+  the Julian-day reading, and `auto` picks Julian when the value is inside the
+  Julian-day window else Unix — matching SQLite. So `datetime(1234567890,
+  'unixepoch')` → `2009-02-13 23:31:30`, and further modifiers still apply. A
+  non-numeric value (e.g. an ISO date) with one of these is NULL. New helpers
+  `numeric_time_value` / `unix_seconds_to_ijd` / `interpret_time_value`;
+  `datetime_base_ijd` peeks the first modifier and the shared final range gate is
+  factored into `finish_datetime_ijd`. `localtime`/`utc` stay unimplemented (they
+  need a timezone database) — they, like any unknown modifier, yield NULL.
+
 ## [0.4.44] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.44"
+version = "0.4.45"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -3378,23 +3378,97 @@ fn offset_calendar(ijd: i64, months: i64) -> Option<i64> {
     ymd_hms_to_ijd(ny, nmo, d, 0, 0, 0.0).checked_add(tod)
 }
 
+/// Extract a plain number from a time-value argument, for the interpretation
+/// modifiers (`unixepoch`/`julianday`/`auto`), which reinterpret the RAW value
+/// rather than parsing it as a date. Integers/reals/booleans are their value;
+/// a numeric string parses; anything else (an ISO date string, NULL, blob) has
+/// no numeric reading, so the modified call is NULL — matching SQLite.
+fn numeric_time_value(v: &SqlValue) -> Option<f64> {
+    match v {
+        SqlValue::Int(i) => Some(*i as f64),
+        SqlValue::Bool(b) => Some(*b as i64 as f64),
+        SqlValue::Float(f) => Some(*f),
+        SqlValue::Text(s) => s.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// Convert Unix epoch seconds to `iJD` milliseconds (for the `unixepoch`
+/// modifier). Fractional seconds are kept to the millisecond; overflow → None.
+fn unix_seconds_to_ijd(secs: f64) -> Option<i64> {
+    if !secs.is_finite() {
+        return None;
+    }
+    let ms = (secs * 1000.0).round();
+    if !ms.is_finite() {
+        return None;
+    }
+    UNIX_EPOCH_IJD_MS.checked_add(ms as i64)
+}
+
+/// Apply a leading INTERPRETATION modifier (`unixepoch` / `julianday` / `auto`)
+/// to the raw time value, returning the resulting `iJD`. These reinterpret a
+/// NUMBER: `unixepoch` reads it as Unix seconds; `julianday` as a Julian day;
+/// `auto` picks Julian when the number is in the Julian-day range, else Unix
+/// (matching SQLite). Returns `None` for a non-numeric value. Not one of these
+/// keywords → `Ok(None)` sentinel via the outer match (handled by the caller).
+fn interpret_time_value(kind: &str, v: &SqlValue) -> Option<i64> {
+    let n = numeric_time_value(v)?;
+    match kind {
+        "unixepoch" => unix_seconds_to_ijd(n),
+        "julianday" => julian_number_to_ijd(n),
+        // `auto`: a value inside the Julian-day window is a Julian day; anything
+        // else (e.g. a large Unix timestamp) is Unix epoch seconds.
+        "auto" => {
+            if (0.0..MAX_JULIAN_DAY).contains(&n) {
+                julian_number_to_ijd(n)
+            } else {
+                unix_seconds_to_ijd(n)
+            }
+        }
+        _ => None,
+    }
+}
+
 /// Shared front-end for `date`/`time`/`datetime`/`julianday`/`unixepoch`: resolve
 /// the first (time-value) argument to `iJD`, then fold in any trailing modifier
 /// arguments left-to-right. Returns `None` (→ SQL NULL) if the time value or any
 /// modifier is invalid, or if a modifier pushes the result outside the
 /// representable Julian-day range. The zero-argument form means `'now'`.
+///
+/// A leading `unixepoch`/`julianday`/`auto` modifier is special: it reinterprets
+/// the raw time value (see [`interpret_time_value`]) instead of the default
+/// Julian-day/ISO parse, so `datetime(1234567890, 'unixepoch')` works. Elsewhere
+/// those keywords are not recognized (→ NULL), as are `localtime`/`utc` (which
+/// would need a timezone database).
 fn datetime_base_ijd(args: &[SqlValue]) -> Option<i64> {
-    let (mut ijd, mods) = match args.split_first() {
-        None => (now_ijd()?, &[][..]),
-        Some((first, rest)) => (time_value_to_ijd(first)?, rest),
+    let (first, mods) = match args.split_first() {
+        None => return finish_datetime_ijd(now_ijd()?, &[]),
+        Some((first, rest)) => (first, rest),
     };
-    for m in mods {
+    // A leading interpretation modifier changes how the raw value is read.
+    let (mut ijd, rest) = match mods.first() {
+        Some(SqlValue::Text(m0))
+            if matches!(m0.to_ascii_lowercase().as_str(), "unixepoch" | "julianday" | "auto") =>
+        {
+            (interpret_time_value(&m0.to_ascii_lowercase(), first)?, &mods[1..])
+        }
+        _ => (time_value_to_ijd(first)?, mods),
+    };
+    for m in rest {
         let text = match m {
             SqlValue::Text(s) => s,
             _ => return None, // NULL or non-text modifier → NULL
         };
         ijd = apply_modifier(ijd, text)?;
     }
+    finish_datetime_ijd(ijd, &[])
+}
+
+/// Final validity gate shared by both entry paths: an out-of-range `iJD` (a
+/// modifier walked it past year 9999 or before year 0) is NULL. The `_unused`
+/// slice keeps the signature symmetric with the fold above.
+fn finish_datetime_ijd(ijd: i64, _unused: &[SqlValue]) -> Option<i64> {
     // A modifier may have walked the value out of the valid Julian-day window.
     if !(0.0..MAX_JULIAN_DAY).contains(&(ijd as f64 / 86_400_000.0)) {
         return None;
@@ -6715,6 +6789,28 @@ mod tests {
         assert_eq!(m("2026-07-30", &["+1000000000000000000 years"]), SqlValue::Null);
         assert_eq!(m("2026-07-30", &["+9999999999999999999 days"]), SqlValue::Null);
         assert_eq!(m("2026-07-30", &["+106749529914.55 days", "weekday 0"]), SqlValue::Null);
+
+        // Interpretation modifiers reinterpret the RAW numeric value.
+        let dt = |args: Vec<SqlValue>| call_builtin("DATETIME", args).unwrap();
+        // unixepoch: number OR numeric string → Unix seconds; further mods apply.
+        assert_eq!(dt(vec![SqlValue::Int(1234567890), txt("unixepoch")]), txt("2009-02-13 23:31:30"));
+        assert_eq!(dt(vec![txt("1234567890"), txt("unixepoch")]), txt("2009-02-13 23:31:30"));
+        assert_eq!(
+            dt(vec![SqlValue::Int(1234567890), txt("unixepoch"), txt("+1 day")]),
+            txt("2009-02-14 23:31:30")
+        );
+        assert_eq!(dt(vec![SqlValue::Float(1234567890.5), txt("unixepoch")]), txt("2009-02-13 23:31:30"));
+        // A non-numeric value with 'unixepoch' is NULL (nothing to reinterpret).
+        assert_eq!(dt(vec![txt("2026-07-30"), txt("unixepoch")]), SqlValue::Null);
+        // julianday forces the default numeric (Julian) reading; auto chooses.
+        assert_eq!(dt(vec![SqlValue::Float(2451545.0), txt("julianday")]), txt("2000-01-01 12:00:00"));
+        assert_eq!(dt(vec![SqlValue::Float(2451545.0), txt("auto")]), txt("2000-01-01 12:00:00"));
+        assert_eq!(dt(vec![SqlValue::Int(1234567890), txt("auto")]), txt("2009-02-13 23:31:30"));
+        // Extreme / non-finite Unix seconds must NULL out (checked_add + is_finite
+        // guards), never panic or land out of the representable range.
+        assert_eq!(dt(vec![SqlValue::Float(1e300), txt("unixepoch")]), SqlValue::Null);
+        assert_eq!(dt(vec![txt("1e400"), txt("unixepoch")]), SqlValue::Null); // parses to +inf
+        assert_eq!(dt(vec![SqlValue::Int(i64::MAX), txt("unixepoch")]), SqlValue::Null);
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Fills in the date/time subsystem's remaining common gap: the **interpretation
modifiers** `unixepoch` / `julianday` / `auto`. A leading one reinterprets the
**raw numeric** time value instead of the default Julian-day/ISO parse, matching
SQLite — `unixepoch` in particular is how you turn a Unix timestamp into a date.

| query | → |
|-------|---|
| `datetime(1234567890,'unixepoch')` | `2009-02-13 23:31:30` |
| `datetime('1234567890','unixepoch')` | same (numeric string) |
| `datetime(1234567890,'unixepoch','+1 day')` | `2009-02-14 23:31:30` (further mods apply) |
| `datetime(2451545.0,'julianday')` | `2000-01-01 12:00:00` (force Julian) |
| `datetime(1234567890,'auto')` | Unix (out of Julian range) |
| `datetime(2451545.0,'auto')` | Julian (in range) |
| `datetime('2026-07-30','unixepoch')` | NULL (nothing numeric to reinterpret) |

## How

`datetime_base_ijd` peeks the first modifier; new helpers `numeric_time_value` /
`unix_seconds_to_ijd` / `interpret_time_value` do the reinterpretation, and the
shared final Julian-day range gate is factored into `finish_datetime_ijd`.
`localtime`/`utc` stay unimplemented (they need a timezone database) — like any
unknown modifier they yield NULL.

## Safety

The only new arithmetic is `unix_seconds_to_ijd`, guarded with `is_finite` +
`checked_add`, so extreme/non-finite inputs (`1e300`, `'1e400'`→+inf, `i64::MAX`
seconds) yield NULL rather than panicking/wrapping — covered by new adversarial
tests. No byte-slicing; no new deps; no `unsafe`.

## Verification

- 2 new differential-oracle cases (unixepoch number/string/date/negative/
  fractional/+modifier/non-numeric; julianday/auto) match bundled real SQLite;
  ledger stays **empty**.
- Full sql-vm suite (116) + all mini-sqlite suites green; clippy clean.

`sql-vm 0.4.45 / mini-sqlite 0.5.76`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
