### PR TITLE
feat(human-languages): migrate Spanish Chapters 4–6 to schema v2

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,12 +5,12 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Spanish duration
-tranche: 20 registered tracks, 1,063 Markdown lessons, 20 downloadable LaTeX
-books, and zero duration violations. HL-V01 keeps the remaining migration debt
-reproducible in both JSON and human-readable reports; HL-S01 proves the strict
-schema on the first 24 Spanish lessons, and the completed HL-D01 tranches prove
-duration remediation without discarding deep content.
+Last prioritized: 2026-08-02. Current baseline after the Spanish Chapters 4–6
+schema tranche: 20 registered tracks, 1,065 Markdown lessons, 20 downloadable
+LaTeX books, and zero duration violations. HL-V01 keeps the remaining migration
+debt reproducible in both JSON and human-readable reports; HL-S01 and HL-S02
+prove the strict schema on the first 51 Spanish lessons, and the completed
+HL-D01 tranches prove duration remediation without discarding deep content.
 
 ## Priority rules
 
@@ -62,12 +62,13 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01M | Complete in the Malayalam duration PR | Remove all thirty-seven sub-five-minute violations from the Malayalam track. | The report measures zero Malayalam violations; four new prerequisite-ordered micro-lessons separate vocabulary from etymology, register, and cross-language comparison. |
 | HL-D01N | Complete in the Arabic duration PR | Remove all thirty-nine sub-five-minute violations from the Arabic track. | The report measures zero Arabic violations; four new prerequisite-ordered writing steps preserve the abjad, joining, whole-word assembly, and hamza content. |
 | HL-D01O | Complete in the Hindi duration PR | Remove all forty sub-five-minute violations from the Hindi track. | The report measures zero Hindi violations; thirteen new prerequisite-ordered lessons preserve its script, etymology, grammar, and register depth. |
-| HL-D01P | Complete in this PR | Remove all forty-two sub-five-minute violations from the Tamil track. | The report measures zero Tamil violations; twenty new prerequisite-ordered lessons preserve its script, etymology, grammar, register, and source-evidence depth. |
-| HL-D01Q | Complete in this PR | Remove all forty-three sub-five-minute violations from the Latin track. | The report measures zero Latin violations; six new prerequisite-ordered lessons preserve its grammar, etymology, usage, and attestation depth. |
-| HL-D01R | Complete in this PR | Remove all fifty-five remaining sub-five-minute violations from the Spanish track. | The report measures zero Spanish violations; twelve new prerequisite-ordered lessons preserve the grammar, etymology, usage, writing, and practice depth from the genuinely long lessons. |
-| HL-D01 | Complete in this PR | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The deterministic report now reaches zero effective-duration violations across all twenty tracks. |
-| HL-S02 | Next | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | Chapters 1–3 prove generation; the next source slice must earn the same prerequisite and duration guarantees first. |
-| HL-G03 | Queued | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | Replaces the first three handwritten post-pilot chapters and extends app/book source-hash parity. |
+| HL-D01P | Complete (#9604) | Remove all forty-two sub-five-minute violations from the Tamil track. | The report measures zero Tamil violations; twenty new prerequisite-ordered lessons preserve its script, etymology, grammar, register, and source-evidence depth. |
+| HL-D01Q | Complete (#9610) | Remove all forty-three sub-five-minute violations from the Latin track. | The report measures zero Latin violations; six new prerequisite-ordered lessons preserve its grammar, etymology, usage, and attestation depth. |
+| HL-D01R | Complete (#9624) | Remove all fifty-five remaining sub-five-minute violations from the Spanish track. | The report measures zero Spanish violations; twelve new prerequisite-ordered lessons preserve the grammar, etymology, usage, writing, and practice depth from the genuinely long lessons. |
+| HL-D01 | Complete (#9624) | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The deterministic report now reaches zero effective-duration violations across all twenty tracks. |
+| HL-S02 | Complete in this PR | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | All 27 lessons have typed blocks, unique sequence, transitive knowledge closure, and sub-five-minute duration guarantees. |
+| HL-G03 | Next | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | Replaces the first three handwritten post-pilot chapters and extends app/book source-hash parity. |
+| HL-V02 | Queued | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B05 | Queued | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | A forced build succeeds but reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and two underfull boxes; the clean-build signal is zero of each. |
 | HL-B06 | Queued | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -138,6 +139,29 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   typed body blocks, explicit coverage metadata, same-language prerequisites,
   and transitive knowledge closure. Block-boundary prompt/answer knowledge
   declarations remain a later refinement; this slice does not claim them.
+
+## Findings from HL-S02
+
+- Spanish Chapters 4–6 now contain 27 schema-v2 lessons: the 25 existing
+  vocabulary, grammar, practice, and writing lessons plus two short repair
+  lessons that teach **y** and **café** before later dialogue asks learners to
+  use them. Spanish now has 51 schema-v2 lessons and 77 legacy lessons.
+- Every migrated lesson has a unique sequence from 250 through 510, begins with
+  a typed warm-up, ends with typed recall, closes all declared knowledge over
+  its transitive prerequisites, and remains below 300 effective seconds.
+- Forward references to later material such as *sí*, *un poco*, *ojalá*, and
+  untaught future farewells were removed from production prompts. The surviving
+  dialogues and script exercises require only what the learner already knows.
+- The editorial audit also caught undeclared prompt tokens that lesson-level
+  atom closure cannot see. HL-V02 records block-level prompt closure as the
+  next validation enhancement before schema migration expands beyond this
+  carefully audited slice.
+- The typed-block parser now recognizes `Script` sections explicitly, so the
+  accent, eñe, and inverted-question lessons remain first-class canonical app
+  content rather than falling into an unknown presentation bucket.
+- This tranche deliberately does not replace the handwritten LaTeX chapters.
+  HL-G03 is next and will generate Chapters 4–6 only after this canonical
+  content contract has merged.
 
 ## Findings from HL-G01
 

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Chapters 4–6 — prerequisite-safe schema-v2 content
+
+- Migrated all 25 existing lessons across well-being, farewells, first verbs,
+  accents, eñe, and question punctuation to the same typed schema consumed by
+  Language Ladder and canonical book generation.
+- Added two gentle prerequisite-repair lessons for **y / ¿y tú?** and **café**.
+  Later dialogue no longer asks learners to produce these words—or *sí*, *un
+  poco*, *ojalá*, and other future material—before teaching them.
+- Assigned unique sequences 250–510 and explicit knowledge, coverage,
+  register, variety, and sub-five-minute duration metadata to all 27 lessons.
+  The full Spanish track now has 51 schema-v2 lessons and 77 legacy lessons.
+- Classified `Script` sections as typed canonical blocks, preserving the inline
+  accent, eñe, and inverted-question ramp for both app and future generated-book
+  renderers. The LaTeX swap remains intentionally queued as HL-G03.
+
 ## Every Spanish lesson now fits a sub-five-minute step
 
 - Removed all 55 remaining Spanish duration violations and brought the full

--- a/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C04-como-esta
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 280
 chapter: 4
 type: phrase
 headword: ¿cómo está usted?
@@ -9,7 +12,19 @@ prerequisites: [ES-C04-estar, ES-C03-como, ES-C03-tu-usted]
 sounds: [vowel-o, r-tap]
 roots: [quomodo-latin, stare-latin]
 etymology_hook: "cómo (← Latin quōmodo 'in what manner') + está (estar) — 'in what manner are you standing?'"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-ESTAR, ES-GRAMMAR-ESTAR-ESTA-ESTAS, ES-LEX-COMO, ES-LEX-USTED, ES-REGISTER-TU-USTED]
+introduces:
+  knowledge: [ES-LEX-COMO-ESTA-USTED]
+practises:
+  knowledge: [ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO, ES-LEX-USTED]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: formal
+variety: general
 reviews_of: [ES-C04-estar, ES-C03-como, ES-C03-tu-usted]
 ---
 
@@ -21,7 +36,7 @@ reviews_of: [ES-C04-estar, ES-C03-como, ES-C03-tu-usted]
 question. You already met **cómo** ("how") and the **tú / usted** choice back in
 Chapter 3; you just learned **estar**. Assemble them.
 
-## The phrase, taken apart
+## The word, taken apart — assembling the phrase
 
 > **¿Cómo está usted?** = "How are you?" (formal)
 > literally: **"In what manner are you standing?"**

--- a/code/learning/human-languages/spanish/lessons/ES-C04-como-estas-register.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-como-estas-register.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C04-como-estas-register
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 290
 chapter: 4
 type: grammar
 headword: ¿cómo está usted? / ¿cómo estás?
@@ -8,13 +11,30 @@ prerequisites: [ES-C04-como-esta]
 sounds: [vowel-o, r-tap]
 roots: [quomodo-latin, stare-latin]
 etymology_hook: "the formal/informal split reuses the usted/tú register choice and estar endings already learned: está usted versus estás"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-COMO-ESTA-USTED, ES-LEX-TU, ES-LEX-USTED, ES-REGISTER-TU-USTED, ES-GRAMMAR-ESTAR-ESTA-ESTAS]
+introduces:
+  knowledge: [ES-LEX-COMO-ESTAS, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST]
+practises:
+  knowledge: [ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-GRAMMAR-ESTAR-REGISTER-CONTRAST]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: contrastive-formal-informal
+variety: general
 reviews_of: [ES-C04-como-esta, ES-C03-tu-usted]
 ---
 
 # ¿cómo está usted? / ¿cómo estás? — choose the register
 
-## One question, two relationships
+## Warm-up
+
+[PAUSE 2s] You can already ask a stranger **¿Cómo está usted?** Now change
+only the relationship: ask the same question of a friend.
+
+## Grammar Lens: one question, two relationships
 
 | register | question |
 |---|---|

--- a/code/learning/human-languages/spanish/lessons/ES-C04-de-nada.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-de-nada.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C04-de-nada
+spine_node: SPINE-COURTESY-THANK
+sequence: 260
 chapter: 4
 type: phrase
 headword: de nada
@@ -9,7 +12,19 @@ prerequisites: [ES-C04-gracias]
 sounds: [vowel-a, d-soft]
 roots: [de-latin, nada-nata-latin]
 etymology_hook: "nada ← Latin (rem) nata '(thing) born' → 'nothing'; the reply waves the favour away"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-GRACIAS]
+introduces:
+  knowledge: [ES-LEX-DE-NADA, ES-ETYMON-NATA]
+practises:
+  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C04-gracias]
 ---
 
