### PR TITLE
fix(spice): validate parser MOS nominal temperature

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `TNOM` / `T_NOM` values
+  before lowering Level-1 nominal temperature.
 - Reject zero, negative, and non-finite MOS model-card `IS` values before
   lowering Level-1 saturation current.
 - Reject zero, negative, and non-finite MOS model-card `L` values before

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1922,6 +1922,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["IS"]) or params["IS"] <= 0.0
         ):
             raise NetlistParseError("MOSFET IS must be finite and positive")
+        nominal_temperature = params.get("T_NOM", params.get("TNOM"))
+        if nominal_temperature is not None and (
+            not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0
+        ):
+            raise NetlistParseError("MOSFET TNOM must be finite and positive")
     return ModelCard(name=name, kind=kind, params=params)
 
 

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1571,6 +1571,23 @@ def test_lowers_positive_mosfet_model_saturation_current() -> None:
     assert isclose(mosfet.model.model.params.IS, 2.0e-15)
 
 
+@pytest.mark.parametrize("alias", ["TNOM", "T_NOM"])
+@pytest.mark.parametrize("temperature", ["0", "-1", "1e999"])
+def test_rejects_invalid_mosfet_model_nominal_temperature(
+    alias: str, temperature: str
+) -> None:
+    with pytest.raises(NetlistParseError, match="MOSFET TNOM must be finite and positive"):
+        parse_netlist(f".model nfast NMOS({alias}={temperature})\nM1 d g s b nfast\n")
+
+
+@pytest.mark.parametrize("alias", ["TNOM", "T_NOM"])
+def test_lowers_positive_mosfet_model_nominal_temperature(alias: str) -> None:
+    parsed = parse_netlist(f".model nfast NMOS({alias}=325)\nM1 d g s b nfast\n")
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.T_NOM == 325.0
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject zero, negative, and non-finite MOS model-card `TNOM` / `T_NOM` values
+  before lowering Level-1 nominal temperature.
 - Reject zero, negative, and non-finite MOS model-card `IS` values before
   lowering Level-1 saturation current.
 - Reject zero, negative, and non-finite MOS model-card `L` values before

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1237,6 +1237,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET IS must be finite and positive");
   }
+  const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    nominalTemperature !== undefined &&
+    (!Number.isFinite(nominalTemperature) || nominalTemperature <= 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET TNOM must be finite and positive");
+  }
   return {
     name: fields[1],
     kind,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1502,6 +1502,19 @@ Xright c d load
     expect(element.params.IS).toBeCloseTo(2.0e-15, 20);
   });
 
