### PR TITLE
fix(spice): validate parser MOS saturation current

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `IS` values before
+  lowering Level-1 saturation current.
 - Reject zero, negative, and non-finite MOS model-card `L` values before
   lowering Level-1 default length.
 - Reject zero, negative, and non-finite MOS model-card `W` values before

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1918,6 +1918,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["L"]) or params["L"] <= 0.0
         ):
             raise NetlistParseError("MOSFET L must be finite and positive")
+        if "IS" in params and (
+            not math.isfinite(params["IS"]) or params["IS"] <= 0.0
+        ):
+            raise NetlistParseError("MOSFET IS must be finite and positive")
     return ModelCard(name=name, kind=kind, params=params)
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1554,6 +1554,23 @@ def test_lowers_positive_mosfet_model_length() -> None:
     assert isclose(mosfet.model.model.params.L, 2.0e-6)
 
 
+@pytest.mark.parametrize("saturation_current", ["0", "-1p", "1e999"])
+def test_rejects_invalid_mosfet_model_saturation_current(
+    saturation_current: str,
+) -> None:
+    with pytest.raises(NetlistParseError, match="MOSFET IS must be finite and positive"):
+        parse_netlist(
+            f".model nfast NMOS(IS={saturation_current})\nM1 d g s b nfast\n"
+        )
+
+
+def test_lowers_positive_mosfet_model_saturation_current() -> None:
+    parsed = parse_netlist(".model nfast NMOS(IS=2f)\nM1 d g s b nfast\n")
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.IS, 2.0e-15)
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `IS` values before
+  lowering Level-1 saturation current.
 - Reject zero, negative, and non-finite MOS model-card `L` values before
   lowering Level-1 default length.
 - Reject zero, negative, and non-finite MOS model-card `W` values before

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1229,6 +1229,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET L must be finite and positive");
   }
+  const saturationCurrent = params.get("IS");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    saturationCurrent !== undefined &&
+    (!Number.isFinite(saturationCurrent) || saturationCurrent <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET IS must be finite and positive");
+  }
   return {
     name: fields[1],
     kind,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1485,6 +1485,23 @@ Xright c d load
     expect(element.params.L).toBeCloseTo(2.0e-6, 15);
   });
 
+  it.each(["0", "-1p", "1e999"])(
+    "rejects invalid MOSFET model IS=%s",
+    (saturationCurrent) => {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(IS=${saturationCurrent})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET IS must be finite and positive");
+    },
+  );
+
+  it("lowers positive MOSFET model saturation current", () => {
+    const parsed = parseNetlist(".model nfast NMOS(IS=2f)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.IS).toBeCloseTo(2.0e-15, 20);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,10 +33,10 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS model-card length validation parity.
+1. Python and TypeScript Berkeley SPICE MOS saturation-current validation parity.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite `L` values with the shared diagnostic.
-   - Preserve positive model-card lengths through canonical Level-1 lowering.
+   - Reject zero, negative, and non-finite `IS` values with the shared diagnostic.
+   - Preserve positive saturation currents through canonical Level-1 lowering.
 
 ## Completed Slices
 
@@ -4178,11 +4178,16 @@ the Rust, Python, and TypeScript surfaces together.
    - Zero, negative, and non-finite `W` values are rejected with the shared
      diagnostic while positive widths lower into Level-1 parameters.
 
+377. Python and TypeScript Berkeley SPICE MOS model-card length validation parity.
+   - Status: completed in PR 9621.
+   - Zero, negative, and non-finite `L` values are rejected with the shared
+     diagnostic while positive lengths lower into Level-1 parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
-   - Apply Rust-aligned domains and diagnostics to already lowered `IS` and
-     nominal-temperature fields.
+   - Apply Rust-aligned domains and diagnostics to the already lowered
+     nominal-temperature field.
 
 2. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
    - Lower missing canonical resistance, geometry, capacitance, junction, and


### PR DESCRIPTION
## Summary
- reject zero, negative, and non-finite MOS model-card `IS` values in Python and TypeScript parsers
- preserve positive saturation currents through Level-1 lowering
- add cross-language regression coverage, changelogs, and advance the SPICE plan

## Verification
- Python parser: 123 tests passed, 88.14% coverage; Ruff passed
- TypeScript engine/parser builds passed
- TypeScript parser: 122 tests passed, 83.56% statement / 84.21% line coverage
- `git diff --check origin/main...HEAD`