@@ -28,7 +43,7 @@ problem."*
   not a hard English *d*. Spanish *d* between vowels always softens.
 - `vowel-a` — three clean *ah* sounds: *deh NAH-thah*.
 
-## The phrase, taken apart
+## The word, taken apart — the phrase
 
 - **de** = "of / from" (Latin **dē**) — the same *de* hiding in English
   **de**part, **de**duct, **de**scend.

--- a/code/learning/human-languages/spanish/lessons/ES-C04-estar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-estar.md
@@ -1,15 +1,30 @@
 ---
+schema_version: 2
 id: ES-C04-estar
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 270
 chapter: 4
 type: word
 headword: estar
 gloss: to be (a state or location — temporary)
 concept_tag: ES-VERB-ESTAR
-prerequisites: []
+prerequisites: [ES-C04-de-nada]
 sounds: [vowel-e, r-tap, st-no-e]
 roots: [stare-latin]
 etymology_hook: "estar ← Latin stare 'to stand' → English stay, state, status, stable, stance, estate"
-est_minutes: 4
+duration:
+  max_seconds: 290
+requires:
+  knowledge: [ES-LEX-TU, ES-LEX-USTED, ES-REGISTER-TU-USTED, ES-GRAMMAR-USTED-THIRD-PERSON]
+introduces:
+  knowledge: [ES-LEX-ESTAR, ES-GRAMMAR-ESTAR-ESTA-ESTAS, ES-GRAMMAR-STATE-LOCATION-ESTAR, ES-ETYMON-STARE]
+practises:
+  knowledge: [ES-LEX-ESTAR, ES-GRAMMAR-ESTAR-ESTA-ESTAS, ES-GRAMMAR-STATE-LOCATION-ESTAR]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C04-gracias]
 ---
 
@@ -17,9 +32,9 @@ reviews_of: [ES-C04-gracias]
 
 ## Warm-up
 
-[PAUSE 2s] To ask *how are you?* Spanish needs a verb for **being** — but
-Spanish has **two**, and the split is one of the language's signatures. Today:
-**estar**, the *temporary* one — how you *are right now*, and *where* you are.
+[PAUSE 2s] To ask *how are you?* Spanish needs a verb for **being**. Today:
+**estar** — the verb used for how someone is right now and where someone is.
+Spanish has another identity verb later; you do not need it yet.
 
 ## Sounds you'll need
 
@@ -47,17 +62,12 @@ That root **stā-/sta-** ("stand") is one of the most productive in English.
 So *¿cómo estás?* is, at the root, **"how are you standing?"** — a snapshot of
 right now.
 
-## Grammar Lens: estar vs. ser (the famous split)
+## Grammar Lens: state and location use estar
 
-Spanish has **two** verbs for "to be":
-
-| verb | from | used for |
-|---|---|---|
-| **ser** | Latin *esse* ("to be") | permanent identity — *soy David*, "I am David" |
-| **estar** | Latin *stāre* ("to stand") | temporary state & location — *estoy bien*, "I am well (now)"; *estoy aquí*, "I am here" |
-
-Rule of thumb: **how you feel and where you are → estar.** Who you *are* → ser.
-"How are you?" is about your current state, so it always takes **estar**.
+Use **estar** for a current state or location. “How are you?” asks about a
+current state, so it takes **estar**. The other Spanish be-verb handles
+identity and arrives in its own later lesson; keeping it out of today's drill
+lets one contrast settle at a time.
 
 You only need two forms of it this chapter:
 
@@ -73,6 +83,6 @@ You only need two forms of it this chapter:
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Which Latin verb is *estar* — "to be" or "to stand"? (To *stand* —
-*stāre*.) Which be-verb do you use for how you feel right now, *ser* or *estar*?
-(*estar*.) Next lesson, you finally ask it: **¿cómo está usted?**
+[PAUSE 3s] Which Latin verb is *estar* — “to be” or “to stand”? (To *stand* —
+*stāre*.) Which verb do you use for how you feel right now? (*estar*.) Next
+lesson, you finally ask it: **¿cómo está usted?**

--- a/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
@@ -1,15 +1,30 @@
 ---
+schema_version: 2
 id: ES-C04-gracias
+spine_node: SPINE-COURTESY-THANK
+sequence: 250
 chapter: 4
 type: word
 headword: gracias
 gloss: thank you
 concept_tag: COURTESY-THANKS
-prerequisites: []
+prerequisites: [ES-C03-practice]
 sounds: [vowel-a, r-tap, ci-th-s]
 roots: [gratia-latin]
 etymology_hook: "gracias ← Latin gratia 'favour, grace' → English grace, grateful, gratis, congratulate"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HOLA]
+introduces:
+  knowledge: [ES-LEX-GRACIAS, ES-ETYMON-GRATIA]
+practises:
+  knowledge: [ES-LEX-GRACIAS, ES-ETYMON-GRATIA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C03-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
@@ -1,14 +1,29 @@
 ---
+schema_version: 2
 id: ES-C04-practice
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 370
 chapter: 4
 type: practice-mix
 headword: (practice)
 gloss: the full "how are you?" exchange, formal and informal
 concept_tag: CH4-PRACTICE
-prerequisites: [ES-C04-gracias, ES-C04-de-nada, ES-C04-estar, ES-C04-como-estas-register, ES-C04-regular]
+prerequisites: [ES-C04-de-nada, ES-C04-regular, ES-C04-y, ES-W03-question-span]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 280
+requires:
+  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-Y, ES-ORTHOGRAPHY-PUNCTUATION-SPAN]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [ES-LEX-GRACIAS, ES-LEX-DE-NADA, ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN, ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-PRAGMATICS-AND-YOU]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus, fluency]
+register: contrastive-formal-informal
+variety: general
 reviews_of: [ES-C04-gracias, ES-C04-de-nada, ES-C04-como-estas-register, ES-C04-como-esta, ES-C04-regular, ES-C03-practice]
 ---
 
@@ -36,14 +51,14 @@ introduction left off.
 > — **Regular.** ¿Y tú?
 > — Bien, gracias.
 
-The one new glue word here is **¿y usted? / ¿y tú?** — "and you?" (*y* = "and,"
-from Latin *et*). It bounces the question back.
+The glue pattern you just secured is **¿y usted? / ¿y tú?** — “and you?”
+It bounces the question back without repeating the whole sentence.
 
 ## What you've built this chapter
 
 - **gracias** — thank you (← *grātia*, "grace").
 - **de nada** — you're welcome (← "of a born-thing" → "of nothing").
-- **estar** — the *temporary* to-be (← *stāre*, "to stand"); vs *ser* (identity).
+- **estar** — the state/location be-verb (← *stāre*, “to stand”).
 - **¿cómo está usted? / ¿cómo estás?** — how are you, formal / informal.
 - **bien / regular / más o menos** — well / so-so / more-or-less.
 

--- a/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C04-regular
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 300
 chapter: 4
 type: word
 headword: regular
@@ -9,7 +12,19 @@ prerequisites: [ES-C04-como-estas-register]
 sounds: [vowel-e, r-tap, l-clear]
 roots: [regula-latin, magis-minus-latin]
 etymology_hook: "regular ← Latin regula 'straight rod, rule'; the middling answer — 'on the rule / average'"
-est_minutes: 4
+duration:
+  max_seconds: 270
+requires:
+  knowledge: [ES-LEX-COMO-ESTA-USTED, ES-LEX-COMO-ESTAS, ES-LEX-BIEN]
+introduces:
+  knowledge: [ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-ETYMON-REGULA]
+practises:
+  knowledge: [ES-LEX-REGULAR, ES-LEX-MAS-O-MENOS, ES-LEX-BIEN, ES-LEX-COMO-ESTAS]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C01-bien, ES-C04-como-estas-register, ES-C04-como-esta]
 ---
 
@@ -21,13 +36,13 @@ reviews_of: [ES-C01-bien, ES-C04-como-estas-register, ES-C04-como-esta]
 middling, or a wave of the hand. You already have **bien** ("well," Chapter 1).
 Today, the *middling* answers — because nobody is *bien* every day.
 
