### PR TITLE
feat(sir-c): Array block methods (Collections slice 5)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.25.0 — Collections slice 5: Array block methods (closure-calling)
+
+The first Collections slice covering methods that take a trailing **block**
+argument. No new `Feature`.
+
+- The Ruby frontend already appends a block as the last `__method__` call arg
+  (a `MakeClosure`, RB1), so it reaches this runtime as an ordinary
+  `SIR_CLOSURE` value — no new calling convention needed. Every element-wise
+  call goes through the EXISTING `_sir_apply` (the same dispatcher a
+  first-class `Proc`/`sir_apply` call already uses).
+- New Array methods: `each`, `map`, `select`, `reject`, `any?`, `all?`,
+  `none?`, `sort_by`, `each_with_index`, `reduce`/`inject` (`argc==1`
+  block-only, seeding the accumulator with the first element; `argc==2`
+  `(initial, block)`). `sort_by` computes each key once (Schwartzian
+  transform) rather than re-invoking the block per comparison.
+- **Fix (found while wiring this slice):** slice 3's 0-arg `count` ignored
+  `argc`/`args` entirely, so `arr.count { |x| .. }` (Ruby's block form, which
+  counts only matching elements) silently returned the total length instead —
+  wrong, not just unsupported. `count` now checks `argc` and dispatches to a
+  real block-counting loop for the 1-arg closure form.
+- Each block-taking arm requires the exact shape the frontend emits
+  (`argc == 1` and a closure, except `reduce`/`inject`'s `argc` 1–2); anything
+  else (missing block, extra args, a non-closure last arg) falls through to
+  the existing `NoMethodError`, matching every other malformed-call case here.
+
+**Anti-RCE preserved:** the method name is a compiler-emitted quoted C literal
+used only as a `strcmp` target — never reflection. Calling the block itself
+goes through `_sir_apply`, which only ever invokes a `SIR_CLOSURE`'s
+compiler-emitted function pointer — never a name-based lookup.
+
 ## 0.24.0 — Collections slice 3: 0-arg Array query/transform methods
 
 Third Collections slice — the first to cover **Array** (`SIR_SEQ`) receivers

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -159,8 +159,14 @@ returns a **fresh** sequence (or scalar), never mutating the receiver;
 ordering/equality reuse the runtime's own `<`/`>`/`==` (`_sir_lt`/`_sir_gt`/
 `_sir_value_eq`), and `flatten` shares the same recursion-depth cap as
 `_sir_fmt`/`_sir_value_eq` so a self-referential array (`a[0] = a`) terminates
-instead of overflowing the stack.  A wrong-type receiver or argument raises
-`NoMethodError`; a built-in method not lowered yet is still rejected cleanly.
+instead of overflowing the stack; **slice 5** (Array block methods): `each`,
+`map`, `select`, `reject`, `any?`, `all?`, `none?`, `sort_by`,
+`each_with_index`, `reduce`/`inject` — the block the Ruby frontend appends as
+the trailing `__method__` arg reaches this runtime as an ordinary `SIR_CLOSURE`
+value, so each element-wise call goes through the SAME `_sir_apply` a
+first-class closure call already uses (no new calling convention).  A
+wrong-type receiver or argument raises `NoMethodError`; a built-in method not
+lowered yet is still rejected cleanly.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, a `class << self` singleton, and

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1760,8 +1760,12 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// = 1-arg String queries (`include?`/`start_with?`/`end_with?`/`index`, the arg
 /// a String); slice 3 = 0-arg Array query/transform methods (`count`/`first`/
 /// `last`/`sort`/`min`/`max`/`sum`/`uniq`/`compact`/`flatten`/`to_a`; `reverse`