+  it.each(["TNOM", "T_NOM"])("validates MOSFET model nominal-temperature alias %s", (alias) => {
+    for (const temperature of ["0", "-1", "1e999"]) {
+      expect(() =>
+        parseNetlist(`.model nfast NMOS(${alias}=${temperature})\nM1 d g s b nfast\n`),
+      ).toThrow("MOSFET TNOM must be finite and positive");
+    }
+    const parsed = parseNetlist(`.model nfast NMOS(${alias}=325)\nM1 d g s b nfast\n`);
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.T_NOM).toBe(325);
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,10 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley SPICE MOS saturation-current validation parity.
+1. Python and TypeScript Berkeley SPICE MOS nominal-temperature validation parity.
    - Status: current PR completion candidate.
-   - Reject zero, negative, and non-finite `IS` values with the shared diagnostic.
-   - Preserve positive saturation currents through canonical Level-1 lowering.
+   - Reject zero, negative, and non-finite `TNOM` / `T_NOM` values with the
+     shared diagnostic.
+   - Preserve positive Kelvin values through canonical Level-1 lowering.
 
 ## Completed Slices
 
@@ -4183,21 +4184,22 @@ the Rust, Python, and TypeScript surfaces together.
    - Zero, negative, and non-finite `L` values are rejected with the shared
      diagnostic while positive lengths lower into Level-1 parameters.
 
+378. Python and TypeScript Berkeley SPICE MOS saturation-current validation parity.
+   - Status: completed in PR 9627.
+   - Zero, negative, and non-finite `IS` values are rejected with the shared
+     diagnostic while positive saturation currents lower into Level-1 parameters.
+
 ## Backlog
 
-1. Python and TypeScript Berkeley SPICE MOS core model-card validation parity.
-   - Apply Rust-aligned domains and diagnostics to the already lowered
-     nominal-temperature field.
-
-2. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
+1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
    - Lower missing canonical resistance, geometry, capacitance, junction, and
      noise fields, then align the `CJS` and `CJD` aliases.
 
-3. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
+2. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
    - Validate and consume `NSS` / `TPG`, then derive `VT0`, `GAMMA`, and `PHI`
      from `N_SUB` / `TOX` with shared engine semantics.
 
-4. Grammar-backed parser and app facade.
+3. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
@@ -4205,7 +4207,7 @@ the Rust, Python, and TypeScript surfaces together.
      toward packaging, WebAssembly embedding, and product integration backed by
      the same public parser contract.
 
-5. Deck compatibility follow-up.
+4. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis
      execution and stable artifact exports toward nested sweeps, raw-format
      interoperability, and remaining vendor-style output controls.
@@ -4216,7 +4218,7 @@ the Rust, Python, and TypeScript surfaces together.
      command routing, including control flow, variables, and script execution
      policy.
 
-6. Production solver core follow-up.
+5. Production solver core follow-up.
    - Sparse real/complex matrix paths now have cross-language native coverage,
      and Python real DC solves now use an optional SciPy sparse-LU backend with
      structured native fallback metadata.
@@ -4227,14 +4229,14 @@ the Rust, Python, and TypeScript surfaces together.
      damping, device limiting, tolerance policy, and additional convergence
      diagnostics for difficult transistor decks.
 
-7. Device model depth.
+6. Device model depth.
    - Audit diode, BJT, JFET, and MOS Level 1 behavior against reference decks.
    - Decide whether Level 2/3 MOS is in scope before BSIM; if BSIM lands, make
      Rust the first fast path and port stable semantics outward.
    - Expand temperature behavior, capacitance, noise, charge conservation, model
      card aliases, and error messages.
 
-8. Analysis completion.
+7. Analysis completion.
    - Generalize pole-zero beyond constrained fixture helpers.
    - Expand nonlinear distortion coverage.
    - Expand parsed `.FOUR` / `.MEASURE` integration across output plans and
@@ -4243,14 +4245,14 @@ the Rust, Python, and TypeScript surfaces together.
      Carlo trials.
    - Stabilize raw, CSV, JSON, and browser-friendly result formats.
 
-9. Mixed-signal integration.
+8. Mixed-signal integration.
    - Connect SPICE transient stepping to the hardware VM scheduler.
    - Support bidirectional analog/digital thresholds, event scheduling,
      breakpoint coordination, and VCD correlation.
    - Keep mixed-signal coupling deterministic across Python, Rust, and
      TypeScript.
 
-10. Verilog-A and custom models.
+9. Verilog-A and custom models.
    - Specify the accepted model subset and residual/Jacobian hooks.
    - Add parser or compiler support with sandboxing for TypeScript/web usage.
    - Provide a Rust-native fast path for compiled models.


### PR DESCRIPTION
## Summary
- validate MOS model-card `TNOM` and `T_NOM` values in the Python and TypeScript parsers
- reject zero, negative, and non-finite nominal temperatures while preserving valid Kelvin values
- add synchronized regression coverage, changelogs, and completion-plan tracking

## Verification
- Python: 131 tests passed; 88.17% coverage
- Python: `ruff check src tests`
- TypeScript spice-engine: `npm run build`
- TypeScript spice-netlist-parser: `npm run build`
- TypeScript spice-netlist-parser: 124 tests passed with coverage