-## Review first (20 seconds)
+## You'll want to know first
 
 [PAUSE 2s] Recall from Chapter 1: **bien** — "well." Root? (Latin *bene*, "well"
 — same as *bene*fit, *bene*volent.) So *estoy bien* = "I'm well." Now the answer
 for when you're *not* quite bien.
 
-## The words, taken apart
+## The word, taken apart — two answers
 
 **regular** — as an answer to "how are you?", it means **"so-so, average, not
 great."** (A famous false-friend trap: it does **not** mean English "regular /

--- a/code/learning/human-languages/spanish/lessons/ES-C04-y.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-y.md
@@ -1,0 +1,65 @@
+---
+schema_version: 2
+id: ES-C04-y
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 310
+chapter: 4
+type: word
+headword: y / ¿y tú?
+gloss: and / and you? — a tiny connector that hands the conversation back
+concept_tag: ES-WORD-Y
+prerequisites: [ES-C04-regular]
+sounds: [vowel-i]
+roots: [et-latin]
+etymology_hook: "y continues Latin et 'and'; English keeps that same Latin word inside et cetera, 'and the rest'"
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-LEX-TU, ES-LEX-USTED, ES-LEX-COMO-ESTAS, ES-LEX-REGULAR]
+introduces:
+  knowledge: [ES-LEX-Y, ES-PRAGMATICS-AND-YOU, ES-ETYMON-ET]
+practises:
+  knowledge: [ES-LEX-Y, ES-PRAGMATICS-AND-YOU, ES-LEX-TU, ES-LEX-USTED]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C04-como-estas-register, ES-C03-tu-usted]
+---
+
+# y / ¿y tú? — pass the question back
+
+## Warm-up
+
+[PAUSE 2s] You can ask how someone is and answer. One tiny connector turns
+that exchange around so the other person gets a turn too.
+
+## The word, taken apart
+
+**Y** means **and** and sounds like Spanish **i**: *ee*. It continues Latin
+**et**, also “and.” English borrowed that Latin word intact inside **et
+cetera**, literally “and the rest.”
+
+## Grammar Lens: the shortest return question
+
+Put **y** before a person you already know:
+
+- **¿Y tú?** — And you? *(informal)*
+- **¿Y usted?** — And you? *(formal)*
+
+Nothing else needs repeating. The little question hands the previous topic
+back to the other person.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “Bien. ¿Y tú?” to a friend]
+- [YOU SAY: “Regular. ¿Y usted?” to a stranger]
+- [YOU SAY: “y” — one clear *ee* sound]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **y** mean? (**And.**) How do you hand a question back
+to a friend? (**¿Y tú?**) To a stranger? (**¿Y usted?**) Which Latin word
+survives inside English **et cetera**? (**Et**, “and.”)

--- a/code/learning/human-languages/spanish/lessons/ES-C05-adios.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-adios.md
@@ -1,15 +1,30 @@
 ---
+schema_version: 2
 id: ES-C05-adios
+spine_node: SPINE-TAKE-LEAVE
+sequence: 380
 chapter: 5
 type: word
 headword: adiós
 gloss: goodbye
 concept_tag: FAREWELL
-prerequisites: []
+prerequisites: [ES-C04-practice]
 sounds: [vowel-a, diphthong-io, s-final]
 roots: [a-dios-latin]
 etymology_hook: "adiós ← 'a Dios' — '(I commend you) to God'; twin of French adieu, and of English goodbye ← 'God be with ye'"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HOLA, ES-LEX-BUENOS-DIAS, ES-LEX-COMO-ESTA-USTED]
+introduces:
+  knowledge: [ES-LEX-ADIOS, ES-PRAGMATICS-FINAL-FAREWELL, ES-ETYMON-A-DIOS]
+practises:
+  knowledge: [ES-LEX-ADIOS, ES-PRAGMATICS-FINAL-FAREWELL]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C04-practice]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-limits.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-limits.md
@@ -1,49 +1,61 @@
 ---
+schema_version: 2
 id: ES-C05-hasta-limits
+spine_node: SPINE-TAKE-LEAVE
+sequence: 400
 chapter: 5
 type: grammar
-headword: hasta aquí, hasta las tres, hasta luego
-gloss: hasta points to an endpoint in space or time and builds several everyday farewells
+headword: hasta aquí / hasta la noche
+gloss: hasta points to an endpoint in space or time
 prerequisites: [ES-C05-hasta]
 sounds: [silent-h, vowel-a]
-roots: [hatta-arabic, arabic-law-sha-allah]
-etymology_hook: "hasta marks a spatial or temporal limit; beside it, ojalá is another rare Arabic function-word loan that will later select the subjunctive"
-est_minutes: 4
+roots: [hatta-arabic]
+etymology_hook: "hasta marks a spatial or temporal limit; the endpoint may be a place such as aquí or a known time word such as la noche"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HASTA, ES-LEX-NOCHE, ES-GRAMMAR-DEFINITE-ARTICLES]
+introduces:
+  knowledge: [ES-LEX-AQUI, ES-GRAMMAR-HASTA-ENDPOINT]
+practises:
+  knowledge: [ES-LEX-HASTA, ES-LEX-AQUI, ES-LEX-NOCHE, ES-GRAMMAR-HASTA-ENDPOINT]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C05-hasta, ES-C05-adios]
 ---
 
-# hasta aquí, hasta luego — point to the limit
+# hasta aquí / hasta la noche — point to the limit
 
-## Space and time
+## Warm-up
 
-**Hasta** marks the endpoint of movement or duration:
+[PAUSE 2s] You know **hasta** means “until” or “up to.” Give that small word
+one spatial endpoint and one temporal endpoint, using only one new word.
 
-- **hasta aquí** — up to here
-- **hasta las tres** — until three o'clock
-- **hasta luego** — until later
-- **hasta mañana** — until tomorrow
-- **hasta pronto** — until soon
+## Grammar Lens: endpoints in space and time
 
-The same preposition points to a place, a clock time, or the next meeting.
-That is why farewells built with **hasta** become transparent once "until"
-is secure.
+**Aquí** means **here**. Put it after **hasta**:
 
-## One more Arabic function word
+> **hasta aquí** — up to here
 
-**Hasta** is not the only grammatical tool Spanish borrowed from Arabic.
-**Ojalá**, from Andalusi Arabic *law šāʾ Allāh* ("if God should will"),
-will later trigger the subjunctive. A preposition and a mood-trigger show
-that Arabic contact reached beyond objects into everyday grammar.
+For a time endpoint, reuse **la noche**, “the night,” from Chapter 2:
+
+> **hasta la noche** — until the night / until tonight
+
+The same preposition points to a place or the end of a stretch of time.
+The next lessons will place new time words after it one at a time.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "hasta aquí" — up to here]
-- [YOU SAY: "hasta las tres" — until three]
-- [YOU SAY: "hasta luego / mañana / pronto"]
+- [YOU SAY: “aquí” — here]
+- [YOU SAY: “hasta aquí” — up to here]
+- [YOU SAY: “hasta la noche” — until tonight]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What does **hasta** point to? (**An endpoint.**) Give one spatial
-and one temporal example. (**Hasta aquí; hasta las tres.**) Which other
-Arabic function word returns later? (**Ojalá.**)
+and one temporal example. (**Hasta aquí; hasta la noche.**) What is the only
+new lexical item? (**Aquí**, “here.”)

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C05-hasta-luego
+spine_node: SPINE-TAKE-LEAVE
+sequence: 410
 chapter: 5
 type: phrase
 headword: hasta luego
@@ -9,7 +12,19 @@ prerequisites: [ES-C05-hasta-limits]
 sounds: [diphthong-ue, g-soft-gw]
 roots: [hatta-arabic, loco-latin]
 etymology_hook: "hasta (Arabic) + luego (← Latin loco 'at the place' → then/soon) — 'until soon'"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HASTA, ES-GRAMMAR-HASTA-ENDPOINT]
+introduces:
+  knowledge: [ES-LEX-LUEGO, ES-LEX-HASTA-LUEGO, ES-ETYMON-LOCUS]
+practises:
+  knowledge: [ES-LEX-HASTA, ES-LEX-LUEGO, ES-LEX-HASTA-LUEGO]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C05-hasta-limits, ES-C05-hasta, ES-C05-adios]
 ---
 
@@ -26,7 +41,7 @@ today you add **luego** ("later"), and it has a very Latin backstory.
 - `diphthong-ue` — **luego** = *LWEH-goh*: the *ue* is a *w*-glide, *lweh-*.
 - The whole phrase: *AHS-tah LWEH-goh*.
 
-## The phrase, taken apart
+## The word, taken apart — the phrase
 
 > **hasta luego** = "until later" → "see you later."
 

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-manana.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-manana.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C05-hasta-manana
+spine_node: SPINE-TAKE-LEAVE
+sequence: 420
 chapter: 5
 type: phrase
 headword: hasta mañana
@@ -9,7 +12,19 @@ prerequisites: [ES-C05-hasta-luego, ES-W02-enye]
 sounds: [enye-ny, vowel-a]
 roots: [hatta-arabic, maneana-latin]
 etymology_hook: "mañana ← Latin (hora) maneana 'early hour' → morning → tomorrow; carries the ñ from the ñ-lesson"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HASTA, ES-LEX-HASTA-LUEGO, ES-FORM-MANANA, ES-SCRIPT-ENYE]