-/// widens to accept an Array receiver too, alongside its slice-1 String arm).
-/// The dispatcher raises `NoMethodError` on an unsupported receiver type,
+/// widens to accept an Array receiver too, alongside its slice-1 String arm);
+/// slice 5 = Array methods taking a trailing BLOCK argument (`each`/`map`/
+/// `select`/`reject`/`any?`/`all?`/`none?`/`sort_by`/`each_with_index`/
+/// `reduce`/`inject`; `count` also widens to accept its block form). The
+/// dispatcher raises `NoMethodError` on an unsupported receiver type or a
+/// malformed call (missing/extra args, a non-closure block position),
 /// matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
     matches!(
@@ -1773,6 +1777,9 @@ fn is_builtin_method(name: &str) -> bool {
         // slice 3 — 0-arg Array query/transform methods
         | "count" | "first" | "last" | "sort" | "min" | "max" | "sum" | "uniq"
         | "compact" | "flatten" | "to_a"
+        // slice 5 — Array block methods
+        | "each" | "map" | "select" | "reject" | "any?" | "all?" | "none?"
+        | "sort_by" | "each_with_index" | "reduce" | "inject"
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1573,6 +1573,109 @@ static SirValue _sir_array_flatten(SirValue recv) {
     return _sir_seq_wrap(r);
 }
 
+/* ---- Collections slice 5: Array block methods (closure-calling) -----------
+ *
+ * The first Array methods that take a trailing BLOCK argument: the Ruby
+ * frontend appends a `MakeClosure` as the LAST `__method__` call arg for
+ * `recv.meth { |x| ... }` (RB1 in `ruby-to-semantic-ir`), so it reaches this
+ * runtime as an ordinary `SIR_CLOSURE` value. Each element-wise call goes
+ * through the EXISTING `_sir_apply` — the same dispatcher a first-class
+ * `Proc`/`sir_apply(f, ...)` call already uses — so a block is called
+ * exactly like any other closure value; no new calling convention. */
+
+static SirValue _sir_array_each(SirSeq *s, SirValue block) {
+    for (int64_t i = 0; i < s->len; i++) _sir_apply(block, 1, s->items[i]);
+    return _sir_seq_wrap(s);  /* Array#each returns the receiver */
+}
+static SirValue _sir_array_map(SirSeq *s, SirValue block) {
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = s->len;
+    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    for (int64_t i = 0; i < s->len; i++) r->items[i] = _sir_apply(block, 1, s->items[i]);
+    return _sir_seq_wrap(r);
+}
+/* Shared by `select` (keep_if_truthy=1) and `reject` (keep_if_truthy=0). */
+static SirValue _sir_array_filter(SirSeq *s, SirValue block, int keep_if_truthy) {
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    int64_t k = 0;
+    for (int64_t i = 0; i < s->len; i++) {
+        int truthy = _sir_truthy(_sir_apply(block, 1, s->items[i]));
+        if (truthy == keep_if_truthy) r->items[k++] = s->items[i];
+    }
+    r->len = k;
+    return _sir_seq_wrap(r);
+}
+static SirValue _sir_array_any(SirSeq *s, SirValue block) {
+    for (int64_t i = 0; i < s->len; i++) {
+        if (_sir_truthy(_sir_apply(block, 1, s->items[i]))) return _sir_bool(1);
+    }
+    return _sir_bool(0);
+}
+static SirValue _sir_array_all(SirSeq *s, SirValue block) {
+    for (int64_t i = 0; i < s->len; i++) {
+        if (!_sir_truthy(_sir_apply(block, 1, s->items[i]))) return _sir_bool(0);
+    }
+    return _sir_bool(1);
+}
+static SirValue _sir_array_none(SirSeq *s, SirValue block) {
+    for (int64_t i = 0; i < s->len; i++) {
+        if (_sir_truthy(_sir_apply(block, 1, s->items[i]))) return _sir_bool(0);
+    }
+    return _sir_bool(1);
+}
+/* Schwartzian transform: compute each element's sort key ONCE (a naive
+ * `_sir_lt(block(a), block(b))` comparator would re-invoke the block O(n log n)
+ * or worse per comparison), then insertion-sort (key, value) pairs together via
+ * `_sir_lt` -- the SAME comparator plain `sort` uses -- and return the values in
+ * the new order. */
+static SirValue _sir_array_sort_by(SirSeq *s, SirValue block) {
+    SirValue *keys = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = s->len;
+    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    for (int64_t i = 0; i < s->len; i++) {
+        keys[i] = _sir_apply(block, 1, s->items[i]);
+        r->items[i] = s->items[i];
+    }
+    for (int64_t i = 1; i < r->len; i++) {
+        SirValue key = keys[i], val = r->items[i];
+        int64_t j = i - 1;
+        while (j >= 0 && _sir_truthy(_sir_lt(key, keys[j]))) {
+            keys[j + 1] = keys[j];
+            r->items[j + 1] = r->items[j];
+            j--;
+        }
+        keys[j + 1] = key;
+        r->items[j + 1] = val;
+    }
+    return _sir_seq_wrap(r);
+}
+static SirValue _sir_array_each_with_index(SirSeq *s, SirValue block) {
+    for (int64_t i = 0; i < s->len; i++) _sir_apply(block, 2, s->items[i], _sir_int(i));
+    return _sir_seq_wrap(s);
+}
+/* `reduce`/`inject`: `argc==1` is block-only (Ruby seeds the accumulator with
+ * the FIRST element and folds from the second -- `[].reduce { }` => nil, no
+ * element to seed with); `argc==2` is `(initial, block)` (an empty receiver
+ * just returns `initial` untouched, matching Ruby). `args[argc-1]` is always
+ * the block (the caller already checked it's a closure before calling in). */
+static SirValue _sir_array_reduce(SirSeq *s, int argc, SirValue *args) {
+    SirValue block = args[argc - 1];
+    SirValue acc;
+    int64_t start;
+    if (argc >= 2) {
+        acc = args[argc - 2];
+        start = 0;
+    } else {
+        if (s->len == 0) return _sir_nil();
+        acc = s->items[0];
+        start = 1;
+    }
+    for (int64_t i = start; i < s->len; i++) acc = _sir_apply(block, 2, acc, s->items[i]);
+    return acc;
+}
+
 /* ---- Collections slice 1: built-in String methods --------------------------
  *
  * A `__method__` dispatch whose name is a KNOWN built-in method — and which the
@@ -1608,8 +1711,22 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
     }
     /* Collections slice 3: 0-arg Array query/transform methods. */
     else if (strcmp(m, "count") == 0) {
-        if (recv.tag == SIR_SEQ) return _sir_int(recv.as.seq->len);
-        if (recv.tag == SIR_MAP) return _sir_int(recv.as.map->len);
+        /* Slice 5 fix: `count` also has a BLOCK form (`arr.count { |x| .. }`,
+           counting only matching elements) -- the slice-3 arm below ignored
+           `argc`/`args` entirely, so it silently returned the total length
+           for a block call too (wrong, not just unsupported). Guard on argc
+           so the two forms route correctly instead of one shadowing. */
+        if (recv.tag == SIR_SEQ) {
+            if (argc == 0) return _sir_int(recv.as.seq->len);
+            if (argc == 1 && args[0].tag == SIR_CLOSURE) {
+                int64_t n = 0;
+                for (int64_t i = 0; i < recv.as.seq->len; i++) {
+                    if (_sir_truthy(_sir_apply(args[0], 1, recv.as.seq->items[i]))) n++;
+                }
+                return _sir_int(n);
+            }
+        }
+        if (recv.tag == SIR_MAP && argc == 0) return _sir_int(recv.as.map->len);
     } else if (strcmp(m, "first") == 0) {
         if (recv.tag == SIR_SEQ) return recv.as.seq->len > 0 ? recv.as.seq->items[0] : _sir_nil();
     } else if (strcmp(m, "last") == 0) {
@@ -1633,6 +1750,42 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         if (recv.tag == SIR_SEQ) return _sir_array_flatten(recv);
     } else if (strcmp(m, "to_a") == 0) {
         if (recv.tag == SIR_SEQ) return recv;  /* Array#to_a is the array itself */
+    }
+    /* Collections slice 5: Array block methods. Each requires exactly the
+       trailing-block shape the frontend emits (`argc==1`, a closure) except
+       `reduce`/`inject` (`argc` 1 or 2) -- anything else (missing/extra args,
+       a non-closure last arg) falls through to the NoMethodError below rather
+       than misbehaving on a malformed call. */
+    else if (strcmp(m, "each") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_array_each(recv.as.seq, args[0]);
+    } else if (strcmp(m, "map") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_array_map(recv.as.seq, args[0]);
+    } else if (strcmp(m, "select") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_array_filter(recv.as.seq, args[0], 1);
+    } else if (strcmp(m, "reject") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_array_filter(recv.as.seq, args[0], 0);
+    } else if (strcmp(m, "any?") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_array_any(recv.as.seq, args[0]);
+    } else if (strcmp(m, "all?") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_array_all(recv.as.seq, args[0]);
+    } else if (strcmp(m, "none?") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_array_none(recv.as.seq, args[0]);
+    } else if (strcmp(m, "sort_by") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_array_sort_by(recv.as.seq, args[0]);
+    } else if (strcmp(m, "each_with_index") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1 && args[0].tag == SIR_CLOSURE)
+            return _sir_array_each_with_index(recv.as.seq, args[0]);
+    } else if (strcmp(m, "reduce") == 0 || strcmp(m, "inject") == 0) {
+        if (recv.tag == SIR_SEQ && argc >= 1 && argc <= 2 && args[argc - 1].tag == SIR_CLOSURE)
+            return _sir_array_reduce(recv.as.seq, argc, args);
     }
     /* Collections slice 2: 1-arg String queries (arg is a String). */
     else if (strcmp(m, "include?") == 0) {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_block_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_block_methods.rs
@@ -1,0 +1,195 @@
+//! Execution proof for Collections slice 5 (Array block methods) on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run,
+//! assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! `[..].method { |x| .. }` lowers to `__method__(recv, "method", MakeClosure)`
+//! — the block is an ordinary trailing `SIR_CLOSURE` argument, invoked through
+//! the existing `_sir_apply`, so a block-taking built-in behaves exactly like
+//! any other closure call.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process and would collide on
+    // a length-keyed stem (see the temp-file-collision fix elsewhere in this
+    // test suite).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_arrblk_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn each_runs_the_block_and_returns_the_receiver() {
+    match run_ruby("puts [1, 2, 3].each { |x| puts x * 10 }\n") {
+        Some(out) => assert_eq!(out, "10\n20\n30\n[1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn map_transforms_every_element() {
+    match run_ruby("puts [1, 2, 3].map { |x| x * x }\n") {
+        Some(out) => assert_eq!(out, "[1, 4, 9]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+// NOTE: these predicates read `r = x > N\nr` (assign-then-return) instead of
+// the more natural bare `x > N`. That bare form currently fails to lower at
+// ALL for `<`/`>`/`<=`/`>=`/`!=` when it is the TAIL expression of a block --
+// a pre-existing `ruby-to-semantic-ir`/shared-validator bug independent of
+// this slice (confirmed: the same operators work fine at top level, only
+// inside a block's implicit-return position do they mis-lower to "direct call
+// to unknown function `x`"; filed as its own follow-up, not fixed here since
+// it's outside the Collections/C-backend surface this PR touches). The
+// assign-then-return shape sidesteps the bug without changing test intent.
+
+#[test]
+fn select_and_reject_are_complementary() {
+    match run_ruby(
+        "puts [1, 2, 3, 4, 5].select { |x| r = x > 2\nr }\n\
+         puts [1, 2, 3, 4, 5].reject { |x| r = x > 2\nr }\n",
+    ) {
+        Some(out) => assert_eq!(out, "[3, 4, 5]\n[1, 2]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn any_all_none_predicates() {
+    match run_ruby(
+        "puts [1, 2, 3].any? { |x| r = x > 2\nr }\n\
+         puts [1, 2, 3].all? { |x| r = x > 2\nr }\n\
+         puts [1, 2, 3].none? { |x| r = x > 5\nr }\n",
+    ) {
+        Some(out) => assert_eq!(out, "#t\n#f\n#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn sort_by_orders_by_the_computed_key() {
+    // Sort strings by length, not lexicographically.
+    match run_ruby("puts [\"ccc\", \"a\", \"bb\"].sort_by { |x| x.length }\n") {
+        Some(out) => assert_eq!(out, "[a, bb, ccc]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn each_with_index_passes_both_element_and_index() {
+    match run_ruby("[10, 20, 30].each_with_index { |x, i| puts x + i }\n") {
+        Some(out) => assert_eq!(out, "10\n21\n32\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn reduce_with_initial_value() {
+    match run_ruby("puts [1, 2, 3, 4].reduce(0) { |acc, x| acc + x }\n") {
+        Some(out) => assert_eq!(out, "10\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn reduce_without_initial_value_seeds_from_the_first_element() {
+    match run_ruby("puts [1, 2, 3, 4].reduce { |acc, x| acc + x }\n") {
+        Some(out) => assert_eq!(out, "10\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn inject_is_an_alias_for_reduce() {
+    match run_ruby("puts [2, 3, 4].inject(1) { |acc, x| acc * x }\n") {
+        Some(out) => assert_eq!(out, "24\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn count_with_a_block_counts_only_matching_elements() {
+    // Regression for the slice-3 `count` gap: the 0-arg form still returns the
+    // total length, but the block form must count only matches, not shadow it.
+    // (`x.even?` isn't lowered yet -- Numeric methods are a later slice -- and
+    // `x % 2 == 0` hits a SEPARATE variant of the block-tail-position bug
+    // (fails on `%` itself, not just the comparison) -- so this uses `x > 3`,
+    // same as the other predicates above.)
+    match run_ruby(
+        "puts [1, 2, 3, 4, 5].count\nputs [1, 2, 3, 4, 5].count { |x| r = x > 3\nr }\n",
+    ) {
+        Some(out) => assert_eq!(out, "5\n2\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn block_methods_chain_and_close_over_an_outer_local() {
+    // `map` returns an Array, so another built-in dispatches on it; the block
+    // captures the enclosing local `factor` (RB2 capture).
+    match run_ruby(
+        "factor = 10\nputs [1, 2, 3].map { |x| x * factor }.select { |x| r = x > 15\nr }\n",
+    ) {
+        Some(out) => assert_eq!(out, "[20, 30]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn reduce_on_empty_with_no_initial_is_nil() {
+    match run_ruby("puts [].reduce { |acc, x| acc + x }\n") {
+        Some(out) => assert_eq!(out, "nil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn reduce_on_empty_with_initial_returns_it_untouched() {
+    match run_ruby("puts [].reduce(42) { |acc, x| acc + x }\n") {
+        Some(out) => assert_eq!(out, "42\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Array collection methods that take a trailing **block** argument to the C backend's `_sir_builtin_method` dispatcher: `each`, `map`, `select`, `reject`, `any?`, `all?`, `none?`, `sort_by`, `each_with_index`, `reduce`/`inject`.
- The Ruby frontend already appends the block as an ordinary trailing `MakeClosure` call arg (RB1); it reaches this runtime as a `SIR_CLOSURE` value and is invoked through the **existing** `_sir_apply` — the same dispatcher a first-class closure call already uses. No new calling convention.
- **Fix**: slice 3's 0-arg `count` ignored `argc`/`args` entirely, so `arr.count { |x| .. }` (Ruby's block form) silently returned the total length instead of counting matches. Now checks `argc` and dispatches correctly for both forms.
- **Discovered, not fixed here** (filed as [task #11] in my backlog, its own follow-up): a pre-existing `ruby-to-semantic-ir` bug where a comparison other than a bare `==` — or a compound expression like `x % 2 == 0` — used as a block's tail expression fails `semantic-ir`'s shared validator ("direct call to unknown function"). Confirmed the same expressions work fine at the top level; only the implicit-return position of a hoisted block trips it. This affects every backend (Go/Rust/Python/JS/Ruby/C), not just C. Worked around in this PR's own tests via an assign-then-return shape (`{ |x| r = x > 2; r }`).
- Security review flagged (informationally, no fix needed *now*) that `map`/`select`/`sort_by` pre-allocate an output buffer sized to the receiver's length and loop re-reading that length — safe today since no growing array mutator exists yet, but a future slice adding `push`/`concat` will need to snapshot the length before allocating in these helpers. Noted on the backlog item for that slice.

## Test plan
- [x] `cargo test -p semantic-ir-to-c` — full suite green (58 tests)
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` — clean
- [x] Security review — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>