### PR TITLE
feat(num7a): BigDouble::from_rational primitive + per-KB real precision

### DIFF
--- a/code/packages/rust/bignum-core/CHANGELOG.md
+++ b/code/packages/rust/bignum-core/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the `bignum-core` package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-08-02
+
+### Added
+
+- **`BigDouble::from_rational(r: &BigRational, prec: u32, mode: RoundingMode) -> BigDouble`** (NUM-7a)
+  — the promotion primitive from the exact `BigRational` world into the approximate `BigDouble`
+  world: the counterpart to `BigRational::to_f64`, generalized from a fixed 53-bit `f64` target to a
+  caller-requested precision. Both parts enter exactly (each at its own bit length, capped at
+  `MAX_PRECISION`), and the quotient is taken at `prec` bits so the result is the correctly rounded
+  `BigDouble` for any rational of practical size. Introduced so the logic engine can wire a
+  per-`KnowledgeBase`-configurable `Real`/`BigDouble` audit companion (ADJ-NUMERIC-SUBSTRATE §8).
+
 ## [0.7.0] - 2026-07-14
 
 ### Added

--- a/code/packages/rust/bignum-core/Cargo.toml
+++ b/code/packages/rust/bignum-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignum-core"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "A zero-dependency arbitrary-precision numeric core: a signed integer (BigInteger), an exact rational (BigRational), an exact base-10 decimal (BigDecimal), and a correctly-rounded binary float of arbitrary precision (BigDouble) — all built from scratch with no third-party deps and no unsafe."
 license = "MIT"

--- a/code/packages/rust/bignum-core/src/float.rs
+++ b/code/packages/rust/bignum-core/src/float.rs
@@ -49,7 +49,7 @@
 //! Transcendental functions (`ln`, `exp`, `sin`, …) are a separate later effort that builds on
 //! this core; NUM-4 here is the representation plus correctly-rounded `+ − × ÷` and `√`.
 
-use crate::{BigDecimal, BigInteger, RoundingMode};
+use crate::{BigDecimal, BigInteger, BigRational, RoundingMode};
 use std::cmp::Ordering;
 use std::fmt;
 
