### PR TITLE
fix(html-parser): retain implied after-body mode

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- An accepted `</body>` token now enters the after-body insertion mode even
+  when `html`, `head`, and `body` were all implied, closing 5 previously silent
+  malformed corpus cases for following head-only and frameset start tags.
 - Full-document parsing now reports unexpected tokens that force recovery from
   the Standard's after-body and after-after-body insertion modes, closing 8
   previously silent malformed corpus cases without changing DOM recovery.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -25,8 +25,8 @@ The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
 all 6,806 html5lib tokenizer cases with zero missing signatures and zero
 normalized skips. DOM output is complete, but diagnostic coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the document-tail insertion-mode slice, 1,781 of those cases emit at
-least one lexer or parser diagnostic and 402 remain uncovered. Another 139
+After the implied-body tail-transition slice, 1,786 of those cases emit at
+least one lexer or parser diagnostic and 397 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -38,15 +38,20 @@ Prioritized work items:
    explicit and implied `html`, `head`, and `body` creation. Missing-doctype
    handling, nonconforming initial-doctype diagnostics, duplicate shell
    start-tag diagnostics, body/html end tags with disallowed open elements,
-   full-document in-body EOF diagnostics, and unexpected-token recovery in the
-   after-body and after-after-body modes are complete. Re-audit the remaining
-   silent shell cases before selecting the next bounded diagnostic slice.
+   full-document in-body EOF diagnostics, unexpected-token recovery in the
+   after-body and after-after-body modes, and the implied-shell `</body>`
+   transition are complete. The fresh 397-case inventory identifies
+   after-after-frameset unexpected tokens, stray end tags before an implied
+   root or body, and rejected frameset starts as the remaining concrete shell
+   slices, in that order.
 2. **Fragment EOF diagnostics.** Audit the current in-body EOF rule against
    fragment parsing. Legacy fragment fixtures omit many EOF error rows, so add
    explicit current-WHATWG evidence before extending the full-document
    diagnostic into fragments.
 3. **In-body and text insertion modes.** Cover scope failures, implied-end-tag
-   recovery, formatting reconstruction, and stray start/end tags.
+   recovery, formatting reconstruction, stray start/end tags, and the large
+   executable cluster of unclosed script/style/title/noframes text-mode EOF
+   diagnostics.
 4. **Table, select, and template insertion modes.** Cover foster parenting,
    table scopes, select recovery, and template mode-stack errors.
 5. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6744,6 +6744,7 @@ impl HtmlParser {
                 self.append_implied_element("html");
                 self.append_implied_element("body");
                 self.open_elements.clear();
+                self.document_tail_mode = DocumentTailMode::AfterBody;
             }
             "br" => {
                 self.diagnostics.push(ParserDiagnostic::new(
@@ -33061,6 +33062,18 @@ mod tests {
             (
                 "<!doctype html><body></body></html>text<p>x</p>",
                 "unexpected-token-after-html",
+            ),
+            (
+                "<!doctype html></body><meta>",
+                "unexpected-token-after-body",
+            ),
+            (
+                "<!doctype html></body><title>x</title>",
+                "unexpected-token-after-body",
+            ),
+            (
+                "<!doctype html></body><frameset>",
+                "unexpected-token-after-body",
             ),
         ] {
             let output = parse_html_with_diagnostics(source).unwrap();

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 402);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1781);
+    assert_eq!(missing_diagnostic_cases, 397);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1786);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- enter the Standard's after-body insertion mode when `</body>` is accepted after an entirely implied document shell
- report the resulting unexpected head-only and frameset start tags without changing tree construction
- update the executable diagnostic ratchet and reprioritized conformance backlog

## Evidence
- preserves all 2,637 checked tree-construction DOM outputs
- reduces declared-error cases without diagnostics from 402 to 397
- raises covered declared-error cases from 1,781 to 1,786 while undeclared-diagnostic cases remain 139
- live upstream audit covers 1,934/1,934 WPT tree signatures and 6,806/6,806 html5lib tokenizer signatures with zero normalized skips

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- `git diff --check`
