### PR TITLE
fix(ruby-parser): bare comparison/logical statement mis-parsed as a call

### DIFF
--- a/code/grammars/ruby/ruby.grammar
+++ b/code/grammars/ruby/ruby.grammar
@@ -587,7 +587,36 @@ call_arg     = NAME COLON expression | [ "*" | "**" | "&" ] expression ;
 # Issue #59 — `!"super"` guard mirrors `method_call`: a parenless
 # `super x` at statement level routes to `super_expr` (via expression_stmt),
 # not to a spurious paren-less call to a method named `super`.
-method_call_no_paren = ( NAME | !"super" KEYWORD ) expression { COMMA expression } ;
+#
+# Bug fix — bare comparison/logical statement mis-lowered as a paren-less
+# call.  `<`, `>`, `<=`, `>=`, `!=`, `&&`, `||` have no dedicated token type
+# (`classify_op_token` in ruby-lexer, by design, leaves every operator
+# lexeme without one on `TokenType::Name` — "the parser dispatches by
+# value").  `factor`'s bare `NAME` alternative doesn't check a Name token's
+# VALUE, so for a bare statement like `x > 2`, this rule matched `x` as the
+# callee and then happily consumed the `>` token AS THE CALL'S SOLE
+# ARGUMENT (an ordinary-looking `factor → NAME` atom, since nothing here
+# excludes an operator-shaped value) — leaving `2` behind as an unrelated
+# SECOND statement.  Lowering that argument then emitted a `DirectCall` to
+# whatever the bare name resolved to (here, literally `x` — the *receiver*,
+# reused as if it were a callee), which `semantic-ir`'s validator correctly
+# rejected as a call to an unknown function.  (`==` and `<=>` were
+# accidentally immune: `classify_op_token` gives `==` its own dedicated
+# `EqualsEquals` type, and `<=>` apparently follows a different path, so
+# neither is `TokenType::Name` and `factor`'s `NAME` alternative can't touch
+# them.)  The fix: negative-lookahead these operator lexemes right after the
+# leading name, so `method_call_no_paren` itself fails to match (rather than
+# succeeding on a malformed one-token "argument") and the `statement` /
+# `modifier_statement` alternation falls through to `expression_stmt`, which
+# parses the WHOLE `x > 2` correctly via `comparison`/`logical_and`/
+# `logical_or`.  (`**`/bitwise `<<`/`>>`/`^`/`&`/`|` are NOT included: this
+# grammar has no binary-operator rule for them at all — `x ** 2` was never a
+# supported expression, so there is no correct fallback parse to preserve;
+# only the operators actually implemented in `comparison`/`logical_and`/
+# `logical_or` are guarded here.)
+method_call_no_paren = ( NAME | !"super" KEYWORD )
+    !"<" !">" !"<=" !">=" !"!=" !"&&" !"||"
+    expression { COMMA expression } ;
 expression_stmt = expression ;
 # Phase 6i — comparison operators at the top of the precedence pyramid.
 #

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.6.0] - 2026-08-03
+
+### Fixed — bare comparison/logical statement mis-parsed as a paren-less call
+
+`<`, `>`, `<=`, `>=`, `!=`, `&&`, `||` have no dedicated lexer token type
+(`classify_op_token` in `ruby-lexer` deliberately leaves every operator
+lexeme without one on `TokenType::Name` — "the parser dispatches by
+value"). `factor`'s bare `NAME` alternative doesn't check a Name token's
+VALUE, so `method_call_no_paren = ( NAME | ... ) expression { ... }` — the
+paren-less "command call" production (`puts "hi"`) — could match a bare
+statement like `x > 2` as `x` (callee) applied to `>` itself, swallowed
+whole as an ordinary name-shaped argument, leaving `2` behind as an
+unrelated second statement. Lowering the malformed "argument" then emitted
+a call to whatever that bare name resolved to, which downstream validation
+correctly rejected. Found while writing block-predicate tests for the SIR
+Collections cascade (`[1,2,3].select { |x| x > 2 }` failed identically —
+every backend consumes this same grammar, so the bug wasn't C-specific).
+
+Fixed with a negative lookahead in `method_call_no_paren` (`ruby.grammar`)
+for these seven operators, so the rule fails to match on them and
+`expression_stmt` (`comparison`/`logical_and`/`logical_or`) parses the
+whole expression correctly instead. `==` was accidentally already immune
+(`classify_op_token` gives it its own dedicated `EqualsEquals` type).
+`**`/bitwise `<<`/`>>`/`^`/`&`/`|` are deliberately NOT included: this
+grammar has no binary-operator rule for them at all, so there is no
+correct fallback parse to preserve — pinned by a regression test that they
+remain unchanged.
+
+### Added
+
+- `src/bin/regen_grammars.rs` — a `cargo run -p coding-adventures-ruby-parser
+  --bin regen_grammars` binary that regenerates `src/_grammar.rs` from
+  `ruby.grammar` (mirrors `adj-lang`'s binary of the same name). Previously
+  this crate had no committed regeneration tool despite `_grammar.rs`'s own
+  header directing readers to one.
+
 ## [0.5.0] - 2026-07-01
 
 (Cargo manifest minor bump 0.4.0 → 0.5.0.  Note: the older CHANGELOG headers

--- a/code/packages/rust/ruby-parser/Cargo.toml
+++ b/code/packages/rust/ruby-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-ruby-parser"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Ruby parser — parses Ruby source code into an AST using the grammar-driven parser and the ruby.grammar file"
 

--- a/code/packages/rust/ruby-parser/README.md
+++ b/code/packages/rust/ruby-parser/README.md
@@ -48,3 +48,10 @@ The Ruby grammar covers:
 - **def_statement** — method definitions with parameters and body, terminated by `end`
 - **class_statement** — class definitions with methods and body, terminated by `end`
 - **if_statement** / **while_statement** — control flow with `end` terminators
+
+`src/_grammar.rs` is generated from `ruby.grammar` — never edit it by hand.
+After changing `ruby.grammar`, regenerate it with:
+
+```sh
+cargo run -p coding-adventures-ruby-parser --bin regen_grammars
+```

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -817,23 +817,30 @@ pub fn parser_grammar() -> ParserGrammar {
                             GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                         ] },
                     ] }) },