+introduces:
+  knowledge: [ES-LEX-MANANA, ES-LEX-HASTA-MANANA, ES-ETYMON-MANEANA]
+practises:
+  knowledge: [ES-LEX-HASTA, ES-LEX-MANANA, ES-LEX-HASTA-MANANA, ES-SCRIPT-ENYE]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C05-hasta-luego, ES-W02-enye]
 ---
 
@@ -27,7 +42,7 @@ in a word you'll say every evening.
   "canyon" (your ñ writing lesson — the tilde is a tiny second *n*, remember).
   Three soft *ah*'s: *ma-**ÑA**-na*.
 
-## The phrase, taken apart
+## The word, taken apart — the phrase
 
 > **hasta mañana** = "until tomorrow" → "see you tomorrow."
 
@@ -36,8 +51,6 @@ in a word you'll say every evening.
   **(hōra) maneana**, "the **early** hour" (from *māne*, "in the morning"). The
   logic: the next "early hour" you'll see is *tomorrow morning* → *mañana* came to
   mean both **morning** and **tomorrow**.
-  - *por la mañana* = "in the morning."
-  - *hasta mañana* = "until tomorrow."
 
 **The ñ, in the wild.** Recall the writing lesson: *ñ* is a frozen *nn* — a
 scribe's shorthand for a doubled *n*. *mañana* comes from Latin *maneana*, whose
@@ -54,8 +67,7 @@ with *hasta*, it's always **tomorrow**: *hasta mañana*, "until tomorrow."
 [PAUSE 1s]
 - [YOU SAY: "mañana" — *mah-NYAH-nah*, squished *ñ*]
 - [YOU SAY: "hasta mañana" — until tomorrow]
-- [YOU SAY: "por la mañana" (in the morning) vs "hasta mañana" (until tomorrow) —
-  same word, context decides]
+- [YOU SAY: “mañana” once as “morning,” then once as “tomorrow” — context decides]
 
 ## Wrap-up Recall
 

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-pronto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-pronto.md
@@ -1,15 +1,30 @@
 ---
+schema_version: 2
 id: ES-C05-hasta-pronto
+spine_node: SPINE-TAKE-LEAVE
+sequence: 430
 chapter: 5
 type: phrase
 headword: hasta pronto
 gloss: see you soon (literally "until soon")
 concept_tag: FAREWELL-SOON
-prerequisites: [ES-C05-hasta-luego]
+prerequisites: [ES-C05-hasta-manana]
 sounds: [vowel-o, pr-cluster]
 roots: [hatta-arabic, promptus-latin]
 etymology_hook: "pronto ← Latin promptus 'brought forth, ready' → English prompt; 'until soon'"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HASTA, ES-LEX-HASTA-LUEGO, ES-LEX-HASTA-MANANA]
+introduces:
+  knowledge: [ES-LEX-PRONTO, ES-LEX-HASTA-PRONTO, ES-ETYMON-PROMPTUS]
+practises:
+  knowledge: [ES-LEX-HASTA, ES-LEX-PRONTO, ES-LEX-HASTA-PRONTO]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C05-hasta-luego, ES-C05-hasta-manana]
 ---
 
@@ -25,7 +40,7 @@ it's hiding in plain sight in English.
 
 - **hasta pronto** = *AHS-tah PRON-toh* — a clean *pr*, a pure *o*.
 
-## The phrase, taken apart
+## The word, taken apart — the phrase
 
 > **hasta pronto** = "until soon" → "see you soon."
 

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C05-hasta
+spine_node: SPINE-TAKE-LEAVE
+sequence: 390
 chapter: 5
 type: word
 headword: hasta
@@ -9,7 +12,19 @@ prerequisites: [ES-C05-adios]
 sounds: [silent-h, vowel-a]
 roots: [hatta-arabic]
 etymology_hook: "hasta ← Arabic ḥattā حتى 'until' — a rare Arabic FUNCTION word in Spanish (most loans are nouns)"
-est_minutes: 4
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [ES-LEX-ADIOS]
+introduces:
+  knowledge: [ES-LEX-HASTA, ES-ETYMON-HATTA, ES-HISTORY-AL-ANDALUS-LOANS]
+practises:
+  knowledge: [ES-LEX-HASTA, ES-ETYMON-HATTA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C05-adios]
 ---
 

--- a/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
@@ -1,14 +1,29 @@
 ---
+schema_version: 2
 id: ES-C05-practice
+spine_node: SPINE-TAKE-LEAVE
+sequence: 440
 chapter: 5
 type: practice-mix
 headword: (practice)
 gloss: closing a conversation — the full set of farewells
 concept_tag: CH5-PRACTICE
-prerequisites: [ES-C05-adios, ES-C05-hasta-limits, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto]
+prerequisites: [ES-C05-adios, ES-C05-hasta-pronto]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-ADIOS, ES-PRAGMATICS-FINAL-FAREWELL, ES-LEX-HASTA-LUEGO, ES-LEX-HASTA-MANANA, ES-LEX-HASTA-PRONTO, ES-LEX-COMO-ESTA-USTED, ES-PRAGMATICS-AND-YOU]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [ES-LEX-ADIOS, ES-LEX-HASTA-LUEGO, ES-LEX-HASTA-MANANA, ES-LEX-HASTA-PRONTO, ES-LEX-HOLA, ES-LEX-COMO-ESTA-USTED]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus, fluency]
+register: neutral
+variety: general
 reviews_of: [ES-C05-adios, ES-C05-hasta-limits, ES-C05-hasta, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto, ES-C04-practice]
 ---
 
@@ -20,7 +35,7 @@ reviews_of: [ES-C05-adios, ES-C05-hasta-limits, ES-C05-hasta, ES-C05-hasta-luego
 …* goodbyes — now close a real conversation, and fold back into the whole arc
 you've built since *hola*.
 
-## Choosing the right goodbye
+## Grammar Lens: choosing the right goodbye
 
 The choice is about **when you'll meet again**:
 
@@ -31,7 +46,7 @@ The choice is about **when you'll meet again**:
 | just "see you" (neutral default) | **Hasta luego.** |
 | leaving for the day | **Hasta mañana.** |
 
-## The whole exchange, start to finish
+## The exchange — start to finish
 
 Everything from Chapters 1–5, in one conversation:
 
@@ -39,7 +54,7 @@ Everything from Chapters 1–5, in one conversation:
 > — Me llamo Luis. Mucho gusto.
 > — ¿Cómo está usted?
 > — Bien, gracias. ¿Y usted?
-> — Muy bien. Bueno… **hasta mañana**, Luis.
+> — Bien. **Hasta mañana**, Luis.
 > — **Hasta mañana**, Ana. **¡Adiós!**
 
 ## What you've built this chapter

--- a/code/learning/human-languages/spanish/lessons/ES-C06-cafe.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-cafe.md
@@ -1,0 +1,65 @@
+---
+schema_version: 2
+id: ES-C06-cafe
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 450
+chapter: 6
+type: word
+headword: café
+gloss: coffee / a café — one useful noun before the polite request that follows
+concept_tag: ES-WORD-CAFE
+prerequisites: [ES-C05-practice]
+sounds: [accent-acute, stress-final]
+roots: [qahwah-arabic, kahve-turkish, caffe-italian]
+etymology_hook: "café came through Italian caffè and Turkish kahve from Arabic qahwah; English coffee reached the same family by a different European route"
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [ES-SOUND-WRITTEN-ACCENT, ES-SCRIPT-ACUTE-ACCENT]
+introduces:
+  knowledge: [ES-LEX-CAFE, ES-ETYMON-QAHWA, ES-GRAMMAR-CAFE-MASCULINE]
+practises:
+  knowledge: [ES-LEX-CAFE, ES-SCRIPT-ACUTE-ACCENT]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-W01-acento, ES-C05-hasta]
+---
+
+# café — coffee, and a place to drink it
+
+## Warm-up
+
+[PAUSE 2s] Before you can make a polite request, you need one small thing to
+request. **Café** gives you a useful noun and lets the written accent do a job
+you already understand.
+
+## Sounds you'll need
+
+Say **ca-FÉ**. A vowel-final word would normally stress the second-to-last
+syllable, so the acute accent records the unexpected final stress.
+
+## The word, taken apart
+
+Spanish **café** came through Italian **caffè** and Turkish **kahve** from
+Arabic **qahwah**. English **coffee** reached the same travelling word by a
+different European route. The drink and the word both crossed languages.
+
+**Café** can name the drink or the place, just as English **coffee** and
+**café** divide those jobs. It is masculine: **el café**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: “café” — final stress]
+- [YOU SAY: “el café”]
+- [YOU SAY: the route — “qahwah → kahve → caffè → café”]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does the stress fall? (**On the final é.**) Why is the
+accent written? (**It overrides the usual vowel-final stress.**) What route
+carried the word into Spanish? (**Arabic qahwah → Turkish kahve → Italian
+caffè → Spanish café.**)

--- a/code/learning/human-languages/spanish/lessons/ES-C06-espanol.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-espanol.md
@@ -1,15 +1,30 @@
 ---
