### PR TITLE
feat(human-languages): split Spanish lessons into micro-steps

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,12 +5,12 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Latin duration
-tranche: 20 registered tracks, 1,051 Markdown lessons, and 20 downloadable LaTeX
-books. HL-V01 makes the remaining migration debt reproducible in both JSON and
-human-readable reports; HL-S01 proves the strict schema on the first 24 Spanish
-lessons, and the HL-D01 tranches prove duration remediation without discarding
-deep content.
+Last prioritized: 2026-08-02. Current baseline after the Spanish duration
+tranche: 20 registered tracks, 1,063 Markdown lessons, 20 downloadable LaTeX
+books, and zero duration violations. HL-V01 keeps the remaining migration debt
+reproducible in both JSON and human-readable reports; HL-S01 proves the strict
+schema on the first 24 Spanish lessons, and the completed HL-D01 tranches prove
+duration remediation without discarding deep content.
 
 ## Priority rules
 
@@ -64,9 +64,10 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01O | Complete in the Hindi duration PR | Remove all forty sub-five-minute violations from the Hindi track. | The report measures zero Hindi violations; thirteen new prerequisite-ordered lessons preserve its script, etymology, grammar, and register depth. |
 | HL-D01P | Complete in this PR | Remove all forty-two sub-five-minute violations from the Tamil track. | The report measures zero Tamil violations; twenty new prerequisite-ordered lessons preserve its script, etymology, grammar, register, and source-evidence depth. |
 | HL-D01Q | Complete in this PR | Remove all forty-three sub-five-minute violations from the Latin track. | The report measures zero Latin violations; six new prerequisite-ordered lessons preserve its grammar, etymology, usage, and attestation depth. |
-| HL-D01R | Next | Remove all fifty-five remaining sub-five-minute violations from the Spanish track. | Spanish is the final track with duration debt: forty-one declaration-only lessons and fourteen genuinely computed violations, with a 731-second maximum; schema-v2 lessons require closure-aware splits. |
-| HL-D01 | Queued | Split or rewrite every lesson whose computed duration is at least 300 seconds. | Deliver in measured track-sized tranches, beginning with HL-D01A, until the report reaches zero. |
-| HL-S02 | Queued | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
+| HL-D01R | Complete in this PR | Remove all fifty-five remaining sub-five-minute violations from the Spanish track. | The report measures zero Spanish violations; twelve new prerequisite-ordered lessons preserve the grammar, etymology, usage, writing, and practice depth from the genuinely long lessons. |
+| HL-D01 | Complete in this PR | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The deterministic report now reaches zero effective-duration violations across all twenty tracks. |
+| HL-S02 | Next | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
+| HL-G03 | Queued | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | Replaces the first three handwritten post-pilot chapters and extends app/book source-hash parity. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B05 | Queued | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | A forced build succeeds but reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and two underfull boxes; the clean-build signal is zero of each. |
 | HL-B06 | Queued | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -99,6 +100,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B33 | Queued | Remove Tamil's LaTeX layout, duplicate-label, bookmark, and font warnings. | A forced build succeeds with no missing glyphs but reports six overfull boxes, six underfull boxes, four duplicate practice labels, 27 Hyperref warnings, and undefined bold/italic Tamil font shapes; the clean-build signal is zero of each. |
 | HL-B34 | Queued | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | The Latin PDF contains only Chapter 1 while canonical app content continues through Chapter 36; schema-v2 migration plus generation should close that drift safely. |
 | HL-B35 | Queued | Remove Latin's remaining LaTeX layout and font warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports one underfull box and a small-caps font-shape substitution; the clean-build signal is zero of each. |
+| HL-B36 | Queued | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF stops after Chapter 18 while canonical app content continues through Chapter 33; schema-v2 migration plus generation should raise book coverage from 55% to 100%. |
+| HL-B37 | Queued | Remove Spanish's LaTeX layout, bookmark, and font warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports 52 overfull boxes, 19 underfull boxes, 14 Hyperref warnings, and two font warnings; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
@@ -107,6 +110,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-M06 | Queued | Reconcile Hindi's roadmap and authoritative session map with canonical Chapters 1–33 and the eleven-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 6 planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 33. |
 | HL-M07 | Queued | Reconcile Tamil's roadmap and authoritative session map with canonical Chapters 1–31 and the eight-step writing sequence. | The roadmap details only Chapters 1–6 and still calls Chapter 7+ planned; the session map stops at Chapter 5 even though prerequisite-ordered canonical lessons continue through Chapter 31. |
 | HL-M08 | Queued | Reconcile Latin's roadmap and authoritative session map with canonical Chapters 1–36. | Both files stop at Chapter 1 and describe Chapter 2+ as planned even though prerequisite-ordered canonical lessons continue through Chapter 36. |
+| HL-M09 | Queued | Reconcile Spanish's roadmap and authoritative session map with canonical Chapters 1–33 and the new support steps. | The roadmap stops at Chapter 18 and calls Chapter 19 next, while the session map stops at Chapter 3; both lag the prerequisite-ordered canonical curriculum. |
 | HL-T01 | Queued | Complete session maps and pronunciation references for Persian and Urdu. | The starter-book work supplies both roadmaps and changelogs; these remaining pieces complete the standard track shape. |
 | HL-U01 | Queued | Vendor and verify an appropriately licensed static Nastaliq font for normal Urdu presentation. | Naskh remains an explicit accessibility fallback, not the intended printed style. |
 
@@ -584,6 +588,39 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   corpus. Forty-one are declaration-only and fourteen genuinely compute above
   the limit, led by a 731-second subjunctive lesson; HL-D01R is the final
   duration tranche.
+
+## Findings from HL-D01R
+
+- Spanish now has zero duration violations. The corpus grows from 1,051 to
+  1,063 lessons and drops from 55 to zero violations overall; unknown
+  prerequisites remain at zero. The integration suite now enforces zero as an
+  invariant instead of asserting that migration debt must exist.
+- Forty-one declaration-only lessons already computed below the limit and keep
+  their bodies unchanged with honest four-minute budgets. The fourteen
+  genuinely long lessons become prerequisite-ordered micro-steps or lose only
+  duplicated recap prose.
+- Twelve new support lessons separate regular subjunctive formation, inherited
+  stems, outliers, the mood's name, two-subject clause traps, Arabic
+  *ojalá*, form/subject/mood practice, formal/informal register, Arabic
+  *hasta* limits, future conjecture, diacritic accents, and punctuation span.
+  The unchanged long-form book narrative still preserves the combined depth.
+- All 26 rewritten, added, or borderline-trimmed lessons inspected directly
+  compute between 122 and 299 seconds. `ES-C17-practice` at 299 seconds and
+  four lessons at 294–295 seconds should be watched during future copy edits.
+- The 138-page Spanish PDF builds with no missing glyphs or duplicate labels,
+  and visual inspection of its cover, middle, and final pages finds no clipping
+  or collision. It stops at Chapter 18 while canonical lessons continue through
+  Chapter 33; HL-B36 records the fifteen missing generated chapters.
+- Chapters 4–18 remain handwritten rather than source-hash-checked from the
+  canonical lesson AST. HL-S02 and HL-G03 form the next migration/generation
+  slice for Chapters 4–6 before that approach expands further.
+- The build reports 52 overfull boxes, 19 underfull boxes, 14 Hyperref warnings,
+  and two font warnings. HL-B37 records that pre-existing clean-build debt.
+- The roadmap stops at Chapter 18 and still calls Chapter 19 next, while the
+  authoritative session map stops at Chapter 3. HL-M09 records reconciliation
+  through canonical Chapter 33 and the new micro-lesson chains.
+- With duration debt closed, HL-S02 is next: migrate Spanish Chapters 4–6 to the
+  strict one-source schema, then generate the same content for the book and app.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Every Spanish lesson now fits a sub-five-minute step
+
+- Removed all 55 remaining Spanish duration violations and brought the full
+  20-language corpus to zero. Forty-one lessons already computed below the
+  limit and now declare honest four-minute budgets; six borderline lessons lost
+  only duplicated recap prose.
+- Split the genuinely deep material into twelve prerequisite-ordered support
+  lessons. The new steps isolate subjunctive formation, inherited stems,
+  outliers, name history, two-subject traps, *ojalá*, three practice lenses,
+  formal/informal register, *hasta* limits, future conjecture, written accents,
+  and question-span punctuation without discarding their etymology or grammar.
+- Kept the schema-v2 Chapters 1–3 pilot unchanged and validated every rewritten
+  or new lesson below 300 effective seconds. The data package and Language
+  Ladder now consume 1,063 canonical lessons with no unknown prerequisites.
+- Forced and visually audited the 138-page Spanish XeLaTeX book. Its long-form
+  Chapter 18 still preserves the combined narrative; the backlog now records
+  canonical generation for Chapters 4–6, publication of Chapters 19–33, and
+  the pre-existing layout, bookmark, and font warnings.
+
 ## Chapters 2–3 — complete the generated schema-v2 pilot
 
 - Added the remaining 17 migrated lessons to canonical book generation, so all

--- a/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
@@ -3,7 +3,7 @@ id: ES-C04-como-esta
 chapter: 4
 type: phrase
 headword: ¿cómo está usted?
-gloss: how are you? (formal); informal ¿cómo estás?
+gloss: how are you? — assemble the formal question from cómo, estar, and usted
 concept_tag: STATE-HOW-ARE-YOU
 prerequisites: [ES-C04-estar, ES-C03-como, ES-C03-tu-usted]
 sounds: [vowel-o, r-tap]
@@ -21,17 +21,6 @@ reviews_of: [ES-C04-estar, ES-C03-como, ES-C03-tu-usted]
 question. You already met **cómo** ("how") and the **tú / usted** choice back in
 Chapter 3; you just learned **estar**. Assemble them.
 
-## Review first (30 seconds)
-
-[PAUSE 2s] Before the new phrase, recall the pieces — no peeking:
-
-- **cómo** — "how." From Latin *quōmodo*, "in what manner." (Its cousin? English
-  *how* is Germanic, but *cómo* is the *qu-* question family: *qué, quién, cuándo*.)
-- **usted** vs **tú** — the formal vs informal "you." *usted* is worn down from
-  *vuestra merced*, "your grace"; *tú* is the old intimate "thou."
-
-Got them? Good — now the assembly.
-
 ## The phrase, taken apart
 
 > **¿Cómo está usted?** = "How are you?" (formal)
@@ -41,14 +30,6 @@ Got them? Good — now the assembly.
 - **está** = "you are" (the *usted*/he-she form of **estar** — state, not identity)
 - **usted** = the formal "you"
 
-Two registers, and only the verb ending + pronoun change — exactly the *se
-llama* / *te llamas* split you already drilled:
-
-| register | question |
-|---|---|
-| **formal** (stranger, elder, customer) | **¿Cómo está usted?** |
-| **informal** (friend, peer, child) | **¿Cómo estás?** |
-
 Note the **¿** — Spanish opens a question with an upside-down mark so you know
 the melody is coming before you start reading aloud. (We take that mark apart in
 a dedicated writing lesson.)
@@ -57,15 +38,11 @@ a dedicated writing lesson.)
 
 [PAUSE 1s]
 - [YOU SAY: "¿Cómo está usted?" — formal, for a stranger]
