### PR TITLE
feat(sir-c): Array 0-arg query/transform methods (Collections slice 3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.24.0 — Collections slice 3: 0-arg Array query/transform methods
+
+Third Collections slice — the first to cover **Array** (`SIR_SEQ`) receivers
+beyond the polymorphic `length`/`size`/`empty?` from slice 1. No new `Feature`.
+
+- New 0-arg methods on `is_builtin_method`/`_sir_builtin_method`: `count`,
+  `first`, `last`, `sort`, `min`, `max`, `sum`, `uniq`, `compact`, `flatten`,
+  `to_a`. `reverse` (already allowlisted for String in slice 1) gains a
+  `SIR_SEQ` arm. `count` is polymorphic over Array/Hash, mirroring slice 1's
+  `length`/`size`.
+- Each returns a **fresh** sequence (or scalar) — the receiver's backing array
+  is never mutated, unlike `SeqSet`. `sort`/`min`/`max` reuse `_sir_lt`/
+  `_sir_gt` (the same comparators `<`/`>` use); `uniq` reuses `_sir_value_eq`
+  (structural, so nested-array elements dedup correctly); `sum` reuses
+  `_sir_plus_v`'s existing int/float promotion, defaulting the accumulator to
+  `0` (Ruby's `Array#sum` default). `first`/`last`/`min`/`max` return `nil` on
+  an empty array (matching Ruby); `sum` returns `0`.
+- `flatten` recursively unwraps nested arrays fully (Ruby's default, no depth
+  limit in the *language* semantics) but the **implementation** shares
+  `SIR_MAX_EQ_DEPTH` — the same cap `_sir_value_eq`/`_sir_fmt` use — so a
+  self-referential array (`a[0] = a`, constructible via `SeqSet`) terminates
+  (an element past the cap is taken as-is) instead of a stack-overflow DoS.
+  Two-pass count-then-fill avoids a growable buffer.
+- A wrong-type receiver (e.g. `"str".sort`) still raises `NoMethodError` via
+  the existing fallthrough — no new guard needed, since every new arm only
+  matches on `SIR_SEQ`.
+
+**Anti-RCE preserved:** the method name is a compiler-emitted quoted C literal
+used only as a `strcmp` target — never reflection.
+
 ## 0.23.1 — fix: cyclic-map/seq display + equality no longer overflow the stack on Windows
 
 Fixes `cyclic_map_does_not_stack_overflow` (and the sibling cyclic-sequence

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -18,11 +18,21 @@ beyond the polymorphic `length`/`size`/`empty?` from slice 1. No new `Feature`.
   `0` (Ruby's `Array#sum` default). `first`/`last`/`min`/`max` return `nil` on
   an empty array (matching Ruby); `sum` returns `0`.
 - `flatten` recursively unwraps nested arrays fully (Ruby's default, no depth
-  limit in the *language* semantics) but the **implementation** shares
-  `SIR_MAX_EQ_DEPTH` — the same cap `_sir_value_eq`/`_sir_fmt` use — so a
-  self-referential array (`a[0] = a`, constructible via `SeqSet`) terminates
-  (an element past the cap is taken as-is) instead of a stack-overflow DoS.
-  Two-pass count-then-fill avoids a growable buffer.
+  limit in the *language* semantics). It shares `SIR_MAX_EQ_DEPTH` — the same
+  depth cap `_sir_value_eq`/`_sir_fmt` use — to bound recursion depth on a
+  self-referential array (`a[0] = a`, constructible via `SeqSet`). Security
+  review caught that depth ALONE is not enough here (unlike those two
+  functions, `flatten` recurses into every element of every nested array, so
+  a self-referential array whose elements ALL point back to itself — e.g.
+  `a=[1,2]; a[0]=a; a[1]=a` — fans out ~branching^depth calls, which at a
+  500-deep cap is astronomically more work, overflows the `int64_t` element
+  count well before the cap, and would under-allocate the output buffer for
+  the writes actually performed): both the count and fill passes now ALSO
+  thread a shared total-work budget (`SIR_MAX_FLATTEN_NODES`, decremented once
+  per node visited, leaf or container), so total calls across the whole
+  traversal are bounded regardless of fan-out, not just depth. The two passes
+  share the same starting budget and traversal order, so they still agree on
+  the exact element count. Two-pass count-then-fill avoids a growable buffer.
 - A wrong-type receiver (e.g. `"str".sort`) still raises `NoMethodError` via
   the existing fallthrough — no new guard needed, since every new arm only
   matches on `SIR_SEQ`.

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.23.1"
+version = "0.24.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -152,8 +152,15 @@ implementation.  Covered so far — **slice 1** (0-arity String): `length`/`size
 `upcase`, `downcase`, `reverse`, `empty?`, `to_s` (`length`/`size`/`empty?`
 polymorphic over String/Array/Hash); **slice 2** (1-arg String queries):
 `include?`, `start_with?`, `end_with?` → bool and `index` → Int/nil (the argument
-a String).  A wrong-type receiver or argument raises `NoMethodError`; a built-in
-method not lowered yet is still rejected cleanly.
+a String); **slice 3** (0-arg Array query/transform methods): `count`, `first`,
+`last`, `sort`, `min`, `max`, `sum`, `uniq`, `compact`, `flatten`, `to_a`, and
+`reverse` widens to accept an Array alongside its slice-1 String form — each
+returns a **fresh** sequence (or scalar), never mutating the receiver;
+ordering/equality reuse the runtime's own `<`/`>`/`==` (`_sir_lt`/`_sir_gt`/
+`_sir_value_eq`), and `flatten` shares the same recursion-depth cap as
+`_sir_fmt`/`_sir_value_eq` so a self-referential array (`a[0] = a`) terminates
+instead of overflowing the stack.  A wrong-type receiver or argument raises
+`NoMethodError`; a built-in method not lowered yet is still rejected cleanly.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, a `class << self` singleton, and

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1758,8 +1758,11 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// than deferring it to a later Collections batch).  Slice 1 = 0-arity String
 /// methods (`length`/`size`/`empty?` polymorphic over String/Array/Hash); slice 2
 /// = 1-arg String queries (`include?`/`start_with?`/`end_with?`/`index`, the arg
-/// a String).  The dispatcher raises `NoMethodError` on an unsupported receiver
-/// type, matching Ruby.
+/// a String); slice 3 = 0-arg Array query/transform methods (`count`/`first`/
+/// `last`/`sort`/`min`/`max`/`sum`/`uniq`/`compact`/`flatten`/`to_a`; `reverse`
+/// widens to accept an Array receiver too, alongside its slice-1 String arm).
+/// The dispatcher raises `NoMethodError` on an unsupported receiver type,
+/// matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
     matches!(
         name,
@@ -1767,6 +1770,9 @@ fn is_builtin_method(name: &str) -> bool {
         "length" | "size" | "upcase" | "downcase" | "reverse" | "empty?" | "to_s"
         // slice 2 — 1-arg String queries (the arg is a String)
         | "include?" | "start_with?" | "end_with?" | "index"
+        // slice 3 — 0-arg Array query/transform methods
+        | "count" | "first" | "last" | "sort" | "min" | "max" | "sum" | "uniq"
+        | "compact" | "flatten" | "to_a"
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1522,29 +1522,54 @@ static SirValue _sir_array_compact(SirSeq *s) {
     return _sir_seq_wrap(r);
 }
 
-/* `flatten` is a recursive aggregate walk, so it shares `SIR_MAX_EQ_DEPTH` —
- * the same "smallest common C stack" cap `_sir_value_eq`/`_sir_fmt` use — to
- * stay sound on a self-referential array (`a[0] = a`, constructible via
- * `SeqSet`).  Past the cap an element is taken AS-IS rather than recursed into
- * (matching the assumed-equal / ellipsis choice those functions make at their
- * cap), so a cyclic input still terminates rather than stack-overflowing. */
-static int64_t _sir_flatten_count(SirValue v, int depth) {
-    if (v.tag != SIR_SEQ || depth > SIR_MAX_EQ_DEPTH) return 1;
+/* `flatten` is a recursive aggregate walk over a structure a `SeqSet` can make
+ * self-referential (`a[0] = a`).  A DEPTH cap alone (`SIR_MAX_EQ_DEPTH`, as
+ * `_sir_value_eq`/`_sir_fmt` use) is NOT enough here: those two only ever
+ * recurse into a FIXED small arity (a pair's two sides, or one seq/map
+ * paired element-for-element against another of the SAME length), so depth
+ * bounds their total work too. `flatten` instead recurses into EVERY element
+ * of EVERY nested array, so a self-referential array with two or more
+ * elements that all point back to itself (`a=[1,2]; a[0]=a; a[1]=a`) fans out
+ * ~branching^depth calls — with depth capped at 500 that is astronomically
+ * more work than the cap was sized for, and the resulting count can overflow
+ * `int64_t`, in turn under-allocating `_sir_array_flatten`'s output buffer
+ * for the (enormous) number of writes `_sir_flatten_fill` actually performs.
+ *
+ * So `flatten` ALSO threads a total-work `budget`, decremented once per call
+ * — leaf or container — BEFORE it looks at `depth`/`tag`. Once the budget
+ * runs out, the current node is treated as opaque (same as a past-depth-cap
+ * node), so no more calls are spawned from it. That bounds the TOTAL number
+ * of calls across the whole traversal to `SIR_MAX_FLATTEN_NODES`, regardless
+ * of fan-out — unlike the depth cap alone, which only bounds one AXIS of the
+ * traversal. The count and fill passes decrement from the SAME starting
+ * budget in the SAME traversal order, so they agree on exactly which nodes
+ * are opaque and produce a matching element count and write count. */
+#define SIR_MAX_FLATTEN_NODES 1000000
+static int64_t _sir_flatten_count(SirValue v, int depth, int64_t *budget) {
+    (*budget)--;
+    if (*budget < 0 || v.tag != SIR_SEQ || depth > SIR_MAX_EQ_DEPTH) return 1;
     int64_t n = 0;
-    for (int64_t i = 0; i < v.as.seq->len; i++) n += _sir_flatten_count(v.as.seq->items[i], depth + 1);
+    for (int64_t i = 0; i < v.as.seq->len; i++) {
+        n += _sir_flatten_count(v.as.seq->items[i], depth + 1, budget);
+    }
     return n;
 }
-static void _sir_flatten_fill(SirValue v, int depth, SirValue *out, int64_t *idx) {
-    if (v.tag != SIR_SEQ || depth > SIR_MAX_EQ_DEPTH) { out[(*idx)++] = v; return; }
-    for (int64_t i = 0; i < v.as.seq->len; i++) _sir_flatten_fill(v.as.seq->items[i], depth + 1, out, idx);
+static void _sir_flatten_fill(SirValue v, int depth, int64_t *budget, SirValue *out, int64_t *idx) {
+    (*budget)--;
+    if (*budget < 0 || v.tag != SIR_SEQ || depth > SIR_MAX_EQ_DEPTH) { out[(*idx)++] = v; return; }
+    for (int64_t i = 0; i < v.as.seq->len; i++) {
+        _sir_flatten_fill(v.as.seq->items[i], depth + 1, budget, out, idx);
+    }
 }
 static SirValue _sir_array_flatten(SirValue recv) {
-    int64_t n = _sir_flatten_count(recv, 0);
+    int64_t count_budget = SIR_MAX_FLATTEN_NODES;
+    int64_t n = _sir_flatten_count(recv, 0, &count_budget);
     SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
     r->len = n;
     r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
     int64_t idx = 0;
-    _sir_flatten_fill(recv, 0, r->items, &idx);
+    int64_t fill_budget = SIR_MAX_FLATTEN_NODES;
+    _sir_flatten_fill(recv, 0, &fill_budget, r->items, &idx);
     return _sir_seq_wrap(r);
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1422,6 +1422,132 @@ SirValue _sir_call_class_method(const char *cls, const char *method, int argc, .
     return r;
 }
 
+/* ---- Collections slice 3: 0-arg Array query/transform methods --------------
+ *
+ * Non-mutating queries/transforms over a `SIR_SEQ` receiver — each returns a
+ * FRESH sequence (or scalar); the receiver's backing array is never touched
+ * (unlike `SeqSet`).  Ordering/equality reuse `_sir_lt`/`_sir_gt`/`_sir_value_eq`
+ * — the SAME comparators `<`/`>`/`==` use — so `sort`/`min`/`max`/`uniq` agree
+ * with the rest of the runtime instead of inventing a second notion of
+ * "less"/"equal". */
+
+static SirValue _sir_seq_wrap(SirSeq *s) {
+    SirValue v; v.tag = SIR_SEQ; v.as.seq = s;
+    return v;
+}
+
+static SirValue _sir_array_reverse(SirSeq *s) {
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = s->len;
+    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    for (int64_t i = 0; i < s->len; i++) r->items[i] = s->items[s->len - 1 - i];
+    return _sir_seq_wrap(r);
+}
+
+/* Insertion sort via `_sir_lt` — O(n^2), fine for the v0 collection sizes this
+ * runtime targets (matches the rest of this backend's "correctness over
+ * micro-perf" v0 stance; see the sir-bench findings). */
+static SirValue _sir_array_sort(SirSeq *s) {
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = s->len;
+    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    for (int64_t i = 0; i < s->len; i++) r->items[i] = s->items[i];
+    for (int64_t i = 1; i < r->len; i++) {
+        SirValue key = r->items[i];
+        int64_t j = i - 1;
+        while (j >= 0 && _sir_truthy(_sir_lt(key, r->items[j]))) {
+            r->items[j + 1] = r->items[j];
+            j--;
+        }
+        r->items[j + 1] = key;
+    }
+    return _sir_seq_wrap(r);
+}
+
+static SirValue _sir_array_min(SirSeq *s) {
+    if (s->len == 0) return _sir_nil();
+    SirValue best = s->items[0];
+    for (int64_t i = 1; i < s->len; i++) {
+        if (_sir_truthy(_sir_lt(s->items[i], best))) best = s->items[i];
+    }
+    return best;
+}
+static SirValue _sir_array_max(SirSeq *s) {
+    if (s->len == 0) return _sir_nil();
+    SirValue best = s->items[0];
+    for (int64_t i = 1; i < s->len; i++) {
+        if (_sir_truthy(_sir_gt(s->items[i], best))) best = s->items[i];
+    }
+    return best;
+}
+/* Ruby `Array#sum` defaults the accumulator to integer 0; `_sir_plus_v`'s
+ * existing int/float promotion (the same rule `+` uses) carries a float
+ * element through, so `[1, 2.5].sum` promotes correctly. */
+static SirValue _sir_array_sum(SirSeq *s) {
+    SirValue acc = _sir_int(0);
+    for (int64_t i = 0; i < s->len; i++) {
+        SirValue pair[2];
+        pair[0] = acc;
+        pair[1] = s->items[i];
+        acc = _sir_plus_v(pair, 2);
+    }
+    return acc;
+}
+/* First-occurrence order preserved (matches Ruby); dedup via `_sir_value_eq`
+ * (structural, so `[[1], [1]].uniq` collapses to one `[1]`) — O(n^2), same
+ * trade-off as `sort` above. Over-allocates to `s->len` (a safe upper bound on
+ * the unique count) rather than a second exact-size pass. */
+static SirValue _sir_array_uniq(SirSeq *s) {
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    int64_t k = 0;
+    for (int64_t i = 0; i < s->len; i++) {
+        int dup = 0;
+        for (int64_t j = 0; j < k; j++) {
+            if (_sir_value_eq(s->items[i], r->items[j])) { dup = 1; break; }
+        }
+        if (!dup) r->items[k++] = s->items[i];
+    }
+    r->len = k;
+    return _sir_seq_wrap(r);
+}
+static SirValue _sir_array_compact(SirSeq *s) {
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    int64_t k = 0;
+    for (int64_t i = 0; i < s->len; i++) {
+        if (s->items[i].tag != SIR_NIL) r->items[k++] = s->items[i];
+    }
+    r->len = k;
+    return _sir_seq_wrap(r);
+}
+
+/* `flatten` is a recursive aggregate walk, so it shares `SIR_MAX_EQ_DEPTH` —
+ * the same "smallest common C stack" cap `_sir_value_eq`/`_sir_fmt` use — to
+ * stay sound on a self-referential array (`a[0] = a`, constructible via
+ * `SeqSet`).  Past the cap an element is taken AS-IS rather than recursed into
+ * (matching the assumed-equal / ellipsis choice those functions make at their
+ * cap), so a cyclic input still terminates rather than stack-overflowing. */
+static int64_t _sir_flatten_count(SirValue v, int depth) {
+    if (v.tag != SIR_SEQ || depth > SIR_MAX_EQ_DEPTH) return 1;
+    int64_t n = 0;
+    for (int64_t i = 0; i < v.as.seq->len; i++) n += _sir_flatten_count(v.as.seq->items[i], depth + 1);
+    return n;
+}
+static void _sir_flatten_fill(SirValue v, int depth, SirValue *out, int64_t *idx) {
+    if (v.tag != SIR_SEQ || depth > SIR_MAX_EQ_DEPTH) { out[(*idx)++] = v; return; }
+    for (int64_t i = 0; i < v.as.seq->len; i++) _sir_flatten_fill(v.as.seq->items[i], depth + 1, out, idx);
+}
+static SirValue _sir_array_flatten(SirValue recv) {
+    int64_t n = _sir_flatten_count(recv, 0);
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = n;
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    int64_t idx = 0;
+    _sir_flatten_fill(recv, 0, r->items, &idx);
+    return _sir_seq_wrap(r);
+}
+
 /* ---- Collections slice 1: built-in String methods --------------------------
  *
  * A `__method__` dispatch whose name is a KNOWN built-in method — and which the
@@ -1447,12 +1573,41 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         if (recv.tag == SIR_STR) return _sir_str(_sir_str_downcase(recv.as.s));
     } else if (strcmp(m, "reverse") == 0) {
         if (recv.tag == SIR_STR) return _sir_str(_sir_str_reverse(recv.as.s));
+        if (recv.tag == SIR_SEQ) return _sir_array_reverse(recv.as.seq);
     } else if (strcmp(m, "empty?") == 0) {
         if (recv.tag == SIR_STR) return _sir_bool(recv.as.s[0] == '\0');
         if (recv.tag == SIR_SEQ) return _sir_bool(recv.as.seq->len == 0);
         if (recv.tag == SIR_MAP) return _sir_bool(recv.as.map->len == 0);
     } else if (strcmp(m, "to_s") == 0) {
         if (recv.tag == SIR_STR) return recv;  /* String#to_s is the string itself */
+    }
+    /* Collections slice 3: 0-arg Array query/transform methods. */
+    else if (strcmp(m, "count") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_int(recv.as.seq->len);
+        if (recv.tag == SIR_MAP) return _sir_int(recv.as.map->len);
+    } else if (strcmp(m, "first") == 0) {
+        if (recv.tag == SIR_SEQ) return recv.as.seq->len > 0 ? recv.as.seq->items[0] : _sir_nil();
+    } else if (strcmp(m, "last") == 0) {
+        if (recv.tag == SIR_SEQ) {
+            int64_t n = recv.as.seq->len;
+            return n > 0 ? recv.as.seq->items[n - 1] : _sir_nil();
+        }
+    } else if (strcmp(m, "sort") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_array_sort(recv.as.seq);
+    } else if (strcmp(m, "min") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_array_min(recv.as.seq);
+    } else if (strcmp(m, "max") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_array_max(recv.as.seq);
+    } else if (strcmp(m, "sum") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_array_sum(recv.as.seq);
+    } else if (strcmp(m, "uniq") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_array_uniq(recv.as.seq);
+    } else if (strcmp(m, "compact") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_array_compact(recv.as.seq);
+    } else if (strcmp(m, "flatten") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_array_flatten(recv);
+    } else if (strcmp(m, "to_a") == 0) {
+        if (recv.tag == SIR_SEQ) return recv;  /* Array#to_a is the array itself */
     }
     /* Collections slice 2: 1-arg String queries (arg is a String). */
     else if (strcmp(m, "include?") == 0) {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_methods.rs
@@ -1,0 +1,290 @@
+//! Execution proof for Collections slice 3 (0-arg Array query/transform
+//! methods) on the C backend — lower REAL Ruby source, emit C, compile with a
+//! real cc, run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! `[..].method` lowers to `__method__(recv, "method")`; when `method` is a
+//! built-in name (not a user-defined method) it routes to the runtime
+//! `_sir_builtin_method` dispatcher, which type-checks the receiver and
+//! applies the Array implementation — a FRESH array/scalar, never mutating
+//! the receiver.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    // Hash the full source (not just its length — the sibling test files' `len()`
+    // scheme collides whenever two same-length sources run as parallel test
+    // threads in the same process, each clobbering the other's temp file).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_arrm_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn array_count_first_last() {
+    match run_ruby("puts [10, 20, 30].count\nputs [10, 20, 30].first\nputs [10, 20, 30].last\n") {
+        Some(out) => assert_eq!(out, "3\n10\n30\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_first_last_on_empty_is_nil() {
+    // Ruby's `[].first`/`[].last` return nil, not raise; this backend's `puts`
+    // prints nil as the literal text `nil` (see `compile_and_run_sequences.rs`'s
+    // own OOB-index case for the same convention).
+    match run_ruby("puts [].first\nputs [].last\n") {
+        Some(out) => assert_eq!(out, "nil\nnil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_reverse_and_sort() {
+    match run_ruby("puts [1, 2, 3].reverse\nputs [3, 1, 2].sort\n") {
+        Some(out) => assert_eq!(out, "[3, 2, 1]\n[1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_reverse_does_not_mutate_the_receiver() {
+    // `reverse` (unlike a hypothetical `reverse!`) returns a FRESH array; the
+    // original binding must still print in its original order afterward.
+    match run_ruby("a = [1, 2, 3]\na.reverse\nputs a\n") {
+        Some(out) => assert_eq!(out, "[1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_sort_strings() {
+    // `sort` reuses `_sir_lt`, which has a String branch (`strcmp`), so a
+    // String array sorts lexicographically, not just numeric arrays.
+    match run_ruby("puts [\"banana\", \"apple\", \"cherry\"].sort\n") {
+        Some(out) => assert_eq!(out, "[apple, banana, cherry]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_min_max_sum() {
+    match run_ruby("puts [5, 1, 9, 3].min\nputs [5, 1, 9, 3].max\nputs [1, 2, 3, 4].sum\n") {
+        Some(out) => assert_eq!(out, "1\n9\n10\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_min_max_on_empty_is_nil_sum_is_zero() {
+    match run_ruby("puts [].min\nputs [].max\nputs [].sum\n") {
+        Some(out) => assert_eq!(out, "nil\nnil\n0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_sum_promotes_to_float() {
+    // Mirrors `+`'s own int/float promotion (`_sir_plus_v`, reused by `sum`).
+    match run_ruby("puts [1, 2.5].sum\n") {
+        Some(out) => assert_eq!(out, "3.5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_uniq_preserves_first_occurrence_order() {
+    match run_ruby("puts [1, 2, 1, 3, 2].uniq\n") {
+        Some(out) => assert_eq!(out, "[1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_compact_drops_nils() {
+    match run_ruby("puts [1, nil, 2, nil, 3].compact\n") {
+        Some(out) => assert_eq!(out, "[1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_flatten_is_fully_recursive() {
+    match run_ruby("puts [1, [2, [3, 4], 5], 6].flatten\n") {
+        Some(out) => assert_eq!(out, "[1, 2, 3, 4, 5, 6]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_to_a_is_the_array_itself() {
+    match run_ruby("puts [1, 2, 3].to_a\n") {
+        Some(out) => assert_eq!(out, "[1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_methods_chain() {
+    // `sort` returns an Array, so another built-in method dispatches on it.
+    match run_ruby("puts [3, 1, 2].sort.reverse\n") {
+        Some(out) => assert_eq!(out, "[3, 2, 1]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+// The Ruby frontend has no source syntax for an index-assignment TARGET like
+// `a[0] = a` yet (only `SeqSet` built by hand reaches it — see the sibling
+// `compile_and_run_sequences.rs`'s own `cyclic_sequence_does_not_stack_overflow`,
+// which hand-builds for the same reason), so the cyclic-flatten proof below
+// hand-builds a `semantic_ir::Module` directly rather than going through
+// `run_ruby`.
+mod cyclic {
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use semantic_ir::{
+        Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span,
+        Stmt, CURRENT_SIR_VERSION,
+    };
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn run(module: &Module) -> Option<String> {
+        let cc = super::find_cc()?;
+        let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+        let dir = std::env::temp_dir();
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let stem = format!("sirc_arrm_cyc_{}_{}", std::process::id(), n);
+        let cpath: PathBuf = dir.join(format!("{stem}.c"));
+        let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&cpath, &artifact.source).expect("write .c");
+        let out = Command::new(&cc)
+            .args(["-std=c99", "-Wall", "-o"])
+            .arg(&exe)
+            .arg(&cpath)
+            .output()
+            .expect("spawn cc");
+        assert!(
+            out.status.success(),
+            "compile failed:\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&out.stderr),
+            artifact.source
+        );
+        let r = Command::new(&exe).output().expect("run");
+        assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+        Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+    }
+
+    fn s() -> Span {
+        Span::synthetic()
+    }
+    fn ilit(v: i64) -> Expr {
+        Expr::IntLit { value: v, span: s() }
+    }
+    fn local(name: &str) -> Expr {
+        Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+    }
+    fn bc(name: &str, args: Vec<Expr>) -> Expr {
+        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+    }
+    fn puts(arg: Expr) -> Stmt {
+        Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+    }
+    fn let_(name: &str, value: Expr) -> Stmt {
+        Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+    }
+
+    #[test]
+    fn array_flatten_on_a_cyclic_array_terminates() {
+        // A self-referential array (`a[0] = a`, constructible via the existing
+        // mutable `SeqSet`) must not stack-overflow `flatten` — the recursion
+        // shares `SIR_MAX_EQ_DEPTH` with `_sir_value_eq`/`_sir_fmt`. The exact
+        // shape past the cap is unspecified, so `flatten`'s result is computed
+        // but deliberately not printed — only that the process reaches and
+        // prints past it (exit 0) is asserted.
+        let m = Module {
+            name: "arrcycprog".into(),
+            manifest: FeatureManifest::from_features(&[
+                Feature::Sequences,
+                Feature::Strings,
+                Feature::MutableBindings,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![Function {
+                name: "main".into(),
+                params: vec![],
+                return_type: None,
+                captures: vec![],
+                body: Block {
+                    stmts: vec![
+                        let_("a", Expr::SeqLit { items: vec![ilit(1), ilit(2)], span: s() }),
+                        Stmt::SeqSet { seq: local("a"), index: ilit(0), value: local("a"), span: s() },
+                        let_(
+                            "b",
+                            bc(
+                                "__method__",
+                                vec![local("a"), Expr::StrLit { value: "flatten".into(), span: s() }],
+                            ),
+                        ),
+                        puts(Expr::StrLit { value: "ok".into(), span: s() }),
+                    ],
+                    value: Expr::NilLit { span: s() },
+                    span: s(),
+                },
+                effects: EffectSet::PURE,
+                metadata: Metadata::new(),
+                span: s(),
+            }],
+            globals: vec![],
+            metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        match run(&m) {
+            Some(out) => assert_eq!(out, "ok\n"),
+            None => eprintln!("skip: no cc"),
+        }
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_methods.rs
@@ -236,15 +236,21 @@ mod cyclic {
         Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
     }
 
-    #[test]
-    fn array_flatten_on_a_cyclic_array_terminates() {
-        // A self-referential array (`a[0] = a`, constructible via the existing
-        // mutable `SeqSet`) must not stack-overflow `flatten` — the recursion
-        // shares `SIR_MAX_EQ_DEPTH` with `_sir_value_eq`/`_sir_fmt`. The exact
-        // shape past the cap is unspecified, so `flatten`'s result is computed
-        // but deliberately not printed — only that the process reaches and
-        // prints past it (exit 0) is asserted.
-        let m = Module {
+    /// A `main` module: `a = [1, 2]`, then `sets` (each an index to point back
+    /// at `a` itself), then `a.flatten`, then `puts "ok"`. Shared by both the
+    /// linear (one self-pointing element) and branching (every element
+    /// self-pointing) cyclic-flatten proofs below.
+    fn cyclic_flatten_module(sets: &[i64]) -> Module {
+        let mut stmts = vec![let_("a", Expr::SeqLit { items: vec![ilit(1), ilit(2)], span: s() })];
+        for &i in sets {
+            stmts.push(Stmt::SeqSet { seq: local("a"), index: ilit(i), value: local("a"), span: s() });
+        }
+        stmts.push(let_(
+            "b",
+            bc("__method__", vec![local("a"), Expr::StrLit { value: "flatten".into(), span: s() }]),
+        ));
+        stmts.push(puts(Expr::StrLit { value: "ok".into(), span: s() }));
+        Module {
             name: "arrcycprog".into(),
             manifest: FeatureManifest::from_features(&[
                 Feature::Sequences,
@@ -258,22 +264,7 @@ mod cyclic {
                 params: vec![],
                 return_type: None,
                 captures: vec![],
-                body: Block {
-                    stmts: vec![
-                        let_("a", Expr::SeqLit { items: vec![ilit(1), ilit(2)], span: s() }),
-                        Stmt::SeqSet { seq: local("a"), index: ilit(0), value: local("a"), span: s() },
-                        let_(
-                            "b",
-                            bc(
-                                "__method__",
-                                vec![local("a"), Expr::StrLit { value: "flatten".into(), span: s() }],
-                            ),
-                        ),
-                        puts(Expr::StrLit { value: "ok".into(), span: s() }),
-                    ],
-                    value: Expr::NilLit { span: s() },
-                    span: s(),
-                },
+                body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
                 effects: EffectSet::PURE,
                 metadata: Metadata::new(),
                 span: s(),
@@ -281,8 +272,36 @@ mod cyclic {
             globals: vec![],
             metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
             span: s(),
-        };
-        match run(&m) {
+        }
+    }
+
+    #[test]
+    fn array_flatten_on_a_linearly_cyclic_array_terminates() {
+        // `a = [1, 2]; a[0] = a` — ONE element points back to `a`, the other
+        // (`2`) is a plain leaf. `flatten`'s recursion has a fixed fan-out of
+        // 1 down the cyclic branch, so this is bounded by the DEPTH cap alone.
+        // The exact shape past the cap is unspecified, so `flatten`'s result
+        // is computed but deliberately not printed — only that the process
+        // reaches and prints past it (exit 0) is asserted.
+        match run(&cyclic_flatten_module(&[0])) {
+            Some(out) => assert_eq!(out, "ok\n"),
+            None => eprintln!("skip: no cc"),
+        }
+    }
+
+    #[test]
+    fn array_flatten_on_a_branching_cyclic_array_terminates() {
+        // `a = [1, 2]; a[0] = a; a[1] = a` — BOTH elements point back to `a`,
+        // so naive recursion fans out ~2^depth calls; with the depth cap at
+        // 500 that is astronomically more work than a depth-only guard could
+        // ever finish (and would overflow the `int64_t` element count well
+        // before the cap, under-allocating the output buffer). This is
+        // exactly the gap a depth-only cap leaves open — `flatten` must ALSO
+        // cap total nodes visited, independent of depth, for this to
+        // terminate promptly. Asserts only that the process completes
+        // (exit 0) in reasonable time; the flattened shape past the budget
+        // is unspecified.
+        match run(&cyclic_flatten_module(&[0, 1])) {
             Some(out) => assert_eq!(out, "ok\n"),
             None => eprintln!("skip: no cc"),
         }

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -331,6 +331,39 @@ fn collection_string_query_passes_its_argument() {
 }
 
 #[test]
+fn collection_array_methods_route_to_the_builtin_dispatcher() {
+    // Collections slice 3: a `__method__` dispatch to a 0-arg Array method
+    // (`sort`) that is NOT a user-defined method routes to
+    // `_sir_builtin_method`, same as the slice-1 String methods.
+    let m = lower_ruby("puts [3, 1, 2].sort");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_builtin_method("),
+        "a built-in Array method dispatches through the runtime dispatcher\n{src}"
+    );
+    assert!(
+        src.contains("\"sort\""),
+        "the method name is a quoted C string literal\n{src}"
+    );
+}
+
+#[test]
+fn collection_array_reverse_shares_the_slice1_string_name() {
+    // `reverse` is allowlisted once (slice 1, for String) and its runtime arm
+    // widens to accept `SIR_SEQ` in slice 3 — the allowlist itself does not
+    // change, so this just confirms an Array receiver still dispatches (not
+    // rejected as an unknown-for-this-receiver-type name at compile time; the
+    // receiver-type check happens at RUNTIME, matching every other polymorphic
+    // built-in here).
+    let m = lower_ruby("puts [1, 2, 3].reverse");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_builtin_method("),
+        "an Array `reverse` dispatches through the runtime dispatcher, not rejected at compile time\n{src}"
+    );
+}
+
+#[test]
 fn sanitize_ident_maps_into_c() {
     assert_eq!(sanitize_ident("foo"), "foo");
     assert_eq!(sanitize_ident("foo_bar1"), "foo_bar1");


### PR DESCRIPTION
## Summary
- Extends the C backend's `_sir_builtin_method` dispatcher with 0-arg Array (`SIR_SEQ`) collection methods: `count`, `first`, `last`, `sort`, `min`, `max`, `sum`, `uniq`, `compact`, `flatten`, `to_a` — plus a `SIR_SEQ` arm for the existing slice-1 `reverse`. No new `Feature` variant.
- Each method returns a **fresh** value; the receiver is never mutated (mirrors slice 1/2's shape). `sort`/`min`/`max` reuse the runtime's own `_sir_lt`/`_sir_gt`; `uniq` reuses `_sir_value_eq` (structural).
- Security review (2 rounds) caught and fixed a real HIGH-severity gap in `flatten`: a depth-only recursion cap is unsound for a *branching* self-referential array (`a=[1,2]; a[0]=a; a[1]=a`, constructible via the existing mutable `SeqSet`) — it fans out exponentially, risking a CPU-exhaustion hang, `int64_t` overflow, and a resulting heap under-allocation. Fixed by threading a shared total-work budget (`SIR_MAX_FLATTEN_NODES`) through both the counting and filling passes, in addition to the depth cap. New test (`array_flatten_on_a_branching_cyclic_array_terminates`) pins the fix.
- CHANGELOG (0.24.0) + README updated; version bumped 0.23.1 → 0.24.0.

## Test plan
- [x] `cargo test -p semantic-ir-to-c` — full crate suite green (execution-proof tests compile+run real emitted C via `cc`)
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` — clean
- [x] `cargo build --workspace` — green (no ripple; no core `Feature` enum touched)
- [x] Security review — 2 rounds, PASSED (round 1 found the flatten DoS/overflow gap; round 2 verified the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>