### PR TITLE
Report nonconforming HTML doctypes

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Initial doctypes now report the Standard's parse error when their name,
+  public identifier, or system identifier does not match the allowed HTML
+  forms, closing 14 previously silent malformed corpus cases.
 - Full-document parsing now reports the in-body EOF parse error when disallowed
   elements remain on the stack, closing 335 previously silent malformed corpus
   cases without changing DOM recovery or fragment diagnostics.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -25,8 +25,8 @@ The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
 all 6,806 html5lib tokenizer cases with zero missing signatures and zero
 normalized skips. DOM output is complete, but diagnostic coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the full-document in-body EOF slice, 1,759 of those cases emit at least
-one lexer or parser diagnostic and 424 remain uncovered. Another 139
+After the initial-doctype conformance slice, 1,773 of those cases emit at least
+one lexer or parser diagnostic and 410 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -36,9 +36,12 @@ Prioritized work items:
 
 1. **Document shell insertion modes.** Emit the remaining parse errors around
    explicit and implied `html`, `head`, and `body` creation. Missing-doctype
-   handling, duplicate shell start-tag diagnostics, body/html end tags with
-   disallowed open elements, and full-document in-body EOF diagnostics are
-   complete.
+   handling, nonconforming initial-doctype diagnostics, duplicate shell
+   start-tag diagnostics, body/html end tags with disallowed open elements,
+   and full-document in-body EOF diagnostics are complete. The current
+   silent-case inventory identifies unexpected character, start-tag, and
+   end-tag tokens in the after-body and after-after-body modes as the next
+   concrete shell slice.
 2. **Fragment EOF diagnostics.** Audit the current in-body EOF rule against
    fragment parsing. Legacy fragment fixtures omit many EOF error rows, so add
    explicit current-WHATWG evidence before extending the full-document

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4654,7 +4654,24 @@ impl HtmlParser {
         match token {
             Token::Text(text) if is_html_whitespace_text(text) => {}
             Token::Comment(_) | Token::ProcessingInstruction { .. } => {}
-            Token::Doctype { .. } => self.initial_insertion_mode = false,
+            Token::Doctype {
+                name,
+                public_identifier,
+                system_identifier,
+                ..
+            } => {
+                if !is_conforming_initial_doctype(
+                    name.as_deref(),
+                    public_identifier.as_deref(),
+                    system_identifier.as_deref(),
+                ) {
+                    self.diagnostics.push(ParserDiagnostic::new(
+                        "nonconforming-doctype",
+                        "initial doctype did not match the HTML Standard's allowed form",
+                    ));
+                }
+                self.initial_insertion_mode = false;
+            }
             _ => {
                 self.initial_insertion_mode = false;
                 self.quirks_mode = true;
@@ -10269,6 +10286,16 @@ fn doctype_triggers_quirks(
         system_identifier
             .eq_ignore_ascii_case("http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd")
     })
+}
+
+fn is_conforming_initial_doctype(
+    name: Option<&str>,
+    public_identifier: Option<&str>,
+    system_identifier: Option<&str>,
+) -> bool {
+    name.is_some_and(|name| name.eq_ignore_ascii_case("html"))
+        && public_identifier.is_none()
+        && system_identifier.is_none_or(|identifier| identifier == "about:legacy-compat")
 }
 
 fn is_table_section(name: &str) -> bool {
@@ -32749,6 +32776,33 @@ mod tests {
             .parser_diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "missing-doctype"));
+    }
+
+    #[test]
+    fn reports_nonconforming_initial_doctypes() {
+        for source in [
+            "<!doctype potato>",
+            "<!doctype html public 'legacy'>",
+            "<!doctype html system 'legacy'>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "nonconforming-doctype",
+                    "initial doctype did not match the HTML Standard's allowed form"
+                )],
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html>",
+            "<!doctype html system 'about:legacy-compat'>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.is_empty(), "source {source:?}");
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -14,7 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
-    "upstream_revision": "34174a4a37b1c0b8570fd816600191aaa7a5d7f7",
+    "upstream_revision": "8ff51b7de9b569733c5be7d0636c92c258ffdd27",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 424);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1759);
+    assert_eq!(missing_diagnostic_cases, 410);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1773);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the current HTML Standard's initial insertion-mode parse error for doctypes whose name, public identifier, or system identifier does not match the allowed HTML forms
- preserve existing DOM construction and quirks-mode selection while adding focused valid and invalid doctype evidence
- refresh the checked live WPT audit revision and ratchet diagnostic coverage from 1,759 to 1,773 malformed tree-construction cases

## Evidence
The current Standard requires a parse error for an initial doctype when its name is not `html`, its public identifier is present, or its system identifier is neither absent nor exactly `about:legacy-compat`.

This closes 14 previously silent declared-error cases:
- missing diagnostic cases: 424 -> 410
- covered declared-error cases: 1,759 -> 1,773
- undeclared diagnostic cases: unchanged at 139
- checked DOM outputs: all 2,637 preserved

A fresh upstream audit at WPT revision `8ff51b7de9b569733c5be7d0636c92c258ffdd27` confirms:
- WPT tree construction: 1,934/1,934 signatures covered
- html5lib tokenizer: 6,806/6,806 signatures covered
- normalized tokenizer skips: 0

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`