-- [YOU SAY: "¿Cómo estás?" — informal, for a friend]
-- [YOU SAY: for a doctor you just met, then your cousin — which form for each?]
-
-[REPEAT x2] Ask both versions back to back until the *está / estás* swap is
-automatic.
+- [YOU SAY: the pieces — "cómo + está + usted"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Which be-verb does "how are you?" use — *ser* or *estar*, and why?
 (*estar* — it's about your current state.) What changes between formal and
-informal? (The verb ending *está → estás*, and you drop *usted*.) Next: how to
-answer — **bien, regular, más o menos.**
+informal? (**The next step changes the ending and pronoun.**) Next: choosing
+the register.

--- a/code/learning/human-languages/spanish/lessons/ES-C04-como-estas-register.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-como-estas-register.md
@@ -1,0 +1,42 @@
+---
+id: ES-C04-como-estas-register
+chapter: 4
+type: grammar
+headword: ¿cómo está usted? / ¿cómo estás?
+gloss: formal and informal how-are-you questions differ in the verb ending and presence of usted
+prerequisites: [ES-C04-como-esta]
+sounds: [vowel-o, r-tap]
+roots: [quomodo-latin, stare-latin]
+etymology_hook: "the formal/informal split reuses the usted/tú register choice and estar endings already learned: está usted versus estás"
+est_minutes: 4
+reviews_of: [ES-C04-como-esta, ES-C03-tu-usted]
+---
+
+# ¿cómo está usted? / ¿cómo estás? — choose the register
+
+## One question, two relationships
+
+| register | question |
+|---|---|
+| formal (stranger, elder, customer) | **¿Cómo está usted?** |
+| informal (friend, peer, child) | **¿Cómo estás?** |
+
+The formal version uses the third-person ending **está** plus **usted**.
+The informal version uses second-person **estás** and normally omits **tú**.
+This is the same relationship contrast you drilled with **se llama / te
+llamas**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: to a doctor you just met — "¿Cómo está usted?"]
+- [YOU SAY: to your cousin — "¿Cómo estás?"]
+- [YOU SAY: swap back and forth — "está usted / estás"]
+
+[REPEAT x2] Ask both versions until the ending swap is automatic.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which version fits a stranger? (**¿Cómo está usted?**)
+Which fits a friend? (**¿Cómo estás?**) What two things change?
+(**The verb ending and the pronoun.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
@@ -5,11 +5,11 @@ type: practice-mix
 headword: (practice)
 gloss: the full "how are you?" exchange, formal and informal
 concept_tag: CH4-PRACTICE
-prerequisites: [ES-C04-gracias, ES-C04-de-nada, ES-C04-estar, ES-C04-como-esta, ES-C04-regular]
+prerequisites: [ES-C04-gracias, ES-C04-de-nada, ES-C04-estar, ES-C04-como-estas-register, ES-C04-regular]
 sounds: []
 roots: []
-est_minutes: 5
-reviews_of: [ES-C04-gracias, ES-C04-de-nada, ES-C04-como-esta, ES-C04-regular, ES-C03-practice]
+est_minutes: 4
+reviews_of: [ES-C04-gracias, ES-C04-de-nada, ES-C04-como-estas-register, ES-C04-como-esta, ES-C04-regular, ES-C03-practice]
 ---
 
 # Practice — "how are you?", start to finish

--- a/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
@@ -5,12 +5,12 @@ type: word
 headword: regular
 gloss: so-so / not great (also "más o menos")
 concept_tag: WORD-SOSO
-prerequisites: [ES-C04-como-esta]
+prerequisites: [ES-C04-como-estas-register]
 sounds: [vowel-e, r-tap, l-clear]
 roots: [regula-latin, magis-minus-latin]
 etymology_hook: "regular ← Latin regula 'straight rod, rule'; the middling answer — 'on the rule / average'"
 est_minutes: 4
-reviews_of: [ES-C01-bien, ES-C04-como-esta]
+reviews_of: [ES-C01-bien, ES-C04-como-estas-register, ES-C04-como-esta]
 ---
 
 # regular / más o menos — the honest "so-so"

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-limits.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-limits.md
@@ -1,0 +1,49 @@
+---
+id: ES-C05-hasta-limits
+chapter: 5
+type: grammar
+headword: hasta aquí, hasta las tres, hasta luego
+gloss: hasta points to an endpoint in space or time and builds several everyday farewells
+prerequisites: [ES-C05-hasta]
+sounds: [silent-h, vowel-a]
+roots: [hatta-arabic, arabic-law-sha-allah]
+etymology_hook: "hasta marks a spatial or temporal limit; beside it, ojalá is another rare Arabic function-word loan that will later select the subjunctive"
+est_minutes: 4
+reviews_of: [ES-C05-hasta, ES-C05-adios]
+---
+
+# hasta aquí, hasta luego — point to the limit
+
+## Space and time
+
+**Hasta** marks the endpoint of movement or duration:
+
+- **hasta aquí** — up to here
+- **hasta las tres** — until three o'clock
+- **hasta luego** — until later
+- **hasta mañana** — until tomorrow
+- **hasta pronto** — until soon
+
+The same preposition points to a place, a clock time, or the next meeting.
+That is why farewells built with **hasta** become transparent once "until"
+is secure.
+
+## One more Arabic function word
+
+**Hasta** is not the only grammatical tool Spanish borrowed from Arabic.
+**Ojalá**, from Andalusi Arabic *law šāʾ Allāh* ("if God should will"),
+will later trigger the subjunctive. A preposition and a mood-trigger show
+that Arabic contact reached beyond objects into everyday grammar.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hasta aquí" — up to here]
+- [YOU SAY: "hasta las tres" — until three]
+- [YOU SAY: "hasta luego / mañana / pronto"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **hasta** point to? (**An endpoint.**) Give one spatial
+and one temporal example. (**Hasta aquí; hasta las tres.**) Which other
+Arabic function word returns later? (**Ojalá.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
@@ -5,12 +5,12 @@ type: phrase
 headword: hasta luego
 gloss: see you later (literally "until later")
 concept_tag: FAREWELL-LATER
-prerequisites: [ES-C05-hasta]
+prerequisites: [ES-C05-hasta-limits]
 sounds: [diphthong-ue, g-soft-gw]
 roots: [hatta-arabic, loco-latin]
 etymology_hook: "hasta (Arabic) + luego (← Latin loco 'at the place' → then/soon) — 'until soon'"
 est_minutes: 3
-reviews_of: [ES-C05-hasta, ES-C05-adios]
+reviews_of: [ES-C05-hasta-limits, ES-C05-hasta, ES-C05-adios]
 ---
 
 # hasta luego — the everyday "see you later"

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
@@ -49,26 +49,10 @@ deep, how *intimate*, those centuries of contact were. (Its Latin rival *ad*
 "to"/*usque* "up to" simply lost.) You say a piece of al-Andalus every time you
 say goodbye.
 
-And *hasta* is not quite alone. **Ojalá** ("would that…") is also a function
-word, from Andalusi Arabic *law šāʾ Allāh*, "**if God should will**" — the
-*Allāh* is still sitting in its second half. It is arguably the stronger case:
-where *hasta* is a preposition, *ojalá* reaches into the grammar and forces the
-verb after it into a whole different **mood**. Chapter 18 puts it to work.
-
-## Grammar Lens: hasta = "until," a pointer at a limit
-
-*hasta* marks the **end point** of something — in space or time:
-
-- **hasta aquí** — "up to here."
-- **hasta las tres** — "until three o'clock."
-- **hasta luego / mañana / pronto** — "until later / tomorrow / soon" → the
-  farewells that fill the rest of this chapter.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "hasta" — *AHS-tah*, silent h]
-- [YOU SAY: "hasta las tres" — "until three"]
 - [YOU SAY: "hasta" then Arabic *ḥattā* — the same word, 1,300 years apart]
 
 ## Wrap-up Recall
@@ -78,6 +62,5 @@ verb after it into a whole different **mood**. Chapter 18 puts it to work.
 word* / preposition — languages almost never borrow those; it shows how deep the
 Arabic centuries went.) How do you spot many Arabic nouns in Spanish? (The frozen
 *al-* article: *almohada, azúcar, álgebra*.) Which **other** Arabic function word
-did this lesson mention, and what is hiding inside it? (***Ojalá***, from *law
-šāʾ Allāh* — "**if God should will**"; the *Allāh* is still in it.) Next:
-**hasta luego**.
+will return in Chapter 18? (***Ojalá***, a word that triggers a grammatical
+mood.)

--- a/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
@@ -5,11 +5,11 @@ type: practice-mix
 headword: (practice)
 gloss: closing a conversation — the full set of farewells
 concept_tag: CH5-PRACTICE
-prerequisites: [ES-C05-adios, ES-C05-hasta, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto]
+prerequisites: [ES-C05-adios, ES-C05-hasta-limits, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto]
 sounds: []
 roots: []
-est_minutes: 5
-reviews_of: [ES-C05-adios, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto, ES-C04-practice]
+est_minutes: 4
+reviews_of: [ES-C05-adios, ES-C05-hasta-limits, ES-C05-hasta, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto, ES-C04-practice]
 ---
 
 # Practice — saying goodbye

--- a/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
@@ -9,7 +9,7 @@ prerequisites: []
 sounds: [silent-h, r-tap, v-b]
 roots: [fabulari-latin]
 etymology_hook: "hablar ← Latin fabulārī 'to chat, tell tales' (← fābula 'story' → fable); the f→h sound-law"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C06-por-favor]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C06-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH6-PRACTICE
 prerequisites: [ES-C06-por-favor, ES-C06-hablar, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C06-hablar, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol, ES-C04-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C07-comer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-comer.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C06-hablar]
 sounds: [r-tap, vowel-o]
 roots: [comedere-latin]
 etymology_hook: "comer ← Latin comedere 'to eat up' (com- + edere 'eat') → English edible, comestible"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C06-hablar, ES-C06-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C07-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH7-PRACTICE
 prerequisites: [ES-C07-comer, ES-C07-vivir, ES-C07-beber, ES-C07-que, ES-C07-donde]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C07-comer, ES-C07-vivir, ES-C07-que, ES-C07-donde, ES-C06-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C08-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH8-PRACTICE
 prerequisites: [ES-C08-numeros-1-5, ES-C08-numeros-6-10, ES-C08-tener, ES-C08-cuantos-anos]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C08-tener, ES-C08-cuantos-anos, ES-C08-numeros-6-10, ES-C07-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C08-tener.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-tener.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C06-hablar]
 sounds: [diphthong-ie, r-tap]
 roots: [tenere-latin]
 etymology_hook: "tener ← Latin tenēre 'to hold' → English tenant, tenacious, contain, retain, maintain, sustain"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C07-comer, ES-C06-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C09-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH9-PRACTICE
 prerequisites: [ES-C09-ser, ES-C09-ser-vs-estar, ES-C09-soy-de, ES-C09-esta-en]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C09-ser-vs-estar, ES-C09-soy-de, ES-C09-esta-en, ES-C04-estar, ES-C08-practice]
 ---
 
@@ -54,18 +54,6 @@ every sentence, name *why* the verb is the one it is.
 
 Two verbs, one conversation: *soy de / soy profesor* (essence → **ser**), *estoy
 en casa / estoy cansado* (state → **estar**).
-
-## What you've built this chapter
-
-- **ser** — the *essence* to-be (← *esse* → essence/present; suppletive **soy ·
-  eres · es · somos · son**, cousins of English *is/am/are*), completing the pair
-  begun with *estar* back in Ch.4.
-- **the ser/estar split**, from the roots: *essence* (ser) vs *estado/standing*
-  (estar) — with **minimal pairs** that flip meaning (*es/está aburrido*, *rico*,
-  *verde*, *listo*).
-- **soy de…** (origin → **ser**; *de* ← *dē*) and **está en…** (location →
-  **estar**; *en* ← *in*), plus the twin questions *¿De dónde eres?* vs *¿Dónde
-  estás?*
 
 ## Guided Practice
 

--- a/code/learning/human-languages/spanish/lessons/ES-C09-ser-vs-estar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-ser-vs-estar.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C09-ser, ES-C04-estar]
 sounds: [r-tap, st-no-e]
 roots: [esse-latin, stare-latin]
 etymology_hook: "the split is baked into the roots: ser ← esse (essence, what a thing IS) vs estar ← stāre (to stand, how it stands right now)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C09-ser, ES-C04-estar, ES-C04-como-esta]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C04-estar, ES-C08-tener]
 sounds: [vowel-e, r-tap]
 roots: [esse-latin, sedere-latin]
 etymology_hook: "ser ← Latin esse 'to be' (+ sedēre 'to sit'); its forms are suppletive — soy/es/son are cousins of English am/is/are"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C04-estar, ES-C08-tener]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C09-ser, ES-C04-estar]
 sounds: [vowel-i, diphthong-oy]
 roots: [ire-vadere-latin]
 etymology_hook: "ir ← Latin īre 'to go', but its present (voy/vas/va/vamos/van) comes from a DIFFERENT verb, vādere — suppletion, exactly like English go/went"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C09-ser, ES-C09-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C10-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH10-PRACTICE
 prerequisites: [ES-C10-ir, ES-C10-ir-a-futuro, ES-C10-mi-tu-su]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C10-ir, ES-C10-ir-a-futuro, ES-C10-mi-tu-su, ES-C09-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C11-querer, ES-C06-hablar]
 sounds: [diphthong-ue, r-tap]
 roots: [potere-latin]
 etymology_hook: "poder ← Latin potēre 'to be able' → power, potent, possible, potential; the stressed o breaks to ue (puedo) — the second stem-change pattern"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C11-querer, ES-C10-ir-a-futuro]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C11-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH11-PRACTICE
 prerequisites: [ES-C11-querer, ES-C11-poder, ES-C11-stem-changes, ES-C11-nuestro]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C11-querer, ES-C11-poder, ES-C11-nuestro, ES-C10-practice]
 ---
 
@@ -51,17 +51,6 @@ without thinking.
 
 Every tool of the chapter: *quiero* (want, e→ie), *puedes/puedo/podemos* (can,
 o→ue), *nuestros* (our, agreeing), and *ir a* from Ch.10.
-
-## What you've built this chapter
-
-- **querer** (want, ← *quaerere* "seek" → query/quest/conquer) — the **e→ie**
-  stem-changer.
-- **poder** (can, ← *potēre* → power/potent/possible) — the **o→ue** stem-changer,
-  and *poder* + infinitive for ability.
-- **the boot**: one sound-law (short stressed *e→ie*, *o→ue*; *tierra*, *puerta*)
-  cracking all forms but *nosotros/vosotros*.
-- **nuestro/vuestro** (← *noster/voster* → Paternoster) — the possessive that agrees
-  in **gender and number**, four forms.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/spanish/lessons/ES-C11-querer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-querer.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C08-tener, ES-C06-hablar]
 sounds: [diphthong-ie, r-tap]
 roots: [quaerere-latin]
 etymology_hook: "querer ← Latin quaerere 'to seek, ask' → query, quest, question, inquire, require, conquer; the stressed e breaks to ie (quiero) — the same crack you met in tener"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C08-tener, ES-C10-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C12-hacer, ES-C11-querer]
 sounds: [diphthong-none-i, g-hard]
 roots: [dicere-latin]
 etymology_hook: "decir ← Latin dīcere 'to say, tell' → dictate, diction, dictionary, predict, verdict, contradict; doubly irregular — the -go yo-form digo (like hago/tengo) AND the e→i stem-change (dices/dice)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C12-hacer, ES-C11-querer, ES-C11-stem-changes]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C08-tener, ES-C06-hablar]
 sounds: [jota-h-silent, g-hard]
 roots: [facere-latin]
 etymology_hook: "hacer ← Latin facere 'to do, make' → fact, factory, affect, perfect, manufacture, satisfy; the f→h softening (facere→hacer, like Ch.6 hablar) and the -go yo-form hago (like tengo)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C08-tener, ES-C10-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C12-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH12-PRACTICE
 prerequisites: [ES-C12-hacer, ES-C12-decir, ES-C12-yo-go]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C12-hacer, ES-C12-decir, ES-C12-yo-go, ES-C11-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C12-yo-go, ES-C12-hacer]
 sounds: [g-hard, r-tap]
 roots: [ponere-latin]
 etymology_hook: "poner ← Latin pōnere 'to put, place' → position, compose, deposit, component, opponent, postpone; the -go yo-form pongo joins tengo/hago/digo"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C12-yo-go, ES-C12-hacer, ES-C08-tener]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C13-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH13-PRACTICE
 prerequisites: [ES-C13-poner, ES-C13-salir, ES-C13-venir]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C13-poner, ES-C13-salir, ES-C13-venir, ES-C12-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C13-salir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-salir.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C13-poner]
 sounds: [g-hard, l-clear]
 roots: [salire-latin]
 etymology_hook: "salir ← Latin salīre 'to leap, jump' → sally, salient, somersault, salmon (the leaping fish); the -go yo-form salgo joins pongo/tengo — 'going out' as an old 'leaping out'"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C13-poner, ES-C12-yo-go]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C13-salir, ES-C11-querer]
 sounds: [g-hard, diphthong-ie]
 roots: [venire-latin]
 etymology_hook: "venir ← Latin venīre 'to come' → adventure, convene, event, invent, avenue, souvenir; doubly irregular like decir — the -go yo-form vengo AND the e→ie stem-change (vienes/viene), completing the club"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C13-salir, ES-C13-poner, ES-C11-querer, ES-C12-decir]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C14-hablar-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-hablar-preterite.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C14-ser-ir-preterite, ES-C06-hablar]
 sounds: [stress-final, accent-acute]
 roots: [latin-perfect-avi]
 etymology_hook: "the -ar preterite endings -é/-aste/-ó/-amos/-aron ← Latin perfect -āvī/-āvistī/-āvit (amāvī → amé); the written accent on hablé/habló marks the stress Latin put on that final vowel"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C14-ser-ir-preterite, ES-C06-hablar]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C14-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH14-PRACTICE
 prerequisites: [ES-C14-ser-ir-preterite, ES-C14-hablar-preterite]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C14-ser-ir-preterite, ES-C14-hablar-preterite, ES-C13-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C14-ser-ir-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-ser-ir-preterite.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C13-venir, ES-C09-ser, ES-C10-ir]
 sounds: [diphthong-ui, stress-final]
 roots: [fui-latin]
 etymology_hook: "fui ← Latin fuī 'I have been' (perfect of a second 'be' root — cousin of English BE, future, physics); ser AND ir share this ONE preterite, so fui = 'I was' AND 'I went', context deciding"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C13-venir, ES-C09-ser, ES-C10-ir]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C15-comer-vivir-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-comer-vivir-preterite.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C14-hablar-preterite, ES-C07-comer, ES-C07-vivir]
 sounds: [stress-final, accent-acute]
 roots: [latin-perfect-i]
 etymology_hook: "the -er and -ir preterites are IDENTICAL (-í/-iste/-ió/-imos/-ieron) though their presents differ — two conjugations merging into one; ← Latin perfect -ī/-istī/-it, with -istī → -iste still plainly visible"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C14-hablar-preterite, ES-C07-comer, ES-C07-vivir]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C15-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH15-PRACTICE
 prerequisites: [ES-C15-comer-vivir-preterite, ES-C15-preterite-fuertes]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C15-comer-vivir-preterite, ES-C15-preterite-fuertes, ES-C14-practice]
 ---
 
@@ -29,11 +29,8 @@ one question sorts them: **where does the stress land?**
 | strong *tener* | **tuve** | **tuviste** | **tuvo** | **tuvimos** | **tuvieron** |
 | ser / ir | **fui** | **fuiste** | **fue** | **fuimos** | **fueron** |
 
-Two things to notice:
-
-1. Rows 2 and 3 are the **same** — *-er* and *-ir* merged.
-2. Only rows 1–3 carry accents, and only on *yo* and *él*. Those are exactly the
-   forms where **the stress is on the ending**.
+Rows 2 and 3 are the **same**: *-er* and *-ir* merged. Rows 1–3 carry
+accents only on *yo* and *él*, where **the ending is stressed**.
 
 ## The stress test
 
@@ -44,7 +41,7 @@ Read any preterite and ask: is the loud syllable the **last** one?
 
 ## Drill — past or present?
 
-Some forms live in both tenses. Decide by context:
+Use context for forms shared by two tenses:
 
 | form | could be | which? |
 |---|---|---|

--- a/code/learning/human-languages/spanish/lessons/ES-C15-preterite-fuertes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-preterite-fuertes.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C15-comer-vivir-preterite, ES-C08-tener, ES-C12-hacer, ES-C04
 sounds: [stress-stem, spelling-c-z]
 roots: [latin-perfect-strong]
 etymology_hook: "'strong' = the stress lives in the STEM, not the ending — TUve, HIce, so no written accent, the exact reverse of hablÉ/hablÓ; these are the Latin strong perfects (tenuī, fēcī, stetī) inherited whole instead of rebuilt"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C15-comer-vivir-preterite, ES-C14-hablar-preterite, ES-C08-tener, ES-C12-hacer]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C16-imperfecto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-imperfecto.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C15-practice, ES-C07-comer, ES-C07-vivir]
 sounds: [accent-acute, hiatus-ia]
 roots: [latin-abam-ebam]
 etymology_hook: "-aba ← Latin -ābam, -ía ← -ēbam (the b wore away in the -er/-ir set but survives whole in -ar); -er and -ir share ONE set a third time; the accent on -ía breaks the diphthong so i and a are two syllables"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C15-practice, ES-C15-comer-vivir-preterite, ES-C06-hablar, ES-C07-comer]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C16-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-practice.md
@@ -8,7 +8,7 @@ concept_tag: CH16-PRACTICE
 prerequisites: [ES-C16-imperfecto, ES-C16-tres-irregulares]
 sounds: []
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C16-imperfecto, ES-C16-tres-irregulares, ES-C15-practice, ES-C14-practice]
 ---
 
@@ -16,9 +16,8 @@ reviews_of: [ES-C16-imperfecto, ES-C16-tres-irregulares, ES-C15-practice, ES-C14
 
 ## Warm-up
 
-[PAUSE 2s] You now have **both** past tenses. English marks this difference only
-sometimes, and never with an ending — so this is a genuinely **new distinction**
-to think in, not just new forms to learn.
+[PAUSE 2s] You now have **both** past tenses. English never marks this whole
+distinction with an ending, so it is a new contrast to think in.
 
 ## The split
 
@@ -39,8 +38,7 @@ The classic pairing — the imperfect sets the scene, the preterite breaks it:
 > **Hablaba** con María cuando **llegó** Juan.
 > *(I was talking to María when Juan arrived.)*
 
-The talking is the **line**; the arriving is the **point** that lands on it. Swap
-the tenses and the sentence stops making sense.
+The talking is the **line**; the arriving is the **point** that lands on it.
 
 ## Verbs that change meaning
 

--- a/code/learning/human-languages/spanish/lessons/ES-C16-tres-irregulares.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-tres-irregulares.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C16-imperfecto, ES-C09-ser, ES-C10-ir]
 sounds: [accent-acute, stress-antepenultimate]
 roots: [latin-eram, latin-ibam, latin-videre]
 etymology_hook: "iba ← Latin ībam — the imperfect is the ONE tense where ir uses its own original verb īre; its present came from vādere and its preterite from fuī, so ir's three tenses come from THREE different Latin verbs"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C16-imperfecto, ES-C09-ser, ES-C10-ir, ES-C14-ser-ir-preterite]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C17-condicional.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-condicional.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C17-futuro, ES-C16-imperfecto]
 sounds: [hiatus-ia, accent-acute]
 roots: [latin-infinitive-habere]
 etymology_hook: "hablaría = hablar + ía (← the old reduced imperfect avía) — the SAME infinitive weld as the future, but with the IMPERFECT of haber instead of the present, which is why its endings are exactly the -ía endings of Ch.16's imperfect; two tenses, one trick, two tenses of haber"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C17-futuro, ES-C16-imperfecto, ES-C11-querer]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C17-future-guessing.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-future-guessing.md
@@ -1,0 +1,51 @@
+---
+id: ES-C17-future-guessing
+chapter: 17
+type: grammar
+headword: serán las tres
+gloss: the future can express a present guess, and the conditional can express a past guess
+prerequisites: [ES-C17-practice]
+sounds: [accent-acute, stress-final]
+roots: [latin-infinitive-habere]
+etymology_hook: "the future grew from 'have to' and retains a path from obligation to likelihood, allowing future forms to mark present conjecture and conditional forms to mark past conjecture"
+est_minutes: 4
+reviews_of: [ES-C17-practice, ES-C17-futuro, ES-C17-condicional]
+---
+
+# serán las tres — future form, present guess
+
+## Guessing now
+
+Spanish uses the future to express a present conjecture:
+
+| Spanish | natural meaning |
+|---|---|
+| **¿Dónde estará Juan?** | Where can Juan be? *(now)* |
+| **Serán las tres.** | It must be three o'clock. |
+| **¿Quién será?** | Who could that be? |
+
+The verb's form is future, but the uncertain situation is present.
+
+## Guessing about the past
+
+The conditional moves the same conjecture backward:
+
+> **Serían las tres cuando llegó.** — It must have been three when he arrived.
+
+These tenses grew from constructions with **haber**, "have." The semantic
+path from "have to" toward obligation and likelihood helps the guessing use
+feel less arbitrary.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "¿Dónde estará?" — where can he be?]
+- [YOU SAY: "Serán las tres" — it must be three]
+- [YOU SAY: "Serían las tres" — it must have been three]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **serán las tres** necessarily refer to later? (**No — it
+can guess the time now.**) Which form guesses about the past?
+(**Conditional: serían.**) What older meaning helps connect future form to
+likelihood? (**The construction with haber, "have to."**)

--- a/code/learning/human-languages/spanish/lessons/ES-C17-futuro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-futuro.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C16-practice, ES-C10-ir-a-futuro]
 sounds: [accent-acute, stress-final]
 roots: [latin-infinitive-habere]
 etymology_hook: "hablaré is hablar + he — the infinitive plus the present of haber, 'I HAVE to speak' → 'I will speak'; Latin's own future (amābō) died and Romance built a compound to replace it, which then FUSED into a single word, so the endings -é/-ás/-á/-emos/-án are a whole verb worn down to a suffix"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C16-practice, ES-C10-ir-a-futuro, ES-C06-hablar]
 ---
 
@@ -17,8 +17,7 @@ reviews_of: [ES-C16-practice, ES-C10-ir-a-futuro, ES-C06-hablar]
 
 ## Warm-up
 
-[PAUSE 2s] Chapter 10 gave you one future (*voy a hablar*). Here is the other —
-and it has the best origin story of any Spanish tense.
+[PAUSE 2s] Chapter 10 gave you one future (*voy a hablar*). Here is the other.
 
 ## The forms
 

--- a/code/learning/human-languages/spanish/lessons/ES-C17-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-practice.md
@@ -3,12 +3,12 @@ id: ES-C17-practice
 chapter: 17
 type: practice-mix
 headword: (practice)
-gloss: the ten irregular stems that serve both tenses — and the future that isn't about the future
+gloss: the ten irregular stems that serve both future and conditional
 concept_tag: CH17-PRACTICE
 prerequisites: [ES-C17-futuro, ES-C17-condicional]
 sounds: [epenthetic-d]
 roots: []
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C17-futuro, ES-C17-condicional, ES-C13-practice, ES-C12-yo-go]
 ---
 
@@ -67,31 +67,12 @@ Every irregular here is irregular in the **stem only**. The endings never change
 
 > **irregular stem + the same -é/-ás/-á… or -ía/-ías…**
 
-## The future that isn't about the future
-
-One more use, and it surprises everyone. Spanish uses the **future** to express
-**present guessing**:
-
-| Spanish | means |
-|---|---|
-| *¿Dónde **estará** Juan?* | "Where **can** Juan be?" (right now) |
-| ***Serán** las tres.* | "It **must be** three o'clock." |
-| *¿Quién **será**?* | "Who **could** that be?" |
-
-And the **conditional** does the same for the **past**:
-
-> ***Serían** las tres cuando llegó.* — "It **must have been** three when he arrived."
-
-If you remember that these tenses were built from "**I have to…**," the leap makes
-sense: *have to* is about **obligation and likelihood**, not only time.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: the d-group — "tendré, pondré, vendré, saldré"]
 - [YOU SAY: the choppers — "diré, haré"]
 - [YOU SAY: one verb, both tenses — "tendré … tendría"]
-- [YOU SAY: the guess — "¿Dónde estará?" ("Where can he be?")]
 
 ## Wrap-up Recall
 
@@ -100,6 +81,4 @@ Why does *tener* become *tendr-*? (Dropping the vowel squeezed *-n'r-* together,
 and a **d** wedged in to fix it — medieval Spanish also tried *terné*.) How do the
 **-go club** verbs fare here? (**All six are irregular** — four take the *-dr-*,
 and *hacer/decir* chop instead.) Which two verbs chop hardest? (**Decir → diré**,
-**hacer → haré**.) What does *Serán las tres* mean? ("It **must be** three" — the
-future used for **guessing**.) Next chapter: the subjunctive — the mood for
-things that aren't facts.
+**hacer → haré**.) Do irregular stems change the endings? (**No.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-inherited-subjunctive-stems.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-inherited-subjunctive-stems.md
@@ -1,0 +1,61 @@
+---
+id: ES-C18-inherited-subjunctive-stems
+chapter: 18
+type: grammar
+headword: tenga, diga, haga; quiera, pueda
+gloss: irregular yo stems and stressed stem changes carry into the subjunctive automatically
+prerequisites: [ES-C18-subjuntivo]
+sounds: [vowel-a, diphthong-ie, diphthong-ue]
+roots: []
+etymology_hook: "because the subjunctive starts from the present yo form, the -go club and stressed stem changes are inherited rather than memorized again"
+est_minutes: 4
+reviews_of: [ES-C18-subjuntivo, ES-C12-yo-go, ES-C11-stem-changes]
+---
+
+# tenga, diga, quiera — old irregularities come free
+
+## Warm-up
+
+[PAUSE 2s] The subjunctive recipe begins with the present **yo** form. That
+means irregular stems you already know travel into the new mood with you.
+
+## The -go club
+
+Drop the final **-o**, keep the **g**, and add the opposite-vowel endings:
+
+| verb | yo form | subjunctive |
+|---|---|---|
+| tener | tengo | **tenga** |
+| decir | digo | **diga** |
+| hacer | hago | **haga** |
+| poner | pongo | **ponga** |
+| salir | salgo | **salga** |
+| venir | vengo | **venga** |
+
+Six irregular verbs require no new irregular stem.
+
+## Stem-changers
+
+Chapter 11's stressed changes also carry over:
+
+| verb | yo form | subjunctive |
+|---|---|---|
+| querer | quiero | **quiera** |
+| poder | puedo | **pueda** |
+
+The **nosotros** forms keep the plain stem: **queramos**, **podamos**, not
+~~quieramos~~ or ~~puedamos~~. As in the indicative, the stress has moved
+away from the stem, so the diphthong disappears.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tengo → tenga; digo → diga; hago → haga"]
+- [YOU SAY: "pongo → ponga; salgo → salga; vengo → venga"]
+- [YOU SAY: "quiera / queramos; pueda / podamos"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does **tenga** keep its **g**? (**It comes from tengo.**)
+How many new stems does the -go club require? (**Zero.**) Why are
+**queramos** and **podamos** plain? (**The stem is unstressed in nosotros.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-ojala.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-ojala.md
@@ -1,0 +1,51 @@
+---
+id: ES-C18-ojala
+chapter: 18
+type: etymology
+headword: ojalá
+gloss: a wish-word borrowed from Andalusi Arabic that triggers the subjunctive without que or a main verb
+prerequisites: [ES-C18-wanting-clause-trap]
+sounds: [vowel-a, accent-mark]
+roots: [arabic-law-sha-allah]
+etymology_hook: "ojalá comes from Andalusi Arabic law šāʾ Allāh, 'if God should will'; Spanish borrowed a function word that now triggers a whole grammatical mood"
+est_minutes: 4
+reviews_of: [ES-C18-wanting-clause-trap, ES-C05-hasta]
+---
+
+# ojalá — a wish borrowed whole
+
+## A trigger by itself
+
+> **Ojalá hable español.** — I hope he speaks Spanish. / May he speak Spanish.
+
+**Ojalá** takes the subjunctive without **que** or a separate main verb. The
+word itself expresses the wish, so there is no factual assertion to put in
+the indicative.
+
+## From Andalusi Arabic
+
+The standard account derives **ojalá** from Andalusi Arabic **law šāʾ
+Allāh**, "if God should will." The **Allāh** remains audible in the second
+half.
+
+Chapter 5 gave you another Arabic function word: **hasta**, from **ḥattā**.
+Borrowing nouns such as **azúcar**, **aceite**, and **álgebra** is ordinary.
+Borrowing grammatical tools is rarer. Spanish borrowed both a preposition
+and a word that selects a whole mood.
+
+English "God willing" expresses the same idea, and English has now borrowed
+Arabic **inshallah** directly as well.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ojalá hable" — may he speak]
+- [YOU SAY: "ojalá venga" — I hope she comes]
+- [YOU SAY: "hasta / ojalá" — two Arabic function words]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Does **ojalá** require **que**? (**No.**) Which mood follows it?
+(**The subjunctive.**) What is its source phrase? (**Andalusi Arabic law
+šāʾ Allāh, "if God should will."**) Which other Arabic function word have
+you learned? (**Hasta.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-practice-mood.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-practice-mood.md
@@ -1,0 +1,58 @@
+---
+id: ES-C18-practice-mood
+chapter: 18
+type: practice-mix
+headword: fact or wish?
+gloss: choosing indicative versus subjunctive and hearing the opposite-vowel contrast
+concept_tag: ES-CH18-PRACTICE-MOOD
+prerequisites: [ES-C18-practice-subjects]
+sounds: [vowel-e, vowel-a, accent-mark]
+roots: [arabic-law-sha-allah]
+est_minutes: 4
+reviews_of: [ES-C18-practice-subjects, ES-C18-ojala, ES-C14-hablar-preterite]
+---
+
+# Practice — fact or wish?
+
+## Report or reach
+
+Report the world with the **indicative**; reach for a different world with
+the **subjunctive**.
+
+| | |
+|---|---|
+| Sé que **comes** aquí. | I know you eat here. *(fact)* |
+| Quiero que **comas** aquí. | I want you to eat here. *(wish)* |
+| Sé que **está** aquí. | I know he is here. *(fact)* |
+| Ojalá **esté** aquí. | I hope he is here. *(wish)* |
+| Dice que **viene**. | She says she is coming. *(report)* |
+| Quiero que **venga**. | I want her to come. *(wish)* |
+
+**Ojalá** needs no **que** and no main verb. It is the wish.
+
+## Hear the flip
+
+| indicative | subjunctive |
+|---|---|
+| habl**a** | habl**e** |
+| com**e** | com**a** |
+| trabaj**a** | trabaj**e** |
+| viv**e** | viv**a** |
+
+Also distinguish **hable** from **hablé**, and **trabaje** from
+**trabajé**. The written accent separates present subjunctive from "I"
+preterite.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "sé que comes / quiero que comas"]
+- [YOU SAY: "dice que viene / quiero que venga"]
+- [YOU SAY: "hable / hablé"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why is **sé que comes** indicative? (**It reports a fact.**)
+What does **ojalá** need before its subjunctive? (**Nothing.**) What does
+the accent distinguish in **hable/hablé**? (**Present subjunctive from
+first-person preterite.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-practice-subjects.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-practice-subjects.md
@@ -1,0 +1,44 @@
+---
+id: ES-C18-practice-subjects
+chapter: 18
+type: practice-mix
+headword: one subject or two?
+gloss: choosing infinitive versus que plus subjunctive after wanting
+concept_tag: ES-CH18-PRACTICE-SUBJECTS
+prerequisites: [ES-C18-practice]
+sounds: [vowel-e, vowel-a]
+roots: []
+est_minutes: 4
+reviews_of: [ES-C18-practice, ES-C18-quiero-que, ES-C18-wanting-clause-trap]
+---
+
+# Practice — one subject or two?
+
+## The test
+
+Does the second verb have a different subject?
+
+| | |
+|---|---|
+| I want to eat. | Quiero **comer**. *(same → infinitive)* |
+| I want you to eat. | Quiero **que comas**. *(two → clause)* |
+| We want to live here. | Queremos **vivir** aquí. |
+| We want them to live here. | Queremos **que vivan** aquí. |
+| She wants to work. | Quiere **trabajar**. |
+| She wants me to work. | Quiere **que yo trabaje**. |
+
+Say each pair back to back. English changes quietly from "to eat" to "you
+to eat." Spanish marks the new subject with **que** and a conjugated verb.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "quiero comer / quiero que comas"]
+- [YOU SAY: "queremos vivir / queremos que vivan"]
+- [YOU SAY: "quiere trabajar / quiere que yo trabaje"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Same subject after **querer**: which form? (**Infinitive.**)
+Different subject? (**Que + subjunctive.**) Translate "I want to eat" and
+"I want you to eat." (**Quiero comer / Quiero que comas.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-practice.md
@@ -3,13 +3,13 @@ id: ES-C18-practice
 chapter: 18
 type: practice-mix
 headword: "Chapter 18 practice"
-gloss: "drilling the vowel flip, the two-subject test, and fact vs. wish"
+gloss: "drilling the vowel flip and inherited stems"
 concept_tag: CH18-PRACTICE
-prerequisites: [ES-C18-subjuntivo, ES-C18-quiero-que]
+prerequisites: [ES-C18-subjunctive-name, ES-C18-ojala]
 sounds: [vowel-e, vowel-a, accent-mark, stress-default-vowel-ns]
 roots: [latin-subiunctivus]
-est_minutes: 6
-reviews_of: [ES-C18-subjuntivo, ES-C18-quiero-que, ES-C12-yo-go, ES-C14-hablar-preterite]
+est_minutes: 4
+reviews_of: [ES-C18-subjunctive-name, ES-C18-ojala, ES-C18-subjuntivo, ES-C18-quiero-que, ES-C12-yo-go, ES-C14-hablar-preterite]
 ---
 
 # Chapter 18 practice — fact or wish?
@@ -52,67 +52,13 @@ throughout (**HA**-ble, ha-**BLE**-mos, **HA**-blen). *Estar* doesn't: es-**TÉ*
 es-**TÉS**, es-**TÉN** all land on the **last** syllable, so each needs a written
 accent. Only es-**TE**-mos falls where Spanish expects, and it takes none.
 
-## Drill 2 — one subject or two?
-
-The test: **does the second verb have a different subject?**
-
-| | |
-|---|---|
-| I want to eat. | Quiero **comer**. *(same subject → infinitive)* |
-| I want you to eat. | Quiero **que comas**. *(two → que + subjunctive)* |
-| We want to live here. | Queremos **vivir** aquí. |
-| We want them to live here. | Queremos **que vivan** aquí. |
-| She wants to work. | Quiere **trabajar**. |
-| She wants me to work. | Quiere **que yo trabaje**. |
-
-Say each pair aloud back to back. The English switches quietly from *"to eat"* to
-*"you to eat"*; Spanish switches loudly, and the loudness is the help.
-
-## Drill 3 — fact or not?
-
-Same *que*, different mood. Report the world → **indicative**. Reach for it →
-**subjunctive**.
-
-| | |
-|---|---|
-| Sé que **comes** aquí. | I know you eat here. *(fact)* |
-| Quiero que **comas** aquí. | I want you to eat here. *(wish)* |
-| Sé que **está** aquí. | I know he's here. *(fact)* |
-| Ojalá **esté** aquí. | I hope he's here. *(wish)* |
-| Dice que **viene**. | She says she's coming. *(report)* |
-| Quiero que **venga**. | I want her to come. *(wish)* |
-
-Notice *ojalá* needs no *que* and no main verb. The word **is** the wish, so it
-triggers the mood by itself.
-
-## Drill 4 — hear the flip
-
-The vowel swap is small on paper and clear in the mouth. Say each pair:
-
-| indicative | subjunctive |
-|---|---|
-| habl**a** | habl**e** |
-| com**e** | com**a** |
-| trabaj**a** | trabaj**e** |
-| viv**e** | viv**a** |
-
-The two *-ar* rows are also a reminder from Chapter 14. *Hable* and *hablé* are
-different words — and so are *trabaje* and *trabajé*. The written accent is the
-only thing separating "**(that) he speak**" from "**I spoke**," which is exactly
-what Chapter 14 meant by saying the accent **carries** the tense.
-
 ## Wrap-up Recall
 
 [PAUSE 3s] Recite the recipe. (***Yo* form, drop the *-o*, flip the vowel**.)
 Which earlier irregulars come along free? (The ***-go* club** of Ch. 12–13 and
 **Ch. 11's stem-changers**.) What's the two-subject test? (If the second verb has
-a **different subject**, use *que* + subjunctive; if the same, use the
-**infinitive**.) Translate both: "I want to eat" / "I want you to eat."
-(*Quiero comer* / *Quiero que comas*.) Why is *Sé que comes aquí* indicative?
-(It **reports a fact**.) Which *yo* forms leave no *-o* to strip, and which of
+**Ch. 11's stem-changers**.) Which *yo* forms leave no *-o* to strip, and which of
 them is still predictable? (*Soy, voy, sé, he, estoy* — and ***estoy*** is the
 predictable one, *est-* + normal endings.) Where does *estar*'s irregularity
 actually live? (**In the stress** — es-**TÉ** lands on the **last** syllable,
-breaking Spanish's second-to-last default, which is what the accent is recording.) What does *ojalá* need to work? (**Nothing** — no *que*,
-no main verb; it's a wish by itself.) And where is it from? (Arabic **law šāʾ
-Allāh**.) Next chapter: describing the world around you.
+breaking Spanish's second-to-last default, which is what the accent records.)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-quiero-que.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-quiero-que.md
@@ -3,14 +3,14 @@ id: ES-C18-quiero-que
 chapter: 18
 type: phrase
 headword: quiero que…
-gloss: "what triggers the subjunctive — one subject wanting another to act, and ojalá, a mood-trigger borrowed from Arabic"
+gloss: "what triggers the subjunctive — one subject wanting another to act"
 concept_tag: ES-SUBJUNCTIVE-TRIGGER
-prerequisites: [ES-C18-subjuntivo, ES-C11-querer, ES-C07-que, ES-C05-hasta]
+prerequisites: [ES-C18-subjunctive-name, ES-C11-querer, ES-C07-que, ES-C05-hasta]
 sounds: [vowel-e, diphthong-ie, accent-mark]
-roots: [arabic-law-sha-allah, latin-quaerere]
-etymology_hook: "OJALÁ comes from Andalusi Arabic law šāʾ Allāh, 'if God should will' — so Spanish borrowed not just a word but a whole SUBJUNCTIVE TRIGGER, and the Allāh is still in there; it is the second Arabic function word this course has met, after hasta ← ḥattā in Ch.5"
-est_minutes: 6
-reviews_of: [ES-C18-subjuntivo, ES-C11-querer, ES-C05-hasta, ES-C06-hablar]
+roots: [latin-quaerere]
+etymology_hook: "after querer, one subject uses an infinitive (quiero hablar), while a different subject requires que plus the subjunctive (quiero que hables)"
+est_minutes: 4
+reviews_of: [ES-C18-subjunctive-name, ES-C18-subjuntivo, ES-C11-querer, ES-C05-hasta, ES-C06-hablar]
 ---
 
 # quiero que… — making the subjunctive appear
@@ -60,64 +60,17 @@ Watch the difference this makes:
 Same *que*, same person, different mood — because knowing reports the world and
 wanting tries to change it.
 
-## The English trap
-
-English says *"I want **you to speak**"* — an object plus an infinitive. **After
-verbs of wanting, Spanish will not do this.** There is no ~~*Quiero te hablar*~~
-meaning "I want you to speak." You must build the full clause: **Quiero que
-hables.**
-
-This is the single most common English-speaker error with the Spanish
-subjunctive, and it comes from translating the shape instead of the meaning.
-
-Two things to keep the rule honest:
-
-- **It is about *wanting*, not about Spanish in general.** Object + infinitive is
-  perfectly good after verbs of **perceiving** and **causing**: *Te vi salir* ("I
-  saw you leave"), *Me hizo hablar* ("he made me speak"), *Déjame hablar* ("let
-  me speak"). Volition is the family that demands a clause.
-- ***Quiero hablarte* is fine** — it just means "I want to **speak to you**,"
-  one subject, with the pronoun attached to the infinitive. What's impossible is
-  using a pronoun to smuggle in a *second* subject.
-
-## ojalá — a wish, borrowed whole
-
-Spanish has another trigger, and it is a wonderful word:
-
-> **Ojalá hable** español. — *I hope he speaks Spanish. / May he speak Spanish.*
-
-**Ojalá** takes the subjunctive **always** — there is no indicative version,
-because the word *is* a wish.
-
-And it is Arabic. The standard account derives it from Andalusi Arabic **law šāʾ
-Allāh**, "**if God should will**." The **Allāh** is still sitting in the second
-half of the word every time a Spanish speaker says it.
-
-Which puts it beside something from Chapter 5: **hasta**, from Arabic *ḥattā*.
-Languages borrow nouns constantly — *azúcar*, *aceite*, *álgebra*. Borrowing a
-**function word** is much rarer, and these are the two this course will teach
-you: a preposition, and a word that **forces a grammatical mood**. (Spanish has a
-few others, but they are marginal; these two you will use.)
-
-The English cousin is *"God willing"* — and, still nearer, the Arabic *inshallah*
-that English has now borrowed in its own right.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: the one-subject version — "Quiero **hablar** español"]
 - [YOU SAY: the two-subject version — "Quiero **que hables** español"]
 - [YOU SAY: the contrast — "Sé que **hablas** … quiero que **hables**"]
-- [YOU SAY: the trap — "there is **no** *quiero te hablar*"]
-- [YOU SAY: "**Ojalá** hable español" — and hear the *Allāh* in it]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What makes the subjunctive appear after *querer*? (**Two different
 subjects** — joined by *que*.) Say "I want to speak" and "I want you to speak."
 (*Quiero hablar* / *Quiero **que hables***.) Why does *Sé que hablas* stay
-indicative? (Knowing reports a **fact**; wanting doesn't.) What's the commonest
-English-speaker error? (Copying *"want you to speak"* — Spanish needs the **full
-clause**.) Where does *ojalá* come from? (Arabic **law šāʾ Allāh**, "if God
-should will".) Which other Arabic function word do you know? (***Hasta***, from
-*ḥattā*, Ch. 5.) Next: putting the mood to work.
+indicative? (Knowing reports a **fact**; wanting doesn't.) What joins the two
+subjects? (**Que**, followed by the subjunctive.)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-name.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-name.md
@@ -1,0 +1,43 @@
+---
+id: ES-C18-subjunctive-name
+chapter: 18
+type: etymology
+headword: subjuntivo
+gloss: joined underneath — a mood named for its grammatical position in a subordinate clause
+prerequisites: [ES-C18-subjunctive-outliers]
+sounds: [stress-default-vowel-ns]
+roots: [latin-subiunctivus, pie-yewg]
+etymology_hook: "Latin subiūnctīvus means 'joined underneath,' from sub- plus iungere; join, junction, and conjunction descend from it, while yoke and yoga are PIE cousins"
+est_minutes: 4
+reviews_of: [ES-C18-subjunctive-outliers, ES-C18-subjuntivo]
+---
+
+# subjuntivo — "joined underneath"
+
+## The name describes its grammar
+
+Latin **subiūnctīvus** means "joined underneath": **sub-** (under) +
+**iungere** (join). English **join**, **junction**, and **conjunction**
+descend from that Latin verb.
+
+English **yoke** and Sanskrit **yoga** are cousins rather than descendants.
+All three branches reach Proto-Indo-European ***yewg-**, "join": a yoke
+joins oxen; yoga names a yoking; a conjunction joins clauses.
+
+Latin's term translated Greek **hypotaktikḗ**, "subordinated." The name
+describes where the mood lives: in a clause hanging under a main clause. It
+does not claim that every subjunctive sentence has one single meaning.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "sub-" — underneath]
+- [YOU SAY: "iungere" — to join]
+- [YOU SAY: "subjunctive" — joined underneath]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **subjunctive** literally mean? (**Joined
+underneath.**) Which English words descend from **iungere**? (**Join,
+junction, conjunction.**) Which two are older cousins? (**Yoke and yoga.**)
+What does the name describe? (**The mood's grammatical position.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-outliers.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-outliers.md
@@ -1,0 +1,62 @@
+---
+id: ES-C18-subjunctive-outliers
+chapter: 18
+type: grammar
+headword: sea, vaya, sepa, haya; esté
+gloss: four forms must be learned outright, while estar keeps a regular stem with exceptional stress
+prerequisites: [ES-C18-inherited-subjunctive-stems]
+sounds: [accent-mark, stress-default-vowel-ns]
+roots: [latin-sedere, latin-vadere, latin-sapere, latin-habere]
+etymology_hook: "sea, vaya, sepa, and haya descend from Latin subjunctives; modern 'no -o to strip' is a memory aid, while esté follows the regular est- stem but needs accents where final stress breaks the default"
+est_minutes: 4
+reviews_of: [ES-C18-inherited-subjunctive-stems, ES-W01-acento]
+---
+
+# sea, vaya, sepa, haya; esté — where the shortcut stops
+
+## Four forms to learn
+
+The drop-**o** recipe cannot start from **soy, voy, sé, he**:
+
+| verb | yo form | subjunctive |
+|---|---|---|
+| ser | soy | **sea** |
+| ir | voy | **vaya** |
+| saber | sé | **sepa** |
+| haber | he | **haya** |
+
+Learn those four. **Sea** also recalls a fact from Chapter 9: forms of Latin
+**sedēre**, "to sit," joined the history of **ser**. It descends from Latin
+*sedeam*.
+
+## estar — regular stem, exceptional stress
+
+Remove all of **-oy** from **estoy** and the ordinary stem **est-** remains:
+**esté, estés, esté, estemos, estén**.
+
+The accents record final stress that breaks Spanish's default:
+
+- es-**TÉ**, es-**TÉS**, es-**TÉN** — accent required
+- es-**TE**-mos — default second-to-last stress, no accent
+
+**Dar** similarly shrinks **doy** to **d-**: **dé, des, dé, demos, den**.
+The accent on one-syllable **dé** distinguishes the verb from preposition
+**de**; it does not move stress.
+
+Treat "no **-o** to strip" as a modern memory aid, not a historical cause.
+**Sea, vaya, sepa, haya** descend from Latin *sedeam, vādam, sapiam,
+habeam*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "sea, vaya, sepa, haya"]
+- [YOU SAY: "esté, estés, esté, estemos, estén"]
+- [YOU SAY: "dé" the verb versus "de" the preposition]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which four forms are learned outright? (**Sea, vaya, sepa,
+haya.**) What is regular about **estar**? (**Its est- stem and endings.**)
+Why does **esté** need an accent but **estemos** does not? (**Final stress
+breaks the default; second-to-last stress obeys it.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-subjuntivo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-subjuntivo.md
@@ -3,13 +3,13 @@ id: ES-C18-subjuntivo
 chapter: 18
 type: word
 headword: hable, coma, viva
-gloss: "the present subjunctive — built from the yo form, with the vowel flipped"
+gloss: "the regular present subjunctive — built from the yo form, with the vowel flipped"
 concept_tag: ES-SUBJUNCTIVE-PRESENT
-prerequisites: [ES-C12-yo-go, ES-C11-stem-changes, ES-C06-hablar, ES-C07-comer]
+prerequisites: [ES-C17-future-guessing, ES-C12-yo-go, ES-C11-stem-changes, ES-C06-hablar, ES-C07-comer]
 sounds: [vowel-e, vowel-a, accent-mark, stress-default-vowel-ns]
 roots: [latin-subiunctivus, pie-yewg]
-etymology_hook: "SUBJUNCTIVE ← Latin subiūnctīvus, 'joined UNDERNEATH' (sub- + iungere 'to join', whence JOIN, JUNCTION, CONJUNCTION; YOKE and Sanskrit YOGA are cousins via PIE *yewg-, not descendants) — a calque of Greek hypotaktikḗ 'subordinated', because this mood lives in a clause hanging under another one; the name describes its GRAMMAR, not its meaning"
-est_minutes: 6
+etymology_hook: "build the regular present subjunctive from the present yo form: drop -o, then give -ar verbs e-endings and -er/-ir verbs a-endings"
+est_minutes: 4
 reviews_of: [ES-C12-yo-go, ES-C11-stem-changes, ES-C06-hablar, ES-C07-vivir]
 ---
 
@@ -56,112 +56,12 @@ Note *-er* and *-ir* are **identical** here — as they already were in the Ch. 
 preterite and the Ch. 16 imperfect. Outside the present tense, those two
 conjugations keep merging.
 
-## Why this is a gift: every irregular yo form comes along
-
-Because the subjunctive is built from *yo*, **any irregularity in the yo form is
-inherited automatically.** The ***-go* club** of Chapters 12–13 — six verbs you
-already know — transfers whole:
-
-| verb | yo form (Ch. 12–13) | subjunctive |
-|---|---|---|
-| tener | ten**go** | **tenga** |
-| decir | di**go** | **diga** |
-| hacer | ha**go** | **haga** |
-| poner | pon**go** | **ponga** |
-| salir | sal**go** | **salga** |
-| venir | ven**go** | **venga** |
-
-Six irregular verbs, and **zero new memorisation** — the *-g-* was already in the
-form you knew.
-
-Chapter 11's **stem-changers** come along too:
-
-| verb | yo form | subjunctive |
-|---|---|---|
-| querer | qu**ie**ro | qu**ie**ra |
-| poder | p**ue**do | p**ue**da |
-
-One caution: for these, *nosotros* keeps the **plain** stem — *queramos*,
-*podamos*, not ~~*quieramos*~~. Same rule as the present, where the stress falls
-elsewhere and the diphthong doesn't appear.
-
-## Where the recipe runs out
-
-The recipe says "drop the **-o**." So it needs a *yo* form that ends in a
-strippable *-o* — and five verbs you know don't have one:
-
-| verb | yo form | subjunctive | |
-|---|---|---|---|
-| ser | s**oy** | **sea** | unpredictable |
-| ir | v**oy** | **vaya** | unpredictable |
-| saber | s**é** | **sepa** | unpredictable |
-| haber | h**e** | **haya** | unpredictable |
-| estar | est**oy** | **esté** | **predictable** |
-
-The first four you simply learn — and *sea* has a footnote you've already met:
-Chapter 9 said *ser* had a second Latin verb, ***sedēre*** "to sit," folded into
-it. *Sea* is from that verb's subjunctive, *sedeam*. The wanderer turns up again.
-
-But notice *estar* behaves differently: strip the whole *-oy* and a perfectly
-ordinary stem is left — ***est-*** — which then takes the normal *-ar* endings:
-*esté, estés, esté, estemos, estén*.
-
-One real oddity, though, and it's about **stress**, not spelling. Recall Spanish's
-default: a word ending in a **vowel, -n or -s** is stressed on the
-**second-to-last** syllable. *Hablar* obeys it throughout — **HA**-ble,
-ha-**BLE**-mos, **HA**-blen — so it never needs a mark.
-
-*Estar* breaks it. The stress lands on the **last** syllable:
-
-| | | |
-|---|---|---|
-| es-**TÉ**, es-**TÉS**, es-**TÉN** | break the default | **accent required** |
-| es-**TE**-mos | obeys the default | **no accent** |
-
-So the written accents aren't decoration and aren't arbitrary: they are the
-receipt for a stress that doesn't sit where Spanish expects. Four forms need one;
-*estemos* doesn't.
-
-So: **four irregular, plus one whose stem is regular but whose stress isn't.**
-
-(*Dar* has the same *-oy* tail — *doy* — and its stem shrinks the same way, to
-*d-*: **dé, des, dé, demos, den**. Careful, though: that single accent is *not* a
-stress mark. *Dé* is one syllable; the tilde is the ***qué*/*que*** kind from
-Chapter 7, separating the verb from the preposition *de*. You'll meet *dar*
-properly later.)
-
-(A caution about *why*. "No *-o* to strip" is a **memory aid for the modern
-language**, not the history. *Sea, vaya, sepa* and *haya* come down from Latin
-*sedeam, vādam, sapiam, habeam* — and *saber* and *haber* obviously do have
-usable stems elsewhere, *sab-* and *hab-*. The *yo*-form recipe is a superb
-shortcut, and these five are where it stops describing the language.)
-
-## The name
-
-**Subjunctive** is Latin *subiūnctīvus*, "**joined underneath**" — *sub-* +
-*iungere*, "to join." English **join**, **junction** and **conjunction** all
-descend from that verb.
-
-Two more words belong to the family without descending from Latin: **yoke** (a
-native English word, Old English *geoc*) and **yoga** (Sanskrit *yuj-*, literally
-"a yoking"). Those are *iungere*'s **cousins**, not its children — all three go
-back to the same Proto-Indo-European root \**yewg-*, "to join." A yoke is what
-joins two oxen; yoga is what joins the self to something larger; a conjunction is
-what joins two clauses.
-
-Latin coined it to translate Greek *hypotaktikḗ*, "**subordinated**," and the
-name describes where the mood **lives**, not what it means: in a clause **hanging
-underneath** another one. Next lesson shows exactly that structure.
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: the recipe — "**yo** form, drop the **-o**, **flip the vowel**"]
 - [YOU SAY: "hable, hables, hable, hablemos, hablen"]
 - [YOU SAY: "coma, comas, coma, comamos, coman"]
-- [YOU SAY: the club — "tengo → **tenga**, digo → **diga**, hago → **haga**"]
-- [YOU SAY: the four outliers — "sea, vaya, sepa, haya"]
-- [YOU SAY: the fifth that behaves — "estoy → **est-** → esté, estemos, estén"]
 
 ## Wrap-up Recall
 
@@ -169,16 +69,5 @@ underneath** another one. Next lesson shows exactly that structure.
 present — not the infinitive.) What happens to the vowel? (It **flips**: *-ar*
 verbs take **-e**, *-er/-ir* take **-a**.) Give *comer*. (*Coma, comas, coma,
 comamos, coman*.) What happens to the *-go* club? (**It transfers whole** —
-*tenga, diga, haga, ponga, salga, venga*; nothing new to learn.) Which **four**
-verbs must be learned outright? (***Sea*, *vaya*, *sepa*, *haya*** — *soy, voy,
-sé, he* leave no *-o* to strip.) What about *estar*, whose *yo* form is *estoy*?
-(Strip the whole *-oy* and the stem ***est-*** is ordinary — but the **stress**
-isn't: es-**TÉ** puts it on the **last** syllable, breaking Spanish's
-second-to-last default, which is why four forms need a written accent and
-es-**TE**-mos doesn't.) Is "no *-o* to strip" history or a
-memory aid? (**A memory aid** — *sea* and *sepa* really descend from *sedeam*
-and *sapiam*.) What does
-"subjunctive" literally mean? ("**Joined underneath**" — it lives in a
-subordinate clause.) Which two family words are *cousins* of *iungere* rather
-than descendants? (**Yoke** and **yoga** — all three from PIE \**yewg-*.)
-Next: what makes it appear.
+*tenga, diga, haga, ponga, salga, venga*; the next step makes that inheritance
+explicit.)

--- a/code/learning/human-languages/spanish/lessons/ES-C18-wanting-clause-trap.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-wanting-clause-trap.md
@@ -1,0 +1,48 @@
+---
+id: ES-C18-wanting-clause-trap
+chapter: 18
+type: grammar
+headword: quiero que hables / quiero hablarte
+gloss: Spanish requires a full clause for a second subject after wanting, but permits object plus infinitive with perception and causation
+prerequisites: [ES-C18-quiero-que]
+sounds: [vowel-e, diphthong-ie]
+roots: [latin-quaerere]
+etymology_hook: "quiero hablarte keeps one subject and attaches an object pronoun; quiero que hables introduces a genuinely different subject, while perception and causation may use object plus infinitive"
+est_minutes: 4
+reviews_of: [ES-C18-quiero-que, ES-C11-querer]
+---
+
+# quiero que hables — do not smuggle in a subject
+
+## The English trap
+
+English says "I want **you to speak**": an object plus an infinitive.
+Spanish will not copy that shape after a verb of wanting. There is no
+~~quiero te hablar~~ with that meaning. Use a full clause:
+
+> **Quiero que hables.** — I want you to speak.
+
+The rule belongs to volition, not to every Spanish verb. Object plus
+infinitive works after perception and causation:
+
+- **Te vi salir.** — I saw you leave.
+- **Me hizo hablar.** — He made me speak.
+- **Déjame hablar.** — Let me speak.
+
+And **quiero hablarte** is valid: "I want to speak **to you**." It still has
+one subject—**I** want and **I** speak—and **te** is the object of speaking.
+What fails is using a pronoun to introduce a second doer after **querer**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "quiero hablarte" — I want to speak to you]
+- [YOU SAY: "quiero que hables" — I want you to speak]
+- [YOU SAY: "te vi salir" — perception allows object + infinitive]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Spanish say "I want you to speak"? (**Quiero que
+hables.**) Why is **quiero hablarte** different? (**It has one subject;
+te is an object.**) Name one verb family that permits object plus
+infinitive. (**Perception or causation.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C08-numeros-6-10]
 sounds: [r-tap, diphthong-ie]
 roots: [dies-latin, planet-gods]
 etymology_hook: "Spanish weekdays mostly just DROPPED diēs 'day' — martes 'Mars's [day]' keeps its trailing -s from Martis itself, not from diēs — where French still spells 'day' out loud as -di"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C08-numeros-6-10]
 ---
 
