### PR TITLE
fix(html-parser): report after-frameset tail errors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- The after-after-frameset insertion mode now reports unexpected character,
+  start-tag, and end-tag tokens, closing 8 previously silent malformed corpus
+  cases without changing DOM recovery.
 - An accepted `</body>` token now enters the after-body insertion mode even
   when `html`, `head`, and `body` were all implied, closing 5 previously silent
   malformed corpus cases for following head-only and frameset start tags.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -25,8 +25,8 @@ The 2026-08-02 upstream audit covered all 1,934 WPT tree-construction cases and
 all 6,806 html5lib tokenizer cases with zero missing signatures and zero
 normalized skips. DOM output is complete, but diagnostic coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the implied-body tail-transition slice, 1,786 of those cases emit at
-least one lexer or parser diagnostic and 397 remain uncovered. Another 139
+After the after-after-frameset diagnostic slice, 1,794 of those cases emit at
+least one lexer or parser diagnostic and 389 remain uncovered. Another 139
 cases emit diagnostics despite having no legacy `#errors` rows. These are
 reviewed rather than automatically removed: 89 are full-document inputs for
 which the legacy fixtures omit the Standard-required missing-doctype error,
@@ -40,10 +40,10 @@ Prioritized work items:
    start-tag diagnostics, body/html end tags with disallowed open elements,
    full-document in-body EOF diagnostics, unexpected-token recovery in the
    after-body and after-after-body modes, and the implied-shell `</body>`
-   transition are complete. The fresh 397-case inventory identifies
-   after-after-frameset unexpected tokens, stray end tags before an implied
-   root or body, and rejected frameset starts as the remaining concrete shell
-   slices, in that order.
+   transition, and after-after-frameset unexpected-token diagnostics are
+   complete. The fresh 389-case inventory identifies stray end tags before an
+   implied root or body and rejected frameset starts as the remaining concrete
+   shell slices, in that order.
 2. **Fragment EOF diagnostics.** Audit the current in-body EOF rule against
    fragment parsing. Legacy fragment fixtures omit many EOF error rows, so add
    explicit current-WHATWG evidence before extending the full-document

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4677,7 +4677,11 @@ impl HtmlParser {
     }
 
     fn process_document_tail_mode(&mut self, token: &Token) {
-        if self.is_fragment || self.document_has_closed_frameset() {
+        if self.is_fragment {
+            return;
+        }
+        if self.document_has_closed_frameset() {
+            self.process_closed_frameset_tail_mode(token);
             return;
         }
 
@@ -4710,6 +4714,32 @@ impl HtmlParser {
                 ),
             ));
             self.document_tail_mode = DocumentTailMode::InBody;
+        }
+    }
+
+    fn process_closed_frameset_tail_mode(&mut self, token: &Token) {
+        if !self.explicit_html_end_seen || self.current_element_is("noframes") {
+            return;
+        }
+
+        let allowed = matches!(
+            token,
+            Token::Comment(_)
+                | Token::ProcessingInstruction { .. }
+                | Token::Doctype { .. }
+                | Token::Eof
+        ) || matches!(token, Token::Text(text) if is_html_whitespace_text(text))
+            || matches!(
+                token,
+                Token::StartTag { name, .. }
+                    if matches!(name.as_str(), "html" | "noframes")
+            );
+
+        if !allowed {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-token-after-after-frameset",
+                "unexpected token was ignored in the after after frameset insertion mode",
+            ));
         }
     }
 
@@ -33103,6 +33133,40 @@ mod tests {
             parse_html_with_diagnostics("<!doctype html><menuitem></html><p>x").unwrap();
         assert!(!ignored_html_end.parser_diagnostics.iter().any(|diagnostic| {
             diagnostic.code == "unexpected-token-after-html"
+        }));
+    }
+
+    #[test]
+    fn reports_unexpected_tokens_after_after_frameset() {
+        for (source, expected_count) in [
+            ("<!doctype html><frameset></frameset></html>text", 1),
+            ("<!doctype html><frameset></frameset></html><p>", 1),
+            ("<!doctype html><frameset></frameset></html></p>", 1),
+            (
+                "<!doctype html><frameset></frameset></html><plaintext></plaintext>",
+                2,
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .filter(|diagnostic| {
+                        diagnostic.code == "unexpected-token-after-after-frameset"
+                    })
+                    .count(),
+                expected_count,
+                "source {source:?}"
+            );
+        }
+
+        let allowed = parse_html_with_diagnostics(
+            "<!doctype html><frameset></frameset></html> \n<!--tail--><?pi?><noframes>x</noframes>",
+        )
+        .unwrap();
+        assert!(allowed.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-token-after-after-frameset"
         }));
     }
 

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 397);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1786);
+    assert_eq!(missing_diagnostic_cases, 389);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 1794);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report unexpected character, start-tag, and end-tag tokens in the Standard's after-after-frameset insertion mode
- preserve allowed whitespace, comments, processing instructions, `html`, and trailing `noframes` handling
- update the executable diagnostic ratchet and reprioritized conformance backlog

## Evidence
- preserves all 2,637 checked tree-construction DOM outputs
- reduces declared-error cases without diagnostics from 397 to 389
- raises covered declared-error cases from 1,786 to 1,794 while undeclared-diagnostic cases remain 139
- live upstream audit covers 1,934/1,934 WPT tree signatures and 6,806/6,806 html5lib tokenizer signatures with zero normalized skips

## Validation
- `cargo test -p coding-adventures-html-parser --test tree_construction_test`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- parser audit manifest, Rust-test, and coverage checks
- generated HTML fixture and README inventory checks
- live upstream WPT/html5lib coverage audit
- `git diff --check`
