### PR TITLE
fix(spice): validate parser MOS model length

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `L` values before
+  lowering Level-1 default length.
 - Reject zero, negative, and non-finite MOS model-card `W` values before
   lowering Level-1 default width.
 - Reject zero, negative, and non-finite MOS model-card `PHI` values before

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1914,6 +1914,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["W"]) or params["W"] <= 0.0
         ):
             raise NetlistParseError("MOSFET W must be finite and positive")
+        if "L" in params and (
+            not math.isfinite(params["L"]) or params["L"] <= 0.0
+        ):
+            raise NetlistParseError("MOSFET L must be finite and positive")
     return ModelCard(name=name, kind=kind, params=params)
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1541,6 +1541,19 @@ def test_lowers_positive_mosfet_model_width() -> None:
     assert isclose(mosfet.model.model.params.W, 4.0e-6)
 
 
+@pytest.mark.parametrize("length", ["0", "-1u", "1e999"])
+def test_rejects_invalid_mosfet_model_length(length: str) -> None:
+    with pytest.raises(NetlistParseError, match="MOSFET L must be finite and positive"):
+        parse_netlist(f".model nfast NMOS(L={length})\nM1 d g s b nfast\n")
+
+
+def test_lowers_positive_mosfet_model_length() -> None:
+    parsed = parse_netlist(".model nfast NMOS(L=2u)\nM1 d g s b nfast\n")
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.L, 2.0e-6)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `L` values before
+  lowering Level-1 default length.
 - Reject zero, negative, and non-finite MOS model-card `W` values before
   lowering Level-1 default width.
 - Reject zero, negative, and non-finite MOS model-card `PHI` values before

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1221,6 +1221,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET W must be finite and positive");
   }
+  const length = params.get("L");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    length !== undefined &&
+    (!Number.isFinite(length) || length <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET L must be finite and positive");
+  }
   return {
     name: fields[1],
     kind,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1471,6 +1471,20 @@ Xright c d load
     expect(element.params.W).toBeCloseTo(4.0e-6, 15);
   });
 
+  it.each(["0", "-1u", "1e999"])("rejects invalid MOSFET model L=%s", (length) => {
+    expect(() => parseNetlist(`.model nfast NMOS(L=${length})\nM1 d g s b nfast\n`)).toThrow(
+      "MOSFET L must be finite and positive",
+    );
+  });
+
+  it("lowers positive MOSFET model length", () => {
+    const parsed = parseNetlist(".model nfast NMOS(L=2u)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.L).toBeCloseTo(2.0e-6, 15);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,10 +33,10 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS model-card width validation parity.
+1. Python and TypeScript Berkeley SPICE MOS model-card length validation parity.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite `W` values with the shared diagnostic.
-   - Preserve positive model-card widths through canonical Level-1 lowering.
+   - Reject zero, negative, and non-finite `L` values with the shared diagnostic.
+   - Preserve positive model-card lengths through canonical Level-1 lowering.
 
 ## Completed Slices
 
@@ -4173,11 +4173,16 @@ the Rust, Python, and TypeScript surfaces together.
      diagnostic.
    - Positive surface potentials lower into canonical Level-1 parameters.
 
+376. Python and TypeScript Berkeley SPICE MOS model-card width validation parity.
+   - Status: completed in PR 9616.
+   - Zero, negative, and non-finite `W` values are rejected with the shared
+     diagnostic while positive widths lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
-   - Apply Rust-aligned domains and diagnostics to already lowered `L`, `IS`,
-     and nominal-temperature fields.
+   - Apply Rust-aligned domains and diagnostics to already lowered `IS` and
+     nominal-temperature fields.
 
 2. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
    - Lower missing canonical resistance, geometry, capacitance, junction, and


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite MOS model-card `L` values in Python and TypeScript parsers
- preserve positive default lengths through Level-1 lowering
- add cross-language regression coverage, changelogs, and advance the SPICE plan

## Verification
- Python parser: 119 tests passed, 88.12% coverage; Ruff passed
- TypeScript engine/parser builds passed
- TypeScript parser: 118 tests passed, 83.51% statement / 84.16% line coverage
- `git diff --check`