### PR TITLE
fix(spice): lower parser MOS drain resistance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `RD` values before lowering
+  Level-1 drain resistance.
 - Reject zero, negative, and non-finite MOS model-card `TNOM` / `T_NOM` values
   before lowering Level-1 nominal temperature.
 - Reject zero, negative, and non-finite MOS model-card `IS` values before

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1922,6 +1922,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["IS"]) or params["IS"] <= 0.0
         ):
             raise NetlistParseError("MOSFET IS must be finite and positive")
+        if "RD" in params and (
+            not math.isfinite(params["RD"]) or params["RD"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET RD must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1588,6 +1588,31 @@ def test_lowers_positive_mosfet_model_nominal_temperature(alias: str) -> None:
     assert mosfet.model.model.params.T_NOM == 325.0
 
 
+@pytest.mark.parametrize("drain_resistance", ["-1", "1e999"])
+def test_rejects_invalid_mosfet_model_drain_resistance(
+    drain_resistance: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET RD must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(RD={drain_resistance})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize("drain_resistance", ["0", "12.5"])
+def test_lowers_valid_mosfet_model_drain_resistance(
+    drain_resistance: str,
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(RD={drain_resistance})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert float(drain_resistance) == mosfet.model.model.params.RD
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `RD` values and lower valid
+  Level-1 drain resistance instead of silently dropping it.
 - Reject zero, negative, and non-finite MOS model-card `TNOM` / `T_NOM` values
   before lowering Level-1 nominal temperature.
 - Reject zero, negative, and non-finite MOS model-card `IS` values before

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1237,6 +1237,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET IS must be finite and positive");
   }
+  const drainResistance = params.get("RD");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    drainResistance !== undefined &&
+    (!Number.isFinite(drainResistance) || drainResistance < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET RD must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1327,6 +1335,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "L",
     "TOX",
     "U0",
+    "RD",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1515,6 +1515,22 @@ Xright c d load
     expect(element.params.T_NOM).toBe(325);
   });
 
+  it.each(["-1", "1e999"])("rejects invalid MOSFET model RD=%s", (drainResistance) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(RD=${drainResistance})\nM1 d g s b nfast\n`),
+    ).toThrow("MOSFET RD must be finite and non-negative");
+  });
+
+  it.each(["0", "12.5"])("lowers valid MOSFET model RD=%s", (drainResistance) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(RD=${drainResistance})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.RD).toBe(Number(drainResistance));
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4189,11 +4189,21 @@ the Rust, Python, and TypeScript surfaces together.
    - Zero, negative, and non-finite `IS` values are rejected with the shared
      diagnostic while positive saturation currents lower into Level-1 parameters.
 
+379. Python and TypeScript Berkeley SPICE MOS nominal-temperature validation parity.
+   - Status: completed in PR 9631.
+   - Zero, negative, and non-finite `TNOM` / `T_NOM` values are rejected with
+     the shared diagnostic while positive Kelvin values lower into Level-1
+     parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - Lower missing canonical resistance, geometry, capacitance, junction, and
-     noise fields, then align the `CJS` and `CJD` aliases.
+   - TypeScript still needs canonical lowering for `RD`, `RS`, `RSH`, `LD`,
+     `NRD`, `NRS`, `AD`, `AS`, `PD`, `PS`, `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
+     `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
+     but still needs matching facade validation coverage.
+   - Align the `CJS` and `CJD` aliases with canonical `CBS` and `CBD` in both
+     facades after the canonical-field slices.
 
 2. Python and TypeScript Berkeley SPICE MOS electrostatic-default parity.
    - Validate and consume `NSS` / `TPG`, then derive `VT0`, `GAMMA`, and `PHI`


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `RD` values in the Python and TypeScript parsers
- lower valid TypeScript drain resistance instead of silently dropping it
- record merged TNOM parity and the audited remaining lowering inventory in the SPICE plan

## Verification
- Python spice-netlist-parser: 135 tests passed; 88.19% coverage
- Python spice-netlist-parser: `ruff check src tests`
- TypeScript spice-engine: `npm run build`
- TypeScript spice-netlist-parser: `npm run build`
- TypeScript spice-netlist-parser: 128 tests passed with coverage