@@ -47,11 +47,6 @@ its five weekdays. **miércoles** is the odd one out: some historians of the
 language think its extra "**‑coles**" is a genuine surviving trace of *diēs*
 itself (fused in and reshaped) — though the exact sound changes are debated,
 unlike the plainer, better-understood story for its four siblings.
-
-And once again: **martes and Tuesday are the same day** — both "the war-god's
-day" — Latin naming **Mars**, the Germanic tribes naming **their** war-god
-**Tiw** instead (*interpretatio germanica*, the same swap French's *mardi*
-shows).
 
 ## Guided Practice
 

--- a/code/learning/human-languages/spanish/lessons/ES-C22-negro-blanco.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-negro-blanco.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C21-sabado-domingo]
 sounds: [r-tap, nasal-n]
 roots: [latin-niger, germanic-blank]
 etymology_hook: "negro ← Latin niger, but blanco is NOT from Latin albus — it's Germanic *blank 'shining', traditionally linked to Visigothic-era contact, the same word French borrowed (more firmly attested) via the Franks"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C21-sabado-domingo, ES-C21-lunes-viernes]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C22-rojo-azul.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-rojo-azul.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C22-negro-blanco]
 sounds: [r-tap, palatal-j]
 roots: [pie-rewdh-russus, arabic-lazaward]
 etymology_hook: "rojo ← Latin russus, a cousin (not a copy) of French's rouge (← rubeus) — both ultimately from PIE *h₁rewdʰ-; azul ← Arabic lāzaward, and unlike French, this IS Spanish's everyday word for blue"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C22-negro-blanco]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hermana.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hermana.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C23-padre-madre]
 sounds: [silent-h, r-tap]
 roots: [germanus-latin, germen-latin]
 etymology_hook: "hermano is NOT Spanish for frater — it's from germanus, 'of the same stock/seed' (→ English germ, germinate, germane); its initial g simply dropped in an unstressed syllable, and the h you see today was added later, purely in spelling"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C23-padre-madre]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C23-padre-madre.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C23-padre-madre.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C22-rojo-azul]
 sounds: [r-tap, d-soft]
 roots: [pater-latin, mater-latin]
 etymology_hook: "padre ← pater, madre ← mater — the same PIE *ph2ter/*meh2ter that gave English father/mother via Grimm's law (p→f, t→th)"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C22-rojo-azul, ES-C22-negro-blanco]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C25-las-estaciones.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C25-las-estaciones.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C24-mano, ES-C24-cabeza]
 sounds: [r-tap, diphthong-ie]
 roots: [latin-prima-vera, latin-autumnus, latin-hibernum, latin-veranum]
 etymology_hook: "primavera = prima vera 'first spring' (Italian keeps the same word); otoño ← autumnus; invierno ← hibernum ('wintry') — but verano did NOT come from aestas like French été; it's veranum, 'of spring,' whose MEANING drifted to summer once primavera took over spring's job"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C24-mano, ES-C24-cabeza]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C26-agua-vino.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C26-agua-vino.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C25-las-estaciones]
 sounds: [stressed-a-el-not-la, nasal-none]
 roots: [aqua-latin, vinum-latin]
 etymology_hook: "agua ← Latin aqua, barely changed at all — where French wore aqua all the way down to just 'eau' (a bare 'oh'); agua also takes EL despite being feminine, a purely phonological rule (avoiding la agua), not a gender change like mano's"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C25-las-estaciones]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C27-los-meses.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C27-los-meses.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C21-lunes-viernes, ES-C08-numeros-6-10]
 sounds: [r-tap, diphthong-ie]
 roots: [latin-months, roman-gods]
 etymology_hook: "marzo ← Martius ← Mars, the SAME war-god behind martes; septiembre–diciembre still mean Latin 7–10 because the year once started in March — Julius and Augustus didn't ADD months, they just got two already-existing ones (Quintilis, Sextilis) RENAMED after them"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C21-lunes-viernes, ES-C08-numeros-6-10]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C29-la-hora.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C29-la-hora.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C28-mediodia-medianoche]
 sounds: [silent-h, article-la-las]
 roots: [hora-latin, hora-greek]
 etymology_hook: "hora ← Latin hōra ← Greek hṓrā, 'a season, a time of day' — Spanish inherited it almost unchanged, with a silent h that's a fossil of an already-weak Latin h (NOT the same story as hijo/hacer's silent h, which comes from Spanish's own later f- → h- sound change); the same Latin source as French heure, German's separately-borrowed Uhr, and English hour"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C28-mediodia-medianoche]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C30-el-tiempo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C30-el-tiempo.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C12-hacer, ES-C03-llamar]
 sounds: [ll-digraph, diphthong-ue]
 roots: [tempus-latin, calor-latin, frigidus-latin, sol-latin, pluere-latin]
 etymology_hook: "el tiempo means BOTH 'time' and 'weather' — from Latin tempus, which already covered both senses; hace calor/frío/sol reuse hacer ('it makes'), but llueve ('it's raining') is its own dedicated verb, llover ← Latin pluere, the SAME cl-/fl-/pl- → ll- sound change you met in llamar/llave/llama"
