### PR TITLE
fix(spice): lower parser MOS source resistance

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `RS` values before lowering
+  Level-1 source resistance.
 - Reject negative and non-finite MOS model-card `RD` values before lowering
   Level-1 drain resistance.
 - Reject zero, negative, and non-finite MOS model-card `TNOM` / `T_NOM` values

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1926,6 +1926,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["RD"]) or params["RD"] < 0.0
         ):
             raise NetlistParseError("MOSFET RD must be finite and non-negative")
+        if "RS" in params and (
+            not math.isfinite(params["RS"]) or params["RS"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET RS must be finite and non-negative")
         nominal_temperature = params.get("T_NOM", params.get("TNOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1613,6 +1613,31 @@ def test_lowers_valid_mosfet_model_drain_resistance(
     assert float(drain_resistance) == mosfet.model.model.params.RD
 
 
+@pytest.mark.parametrize("source_resistance", ["-1", "1e999"])
+def test_rejects_invalid_mosfet_model_source_resistance(
+    source_resistance: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET RS must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(RS={source_resistance})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize("source_resistance", ["0", "9.75"])
+def test_lowers_valid_mosfet_model_source_resistance(
+    source_resistance: str,
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(RS={source_resistance})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert float(source_resistance) == mosfet.model.model.params.RS
+
+
 def test_rejects_unbalanced_waveform_parenthesis() -> None:
     with pytest.raises(NetlistParseError, match="unclosed parenthesis"):
         parse_netlist("V1 in 0 PULSE(0 1\n")

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject negative and non-finite MOS model-card `RS` values and lower valid
+  Level-1 source resistance instead of silently dropping it.
 - Reject negative and non-finite MOS model-card `RD` values and lower valid
   Level-1 drain resistance instead of silently dropping it.
 - Reject zero, negative, and non-finite MOS model-card `TNOM` / `T_NOM` values

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1245,6 +1245,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET RD must be finite and non-negative");
   }
+  const sourceResistance = params.get("RS");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    sourceResistance !== undefined &&
+    (!Number.isFinite(sourceResistance) || sourceResistance < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET RS must be finite and non-negative");
+  }
   const nominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -1336,6 +1344,7 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "TOX",
     "U0",
     "RD",
+    "RS",
     "IS",
     "N_SUB",
     "T_NOM",

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1531,6 +1531,22 @@ Xright c d load
     expect(element.params.RD).toBe(Number(drainResistance));
   });
 
+  it.each(["-1", "1e999"])("rejects invalid MOSFET model RS=%s", (sourceResistance) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(RS=${sourceResistance})\nM1 d g s b nfast\n`),
+    ).toThrow("MOSFET RS must be finite and non-negative");
+  });
+
+  it.each(["0", "9.75"])("lowers valid MOSFET model RS=%s", (sourceResistance) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(RS=${sourceResistance})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.RS).toBe(Number(sourceResistance));
+  });
+
   it("rejects unbalanced waveform parentheses", () => {
     expect(() => parseNetlist("V1 in 0 PULSE(0 1\n")).toThrow("unclosed parenthesis");
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4195,10 +4195,16 @@ the Rust, Python, and TypeScript surfaces together.
      the shared diagnostic while positive Kelvin values lower into Level-1
      parameters.
 
+380. Python and TypeScript Berkeley SPICE MOS drain-resistance parity.
+   - Status: completed in PR 9637.
+   - Negative and non-finite `RD` values are rejected with the shared
+     diagnostic while zero and positive drain resistances lower into Level-1
+     parameters.
+
 ## Backlog
 
 1. Python and TypeScript Berkeley SPICE MOS remaining parameter lowering parity.
-   - TypeScript still needs canonical lowering for `RD`, `RS`, `RSH`, `LD`,
+   - TypeScript still needs canonical lowering for `RS`, `RSH`, `LD`,
      `NRD`, `NRS`, `AD`, `AS`, `PD`, `PS`, `CJ`, `CJSW`, `JS`, `PB`, `MJ`,
      `MJSW`, `FC`, `KF`, and `AF`; Python already lowers these canonical fields
      but still needs matching facade validation coverage.


### PR DESCRIPTION
## Summary
- reject negative and non-finite MOS model-card `RS` values in the Python and TypeScript parsers
- lower valid TypeScript source resistance instead of silently dropping it
- record the merged drain-resistance parity slice and advance the audited backlog

## Verification
- Python spice-netlist-parser: 139 tests passed; 88.21% coverage
- Python spice-netlist-parser: `ruff check src tests`
- TypeScript spice-engine: `npm run build`
- TypeScript spice-netlist-parser: `npm run build`
- TypeScript spice-netlist-parser: 132 tests passed with coverage