### PR TITLE
feat(num7c): adj-verify recheck for the sqrt Real/BigDouble companion

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.35.0] - 2026-08-02 - NUM-7c: adj-verify rechecks the sqrt Real companion
+
+- No CLI code changes — `adj-verify` already walks every `DerivationNode` generically via
+  `recheck_narrowings`, so logic-engine's new `real` recheck arm is picked up for free.
+- New e2e coverage (`tests/num7c_verify_real_e2e.rs`): a bare sqrt's real companion rechecks
+  (`narrowings_rechecked:1`); a `round_to(sqrt(x), n)` shows both audit channels independently —
+  the inner sqrt's real companion rechecks while the outer `round_to` is honestly reported
+  `unverifiable` (its own operand's exact sidecar is `None`, since sqrt is irrational) — matching
+  NUM-6v's "never a pass" standard for an inexact source.
+
 ## [0.34.0] - 2026-08-02 - NUM-7b: render the sqrt Real/BigDouble audit companion
 
 - The `op` node's JSON audit gains an additive `"real":{"precision_bits":…,"mode":…,"value":…}`

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/tests/num7c_verify_real_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/num7c_verify_real_e2e.rs
@@ -1,0 +1,81 @@
+//! End-to-end tests for **NUM-7c — `adj-verify` re-checks the sqrt `Real`/
+//! `BigDouble` audit companion** (ADJ-NUMERIC-SUBSTRATE §8), driven through the
+//! built `adj-verify` binary.
+//!
+//! A sqrt's `Real` companion is technically a *widening* (exact source →
+//! approximate `BigDouble`), not a narrowing — but it reuses the same
+//! recheck machinery as NUM-6v for the identical reason: turn the engine's own
+//! claim about its precision into independently re-derived evidence, not
+//! testimony.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("num7c_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(dir: &Path, name: &str, src: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, src).unwrap();
+    p
+}
+
+fn verify(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-verify"))
+        .arg(program)
+        .output()
+        .expect("run adj-verify");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn sqrt_real_companion_is_rechecked_through_adj_verify() {
+    let dir = scratch("sqrt");
+    let src = "let r = latex \"$\\sqrt{2}$\"\n? r\n";
+    let p = write(&dir, "sqrt.adj", src);
+    let (ok, out) = verify(&p);
+
+    assert!(ok, "a sound sqrt real companion must exit 0:\n{out}");
+    assert!(out.contains("\"verified\":true"), "{out}");
+    assert!(
+        out.contains("\"narrowings_rechecked\":1"),
+        "the sqrt's real companion must be independently re-derived and confirmed:\n{out}"
+    );
+    assert!(out.contains("\"narrowings_mismatched\":0"), "{out}");
+}
+
+#[test]
+fn a_sqrt_narrowed_by_round_to_rechecks_both_the_round_and_the_real_companion() {
+    // round_to(sqrt(2), 5): the sqrt's own Real companion re-checks (exact source
+    // present), while the OUTER round_to has no exact sidecar to re-round from
+    // (sqrt's returned exact rational is None — irrational) and is honestly
+    // reported unverifiable, never a pass — which correctly makes the run as a
+    // whole NOT fully verified (exit non-zero), the same "never a pass" honesty
+    // NUM-6v already established for a transcendental's narrowing. Both audit
+    // channels are independently visible in the per-narrowing breakdown, without
+    // interfering with each other.
+    let dir = scratch("nested");
+    let src = "let r = round_to(latex \"$\\sqrt{2}$\", 5)\n? r\n";
+    let p = write(&dir, "nested.adj", src);
+    let (ok, out) = verify(&p);
+
+    assert!(!ok, "an unverifiable narrowing must not exit 0:\n{out}");
+    assert!(out.contains("\"verified\":false"), "{out}");
+    assert!(
+        out.contains("\"narrowings_rechecked\":1"),
+        "the inner sqrt's real companion rechecks:\n{out}"
+    );
+    assert!(
+        out.contains("\"narrowings_unverifiable\":1"),
+        "the outer round_to has no exact source to re-round from, honestly reported:\n{out}"
+    );
+    assert!(out.contains("\"narrowings_mismatched\":0"), "{out}");
+    assert!(
+        out.contains("{\"depth\":0,\"status\":\"unverifiable\"}") && out.contains("{\"depth\":1,\"status\":\"rechecked\"}"),
+        "both the outer (unverifiable) and inner (rechecked) status are individually visible:\n{out}"
+    );
+}

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.54.0] - 2026-08-02 - NUM-7c: `adj-verify` recheck of the sqrt Real companion
+
+- `recheck_narrowing` gains two new `DerivationNode::Op` arms: `real: None` is not a narrowing
+  (unchanged catch-all behavior); `real: Some(rc)` re-promotes and re-derives `rc.source` via
+  `BigDouble::from_rational(..).sqrt(..)` at `rc`'s own recorded precision/mode and compares
+  against the recorded `BigDouble` (value-based `PartialEq`), reporting `ReChecked` or a
+  `Mismatch{why:"real_differs"}`. Reuses the existing `NarrowingCheck` machinery — a `Real`
+  companion is technically a *widening* (exact source → approximate), not a narrowing, but the
+  re-derive-and-compare shape is identical.
+- No changes to the tree-walker (`collect_narrowings`) or the `adj-verify` binary — both are
+  already generic over `DerivationNode`/`NarrowingCheck`, so this falls out of the existing
+  recursion for free. This closes NUM-7 (ADJ-NUMERIC-SUBSTRATE §8): the sqrt `Real` companion is
+  now audited, not just computed.
+
 ## [0.53.0] - 2026-08-02 - NUM-7b: the sqrt `Real`/`BigDouble` audit companion
 
 - `DerivationNode::Op` gains an additive `real: Option<RealCompanion>` field (new public types

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -1977,6 +1977,26 @@ pub fn recheck_narrowing(node: &DerivationNode) -> NarrowingCheck {
                 check_rendered(&format!("{code} {amount}"), narrowed.to_f64(), rendered, *result)
             }
         },