-est_minutes: 5
+est_minutes: 4
 reviews_of: [ES-C12-hacer, ES-C03-llamar]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C31-numeros-11-20.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C31-numeros-11-20.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C08-numeros-6-10]
 sounds: [diphthong-ie, silent-none]
 roots: [latin-undecim-quindecim, latin-viginti]
 etymology_hook: "once-quince (11-15) are Latin's ūndecim-quīndecim, fused down almost past recognition; dieciséis-diecinueve (16-19) are perfectly transparent 'diez y seis' compounds — but Latin's OWN 18 and 19 were subtractive oddities, duodēvīgintī ('two from twenty') and ūndēvīgintī ('one from twenty'); Spanish didn't inherit that quirk, it replaced it with plain addition"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ES-C08-numeros-6-10]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C32-perro-gato.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C32-perro-gato.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C08-numeros-6-10]
 sounds: [rolled-rr, silent-none]
 roots: [latin-cattus-afroasiatic, unknown-perro]
 etymology_hook: "gato ← Latin cattus, itself probably from an Afro-Asiatic word (compare Nubian kadis) that traveled along Roman trade routes as domestic cats spread out of Egypt — a real, sourced etymology; perro, by honest contrast, is a genuine UNSOLVED mystery with no confirmed origin at all, and it quietly REPLACED Latin's own word for dog, canis (which survives as archaic Spanish can)"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ES-C08-numeros-6-10]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C33-verde-amarillo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C33-verde-amarillo.md
