### PR TITLE
feat(smart-home): add authorized AirGradient local controls

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Expose device indicator/display and sensor calibration command labels across
+  the Chief smart-home tool boundary.
+
 All notable changes to this package will be documented in this file.
 
 ## Unreleased

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -25,7 +25,8 @@ use smart_home_core::{
     AuthorizationSubject, Bridge, BridgeId, Capability, CapabilityGrant, CapabilityGrantId,
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
     CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device, DeviceCommand,
-    DeviceEvent, DeviceEventType, DeviceId, EntityId, EntityKind, EventId, Health,
+    DeviceControlCommandType, DeviceEvent, DeviceEventType, DeviceId, EntityId, EntityKind, EventId,
+    Health,
     IntegrationCatalogSummary, IntegrationId, MediaCommandType, Metadata, PrivilegeTier,
     ProtocolFamily,
     ProtocolIdentifier, RuntimeKind, Scene, SceneAction, SceneId, SceneScope,
@@ -89725,8 +89726,12 @@ fn json_to_smart_value_for_command(
         | CommandType::RecallScene
         | CommandType::Media(MediaCommandType::PlayNext)
         | CommandType::Media(MediaCommandType::PlayPrevious)
-        | CommandType::Media(MediaCommandType::ClearQueue) => Ok(Value::Null),
-        CommandType::SetBrightness | CommandType::Media(MediaCommandType::SetVolume) => {
+        | CommandType::Media(MediaCommandType::ClearQueue)
+        | CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor) => Ok(Value::Null),
+        CommandType::SetBrightness
+        | CommandType::Media(MediaCommandType::SetVolume)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorBrightness)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness) => {
             match json_to_smart_value(value)? {
                 Value::Integer(value) if (0..=100).contains(&value) => {
                     Ok(Value::Percentage(value as u8))
@@ -89739,7 +89744,8 @@ fn json_to_smart_value_for_command(
         | CommandType::SetColorTemperature
         | CommandType::SetLock
         | CommandType::SetThermostatSetpoint
-        | CommandType::Media(_) => json_to_smart_value(value),
+        | CommandType::Media(_)
+        | CommandType::DeviceControl(_) => json_to_smart_value(value),
     }
 }
 
@@ -90141,6 +90147,18 @@ fn parse_command_type(label: &str) -> Result<CommandType, ToolCallError> {
         "media_play_queue_item" => Ok(CommandType::Media(MediaCommandType::PlayQueueItem)),
         "media_remove_queue_item" => Ok(CommandType::Media(MediaCommandType::RemoveQueueItem)),
         "media_move_queue_item" => Ok(CommandType::Media(MediaCommandType::MoveQueueItem)),
+        "device_set_indicator_mode" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetIndicatorMode,
+        )),
+        "device_set_indicator_brightness" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetIndicatorBrightness,
+        )),
+        "device_set_display_brightness" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetDisplayBrightness,
+        )),
+        "sensor_calibrate" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::CalibrateSensor,
+        )),
         _ => Err(validation_error(format!("unknown command_type `{label}`"))),
     }
 }
@@ -92517,6 +92535,18 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         CommandType::Media(MediaCommandType::PlayQueueItem) => "media_play_queue_item",
         CommandType::Media(MediaCommandType::RemoveQueueItem) => "media_remove_queue_item",
         CommandType::Media(MediaCommandType::MoveQueueItem) => "media_move_queue_item",
+        CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorMode) => {
+            "device_set_indicator_mode"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorBrightness) => {
+            "device_set_indicator_brightness"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness) => {
+            "device_set_display_brightness"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor) => {
+            "sensor_calibrate"
+        }
     }
 }
 
