### PR TITLE
fix(build-tool): enforce Ruby rockspec UTF-8

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -365,7 +365,7 @@
       "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-ruby-rockspec-utf8",
       "pr_number": null,
-      "notes": "Selected after merged PR #9632 and the collision-clean 46d95281 inventory. Ruby currently reads rockspec text through the process locale/default external encoding. Consume the exact shared valid and invalid fixtures, decode raw bytes as strict UTF-8 before parsing, preserve exact dependency edges, raise a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, and prove real CLI exit 2 plus stable root-redacted stderr. The quick post-merge leverage pass ranked Ruby before Haskell and Elixir because Ruby 3.4.9 and Bundler 2.6.9 are locally available, its direct read is the narrowest remaining boundary, and six merged implementations pin the behavior without the broader lazy-I/O or regex-position audit."
+      "notes": "Selected after merged PR #9632 and the collision-clean 46d95281 inventory. Ruby currently reads rockspec text through the process locale/default external encoding. Consume the exact shared valid and invalid fixtures, decode raw bytes as strict UTF-8 before parsing, preserve exact dependency edges, raise a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, and prove real CLI exit 2 plus stable root-redacted stderr. The quick post-merge leverage pass ranked Ruby before Haskell and Elixir because Ruby 3.4.9 and Bundler 2.6.9 are locally available, its direct read is the narrowest remaining boundary, and six merged implementations pin the behavior without the broader lazy-I/O or regex-position audit. Pre-rebase validation passes 296 Ruby runs/585 assertions with 87.41% line and 72.05% branch coverage, syntax, changed-file Lint/Security RuboCop, zero-advisory bundle audit, current dependencies, canonical Go test/vet/build and 300-package Ruby validation, 57 conformance tests, the 37-case/56-file corpus, and a real 258-Lua-package/382-edge plan. Full-repository validation separately discovered the undeclared Starlark runtime dependency and recurring canonical BUILD parse failures; both have dedicated pending owners below and do not expand this UTF-8 slice."
     },
     {
       "id": "build-tool-haskell-engine-rockspec-utf8-conformance",
@@ -384,6 +384,24 @@
       "branch": null,
       "pr_number": null,
       "notes": "Materialized after merged PR #9632. Elixir reads binaries but its current regex extraction has position-dependent behavior on malformed UTF-8. Add an explicit UTF-8 validity gate before parsing, consume both exact shared fixtures, preserve exact dependency edges, return typed METADATA_INVALID_UTF8 identity, and prove the real CLI exit/stderr contract. Schedule after the direct locale-sensitive Ruby and Haskell boundaries so their references further pin cross-platform behavior."
+    },
+    {
+      "id": "build-tool-ruby-starlark-runtime-closure",
+      "title": "Make the Ruby build tool declare and load its Starlark runtime closure",
+      "status": "pending",
+      "depends_on": ["build-tool-ruby-engine-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered while running the real full-repository Lua plan for the Ruby UTF-8 slice. The build tool lazily requires coding_adventures_starlark_interpreter whenever a Starlark BUILD file is present, but its Gemfile declares only progress_bar and test gems; a clean source-tree invocation therefore aborts with LoadError until every Ruby package lib directory is injected through RUBYLIB. Declare a repository-local runtime closure or a supported bootstrap path, exercise it from a clean environment on Windows and Unix, and preserve the tool's zero-network build execution policy."
+    },
+    {
+      "id": "build-tool-ruby-starlark-canonical-build-compatibility",
+      "title": "Make the Ruby Starlark path parse canonical BUILD files without fallback",
+      "status": "pending",
+      "depends_on": ["build-tool-ruby-starlark-runtime-closure"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered after supplying the repository Ruby libraries to the real Lua plan. The Ruby Starlark interpreter emits repeatable end-of-file parse errors for canonical Elixir, Go, and Rust BUILD templates and the build tool silently falls back to raw commands; the plan still succeeds at 258 Lua packages and 382 edges. Minimize the failing template suffixes into language-neutral fixtures, repair the parser/compiler boundary or evaluator contract, fail closed where structured declarations are required, and prove exact plan equivalence across affected platform templates."
     },
     {
       "id": "build-tool-perl-runtime-security-floor",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,12 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "build-tool-ruby-engine-rockspec-utf8-conformance",
+    "number": 9648,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9648",
+    "branch": "codex/build-tool-ruby-rockspec-utf8"
+  },
   "last_inventory": {
     "revision": "816bd31f41bd21ce5bda30c1dfaac8b8b5102de0",
     "schema_version": 3,
@@ -361,10 +366,10 @@
     {
       "id": "build-tool-ruby-engine-rockspec-utf8-conformance",
       "title": "Make the Ruby build tool enforce strict UTF-8 rockspec metadata",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-ruby-rockspec-utf8",
-      "pr_number": null,
+      "pr_number": 9648,
       "notes": "Selected after merged PR #9632 and the collision-clean 46d95281 inventory. Ruby currently reads rockspec text through the process locale/default external encoding. Consume the exact shared valid and invalid fixtures, decode raw bytes as strict UTF-8 before parsing, preserve exact dependency edges, raise a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, and prove real CLI exit 2 plus stable root-redacted stderr. The quick post-merge leverage pass ranked Ruby before Haskell and Elixir because Ruby 3.4.9 and Bundler 2.6.9 are locally available, its direct read is the narrowest remaining boundary, and six merged implementations pin the behavior without the broader lazy-I/O or regex-position audit. After conflict-free rebases through 816bd31f, exact-head validation passes 296 Ruby runs/585 assertions with 87.41% line and 72.05% branch coverage, syntax, changed-file Lint/Security RuboCop, zero-advisory bundle audit, current dependencies, canonical Go test/vet/build and 300-package Ruby validation, 57 conformance tests, the 37-case/56-file corpus, a real 258-Lua-package/382-edge plan, and the collision-clean inventory. Full-repository validation separately discovered the undeclared Starlark runtime dependency and 44 canonical BUILD parse fallbacks; both have dedicated pending owners below and do not expand this UTF-8 slice."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,14 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": {
-    "item_id": "build-tool-perl-engine-rockspec-utf8-conformance",
-    "number": 9632,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9632",
-    "branch": "codex/build-tool-perl-rockspec-utf8"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "ec53a3f9e9b2f31deefc43552a4d48658c49f3f4",
+    "revision": "46d95281010e384243dd027a0b94063d5cd6b382",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1224,
@@ -343,7 +338,7 @@
       "depends_on": ["build-tool-lua-rockspec-encoding"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered by the Python encoding-blocker audit. Go, Rust, Swift, TypeScript, and Lua were remediated in merged PRs #9504, #9510, #9537, #9572, and #9603. Four engines remain: Perl accepts malformed bytes, Ruby and Haskell use locale-sensitive text decoding, and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity. The Perl engine is materialized as the next pending child because its raw byte boundary is narrow and Perl 5.38 is locally available."
+      "notes": "Discovered by the Python encoding-blocker audit. Go, Rust, Swift, TypeScript, Lua, and Perl were remediated in merged PRs #9504, #9510, #9537, #9572, #9603, and #9632. Three engines remain: Ruby and Haskell use locale-sensitive text decoding, and Elixir is position-dependent. Remediate each engine against resolution/lua-utf8 and resolution/lua-invalid-utf8 in small dependency-shaped slices, preserving METADATA_INVALID_UTF8 with repository-relative path and package identity. All three remaining children are explicitly materialized below."
     },
     {
       "id": "build-tool-lua-engine-rockspec-utf8-conformance",
@@ -357,11 +352,38 @@
     {
       "id": "build-tool-perl-engine-rockspec-utf8-conformance",
       "title": "Make the Perl build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-lua-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-perl-rockspec-utf8",
       "pr_number": 9632,
-      "notes": "Ready-for-review PR #9632 opened at b60299988ed47b8acc21ea838f99d9f39648d8ed after merged PR #9603 and the collision-clean ec53a3f9 inventory. The four-engine leverage pass ranked Perl first because its raw-byte rockspec reader is the narrowest remaining boundary, and the shared valid/invalid fixtures plus five merged reference implementations pin the exact contract. Implemented strict raw-byte decoding, a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, exact success edges without the rockspec package field becoming a self-dependency, malformed-sequence and literal-U+FFFD coverage, and a real CLI exit-2 contract without checkout-root leakage. Rebased conflict-free onto ec53a3f9; the full 127-test Perl suite, MakeMaker workflow, syntax, severity-5 Perl::Critic, coverage, canonical Go test/vet/build and 256-package Perl validator, 57 conformance tests, 37-case/56-file corpus, 258-package real Lua plan, collision inventory, diff, dependency, and credential scans pass. Keep Ruby and Haskell locale-sensitive decoding and Elixir's position-dependent decoding as separate later children."
+      "notes": "Merged PR #9632 as 46d95281010e384243dd027a0b94063d5cd6b382 on 2026-08-03 after all exact-head checks were terminal: two detects, two fixture consumers, two Ubuntu builds, macOS, Windows, two CI gates, and CodeQL detection passed; five irrelevant CodeQL analyzers skipped. The resolver strictly decodes raw bytes, emits typed METADATA_INVALID_UTF8 with package and repository-relative manifest identity, preserves exact success edges without a package-field self-dependency, accepts literal U+FFFD, rejects five malformed-sequence classes, and maps the real CLI to exit 2 without checkout-root leakage. Local validation passed the full 127-test Perl suite, MakeMaker workflow, syntax, severity-5 Perl::Critic, 83.9% aggregate coverage, canonical Go test/vet/build and 256-package Perl validator, 57 conformance tests, 37-case/56-file corpus, 258-package real Lua plan, collision inventory, diff, direct Encode dependency, and credential scans."
+    },
+    {
+      "id": "build-tool-ruby-engine-rockspec-utf8-conformance",
+      "title": "Make the Ruby build tool enforce strict UTF-8 rockspec metadata",
+      "status": "pending",
+      "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized after merged PR #9632. Ruby currently reads rockspec text through the process locale/default external encoding. Consume the exact shared valid and invalid fixtures, decode raw bytes as strict UTF-8 before parsing, preserve exact dependency edges, raise a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, and prove real CLI exit 2 plus stable root-redacted stderr. Ruby 3.4.9 and Bundler 2.6.9 are locally available, making this the narrowest and fastest remaining boundary to validate."
+    },
+    {
+      "id": "build-tool-haskell-engine-rockspec-utf8-conformance",
+      "title": "Make the Haskell build tool enforce strict UTF-8 rockspec metadata",
+      "status": "pending",
+      "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized after merged PR #9632. Replace locale-sensitive lazy text I/O at the rockspec boundary with explicit strict UTF-8 decoding, consume both exact shared fixtures, preserve exact dependency edges, propagate typed METADATA_INVALID_UTF8 identity, and cover the real executable exit/stderr contract. Schedule after Ruby because the Haskell toolchain and lazy-I/O boundary require a broader build and resource audit."
+    },
+    {
+      "id": "build-tool-elixir-engine-rockspec-utf8-conformance",
+      "title": "Make the Elixir build tool enforce strict UTF-8 rockspec metadata",
+      "status": "pending",
+      "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Materialized after merged PR #9632. Elixir reads binaries but its current regex extraction has position-dependent behavior on malformed UTF-8. Add an explicit UTF-8 validity gate before parsing, consume both exact shared fixtures, preserve exact dependency edges, return typed METADATA_INVALID_UTF8 identity, and prove the real CLI exit/stderr contract. Schedule after the direct locale-sensitive Ruby and Haskell boundaries so their references further pin cross-platform behavior."
     },
     {
       "id": "build-tool-perl-runtime-security-floor",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,16 +13,16 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "46d95281010e384243dd027a0b94063d5cd6b382",
+    "revision": "816bd31f41bd21ce5bda30c1dfaac8b8b5102de0",
     "schema_version": 3,
     "established_languages": 15,
-    "implementation_identities": 1224,
-    "implementation_package_slots": 4372,
+    "implementation_identities": 1225,
+    "implementation_package_slots": 4373,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 271,
-    "singleton_packages": 774,
-    "singleton_missing_slots": 10836,
-    "rust_singletons": 579,
+    "singleton_packages": 775,
+    "singleton_missing_slots": 10850,
+    "rust_singletons": 580,
     "canonical_collisions": 0,
     "unknown_language_buckets": 0
   },
@@ -365,7 +365,7 @@
       "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
       "branch": "codex/build-tool-ruby-rockspec-utf8",
       "pr_number": null,
-      "notes": "Selected after merged PR #9632 and the collision-clean 46d95281 inventory. Ruby currently reads rockspec text through the process locale/default external encoding. Consume the exact shared valid and invalid fixtures, decode raw bytes as strict UTF-8 before parsing, preserve exact dependency edges, raise a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, and prove real CLI exit 2 plus stable root-redacted stderr. The quick post-merge leverage pass ranked Ruby before Haskell and Elixir because Ruby 3.4.9 and Bundler 2.6.9 are locally available, its direct read is the narrowest remaining boundary, and six merged implementations pin the behavior without the broader lazy-I/O or regex-position audit. Pre-rebase validation passes 296 Ruby runs/585 assertions with 87.41% line and 72.05% branch coverage, syntax, changed-file Lint/Security RuboCop, zero-advisory bundle audit, current dependencies, canonical Go test/vet/build and 300-package Ruby validation, 57 conformance tests, the 37-case/56-file corpus, and a real 258-Lua-package/382-edge plan. Full-repository validation separately discovered the undeclared Starlark runtime dependency and recurring canonical BUILD parse failures; both have dedicated pending owners below and do not expand this UTF-8 slice."
+      "notes": "Selected after merged PR #9632 and the collision-clean 46d95281 inventory. Ruby currently reads rockspec text through the process locale/default external encoding. Consume the exact shared valid and invalid fixtures, decode raw bytes as strict UTF-8 before parsing, preserve exact dependency edges, raise a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, and prove real CLI exit 2 plus stable root-redacted stderr. The quick post-merge leverage pass ranked Ruby before Haskell and Elixir because Ruby 3.4.9 and Bundler 2.6.9 are locally available, its direct read is the narrowest remaining boundary, and six merged implementations pin the behavior without the broader lazy-I/O or regex-position audit. After conflict-free rebases through 816bd31f, exact-head validation passes 296 Ruby runs/585 assertions with 87.41% line and 72.05% branch coverage, syntax, changed-file Lint/Security RuboCop, zero-advisory bundle audit, current dependencies, canonical Go test/vet/build and 300-package Ruby validation, 57 conformance tests, the 37-case/56-file corpus, a real 258-Lua-package/382-edge plan, and the collision-clean inventory. Full-repository validation separately discovered the undeclared Starlark runtime dependency and 44 canonical BUILD parse fallbacks; both have dedicated pending owners below and do not expand this UTF-8 slice."
     },
     {
       "id": "build-tool-haskell-engine-rockspec-utf8-conformance",
@@ -401,7 +401,7 @@
       "depends_on": ["build-tool-ruby-starlark-runtime-closure"],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered after supplying the repository Ruby libraries to the real Lua plan. The Ruby Starlark interpreter emits repeatable end-of-file parse errors for canonical Elixir, Go, and Rust BUILD templates and the build tool silently falls back to raw commands; the plan still succeeds at 258 Lua packages and 382 edges. Minimize the failing template suffixes into language-neutral fixtures, repair the parser/compiler boundary or evaluator contract, fail closed where structured declarations are required, and prove exact plan equivalence across affected platform templates."
+      "notes": "Discovered after supplying the repository Ruby libraries to the real Lua plan. The Ruby Starlark interpreter emits 44 repeatable end-of-file parse errors for canonical Elixir, Go, and Rust BUILD templates and the build tool silently falls back to raw commands; the plan still succeeds at 258 Lua packages and 382 edges. Minimize the failing template suffixes into language-neutral fixtures, repair the parser/compiler boundary or evaluator contract, fail closed where structured declarations are required, and prove exact plan equivalence across affected platform templates."
     },
     {
       "id": "build-tool-perl-runtime-security-floor",
@@ -905,6 +905,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered in the collision-clean ec53a3f9 inventory after PR #9609 added Rust-only chief-of-staff-channel-crypto. Define language-neutral vectors for the versioned bounded grant/message wire records, stable storage keys, framed authenticated headers, digest/signature inputs, epoch transition rules, retry/conflict handling, and sequence reservation/recovery. Expand deterministic codecs and cryptographic behavior only where each lane has suitable constant-time primitives; keep OS CSPRNG access, key custody, durable sequence persistence, storage, and actor routing behind injected or native authority boundaries, with reviewed exceptions where a safe implementation is unavailable."
+    },
+    {
+      "id": "chief-channel-store-portable-conformance",
+      "title": "Fixture and expand the portable Chief encrypted channel store",
+      "status": "pending",
+      "depends_on": ["chief-channel-crypto-portable-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered in the collision-clean 9bb12864 inventory after PR #9640 added Rust-only chief-of-staff-channel-store. Define language-neutral fixtures for two-phase CAS sequence reservation, exact pending-header recovery, nonce-safe abandoned gaps, idempotent encrypted-message and sealed-grant persistence, ordered pagination, monotonic per-receiver acknowledgements, conflict/retry ceilings, corrupt-record rejection, and stable repository-owned storage keys/errors. Expand the authority-free orchestration over injected StorageBackend and channel-crypto contracts after the cryptographic vectors land; backend I/O, filesystem durability, key custody, entropy, and actor routing remain separately injected or native and are not part of this portable package."
     },
     {
       "id": "venture-browser-qt-portable-bridge-and-native-host",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -361,11 +361,11 @@
     {
       "id": "build-tool-ruby-engine-rockspec-utf8-conformance",
       "title": "Make the Ruby build tool enforce strict UTF-8 rockspec metadata",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-perl-engine-rockspec-utf8-conformance"],
-      "branch": null,
+      "branch": "codex/build-tool-ruby-rockspec-utf8",
       "pr_number": null,
-      "notes": "Materialized after merged PR #9632. Ruby currently reads rockspec text through the process locale/default external encoding. Consume the exact shared valid and invalid fixtures, decode raw bytes as strict UTF-8 before parsing, preserve exact dependency edges, raise a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, and prove real CLI exit 2 plus stable root-redacted stderr. Ruby 3.4.9 and Bundler 2.6.9 are locally available, making this the narrowest and fastest remaining boundary to validate."
+      "notes": "Selected after merged PR #9632 and the collision-clean 46d95281 inventory. Ruby currently reads rockspec text through the process locale/default external encoding. Consume the exact shared valid and invalid fixtures, decode raw bytes as strict UTF-8 before parsing, preserve exact dependency edges, raise a typed METADATA_INVALID_UTF8 failure with package and repository-relative manifest identity, and prove real CLI exit 2 plus stable root-redacted stderr. The quick post-merge leverage pass ranked Ruby before Haskell and Elixir because Ruby 3.4.9 and Bundler 2.6.9 are locally available, its direct read is the narrowest remaining boundary, and six merged implementations pin the behavior without the broader lazy-I/O or regex-position audit."
     },
     {
       "id": "build-tool-haskell-engine-rockspec-utf8-conformance",

--- a/code/programs/ruby/build-tool/CHANGELOG.md
+++ b/code/programs/ruby/build-tool/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Ruby build tool are documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Lua rockspecs are decoded from raw bytes as strict UTF-8 before dependency
+  parsing. Malformed metadata raises a typed `METADATA_INVALID_UTF8` error with
+  stable package and repository-relative manifest identity.
+- The real CLI maps only that metadata error to exit code 2 and root-redacted
+  stderr. Shared valid and invalid fixtures, literal U+FFFD, and five malformed
+  UTF-8 classes are covered by the Ruby test suite.
+
 ## [0.3.0] - 2026-03-29
 
 ### Added

--- a/code/programs/ruby/build-tool/README.md
+++ b/code/programs/ruby/build-tool/README.md
@@ -29,12 +29,31 @@ ruby build.rb --language python      # Only build Python packages
 ruby build.rb --cache-file FILE      # Custom cache file path
 ```
 
+## Metadata Safety
+
+Lua rockspecs are read as raw bytes and decoded as strict UTF-8 before any
+dependency parsing. Malformed metadata fails closed with CLI exit code `2` and
+a stable diagnostic that contains only portable identities:
+
+```text
+METADATA_INVALID_UTF8: package=lua/pkg manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec encoding=UTF-8
+```
+
+The resolver never inserts replacement characters and never includes the host
+checkout root in this error. A literal U+FFFD character encoded correctly as
+UTF-8 remains valid metadata.
+
 ## Testing
 
 ```bash
 bundle install
 bundle exec rake test
 ```
+
+The `test/test_resolution_utf8.rb` coverage exercises the shared
+language-neutral valid and invalid fixtures, representative malformed sequence
+classes, and the real CLI subprocess. The full Rake suite enforces the
+whole-program coverage threshold.
 
 ## Dependencies
 

--- a/code/programs/ruby/build-tool/build.rb
+++ b/code/programs/ruby/build-tool/build.rb
@@ -318,7 +318,12 @@ module BuildTool
       puts "Discovered #{packages.size} packages"
 
       # -- Step 4: Resolve dependencies -----------------------------------------
-      graph = Resolver.resolve_dependencies(packages)
+      graph = begin
+        Resolver.resolve_dependencies(packages)
+      rescue MetadataEncodingError => e
+        $stderr.puts e.message
+        return 2
+      end
 
       # -- Step 5: Git-diff change detection (default mode) ---------------------
       #

--- a/code/programs/ruby/build-tool/lib/build_tool/resolver.rb
+++ b/code/programs/ruby/build-tool/lib/build_tool/resolver.rb
@@ -38,6 +38,23 @@
 # skipped.
 
 module BuildTool
+  # MetadataEncodingError -- Stable failure for malformed package metadata.
+  #
+  # The error carries only portable package and repository-relative manifest
+  # identities. CLI callers can therefore report malformed UTF-8 without
+  # exposing a host-specific checkout root.
+  class MetadataEncodingError < StandardError
+    attr_reader :code, :package, :manifest, :encoding
+
+    def initialize(package:, manifest:)
+      @code = "METADATA_INVALID_UTF8"
+      @package = package
+      @manifest = manifest
+      @encoding = "UTF-8"
+      super("#{code}: package=#{package} manifest=#{manifest} encoding=#{encoding}")
+    end
+  end
+
   # --------------------------------------------------------------------------
   # DirectedGraph -- A minimal directed graph for dependency resolution.
   #
@@ -374,7 +391,7 @@ module BuildTool
       rockspec_files = package.path.glob("*.rockspec").to_a
       return [] if rockspec_files.empty?
 
-      text = rockspec_files.first.read
+      text = read_utf8_metadata(package, rockspec_files.first)
       internal_deps = []
       in_deps = false
 
@@ -402,6 +419,29 @@ module BuildTool
       end
 
       internal_deps
+    end
+
+    # read_utf8_metadata -- Read raw metadata bytes and decode strict UTF-8.
+    #
+    # Pathname#read inherits Ruby's process-default external encoding. Package
+    # manifests are portable repository data, so their decoding must not vary
+    # with a runner locale or silently replace malformed byte sequences.
+    def read_utf8_metadata(package, path)
+      text = File.binread(path).force_encoding(Encoding::UTF_8)
+      return text if text.valid_encoding?
+
+      raise MetadataEncodingError.new(
+        package: package.name,
+        manifest: repository_relative_manifest(path)
+      )
+    end
+
+    def repository_relative_manifest(path)
+      normalized = Pathname(path).cleanpath.to_s.tr("\\", "/")
+      match = normalized.match(%r{(?:\A|/)(code/(?:packages|programs)/.+)\z})
+      return match[1] if match
+
+      Pathname(normalized).basename.to_s
     end
 
     # extract_lua_deps -- Extract dependency names from a line of a rockspec.

--- a/code/programs/ruby/build-tool/test/test_resolution_utf8.rb
+++ b/code/programs/ruby/build-tool/test/test_resolution_utf8.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+# test_resolution_utf8.rb -- Shared rockspec UTF-8 conformance
+# ============================================================
+
+require_relative "test_helper"
+
+require "open3"
+require "rbconfig"
+
+class TestResolutionUtf8 < Minitest::Test
+  include TestHelper
+
+  REPO_ROOT = Pathname(__dir__).join("..", "..", "..", "..", "..").expand_path
+  CASES_DIR = REPO_ROOT / "code" / "specs" / "fixtures" / "build-tool-v1" / "cases"
+  BUILD_TOOL = REPO_ROOT / "code" / "programs" / "ruby" / "build-tool" / "build.rb"
+  INVALID_SEQUENCES = {
+    illegal_lead: "\xFF".b,
+    unexpected_continuation: "\x80".b,
+    truncated_sequence: "\xE2\x82".b,
+    overlong_encoding: "\xC0\xAF".b,
+    surrogate: "\xED\xA0\x80".b
+  }.freeze
+
+  def test_shared_valid_fixture_has_exact_edges
+    workspace, fixture = materialize_case("resolution-lua-utf8.json")
+    packages = BuildTool::Discovery.discover_packages(workspace / "code")
+
+    graph = BuildTool::Resolver.resolve_dependencies(packages)
+
+    assert_equal fixture.dig("expected", "result", "edges"), graph_edges(graph)
+    assert_equal %w[lua/other lua/pkg], graph.nodes.sort
+  ensure
+    FileUtils.rm_rf(workspace)
+  end
+
+  def test_shared_invalid_fixture_raises_typed_stable_error
+    workspace, = materialize_case("resolution-lua-invalid-utf8.json")
+    packages = BuildTool::Discovery.discover_packages(workspace / "code")
+
+    error = assert_raises(BuildTool::MetadataEncodingError) do
+      BuildTool::Resolver.resolve_dependencies(packages)
+    end
+
+    assert_equal "METADATA_INVALID_UTF8", error.code
+    assert_equal "lua/pkg", error.package
+    assert_equal "code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec", error.manifest
+    assert_equal "UTF-8", error.encoding
+    assert_equal expected_diagnostic, error.message
+    refute_includes error.message, workspace.to_s
+  ensure
+    FileUtils.rm_rf(workspace)
+  end
+
+  def test_literal_replacement_character_is_valid_utf8
+    workspace = create_temp_dir
+    package = write_lua_package(
+      workspace,
+      "pkg",
+      <<~ROCKSPEC
+        package = "coding-adventures-pkg"
+        version = "0.1.0-1"
+        description = { summary = "Literal replacement character: �" }
+        dependencies = { "lua >= 5.4" }
+      ROCKSPEC
+    )
+
+    assert_equal [], BuildTool::Resolver.parse_lua_deps(package, {})
+  ensure
+    FileUtils.rm_rf(workspace)
+  end
+
+  def test_rejects_representative_malformed_utf8_classes
+    INVALID_SEQUENCES.each do |name, sequence|
+      workspace = create_temp_dir
+      bytes = <<~ROCKSPEC.b + sequence + "\n".b
+        package = "coding-adventures-pkg"
+        version = "0.1.0-1"
+        dependencies = { "lua >= 5.4" }
+        -- malformed #{name}:
+      ROCKSPEC
+      package = write_lua_package(workspace, "pkg", bytes, binary: true)
+
+      error = assert_raises(BuildTool::MetadataEncodingError, name.to_s) do
+        BuildTool::Resolver.parse_lua_deps(package, {})
+      end
+      assert_equal expected_diagnostic, error.message, name.to_s
+    ensure
+      FileUtils.rm_rf(workspace)
+    end
+  end
+
+  def test_real_cli_returns_exit_two_with_stable_stderr
+    workspace, = materialize_case("resolution-lua-invalid-utf8.json")
+
+    stdout, stderr, status = Open3.capture3(
+      RbConfig.ruby,
+      BUILD_TOOL.to_s,
+      "--root", workspace.to_s,
+      "--language", "lua",
+      "--force",
+      "--dry-run"
+    )
+
+    assert_equal 2, status.exitstatus
+    assert_includes stderr.lines.map(&:strip), expected_diagnostic
+    refute_includes stderr, workspace.to_s
+    refute_includes stdout, workspace.to_s
+  ensure
+    FileUtils.rm_rf(workspace)
+  end
+
+  private
+
+  def materialize_case(filename)
+    fixture = JSON.parse((CASES_DIR / filename).read(encoding: "UTF-8"))
+    workspace = create_temp_dir
+    fixture.fetch("workspace").fetch("files").each do |entry|
+      path = workspace / entry.fetch("path")
+      path.dirname.mkpath
+      content = if entry.key?("content_utf8")
+                  entry.fetch("content_utf8").encode(Encoding::UTF_8)
+                else
+                  entry.fetch("content_base64").unpack1("m0")
+                end
+      File.binwrite(path, content)
+    end
+    [workspace, fixture]
+  end
+
+  def write_lua_package(workspace, name, content, binary: false)
+    package_dir = workspace / "code" / "packages" / "lua" / name
+    package_dir.mkpath
+    File.write(package_dir / "BUILD", "echo building #{name}\n")
+    manifest = package_dir / "coding-adventures-#{name}-0.1.0-1.rockspec"
+    binary ? File.binwrite(manifest, content) : File.write(manifest, content, encoding: "UTF-8")
+    BuildTool::Package.new(
+      name: "lua/#{name}",
+      path: package_dir,
+      build_commands: ["echo building #{name}"],
+      language: "lua"
+    )
+  end
+
+  def graph_edges(graph)
+    graph.nodes.flat_map do |from|
+      graph.successors(from).map { |to| [from, to] }
+    end.sort
+  end
+
+  def expected_diagnostic
+    "METADATA_INVALID_UTF8: package=lua/pkg " \
+      "manifest=code/packages/lua/pkg/coding-adventures-pkg-0.1.0-1.rockspec " \
+      "encoding=UTF-8"
+  end
+end

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,9 +106,9 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-working inventory was regenerated on August 2, 2026 from `ec53a3f9` after the
-Perl build-tool branch was rebased onto current `origin/main`. The inventory
-contains 1,224 normalized implementation identities across 4,372 established-lane
+working inventory was regenerated on August 2, 2026 from `816bd31f` after the
+Ruby build-tool branch was rebased onto current `origin/main`. The inventory
+contains 1,225 normalized implementation identities across 4,373 established-lane
 package slots and found zero canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
@@ -116,15 +116,15 @@ package slots and found zero canonical collisions or unknown language buckets:
 | Present in 10-15 languages | 172 | 271 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 774 | 10,836 |
+| Present in one language | 775 | 10,850 |
 
-The loop must not start by attempting 10,836 singleton ports. It should finish
+The loop must not start by attempting 10,850 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The current working inventory on
-`ec53a3f9e9b2f31deefc43552a4d48658c49f3f4` is collision-clean at 1,224
-normalized implementation identities, 4,372 implementation slots, 172
-high-consensus packages, 271 high-consensus missing slots, 774 singletons, 579
+`816bd31f41bd21ce5bda30c1dfaac8b8b5102de0` is collision-clean at 1,225
+normalized implementation identities, 4,373 implementation slots, 172
+high-consensus packages, 271 high-consensus missing slots, 775 singletons, 580
 Rust singletons, zero canonical collisions, and zero unknown language buckets.
 The seventeen newest mixed Rust identities are `smart-home-camera-media`,
 `smart-home-onvif-integration`, `smart-home-shelly-integration`,
@@ -183,6 +183,15 @@ framing, epoch, and cryptographic core around explicit entropy, persistence,
 and key-custody boundaries. The latter has a reusable deterministic host-bridge
 contract around a Qt/Cairo/C++ native shell. Both now have explicit backlog
 owners; neither is treated as an unclassified blind all-language port.
+
+The `9bb12864` refresh also added `chief-of-staff-channel-store`. It is an
+authority-free orchestration layer over injected storage and cryptography:
+two-phase CAS reservation, crash recovery, nonce-safe abandoned gaps,
+idempotent encrypted records and grants, ordered paging, acknowledgements,
+and stable record errors are portable fixture candidates. Backend I/O,
+filesystem durability, key custody, entropy, and actor routing remain injected
+or native. A dedicated backlog owner depends on the channel-crypto vectors, so
+the new singleton is classified but is not eligible to preempt that dependency.
 
 This loop delivers only deterministic, authority-free package contracts and
 implementations. DNS/UDP/TCP/TLS, endpoint review, credentials and Vault,
@@ -260,7 +269,7 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
 - close the Ruby build tool's Starlark source-tree execution gaps. The Ruby
   UTF-8 validation found that a clean real plan cannot load the undeclared
   `coding_adventures_starlark_interpreter` runtime until repository library
-  paths are injected, after which recurring canonical Elixir, Go, and Rust
+  paths are injected, after which 44 canonical Elixir, Go, and Rust
   BUILD suffixes still produce parse warnings and raw-command fallback. Runtime
   closure and canonical BUILD compatibility are separate pending children so
   the metadata-decoding slice stays behaviorally narrow;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -246,13 +246,17 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   Ubuntu, macOS, Windows, and JavaScript/TypeScript CodeQL checks. Merged PR
   #9603 completed Lua with strict raw-byte validation, both shared fixtures,
   the stable repository-relative diagnostic, real CLI exit code 2, malformed
-  Unicode coverage, and green Ubuntu, macOS, and Windows checks. The selected
-  Ready-for-review PR #9632 is the Perl child because its raw-byte boundary is
-  the narrowest remaining resolver. Its security gate
+  Unicode coverage, and green Ubuntu, macOS, and Windows checks. Merged PR
+  #9632 completed Perl with strict decoding, exact success edges, typed stable
+  diagnostics, real CLI exit 2, malformed-sequence coverage, and green Ubuntu,
+  macOS, Windows, fixture, CI-gate, and CodeQL checks. Its security gate
   also discovered that the Perl build tool's `5.026` runtime floor and
   version-free core-module declarations do not produce an auditable clean
   dependency floor; that compatibility-policy review is logged as a separate
-  pending child instead of expanding the UTF-8 behavior slice;
+  pending child instead of expanding the UTF-8 behavior slice. Ruby, Haskell,
+  and Elixir are now explicit pending children; the post-merge leverage pass
+  ranks Ruby first because its locally available toolchain and direct
+  locale-sensitive read form the narrowest remaining boundary;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -257,6 +257,13 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   and Elixir are now explicit pending children; the post-merge leverage pass
   ranks Ruby first because its locally available toolchain and direct
   locale-sensitive read form the narrowest remaining boundary;
+- close the Ruby build tool's Starlark source-tree execution gaps. The Ruby
+  UTF-8 validation found that a clean real plan cannot load the undeclared
+  `coding_adventures_starlark_interpreter` runtime until repository library
+  paths are injected, after which recurring canonical Elixir, Go, and Rust
+  BUILD suffixes still produce parse warnings and raw-command fallback. Runtime
+  closure and canonical BUILD compatibility are separate pending children so
+  the metadata-decoding slice stays behaviorally narrow;
 - make the TypeScript build-tool git-diff suite portable on Windows. The strict-
   UTF-8 validation run found two hard-coded `/bin/sh` invocations and five
   POSIX-only `/repo` path fixtures. Merged PR #9592 is the completed slice: it

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -262,10 +262,10 @@ Remaining inventory/build-integrity work discovered in the July 29 audit:
   also discovered that the Perl build tool's `5.026` runtime floor and
   version-free core-module declarations do not produce an auditable clean
   dependency floor; that compatibility-policy review is logged as a separate
-  pending child instead of expanding the UTF-8 behavior slice. Ruby, Haskell,
-  and Elixir are now explicit pending children; the post-merge leverage pass
-  ranks Ruby first because its locally available toolchain and direct
-  locale-sensitive read form the narrowest remaining boundary;
+  pending child instead of expanding the UTF-8 behavior slice. Ready-for-review
+  PR #9648 owns the Ruby child with strict byte decoding, typed stable
+  diagnostics, the exact shared fixtures, and real CLI exit 2. Haskell and
+  Elixir remain pending until that sole active parity PR merges;
 - close the Ruby build tool's Starlark source-tree execution gaps. The Ruby
   UTF-8 validation found that a clean real plan cannot load the undeclared
   `coding_adventures_starlark_interpreter` runtime until repository library


### PR DESCRIPTION
## Summary
- read Lua rockspec metadata as raw bytes and require strict UTF-8 before dependency parsing
- raise typed `METADATA_INVALID_UTF8` failures with package and repository-relative manifest identity, and map the real CLI failure to stable stderr plus exit 2
- consume the shared valid/non-ASCII and malformed-byte fixtures, including literal U+FFFD and five malformed-sequence classes
- refresh the parity state/roadmap, including separately owned Ruby Starlark closure/compatibility debt and the newly discovered Chief encrypted channel-store parity item

## Validation
- `bundle exec rake test`: 296 runs, 585 assertions, 0 failures/errors, 2 existing skips; 87.41% line and 72.05% branch coverage
- Ruby syntax checks: `build.rb`, `resolver.rb`, and `test_resolution_utf8.rb`
- changed-file RuboCop `Lint,Security`: 3 files, no offenses
- `bundle audit check`: no vulnerabilities; `bundle outdated --strict`: bundle up to date
- canonical Go build tool: `go test ./...`, `go vet ./...`, trimpath build, and 300-package Ruby BUILD validation
- shared conformance: 17 schema tests, 40 runner tests, and the valid 37-case / 56-file corpus across 15 established languages, 16 implementations, and 12 front doors
- real Ruby build-tool Lua plan: 258 packages, 382 dependency edges, exit 0; 44 repeatable canonical Starlark parse fallbacks are separately backlogged
- collision inventory: 1,225 identities / 4,373 slots, 172 high-consensus packages / 271 missing slots, 775 singletons / 580 Rust singletons, 0 collisions, 0 unknown buckets
- `git diff --check`, state graph validation, changed-path audit, and added credential-assignment scan