+schema_version: 2
 id: ES-C06-espanol
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 500
 chapter: 6
 type: phrase
 headword: Hablo español
 gloss: "I speak Spanish" — your first full sentence (español = Spanish)
 concept_tag: ES-WORD-ESPANOL
-prerequisites: [ES-C06-hablar]
+prerequisites: [ES-C06-estudiar, ES-W02-enye, ES-W03-question-span]
 sounds: [enye-ny, silent-h]
 roots: [hispania-latin]
 etymology_hook: "español ← Hispania (Roman name for Iberia); the -ñol ending brings back the ñ"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HABLAR, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-FORM-ESPANOL, ES-SCRIPT-ENYE, ES-ORTHOGRAPHY-PUNCTUATION-SPAN]
+introduces:
+  knowledge: [ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-GRAMMAR-BARE-LANGUAGE, ES-ETYMON-HISPANIA]
+practises:
+  knowledge: [ES-LEX-HABLO-ESPANOL, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-SCRIPT-ENYE]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C06-hablar, ES-W02-enye]
 ---
 
@@ -21,7 +36,7 @@ reviews_of: [ES-C06-hablar, ES-W02-enye]
 you conjugated and a **noun**, and make a sentence **nobody handed you
 pre-assembled**. *Hablo español* — "I speak Spanish."
 
-## The new word: español
+## The word, taken apart — español
 
 **español** = "Spanish" (the language, and a Spaniard), from **Hispania**, the
 Roman name for the Iberian peninsula. The path *Hispania → hispaniolus → español*
@@ -33,7 +48,7 @@ a-tilde you met in the writing lesson (*Hispaniolus* → *españ-ol*). Say it
 fittingly, *español* itself may trace back through Latin to a **Phoenician** name
 for the coast, "land of hyraxes / rabbits.")
 
-## The sentence, assembled
+## What you've built — the sentence assembled
 
 Snap two things you already own together:
 
@@ -41,26 +56,27 @@ Snap two things you already own together:
 
 That's it — a complete, grammatical Spanish sentence. Note what's *not* there:
 
-- **No *yo*.** The *-o* of *hablo* already says "I" (the pro-drop you met with
-  *io*/*eu*). *Yo hablo español* is fine too, but only for emphasis.
+- **No separate subject word.** The *-o* of *hablo* already says “I,” reusing
+  the pro-drop pattern from the previous lesson.
 - **No "the" or "a."** Languages are bare: *hablo español*, not "*el* español."
 
 Now swap the pieces and watch it generate:
 
-- **Estudio español.** — "I study Spanish."
-- **Trabajo** … , **Hablas español?** — "Do you speak Spanish?" (just raise the
-  tone — and remember the **¿ ?** from the writing chapter).
+- **Estudio español.** — “I study Spanish.”
+- **Trabajo.** — “I work.”
+- **¿Hablas español?** — “Do you speak Spanish?” (reuse the **¿ ?** from the
+  writing lesson).
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "Hablo español" — *AH-bloh es-pa-NYOL*]
-- [YOU SAY: swap the verb — "Estudio español", "Trabajo mucho"]
+- [YOU SAY: swap the verb — “Estudio español”, “Trabajo”]
 - [YOU SAY: ask it — "¿Hablas español?" (raise the pitch, ¿ opens the question)]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Where does *español* come from, and what letter does its ending bring
-back? (*Hispania*; the *ñ*.) In *Hablo español*, why is there no *yo* and no
-"the"? (The *-o* ending is "I"; languages take no article.) You just built your
+back? (*Hispania*; the *ñ*.) In *Hablo español*, why is there no separate subject
+word and no “the”? (The *-o* ending carries “I”; languages take no article.) You just built your
 first sentence from parts — that's the whole game from here. Next: practice.

--- a/code/learning/human-languages/spanish/lessons/ES-C06-estudiar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-estudiar.md
@@ -1,15 +1,30 @@
 ---
+schema_version: 2
 id: ES-C06-estudiar
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 490
 chapter: 6
 type: word
 headword: estudiar
 gloss: to study (a third -ar verb — the pattern is automatic now)
 concept_tag: ES-VERB-ESTUDIAR
-prerequisites: [ES-C06-hablar]
+prerequisites: [ES-C06-trabajar]
 sounds: [st-no-e, r-tap, diphthong-io]
 roots: [studere-latin]
 etymology_hook: "estudiar ← Latin studēre 'to be eager, apply oneself' → English student, studio, studious"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HABLAR, ES-LEX-TRABAJAR, ES-GRAMMAR-AR-PRESENT-SINGULAR]
+introduces:
+  knowledge: [ES-LEX-ESTUDIAR, ES-ETYMON-STUDERE]
+practises:
+  knowledge: [ES-LEX-ESTUDIAR, ES-GRAMMAR-AR-PRESENT-SINGULAR]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C06-trabajar]
 ---
 
@@ -46,12 +61,12 @@ than mere schoolwork.
 
 Drop **-ar**, add the ending — for the third time:
 
-| yo | **estudio** | I study |
+| I (ending carries the subject) | **estudio** | I study |
 | tú | **estudias** | you study |
-| él/ella/usted | **estudia** | he/she studies / you (formal) study |
+| usted | **estudia** | you (formal) study |
 
-Three verbs, one pattern: *hablo, trabajo, estudio*. You've internalized the
-whole regular **-ar** present tense.
+Three verbs, one pattern: *hablo, trabajo, estudio*. The singular regular
+**-ar** present is now reusable rather than memorized verb by verb.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
@@ -1,15 +1,30 @@
 ---
+schema_version: 2
 id: ES-C06-hablar
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 470
 chapter: 6
 type: word
 headword: hablar
 gloss: to speak / to talk (your first regular -ar verb)
 concept_tag: ES-VERB-HABLAR
-prerequisites: []
+prerequisites: [ES-C06-por-favor]
 sounds: [silent-h, r-tap, v-b]
 roots: [fabulari-latin]
 etymology_hook: "hablar ← Latin fabulārī 'to chat, tell tales' (← fābula 'story' → fable); the f→h sound-law"
-est_minutes: 4
+duration:
+  max_seconds: 270
+requires:
+  knowledge: [ES-LEX-TU, ES-LEX-USTED, ES-REGISTER-TU-USTED, ES-GRAMMAR-USTED-THIRD-PERSON, ES-GRAMMAR-FIRST-PERSON-VERB, ES-SOUND-H-SILENT]
+introduces:
+  knowledge: [ES-LEX-HABLAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-SOUND-F-TO-H, ES-ETYMON-FABULARI]
+practises:
+  knowledge: [ES-LEX-HABLAR, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-SOUND-F-TO-H]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C06-por-favor]
 ---
 
@@ -17,10 +32,10 @@ reviews_of: [ES-C06-por-favor]
 
 ## Warm-up
 
-[PAUSE 2s] Until now you've assembled fixed phrases. **hablar** ("to speak") is
-your first real **verb** — and with it comes the single most powerful pattern in
-Spanish: the **-ar present tense**. Learn this one template and you can drive
-*hundreds* of verbs.
+[PAUSE 2s] Until now you've assembled fixed phrases. **hablar** (“to speak”)
+gives you the first reusable verb pattern: the singular **-ar present**. One
+small ending swap will let you say “I speak,” ask a friend, or address someone
+formally.
 
 ## Sounds you'll need
 
@@ -35,36 +50,24 @@ Spanish: the **-ar present tense**. Learn this one template and you can drive
 That **fābula** is thoroughly English: **fable**, **fabulous** ("story-like"),
 **confabulate**, and **ineffable** ("un-speak-able").
 
-### The f→h sound-law (a decoder for hundreds of words)
-
-Notice: Latin **f-** became Spanish **h-**. This happened across the whole
-language, and it's a superpower — put the *f* back and the Latin/English cousin
-appears:
-
-| Spanish (h-) | Latin (f-) | English cousin |
-|---|---|---|
-| **hablar** | *fābulārī* | fable |
-| **harina** (flour) | *farīna* | farina, farinaceous |
-| **hacer** (to do) | *facere* | fact, factory |
-| **hijo** (son) | *fīlius* | filial, affiliate |
-| **hierro** (iron) | *ferrum* | ferrous, ferric |
+The initial Latin **f-** weakened and eventually disappeared in this word,
+leaving the written but silent Spanish **h-**. The single path you need today
+is **fābulārī → hablar**; later words will let you test how broadly the same
+historical pattern reaches.
 
 ## Grammar Lens: the -ar present tense (the big one)
 
-Spanish verbs come in three families, by their ending: **-ar**, **-er**, **-ir**.
-*hablar* is **-ar**, the biggest. To conjugate, **drop -ar** and add the ending
-for the person:
+**Hablar** belongs to the **-ar** family. To conjugate the three singular
+forms you need now, **drop -ar** and add the ending for the person:
 
 | person | ending | *hablar* → | meaning |
 |---|---|---|---|
-| yo (I) | **-o** | **hablo** | I speak |
+| I (the ending carries the subject) | **-o** | **hablo** | I speak |
 | tú (you) | **-as** | **hablas** | you speak |
-| él/ella/usted | **-a** | **habla** | he/she speaks / you (formal) speak |
-| (nosotros) | -amos | hablamos | we speak |
-| (ellos/ustedes) | -an | hablan | they/you-all speak |
+| usted (you, formal) | **-a** | **habla** | you speak |
 
-And — as with *io*/*eu* in the other tracks — **you drop the *yo***: the *-o*
-ending already says "I." *Hablo español* = "I speak Spanish," no *yo* needed.
+The **-o** ending already says “I,” so Spanish normally leaves the subject
+pronoun unstated. That is **pro-drop**: *hablo* is a complete “I speak.”
 
 **This same template fits every regular -ar verb.** Next you'll snap two more
 verbs straight into it.
@@ -73,12 +76,13 @@ verbs straight into it.
 
 [PAUSE 1s]
 - [YOU SAY: "hablar" — *ah-BLAR*, silent *h*]
-- [YOU SAY: the pattern — "hablo, hablas, habla" (I / you / he-she speak)]
+- [YOU SAY: the pattern — “hablo, hablas, habla” (I / tú / usted)]
 - [YOU SAY: "hablar" then English "fable, fabulous, ineffable" — the *fābula* root]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What Latin word is *hablar* from, and what English word shares it?
-(*fābulārī* ← *fābula* — fable.) What sound-law turned *f-* into *h-*? (Latin *f*
-→ Spanish *h*: *facere* → *hacer*.) How do you say "I speak," and why no *yo*?
-(*Hablo* — the *-o* ending is "I".) Next: **trabajar**, "to work."
+(*fābulārī* ← *fābula* — fable.) What happened to its initial Latin *f-*?
+(It weakened away, leaving silent Spanish *h-*.) How do you say “I speak,”
+and why is no subject pronoun required? (*Hablo* — the *-o* ending carries
+“I.”) Next: **trabajar**, “to work.”

--- a/code/learning/human-languages/spanish/lessons/ES-C06-por-favor.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-por-favor.md
@@ -1,15 +1,30 @@
 ---
+schema_version: 2
 id: ES-C06-por-favor
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 460
 chapter: 6
 type: phrase
 headword: por favor
 gloss: please (literally "for [a] favour")
 concept_tag: COURTESY-PLEASE
-prerequisites: []
+prerequisites: [ES-C06-cafe]
 sounds: [r-tap, v-b]
 roots: [pro-latin, favere-latin]
 etymology_hook: "por (← pro 'for') + favor (← favēre 'to favour') → English favour, favorite, favorable"
-est_minutes: 3
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-CAFE, ES-LEX-GRACIAS, ES-LEX-DE-NADA]
+introduces:
+  knowledge: [ES-LEX-POR-FAVOR, ES-PRAGMATICS-POLITE-REQUEST, ES-ETYMON-PRO-FAVOR]
+practises:
+  knowledge: [ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-GRACIAS, ES-LEX-DE-NADA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C04-gracias, ES-C04-de-nada]
 ---
 