@@ -355,6 +355,29 @@ impl BigDouble {
     /// Re-round this value to a different precision under `mode`.
     pub fn with_precision(&self, prec: u32, mode: RoundingMode) -> BigDouble {
         BigDouble::from_parts(self.mant.clone(), self.exp, prec, mode)
+    }
+
+    /// Promote an exact rational to a `BigDouble`, correctly rounded to `prec` bits under `mode`
+    /// — the promotion primitive from the exact `BigRational` world into the approximate
+    /// `BigDouble` world (NUM-7). It is the same shape as [`BigRational::to_f64`], generalized
+    /// from a fixed 64-bit division target to a caller-requested precision: both parts enter
+    /// exactly (each at its own bit length, capped at [`MAX_PRECISION`]), and the quotient is
+    /// taken at `prec` bits so the result is the correctly rounded `BigDouble` for any rational
+    /// of practical size.
+    pub fn from_rational(r: &BigRational, prec: u32, mode: RoundingMode) -> BigDouble {
+        let prec = check_prec(prec);
+        if r.numerator().is_zero() {
+            return BigDouble::zero(prec);
+        }
+        let np = u32::try_from(r.numerator().bit_len())
+            .unwrap_or(MAX_PRECISION)
+            .clamp(1, MAX_PRECISION);
+        let dp = u32::try_from(r.denominator().bit_len())
+            .unwrap_or(MAX_PRECISION)
+            .clamp(1, MAX_PRECISION);
+        let n = BigDouble::from_bigint(r.numerator().clone(), np, mode);
+        let d = BigDouble::from_bigint(r.denominator().clone(), dp, mode);
+        n.div(&d, prec, mode)
     }
 
     /// The signed significand.
@@ -1025,5 +1048,56 @@ mod tests {
         // negative tie: -3 → -4 under Floor, -2 under Ceiling.
         assert_eq!(BigDouble::from_i64(-3).with_precision(1, Floor).to_f64(), -4.0);
         assert_eq!(BigDouble::from_i64(-3).with_precision(1, Ceiling).to_f64(), -2.0);
+    }
+
+    // ---- from_rational: the exact-rational → BigDouble promotion (NUM-7a) ----
+
+    #[test]
+    fn from_rational_of_an_integer_is_exact() {
+        let r = BigRational::from_ints(3, 1);
+        assert_eq!(BigDouble::from_rational(&r, 64, HalfEven).to_decimal().unwrap().to_string(), "3");
+    }
+
+    #[test]
+    fn from_rational_of_zero_is_zero() {
+        let r = BigRational::from_ints(0, 5);
+        assert!(BigDouble::from_rational(&r, 64, HalfEven).is_zero());
+    }
+
+    #[test]
+    fn from_rational_is_negative_for_a_negative_rational() {
+        let r = BigRational::from_ints(-3, 4);
+        assert!(BigDouble::from_rational(&r, 64, HalfEven).is_negative());
+    }
+
+    #[test]
+    fn from_rational_matches_to_f64_at_53_bits() {
+        // Differential: at f64 width, from_rational should agree with BigRational's own,
+        // independently-implemented to_f64 (rational.rs) for a spread of rationals.
+        for (n, d) in [(1, 3), (22, 7), (1, 1_000_000), (-5, 8), (7, 2), (1, 2)] {
+            let r = BigRational::from_ints(n, d);
+            let via_from_rational = BigDouble::from_rational(&r, 53, HalfEven).to_f64();
+            assert_eq!(via_from_rational, r.to_f64(), "{n}/{d}");
+        }
+    }
+
+    #[test]
+    fn from_rational_one_third_at_high_precision_matches_known_digits() {
+        let third = BigRational::from_ints(1, 3);
+        let rendered = BigDouble::from_rational(&third, 200, HalfEven).to_decimal().unwrap().to_string();
+        assert!(rendered.starts_with("0.3333333333333333333"), "got {rendered}");
+    }
+
+    #[test]
+    fn from_rational_handles_a_numerator_far_larger_than_the_requested_precision() {
+        // The numerator's own bit length (thousands of bits, from repeated squaring) vastly
+        // exceeds the requested working `prec` (64) — `np`/`dp` are derived from the operands'
+        // own bit lengths, not `prec`, and must not panic or silently misbehave when they differ
+        // this much.
+        let big = BigInteger::from_i64(2).pow(4000);
+        let r = BigRational::new(big, BigInteger::from_i64(3));
+        let result = BigDouble::from_rational(&r, 64, HalfEven);
+        assert!(!result.is_zero());
+        assert!(!result.is_negative());
     }
 }

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.52.0] - 2026-08-02 - NUM-7a: per-KnowledgeBase `Real`/`BigDouble` precision setting
+
+- Added `KnowledgeBase::real_precision_bits()`/`with_real_precision_bits(u32)`/
+  `set_real_precision_bits(u32)`, backed by a new `RealPrecisionBits` type (default 256 bits,
+  per ADJ-NUMERIC-SUBSTRATE §3). This is `KnowledgeBase`'s first per-KB configuration field —
+  every prior field was data (facts/rules/derived values/etc). Clamped to
+  `[1, bignum_core::MAX_PRECISION]`, since `BigDouble`'s internal precision guard panics outside
+  that range. No engine wiring yet (§8, NUM-7b) — this PR only lands the setting itself.
+
 ## [0.51.0] - 2026-08-02 - computed-answer verification
 
 - Added `verify_derived`, which re-evaluates a compiler-owned expression stored separately

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -393,6 +393,35 @@ pub struct ObservedEvidence {
     pub confidence: f64,
 }
 
+/// The working precision, in mantissa bits, for `BigDouble`-backed `Real` audit companions
+/// (NUM-7 — see [`compute::RealCompanion`]) computed within a [`KnowledgeBase`]. Wrapped in its
+/// own type, rather than a bare `u32` field, purely so a non-1 default can be expressed via
+/// `#[derive(Default)]` on `KnowledgeBase`.
+///
+/// This is `KnowledgeBase`'s **first** per-KB configuration field — previously every field was
+/// data (facts/rules/derived values/etc), with no settings knob. Always in `[1,
+/// bignum_core::MAX_PRECISION]`: `BigDouble`'s internal precision guard *panics* outside that
+/// range, so every constructor here clamps rather than passing an unchecked value through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RealPrecisionBits(u32);
+
+impl Default for RealPrecisionBits {
+    /// 256 bits ≈ 77 significant decimal digits — ADJ-NUMERIC-SUBSTRATE §3's stated default.
+    fn default() -> Self {
+        RealPrecisionBits(256)
+    }
+}
+
+impl RealPrecisionBits {
+    fn clamped(bits: u32) -> Self {
+        RealPrecisionBits(bits.clamp(1, bignum_core::MAX_PRECISION))
+    }
+
+    pub fn get(self) -> u32 {
+        self.0
+    }
+}
+
 /// A collection of Facts and Rules, indexed for clause selection by
 /// the head's functor/arity. Per LP19e, also stores prior /
 /// contribution / joint-contribution clauses in parallel maps; the