@@ -9,7 +9,7 @@ prerequisites: [ES-C22-rojo-azul]
 sounds: [rolled-none, double-l-y]
 roots: [latin-viridis-vireo, latin-amarus-bitter]
 etymology_hook: "verde ← Latin viridis, 'green,' from virere, 'to be green/vigorous' (cousin of English verdant, verdure — NOT of English green itself, a separate Germanic root); amarillo is the real surprise — it does NOT come from any Latin word for yellow at all, but from amarellus, 'a little bitter,' a diminutive of amarus, 'bitter' — the same root as Spanish's own amargo, 'bitter'"
-est_minutes: 6
+est_minutes: 4
 reviews_of: [ES-C22-rojo-azul]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
@@ -3,8 +3,8 @@ id: ES-W01-acento
 chapter: 4
 type: writing
 headword: "á é í ó ú"
-gloss: the acute accent (el acento / la tilde) — Spanish's one and only accent mark
-prerequisites: [ES-C03-como, ES-C03-tu-usted, ES-C04-como-esta]
+gloss: the acute accent as a visible exception to Spanish's default stress rules
+prerequisites: [ES-C03-como, ES-C03-tu-usted, ES-C04-como-estas-register]
 sounds: [stress]
 roots: []
 est_minutes: 4
@@ -43,37 +43,17 @@ overrides it to *es-**TÁ***. *cómo* ends in a vowel (rule wants *co-**MO***) b
 is stressed *CÓ-mo*, so it gets the mark. The accent is a **spoken stress you
 can see** — it never changes the vowel's sound, only which syllable you hit.
 
