### PR TITLE
fix(symbolic-vm): reject unbounded value growth from self-referential assignment

### DIFF
--- a/code/packages/rust/axiom-runtime/CHANGELOG.md
+++ b/code/packages/rust/axiom-runtime/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## [0.1.1] - 2026-08-02
+
+### Fixed
+
+- **CRITICAL — self-referential reassignment DoS, own bypass of
+  `symbolic-vm`'s shared fix.** A security audit directly reproduced (built
+  and ran the real `axiom` binary) an unbounded value-growth
+  denial-of-service: a self-referential reassignment like `a := a * a` or
+  `a := a + a`, repeated even a handful of times — all inside ONE
+  parenthesised `;`-block (`( a := x + y; a := a * a; ... )`, ~250 bytes) —
+  clones the entire current value of `a` into both operand positions of
+  the new node every step, roughly doubling total node count (and/or
+  nesting depth) each time, hanging/OOMing the process within ~15 steps.
+  `symbolic-vm`'s own `handlers::assign_handler` was fixed with a shared
+  choke-point guard (see that crate's changelog, `MAX_BOUND_VALUE_NODES`/
+  `MAX_BOUND_VALUE_DEPTH`) — but this crate's plain `NAME ASSIGN expr`
+  assignment (`eval::eval_assignment`) does **not** route through it: it
+  evaluates the right-hand side via this crate's own `eval_expr` walker
+  and binds directly through `Backend::bind`, bypassing the shared handler
+  entirely (this crate is an eager AST-walking interpreter, not a
+  lower-then-`VM::eval`-once pipeline, unlike every other CAS-family
+  runtime here — see `eval`'s own module doc comment). Confirmed this
+  bypass is real for BOTH plain assignment and this crate's own iterative
+  arithmetic folding (`eval_binary_chain` still hands each fold step to
+  the shared `symbolic_vm::VM::eval`, so `+`/`*` here hit the identical
+  shared `Add`/`Mul` handlers and are equally exposed).
+- Fixed by applying the identical two checks —
+  `symbolic_vm::handlers::count_nodes_within_cap`/`depth_within_cap`
+  against `MAX_BOUND_VALUE_NODES`/`MAX_BOUND_VALUE_DEPTH` — at this
+  crate's own bind site in `eval_assignment`, immediately before
+  `ctx.vm.backend.bind(...)`. On trip: a clean `Err(EvalError)` through
+  this crate's existing `Result`-based error channel (more direct than a
+  `panic!` + `catch_unwind` round-trip, since `eval_assignment` already
+  returns `Result` for other validation failures such as a `:`-declared
+  domain mismatch) — no architecture change, no new panic path.
+- Added regression tests reproducing the exact audited scenario end-to-end
+  through a real `AxiomSession`, for both `a := a * a` (trips the
+  node-count cap) and `a := a + a` (trips the depth cap — the `Add`
+  flatten-then-left-associate canonicalization this crate shares with
+  every other consumer of `symbolic-vm`'s `add_handler` makes this shape
+  independently dangerous, see `symbolic-vm`'s own changelog), plus a
+  non-false-positive check that a handful of self-multiplications under
+  the caps still evaluates correctly. All three prove the session remains
+  usable afterward.
+- **Secondary fix (review-caught while auditing this incident): display
+  formatting now runs inside the guarded worker thread.**
+  `AxiomSession::eval_to_output`'s success arm used to call
+  `format_value(&value)`/`print_axiom` (both native-recursive) AFTER the
+  worker thread — the one with the enlarged, bounded stack — had already
+  been joined, so a pathologically deep (but under the new node/depth
+  caps) result value's own *printing* recursion ran on the caller's
+  default-size stack, contradicting this module's own doc comment
+  claiming ALL untrusted-input-touching code runs inside the enlarged-
+  stack/`catch_unwind` boundary. Moved the `format_value` call inside the
+  worker closure, before it's joined — no behavior change, same output,
+  just computed on the safe stack.
+- **Secondary fix (LOW severity, addressed since straightforward once
+  found): `eval_binary_chain`'s O(N²) domain-inference cost.**
+  `domains::is_polynomial_over_integers` is a structural, whole-tree walk;
+  the fold loop was calling it (via `AxiomValue::inferred`) on the
+  *accumulator* at every one of N fold steps, and the accumulator grows by
+  one term each step — O(N) work × N steps = O(N²) total for one N-term
+  flat arithmetic chain, despite this crate's own doc comment claiming the
+  iterative fold design "sidesteps the DoS vector by construction" (true
+  only for native-recursion stack depth, not total CPU work). Every
+  intermediate accumulator's inferred domain was discarded anyway — only
+  `.node` ever fed the next fold step — so `eval_binary_chain` now carries
+  a bare `IRNode` through the loop and infers the domain exactly once, on
+  the final result. No behavior change (same final `AxiomValue` for every
+  existing test), now O(N) total instead of O(N²).
+
 ## [0.1.0] - 2026-07-28
 
 ### Added

--- a/code/packages/rust/axiom-runtime/Cargo.toml
+++ b/code/packages/rust/axiom-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-axiom-runtime"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Axiom runtime — lowers Axiom's arithmetic to symbolic-ir/symbolic-vm, and adds a fixed domain/category layer for `:`/`::`/`has`"
 license = "MIT"

--- a/code/packages/rust/axiom-runtime/README.md
+++ b/code/packages/rust/axiom-runtime/README.md
@@ -154,7 +154,7 @@ callers that don't need a persistent session.
 ## Robustness
 
 `feed`/`eval_to_output` are the trust boundary for arbitrary Axiom source —
-**four** independent recursion/panic vectors are closed, not three:
+**five** independent recursion/panic/growth vectors are closed, not four:
 
 1. **Deeply nested source** (`((((…))))`) — already rejected by
    `axiom-parser`'s own `MAX_RULE_DEPTH`.
@@ -174,7 +174,26 @@ callers that don't need a persistent session.
    incident this was added to close in review (this crate used to delegate
    function calls to `symbolic_vm`'s own uncapped mechanism, and a genuine
    native stack overflow is not catchable by `catch_unwind` at all).
-4. **Unwinding panics** from the reused shared handler table run inside
+4. **Unbounded self-referential-reassignment growth** — `a := a * a` or
+   `a := a + a`, repeated even a handful of times (all inside ONE
+   parenthesised `;`-block, `( a := x + y; a := a * a; ... )`, ~250 bytes),
+   clones the current value of `a` into both operand positions of the new
+   node every step, roughly *doubling* its node count (`a := a * a`) and/or
+   nesting depth (`a := a + a`, which additionally hits the shared `Add`
+   handler's flatten-then-left-associate canonicalization) on every step —
+   a *fourth*, independent vector: none of the first three bound the size
+   of a value already sitting bound in the environment before it gets
+   combined with itself again. Closed by applying `symbolic_vm::handlers::
+   count_nodes_within_cap`/`depth_within_cap` (against `MAX_BOUND_VALUE_
+   NODES`/`MAX_BOUND_VALUE_DEPTH`) at this crate's own `eval_assignment`
+   bind site — this crate's plain assignment binds directly through
+   `Backend::bind` rather than through `symbolic-vm`'s shared
+   `assign_handler` the way every other CAS-family runtime here does (see
+   `eval`'s own module doc comment), so it needed this fix applied at its
+   own bypass point, not just at the shared choke point. See
+   `symbolic-vm`'s own README/changelog for the full mechanism and why two
+   independent budgets (node count *and* depth) are both necessary.
+5. **Unwinding panics** from the reused shared handler table run inside
    `catch_unwind` on a worker thread with a large bounded stack; the session
    (VM environment, declared-domain table, *and* function table) is rebuilt
    afterward rather than left corrupted. This is a narrower guarantee than
@@ -198,4 +217,8 @@ correctness delegated to the shared engine; `:=`/`==`/`if`/block evaluation
 disclosed function-body restriction; the `MAX_CALL_DEPTH` guard (both on a
 generously-sized worker-thread stack, confirming the cap — not the stack —
 is what trips, and on a deliberately small one, confirming the cap trips
-*before* any native overflow risk); and all four robustness guards.
+*before* any native overflow risk); the self-referential-reassignment
+growth guard (both `a := a * a` and `a := a + a`, reproducing the exact
+audited scenario, plus a non-false-positive check that a handful of
+self-multiplications under the caps still evaluates correctly); and all
+five robustness guards.

--- a/code/packages/rust/axiom-runtime/src/eval.rs
+++ b/code/packages/rust/axiom-runtime/src/eval.rs
@@ -344,6 +344,58 @@ fn eval_assignment(ctx: &mut EvalContext, node: &GrammarASTNode) -> Result<Axiom
         (rhs.node, rhs.domain)
     };
 
+    // Self-referential reassignment guard -- see `symbolic_vm::handlers::
+    // MAX_BOUND_VALUE_NODES`/`MAX_BOUND_VALUE_DEPTH`'s own doc comments for
+    // the full incident this closes: repeated `a := a * a` doubles the
+    // bound value's node count every step (reaching millions of nodes from
+    // a few hundred bytes of source); repeated `a := a + a` ALSO doubles
+    // nesting depth (via the shared `Add` handler's flatten-then-left-
+    // associate canonicalization), which is independently dangerous
+    // because a too-deep bound value can overflow the native stack on the
+    // very NEXT lookup -- an uncatchable process abort, not a catchable
+    // error -- before a node-count check on that next statement's result
+    // would ever get a chance to run.
+    //
+    // This crate's plain `NAME ASSIGN expr` assignment does NOT lower to
+    // `symbolic_ir::ASSIGN` and go through `symbolic_vm`'s shared
+    // `assign_handler` the way every other CAS-family runtime's does (see
+    // this module's own doc comment for why: Axiom is an eager AST-walking
+    // interpreter, not a lower-then-`VM::eval`-once pipeline) -- it binds
+    // directly through `ctx.vm.backend.bind` below, bypassing that shared
+    // choke point entirely. Axiom's own `+`/`*`/etc. still fold through
+    // `symbolic_vm::VM::eval` one step at a time (this module's own doc
+    // comment, "Pure arithmetic ... is still reused unchanged"), so it hits
+    // the identical shared `Add`/`Mul` handlers and is equally exposed to
+    // both growth axes -- applying the identical, shared budget checks here
+    // closes the same hole at Axiom's own bind site rather than leaving it
+    // open behind a guard that only covers the other runtimes.
+    if symbolic_vm::handlers::count_nodes_within_cap(
+        &stored_node,
+        symbolic_vm::handlers::MAX_BOUND_VALUE_NODES,
+    )
+    .is_none()
+    {
+        return Err(EvalError::new(format!(
+            "Assign target '{name}' would bind a value exceeding {} nodes -- rejecting to \
+             prevent unbounded growth from self-referential reassignment (e.g. repeated \
+             '{name} := {name} * {name}')",
+            symbolic_vm::handlers::MAX_BOUND_VALUE_NODES
+        )));
+    }
+    if symbolic_vm::handlers::depth_within_cap(
+        &stored_node,
+        symbolic_vm::handlers::MAX_BOUND_VALUE_DEPTH,
+    )
+    .is_none()
+    {
+        return Err(EvalError::new(format!(
+            "Assign target '{name}' would bind a value nested deeper than {} levels -- \
+             rejecting to prevent unbounded growth from self-referential reassignment \
+             (e.g. repeated '{name} := {name} + {name}')",
+            symbolic_vm::handlers::MAX_BOUND_VALUE_DEPTH
+        )));
+    }
+
     ctx.vm.backend.bind(&name, stored_node.clone());
     Ok(AxiomValue {
         node: stored_node,
@@ -513,7 +565,21 @@ fn eval_binary_chain(
     let first = children
         .next()
         .ok_or_else(|| EvalError::new("empty binary chain"))?;
-    let mut acc = eval_expr_child(ctx, first)?;
+    // Carry the bare `IRNode` through the fold, not a domain-inferred
+    // `AxiomValue` -- a review-caught O(N^2) cost: `AxiomValue::inferred`
+    // calls `domains::is_polynomial_over_integers`, which walks the WHOLE
+    // node structurally. Calling it on the accumulator at every one of N
+    // fold steps re-walks an accumulator that grows by one step each time,
+    // giving O(N^2) total work for one N-term chain -- despite this
+    // function's own iterative, one-fold-at-a-time shape already being O(N)
+    // for the actual arithmetic (the shape this module's doc comment
+    // credits with "sidestepping the flat-repetition DoS vector by
+    // construction" -- true for native-recursion STACK DEPTH, which this
+    // fix doesn't change, but not for total CPU work, which it does).
+    // Every intermediate accumulator's `.domain` is discarded anyway (only
+    // `.node` ever feeds the next fold step), so there is no behavior
+    // change: domain inference now runs exactly ONCE, on the final result.
+    let mut acc = eval_expr_child(ctx, first)?.node;
     while let Some(op_child) = children.next() {
         let head = as_token(op_child)
             .and_then(|t| head_of(token_type(t)))
@@ -522,10 +588,9 @@ fn eval_binary_chain(
             .next()
             .ok_or_else(|| EvalError::new("binary operator with no right operand"))?;
         let rhs = eval_expr_child(ctx, rhs_child)?;
-        let result = ctx.vm.eval(apply(sym(head), vec![acc.node, rhs.node]));
-        acc = AxiomValue::inferred(result);
+        acc = ctx.vm.eval(apply(sym(head), vec![acc, rhs.node]));
     }
-    Ok(acc)
+    Ok(AxiomValue::inferred(acc))
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/axiom-runtime/src/lib.rs
+++ b/code/packages/rust/axiom-runtime/src/lib.rs
@@ -263,11 +263,18 @@ impl AxiomSession {
 
         // Guards 2-3 + panics: run entirely on a worker thread with a large
         // bounded stack, inside `catch_unwind`, so that EVERY step touching
-        // untrusted `src` -- lexing for the token-count guard, parsing, and
-        // evaluation -- is covered by the same panic boundary (Guard 2 used
-        // to run on the caller's own thread, outside `catch_unwind`; moved
-        // in here so a hypothetical future lexer panic can never escape
-        // uncaught either).
+        // untrusted `src` -- lexing for the token-count guard, parsing,
+        // evaluation, AND display formatting -- is covered by the same
+        // panic boundary and the same enlarged stack (Guard 2 used to run
+        // on the caller's own thread, outside `catch_unwind`; moved in here
+        // so a hypothetical future lexer panic can never escape uncaught
+        // either. `format_value`/`print_axiom` used to run AFTER the worker
+        // was joined, back on the caller's own default-size stack -- a
+        // review-caught gap: a pathologically deep, but under the node/
+        // depth caps above, result value could defeat this module's own
+        // stack-size guarantee purely by being *printed* rather than
+        // evaluated. Formatting the value here, before the thread is
+        // joined, closes that gap).
         let vm = &mut self.vm;
         let declared = &mut self.declared_domains;
         let functions = &mut self.functions;
@@ -278,7 +285,8 @@ impl AxiomSession {
                 .spawn_scoped(scope, || {
                     catch_unwind(AssertUnwindSafe(|| {
                         check_statement_token_count(&src_owned)?;
-                        eval_source(vm, declared, functions, &src_owned)
+                        let value = eval_source(vm, declared, functions, &src_owned)?;
+                        Ok::<String, String>(format_value(&value))
                     }))
                 })
                 .expect("failed to spawn axiom evaluation thread")
@@ -286,9 +294,8 @@ impl AxiomSession {
         });
 
         match outcome {
-            Ok(Ok(Ok(value))) => {
+            Ok(Ok(Ok(text))) => {
                 self.output_index += 1;
-                let text = format_value(&value);
                 Ok(Output {
                     index: self.output_index,
                     text,
@@ -769,6 +776,81 @@ mod tests {
             assert!(s.feed("loop(1)").is_err());
         });
         handle.join().expect("must not crash the worker thread");
+    }
+
+    // --- Self-referential-reassignment DoS guard (see crate::eval's own
+    // `eval_assignment`, and `symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`/
+    // `MAX_BOUND_VALUE_DEPTH`'s own doc comments) -- a security audit found
+    // that `a := a * a` / `a := a + a`, repeated even a handful of times
+    // inside ONE parenthesised `;`-block (`axiom.grammar`'s `group = LPAREN
+    // expr { SEMI expr } RPAREN`), doubles the bound value's node count
+    // and/or nesting depth every step, reaching millions of nodes from a
+    // ~250-byte program. Axiom's own plain assignment binds directly
+    // through `Backend::bind` rather than through `symbolic_vm`'s shared
+    // `assign_handler`, so this crate needed its OWN copy of the guard at
+    // its own bind site -- these tests reproduce the exact reported
+    // scenario end-to-end through a real `AxiomSession`.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn self_referential_multiplication_inside_one_block_is_rejected_cleanly() {
+        // The exact audited scenario: `( a := x + y; a := a * a; a := a *
+        // a; ... )`, all inside ONE `feed` call. 30 repetitions is far past
+        // the real trip point (~15th step) -- without the guard this
+        // reaches billions of nodes; with it, a clean `Err` in well under a
+        // second, and the session remains usable afterward.
+        let mut src = String::from("(a := x + y");
+        for _ in 0..30 {
+            src.push_str("; a := a * a");
+        }
+        src.push(')');
+        assert!(src.len() < 500, "source should stay tiny: {} bytes", src.len());
+
+        let mut s = AxiomSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(err.contains("nodes"), "expected a node-count rejection, got {err:?}");
+        // The session must remain usable afterward -- a clean `Err` does
+        // not rebuild the session (only a caught panic does; see
+        // `session_survives_a_rejected_deep_recursion_and_keeps_working`
+        // above for the identical pattern with the call-depth guard).
+        assert_eq!(s.feed("2 + 2").unwrap(), "(1) 4 : PositiveInteger\n");
+    }
+
+    #[test]
+    fn self_referential_addition_inside_one_block_is_rejected_cleanly() {
+        // Same attack shape via the audit's other named example, `a := a +
+        // a`. This one trips the DEPTH guard, not the node-count guard --
+        // `Add`'s own flatten-then-left-associate canonicalization
+        // (Phase 47, shared via `symbolic_vm`) rebuilds a chain whose depth
+        // equals its leaf count, and leaf count doubles too. Without a
+        // depth guard this reproduces a genuine, uncatchable native stack
+        // overflow (not merely a slow hang) on a later statement's symbol
+        // lookup -- see `MAX_BOUND_VALUE_DEPTH`'s own doc comment in
+        // `symbolic-vm` for the full mechanism.
+        let mut src = String::from("(a := x + y");
+        for _ in 0..30 {
+            src.push_str("; a := a + a");
+        }
+        src.push(')');
+
+        let mut s = AxiomSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(
+            err.contains("levels"),
+            "expected a nesting-depth rejection, got {err:?}"
+        );
+        assert_eq!(s.feed("2 + 2").unwrap(), "(1) 4 : PositiveInteger\n");
+    }
+
+    #[test]
+    fn a_handful_of_self_multiplications_under_the_cap_still_evaluate_correctly() {
+        // Non-false-positive check: a FEW self-referential reassignments,
+        // comfortably under the caps, must still evaluate normally and
+        // produce the mathematically correct result -- the guard must trip
+        // on VALUE SIZE, not merely on a variable referencing itself.
+        let mut s = AxiomSession::new();
+        s.feed("(a := 2; a := a * a; a := a * a)").unwrap(); // 2 -> 4 -> 16
+        assert_eq!(s.feed("a").unwrap(), "(2) 16 : PositiveInteger\n");
     }
 
     // --- Robustness guards ---------------------------------------------------

--- a/code/packages/rust/derive-runtime/CHANGELOG.md
+++ b/code/packages/rust/derive-runtime/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.2.1] - 2026-08-02
+
+### Fixed
+
+- **CRITICAL — self-referential reassignment DoS, shared fix (no bypass
+  here).** A security audit found and directly reproduced (built and ran
+  the real `derive-repl` binary, source ~250 bytes) an unbounded
+  value-growth denial-of-service in `symbolic-vm`'s shared
+  `handlers::assign_handler`: `a := a * a` / `a := a + a`, repeated even a
+  handful of times, doubles the bound value's node count and/or nesting
+  depth every step, reaching millions of nodes within ~15 steps and
+  hanging/OOMing the process. Fixed at the shared choke point
+  (`symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`/`MAX_BOUND_VALUE_DEPTH`,
+  see that crate's own changelog for the full mechanism, including a
+  second independent growth axis found while writing this crate's own
+  `a := a + a` regression test — that shape hits the shared `Add`
+  handler's own flatten-then-left-associate canonicalization and needs a
+  *depth* cap, not just the node-count cap, or it reproduces a genuine
+  uncatchable native stack overflow rather than a clean error). Verified
+  this crate's own `:=` lowers straight to `symbolic_ir::ASSIGN`
+  (`lower.rs`) and evaluates through the shared `vm.eval` (`eval_source`'s
+  per-statement loop) — no crate-specific bypass, so no code change was
+  needed here, just proof of coverage. Added regression tests reproducing
+  the exact audited scenario end-to-end through a real `DeriveSession` as
+  a multi-line worksheet (both the node-count-tripping `a := a * a` shape
+  and the depth-tripping `a := a + a` shape), plus a non-false-positive
+  check that a handful of self-multiplications under the caps still
+  evaluates correctly. The worker-thread `catch_unwind` this crate already
+  had in place correctly converts the new panic into a clean `Err` and
+  rebuilds the session, exactly as it does for the existing malformed-
+  assign-lhs case.
+
 ## [0.2.0] - 2026-07-14
 
 ### Added

--- a/code/packages/rust/derive-runtime/Cargo.toml
+++ b/code/packages/rust/derive-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-derive-runtime"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Derive runtime — lowers Derive syntax to symbolic-ir and evaluates via symbolic-vm"
 license = "MIT"

--- a/code/packages/rust/derive-runtime/README.md
+++ b/code/packages/rust/derive-runtime/README.md
@@ -80,8 +80,8 @@ callers that don't need a persistent session.
 ## Robustness
 
 `feed`/`eval_to_outputs` are the trust boundary for arbitrary Derive source.
-Two independent deep-recursion vectors are closed (see the crate doc
-comment for the full rationale):
+Three independent deep-recursion/growth vectors are closed (see the crate
+doc comment for the full rationale):
 
 1. **Deeply nested source** (`((((…))))`) — already rejected by
    `derive-parser`'s own `MAX_RULE_DEPTH`.
@@ -89,10 +89,23 @@ comment for the full rationale):
    lowered tree — grammar repetitions aren't bounded by `MAX_RULE_DEPTH`, so
    `MAX_STATEMENT_TOKENS` (measured against the real lexer token stream)
    closes this separately.
+3. **Unbounded self-referential-reassignment growth** — `a := a * a` / `a
+   := a + a`, repeated even a handful of times, doubles the bound value's
+   node count and/or nesting depth every step (a security audit's
+   finding). Neither guard above bounds the size of a value already
+   sitting in the environment before it gets combined with itself again.
+   This one is closed in the shared `symbolic-vm` crate itself
+   (`handlers::assign_handler`'s `MAX_BOUND_VALUE_NODES`/
+   `MAX_BOUND_VALUE_DEPTH` checks, run before every `:=` durably binds) —
+   this crate's own `:=` lowers straight to `symbolic_ir::ASSIGN` and
+   evaluates through that same shared handler with no bypass, so it is
+   protected automatically; see `symbolic-vm`'s own README/changelog for
+   the full mechanism.
 
 Evaluation itself runs on a worker thread with a large bounded stack inside
-`catch_unwind`, so a reused-handler panic (e.g. a malformed `Assign` LHS)
-becomes a clean `Err` and the session is rebuilt rather than left corrupted.
+`catch_unwind`, so a reused-handler panic (e.g. a malformed `Assign` LHS,
+or the new self-referential-reassignment guard tripping) becomes a clean
+`Err` and the session is rebuilt rather than left corrupted.
 
 ## Tests
 
@@ -102,5 +115,6 @@ cargo test -p coding-adventures-derive-runtime
 
 Unit tests for every `lower`/`printer` construct, plus end-to-end session
 tests: arithmetic, persistent assignment/user-defined functions, `DIF`/`INT`/`IF`
-wiring through the shared handler table, the two robustness guards, and
+wiring through the shared handler table, all three robustness guards
+(including the exact audited self-referential-reassignment scenario), and
 panic recovery.

--- a/code/packages/rust/derive-runtime/src/lib.rs
+++ b/code/packages/rust/derive-runtime/src/lib.rs
@@ -447,6 +447,73 @@ mod tests {
         assert_eq!(s.feed("2 + 2\n").unwrap(), "#1: 4\n");
     }
 
+    // --- Self-referential-reassignment DoS guard (a security audit's
+    // finding, shared with every consumer of `symbolic-vm`'s
+    // `assign_handler` -- see `symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`
+    // / `MAX_BOUND_VALUE_DEPTH`'s own doc comments) -- `a := a * a` /
+    // `a := a + a`, repeated even a handful of times, doubles the bound
+    // value's node count and/or nesting depth every step, reaching
+    // millions of nodes from a few hundred bytes of source. Derive lowers
+    // its own `:=` straight to `symbolic_ir::ASSIGN` and evaluates through
+    // the shared `vm.eval`, so it is protected by the same choke-point fix
+    // with no crate-specific bypass work needed -- these tests prove that
+    // end-to-end through a real `DeriveSession`.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn self_referential_multiplication_worksheet_is_rejected_cleanly() {
+        // The exact audited scenario, as a Derive worksheet (derive.grammar's
+        // `program = { statement_line }` accepts many newline-terminated
+        // statements in ONE `feed` call): `a := x + y` then `a := a * a`
+        // repeated. 30 repetitions is far past the real trip point (~15th
+        // step) -- without the guard this reaches billions of nodes; with
+        // it, a clean `Err` in well under a second.
+        let mut src = String::from("a := x + y\n");
+        for _ in 0..30 {
+            src.push_str("a := a * a\n");
+        }
+        assert!(src.len() < 500, "source should stay tiny: {} bytes", src.len());
+
+        let mut s = DeriveSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(err.contains("nodes"), "expected a node-count rejection, got {err:?}");
+        // The worker-thread `catch_unwind` rebuilds the session on panic —
+        // it must remain usable afterward.
+        assert_eq!(s.feed("2 + 2\n").unwrap(), "#1: 4\n");
+    }
+
+    #[test]
+    fn self_referential_addition_worksheet_is_rejected_cleanly() {
+        // Same attack shape via the audit's other named example, `a := a +
+        // a`. This one trips the DEPTH guard, not the node-count guard --
+        // `Add`'s own flatten-then-left-associate canonicalization rebuilds
+        // a chain whose depth equals its leaf count, and leaf count doubles
+        // too. Without a depth guard this reproduces a genuine, uncatchable
+        // native stack overflow on a later statement's symbol lookup, not
+        // merely a slow hang.
+        let mut src = String::from("a := x + y\n");
+        for _ in 0..30 {
+            src.push_str("a := a + a\n");
+        }
+
+        let mut s = DeriveSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(
+            err.contains("levels"),
+            "expected a nesting-depth rejection, got {err:?}"
+        );
+        assert_eq!(s.feed("2 + 2\n").unwrap(), "#1: 4\n");
+    }
+
+    #[test]
+    fn a_handful_of_self_multiplications_under_the_cap_still_evaluate_correctly() {
+        // Non-false-positive check: a FEW self-referential reassignments,
+        // comfortably under the caps, must still evaluate normally.
+        let mut s = DeriveSession::new();
+        s.feed("a := 2\na := a * a\na := a * a\n").unwrap(); // 2 -> 4 -> 16
+        assert_eq!(s.feed("a\n").unwrap(), "#4: 16\n");
+    }
+
     #[test]
     fn vector_literal_evaluates_elementwise() {
         // [1+1, 2*3, 2^3] -> [2, 6, 8] — a List's own head is data (held), but

--- a/code/packages/rust/macsyma-wasm/CHANGELOG.md
+++ b/code/packages/rust/macsyma-wasm/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.1.1
+
+- **CRITICAL — self-referential reassignment DoS, shared fix (no bypass
+  here).** A security audit found and directly reproduced (against the
+  `derive-repl` binary) an unbounded value-growth denial-of-service in
+  `symbolic-vm`'s shared `handlers::assign_handler`: `a: a * a` / `a: a +
+  a` (Macsyma's `:` assignment), repeated even a handful of times,
+  doubles the bound value's node count and/or nesting depth every step,
+  reaching millions of nodes from a few hundred bytes of source. Fixed at
+  the shared choke point (`symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`/
+  `MAX_BOUND_VALUE_DEPTH`, see that crate's own changelog for the full
+  mechanism). Verified `coding-adventures-macsyma-runtime`'s own `:`
+  assignment lowers straight to `symbolic_ir::ASSIGN` and evaluates
+  through the shared `vm.eval` (via `MacsymaBackend`'s handler table,
+  built from `symbolic_vm::handlers::build_handler_table` with no
+  override for `Assign`) — no crate-specific bypass, so no code change was
+  needed in `macsyma-runtime` itself. `macsyma-runtime`'s own `eval_source`
+  has no `catch_unwind` boundary of its own — this crate is where that
+  boundary actually lives for Macsyma's real deployed surface
+  (`catch_parser_panics`, wrapping `eval_source` inside `eval_json`) — so
+  the regression tests reproducing the exact audited scenario end-to-end
+  (both the node-count-tripping `a: a * a` shape and the depth-tripping
+  `a: a + a` shape — the shared `Add` handler's flatten-then-left-
+  associate canonicalization makes that shape independently dangerous,
+  see `symbolic-vm`'s changelog) live here, plus a non-false-positive
+  check that a handful of self-multiplications under the caps still
+  evaluates correctly.
+
 ## 0.1.0
 
 - Add JSON-oriented WASM facade for the Rust MACSYMA runtime.

--- a/code/packages/rust/macsyma-wasm/Cargo.toml
+++ b/code/packages/rust/macsyma-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-macsyma-wasm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "JSON support facade for the Rust MACSYMA WASM bindings"
 license = "MIT"

--- a/code/packages/rust/macsyma-wasm/README.md
+++ b/code/packages/rust/macsyma-wasm/README.md
@@ -8,3 +8,21 @@ source text and receive JSON strings containing display metadata, pretty
 MACSYMA text, Lisp-style IR text, recursive IR JSON, and session history
 indices. The actual `wasm-bindgen` exports live in
 `code/packages/wasm/macsyma-runtime`.
+
+## Robustness
+
+`eval_json`/`eval_source_json` wrap `MacsymaSession::eval_source` in
+`catch_parser_panics` (`catch_unwind`), so a panic anywhere in the reused
+evaluation stack — `macsyma-runtime`'s own `eval_source` has no
+`catch_unwind` boundary of its own — becomes a clean `{"ok": false,
+"error": {...}}` JSON response rather than crashing the process. This is
+where that boundary actually lives for Macsyma's real deployed surface.
+
+This includes the shared `symbolic-vm::handlers::assign_handler`'s
+self-referential-reassignment guard (`a: a * a` / `a: a + a`, repeated,
+doubling the bound value's node count and/or nesting depth every step — a
+security audit's finding; see `symbolic-vm`'s own README/changelog for the
+full mechanism): Macsyma's own `:` assignment lowers straight to
+`symbolic_ir::ASSIGN` and evaluates through that shared handler with no
+crate-specific bypass, so it is protected automatically and surfaces here
+as an ordinary clean error, not a crash.

--- a/code/packages/rust/macsyma-wasm/src/lib.rs
+++ b/code/packages/rust/macsyma-wasm/src/lib.rs
@@ -328,6 +328,83 @@ mod tests {
             .starts_with("Incorrect syntax at line 1, column "));
     }
 
+    // --- Self-referential-reassignment DoS guard (a security audit's
+    // finding, shared with every consumer of `symbolic-vm`'s
+    // `assign_handler` -- see `symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`
+    // / `MAX_BOUND_VALUE_DEPTH`'s own doc comments) -- `a: a * a` /
+    // `a: a + a`, repeated even a handful of times, doubles the bound
+    // value's node count and/or nesting depth every step, reaching millions
+    // of nodes from a few hundred bytes of source. `macsyma-runtime` lowers
+    // its own `:` assignment straight to `symbolic_ir::ASSIGN` and evaluates
+    // through the shared `vm.eval`, so it is protected by the same
+    // choke-point fix with no crate-specific bypass work needed. Unlike the
+    // other CAS-family runtimes, `macsyma-runtime`'s own `eval_source` has
+    // no `catch_unwind` boundary of its own -- this crate (`macsyma-wasm`)
+    // is where that boundary actually lives for Macsyma's real deployed
+    // surface (`catch_parser_panics`, above), so these regression tests
+    // exercise it here.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn self_referential_multiplication_is_rejected_cleanly() {
+        // The exact audited scenario, as `$`-terminated Macsyma statements
+        // (`program = { statement }` accepts many in one call): `a: x + y`
+        // then `a: a * a` repeated. 30 repetitions is far past the real
+        // trip point (~15th step) -- without the guard this reaches
+        // billions of nodes; with it, a clean JSON error in well under a
+        // second.
+        let mut src = String::from("a: x + y$ ");
+        for _ in 0..30 {
+            src.push_str("a: a * a$ ");
+        }
+        assert!(src.len() < 500, "source should stay tiny: {} bytes", src.len());
+
+        let mut session = MacsymaWasmSession::new();
+        let payload = json(&session.eval_json(&src));
+        assert_eq!(payload["ok"], false);
+        let message = payload["error"]["message"].as_str().unwrap();
+        assert!(message.contains("nodes"), "expected a node-count rejection, got {message:?}");
+
+        // `catch_parser_panics` must leave the session usable afterward.
+        let recovered = json(&session.eval_json("2 + 2;"));
+        assert_eq!(recovered["results"][0]["output_macsyma"], "4");
+    }
+
+    #[test]
+    fn self_referential_addition_is_rejected_cleanly() {
+        // Same attack shape via the audit's other named example, `a: a +
+        // a`. This one trips the DEPTH guard, not the node-count guard --
+        // `Add`'s own flatten-then-left-associate canonicalization rebuilds
+        // a chain whose depth equals its leaf count, and leaf count doubles
+        // too. Without a depth guard this reproduces a genuine, uncatchable
+        // native stack overflow on a later statement's symbol lookup, not
+        // merely a slow hang.
+        let mut src = String::from("a: x + y$ ");
+        for _ in 0..30 {
+            src.push_str("a: a + a$ ");
+        }
+
+        let mut session = MacsymaWasmSession::new();
+        let payload = json(&session.eval_json(&src));
+        assert_eq!(payload["ok"], false);
+        let message = payload["error"]["message"].as_str().unwrap();
+        assert!(message.contains("levels"), "expected a nesting-depth rejection, got {message:?}");
+
+        let recovered = json(&session.eval_json("2 + 2;"));
+        assert_eq!(recovered["results"][0]["output_macsyma"], "4");
+    }
+
+    #[test]
+    fn a_handful_of_self_multiplications_under_the_cap_still_evaluate_correctly() {
+        // Non-false-positive check: a FEW self-referential reassignments,
+        // comfortably under the caps, must still evaluate normally.
+        let mut session = MacsymaWasmSession::new();
+        session.eval_json("a: 2$ a: a * a$ a: a * a$"); // 2 -> 4 -> 16
+        let payload = json(&session.eval_json("a;"));
+        assert_eq!(payload["ok"], true);
+        assert_eq!(payload["results"][0]["output_macsyma"], "16");
+    }
+
     #[test]
     fn reports_help_queries_as_json_visible_output() {
         let payload = json(&eval_source_json("? solve"));

--- a/code/packages/rust/maple-runtime/CHANGELOG.md
+++ b/code/packages/rust/maple-runtime/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.1.1] - 2026-08-02
+
+### Fixed
+
+- **CRITICAL — self-referential reassignment DoS, shared fix (no bypass
+  here).** A security audit found and directly reproduced (against the
+  `derive-repl` binary) an unbounded value-growth denial-of-service in
+  `symbolic-vm`'s shared `handlers::assign_handler`: `a := a * a` / `a :=
+  a + a`, repeated even a handful of times, doubles the bound value's node
+  count and/or nesting depth every step, reaching millions of nodes from a
+  few hundred bytes of source. Fixed at the shared choke point
+  (`symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`/`MAX_BOUND_VALUE_DEPTH`,
+  see that crate's own changelog for the full mechanism). Verified this
+  crate's own `:=` lowers straight to `symbolic_ir::ASSIGN` and evaluates
+  through the shared `vm.eval` (`eval_source`'s per-statement loop) — no
+  crate-specific bypass, so no code change was needed here, just proof of
+  coverage. Added regression tests reproducing the exact audited scenario
+  end-to-end through a real `MapleSession` (both the node-count-tripping
+  `a := a * a` shape and the depth-tripping `a := a + a` shape — the
+  shared `Add` handler's flatten-then-left-associate canonicalization
+  makes that shape independently dangerous, see `symbolic-vm`'s changelog),
+  plus a non-false-positive check that a handful of self-multiplications
+  under the caps still evaluates correctly.
+
 ## [0.1.0] - 2026-07-19
 
 ### Added

--- a/code/packages/rust/maple-runtime/Cargo.toml
+++ b/code/packages/rust/maple-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-maple-runtime"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Maple runtime — lowers Maple syntax to symbolic-ir and evaluates via symbolic-vm (MP-4)"
 license = "MIT"

--- a/code/packages/rust/maple-runtime/README.md
+++ b/code/packages/rust/maple-runtime/README.md
@@ -136,8 +136,8 @@ mean the narrower remember-table thing.
 ## Robustness
 
 `feed`/`eval_to_outputs` are the trust boundary for arbitrary Maple source.
-Two independent deep-recursion vectors are closed (see the crate doc
-comment for the full rationale):
+Three independent deep-recursion/growth vectors are closed (see the crate
+doc comment for the full rationale):
 
 1. **Deeply nested source** (parenthesised, list/set-literal nesting,
    `not`/unary-minus prefix chains, a flat `^` chain, or nested `if`/`end
@@ -156,13 +156,27 @@ comment for the full rationale):
    top-level statement boundary (this subset has no bare compound-statement
    grouping construct the way REDUCE's `<< ... >>` is — MA09 §4 defers bare
    expression sequences entirely).
+3. **Unbounded self-referential-reassignment growth** — `a := a * a` / `a
+   := a + a`, repeated even a handful of times, doubles the bound value's
+   node count and/or nesting depth every step (a security audit's
+   finding). Neither guard above bounds the size of a value already
+   sitting in the environment before it gets combined with itself again.
+   This one is closed in the shared `symbolic-vm` crate itself
+   (`handlers::assign_handler`'s `MAX_BOUND_VALUE_NODES`/
+   `MAX_BOUND_VALUE_DEPTH` checks, run before every `:=` durably binds) —
+   this crate's own `:=` lowers straight to `symbolic_ir::ASSIGN` and
+   evaluates through that same shared handler with no bypass, so it is
+   protected automatically; see `symbolic-vm`'s own README/changelog for
+   the full mechanism.
 
 Evaluation itself runs on a worker thread with a large bounded stack inside
 `catch_unwind`, so a reused-handler panic (e.g. a wrong-arity `diff(x)`
-call) becomes a clean `Err` and the session is rebuilt rather than left
-corrupted. Maple's grammar-enforced bare-`NAME` `Assign`/`Define`
-left-hand side means, unlike Reduce's, there is no malformed-`Assign`-lhs
-panic vector at all in this crate.
+call, or the self-referential-reassignment guard tripping) becomes a clean
+`Err` and the session is rebuilt rather than left corrupted. Maple's
+grammar-enforced bare-`NAME` `Assign`/`Define` left-hand side means, unlike
+Reduce's, there is no malformed-`Assign`-lhs panic vector at all in this
+crate — the self-referential-reassignment guard is a separate vector,
+gated on bound-value *size*, not lhs shape.
 
 ## Out-of-scope constructs are rejected at parse time (MA09 §4)
 

--- a/code/packages/rust/maple-runtime/src/lib.rs
+++ b/code/packages/rust/maple-runtime/src/lib.rs
@@ -698,6 +698,73 @@ mod tests {
         assert_eq!(s.feed("2 + 2;\n").unwrap(), "4\n");
     }
 
+    // --- Self-referential-reassignment DoS guard (a security audit's
+    // finding, shared with every consumer of `symbolic-vm`'s
+    // `assign_handler` -- see `symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`
+    // / `MAX_BOUND_VALUE_DEPTH`'s own doc comments) -- `a := a * a` /
+    // `a := a + a`, repeated even a handful of times, doubles the bound
+    // value's node count and/or nesting depth every step, reaching millions
+    // of nodes from a few hundred bytes of source. Maple lowers its own
+    // `:=` straight to `symbolic_ir::ASSIGN` and evaluates through the
+    // shared `vm.eval`, so it is protected by the same choke-point fix with
+    // no crate-specific bypass work needed -- these tests prove that
+    // end-to-end through a real `MapleSession`.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn self_referential_multiplication_worksheet_is_rejected_cleanly() {
+        // The exact audited scenario, as a Maple worksheet
+        // (maple.grammar's `;`/`:`-terminated statement sequence accepts
+        // many statements in ONE `feed` call): `a := x + y` then
+        // `a := a * a` repeated. 30 repetitions is far past the real trip
+        // point (~15th step) -- without the guard this reaches billions of
+        // nodes; with it, a clean `Err` in well under a second.
+        let mut src = String::from("a := x + y;\n");
+        for _ in 0..30 {
+            src.push_str("a := a * a;\n");
+        }
+        assert!(src.len() < 500, "source should stay tiny: {} bytes", src.len());
+
+        let mut s = MapleSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(err.contains("nodes"), "expected a node-count rejection, got {err:?}");
+        // The worker-thread `catch_unwind` rebuilds the session on panic —
+        // it must remain usable afterward.
+        assert_eq!(s.feed("2 + 2;\n").unwrap(), "4\n");
+    }
+
+    #[test]
+    fn self_referential_addition_worksheet_is_rejected_cleanly() {
+        // Same attack shape via the audit's other named example, `a := a +
+        // a`. This one trips the DEPTH guard, not the node-count guard --
+        // `Add`'s own flatten-then-left-associate canonicalization rebuilds
+        // a chain whose depth equals its leaf count, and leaf count doubles
+        // too. Without a depth guard this reproduces a genuine, uncatchable
+        // native stack overflow on a later statement's symbol lookup, not
+        // merely a slow hang.
+        let mut src = String::from("a := x + y;\n");
+        for _ in 0..30 {
+            src.push_str("a := a + a;\n");
+        }
+
+        let mut s = MapleSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(
+            err.contains("levels"),
+            "expected a nesting-depth rejection, got {err:?}"
+        );
+        assert_eq!(s.feed("2 + 2;\n").unwrap(), "4\n");
+    }
+
+    #[test]
+    fn a_handful_of_self_multiplications_under_the_cap_still_evaluate_correctly() {
+        // Non-false-positive check: a FEW self-referential reassignments,
+        // comfortably under the caps, must still evaluate normally.
+        let mut s = MapleSession::new();
+        s.feed("a := 2;\na := a * a;\na := a * a;\n").unwrap(); // 2 -> 4 -> 16
+        assert_eq!(s.feed("a;\n").unwrap(), "16\n");
+    }
+
     #[test]
     fn the_one_shot_eval_helper_matches_a_session() {
         let one = eval("2 + 3;\n").unwrap();

--- a/code/packages/rust/reduce-runtime/CHANGELOG.md
+++ b/code/packages/rust/reduce-runtime/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.1.1] - 2026-08-02
+
+### Fixed
+
+- **CRITICAL — self-referential reassignment DoS, shared fix (no bypass
+  here).** A security audit found and directly reproduced (against the
+  `derive-repl` binary) an unbounded value-growth denial-of-service in
+  `symbolic-vm`'s shared `handlers::assign_handler`: `a := a * a` / `a :=
+  a + a`, repeated even a handful of times, doubles the bound value's node
+  count and/or nesting depth every step, reaching millions of nodes from a
+  few hundred bytes of source. Fixed at the shared choke point
+  (`symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`/`MAX_BOUND_VALUE_DEPTH`,
+  see that crate's own changelog for the full mechanism). Verified this
+  crate's own `:=` lowers straight to `symbolic_ir::ASSIGN` and evaluates
+  through the shared `vm.eval` (`eval_source`'s per-statement loop) — no
+  crate-specific bypass, so no code change was needed here, just proof of
+  coverage. Added regression tests reproducing the exact audited scenario
+  end-to-end through a real `ReduceSession` (both the node-count-tripping
+  `a := a * a` shape and the depth-tripping `a := a + a` shape — the
+  shared `Add` handler's flatten-then-left-associate canonicalization
+  makes that shape independently dangerous, see `symbolic-vm`'s changelog),
+  plus a non-false-positive check that a handful of self-multiplications
+  under the caps still evaluates correctly.
+
 ## [0.1.0] - 2026-07-18
 
 ### Added

--- a/code/packages/rust/reduce-runtime/Cargo.toml
+++ b/code/packages/rust/reduce-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-reduce-runtime"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Reduce runtime — lowers Reduce syntax to symbolic-ir and evaluates via symbolic-vm (R-4)"
 license = "MIT"

--- a/code/packages/rust/reduce-runtime/README.md
+++ b/code/packages/rust/reduce-runtime/README.md
@@ -109,8 +109,8 @@ plain text.
 ## Robustness
 
 `feed`/`eval_to_outputs` are the trust boundary for arbitrary Reduce source.
-Two independent deep-recursion vectors are closed (see the crate doc
-comment for the full rationale):
+Three independent deep-recursion/growth vectors are closed (see the crate
+doc comment for the full rationale):
 
 1. **Deeply nested source** (parenthesised, or a right-recursive
    `:=`/`if`-`else`/cons/power chain) — already rejected by
@@ -126,13 +126,26 @@ comment for the full rationale):
    group statement embedded as one operand of a much larger enclosing
    chain (`1 + 1 + (<<0;0>>) + 1 + 1 + ...`) — see `check_statement_token_
    counts`'s doc comment for the full accounting.
+3. **Unbounded self-referential-reassignment growth** — `a := a * a` / `a
+   := a + a`, repeated even a handful of times, doubles the bound value's
+   node count and/or nesting depth every step (a security audit's
+   finding). Neither guard above bounds the size of a value already
+   sitting in the environment before it gets combined with itself again.
+   This one is closed in the shared `symbolic-vm` crate itself
+   (`handlers::assign_handler`'s `MAX_BOUND_VALUE_NODES`/
+   `MAX_BOUND_VALUE_DEPTH` checks, run before every `:=` durably binds) —
+   this crate's own `:=` lowers straight to `symbolic_ir::ASSIGN` and
+   evaluates through that same shared handler with no bypass, so it is
+   protected automatically; see `symbolic-vm`'s own README/changelog for
+   the full mechanism.
 
 Evaluation itself runs on a worker thread with a large bounded stack inside
-`catch_unwind`, so a reused-handler panic (e.g. a malformed `Assign` LHS)
-becomes a clean `Err` and the session is rebuilt rather than left corrupted.
-A thread-spawn failure itself (OS thread-count/memory pressure) is also
-handled as an ordinary `Err`, not a caller-thread panic — a second
-`/security-review` finding against an earlier `.expect()`-based version.
+`catch_unwind`, so a reused-handler panic (e.g. a malformed `Assign` LHS,
+or the self-referential-reassignment guard tripping) becomes a clean `Err`
+and the session is rebuilt rather than left corrupted. A thread-spawn
+failure itself (OS thread-count/memory pressure) is also handled as an
+ordinary `Err`, not a caller-thread panic — a second `/security-review`
+finding against an earlier `.expect()`-based version.
 
 ## Tests
 

--- a/code/packages/rust/reduce-runtime/src/lib.rs
+++ b/code/packages/rust/reduce-runtime/src/lib.rs
@@ -624,6 +624,74 @@ mod tests {
         assert_eq!(s.feed("2 + 2;\n").unwrap(), "4\n");
     }
 
+    // --- Self-referential-reassignment DoS guard (a security audit's
+    // finding, shared with every consumer of `symbolic-vm`'s
+    // `assign_handler` -- see `symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`
+    // / `MAX_BOUND_VALUE_DEPTH`'s own doc comments) -- `a := a * a` /
+    // `a := a + a`, repeated even a handful of times, doubles the bound
+    // value's node count and/or nesting depth every step, reaching millions
+    // of nodes from a few hundred bytes of source. Reduce lowers its own
+    // `:=` straight to `symbolic_ir::ASSIGN` and evaluates through the
+    // shared `vm.eval`, so it is protected by the same choke-point fix with
+    // no crate-specific bypass work needed -- these tests prove that
+    // end-to-end through a real `ReduceSession`.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn self_referential_multiplication_worksheet_is_rejected_cleanly() {
+        // The exact audited scenario, as a Reduce worksheet
+        // (reduce.grammar's `program = { statement_line } [ statement ]`
+        // accepts many `;`-terminated statements in ONE `feed` call):
+        // `a := x + y` then `a := a * a` repeated. 30 repetitions is far
+        // past the real trip point (~15th step) -- without the guard this
+        // reaches billions of nodes; with it, a clean `Err` in well under a
+        // second.
+        let mut src = String::from("a := x + y;\n");
+        for _ in 0..30 {
+            src.push_str("a := a * a;\n");
+        }
+        assert!(src.len() < 500, "source should stay tiny: {} bytes", src.len());
+
+        let mut s = ReduceSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(err.contains("nodes"), "expected a node-count rejection, got {err:?}");
+        // The worker-thread `catch_unwind` rebuilds the session on panic —
+        // it must remain usable afterward.
+        assert_eq!(s.feed("2 + 2;\n").unwrap(), "4\n");
+    }
+
+    #[test]
+    fn self_referential_addition_worksheet_is_rejected_cleanly() {
+        // Same attack shape via the audit's other named example, `a := a +
+        // a`. This one trips the DEPTH guard, not the node-count guard --
+        // `Add`'s own flatten-then-left-associate canonicalization rebuilds
+        // a chain whose depth equals its leaf count, and leaf count doubles
+        // too. Without a depth guard this reproduces a genuine, uncatchable
+        // native stack overflow on a later statement's symbol lookup, not
+        // merely a slow hang.
+        let mut src = String::from("a := x + y;\n");
+        for _ in 0..30 {
+            src.push_str("a := a + a;\n");
+        }
+
+        let mut s = ReduceSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(
+            err.contains("levels"),
+            "expected a nesting-depth rejection, got {err:?}"
+        );
+        assert_eq!(s.feed("2 + 2;\n").unwrap(), "4\n");
+    }
+
+    #[test]
+    fn a_handful_of_self_multiplications_under_the_cap_still_evaluate_correctly() {
+        // Non-false-positive check: a FEW self-referential reassignments,
+        // comfortably under the caps, must still evaluate normally.
+        let mut s = ReduceSession::new();
+        s.feed("a := 2;\na := a * a;\na := a * a;\n").unwrap(); // 2 -> 4 -> 16
+        assert_eq!(s.feed("a;\n").unwrap(), "16\n");
+    }
+
     #[test]
     fn the_one_shot_eval_helper_matches_a_session() {
         let one = eval("2 + 3;\n").unwrap();

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.20.4] — 2026-08-02
+
+### Fixed
+
+- **CRITICAL — self-referential reassignment DoS.** A security audit found
+  and directly reproduced (built and ran the real `axiom`/`derive-repl`
+  binaries) an unbounded value-growth denial-of-service in the shared
+  `handlers::assign_handler`: a self-referential reassignment like
+  `a := a * a` or `a := a + a`, repeated even a handful of times — all
+  inside one ~250-byte program — clones the entire current value of `a`
+  into BOTH operand positions of the new node, roughly DOUBLING its total
+  `IRNode` count on every step (measured directly against this crate:
+  10, 22, 46, 94, 190, 382, 766, 1534, ..., 98,302 by the 14th step),
+  reaching millions of nodes and hanging/OOMing the process. Neither of
+  this repo's other two DoS guards catches this — parser `MAX_RULE_DEPTH`
+  bounds *nesting* in the source text, `MAX_STATEMENT_TOKENS`/
+  `MAX_INPUT_LEN` bound *chain length* in the source text — both bound
+  source-text size, not the size of a value already sitting bound in the
+  environment.
+- Added `handlers::MAX_BOUND_VALUE_NODES` (100,000) and
+  `handlers::count_nodes_within_cap` (a `pub`, iterative — explicit
+  work-stack, never native recursion — node-counting walk), checked in
+  `assign_handler` immediately after `vm.eval(rhs)` and before
+  `vm.backend.bind(...)`. Trips by the 15th self-multiplication step, well
+  before any legitimate CAS value (an expanded polynomial, an explicit
+  literal list/matrix a user types by hand) would ever approach it.
+- **A second, independent growth axis, found while writing the `a := a +
+  a` regression test**: that shape does NOT reach `MAX_BOUND_VALUE_NODES`
+  first — it hits this crate's own `Add` handler's flatten-then-left-
+  associate canonicalization (Phase 47), which rebuilds a chain whose
+  DEPTH equals its leaf count. Leaf count doubles too, so depth grows
+  exponentially — and because `VM::eval_symbol` natively re-walks (via a
+  recursive `self.eval` call) a symbol's entire bound value on every
+  lookup, a sufficiently deep bound value overflows the native call stack
+  on the very NEXT statement that looks it up: an uncatchable process
+  abort (`SIGABRT`), not a catchable panic, and it happens *inside* the
+  next statement's `vm.eval(rhs)` call — before this handler's own
+  node-count check on that later statement's result ever runs. Confirmed
+  by direct reproduction against this crate before the fix. Added
+  `handlers::MAX_BOUND_VALUE_DEPTH` (128 — reuses this repo's own already-
+  vetted native-recursion safety threshold, `parser::DEFAULT_MAX_RULE_
+  DEPTH`) and `handlers::depth_within_cap` (same iterative-walk shape),
+  checked alongside the node-count cap in `assign_handler`.
+- Both new pub functions/constants are exposed specifically so a
+  consuming runtime with its own bypass of `assign_handler` can apply the
+  identical checks at its own bind site — see `axiom-runtime`'s changelog:
+  its plain `NAME ASSIGN expr` assignment binds directly through
+  `Backend::bind`, never routing through this handler.
+- On trip: a clean `panic!` with a descriptive message (matching this
+  handler's existing malformed-lhs panic convention), caught by every
+  consuming runtime's own worker-thread `catch_unwind` boundary and
+  surfaced as a clean REPL/CLI error, never a process crash.
+- Verified every confirmed consumer of `symbolic-vm::handlers::
+  assign_handler` — `derive-runtime`, `reduce-runtime`, `maple-runtime`,
+  `wolfram-runtime`, `macsyma-runtime` (via `macsyma-wasm`'s
+  `catch_parser_panics` boundary) — all lower their own `:=`/`=` straight
+  to `symbolic_ir::ASSIGN` and evaluate through the shared `vm.eval`, so
+  all are protected by this one choke-point fix with no crate-specific
+  bypass work needed. `axiom-runtime` is the one exception (see its own
+  changelog). `cas-summation`/`task-core` (other `symbolic-vm` consumers)
+  re-tested with no regressions.
+- Added regression tests: exact-scenario reproduction for both
+  `a := a * a` and `a := a + a` (30 repetitions, far past the real trip
+  point), a non-false-positive check that a handful of self-multiplications
+  under the caps still evaluate correctly, a non-false-positive check that
+  a large single-step literal (a 2000-element list) is not rejected, and
+  unit tests directly on `count_nodes_within_cap` (leaf counting, head+args
+  counting, cap-boundary exactness, and a 50,000-deep tree proving the walk
+  is genuinely iterative — torn down iteratively too, to avoid
+  reintroducing a recursive-`Drop`-overflows-the-stack bug in the test's
+  own cleanup).
+
 ## [0.20.3] — 2026-07-17
 
 ### Changed

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.20.3"
+version = "0.20.4"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/README.md
+++ b/code/packages/rust/symbolic-vm/README.md
@@ -96,6 +96,31 @@ The `handlers` module uses a `Numeric` enum (`Int(i64)`, `Rat(i64, i64)`,
 
 Integer overflow falls back to `Float`.
 
+## Security: self-referential-reassignment DoS guard
+
+`handlers::assign_handler` — the shared implementation behind every
+consuming CAS runtime's `:=`/`=` — rejects a value before binding it if
+either of two budgets is exceeded:
+
+| Budget | Constant | Why |
+|--------|----------|-----|
+| Total `IRNode` count | `handlers::MAX_BOUND_VALUE_NODES` (100,000) | `a := a * a`, repeated, clones the whole current value into both operand positions, roughly *doubling* node count every step |
+| Nesting depth | `handlers::MAX_BOUND_VALUE_DEPTH` (128) | `a := a + a`, repeated, additionally hits `Add`'s own flatten-then-left-associate canonicalization, whose rebuilt chain's depth equals its leaf count — also doubling, and dangerous *sooner* than node count because `VM::eval_symbol` natively re-walks a symbol's whole bound value on every lookup |
+
+Both checks use an explicit-work-stack iterative walk
+(`handlers::count_nodes_within_cap`/`handlers::depth_within_cap`, both
+`pub`), never native recursion, so checking a pathological value can never
+itself overflow the stack. On trip, `assign_handler` panics with a
+descriptive message — the same failure shape it already uses for a
+malformed (non-symbol) assignment target — which every consuming runtime's
+own worker-thread `catch_unwind` boundary converts into a clean error.
+
+A consuming runtime that bypasses `assign_handler` for its own plain
+assignment (`axiom-runtime` is the one example in this repo — it binds
+directly through `Backend::bind` rather than lowering to
+`symbolic_ir::ASSIGN`) must apply the identical two checks at its own bind
+site; both functions and constants are exported specifically for that.
+
 ## Stack position
 
 ```

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1442,6 +1442,177 @@ fn if_handler(_simplify: bool) -> Handler {
 // Assign / Define — binding forms
 // ---------------------------------------------------------------------------
 
+/// Maximum total `IRNode` count a value may have before `assign_handler`
+/// will durably bind it into the environment via `:=`/`=`.
+///
+/// # Why this exists — self-referential reassignment doubles a value's size
+///
+/// A self-referential reassignment like `a := a * a` or `a := a + a`,
+/// repeated even a handful of times, clones the *entire current value* of
+/// `a` into **both** operand positions of the new node. When the value
+/// can't be numerically collapsed (e.g. it started from free symbols, as in
+/// `a := x + y`), the clone survives structurally and the total node count
+/// roughly **doubles on every step**. Measured directly against this crate
+/// (`a := x + y;` seed, then `a := a * a;` repeated — the `SymbolicBackend`,
+/// same as every reference backend below):
+///
+/// ```text
+/// step:   1   2   3   4   5    6    7    8    9     10    11    12     13     14
+/// nodes: 10  22  46  94  190  382  766  1534  3070  6142  12286  24574  49150  98302
+/// ```
+///
+/// This is architecturally different from — and NOT caught by — either of
+/// this repo's other two DoS guards:
+///
+/// - **Deep *nesting*** (`((((…))))`) is bounded by each frontend's parser
+///   `MAX_RULE_DEPTH`.
+/// - **Long flat *chains*** (`1+1+1+…`) are bounded by source-size guards
+///   like `MAX_STATEMENT_TOKENS`/`MAX_INPUT_LEN`.
+///
+/// Both of those bound the *source text*. This attack needs only a
+/// constant, tiny amount of *additional* source per step (one more
+/// `a := a * a;`, ~15 bytes) to *double* the bound *value*'s size — so a
+/// few hundred bytes of source reaches millions of nodes within a couple
+/// dozen more steps. Neither guard above ever inspects the size of an
+/// already-bound value before it is combined with itself again, which is
+/// exactly the gap this cap closes.
+///
+/// # Why 100,000
+///
+/// 100,000 sits just above the measured series above: an attacker trips
+/// this cap on the 15th self-multiplication step (98,302 nodes at step 14,
+/// the next doubling clears 100,000) — long before a session's memory is
+/// meaningfully impacted — while comfortably clearing any legitimate CAS
+/// value a user would construct in a single assignment by hand: an
+/// expanded polynomial with a few hundred terms, or an explicit literal
+/// list/matrix with a few thousand elements, tops out at a few thousand
+/// nodes — an order of magnitude or more below this cap.
+pub const MAX_BOUND_VALUE_NODES: usize = 100_000;
+
+/// Count the total number of [`IRNode`]s in `node`, stopping as soon as the
+/// running count exceeds `cap`.
+///
+/// Returns `Some(count)` (the exact total) when the tree's node count is at
+/// or under `cap`; returns `None` as soon as the count is certain to exceed
+/// it, without walking the remainder of the (potentially still-large) tree.
+///
+/// Uses an explicit heap-allocated work stack rather than native recursion,
+/// so counting can never itself overflow the stack no matter how deep
+/// `node` already is — mirrors `axiom-to-semantic-ir`'s
+/// `measure_depth_iterative`/`drop_iterative` iterative-walk idiom, applied
+/// here to total node count rather than depth. `cap` is always far below
+/// `usize::MAX` (see [`MAX_BOUND_VALUE_NODES`]), so the running count can
+/// never itself overflow — the early `return None` fires long before that
+/// could matter.
+///
+/// `pub` (not just crate-private) so that a consuming runtime with its own
+/// bypass of `assign_handler` — see `axiom-runtime::eval::eval_assignment`,
+/// which binds directly through `Backend::bind` rather than routing
+/// `Assign` through this handler — can apply the *identical* budget check
+/// at its own bind call site, rather than hand-rolling a second, possibly
+/// divergent, node-counting walk.
+pub fn count_nodes_within_cap(node: &IRNode, cap: usize) -> Option<usize> {
+    let mut stack: Vec<&IRNode> = vec![node];
+    let mut count: usize = 0;
+    while let Some(current) = stack.pop() {
+        count += 1;
+        if count > cap {
+            return None;
+        }
+        if let IRNode::Apply(apply) = current {
+            stack.push(&apply.head);
+            for arg in &apply.args {
+                stack.push(arg);
+            }
+        }
+    }
+    Some(count)
+}
+
+/// Maximum nesting depth a value may have before `assign_handler` will
+/// durably bind it into the environment via `:=`/`=`.
+///
+/// # Why this exists — a SEPARATE growth axis from `MAX_BOUND_VALUE_NODES`
+///
+/// `a := a * a` grows a value's *node count* exponentially while its
+/// *depth* only grows linearly (each step clones the whole prior value
+/// whole into one more `Mul` wrapper) — `MAX_BOUND_VALUE_NODES` alone
+/// catches that shape fine. But `a := a + a` hits this crate's own `Add`
+/// handler's flatten-then-left-associate canonicalization (Phase 47,
+/// `flatten_add_leaves` below): every step gathers the operands' leaves
+/// into one flat list and rebuilds a *left-associated chain whose depth
+/// equals its leaf count*. Because leaf count doubles every step (same
+/// mechanism as the node-count case), **depth doubles too** — and unlike
+/// node count, a too-deep value is dangerous *before* `MAX_BOUND_VALUE_
+/// NODES` ever gets a chance to reject it: `VM::eval_symbol` natively
+/// re-walks (via a recursive `self.eval` call) a symbol's *entire* bound
+/// value on every lookup (this is intentional — see its own "self-loop
+/// guard" comment — a bound value can itself reference other symbols that
+/// may have been updated since). Looking up a sufficiently deep bound
+/// value therefore recurses natively to a depth proportional to the
+/// value's own depth, and can overflow the native call stack — an
+/// uncatchable process abort, not a catchable `panic!`, and critically
+/// this happens *inside* the recursive `vm.eval(rhs)` call for the *next*
+/// statement that looks the name up, i.e. **before** this handler's own
+/// node-count check on the *current* statement's result ever runs.
+/// Confirmed by direct reproduction against this crate: `a := x + y;`
+/// then `a := a + a;` repeated aborts the process with a genuine native
+/// stack overflow well before `MAX_BOUND_VALUE_NODES` alone would trip.
+///
+/// Capping *depth* at bind time (in addition to node count) closes this:
+/// a value deep enough to be dangerous on a later lookup is rejected
+/// before it can ever become durably reachable, so no subsequent lookup
+/// can ever walk it.
+///
+/// # Why 128
+///
+/// Reuses this repo's own already-established, empirically-derived
+/// native-recursion safety threshold (`parser::DEFAULT_MAX_RULE_DEPTH`,
+/// documented there as sitting safely below the ~192–224-frame point at
+/// which *fat* recursive frames have been observed to overflow a 2 MiB
+/// stack in this repo's own CI history) rather than inventing a new,
+/// unvetted number. 128 is comfortably deep enough for any legitimately
+/// *parsed* expression to begin with (parser-level `MAX_RULE_DEPTH` caps
+/// already bound source-level nesting to the same figure), and small
+/// enough that re-walking a value at exactly this depth — via
+/// `eval_symbol`'s recursive re-evaluation, plus whatever additional
+/// native frames a consuming runtime's own AST-walking interpreter (e.g.
+/// `axiom-runtime`) layers on top of that — stays safely within bounds
+/// even on a default-sized thread stack, well before reaching a dedicated
+/// large worker-thread stack's much larger headroom.
+pub const MAX_BOUND_VALUE_DEPTH: usize = 128;
+
+/// Measure `node`'s nesting depth iteratively, stopping as soon as it's
+/// certain to exceed `cap`.
+///
+/// Returns `Some(depth)` (the exact maximum depth, root = depth 0) when
+/// `node`'s depth is at or under `cap`; returns `None` as soon as the
+/// depth is certain to exceed it.
+///
+/// Uses an explicit heap-allocated work stack rather than native
+/// recursion, for the same reason as [`count_nodes_within_cap`] — mirrors
+/// `axiom-to-semantic-ir::measure_depth_iterative`'s idiom exactly, just
+/// applied as a pre-bind check here. `pub` for the same reason as
+/// [`count_nodes_within_cap`]: `axiom-runtime`'s own `assign_handler`
+/// bypass needs the identical check.
+pub fn depth_within_cap(node: &IRNode, cap: usize) -> Option<usize> {
+    let mut stack: Vec<(&IRNode, usize)> = vec![(node, 0)];
+    let mut max_depth: usize = 0;
+    while let Some((current, depth)) = stack.pop() {
+        if depth > cap {
+            return None;
+        }
+        max_depth = max_depth.max(depth);
+        if let IRNode::Apply(apply) = current {
+            stack.push((&apply.head, depth + 1));
+            for arg in &apply.args {
+                stack.push((arg, depth + 1));
+            }
+        }
+    }
+    Some(max_depth)
+}
+
 fn assign_handler(_simplify: bool) -> Handler {
     std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
         let (lhs, rhs) = match binary_args(&expr) {
@@ -1453,6 +1624,28 @@ fn assign_handler(_simplify: bool) -> Handler {
             _ => panic!("Assign lhs must be a symbol, got {lhs}"),
         };
         let value = vm.eval(rhs);
+        // See `MAX_BOUND_VALUE_NODES`/`MAX_BOUND_VALUE_DEPTH` doc comments:
+        // self-referential reassignment (`a := a * a` / `a := a + a`,
+        // repeated) doubles the bound value's node count AND/OR nesting
+        // depth on every step, along two independent axes. Reject BEFORE
+        // binding — once bound, the oversized value is durably reachable
+        // and can feed into further self-combination (node-count growth)
+        // or be natively re-walked on the next lookup (depth-driven native
+        // stack overflow).
+        if count_nodes_within_cap(&value, MAX_BOUND_VALUE_NODES).is_none() {
+            panic!(
+                "Assign target '{name}' would bind a value exceeding \
+                 {MAX_BOUND_VALUE_NODES} nodes — rejecting to prevent unbounded growth \
+                 from self-referential reassignment (e.g. repeated '{name} := {name} * {name}')"
+            );
+        }
+        if depth_within_cap(&value, MAX_BOUND_VALUE_DEPTH).is_none() {
+            panic!(
+                "Assign target '{name}' would bind a value nested deeper than \
+                 {MAX_BOUND_VALUE_DEPTH} levels — rejecting to prevent unbounded growth \
+                 from self-referential reassignment (e.g. repeated '{name} := {name} + {name}')"
+            );
+        }
         vm.backend.bind(&name, value.clone());
         value
     })

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -2587,6 +2587,192 @@ fn assign_binds_and_returns_value() {
 }
 
 // ---------------------------------------------------------------------------
+// Assign — self-referential-reassignment DoS guard
+// (MAX_BOUND_VALUE_NODES / MAX_BOUND_VALUE_DEPTH)
+//
+// A security audit found that `a := a * a` (or `a := a + a`), repeated even
+// a handful of times, clones `a`'s entire current value into BOTH operand
+// positions of the new node. When the value can't numerically collapse
+// (started from free symbols, e.g. `a := x + y`), this roughly DOUBLES the
+// bound value's total node count on every step — measured directly against
+// this crate: 10, 22, 46, 94, 190, 382, 766, 1534, 3070, 6142, 12286,
+// 24574, 49150, 98302, ... — reaching ~100,000 nodes from ~250 bytes of
+// source by the 15th self-multiplication. Neither of this repo's other two
+// DoS guards (parser `MAX_RULE_DEPTH` for deep NESTING, `MAX_STATEMENT_
+// TOKENS`/`MAX_INPUT_LEN` for long flat CHAINS) catches this, because both
+// bound source-text size, not the size of a value already sitting in the
+// environment. See `MAX_BOUND_VALUE_NODES`'s own doc comment for the full
+// reasoning and the cap's derivation.
+//
+// `a := a + a` specifically ALSO hits a second, independent growth axis:
+// the shared `Add` handler's flatten-then-left-associate canonicalization
+// (Phase 47) rebuilds a chain whose DEPTH equals its leaf count, and leaf
+// count doubles too — so depth grows exponentially, which is dangerous
+// even sooner than node count because a too-deep bound value can overflow
+// the native stack (an uncatchable process abort) the moment it's next
+// looked up, before a node-count check on that later statement's result
+// would ever run. See `MAX_BOUND_VALUE_DEPTH`'s own doc comment.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "exceeding 100000 nodes")]
+fn assign_rejects_self_referential_multiplication_before_unbounded_growth() {
+    // Exact reported scenario: `a := x + y;` then `a := a * a;` repeated.
+    // 30 repetitions is far past the real trip point (~15th step) — if the
+    // guard were missing, 30 doublings from a 10-node seed would reach
+    // roughly 10 * 2^30 ≈ 10 BILLION nodes; with the guard this panics in
+    // a handful of milliseconds around step 15, proving both that the
+    // guard fires and that it fires before any unbounded growth happens.
+    let mut vm = symbolic();
+    let mut statements = vec![apply(
+        sym(ASSIGN),
+        vec![sym("a"), apply(sym(ADD), vec![sym("x"), sym("y")])],
+    )];
+    for _ in 0..30 {
+        statements.push(apply(
+            sym(ASSIGN),
+            vec![sym("a"), apply(sym(MUL), vec![sym("a"), sym("a")])],
+        ));
+    }
+    vm.eval_program(statements);
+}
+
+#[test]
+#[should_panic(expected = "nested deeper than 128 levels")]
+fn assign_rejects_self_referential_addition_before_unbounded_growth() {
+    // Same self-referential-reassignment attack shape via the task's other
+    // named example, `a := a + a` instead of `a := a * a` -- but this one
+    // trips the DEPTH cap first, not the node-count cap: `Add`'s own
+    // flatten-then-left-associate canonicalization (Phase 47) rebuilds a
+    // chain whose depth equals its leaf count, and leaf count doubles just
+    // like node count does. Depth becomes dangerous (native stack overflow
+    // on the next lookup) well before node count alone would reach
+    // MAX_BOUND_VALUE_NODES -- see `MAX_BOUND_VALUE_DEPTH`'s own doc
+    // comment for the full mechanism. Without BOTH caps this reproduces an
+    // actual `SIGABRT` (uncatchable native stack overflow), not merely a
+    // slow/hanging process -- confirmed by removing the depth check
+    // locally and observing the abort while writing this test.
+    let mut vm = symbolic();
+    let mut statements = vec![apply(
+        sym(ASSIGN),
+        vec![sym("a"), apply(sym(ADD), vec![sym("x"), sym("y")])],
+    )];
+    for _ in 0..30 {
+        statements.push(apply(
+            sym(ASSIGN),
+            vec![sym("a"), apply(sym(ADD), vec![sym("a"), sym("a")])],
+        ));
+    }
+    vm.eval_program(statements);
+}
+
+#[test]
+fn assign_still_allows_a_handful_of_self_multiplications_under_the_cap() {
+    // Non-false-positive check: a FEW self-referential reassignments,
+    // comfortably under MAX_BOUND_VALUE_NODES, must still evaluate
+    // normally and produce the mathematically correct result — the guard
+    // must trip on VALUE SIZE, not merely on a variable referencing itself.
+    let mut vm = symbolic();
+    vm.eval(apply(sym(ASSIGN), vec![sym("a"), int(2)]));
+    vm.eval(apply(
+        sym(ASSIGN),
+        vec![sym("a"), apply(sym(MUL), vec![sym("a"), sym("a")])],
+    )); // a = 4
+    let result = vm.eval(apply(
+        sym(ASSIGN),
+        vec![sym("a"), apply(sym(MUL), vec![sym("a"), sym("a")])],
+    )); // a = 16
+    assert_eq!(result, int(16));
+    assert_eq!(vm.backend.lookup("a"), Some(int(16)));
+}
+
+#[test]
+fn assign_allows_a_large_explicit_literal_built_in_one_step() {
+    // Non-false-positive check on the other axis the doc comment calls
+    // out: a single large literal a real user might type by hand (a
+    // 2000-element list), built directly with no self-reference at all,
+    // must not be rejected — it sits nowhere near the cap.
+    let mut vm = symbolic();
+    let elems: Vec<_> = (0..2000).map(int).collect();
+    let expr = apply(sym(ASSIGN), vec![sym("big"), apply(sym(LIST), elems)]);
+    let result = vm.eval(expr);
+    // LIST Apply node + LIST head symbol + 2000 elements = 2002 nodes.
+    assert_eq!(
+        symbolic_vm::handlers::count_nodes_within_cap(
+            &result,
+            symbolic_vm::handlers::MAX_BOUND_VALUE_NODES
+        ),
+        Some(2002)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// count_nodes_within_cap — the shared, DoS-safe node-counting walk itself
+// ---------------------------------------------------------------------------
+
+#[test]
+fn count_nodes_within_cap_counts_a_leaf_as_one() {
+    use symbolic_vm::handlers::count_nodes_within_cap;
+    assert_eq!(count_nodes_within_cap(&int(5), 10), Some(1));
+    assert_eq!(count_nodes_within_cap(&sym("x"), 10), Some(1));
+}
+
+#[test]
+fn count_nodes_within_cap_counts_the_apply_node_head_and_args() {
+    use symbolic_vm::handlers::count_nodes_within_cap;
+    // Add(x, y): the Apply node itself + the Add head symbol + x + y = 4.
+    let expr = apply(sym(ADD), vec![sym("x"), sym("y")]);
+    assert_eq!(count_nodes_within_cap(&expr, 10), Some(4));
+}
+
+#[test]
+fn count_nodes_within_cap_returns_none_when_over_cap() {
+    use symbolic_vm::handlers::count_nodes_within_cap;
+    let expr = apply(sym(ADD), vec![sym("x"), sym("y")]); // 4 nodes
+    assert_eq!(count_nodes_within_cap(&expr, 3), None);
+}
+
+#[test]
+fn count_nodes_within_cap_returns_exact_count_at_the_cap_boundary() {
+    use symbolic_vm::handlers::count_nodes_within_cap;
+    let expr = apply(sym(ADD), vec![sym("x"), sym("y")]); // 4 nodes
+    assert_eq!(count_nodes_within_cap(&expr, 4), Some(4));
+    assert_eq!(count_nodes_within_cap(&expr, 3), None);
+}
+
+#[test]
+fn count_nodes_within_cap_handles_a_deeply_nested_tree_without_recursing_natively() {
+    // Build a 50,000-deep right-leaning chain (Add(1, Add(1, Add(1, ...))))
+    // to prove the counting walk is genuinely iterative — a native-
+    // recursive counter would risk overflowing the test thread's stack
+    // well before this depth (see this repo's own lessons.md entries on
+    // "flat repetition chains fold into a deep tree").
+    let mut expr = int(0);
+    for _ in 0..50_000 {
+        expr = apply(sym(ADD), vec![int(1), expr]);
+    }
+    // 3 new nodes per level (Apply + ADD head + literal 1) + 1 for the
+    // int(0) base case = 3 * 50_000 + 1.
+    use symbolic_vm::handlers::count_nodes_within_cap;
+    assert_eq!(count_nodes_within_cap(&expr, 200_000), Some(150_001));
+
+    // Tear the tree down iteratively too — mirrors `axiom-to-semantic-ir`'s
+    // `drop_iterative` idiom — so this test's own cleanup doesn't
+    // reintroduce the exact "recursive Drop of a deep Box tree overflows
+    // the stack" class of bug the counting walk above was written to
+    // avoid. `count_nodes_within_cap` only guarantees iterative COUNTING;
+    // it says nothing about how Rust drops the tree afterward.
+    let mut stack = vec![expr];
+    while let Some(current) = stack.pop() {
+        if let symbolic_ir::IRNode::Apply(boxed) = current {
+            let symbolic_ir::IRApply { head, args } = *boxed;
+            stack.push(head);
+            stack.extend(args);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Define / user-defined functions
 // ---------------------------------------------------------------------------
 

--- a/code/packages/rust/wolfram-runtime/CHANGELOG.md
+++ b/code/packages/rust/wolfram-runtime/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `wolfram-runtime` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.19.6] — 2026-08-02
+
+### Fixed
+
+- **CRITICAL — self-referential reassignment DoS, shared fix (no bypass
+  here).** A security audit found and directly reproduced (against the
+  `derive-repl` binary) an unbounded value-growth denial-of-service in
+  `symbolic-vm`'s shared `handlers::assign_handler`: `a = a * a` / `a = a
+  + a` (Wolfram's `Set`), repeated even a handful of times, doubles the
+  bound value's node count and/or nesting depth every step, reaching
+  millions of nodes from a few hundred bytes of source. Fixed at the
+  shared choke point (`symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`/
+  `MAX_BOUND_VALUE_DEPTH`, see that crate's own changelog for the full
+  mechanism). Verified `Set`/`SetDelayed` lower straight to
+  `symbolic_ir::ASSIGN` and evaluate through the shared `vm.eval`
+  (`eval_source`'s per-statement loop) — `WolframBackend::handler_for`
+  checks the W-5 builtin table first but has no entry for `Assign`, so it
+  always falls through to the shared handler — no crate-specific bypass,
+  so no code change was needed here, just proof of coverage. Added
+  regression tests reproducing the exact audited scenario end-to-end
+  through a real `WolframSession` (both the node-count-tripping `a = a *
+  a` shape and the depth-tripping `a = a + a` shape — the shared `Add`
+  handler's flatten-then-left-associate canonicalization makes that shape
+  independently dangerous, see `symbolic-vm`'s changelog), plus a
+  non-false-positive check that a handful of self-multiplications under
+  the caps still evaluates correctly.
+
 ## [0.19.5] — 2026-07-17
 
 ### Added (W-22 — `Integrate`, fifth `cas-*` head)

--- a/code/packages/rust/wolfram-runtime/Cargo.toml
+++ b/code/packages/rust/wolfram-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-wolfram-runtime"
-version = "0.19.5"
+version = "0.19.6"
 edition = "2021"
 description = "Wolfram Language runtime — lowers M-expressions to symbolic-ir and evaluates via symbolic-vm"
 license = "MIT"

--- a/code/packages/rust/wolfram-runtime/README.md
+++ b/code/packages/rust/wolfram-runtime/README.md
@@ -648,6 +648,20 @@ the real lexer token stream) that bounds parse-tree depth so deep nesting cannot
 overflow the stack, and a bounded worker thread with `catch_unwind` plus
 session-rebuild so a panic becomes a clean `Err` rather than a crash.
 
+A security audit found and directly reproduced a further, independent
+vector neither cap above closes: `a = a * a` / `a = a + a` (`Set`),
+repeated even a handful of times, doubles the bound value's node count
+and/or nesting depth every step — `MAX_INPUT_LEN`/`MAX_STATEMENT_TOKENS`
+bound *source-text* size, not the size of a value already sitting bound in
+the environment before it gets combined with itself again. This is closed
+in the shared `symbolic-vm` crate itself (`handlers::assign_handler`'s
+`MAX_BOUND_VALUE_NODES`/`MAX_BOUND_VALUE_DEPTH` checks, run before every
+`Assign` durably binds) — `WolframBackend::handler_for` checks the W-5
+builtin table first but has no entry for `Assign`, so `Set`/`SetDelayed`
+always fall through to that same shared handler with no bypass, and are
+protected automatically. See `symbolic-vm`'s own README/changelog for the
+full mechanism.
+
 ## Where it fits
 
 - **W-1** spec + grammar, **W-2** `wolfram-lexer`, **W-3** `wolfram-parser`

--- a/code/packages/rust/wolfram-runtime/src/lib.rs
+++ b/code/packages/rust/wolfram-runtime/src/lib.rs
@@ -651,6 +651,73 @@ mod tests {
         assert_eq!(s.feed("2 + 2\n").unwrap(), "Out[1]= 4\n");
     }
 
+    // --- Self-referential-reassignment DoS guard (a security audit's
+    // finding, shared with every consumer of `symbolic-vm`'s
+    // `assign_handler` -- see `symbolic_vm::handlers::MAX_BOUND_VALUE_NODES`
+    // / `MAX_BOUND_VALUE_DEPTH`'s own doc comments) -- `a = a * a` /
+    // `a = a + a`, repeated even a handful of times, doubles the bound
+    // value's node count and/or nesting depth every step, reaching millions
+    // of nodes from a few hundred bytes of source. Wolfram's `Set` (`=`)
+    // lowers straight to `symbolic_ir::ASSIGN` and evaluates through the
+    // shared `vm.eval`, so it is protected by the same choke-point fix with
+    // no crate-specific bypass work needed -- these tests prove that
+    // end-to-end through a real `WolframSession`.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn self_referential_multiplication_is_rejected_cleanly() {
+        // The exact audited scenario, as newline-separated Wolfram
+        // statements (`multiple_statements_in_one_feed` above confirms one
+        // `feed` call accepts many): `a = x + y` then `a = a * a` repeated.
+        // 30 repetitions is far past the real trip point (~15th step) --
+        // without the guard this reaches billions of nodes; with it, a
+        // clean `Err` in well under a second.
+        let mut src = String::from("a = x + y\n");
+        for _ in 0..30 {
+            src.push_str("a = a * a\n");
+        }
+        assert!(src.len() < 500, "source should stay tiny: {} bytes", src.len());
+
+        let mut s = WolframSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(err.contains("nodes"), "expected a node-count rejection, got {err:?}");
+        // The worker-thread `catch_unwind` rebuilds the session on panic —
+        // it must remain usable afterward.
+        assert_eq!(s.feed("2 + 2\n").unwrap(), "Out[1]= 4\n");
+    }
+
+    #[test]
+    fn self_referential_addition_is_rejected_cleanly() {
+        // Same attack shape via the audit's other named example, `a = a +
+        // a`. This one trips the DEPTH guard, not the node-count guard --
+        // `Add`'s own flatten-then-left-associate canonicalization rebuilds
+        // a chain whose depth equals its leaf count, and leaf count doubles
+        // too. Without a depth guard this reproduces a genuine, uncatchable
+        // native stack overflow on a later statement's symbol lookup, not
+        // merely a slow hang.
+        let mut src = String::from("a = x + y\n");
+        for _ in 0..30 {
+            src.push_str("a = a + a\n");
+        }
+
+        let mut s = WolframSession::new();
+        let err = s.feed(&src).unwrap_err();
+        assert!(
+            err.contains("levels"),
+            "expected a nesting-depth rejection, got {err:?}"
+        );
+        assert_eq!(s.feed("2 + 2\n").unwrap(), "Out[1]= 4\n");
+    }
+
+    #[test]
+    fn a_handful_of_self_multiplications_under_the_cap_still_evaluate_correctly() {
+        // Non-false-positive check: a FEW self-referential reassignments,
+        // comfortably under the caps, must still evaluate normally.
+        let mut s = WolframSession::new();
+        s.feed("a = 2\na = a * a\na = a * a\n").unwrap(); // 2 -> 4 -> 16
+        assert_eq!(s.feed("a\n").unwrap(), "Out[4]= 16\n");
+    }
+
     #[test]
     fn negative_results_render() {
         assert_eq!(eval("3 - 10\n").unwrap(), "Out[1]= -7\n");


### PR DESCRIPTION
## Summary

A security audit found and directly reproduced (built and ran the real `axiom` and `derive-repl` binaries) a **CRITICAL** denial-of-service in the shared `symbolic-vm` engine that every CAS-family language runtime in this repo (Derive, Reduce, Maple, Wolfram, Macsyma, Axiom) is built on.

**The bug**: a self-referential arithmetic reassignment like `a := a * a` or `a := a + a`, repeated even a handful of times — all inside one semicolon-delimited block, ~250 bytes of source — clones the *entire current value* of `a` into both operand positions of the new node every step, roughly **doubling** the bound value's total `IRNode` count on every self-multiplication:

```
step:   1   2   3   4   5    6    7    8    9     10    11    12     13     14
nodes: 10  22  46  94  190  382  766  1534  3070  6142  12286  24574  49150  98302
```

By step ~15 you're past 100,000 nodes and climbing exponentially — reaching millions of nodes and hanging/OOMing the process from a tiny, innocuous-looking program.

**Why existing guards miss it**: every DoS guard in this repo (`MAX_RULE_DEPTH`, `MAX_STATEMENT_TOKENS`, `MAX_INPUT_LEN`) bounds either source-text nesting or source-text chain length. This attack needs only a *constant* amount of *additional source per step* to *double* the *value*'s size — neither guard ever inspects the size of a value already sitting bound in the environment before it gets combined with itself again.

**A second, independent growth axis found while writing the `a := a + a` regression test**: that shape does *not* trip the node-count cap first — it hits the shared `Add` handler's own flatten-then-left-associate canonicalization (Phase 47), which rebuilds a chain whose *depth* equals its leaf count. Leaf count doubles too, so depth grows exponentially — and because `VM::eval_symbol` natively re-walks (recursive `self.eval`) a symbol's entire bound value on every lookup, a sufficiently deep bound value overflows the native call stack on the very next lookup: an **uncatchable process abort (`SIGABRT`)**, not a catchable panic — reproduced directly against this crate before the fix, confirming this needed its own depth cap, not just a node-count cap.

## Fix

- `symbolic-vm::handlers::assign_handler` (the shared choke point behind every runtime's `:=`/`=`) now checks two budgets, immediately after `vm.eval(rhs)` and before `vm.backend.bind(...)`:
  - `MAX_BOUND_VALUE_NODES` (100,000) via `count_nodes_within_cap` — an iterative, explicit-work-stack walk (never native recursion).
  - `MAX_BOUND_VALUE_DEPTH` (128, reusing this repo's own already-vetted `DEFAULT_MAX_RULE_DEPTH` safety threshold) via `depth_within_cap` — same iterative shape.
  - Both functions are `pub` so a consuming runtime with its own bypass can reuse them directly.
- On trip: a clean `panic!`, matching this handler's existing malformed-lhs failure convention, caught by every consuming runtime's own worker-thread `catch_unwind` boundary.

## Architecture verification (which runtimes needed their own fix)

Verified by reading each crate's actual lowering/eval code, not assumption:

| Runtime | Routes through shared `assign_handler`? | Fix needed |
|---|---|---|
| `derive-runtime` | Yes — lowers `:=` to `symbolic_ir::ASSIGN`, evaluates via `vm.eval` | None — protected automatically |
| `reduce-runtime` | Yes | None — protected automatically |
| `maple-runtime` | Yes | None — protected automatically |
| `wolfram-runtime` | Yes (`Set`/`SetDelayed`; `WolframBackend::handler_for` has no override for `Assign`) | None — protected automatically |
| `macsyma-runtime` (via `macsyma-wasm`) | Yes (`MacsymaBackend`'s handler table built from `build_handler_table`, no override) | None — protected automatically |
| `axiom-runtime` | **No** — binds directly through `Backend::bind` in `eval::eval_assignment`, bypassing the shared handler entirely (an eager AST-walking interpreter, not a lower-then-eval pipeline) | **Yes** — applied the identical two checks at its own bind site |

Every consumer above (plus `cas-summation`/`task-core`, `axiom-repl`/`derive-repl`/`reduce-repl`/`maple-repl`/`wolfram-repl`, and every `*-to-semantic-ir` crate) was re-tested with no regressions.

## Secondary fixes (included, since straightforward)

1. `axiom-runtime`'s `eval_to_output` used to call `format_value`/`print_axiom` (native-recursive) *after* the guarded worker thread was joined, back on the caller's default-size stack — defeating the module's own stack-size guarantee purely by printing rather than evaluating a result. Moved inside the worker closure.
2. `axiom-runtime`'s `eval_binary_chain` was re-deriving the *entire accumulator's* domain via `is_polynomial_over_integers` (a whole-tree walk) at every one of N fold steps — O(N²) total for one N-term chain, despite this crate's own doc comment claiming the iterative fold "sidesteps the DoS vector by construction" (true only for stack depth, not total CPU work). Now inferred once, on the final result — no behavior change.

## Regression tests

Added for every runtime confirmed to share the exposure, reproducing the exact audited scenario end-to-end (both the node-count-tripping `a := a * a` shape and the depth-tripping `a := a + a` shape), plus non-false-positive checks that a handful of self-multiplications under the caps still evaluates correctly, and a large single-step literal isn't rejected:

- `symbolic-vm`: unit tests on `count_nodes_within_cap`/`depth_within_cap` directly (leaf/head+args counting, cap-boundary exactness, a 50,000-deep tree proving genuine iterative behavior — torn down iteratively too), plus integration tests via `VM::eval_program`.
- `axiom-runtime`: end-to-end via a real `AxiomSession`, reproducing the exact `( a := x + y; a := a * a; ... )` block syntax from the audit.
- `derive-runtime`, `reduce-runtime`, `maple-runtime`, `wolfram-runtime`, `macsyma-wasm`: end-to-end via each crate's own session/facade type.

All new tests pass; full existing suites for every touched crate pass with no regressions (symbolic-vm 234, axiom-runtime 108, derive-runtime 68, reduce-runtime 88, maple-runtime 107, wolfram-runtime 350+85, macsyma-wasm 10). `cargo clippy --all-targets -- -D warnings` is clean on every touched crate.

## Follow-up (explicitly out of scope for this PR)

The security-review sub-agent that reviewed this diff surfaced a **separate, pre-existing** vulnerability: `symbolic-vm`'s shared user-function-call mechanism (backing `Define`) has no call-depth cap at all, and only `axiom-runtime` built its own bypass with a `MAX_CALL_DEPTH` guard to close this for itself. `derive-runtime`/`reduce-runtime`/`maple-runtime`/`wolfram-runtime`/`macsyma-runtime` still route ordinary recursive user-defined functions through the shared, uncapped mechanism, so an everyday unbounded-recursion program (not even a self-referential-reassignment attack) could crash those processes via an uncatchable native stack overflow. This is a different bug class from the one this PR fixes and was **not** introduced or worsened by this change — flagged as a follow-up task, not fixed here, to keep this PR focused.

## Test plan

- [x] `cargo test` green on `symbolic-vm`, `axiom-runtime`, `derive-runtime`, `reduce-runtime`, `maple-runtime`, `wolfram-runtime`, `macsyma-wasm`, `macsyma-runtime`, `cas-summation`, `task-core`
- [x] `cargo test` green on every REPL/`-to-semantic-ir` crate depending on the above (no regressions from the shared-crate change)
- [x] `cargo clippy --all-targets -- -D warnings` clean on every touched crate
- [x] Security review sub-agent: PASSED (no vulnerabilities found in the diff; one pre-existing, out-of-scope finding noted above and filed as a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)