@@ -28,7 +43,7 @@ favour."* You're asking someone to do you a kindness.
   *fah-BOR*. (So *favor* and English *favour* look alike *and* the *v* even sounds
   like the *b* you'd hear in "harbour.")
 
-## The phrase, taken apart
+## The word, taken apart — the phrase
 
 - **por** = "for / through / by," from Latin **prō** ("for, on behalf of") — the
   same *pro-* in English **pro**noun, **pro**pose, **pro**tect.
@@ -36,15 +51,9 @@ favour."* You're asking someone to do you a kindness.
   to support."* It's the very word English borrowed: **favour**, **favorite**,
   **favorable**, **favouritism**.
 
-So *por favor* literally says **"for a favour"** — *[do this] as a kindness to
-me.* Compare the family:
-
-| language | "please" | literally |
-|---|---|---|
-| **Spanish** | *por favor* | "for a favour" |
-| **French** | *s'il vous plaît* | "if it pleases you" |
-| **Italian** | *per favore* | "for a favour" (the twin) |
-| **German** | *bitte* | "I ask / pray" |
+So *por favor* literally says **“for a favour”** — *[do this] as a kindness
+to me.* English **favour**, **favorite**, and **favorable** keep the same
+Latin family visible without asking you to learn another language's formula.
 
 ## Grammar Lens: the courtesy set is complete
 
@@ -58,12 +67,12 @@ You now hold the three pillars of politeness:
 
 [PAUSE 1s]
 - [YOU SAY: "por favor" — *por fah-BOR*, soft *v/b*]
-- [YOU SAY: "Un café, por favor" — "a coffee, please"]
+- [YOU SAY: "Café, por favor" — "Coffee, please"]
 - [YOU SAY: "favor" then English "favour, favorite" — one family]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What does *por favor* literally mean? ("For a favour.") What Latin
 verb is *favor* from, and its English cousins? (*favēre* — favour, favorite,
-favorable.) Which Italian phrase is its exact twin? (*Per favore*.) Next: your
-first real **verb** — *hablar*, "to speak."
+favorable.) Which three-word courtesy loop do you now own? (*Por favor →
+gracias → de nada*.) Next: your first regular **verb** — *hablar*, “to speak.”

--- a/code/learning/human-languages/spanish/lessons/ES-C06-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-practice.md
@@ -1,14 +1,29 @@
 ---
+schema_version: 2
 id: ES-C06-practice
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 510
 chapter: 6
 type: practice-mix
 headword: (practice)
 gloss: your first sentences — the -ar present tense in action
 concept_tag: CH6-PRACTICE
-prerequisites: [ES-C06-por-favor, ES-C06-hablar, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol]
+prerequisites: [ES-C06-espanol]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 270
+requires:
+  knowledge: [ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-HABLAR, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-LEX-ESPANOL, ES-LEX-HABLO-ESPANOL, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-LEX-GRACIAS, ES-LEX-DE-NADA]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [ES-LEX-CAFE, ES-LEX-POR-FAVOR, ES-LEX-HABLAR, ES-LEX-TRABAJAR, ES-LEX-ESTUDIAR, ES-LEX-HABLO-ESPANOL, ES-GRAMMAR-AR-PRESENT-SINGULAR, ES-GRAMMAR-PRO-DROP, ES-LEX-GRACIAS, ES-LEX-DE-NADA]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus, fluency]
+register: neutral
+variety: general
 reviews_of: [ES-C06-hablar, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol, ES-C04-practice]
 ---
 
@@ -20,9 +35,10 @@ reviews_of: [ES-C06-hablar, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol, ES
 phrases, you're **building sentences from a pattern**. Drill the three verbs
 through the endings until *hablo / hablas / habla* is automatic.
 
-## Conjugate on command
+## Grammar Lens: conjugate on command
 
-[PAUSE 1s] Run each verb through *yo → tú → él/ella*:
+[PAUSE 1s] Run each verb through the three singular jobs you know: the ending
+alone for **I** → **tú** → **usted**:
 
 - **hablar**: hablo · hablas · habla
 - **trabajar**: trabajo · trabajas · trabaja
@@ -31,20 +47,18 @@ through the endings until *hablo / hablas / habla* is automatic.
 Same three endings (**-o / -as / -a**) every time — that's the whole regular
 **-ar** present, singular.
 
-## Say something real
+## The exchange — say something real
 
-> — ¿**Hablas** español? — Sí, **hablo** un poco. (Do you speak Spanish? — Yes, I
-> speak a little.)
-> — ¿**Trabajas** o **estudias**? — **Estudio** español. (Do you work or study? —
-> I study Spanish.)
-> — Un café, **por favor**. — ¡Gracias! — De nada.
+> — ¿**Hablas** español? — **Hablo español.**
+> — ¿**Estudias** español? — **Estudio español.**
+> — **Café, por favor.** — ¡Gracias! — De nada.
 
 ## What you've built this chapter
 
 - **por favor** — please (← "for a favour"), completing gracias / de nada / por
   favor.
-- **the regular -ar present tense** — drop *-ar*, add **-o / -as / -a** (…-amos /
-  -an): the template behind *hablar, trabajar, estudiar*, and hundreds more.
+- **the singular regular -ar pattern** — drop *-ar*, add **-o / -as / -a**: the
+  template behind *hablar, trabajar,* and *estudiar*.
 - **hablar** (← *fābula*, fable; the f→h law), **trabajar** (← *tripalium*,
   torture → travail/travel), **estudiar** (← *studēre*, eagerness → student).
 - **Hablo español** — your first self-assembled sentence (pro-drop, no article).
@@ -52,16 +66,17 @@ Same three endings (**-o / -as / -a**) every time — that's the whole regular
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: conjugate all three verbs, yo/tú/él, without stopping]
-- [YOU SAY: answer "¿Hablas español?" and "¿Trabajas o estudias?" about yourself]
-- [YOU SAY: order something "…, por favor" and run the full gracias/de nada loop]
+- [YOU SAY: conjugate all three verbs for I / tú / usted, without stopping]
+- [YOU SAY: answer “¿Hablas español?” and “¿Estudias español?” about yourself]
+- [YOU SAY: request “Café, por favor” and run the full gracias/de nada loop]
 
