### PR TITLE
fix(html-parser): report document tail recovery errors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Full-document parsing now reports unexpected tokens that force recovery from
+  the Standard's after-body and after-after-body insertion modes, closing 8
+  previously silent malformed corpus cases without changing DOM recovery.
 - Initial doctypes now report the Standard's parse error when their name,
   public identifier, or system identifier does not match the allowed HTML
   forms, closing 14 previously silent malformed corpus cases.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -25,8 +25,8 @@ The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
 all 6,806 html5lib tokenizer cases with zero missing signatures and zero
 normalized skips. DOM output is complete, but diagnostic coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the initial-doctype conformance slice, 1,773 of those cases emit at least
-one lexer or parser diagnostic and 410 remain uncovered. Another 139
+After the document-tail insertion-mode slice, 1,781 of those cases emit at
+least one lexer or parser diagnostic and 402 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -38,10 +38,9 @@ Prioritized work items:
    explicit and implied `html`, `head`, and `body` creation. Missing-doctype
    handling, nonconforming initial-doctype diagnostics, duplicate shell
    start-tag diagnostics, body/html end tags with disallowed open elements,
-   and full-document in-body EOF diagnostics are complete. The current
-   silent-case inventory identifies unexpected character, start-tag, and
-   end-tag tokens in the after-body and after-after-body modes as the next
-   concrete shell slice.
+   full-document in-body EOF diagnostics, and unexpected-token recovery in the
+   after-body and after-after-body modes are complete. Re-audit the remaining
+   silent shell cases before selecting the next bounded diagnostic slice.
 2. **Fragment EOF diagnostics.** Audit the current in-body EOF rule against
    fragment parsing. Legacy fragment fixtures omit many EOF error rows, so add
    explicit current-WHATWG evidence before extending the full-document

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4341,6 +4341,31 @@ impl BrowserRenderNode {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DocumentTailMode {
+    InBody,
+    AfterBody,
+    AfterHtml,
+}
+
+impl DocumentTailMode {
+    fn diagnostic_code(self) -> &'static str {
+        match self {
+            Self::AfterBody => "unexpected-token-after-body",
+            Self::AfterHtml => "unexpected-token-after-html",
+            Self::InBody => unreachable!("the in-body mode does not report tail diagnostics"),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::AfterBody => "after body",
+            Self::AfterHtml => "after after body",
+            Self::InBody => "in body",
+        }
+    }
+}
+
 /// Streaming-friendly parser core over already-tokenized HTML.
 #[derive(Debug)]
 pub struct HtmlParser {
@@ -4358,6 +4383,7 @@ pub struct HtmlParser {
     explicit_body_end_seen: bool,
     explicit_body_start_seen: bool,
     explicit_html_end_seen: bool,
+    document_tail_mode: DocumentTailMode,
     pending_table_text: String,
     strip_next_leading_noscript_literal: bool,
     form_element_pointer_set: bool,
@@ -4381,6 +4407,7 @@ impl Default for HtmlParser {
             explicit_body_end_seen: false,
             explicit_body_start_seen: false,
             explicit_html_end_seen: false,
+            document_tail_mode: DocumentTailMode::InBody,
             pending_table_text: String::new(),
             strip_next_leading_noscript_literal: false,
             form_element_pointer_set: false,
@@ -4434,6 +4461,7 @@ impl HtmlParser {
             explicit_body_end_seen: false,
             explicit_body_start_seen: false,
             explicit_html_end_seen: false,
+            document_tail_mode: DocumentTailMode::InBody,
             pending_table_text: String::new(),
             strip_next_leading_noscript_literal: false,
             form_element_pointer_set: false,
@@ -4459,6 +4487,7 @@ impl HtmlParser {
             explicit_body_end_seen: false,
             explicit_body_start_seen: matches!(context_element, "body"),
             explicit_html_end_seen: false,
+            document_tail_mode: DocumentTailMode::InBody,
             pending_table_text: String::new(),
             strip_next_leading_noscript_literal: false,
             form_element_pointer_set: matches!(context_element, "form"),
@@ -4576,6 +4605,7 @@ impl HtmlParser {
 
     fn process_token(&mut self, token: Token) {
         self.process_initial_insertion_mode(&token);
+        self.process_document_tail_mode(&token);
         if matches!(token, Token::Eof) {
             self.flush_foreign_cdata_text();
         }
@@ -4643,6 +4673,43 @@ impl HtmlParser {
                     Token::Text(_) => unreachable!("text token handled before clearing LF state"),
                 }
             }
+        }
+    }
+
+    fn process_document_tail_mode(&mut self, token: &Token) {
+        if self.is_fragment || self.document_has_closed_frameset() {
+            return;
+        }
+
+        if matches!(self.document_tail_mode, DocumentTailMode::InBody) {
+            return;
+        }
+        let allowed_in_both_modes = matches!(
+            token,
+            Token::Comment(_)
+                | Token::ProcessingInstruction { .. }
+                | Token::Doctype { .. }
+                | Token::Eof
+        ) || matches!(token, Token::Text(text) if is_html_whitespace_text(text))
+            || matches!(token, Token::StartTag { name, .. } if name == "html");
+        let allowed = allowed_in_both_modes
+            || (matches!(self.document_tail_mode, DocumentTailMode::AfterBody)
+                && matches!(token, Token::EndTag { name } if name == "html"));
+
+        if matches!(self.document_tail_mode, DocumentTailMode::AfterBody)
+            && matches!(token, Token::EndTag { name } if name == "html")
+        {
+            self.document_tail_mode = DocumentTailMode::AfterHtml;
+        } else if !allowed {
+            let mode = self.document_tail_mode;
+            self.diagnostics.push(ParserDiagnostic::new(
+                mode.diagnostic_code(),
+                format!(
+                    "unexpected token was reprocessed from the {} insertion mode",
+                    mode.name()
+                ),
+            ));
+            self.document_tail_mode = DocumentTailMode::InBody;
         }
     }
 
@@ -6623,6 +6690,24 @@ impl HtmlParser {
         }
         if name == "body" && self.has_open_element("body") && self.current_element_is("bdy") {
             return;
+        }
+        if !self.is_fragment
+            && !self.document_has_closed_frameset()
+            && name == "body"
+            && self.has_open_element("body")
+            && !self.has_disallowed_open_element_for_body_end_tag()
+        {
+            self.document_tail_mode = DocumentTailMode::AfterBody;
+        }
+        if !self.is_fragment
+            && !self.document_has_closed_frameset()
+            && name == "html"
+            && self.has_open_element("html")
+            && !self.has_open_table_context()
+            && (!self.has_open_element("body")
+                || !self.has_disallowed_open_element_for_body_end_tag())
+        {
+            self.document_tail_mode = DocumentTailMode::AfterHtml;
         }
         if name == "body" {
             self.explicit_body_end_seen = true;
@@ -32964,6 +33049,48 @@ mod tests {
             let allowed = parse_html_with_diagnostics(source).unwrap();
             assert!(allowed.parser_diagnostics.is_empty(), "source {source:?}");
         }
+    }
+
+    #[test]
+    fn reports_unexpected_tokens_after_body_and_html() {
+        for (source, code) in [
+            (
+                "<!doctype html><body></body><p>x</p><div>y</div>",
+                "unexpected-token-after-body",
+            ),
+            (
+                "<!doctype html><body></body></html>text<p>x</p>",
+                "unexpected-token-after-html",
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .filter(|diagnostic| diagnostic.code == code)
+                    .count(),
+                1,
+                "source {source:?}"
+            );
+        }
+
+        let allowed = parse_html_with_diagnostics(
+            "<!doctype html><body></body> \n<!--after body--><?pi?></html><!--after html-->",
+        )
+        .unwrap();
+        assert!(allowed.parser_diagnostics.iter().all(|diagnostic| {
+            !matches!(
+                diagnostic.code.as_str(),
+                "unexpected-token-after-body" | "unexpected-token-after-html"
+            )
+        }));
+
+        let ignored_html_end =
+            parse_html_with_diagnostics("<!doctype html><menuitem></html><p>x").unwrap();
+        assert!(!ignored_html_end.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "unexpected-token-after-html"
+        }));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 410);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1773);
+    assert_eq!(missing_diagnostic_cases, 402);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1781);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- track full-document after-body and after-after-body insertion-mode transitions explicitly
- report unexpected tokens once before reprocessing them through in-body recovery
- preserve permitted tail tokens, ignored shell end tags, fragment behavior, and all 2,637 checked DOM outputs
- reduce malformed tree cases without diagnostics from 410 to 402 while keeping undeclared-diagnostic cases at 139

## Evidence
- current WPT audit: 1,934/1,934 tree signatures, zero missing
- current html5lib tokenizer audit: 6,806/6,806 upstream signatures, zero normalized skips
- WHATWG HTML Standard: after-body and after-after-body insertion modes

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`