### PR TITLE
fix(test): stop keying semantic-ir-to-c temp-file stems on source length

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_methods.rs
@@ -33,7 +33,14 @@ fn run_ruby(src: &str) -> Option<String> {
     let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
     let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
     let dir = std::env::temp_dir();
-    let stem = format!("sirc_cm_{}_{}", std::process::id(), src.len());
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process (cargo test's
+    // default), so a length-keyed stem collides and one test's compile/run
+    // clobbers the other's temp file (a real, hit-in-CI flake).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_cm_{}_{}", std::process::id(), hasher.finish());
     let cpath = dir.join(format!("{stem}.c"));
     let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
     std::fs::write(&cpath, &art.source).expect("write .c");

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_vars.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_vars.rs
@@ -33,7 +33,14 @@ fn run_ruby(src: &str) -> Option<String> {
     let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
     let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
     let dir = std::env::temp_dir();
-    let stem = format!("sirc_cv_{}_{}", std::process::id(), src.len());
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process (cargo test's
+    // default), so a length-keyed stem collides and one test's compile/run
+    // clobbers the other's temp file (a real, hit-in-CI flake).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_cv_{}_{}", std::process::id(), hasher.finish());
     let cpath = dir.join(format!("{stem}.c"));
     let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
     std::fs::write(&cpath, &art.source).expect("write .c");

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_inheritance.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_inheritance.rs
@@ -35,7 +35,14 @@ fn run_ruby(src: &str) -> Option<String> {
     let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
     let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
     let dir = std::env::temp_dir();
-    let stem = format!("sirc_inh_{}_{}", std::process::id(), src.len());
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process (cargo test's
+    // default), so a length-keyed stem collides and one test's compile/run
+    // clobbers the other's temp file (a real, hit-in-CI flake).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_inh_{}_{}", std::process::id(), hasher.finish());
     let cpath = dir.join(format!("{stem}.c"));
     let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
     std::fs::write(&cpath, &art.source).expect("write .c");

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_ivars.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_ivars.rs
@@ -33,7 +33,14 @@ fn run_ruby(src: &str) -> Option<String> {
     let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
     let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
     let dir = std::env::temp_dir();
-    let stem = format!("sirc_ivar_{}_{}", std::process::id(), src.len());
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process (cargo test's
+    // default), so a length-keyed stem collides and one test's compile/run
+    // clobbers the other's temp file (a real, hit-in-CI flake).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_ivar_{}_{}", std::process::id(), hasher.finish());
     let cpath = dir.join(format!("{stem}.c"));
     let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
     std::fs::write(&cpath, &art.source).expect("write .c");

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_methods.rs
@@ -32,7 +32,14 @@ fn run_ruby(src: &str) -> Option<String> {
     let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
     let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
     let dir = std::env::temp_dir();
-    let stem = format!("sirc_meth_{}_{}", std::process::id(), src.len());
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process (cargo test's
+    // default), so a length-keyed stem collides and one test's compile/run
+    // clobbers the other's temp file (a real, hit-in-CI flake).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_meth_{}_{}", std::process::id(), hasher.finish());
     let cpath = dir.join(format!("{stem}.c"));
     let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
     std::fs::write(&cpath, &art.source).expect("write .c");

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_modules.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_modules.rs
@@ -34,7 +34,14 @@ fn run_ruby(src: &str) -> Option<String> {
     let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
     let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
     let dir = std::env::temp_dir();
-    let stem = format!("sirc_mod_{}_{}", std::process::id(), src.len());
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process (cargo test's
+    // default), so a length-keyed stem collides and one test's compile/run
+    // clobbers the other's temp file (a real, hit-in-CI flake).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_mod_{}_{}", std::process::id(), hasher.finish());
     let cpath = dir.join(format!("{stem}.c"));
     let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
     std::fs::write(&cpath, &art.source).expect("write .c");

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_methods.rs
@@ -33,7 +33,14 @@ fn run_ruby(src: &str) -> Option<String> {
     let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
     let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
     let dir = std::env::temp_dir();
-    let stem = format!("sirc_strm_{}_{}", std::process::id(), src.len());
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process (cargo test's
+    // default), so a length-keyed stem collides and one test's compile/run
+    // clobbers the other's temp file (a real, hit-in-CI flake).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_strm_{}_{}", std::process::id(), hasher.finish());
     let cpath = dir.join(format!("{stem}.c"));
     let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
     std::fs::write(&cpath, &art.source).expect("write .c");

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_queries.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_string_queries.rs
@@ -32,7 +32,14 @@ fn run_ruby(src: &str) -> Option<String> {
     let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
     let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
     let dir = std::env::temp_dir();
-    let stem = format!("sirc_strq_{}_{}", std::process::id(), src.len());
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process (cargo test's
+    // default), so a length-keyed stem collides and one test's compile/run
+    // clobbers the other's temp file (a real, hit-in-CI flake).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_strq_{}_{}", std::process::id(), hasher.finish());
     let cpath = dir.join(format!("{stem}.c"));
     let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
     std::fs::write(&cpath, &art.source).expect("write .c");


### PR DESCRIPTION
## Summary
- 8 `semantic-ir-to-c` execution-proof test files built their scratch `.c`/exe temp filename from `(pid, src.len())`. `cargo test` runs a file's tests as parallel threads in the same process (same pid), so two tests whose Ruby source happens to be the same length race on the same temp path and clobber each other's output.
- Hit for real this session while adding a 9th such file (`compile_and_run_array_methods.rs`, PR #9617): two 36-character sources collided and one test read the other's compiled binary's stdout.
- Fix: hash the full source string instead of using its length, so two different sources can never produce the same stem.
- No crate behavior/version change — test-only, so no CHANGELOG/version bump.

## Test plan
- [x] `cargo test -p semantic-ir-to-c` — full suite green (44 tests across all touched files)
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` — clean
- [x] Security review — PASSED (test-only change, no new attack surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>