-[REPEAT x2] Ask and answer "¿Hablas español? — Sí, hablo español."
+[REPEAT x2] Ask and answer “¿Hablas español? — Hablo español.”
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What are the three singular *-ar* endings? (*-o / -as / -a*.) Give the
-"I" form of all three verbs. (*Hablo, trabajo, estudio*.) Why no *yo* in *Hablo
-español*? (The *-o* is "I".) You can now generate sentences — the course stops
+“I” form of all three verbs. (*Hablo, trabajo, estudio*.) Why does *Hablo
+español* need no separate subject word? (The *-o* carries “I.”) You can now
+generate sentences — the course stops
 handing you phrases and starts handing you *rules*. Next chapter: the *-er/-ir*
 verbs, and questions with *qué / dónde*.

--- a/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-C06-trabajar
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 480
 chapter: 6
 type: word
 headword: trabajar
@@ -9,7 +12,19 @@ prerequisites: [ES-C06-hablar]
 sounds: [r-tap, j-jota, b-soft]
 roots: [tripalium-latin]
 etymology_hook: "trabajar ← Latin tripaliāre 'to torture' (← tripalium, a 3-stake device) → English travail, travel"
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-HABLAR, ES-GRAMMAR-AR-PRESENT-SINGULAR]
+introduces:
+  knowledge: [ES-LEX-TRABAJAR, ES-ETYMON-TRIPALIUM]
+practises:
+  knowledge: [ES-LEX-TRABAJAR, ES-GRAMMAR-AR-PRESENT-SINGULAR]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C06-hablar]
 ---
 
@@ -24,7 +39,7 @@ as a word for **torture**, and it's the secret origin of English **travel**.
 ## Sounds you'll need
 
 - `j-jota` — the **j** is a raspy *h*-from-the-throat (the *jota*): *trabajar* =
-  *tra-ba-**HAR***. (Same sound as the *j* in *jamón*.)
+  *tra-ba-**HAR***.
 - `r-tap`, `b-soft` — tapped *r*, soft *b*.
 
 ## The word, taken apart
@@ -42,19 +57,19 @@ road:
   became **travel** (to make a journey). Every time you *travel*, you're
   etymologically being *tortured*.
 
-So *Trabajo mucho* ("I work a lot") is, at the root, "I am tortured a lot" — a
-joke every Spanish learner should enjoy.
+So even plain **trabajo**, “I work,” hides the old idea of toil as torment — a
+dark little joke inside an everyday verb.
 
 ## Grammar Lens: same -ar template
 
 Drop **-ar**, add the ending — identical to *hablar*:
 
-| yo | **trabajo** | I work |
+| I (ending carries the subject) | **trabajo** | I work |
 | tú | **trabajas** | you work |
-| él/ella/usted | **trabaja** | he/she works / you (formal) work |
+| usted | **trabaja** | you (formal) work |
 
-Notice you didn't learn anything new — that's the point. **One template, every
--ar verb.**
+Notice you didn't learn a new ending — that's the point. **One template, every
+regular -ar verb.**
 
 ## Guided Practice
 

--- a/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
@@ -1,13 +1,28 @@
 ---
+schema_version: 2
 id: ES-W01-acento
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 320
 chapter: 4
 type: writing
 headword: "á é í ó ú"
 gloss: the acute accent as a visible exception to Spanish's default stress rules
-prerequisites: [ES-C03-como, ES-C03-tu-usted, ES-C04-como-estas-register]
+prerequisites: [ES-C04-y]
 sounds: [stress]
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-SOUND-WRITTEN-ACCENT, ES-GRAMMAR-QUESTION-ACCENT, ES-LEX-COMO]
+introduces:
+  knowledge: [ES-SCRIPT-ACUTE-ACCENT, ES-GRAMMAR-DEFAULT-STRESS, ES-GRAMMAR-STRESS-EXCEPTION]
+practises:
+  knowledge: [ES-SCRIPT-ACUTE-ACCENT, ES-GRAMMAR-DEFAULT-STRESS, ES-GRAMMAR-STRESS-EXCEPTION]
+skills: [speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C03-como, ES-C04-regular]
 ---
 
@@ -17,25 +32,25 @@ reviews_of: [ES-C03-como, ES-C04-regular]
 
 [PAUSE 2s] You've been reading accented words since your very first noun —
 **dí**a, **có**mo, es**tá**, **má**s. Time to make that little stroke make
-sense. Spanish has exactly **one** accent mark — the *acute* accent, `´`,
-leaning right — and it does just **two** jobs. Learn both and you can read any
-Spanish word aloud correctly, first try.
+sense. Spanish uses one mark to write exceptional stress — the *acute* accent,
+`´`, leaning right — and it does two jobs in the words you know. Learn the
+stress job now; the next lesson adds its grammar-label job.
 
-## What it looks like, and how to write it
+## Script — shape and stroke
 
 A short stroke rising **left-to-right**, sitting on top of a vowel:
 **á é í ó ú**. (On the *í*, it replaces the dot.) One clean up-stroke — the
 opposite lean from the French *grave* accent `à`. Spanish never uses grave or
 circumflex; if it leans the wrong way, it isn't Spanish.
 
-## Job 1 — it tells you where to shout
+## Grammar Lens: the mark records exceptional stress
 
 Spanish stress is regular, so most words need **no** mark. The default:
 
 - word ends in a **vowel, -n, or -s** → stress the **second-to-last** syllable
-  (*ca-**sa***, *jo-ven*, *lla-mo*).
+  (*ho-la*, *lla-mo*, *gus-to*).
 - word ends in **any other consonant** → stress the **last** syllable
-  (*us-**ted***, *re-gu-**lar***, *ha-blar*).
+  (*us-**ted***, *re-gu-**lar***, *es-**tar***).
 
 The accent appears **only when a word breaks that rule** — it marks the
 exception. *está* ends in a vowel, so the rule wants *ES-ta*; the accent
@@ -46,8 +61,8 @@ can see** — it never changes the vowel's sound, only which syllable you hit.
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "casa, joven, llamo" — second-to-last stress]
-- [YOU SAY: "usted, regular, hablar" — final stress]
+- [YOU SAY: “hola, llamo, gusto” — second-to-last stress]
+- [YOU SAY: “usted, regular, estar” — final stress]
 - [YOU SAY: "está, cómo" — the accent overrides the default]
 
 ## Wrap-up Recall

--- a/code/learning/human-languages/spanish/lessons/ES-W01-tilde-diacritica.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W01-tilde-diacritica.md
@@ -1,49 +1,59 @@
 ---
+schema_version: 2
 id: ES-W01-tilde-diacritica
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 330
 chapter: 4
 type: writing
-headword: "tu/tú, el/él, como/cómo"
-gloss: the acute accent separates look-alike words with different grammatical jobs
+headword: "el / él"
+gloss: the acute accent separates the article el from the pronoun él
 prerequisites: [ES-W01-acento]
 sounds: [stress]
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-SCRIPT-ACUTE-ACCENT, ES-GRAMMAR-DEFINITE-ARTICLES]
+introduces:
+  knowledge: [ES-LEX-EL-PRONOUN, ES-GRAMMAR-DIACRITIC-ACCENT]
+practises:
+  knowledge: [ES-GRAMMAR-DEFINITE-ARTICLES, ES-LEX-EL-PRONOUN, ES-GRAMMAR-DIACRITIC-ACCENT]
+skills: [speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-W01-acento, ES-C03-como, ES-C03-tu-usted]
 ---
 
-# tu or tú? — the accent as a meaning label
+# el or él? — the accent as a meaning label
 
-## The second job
+## Warm-up
+
+[PAUSE 2s] You know **el** as the article “the.” Add one acute accent and the
+same two letters do a different job.
+
+## Grammar Lens: one mark, two grammatical jobs
 
 The **tilde diacrítica** separates words that otherwise look alike:
 
 | no accent | with accent |
 |---|---|
-| **tu** = your | **tú** = you |
 | **el** = the | **él** = he |
-| **si** = if | **sí** = yes |
-| **se** = reflexive se | **sé** = I know |
-| **mas** = but (literary) | **más** = more |
-| **como** = like/as | **cómo** = how? |
-| **que** = that | **qué** = what? |
 
-Question words normally wear the accent: **qué, cómo, cuándo, dónde,
-quién**. Writing uses it to distinguish the questioning job even when the
-letters are otherwise identical.
-
-Compare **¿Cómo está?** ("How are you?") with **como** ("like/as"). Here
-the mark labels meaning and grammar, not merely a surprising stress pattern.
+The two words are pronounced alike. Here the accent does not move stress; it
+labels meaning and grammar. Other pairs will arrive only when you know both
+words, so this lesson asks you to hold one contrast, not memorize a list.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "tu / tú" — your / you]
-- [YOU SAY: "el / él" — the / he]
-- [YOU SAY: "como / cómo" — like / how]
+- [YOU SAY: “el” — the]
+- [YOU SAY: “él” — he]
+- [YOU WRITE: **el / él**, adding the meaning-label accent only to the pronoun]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What is the accent's second job? (**Separate look-alike words.**)
-Which means "your," **tu** or **tú**? (**Tu.**) Which one asks "how"?
-(**Cómo.**) Name three accented question words. (**Qué, cómo, dónde**, for
-example.)
+Which means “the”? (**El**, no accent.) Which means “he”? (**Él**, with the
+accent.) Does this mark change their stress? (**No — it labels the job.**)

--- a/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-W02-enye
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 340
 chapter: 4
 type: writing
 headword: "ñ"