-## Job 2 — it splits look-alike words (la tilde diacrítica)
-
-The same mark pulls apart pairs that are spelled identically but do different
-jobs. This is the one you *must* know — you've already met most of them:
-
-| no accent | with accent |
-|---|---|
-| **tu** = your | **tú** = you (Ch. 3) |
-| **el** = the | **él** = he |
-| **si** = if | **sí** = yes |
-| **se** = (reflexive *se*, Ch. 3) | **sé** = I know |
-| **mas** = but (literary) | **más** = more (Ch. 4) |
-| **como** = like/as | **cómo** = how? (Ch. 3) |
-| **que** = that | **qué** = what? |
-
-Notice the pattern in the bottom rows: **question words wear the accent**
-(*qué, cómo, cuándo, dónde, quién*) — the mark is how writing shows the rising
-"I'm asking" stress. That's why *¿**Có**mo está?* has the accent but *tan
-**co**mo* would not.
-
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "tu" vs "tú", "el" vs "él", "si" vs "sí" — same spelling, the accent
-  is the only difference, and it changes the meaning entirely]
-- [YOU SAY: "cómo" as a question, then "como" as "like" — hear the accent land]
+- [YOU SAY: "casa, joven, llamo" — second-to-last stress]
+- [YOU SAY: "usted, regular, hablar" — final stress]
+- [YOU SAY: "está, cómo" — the accent overrides the default]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] How many accent marks does Spanish have, and which way does it lean?
 (One — the acute, `´`, rising left-to-right.) Its two jobs? (Mark irregular
-stress; split look-alike words like *tu/tú*, *si/sí*.) Which class of words
-almost always carries it? (Question words — *qué, cómo, dónde*.) Next writing
-lesson: the letter that is a *tilde* wearing a hat — **ñ**.
+stress; the next step covers its look-alike job.) When does a word ending in
+a vowel, **-n**, or **-s** need an accent? (**When its stress breaks the
+second-to-last default.**)

