### PR TITLE
fix(spice): validate parser MOS model width

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `W` values before
+  lowering Level-1 default width.
 - Reject zero, negative, and non-finite MOS model-card `PHI` values before
   lowering Level-1 surface potential.
 - Reject negative and non-finite MOS model-card `GAMMA` values before lowering

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1910,6 +1910,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["PHI"]) or params["PHI"] <= 0.0
         ):
             raise NetlistParseError("MOSFET PHI must be finite and positive")
+        if "W" in params and (
+            not math.isfinite(params["W"]) or params["W"] <= 0.0
+        ):
+            raise NetlistParseError("MOSFET W must be finite and positive")
     return ModelCard(name=name, kind=kind, params=params)
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1524,6 +1524,23 @@ def test_lowers_positive_mosfet_model_surface_potential() -> None:
     assert mosfet.model.model.params.PHI == 0.65
 
 
+@pytest.mark.parametrize("width", ["0", "-1u", "1e999"])
+def test_rejects_invalid_mosfet_model_width(width: str) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET W must be finite and positive",
+    ):
+        parse_netlist(f".model nfast NMOS(W={width})\nM1 d g s b nfast\n")
+
+
+def test_lowers_positive_mosfet_model_width() -> None:
+    parsed = parse_netlist(".model nfast NMOS(W=4u)\nM1 d g s b nfast\n")
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.W, 4.0e-6)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `W` values before
+  lowering Level-1 default width.
 - Reject zero, negative, and non-finite MOS model-card `PHI` values before
   lowering Level-1 surface potential.
 - Reject negative and non-finite MOS model-card `GAMMA` values before lowering

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1213,6 +1213,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET PHI must be finite and positive");
   }
+  const width = params.get("W");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    width !== undefined &&
+    (!Number.isFinite(width) || width <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET W must be finite and positive");
+  }
   return {
     name: fields[1],
     kind,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1455,6 +1455,22 @@ Xright c d load
     expect(element.params.PHI).toBe(0.65);
   });
 
+  it.each(["0", "-1u", "1e999"])("rejects invalid MOSFET model W=%s", (width) => {
+    expect(() => parseNetlist(`.model nfast NMOS(W=${width})\nM1 d g s b nfast\n`)).toThrow(
+      "MOSFET W must be finite and positive",
+    );
+  });
+
+  it("lowers positive MOSFET model width", () => {
+    const parsed = parseNetlist(".model nfast NMOS(W=4u)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.params.W).toBeCloseTo(4.0e-6, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,10 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS surface-potential validation parity.
+1. Python and TypeScript Berkeley SPICE MOS model-card width validation parity.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite `PHI` values with the shared
-     diagnostic.
-   - Preserve positive surface potentials through canonical Level-1 lowering.
+   - Reject zero, negative, and non-finite `W` values with the shared diagnostic.
+   - Preserve positive model-card widths through canonical Level-1 lowering.
 
 ## Completed Slices
 
@@ -4168,11 +4167,17 @@ the Rust, Python, and TypeScript surfaces together.
    - Zero and positive body-effect coefficients lower into canonical Level-1
      parameters.
 
+375. Python and TypeScript Berkeley SPICE MOS surface-potential validation parity.
+   - Status: completed in PR 9611.
+   - Zero, negative, and non-finite `PHI` values are rejected with the shared
+     diagnostic.
+   - Positive surface potentials lower into canonical Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
-   - Apply Rust-aligned domains and diagnostics to already lowered `W`, `L`,
-     `IS`, and nominal-temperature fields.
+   - Apply Rust-aligned domains and diagnostics to already lowered `L`, `IS`,
+     and nominal-temperature fields.
 
 2. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
    - Lower missing canonical resistance, geometry, capacitance, junction, and


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite MOS model-card `W` values in Python and TypeScript parsers
- preserve positive default widths through Level-1 lowering
- add cross-language regression coverage, changelogs, and advance the SPICE implementation plan

## Verification
- Python spice-netlist-parser: 115 tests passed, 88.10% coverage
- Python Ruff: passed
- TypeScript spice-engine: build passed
- TypeScript spice-netlist-parser: build passed; 114 tests passed; 83.45% statement / 84.1% line coverage
- `git diff --check origin/main...HEAD`