### PR TITLE
feat(sir-c): Array mutation + 1-arg query methods (Collections slice 4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 0.26.0 — Collections slice 4: Array mutation + 1-arg query methods
+
+`push`/`pop`/`shift` are the FIRST Array methods that mutate the receiver
+after construction. No new `Feature`.
+
+- `push(v1, v2, ...)` appends one or more values (each call reallocates a
+  fresh buffer sized to the exact new length — no `cap` field added to the
+  shared `SirSeq` struct, which would have required auditing every existing
+  `_sir_alloc(sizeof(SirSeq))` call site for an amortized-growth win this v0
+  runtime doesn't need); `pop`/`shift` remove and return the last/first
+  element (`nil` on empty, matching Ruby), mutating `len` in place with no
+  reallocation (`shift` also shifts the remaining elements down). All three
+  mutate the EXISTING `SirSeq` box, like `SeqSet` — every binding sharing the
+  array sees the change.
+- New 1-arg query methods: `fetch(i)` (like `a[i]` but RAISES `IndexError`
+  out of range, instead of returning nil), `values_at(i0, i1, ...)` (a fresh
+  array of the elements at each index, nil-on-OOB per index), `rotate(n = 1)`
+  (a fresh array shifted left by `n`, negative rotates right, never mutates
+  the receiver), `zip(other1, other2, ...)` (a fresh array of arrays pairing
+  elements positionally, padding a shorter `other` with nil). `include?` and
+  `index` (both already allowlisted for String since slice 2) widen to accept
+  an Array receiver too.
+- **Security retrofit**: `push` is the first operation that can change
+  `SirSeq.len`/`.items` AFTER a block-taking helper (slice 3/5's `map`/
+  `select`/`reject`/`sort_by`/`each`/`any?`/`all?`/`none?`/`each_with_index`/
+  `reduce`/`inject`, plus `count`'s block form) has already started iterating
+  — e.g. `arr.map { |x| arr.push(x); x }`. Every such helper now snapshots
+  `s->len` into a local ONCE before its loop/allocation and uses that
+  snapshot (never `s->len` directly) as both the output-buffer size and the
+  loop bound, so a block that grows or shrinks the receiver mid-iteration
+  can't run unbounded or write past a buffer sized at the OLD length. Since
+  this arena never frees, a stale snapshot pointer stays valid even after a
+  `push` reallocates — the same "iterate a snapshot" convention
+  `_sir_seq_iter` (`ForEach`) already uses. Pinned by two new tests: `each`
+  pushing to its own receiver terminates instead of looping forever, and
+  `map` pushing to its own receiver returns output reflecting only the
+  original elements (not a heap overflow).
+
+**Anti-RCE preserved:** the method name is a compiler-emitted quoted C literal
+used only as a `strcmp` target — never reflection.
+
+**Out of scope:** `<<` (Ruby's shove/append operator) is NOT implemented
+here — `ruby-to-semantic-ir` has no grammar rule for `<<` as a binary infix
+operator at all yet (a separate, pre-existing frontend gap, found while
+fixing the comparison-in-block-tail-position bug), so `a << x` can't reach
+`__method__` to dispatch to `push` regardless. `arr.push(x)` (an ordinary
+dot-call) is unaffected and fully supported.
+
 ## 0.25.0 — Collections slice 5: Array block methods (closure-calling)
 
 The first Collections slice covering methods that take a trailing **block**

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -22,21 +22,40 @@ after construction. No new `Feature`.
   elements positionally, padding a shorter `other` with nil). `include?` and
   `index` (both already allowlisted for String since slice 2) widen to accept
   an Array receiver too.
-- **Security retrofit**: `push` is the first operation that can change
-  `SirSeq.len`/`.items` AFTER a block-taking helper (slice 3/5's `map`/
-  `select`/`reject`/`sort_by`/`each`/`any?`/`all?`/`none?`/`each_with_index`/
-  `reduce`/`inject`, plus `count`'s block form) has already started iterating
-  — e.g. `arr.map { |x| arr.push(x); x }`. Every such helper now snapshots
-  `s->len` into a local ONCE before its loop/allocation and uses that
-  snapshot (never `s->len` directly) as both the output-buffer size and the
-  loop bound, so a block that grows or shrinks the receiver mid-iteration
-  can't run unbounded or write past a buffer sized at the OLD length. Since
-  this arena never frees, a stale snapshot pointer stays valid even after a
-  `push` reallocates — the same "iterate a snapshot" convention
-  `_sir_seq_iter` (`ForEach`) already uses. Pinned by two new tests: `each`
-  pushing to its own receiver terminates instead of looping forever, and
-  `map` pushing to its own receiver returns output reflecting only the
-  original elements (not a heap overflow).
+- **Security retrofit** (two rounds; see below): `push` is the first
+  operation that can change `SirSeq.len`/`.items` AFTER a block-taking helper
+  (slice 3/5's `map`/`select`/`reject`/`sort_by`/`each`/`any?`/`all?`/`none?`/
+  `each_with_index`/`reduce`/`inject`, plus `count`'s block form) has already
+  started iterating — e.g. `arr.map { |x| arr.push(x); x }`. Every such
+  helper now snapshots BOTH `s->len` AND `s->items` into locals ONCE before
+  its loop/allocation and uses only those locals — never `s->len`/`s->items`
+  directly — for the output-buffer size and every element read, so a block
+  that mutates the receiver mid-iteration can't run unbounded, read/write
+  past a buffer sized at the OLD length, or read past a buffer `push`
+  reallocated smaller than an outer snapshot (see below). Since this arena
+  never frees, a snapshotted buffer stays valid indefinitely regardless of
+  what `s->items` is reassigned to afterward — the same "iterate a snapshot"
+  convention `_sir_seq_iter` (`ForEach`) already uses.
+
+  Security review round 1 caught that snapshotting `s->len` ALONE (the
+  initial draft) is insufficient in two ways, both now fixed:
+  1. The `count` block-form arm (added in slice 5, before `push` existed)
+     was missed by the retrofit entirely — a block that pushes to its own
+     receiver inside `arr.count { |x| ... }` never terminated (unbounded
+     loop + unbounded reallocation, a real DoS/OOM).
+  2. `push` reallocates its new buffer sized to the CURRENT (live) `s->len`;
+     if a block first shrinks the receiver (`pop`/`shift`, in place, no
+     reallocation) and THEN pushes, the fresh buffer is smaller than a `len`
+     an outer helper already snapshotted — continuing to read the LIVE
+     `s->items` up to that stale, larger count then reads past the new,
+     smaller allocation (a genuine heap out-of-bounds read). Fixed by
+     snapshotting the ITEMS POINTER too, not just the length (see above).
+
+  Pinned by four tests: `each`/`count` pushing to their own receiver
+  terminate instead of looping forever; `map` pushing to its own receiver
+  returns output reflecting only the original elements (not a heap
+  overflow); and a receiver shrunk-then-regrown mid-`each` still yields the
+  ORIGINAL snapshotted elements without over-reading.
 
 **Anti-RCE preserved:** the method name is a compiler-emitted quoted C literal
 used only as a `strcmp` target — never reflection.

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -170,9 +170,12 @@ that mutate a `SirSeq` after construction (`push` reallocates to grow,
 `pop`/`shift` shrink `len` in place) — plus `fetch`/`values_at`/`rotate`/
 `zip`, and `include?`/`index` widen to accept an Array alongside their
 slice-2 String forms.  Because a block can now grow/shrink the very receiver
-it's iterating, every block-taking helper (slice 3/5) snapshots the array's
-length once before its loop/allocation instead of re-reading it — the same
-"iterate a snapshot" convention `_sir_seq_iter`'s `ForEach` already uses.  A
+it's iterating, every block-taking helper (slice 3/5) snapshots BOTH the
+array's length AND its items pointer once before its loop/allocation instead
+of re-reading either — length alone isn't enough, since `push` reallocates
+relative to the CURRENT length, which can be smaller than an outer snapshot
+after a `pop`/`shift` — the same "iterate a snapshot" convention
+`_sir_seq_iter`'s `ForEach` already uses.  A
 wrong-type receiver or argument raises `NoMethodError`; a built-in method not
 lowered yet is still rejected cleanly.
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -164,7 +164,15 @@ instead of overflowing the stack; **slice 5** (Array block methods): `each`,
 `each_with_index`, `reduce`/`inject` — the block the Ruby frontend appends as
 the trailing `__method__` arg reaches this runtime as an ordinary `SIR_CLOSURE`
 value, so each element-wise call goes through the SAME `_sir_apply` a
-first-class closure call already uses (no new calling convention).  A
+first-class closure call already uses (no new calling convention); **slice 4**
+(Array mutation + 1-arg queries): `push`/`pop`/`shift` — the FIRST methods
+that mutate a `SirSeq` after construction (`push` reallocates to grow,
+`pop`/`shift` shrink `len` in place) — plus `fetch`/`values_at`/`rotate`/
+`zip`, and `include?`/`index` widen to accept an Array alongside their
+slice-2 String forms.  Because a block can now grow/shrink the very receiver
+it's iterating, every block-taking helper (slice 3/5) snapshots the array's
+length once before its loop/allocation instead of re-reading it — the same
+"iterate a snapshot" convention `_sir_seq_iter`'s `ForEach` already uses.  A
 wrong-type receiver or argument raises `NoMethodError`; a built-in method not
 lowered yet is still rejected cleanly.
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1763,10 +1763,12 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// widens to accept an Array receiver too, alongside its slice-1 String arm);
 /// slice 5 = Array methods taking a trailing BLOCK argument (`each`/`map`/
 /// `select`/`reject`/`any?`/`all?`/`none?`/`sort_by`/`each_with_index`/
-/// `reduce`/`inject`; `count` also widens to accept its block form). The
-/// dispatcher raises `NoMethodError` on an unsupported receiver type or a
-/// malformed call (missing/extra args, a non-closure block position),
-/// matching Ruby.
+/// `reduce`/`inject`; `count` also widens to accept its block form); slice 4
+/// = Array mutation (`push`/`pop`/`shift`) + 1-arg query methods (`fetch`/
+/// `values_at`/`rotate`/`zip`; `include?`/`index` widen to accept an Array
+/// receiver alongside their slice-2 String arms). The dispatcher raises
+/// `NoMethodError` on an unsupported receiver type or a malformed call
+/// (missing/extra args, a non-closure block position), matching Ruby.
 fn is_builtin_method(name: &str) -> bool {
     matches!(
         name,
@@ -1780,6 +1782,8 @@ fn is_builtin_method(name: &str) -> bool {
         // slice 5 — Array block methods
         | "each" | "map" | "select" | "reject" | "any?" | "all?" | "none?"
         | "sort_by" | "each_with_index" | "reduce" | "inject"
+        // slice 4 — Array mutation + 1-arg query methods
+        | "push" | "pop" | "shift" | "fetch" | "values_at" | "rotate" | "zip"
     )
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1586,63 +1586,76 @@ static SirValue _sir_array_flatten(SirValue recv) {
 /* SECURITY (retrofitted for slice 4's `push`/`pop`/`shift`, which made
  * `SirSeq.items`/`.len` MUTABLE after construction — see `_sir_array_push`/
  * `_sir_array_pop`/`_sir_array_shift` below): every helper here that invokes
- * a block MUST snapshot `s->len` into a local (`n`) ONCE, before its loop,
- * and use `n` — never `s->len` directly — as both the output-buffer size and
- * the loop bound. If the block mutates the RECEIVER mid-iteration (e.g.
- * `arr.each { |x| arr.push(x) }`), a loop that re-read `s->len` fresh each
- * iteration could keep growing (unbounded work) or, worse, run PAST an
- * output buffer that was already allocated at the OLD (smaller) length —
- * an out-of-bounds write. Reading `s->items[i]` for `i < n` stays safe
- * regardless of what happens to `s->items`/`s->len` afterward: this arena
- * never frees, so even a `push`-triggered reallocation leaves the OLD
- * buffer's memory valid (just superseded) — `n` simply pins the iteration to
- * a consistent snapshot, the same convention `_sir_seq_iter` already uses
- * for `ForEach`. */
+ * a block MUST snapshot BOTH `s->len` AND `s->items` into locals (`n`/
+ * `items`) ONCE, before its loop, and use ONLY those locals — never
+ * `s->len`/`s->items` directly — for the output-buffer size and every
+ * element read. Snapshotting `len` alone is NOT enough: `push` reallocates
+ * its NEW buffer sized to the CURRENT (live) `s->len`, so if a block first
+ * shrinks the receiver (`pop`/`shift`, in place, no reallocation) and THEN
+ * pushes, the fresh buffer `push` allocates is sized to the SHRUNK length —
+ * smaller than a `len` this helper already snapshotted before the block ran.
+ * Continuing to read the LIVE `s->items[i]` for `i` up to the stale, larger
+ * `n` would then run past that fresh (smaller) allocation — a heap
+ * out-of-bounds read (caught by security review; a real, exploitable gap in
+ * an earlier draft of this fix that only snapshotted `len`). Snapshotting
+ * the ITEMS POINTER too closes it: `items[i]` for `i < n` always reads the
+ * buffer that existed AT SNAPSHOT TIME, which `push`'s copy-then-append
+ * preserves byte-for-byte at indices `0..old_len-1` — and since this arena
+ * never frees, that original buffer stays validly allocated for the whole
+ * loop regardless of what `s->items` is reassigned to afterward. Matches the
+ * "iterate a snapshot" convention `_sir_seq_iter` already uses for
+ * `ForEach`. */
 
 static SirValue _sir_array_each(SirSeq *s, SirValue block) {
     int64_t n = s->len;
-    for (int64_t i = 0; i < n; i++) _sir_apply(block, 1, s->items[i]);
+    SirValue *items = s->items;
+    for (int64_t i = 0; i < n; i++) _sir_apply(block, 1, items[i]);
     return _sir_seq_wrap(s);  /* Array#each returns the receiver */
 }
 static SirValue _sir_array_map(SirSeq *s, SirValue block) {
     int64_t n = s->len;
+    SirValue *items = s->items;
     SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
     r->len = n;
     r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
-    for (int64_t i = 0; i < n; i++) r->items[i] = _sir_apply(block, 1, s->items[i]);
+    for (int64_t i = 0; i < n; i++) r->items[i] = _sir_apply(block, 1, items[i]);
     return _sir_seq_wrap(r);
 }
 /* Shared by `select` (keep_if_truthy=1) and `reject` (keep_if_truthy=0). */
 static SirValue _sir_array_filter(SirSeq *s, SirValue block, int keep_if_truthy) {
     int64_t n = s->len;
+    SirValue *items = s->items;
     SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
     r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
     int64_t k = 0;
     for (int64_t i = 0; i < n; i++) {
-        int truthy = _sir_truthy(_sir_apply(block, 1, s->items[i]));
-        if (truthy == keep_if_truthy) r->items[k++] = s->items[i];
+        int truthy = _sir_truthy(_sir_apply(block, 1, items[i]));
+        if (truthy == keep_if_truthy) r->items[k++] = items[i];
     }
     r->len = k;
     return _sir_seq_wrap(r);
 }
 static SirValue _sir_array_any(SirSeq *s, SirValue block) {
     int64_t n = s->len;
+    SirValue *items = s->items;
     for (int64_t i = 0; i < n; i++) {
-        if (_sir_truthy(_sir_apply(block, 1, s->items[i]))) return _sir_bool(1);
+        if (_sir_truthy(_sir_apply(block, 1, items[i]))) return _sir_bool(1);
     }
     return _sir_bool(0);
 }
 static SirValue _sir_array_all(SirSeq *s, SirValue block) {
     int64_t n = s->len;
+    SirValue *items = s->items;
     for (int64_t i = 0; i < n; i++) {
-        if (!_sir_truthy(_sir_apply(block, 1, s->items[i]))) return _sir_bool(0);
+        if (!_sir_truthy(_sir_apply(block, 1, items[i]))) return _sir_bool(0);
     }
     return _sir_bool(1);
 }
 static SirValue _sir_array_none(SirSeq *s, SirValue block) {
     int64_t n = s->len;
+    SirValue *items = s->items;
     for (int64_t i = 0; i < n; i++) {
-        if (_sir_truthy(_sir_apply(block, 1, s->items[i]))) return _sir_bool(0);
+        if (_sir_truthy(_sir_apply(block, 1, items[i]))) return _sir_bool(0);
     }
     return _sir_bool(1);
 }
@@ -1653,13 +1666,14 @@ static SirValue _sir_array_none(SirSeq *s, SirValue block) {
  * the new order. */
 static SirValue _sir_array_sort_by(SirSeq *s, SirValue block) {
     int64_t n = s->len;
+    SirValue *items = s->items;
     SirValue *keys = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
     SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
     r->len = n;
     r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
     for (int64_t i = 0; i < n; i++) {
-        keys[i] = _sir_apply(block, 1, s->items[i]);
-        r->items[i] = s->items[i];
+        keys[i] = _sir_apply(block, 1, items[i]);
+        r->items[i] = items[i];
     }
     for (int64_t i = 1; i < n; i++) {
         SirValue key = keys[i], val = r->items[i];
@@ -1676,7 +1690,8 @@ static SirValue _sir_array_sort_by(SirSeq *s, SirValue block) {
 }
 static SirValue _sir_array_each_with_index(SirSeq *s, SirValue block) {
     int64_t n = s->len;
-    for (int64_t i = 0; i < n; i++) _sir_apply(block, 2, s->items[i], _sir_int(i));
+    SirValue *items = s->items;
+    for (int64_t i = 0; i < n; i++) _sir_apply(block, 2, items[i], _sir_int(i));
     return _sir_seq_wrap(s);
 }
 /* `reduce`/`inject`: `argc==1` is block-only (Ruby seeds the accumulator with
@@ -1686,6 +1701,7 @@ static SirValue _sir_array_each_with_index(SirSeq *s, SirValue block) {
  * the block (the caller already checked it's a closure before calling in). */
 static SirValue _sir_array_reduce(SirSeq *s, int argc, SirValue *args) {
     int64_t n = s->len;
+    SirValue *items = s->items;
     SirValue block = args[argc - 1];
     SirValue acc;
     int64_t start;
@@ -1694,10 +1710,10 @@ static SirValue _sir_array_reduce(SirSeq *s, int argc, SirValue *args) {
         start = 0;
     } else {
         if (n == 0) return _sir_nil();
-        acc = s->items[0];
+        acc = items[0];
         start = 1;
     }
-    for (int64_t i = start; i < n; i++) acc = _sir_apply(block, 2, acc, s->items[i]);
+    for (int64_t i = start; i < n; i++) acc = _sir_apply(block, 2, acc, items[i]);
     return acc;
 }
 
@@ -1857,9 +1873,16 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         if (recv.tag == SIR_SEQ) {
             if (argc == 0) return _sir_int(recv.as.seq->len);
             if (argc == 1 && args[0].tag == SIR_CLOSURE) {
+                /* SECURITY (slice 4): snapshot len/items BEFORE the loop, like
+                   every other block-taking helper -- see the doc comment on
+                   the slice-5 helpers above. `push` (slice 4) can grow this
+                   same receiver from inside the block; a live `recv.as.seq->
+                   len` read in the loop condition would never terminate. */
+                int64_t cnt_len = recv.as.seq->len;
+                SirValue *cnt_items = recv.as.seq->items;
                 int64_t n = 0;
-                for (int64_t i = 0; i < recv.as.seq->len; i++) {
-                    if (_sir_truthy(_sir_apply(args[0], 1, recv.as.seq->items[i]))) n++;
+                for (int64_t i = 0; i < cnt_len; i++) {
+                    if (_sir_truthy(_sir_apply(args[0], 1, cnt_items[i]))) n++;
                 }
                 return _sir_int(n);
             }

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1583,23 +1583,42 @@ static SirValue _sir_array_flatten(SirValue recv) {
  * `Proc`/`sir_apply(f, ...)` call already uses — so a block is called
  * exactly like any other closure value; no new calling convention. */
 
+/* SECURITY (retrofitted for slice 4's `push`/`pop`/`shift`, which made
+ * `SirSeq.items`/`.len` MUTABLE after construction — see `_sir_array_push`/
+ * `_sir_array_pop`/`_sir_array_shift` below): every helper here that invokes
+ * a block MUST snapshot `s->len` into a local (`n`) ONCE, before its loop,
+ * and use `n` — never `s->len` directly — as both the output-buffer size and
+ * the loop bound. If the block mutates the RECEIVER mid-iteration (e.g.
+ * `arr.each { |x| arr.push(x) }`), a loop that re-read `s->len` fresh each
+ * iteration could keep growing (unbounded work) or, worse, run PAST an
+ * output buffer that was already allocated at the OLD (smaller) length —
+ * an out-of-bounds write. Reading `s->items[i]` for `i < n` stays safe
+ * regardless of what happens to `s->items`/`s->len` afterward: this arena
+ * never frees, so even a `push`-triggered reallocation leaves the OLD
+ * buffer's memory valid (just superseded) — `n` simply pins the iteration to
+ * a consistent snapshot, the same convention `_sir_seq_iter` already uses
+ * for `ForEach`. */
+
 static SirValue _sir_array_each(SirSeq *s, SirValue block) {
-    for (int64_t i = 0; i < s->len; i++) _sir_apply(block, 1, s->items[i]);
+    int64_t n = s->len;
+    for (int64_t i = 0; i < n; i++) _sir_apply(block, 1, s->items[i]);
     return _sir_seq_wrap(s);  /* Array#each returns the receiver */
 }
 static SirValue _sir_array_map(SirSeq *s, SirValue block) {
+    int64_t n = s->len;
     SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
-    r->len = s->len;
-    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
-    for (int64_t i = 0; i < s->len; i++) r->items[i] = _sir_apply(block, 1, s->items[i]);
+    r->len = n;
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    for (int64_t i = 0; i < n; i++) r->items[i] = _sir_apply(block, 1, s->items[i]);
     return _sir_seq_wrap(r);
 }
 /* Shared by `select` (keep_if_truthy=1) and `reject` (keep_if_truthy=0). */
 static SirValue _sir_array_filter(SirSeq *s, SirValue block, int keep_if_truthy) {
+    int64_t n = s->len;
     SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
-    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
     int64_t k = 0;
-    for (int64_t i = 0; i < s->len; i++) {
+    for (int64_t i = 0; i < n; i++) {
         int truthy = _sir_truthy(_sir_apply(block, 1, s->items[i]));
         if (truthy == keep_if_truthy) r->items[k++] = s->items[i];
     }
@@ -1607,19 +1626,22 @@ static SirValue _sir_array_filter(SirSeq *s, SirValue block, int keep_if_truthy)
     return _sir_seq_wrap(r);
 }
 static SirValue _sir_array_any(SirSeq *s, SirValue block) {
-    for (int64_t i = 0; i < s->len; i++) {
+    int64_t n = s->len;
+    for (int64_t i = 0; i < n; i++) {
         if (_sir_truthy(_sir_apply(block, 1, s->items[i]))) return _sir_bool(1);
     }
     return _sir_bool(0);
 }
 static SirValue _sir_array_all(SirSeq *s, SirValue block) {
-    for (int64_t i = 0; i < s->len; i++) {
+    int64_t n = s->len;
+    for (int64_t i = 0; i < n; i++) {
         if (!_sir_truthy(_sir_apply(block, 1, s->items[i]))) return _sir_bool(0);
     }
     return _sir_bool(1);
 }
 static SirValue _sir_array_none(SirSeq *s, SirValue block) {
-    for (int64_t i = 0; i < s->len; i++) {
+    int64_t n = s->len;
+    for (int64_t i = 0; i < n; i++) {
         if (_sir_truthy(_sir_apply(block, 1, s->items[i]))) return _sir_bool(0);
     }
     return _sir_bool(1);
@@ -1630,15 +1652,16 @@ static SirValue _sir_array_none(SirSeq *s, SirValue block) {
  * `_sir_lt` -- the SAME comparator plain `sort` uses -- and return the values in
  * the new order. */
 static SirValue _sir_array_sort_by(SirSeq *s, SirValue block) {
-    SirValue *keys = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
+    int64_t n = s->len;
+    SirValue *keys = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
     SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
-    r->len = s->len;
-    r->items = (s->len > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)s->len) : NULL;
-    for (int64_t i = 0; i < s->len; i++) {
+    r->len = n;
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    for (int64_t i = 0; i < n; i++) {
         keys[i] = _sir_apply(block, 1, s->items[i]);
         r->items[i] = s->items[i];
     }
-    for (int64_t i = 1; i < r->len; i++) {
+    for (int64_t i = 1; i < n; i++) {
         SirValue key = keys[i], val = r->items[i];
         int64_t j = i - 1;
         while (j >= 0 && _sir_truthy(_sir_lt(key, keys[j]))) {
@@ -1652,7 +1675,8 @@ static SirValue _sir_array_sort_by(SirSeq *s, SirValue block) {
     return _sir_seq_wrap(r);
 }
 static SirValue _sir_array_each_with_index(SirSeq *s, SirValue block) {
-    for (int64_t i = 0; i < s->len; i++) _sir_apply(block, 2, s->items[i], _sir_int(i));
+    int64_t n = s->len;
+    for (int64_t i = 0; i < n; i++) _sir_apply(block, 2, s->items[i], _sir_int(i));
     return _sir_seq_wrap(s);
 }
 /* `reduce`/`inject`: `argc==1` is block-only (Ruby seeds the accumulator with
@@ -1661,6 +1685,7 @@ static SirValue _sir_array_each_with_index(SirSeq *s, SirValue block) {
  * just returns `initial` untouched, matching Ruby). `args[argc-1]` is always
  * the block (the caller already checked it's a closure before calling in). */
 static SirValue _sir_array_reduce(SirSeq *s, int argc, SirValue *args) {
+    int64_t n = s->len;
     SirValue block = args[argc - 1];
     SirValue acc;
     int64_t start;
@@ -1668,12 +1693,125 @@ static SirValue _sir_array_reduce(SirSeq *s, int argc, SirValue *args) {
         acc = args[argc - 2];
         start = 0;
     } else {
-        if (s->len == 0) return _sir_nil();
+        if (n == 0) return _sir_nil();
         acc = s->items[0];
         start = 1;
     }
-    for (int64_t i = start; i < s->len; i++) acc = _sir_apply(block, 2, acc, s->items[i]);
+    for (int64_t i = start; i < n; i++) acc = _sir_apply(block, 2, acc, s->items[i]);
     return acc;
+}
+
+/* ---- Collections slice 4: Array mutation (push/<</pop/shift) + 1-arg
+ * query methods -----------------------------------------------------------
+ *
+ * `push`/`<<` are the FIRST operations that grow a `SirSeq` after
+ * construction. Each call reallocates a fresh buffer sized to the exact new
+ * length (no spare capacity tracked) rather than adding a `cap` field to the
+ * shared `SirSeq` struct — that would require auditing and updating every
+ * existing `_sir_alloc(sizeof(SirSeq))` call site (uninitialized-`cap` risk
+ * for any missed one) for an amortized-growth win this v0 runtime doesn't
+ * need; O(n) per push matches the rest of this backend's "correctness over
+ * micro-perf" stance (see `sort`'s insertion sort, `sort_by`'s Schwartzian
+ * transform). `pop`/`shift` mutate `len` (and, for `shift`, shift elements
+ * down) IN PLACE with no reallocation. All three mutate the EXISTING SirSeq
+ * box, like `SeqSet` — every binding sharing this array sees the change. */
+static void _sir_array_push_one(SirSeq *s, SirValue v) {
+    SirValue *ni = (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)(s->len + 1));
+    for (int64_t i = 0; i < s->len; i++) ni[i] = s->items[i];
+    ni[s->len] = v;
+    s->items = ni;
+    s->len++;
+}
+static SirValue _sir_array_pop(SirSeq *s) {
+    if (s->len == 0) return _sir_nil();
+    SirValue v = s->items[s->len - 1];
+    s->len--;
+    return v;
+}
+static SirValue _sir_array_shift(SirSeq *s) {
+    if (s->len == 0) return _sir_nil();
+    SirValue v = s->items[0];
+    for (int64_t i = 1; i < s->len; i++) s->items[i - 1] = s->items[i];
+    s->len--;
+    return v;
+}
+static SirValue _sir_array_include(SirSeq *s, SirValue needle) {
+    int64_t n = s->len;
+    for (int64_t i = 0; i < n; i++) {
+        if (_sir_value_eq(s->items[i], needle)) return _sir_bool(1);
+    }
+    return _sir_bool(0);
+}
+static SirValue _sir_array_index(SirSeq *s, SirValue needle) {
+    int64_t n = s->len;
+    for (int64_t i = 0; i < n; i++) {
+        if (_sir_value_eq(s->items[i], needle)) return _sir_int(i);
+    }
+    return _sir_nil();
+}
+/* `fetch(i)` — like `a[i]` but RAISES on an out-of-range index instead of
+ * returning nil (matching Ruby's `Array#fetch`, and this backend's
+ * `_sir_seq_set`, which already traps rather than silently no-ops). Supports
+ * the same negative-from-end indexing `_sir_seq_index` does. */
+static SirValue _sir_array_fetch(SirSeq *s, SirValue idx) {
+    int64_t n = s->len;
+    int64_t i = _sir_as_int(idx);
+    if (i < 0) i += n;
+    if (i < 0 || i >= n) {
+        return _sir_raise(_sir_error("IndexError", _sir_str("index out of range")));
+    }
+    return s->items[i];
+}
+/* `values_at(i0, i1, ...)` — a fresh array of the elements at each given
+ * index (each independently negative-from-end and nil-on-OOB, exactly like
+ * `_sir_seq_index`, NOT `fetch`'s raising form — matching Ruby). */
+static SirValue _sir_array_values_at(SirSeq *s, int argc, SirValue *args) {
+    SirValue seq_val = _sir_seq_wrap(s);
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = argc;
+    r->items = (argc > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)argc) : NULL;
+    for (int i = 0; i < argc; i++) r->items[i] = _sir_seq_index(seq_val, args[i]);
+    return _sir_seq_wrap(r);
+}
+/* `rotate(n = 1)` — a FRESH array with elements shifted left by `n`
+ * (negative `n` rotates right), matching Ruby (never mutates the
+ * receiver). `n` is reduced modulo the length first (Ruby allows any
+ * magnitude); an empty array rotates to itself. */
+static SirValue _sir_array_rotate(SirSeq *s, int64_t by) {
+    int64_t n = s->len;
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = n;
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    if (n > 0) {
+        int64_t k = ((by % n) + n) % n;  /* normalise to [0, n) even for negative `by` */
+        for (int64_t i = 0; i < n; i++) r->items[i] = s->items[(i + k) % n];
+    }
+    return _sir_seq_wrap(r);
+}
+/* `zip(other1, other2, ...)` — a fresh array of arrays, pairing `self[i]`
+ * with each `otherN[i]`; a shorter `other` pads with nil past its own
+ * length (matching Ruby). Non-Array `other` arguments are treated as
+ * length-0 (every pairing position is nil), the same lenient-nil-on-OOB
+ * convention `_sir_seq_index` already uses for a non-sequence. */
+static SirValue _sir_array_zip(SirSeq *s, int argc, SirValue *args) {
+    int64_t n = s->len;
+    SirSeq *r = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    r->len = n;
+    r->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    for (int64_t i = 0; i < n; i++) {
+        SirSeq *row = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+        row->len = argc + 1;
+        row->items = (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)(argc + 1));
+        row->items[0] = s->items[i];
+        for (int a = 0; a < argc; a++) {
+            SirValue other = args[a];
+            row->items[a + 1] = (other.tag == SIR_SEQ && i < other.as.seq->len)
+                ? other.as.seq->items[i]
+                : _sir_nil();
+        }
+        r->items[i] = _sir_seq_wrap(row);
+    }
+    return _sir_seq_wrap(r);
 }
 
 /* ---- Collections slice 1: built-in String methods --------------------------
@@ -1787,10 +1925,34 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
         if (recv.tag == SIR_SEQ && argc >= 1 && argc <= 2 && args[argc - 1].tag == SIR_CLOSURE)
             return _sir_array_reduce(recv.as.seq, argc, args);
     }
-    /* Collections slice 2: 1-arg String queries (arg is a String). */
+    /* Collections slice 4: Array mutation + 1-arg query methods. */
+    else if (strcmp(m, "push") == 0) {
+        if (recv.tag == SIR_SEQ) {
+            for (int i = 0; i < argc; i++) _sir_array_push_one(recv.as.seq, args[i]);
+            return recv;  /* Array#push returns the (mutated) receiver */
+        }
+    } else if (strcmp(m, "pop") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 0) return _sir_array_pop(recv.as.seq);
+    } else if (strcmp(m, "shift") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 0) return _sir_array_shift(recv.as.seq);
+    } else if (strcmp(m, "fetch") == 0) {
+        if (recv.tag == SIR_SEQ && argc == 1) return _sir_array_fetch(recv.as.seq, args[0]);
+    } else if (strcmp(m, "values_at") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_array_values_at(recv.as.seq, argc, args);
+    } else if (strcmp(m, "rotate") == 0) {
+        if (recv.tag == SIR_SEQ) {
+            int64_t by = (argc >= 1) ? _sir_as_int(args[0]) : 1;
+            return _sir_array_rotate(recv.as.seq, by);
+        }
+    } else if (strcmp(m, "zip") == 0) {
+        if (recv.tag == SIR_SEQ) return _sir_array_zip(recv.as.seq, argc, args);
+    }
+    /* Collections slice 2: 1-arg String queries (arg is a String); slice 4
+       widens `include?`/`index` to accept an Array receiver too. */
     else if (strcmp(m, "include?") == 0) {
         if (recv.tag == SIR_STR && argc >= 1 && args[0].tag == SIR_STR)
             return _sir_bool(strstr(recv.as.s, args[0].as.s) != NULL);
+        if (recv.tag == SIR_SEQ && argc >= 1) return _sir_array_include(recv.as.seq, args[0]);
     } else if (strcmp(m, "start_with?") == 0) {
         if (recv.tag == SIR_STR && argc >= 1 && args[0].tag == SIR_STR) {
             size_t pl = strlen(args[0].as.s);
@@ -1806,6 +1968,7 @@ static SirValue _sir_builtin_method_v(SirValue recv, const char *m, int argc, Si
             const char *p = strstr(recv.as.s, args[0].as.s);
             return p ? _sir_int((int64_t)(p - recv.as.s)) : _sir_nil();
         }
+        if (recv.tag == SIR_SEQ && argc >= 1) return _sir_array_index(recv.as.seq, args[0]);
     }
     return _sir_raise(
         _sir_error("NoMethodError", _sir_str(_sir_cat("undefined method ", m))));

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_mutation_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_mutation_methods.rs
@@ -220,3 +220,34 @@ fn array_map_pushing_to_the_receiver_does_not_overrun_its_output_buffer() {
         None => eprintln!("skip: no cc"),
     }
 }
+
+#[test]
+fn count_with_block_pushing_to_the_receiver_terminates() {
+    // Security regression: an earlier draft of the slice-4 safety retrofit
+    // touched every slice-3/5 helper but MISSED `count`'s block form (added
+    // in slice 5) -- caught by security review. `count`'s block-form loop
+    // must snapshot len/items BEFORE the loop too, or a block that pushes to
+    // its own receiver never terminates.
+    match run_ruby("a = [1, 2, 3]\nputs a.count { |x| a.push(x)\ntrue }\n") {
+        Some(out) => assert_eq!(out, "3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_each_shrinking_then_growing_the_receiver_does_not_overread() {
+    // Security regression: snapshotting `len` ALONE is not enough -- `push`
+    // reallocates its new buffer sized to the CURRENT (live) `s->len`, so a
+    // block that first shrinks the receiver (`pop`/`shift`, in place, no
+    // reallocation) and THEN pushes produces a buffer smaller than a `len`
+    // already snapshotted by an outer iterating helper. Continuing to read
+    // via a live `s->items` pointer up to that stale, larger snapshot would
+    // then run past the fresh (smaller) allocation -- caught by security
+    // review. The fix snapshots the ITEMS POINTER too, not just the length,
+    // so this must not crash, and `x` must reflect the ORIGINAL 5-element
+    // buffer (`each`'s own snapshot at entry), never the shrunk/regrown one.
+    match run_ruby("a = [1, 2, 3, 4, 5]\na.each { |x| a.pop\na.pop\na.push(99)\nputs x }\n") {
+        Some(out) => assert_eq!(out, "1\n2\n3\n4\n5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_mutation_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_array_mutation_methods.rs
@@ -1,0 +1,222 @@
+//! Execution proof for Collections slice 4 (Array mutation + 1-arg query
+//! methods) on the C backend — lower REAL Ruby source, emit C, compile with a
+//! real cc, run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! `push`/`pop`/`shift` are the FIRST Array methods that mutate the receiver
+//! (grow/shrink `SirSeq.len`/`.items`) after construction; `fetch`/
+//! `values_at`/`rotate`/`zip` are non-mutating 1-arg queries, and
+//! `include?`/`index` widen their slice-2 String-only forms to accept an
+//! Array receiver too.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    // Hash the full source, not just its length -- two tests with equal-length
+    // sources run as parallel threads in the SAME process and would collide on
+    // a length-keyed stem (see the temp-file-collision fix elsewhere in this
+    // test suite).
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    src.hash(&mut hasher);
+    let stem = format!("sirc_arrmut_{}_{}", std::process::id(), hasher.finish());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn push_appends_one_or_more_and_returns_the_receiver() {
+    match run_ruby("a = [1, 2]\nputs a.push(3)\nputs a\na.push(4, 5)\nputs a\n") {
+        Some(out) => assert_eq!(out, "[1, 2, 3]\n[1, 2, 3]\n[1, 2, 3, 4, 5]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn push_mutates_a_shared_binding() {
+    // Every binding sharing the array (not just the one `push` was called
+    // through) sees the appended element -- the same shared-box semantics
+    // `SeqSet` already has.
+    match run_ruby("a = [1]\nb = a\na.push(2)\nputs b\n") {
+        Some(out) => assert_eq!(out, "[1, 2]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn pop_removes_and_returns_the_last_element() {
+    match run_ruby("a = [1, 2, 3]\nputs a.pop\nputs a\n") {
+        Some(out) => assert_eq!(out, "3\n[1, 2]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn pop_on_empty_is_nil() {
+    match run_ruby("puts [].pop\n") {
+        Some(out) => assert_eq!(out, "nil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn shift_removes_and_returns_the_first_element_and_shifts_the_rest() {
+    match run_ruby("a = [1, 2, 3]\nputs a.shift\nputs a\n") {
+        Some(out) => assert_eq!(out, "1\n[2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn shift_on_empty_is_nil() {
+    match run_ruby("puts [].shift\n") {
+        Some(out) => assert_eq!(out, "nil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn push_pop_shift_interleaved() {
+    match run_ruby(
+        "a = [1, 2]\na.push(3)\nputs a.shift\na.push(4)\nputs a.pop\nputs a\n",
+    ) {
+        Some(out) => assert_eq!(out, "1\n4\n[2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_include_and_index() {
+    match run_ruby(
+        "puts [1, 2, 3].include?(2)\nputs [1, 2, 3].include?(9)\nputs [1, 2, 3].index(2)\nputs [1, 2, 3].index(9)\n",
+    ) {
+        Some(out) => assert_eq!(out, "#t\n#f\n1\nnil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_fetch_in_range_and_out_of_range_raises() {
+    match run_ruby(
+        "puts [10, 20, 30].fetch(1)\nbegin\n  [10, 20, 30].fetch(9)\nrescue IndexError => e\n  puts \"caught\"\nend\n",
+    ) {
+        Some(out) => assert_eq!(out, "20\ncaught\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_fetch_negative_index_counts_from_the_end() {
+    match run_ruby("puts [10, 20, 30].fetch(-1)\n") {
+        Some(out) => assert_eq!(out, "30\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_values_at_multiple_indices() {
+    match run_ruby("puts [10, 20, 30, 40].values_at(0, 2, 9, -1)\n") {
+        Some(out) => assert_eq!(out, "[10, 30, nil, 40]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_rotate_default_and_explicit_and_negative() {
+    match run_ruby(
+        "puts [1, 2, 3, 4].rotate\nputs [1, 2, 3, 4].rotate(2)\nputs [1, 2, 3, 4].rotate(-1)\n",
+    ) {
+        Some(out) => assert_eq!(out, "[2, 3, 4, 1]\n[3, 4, 1, 2]\n[4, 1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_rotate_does_not_mutate_the_receiver() {
+    match run_ruby("a = [1, 2, 3]\na.rotate\nputs a\n") {
+        Some(out) => assert_eq!(out, "[1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_zip_pads_shorter_others_with_nil() {
+    match run_ruby("puts [1, 2, 3].zip([4, 5])\n") {
+        Some(out) => assert_eq!(out, "[[1, 4], [2, 5], [3, nil]]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_zip_multiple_others() {
+    match run_ruby("puts [1, 2].zip([10, 20], [100, 200])\n") {
+        Some(out) => assert_eq!(out, "[[1, 10, 100], [2, 20, 200]]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn each_pushing_to_the_receiver_terminates_and_does_not_see_pushed_elements() {
+    // Security regression: `each`'s loop bound is snapshotted BEFORE any
+    // block call, so a block that grows the very array being iterated (1)
+    // does not run unbounded, and (2) does not read/write past the
+    // originally-allocated output where applicable. `each` has no output
+    // buffer, so this mainly proves termination; `array_map_pushing_to_the_
+    // receiver_does_not_overrun_its_output_buffer` below proves the
+    // allocation-safety half.
+    match run_ruby("a = [1, 2, 3]\na.each { |x| a.push(x) }\nputs a.length\n") {
+        Some(out) => assert_eq!(out, "6\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn array_map_pushing_to_the_receiver_does_not_overrun_its_output_buffer() {
+    // The exact scenario the security review flagged: `map` pre-allocates
+    // its output sized to the receiver's length; if the block grows the
+    // SAME receiver mid-loop and `map`'s loop bound re-read that (now
+    // larger) length, it would write past the allocation. `map`'s output
+    // must reflect only the ORIGINAL 3 elements, and the process must not
+    // crash (a heap overflow would corrupt or crash under most allocators).
+    match run_ruby("a = [1, 2, 3]\nb = a.map { |x| a.push(x)\nx * 10 }\nputs b\n") {
+        Some(out) => assert_eq!(out, "[10, 20, 30]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}


### PR DESCRIPTION
## Summary
- `push`/`pop`/`shift` are the FIRST Array methods that mutate a `SirSeq` after construction (`push` reallocates to grow; `pop`/`shift` shrink `len` in place, `shift` also shifting elements down). Plus `fetch` (raises `IndexError` OOB), `values_at`, `rotate`, `zip`, and widened `include?`/`index` (String-only since slice 2) to also accept an Array receiver.
- **Security retrofit (2 rounds)**: since `push` can now change `SirSeq.len`/`.items` mid-iteration, every block-taking helper from slices 3/5 (`map`/`select`/`reject`/`sort_by`/`each`/`any?`/`all?`/`none?`/`each_with_index`/`reduce`/`inject`, plus `count`'s block form) now snapshots BOTH the array's length AND its items pointer once before its loop/allocation — length alone isn't sufficient, since `push` reallocates relative to the *current* length, which can be smaller than an outer snapshot after a `pop`/`shift`. Round 1 review caught this plus a missed `count` block-form arm; round 2 confirmed the fix is complete and correct.
- **Out of scope**: `<<` (shovel) isn't implemented — `ruby-to-semantic-ir` has no binary-operator grammar rule for it at all yet (a separate, pre-existing frontend gap, tracked on the backlog). `arr.push(x)` (ordinary dot-call) is unaffected.

## Test plan
- [x] `cargo test -p semantic-ir-to-c` — full suite green (77 tests, including 4 dedicated security-regression tests reproducing the exact scenarios both review rounds flagged)
- [x] `cargo clippy -p semantic-ir-to-c --all-targets` — clean
- [x] Security review — 2 rounds, PASSED (round 1 found 2 HIGH findings — incomplete retrofit coverage + insufficient snapshot technique — round 2 verified both fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>