+                GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"<"#.to_string() }) },
+                GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#">"#.to_string() }) },
+                GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"<="#.to_string() }) },
+                GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#">="#.to_string() }) },
+                GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"!="#.to_string() }) },
+                GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"&&"#.to_string() }) },
+                GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"||"#.to_string() }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 590,
+            line_number: 617,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 591,
+            line_number: 620,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 698,
+            line_number: 727,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -846,7 +853,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 699,
+            line_number: 728,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -869,7 +876,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 700,
+            line_number: 729,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -883,7 +890,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 701,
+            line_number: 730,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -897,7 +904,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 702,
+            line_number: 731,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -908,7 +915,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 709,
+            line_number: 738,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -926,7 +933,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 710,
+            line_number: 739,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -940,7 +947,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 711,
+            line_number: 740,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -954,7 +961,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 712,
+            line_number: 741,
         },
         GrammarRule {
             name: r#"super_expr"#.to_string(),
@@ -962,7 +969,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"super"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
             ] },
-            line_number: 781,
+            line_number: 810,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -1002,7 +1009,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 782,
+            line_number: 811,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -1015,7 +1022,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 801,
+            line_number: 830,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -1023,7 +1030,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 802,
+            line_number: 831,
         },
         GrammarRule {
             name: r#"defined_expression"#.to_string(),
@@ -1031,7 +1038,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"defined?"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 813,
+            line_number: 842,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -1043,7 +1050,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 820,
+            line_number: 849,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -1058,7 +1065,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 821,
+            line_number: 850,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -1073,7 +1080,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 822,
+            line_number: 851,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -1093,7 +1100,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 823,
+            line_number: 852,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/bin/regen_grammars.rs
+++ b/code/packages/rust/ruby-parser/src/bin/regen_grammars.rs
@@ -1,0 +1,31 @@
+//! `regen_grammars` — regenerate `src/_grammar.rs` from the source
+//! `ruby.grammar` in `code/grammars/ruby/`.
+//!
+//! The generated `src/_grammar.rs` is AUTO-GENERATED — do not edit it by
+//! hand. After editing `ruby.grammar`, run:
+//!
+//! ```sh
+//! cargo run -p coding-adventures-ruby-parser --bin regen_grammars
+//! ```
+//!
+//! Mirrors `adj-lang`'s `regen_grammars` binary (the same pattern, applied to
+//! the Ruby grammar). The Ruby *lexer* is hand-written (not grammar-driven),
+//! so only the parser grammar is regenerated here.
+
+use std::fs;
+use std::path::PathBuf;
+
+use grammar_tools::compiler::compile_parser_grammar;
+use grammar_tools::parser_grammar::parse_parser_grammar;
+
+fn main() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let grammars = manifest.join("../../../grammars");
+    let src = manifest.join("src");
+
+    let gram = fs::read_to_string(grammars.join("ruby").join("ruby.grammar")).expect("read ruby.grammar");
+    let pg = parse_parser_grammar(&gram).expect("parse ruby.grammar");
+    fs::write(src.join("_grammar.rs"), compile_parser_grammar(&pg, "ruby.grammar")).expect("write _grammar.rs");
+
+    println!("regenerated src/_grammar.rs");
+}

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -5053,5 +5053,61 @@ mod tests {
     fn test_reasonable_nesting_stays_under_the_cap() {
         assert!(try_parse(&nested_paren_source(10)).is_ok());
     }
+
+    // -------------------------------------------------------------------
+    // Bug fix: a bare comparison/logical statement must parse as ONE
+    // statement, not split across a mis-parsed `method_call_no_paren` and a
+    // leftover operand.
+    //
+    // `<`, `>`, `<=`, `>=`, `!=`, `&&`, `||` have no dedicated lexer token
+    // type (`classify_op_token` in `ruby-lexer` deliberately leaves every
+    // operator lexeme without one on `TokenType::Name` — "the parser
+    // dispatches by value"). `factor`'s bare `NAME` alternative doesn't
+    // check a Name token's VALUE, so `method_call_no_paren = ( NAME | ... )
+    // expression { ... }` could match `x` as the callee and then swallow the
+    // operator token itself as an ordinary name-shaped "argument" — e.g.
+    // `x > 2` parsed as TWO statements (`x(>)` and a leftover `2`) instead of
+    // one (`x > 2`). Fixed by a negative lookahead in `method_call_no_paren`
+    // (`ruby.grammar`) for these operators, so the rule fails to match and
+    // `expression_stmt` correctly parses the whole comparison/logical chain.
+    // -------------------------------------------------------------------
+
+    /// `==` has its own dedicated `EqualsEquals` token type, so it was
+    /// accidentally already immune — included as a same-shape control case.
+    #[test]
+    fn test_bare_comparison_statement_parses_as_one_statement() {
+        for op in ["<", ">", "<=", ">=", "!=", "&&", "||", "=="] {
+            let ast = parse_ruby(&format!("x = 3\nx {op} 2\n"));
+            assert_program_root(&ast);
+            assert_eq!(
+                count_statements(&ast),
+                2,
+                "`x = 3` then `x {op} 2` should be exactly two statements, not \
+                 three (a mis-parsed call plus a leftover operand)"
+            );
+        }
+    }
+
+    /// `**`/`<<`/`>>`/`^`/`&`/`|` have NO binary-operator grammar rule at
+    /// all in this Ruby subset (only used elsewhere: `**`/`&` as call-arg
+    /// prefixes, `<<` for singleton-class, `|` for block params, `^` for pin
+    /// patterns) — so the fix does NOT guard them; there is no correct
+    /// fallback parse to preserve for e.g. `x << 2`. This pins that they are
+    /// UNCHANGED (still split into three statements), so a future
+    /// contributor doesn't assume this fix silently added bitwise-operator
+    /// support.
+    #[test]
+    fn test_unsupported_bitwise_operators_still_split_unchanged() {
+        for op in ["**", "<<", ">>", "^", "&", "|"] {
+            let ast = parse_ruby(&format!("x = 3\nx {op} 2\n"));
+            assert_program_root(&ast);
+            assert_eq!(
+                count_statements(&ast),
+                3,
+                "`x {op} 2` is not a supported binary expression here; it \
+                 should still split into three statements (unchanged)"
+            );
+        }
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## 0.7.1 — regression tests for a `ruby-parser` grammar fix
+
+No behavior change in this crate — the actual fix (a bare comparison/logical
+statement, e.g. `x > 2`, mis-parsing as a paren-less call and splitting into
+two statements) lives entirely in `coding-adventures-ruby-parser`'s
+`ruby.grammar` (see that crate's 0.6.0 CHANGELOG entry). Adds regression
+tests here at the lowering/validation layer — the level a consumer would
+actually notice the bug at — covering the bare-statement, block-tail, and
+`def`-tail positions, plus a control case pinning that the (deliberately
+unguarded) bitwise operators remain unchanged.
+
 ## 0.7.0 — lift a class CONSTANT to its name for `is_a?` / `when SomeClass`
 
 `case x when Integer` and `x.is_a?(Integer)` compiled on **Python alone**. Both

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -9351,4 +9351,95 @@ b = "y"
             result.errors().collect::<Vec<_>>()
         );
     }
+
+    // Regression for a grammar bug: `<`, `>`, `<=`, `>=`, `!=`, `&&`, `||` have
+    // no dedicated lexer token type (`classify_op_token` in `ruby-lexer`
+    // deliberately leaves every operator lexeme without one on
+    // `TokenType::Name` — "the parser dispatches by value"), so `factor`'s
+    // bare `NAME` alternative could match one of THEM too. A bare statement
+    // like `x > 2` mis-parsed as `method_call_no_paren` — `x` as the callee,
+    // the `>` token swallowed whole as if it were an ordinary name-shaped
+    // argument — leaving `2` behind as an unrelated second statement, and
+    // lowering the malformed "argument" emitted a `DirectCall` to whatever
+    // that bare name resolved to (here, `x` itself), which the SIR validator
+    // correctly rejected as a call to an unknown function. Fixed by a
+    // negative-lookahead in `method_call_no_paren` (`ruby.grammar`) so it
+    // fails to match on these operators and `expression_stmt` (`comparison`/
+    // `logical_and`/`logical_or`) parses the whole expression correctly
+    // instead. `==` was accidentally already immune (its own dedicated
+    // `EqualsEquals` token type) — included below as a same-shape control
+    // case that must keep passing. (`<=>` is a SEPARATE, pre-existing,
+    // out-of-scope gap: it isn't in `comparison`'s operator set at all, so it
+    // was never supported as a bare statement or otherwise — not touched
+    // here.)
+    #[test]
+    fn bare_comparison_statement_validates() {
+        // The BARE (unwrapped) shape that originally triggered the bug — as
+        // opposed to `puts(x > 2)`, where the comparison is nested as a call
+        // ARGUMENT and always worked. `==` was accidentally already immune
+        // (see the module-level comment above) — included as a same-shape
+        // control case that must keep validating.
+        for op in ["<", ">", "<=", ">=", "!=", "&&", "||", "=="] {
+            let src = format!("x = 3\nx {op} 2\n");
+            let m = lower(&src);
+            let result = semantic_ir::validate(&m);
+            assert!(
+                result.is_ok(),
+                "bare `x {op} 2` should validate: {:?}",
+                result.errors().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn bare_comparison_in_block_tail_position_validates() {
+        // The shape that originally surfaced the bug: a comparison as a
+        // block's IMPLICIT RETURN value (`select`/`any?`/etc.'s predicate).
+        for op in ["<", ">", "<=", ">=", "!="] {
+            let src = format!("puts [1, 2, 3].select {{ |x| x {op} 2 }}\n");
+            let m = lower(&src);
+            let result = semantic_ir::validate(&m);
+            assert!(
+                result.is_ok(),
+                "`{{ |x| x {op} 2 }}` should validate: {:?}",
+                result.errors().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn bare_comparison_in_def_tail_position_validates() {
+        for op in ["<", ">", "<=", ">=", "!=", "&&", "||"] {
+            let src = format!("def f(x)\n  x {op} 2\nend\nputs f(3)\n");
+            let m = lower(&src);
+            let result = semantic_ir::validate(&m);
+            assert!(
+                result.is_ok(),
+                "`def f(x); x {op} 2; end` should validate: {:?}",
+                result.errors().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn bitwise_operators_are_still_cleanly_unsupported_not_mis_parsed() {
+        // `**`/`<<`/`>>`/`^`/`&`/`|` have NO binary-operator grammar rule in
+        // this Ruby subset at all (only used elsewhere: `**`/`&` as call-arg
+        // prefixes, `<<` for singleton-class, `|` for block params, `^` for
+        // pin patterns) — so the fix deliberately does NOT guard them: there
+        // is no correct fallback parse to preserve for `x << 2`. This pins
+        // that they remain UNCHANGED (still lower as separate statements,
+        // same as before the fix), so a future contributor doesn't assume
+        // this fix silently added bitwise-operator support.
+        for op in ["**", "<<", ">>", "^", "&", "|"] {
+            let src = format!("x = 3\nx {op} 2\n");
+            let m = lower(&src);
+            assert_eq!(
+                m.functions.iter().find(|f| f.name == "main").unwrap().body.stmts.len(),
+                2,
+                "`x {op} 2` is not a supported binary expression here; it should \
+                 still split into two statements (unchanged), not one: {src:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- **Bug**: `<`, `>`, `<=`, `>=`, `!=`, `&&`, `||` have no dedicated lexer token type (`classify_op_token` deliberately leaves every operator lexeme without one on `TokenType::Name` — "the parser dispatches by value"). `factor`'s bare `NAME` alternative doesn't check a Name token's VALUE, so `method_call_no_paren` (Ruby's paren-less "command call" syntax, e.g. `puts "hi"`) could match a bare statement like `x > 2` as `x` (callee) applied to `>` itself — swallowed whole as an ordinary name-shaped argument — leaving `2` behind as an unrelated second statement. Lowering the malformed "argument" then emitted a call to whatever that bare name resolved to, which `semantic-ir`'s validator correctly rejected as an unknown function.
- **Found while** writing block-predicate tests for the SIR Collections cascade (PR #9628): `[1,2,3].select { |x| x > 2 }` failed identically — every backend shares this frontend, so it wasn't C-specific.
- **Fix**: a negative lookahead in `method_call_no_paren` (`ruby.grammar`) for these seven operators, so the rule fails to match on them and `expression_stmt` (`comparison`/`logical_and`/`logical_or`) parses the whole expression correctly instead. `==` was accidentally already immune (its own dedicated `EqualsEquals` token type) — kept as a control case. `**`/bitwise `<<`/`>>`/`^`/`&`/`|` are deliberately **not** touched: this grammar has no binary-operator rule for them at all, so there's no correct fallback parse to preserve — pinned as unchanged by a regression test.
- Also adds `ruby-parser/src/bin/regen_grammars.rs` (mirroring `adj-lang`'s binary of the same name) since none existed for this crate despite `_grammar.rs`'s own header pointing to one — needed to regenerate `_grammar.rs` from the edited `ruby.grammar`.

## Test plan
- [x] Full existing suites for `ruby-parser` (291) and `ruby-to-semantic-ir` (431) — green, plus new regression tests for the bare-statement, block-tail, and `def`-tail positions, and a control case for the untouched bitwise operators
- [x] Every consuming backend's test suite (`semantic-ir-to-c`, `-python`, `-typescript`, `-ruby`) — green, no regressions
- [x] Full cross-backend `sir-conformance` harness (arithmetic/comparisons/conformance/division/reflection, real toolchains) — green
- [x] `cargo build --workspace` — green
- [x] `cargo clippy` (both touched crates + the new bin) — clean
- [x] Security review — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>