--- a/code/learning/human-languages/spanish/lessons/ES-W01-tilde-diacritica.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W01-tilde-diacritica.md
@@ -1,0 +1,49 @@
+---
+id: ES-W01-tilde-diacritica
+chapter: 4
+type: writing
+headword: "tu/tú, el/él, como/cómo"
+gloss: the acute accent separates look-alike words with different grammatical jobs
+prerequisites: [ES-W01-acento]
+sounds: [stress]
+roots: []
+est_minutes: 4
+reviews_of: [ES-W01-acento, ES-C03-como, ES-C03-tu-usted]
+---
+
+# tu or tú? — the accent as a meaning label
+
+## The second job
+
+The **tilde diacrítica** separates words that otherwise look alike:
+
+| no accent | with accent |
+|---|---|
+| **tu** = your | **tú** = you |
+| **el** = the | **él** = he |
+| **si** = if | **sí** = yes |
+| **se** = reflexive se | **sé** = I know |
+| **mas** = but (literary) | **más** = more |
+| **como** = like/as | **cómo** = how? |
+| **que** = that | **qué** = what? |
+
+Question words normally wear the accent: **qué, cómo, cuándo, dónde,
+quién**. Writing uses it to distinguish the questioning job even when the
+letters are otherwise identical.
+
+Compare **¿Cómo está?** ("How are you?") with **como** ("like/as"). Here
+the mark labels meaning and grammar, not merely a surprising stress pattern.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tu / tú" — your / you]
+- [YOU SAY: "el / él" — the / he]
+- [YOU SAY: "como / cómo" — like / how]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the accent's second job? (**Separate look-alike words.**)
+Which means "your," **tu** or **tú**? (**Tu.**) Which one asks "how"?
+(**Cómo.**) Name three accented question words. (**Qué, cómo, dónde**, for
+example.)

