### PR TITLE
fix(build-tool): enforce Perl rockspec UTF-8

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 9603,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "5042eadeb84f9f992634a160590938e4453dba2d",
+    "revision": "51797a6fe0878f5fbb6bfdcdb6f0e453f0213beb",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1222,
@@ -338,16 +338,25 @@
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered by the Python encoding-blocker audit. Go, Rust, Swift, and TypeScript were remediated in merged PRs #9504, #9510, #9537, and #9572. PR #9603 is the active Lua remediation. Four engines remain after it: Perl accepts malformed bytes, Ruby and Haskell use locale-sensitive text decoding, and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity."
+      "notes": "Discovered by the Python encoding-blocker audit. Go, Rust, Swift, TypeScript, and Lua were remediated in merged PRs #9504, #9510, #9537, #9572, and #9603. Four engines remain: Perl accepts malformed bytes, Ruby and Haskell use locale-sensitive text decoding, and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity. The Perl engine is materialized as the next pending child because its raw byte boundary is narrow and Perl 5.38 is locally available."
     },
     {
       "id": "build-tool-lua-engine-rockspec-utf8-conformance",
       "title": "Make the Lua build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-typescript-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-lua-rockspec-utf8",
       "pr_number": 9603,
-      "notes": "Ready-for-review PR #9603 opened from codex/build-tool-lua-rockspec-utf8 after rebasing onto f52f1000c. The resolver validates raw rockspec bytes as strict UTF-8 before pattern parsing, preserves the exact shared-fixture success edge, throws typed METADATA_INVALID_UTF8 with package and repository-relative manifest identity, accepts literal U+FFFD, rejects overlong, truncated, surrogate, bad-continuation, and out-of-range sequences, and maps the real CLI failure to exit 2 without disclosing the checkout root. Validation: 61 Lua tests; 56.88% resolver and 44.93% aggregate LuaCov coverage including dependencies; changed-file luacheck and all-file luac syntax clean; real 4,770-package/258-Lua-package dry run with eight levels; 57 conformance tests plus 52 subtests; valid 37-case/56-file corpus; collision-clean 1,222-identity/4,370-slot inventory; diff and secret-pattern scans clean. The build-file validator reports only the exact 10 already-backlogged Lua BUILD_windows sibling-install debts, and whole-package lint reports only 11 pre-existing warnings in untouched files."
+      "notes": "Merged PR #9603 as 51797a6fe0878f5fbb6bfdcdb6f0e453f0213beb on 2026-08-03 after all 14 exact-head checks were terminal: both detects, both fixture consumers, both Ubuntu builds, macOS, Windows, and CodeQL detection passed; five irrelevant CodeQL analyzers skipped. The resolver validates raw rockspec bytes as strict UTF-8 before pattern parsing, preserves the exact shared-fixture success edge, throws typed METADATA_INVALID_UTF8 with package and repository-relative manifest identity, accepts literal U+FFFD, rejects overlong, truncated, surrogate, bad-continuation, and out-of-range sequences, and maps the real CLI failure to exit 2 without disclosing the checkout root. Validation: 61 Lua tests; 56.88% resolver and 44.93% aggregate LuaCov coverage including dependencies; changed-file luacheck and all-file luac syntax clean; real 4,770-package/258-Lua-package dry run with eight levels; 57 conformance tests plus 52 subtests; valid 37-case/56-file corpus; collision-clean 1,222-identity/4,370-slot inventory; diff and secret-pattern scans clean. The build-file validator reported only the exact 10 already-backlogged Lua BUILD_windows sibling-install debts, and whole-package lint reported only 11 pre-existing warnings in untouched files."
+    },
+    {
+      "id": "build-tool-perl-engine-rockspec-utf8-conformance",
+      "title": "Make the Perl build tool enforce strict UTF-8 rockspec metadata",
+      "status": "pending",
+      "depends_on": ["build-tool-lua-engine-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized after merged PR #9603 and the collision-clean 51797a6f inventory. The four-engine leverage pass selected Perl as the next candidate because its raw-byte rockspec reader is the narrowest remaining boundary, Perl 5.38 is locally available, and the shared valid/invalid fixtures plus five merged reference implementations pin the exact contract. Keep Ruby and Haskell locale-sensitive decoding and Elixir's position-dependent decoding as separate later children."
     },
     {
       "id": "build-tool-typescript-rockspec-utf8-conformance",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -359,6 +359,15 @@
       "notes": "Selected after merged PR #9603 and the collision-clean 51797a6f inventory. The four-engine leverage pass ranked Perl first because its raw-byte rockspec reader is the narrowest remaining boundary, Perl 5.38 is locally available, and the shared valid/invalid fixtures plus five merged reference implementations pin the exact contract. Consume the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 cases, preserve the success edge set, fail closed with METADATA_INVALID_UTF8 plus package and repository-relative manifest identity, and test the real CLI exit contract without leaking the checkout root. Keep Ruby and Haskell locale-sensitive decoding and Elixir's position-dependent decoding as separate later children."
     },
     {
+      "id": "build-tool-perl-runtime-security-floor",
+      "title": "Define audited Perl and core-module security floors for the Perl build tool",
+      "status": "pending",
+      "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the Perl rockspec UTF-8 security validation. CPAN::Audit 20260622.001 with database 20260726.001 cannot give the unconstrained cpanfile a clean dependency result: the declared Perl 5.26.0 and version-free core modules span historical Perl, PathTools, File-Path, and direct-distribution advisories, while core-module queries are grouped under the Perl distribution and need supported-toolchain review rather than blanket exclusions. Audit the exact Ubuntu, macOS, and Windows Perl/core versions, raise minimum safe runtime and module floors where portable, record only evidence-backed non-applicable exceptions, and add CI/toolchain contract tests. Keep this compatibility-policy decision separate from strict rockspec decoding."
+    },
+    {
       "id": "build-tool-typescript-rockspec-utf8-conformance",
       "title": "Make the TypeScript build tool enforce strict UTF-8 rockspec metadata",
       "status": "merged",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,12 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "build-tool-perl-engine-rockspec-utf8-conformance",
+    "number": 9632,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9632",
+    "branch": "codex/build-tool-perl-rockspec-utf8"
+  },
   "last_inventory": {
     "revision": "ec53a3f9e9b2f31deefc43552a4d48658c49f3f4",
     "schema_version": 3,
@@ -352,11 +357,11 @@
     {
       "id": "build-tool-perl-engine-rockspec-utf8-conformance",
       "title": "Make the Perl build tool enforce strict UTF-8 rockspec metadata",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-lua-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-perl-rockspec-utf8",
-      "pr_number": null,
-      "notes": "Selected after merged PR #9603 and the collision-clean 51797a6f inventory. The four-engine leverage pass ranked Perl first because its raw-byte rockspec reader is the narrowest remaining boundary, and the shared valid/invalid fixtures plus five merged reference implementations pin the exact contract. Implemented strict raw-byte decoding, a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, exact success edges without the rockspec package field becoming a self-dependency, malformed-sequence and literal-U+FFFD coverage, and a real CLI exit-2 contract without checkout-root leakage. Rebased conflict-free onto ec53a3f9; the full 127-test Perl suite, MakeMaker workflow, syntax, severity-5 Perl::Critic, coverage, canonical Go test/vet/build and 256-package Perl validator, 57 conformance tests, 37-case/56-file corpus, 258-package real Lua plan, collision inventory, diff, dependency, and credential scans pass. Keep Ruby and Haskell locale-sensitive decoding and Elixir's position-dependent decoding as separate later children."
+      "pr_number": 9632,
+      "notes": "Ready-for-review PR #9632 opened at b60299988ed47b8acc21ea838f99d9f39648d8ed after merged PR #9603 and the collision-clean ec53a3f9 inventory. The four-engine leverage pass ranked Perl first because its raw-byte rockspec reader is the narrowest remaining boundary, and the shared valid/invalid fixtures plus five merged reference implementations pin the exact contract. Implemented strict raw-byte decoding, a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, exact success edges without the rockspec package field becoming a self-dependency, malformed-sequence and literal-U+FFFD coverage, and a real CLI exit-2 contract without checkout-root leakage. Rebased conflict-free onto ec53a3f9; the full 127-test Perl suite, MakeMaker workflow, syntax, severity-5 Perl::Critic, coverage, canonical Go test/vet/build and 256-package Perl validator, 57 conformance tests, 37-case/56-file corpus, 258-package real Lua plan, collision inventory, diff, dependency, and credential scans pass. Keep Ruby and Haskell locale-sensitive decoding and Elixir's position-dependent decoding as separate later children."
     },
     {
       "id": "build-tool-perl-runtime-security-floor",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,16 +13,16 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "51797a6fe0878f5fbb6bfdcdb6f0e453f0213beb",
+    "revision": "ec53a3f9e9b2f31deefc43552a4d48658c49f3f4",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1222,
-    "implementation_package_slots": 4370,
+    "implementation_identities": 1224,
+    "implementation_package_slots": 4372,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 772,
-    "singleton_missing_slots": 10808,
-    "rust_singletons": 577,
+    "singleton_packages": 774,
+    "singleton_missing_slots": 10836,
+    "rust_singletons": 579,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -356,7 +356,7 @@
       "depends_on": ["build-tool-lua-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-perl-rockspec-utf8",
       "pr_number": null,
-      "notes": "Selected after merged PR #9603 and the collision-clean 51797a6f inventory. The four-engine leverage pass ranked Perl first because its raw-byte rockspec reader is the narrowest remaining boundary, Perl 5.38 is locally available, and the shared valid/invalid fixtures plus five merged reference implementations pin the exact contract. Consume the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 cases, preserve the success edge set, fail closed with METADATA_INVALID_UTF8 plus package and repository-relative manifest identity, and test the real CLI exit contract without leaking the checkout root. Keep Ruby and Haskell locale-sensitive decoding and Elixir's position-dependent decoding as separate later children."
+      "notes": "Selected after merged PR #9603 and the collision-clean 51797a6f inventory. The four-engine leverage pass ranked Perl first because its raw-byte rockspec reader is the narrowest remaining boundary, and the shared valid/invalid fixtures plus five merged reference implementations pin the exact contract. Implemented strict raw-byte decoding, a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, exact success edges without the rockspec package field becoming a self-dependency, malformed-sequence and literal-U+FFFD coverage, and a real CLI exit-2 contract without checkout-root leakage. Rebased conflict-free onto ec53a3f9; the full 127-test Perl suite, MakeMaker workflow, syntax, severity-5 Perl::Critic, coverage, canonical Go test/vet/build and 256-package Perl validator, 57 conformance tests, 37-case/56-file corpus, 258-package real Lua plan, collision inventory, diff, dependency, and credential scans pass. Keep Ruby and Haskell locale-sensitive decoding and Elixir's position-dependent decoding as separate later children."
     },
     {
       "id": "build-tool-perl-runtime-security-floor",
@@ -851,6 +851,24 @@
       "branch": null,
       "pr_number": null,
       "notes": "The July 30-August 1 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, venture-browser-core, smart-home-runtime-store, venture-browser-macos, smart-home-automation-runtime, smart-home-zwave-integration, smart-home-zwave-host, smart-home-mqtt-integration, smart-home-zigbee-integration, smart-home-matter-integration, smart-home-home-assistant-migration, smart-home-home-assistant-export, smart-home-home-assistant-history, smart-home-home-assistant-definitions, smart-home-home-assistant-dashboard-migration, smart-home-dashboard-core, venture-browser-windows, smart-home-camera-media, smart-home-onvif-integration, and smart-home-shelly-integration; also reconcile the existing matter-core contract with the new adapter split. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; the smart-home discovery, Hue, runtime-store, automation-runtime, Z-Wave integration, Z-Wave serial-host, MQTT integration, Zigbee adapter, Matter adapter, camera-media broker, ONVIF integration, Shelly integration, and Home Assistant packages as native/service/storage boundary cases; venture-browser-macos as an Apple-native AppKit/CoreText/Metal host with native-source applicability; and venture-browser-windows as a mixed boundary whose duplicated session/chrome/status/event bridge belongs in venture-browser-core or a shared portable bridge while WinUI/Direct2D/C-ABI behavior remains native-source. Home Assistant migration, export, history, definitions, and dashboard migration contain deterministic parsing or validation, normalization, planning, diagnostics, identities, fingerprints, projections, and receipts that are portable-core candidates, while WebSocket/TLS collection, runtime application, atomic filesystem writes, CLI behavior, Rust-only runtime dependencies, environment-token intake, clock/console effects, and missing capability manifests require explicit host-boundary review. Smart-home-dashboard-core is already a zero-capability, protocol-neutral deterministic manifest parser, validator, and summarizer, so its fixture and cross-lane expansion has a separate explicit owner. The MQTT package's deterministic discovery/topic/entity/value/payload transformations remain candidates for a separately fixture-driven portable core. The Zigbee adapter is pure logic above coordinator transport, uses only an opaque VaultRef for the network key, and should be reviewed as a portable adapter core with a separate native coordinator-host boundary. The Matter adapter is likewise zero-capability deterministic logic above commissioning, sessions, credentials, and I/O; extract or fold its portable projection/report/command logic through matter-core, classify residual SmartHomeRuntime wiring as Rust-canonical under D23, and keep the future commissioning/CASE/PASE/certificate/subscription controller as the native host boundary. Camera-media policy, generation-bound lease state, quotas, and redacted audit are portable candidates, but endpoint use belongs behind an injected trusted host. ONVIF discovery/SOAP/profile parsing, deterministic UsernameToken construction, origin policy, projection, and hostile fixtures are portable candidates, while UDP/DNS/TCP/TLS, trusted time/randomness, Vault leases, process I/O, and endpoint allowlists remain host-owned. Shelly JSON-RPC validation, component projection, stable identities, command planning, and normalized error classes are portable candidates; mDNS, DNS/TCP, plaintext LAN HTTP, trusted clock, console I/O, runtime-effect ordering, future credentials, endpoint policy, and truthful capability profiles remain host-owned."
+    },
+    {
+      "id": "chief-channel-crypto-portable-conformance",
+      "title": "Classify and fixture the portable Chief channel cryptography core",
+      "status": "pending",
+      "depends_on": ["rust-singletons-20260730-classification"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean ec53a3f9 inventory after PR #9609 added Rust-only chief-of-staff-channel-crypto. Define language-neutral vectors for the versioned bounded grant/message wire records, stable storage keys, framed authenticated headers, digest/signature inputs, epoch transition rules, retry/conflict handling, and sequence reservation/recovery. Expand deterministic codecs and cryptographic behavior only where each lane has suitable constant-time primitives; keep OS CSPRNG access, key custody, durable sequence persistence, storage, and actor routing behind injected or native authority boundaries, with reviewed exceptions where a safe implementation is unavailable."
+    },
+    {
+      "id": "venture-browser-qt-portable-bridge-and-native-host",
+      "title": "Classify the Venture Qt bridge and its native shell",
+      "status": "pending",
+      "depends_on": ["rust-singletons-20260730-classification"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean ec53a3f9 inventory after PR #9615 added Rust-only venture-browser-qt. Reconcile its deterministic BrowserHostController projection, Mosaic event decoding, input normalization, and C-ABI state/error contract with venture-browser-core and the Windows/macOS bridge owners, using shared language-neutral fixtures where portable. Classify Cairo rasterization, Qt Quick/QML registration, dynamic-library loading, C++ adapter code, native pointer and buffer lifetimes, CMake/Qt discovery, and live application launch as native-source or wrapper behavior with direct platform tests rather than all-language gaps."
     },
     {
       "id": "smart-home-camera-media-security-boundary-hardening",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -352,11 +352,11 @@
     {
       "id": "build-tool-perl-engine-rockspec-utf8-conformance",
       "title": "Make the Perl build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-lua-engine-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-perl-rockspec-utf8",
       "pr_number": null,
-      "notes": "Materialized after merged PR #9603 and the collision-clean 51797a6f inventory. The four-engine leverage pass selected Perl as the next candidate because its raw-byte rockspec reader is the narrowest remaining boundary, Perl 5.38 is locally available, and the shared valid/invalid fixtures plus five merged reference implementations pin the exact contract. Keep Ruby and Haskell locale-sensitive decoding and Elixir's position-dependent decoding as separate later children."
+      "notes": "Selected after merged PR #9603 and the collision-clean 51797a6f inventory. The four-engine leverage pass ranked Perl first because its raw-byte rockspec reader is the narrowest remaining boundary, Perl 5.38 is locally available, and the shared valid/invalid fixtures plus five merged reference implementations pin the exact contract. Consume the exact resolution/lua-utf8 and resolution/lua-invalid-utf8 cases, preserve the success edge set, fail closed with METADATA_INVALID_UTF8 plus package and repository-relative manifest identity, and test the real CLI exit contract without leaking the checkout root. Keep Ruby and Haskell locale-sensitive decoding and Elixir's position-dependent decoding as separate later children."
     },
     {
       "id": "build-tool-typescript-rockspec-utf8-conformance",

--- a/code/programs/perl/build-tool/CHANGELOG.md
+++ b/code/programs/perl/build-tool/CHANGELOG.md
@@ -6,6 +6,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- Lua `.rockspec` dependency metadata now follows the shared strict UTF-8
+  contract. Invalid bytes fail closed with the stable
+  `METADATA_INVALID_UTF8` diagnostic and CLI exit code 2 without leaking host
+  checkout paths. Version constraints are parsed without introducing manifest
+  self-edges.
+
 ## [0.1.0] — 2026-03-23
 
 ### Added

--- a/code/programs/perl/build-tool/Makefile.PL
+++ b/code/programs/perl/build-tool/Makefile.PL
@@ -43,6 +43,7 @@ WriteMakefile(
     # available, otherwise falls back to the inline graph implementation).
     PREREQ_PM => {
         'Digest::SHA'     => '0',
+        'Encode'          => '0',
         'JSON::PP'        => '2.0',
         'File::Find'      => '0',
         'File::Spec'      => '0',

--- a/code/programs/perl/build-tool/README.md
+++ b/code/programs/perl/build-tool/README.md
@@ -80,6 +80,14 @@ perl bin/build-tool --root /path/to/repo --force --jobs 8
 | `1` | One or more builds failed |
 | `2` | Configuration error |
 
+## Metadata Safety
+
+Lua `.rockspec` package metadata is decoded as strict UTF-8 before dependency
+resolution. Invalid bytes fail closed with `METADATA_INVALID_UTF8`, identify
+the package and repository-relative manifest, and make the CLI exit with code
+2. Diagnostics never expose the checkout path or silently replace invalid
+input bytes; a well-formed literal Unicode replacement character remains valid.
+
 ## Architecture
 
 | Module | Responsibility |
@@ -134,6 +142,7 @@ my $content = <$fh>;
 | Dependency | Source | Purpose |
 |-----------|--------|---------|
 | `Digest::SHA` | Core (5.9.3+) | SHA256 hashing |
+| `Encode` | Core | Strict UTF-8 package metadata decoding |
 | `JSON::PP` | Core (5.14+) | Cache/plan serialisation |
 | `File::Find` | Core | Directory walking |
 | `Getopt::Long` | Core | CLI argument parsing |
@@ -154,6 +163,9 @@ t/07-starlark.t      8 cases — Starlark detection, command generation
 t/08-glob-match.t    8 cases — glob pattern matching
 t/09-plan.t          3 cases — build plan serialisation
 t/10-integration.t   2 cases — end-to-end pipeline
+t/11-validator.t       BUILD and CI metadata contract validation
+t/12-ci-workflow.t     canonical CI workflow validation
+t/13-resolution-utf8.t shared fixtures — strict Lua rockspec UTF-8 and CLI diagnostics
 ```
 
 Run all tests:

--- a/code/programs/perl/build-tool/cpanfile
+++ b/code/programs/perl/build-tool/cpanfile
@@ -12,6 +12,7 @@
 # `cpanm --installdeps` will skip these because they are bundled with Perl.
 requires 'perl', '5.026';
 requires 'Digest::SHA';
+requires 'Encode';
 requires 'JSON::PP', '2.00';
 requires 'File::Find';
 requires 'File::Spec';

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool.pm
@@ -36,6 +36,7 @@ use warnings;
 use Cwd ();
 use File::Spec ();
 use List::Util qw(any);
+use Scalar::Util qw(blessed);
 
 use CodingAdventures::BuildTool::Discovery  ();
 use CodingAdventures::BuildTool::Resolver   ();
@@ -110,7 +111,20 @@ sub run {
 
     # Step 3: Resolve dependencies.
     my $resolver = CodingAdventures::BuildTool::Resolver->new();
-    my $graph    = $resolver->resolve(\@all_packages);
+    my $graph;
+    my $resolved = eval {
+        $graph = $resolver->resolve(\@all_packages);
+        1;
+    };
+    if (!$resolved) {
+        my $error = $@;
+        if (blessed($error)
+            && $error->isa('CodingAdventures::BuildTool::MetadataEncodingError')) {
+            warn "$error\n";
+            return 2;
+        }
+        die $error;
+    }
 
     # Step 4: Determine which packages need building.
     my @to_build;

--- a/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Resolver.pm
+++ b/code/programs/perl/build-tool/lib/CodingAdventures/BuildTool/Resolver.pm
@@ -48,12 +48,40 @@ package CodingAdventures::BuildTool::Resolver;
 
 use strict;
 use warnings;
+use Encode qw(decode FB_CROAK);
 use File::Spec ();
 use File::Basename ();
 use File::Find ();
 use Scalar::Util qw(blessed);
 
 our $VERSION = '0.01';
+
+# ===========================================================================
+# MetadataEncodingError -- Stable failure for malformed package metadata
+# ===========================================================================
+
+package CodingAdventures::BuildTool::MetadataEncodingError;
+
+use overload '""' => 'as_string', fallback => 1;
+
+sub new {
+    my ($class, %args) = @_;
+    return bless {
+        code     => 'METADATA_INVALID_UTF8',
+        package  => $args{package},
+        manifest => $args{manifest},
+        encoding => 'UTF-8',
+    }, $class;
+}
+
+sub as_string {
+    my ($self) = @_;
+    return join ' ',
+        $self->{code} . ':',
+        "package=$self->{package}",
+        "manifest=$self->{manifest}",
+        "encoding=$self->{encoding}";
+}
 
 # ===========================================================================
 # DirectedGraph -- Inline graph implementation
@@ -641,12 +669,14 @@ sub _parse_lua_deps {
     closedir $dh;
     return () unless $rockspec;
 
-    my $text = _slurp($rockspec) // return ();
+    my $text = _slurp_utf8_metadata($pkg, $rockspec) // return ();
 
     my @deps;
-    while ($text =~ /"(coding-adventures-[^"]+)"/g) {
+    while ($text =~ /"(coding-adventures-[A-Za-z0-9-]+)/g) {
         my $dep = lc $1;
-        push @deps, $known_ref->{$dep} if exists $known_ref->{$dep};
+        next unless exists $known_ref->{$dep};
+        next if $known_ref->{$dep} eq $pkg->{name};
+        push @deps, $known_ref->{$dep};
     }
     return @deps;
 }
@@ -750,6 +780,43 @@ sub _slurp {
     my $content = <$fh>;
     close $fh;
     return $content;
+}
+
+# _slurp_utf8_metadata -- Strictly decode a package metadata file as UTF-8.
+#
+# Package manifests are portable repository data. Decoding with FB_CROAK
+# rejects malformed byte sequences instead of silently replacing them. The
+# thrown object carries only stable package and repository-relative identities
+# so callers never expose a host-specific absolute path.
+sub _slurp_utf8_metadata {
+    my ($pkg, $path) = @_;
+    return unless defined $path && -f $path;
+
+    open(my $fh, '<:raw', $path) or return;
+    local $/;
+    my $bytes = <$fh>;
+    close $fh;
+
+    my $text;
+    my $decoded = eval {
+        $text = decode('UTF-8', $bytes, FB_CROAK);
+        1;
+    };
+    if (!$decoded) {
+        die CodingAdventures::BuildTool::MetadataEncodingError->new(
+            package  => $pkg->{name},
+            manifest => _repository_relative_manifest($path),
+        );
+    }
+    return $text;
+}
+
+sub _repository_relative_manifest {
+    my ($path) = @_;
+    my $normalized = File::Spec->canonpath($path);
+    $normalized =~ s{\\}{/}g;
+    return $1 if $normalized =~ m{(?:^|/)(code/(?:packages|programs)/.+)\z};
+    return File::Basename::basename($normalized);
 }
 
 1;

--- a/code/programs/perl/build-tool/t/13-resolution-utf8.t
+++ b/code/programs/perl/build-tool/t/13-resolution-utf8.t
@@ -1,0 +1,194 @@
+#!/usr/bin/env perl
+
+# t/13-resolution-utf8.t -- Shared Lua rockspec UTF-8 conformance tests.
+
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+
+use Test2::V0;
+use Cwd qw(abs_path);
+use Encode qw(encode);
+use File::Basename qw(dirname);
+use File::Path qw(make_path);
+use File::Spec ();
+use File::Temp qw(tempdir);
+use IPC::Open3 qw(open3);
+use JSON::PP ();
+use MIME::Base64 qw(decode_base64);
+use Scalar::Util qw(blessed);
+use Symbol qw(gensym);
+
+use CodingAdventures::BuildTool::Discovery;
+use CodingAdventures::BuildTool::Resolver;
+
+my $PACKAGE_ROOT = abs_path(File::Spec->catdir($Bin, '..'));
+my $CASES_ROOT = abs_path(
+    File::Spec->catdir($PACKAGE_ROOT, '..', '..', '..', 'specs', 'fixtures', 'build-tool-v1', 'cases')
+);
+
+sub read_bytes {
+    my ($path) = @_;
+    open(my $fh, '<:raw', $path) or die "Cannot read $path: $!";
+    local $/;
+    my $bytes = <$fh>;
+    close $fh;
+    return $bytes;
+}
+
+sub write_bytes {
+    my ($path, $bytes) = @_;
+    make_path(dirname($path));
+    open(my $fh, '>:raw', $path) or die "Cannot write $path: $!";
+    print {$fh} $bytes;
+    close $fh;
+}
+
+sub load_case {
+    my ($name) = @_;
+    my $path = File::Spec->catfile($CASES_ROOT, $name);
+    return JSON::PP::decode_json(read_bytes($path));
+}
+
+sub materialize_case {
+    my ($case) = @_;
+    my $root = tempdir(CLEANUP => 1);
+    for my $file (@{ $case->{workspace}{files} }) {
+        my $path = File::Spec->catfile($root, split m{/}, $file->{path});
+        my $bytes = exists $file->{content_utf8}
+            ? encode('UTF-8', $file->{content_utf8})
+            : decode_base64($file->{content_base64});
+        write_bytes($path, $bytes);
+    }
+    return $root;
+}
+
+sub discover_lua {
+    my ($root) = @_;
+    my $discovery = CodingAdventures::BuildTool::Discovery->new(root => $root);
+    $discovery->discover();
+    return [grep { $_->{language} eq 'lua' } @{ $discovery->packages() }];
+}
+
+sub resolve_error {
+    my ($root) = @_;
+    my $error;
+    eval {
+        CodingAdventures::BuildTool::Resolver->new()->resolve(discover_lua($root));
+        1;
+    } or $error = $@;
+    return $error;
+}
+
+sub graph_edges {
+    my ($graph) = @_;
+    my @edges;
+    for my $node (sort $graph->nodes()) {
+        push @edges, map { [$node, $_] } sort $graph->successors($node);
+    }
+    return \@edges;
+}
+
+sub run_cli {
+    my ($root) = @_;
+    my $stderr = gensym();
+    my $pid = open3(
+        undef,
+        my $stdout,
+        $stderr,
+        $^X,
+        File::Spec->catfile($PACKAGE_ROOT, 'bin', 'build-tool'),
+        '--root', $root,
+        '--language', 'lua',
+        '--force',
+        '--dry-run',
+    );
+    my $out = do { local $/; <$stdout> // '' };
+    my $err = do { local $/; <$stderr> // '' };
+    waitpid($pid, 0);
+    return ($? >> 8, $out, $err);
+}
+
+sub assert_metadata_error {
+    my ($error, $root, $manifest) = @_;
+    ok(blessed($error), 'resolver throws a typed error object');
+    isa_ok($error, ['CodingAdventures::BuildTool::MetadataEncodingError']);
+    is($error->{code}, 'METADATA_INVALID_UTF8', 'diagnostic code is stable');
+    is($error->{package}, 'lua/pkg', 'package identity is stable');
+    is($error->{manifest}, $manifest, 'manifest path is repository-relative');
+    is($error->{encoding}, 'UTF-8', 'encoding is explicit');
+    unlike("$error", qr/\Q$root\E/, 'diagnostic does not leak the temporary root');
+}
+
+subtest 'shared valid UTF-8 fixture resolves the exact edge' => sub {
+    my $root = materialize_case(load_case('resolution-lua-utf8.json'));
+    my $graph = CodingAdventures::BuildTool::Resolver->new()->resolve(discover_lua($root));
+    is(graph_edges($graph), [['lua/other', 'lua/pkg']], 'fixture produces only the expected edge');
+};
+
+subtest 'shared invalid UTF-8 fixture fails closed with typed metadata' => sub {
+    my $root = materialize_case(load_case('resolution-lua-invalid-utf8.json'));
+    my $manifest = 'code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec';
+    my $error = resolve_error($root);
+    assert_metadata_error($error, $root, $manifest);
+    is(
+        "$error",
+        "METADATA_INVALID_UTF8: package=lua/pkg manifest=$manifest encoding=UTF-8",
+        'typed error string is the language-neutral diagnostic',
+    );
+};
+
+subtest 'a literal replacement character remains valid UTF-8' => sub {
+    my $case = load_case('resolution-lua-utf8.json');
+    $case->{workspace}{files}[1]{content_utf8} =~ s/UTF-8/UTF-8 \x{FFFD}/;
+    my $root = materialize_case($case);
+    my $graph = CodingAdventures::BuildTool::Resolver->new()->resolve(discover_lua($root));
+    is(
+        graph_edges($graph),
+        [['lua/other', 'lua/pkg']],
+        'U+FFFD is not confused with a decode failure',
+    );
+};
+
+my @malformed = (
+    ['illegal leading byte', "\xFF"],
+    ['unexpected continuation byte', "\x80"],
+    ['truncated multibyte sequence', "\xE2\x82"],
+    ['overlong encoding', "\xC0\xAF"],
+    ['UTF-16 surrogate encoding', "\xED\xA0\x80"],
+);
+
+for my $malformed (@malformed) {
+    my ($label, $bytes) = @{$malformed};
+    subtest "rejects $label" => sub {
+        my $root = tempdir(CLEANUP => 1);
+        my $package_dir = File::Spec->catdir($root, 'code', 'packages', 'lua', 'pkg');
+        my $manifest_name = 'coding-adventures-pkg-0.1.0-1.rockspec';
+        write_bytes(File::Spec->catfile($package_dir, 'BUILD'), "echo build\n");
+        write_bytes(
+            File::Spec->catfile($package_dir, $manifest_name),
+            qq{package = "coding-adventures-pkg"\n-- malformed: } . $bytes . "\n",
+        );
+        my $error = resolve_error($root);
+        assert_metadata_error($error, $root, "code/packages/lua/pkg/$manifest_name");
+    };
+}
+
+subtest 'real CLI reports the stable diagnostic on stderr and exits 2' => sub {
+    my $root = materialize_case(load_case('resolution-lua-invalid-utf8.json'));
+    my ($exit, $stdout, $stderr) = run_cli($root);
+    my $normalized_stderr = $stderr;
+    $normalized_stderr =~ s/\r\n/\n/g;
+    is($exit, 2, 'CLI returns configuration-error exit code 2');
+    is($stdout, '', 'CLI emits no stdout on malformed metadata');
+    is(
+        $normalized_stderr,
+        "METADATA_INVALID_UTF8: package=lua/pkg "
+            . "manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec encoding=UTF-8\n",
+        'CLI emits only the stable diagnostic on stderr',
+    );
+    unlike($stderr, qr/\Q$root\E/, 'CLI diagnostic does not leak the temporary root');
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -242,7 +242,11 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   the stable repository-relative diagnostic, real CLI exit code 2, malformed
   Unicode coverage, and green Ubuntu, macOS, and Windows checks. The selected
   Perl child is now in progress because its raw-byte boundary is the narrowest
-  remaining resolver and Perl 5.38 is locally available;
+  remaining resolver and Perl 5.38 is locally available. Its security gate
+  also discovered that the Perl build tool's `5.026` runtime floor and
+  version-free core-module declarations do not produce an auditable clean
+  dependency floor; that compatibility-policy review is logged as a separate
+  pending child instead of expanding the UTF-8 behavior slice;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,10 +106,9 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `0cbae0ca` after
-merged PR #9553 completed the Swift build-tool identity registry and subsequent
-merges added no implementation package directory. The inventory contains
-1,222 normalized implementation identities across 4,370 established-lane
+working inventory was regenerated on August 2, 2026 from `ec53a3f9` after the
+Perl build-tool branch was rebased onto current `origin/main`. The inventory
+contains 1,224 normalized implementation identities across 4,372 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -117,15 +116,15 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 772 | 10,808 |
+| Present in one language | 774 | 10,836 |
 
-The loop must not start by attempting 10,780 singleton ports. It should finish
+The loop must not start by attempting 10,836 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`0cbae0ca3799671ca7db79e92c5f38b957c2c27e` is collision-clean at 1,222
-normalized implementation identities, 4,370 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 772 singletons, 577
+`ec53a3f9e9b2f31deefc43552a4d48658c49f3f4` is collision-clean at 1,224
+normalized implementation identities, 4,372 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 774 singletons, 579
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
 The seventeen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
@@ -178,6 +177,13 @@ multicast, DNS/TCP, LAN HTTP and HEOS TCP execution,
 timeouts, endpoint approval, CLI I/O, authorization, and runtime mutation remain
 native-host responsibilities.
 
+The same refresh added `chief-of-staff-channel-crypto` and
+`venture-browser-qt`. The former has a portable, vector-testable record,
+framing, epoch, and cryptographic core around explicit entropy, persistence,
+and key-custody boundaries. The latter has a reusable deterministic host-bridge
+contract around a Qt/Cairo/C++ native shell. Both now have explicit backlog
+owners; neither is treated as an unclassified blind all-language port.
+
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
 capability approval, runtime mutation, native executors, and host hardening are
@@ -201,7 +207,7 @@ The August 2 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 983 | 0 | 100% |
+| Rust | 989 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -237,10 +237,12 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   Rust. Merged PR #9537 completed Swift with exact shared success and invalid-
   byte fixtures plus real CLI exit-2 coverage. Merged PR #9572 completed
   TypeScript with strict decoding, exact shared-fixture coverage, and green
-  Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks. Ready PR
-  #9603 is the active Lua child: it validates raw rockspec bytes strictly,
-  consumes both shared fixtures, returns the stable repository-relative
-  diagnostic with real CLI exit code 2, and covers malformed Unicode classes;
+  Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks. Merged PR
+  #9603 completed Lua with strict raw-byte validation, both shared fixtures,
+  the stable repository-relative diagnostic, real CLI exit code 2, malformed
+  Unicode coverage, and green Ubuntu, macOS, and Windows checks. The Perl child
+  is materialized next because its raw-byte boundary is the narrowest remaining
+  resolver and Perl 5.38 is locally available;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -247,8 +247,8 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   #9603 completed Lua with strict raw-byte validation, both shared fixtures,
   the stable repository-relative diagnostic, real CLI exit code 2, malformed
   Unicode coverage, and green Ubuntu, macOS, and Windows checks. The selected
-  Perl child is now in progress because its raw-byte boundary is the narrowest
-  remaining resolver and Perl 5.38 is locally available. Its security gate
+  Ready-for-review PR #9632 is the Perl child because its raw-byte boundary is
+  the narrowest remaining resolver. Its security gate
   also discovered that the Perl build tool's `5.026` runtime floor and
   version-free core-module declarations do not produce an auditable clean
   dependency floor; that compatibility-policy review is logged as a separate

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -240,9 +240,9 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks. Merged PR
   #9603 completed Lua with strict raw-byte validation, both shared fixtures,
   the stable repository-relative diagnostic, real CLI exit code 2, malformed
-  Unicode coverage, and green Ubuntu, macOS, and Windows checks. The Perl child
-  is materialized next because its raw-byte boundary is the narrowest remaining
-  resolver and Perl 5.38 is locally available;
+  Unicode coverage, and green Ubuntu, macOS, and Windows checks. The selected
+  Perl child is now in progress because its raw-byte boundary is the narrowest
+  remaining resolver and Perl 5.38 is locally available;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it


### PR DESCRIPTION
## Summary

- enforce strict UTF-8 decoding at the Perl build tool's raw `.rockspec` boundary before metadata parsing
- surface a typed, stable `METADATA_INVALID_UTF8` diagnostic with package and repository-relative manifest identity, and map only that failure to CLI exit 2
- consume the shared valid/invalid Lua metadata fixtures, preserve the exact success edge set, reject five malformed UTF-8 classes, accept literal U+FFFD, and prevent the rockspec `package` field from becoming a self-dependency
- refresh the collision-checked parity inventory and assign explicit backlog owners to the two newly discovered Rust singleton identities

## Validation

- `prove -lv t/13-resolution-utf8.t`: 9 top-level subtests passed, including the real CLI subprocess contract
- full Perl suite: 14 files / 127 tests passed
- MakeMaker workflow: `cpanm --installdeps --quiet .`, `perl Makefile.PL`, `gmake test` — 127 tests passed
- syntax and Perl::Critic severity 5 passed on changed Perl files (excluding only the pre-existing explicit-return-undef policy)
- Devel::Cover full-suite result: 83.9% aggregate, 73.4% `Resolver.pm`, 96.8% new UTF-8 test
- canonical Go build tool: `go test ./...`, `go vet ./...`, trimpath build passed
- canonical build-file validation: 256 Perl packages discovered and validated, all WOULD-BUILD
- shared contract: 17 schema tests + 40 runner tests passed; valid corpus is 37 cases / 56 files / 15 established languages / 16 implementations / 12 front doors
- real Perl build-tool Lua plan: 258 packages across 4 levels, exit 0
- refreshed parity inventory: 1,224 identities / 4,372 slots / 172 high-consensus packages / 271 high-consensus missing slots / 774 singletons / 579 Rust singletons / 0 collisions / 0 unknown buckets
- `cpan-audit dist Encode 3.21 --json`: 0 advisories; the broader unconstrained Perl/core-module runtime floor is recorded as a separate compatibility-policy backlog item
- `git diff --check`, state graph validation, dependency-edge validation, and changed-diff credential-pattern scan passed

## Scope

This remains one build-tool parity slice. Ruby, Haskell, and Elixir rockspec decoding are separate queued children. The newly observed Chief channel crypto and Venture Qt identities are classified and backlogged; no host-security or native-runtime work is included.