+        // NUM-7c: a sqrt's Real/BigDouble companion is technically a *widening* (exact →
+        // approximate), not a narrowing — but it reuses this same machinery (recorded exact
+        // source + recorded spec/mode, re-derived and compared) for the identical reason: turn
+        // the engine's own claim about its precision into independently-checked evidence.
+        DerivationNode::Op { real: None, .. } => NarrowingCheck::NotANarrowing,
+        DerivationNode::Op {
+            real: Some(rc), ..
+        } => {
+            let prec = rc.value.precision_bits();
+            let recomputed = BigDouble::from_rational(rc.source.as_ratio(), prec, rc.mode).sqrt(prec, rc.mode);
+            if recomputed == *rc.value.as_big_double() {
+                NarrowingCheck::ReChecked
+            } else {
+                NarrowingCheck::Mismatch {
+                    why: "real_differs",
+                    recorded: rc.value.as_big_double().to_string(),
+                    recomputed: recomputed.to_string(),
+                }
+            }
+        }
         _ => NarrowingCheck::NotANarrowing,
     }
 }
@@ -3960,6 +3980,50 @@ mod tests {
     fn recheck_a_non_narrowing_node_is_inert() {
         let node = DerivationNode::Lit { value: 1.0 };
         assert_eq!(recheck_narrowing(&node), NarrowingCheck::NotANarrowing);
+    }
+
+    // ---- NUM-7c: adj-verify recheck of the sqrt Real companion ----------
+
+    #[test]
+    fn real_companion_rechecks_from_its_exact_source() {
+        let d = compute(
+            "root",
+            &bin(ComputeOp::Pow, ComputeExpr::Lit(2.0), ComputeExpr::Lit(0.5)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(recheck_narrowing(&d.tree), NarrowingCheck::ReChecked);
+    }
+
+    #[test]
+    fn a_tampered_real_companion_is_a_mismatch() {
+        let mut d = compute(
+            "root",
+            &bin(ComputeOp::Pow, ComputeExpr::Lit(2.0), ComputeExpr::Lit(0.5)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        if let DerivationNode::Op { real: Some(rc), .. } = &mut d.tree {
+            rc.value = ApproxReal(BigDouble::from_i64(999));
+        } else {
+            panic!("expected an Op node with a real companion");
+        }
+        match recheck_narrowing(&d.tree) {
+            NarrowingCheck::Mismatch { why, .. } => assert_eq!(why, "real_differs"),
+            other => panic!("expected a real_differs mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_op_with_no_real_companion_is_not_a_narrowing() {
+        // A regression guard: ordinary Op nodes (no sqrt involved) stay unaffected.
+        let d = compute(
+            "p",
+            &bin(ComputeOp::Pow, ComputeExpr::Lit(2.0), ComputeExpr::Lit(3.0)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(recheck_narrowing(&d.tree), NarrowingCheck::NotANarrowing);
     }
 
     #[test]

--- a/code/specs/ADJ-NUMERIC-SUBSTRATE.md
+++ b/code/specs/ADJ-NUMERIC-SUBSTRATE.md
@@ -277,8 +277,10 @@ Big arithmetic; a constraint solves over exact rationals where the backend allow
   NOT the full NUM-5 tower swap (see the naming note in §4.4) — a small, additive first rung
   that wires `bignum-core::BigDouble` into `compute.rs` for `sqrt` only, alongside the existing
   `f64` value and `ExactRational` sidecar (nothing existing changes shape). See §8 for the full
-  design; sub-staged **NUM-7a** (bignum-core primitive + KB setting) → **NUM-7b** (engine wiring
-  + audit JSON) → **NUM-7c** (`adj-verify` recheck).
+  design. ✅ **shipped in full**: **NUM-7a** (bignum-core `from_rational` primitive + per-KB
+  `real_precision_bits` setting) → **NUM-7b** (engine wiring — the `real` companion field, CLI
+  JSON, `--explain`; includes a security fix for a negative-underflowed-base edge case that could
+  otherwise panic `BigDouble::sqrt`) → **NUM-7c** (`adj-verify` recheck) all landed.
 - **Later — retire `numeric-tower`'s `num-bigint`** onto `bignum-core` (pays down the
   existing third-party debt; out of this spec's critical path).
 - **Later still — the full NUM-5 tower swap** (§5) and transcendentals (`ln`/`exp`/`sin`/`cos`/…)
@@ -340,18 +342,22 @@ per-`KnowledgeBase` precision promise, **additively**: nothing about the existin
   though a promotion to `Real` is technically a *widening* (exact → approximate) rather than a
   narrowing.
 
-**Sub-staging** (each: spec-sync → tests → impl → security-review → babysit):
+**Sub-staging** (each: spec-sync → tests → impl → security-review → babysit) — ✅ **all shipped**:
 
-- **NUM-7a** — `bignum-core::BigDouble::from_rational` (the exact-rational → `BigDouble`
+- **NUM-7a** ✅ — `bignum-core::BigDouble::from_rational` (the exact-rational → `BigDouble`
   promotion primitive, generalizing the existing private-use pattern inside
   `BigRational::to_f64()` to a caller-supplied precision) + `KnowledgeBase::real_precision_bits`
   (default 256, clamped to `bignum_core::MAX_PRECISION` since `BigDouble`'s internal precision
   guard panics outside range).
-- **NUM-7b** — engine wiring: a new `real: Option<RealCompanion>` field on
+- **NUM-7b** ✅ — engine wiring: a new `real: Option<RealCompanion>` field on
   `DerivationNode::Op` (additive; `Round`/`ToScientific`/`ToPercent`/`ToCurrency` and their
   `ExactRational`-typed audit fields are untouched), populated when a `Pow` node's evaluated
   exponent is bit-exactly `0.5` and its base carried an exact sidecar. CLI JSON gains an additive
-  `"real"` key when present.
-- **NUM-7c** — `adj-verify` recheck: an `Op` node with a `Real` companion is re-promoted and
+  `"real"` key when present. **Security-reviewed fix included**: the `f64` finiteness guard alone
+  does not exclude every negative base — an exact rational whose magnitude underflows the `f64`
+  path rounds to `-0.0`, and IEEE-754 `powf(-0.0, 0.5) == +0.0` (finite), which would otherwise
+  let a negative exact sidecar reach `BigDouble::sqrt` (which panics on a negative operand). The
+  exact sidecar's own sign is now checked explicitly before promoting.
+- **NUM-7c** ✅ — `adj-verify` recheck: an `Op` node with a `Real` companion is re-promoted and
   re-`sqrt`'d at its recorded precision/mode and compared, reported through the existing
   `NarrowingCheck` machinery.


### PR DESCRIPTION
## Summary
Stacked on #9636 (NUM-7b) — targets that branch so the diff here is scoped to just this rung; will retarget to `main` once #9636 merges.

- Closes NUM-7 (ADJ-NUMERIC-SUBSTRATE §8): extends `recheck_narrowing` with two new `DerivationNode::Op` arms — `real: None` is not a narrowing (unchanged); `real: Some(rc)` re-promotes and re-derives `rc.source` via `BigDouble::from_rational(..).sqrt(..)` at its own recorded precision/mode and compares against the recorded value (value-based `PartialEq`), reporting `ReChecked` or `Mismatch{why:"real_differs"}`.
- No changes needed to the tree-walker or the `adj-verify` binary — both are already generic over `DerivationNode`/`NarrowingCheck`, so this falls out of the existing recursion for free.
- Version bumps + changelogs; marks NUM-7a/7b/7c all shipped in the spec.

## Test plan
- [x] `cargo test -p bignum-core -p logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver` — all green (logic-engine now at 216 lib tests, up from 204 at the start of this rung), including 3 new compute.rs unit tests (recheck succeeds / tampered companion is caught / ordinary Op unaffected) + 2 new e2e tests (`num7c_verify_real_e2e.rs`: a bare sqrt rechecks; a `round_to(sqrt(x),n)` shows both audit channels — inner rechecked, outer honestly unverifiable — coexisting without interference).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `/security-review` passed — verified `rc.source` can't be attacker-influenced to bypass the sign-check from the prior PR's fix (single construction site, already-validated non-negative; no (de)serialization path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)