### PR TITLE
test(venture): promote Qt live interaction gate

### DIFF
--- a/code/packages/rust/venture-browser-qt/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-qt/CHANGELOG.md
@@ -7,3 +7,7 @@
   projection, scrolling, link activation, hover, and retained-page reflow.
 - Add a generated-project direct-launch test that requires a live HTTP fetch,
   mounted QML surface, and non-empty Cairo frame on provisioned Qt hosts.
+- Promote the generated-project gate to real address, history, wheel, hover,
+  and link interaction acceptance through the package-owned Qt adapter.
+- Accept either CMake's plain macOS executable or an application-bundle shell
+  when launching the generated project.

--- a/code/packages/rust/venture-browser-qt/README.md
+++ b/code/packages/rust/venture-browser-qt/README.md
@@ -11,6 +11,10 @@ surface as a QML type, and forwards generated Mosaic events and native surface
 input to the same Rust session. Its direct-launch test emits and builds the
 real Qt project when CMake and Qt6 are present, serves a deterministic page,
 and requires a mounted Cairo frame before the application can report success.
+The same direct gate drives native Return through the generated address field,
+Back/Forward through the emitted buttons, and wheel/hover/click input through
+the real `QQuickPaintedItem`, verifying every transition through the shared
+Rust session rather than a recording Qt host.
 
 ```sh
 cargo test -p venture-browser-qt

--- a/code/packages/rust/venture-browser-qt/tests/qt_project_launch.rs
+++ b/code/packages/rust/venture-browser-qt/tests/qt_project_launch.rs
@@ -70,32 +70,78 @@ fn build_native_bridge(output: &Path) -> PathBuf {
     library
 }
 
-fn serve_html() -> String {
+struct AcceptanceUrls {
+    start: String,
+    target: String,
+    link: String,
+}
+
+fn serve_html() -> AcceptanceUrls {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind Qt acceptance server");
     let address = listener.local_addr().expect("read Qt acceptance address");
+    let base = format!("http://{address}");
+    let urls = AcceptanceUrls {
+        start: format!("{base}/start"),
+        target: format!("{base}/target"),
+        link: format!("{base}/link"),
+    };
+    let link_url = urls.link.clone();
     thread::spawn(move || {
-        let (mut stream, _) = listener.accept().expect("accept Venture Qt request");
-        let mut request = [0_u8; 1024];
-        let _ = stream.read(&mut request);
-        let body = "<!doctype html><title>Venture Qt launch acceptance</title><main><h1>Venture Qt live page</h1><p>Rendered by the shared browser pipeline.</p></main>";
-        write!(
-            stream,
-            "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-            body.len()
-        )
-        .expect("write Qt acceptance response headers");
-        stream
-            .write_all(body.as_bytes())
-            .expect("write Qt acceptance response body");
+        for _ in 0..8 {
+            let (mut stream, _) = listener.accept().expect("accept Venture Qt request");
+            let mut request = [0_u8; 2048];
+            let request_len = stream.read(&mut request).unwrap_or_default();
+            let request = String::from_utf8_lossy(&request[..request_len]);
+            let path = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .unwrap_or("/");
+            let (status, body) = match path {
+                "/start" => (
+                    "200 OK",
+                    format!(
+                        "<!doctype html><title>Venture Qt launch acceptance</title><main><a href=\"{link_url}\">Open the linked page</a><h1>Venture Qt live page</h1>{}</main>",
+                        "<p>Scrollable live content.</p>".repeat(120)
+                    ),
+                ),
+                "/target" => (
+                    "200 OK",
+                    "<!doctype html><title>Venture Qt interaction acceptance</title><main><h1>Native address navigation</h1></main>".to_string(),
+                ),
+                "/link" => (
+                    "200 OK",
+                    "<!doctype html><title>Venture Qt link acceptance</title><main><h1>Native link activation</h1></main>".to_string(),
+                ),
+                _ => (
+                    "404 Not Found",
+                    "<!doctype html><title>Not found</title>".to_string(),
+                ),
+            };
+            write!(
+                stream,
+                "HTTP/1.0 {status}\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .expect("write Qt acceptance response headers");
+            stream
+                .write_all(body.as_bytes())
+                .expect("write Qt acceptance response body");
+        }
     });
-    format!("http://{address}/")
+    urls
 }
 
 fn generated_executable(project: &Path) -> PathBuf {
+    let plain = project.join("build/VentureChrome");
     #[cfg(target_os = "macos")]
-    return project.join("build/VentureChrome.app/Contents/MacOS/VentureChrome");
-    #[cfg(target_os = "linux")]
-    return project.join("build/VentureChrome");
+    {
+        let bundled = project.join("build/VentureChrome.app/Contents/MacOS/VentureChrome");
+        if bundled.exists() {
+            return bundled;
+        }
+    }
+    plain
 }
 
 fn wait_for_marker(child: &mut Child, marker: &Path, log: &Path) {
@@ -117,7 +163,7 @@ fn wait_for_marker(child: &mut Child, marker: &Path, log: &Path) {
 }
 
 #[test]
-fn package_owned_qt_project_launches_and_renders_live_page() {
+fn package_owned_qt_project_launches_and_drives_live_interactions() {
     let required = std::env::var_os("VENTURE_QT_ACCEPTANCE_REQUIRED").is_some();
     if !qt_build_available() {
         assert!(
@@ -182,10 +228,13 @@ fn package_owned_qt_project_launches_and_renders_live_page() {
     let marker = output.join("qt-ready.json");
     let app_log = output.join("qt-app.log");
     let log = File::create(&app_log).expect("create Qt app log");
+    let urls = serve_html();
     let mut child = Command::new(&executable)
         .current_dir(&project)
         .env("QT_QPA_PLATFORM", "offscreen")
-        .env("VENTURE_START_URL", serve_html())
+        .env("VENTURE_START_URL", &urls.start)
+        .env("VENTURE_BROWSER_INTERACTION_URL", &urls.target)
+        .env("VENTURE_BROWSER_INTERACTION_LINK_URL", &urls.link)
         .env("VENTURE_BROWSER_LIBRARY", &library)
         .env("VENTURE_BROWSER_ACCEPTANCE_PATH", &marker)
         .stdout(Stdio::from(log.try_clone().expect("clone Qt app log")))
@@ -204,10 +253,15 @@ fn package_owned_qt_project_launches_and_renders_live_page() {
         report.contains("\"ok\":true"),
         "unexpected marker: {report}"
     );
-    assert!(report.contains("Venture Qt launch acceptance"));
+    assert!(report.contains("\"status\":\"interacted\""));
+    assert!(report.contains("\"addressCommit\":\"native-return\""));
+    assert!(report.contains("\"historyControls\":\"back-forward\""));
+    assert!(report.contains("\"surfaceWheel\":\"scroll\""));
+    assert!(report.contains("\"surfaceHover\":\"status\""));
+    assert!(report.contains("\"surfacePointer\":\"link\""));
+    assert!(report.contains("Venture Qt link acceptance"));
+    assert!(report.contains(&urls.link));
     assert!(report.contains("\"rendered\":true"));
-    assert!(report.contains("\"componentReady\":true"));
-    assert!(report.contains("\"surfaceMounted\":true"));
 
     fs::remove_dir_all(&output).expect("remove clean Qt acceptance output");
 }

--- a/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
+++ b/code/programs/mosaic/venture-browser/ACCEPTANCE-BACKLOG.md
@@ -17,11 +17,16 @@ cross-platform proving application. Items are ordered by risk and dependency.
   - [x] Qt bridge foundation: generated Qt shells load the shared Rust session,
     mount a Cairo-backed `QQuickPaintedItem`, and directly launch against a
     deterministic live page before reporting render acceptance.
-  - [ ] Qt live interaction promotion: drive the generated address and history
+  - [x] Qt live interaction promotion: drive the generated address and history
     controls plus native scroll/link input through the real bridge, replacing
-    the remaining recording host in the Qt interaction gate.
+    the recording host as the authoritative Qt interaction gate.
   - [ ] Flutter live page bridge and direct acceptance.
   - [ ] Compose Desktop live page bridge and direct acceptance.
+- [ ] **P2 — Qt native-control style compatibility.** The macOS-native Qt
+  Quick Controls style rejects custom `background` items emitted from Mosaic
+  MSL. Define a native-compatible palette/appearance lowering (or an explicit
+  per-project style contract) so generated Qt shells do not warn and silently
+  drop authored button backgrounds while retaining native controls.
 - [x] **P0 regression — POSIX entry-point shell compatibility.** Keep `BUILD`
   compatible with the repository build tool's `/bin/sh` executor while it
   delegates the backend matrix to the Bash-specific implementation script.

--- a/code/programs/mosaic/venture-browser/CHANGELOG.md
+++ b/code/programs/mosaic/venture-browser/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Add a generated Qt direct-launch gate that fetches a deterministic HTTP
   page, mounts the real QML content surface, renders through Cairo, and only
   then writes its acceptance marker.
+- Promote that Qt gate through live interactions: native Return in the
+  Mosaic-emitted address field, Back/Forward key activation, painted-surface
+  wheel scrolling, link hover projection, and pointer navigation all cross the
+  package-owned C++ adapter into the shared Rust browser session.
 - Provision the Linux Venture CI lane with Qt6 Quick/QML/Widgets and Quick
   Test so that gate is required rather than reported as a missing-tool skip.
 - Run the primary generated SwiftUI and WinUI direct-launch interaction tests

--- a/code/programs/mosaic/venture-browser/README.md
+++ b/code/programs/mosaic/venture-browser/README.md
@@ -53,6 +53,9 @@ recreating the surrounding chrome in backend-specific UI code.
   chrome contract and mounts a Cairo-rendered `QQuickPaintedItem`; resize,
   wheel, keyboard scroll, hover, and link activation all delegate to the
   shared `BrowserHostController` instead of owning Qt-specific browser state.
+  Its direct generated-app gate edits the Mosaic-emitted address field, drives
+  Back and Forward with native key input, scrolls the real painted item, and
+  activates a live HTML link through Qt hover and pointer events.
 - The native content surfaces are keyboard focus targets. Arrow, Page,
   Space/Shift-Space, Home, and End keys use the exact semantic scroll-command
   contract owned by `venture-browser-core`; Command-Left/Right on macOS and
@@ -101,10 +104,13 @@ disabled dispatch suppression, node-slot mounting, Return, Go, and
 with a recording host and drives the generated native controls, including
 disabled buttons, address editing, Return, Go, and host-driven prop refresh.
 The Qt gate runs the same chrome contract through Qt Quick Test against the
-emitted part-backed native controls and its generated `mosaicHost` seam. On
-Linux and macOS with Qt and CMake available, it also directly launches the
-generated application against a deterministic HTTP page and requires the real
-Rust/Cairo bridge and mounted QML content surface to render before success.
+emitted part-backed native controls and a recording `mosaicHost` seam as a
+fast emitter-contract test. On Linux and macOS with Qt and CMake available,
+the authoritative interaction gate directly launches the generated
+application against deterministic HTTP pages. It requires the real Rust/Cairo
+bridge, native address and history control input, shared viewport scrolling,
+live-link hover projection, pointer activation, and a final rendered frame
+before success.
 The Compose gate uses the emitted Mosaic-part test tags to drive native
 Compose controls through the generated injectable `MosaicComposeHost` seam,
 including disabled buttons, address editing, Return, Go, and host prop refresh.
@@ -132,7 +138,7 @@ layer.
 On Qt-capable Linux and macOS hosts, both matrix scripts build
 `venture-browser-qt`, copy its native library into the generated Qt project,
 compile the C++/QML shell, and run `qt_project_launch` with the direct-launch
-gate required. Other workspace test environments may skip that one native
+interaction gate required. Other workspace test environments may skip that one native
 launch test when CMake or Qt6 is unavailable; the package matrix does not.
 Repository CI provisions those Qt6 dependencies on its Linux Venture lane so
 the generated project build and direct launch are mandatory there.

--- a/code/programs/mosaic/venture-browser/host/qt/MosaicHost.cpp
+++ b/code/programs/mosaic/venture-browser/host/qt/MosaicHost.cpp
@@ -9,6 +9,8 @@
 #include <QKeyEvent>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QQuickItem>
+#include <QQuickWindow>
 #include <QQmlComponent>
 #include <QQmlEngine>
 #include <QTimer>
@@ -46,6 +48,37 @@ QByteArray keyCommand(QKeyEvent *event)
     return event->modifiers().testFlag(Qt::ShiftModifier) ? "page-up" : "page-down";
   default: return {};
   }
+}
+
+bool sendKey(QObject *control, int key)
+{
+  auto *item = qobject_cast<QQuickItem *>(control);
+  if (!item) {
+    return false;
+  }
+  if (item->window()) {
+    item->window()->requestActivate();
+  }
+  item->forceActiveFocus();
+  QKeyEvent press(QEvent::KeyPress, key, Qt::NoModifier);
+  QKeyEvent release(QEvent::KeyRelease, key, Qt::NoModifier);
+  QObject *receiver = item->window() ? static_cast<QObject *>(item->window())
+                                     : static_cast<QObject *>(item);
+  QCoreApplication::sendEvent(receiver, &press);
+  QCoreApplication::sendEvent(receiver, &release);
+  QCoreApplication::processEvents();
+  return true;
+}
+
+void finishAcceptance(const QByteArray &markerPath, QJsonObject report, bool ok)
+{
+  report.insert(QStringLiteral("ok"), ok);
+  QFile marker(QString::fromUtf8(markerPath));
+  if (marker.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    marker.write(QJsonDocument(report).toJson(QJsonDocument::Compact));
+    marker.close();
+  }
+  QCoreApplication::exit(ok ? 0 : 2);
 }
 
 } // namespace
@@ -253,6 +286,7 @@ bool MosaicHost::loadBridge()
   RESOLVE(handleEvent_, "handle_event");
   RESOLVE(scroll_, "scroll");
   RESOLVE(scrollCommand_, "scroll_command");
+  RESOLVE(scrollMetrics_, "scroll_metrics");
   RESOLVE(activateLink_, "activate_link");
   RESOLVE(updateHover_, "update_hover");
   RESOLVE(resize_, "resize");
@@ -261,8 +295,8 @@ bool MosaicHost::loadBridge()
 #undef RESOLVE
 
   if (!new_ || !free_ || !applyProps_ || !handleEvent_ || !scroll_
-      || !scrollCommand_ || !activateLink_ || !updateHover_ || !resize_
-      || !render_ || !stringFree_) {
+      || !scrollCommand_ || !scrollMetrics_ || !activateLink_ || !updateHover_
+      || !resize_ || !render_ || !stringFree_) {
     library_.unload();
     return false;
   }
@@ -282,6 +316,13 @@ void MosaicHost::scheduleAcceptance()
   }
 
   QTimer::singleShot(250, this, [this, markerPath]() {
+    const QByteArray targetUrl = qgetenv("VENTURE_BROWSER_INTERACTION_URL");
+    const QByteArray linkUrl = qgetenv("VENTURE_BROWSER_INTERACTION_LINK_URL");
+    if (!targetUrl.isEmpty() && !linkUrl.isEmpty()) {
+      runInteractionAcceptance(markerPath, targetUrl, linkUrl);
+      return;
+    }
+
     const QVariantMap browserResponse = props();
     const QVariantMap browserProps = browserResponse.value(QStringLiteral("props")).toMap();
     QImage frame;
@@ -302,13 +343,161 @@ void MosaicHost::scheduleAcceptance()
       {QStringLiteral("width"), frame.width()},
       {QStringLiteral("height"), frame.height()},
     };
-    QFile marker(QString::fromUtf8(markerPath));
-    if (marker.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-      marker.write(QJsonDocument(report).toJson(QJsonDocument::Compact));
-      marker.close();
-    }
-    QCoreApplication::exit(ok ? 0 : 2);
+    finishAcceptance(markerPath, report, ok);
   });
+}
+
+bool MosaicHost::scrollOffset(double *offsetY) const
+{
+  if (!browser_ || !scrollMetrics_ || !offsetY) {
+    return false;
+  }
+  double viewportHeight = 0;
+  double contentHeight = 0;
+  double maxOffsetY = 0;
+  return scrollMetrics_(browser_, offsetY, &viewportHeight, &contentHeight,
+                        &maxOffsetY) != 0;
+}
+
+void MosaicHost::runInteractionAcceptance(const QByteArray &markerPath,
+                                          const QByteArray &targetUrl,
+                                          const QByteArray &linkUrl)
+{
+  auto fail = [&markerPath](const QString &message) {
+    finishAcceptance(markerPath,
+                     {{QStringLiteral("backend"), QStringLiteral("qt")},
+                      {QStringLiteral("status"), QStringLiteral("error")},
+                      {QStringLiteral("error"), message}},
+                     false);
+  };
+  if (!root_) {
+    fail(QStringLiteral("generated Qt root is unavailable"));
+    return;
+  }
+
+  auto *address = root_->findChild<QObject *>(QStringLiteral("address-input"));
+  auto *back = root_->findChild<QObject *>(QStringLiteral("back-button"));
+  auto *forward = root_->findChild<QObject *>(QStringLiteral("forward-button"));
+  auto *surface = root_->findChild<VentureContentSurface *>();
+  if (!address || !back || !forward || !surface) {
+    fail(QStringLiteral("generated address/history controls or live surface are unavailable"));
+    return;
+  }
+  const QString startUrl = QString::fromUtf8(qgetenv("VENTURE_START_URL"));
+  if (back->property("enabled").toBool() || forward->property("enabled").toBool()) {
+    fail(QStringLiteral("initial generated history controls are not disabled"));
+    return;
+  }
+
+  address->setProperty("text", QString::fromUtf8(targetUrl));
+  QCoreApplication::processEvents();
+  if (!sendKey(address, Qt::Key_Return)) {
+    fail(QStringLiteral("generated address control rejected native Return"));
+    return;
+  }
+  QVariantMap current = props().value(QStringLiteral("props")).toMap();
+  if (current.value(QStringLiteral("address")).toString() != QString::fromUtf8(targetUrl)
+      || current.value(QStringLiteral("pageTitle")).toString()
+           != QStringLiteral("Venture Qt interaction acceptance")
+      || !back->property("enabled").toBool()
+      || forward->property("enabled").toBool()) {
+    fail(QStringLiteral("native address commit did not update shared history state"));
+    return;
+  }
+
+  if (!sendKey(back, Qt::Key_Space)) {
+    fail(QStringLiteral("generated Back control rejected native Space"));
+    return;
+  }
+  current = props().value(QStringLiteral("props")).toMap();
+  if (current.value(QStringLiteral("address")).toString() != startUrl
+      || !forward->property("enabled").toBool()) {
+    fail(QStringLiteral("generated Back control did not traverse shared history"));
+    return;
+  }
+
+  if (!sendKey(forward, Qt::Key_Space)) {
+    fail(QStringLiteral("generated Forward control rejected native Space"));
+    return;
+  }
+  current = props().value(QStringLiteral("props")).toMap();
+  if (current.value(QStringLiteral("address")).toString() != QString::fromUtf8(targetUrl)) {
+    fail(QStringLiteral("generated Forward control did not traverse shared history"));
+    return;
+  }
+  if (!sendKey(back, Qt::Key_Space)) {
+    fail(QStringLiteral("generated Back control could not restore the start page"));
+    return;
+  }
+
+  double beforeWheel = 0;
+  double afterWheel = 0;
+  const QPointF wheelPoint(32, 100);
+  QWheelEvent wheel(wheelPoint, wheelPoint, QPoint(), QPoint(0, -120), Qt::NoButton,
+                    Qt::NoModifier, Qt::ScrollUpdate, false);
+  surface->forceActiveFocus();
+  if (!scrollOffset(&beforeWheel)) {
+    fail(QStringLiteral("shared viewport metrics are unavailable"));
+    return;
+  }
+  QCoreApplication::sendEvent(surface, &wheel);
+  QCoreApplication::processEvents();
+  if (!wheel.isAccepted() || !scrollOffset(&afterWheel) || afterWheel <= beforeWheel) {
+    fail(QStringLiteral("native wheel did not scroll the shared viewport"));
+    return;
+  }
+  QWheelEvent resetWheel(wheelPoint, wheelPoint, QPoint(), QPoint(0, 120),
+                         Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+  QCoreApplication::sendEvent(surface, &resetWheel);
+  QCoreApplication::processEvents();
+  if (!resetWheel.isAccepted() || !scrollOffset(&afterWheel)
+      || std::abs(afterWheel) > 0.5) {
+    fail(QStringLiteral("native reverse wheel did not reset the shared viewport (offset %1)")
+           .arg(afterWheel));
+    return;
+  }
+
+  const QPointF linkPoint(32, 26);
+  QHoverEvent hover(QEvent::HoverMove, linkPoint, linkPoint, QPointF(-1, -1));
+  QCoreApplication::sendEvent(surface, &hover);
+  QCoreApplication::processEvents();
+  current = props().value(QStringLiteral("props")).toMap();
+  if (current.value(QStringLiteral("statusText")).toString() != QString::fromUtf8(linkUrl)) {
+    fail(QStringLiteral("native hover did not project the live link URL"));
+    return;
+  }
+
+  QMouseEvent press(QEvent::MouseButtonPress, linkPoint, linkPoint, linkPoint,
+                    Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+  QMouseEvent release(QEvent::MouseButtonRelease, linkPoint, linkPoint, linkPoint,
+                      Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+  QCoreApplication::sendEvent(surface, &press);
+  QCoreApplication::sendEvent(surface, &release);
+  QCoreApplication::processEvents();
+  current = props().value(QStringLiteral("props")).toMap();
+  QImage frame;
+  const bool rendered = render(&frame);
+  const bool ok = current.value(QStringLiteral("address")).toString()
+                    == QString::fromUtf8(linkUrl)
+    && current.value(QStringLiteral("pageTitle")).toString()
+         == QStringLiteral("Venture Qt link acceptance")
+    && rendered && !frame.isNull();
+  finishAcceptance(
+    markerPath,
+    {{QStringLiteral("backend"), QStringLiteral("qt")},
+     {QStringLiteral("status"), ok ? QStringLiteral("interacted")
+                                    : QStringLiteral("error")},
+     {QStringLiteral("addressCommit"), QStringLiteral("native-return")},
+     {QStringLiteral("historyControls"), QStringLiteral("back-forward")},
+     {QStringLiteral("surfaceWheel"), QStringLiteral("scroll")},
+     {QStringLiteral("surfaceHover"), QStringLiteral("status")},
+     {QStringLiteral("surfacePointer"), QStringLiteral("link")},
+     {QStringLiteral("address"), current.value(QStringLiteral("address")).toString()},
+     {QStringLiteral("pageTitle"), current.value(QStringLiteral("pageTitle")).toString()},
+     {QStringLiteral("rendered"), rendered},
+     {QStringLiteral("width"), frame.width()},
+     {QStringLiteral("height"), frame.height()}},
+    ok);
 }
 
 QVariantMap MosaicHost::response(char *json) const

--- a/code/programs/mosaic/venture-browser/host/qt/MosaicHost.h
+++ b/code/programs/mosaic/venture-browser/host/qt/MosaicHost.h
@@ -59,6 +59,7 @@ private:
   using HandleEventFn = char *(*)(void *, const char *, const char *);
   using ScrollFn = unsigned char (*)(void *, double);
   using ScrollCommandFn = unsigned char (*)(void *, const char *);
+  using ScrollMetricsFn = unsigned char (*)(void *, double *, double *, double *, double *);
   using PointFn = unsigned char (*)(void *, double, double);
   using ResizeFn = unsigned char (*)(void *, double, double);
   using RenderFn = size_t (*)(void *, unsigned char *, size_t, unsigned int *, unsigned int *);
@@ -66,6 +67,10 @@ private:
 
   bool loadBridge();
   void scheduleAcceptance();
+  void runInteractionAcceptance(const QByteArray &markerPath,
+                                const QByteArray &targetUrl,
+                                const QByteArray &linkUrl);
+  bool scrollOffset(double *offsetY) const;
   QVariantMap response(char *json) const;
   QVariantMap withContentSurface(QVariantMap response) const;
   static QVariantMap normalizeProps(const QVariantMap &props);
@@ -81,6 +86,7 @@ private:
   HandleEventFn handleEvent_ = nullptr;
   ScrollFn scroll_ = nullptr;
   ScrollCommandFn scrollCommand_ = nullptr;
+  ScrollMetricsFn scrollMetrics_ = nullptr;
   PointFn activateLink_ = nullptr;
   PointFn updateHover_ = nullptr;
   ResizeFn resize_ = nullptr;

--- a/code/programs/mosaic/venture-browser/tests/package_compiles.rs
+++ b/code/programs/mosaic/venture-browser/tests/package_compiles.rs
@@ -117,10 +117,7 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
     );
     assert_eq!(package.host_assets.files[3].target, "MosaicHost.cpp");
     assert_eq!(package.host_assets.files[4].backend, "qt");
-    assert_eq!(
-        package.host_assets.files[4].source,
-        "host/qt/MosaicHost.h"
-    );
+    assert_eq!(package.host_assets.files[4].source, "host/qt/MosaicHost.h");
     assert_eq!(package.host_assets.files[4].target, "MosaicHost.h");
     assert_eq!(package.host_assets.files[5].backend, "qt");
     assert_eq!(
@@ -345,8 +342,16 @@ fn interface_and_manifest_pin_the_browser_chrome_contract() {
         "MosaicHost::publishProps",
         "MosaicHost::activateLink",
         "MosaicHost::scrollCommand",
+        "MosaicHost::scrollOffset",
+        "MosaicHost::runInteractionAcceptance",
         "MosaicHost::scheduleAcceptance",
         "VENTURE_BROWSER_ACCEPTANCE_PATH",
+        "VENTURE_BROWSER_INTERACTION_URL",
+        "VENTURE_BROWSER_INTERACTION_LINK_URL",
+        "generated address/history controls or live surface are unavailable",
+        "native wheel did not scroll the shared viewport",
+        "native hover did not project the live link URL",
+        "historyControls",
         "surfaceMounted",
     ] {
         assert!(qt_host.contains(symbol), "Qt live host omits {symbol}");


### PR DESCRIPTION
## Summary
- drive Mosaic-emitted Qt address, history, scroll, hover, and link controls through native Qt events
- require the generated package-owned Qt project to prove live shared Venture session updates and Cairo rendering
- ratchet the package contract, documentation, changelogs, and prioritized acceptance backlog

## Validation
- strict `clang++ -Wall -Wextra -Werror -fsyntax-only` against Qt 6 Quick/QML/Widgets
- `VENTURE_QT_ACCEPTANCE_REQUIRED=1 cargo test -p venture-browser-qt --test qt_project_launch`
- `cargo test -p venture-browser-core -p venture-browser-qt -p mosaic-emit-qt`
- `cargo test --manifest-path code/programs/mosaic/venture-browser/Cargo.toml`
- `cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test`
- targeted clippy with `-D warnings`

## Conformance scope
This promotes a direct Qt interaction acceptance gate. It does not claim full browser conformance; browser wiring and the remaining direct platform acceptance gates remain tracked.