### PR TITLE
feat(num7b): wire the sqrt Real/BigDouble audit companion into compute

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.34.0] - 2026-08-02 - NUM-7b: render the sqrt Real/BigDouble audit companion
+
+- The `op` node's JSON audit gains an additive `"real":{"precision_bits":…,"mode":…,"value":…}`
+  key when logic-engine populates a square root's `RealCompanion` — absent for every other `Op`
+  node, byte-neutral otherwise.
+- `--explain` shows the same companion inline (`[real: <digits> @ <bits> bits, <mode>]`) next to
+  a sqrt's ordinary derivation line.
+- New e2e coverage (`tests/num7b_real_sqrt_e2e.rs`): default 256-bit precision renders far more
+  digits than an `f64` could hold; a perfect square (`sqrt(9)`) still gets a companion (not
+  special-cased away); an ordinary (non-sqrt) power carries no `"real"` key.
+
 ## [0.33.0] - 2026-08-02 - parser-backed formula inventory
 
 - Added `adj-formula-inventory`, which emits canonical JSON from the real Adj-Lang parser for

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/explain.rs
+++ b/code/packages/rust/adj-lang-cli/src/explain.rs
@@ -678,10 +678,24 @@ fn expand(n: &DerivationNode, depth: usize, kb: &KnowledgeBase, out: &mut Vec<St
             op,
             operands,
             result,
+            real,
         } => {
             let sep = format!(" {} ", op.symbol());
             let expr = operands.iter().map(label).collect::<Vec<_>>().join(&sep);
-            out.push(format!("{ind}{} = {}", fmt_num(*result), expr));
+            // NUM-7: a square root of an exact base additionally shows the arbitrary-precision
+            // `Real`/`BigDouble` companion the `f64` result was cross-checked against.
+            let real_note = match real {
+                Some(rc) => format!(
+                    " [real: {} @ {} bits, {}]",
+                    rc.value
+                        .to_decimal_string()
+                        .unwrap_or_else(|| rc.value.to_f64().to_string()),
+                    rc.value.precision_bits(),
+                    fmt_mode(rc.mode)
+                ),
+                None => String::new(),
+            };
+            out.push(format!("{ind}{} = {}{}", fmt_num(*result), expr, real_note));
             for c in operands {
                 if expands(c) {
                     expand(c, depth + 1, kb, out);

--- a/code/packages/rust/adj-lang-cli/src/formula_audit.rs
+++ b/code/packages/rust/adj-lang-cli/src/formula_audit.rs
@@ -562,6 +562,9 @@ fn tree(value: &DerivationNode, kb: &KnowledgeBase) -> Result<TreeDto, Failure> 
             op,
             operands,
             result,
+            // NUM-7's Real/BigDouble sqrt companion is a separate additive audit channel
+            // (rendered in the CLI JSON and --explain); this witness format doesn't capture it.
+            real: _,
         } => TreeDto::Operation {
             f64_bits: bits(*result),
             operands: operands

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -147,16 +147,32 @@ fn derivation_tree_json(
             op,
             operands,
             result,
+            real,
         } => {
             let kids: Vec<String> = operands
                 .iter()
                 .map(|o| derivation_tree_json(o, kb))
                 .collect();
+            // NUM-7: an additive audit companion, present only for a square root of an exact
+            // base. Absent for every other op, including a sqrt whose base had no exact sidecar.
+            let real_json = match real {
+                Some(rc) => format!(
+                    ",\"real\":{{\"precision_bits\":{},\"mode\":\"{}\",\"value\":\"{}\"}}",
+                    rc.value.precision_bits(),
+                    rounding_mode_name(rc.mode),
+                    esc(&rc
+                        .value
+                        .to_decimal_string()
+                        .unwrap_or_else(|| rc.value.to_f64().to_string())),
+                ),
+                None => String::new(),
+            };
             format!(
-                "{{\"node\":\"op\",\"op\":\"{}\",\"value\":{},\"operands\":[{}]}}",
+                "{{\"node\":\"op\",\"op\":\"{}\",\"value\":{},\"operands\":[{}]{}}}",
                 esc(op.symbol()),
                 jnum(*result),
-                kids.join(",")
+                kids.join(","),
+                real_json
             )
         }
         // A `round_to(x, n)` narrowing (NUM-6a): the audit exposes the precision,

--- a/code/packages/rust/adj-lang-cli/tests/num7b_real_sqrt_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/num7b_real_sqrt_e2e.rs
@@ -1,0 +1,66 @@
+//! End-to-end tests for the NUM-7b `Real`/`BigDouble` audit companion, driven
+//! through the built `adj-lang-cli` binary. A square root's audit gains an
+//! additive `"real"` block — the arbitrary-precision value, its precision, and
+//! its rounding mode — alongside the ordinary `f64` `"value"`; every other
+//! `Pow` node (including a non-square-root power) carries no such key
+//! (ADJ-NUMERIC-SUBSTRATE §8).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_num7b_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(src: &str, tag: &str) -> (bool, String) {
+    let dir = scratch(tag);
+    let p = dir.join("case.adj");
+    std::fs::write(&p, src).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&p)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn sqrt_audits_a_real_companion_at_default_precision() {
+    let (ok, s) = run("let r = latex \"$\\sqrt{2}$\"\n? r\n", "sqrt2");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The ordinary f64 result is still there.
+    assert!(s.contains("\"value\":1.41421"), "f64 result present: {s}");
+    // The additive Real companion: default 256-bit precision, half-even mode,
+    // and a decimal rendering with far more digits than f64 could carry.
+    assert!(
+        s.contains("\"real\":{\"precision_bits\":256"),
+        "real companion at the default 256-bit precision: {s}"
+    );
+    assert!(s.contains("\"mode\":\"half_even\""), "records its rounding mode: {s}");
+    assert!(
+        s.contains("1.41421356237309504880168872420969807856"),
+        "renders far more digits than an f64 could hold: {s}"
+    );
+}
+
+#[test]
+fn a_perfect_square_still_gets_a_real_companion() {
+    // sqrt(9) = 3 exactly — NUM-7 does not special-case a perfect square away,
+    // so it gets a real companion like any other sqrt.
+    let (ok, s) = run("let r = latex \"$\\sqrt{9}$\"\n? r\n", "sqrt9");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(s.contains("\"value\":3"), "f64 result present: {s}");
+    assert!(s.contains("\"real\":{\"precision_bits\":256"), "still gets a real companion: {s}");
+    assert!(s.contains("\"value\":\"3\""), "renders the exact digit: {s}");
+}
+
+#[test]
+fn pow_that_is_not_a_sqrt_has_no_real_key() {
+    let (ok, s) = run("let r = latex \"$2^3$\"\n? r\n", "pow23");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(s.contains("\"value\":8"), "computes the power: {s}");
+    assert!(!s.contains("\"real\":"), "an ordinary power carries no real companion: {s}");
+}

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -11,9 +11,12 @@
 - The plain `f64` result for this case now uses `f64::sqrt()` instead of `powf(0.5)`, so it can
   never disagree in the last bit with the correctly-rounded `BigDouble` companion computed
   alongside it.
-- Ordering is safety-load-bearing: the companion is only computed after the existing
-  `result.is_finite()` guard, so a negative base (which would make `BigDouble::sqrt` panic) is
-  already routed to a clean `Err` before this code runs — regression-tested explicitly.
+- Safety-critical: `BigDouble::sqrt` panics on a negative operand. The `result.is_finite()` guard
+  alone does **not** exclude every negative base — an exact rational whose magnitude underflows
+  the `f64` path rounds to `-0.0`, and IEEE-754 `powf(-0.0, 0.5) == +0.0` (finite!), so a
+  since-security-reviewed fix checks the *exact* sidecar's own sign explicitly before promoting,
+  skipping the companion (never a panic) for a negative base — regression-tested with an
+  underflowed-negative-exact-base case that reaches this code without one.
 - No contagion this rung: further arithmetic on a sqrt's result does not carry its `Real`
   companion forward (ADJ-NUMERIC-SUBSTRATE §8's scoped, additive design, not the full §5 tower).
 

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.53.0] - 2026-08-02 - NUM-7b: the sqrt `Real`/`BigDouble` audit companion
+
+- `DerivationNode::Op` gains an additive `real: Option<RealCompanion>` field (new public types
+  `ApproxReal`, `RealCompanion`), populated only when a `Pow` node is a square root (evaluated
+  exponent bit-exactly `0.5`) of a base that carried an exact rational sidecar — every other `Op`,
+  including a sqrt of an inexact base, keeps `real: None`. Detected on the evaluated `f64`
+  exponent rather than its exact sidecar, since a literal `0.5` (how both `\sqrt{x}` and
+  `\sqrt[n]{x}` lower) never carries one.
+- The plain `f64` result for this case now uses `f64::sqrt()` instead of `powf(0.5)`, so it can
+  never disagree in the last bit with the correctly-rounded `BigDouble` companion computed
+  alongside it.
+- Ordering is safety-load-bearing: the companion is only computed after the existing
+  `result.is_finite()` guard, so a negative base (which would make `BigDouble::sqrt` panic) is
+  already routed to a clean `Err` before this code runs — regression-tested explicitly.
+- No contagion this rung: further arithmetic on a sqrt's result does not carry its `Real`
+  companion forward (ADJ-NUMERIC-SUBSTRATE §8's scoped, additive design, not the full §5 tower).
+
 ## [0.52.0] - 2026-08-02 - NUM-7a: per-KnowledgeBase `Real`/`BigDouble` precision setting
 
 - Added `KnowledgeBase::real_precision_bits()`/`with_real_precision_bits(u32)`/

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -52,7 +52,7 @@
 
 use crate::dimension::{DimOp, Dimension};
 use crate::{FactId, KnowledgeBase};
-use bignum_core::{BigDecimal, BigInteger, BigRational, RoundingMode};
+use bignum_core::{BigDecimal, BigDouble, BigInteger, BigRational, RoundingMode};
 
 /// An exact rational value for CPU arithmetic — a [`BigRational`] from `bignum-core`, so it is
 /// **unbounded** (no `i128` overflow) and every `+ − × ÷` of rationals stays exact forever.
@@ -187,6 +187,53 @@ impl ExactRational {
             .ok()
             .map(Self)
     }
+}
+
+/// An arbitrary-precision APPROXIMATE real value — the audit-visible "Real" companion (NUM-7,
+/// ADJ-NUMERIC-SUBSTRATE §8). Wraps a [`BigDouble`] at a stated, carried precision. Unlike
+/// [`ExactRational`], a value of this type is never a `Derived`'s ground representation — it
+/// exists only where the true value is genuinely irrational (today: `sqrt`), captured alongside
+/// the ordinary `f64` `result` and, independently, an `ExactRational` sidecar (when the operand
+/// itself was exact). This is deliberately **additive**: it does not replace or contagiously
+/// propagate through either of those, unlike the full `Number` tower ADJ-NUMERIC-SUBSTRATE §5
+/// describes and NUM-7 does not attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApproxReal(BigDouble);
+
+impl ApproxReal {
+    /// The working precision, in mantissa bits, this value was computed at.
+    pub fn precision_bits(&self) -> u32 {
+        self.0.precision()
+    }
+
+    /// The underlying arbitrary-precision float.
+    pub fn as_big_double(&self) -> &BigDouble {
+        &self.0
+    }
+
+    /// A **lossy** narrowing to `f64`, for a boundary consumer that has no use for the extra
+    /// precision (mirrors [`ExactRational::to_f64`]).
+    pub fn to_f64(&self) -> f64 {
+        self.0.to_f64()
+    }
+
+    /// An exact base-10 rendering, when practical — `None` only when [`BigDouble::to_decimal`]'s
+    /// own huge-exponent DoS budget refuses (astronomically far beyond any real precision this
+    /// engine would ever be configured to).
+    pub fn to_decimal_string(&self) -> Option<String> {
+        self.0.to_decimal().map(|d| d.to_string())
+    }
+}
+
+/// A [`DerivationNode::Op`]'s optional `Real` companion (NUM-7): the [`ApproxReal`] value,
+/// alongside the exact rational `source` it was promoted from and the `mode` it was rounded
+/// under — captured so [`recheck_narrowing`] can independently re-derive it, mirroring how
+/// `Round`/`ToScientific`/etc. capture `operand_exact` for the same purpose.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RealCompanion {
+    pub value: ApproxReal,
+    pub source: ExactRational,
+    pub mode: RoundingMode,
 }
 
 /// The largest exponent [`ExactRational::powi`] accepts; beyond it the `f64` magnitude is
@@ -513,6 +560,11 @@ pub enum DerivationNode {
         op: ComputeOp,
         operands: Vec<DerivationNode>,
         result: f64,
+        /// NUM-7: the `Real`/`BigDouble` audit companion, populated only for a `Pow` node that
+        /// is a square root (evaluated exponent bit-exactly `0.5`) whose base carried an exact
+        /// rational sidecar. `None` for every other `Op` — including a sqrt whose base itself
+        /// had no exact sidecar (this rung does not chain/contagiously propagate `Real`).
+        real: Option<RealCompanion>,
     },
     /// A **precision narrowing** node (NUM-6a) — the audit record for a
     /// `round_to(x, n)`. Carries the `spec`/`mode` it rounded under and its single
@@ -948,6 +1000,35 @@ fn eval(
                 if !result.is_finite() {
                     return Err(ComputeError::NonFinite { op: *op });
                 }
+                // A square root gets a correctly-rounded `BigDouble` "Real" audit companion
+                // (NUM-7). Detected on the *evaluated* exponent, bit-exactly `0.5` — not the
+                // exponent's exact sidecar, which is always `None` here: `ExactRational::
+                // from_integer_f64` is integer-only, and both `\sqrt{x}` and `\sqrt[n]{x}` lower
+                // their exponent to exactly this literal (adj-lang's LaTeX-root lowering), so an
+                // exact-sidecar check would simply never fire. Safe by construction: `result` is
+                // already finite-checked just above, so a negative base — which would make
+                // `BigDouble::sqrt` *panic* — can never reach here (f64 `powf`/`sqrt` of a
+                // negative base is `NaN`, already routed to `Err` above).
+                let real = if exponent == 0.5 {
+                    exact_l.as_ref().map(|base_exact| {
+                        let prec = kb.real_precision_bits();
+                        let mode = RoundingMode::HalfEven;
+                        let promoted = BigDouble::from_rational(base_exact.as_ratio(), prec, mode);
+                        RealCompanion {
+                            value: ApproxReal(promoted.sqrt(prec, mode)),
+                            source: base_exact.clone(),
+                            mode,
+                        }
+                    })
+                } else {
+                    None
+                };
+                // Tighten the plain f64 `result` to `f64::sqrt` for this case: `powf` is not
+                // guaranteed correctly-rounded on every platform, while `BigDouble::sqrt` at
+                // `prec = 53` reproduces `f64::sqrt` bit-for-bit (bignum-core's own module doc),
+                // so this keeps the two audit-visible values from ever disagreeing in the last
+                // bit.
+                let result = if exponent == 0.5 { base.sqrt() } else { result };
                 // Exact sidecar only for a non-negative integer exponent of an
                 // exact base — `(3/2)^2 = 9/4` stays exact; anything else keeps
                 // just the `f64` result.
@@ -965,6 +1046,7 @@ fn eval(
                         op: *op,
                         operands: vec![lhs, rhs],
                         result,
+                        real,
                     },
                     result_dim,
                     exact,
@@ -1057,6 +1139,7 @@ fn eval(
                     op: *op,
                     operands: vec![lhs, rhs],
                     result,
+                    real: None,
                 },
                 result_dim,
                 exact,
@@ -1136,6 +1219,7 @@ fn eval(
                     op: *op,
                     operands,
                     result,
+                    real: None,
                 },
                 result_dim,
                 None,
@@ -1315,6 +1399,7 @@ fn eval_unary(
             op,
             operands: vec![operand],
             result,
+            real: None,
         },
         result_dim,
         exact,
@@ -2205,6 +2290,107 @@ mod tests {
         assert_eq!(d.exact, None);
     }
 
+    // ---- NUM-7b: the sqrt Real/BigDouble audit companion ----------------
+
+    fn real_companion_of(d: &Derived) -> Option<&RealCompanion> {
+        match &d.tree {
+            DerivationNode::Op { real, .. } => real.as_ref(),
+            other => panic!("expected an Op node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sqrt_of_an_exact_base_gets_a_real_companion() {
+        let d = compute(
+            "root",
+            &bin(ComputeOp::Pow, ComputeExpr::Lit(4.0), ComputeExpr::Lit(0.5)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        let real = real_companion_of(&d).expect("sqrt of an exact base should get a real companion");
+        assert_eq!(real.value.precision_bits(), 256);
+        assert_eq!(real.value.to_decimal_string().unwrap(), "2");
+    }
+
+    #[test]
+    fn sqrt_of_an_irrational_base_matches_known_digits() {
+        let d = compute(
+            "root",
+            &bin(ComputeOp::Pow, ComputeExpr::Lit(2.0), ComputeExpr::Lit(0.5)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        let real = real_companion_of(&d).expect("sqrt of 2 should get a real companion");
+        let rendered = real.value.to_decimal_string().unwrap();
+        assert!(rendered.starts_with("1.41421356237309504880168"), "got {rendered}");
+    }
+
+    #[test]
+    fn sqrt_respects_a_configured_kb_precision() {
+        let kb = kb_with(vec![]).with_real_precision_bits(64);
+        let d = compute(
+            "root",
+            &bin(ComputeOp::Pow, ComputeExpr::Lit(2.0), ComputeExpr::Lit(0.5)),
+            &kb,
+        )
+        .unwrap();
+        let real = real_companion_of(&d).expect("sqrt should get a real companion");
+        assert_eq!(real.value.precision_bits(), 64);
+    }
+
+    #[test]
+    fn sqrt_of_a_negative_base_stays_a_clean_error_not_a_panic() {
+        // BigDouble::sqrt PANICS on a negative operand — the ordering that computes the Real
+        // companion only after the existing f64 finiteness check must keep this reachable ONLY
+        // as a clean Err, never as a panic deep inside bignum-core.
+        let err = compute(
+            "root",
+            &bin(ComputeOp::Pow, ComputeExpr::Lit(-4.0), ComputeExpr::Lit(0.5)),
+            &kb_with(vec![]),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ComputeError::NonFinite { op: ComputeOp::Pow }));
+    }
+
+    #[test]
+    fn non_sqrt_pow_has_no_real_companion() {
+        let d = compute(
+            "p",
+            &bin(ComputeOp::Pow, ComputeExpr::Lit(2.0), ComputeExpr::Lit(3.0)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert!(real_companion_of(&d).is_none());
+    }
+
+    #[test]
+    fn cube_root_shaped_pow_has_no_real_companion() {
+        // 27 ^ (1/3) = 3 — a genuine root, but NOT a square root (exponent != 0.5 bit-exactly),
+        // and BigDouble has no cbrt: this must not be mistaken for a sqrt.
+        let d = compute(
+            "root",
+            &bin(ComputeOp::Pow, ComputeExpr::Lit(27.0), ComputeExpr::Lit(1.0 / 3.0)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert!(real_companion_of(&d).is_none());
+    }
+
+    #[test]
+    fn sqrt_of_an_inexact_base_skips_the_real_companion() {
+        // sqrt(sqrt(2)): the inner sqrt's own returned "exact" sidecar is None (2's square root
+        // is irrational), so the outer sqrt's base carries no exact sidecar to promote from —
+        // NUM-7 does not chain/contagiously propagate Real companions.
+        let inner = bin(ComputeOp::Pow, ComputeExpr::Lit(2.0), ComputeExpr::Lit(0.5));
+        let d = compute(
+            "root",
+            &bin(ComputeOp::Pow, inner, ComputeExpr::Lit(0.5)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert!(real_companion_of(&d).is_none());
+    }
+
     #[test]
     fn absolute_value_flips_a_negative_scalar_and_stays_exact() {
         // |−7| = 7, scalar, and the exact sidecar stays exact (|−7/1| = 7/1) —
@@ -2825,6 +3011,7 @@ mod tests {
                 op,
                 operands,
                 result,
+                real: _,
             } => {
                 assert_eq!(*op, ComputeOp::Div);
                 assert!((result - 0.4).abs() < 1e-12);

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -1005,20 +1005,30 @@ fn eval(
                 // exponent's exact sidecar, which is always `None` here: `ExactRational::
                 // from_integer_f64` is integer-only, and both `\sqrt{x}` and `\sqrt[n]{x}` lower
                 // their exponent to exactly this literal (adj-lang's LaTeX-root lowering), so an
-                // exact-sidecar check would simply never fire. Safe by construction: `result` is
-                // already finite-checked just above, so a negative base — which would make
-                // `BigDouble::sqrt` *panic* — can never reach here (f64 `powf`/`sqrt` of a
-                // negative base is `NaN`, already routed to `Err` above).
+                // exact-sidecar check would simply never fire.
+                //
+                // The `result.is_finite()` guard just above is NOT sufficient on its own to keep
+                // a negative base out of `BigDouble::sqrt` (which panics on one): an exact
+                // rational whose magnitude underflows the `f64` path can round to `-0.0`, and
+                // IEEE-754 `powf(-0.0, 0.5) == +0.0` — finite and non-negative — while the exact
+                // sidecar still faithfully carries the true negative sign (e.g. `(-0.5)^2001`
+                // underflows `result` to `-0.0` but keeps its exact sign). So this checks the
+                // EXACT sidecar's own sign explicitly and skips the companion (never a panic) for
+                // a negative base, exactly like every other not-applicable case already yields
+                // `None`.
                 let real = if exponent == 0.5 {
-                    exact_l.as_ref().map(|base_exact| {
+                    exact_l.as_ref().and_then(|base_exact| {
+                        if base_exact.numerator().is_negative() {
+                            return None;
+                        }
                         let prec = kb.real_precision_bits();
                         let mode = RoundingMode::HalfEven;
                         let promoted = BigDouble::from_rational(base_exact.as_ratio(), prec, mode);
-                        RealCompanion {
+                        Some(RealCompanion {
                             value: ApproxReal(promoted.sqrt(prec, mode)),
                             source: base_exact.clone(),
                             mode,
-                        }
+                        })
                     })
                 } else {
                     None
@@ -2350,6 +2360,35 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, ComputeError::NonFinite { op: ComputeOp::Pow }));
+    }
+
+    #[test]
+    fn sqrt_of_an_underflowed_negative_exact_base_does_not_panic() {
+        // A negative EXACT base can still reach here even though the f64 finiteness guard
+        // above passed: `powf(-0.0, 0.5) == +0.0` (finite!) under IEEE-754, not NaN, once the
+        // true magnitude has underflowed f64 to negative zero — while the exact rational
+        // sidecar still faithfully carries the true negative sign. `BigDouble::sqrt` PANICS on
+        // a negative operand, so the exact sidecar's OWN sign must be checked explicitly rather
+        // than trusting the f64 finiteness check alone (security-reviewed regression).
+        //
+        // Build an exact value of magnitude 1/2^2048 (far below f64's smallest subnormal,
+        // 2^-1074, so its f64 companion underflows to zero) via repeated squaring — only 11
+        // nesting levels, well under MAX_EVAL_DEPTH — then flip its sign with one more Mul.
+        let mut magnitude = frac(1, 2);
+        for _ in 0..11 {
+            magnitude = ComputeExpr::Bin(ComputeOp::Mul, Box::new(magnitude.clone()), Box::new(magnitude));
+        }
+        let negative_underflowed =
+            ComputeExpr::Bin(ComputeOp::Mul, Box::new(magnitude), Box::new(ComputeExpr::Lit(-1.0)));
+        let expr = ComputeExpr::Bin(
+            ComputeOp::Pow,
+            Box::new(negative_underflowed),
+            Box::new(ComputeExpr::Lit(0.5)),
+        );
+        // Must not panic — and since the true base is negative, no real companion is produced
+        // (the same "not applicable" `None` every other non-square-root case already yields).
+        let d = compute("r", &expr, &kb_with(vec![])).unwrap();
+        assert!(real_companion_of(&d).is_none());
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -54,9 +54,9 @@ use logic_core::{unify, LogicVar, Number, Substitution, Term};
 /// `bignum-core` directly (NUM-6a).
 pub use bignum_core::RoundingMode;
 pub use compute::{
-    compute, recheck_narrowing, recheck_narrowings, ComputationId, ComputationPlanRef,
+    compute, recheck_narrowing, recheck_narrowings, ApproxReal, ComputationId, ComputationPlanRef,
     ComputationScope, ComputeError, ComputeExpr, ComputeOp, DerivationNode, Derived,
-    NarrowingCheck, RoundSpec,
+    NarrowingCheck, RealCompanion, RoundSpec,
 };
 pub use conversion::{add_or_sub, convert_value, ConvError, Conversion, ConversionTable};
 pub use datetime::{


### PR DESCRIPTION
## Summary
- `DerivationNode::Op` gains an additive `real: Option<RealCompanion>` field, populated only when a `Pow` node is a square root (evaluated exponent bit-exactly `0.5`) of a base carrying an exact rational sidecar — every other `Op` (including a sqrt of an inexact base) stays `real: None`. No contagion: further arithmetic on a sqrt's result doesn't carry the companion forward (ADJ-NUMERIC-SUBSTRATE §8's scoped, additive design — see #9620).
- The `f64` result for this case switches to `f64::sqrt()` instead of `powf(0.5)` so it can't disagree with the correctly-rounded `BigDouble` companion.
- CLI JSON gains an additive `"real"` key; `--explain` renders it inline.
- **Security fix included** (caught by `/security-review`, verified by a second independent pass): `result.is_finite()` alone didn't exclude every negative base — an exact rational whose magnitude underflows the `f64` path rounds to `-0.0`, and IEEE-754 `powf(-0.0, 0.5) == +0.0` (finite), so a negative exact sidecar could reach `BigDouble::sqrt`, which panics on a negative operand (a DoS on the CLI process for an adversarial/edge-case `.adj` program). Now checks the exact sidecar's own sign explicitly before promoting. Regression test included.
- Builds on #9625 (NUM-7a, merged) — rebased cleanly onto current `main`.

## Test plan
- [x] `cargo test -p bignum-core -p logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver` — all green, including 7 new compute.rs unit tests (sqrt companion presence/precision/negative-base-error/non-sqrt/cube-root/inexact-base cases) + 1 security regression test + 3 new e2e tests (`num7b_real_sqrt_e2e.rs`).
- [x] `cargo clippy --all-targets -- -D warnings` clean across all touched + downstream crates.
- [x] `/security-review` — found and fixed one HIGH finding (see above), re-reviewed and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)