@@ -7,7 +10,19 @@ gloss: the letter eñe — a tiny second n riding on the first
 prerequisites: [ES-W01-tilde-diacritica]
 sounds: [ny-palatal]
 roots: [annus-latin]
-est_minutes: 3
+duration:
+  max_seconds: 270
+requires:
+  knowledge: [ES-SCRIPT-ACUTE-ACCENT]
+introduces:
+  knowledge: [ES-SCRIPT-ENYE, ES-SOUND-ENYE, ES-FORM-MANANA, ES-FORM-ESPANOL, ES-ETYMON-DOUBLE-N]
+practises:
+  knowledge: [ES-SCRIPT-ENYE, ES-SOUND-ENYE, ES-FORM-MANANA, ES-FORM-ESPANOL]
+skills: [speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-W01-tilde-diacritica, ES-W01-acento]
 ---
 
@@ -20,14 +35,14 @@ origin story in the alphabet. That wavy hat (`~`, a *tilde*) is not decoration.
 It is **a tiny second *n*, written on top to save space.** Once you know that,
 you know both how to write it *and* why it sounds the way it does.
 
-## The sound
+## Sounds you'll need
 
 **ñ** = the *ny* in "ca**ny**on" or "o**ni**on" — one squished sound, tongue
 flat against the roof of the mouth. English *canyon* is, in fact, Spanish
 **cañón** with the *ñ* spelled out as *ny*. Say "onion," freeze on the middle:
 that's ñ.
 
-## How to write it, and where the hat came from
+## Script — how to write it, and where the hat came from
 
 Write a normal **n**, then a small wavy **~** floating above it. That wave is a
 **medieval shorthand**. Scribes copying Latin were forever writing double
@@ -40,7 +55,7 @@ Spanish is full of words where a Latin **-nn-** did exactly this:
 
 - Latin **annus** ("year") → *anno* → **año** — the *nn* collapsed into *ñ*.
   (That same *annus* gives English **ann**ual, **ann**iversary, bi-**enn**ial.)
-- Latin **cannon** → *caña* → **cañón**; Latin *domina* line → *doña*.
+- Latin **canna** (“reed”) → **caña**; Latin *domina* → *donna* → **doña**.
 
 So the tilde on **ñ** is a **frozen abbreviation**: a thousand-year-old note
 that says "there used to be two *n*'s here." You are writing a scribe's
@@ -55,8 +70,7 @@ shortcut.
 [PAUSE 1s]
 - [YOU SAY: "año" — *AH-nyo*, one squished *ny*; then English "annual" — same
   Latin *annus*]
-- [YOU SAY: "señor", "mañana", "España" — the ñ in three everyday words you'll
-  meet soon]
+- [YOU SAY: “año, mañana, español” — the ñ in three forms from this lesson]
 
 ## Wrap-up Recall
 

--- a/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
@@ -1,13 +1,28 @@
 ---
+schema_version: 2
 id: ES-W03-inverted
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 350
 chapter: 4
 type: writing
 headword: "¿ ¡"
 gloss: the inverted opening marks — an early cue for question or exclamation intonation
-prerequisites: [ES-C04-como-estas-register]
+prerequisites: [ES-W02-enye]
 sounds: []
 roots: []
-est_minutes: 3
+duration:
+  max_seconds: 290
+requires:
+  knowledge: [ES-SCRIPT-INVERTED-QUESTION, ES-LEX-COMO-ESTAS, ES-LEX-BUENOS-DIAS]
+introduces:
+  knowledge: [ES-SCRIPT-INVERTED-EXCLAMATION, ES-ORTHOGRAPHY-OPENING-PUNCTUATION, ES-HISTORY-RAE-INVERTED-MARKS]
+practises:
+  knowledge: [ES-SCRIPT-INVERTED-QUESTION, ES-SCRIPT-INVERTED-EXCLAMATION, ES-ORTHOGRAPHY-OPENING-PUNCTUATION]
+skills: [speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-C04-como-estas-register, ES-C04-como-esta, ES-W01-acento]
 ---
 
@@ -20,7 +35,7 @@ major language that puts an **upside-down** question or exclamation mark at the
 **start** of the sentence, as well as the normal one at the end. It looks exotic;
 the reason is purely practical.
 
-## What they are
+## Script — the two opening marks
 
 - **¿ … ?** wraps a question: *¿Cómo estás?*
 - **¡ … !** wraps an exclamation: *¡Hola!* *¡Gracias!*
@@ -29,7 +44,7 @@ The opening mark is just the closing mark **flipped 180°** — turned upside do
 *and* left-right. To write **¿**, draw a normal *?* and rotate it half a turn:
 the hook ends up at the bottom, the dot on top.
 
-## Why open a question at all?
+## Why it's said this way — the opening mark is an early cue
 
 English lets you read most of a sentence before the final **?** reveals it was a
 question — fine, because English usually flags a question early with word order

--- a/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
@@ -1,5 +1,8 @@
 ---
+schema_version: 2
 id: ES-W03-question-span
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 360
 chapter: 4
 type: writing
 headword: "Roberto, ¿cómo estás?"
@@ -7,13 +10,30 @@ gloss: opening punctuation brackets only the question or exclamation span inside
 prerequisites: [ES-W03-inverted]
 sounds: []
 roots: []
-est_minutes: 4
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-ORTHOGRAPHY-OPENING-PUNCTUATION, ES-LEX-COMO-ESTAS, ES-LEX-BUENOS-DIAS]
+introduces:
+  knowledge: [ES-ORTHOGRAPHY-PUNCTUATION-SPAN]
+practises:
+  knowledge: [ES-ORTHOGRAPHY-PUNCTUATION-SPAN, ES-SCRIPT-INVERTED-QUESTION, ES-SCRIPT-INVERTED-EXCLAMATION]
+skills: [speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
 reviews_of: [ES-W03-inverted, ES-W01-tilde-diacritica]
 ---
 
 # Where does ¿ begin? — bracket the spoken span
 
-## Not always at the capital
+## Warm-up
+
+[PAUSE 2s] You can open a whole question with **¿**. Now place that mark
+inside a larger sentence, exactly where the questioning voice begins.
+
+## Script — bracket the spoken span
 
 The opening mark goes where the **question** begins, even if the sentence
 started earlier:
@@ -31,8 +51,8 @@ exactly where to begin and end a change in spoken melody.
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU WRITE: "María, ¿tienes hambre?"]
-- [YOU WRITE: "Amigos, ¡buenos días!"]
+- [YOU WRITE: “María, ¿cómo estás?”]
+- [YOU WRITE: “María, ¡buenos días!”]
 - [YOU SAY: begin the new melody at ¿ or ¡, not at the first capital]
 
 ## Wrap-up Recall

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -48,6 +48,7 @@ function classifyBlock(title: string): LessonBlockType {
   if (normalized === "warm-up" || normalized === "warmup") return "warmup";
   if (normalized.startsWith("you'll want to know")) return "input";
   if (normalized.startsWith("sounds you'll need")) return "pronunciation";
+  if (normalized.startsWith("script")) return "script";
   if (normalized.startsWith("the word, taken apart")) return "etymology";
   if (normalized.startsWith("why it's said this way")) return "culture-pragmatics";
   if (

--- a/code/packages/typescript/human-language-data/tests/parse.test.ts
+++ b/code/packages/typescript/human-language-data/tests/parse.test.ts
@@ -82,6 +82,9 @@ describe("parseLesson", () => {
       "## The word, taken apart",
       "A root note.",
       "",
+      "## Script — shape and stroke",
+      "A writing note.",
+      "",
       "## Wrap-up Recall",
       "Say it once.",
     ].join("\n");
@@ -90,6 +93,7 @@ describe("parseLesson", () => {
     expect(parsed.blocks).toEqual([
       { type: "warmup", title: "Warm-up", markdown: "Remember yesterday." },
       { type: "etymology", title: "The word, taken apart", markdown: "A root note." },
+      { type: "script", title: "Script — shape and stroke", markdown: "A writing note." },
       { type: "recall", title: "Wrap-up Recall", markdown: "Say it once." },
     ]);
   });


### PR DESCRIPTION
## Summary

- migrate all 25 existing Spanish Chapters 4–6 lessons to the HL04 schema-v2 contract
- add prerequisite-repair micro-lessons for **y / ¿y tú?** and **café**, bringing the corpus to 1,065 lessons
- remove learner-facing forward references from dialogue, production, and writing prompts
- classify `Script` sections as typed canonical blocks for app and generated-book reuse
- update the backlog: complete HL-S02, promote HL-G03, and record HL-V02 block-level prompt closure

## Guarantees

- 27 migrated lessons; unique sequence 250–510
- every lesson starts with `warmup`, ends with `recall`, and has no unknown block
- transitive prerequisite knowledge closure is valid
- every effective duration is below 300 seconds
- no generated Spanish book output changes in this tranche; HL-G03 remains the explicit next item

## Validation

- `npm run build` — human-language-data
- `npm run test:coverage` — 68 tests; 93.37% line coverage
- `npm run report` — 20 tracks, 1,065 lessons, 20 books, 0 duration violations, 0 unknown prerequisites
- `npm run check:books`
- `npm run test:coverage` — Language Ladder, 278 tests; 98.37% line coverage
- `npm run build` — Language Ladder, 1,115 modules
- `git diff --check`