@@ -121415,6 +121445,33 @@ mod tests {
         ];
         for (label, media_command) in commands {
             let command = CommandType::Media(media_command);
+            assert_eq!(parse_command_type(label).unwrap(), command);
+            assert_eq!(command_type_label(command), label);
+        }
+    }
+
+    #[test]
+    fn device_control_command_labels_round_trip_through_the_chief_boundary() {
+        let commands = [
+            (
+                "device_set_indicator_mode",
+                DeviceControlCommandType::SetIndicatorMode,
+            ),
+            (
+                "device_set_indicator_brightness",
+                DeviceControlCommandType::SetIndicatorBrightness,
+            ),
+            (
+                "device_set_display_brightness",
+                DeviceControlCommandType::SetDisplayBrightness,
+            ),
+            (
+                "sensor_calibrate",
+                DeviceControlCommandType::CalibrateSensor,
+            ),
+        ];
+        for (label, device_command) in commands {
+            let command = CommandType::DeviceControl(device_command);
             assert_eq!(parse_command_type(label).unwrap(), command);
             assert_eq!(command_type_label(command), label);
         }

--- a/code/packages/rust/matter-core/src/lib.rs
+++ b/code/packages/rust/matter-core/src/lib.rs
@@ -675,7 +675,8 @@ pub fn matter_command_for_device_command(
         CommandType::SetColor
         | CommandType::RecallScene
         | CommandType::SetThermostatSetpoint
-        | CommandType::Media(_) => {
+        | CommandType::Media(_)
+        | CommandType::DeviceControl(_) => {
             Err(MatterError::UnsupportedCommand {
                 command_type: command.command_type,
             })

--- a/code/packages/rust/smart-home-airgradient-local-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-airgradient-local-integration/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.2.0
+
+- Add authorized LED-bar mode and brightness plus display-brightness controls.
+- Add a human-approval CO2 calibration command over the local configuration API.
+- Read configuration-control mode before writes, reject cloud-only conflicts,
+  warn when cloud configuration can overwrite a local change, and verify
+  persistent settings through readback.
+- Add real loopback coverage for every command and denial-before-I/O coverage.
+
 ## 0.1.0
 
 - Add verified `airgradient_<serial>.local` and manual HTTP discovery.

--- a/code/packages/rust/smart-home-airgradient-local-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-airgradient-local-integration/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smart-home-airgradient-local-integration"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "AirGradient local monitor telemetry integration for the smart-home runtime"
+description = "AirGradient local monitor telemetry and control integration for the smart-home runtime"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/smart-home-airgradient-local-integration/README.md
+++ b/code/packages/rust/smart-home-airgradient-local-integration/README.md
@@ -1,15 +1,21 @@
 # smart-home-airgradient-local-integration
 
-First-party, read-only AirGradient local monitor integration for D23.
+First-party AirGradient local monitor integration for D23.
 
 It resolves the documented `airgradient_<serial>.local` mDNS hostname or
 accepts a manual host. A bounded local HTTP client reads
 `/measures/current`, verifies the returned serial, model, and firmware, and
 installs normalized PM, CO2, temperature, humidity, VOC, NOx, particle-count,
-and Wi-Fi sensor entities. D23 authorization is checked before any network I/O.
+and Wi-Fi sensor entities. It also reads `/config` and installs an indicator and
+display control surface plus an explicit CO2 calibration command.
 
-Local configuration mutation, LED/display control, and CO2 calibration remain
-separate work.
+The local runtime supports LED-bar mode (`co2`, `pm`, `iaqs`, or `off`), LED-bar
+brightness, display brightness, and the documented 400 ppm CO2 calibration
+trigger. Every command is validated and authorized before transport I/O.
+Brightness and mode updates are confirmed with a configuration readback.
+Monitors with `configurationControl=cloud` reject local commands explicitly;
+`configurationControl=both` succeeds with a warning that a later cloud update
+may overwrite the local value.
 
 ```bash
 cargo run -p smart-home-airgradient-local-integration -- discover ecda3b1eaaaf

--- a/code/packages/rust/smart-home-airgradient-local-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-airgradient-local-integration/src/lib.rs
@@ -7,9 +7,9 @@ use http_core::BodyKind;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use smart_home_core::{
     AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CapabilityMode, Device,
-    DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId, Metadata, ProtocolFamily,
-    ProtocolIdentifier, SmartHomeTool, StateConfidence, StateSnapshot, StateSource, Value,
-    ValueKind,
+    CommandResult, CommandType, DeviceControlCommandType, DeviceId, Entity, EntityId, EntityKind,
+    Health, IntegrationId, Metadata, ProtocolFamily, ProtocolIdentifier, SmartHomeTool,
+    StateConfidence, StateSnapshot, StateSource, Value, ValueKind,
 };
 use smart_home_discovery::{
     DiscoveryConfidence, DiscoveryRecord, DiscoverySource, PairingRequirement,
@@ -18,18 +18,19 @@ use smart_home_local_http::{
     LocalHttpEndpoint, LocalHttpError, LocalHttpMethod, LocalHttpRequestPlan,
     LocalHttpRequestTemplate, LocalHttpScheme,
 };
-use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
-use std::collections::BTreeSet;
+use smart_home_runtime::{RuntimeCommandToolRequest, RuntimeError, SmartHomeRuntime};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 pub const INTEGRATION_ID: &str = "airgradient";
 pub const PROTOCOL_ID: &str = "airgradient_local_api";
 pub const MEASUREMENT_PATH: &str = "/measures/current";
+pub const CONFIGURATION_PATH: &str = "/config";
 pub const DEFAULT_PORT: u16 = 80;
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
 
@@ -46,6 +47,14 @@ pub enum AirGradientError {
     Json(serde_json::Error),
     MissingField(&'static str),
     NoMeasurements,
+    UnknownEntity(EntityId),
+    UnsupportedCommand(CommandType),
+    InvalidCommandArguments {
+        command_type: CommandType,
+        expected: &'static str,
+    },
+    CloudConfigurationConflict,
+    VerificationFailed(&'static str),
     Runtime(RuntimeError),
 }
 
@@ -75,6 +84,25 @@ impl fmt::Display for AirGradientError {
             }
             Self::NoMeasurements => {
                 formatter.write_str("AirGradient response contains no numeric measurements")
+            }
+            Self::UnknownEntity(entity_id) => {
+                write!(formatter, "unknown AirGradient entity {entity_id}")
+            }
+            Self::UnsupportedCommand(command_type) => {
+                write!(formatter, "unsupported AirGradient command {command_type:?}")
+            }
+            Self::InvalidCommandArguments {
+                command_type,
+                expected,
+            } => write!(
+                formatter,
+                "invalid arguments for AirGradient command {command_type:?}; expected {expected}"
+            ),
+            Self::CloudConfigurationConflict => formatter.write_str(
+                "AirGradient configurationControl=cloud rejects local configuration; changing it to local requires a factory reset"
+            ),
+            Self::VerificationFailed(field) => {
+                write!(formatter, "AirGradient did not confirm updated {field}")
             }
             Self::Runtime(error) => error.fmt(formatter),
         }
@@ -201,6 +229,31 @@ pub struct AirGradientSnapshot {
     pub measurements: Vec<AirGradientMeasurement>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AirGradientConfigurationControl {
+    Local,
+    Both,
+    Cloud,
+}
+
+impl AirGradientConfigurationControl {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Both => "both",
+            Self::Cloud => "cloud",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AirGradientConfiguration {
+    pub control: AirGradientConfigurationControl,
+    pub led_bar_mode: String,
+    pub led_bar_brightness: u8,
+    pub display_brightness: u8,
+}
+
 pub fn discovery_record(
     config: &AirGradientConfig,
     snapshot: &AirGradientSnapshot,
@@ -299,6 +352,10 @@ impl<T: AirGradientTransport> AirGradientClient<T> {
         &self.transport
     }
 
+    pub fn transport_mut(&mut self) -> &mut T {
+        &mut self.transport
+    }
+
     pub fn inspect(&mut self) -> Result<AirGradientSnapshot, AirGradientError> {
         let data = self.request_json(MEASUREMENT_PATH)?;
         let snapshot = parse_snapshot(&data)?;
@@ -313,6 +370,21 @@ impl<T: AirGradientTransport> AirGradientClient<T> {
             ));
         }
         Ok(snapshot)
+    }
+
+    pub fn configuration(&mut self) -> Result<AirGradientConfiguration, AirGradientError> {
+        parse_configuration(&self.request_json(CONFIGURATION_PATH)?)
+    }
+
+    pub fn update_configuration(&mut self, update: &JsonValue) -> Result<(), AirGradientError> {
+        let template = LocalHttpRequestTemplate::new(LocalHttpMethod::Put, CONFIGURATION_PATH)?
+            .with_accept("application/json")
+            .with_content_type("application/json")
+            .with_timeout_ms(duration_ms(self.config.timeout));
+        let body = serde_json::to_vec(update)?;
+        self.transport
+            .execute(&template.plan(&self.endpoint, body)?)?;
+        Ok(())
     }
 
     fn request_json(&mut self, path: &str) -> Result<JsonValue, AirGradientError> {
@@ -344,11 +416,29 @@ pub struct InstalledAirGradientDevice {
 
 pub struct AirGradientRuntimeIntegration<T> {
     client: AirGradientClient<T>,
+    command_targets: BTreeMap<EntityId, AirGradientCommandTarget>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AirGradientCommandTarget {
+    Indicator,
+    Co2Sensor,
 }
 
 impl<T: AirGradientTransport> AirGradientRuntimeIntegration<T> {
     pub fn new(client: AirGradientClient<T>) -> Self {
-        Self { client }
+        Self {
+            client,
+            command_targets: BTreeMap::new(),
+        }
+    }
+
+    pub fn transport(&self) -> &T {
+        self.client.transport()
+    }
+
+    pub fn transport_mut(&mut self) -> &mut T {
+        self.client.transport_mut()
     }
 
     pub fn inspect_and_install_authorized(
@@ -359,7 +449,16 @@ impl<T: AirGradientTransport> AirGradientRuntimeIntegration<T> {
     ) -> Result<InstalledAirGradientDevice, AirGradientError> {
         authorize_read(runtime, principal_id, observed_at_ms)?;
         let snapshot = self.client.inspect()?;
-        self.install_snapshot(runtime, &snapshot, observed_at_ms)
+        let configuration = self.client.configuration()?;
+        let mut installed = self.install_snapshot(runtime, &snapshot, observed_at_ms)?;
+        self.install_control_surface(
+            runtime,
+            &snapshot,
+            &configuration,
+            &mut installed,
+            observed_at_ms,
+        )?;
+        Ok(installed)
     }
 
     pub fn install_snapshot(
@@ -451,6 +550,256 @@ impl<T: AirGradientTransport> AirGradientRuntimeIntegration<T> {
             entity_ids,
         })
     }
+
+    fn install_control_surface(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        snapshot: &AirGradientSnapshot,
+        configuration: &AirGradientConfiguration,
+        installed: &mut InstalledAirGradientDevice,
+        observed_at_ms: u64,
+    ) -> Result<(), AirGradientError> {
+        let native_id = stable_component(&snapshot.device_info.serial);
+        let co2_entity_id = EntityId::trusted(format!(
+            "airgradient:{native_id}:sensor:rco2"
+        ));
+        let mut co2_entity = runtime
+            .registry()
+            .entity(&co2_entity_id)
+            .cloned()
+            .ok_or_else(|| AirGradientError::UnknownEntity(co2_entity_id.clone()))?;
+        co2_entity.capabilities.push(Capability::sensor_calibration());
+        runtime.upsert_entity(co2_entity)?;
+
+        let indicator_entity_id = EntityId::trusted(format!("airgradient:{native_id}:indicator"));
+        runtime.upsert_entity(Entity {
+            entity_id: indicator_entity_id.clone(),
+            device_id: installed.device_id.clone(),
+            kind: EntityKind::Light,
+            name: format!("{} indicator and display", self.client.config.display_name),
+            capabilities: vec![Capability::device_indicator(), Capability::device_display()],
+            state: Some(confirmed_state(
+                indicator_entity_id.clone(),
+                configuration_value(configuration),
+                observed_at_ms,
+            )),
+            metadata: vec![
+                Metadata::new("airgradient.control_surface", "indicator_display"),
+                Metadata::new(
+                    "airgradient.configuration_control",
+                    configuration.control.as_str(),
+                ),
+            ],
+        })?;
+
+        let mut device = runtime
+            .registry()
+            .device(&installed.device_id)
+            .cloned()
+            .ok_or_else(|| AirGradientError::Validation("installed device disappeared".to_string()))?;
+        device.entity_ids.push(indicator_entity_id.clone());
+        device.metadata.push(Metadata::new(
+            "airgradient.configuration_control",
+            configuration.control.as_str(),
+        ));
+        runtime.upsert_device(device)?;
+        installed.entity_ids.push(indicator_entity_id.clone());
+        self.command_targets = BTreeMap::from([
+            (indicator_entity_id, AirGradientCommandTarget::Indicator),
+            (co2_entity_id, AirGradientCommandTarget::Co2Sensor),
+        ]);
+        Ok(())
+    }
+
+    pub fn dispatch_command_authorized(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        request: RuntimeCommandToolRequest,
+        now_ms: u64,
+    ) -> Result<CommandResult, AirGradientError> {
+        let plan = airgradient_command_plan(&self.command_targets, &request)?;
+        let target_entity_id = request.entity_id.clone();
+        let command = runtime.authorize_command_tool(principal_id, request, now_ms)?;
+        let configuration = self.client.configuration()?;
+        if configuration.control == AirGradientConfigurationControl::Cloud {
+            return Err(AirGradientError::CloudConfigurationConflict);
+        }
+        let mut result = runtime.submit_command(command, now_ms)?;
+        self.client.update_configuration(&plan.update)?;
+        if let Some(expected) = plan.expected {
+            let confirmed = self.client.configuration()?;
+            expected.verify(&confirmed)?;
+            let mut entity = runtime
+                .registry()
+                .entity(&target_entity_id)
+                .cloned()
+                .ok_or_else(|| AirGradientError::UnknownEntity(target_entity_id.clone()))?;
+            entity.state = Some(confirmed_state(
+                target_entity_id,
+                configuration_value(&confirmed),
+                now_ms,
+            ));
+            runtime.upsert_entity(entity)?;
+        }
+        result.message = Some(match configuration.control {
+            AirGradientConfigurationControl::Local => {
+                "AirGradient confirmed the local control request".to_string()
+            }
+            AirGradientConfigurationControl::Both => {
+                "AirGradient confirmed the local request, but cloud configuration may overwrite it while configurationControl=both".to_string()
+            }
+            AirGradientConfigurationControl::Cloud => unreachable!(),
+        });
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct AirGradientCommandPlan {
+    update: JsonValue,
+    expected: Option<ExpectedConfiguration>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExpectedConfiguration {
+    IndicatorMode(String),
+    IndicatorBrightness(u8),
+    DisplayBrightness(u8),
+}
+
+impl ExpectedConfiguration {
+    fn verify(&self, configuration: &AirGradientConfiguration) -> Result<(), AirGradientError> {
+        let (matches, field) = match self {
+            Self::IndicatorMode(expected) => {
+                (configuration.led_bar_mode == *expected, "ledBarMode")
+            }
+            Self::IndicatorBrightness(expected) => (
+                configuration.led_bar_brightness == *expected,
+                "ledBarBrightness",
+            ),
+            Self::DisplayBrightness(expected) => (
+                configuration.display_brightness == *expected,
+                "displayBrightness",
+            ),
+        };
+        if matches {
+            Ok(())
+        } else {
+            Err(AirGradientError::VerificationFailed(field))
+        }
+    }
+}
+
+fn airgradient_command_plan(
+    targets: &BTreeMap<EntityId, AirGradientCommandTarget>,
+    request: &RuntimeCommandToolRequest,
+) -> Result<AirGradientCommandPlan, AirGradientError> {
+    let target = targets
+        .get(&request.entity_id)
+        .copied()
+        .ok_or_else(|| AirGradientError::UnknownEntity(request.entity_id.clone()))?;
+    match request.command_type {
+        CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorMode)
+            if target == AirGradientCommandTarget::Indicator =>
+        {
+            let Value::Text(mode) = &request.arguments else {
+                return invalid_command_arguments(request.command_type, "co2, pm, iaqs, or off text");
+            };
+            let mode = mode.to_ascii_lowercase();
+            if !matches!(mode.as_str(), "co2" | "pm" | "iaqs" | "off") {
+                return invalid_command_arguments(request.command_type, "co2, pm, iaqs, or off text");
+            }
+            Ok(AirGradientCommandPlan {
+                update: configuration_update("ledBarMode", JsonValue::String(mode.clone())),
+                expected: Some(ExpectedConfiguration::IndicatorMode(mode)),
+            })
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorBrightness)
+            if target == AirGradientCommandTarget::Indicator =>
+        {
+            let Value::Percentage(brightness) = request.arguments else {
+                return invalid_command_arguments(request.command_type, "a percentage brightness");
+            };
+            Ok(AirGradientCommandPlan {
+                update: configuration_update(
+                    "ledBarBrightness",
+                    JsonValue::from(brightness),
+                ),
+                expected: Some(ExpectedConfiguration::IndicatorBrightness(brightness)),
+            })
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness)
+            if target == AirGradientCommandTarget::Indicator =>
+        {
+            let Value::Percentage(brightness) = request.arguments else {
+                return invalid_command_arguments(request.command_type, "a percentage brightness");
+            };
+            Ok(AirGradientCommandPlan {
+                update: configuration_update(
+                    "displayBrightness",
+                    JsonValue::from(brightness),
+                ),
+                expected: Some(ExpectedConfiguration::DisplayBrightness(brightness)),
+            })
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor)
+            if target == AirGradientCommandTarget::Co2Sensor =>
+        {
+            if request.arguments != Value::Null {
+                return invalid_command_arguments(request.command_type, "null arguments");
+            }
+            Ok(AirGradientCommandPlan {
+                update: configuration_update(
+                    "co2CalibrationRequested",
+                    JsonValue::Bool(true),
+                ),
+                expected: None,
+            })
+        }
+        CommandType::DeviceControl(_) => invalid_command_arguments(
+            request.command_type,
+            "an AirGradient entity that advertises the command capability",
+        ),
+        command_type => Err(AirGradientError::UnsupportedCommand(command_type)),
+    }
+}
+
+fn invalid_command_arguments<T>(
+    command_type: CommandType,
+    expected: &'static str,
+) -> Result<T, AirGradientError> {
+    Err(AirGradientError::InvalidCommandArguments {
+        command_type,
+        expected,
+    })
+}
+
+fn configuration_update(field: &str, value: JsonValue) -> JsonValue {
+    let mut update = JsonMap::new();
+    update.insert(field.to_string(), value);
+    JsonValue::Object(update)
+}
+
+fn configuration_value(configuration: &AirGradientConfiguration) -> Value {
+    Value::Object(vec![
+        (
+            "mode".to_string(),
+            Value::Text(configuration.led_bar_mode.clone()),
+        ),
+        (
+            "indicator_brightness".to_string(),
+            Value::Percentage(configuration.led_bar_brightness),
+        ),
+        (
+            "display_brightness".to_string(),
+            Value::Percentage(configuration.display_brightness),
+        ),
+        (
+            "configuration_control".to_string(),
+            Value::Text(configuration.control.as_str().to_string()),
+        ),
+    ])
 }
 
 fn authorize_read(
@@ -469,6 +818,31 @@ fn authorize_read(
             missing_capabilities: decision.missing_capabilities,
         }))
     }
+}
+
+fn parse_configuration(data: &JsonValue) -> Result<AirGradientConfiguration, AirGradientError> {
+    let data = data
+        .as_object()
+        .ok_or(AirGradientError::MissingField("configuration object"))?;
+    let control = match required_string(data, "configurationControl")?
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "local" => AirGradientConfigurationControl::Local,
+        "both" => AirGradientConfigurationControl::Both,
+        "cloud" => AirGradientConfigurationControl::Cloud,
+        _ => {
+            return Err(AirGradientError::Validation(
+                "configurationControl must be local, both, or cloud".to_string(),
+            ))
+        }
+    };
+    Ok(AirGradientConfiguration {
+        control,
+        led_bar_mode: required_string(data, "ledBarMode")?.to_ascii_lowercase(),
+        led_bar_brightness: required_percentage(data, "ledBarBrightness")?,
+        display_brightness: required_percentage(data, "displayBrightness")?,
+    })
 }
 
 fn parse_snapshot(data: &JsonValue) -> Result<AirGradientSnapshot, AirGradientError> {
@@ -589,6 +963,22 @@ fn required_string(
         .filter(|value| !value.trim().is_empty())
         .map(str::to_string)
         .ok_or(AirGradientError::MissingField(field))
+}
+
+fn required_percentage(
+    value: &JsonMap<String, JsonValue>,
+    field: &'static str,
+) -> Result<u8, AirGradientError> {
+    let value = value
+        .get(field)
+        .and_then(JsonValue::as_u64)
+        .ok_or(AirGradientError::MissingField(field))?;
+    u8::try_from(value)
+        .ok()
+        .filter(|value| *value <= 100)
+        .ok_or_else(|| {
+            AirGradientError::Validation(format!("{field} must be between 0 and 100"))
+        })
 }
 
 fn measurement_value(measurement: &AirGradientMeasurement) -> Value {
@@ -826,6 +1216,11 @@ mod tests {
     use std::thread;
 
     const MEASUREMENTS: &str = r#"{"wifi":-46,"serialno":"ecda3b1eaaaf","rco2":447,"pm01":3,"pm02":7,"pm10":8,"pm003Count":442,"atmp":25.87,"atmpCompensated":24.47,"rhum":43,"rhumCompensated":49,"tvocIndex":100,"tvocRaw":33051,"noxIndex":1,"noxRaw":16307,"boot":6,"firmware":"3.1.3","model":"I-9PSL"}"#;
+    const CONFIG_BOTH: &str = r#"{"configurationControl":"both","ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_CLOUD: &str = r#"{"configurationControl":"cloud","ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_MODE_PM: &str = r#"{"configurationControl":"both","ledBarMode":"pm","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_LED_35: &str = r#"{"configurationControl":"both","ledBarMode":"pm","ledBarBrightness":35,"displayBrightness":70}"#;
+    const CONFIG_DISPLAY_25: &str = r#"{"configurationControl":"both","ledBarMode":"pm","ledBarBrightness":35,"displayBrightness":25}"#;
 
     fn response(body: &str) -> Vec<u8> {
         format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).into_bytes()
@@ -852,7 +1247,7 @@ mod tests {
                         break;
                     }
                     bytes.extend_from_slice(&buffer[..read]);
-                    if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                    if request_complete(&bytes) {
                         break;
                     }
                 }
@@ -864,6 +1259,22 @@ mod tests {
             }
         });
         (port, requests, handle)
+    }
+
+    fn request_complete(bytes: &[u8]) -> bool {
+        let Some(header_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") else {
+            return false;
+        };
+        let headers = String::from_utf8_lossy(&bytes[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())?
+            })
+            .unwrap_or(0);
+        bytes.len() >= header_end + 4 + content_length
     }
 
     fn config(port: u16) -> AirGradientConfig {
@@ -880,7 +1291,7 @@ mod tests {
             CapabilityGrant::for_all_smart_home(
                 CapabilityGrantId::trusted("grant:airgradient-test"),
                 principal.clone(),
-                PrivilegeTier::LowRisk,
+                PrivilegeTier::HumanApproval,
                 "test",
                 1_000,
             )
@@ -919,7 +1330,8 @@ mod tests {
 
     #[test]
     fn real_tcp_inspection_installs_environmental_sensors() {
-        let (port, requests, handle) = start_server(vec![response(MEASUREMENTS)]);
+        let (port, requests, handle) =
+            start_server(vec![response(MEASUREMENTS), response(CONFIG_BOTH)]);
         let client =
             AirGradientClient::new(config(port), AirGradientLanTransport::default()).unwrap();
         let mut integration = AirGradientRuntimeIntegration::new(client);
@@ -930,7 +1342,7 @@ mod tests {
             .inspect_and_install_authorized(&mut runtime, principal, 5_000)
             .unwrap();
         handle.join().unwrap();
-        assert_eq!(installed.entity_ids.len(), 12);
+        assert_eq!(installed.entity_ids.len(), 13);
         let co2 = runtime
             .registry()
             .entity(&EntityId::trusted(format!(
@@ -948,9 +1360,27 @@ mod tests {
         assert_eq!(device.manufacturer, "AirGradient");
         assert_eq!(device.model, "I-9PSL");
         assert_eq!(device.serial.as_deref(), Some("ecda3b1eaaaf"));
+        assert!(device
+            .metadata
+            .iter()
+            .any(|item| item.key == "airgradient.configuration_control" && item.value == "both"));
+        let indicator = runtime
+            .registry()
+            .entity(&EntityId::trusted("airgradient:ecda3b1eaaaf:indicator"))
+            .unwrap();
+        assert_eq!(indicator.kind, EntityKind::Light);
+        assert!(indicator
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id.as_str() == "device.display"));
+        assert!(co2
+            .capabilities
+            .iter()
+            .any(|capability| capability.capability_id.as_str() == "sensor.calibration"));
         let requests = requests.lock().unwrap();
-        assert_eq!(requests.len(), 1);
+        assert_eq!(requests.len(), 2);
         assert!(requests[0].contains(&format!("GET {MEASUREMENT_PATH} HTTP/1.1")));
+        assert!(requests[1].contains(&format!("GET {CONFIGURATION_PATH} HTTP/1.1")));
     }
 
     #[derive(Debug)]
@@ -969,6 +1399,34 @@ mod tests {
     impl AirGradientTransport for StaticTransport {
         fn execute(&mut self, _plan: &LocalHttpRequestPlan) -> Result<Vec<u8>, AirGradientError> {
             Ok(self.0.clone())
+        }
+    }
+
+    #[derive(Debug)]
+    struct SequenceTransport {
+        responses: Vec<Vec<u8>>,
+        calls: usize,
+    }
+
+    impl SequenceTransport {
+        fn new(responses: &[&str]) -> Self {
+            Self {
+                responses: responses
+                    .iter()
+                    .rev()
+                    .map(|response| response.as_bytes().to_vec())
+                    .collect(),
+                calls: 0,
+            }
+        }
+    }
+
+    impl AirGradientTransport for SequenceTransport {
+        fn execute(&mut self, _plan: &LocalHttpRequestPlan) -> Result<Vec<u8>, AirGradientError> {
+            self.calls += 1;
+            self.responses
+                .pop()
+                .ok_or_else(|| AirGradientError::Io("unexpected transport call".to_string()))
         }
     }
 
@@ -1011,6 +1469,182 @@ mod tests {
     }
 
     #[test]
+    fn denied_device_control_reaches_no_additional_transport() {
+        let client = AirGradientClient::new(
+            AirGradientConfig::new(
+                BridgeId::trusted("airgradient.command-denied"),
+                "http://127.0.0.1",
+            )
+            .unwrap(),
+            SequenceTransport::new(&[MEASUREMENTS, CONFIG_BOTH]),
+        )
+        .unwrap();
+        let mut integration = AirGradientRuntimeIntegration::new(client);
+        let installer = AgentId::trusted("agent:airgradient-installer");
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &installer);
+        integration
+            .inspect_and_install_authorized(&mut runtime, installer, 5_000)
+            .unwrap();
+
+        let request = RuntimeCommandToolRequest::new(
+            EntityId::trusted("airgradient:ecda3b1eaaaf:indicator"),
+            CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness),
+            Value::Percentage(25),
+        );
+        assert!(matches!(
+            integration.dispatch_command_authorized(
+                &mut runtime,
+                AgentId::trusted("agent:airgradient-denied"),
+                request,
+                6_000,
+            ),
+            Err(AirGradientError::Runtime(_))
+        ));
+        assert_eq!(integration.transport().calls, 2);
+    }
+
+    #[test]
+    fn cloud_control_conflict_stops_before_local_put() {
+        let client = AirGradientClient::new(
+            AirGradientConfig::new(
+                BridgeId::trusted("airgradient.cloud-conflict"),
+                "http://127.0.0.1",
+            )
+            .unwrap(),
+            SequenceTransport::new(&[MEASUREMENTS, CONFIG_BOTH, CONFIG_CLOUD]),
+        )
+        .unwrap();
+        let mut integration = AirGradientRuntimeIntegration::new(client);
+        let principal = AgentId::trusted("agent:airgradient-cloud-conflict");
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 5_000)
+            .unwrap();
+        let original_state = runtime
+            .registry()
+            .entity(&EntityId::trusted("airgradient:ecda3b1eaaaf:indicator"))
+            .unwrap()
+            .state
+            .clone();
+        let request = RuntimeCommandToolRequest::new(
+            EntityId::trusted("airgradient:ecda3b1eaaaf:indicator"),
+            CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorMode),
+            Value::Text("off".to_string()),
+        );
+        assert!(matches!(
+            integration.dispatch_command_authorized(&mut runtime, principal, request, 6_000),
+            Err(AirGradientError::CloudConfigurationConflict)
+        ));
+        assert_eq!(integration.transport().calls, 3);
+        assert_eq!(
+            runtime
+                .registry()
+                .entity(&EntityId::trusted("airgradient:ecda3b1eaaaf:indicator"))
+                .unwrap()
+                .state,
+            original_state
+        );
+        assert_eq!(runtime.optimistic_state_count(), 0);
+    }
+
+    #[test]
+    fn loopback_authorized_indicator_display_and_calibration_controls() {
+        let payloads = [
+            MEASUREMENTS,
+            CONFIG_BOTH,
+            CONFIG_BOTH,
+            "{}",
+            CONFIG_MODE_PM,
+            CONFIG_MODE_PM,
+            "{}",
+            CONFIG_LED_35,
+            CONFIG_LED_35,
+            "{}",
+            CONFIG_DISPLAY_25,
+            CONFIG_DISPLAY_25,
+            "{}",
+        ]
+        .into_iter()
+        .map(response)
+        .collect();
+        let (port, requests, handle) = start_server(payloads);
+        let client =
+            AirGradientClient::new(config(port), AirGradientLanTransport::default()).unwrap();
+        let mut integration = AirGradientRuntimeIntegration::new(client);
+        let principal = AgentId::trusted("agent:airgradient-control");
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 5_000)
+            .unwrap();
+        let indicator = EntityId::trusted("airgradient:ecda3b1eaaaf:indicator");
+        let co2 = EntityId::trusted("airgradient:ecda3b1eaaaf:sensor:rco2");
+        let commands = [
+            RuntimeCommandToolRequest::new(
+                indicator.clone(),
+                CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorMode),
+                Value::Text("pm".to_string()),
+            ),
+            RuntimeCommandToolRequest::new(
+                indicator.clone(),
+                CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorBrightness),
+                Value::Percentage(35),
+            ),
+            RuntimeCommandToolRequest::new(
+                indicator,
+                CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness),
+                Value::Percentage(25),
+            ),
+            RuntimeCommandToolRequest::new(
+                co2,
+                CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor),
+                Value::Null,
+            ),
+        ];
+        for (index, request) in commands.into_iter().enumerate() {
+            let result = integration
+                .dispatch_command_authorized(
+                    &mut runtime,
+                    principal.clone(),
+                    request,
+                    6_000 + index as u64,
+                )
+                .unwrap();
+            assert!(result
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("cloud configuration may overwrite")));
+        }
+        let indicator_state = runtime
+            .registry()
+            .entity(&EntityId::trusted("airgradient:ecda3b1eaaaf:indicator"))
+            .unwrap()
+            .state
+            .as_ref()
+            .unwrap();
+        assert_eq!(indicator_state.confidence, StateConfidence::Confirmed);
+        assert!(matches!(
+            &indicator_state.value,
+            Value::Object(fields)
+                if fields.contains(&("display_brightness".to_string(), Value::Percentage(25)))
+        ));
+        handle.join().unwrap();
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 13);
+        let put_requests = requests
+            .iter()
+            .filter(|request| request.starts_with(&format!("PUT {CONFIGURATION_PATH}")))
+            .collect::<Vec<_>>();
+        assert_eq!(put_requests.len(), 4);
+        assert!(put_requests[0].contains(r#"{"ledBarMode":"pm"}"#));
+        assert!(put_requests[1].contains(r#"{"ledBarBrightness":35}"#));
+        assert!(put_requests[2].contains(r#"{"displayBrightness":25}"#));
+        assert!(put_requests[3].contains(r#"{"co2CalibrationRequested":true}"#));
+    }
+
+    #[test]
     fn parser_requires_identity_and_known_measurements() {
         let missing_identity: JsonValue = serde_json::from_str(r#"{"rco2":447}"#).unwrap();
         assert!(matches!(
@@ -1040,6 +1674,25 @@ mod tests {
             .measurements
             .iter()
             .any(|measurement| measurement.id == "tvocRaw"));
+    }
+
+    #[test]
+    fn parser_validates_configuration_control_and_percentages() {
+        let configuration =
+            parse_configuration(&serde_json::from_str(CONFIG_BOTH).unwrap()).unwrap();
+        assert_eq!(configuration.control, AirGradientConfigurationControl::Both);
+        assert_eq!(configuration.led_bar_mode, "co2");
+        assert_eq!(configuration.led_bar_brightness, 80);
+        assert_eq!(configuration.display_brightness, 70);
+
+        let invalid = serde_json::from_str(
+            r#"{"configurationControl":"cloudish","ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":101}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            parse_configuration(&invalid),
+            Err(AirGradientError::Validation(_))
+        ));
     }
 
     #[test]

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add canonical device indicator, display, and sensor calibration capabilities
+  with explicit device-control command types and risk tiers.
+
 All notable changes to this package will be documented in this file.
 
 ## Unreleased

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -34,9 +34,11 @@ Current scope:
 - capability-surface summaries for describe-capabilities tools
 - inventory summaries for bridge/device health and entity state coverage
 - canonical capability catalog entries for light, scene, lock, climate, media,
-  sensor, and input families
+  device indicator/display, sensor, calibration, and input families
 - typed media playback, volume, grouping, and queue operations inside the
   existing authorized device-command envelope
+- typed device indicator/display and sensor-calibration operations with
+  command-capability and policy-tier mappings
 - canonical integration descriptors for Hue, Zigbee, Z-Wave, Thread, Matter,
   and MQTT bootstrap families
 - compact integration catalog summaries for runtime, discovery, pairing, and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -327,6 +327,31 @@ impl Capability {
         )
     }
 
+    pub fn device_indicator() -> Self {
+        Self::new(
+            CapabilityId::trusted("device.indicator"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Object,
+        )
+    }
+
+    pub fn device_display() -> Self {
+        Self::new(
+            CapabilityId::trusted("device.display"),
+            CapabilityMode::ObserveAndCommand,
+            ValueKind::Percentage,
+        )
+        .with_range(0.0, 100.0, Some(1.0))
+    }
+
+    pub fn sensor_calibration() -> Self {
+        Self::new(
+            CapabilityId::trusted("sensor.calibration"),
+            CapabilityMode::Command,
+            ValueKind::Null,
+        )
+    }
+
     pub fn sensor_occupancy() -> Self {
         Self::new(
             CapabilityId::trusted("sensor.occupancy"),
@@ -401,6 +426,9 @@ pub fn canonical_capability_catalog() -> Vec<Capability> {
         Capability::media_volume(),
         Capability::media_grouping(),
         Capability::media_queue(),
+        Capability::device_indicator(),
+        Capability::device_display(),
+        Capability::sensor_calibration(),
         Capability::sensor_occupancy(),
         Capability::sensor_contact(),
         Capability::sensor_temperature(),
@@ -1254,6 +1282,7 @@ pub enum CommandType {
     SetLock,
     SetThermostatSetpoint,
     Media(MediaCommandType),
+    DeviceControl(DeviceControlCommandType),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1270,6 +1299,14 @@ pub enum MediaCommandType {
     MoveQueueItem,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeviceControlCommandType {
+    SetIndicatorMode,
+    SetIndicatorBrightness,
+    SetDisplayBrightness,
+    CalibrateSensor,
+}
+
 impl CommandType {
     pub fn canonical_capability_id(self) -> Option<CapabilityId> {
         match self {
@@ -1281,6 +1318,7 @@ impl CommandType {
             Self::SetLock => Some(CapabilityId::trusted("lock.state")),
             Self::SetThermostatSetpoint => Some(CapabilityId::trusted("climate.setpoint")),
             Self::Media(command) => Some(command.canonical_capability_id()),
+            Self::DeviceControl(command) => Some(command.canonical_capability_id()),
         }
     }
 }
@@ -1297,6 +1335,18 @@ impl MediaCommandType {
             | Self::PlayQueueItem
             | Self::RemoveQueueItem
             | Self::MoveQueueItem => CapabilityId::trusted("media.queue"),
+        }
+    }
+}
+
+impl DeviceControlCommandType {
+    pub fn canonical_capability_id(self) -> CapabilityId {
+        match self {
+            Self::SetIndicatorMode | Self::SetIndicatorBrightness => {
+                CapabilityId::trusted("device.indicator")
+            }
+            Self::SetDisplayBrightness => CapabilityId::trusted("device.display"),
+            Self::CalibrateSensor => CapabilityId::trusted("sensor.calibration"),
         }
     }
 }
@@ -1353,14 +1403,18 @@ impl DeviceCommand {
 pub fn tier_for_command(command_type: CommandType) -> PrivilegeTier {
     match command_type {
         CommandType::SetLock => PrivilegeTier::HighRisk,
-        CommandType::SetThermostatSetpoint => PrivilegeTier::HumanApproval,
+        CommandType::SetThermostatSetpoint
+        | CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor) => {
+            PrivilegeTier::HumanApproval
+        }
         CommandType::TurnOn
         | CommandType::TurnOff
         | CommandType::SetBrightness
         | CommandType::SetColor
         | CommandType::SetColorTemperature
         | CommandType::RecallScene
-        | CommandType::Media(_) => PrivilegeTier::LowRisk,
+        | CommandType::Media(_)
+        | CommandType::DeviceControl(_) => PrivilegeTier::LowRisk,
     }
 }
 
@@ -3918,6 +3972,18 @@ mod tests {
             tier_for_command(CommandType::SetThermostatSetpoint),
             PrivilegeTier::HumanApproval
         );
+        assert_eq!(
+            tier_for_command(CommandType::DeviceControl(
+                DeviceControlCommandType::CalibrateSensor
+            )),
+            PrivilegeTier::HumanApproval
+        );
+        assert_eq!(
+            tier_for_command(CommandType::DeviceControl(
+                DeviceControlCommandType::SetDisplayBrightness
+            )),
+            PrivilegeTier::LowRisk
+        );
     }
 
     #[test]
@@ -4201,7 +4267,7 @@ mod tests {
             .map(|capability| capability.capability_id.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(catalog.len(), 18);
+        assert_eq!(catalog.len(), 21);
         assert_eq!(ids[0], "light.on_off");
         assert!(ids.contains(&"light.color"));
         assert!(ids.contains(&"scene.recall"));
@@ -4211,6 +4277,9 @@ mod tests {
         assert!(ids.contains(&"media.volume"));
         assert!(ids.contains(&"media.grouping"));
         assert!(ids.contains(&"media.queue"));
+        assert!(ids.contains(&"device.indicator"));
+        assert!(ids.contains(&"device.display"));
+        assert!(ids.contains(&"sensor.calibration"));
         assert!(ids.contains(&"sensor.contact"));
         assert!(ids.contains(&"sensor.temperature"));
         assert!(ids.contains(&"sensor.humidity"));
@@ -4256,6 +4325,10 @@ mod tests {
             CommandType::Media(MediaCommandType::PlayQueueItem),
             CommandType::Media(MediaCommandType::RemoveQueueItem),
             CommandType::Media(MediaCommandType::MoveQueueItem),
+            CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorMode),
+            CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorBrightness),
+            CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness),
+            CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor),
         ];
 
         for command_type in command_types {

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Upgrade AirGradient runtime coverage with authorized local indicator/display
+  controls, CO2 calibration, readback verification, and explicit cloud-control
+  conflict handling.
+
 - Add first-party AirGradient local environmental telemetry coverage and the
   environmental telemetry primitive.
 

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45368,15 +45368,15 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         base_entry(
             "airgradient",
             "AirGradient",
-            "Local AirGradient monitor identity and environmental telemetry.",
+            "Local AirGradient monitor telemetry, indicator/display control, and CO2 calibration.",
             IntegrationCategory::EnergyClimate,
             ConnectivityClass::LocalPolling,
             ImplementationStatus::FirstPartyRuntime,
-            3,
+            4,
             "airgradient",
         )
-        .with_capabilities(&["smart_home.read"])
-        .with_entities(&[EntityKind::Sensor])
+        .with_capabilities(&["smart_home.read", "smart_home.command.device"])
+        .with_entities(&[EntityKind::Sensor, EntityKind::Light])
         .with_discovery(&[DiscoveryMechanism::Mdns, DiscoveryMechanism::Manual])
         .with_auth(&[AuthMode::None])
         .with_protocols(vec![ProtocolFamily::Vendor(
@@ -45388,12 +45388,14 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
             PrimitiveFamily::Mdns,
             PrimitiveFamily::LocalHttp,
             PrimitiveFamily::EnvironmentalTelemetry,
+            PrimitiveFamily::CommandMapping,
             PrimitiveFamily::CapabilityPolicy,
             PrimitiveFamily::Supervision,
             PrimitiveFamily::TestSimulator,
         ])
         .with_notes(&[
-            "Current runtime support is read-only; local configuration, LED/display control, and CO2 calibration remain separate authorized work.",
+            "Cloud-only configuration is rejected locally; dual local/cloud control returns an explicit overwrite warning.",
+            "Advanced AirGradient configuration fields remain separate typed work, especially credential-bearing MQTT settings and correction profiles.",
         ]),
         energy_entry(
             "tesla_powerwall",
@@ -81245,7 +81247,7 @@ mod tests {
     }
 
     #[test]
-    fn airgradient_entry_exposes_read_only_local_environmental_runtime() {
+    fn airgradient_entry_exposes_authorized_local_environmental_runtime() {
         let catalog = first_party_catalog();
         let airgradient = find_entry(&catalog, &IntegrationId::trusted("airgradient")).unwrap();
 
@@ -81261,12 +81263,16 @@ mod tests {
         );
         assert_eq!(
             airgradient.required_capabilities,
-            vec![CapabilityId::trusted("smart_home.read")]
+            vec![
+                CapabilityId::trusted("smart_home.read"),
+                CapabilityId::trusted("smart_home.command.device")
+            ]
         );
         for primitive in [
             PrimitiveFamily::Mdns,
             PrimitiveFamily::LocalHttp,
             PrimitiveFamily::EnvironmentalTelemetry,
+            PrimitiveFamily::CommandMapping,
             PrimitiveFamily::CapabilityPolicy,
             PrimitiveFamily::TestSimulator,
         ] {

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Expose device indicator/display and sensor calibration command labels through
+  the local smart-home API contract.
+
 All notable changes to this package will be documented in this file.
 
 ## Unreleased

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -18,7 +18,8 @@ use smart_home_core::{
     BridgeTransport, Capability, CapabilityGrant, CapabilityGrantId,
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
     CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device,
-    DeviceCommand, DeviceEvent, DeviceEventType, Entity, EntityId, EntityKind, EventId, Health,
+    DeviceCommand, DeviceControlCommandType, DeviceEvent, DeviceEventType, Entity, EntityId,
+    EntityKind, EventId, Health,
     IntegrationId, MediaCommandType, PrivilegeTier, Scene, SceneScope, SmartHomeTool,
     StateConfidence, StateDelta, StateSource, Value, ValueKind,
 };
@@ -10268,6 +10269,18 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         CommandType::Media(MediaCommandType::PlayQueueItem) => "media_play_queue_item",
         CommandType::Media(MediaCommandType::RemoveQueueItem) => "media_remove_queue_item",
         CommandType::Media(MediaCommandType::MoveQueueItem) => "media_move_queue_item",
+        CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorMode) => {
+            "device_set_indicator_mode"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorBrightness) => {
+            "device_set_indicator_brightness"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness) => {
+            "device_set_display_brightness"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor) => {
+            "sensor_calibrate"
+        }
     }
 }
 
@@ -10291,6 +10304,18 @@ fn command_type_from_label(command_type: &str) -> Result<CommandType, ApiError> 
         "media_play_queue_item" => Ok(CommandType::Media(MediaCommandType::PlayQueueItem)),
         "media_remove_queue_item" => Ok(CommandType::Media(MediaCommandType::RemoveQueueItem)),
         "media_move_queue_item" => Ok(CommandType::Media(MediaCommandType::MoveQueueItem)),
+        "device_set_indicator_mode" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetIndicatorMode,
+        )),
+        "device_set_indicator_brightness" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetIndicatorBrightness,
+        )),
+        "device_set_display_brightness" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetDisplayBrightness,
+        )),
+        "sensor_calibrate" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::CalibrateSensor,
+        )),
         other => Err(ApiError::bad_request(format!(
             "unsupported command_type `{other}`"
         ))),
@@ -13764,6 +13789,33 @@ mod tests {
         ];
         for (label, media_command) in commands {
             let command = CommandType::Media(media_command);
+            assert_eq!(command_type_from_label(label).unwrap(), command);
+            assert_eq!(command_type_label(command), label);
+        }
+    }
+
+    #[test]
+    fn device_control_command_labels_round_trip_through_local_api_labels() {
+        let commands = [
+            (
+                "device_set_indicator_mode",
+                DeviceControlCommandType::SetIndicatorMode,
+            ),
+            (
+                "device_set_indicator_brightness",
+                DeviceControlCommandType::SetIndicatorBrightness,
+            ),
+            (
+                "device_set_display_brightness",
+                DeviceControlCommandType::SetDisplayBrightness,
+            ),
+            (
+                "sensor_calibrate",
+                DeviceControlCommandType::CalibrateSensor,
+            ),
+        ];
+        for (label, device_command) in commands {
+            let command = CommandType::DeviceControl(device_command);
             assert_eq!(command_type_from_label(label).unwrap(), command);
             assert_eq!(command_type_label(command), label);
         }

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+- Support explicit device-control commands in runtime policy and optimistic
+  state handling while keeping sensor calibration non-optimistic.
+
 All notable changes to this package will be documented in this file.
 
 ## Unreleased
+
+- Split command-tool authorization from submission so integrations can perform
+  authorized conflict checks before publishing accepted optimistic state.
 
 ### Added
 

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -13,7 +13,8 @@ use smart_home_core::{
     AuthorizationOutcome, Bridge, BridgeId, Capability, CapabilityGrant,
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
     CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device,
-    DeviceCommand, DeviceEvent, DeviceEventType, DeviceId, Entity, EntityId, EventId, Health,
+    DeviceCommand, DeviceControlCommandType, DeviceEvent, DeviceEventType, DeviceId, Entity,
+    EntityId, EventId, Health,
     IntegrationId, Metadata, PrivilegeTier, Scene, SceneId, SceneScope, SmartHomeError,
     MediaCommandType, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value,
     VaultRef,
@@ -5827,6 +5828,16 @@ impl SmartHomeRuntime {
         request: RuntimeCommandToolRequest,
         now_ms: u64,
     ) -> Result<CommandResult, RuntimeError> {
+        let command = self.authorize_command_tool(principal_id, request, now_ms)?;
+        self.submit_command(command, now_ms)
+    }
+
+    pub fn authorize_command_tool(
+        &mut self,
+        principal_id: AgentId,
+        request: RuntimeCommandToolRequest,
+        now_ms: u64,
+    ) -> Result<DeviceCommand, RuntimeError> {
         let tool = SmartHomeTool::Command;
         let decision = self.authorize_tool_for_principal(principal_id.clone(), tool, now_ms);
         if !decision.missing_capabilities.is_empty() {
@@ -5856,8 +5867,24 @@ impl SmartHomeRuntime {
             .collect();
         let command = request.into_command(command_id, principal_id.as_str(), correlation_id)?;
         let authorization = CommandAuthorization::new(principal_id, grants);
-
-        self.submit_authorized_command(&authorization, command, now_ms)
+        let decision = AuthorizationDecision::for_command(
+            authorization.principal_id.clone(),
+            &command,
+            authorization.grants.iter(),
+            now_ms,
+        );
+        let missing_capabilities = decision.missing_capabilities.clone();
+        self.registry.record_authorization_decision(decision);
+        if !missing_capabilities.is_empty() {
+            return Err(RuntimeError::UnauthorizedCommand {
+                command_id: command.command_id.clone(),
+                principal_id: authorization.principal_id,
+                required_tier: command.required_tier,
+                missing_capabilities,
+            });
+        }
+        self.command_bridge_id(&command)?;
+        Ok(command)
     }
 
     pub fn submit_command(
@@ -5865,6 +5892,27 @@ impl SmartHomeRuntime {
         command: DeviceCommand,
         now_ms: u64,
     ) -> Result<CommandResult, RuntimeError> {
+        let bridge_id = self.command_bridge_id(&command)?;
+
+        if let Some(snapshot) = optimistic_snapshot_for_command(&command, now_ms) {
+            self.registry.apply_state_snapshot(snapshot.clone())?;
+            self.optimistic_states
+                .insert(command.entity_id.clone(), snapshot);
+        }
+
+        let result = CommandResult {
+            command_id: command.command_id,
+            status: CommandStatus::Accepted,
+            bridge_id,
+            correlation_id: command.correlation_id,
+            message: Some("accepted for integration dispatch".to_string()),
+        };
+        self.event_bus
+            .publish(RuntimeEvent::CommandResult(result.clone()));
+        Ok(result)
+    }
+
+    fn command_bridge_id(&self, command: &DeviceCommand) -> Result<BridgeId, RuntimeError> {
         let entity = self
             .registry
             .entity(&command.entity_id)
@@ -5876,24 +5924,8 @@ impl SmartHomeRuntime {
             .cloned()
             .ok_or_else(|| RuntimeError::UnknownDevice(entity.device_id.clone()))?;
 
-        validate_command_capabilities(&entity, &command)?;
-
-        if let Some(snapshot) = optimistic_snapshot_for_command(&command, now_ms) {
-            self.registry.apply_state_snapshot(snapshot.clone())?;
-            self.optimistic_states
-                .insert(command.entity_id.clone(), snapshot);
-        }
-
-        let result = CommandResult {
-            command_id: command.command_id,
-            status: CommandStatus::Accepted,
-            bridge_id: device.bridge_id,
-            correlation_id: command.correlation_id,
-            message: Some("accepted for integration dispatch".to_string()),
-        };
-        self.event_bus
-            .publish(RuntimeEvent::CommandResult(result.clone()));
-        Ok(result)
+        validate_command_capabilities(&entity, command)?;
+        Ok(device.bridge_id)
     }
 
     pub fn submit_authorized_command(
@@ -6343,7 +6375,8 @@ fn command_for_desired_state(
         | CommandType::SetColorTemperature
         | CommandType::SetLock
         | CommandType::SetThermostatSetpoint
-        | CommandType::Media(_) => desired.value.clone(),
+        | CommandType::Media(_)
+        | CommandType::DeviceControl(_) => desired.value.clone(),
         CommandType::RecallScene => Value::Null,
     };
     let command_id = CommandId::trusted(format!(
@@ -6428,9 +6461,15 @@ fn optimistic_snapshot_for_command(command: &DeviceCommand, now_ms: u64) -> Opti
         | CommandType::Media(MediaCommandType::SetPlaybackState)
         | CommandType::Media(MediaCommandType::SetVolume)
         | CommandType::Media(MediaCommandType::SetMute)
-        | CommandType::Media(MediaCommandType::SetGroup) => command.arguments.clone(),
+        | CommandType::Media(MediaCommandType::SetGroup)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorMode)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorBrightness)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness) => {
+            command.arguments.clone()
+        }
         CommandType::RecallScene => return None,
         CommandType::Media(_) => return None,
+        CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor) => return None,
     };
 
     Some(StateSnapshot {

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -830,32 +830,56 @@ control surface without borrowing command semantics from unrelated domains:
 - A real loopback TCP test proves all ten native command transfers, while a
   denial test proves unauthorized media commands never reach the transport.
 
+## Current AirGradient Local Control Slice
+
+This slice extends the verified local telemetry path through the monitor's
+documented `/config` contract without hiding cloud ownership conflicts:
+
+- D23 now has reusable indicator-mode, indicator-brightness,
+  display-brightness, and sensor-calibration command types with canonical
+  capability mappings. Calibration requires human-approval policy.
+- AirGradient inspection reads the current configuration and installs an
+  indicator/display control entity plus a calibration capability on the CO2
+  sensor.
+- Authorized local commands support LED-bar mode, LED-bar brightness, display
+  brightness, and the 400 ppm CO2 calibration trigger. Persistent settings are
+  read back and verified after each PUT.
+- `configurationControl=cloud` fails with an explicit local-control conflict;
+  `both` succeeds with an explicit warning that a later cloud update can
+  overwrite the value.
+- A real loopback HTTP test proves all four native controls, while denial and
+  cloud-conflict tests prove no unauthorized or cloud-rejected PUT reaches the
+  monitor.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-1. Add authorized AirGradient local configuration, LED/display control, and CO2
-   calibration while keeping cloud-controlled configuration conflicts explicit.
-2. Add authenticated HEOS source browsing and queue insertion only after the
+1. Extend typed AirGradient local settings with temperature unit, particulate
+   display standard, automatic CO2 baseline days, gas-sensor learning offsets,
+   compensated-value display, LED self-test, and validated correction profiles.
+2. Add AirGradient MQTT broker and custom HTTP routing settings only after
+   credential-bearing values use Vault leasing and destination validation.
+3. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-3. Extend authenticated Reolink CGI support with concrete camera/NVR control,
+4. Extend authenticated Reolink CGI support with concrete camera/NVR control,
    media, recording, and push-event operations supported by the current host.
-4. Add another vendor-specific camera or NVR integration where authenticated
+5. Add another vendor-specific camera or NVR integration where authenticated
    protocol and transport primitives are concrete.
-5. Add authenticated KLAP/Tapo devices and other broader-device families only
+6. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-6. Add ONVIF PullPoint events once a concrete event host and subscription
+7. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-7. Add RTSP media transfer and recording once concrete media transfer and
+8. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-8. Add a production Matter commissioning, secure-session, and network host only
+9. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-9. Add a Thread border-router host only after an actual host transport exists.
-10. Add a production Zigbee coordinator, join, and security host only after
+10. Add a Thread border-router host only after an actual host transport exists.
+11. Add a production Zigbee coordinator, join, and security host only after
     concrete coordinator transport and security primitives exist.
-11. Add production Z-Wave inclusion and S2 only after concrete host transport
+12. Add production Z-Wave inclusion and S2 only after concrete host transport
     and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary
- add explicit D23 indicator, display, and sensor-calibration command contracts across core, runtime, Chief tools, and the local HTTP boundary
- add authorized AirGradient `/config` controls for LED-bar mode/brightness, display brightness, and CO2 calibration with persistent readback verification
- reject cloud-owned configuration before command submission, warn on dual ownership, and reprioritize newly discovered advanced settings in the completion inventory

## Validation
- `bash smart-home-core/BUILD`
- `bash smart-home-runtime/BUILD`
- `bash smart-home-airgradient-local-integration/BUILD`
- `bash chief-of-staff-smart-home-tools/BUILD`
- `bash smart-home-platform-http/BUILD`
- `bash matter-core/BUILD`
- `bash smart-home-integration-catalog/BUILD`
- `cargo clippy -p smart-home-core -p smart-home-runtime -p smart-home-airgradient-local-integration -p smart-home-integration-catalog -p chief-of-staff-smart-home-tools -p smart-home-platform-http -p matter-core --all-targets -- -D warnings`