@@ -452,6 +481,8 @@ pub struct KnowledgeBase {
     /// the two so both feed [`crate::govern::enumerate_governing`], which consults the order
     /// BEFORE the priority tier (lex superior). Transitive reach is computed cycle-safely.
     context_order: Vec<(String, String)>,
+    /// NUM-7: the working precision for this KB's `Real`/`BigDouble` audit companions.
+    real_precision_bits: RealPrecisionBits,
     next_fact_id: u64,
     next_rule_id: u64,
     next_prior_id: u64,
@@ -464,6 +495,26 @@ pub struct KnowledgeBase {
 impl KnowledgeBase {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Consuming builder for [`RealPrecisionBits`] (NUM-7), matching the `with_*` naming
+    /// convention `Fact`/`Rule` already use for their own (per-clause) builders — this is the
+    /// first per-KB one. Clamped to `[1, bignum_core::MAX_PRECISION]`.
+    pub fn with_real_precision_bits(mut self, bits: u32) -> Self {
+        self.set_real_precision_bits(bits);
+        self
+    }
+
+    /// In-place setter for [`RealPrecisionBits`] (NUM-7), for a KB already under construction.
+    /// Clamped to `[1, bignum_core::MAX_PRECISION]`.
+    pub fn set_real_precision_bits(&mut self, bits: u32) {
+        self.real_precision_bits = RealPrecisionBits::clamped(bits);
+    }
+
+    /// This KB's working precision, in mantissa bits, for `Real`/`BigDouble` audit companions
+    /// (NUM-7). Defaults to 256 (ADJ-NUMERIC-SUBSTRATE §3).
+    pub fn real_precision_bits(&self) -> u32 {
+        self.real_precision_bits.get()
     }
 
     /// Insert a Fact, assigning it a fresh `FactId`.
@@ -1461,6 +1512,31 @@ mod tests {
 
     fn empty_kb() -> KnowledgeBase {
         KnowledgeBase::new()
+    }
+
+    // ---- NUM-7a: per-KB real_precision_bits --------------------------------
+
+    #[test]
+    fn real_precision_bits_defaults_to_256() {
+        assert_eq!(empty_kb().real_precision_bits(), 256);
+    }
+
+    #[test]
+    fn with_real_precision_bits_is_clamped_to_the_bignum_core_budget() {
+        assert_eq!(empty_kb().with_real_precision_bits(0).real_precision_bits(), 1);
+        assert_eq!(
+            empty_kb().with_real_precision_bits(u32::MAX).real_precision_bits(),
+            bignum_core::MAX_PRECISION
+        );
+        assert_eq!(empty_kb().with_real_precision_bits(512).real_precision_bits(), 512);
+    }
+
+    #[test]
+    fn set_real_precision_bits_mutates_an_existing_kb() {
+        let mut kb = empty_kb();
+        assert_eq!(kb.real_precision_bits(), 256);
+        kb.set_real_precision_bits(64);
+        assert_eq!(kb.real_precision_bits(), 64);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `bignum-core::BigDouble::from_rational(r, prec, mode)` — the exact-`BigRational` → approximate-`BigDouble` promotion primitive, generalizing `BigRational::to_f64`'s existing pattern to a caller-requested precision.
- `logic-engine::KnowledgeBase` gains its first per-KB configuration field: `real_precision_bits` (default 256 per ADJ-NUMERIC-SUBSTRATE §3), via `with_real_precision_bits`/`set_real_precision_bits`/`real_precision_bits()`, clamped to `bignum_core::MAX_PRECISION` (BigDouble's internal guard panics outside that range).
- No engine wiring yet — this is the NUM-7a rung of NUM-7 (see #9620); NUM-7b wires this into `compute.rs`'s `sqrt` path.

## Test plan
- [x] `cargo test -p bignum-core -p logic-engine --lib` — 107 + 204 passed, including new tests for `from_rational` (integer/zero/negative/differential-vs-to_f64/high-precision-digits/large-numerator) and `real_precision_bits` (default/clamp/mutate).
- [x] `cargo clippy -p bignum-core -p logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver -p adjudication-connector -p adjudication-pipeline -p prolog-loader -p logic-core --all-targets -- -D warnings` clean.
- [x] `/security-review` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)