### PR TITLE
feat(human-languages): generate Spanish Chapters 4–6

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,12 +5,13 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-02. Current baseline after the Spanish Chapters 4–6
-schema tranche: 20 registered tracks, 1,065 Markdown lessons, 20 downloadable
-LaTeX books, and zero duration violations. HL-V01 keeps the remaining migration
-debt reproducible in both JSON and human-readable reports; HL-S01 and HL-S02
-prove the strict schema on the first 51 Spanish lessons, and the completed
-HL-D01 tranches prove duration remediation without discarding deep content.
+Last prioritized: 2026-08-02. Current baseline after Spanish Chapters 4–6
+canonical generation: 20 registered tracks, 1,065 Markdown lessons, 20
+downloadable LaTeX books, and zero duration violations. HL-V01 keeps the
+remaining migration debt reproducible in both JSON and human-readable reports;
+the first 51 Spanish lessons now prove one typed source across Language Ladder
+and six generated book chapters, and the completed HL-D01 tranches prove
+duration remediation without discarding deep content.
 
 ## Priority rules
 
@@ -45,8 +46,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | ID | Status | Work item | Why it follows P0 |
 |---|---|---|---|
 | HL-S01 | Complete (#9497) | Migrate Spanish Chapters 1–3 to schema version 2 with typed body blocks and knowledge closure. | The 24-lesson slice has unique order, transitive knowledge closure, typed blocks, and no effective-duration violation. |
-| HL-G01 | Complete in the canonical-generation PR | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy now that the AST contract is executable. |
-| HL-G02 | Complete in the Chapters 2–3 generation PR | Generate Spanish Chapters 2–3 from their canonical schema-v2 lesson AST. | Extends the proven one-source path across the rest of the migrated pilot before broad corpus work. |
+| HL-G01 | Complete (#9505) | Generate a Spanish LaTeX chapter from the canonical lesson AST and compare source hashes with the app. | Removes the first handwritten book copy now that the AST contract is executable. |
+| HL-G02 | Complete (#9509) | Generate Spanish Chapters 2–3 from their canonical schema-v2 lesson AST. | Extends the proven one-source path across the rest of the migrated pilot before broad corpus work. |
 | HL-D01A | Complete in the Russian duration PR | Remove all nine sub-five-minute violations from the complete Russian starter track. | The report measures zero Russian violations; every changed or added lesson is below 300 effective seconds. |
 | HL-D01B | Complete in the Marathi duration PR | Remove all eight sub-five-minute violations from the Marathi track. | The report measures zero Marathi violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
 | HL-D01C | Complete in the Gujarati duration PR | Remove all nine sub-five-minute violations from the Gujarati track. | The report measures zero Gujarati violations; the one genuinely long lesson is now two prerequisite-ordered micro-lessons. |
@@ -66,9 +67,9 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-D01Q | Complete (#9610) | Remove all forty-three sub-five-minute violations from the Latin track. | The report measures zero Latin violations; six new prerequisite-ordered lessons preserve its grammar, etymology, usage, and attestation depth. |
 | HL-D01R | Complete (#9624) | Remove all fifty-five remaining sub-five-minute violations from the Spanish track. | The report measures zero Spanish violations; twelve new prerequisite-ordered lessons preserve the grammar, etymology, usage, writing, and practice depth from the genuinely long lessons. |
 | HL-D01 | Complete (#9624) | Split or rewrite every lesson whose computed duration is at least 300 seconds. | The deterministic report now reaches zero effective-duration violations across all twenty tracks. |
-| HL-S02 | Complete in this PR | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | All 27 lessons have typed blocks, unique sequence, transitive knowledge closure, and sub-five-minute duration guarantees. |
-| HL-G03 | Next | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | Replaces the first three handwritten post-pilot chapters and extends app/book source-hash parity. |
-| HL-V02 | Queued | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
+| HL-S02 | Complete (#9634) | Migrate Spanish Chapters 4–6 to schema v2 before generating their book chapters. | All 27 lessons have typed blocks, unique sequence, transitive knowledge closure, and sub-five-minute duration guarantees. |
+| HL-G03 | Complete in this PR | Generate Spanish Chapters 4–6 from their canonical schema-v2 lesson ASTs after HL-S02. | All six generated chapters now share lesson hashes with Language Ladder; Markdown tables retain their structure in print. |
+| HL-V02 | Next | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-B04 | Queued | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
 | HL-B05 | Queued | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | A forced build succeeds but reports four repeated `lesson:practice` labels, 32 Hyperref PDF-string warnings, and two underfull boxes; the clean-build signal is zero of each. |
 | HL-B06 | Queued | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | The duration audit exposed authored app content beyond the current five-chapter PDF; schema-v2 migration plus generation should close that drift safely. |
@@ -102,7 +103,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B34 | Queued | Publish Latin Chapters 2–36 from canonical lessons rather than hand-copying another thirty-five book chapters. | The Latin PDF contains only Chapter 1 while canonical app content continues through Chapter 36; schema-v2 migration plus generation should close that drift safely. |
 | HL-B35 | Queued | Remove Latin's remaining LaTeX layout and font warnings. | A forced build succeeds with no missing glyphs, overfull boxes, duplicate labels, or Hyperref warnings, but reports one underfull box and a small-caps font-shape substitution; the clean-build signal is zero of each. |
 | HL-B36 | Queued | Publish Spanish Chapters 19–33 from canonical lessons rather than hand-copying another fifteen book chapters. | The Spanish PDF stops after Chapter 18 while canonical app content continues through Chapter 33; schema-v2 migration plus generation should raise book coverage from 55% to 100%. |
-| HL-B37 | Queued | Remove Spanish's LaTeX layout, bookmark, and font warnings. | A forced build succeeds with no missing glyphs or duplicate labels but reports 52 overfull boxes, 19 underfull boxes, 14 Hyperref warnings, and two font warnings; the clean-build signal is zero of each. |
+| HL-B37 | Queued | Remove Spanish's remaining legacy LaTeX layout, bookmark, and font warnings. | After Chapters 4–6 generation, a forced build has no missing glyphs or duplicate labels but reports 50 overfull boxes, 14 underfull boxes, 14 Hyperref warnings, and one undefined small-caps shape; the clean-build signal is zero of each. |
 | HL-M01 | Queued | Add per-track spine realization maps and language-specific extension nodes. | Enables safe cross-language scheduling beyond the current concept join. |
 | HL-M02 | Queued | Extend Telugu's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new register support step, needs a scheduled place. |
 | HL-M03 | Queued | Extend Kannada's roadmap and authoritative session map through canonical Chapter 31. | The roadmap narrative stops at Chapter 6 and the session map at Chapter 5 even though prerequisite-ordered lessons continue through Chapter 31; every canonical lesson, including the new stacking support step, needs a scheduled place. |
@@ -195,6 +196,24 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
   smallest complete existing track with measurable debt: nine violations, of
   which five are computed at 312–405 seconds and four only need honest declared
   budgets below the cap. HL-D01A is therefore the next bounded tranche.
+
+## Findings from HL-G03
+
+- All 51 schema-v2 Spanish lessons in Chapters 1–6 now generate the same six
+  LaTeX chapters whose source hashes Language Ladder recomputes from its loaded
+  AST. The per-chapter lesson counts are 7, 5, 12, 13, 7, and 7.
+- The shared renderer now preserves valid Markdown tables as width-aware LaTeX
+  tables and maps the approximation sign safely. This keeps register contrasts,
+  question families, farewell choices, and verb forms structured in both app
+  and book instead of flattening them into pipe-delimited prose.
+- The forced XeLaTeX build produces 158 pages. Every rendered page in the
+  Chapter 4–6 span was checked for clipping, collisions, broken diacritics,
+  malformed tables, and accidental blank pages; those generated chapters have
+  no missing glyph, overfull/underfull box, or Hyperref warning.
+- Remaining Spanish PDF warnings come from legacy Chapters 7–18 and stay
+  explicit in HL-B37. HL-V02 is next because the HL-S02 editorial audit showed
+  that lesson-level atom closure alone cannot detect undeclared target-language
+  tokens inside learner production and recall prompts.
 
 ## Findings from HL-D01A
 

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -21,6 +21,27 @@
       "title": "Introducing Yourself",
       "label": "ch:introductions",
       "output": "spanish/book/chapters/ch03-introductions.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 4,
+      "title": "How Are You?",
+      "label": "ch:how-are-you",
+      "output": "spanish/book/chapters/ch04-how-are-you.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 5,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "output": "spanish/book/chapters/ch05-farewells.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 6,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "output": "spanish/book/chapters/ch06-first-verbs.tex"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -49,6 +49,57 @@
         "ES-C03-practice"
       ],
       "tex": "spanish/book/chapters/ch03-introductions.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 4,
+      "sourceHash": "fnv1a64:a8f2ef77f4c94859",
+      "lessonIds": [
+        "ES-C04-gracias",
+        "ES-C04-de-nada",
+        "ES-C04-estar",
+        "ES-C04-como-esta",
+        "ES-C04-como-estas-register",
+        "ES-C04-regular",
+        "ES-C04-y",
+        "ES-W01-acento",
+        "ES-W01-tilde-diacritica",
+        "ES-W02-enye",
+        "ES-W03-inverted",
+        "ES-W03-question-span",
+        "ES-C04-practice"
+      ],
+      "tex": "spanish/book/chapters/ch04-how-are-you.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 5,
+      "sourceHash": "fnv1a64:3008dfa4a25b0bd2",
+      "lessonIds": [
+        "ES-C05-adios",
+        "ES-C05-hasta",
+        "ES-C05-hasta-limits",
+        "ES-C05-hasta-luego",
+        "ES-C05-hasta-manana",
+        "ES-C05-hasta-pronto",
+        "ES-C05-practice"
+      ],
+      "tex": "spanish/book/chapters/ch05-farewells.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:081983e1f50e4d6c",
+      "lessonIds": [
+        "ES-C06-cafe",
+        "ES-C06-por-favor",
+        "ES-C06-hablar",
+        "ES-C06-trabajar",
+        "ES-C06-estudiar",
+        "ES-C06-espanol",
+        "ES-C06-practice"
+      ],
+      "tex": "spanish/book/chapters/ch06-first-verbs.tex"
     }
   ]
 }

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Chapters 4–6 — canonical book generation
+
+- Replaced three handwritten LaTeX chapters with deterministic output from all
+  27 schema-v2 well-being, writing, farewell, and first-verb micro-lessons.
+  Language Ladder now verifies the same source hashes across all 51 lessons in
+  generated Chapters 1–6.
+- Added width-aware Markdown-table rendering so question families, register
+  choices, farewell timing, and verb conjugations keep their row-and-column
+  meaning in print. The renderer also emits a safe LaTeX approximation symbol.
+- Corrected two headerless canonical verb tables and removed three unsupported
+  glyphs exposed by the first forced build without weakening the etymology.
+- Forced the complete XeLaTeX build to 158 pages and visually inspected every
+  page in Chapters 4–6. The generated span has no missing glyphs, layout-box
+  warnings, bookmark warnings, clipping, collisions, or malformed tables.
+
 ## Chapters 4–6 — prerequisite-safe schema-v2 content
 
 - Migrated all 25 existing lessons across well-being, farewells, first verbs,

--- a/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
@@ -298,7 +298,18 @@ English has no such marker — it relies on word order and context. Spanish puts
 \begin{cousinweb}
 Latin used a recurring \emph{qu-} stem in questions. Spanish preserves that family, although centuries of sound change gave the modern forms different shapes:
 
-| Spanish clue | $\leftarrow$ Latin | future meaning | |---|---|---| | \emph{qué} | \emph{quid} | what | | \emph{quién} | \emph{quem} | who | | \emph{cuál} | \emph{qualis} | which | | \emph{cuándo} | \emph{quando} | when | | \emph{cuánto} | \emph{quantus} | how much | | \textbf{cómo} | \emph{quomodo} | how |
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Spanish clue} & \textbf{$\leftarrow$ Latin} & \textbf{future meaning} \\
+\midrule
+\emph{qué} & \emph{quid} & what \\
+\emph{quién} & \emph{quem} & who \\
+\emph{cuál} & \emph{qualis} & which \\
+\emph{cuándo} & \emph{quando} & when \\
+\emph{cuánto} & \emph{quantus} & how much \\
+\textbf{cómo} & \emph{quomodo} & how \\
+\bottomrule
+\end{tabularx}
 
 These are previews, not vocabulary to produce today. For now, use the family only as an etymological clue: a question form beginning \emph{qu-} or \emph{cu-} may continue the same Latin pattern. \emph{Dónde}, "where," is an exception from Latin \emph{de unde}, "from where."
 \end{cousinweb}

--- a/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
@@ -1,222 +1,576 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:a8f2ef77f4c94859
+% canonical-lessons: ES-C04-gracias, ES-C04-de-nada, ES-C04-estar, ES-C04-como-esta, ES-C04-como-estas-register, ES-C04-regular, ES-C04-y, ES-W01-acento, ES-W01-tilde-diacritica, ES-W02-enye, ES-W03-inverted, ES-W03-question-span, ES-C04-practice
+
 \chapter{How Are You?}
 \label{ch:how-are-you}
 
-Now the conversation moves: you thank someone, you wave the thanks away, and
-you ask how they are --- a question that turns on one of Spanish's most famous
-features, its \emph{two} verbs for ``to be.''
-\emph{Practice lessons: \texttt{lessons/ES-C04-*.md}.}
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section{\emph{gracias} --- ``thank you,'' a whole English family}
-\label{lesson:gracias}
+\section[gracias]{gracias — "thank you," and a whole family of English words}
 
-\begin{sounds}
-\textbf{vowel-a} --- the clean \emph{ah} of \emph{father}, twice.\\[3pt]
-\textbf{r-tap} --- a single flicked \emph{r} (not the English one, and not yet
-the rolled \emph{rr}): the tongue taps once, like the middle of American
-\emph{butter}.\\[3pt]
-\textbf{ci} --- a soft \emph{s} in Latin America (\emph{GRAH-syahs}) and a soft
-\emph{th} in most of Spain (\emph{GRAH-thyahs}). Either is correct --- pick one.
-\end{sounds}
+\label{lesson:ES-C04-gracias}
 
-\begin{cousinweb}
-\textbf{gracias} is the plural of \emph{gracia} (``grace, favour'')
-$\leftarrow$ Latin \emph{gr\={a}tia}, \emph{favour freely given}. Saying
-\emph{gracias} literally offers someone ``graces,'' good will in return for
-theirs.\\[3pt]
-\textbf{The family:} \textbf{grace}, \textbf{gracious}, \textbf{graceful} (the
-direct borrowings); \textbf{grateful}, \textbf{gratitude} (being \emph{full of}
-\emph{gr\={a}tia}); \textbf{gratis}, \textbf{gratuity} (something given as a
-favour --- for free, or a tip); \textbf{congratulate} (``to wish grace
-\emph{together with} someone'').\\[3pt]
-The whole Romance family keeps \emph{gr\={a}tia}: Italian \emph{grazie},
-French \emph{gr\^{a}ces}, Portuguese \emph{gra\c{c}as}.
-\end{cousinweb}
 
-So \emph{gracias} is not a word to memorize cold: it is \textbf{grace}, made
-plural and handed to another person.
 
-\section{\emph{de nada} --- ``you're welcome,'' or ``it was nothing''}
-\label{lesson:de-nada}
-
-\begin{sounds}
-\textbf{d-soft} --- the \emph{d} in \emph{nada} is soft, almost the \emph{th}
-of \emph{this} (\emph{NAH-thah}), not a hard English \emph{d}. Spanish \emph{d}
-between vowels always softens.\\[3pt]
-\textbf{vowel-a} --- three clean \emph{ah} sounds: \emph{deh NAH-thah}.
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{de} (``of / from'') $\leftarrow$ Latin \emph{d\={e}} --- the same
-\emph{de-} hiding in English \textbf{de}part, \textbf{de}duct,
-\textbf{de}scend.\\[3pt]
-\textbf{nada} (``nothing'') $\leftarrow$ Latin \emph{(r\={e}s) n\={a}ta},
-``(a thing) \emph{born},'' from \emph{n\={a}sc\={i}} (``to be born'') $\to$
-\textbf{nat}ive, \textbf{nat}ure, \textbf{nat}al, re\textbf{naiss}ance
-(``re-birth''). Latin speakers said \emph{n\={o}n est r\={e}s n\={a}ta},
-``there is not a born thing'' --- not a single thing that ever came into being
---- and over centuries the emphatic \emph{n\={a}ta} wore down until the word
-for ``born thing'' became the word for ``nothing'' itself.\\[3pt]
-French did the identical trick with \emph{rien} (``nothing''), which is Latin
-\emph{rem}, ``a thing.'' Two languages, same move: the word for \emph{thing}
-collapses into the word for \emph{nothing}.
-\end{cousinweb}
-
-So the reply \emph{de nada} literally says ``of [a] born-thing'' $\to$ ``of
-nothing at all'' --- you are waving the favour off as no trouble, the same move
-English makes with ``it's nothing'' or ``no problem.''
-
-\begin{grammarlens}
-\emph{gracias} $\to$ \emph{de nada} is a fixed \textbf{adjacency pair}: one
-turn expects the other. Learn them as a unit, the way English glues
-``thank you'' $\to$ ``you're welcome.''
-\end{grammarlens}
-
-\section{\emph{estar} --- ``to be,'' the \emph{standing} kind}
-\label{lesson:estar}
-
-\begin{sounds}
-\textbf{st-no-e} --- Spanish never starts a word with a bare \emph{st-}; it
-props it up with an \emph{e}: \emph{es-TAR}. (That reflex is why Spanish
-speakers say \emph{e-Spain}, \emph{e-student} --- the same \emph{e} that Latin
-\emph{stare} grew to become \emph{estar}.)\\[3pt]
-\textbf{r-tap} --- the final \emph{r} is one soft tap: \emph{es-TAR}.
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{estar} $\leftarrow$ Latin \emph{st\={a}re}, ``to stand'' --- exactly
-the right picture for the \emph{temporary} be-verb: how you are \emph{standing}
-at this moment (well, tired, here, there), not what you permanently
-\emph{are}.\\[3pt]
-\textbf{The st\={a}-/sta- family:} \textbf{stay}, \textbf{stand},
-\textbf{stance}, \textbf{station}, \textbf{stable}, \textbf{stationary} --- to
-stand or stay put; \textbf{state}, \textbf{status}, \textbf{statue},
-\textbf{estate} --- a way of \emph{standing} (your state $=$ how you stand);
-\textbf{constant}, \textbf{circumstance}, \textbf{substance} --- ``standing
-with / around / under.''
-\end{cousinweb}
-
-So \emph{\textquestiondown c\'{o}mo est\'{a}s?} is, at the root, ``how are you
-\emph{standing}?'' --- a snapshot of right now.
-
-\begin{grammarlens}
-Spanish has \textbf{two} verbs for ``to be.'' \textbf{ser} $\leftarrow$ Latin
-\emph{esse} (``to be'') carries permanent identity: \emph{soy David}, ``I am
-David.'' \textbf{estar} $\leftarrow$ Latin \emph{st\={a}re} (``to stand'')
-carries temporary state and location: \emph{estoy bien}, ``I am well (now)'';
-\emph{estoy aqu\'{i}}, ``I am here.''\\[3pt]
-Rule of thumb: how you \emph{feel} and \emph{where} you are $\to$ \emph{estar};
-who you \emph{are} $\to$ \emph{ser}. ``How are you?'' is about your current
-state, so it always takes \emph{estar}.\\[3pt]
-You need only two forms this chapter: \emph{est\'{a}s} (``you are,'' informal
-\emph{t\'{u}}) and \emph{est\'{a}} (``you are,'' formal \emph{usted}; also
-``he/she is'').
-\end{grammarlens}
-
-\section{\textquestiondown\emph{C\'{o}mo est\'{a} usted?} --- ``how are you?''}
-\label{lesson:como-esta}
-
-Everything in this chapter now snaps together. Two pieces come from Chapter
-\ref{ch:introductions}: \textbf{c\'{o}mo} (``how'') $\leftarrow$ Latin
-\emph{qu\={o}modo}, ``in what manner'' --- the \emph{qu-} question family with
-\emph{qu\'{e}}, \emph{qui\'{e}n}, \emph{cu\'{a}ndo}; and the \textbf{usted} /
-\textbf{t\'{u}} choice --- \emph{usted} worn down from \emph{vuestra merced},
-``your grace,'' and \emph{t\'{u}} the old intimate ``thou.'' The third piece is
-the \emph{estar} you just met.
-
-\emph{c\'{o}mo} (``how / in what manner'') $+$ \emph{est\'{a}} (``you are,''
-the \emph{usted}/he-she form of \emph{estar} --- state, not identity) $+$
-\emph{usted} (the formal ``you'') $=$ literally ``in what manner are you
-standing?''
-
-\begin{grammarlens}
-Two registers, and only the verb ending and the pronoun change --- exactly the
-\emph{se llama} / \emph{te llamas} split from the last chapter.\\[3pt]
-\textbf{Formal} (a stranger, an elder, a customer):
-\emph{\textquestiondown C\'{o}mo est\'{a} usted?}\\[3pt]
-\textbf{Informal} (a friend, a peer, a child):
-\emph{\textquestiondown C\'{o}mo est\'{a}s?}
-\end{grammarlens}
-
-\begin{culture}
-Note the opening \textquestiondown. Spanish opens a question with an
-upside-down mark so you know the melody is coming \emph{before} you start
-reading aloud --- the sentence tells you how to say it from its first
-character. (A dedicated writing lesson takes that mark apart.)
-\end{culture}
-
-\section{\emph{regular} and \emph{m\'{a}s o menos} --- the honest ``so-so''}
-\label{lesson:regular}
-
-You asked \emph{\textquestiondown c\'{o}mo est\'{a}s?} Now you can answer three
-ways: great, middling, or a wave of the hand. From Chapter
-\ref{ch:first-words} you have \textbf{bien} (``well'') $\leftarrow$ Latin \emph{bene}, the
-\emph{bene-} of \textbf{bene}fit and \textbf{bene}volent --- so \emph{estoy
-bien} is ``I'm well.'' Here are the answers for when you are not quite
-\emph{bien}, because nobody is \emph{bien} every day.
-
-\begin{cousinweb}
-\textbf{regular} $\leftarrow$ Latin \emph{r\={e}gula}, a \emph{straight rod} a
-builder used to check a line --- the \textbf{ruler}. So \emph{regular} is ``on
-the rule, on the average line'' $\to$ middling.\\[3pt]
-That rod is everywhere in English: \textbf{rule}, \textbf{ruler},
-\textbf{regulate}, \textbf{regular}, \textbf{regiment}, and even \textbf{rail}
-(a straight rod). All the same straight stick.\\[3pt]
-\textbf{m\'{a}s} (``more'') $\leftarrow$ Latin \emph{magis} $\to$
-\textbf{major}, \textbf{master}, \textbf{maximum}. \textbf{menos} (``less'')
-$\leftarrow$ Latin \emph{minus} --- the very word English borrowed for
-\textbf{minus}, \textbf{minor}, \textbf{minimum}, \textbf{minus}cule. So
-\emph{m\'{a}s o menos} is literally ``more or less,'' root for root the exact
-phrase English uses for the same shrug.
-\end{cousinweb}
-
-\begin{culture}
-\emph{regular} as an answer to ``how are you?'' is a famous false-friend trap:
-here it does \emph{not} mean English ``regular / normal / usual.'' It means
-\textbf{so-so, average, not great}.
-\end{culture}
-
-\begin{grammarlens}
-A small, complete answer set for \emph{\textquestiondown c\'{o}mo est\'{a}s?}:
-\emph{(muy) bien} $=$ ``(very) well'' $\cdot$ \emph{regular} $=$ ``so-so''
-$\cdot$ \emph{m\'{a}s o menos} $=$ ``more or less / meh.''
-\end{grammarlens}
-
-\section{Practice --- ``how are you?'', start to finish}
-\label{lesson:ch4-practice}
-
-No new words. This chapter's atoms --- \emph{gracias}, \emph{de nada},
-\emph{estar}, \emph{\textquestiondown c\'{o}mo est\'{a}?}, \emph{regular} ---
-now assemble into a real exchange, picking up right where the Chapter
-\ref{ch:introductions} introduction left off.
-
-\textbf{Formal} (a stranger, an elder, a customer):
-
-\begin{quote}\itshape
---- Buenos d\'{i}as. \textquestiondown C\'{o}mo est\'{a} usted?\\
---- Bien, gracias. \textquestiondown Y usted?\\
---- M\'{a}s o menos.\\
---- [replying to a thanks, later in the chat] De nada.
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can now introduce yourself. The next exchange is \emph{how are you?} — but every answer ends the same polite way, so we learn the courtesy word first: \textbf{gracias}.
 \end{quote}
 
-\textbf{Informal} (a friend, a peer) --- only the verb and the pronoun change:
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{vowel-a} — the clean \emph{ah} of \emph{father}, twice.
+  \item \texttt{r-tap} — a single flicked \emph{r} (not the English one, and not yet the rolled \emph{rr}): the tongue taps once, like the middle of American \emph{butter}.
+  \item \texttt{ci-th-s} — the \emph{ci} is a soft \emph{s} in Latin America (\textbf{GRAH-syahs}) and a soft \emph{th} in most of Spain (\textbf{GRAH-thyahs}). Either is correct — pick one.
+\end{itemize}
+\end{sounds}
 
-\begin{quote}\itshape
---- \textexclamdown Hola! \textquestiondown C\'{o}mo est\'{a}s?\\
---- Regular. \textquestiondown Y t\'{u}?\\
---- Bien, gracias.
+\begin{cousinweb}
+\textbf{gracias} is the plural of \textbf{gracia} ("grace, favour"), from Latin \textbf{grātia} — \emph{favour freely given}. Saying \emph{gracias} literally offers someone "graces," i.e. good will in return for theirs.
+
+That one Latin root \textbf{grātia} fans out across English — once you see it, you get a fistful of words for free:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{grace}, \textbf{gracious}, \textbf{graceful} — the direct borrowings.
+  \item \textbf{grateful}, \textbf{gratitude} — being \emph{full of} grātia.
+  \item \textbf{gratis}, \textbf{gratuity} — something given as a \emph{favour} (for free, or a tip).
+  \item \textbf{congratulate} — literally "to wish grace \emph{together with} someone."
+  \item Italian \textbf{grazie}, French \emph{grâces}, Portuguese \emph{graças} — the whole Romance family kept grātia, even where everyday thanks went elsewhere (French says \emph{merci}, Portuguese \emph{obrigado}).
+\end{itemize}
+
+So \emph{gracias} is not a word to memorize cold: it is \textbf{grace}, made plural and handed to another person.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "gracias" — \emph{GRAH-syahs}, one soft tap on the \emph{r}{]}
+  \item {[}YOU SAY: "gracias" then English "grace, grateful, gratitude" — one family{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What everyday English word is \emph{gracias} the plural of, at the root? (\emph{Grace}.) So when you thank someone in Spanish, you are literally handing them — what? (Graces / favours.) Next: the little reply that closes the exchange, \textbf{de nada}.
+\end{tcolorbox}
+\section[de nada]{de nada — "you're welcome," or "it was nothing"}
+
+\label{lesson:ES-C04-de-nada}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Someone says \textbf{gracias}. You need the reply that closes the loop: \textbf{de nada} — literally \emph{"of nothing."} You're waving the favour off as no trouble at all — the same move English makes with \emph{"it's nothing"} / \emph{"no problem."}
 \end{quote}
 
-The one new glue word is \emph{\textquestiondown y usted?} /
-\emph{\textquestiondown y t\'{u}?} --- ``and you?'' (\emph{y} $=$ ``and,''
-from Latin \emph{et}). It bounces the question back.
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{d-soft} — the \emph{d} in \emph{nada} is soft, almost the \emph{th} of \emph{this} (\textbf{NAH-thah}), not a hard English \emph{d}. Spanish \emph{d} between vowels always softens.
+  \item \texttt{vowel-a} — three clean \emph{ah} sounds: \emph{deh NAH-thah}.
+\end{itemize}
+\end{sounds}
 
-What you built: \emph{gracias}, thank you ($\leftarrow$ \emph{gr\={a}tia},
-``grace'') $\cdot$ \emph{de nada}, you're welcome ($\leftarrow$ ``of a
-born-thing'' $\to$ ``of nothing'') $\cdot$ \emph{estar}, the temporary to-be
-($\leftarrow$ \emph{st\={a}re}, ``to stand''), against \emph{ser} for identity
-$\cdot$ \emph{\textquestiondown c\'{o}mo est\'{a} usted?} /
-\emph{\textquestiondown c\'{o}mo est\'{a}s?}, formal and informal $\cdot$
-\emph{bien / regular / m\'{a}s o menos}, well / so-so / more-or-less. Two words
-swap between the registers: \emph{est\'{a}} $\to$ \emph{est\'{a}s}, and
-\emph{usted} $\to$ \emph{t\'{u}}. Next chapter: farewells --- \emph{hasta
-luego}, \emph{hasta ma\~{n}ana}, \emph{adi\'{o}s}.
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{de} = "of / from" (Latin \textbf{dē}) — the same \emph{de} hiding in English \textbf{de}part, \textbf{de}duct, \textbf{de}scend.
+  \item \textbf{nada} = "nothing." And this is the beautiful part.
+\end{itemize}
+
+\textbf{nada} comes from Latin \textbf{(rēs) nāta} — "(a thing) \emph{born}." From \emph{nāscī}, "to be born," the same root as English \textbf{nat}ive, \textbf{nat}ure, \textbf{nat}al, \textbf{re-nais-sance} (re-birth). Latin speakers said \emph{nōn est rēs nāta}, "there is not a born thing" — \emph{not a single thing that ever came into being} — and over centuries the emphatic \emph{nāta} ("born thing") wore down until \textbf{the word for 'born thing' became the word for 'nothing' itself.}
+
+So the reply \emph{de nada} literally says \textbf{"of {[}a{]} born-thing"} $\to$ "of nothing at all." French did the identical trick with \textbf{rien} ("nothing") — which is Latin \textbf{rem}, "a thing." Two languages, same move: the word for \emph{thing} collapses into the word for \emph{nothing}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the courtesy pair}]
+\emph{gracias} $\to$ \emph{de nada} is a fixed \textbf{adjacency pair}: one turn expects the other. Learn them as a unit, the way English glues \emph{thank you} $\to$ \emph{you're welcome}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "gracias" … "de nada" — the full exchange, both voices{]}
+  \item {[}YOU SAY: "de nada" then English "native, nature, natal" — nada's true family{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} \emph{nada} ("nothing") started life as the Latin word for a \emph{born} — what? (A \emph{thing} — \emph{rēs nāta}, a born thing.) What English words share that "born" root? (Native, nature, natal, renaissance.) Next: the verb the whole "how are you?" question turns on — \textbf{estar}.
+\end{tcolorbox}
+\section[estar]{estar — "to be," the \emph{standing} kind}
+
+\label{lesson:ES-C04-estar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} To ask \emph{how are you?} Spanish needs a verb for \textbf{being}. Today: \textbf{estar} — the verb used for how someone is right now and where someone is. Spanish has another identity verb later; you do not need it yet.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{st-no-e} — Spanish never starts a word with a bare \emph{st-}; it props it up with an \emph{e}: \emph{es-TAR}. (That reflex is why Spanish speakers say \emph{e-Spain}, \emph{e-student} — the same \emph{e} that Latin \emph{stare} grew to become \emph{estar}.)
+  \item \texttt{r-tap} — the final \emph{r} is one soft tap: \emph{es-TAR}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{estar} comes straight from Latin \textbf{stāre}, \emph{"to stand."} And "to stand" is exactly the right picture for the \emph{temporary} be-verb: how you are \emph{standing} at this moment — well, tired, here, there — not what you permanently \emph{are}.
+
+That root \textbf{stā-/sta-} ("stand") is one of the most productive in English. \emph{estar} hands you a huge family:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{stay}, \textbf{stand}, \textbf{stance}, \textbf{station}, \textbf{stable}, \textbf{stationary} — to stand / stay put.
+  \item \textbf{state}, \textbf{status}, \textbf{statue}, \textbf{estate}, \textbf{e-state $\to$ estate} — a way of \emph{standing} (your state = how you stand).
+  \item \textbf{constant}, \textbf{circumstance}, \textbf{substance} — "standing with / around / under."
+\end{itemize}
+
+So \emph{¿cómo estás?} is, at the root, \textbf{"how are you standing?"} — a snapshot of right now.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: state and location use estar}]
+Use \textbf{estar} for a current state or location. “How are you?” asks about a current state, so it takes \textbf{estar}. The other Spanish be-verb handles identity and arrives in its own later lesson; keeping it out of today's drill lets one contrast settle at a time.
+
+You only need two forms of it this chapter:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{estás} — "you are" (informal \emph{tú})
+  \item \textbf{está} — "you are" (formal \emph{usted}) / "he/she is"
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "estar" — \emph{es-TAR}, with the little propping \emph{e}{]}
+  \item {[}YOU SAY: "estás" … "está" — the two forms you'll ask with{]}
+  \item {[}YOU SAY: "estar" then English "stay, state, status, stable" — all \emph{standing}{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which Latin verb is \emph{estar} — “to be” or “to stand”? (To \emph{stand} — \emph{stāre}.) Which verb do you use for how you feel right now? (\emph{estar}.) Next lesson, you finally ask it: \textbf{¿cómo está usted?}
+\end{tcolorbox}
+\section[¿cómo está usted?]{¿cómo está usted? — "how are you?"}
+
+\label{lesson:ES-C04-como-esta}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Everything you've built this chapter now snaps together into one question. You already met \textbf{cómo} ("how") and the \textbf{tú / usted} choice back in Chapter 3; you just learned \textbf{estar}. Assemble them.
+\end{quote}
+
+\begin{cousinweb}
+\begin{quote}
+\textbf{¿Cómo está usted?} = "How are you?" (formal) literally: \textbf{"In what manner are you standing?"}
+\end{quote}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{cómo} = "how / in what manner"
+  \item \textbf{está} = "you are" (the \emph{usted}/he-she form of \textbf{estar} — state, not identity)
+  \item \textbf{usted} = the formal "you"
+\end{itemize}
+
+Note the \textbf{¿} — Spanish opens a question with an upside-down mark so you know the melody is coming before you start reading aloud. (We take that mark apart in a dedicated writing lesson.)
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "¿Cómo está usted?" — formal, for a stranger{]}
+  \item {[}YOU SAY: the pieces — "cómo + está + usted"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which be-verb does "how are you?" use — \emph{ser} or \emph{estar}, and why? (\emph{estar} — it's about your current state.) What changes between formal and informal? (\textbf{The next step changes the ending and pronoun.}) Next: choosing the register.
+\end{tcolorbox}
+\section[¿cómo está usted? / ¿cómo estás?]{¿cómo está usted? / ¿cómo estás? — choose the register}
+
+\label{lesson:ES-C04-como-estas-register}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can already ask a stranger \textbf{¿Cómo está usted?} Now change only the relationship: ask the same question of a friend.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: one question, two relationships}]
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{register} & \textbf{question} \\
+\midrule
+formal (stranger, elder, customer) & \textbf{¿Cómo está usted?} \\
+informal (friend, peer, child) & \textbf{¿Cómo estás?} \\
+\bottomrule
+\end{tabularx}
+
+The formal version uses the third-person ending \textbf{está} plus \textbf{usted}. The informal version uses second-person \textbf{estás} and normally omits \textbf{tú}. This is the same relationship contrast you drilled with \textbf{se llama / te llamas}.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: to a doctor you just met — "¿Cómo está usted?"{]}
+  \item {[}YOU SAY: to your cousin — "¿Cómo estás?"{]}
+  \item {[}YOU SAY: swap back and forth — "está usted / estás"{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Ask both versions until the ending swap is automatic.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which version fits a stranger? (\textbf{¿Cómo está usted?}) Which fits a friend? (\textbf{¿Cómo estás?}) What two things change? (\textbf{The verb ending and the pronoun.})
+\end{tcolorbox}
+\section[regular]{regular / más o menos — the honest "so-so"}
+
+\label{lesson:ES-C04-regular}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You asked \emph{¿cómo estás?} Now you can answer three ways: great, middling, or a wave of the hand. You already have \textbf{bien} ("well," Chapter 1). Today, the \emph{middling} answers — because nobody is \emph{bien} every day.
+\end{quote}
+
+\subsection*{You'll want to know first}
+{[}PAUSE 2s{]} Recall from Chapter 1: \textbf{bien} — "well." Root? (Latin \emph{bene}, "well" — same as \emph{bene}fit, \emph{bene}volent.) So \emph{estoy bien} = "I'm well." Now the answer for when you're \emph{not} quite bien.
+
+\begin{cousinweb}
+\textbf{regular} — as an answer to "how are you?", it means \textbf{"so-so, average, not great."} (A famous false-friend trap: it does \textbf{not} mean English "regular / normal / usual" here.) From Latin \textbf{rēgula}, a \emph{straight rod} a builder used to check a line — the \textbf{ruler}. So \emph{regular} is "on the rule, on the average line" $\to$ middling.
+
+That \emph{rēgula} rod is everywhere in English: \textbf{rule}, \textbf{ruler}, \textbf{regulate}, \textbf{regular}, \textbf{regiment}, and even \textbf{rail} (a straight rod). All the same straight stick.
+
+\textbf{más o menos} — "more or less," the shrug-answer:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{más} = "more," from Latin \textbf{magis} ("more") — cousin of \emph{major}, \emph{master}, \emph{maximum}.
+  \item \textbf{menos} = "less," from Latin \textbf{minus} — the very word English borrowed for \emph{minus}, \emph{minor}, \emph{minimum}, \emph{minus}cule.
+\end{itemize}
+
+So \emph{más o menos} is literally \textbf{"more or less"} — the exact phrase, root for root, that English uses for the same shrug.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: a small answer set}]
+You now have a scale to answer \emph{¿cómo estás?}:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{answer} & \textbf{sense} \\
+\midrule
+\textbf{(muy) bien} & (very) well \\
+\textbf{regular} & so-so \\
+\textbf{más o menos} & more or less / meh \\
+\bottomrule
+\end{tabularx}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "regular" — \emph{reh-goo-LAR}, soft tap on both \emph{r}'s{]}
+  \item {[}YOU SAY: "más o menos" — a little shrug in the voice{]}
+  \item {[}YOU SAY: answer "¿cómo estás?" three ways — bien / regular / más o menos{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} As an answer, does \emph{regular} mean "normal" or "so-so"? (So-so — the false-friend trap.) What straight-rod Latin word is it from, and what English "rod" words share it? (\emph{rēgula} $\to$ rule, ruler, regulate, rail.) Next: put the whole exchange together.
+\end{tcolorbox}
+\section[y / ¿y tú?]{y / ¿y tú? — pass the question back}
+
+\label{lesson:ES-C04-y}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can ask how someone is and answer. One tiny connector turns that exchange around so the other person gets a turn too.
+\end{quote}
+
+\begin{cousinweb}
+\textbf{Y} means \textbf{and} and sounds like Spanish \textbf{i}: \emph{ee}. It continues Latin \textbf{et}, also “and.” English borrowed that Latin word intact inside \textbf{et cetera}, literally “and the rest.”
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the shortest return question}]
+Put \textbf{y} before a person you already know:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{¿Y tú?} — And you? \emph{(informal)}
+  \item \textbf{¿Y usted?} — And you? \emph{(formal)}
+\end{itemize}
+
+Nothing else needs repeating. The little question hands the previous topic back to the other person.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “Bien. ¿Y tú?” to a friend{]}
+  \item {[}YOU SAY: “Regular. ¿Y usted?” to a stranger{]}
+  \item {[}YOU SAY: “y” — one clear \emph{ee} sound{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{y} mean? (\textbf{And.}) How do you hand a question back to a friend? (\textbf{¿Y tú?}) To a stranger? (\textbf{¿Y usted?}) Which Latin word survives inside English \textbf{et cetera}? (\textbf{Et}, “and.”)
+\end{tcolorbox}
+\section[á é í ó ú]{á é í ó ú — the acute accent, and the two jobs it does}
+
+\label{lesson:ES-W01-acento}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've been reading accented words since your very first noun — \textbf{dí}a, \textbf{có}mo, es\textbf{tá}, \textbf{má}s. Time to make that little stroke make sense. Spanish uses one mark to write exceptional stress — the \emph{acute} accent, \texttt{´}, leaning right — and it does two jobs in the words you know. Learn the stress job now; the next lesson adds its grammar-label job.
+\end{quote}
+
+\subsection*{Script — shape and stroke}
+A short stroke rising \textbf{left-to-right}, sitting on top of a vowel: \textbf{á é í ó ú}. (On the \emph{í}, it replaces the dot.) One clean up-stroke — the opposite lean from the French \emph{grave} accent \texttt{à}. Spanish never uses grave or circumflex; if it leans the wrong way, it isn't Spanish.
+
+\begin{grammarlens}[title={Grammar Lens: the mark records exceptional stress}]
+Spanish stress is regular, so most words need \textbf{no} mark. The default:
+
+\begin{itemize}
+\raggedright
+  \item word ends in a \textbf{vowel, -n, or -s} $\to$ stress the \textbf{second-to-last} syllable (\emph{ho-la}, \emph{lla-mo}, \emph{gus-to}).
+  \item word ends in \textbf{any other consonant} $\to$ stress the \textbf{last} syllable (\emph{us-\textbf{ted}}, \emph{re-gu-\textbf{lar}}, \emph{es-\textbf{tar}}).
+\end{itemize}
+
+The accent appears \textbf{only when a word breaks that rule} — it marks the exception. \emph{está} ends in a vowel, so the rule wants \emph{ES-ta}; the accent overrides it to \emph{es-\textbf{TÁ}}. \emph{cómo} ends in a vowel (rule wants \emph{co-\textbf{MO}}) but is stressed \emph{CÓ-mo}, so it gets the mark. The accent is a \textbf{spoken stress you can see} — it never changes the vowel's sound, only which syllable you hit.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “hola, llamo, gusto” — second-to-last stress{]}
+  \item {[}YOU SAY: “usted, regular, estar” — final stress{]}
+  \item {[}YOU SAY: "está, cómo" — the accent overrides the default{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} How many accent marks does Spanish have, and which way does it lean? (One — the acute, \texttt{´}, rising left-to-right.) Its two jobs? (Mark irregular stress; the next step covers its look-alike job.) When does a word ending in a vowel, \textbf{-n}, or \textbf{-s} need an accent? (\textbf{When its stress breaks the second-to-last default.})
+\end{tcolorbox}
+\section[el / él]{el or él? — the accent as a meaning label}
+
+\label{lesson:ES-W01-tilde-diacritica}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You know \textbf{el} as the article “the.” Add one acute accent and the same two letters do a different job.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: one mark, two grammatical jobs}]
+The \textbf{tilde diacrítica} separates words that otherwise look alike:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{no accent} & \textbf{with accent} \\
+\midrule
+\textbf{el} = the & \textbf{él} = he \\
+\bottomrule
+\end{tabularx}
+
+The two words are pronounced alike. Here the accent does not move stress; it labels meaning and grammar. Other pairs will arrive only when you know both words, so this lesson asks you to hold one contrast, not memorize a list.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “el” — the{]}
+  \item {[}YOU SAY: “él” — he{]}
+  \item {[}YOU WRITE: \textbf{el / él}, adding the meaning-label accent only to the pronoun{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is the accent's second job? (\textbf{Separate look-alike words.}) Which means “the”? (\textbf{El}, no accent.) Which means “he”? (\textbf{Él}, with the accent.) Does this mark change their stress? (\textbf{No — it labels the job.})
+\end{tcolorbox}
+\section[ñ]{ñ — the letter that remembers a doubled n}
+
+\label{lesson:ES-W02-enye}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} \textbf{ñ} is the one letter English doesn't have — and it has the best origin story in the alphabet. That wavy hat (\texttt{\textasciitilde{}}, a \emph{tilde}) is not decoration. It is \textbf{a tiny second \emph{n}, written on top to save space.} Once you know that, you know both how to write it \emph{and} why it sounds the way it does.
+\end{quote}
+
+\begin{sounds}
+\textbf{ñ} = the \emph{ny} in "ca\textbf{ny}on" or "o\textbf{ni}on" — one squished sound, tongue flat against the roof of the mouth. English \emph{canyon} is, in fact, Spanish \textbf{cañón} with the \emph{ñ} spelled out as \emph{ny}. Say "onion," freeze on the middle: that's ñ.
+\end{sounds}
+
+\subsection*{Script — how to write it, and where the hat came from}
+Write a normal \textbf{n}, then a small wavy \textbf{\textasciitilde{}} floating above it. That wave is a \textbf{medieval shorthand}. Scribes copying Latin were forever writing double letters, so they saved a stroke by writing the letter \textbf{once} and putting a little mark above to mean \emph{"...and one more of these."} A bar/wave over a vowel meant a dropped \emph{n} or \emph{m} (Latin \emph{tantum} $\to$ \emph{tãtum}); a wave over an \emph{n} meant \textbf{nn}.
+
+Spanish is full of words where a Latin \textbf{-nn-} did exactly this:
+
+\begin{itemize}
+\raggedright
+  \item Latin \textbf{annus} ("year") $\to$ \emph{anno} $\to$ \textbf{año} — the \emph{nn} collapsed into \emph{ñ}. (That same \emph{annus} gives English \textbf{ann}ual, \textbf{ann}iversary, bi-\textbf{enn}ial.)
+  \item Latin \textbf{canna} (“reed”) $\to$ \textbf{caña}; Latin \emph{domina} $\to$ \emph{donna} $\to$ \textbf{doña}.
+\end{itemize}
+
+So the tilde on \textbf{ñ} is a \textbf{frozen abbreviation}: a thousand-year-old note that says "there used to be two \emph{n}'s here." You are writing a scribe's shortcut.
+
+\begin{quote}
+\textbf{Careful:} \textbf{ñ is its own letter}, not "n with an accent." \emph{año} ("year") and \emph{ano} (a rather different word) are completely different words — the tilde is not optional flourish, it's a distinct letter of the alphabet.
+\end{quote}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "año" — \emph{AH-nyo}, one squished \emph{ny}; then English "annual" — same Latin \emph{annus}{]}
+  \item {[}YOU SAY: “año, mañana, español” — the ñ in three forms from this lesson{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What is the tilde on \emph{ñ}, really? (A tiny second \emph{n} — a scribe's shorthand for a doubled \emph{nn}.) What Latin word gives \emph{año}, and what English words share it? (\emph{annus} $\to$ annual, anniversary.) Is \emph{ñ} a separate letter or just an accented \emph{n}? (A separate letter.) Next writing lesson: the upside-down marks \textbf{¿ ¡}.
+\end{tcolorbox}
+\section[¿ ¡]{¿ ¡ — the marks that open a question}
+
+\label{lesson:ES-W03-inverted}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You've been writing them since \emph{¿cómo está usted?} Spanish is the one major language that puts an \textbf{upside-down} question or exclamation mark at the \textbf{start} of the sentence, as well as the normal one at the end. It looks exotic; the reason is purely practical.
+\end{quote}
+
+\subsection*{Script — the two opening marks}
+\begin{itemize}
+\raggedright
+  \item \textbf{¿ … ?} wraps a question: \emph{¿Cómo estás?}
+  \item \textbf{¡ … !} wraps an exclamation: \emph{¡Hola!} \emph{¡Gracias!}
+\end{itemize}
+
+The opening mark is just the closing mark \textbf{flipped 180°} — turned upside down \emph{and} left-right. To write \textbf{¿}, draw a normal \emph{?} and rotate it half a turn: the hook ends up at the bottom, the dot on top.
+
+\begin{culture}
+English lets you read most of a sentence before the final \textbf{?} reveals it was a question — fine, because English usually flags a question early with word order ("\emph{Are} you…", "\emph{Do} you…"). Spanish often \textbf{doesn't reorder words}: \emph{Tienes hambre.} ("You're hungry.") and \emph{¿Tienes hambre?} ("Are you hungry?") are the \textbf{same words} — only punctuation and the spoken rising tone tell them apart.
+
+So the Spanish Royal Academy, in \textbf{1754}, made the opening \textbf{¿} official: it warns the reader \emph{"a question is starting — read this with rising intonation from the very first word."} It's a \textbf{melody cue placed before the melody}, the exact same instinct as the written accent marking stress you can't otherwise see. For a language read aloud, it's genuinely useful.
+\end{culture}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: read "¿Cómo estás?" — start the rising \emph{question} melody from the very first word, the way the ¿ tells you to{]}
+  \item {[}YOU SAY: "¡Hola!" — the ¡ warns you to begin with exclamation energy{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Why does Spanish open a question with \textbf{¿}? (Because word order often doesn't change, so the reader needs an early warning to use question intonation.) How do you write it? (A normal \emph{?} rotated 180°.) Does it always sit at the sentence's start? (\textbf{The next step places it around a question inside a larger sentence.})
+\end{tcolorbox}
+\section[Roberto, ¿cómo estás?]{Where does ¿ begin? — bracket the spoken span}
+
+\label{lesson:ES-W03-question-span}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can open a whole question with \textbf{¿}. Now place that mark inside a larger sentence, exactly where the questioning voice begins.
+\end{quote}
+
+\subsection*{Script — bracket the spoken span}
+The opening mark goes where the \textbf{question} begins, even if the sentence started earlier:
+
+\begin{quote}
+Roberto, \textbf{¿cómo estás?}
+\end{quote}
+
+The name \textbf{Roberto} is outside the question. The marks bracket the words that need question intonation. The same principle works for an exclamation:
+
+\begin{quote}
+Roberto, \textbf{¡buenos días!}
+\end{quote}
+
+This is why the opening mark is more than decoration. It tells the reader exactly where to begin and end a change in spoken melody.
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU WRITE: “María, ¿cómo estás?”{]}
+  \item {[}YOU WRITE: “María, ¡buenos días!”{]}
+  \item {[}YOU SAY: begin the new melody at ¿ or ¡, not at the first capital{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} In \textbf{Roberto, ¿cómo estás?}, is \textbf{Roberto} inside the question? (\textbf{No.}) Where does the inverted mark go? (\textbf{At the start of the question or exclamation span.}) What does that placement tell a reader? (\textbf{Where to change the spoken melody.})
+\end{tcolorbox}
+\section[Practice]{Practice — "how are you?", start to finish}
+
+\label{lesson:ES-C04-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} No new words. This chapter's atoms — \emph{gracias, de nada, estar, ¿cómo está?, regular} — now assemble into a real exchange, run formally and informally until the register swap is automatic. It picks up right where the Chapter 3 introduction left off.
+\end{quote}
+
+\subsection*{The exchange}
+\textbf{Formal} (a stranger, an elder, a customer):
+
+\begin{quote}
+— Buenos días. ¿\textbf{Cómo está usted}? — \textbf{Bien, gracias.} ¿Y usted? — \textbf{Más o menos.} — {[}reply to a thanks, later in the chat{]} \textbf{De nada.}
+\end{quote}
+
+\textbf{Informal} (a friend, a peer) — only the verb + pronoun change:
+
+\begin{quote}
+— ¡Hola! ¿\textbf{Cómo estás}? — \textbf{Regular.} ¿Y tú? — Bien, gracias.
+\end{quote}
+
+The glue pattern you just secured is \textbf{¿y usted? / ¿y tú?} — “and you?” It bounces the question back without repeating the whole sentence.
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{gracias} — thank you ($\leftarrow$ \emph{grātia}, "grace").
+  \item \textbf{de nada} — you're welcome ($\leftarrow$ "of a born-thing" $\to$ "of nothing").
+  \item \textbf{estar} — the state/location be-verb ($\leftarrow$ \emph{stāre}, “to stand”).
+  \item \textbf{¿cómo está usted? / ¿cómo estás?} — how are you, formal / informal.
+  \item \textbf{bien / regular / más o menos} — well / so-so / more-or-less.
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the full \emph{formal} exchange, both voices{]}
+  \item {[}YOU SAY: the same exchange \emph{informally} — catch \emph{está $\to$ estás}, \emph{usted $\to$ tú}{]}
+  \item {[}YOU SAY: chain Chapter 3 + 4 — introduce yourself \emph{and} ask how they are: "Me llamo … ¿Cómo está usted?"{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Run the formal exchange, greeting to answer, without stopping.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which be-verb carries "how are you?" and why? (\emph{estar} — current state.) Two words swap between formal and informal — which? (\emph{está $\to$ estás}, and \emph{usted $\to$ tú}.) What does \emph{de nada} literally say? ("Of nothing.") Next chapter: \textbf{farewells} — hasta luego, hasta mañana, adiós.
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
@@ -1,218 +1,372 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3008dfa4a25b0bd2
+% canonical-lessons: ES-C05-adios, ES-C05-hasta, ES-C05-hasta-limits, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto, ES-C05-practice
+
 \chapter{Farewells}
 \label{ch:farewells}
 
-Every conversation needs a door out. Spanish gives you two kinds: a blessing
-worn smooth by centuries, and a small family of ``until\ldots'' phrases built on
-a word Spain took from Arabic. \emph{Practice lessons:
-\texttt{lessons/ES-C05-*.md}.}
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section{\emph{adi\'{o}s} --- ``goodbye,'' or ``to God''}
-\label{lesson:adios}
+\section[adiós]{adiós — "goodbye," or "to God"}
 
-\begin{cousinweb}
-\textbf{adi\'{o}s} (``goodbye'') is \emph{a} $+$ \emph{Dios} $=$ ``\textbf{to
-God}'' --- the front half of an old blessing, \emph{a Dios te encomiendo}, ``I
-commend you to God,'' said to someone setting off when a journey was
-dangerous and you left them in God's keeping.\\[3pt]
-\textbf{Dios} (``God'') $\leftarrow$ Latin \emph{Deus} $\to$ \textbf{deity},
-\textbf{divine}, \emph{adieu}; and, through Greek \emph{Zeus} from the same
-root, the whole sky-god family.\\[3pt]
-\textbf{Every Romance sister kept the same prayer:} Spanish \emph{adi\'{o}s},
-French \emph{adieu} (\emph{\`{a}~Dieu}), Italian \emph{addio}, Portuguese
-\emph{adeus} --- all four literally ``to God.''\\[3pt]
-\textbf{And English is doing it too, quietly:} \textbf{goodbye} is a
-crushed-down ``God be with ye.'' So \emph{adi\'{o}s} and \emph{goodbye} are, at
-heart, the same sentence --- a blessing for the road.
-\end{cousinweb}
+\label{lesson:ES-C05-adios}
 
-\begin{sounds}
-\emph{adi\'{o}s} $=$ \emph{ah-DYOHS}. The \emph{-i\'{o}s} is one glide, not two
-syllables: \emph{ee} $+$ \emph{ohs} run together into \emph{dyohs}. The written
-accent on the \emph{\'{o}} tells you the stress lands at the end.
-\end{sounds}
 
-\begin{grammarlens}
-\emph{adi\'{o}s} is a \emph{final} goodbye. It leans toward a longer parting ---
-you won't see the person soon, or the day is over. For ``see you later'' or
-``see you tomorrow,'' Spanish reaches instead for \emph{hasta \ldots}, which is
-what the rest of this chapter builds --- and \emph{hasta} has a surprising
-origin.
-\end{grammarlens}
 
-\section{\emph{hasta} --- ``until,'' and Spain's Arabic centuries}
-\label{lesson:hasta}
-
-\begin{cousinweb}
-\textbf{hasta} (``until, up to'') $\leftarrow$ Arabic \emph{\d{h}att\={a}},
-``until, up to.'' Not Latin --- Arabic.\\[3pt]
-\textbf{Why there was Arabic in Spain:} from \textbf{711 CE}, Muslim armies
-ruled much of the Iberian Peninsula --- \emph{al-Andalus} --- and Arabic was the
-language of government, science, and poetry there for centuries, until 1492.
-Spanish absorbed roughly \textbf{four thousand} Arabic words in that time ---
-more of its vocabulary than from any source except Latin itself.\\[3pt]
-\textbf{Spotting the loans:} most are nouns, and a huge number carry the frozen
-Arabic article \emph{al-} (``the'') fused onto the front --- \emph{almohada}
-(pillow), \emph{alc\'{a}zar} (fortress), \emph{alcalde} (mayor),
-\emph{alfombra} (rug), \emph{aduana} (customs), \emph{\'{a}lgebra},
-\emph{alcohol}; also \emph{az\'{u}car} (sugar), \emph{aceite} (oil),
-\emph{naranja} (orange).
-\end{cousinweb}
-
-But \emph{hasta} is rare and special: it is a \textbf{function word} --- a
-preposition, part of the grammatical skeleton. Languages borrow nouns easily and
-grammar words almost never, so an Arabic preposition surviving in everyday
-Spanish shows how deep, how \emph{intimate}, those centuries of contact were.
-(Its Latin rivals \emph{ad} ``to'' and \emph{usque} ``up to'' simply lost.) You
-say a piece of al-Andalus every time you say goodbye.
-
-And \emph{hasta} is not quite alone. \textbf{Ojal\'{a}} (``would that\ldots'')
-is also a function word, from Andalusi Arabic \emph{law sh\={a}\textquoteright\
-All\={a}h}, ``\textbf{if God should will}'' --- the \emph{All\={a}h} is still
-sitting in its second half. It is arguably the stronger case: where \emph{hasta}
-is a preposition, \emph{ojal\'{a}} reaches into the grammar and forces the verb
-after it into a whole different \textbf{mood}. Chapter 18 puts it to work.
-
-\begin{sounds}
-Spanish \textbf{h is always silent}: \emph{hasta} $=$ \emph{AHS-tah}, with no
-breath on the \emph{h} at all. Stress the front.
-\end{sounds}
-
-\begin{grammarlens}
-\emph{hasta} marks the \textbf{end point} of something, in space or in time:
-\emph{hasta aqu\'{i}} (``up to here''), \emph{hasta las tres} (``until three
-o'clock''), and \emph{hasta luego / ma\~{n}ana / pronto} (``until later /
-tomorrow / soon'') --- the farewells that fill the rest of this chapter.
-\end{grammarlens}
-
-\section{\emph{hasta luego} --- the everyday ``see you later''}
-\label{lesson:hasta-luego}
-
-This is the goodbye you will actually use most: friendly, casual, open-ended.
-\emph{hasta} (``until'') $+$ \emph{luego} (``later'') $=$ ``until later'' $\to$
-``see you later.''
-
-\begin{cousinweb}
-\textbf{luego} (``later / then / soon'') $\leftarrow$ Latin \emph{loco}, ``at
-the place, at that point.'' The idea slid from \emph{place} $\to$ \emph{point in
-time} $\to$ ``then, next, soon.''\\[3pt]
-\textbf{Its English cousins all stayed about place:} \textbf{local},
-\textbf{locus}, \textbf{loc}ation, \textbf{loc}ate, al\textbf{loc}ate. Spanish
-moved \emph{loco} from \emph{where} to \emph{when}.\\[3pt]
-\textbf{Two histories in three syllables:} \emph{hasta luego} fuses an
-\textbf{Arabic} word and a \textbf{Latin} word --- the two great layers of
-Spanish, shaking hands as you leave.
-\end{cousinweb}
-
-\begin{sounds}
-\emph{luego} $=$ \emph{LWEH-goh}: the \emph{ue} is a \emph{w}-glide, so
-\emph{lu-} becomes \emph{lweh-}. The whole phrase: \emph{AHS-tah LWEH-goh}.
-\end{sounds}
-
-\begin{grammarlens}
-\emph{hasta} $+$ a time word is Spanish's whole toolkit of soft goodbyes:
-\emph{hasta luego} (``until later'') is the default ``see you'';
-\emph{hasta ma\~{n}ana} (``until tomorrow'') is for leaving for the day;
-\emph{hasta pronto} (``until soon'') is for when you expect to meet again
-shortly. You build the other two in the next two sections.
-\end{grammarlens}
-
-\section{\emph{hasta ma\~{n}ana} --- ``see you tomorrow''}
-\label{lesson:hasta-manana}
-
-Leaving for the day? \emph{hasta} (``until'') $+$ \emph{ma\~{n}ana}
-(``tomorrow'') $=$ ``until tomorrow.'' And it brings back a letter of its own:
-the \textbf{\~{n}}.
-
-\begin{cousinweb}
-\textbf{ma\~{n}ana} means ``tomorrow'' \emph{and} ``morning'' --- one word for
-both --- from Latin \emph{(h\={o}ra) maneana}, ``the \textbf{early} hour'' (from
-\emph{m\={a}ne}, ``in the morning''). The logic: the next early hour you will
-see is \emph{tomorrow morning}, so \emph{ma\~{n}ana} came to mean both
-\textbf{morning} and \textbf{tomorrow}. \emph{por la ma\~{n}ana} $=$ ``in the
-morning''; \emph{hasta ma\~{n}ana} $=$ ``until tomorrow.''\\[3pt]
-\textbf{The \~{n}, in the wild.} The \emph{\~{n}} is a frozen \emph{nn} --- a
-scribe's shorthand for a doubled \emph{n}, the tilde being a tiny second
-\emph{n} written on top. \emph{ma\~{n}ana} comes from Latin \emph{maneana},
-whose \emph{n} $+$ \emph{ea} palatalized (softened) into that single \emph{\~{n}}
-sound. The tilde is a little historical fossil sitting in the middle of
-``tomorrow.''
-\end{cousinweb}
-
-\begin{sounds}
-\emph{ma\~{n}ana} $=$ \emph{mah-NYAH-nah}. The \emph{\~{n}} is the squished
-\emph{ny} of ``canyon.'' Three soft \emph{ah}'s, with the stress in the middle.
-\end{sounds}
-
-\begin{grammarlens}
-\emph{ma\~{n}ana} means ``morning'' \textbf{or} ``tomorrow,'' and the sentence
-tells you which --- Spanish lets context do the disambiguating where English
-uses two separate words. Paired with \emph{hasta}, it is always
-\textbf{tomorrow}: \emph{hasta ma\~{n}ana}, ``until tomorrow.''
-\end{grammarlens}
-
-\section{\emph{hasta pronto} --- ``see you soon''}
-\label{lesson:hasta-pronto}
-
-The last of the trio: \emph{hasta} (``until'') $+$ \emph{pronto} (``soon'') $=$
-``until soon,'' for when you genuinely expect to meet again shortly.
-
-\begin{cousinweb}
-\textbf{pronto} (``soon / quickly / ready'') $\leftarrow$ Latin
-\emph{promptus}, ``brought forth, ready at hand'' (from \emph{pr\={o}mere}, ``to
-bring out''). Something \emph{prompt} is brought out without delay --- so
-\emph{pronto} slid to ``soon.''\\[3pt]
-\textbf{Its English twin is hiding in plain sight:} \textbf{prompt} (on time; to
-bring out a response), \textbf{prompt}er, \textbf{prompt}ly, and the computer
-\textbf{prompt} --- the cursor sitting ``ready'' for input.\\[3pt]
-Italian borrowed \emph{pronto} too: it is what Italians say when they pick up
-the phone --- \emph{\textquotedblleft Pronto!\textquotedblright} $=$ ``Ready!''
-\end{cousinweb}
-
-\begin{sounds}
-\emph{hasta pronto} $=$ \emph{AHS-tah PRON-toh} --- a clean \emph{pr} cluster
-and a pure \emph{o} (not the English \emph{oh-w} glide).
-\end{sounds}
-
-\begin{grammarlens}
-The \emph{hasta \ldots} trio, sharpest to vaguest in time: \emph{hasta pronto}
-(soon --- you'll meet again shortly) $\to$ \emph{hasta luego} (later --- the
-neutral default ``see you'') $\to$ \emph{hasta ma\~{n}ana} (tomorrow --- you're
-parting for the day). And \emph{adi\'{o}s} sits outside the trio, for the long
-or final goodbye.
-\end{grammarlens}
-
-\section{Practice --- saying goodbye}
-\label{lesson:ch5-practice}
-
-No new words. The choice among these four is really one question: \textbf{when
-will you meet again?} Parting for good or for a long time $\to$
-\emph{Adi\'{o}s.} Expecting to meet again shortly $\to$ \emph{Hasta pronto.}
-Just ``see you,'' the neutral default $\to$ \emph{Hasta luego.} Leaving for the
-day $\to$ \emph{Hasta ma\~{n}ana.}
-
-Everything from Chapters 1--5, in one conversation:
-
-\begin{quote}\itshape
---- \textexclamdown Hola! Buenos d\'{i}as. Me llamo Ana.
-\textquestiondown C\'{o}mo se llama usted?\\
---- Me llamo Luis. Mucho gusto.\\
---- \textquestiondown C\'{o}mo est\'{a} usted?\\
---- Bien, gracias. \textquestiondown Y usted?\\
---- Muy bien. Bueno\ldots\ hasta ma\~{n}ana, Luis.\\
---- Hasta ma\~{n}ana, Ana. \textexclamdown Adi\'{o}s!
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can greet, introduce yourself, and ask how someone is. Time to leave gracefully. The final, plainest parting is \textbf{adiós} — and, like the English \emph{goodbye}, it's a tiny prayer worn smooth.
 \end{quote}
 
-\begin{culture}
-Spanish closes a conversation by naming \emph{the next meeting}, not the
-parting itself. English says ``bye'' and stops; Spanish says ``until later,''
-``until tomorrow,'' ``until soon'' --- each one a small promise about the
-future. Even \emph{adi\'{o}s}, the one goodbye that does \emph{not} promise a
-next time, still hands the person over to someone: ``to God.''
-\end{culture}
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{diphthong-io} — the \emph{-iós} is one glide, \emph{ee-OHS}: \emph{ah-DYOHS}, stress on the end (that's what the accent on \emph{ó} marks — remember the acute-accent lesson).
+\end{itemize}
+\end{sounds}
 
-What you built this chapter: \emph{adi\'{o}s}, the plain or final goodbye (``to
-God,'' twin of \emph{goodbye}); \emph{hasta}, ``until,'' Spain's everyday Arabic
-word; and \emph{hasta luego / ma\~{n}ana / pronto}, see you later / tomorrow /
-soon, each an Arabic $+$ Latin handshake. You can now open \emph{and} close a
-conversation in Spanish. Next chapter: \emph{por favor}, and the courtesies that
-partner \emph{gracias}.
+\begin{cousinweb}
+\textbf{adiós} is \textbf{a + Dios} — "\textbf{to God}." It's the front half of an old blessing, \emph{a Dios te encomiendo}, "I commend you \textbf{to God}" — said to someone setting off, when a journey was dangerous and you left them in God's keeping.
+
+Every Romance sister kept the same farewell-prayer:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{language} & \textbf{goodbye} & \textbf{literally} \\
+\midrule
+\textbf{Spanish} & \emph{adiós} & "to God" \\
+French & \emph{adieu} & "to God" (\emph{à Dieu}) \\
+Italian & \emph{addio} & "to God" \\
+Portuguese & \emph{adeus} & "to God" \\
+\bottomrule
+\end{tabularx}
+
+And English is doing the \textbf{exact same thing} without telling you: \textbf{goodbye} is a crushed-down \emph{"God be with ye."} So \emph{adiós} and \emph{goodbye} are, at heart, the same sentence — a blessing for the road.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{Dios} ("God") $\leftarrow$ Latin \textbf{Deus} — the \emph{Deus} of English \emph{deity}, \emph{divine}, \emph{adieu}, and (via Greek \emph{Zeus}, same root) the whole sky-god family.
+\end{itemize}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: adiós is a \emph{final} goodbye}]
+\emph{adiós} leans toward a \textbf{longer} parting — you won't see them soon, or it's the end of the day. For "see you later / tomorrow," Spanish reaches for \textbf{hasta …}, which the rest of this chapter is about — and \emph{hasta} has a surprising origin.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "adiós" — \emph{ah-DYOHS}, stress the end{]}
+  \item {[}YOU SAY: adiós / adieu / addio / adeus — four "to God" farewells{]}
+  \item {[}YOU SAY: English "goodbye" = "God be with ye" — the same prayer{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What two words hide inside \emph{adiós}? (\emph{a} + \emph{Dios} — "to God.") What English goodbye is built the same way? (\emph{Goodbye} $\leftarrow$ "God be with ye.") Is \emph{adiós} for a quick "see you soon"? (No — it's the longer/final parting; \emph{hasta …} comes next.) Next: \textbf{hasta}, and a word Spain borrowed from Arabic.
+\end{tcolorbox}
+\section[hasta]{hasta — "until," and Spain's Arabic centuries}
+
+\label{lesson:ES-C05-hasta}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Spanish says "see you later" as \textbf{hasta luego} — literally "\textbf{until} later." So the key word is \textbf{hasta}, "until." And \emph{hasta} carries the single most important fact about Spanish's history: \textbf{for nearly 800 years, much of Spain spoke Arabic.}
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{silent-h} — Spanish \textbf{h is always silent}: \textbf{hasta} = \emph{AHS-tah} (no breath on the \emph{h} at all). Stress the front.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{hasta} comes from Arabic \textbf{ḥattā}, “until, up to.” From \textbf{711 CE}, Muslim armies ruled much of the Iberian Peninsula — \emph{al-Andalus} — and Arabic was the language of government, science, and poetry there for \textbf{centuries}, until 1492. Spanish absorbed roughly \textbf{four thousand} Arabic words in that time — more of its vocabulary than from any source except Latin itself.
+
+Most of those loans are \textbf{nouns}, and you can spot a huge number by the frozen Arabic article \textbf{al-} ("the") fused onto the front:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{almohada} (pillow), \textbf{alcázar} (fortress), \textbf{alcalde} (mayor), \textbf{alfombra} (rug), \textbf{aduana} (customs), \textbf{álgebra}, \textbf{alcohol}.
+  \item \textbf{azúcar} (sugar), \textbf{aceite} (oil), \textbf{naranja} (orange).
+\end{itemize}
+
+But \textbf{hasta} is rare and special: it is a \textbf{function word} — a preposition, part of the grammatical skeleton. Languages borrow nouns easily and grammar words almost never — so an Arabic \emph{preposition} surviving in everyday Spanish shows how deep, how \emph{intimate}, those centuries of contact were. (Its Latin rival \emph{ad} "to"/\emph{usque} "up to" simply lost.) You say a piece of al-Andalus every time you say goodbye.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "hasta" — \emph{AHS-tah}, silent h{]}
+  \item {[}YOU SAY: "hasta" then Arabic \emph{ḥattā} — the same word, 1,300 years apart{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What language is \emph{hasta} from, and what does it mean? (Arabic \emph{ḥattā} — "until.") Why is it remarkable that Spanish borrowed it? (It's a \emph{function word} / preposition — languages almost never borrow those; it shows how deep the Arabic centuries went.) How do you spot many Arabic nouns in Spanish? (The frozen \emph{al-} article: \emph{almohada, azúcar, álgebra}.) Which \textbf{other} Arabic function word will return in Chapter 18? (\emph{\textbf{Ojalá}}, a word that triggers a grammatical mood.)
+\end{tcolorbox}
+\section[hasta aquí / hasta la noche]{hasta aquí / hasta la noche — point to the limit}
+
+\label{lesson:ES-C05-hasta-limits}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You know \textbf{hasta} means “until” or “up to.” Give that small word one spatial endpoint and one temporal endpoint, using only one new word.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: endpoints in space and time}]
+\textbf{Aquí} means \textbf{here}. Put it after \textbf{hasta}:
+
+\begin{quote}
+\textbf{hasta aquí} — up to here
+\end{quote}
+
+For a time endpoint, reuse \textbf{la noche}, “the night,” from Chapter 2:
+
+\begin{quote}
+\textbf{hasta la noche} — until the night / until tonight
+\end{quote}
+
+The same preposition points to a place or the end of a stretch of time. The next lessons will place new time words after it one at a time.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “aquí” — here{]}
+  \item {[}YOU SAY: “hasta aquí” — up to here{]}
+  \item {[}YOU SAY: “hasta la noche” — until tonight{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \textbf{hasta} point to? (\textbf{An endpoint.}) Give one spatial and one temporal example. (\textbf{Hasta aquí; hasta la noche.}) What is the only new lexical item? (\textbf{Aquí}, “here.”)
+\end{tcolorbox}
+\section[hasta luego]{hasta luego — the everyday "see you later"}
+
+\label{lesson:ES-C05-hasta-luego}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} This is the goodbye you'll actually use most — friendly, casual, open-ended. \textbf{hasta luego}: "until later." You already own \textbf{hasta} ("until"); today you add \textbf{luego} ("later"), and it has a very Latin backstory.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{diphthong-ue} — \textbf{luego} = \emph{LWEH-goh}: the \emph{ue} is a \emph{w}-glide, \emph{lweh-}.
+  \item The whole phrase: \emph{AHS-tah LWEH-goh}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{quote}
+\textbf{hasta luego} = "until later" $\to$ "see you later."
+\end{quote}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{hasta} = "until" (last lesson — Arabic \emph{ḥattā}).
+  \item \textbf{luego} = "later / then / soon," from Latin \textbf{loco}, "at the place / at that point." The idea slid from \emph{place} $\to$ \emph{point in time} $\to$ "then, next, soon." So its cousins in English are all about \textbf{place}: \textbf{local}, \textbf{locus}, \textbf{loc}ation, \textbf{loc}ate, \textbf{al-loc-ate}. Spanish moved \emph{loco} from \emph{where} to \emph{when}.
+\end{itemize}
+
+A nice contrast: \textbf{hasta luego} fuses an \textbf{Arabic} word and a \textbf{Latin} word in three syllables — the two great layers of Spanish, shaking hands as you leave.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the "hasta …" family}]
+\emph{hasta} + a time word is Spanish's whole toolkit of soft goodbyes. You'll build the other two this chapter:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{phrase} & \textbf{"until …"} & \textbf{when} \\
+\midrule
+\textbf{hasta luego} & later & the default "see you" \\
+\textbf{hasta mañana} & tomorrow & leaving for the day \\
+\textbf{hasta pronto} & soon & you expect to meet again shortly \\
+\bottomrule
+\end{tabularx}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "hasta luego" — \emph{AHS-tah LWEH-goh}{]}
+  \item {[}YOU SAY: "luego" then English "local, location" — the \emph{loco} "place" family{]}
+  \item {[}YOU SAY: "¡Adiós! … no — ¡hasta luego!" — feel the difference: final vs. soon{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{hasta luego} literally mean? ("Until later.") What did \emph{luego}'s Latin root \emph{loco} first mean, and what English words keep it? (Place — \emph{local, location, locus}.) Which two language layers meet in \emph{hasta luego}? (Arabic \emph{hasta} + Latin \emph{luego}.) Next: \textbf{hasta mañana}.
+\end{tcolorbox}
+\section[hasta mañana]{hasta mañana — "see you tomorrow" (and the ñ returns)}
+
+\label{lesson:ES-C05-hasta-manana}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Leaving for the day? \textbf{hasta mañana} — "until tomorrow." It brings back a letter you studied in the writing lessons: the \textbf{ñ}. Here it is, living in a word you'll say every evening.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{enye-ny} — \textbf{mañana} = \emph{mah-NYAH-nah}: the \textbf{ñ} is the squished \emph{ny} of "canyon" (your ñ writing lesson — the tilde is a tiny second \emph{n}, remember). Three soft \emph{ah}'s: \emph{ma-\textbf{ÑA}-na}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{quote}
+\textbf{hasta mañana} = "until tomorrow" $\to$ "see you tomorrow."
+\end{quote}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{hasta} = "until" (Arabic \emph{ḥattā}).
+  \item \textbf{mañana} = "tomorrow" — \textbf{and} "morning." One word for both, from Latin \textbf{(hōra) maneana}, "the \textbf{early} hour" (from \emph{māne}, "in the morning"). The logic: the next "early hour" you'll see is \emph{tomorrow morning} $\to$ \emph{mañana} came to mean both \textbf{morning} and \textbf{tomorrow}.
+\end{itemize}
+
+\textbf{The ñ, in the wild.} Recall the writing lesson: \emph{ñ} is a frozen \emph{nn} — a scribe's shorthand for a doubled \emph{n}. \emph{mañana} comes from Latin \emph{maneana}, whose \emph{n}+\emph{ea} palatalized (softened) into that single \emph{ñ} sound. So the tilde is a little historical fossil sitting in the middle of "tomorrow."
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: same word, two meanings — context decides}]
+\emph{mañana} means "morning" \textbf{or} "tomorrow"; the sentence tells you which. Paired with \emph{hasta}, it's always \textbf{tomorrow}: \emph{hasta mañana}, "until tomorrow."
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "mañana" — \emph{mah-NYAH-nah}, squished \emph{ñ}{]}
+  \item {[}YOU SAY: "hasta mañana" — until tomorrow{]}
+  \item {[}YOU SAY: “mañana” once as “morning,” then once as “tomorrow” — context decides{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What two meanings does \emph{mañana} carry? (Morning; tomorrow.) With \emph{hasta}, which one? (Tomorrow.) What sound is the \emph{ñ}, and what is its tilde, historically? (The \emph{ny} of "canyon"; a frozen doubled-\emph{n}.) Next: \textbf{hasta pronto}.
+\end{tcolorbox}
+\section[hasta pronto]{hasta pronto — "see you soon"}
+
+\label{lesson:ES-C05-hasta-pronto}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} The last of the "hasta …" trio: \textbf{hasta pronto}, "until soon" — for when you genuinely expect to meet again shortly. One new word, \textbf{pronto}, and it's hiding in plain sight in English.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \textbf{hasta pronto} = \emph{AHS-tah PRON-toh} — a clean \emph{pr}, a pure \emph{o}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{quote}
+\textbf{hasta pronto} = "until soon" $\to$ "see you soon."
+\end{quote}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{hasta} = "until" (Arabic \emph{ḥattā}).
+  \item \textbf{pronto} = "soon / quickly / ready," from Latin \textbf{promptus}, "brought forth, ready at hand" (from \emph{prōmere}, "to bring out"). Something \emph{prompt} is brought out \textbf{without delay} — so \emph{pronto} slid to "soon."
+\end{itemize}
+
+You already know its English twin: \textbf{prompt} (on time; to bring out a response), plus \textbf{prompt}er, \textbf{prompt}ly, and the computer \textbf{prompt} (the cursor "ready" for input). Italian borrowed \emph{pronto} too — it's what Italians say when they pick up the phone (\emph{"Pronto!"} = "Ready!").
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the "hasta …" trio, complete}]
+You now have Spanish's three soft goodbyes, sharpest to vaguest in time:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{phrase} & \textbf{until…} & \textbf{nuance} \\
+\midrule
+\textbf{hasta pronto} & soon & you'll meet again shortly \\
+\textbf{hasta luego} & later & the neutral default "see you" \\
+\textbf{hasta mañana} & tomorrow & you're parting for the day \\
+\bottomrule
+\end{tabularx}
+
+…and \textbf{adiós} for the long or final goodbye.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "hasta pronto" — \emph{AHS-tah PRON-toh}{]}
+  \item {[}YOU SAY: "pronto" then English "prompt, promptly" — one family{]}
+  \item {[}YOU SAY: the trio — hasta pronto / hasta luego / hasta mañana{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{hasta pronto} mean, and \emph{pronto}'s English twin? ("Until soon"; \emph{prompt}.) What Latin word is it from, and its literal sense? (\emph{promptus}, "brought forth / ready.") Order the three \emph{hasta} goodbyes by time. (pronto $\to$ luego $\to$ mañana.) Next: put the whole farewell set together.
+\end{tcolorbox}
+\section[Practice]{Practice — saying goodbye}
+
+\label{lesson:ES-C05-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} No new words. This chapter's farewells — \emph{adiós} and the three \emph{hasta …} goodbyes — now close a real conversation, and fold back into the whole arc you've built since \emph{hola}.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: choosing the right goodbye}]
+The choice is about \textbf{when you'll meet again}:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{you're…} & \textbf{say} \\
+\midrule
+parting for good / a long time & \textbf{Adiós.} \\
+expecting to meet again shortly & \textbf{Hasta pronto.} \\
+just "see you" (neutral default) & \textbf{Hasta luego.} \\
+leaving for the day & \textbf{Hasta mañana.} \\
+\bottomrule
+\end{tabularx}
+\end{grammarlens}
+
+\subsection*{The exchange — start to finish}
+Everything from Chapters 1–5, in one conversation:
+
+\begin{quote}
+— ¡Hola! Buenos días. Me llamo Ana. ¿Cómo se llama usted? — Me llamo Luis. Mucho gusto. — ¿Cómo está usted? — Bien, gracias. ¿Y usted? — Bien. \textbf{Hasta mañana}, Luis. — \textbf{Hasta mañana}, Ana. \textbf{¡Adiós!}
+\end{quote}
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{adiós} — the plain/final goodbye ("to God"; twin of \emph{goodbye}).
+  \item \textbf{hasta} — "until," Spain's everyday Arabic word ($\leftarrow$ \emph{ḥattā}).
+  \item \textbf{hasta luego / mañana / pronto} — see you later / tomorrow / soon, each an Arabic + Latin handshake.
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: the full conversation above, both voices — greeting to goodbye{]}
+  \item {[}YOU SAY: pick the goodbye — for a friend you'll see tomorrow? (hasta mañana); for someone moving away? (adiós){]}
+\end{itemize}
+
+{[}REPEAT x2{]} Run the whole exchange, \emph{hola} to \emph{adiós}, without stopping.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Which goodbye for someone you won't see for a long time? (\emph{Adiós}.) Which everyday word for "until" did Spanish take from Arabic? (\emph{hasta}.) You can now open \emph{and} close a conversation in Spanish. Next chapter: \textbf{por favor} and \textbf{gracias}' partner courtesies, then into everyday verbs.
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
@@ -1,284 +1,380 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:081983e1f50e4d6c
+% canonical-lessons: ES-C06-cafe, ES-C06-por-favor, ES-C06-hablar, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol, ES-C06-practice
+
 \chapter{The First Verbs}
 \label{ch:first-verbs}
 
-The chapter where the course stops handing you phrases and starts handing you
-\emph{rules}. One courtesy word completes the politeness set; then three verbs
-snap into a single template --- the regular \emph{-ar} present tense --- and
-you build a sentence nobody gave you pre-assembled.
-\emph{Practice lessons: \texttt{lessons/ES-C06-*.md}.}
+This chapter is generated from the canonical micro-lessons used by Language Ladder.
+Each section stays independently resumable and preserves the authored prerequisite order.
 
-\section{\emph{por favor} --- ``please,'' i.e.\ ``for a favour''}
-\label{lesson:por-favor}
+\section[café]{café — coffee, and a place to drink it}
 
-\begin{sounds}
-One soft tapped \textbf{r} in \emph{por} and in \emph{favor}: the tongue flicks
-the ridge behind the teeth once, as in the middle of English \emph{butter}.\\[3pt]
-Spanish \textbf{v} and \textbf{b} sound \emph{identical} --- both a soft
-\emph{b}. So \emph{favor} is \emph{fah-BOR}: it looks like English
-\emph{favour} \emph{and} its \emph{v} is pronounced like the \emph{b} you hear
-in \emph{harbour}.
-\end{sounds}
+\label{lesson:ES-C06-cafe}
 
-\begin{cousinweb}
-\textbf{por} (``for / through / by'') $\leftarrow$ Latin \emph{pr\={o}} (``for,
-on behalf of'') --- the same \emph{pro-} in English \textbf{pro}noun,
-\textbf{pro}pose, \textbf{pro}tect.\\[3pt]
-\textbf{favor} (``a favour, goodwill'') $\leftarrow$ Latin \emph{fav\={e}re},
-``to be favourable to, to support.'' English borrowed the very word:
-\textbf{favour}, \textbf{favor}ite, \textbf{favor}able, \textbf{favour}itism.
-\end{cousinweb}
 
-\emph{por} $+$ \emph{favor} $=$ literally ``for a favour'' --- \emph{[do this]
-as a kindness to me}. The neighbours build ``please'' out of very different
-pictures:
 
-\begin{center}
-\begin{tabular}{lll}
-\toprule
-\textbf{Language} & \textbf{``Please''} & \textbf{Literally} \\
-\midrule
-Spanish & \emph{por favor}      & ``for a favour'' \\
-Italian & \emph{per favore}     & ``for a favour'' (the exact twin) \\
-French  & \emph{s'il vous pla\^{i}t} & ``if it pleases you'' \\
-German  & \emph{bitte}          & ``I ask / I pray'' \\
-\bottomrule
-\end{tabular}
-\end{center}
-
-\begin{grammarlens}
-The courtesy set is now complete, and it is only three pieces:
-\emph{por favor} for asking, \emph{gracias} for receiving, \emph{de nada} for
-replying. \emph{Un caf\'{e}, por favor} $\to$ \emph{\textexclamdown Gracias!}
-$\to$ \emph{De nada.} That loop covers nearly every small transaction you will
-have.
-\end{grammarlens}
-
-\section{\emph{hablar} --- ``to speak,'' and the engine of Spanish sentences}
-\label{lesson:hablar}
-
-\begin{sounds}
-The \textbf{h} is completely silent: \emph{hablar} is \emph{ah-BLAR}, never
-\emph{hah-BLAR}. Spanish \emph{h} never makes a sound at all.\\[3pt]
-The \textbf{b} is soft, halfway to a \emph{v}: \emph{hablo} is \emph{AH-bloh}.
-The final \textbf{r} of \emph{hablar} is a single tap.
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{hablar} (``to speak, to talk'') $\leftarrow$ Latin \emph{f\={a}bul\={a}r\={i}},
-``to chat, to tell tales'' $\leftarrow$ \emph{f\={a}bula}, ``a story.'' To
-\emph{speak}, in Spanish, is at root to \emph{tell stories}. That
-\emph{f\={a}bula} is thoroughly English: \textbf{fable}, \textbf{fabul}ous
-(``story-like''), con\textbf{fabul}ate, in\textbf{eff}able
-(``un-speak-able'').\\[3pt]
-\textbf{The f$\to$h sound-law:} Latin \emph{f-} became Spanish \emph{h-} across
-the whole language. Put the \emph{f} back and the cousin appears.
-\end{cousinweb}
-
-That one law decodes hundreds of words:
-
-\begin{center}
-\begin{tabular}{lll}
-\toprule
-\textbf{Spanish (h-)} & \textbf{Latin (f-)} & \textbf{English cousin} \\
-\midrule
-\emph{hablar} (to speak) & \emph{f\={a}bul\={a}r\={i}} & fable \\
-\emph{harina} (flour)    & \emph{far\={i}na}   & farina, farinaceous \\
-\emph{hacer} (to do)     & \emph{facere}       & fact, factory \\
-\emph{hijo} (son)        & \emph{f\={i}lius}   & filial, affiliate \\
-\emph{hierro} (iron)     & \emph{ferrum}       & ferrous, ferric \\
-\bottomrule
-\end{tabular}
-\end{center}
-
-\begin{grammarlens}
-A \textbf{verb} is the action word of a sentence, and its plain dictionary form
---- ``to speak'' --- is the \textbf{infinitive}. Spanish infinitives come in
-three families named for their last two letters: \emph{-ar}, \emph{-er},
-\emph{-ir}. \emph{hablar} is \emph{-ar}, the largest family by far.\\[3pt]
-To \textbf{conjugate} it --- to reshape it for who is doing the action --- you
-drop the \emph{-ar} and add an ending. English barely does this (\emph{I
-speak}, but \emph{he speak\textbf{s}}); Spanish does it for every person, and
-the ending carries so much information that the word for ``I'' becomes
-unnecessary. \emph{Hablo espa\~{n}ol} $=$ ``I speak Spanish'': no \emph{yo}
-needed, because the \emph{-o} already says ``I.''
-\end{grammarlens}
-
-\begin{center}
-\begin{tabular}{llll}
-\toprule
-\textbf{Person} & \textbf{Ending} & \emph{hablar} $\to$ & \textbf{Meaning} \\
-\midrule
-\emph{yo} (I)                  & \emph{-o}    & \emph{hablo}    & I speak \\
-\emph{t\'{u}} (you, informal)  & \emph{-as}   & \emph{hablas}   & you speak \\
-\emph{\'{e}l / ella / usted}   & \emph{-a}    & \emph{habla}    & he/she speaks; you (formal) speak \\
-\emph{nosotros} (we)           & \emph{-amos} & \emph{hablamos} & we speak \\
-\emph{ellos / ustedes}         & \emph{-an}   & \emph{hablan}   & they / you-all speak \\
-\bottomrule
-\end{tabular}
-\end{center}
-
-This same template fits \emph{every} regular \emph{-ar} verb. The next two
-sections add no new grammar at all --- they just snap into it.
-
-\section{\emph{trabajar} --- ``to work,'' which once meant \emph{torture}}
-\label{lesson:trabajar}
-
-\begin{sounds}
-The \textbf{j} (the \emph{jota}) is a raspy \emph{h} scraped from the back of
-the throat: \emph{trabajar} is \emph{tra-ba-HAR}. It is the same sound as the
-\emph{j} of \emph{jam\'{o}n}.\\[3pt]
-The \textbf{r}s are single taps and the \textbf{b} is soft.
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{trabajar} (``to work'') $\leftarrow$ Vulgar Latin
-\emph{tripali\={a}re}, ``to torture'' $\leftarrow$ \emph{tripalium}, a Roman
-instrument of torture made of \emph{three stakes}: \emph{tri-} (``three'')
-$+$ \emph{p\={a}lus} (``stake''), the root of English \textbf{pale} (a fence
-stake) and im\textbf{pale}.\\[3pt]
-English took the same word down a parallel road: \textbf{travail} (painful,
-laborious effort --- and the pains of childbirth) and, astonishingly,
-\textbf{travel}. Journeying was once such an ordeal that the word for
-\emph{toil} became the word for \emph{taking a trip}.
-\end{cousinweb}
-
-\begin{culture}
-The chain of meaning is grimly logical: \emph{torture} $\to$ \emph{torment,
-suffering} $\to$ \emph{hard toil} $\to$ plain \emph{work}. So \emph{Trabajo
-mucho} (``I work a lot'') is, at the root, ``I am tortured a lot'' --- and
-every time you \emph{travel}, you are etymologically being tortured too.
-\end{culture}
-
-Drop the \emph{-ar}, add the ending --- identical to \emph{hablar}:
-
-\begin{center}
-\begin{tabular}{lll}
-\toprule
-\textbf{Person} & \emph{trabajar} $\to$ & \textbf{Meaning} \\
-\midrule
-\emph{yo}                    & \emph{trabajo}  & I work \\
-\emph{t\'{u}}                & \emph{trabajas} & you work \\
-\emph{\'{e}l / ella / usted} & \emph{trabaja}  & he/she works; you (formal) work \\
-\bottomrule
-\end{tabular}
-\end{center}
-
-Notice that you learned nothing new --- that is exactly the point. One
-template, every \emph{-ar} verb.
-
-\section{\emph{estudiar} --- ``to study,'' and the eagerness inside it}
-\label{lesson:estudiar}
-
-\begin{sounds}
-Spanish props up an initial \emph{st-} with an \emph{e}: it is
-\emph{es-tudiar}, never \emph{stu-}. The same reflex gives \emph{estar},
-\emph{Espa\~{n}a}, \emph{escuela}.\\[3pt]
-The \emph{-iar} ending glides into one syllable: \emph{es-too-DYAR}.
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{estudiar} (``to study'') $\leftarrow$ Latin \emph{stud\={e}re}, ``to be
-eager, to apply oneself zealously.'' A \emph{studium} was \emph{zeal,
-enthusiasm, devotion} --- only later ``study.''\\[3pt]
-That root is everywhere in English: a \textbf{student} is literally ``one who
-is eager''; \textbf{studio}, \textbf{studi}ous, and \textbf{study} are the
-place, the trait, and the act. Italian \emph{studio} and the musical
-\emph{studio} keep the ``devoted practice'' sense.
-\end{cousinweb}
-
-So \emph{Estudio espa\~{n}ol} is, at heart, ``I throw myself eagerly at
-Spanish'' --- a nicer picture than mere schoolwork.
-
-\begin{center}
-\begin{tabular}{lll}
-\toprule
-\textbf{Person} & \emph{estudiar} $\to$ & \textbf{Meaning} \\
-\midrule
-\emph{yo}                    & \emph{estudio}  & I study \\
-\emph{t\'{u}}                & \emph{estudias} & you study \\
-\emph{\'{e}l / ella / usted} & \emph{estudia}  & he/she studies; you (formal) study \\
-\bottomrule
-\end{tabular}
-\end{center}
-
-Three verbs, one pattern: \emph{hablo}, \emph{trabajo}, \emph{estudio}. You now
-hold the whole regular \emph{-ar} present tense.
-
-\section{\emph{Hablo espa\~{n}ol} --- your first real sentence}
-\label{lesson:espanol}
-
-\begin{sounds}
-\textbf{\~{n}} is the \emph{ny} of \emph{canyon} --- a doubled \emph{n} that
-Spanish scribes squeezed under a tilde. \emph{espa\~{n}ol} is
-\emph{es-pa-NYOL}, and the \emph{h} of \emph{hablo} stays silent:
-\emph{AH-bloh es-pa-NYOL}.
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{espa\~{n}ol} (``Spanish''; also ``a Spaniard'') $\leftarrow$
-\emph{Hispania}, the Roman name for the Iberian peninsula. The path
-\emph{Hispania} $\to$ \emph{hispaniolus} $\to$ \emph{espa\~{n}ol} wore the word
-down --- and the \emph{-ni-} of \emph{hispaniolus} is precisely where the
-\textbf{\~{n}} comes from. English \textbf{Spanish}, \textbf{Hispan}ic, and
-\textbf{Hispan}iola are all the same root; \emph{Hispania} itself may go back
-through Latin to a \textbf{Phoenician} name for the coast, ``land of hyraxes
-(rabbits).''
-\end{cousinweb}
-
-Snap two things you already own together: \emph{hablo} (``I speak,'' from
-\emph{hablar}) $+$ \emph{espa\~{n}ol} (``Spanish'') $=$ \emph{Hablo
-espa\~{n}ol.} A complete, grammatical Spanish sentence, assembled by you.
-
-\begin{grammarlens}
-Notice what is \emph{not} there.\\[3pt]
-\textbf{No \emph{yo}.} The \emph{-o} of \emph{hablo} already means ``I,'' so
-the subject pronoun is dropped. \emph{Yo hablo espa\~{n}ol} is correct too, but
-it adds emphasis --- ``\emph{I} speak Spanish (whatever the others do).''\\[3pt]
-\textbf{No ``the'' and no ``a.''} Names of languages stand bare in this
-position: \emph{hablo espa\~{n}ol}, not \emph{hablo el espa\~{n}ol}.
-\end{grammarlens}
-
-Now swap the pieces and watch the template generate:
-\emph{Estudio espa\~{n}ol} (``I study Spanish'') $\cdot$ \emph{Trabajo mucho}
-(``I work a lot'') $\cdot$ \emph{\textquestiondown Hablas espa\~{n}ol?} (``Do
-you speak Spanish?'' --- just raise the pitch, and open with the
-\textquestiondown\ from the writing chapter).
-
-\section{Practice --- making sentences with \emph{-ar} verbs}
-\label{lesson:ch6-practice}
-
-Run each verb through \emph{yo} $\to$ \emph{t\'{u}} $\to$ \emph{\'{e}l/ella}
-until it is automatic:
-
-\begin{center}
-\begin{tabular}{llll}
-\toprule
-\textbf{Infinitive} & \emph{yo} ($-$o) & \emph{t\'{u}} ($-$as) & \emph{\'{e}l/ella/usted} ($-$a) \\
-\midrule
-\emph{hablar}   & \emph{hablo}   & \emph{hablas}   & \emph{habla} \\
-\emph{trabajar} & \emph{trabajo} & \emph{trabajas} & \emph{trabaja} \\
-\emph{estudiar} & \emph{estudio} & \emph{estudias} & \emph{estudia} \\
-\bottomrule
-\end{tabular}
-\end{center}
-
-Say something real:
-
-\begin{quote}\itshape
---- \textquestiondown Hablas espa\~{n}ol? --- S\'{i}, hablo un poco.\\
---- \textquestiondown Trabajas o estudias? --- Estudio espa\~{n}ol.\\
---- Un caf\'{e}, por favor. --- \textexclamdown Gracias! --- De nada.
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Before you can make a polite request, you need one small thing to request. \textbf{Café} gives you a useful noun and lets the written accent do a job you already understand.
 \end{quote}
 
-What you built this chapter: \emph{por favor} (``for a favour''), completing
-\emph{gracias} / \emph{de nada} / \emph{por favor}; the regular \emph{-ar}
-present tense --- drop \emph{-ar}, add \emph{-o} / \emph{-as} / \emph{-a}
-(then \emph{-amos} / \emph{-an}); the three verbs \emph{hablar} ($\leftarrow$
-\emph{f\={a}bula}, fable, by the f$\to$h law), \emph{trabajar} ($\leftarrow$
-\emph{tripalium}, torture $\to$ travail, travel), \emph{estudiar} ($\leftarrow$
-\emph{stud\={e}re}, eagerness $\to$ student); and \emph{Hablo espa\~{n}ol},
-your first self-assembled sentence, with no \emph{yo} and no article.
+\begin{sounds}
+Say \textbf{ca-FÉ}. A vowel-final word would normally stress the second-to-last syllable, so the acute accent records the unexpected final stress.
+\end{sounds}
 
-You can now generate sentences rather than recite them. Next chapter: the
-\emph{-er} and \emph{-ir} verbs, and questions with \emph{qu\'{e}} and
-\emph{d\'{o}nde}.
+\begin{cousinweb}
+Spanish \textbf{café} came through Italian \textbf{caffè} and Turkish \textbf{kahve} from Arabic \textbf{qahwah}. English \textbf{coffee} reached the same travelling word by a different European route. The drink and the word both crossed languages.
+
+\textbf{Café} can name the drink or the place, just as English \textbf{coffee} and \textbf{café} divide those jobs. It is masculine: \textbf{el café}.
+\end{cousinweb}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: “café” — final stress{]}
+  \item {[}YOU SAY: “el café”{]}
+  \item {[}YOU SAY: the route — “qahwah $\to$ kahve $\to$ caffè $\to$ café”{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Where does the stress fall? (\textbf{On the final é.}) Why is the accent written? (\textbf{It overrides the usual vowel-final stress.}) What route carried the word into Spanish? (\textbf{Arabic qahwah $\to$ Turkish kahve $\to$ Italian caffè $\to$ Spanish café.})
+\end{tcolorbox}
+\section[por favor]{por favor — "please," i.e. "for a favour"}
+
+\label{lesson:ES-C06-por-favor}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} You can already thank (\emph{gracias}) and reply (\emph{de nada}). The third courtesy completes the set: \textbf{por favor}, "please" — literally \emph{"for {[}a{]} favour."} You're asking someone to do you a kindness.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{r-tap} — one soft tapped \emph{r} in \emph{por} and \emph{favor}.
+  \item \texttt{v-b} — Spanish \emph{v} and \emph{b} sound \textbf{identical} (a soft \emph{b}): \emph{favor} $\approx$ \emph{fah-BOR}. (So \emph{favor} and English \emph{favour} look alike \emph{and} the \emph{v} even sounds like the \emph{b} you'd hear in "harbour.")
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\begin{itemize}
+\raggedright
+  \item \textbf{por} = "for / through / by," from Latin \textbf{prō} ("for, on behalf of") — the same \emph{pro-} in English \textbf{pro}noun, \textbf{pro}pose, \textbf{pro}tect.
+  \item \textbf{favor} = "a favour, goodwill," from Latin \textbf{favēre}, \emph{"to be favourable to, to support."} It's the very word English borrowed: \textbf{favour}, \textbf{favorite}, \textbf{favorable}, \textbf{favouritism}.
+\end{itemize}
+
+So \emph{por favor} literally says \textbf{“for a favour”} — \emph{{[}do this{]} as a kindness to me.} English \textbf{favour}, \textbf{favorite}, and \textbf{favorable} keep the same Latin family visible without asking you to learn another language's formula.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the courtesy set is complete}]
+You now hold the three pillars of politeness:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{por favor} — please (asking).
+  \item \textbf{gracias} — thank you (receiving).
+  \item \textbf{de nada} — you're welcome (replying).
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "por favor" — \emph{por fah-BOR}, soft \emph{v/b}{]}
+  \item {[}YOU SAY: "Café, por favor" — "Coffee, please"{]}
+  \item {[}YOU SAY: "favor" then English "favour, favorite" — one family{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What does \emph{por favor} literally mean? ("For a favour.") What Latin verb is \emph{favor} from, and its English cousins? (\emph{favēre} — favour, favorite, favorable.) Which three-word courtesy loop do you now own? (\emph{Por favor $\to$ gracias $\to$ de nada}.) Next: your first regular \textbf{verb} — \emph{hablar}, “to speak.”
+\end{tcolorbox}
+\section[hablar]{hablar — "to speak," and the engine of Spanish sentences}
+
+\label{lesson:ES-C06-hablar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Fixed phrases got you this far. \textbf{Hablar} (“to speak”) gives you a reusable singular \textbf{-ar} pattern. One ending swap says “I speak,” asks a friend, or addresses someone formally.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{silent-h} — the \textbf{h is completely silent}: \emph{hablar} = \emph{ah-BLAR}. (Spanish \emph{h} never makes a sound.)
+  \item \texttt{v-b} — the \emph{b} is a soft \emph{b}; \emph{hablo} = \emph{AH-bloh}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{hablar} comes from Latin \textbf{fābulārī}, \emph{"to chat, to tell tales"} — from \textbf{fābula}, "a story." So to \emph{speak}, in Spanish, is at root to \emph{tell stories}. That \textbf{fābula} is thoroughly English: \textbf{fable}, \textbf{fabulous} ("story-like"), \textbf{confabulate}, and \textbf{ineffable} ("un-speak-able").
+
+The initial Latin \textbf{f-} weakened and eventually disappeared in this word, leaving the written but silent Spanish \textbf{h-}. The single path you need today is \textbf{fābulārī $\to$ hablar}; later words will let you test how broadly the same historical pattern reaches.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the -ar present tense (the big one)}]
+\textbf{Hablar} belongs to the \textbf{-ar} family. To conjugate the three singular forms you need now, \textbf{drop -ar} and add the ending for the person:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{ending} & \textbf{\emph{hablar} $\to$} & \textbf{meaning} \\
+\midrule
+I (the ending carries the subject) & \textbf{-o} & \textbf{hablo} & I speak \\
+tú (you) & \textbf{-as} & \textbf{hablas} & you speak \\
+usted (you, formal) & \textbf{-a} & \textbf{habla} & you speak \\
+\bottomrule
+\end{tabularx}
+
+The \textbf{-o} ending already says “I,” so Spanish normally leaves the subject pronoun unstated. That is \textbf{pro-drop}: \emph{hablo} is a complete “I speak.”
+
+\textbf{This same template fits every regular -ar verb.} Next you'll snap two more verbs straight into it.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "hablar" — \emph{ah-BLAR}, silent \emph{h}{]}
+  \item {[}YOU SAY: the pattern — “hablo, hablas, habla” (I / tú / usted){]}
+  \item {[}YOU SAY: "hablar" then English "fable, fabulous, ineffable" — the \emph{fābula} root{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What Latin word is \emph{hablar} from, and what English word shares it? (\emph{fābulārī} $\leftarrow$ \emph{fābula} — fable.) What happened to its initial Latin \emph{f-}? (It weakened away, leaving silent Spanish \emph{h-}.) How do you say “I speak,” and why is no subject pronoun required? (\emph{Hablo} — the \emph{-o} ending carries “I.”) Next: \textbf{trabajar}, “to work.”
+\end{tcolorbox}
+\section[trabajar]{trabajar — "to work," and it once meant \emph{torture}}
+
+\label{lesson:ES-C06-trabajar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} A second \textbf{-ar} verb — snap it into the exact template you just learned. And \emph{trabajar} has the darkest, best etymology in this chapter: it began as a word for \textbf{torture}, and it's the secret origin of English \textbf{travel}.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{j-jota} — the \textbf{j} is a raspy \emph{h}-from-the-throat (the \emph{jota}): \emph{trabajar} = \emph{tra-ba-\textbf{HAR}}.
+  \item \texttt{r-tap}, \texttt{b-soft} — tapped \emph{r}, soft \emph{b}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{trabajar} comes from Vulgar Latin \textbf{tripaliāre}, \emph{"to torture"} — from \textbf{tripalium}, a Roman instrument of torture made of \textbf{three stakes} (\emph{tri-} "three" + \emph{pālus} "stake," the root of English \textbf{pale} and \textbf{impale}).
+
+The chain of meaning is grimly logical: \emph{torture} $\to$ \emph{torment / suffering} $\to$ \emph{hard toil} $\to$ just \textbf{work}. And English took the very same word down a parallel road:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{travail} — painful, laborious effort (and the pains of childbirth).
+  \item \textbf{travel} — yes: journeying was once such an \emph{ordeal} that "travail" (toil) became \textbf{travel} (to make a journey). Every time you \emph{travel}, you're etymologically being \emph{tortured}.
+\end{itemize}
+
+So even plain \textbf{trabajo}, “I work,” hides the old idea of toil as torment — a dark little joke inside an everyday verb.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: same -ar template}]
+Drop \textbf{-ar}, add the ending — identical to \emph{hablar}:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} & \textbf{meaning} \\
+\midrule
+I (ending carries the subject) & \textbf{trabajo} & I work \\
+tú & \textbf{trabajas} & you work \\
+usted & \textbf{trabaja} & you (formal) work \\
+\bottomrule
+\end{tabularx}
+
+Notice you didn't learn a new ending — that's the point. \textbf{One template, every regular -ar verb.}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "trabajar" — \emph{tra-ba-HAR}, raspy \emph{j}{]}
+  \item {[}YOU SAY: "trabajo, trabajas, trabaja" — same endings as \emph{hablo/hablas/habla}{]}
+  \item {[}YOU SAY: "trabajar" $\to$ travail $\to$ travel — torture became a journey{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What did \emph{trabajar} originally mean, and from what device? ("To torture," $\leftarrow$ \emph{tripalium}, a three-stake tool.) What two English words come from the same root? (\emph{Travail} and \emph{travel}.) How do you say "I work"? (\emph{Trabajo} — same \emph{-o} ending.) Next: \textbf{estudiar}, "to study."
+\end{tcolorbox}
+\section[estudiar]{estudiar — "to study," and the eagerness inside it}
+
+\label{lesson:ES-C06-estudiar}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} Your third \textbf{-ar} verb. By now the pattern should feel automatic — that's exactly what we want. \emph{estudiar} also hides a nicer feeling than the classroom suggests: at root it means \textbf{eagerness.}
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{st-no-e} — Spanish props up \emph{st-} with an \emph{e}: \textbf{es-tudiar} (the same reflex behind \emph{estar}, \emph{España}, \emph{escuela}). \emph{es-too-DYAR}.
+  \item \texttt{diphthong-io} — the \emph{-iar} glides: \emph{es-too-\textbf{DYAR}}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{estudiar} comes from Latin \textbf{studēre}, \emph{"to be eager, to apply oneself zealously."} A \emph{studium} was \textbf{zeal, enthusiasm, devotion} — only later "study." So to \emph{study} is, at heart, to \emph{throw yourself eagerly} at something.
+
+That \textbf{studēre} is everywhere in English:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{student} — literally "one who is \emph{eager}."
+  \item \textbf{studio}, \textbf{studious}, \textbf{study} — the place, the trait, the act.
+  \item Italian \textbf{studio} and the musical \emph{studio} keep the "devoted practice" sense.
+\end{itemize}
+
+So \emph{Estudio español} is "I \emph{devote myself eagerly} to Spanish" — a nicer picture than mere schoolwork.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the template holds}]
+Drop \textbf{-ar}, add the ending — for the third time:
+
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} & \textbf{meaning} \\
+\midrule
+I (ending carries the subject) & \textbf{estudio} & I study \\
+tú & \textbf{estudias} & you study \\
+usted & \textbf{estudia} & you (formal) study \\
+\bottomrule
+\end{tabularx}
+
+Three verbs, one pattern: \emph{hablo, trabajo, estudio}. The singular regular \textbf{-ar} present is now reusable rather than memorized verb by verb.
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "estudiar" — \emph{es-too-DYAR}{]}
+  \item {[}YOU SAY: "estudio, estudias, estudia" — the now-familiar endings{]}
+  \item {[}YOU SAY: "estudiar" then English "student, studio" — the \emph{studēre} "eagerness"{]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What did \emph{studēre} originally mean? ("To be eager / apply oneself.") Its English cousins? (Student, studio, studious.) Say "I study" — and notice it uses the same \emph{-o} as \emph{hablo} and \emph{trabajo}. (\emph{Estudio}.) Next: put a verb and a noun together into your \textbf{first real sentence}.
+\end{tcolorbox}
+\section[Hablo español]{Hablo español — your first real sentence}
+
+\label{lesson:ES-C06-espanol}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} This is the moment the course has been building to: you take a \textbf{verb} you conjugated and a \textbf{noun}, and make a sentence \textbf{nobody handed you pre-assembled}. \emph{Hablo español} — "I speak Spanish."
+\end{quote}
+
+\begin{cousinweb}
+\textbf{español} = "Spanish" (the language, and a Spaniard), from \textbf{Hispania}, the Roman name for the Iberian peninsula. The path \emph{Hispania $\to$ hispaniolus $\to$ español} wore the word down, and — look — the \textbf{ñ} is back, exactly the doubled-\emph{n}-under- a-tilde you met in the writing lesson (\emph{Hispaniolus} $\to$ \emph{españ-ol}). Say it \emph{es-pa-\textbf{NYOL}}.
+
+(English "Spanish," "Hispanic," and "Hispania" are all the same root — and, fittingly, \emph{español} itself may trace back through Latin to a \textbf{Phoenician} name for the coast, "land of hyraxes / rabbits.")
+\end{cousinweb}
+
+\begin{grammarlens}[title={What you've built — the sentence assembled}]
+Snap two things you already own together:
+
+\begin{quote}
+\textbf{Hablo} (I speak, from \emph{hablar}) + \textbf{español} (Spanish) = \textbf{Hablo español.}
+\end{quote}
+
+That's it — a complete, grammatical Spanish sentence. Note what's \emph{not} there:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{No separate subject word.} The \emph{-o} of \emph{hablo} already says “I,” reusing the pro-drop pattern from the previous lesson.
+  \item \textbf{No "the" or "a."} Languages are bare: \emph{hablo español}, not "\emph{el} español."
+\end{itemize}
+
+Now swap the pieces and watch it generate:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{Estudio español.} — “I study Spanish.”
+  \item \textbf{Trabajo.} — “I work.”
+  \item \textbf{¿Hablas español?} — “Do you speak Spanish?” (reuse the \textbf{¿ ?} from the writing lesson).
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: "Hablo español" — \emph{AH-bloh es-pa-NYOL}{]}
+  \item {[}YOU SAY: swap the verb — “Estudio español”, “Trabajo”{]}
+  \item {[}YOU SAY: ask it — "¿Hablas español?" (raise the pitch, ¿ opens the question){]}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} Where does \emph{español} come from, and what letter does its ending bring back? (\emph{Hispania}; the \emph{ñ}.) In \emph{Hablo español}, why is there no separate subject word and no “the”? (The \emph{-o} ending carries “I”; languages take no article.) You just built your first sentence from parts — that's the whole game from here. Next: practice.
+\end{tcolorbox}
+\section[Practice]{Practice — making sentences with -ar verbs}
+
+\label{lesson:ES-C06-practice}
+
+
+
+\begin{quote}
+\textbf{Warm-up.} {[}PAUSE 2s{]} A milestone chapter: for the first time you're not reciting fixed phrases, you're \textbf{building sentences from a pattern}. Drill the three verbs through the endings until \emph{hablo / hablas / habla} is automatic.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: conjugate on command}]
+{[}PAUSE 1s{]} Run each verb through the three singular jobs you know: the ending alone for \textbf{I} $\to$ \textbf{tú} $\to$ \textbf{usted}:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{hablar}: hablo · hablas · habla
+  \item \textbf{trabajar}: trabajo · trabajas · trabaja
+  \item \textbf{estudiar}: estudio · estudias · estudia
+\end{itemize}
+
+Same three endings (\textbf{-o / -as / -a}) every time — that's the whole regular \textbf{-ar} present, singular.
+\end{grammarlens}
+
+\subsection*{The exchange — say something real}
+\begin{quote}
+— ¿\textbf{Hablas} español? — \textbf{Hablo español.} — ¿\textbf{Estudias} español? — \textbf{Estudio español.} — \textbf{Café, por favor.} — ¡Gracias! — De nada.
+\end{quote}
+
+\begin{grammarlens}[title={What you've built this chapter}]
+\begin{itemize}
+\raggedright
+  \item \textbf{por favor} — please ($\leftarrow$ "for a favour"), completing gracias / de nada / por favor.
+  \item \textbf{the singular regular -ar pattern} — drop \emph{-ar}, add \textbf{-o / -as / -a}: the template behind \emph{hablar, trabajar,} and \emph{estudiar}.
+  \item \textbf{hablar} ($\leftarrow$ \emph{fābula}, fable; the f$\to$h law), \textbf{trabajar} ($\leftarrow$ \emph{tripalium}, torture $\to$ travail/travel), \textbf{estudiar} ($\leftarrow$ \emph{studēre}, eagerness $\to$ student).
+  \item \textbf{Hablo español} — your first self-assembled sentence (pro-drop, no article).
+\end{itemize}
+\end{grammarlens}
+
+\subsection*{Guided Practice}
+{[}PAUSE 1s{]}
+
+\begin{itemize}
+\raggedright
+  \item {[}YOU SAY: conjugate all three verbs for I / tú / usted, without stopping{]}
+  \item {[}YOU SAY: answer “¿Hablas español?” and “¿Estudias español?” about yourself{]}
+  \item {[}YOU SAY: request “Café, por favor” and run the full gracias/de nada loop{]}
+\end{itemize}
+
+{[}REPEAT x2{]} Ask and answer “¿Hablas español? — Hablo español.”
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Wrap-up recall}]
+{[}PAUSE 3s{]} What are the three singular \emph{-ar} endings? (\emph{-o / -as / -a}.) Give the “I” form of all three verbs. (\emph{Hablo, trabajo, estudio}.) Why does \emph{Hablo español} need no separate subject word? (The \emph{-o} carries “I.”) You can now generate sentences — the course stops handing you phrases and starts handing you \emph{rules}. Next chapter: the \emph{-er/-ir} verbs, and questions with \emph{qué / dónde}.
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/preamble.tex
+++ b/code/learning/human-languages/spanish/book/preamble.tex
@@ -20,6 +20,7 @@
 \usepackage{booktabs}
 \usepackage{longtable}
 \usepackage{array}
+\usepackage{tabularx}
 \usepackage[hidelinks]{hyperref}
 \usepackage{titlesec}
 

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
@@ -44,7 +44,7 @@ Spain spoke Arabic.**
 
 ## The word, taken apart
 
-**hasta** comes from Arabic **ḥattā** (حَتَّى), "until, up to." From **711 CE**,
+**hasta** comes from Arabic **ḥattā**, “until, up to.” From **711 CE**,
 Muslim armies ruled much of the Iberian Peninsula — *al-Andalus* — and Arabic was
 the language of government, science, and poetry there for **centuries**, until
 1492. Spanish absorbed roughly **four thousand** Arabic words in that time — more

--- a/code/learning/human-languages/spanish/lessons/ES-C06-estudiar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-estudiar.md
@@ -61,6 +61,8 @@ than mere schoolwork.
 
 Drop **-ar**, add the ending — for the third time:
 
+| person | form | meaning |
+|---|---|---|
 | I (ending carries the subject) | **estudio** | I study |
 | tú | **estudias** | you study |
 | usted | **estudia** | you (formal) study |

--- a/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
@@ -32,10 +32,9 @@ reviews_of: [ES-C06-por-favor]
 
 ## Warm-up
 
-[PAUSE 2s] Until now you've assembled fixed phrases. **hablar** (“to speak”)
-gives you the first reusable verb pattern: the singular **-ar present**. One
-small ending swap will let you say “I speak,” ask a friend, or address someone
-formally.
+[PAUSE 2s] Fixed phrases got you this far. **Hablar** (“to speak”) gives you a
+reusable singular **-ar** pattern. One ending swap says “I speak,” asks a
+friend, or addresses someone formally.
 
 ## Sounds you'll need
 

--- a/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
@@ -64,6 +64,8 @@ dark little joke inside an everyday verb.
 
 Drop **-ar**, add the ending — identical to *hablar*:
 
+| person | form | meaning |
+|---|---|---|
 | I (ending carries the subject) | **trabajo** | I work |
 | tú | **trabajas** | you work |
 | usted | **trabaja** | you (formal) work |

--- a/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
@@ -61,7 +61,7 @@ So the tilde on **ñ** is a **frozen abbreviation**: a thousand-year-old note
 that says "there used to be two *n*'s here." You are writing a scribe's
 shortcut.
 
-> ⚠️ Careful: **ñ is its own letter**, not "n with an accent." *año* ("year")
+> **Careful:** **ñ is its own letter**, not "n with an accent." *año* ("year")
 > and *ano* (a rather different word) are completely different words — the tilde
 > is not optional flourish, it's a distinct letter of the alphabet.
 

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -36,6 +36,7 @@ function escapeLatexCharacter(character: string): string {
     "]": "{]}",
     "←": "$\\leftarrow$",
     "→": "$\\to$",
+    "≈": "$\\approx$",
   };
   return escaped[character] ?? character;
 }
@@ -114,6 +115,7 @@ function renderMarkdown(markdown: string): string {
   const quote: string[] = [];
   let listOpen = false;
   let listItem: string[] = [];
+  const tableRows: string[][] = [];
 
   const flushParagraph = (): void => {
     if (paragraph.length === 0) return;
@@ -137,14 +139,64 @@ function renderMarkdown(markdown: string): string {
     listOpen = false;
   };
 
+  const flushTable = (): void => {
+    if (tableRows.length === 0) return;
+    const [header = [], separator = [], ...body] = tableRows;
+    const isSeparator =
+      separator.length === header.length &&
+      separator.every((cell) => /^:?-{3,}:?$/.test(cell));
+    if (!isSeparator || header.length === 0) {
+      output.push(
+        ...tableRows.flatMap((row) => [renderInlineMarkdown(`| ${row.join(" | ")} |`), ""]),
+      );
+      tableRows.length = 0;
+      return;
+    }
+    const columns = Array.from(
+      { length: header.length },
+      () => ">{\\raggedright\\arraybackslash}X",
+    ).join("");
+    const cells = (row: string[]): string[] =>
+      Array.from({ length: header.length }, (_, index) => renderInlineMarkdown(row[index] ?? ""));
+    output.push(
+      `\\begin{tabularx}{\\linewidth}{@{}${columns}@{}}`,
+      "\\toprule",
+      `${cells(header)
+        .map((cell) => `\\textbf{${cell}}`)
+        .join(" & ")} \\\\`,
+      "\\midrule",
+      ...body.map((row) => `${cells(row).join(" & ")} \\\\`),
+      "\\bottomrule",
+      "\\end{tabularx}",
+      "",
+    );
+    tableRows.length = 0;
+  };
+
   for (const rawLine of markdown.split(/\r?\n/)) {
     const line = rawLine.trimEnd();
     if (line.trim() === "") {
       flushParagraph();
       flushQuote();
       closeList();
+      flushTable();
       continue;
     }
+    if (/^\s*\|.*\|\s*$/.test(line)) {
+      flushParagraph();
+      flushQuote();
+      closeList();
+      tableRows.push(
+        line
+          .trim()
+          .replace(/^\|/, "")
+          .replace(/\|$/, "")
+          .split("|")
+          .map((cell) => cell.trim()),
+      );
+      continue;
+    }
+    flushTable();
     if (line.startsWith("> ")) {
       flushParagraph();
       closeList();
@@ -173,6 +225,7 @@ function renderMarkdown(markdown: string): string {
   flushParagraph();
   flushQuote();
   closeList();
+  flushTable();
   return output.join("\n").trimEnd();
 }
 

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -73,10 +73,25 @@ describe("canonical LaTeX chapter rendering", () => {
     expect(generated.tex).toContain("$\\to$");
   });
 
+  it("renders Markdown tables as width-aware LaTeX tables", () => {
+    const lesson = parseLesson(
+      source("A", 10, "hablar").replace(
+        "## Guided Practice",
+        "## Grammar Lens: singular forms\n\n| person | form |\n|---|---|\n| I | **hablo** |\n\n## Guided Practice",
+      ),
+      "test",
+    );
+    const generated = renderBookChapter(target, [lesson]);
+    expect(generated.tex).toContain("\\begin{tabularx}{\\linewidth}");
+    expect(generated.tex).toContain("\\textbf{person} & \\textbf{form} \\\\");
+    expect(generated.tex).toContain("I & \\textbf{hablo} \\\\");
+  });
+
   it("escapes LaTeX control characters while preserving authored emphasis", () => {
     expect(renderInlineMarkdown("**A&B** costs $5 and uses `x_y`")).toBe(
       "\\textbf{A\\&B} costs \\$5 and uses \\texttt{x\\_y}",
     );
+    expect(renderInlineMarkdown("favor ≈ fah-BOR")).toBe("favor $\\approx$ fah-BOR");
     expect(renderInlineMarkdown("*buen**os*** and ***Como** tú.*")).toBe(
       "\\emph{buen\\textbf{os}} and \\emph{\\textbf{Como} tú.}",
     );

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -8,7 +8,7 @@
   while retaining `est_minutes` for unmigrated tracks.
 - Independently combine loaded lesson fingerprints and show `book synced` for a
   generated chapter only when the app AST matches the committed book manifest;
-  Spanish Chapters 1–3 now verify all 24 migrated lessons this way.
+  Spanish Chapters 1–6 now verify all 51 migrated lessons this way.
 
 ## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
 

--- a/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/bookhashes.test.ts
@@ -7,6 +7,9 @@ describe("generated book source hashes", () => {
     [1, 7],
     [2, 5],
     [3, 12],
+    [4, 13],
+    [5, 7],
+    [6, 7],
   ])("matches the browser-loaded Spanish Chapter %i AST across %i lessons", (chapter, count) => {
     const lessons = loadLessons();
     const expected = expectedBookHash("spanish", chapter);
@@ -21,6 +24,6 @@ describe("generated book source hashes", () => {
       lesson.id === "ES-C01-hola" ? { ...lesson, sourceHash: "fnv1a64:changed" } : lesson,
     );
     expect(bookHashStatus(changed, "spanish", 1)).toBe("stale");
-    expect(bookHashStatus(lessons, "spanish", 4)).toBe("not-generated");
+    expect(bookHashStatus(lessons, "spanish", 7)).toBe("not-generated");
   });
 });


### PR DESCRIPTION
## Summary

- replace handwritten Spanish Chapters 4–6 with deterministic LaTeX generated from 27 canonical schema-v2 lessons
- expand the generated-book manifest and Language Ladder hash parity from 24 lessons / 3 chapters to 51 lessons / 6 chapters
- preserve Markdown comparison and conjugation tables as width-aware `tabularx` output
- repair two headerless canonical verb tables and safely render the approximation sign
- update the human-languages backlog, promote HL-V02, and refresh Spanish/Language Ladder changelogs

## Book verification

- forced XeLaTeX build succeeds at 158 pages
- visually inspected every physical PDF page in the Chapter 4–6 span
- generated Chapters 4–6 have no missing glyphs, overfull/underfull boxes, Hyperref warnings, clipping, collisions, malformed tables, or accidental blank pages
- remaining legacy Chapter 7–18 warnings stay explicit in HL-B37

## Validation

- `npm run build` — human-language-data
- `npm run test:coverage` — 69 tests; 93.14% line coverage
- `npm run report` — 20 tracks, 1,065 lessons, 20 books, 0 duration violations, 0 unknown prerequisites
- `npm run check:books`
- `npm run test:coverage` — Language Ladder, 281 tests; 98.37% line coverage
- `npm run build` — Language Ladder, 1,115 modules
- forced `latexmk -xelatex` build plus rendered-page audit
- `git diff --check`