--- a/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
@@ -4,11 +4,11 @@ chapter: 4
 type: writing
 headword: "ñ"
 gloss: the letter eñe — a tiny second n riding on the first
-prerequisites: [ES-W01-acento]
+prerequisites: [ES-W01-tilde-diacritica]
 sounds: [ny-palatal]
 roots: [annus-latin]
 est_minutes: 3
-reviews_of: [ES-W01-acento]
+reviews_of: [ES-W01-tilde-diacritica, ES-W01-acento]
 ---
 
 # ñ — the letter that remembers a doubled n

--- a/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
@@ -3,12 +3,12 @@ id: ES-W03-inverted
 chapter: 4
 type: writing
 headword: "¿ ¡"
-gloss: the inverted opening marks — Spanish brackets a question or exclamation at both ends
-prerequisites: [ES-C04-como-esta]
+gloss: the inverted opening marks — an early cue for question or exclamation intonation
+prerequisites: [ES-C04-como-estas-register]
 sounds: []
 roots: []
 est_minutes: 3
-reviews_of: [ES-C04-como-esta, ES-W01-acento]
+reviews_of: [ES-C04-como-estas-register, ES-C04-como-esta, ES-W01-acento]
 ---
 
 # ¿ ¡ — the marks that open a question
@@ -43,27 +43,17 @@ the very first word."* It's a **melody cue placed before the melody**, the exact
 same instinct as the written accent marking stress you can't otherwise see. For
 a language read aloud, it's genuinely useful.
 
-## A nuance: they don't have to hug the capital
-
-The opening mark goes where the *question* starts, not where the sentence
-starts:
-
-> Roberto, ¿cómo estás?
-
-The *¿* opens only the question part. Same for *¡*: *Roberto, ¡buenos días!*
-
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: read "¿Cómo estás?" — start the rising *question* melody from the
   very first word, the way the ¿ tells you to]
-- [YOU SAY: "¡Hola!" then "¡Gracias!" — the ¡ warns you to land them with energy]
+- [YOU SAY: "¡Hola!" — the ¡ warns you to begin with exclamation energy]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Why does Spanish open a question with **¿**? (Because word order often
 doesn't change, so the reader needs an early warning to use question
 intonation.) How do you write it? (A normal *?* rotated 180°.) Does it always
-sit at the sentence's start? (No — at the *question's* start: *Roberto, ¿cómo
-estás?*) That's the full writing toolkit for Latin-script Spanish: **the acute
-accent, ñ, and ¿ ¡**.
+sit at the sentence's start? (**The next step places it around a question
+inside a larger sentence.**)

--- a/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
@@ -1,0 +1,43 @@
+---
+id: ES-W03-question-span
+chapter: 4
+type: writing
+headword: "Roberto, ¿cómo estás?"
+gloss: opening punctuation brackets only the question or exclamation span inside a larger sentence
+prerequisites: [ES-W03-inverted]
+sounds: []
+roots: []
+est_minutes: 4
+reviews_of: [ES-W03-inverted, ES-W01-tilde-diacritica]
+---
+
+# Where does ¿ begin? — bracket the spoken span
+
+## Not always at the capital
+
+The opening mark goes where the **question** begins, even if the sentence
+started earlier:
+
+> Roberto, **¿cómo estás?**
+
+The name **Roberto** is outside the question. The marks bracket the words
+that need question intonation. The same principle works for an exclamation:
+
+> Roberto, **¡buenos días!**
+
+This is why the opening mark is more than decoration. It tells the reader
+exactly where to begin and end a change in spoken melody.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: "María, ¿tienes hambre?"]
+- [YOU WRITE: "Amigos, ¡buenos días!"]
+- [YOU SAY: begin the new melody at ¿ or ¡, not at the first capital]
+
+## Wrap-up Recall
+
+[PAUSE 3s] In **Roberto, ¿cómo estás?**, is **Roberto** inside the
+question? (**No.**) Where does the inverted mark go? (**At the start of the
+question or exclamation span.**) What does that placement tell a reader?
+(**Where to change the spoken melody.**)

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -64,7 +64,7 @@ describe("real curriculum", () => {
     expect(report.summary.registeredTracks).toBe(20);
     expect(report.summary.totalLessons).toBe(lessons.length);
     expect(report.summary.authoredBooks).toBe(20);
-    expect(report.summary.durationViolations).toBeGreaterThan(0);
+    expect(report.summary.durationViolations).toBe(0);
     expect(report.summary.unknownPrerequisites).toBe(0);
     expect(report.schemas.tracks).toHaveLength(20);
     expect(report.books.tracks).toHaveLength(20);


### PR DESCRIPTION
## Summary

- remove all 55 remaining Spanish duration violations and bring the 20-language corpus to zero
- split deep subjunctive, register, `hasta`, future-conjecture, accent, and punctuation material into 12 prerequisite-ordered support lessons
- make zero duration violations an enforced integration invariant and record the next schema, book, and progression work in the backlog

## Validation

- `npm run build`, `npm run test:coverage`, `npm run validate`, `npm run check:books` in `human-language-data` (68 tests)
- `npm run test:coverage`, `npm run build` in Language Ladder (278 tests; 1,113 modules)
- gap report: 1,063 lessons, 0 duration violations, 0 unknown prerequisites
- forced XeLaTeX build: 138 pages; cover/middle/final visually audited
- `git diff --check`